### PR TITLE
fix(shell): comprehensive title-bar fit + subtle titlebar glass

### DIFF
--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -28,7 +28,7 @@ export default async function DailyReportPage({ params }: Props) {
   if (!item) {
     return (
       <main className="dr-page">
-        <div className="dr-topbar">
+        <div className="dr-topbar" data-tauri-drag-region="deep">
           <a className="dr-back" href="/dashboard">
             <Icon name="ph:arrow-left" aria-hidden />
             Dashboard
@@ -102,7 +102,7 @@ export default async function DailyReportPage({ params }: Props) {
 
   return (
     <main className="dr-page">
-      <div className="dr-topbar">
+      <div className="dr-topbar" data-tauri-drag-region="deep">
         <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
           <a className="dr-back" href="/dashboard">
             <Icon name="ph:arrow-left" aria-hidden />

--- a/src/app/dashboard/familiars/growth/page.tsx
+++ b/src/app/dashboard/familiars/growth/page.tsx
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 export default function FamiliarGrowthDashboardPage() {
   return (
     <main className="dr-page">
-      <div className="dr-topbar">
+      <div className="dr-topbar" data-tauri-drag-region="deep">
         <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
           <a className="dr-back" href="/dashboard">
             <Icon name="ph:arrow-left" aria-hidden />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,7 @@ export default async function DashboardPage() {
 
   return (
     <main className="dr-page">
-      <div className="dr-topbar">
+      <div className="dr-topbar" data-tauri-drag-region="deep">
         <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
           <a className="dr-back" href="/">
             <Icon name="ph:arrow-left" aria-hidden />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4998,28 +4998,82 @@ button:active > .edge-rail-chip {
    app-region rules stay only as a progressive-enhancement fallback for any
    bundled-scheme build.
    `[data-tauri-titlebar]` is set on <html> only in the macOS desktop shell
-   (see shell.tsx), so browser/Windows/Linux are untouched. Scoped to the
-   desktop layout (≥1024px) to match where `.menu-bar` renders.
+   (see tauri-titlebar-marker.tsx, mounted in the root layout), so
+   browser/Windows/Linux are untouched.
    ──────────────────────────────────────────────── */
+
+/* Shared traffic-light reserve — ~78px clears the three lights + their left
+   inset at standard macOS metrics. */
+:root[data-tauri-titlebar] {
+  --titlebar-lights-inset: 78px;
+}
+
+/* Fit at EVERY window width: the lights float over the webview no matter how
+   narrow the window is, so the reserve can't be desktop-media-gated — in a
+   sub-1024 window the mobile top-bar's controls sat underneath the buttons. */
+:root[data-tauri-titlebar] .shell-top {
+  padding-left: var(--titlebar-lights-inset);
+}
+
+/* Dia-style: with the side panel closed the shell hides the traffic lights
+   (set_traffic_lights_visible in lib.rs, driven by shell.tsx — the attribute
+   flips to "hidden" only AFTER the native hide is confirmed), so the bar
+   releases the room reserved for them and slides back to the window edge. */
+:root[data-tauri-titlebar][data-traffic-lights="hidden"] .shell-top {
+  padding-left: 12px;
+}
+
+/* Subtle titlebar glass (native shell only — the browser tab keeps the fully
+   seamless canvas): a whisper of translucent fill + blur so the band reads
+   as window chrome floating over the backdrop, macOS-native, not a painted
+   strip. Falls back to the seamless transparent band where glass can't
+   render legibly. */
+:root[data-tauri-titlebar] .shell-top {
+  background: color-mix(in oklch, var(--bg-base) 46%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  :root[data-tauri-titlebar] .shell-top { background: transparent; }
+}
+@media (prefers-reduced-transparency: reduce) {
+  :root[data-tauri-titlebar] .shell-top {
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+/* Full-window route bands: Settings, Dashboard/Reports, and the analytics
+   page render in the same overlay-titlebar window once the app navigates
+   away from the workspace shell — their leading controls (Back, breadcrumbs)
+   need the same reserve. The shell restores the native lights on unmount, so
+   these never need a hidden-state variant. */
+:root[data-tauri-titlebar] .settings-shell__header {
+  padding-left: var(--titlebar-lights-inset);
+}
+:root[data-tauri-titlebar] .dr-topbar {
+  padding-left: max(var(--titlebar-lights-inset), clamp(20px, 5vw, 64px));
+}
+:root[data-tauri-titlebar] .fa-topbar {
+  padding-left: var(--titlebar-lights-inset);
+}
+/* …but NOT when the analytics view is embedded inside the workspace shell
+   (the inspector tab) — there the band sits mid-window, under shell chrome. */
+:root[data-tauri-titlebar] .shell-frame .fa-topbar {
+  padding-left: 24px;
+}
+
 @media (min-width: 1024px) {
   :root[data-tauri-titlebar] .shell-top {
-    /* ~78px clears the three traffic lights + their left inset; the slim 29px
-       band hugs the 28px controls so the bar doesn't tower over the lights
-       (was 36px — user asked for ~20% shorter). */
-    padding-left: 78px;
+    /* The slim 29px band hugs the 28px controls so the bar doesn't tower
+       over the lights (was 36px — user asked for ~20% shorter). */
     min-height: 29px;
   }
 
   /* The inner menu-bar would otherwise prop the band back open at 34px. */
   :root[data-tauri-titlebar] .shell-top .menu-bar {
     min-height: 28px;
-  }
-
-  /* Dia-style: with the side panel closed the shell hides the traffic lights
-     (set_traffic_lights_visible in lib.rs, driven by shell.tsx), so the bar
-     releases the room reserved for them and slides back to the window edge. */
-  :root[data-tauri-titlebar][data-traffic-lights="hidden"] .shell-top {
-    padding-left: 12px;
   }
 
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
@@ -9206,9 +9260,11 @@ a.mobile-handoff__link:hover {
   justify-content: space-between;
   gap: 16px;
   padding: 12px clamp(20px, 5vw, 64px);
-  background: color-mix(in oklch, var(--bg-base) 96%, transparent);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  /* Subtly more glass than the old near-opaque wash: content scrolling under
+     the sticky band shows through as a saturated blur, macOS-chrome style. */
+  background: color-mix(in oklch, var(--bg-base) 86%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-bottom: 1px solid var(--border-hairline);
 }
 .dr-back {
@@ -10448,8 +10504,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   color: var(--text-muted);
   font-size: 12px;
   background: color-mix(in oklch, var(--bg-base) 84%, transparent);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 .fa-topbar a {
   color: var(--text-secondary);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { ReadingWeightController } from "@/components/reading-weight-controller"
 import { ReadingHyphensController } from "@/components/reading-hyphens-controller";
 import { CornerRadiusController } from "@/components/corner-radius-controller";
 import { RemoteThemeController } from "@/components/remote-theme-controller";
+import { TauriTitlebarMarker } from "@/components/tauri-titlebar-marker";
 import { ThemeScript } from "@/components/theme-script";
 import { ShellBannersProvider } from "@/lib/shell-banners";
 import { LiveRegionProvider } from "@/components/ui/live-region";
@@ -87,6 +88,7 @@ export default function RootLayout({
             <ReadingHyphensController />
             <CornerRadiusController />
             <RemoteThemeController />
+            <TauriTitlebarMarker />
             <PwaRegister />
             <WebVitalsReporter />
             <PerfOverlay />

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -238,6 +238,10 @@ export function SettingsShell() {
       <header
         className="settings-shell__header surface-compact-header shrink-0"
         style={{ paddingTop: "calc(5px + var(--sai-top))" }}
+        // Real window drag on the loopback webview (the CSS app-region hint is
+        // inert on external URLs — see the titlebar notes in shell.tsx). The
+        // Back button and other controls opt out automatically as clickables.
+        data-tauri-drag-region="deep"
       >
         <button
           type="button"

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -289,4 +289,76 @@ assert.doesNotMatch(
   );
 }
 
+// ── Title-bar fit is comprehensive (cave-i7wf follow-up) ────────────────────
+// The overlay title bar is a property of the WINDOW, not of the workspace
+// shell: the traffic lights float over every route (/settings, /dashboard,
+// reports, analytics) and at every window width. The root marker is owned
+// globally and each full-window title band reserves the lights inset.
+{
+  const layout = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
+  const marker = readFileSync(new URL("./tauri-titlebar-marker.tsx", import.meta.url), "utf8");
+  assert.match(layout, /<TauriTitlebarMarker \/>/, "the root layout owns the titlebar marker");
+  assert.match(
+    marker,
+    /isMacDesktopShell\(\)/,
+    "the marker uses the shared macOS-desktop-shell detection",
+  );
+  assert.doesNotMatch(
+    shell,
+    /dataset\.tauriTitlebar =/,
+    "the workspace shell no longer sets the marker — it must survive shell unmount",
+  );
+  assert.match(
+    shell,
+    /if \(!isMacDesktopShell\(\)\) return;/,
+    "the lights effect detects the platform directly instead of racing the marker mount",
+  );
+  // The shell-top reserve applies at every width (a sub-1024 window put the
+  // mobile top-bar's controls under the lights when it was media-gated).
+  assert.match(
+    css,
+    /:root\[data-tauri-titlebar\] \.shell-top \{\s*padding-left: var\(--titlebar-lights-inset\);\s*\}/,
+    "the shell-top lights inset is not desktop-media-gated",
+  );
+  // Full-window route bands reserve the same inset…
+  for (const band of ["settings-shell__header", "dr-topbar", "fa-topbar"]) {
+    assert.match(
+      css,
+      new RegExp(`:root\\[data-tauri-titlebar\\] \\.${band} \\{\\s*padding-left: (?:var\\(--titlebar-lights-inset\\)|max\\(var\\(--titlebar-lights-inset\\))`),
+      `${band} reserves the traffic-light inset on macOS`,
+    );
+  }
+  // …but the analytics band embedded in the workspace shell (inspector tab)
+  // sits mid-window and must NOT.
+  assert.match(
+    css,
+    /:root\[data-tauri-titlebar\] \.shell-frame \.fa-topbar \{\s*padding-left: 24px;/,
+    "the inspector-embedded analytics breadcrumb keeps its own padding",
+  );
+  // Titlebar glass stays honest: blur is paired with the reduced-transparency
+  // and no-backdrop-filter fallbacks.
+  assert.match(
+    css,
+    /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,340}?backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
+    "the native shell titlebar carries subtle glass",
+  );
+  const dashboardCss = readFileSync(new URL("../styles/dashboard.css", import.meta.url), "utf8");
+  assert.match(
+    dashboardCss,
+    /\.settings-shell__header \{[\s\S]{0,600}?backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
+    "the settings header is glass",
+  );
+  assert.match(
+    dashboardCss,
+    /@media \(prefers-reduced-transparency: reduce\) \{[\s\S]{0,400}?\.settings-shell__header/,
+    "settings header glass respects reduced transparency",
+  );
+  const settingsShell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+  assert.match(
+    settingsShell,
+    /surface-compact-header shrink-0"[\s\S]{0,400}?data-tauri-drag-region="deep"/,
+    "the settings header is a real window drag region (CSS app-region is inert on loopback URLs)",
+  );
+}
+
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -16,6 +16,7 @@ import { useShellBanners } from "@/lib/shell-banners";
 import { UpdateBannerTrigger } from "@/components/update-available";
 import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { useIsMobile } from "@/lib/use-viewport";
+import { isMacDesktopShell } from "@/lib/tauri-platform";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
 import { DetailSplitHost, type DetailSplitTile } from "@/components/detail-split-host";
 import {
@@ -212,10 +213,12 @@ function ShellInner({
   }, [isMobile]);
 
   // Seamless macOS title bar: only the macOS desktop Tauri shell overlays the
-  // native title bar (lib.rs sets TitleBarStyle::Overlay), so only there do we
-  // mark <html> to reserve room for the traffic lights (see
-  // [data-tauri-titlebar] in globals.css). Browser, Windows, Linux, and
-  // Tauri-mobile keep their normal chrome.
+  // native title bar (lib.rs sets TitleBarStyle::Overlay). The root
+  // `data-tauri-titlebar` marker that reserves room for the traffic lights is
+  // owned globally by <TauriTitlebarMarker> in the root layout — the lights
+  // float over EVERY route of the window (Settings, Dashboard, reports…),
+  // not just this shell. Browser, Windows, Linux, and Tauri-mobile never set
+  // it.
   //
   // The drag itself is handled by Tauri's injected drag.js via the
   // `data-tauri-drag-region="deep"` attributes on the titlebar below: a press
@@ -233,26 +236,6 @@ function ShellInner({
   // only bridges it into a real NSWindow drag on the native `tauri://`
   // scheme) — which is why the titlebar historically never dragged. The CSS
   // stays as a progressive-enhancement fallback for any bundled-scheme build.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const isTauri = "__TAURI_INTERNALS__" in window;
-    // navigator.platform is deprecated and empty on newer WebKit, which made
-    // isMac fall through to false and skip the titlebar mode entirely. Prefer
-    // the modern userAgentData.platform, then fall back to the UA string.
-    const platform =
-      (navigator as unknown as { userAgentData?: { platform?: string } })
-        .userAgentData?.platform ||
-      navigator.userAgent ||
-      navigator.platform ||
-      "";
-    const isMac = /Mac/i.test(platform);
-    if (!isTauri || !isMac) return;
-    const root = document.documentElement;
-    root.dataset.tauriTitlebar = "";
-    return () => {
-      delete root.dataset.tauriTitlebar;
-    };
-  }, []);
   const mobileChromeState: ShellMobileChromeState = {
     navDrawerOpen: isMobile && mobileDrawer === "nav",
     listDrawerOpen: isMobile && mobileDrawer === "list",
@@ -355,9 +338,10 @@ function ShellInner({
   const trafficLightsVisible = navOpen || navPeeking || isMobile;
   useEffect(() => {
     const root = document.documentElement;
-    // Only the macOS desktop Tauri shell overlays the title bar (the effect
-    // above sets this marker); everywhere else there are no lights to manage.
-    if (!("tauriTitlebar" in root.dataset)) return;
+    // Only the macOS desktop Tauri shell overlays the title bar; everywhere
+    // else there are no lights to manage. Detected directly (not via the
+    // root marker) so this effect can't race <TauriTitlebarMarker />'s mount.
+    if (!isMacDesktopShell()) return;
     let cancelled = false;
     const applyNative = (visible: boolean) =>
       import("@tauri-apps/api/core").then(({ invoke }) =>

--- a/src/components/tauri-titlebar-marker.tsx
+++ b/src/components/tauri-titlebar-marker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+/**
+ * Global owner of the `data-tauri-titlebar` root marker.
+ *
+ * The macOS desktop shell renders the main window's native title bar as an
+ * Overlay (lib.rs), so the traffic lights float over web content on EVERY
+ * route of the window — not just the workspace shell. The marker used to be
+ * set by <Shell>, which meant full-window routes (/settings, /dashboard,
+ * analytics, reports) lost it the moment the shell unmounted and their title
+ * bands slid their leading controls underneath the lights.
+ *
+ * Mounted once in the root layout; the overlay title bar is a property of
+ * the window, not of a route, so the marker is never removed. globals.css
+ * (and dashboard.css) key their traffic-light insets and titlebar glass off
+ * `:root[data-tauri-titlebar]`. Browser, Windows, Linux, and Tauri-mobile
+ * never set it.
+ */
+
+import { useEffect } from "react";
+import { isMacDesktopShell } from "@/lib/tauri-platform";
+
+export function TauriTitlebarMarker() {
+  useEffect(() => {
+    if (!isMacDesktopShell()) return;
+    document.documentElement.dataset.tauriTitlebar = "";
+  }, []);
+  return null;
+}

--- a/src/lib/tauri-platform.ts
+++ b/src/lib/tauri-platform.ts
@@ -87,3 +87,21 @@ export function useIsTauriMobile(): boolean {
   const p = useTauriPlatform();
   return p === "ios" || p === "android";
 }
+
+/**
+ * True in the macOS *desktop* Tauri shell — the one place the main window's
+ * native title bar is an Overlay (lib.rs) with traffic lights floating over
+ * web content. Synchronous and SSR-safe, so the titlebar marker and the
+ * shell's Dia-style lights logic share one detection instead of racing.
+ *
+ * navigator.platform is deprecated and empty on newer WebKit, so prefer the
+ * modern userAgentData.platform and fall back to the UA string. iOS WebKit
+ * UAs contain "like Mac OS X", so Tauri-mobile is excluded explicitly.
+ */
+export function isMacDesktopShell(): boolean {
+  if (typeof window === "undefined" || !isTauri()) return false;
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = nav.userAgentData?.platform || nav.userAgent || nav.platform || "";
+  if (/iPhone|iPad|iPod/i.test(platform)) return false;
+  return /Mac/i.test(platform);
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -158,9 +158,35 @@
 }
 
 .settings-shell__header {
+  /* Subtle titlebar glass, matching the workspace shell's native band: a
+     translucent panel-to-base wash with blur+saturate instead of the old
+     opaque gradient, so the header reads as window chrome floating over the
+     settings canvas. Fallbacks below restore the opaque wash. */
   background:
-    linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
+    linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--bg-panel) 62%, transparent),
+      color-mix(in oklch, var(--bg-base) 44%, transparent)
+    );
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-app-region: drag;
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .settings-shell__header {
+    background:
+      linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .settings-shell__header {
+    background:
+      linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 .settings-shell__header :is(button, a, input, select, textarea) {


### PR DESCRIPTION
Tracked by bead `cave-y894`. Follow-up to #2856 — this makes the title-bar fit **comprehensive** and the chrome subtly glassmorphic across the app.

## Fit — the lights are a window property, not a shell property

| Bug | Fix |
| --- | --- |
| `data-tauri-titlebar` was set by `<Shell>`, so `/settings`, `/dashboard`, reports, and the analytics page lost the marker on shell unmount — their Back/breadcrumb controls rendered **under the traffic lights** (screenshot-reported on Settings) | New `<TauriTitlebarMarker>` in the **root layout** owns the marker via a shared `isMacDesktopShell()` (tauri-platform.ts, iOS-UA excluded); never removed — the overlay title bar belongs to the window |
| The shell-top 78px reserve was gated `@media (min-width: 1024px)` — sub-1024 windows put the mobile top-bar's controls under the lights | `--titlebar-lights-inset: 78px` now applies to `.shell-top` at **every** width; Dia-style hidden-lights release unchanged |
| Full-window route bands had no reserve at all | `.settings-shell__header`, `.dr-topbar`, `.fa-topbar` all reserve the inset; the inspector-embedded analytics breadcrumb (inside `.shell-frame`) is explicitly excepted |
| Shell's lights effect keyed off the marker's dataset — a mount-order race | It now calls `isMacDesktopShell()` directly |
| Settings/dashboard headers weren't real drag regions (CSS `app-region` is inert on loopback URLs) | `data-tauri-drag-region="deep"` on the Settings header + dashboard/report top bars; controls opt out as clickables |

## Subtly more glassmorphic

- **Native shell `.shell-top`**: translucent `bg-base` wash + `blur(var(--glass-blur)) saturate(var(--glass-saturate))`, scoped to the marker so the browser tab keeps its seamless canvas; `@supports` + `prefers-reduced-transparency` fallbacks restore the seamless band
- **Settings header**: opaque gradient → translucent panel wash with the shared glass tokens + honest fallbacks
- **`.dr-topbar`**: 96% → 86% wash on glass tokens (scrolling content now shows through the sticky band)
- **`.fa-topbar`**: adopts the shared blur/saturate tokens

## Verification

- `shell-edge-rails.test.ts` pins: marker hoisted to layout (+ shell no longer sets it), everywhere-inset un-gated, all three route bands reserve the inset, the embedded-analytics exception, glass declarations + reduced-transparency fallback, and the Settings drag region
- typecheck ✓ · `pnpm test:app` 591 ✓ · `pnpm build` + bundle budget ✓
- Playwright measurement pass (prod build, marker forced): Settings Back at x=78 ✓ · `.shell-top` padding 78px at 1280px **and** 800px ✓ · `.dr-topbar` 78px ✓ · screenshots inspected

Note: the production CSS pipeline emits glass as `-webkit-backdrop-filter` (pre-existing, app-wide) — rendered by the WKWebView the desktop app actually runs in.
