### PR TITLE
fix(release): updater tarball ships no AppleDouble entries — kills the macOS 'app is damaged' update error

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -418,11 +418,63 @@ echo "Wrote checksum entry to $SUMS_PATH"
 # installed app must still pass Gatekeeper, which only the notarized bundle
 # does. Non-fatal by design: a failure here must never sink a release — the
 # DMG is the source of truth and the app falls back to manual download.
+#
+# CRITICAL (v0.0.167 "app is damaged" regression): the tarball must contain
+# NO AppleDouble (._*) entries. macOS bsdtar embeds xattrs/resource forks as
+# `._` sidecar entries by default; the Tauri updater's Rust extractor
+# materializes those as literal files INSIDE the .app, which invalidates the
+# code seal ("a sealed resource is missing or invalid") — Gatekeeper then
+# refuses the updated app with "CovenCave is damaged and can't be opened".
+# COPYFILE_DISABLE=1 + --no-mac-metadata + --no-xattrs keep the archive to
+# real files only, and the round-trip gate below refuses to ship a tarball
+# whose extracted app no longer verifies.
 if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
   echo ""
   echo "==> Building signed updater artifact (.app.tar.gz)"
   UPDATER_TARBALL="$DMG_DIR/CovenCave.app.tar.gz"
-  if tar -czf "$UPDATER_TARBALL" -C "$(dirname "$APP_PATH")" "$(basename "$APP_PATH")"; then
+  build_updater_tarball() {
+    COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs -czf "$UPDATER_TARBALL" \
+      -C "$(dirname "$APP_PATH")" "$(basename "$APP_PATH")"
+  }
+  verify_updater_tarball() {
+    # Round-trip the archive through a metadata-NAIVE extractor (python
+    # tarfile). bsdtar can't be trusted for this check: it hides AppleDouble
+    # entries from `-t` listings and re-merges them into xattrs on extract,
+    # masking exactly the corruption the Tauri updater's Rust extractor
+    # produces — it writes `._*` entries as literal files inside the
+    # swapped-in .app.
+    local probe_dir
+    probe_dir=$(mktemp -d)
+    if ! python3 - "$UPDATER_TARBALL" "$probe_dir" <<'PY'
+import sys, tarfile
+with tarfile.open(sys.argv[1]) as t:
+    try:
+        t.extractall(sys.argv[2], filter="fully_trusted")
+    except TypeError:  # Python < 3.12: no filter kwarg
+        t.extractall(sys.argv[2])
+PY
+    then
+      rm -rf "$probe_dir"
+      echo "    ! updater tarball failed to extract" >&2
+      return 1
+    fi
+    # 1. Zero AppleDouble files may materialize.
+    if find "$probe_dir" -name '._*' -print -quit | grep -q .; then
+      rm -rf "$probe_dir"
+      echo "    ! updater tarball contains AppleDouble (._*) entries — the extracted app would fail Gatekeeper" >&2
+      return 1
+    fi
+    # 2. The code seal must survive the round trip — the same integrity check
+    #    Gatekeeper runs on the swapped-in update.
+    if ! codesign --verify --deep --strict "$probe_dir/CovenCave.app" >/dev/null 2>&1; then
+      rm -rf "$probe_dir"
+      echo "    ! extracted updater app fails codesign verification" >&2
+      return 1
+    fi
+    rm -rf "$probe_dir"
+    return 0
+  }
+  if build_updater_tarball && verify_updater_tarball; then
     if pnpm exec tauri signer sign "$UPDATER_TARBALL"; then
       echo "    wrote $UPDATER_TARBALL (+ .sig)"
     else
@@ -430,7 +482,8 @@ if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
       rm -f "$UPDATER_TARBALL"
     fi
   else
-    echo "    ! updater tarball creation failed; skipping" >&2
+    echo "    ! updater tarball creation/verification failed; skipping (users fall back to manual DMG download)" >&2
+    rm -f "$UPDATER_TARBALL"
   fi
 else
   echo "==> TAURI_SIGNING_PRIVATE_KEY unset; skipping updater artifact"

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -186,3 +186,38 @@ test("macOS release signing preserves bundled Node JIT entitlement", async () =>
     "Node needs executable memory permission under hardened runtime for V8-generated code",
   );
 });
+
+test("macOS updater tarball ships no AppleDouble entries (v0.0.167 'app is damaged' regression)", async () => {
+  const releaseScript = await readFile(
+    new URL("../scripts/release.sh", import.meta.url),
+    "utf8",
+  );
+
+  // macOS bsdtar embeds xattrs/resource forks as `._*` sidecar entries by
+  // default. The Tauri updater's Rust extractor materializes those as literal
+  // files INSIDE the swapped-in .app, invalidating the code seal — Gatekeeper
+  // then rejects the update with "CovenCave is damaged and can't be opened".
+  assert.match(
+    releaseScript,
+    /COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs -czf "\$UPDATER_TARBALL"/,
+    "the updater tarball must be created without AppleDouble/xattr metadata",
+  );
+  // bsdtar hides AppleDouble entries from listings and re-merges them on
+  // extract, so the gate must round-trip through a metadata-naive extractor
+  // (python tarfile — same literal behavior as the updater's Rust extractor).
+  assert.match(
+    releaseScript,
+    /python3 - "\$UPDATER_TARBALL" "\$probe_dir"/,
+    "the release script must extract the tarball with a metadata-naive extractor",
+  );
+  assert.match(
+    releaseScript,
+    /find "\$probe_dir" -name '\._\*' -print -quit/,
+    "the release script must refuse to ship a tarball that materializes AppleDouble files",
+  );
+  assert.match(
+    releaseScript,
+    /codesign --verify --deep --strict "\$probe_dir\/CovenCave\.app"/,
+    "the release script must round-trip the tarball and re-verify the extracted app's code seal",
+  );
+});


### PR DESCRIPTION
Fixes the in-app update flow dying at restart with Gatekeeper's **«CovenCave is damaged and can't be opened. You should move it to the Trash.»** (bead `cave-csl8`).

## Root cause (verified against the shipped v0.0.167 aarch64 artifact)

`release.sh` regenerates the updater `.app.tar.gz` from the notarized app with **plain `tar -czf`**. macOS bsdtar embeds xattrs/resource forks as AppleDouble (`._*`) sidecar entries — the shipped tarball contains **112** of them. The Tauri updater's Rust extractor materializes those as **literal files inside the swapped-in .app**, invalidating the code seal:

```
$ codesign --verify --deep --strict extracted/CovenCave.app
extracted/CovenCave.app: a sealed resource is missing or invalid
```

Gatekeeper then refuses the updated bundle with the "damaged" dialog.

**The trap:** bsdtar *hides* AppleDouble entries from `-t` listings and *re-merges* them into xattrs on extract — so every bsdtar-based inspection shows a perfectly healthy archive. Only a metadata-naive extractor (python tarfile / the updater's Rust tar) exposes the corruption.

## Fix

1. **Create clean archives:** `COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs -czf …` — real files only.
2. **Round-trip gate before signing:** extract with python tarfile (same literal behavior as the Rust extractor), require **zero `._*` files** to materialize, and require `codesign --verify --deep --strict` to pass on the extracted app — the exact integrity check Gatekeeper runs on the swapped-in update. A failing gate skips the updater artifact (users fall back to the DMG) instead of shipping a poisoned update.

## Validation

- Gate run against the **real broken v0.0.167 tarball** → `REJECT: AppleDouble entries present` ✓
- Repack of the same notarized app with the new flags → `ACCEPT` (zero sidecars, seal verifies after naive extraction) ✓
- `release-runtime.test.mjs` pins the tar flags + both gate checks (9/9) ✓
- `bash -n` syntax ✓ · `pnpm test:app` 592 ✓

## Rollout

The damage lives in the published artifact, not the client — after this merges, the **next release cut** ships a clean tarball and in-app updates work again for everyone (including users currently on the broken artifact, since their updater downloads the new tarball).