### PR TITLE
feat(asana): integrate Asana tasks into the board, beads, and Queue

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -423,6 +423,8 @@ export const SUITES = {
     "src/components/familiar-studio-identity-tab.test.ts",
     "src/components/familiar-studio-lifecycle-tab.test.ts",
     "src/components/github-task-field.test.ts",
+    "src/components/asana-task-field.test.ts",
+    "src/lib/task-asana.test.ts",
     "src/components/github-view-polish.test.ts",
     "src/components/github-advanced.test.ts",
     "src/lib/issue-worktree.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -18,6 +18,8 @@ type RouteContract = {
 
 const contracts: RouteContract[] = [
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
+  { route: "/asana/assigned", methods: ["GET"], kind: "json" },
+  { route: "/asana/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/beads", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
   { route: "/beads/prs", methods: ["GET"], kind: "json", localOriginGuard: true, pathGuard: true },
   { route: "/board/[id]/chat", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/asana/assigned/route.ts
+++ b/src/app/api/asana/assigned/route.ts
@@ -1,0 +1,130 @@
+/**
+ * /api/asana/assigned
+ *
+ * Returns the incomplete Asana tasks assigned to the connected user, mirroring
+ * /api/github/assigned. The Asana `/tasks` endpoint needs (assignee + workspace),
+ * so we first read `users/me` for the workspace list, then fan out. `configured`
+ * is false when no PAT is stored — the "Asana connected" signal the UI gates on.
+ */
+
+import { NextResponse } from "next/server";
+import type { AsanaItem } from "@/lib/asana-tasks";
+import { resolveSecret } from "@/lib/vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const API = "https://app.asana.com/api/1.0";
+const TASK_FIELDS = "name,permalink_url,completed,due_on,modified_at,assignee.name,projects.name";
+// Bound the fan-out — a user in many workspaces shouldn't spray dozens of calls.
+const MAX_WORKSPACES = 5;
+const PER_WORKSPACE = 50;
+
+type AsanaMe = {
+  gid: string;
+  name?: string;
+  email?: string;
+  workspaces?: Array<{ gid: string; name?: string }>;
+};
+
+type RawAsanaTask = {
+  gid: string;
+  name?: string;
+  permalink_url?: string;
+  completed?: boolean;
+  due_on?: string | null;
+  modified_at?: string;
+  assignee?: { name?: string } | null;
+  projects?: Array<{ gid: string; name?: string }> | null;
+};
+
+function resolveAsanaToken(): string | undefined {
+  return (
+    resolveSecret("ASANA_PAT") ??
+    process.env.ASANA_PAT?.trim() ??
+    process.env.ASANA_ACCESS_TOKEN?.trim()
+  );
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, Accept: "application/json" };
+}
+
+function permalinkFor(task: RawAsanaTask): string {
+  if (task.permalink_url) return task.permalink_url;
+  // Fallback permalink if the field was omitted — the my-tasks focus layout.
+  return `https://app.asana.com/0/0/${task.gid}/f`;
+}
+
+function toItem(task: RawAsanaTask, workspaceGid: string): AsanaItem {
+  const project = task.projects?.[0];
+  return {
+    kind: "task",
+    id: task.gid,
+    gid: task.gid,
+    title: task.name?.trim() || `Asana task ${task.gid}`,
+    url: permalinkFor(task),
+    projectGid: project?.gid,
+    projectName: project?.name,
+    assignee: task.assignee?.name,
+    completed: task.completed ?? false,
+    dueOn: task.due_on ?? null,
+    updatedAt: task.modified_at ?? new Date(0).toISOString(),
+    workspaceGid,
+  };
+}
+
+export async function GET() {
+  const token = resolveAsanaToken();
+  if (!token) {
+    return NextResponse.json({ ok: true, items: [], configured: false });
+  }
+
+  const headers = authHeaders(token);
+
+  try {
+    const meRes = await fetch(`${API}/users/me?opt_fields=name,email,workspaces.name`, {
+      headers,
+      cache: "no-store",
+    });
+    if (!meRes.ok) {
+      return NextResponse.json(
+        { ok: false, error: `Asana API error: HTTP ${meRes.status}`, items: [] },
+        { status: 502 },
+      );
+    }
+    const meData = (await meRes.json().catch(() => null)) as { data?: AsanaMe } | null;
+    const me = meData?.data;
+    const workspaces = (me?.workspaces ?? []).slice(0, MAX_WORKSPACES);
+    if (workspaces.length === 0) {
+      return NextResponse.json({ ok: true, items: [], configured: true });
+    }
+
+    const perWorkspace = await Promise.all(
+      workspaces.map(async (ws) => {
+        // completed_since=now returns only tasks still incomplete.
+        const url =
+          `${API}/tasks?assignee=me&workspace=${encodeURIComponent(ws.gid)}` +
+          `&completed_since=now&limit=${PER_WORKSPACE}&opt_fields=${encodeURIComponent(TASK_FIELDS)}`;
+        const res = await fetch(url, { headers, cache: "no-store" });
+        if (!res.ok) return [] as AsanaItem[];
+        const data = (await res.json().catch(() => null)) as { data?: RawAsanaTask[] } | null;
+        return (data?.data ?? []).filter((t) => !t.completed).map((t) => toItem(t, ws.gid));
+      }),
+    );
+
+    const seen = new Set<string>();
+    const items: AsanaItem[] = [];
+    for (const item of perWorkspace.flat()) {
+      if (seen.has(item.gid)) continue;
+      seen.add(item.gid);
+      items.push(item);
+    }
+    items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+    return NextResponse.json({ ok: true, items, configured: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ ok: false, error: message, items: [] }, { status: 502 });
+  }
+}

--- a/src/app/api/asana/pat/route.ts
+++ b/src/app/api/asana/pat/route.ts
@@ -1,0 +1,119 @@
+/**
+ * /api/asana/pat
+ *
+ * Connect Asana with a Personal Access Token, mirroring /api/github/pat. This is
+ * the in-app on-ramp that makes the Asana affordances "enabled": once a PAT is
+ * stored, the board inspector and Queue can pull assigned tasks live.
+ *
+ * GET    — { hasPat: boolean, login: string|null, source } — NEVER returns the PAT.
+ * POST   — body { pat } — validates against app.asana.com, stores in the local
+ *          encrypted vault, injects into the running process. Never logged/returned.
+ * DELETE — removes ASANA_PAT from .env.local and the encrypted vault.
+ *
+ * The token is only ever sent to app.asana.com.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import {
+  deleteLocalEncryptedSecret,
+  hasLocalEncryptedSecret,
+  setLocalEncryptedSecret,
+} from "@/lib/local-encrypted-vault";
+import { loadVaultMap, resolveSecret, saveVaultMap } from "@/lib/vault";
+import { envLocalPath, upsertEnvContent } from "@/lib/env-file";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const PAT_KEY = "ASANA_PAT";
+const USER_KEY = "ASANA_USER";
+
+function applyEnvUpdates(updates: Record<string, string | null>): void {
+  const envPath = envLocalPath();
+  mkdirSync(dirname(envPath), { recursive: true });
+  const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+  writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
+}
+
+async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null }> {
+  try {
+    const res = await fetch("https://app.asana.com/api/1.0/users/me", {
+      headers: { Authorization: `Bearer ${pat}`, Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) return { valid: false, login: null };
+    const data = await res.json().catch(() => null);
+    const me = data?.data as { name?: string; email?: string } | undefined;
+    return { valid: true, login: me?.name ?? me?.email ?? null };
+  } catch {
+    return { valid: false, login: null };
+  }
+}
+
+export async function GET() {
+  const patFromVault = resolveSecret(PAT_KEY);
+  const userFromVault = resolveSecret(USER_KEY);
+
+  const hasPat = !!(patFromVault ?? process.env.ASANA_PAT?.trim() ?? process.env.ASANA_ACCESS_TOKEN?.trim());
+  const login = userFromVault ?? process.env.ASANA_USER?.trim() ?? null;
+  const source: "encrypted" | "vault" | "env" | "none" = hasLocalEncryptedSecret(PAT_KEY)
+    ? "encrypted"
+    : patFromVault
+      ? "vault"
+      : hasPat
+        ? "env"
+        : "none";
+
+  return NextResponse.json({ hasPat, login, source });
+}
+
+export async function POST(req: NextRequest) {
+  let body: { pat?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    /* ignore */
+  }
+
+  const pat = typeof body.pat === "string" ? body.pat.trim() : "";
+  if (!pat) {
+    return NextResponse.json({ ok: false, error: "pat is required" }, { status: 400 });
+  }
+
+  const result = await validatePat(pat);
+  if (!result.valid) {
+    return NextResponse.json(
+      { ok: false, error: "Asana PAT is invalid or expired" },
+      { status: 422 },
+    );
+  }
+
+  setLocalEncryptedSecret(PAT_KEY, pat);
+  const map = loadVaultMap(true);
+  map[PAT_KEY] = { storage: "encrypted", description: "Asana Personal Access Token", required: false };
+  saveVaultMap(map);
+
+  const updates: Record<string, string | null> = { [PAT_KEY]: null };
+  if (result.login) updates[USER_KEY] = result.login;
+  applyEnvUpdates(updates);
+
+  // Inject so the next request resolves the token without a restart.
+  process.env[PAT_KEY] = pat;
+  if (result.login) process.env[USER_KEY] = result.login;
+
+  return NextResponse.json({ ok: true, login: result.login, patStoredIn: "encrypted" });
+}
+
+export async function DELETE() {
+  applyEnvUpdates({ [PAT_KEY]: null });
+  deleteLocalEncryptedSecret(PAT_KEY);
+  const map = loadVaultMap(true);
+  if (map[PAT_KEY]?.storage === "encrypted") {
+    delete map[PAT_KEY];
+    saveVaultMap(map);
+  }
+  delete process.env[PAT_KEY];
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/beads/route.ts
+++ b/src/app/api/beads/route.ts
@@ -19,6 +19,14 @@ type BeadsPostBody = {
   comment?: string;
   reason?: string;
   projectRoot?: string;
+  /** create action: the new bead's title (required). */
+  title?: string;
+  /** create action: description body. */
+  description?: string;
+  /** create action: external reference (e.g. an Asana/Linear ticket URL). */
+  externalRef?: string;
+  /** create action: labels to tag the bead with. */
+  labels?: string[];
 };
 
 function jsonFromStdout(stdout: string): unknown {
@@ -117,6 +125,36 @@ export async function POST(req: Request) {
 
   const root = await resolveProjectRoot(parsed.body.projectRoot ?? null);
   if (!root.ok) return projectRootErrorResponse(root);
+
+  // `create` files a new bead (e.g. from an external ticket) and needs a title
+  // rather than an id — handle it before the id requirement below. Links the
+  // source ticket through --external-ref, the beads protocol's visibility layer.
+  if (parsed.body.action === "create") {
+    const title = parsed.body.title?.trim();
+    if (!title) return NextResponse.json({ ok: false, error: "title required" }, { status: 400 });
+    const createArgs = ["create", title, "--json"];
+    const description = parsed.body.description?.trim();
+    if (description) createArgs.push("-d", description);
+    const externalRef = parsed.body.externalRef?.trim();
+    if (externalRef) createArgs.push("--external-ref", externalRef);
+    const labels = (parsed.body.labels ?? []).map((label) => label.trim()).filter(Boolean);
+    if (labels.length) createArgs.push("--labels", labels.join(","));
+
+    const created = await runBd(root.repoRoot, root.beadsDir, createArgs);
+    if (!created.ok) {
+      return NextResponse.json(
+        { ok: false, error: created.error, stdout: created.stdout, stderr: created.stderr },
+        { status: created.status },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      action: "create",
+      projectRoot: root.repoRoot,
+      data: jsonFromStdout(created.stdout),
+      stderr: created.stderr || undefined,
+    });
+  }
 
   const id = parsed.body.id?.trim();
   if (!id) return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });

--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -8,7 +8,7 @@ import {
   type CardStatus,
 } from "@/lib/cave-board";
 import type { CardStep } from "@/lib/cave-board-types";
-import type { CardGitHubLink } from "@/lib/cave-board-types";
+import type { CardAsanaLink, CardGitHubLink } from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import type { CardOps } from "@/lib/board-card-ops";
 import { trustedProjectCwd } from "@/lib/cave-projects";
@@ -33,6 +33,7 @@ export async function PATCH(
     projectId: string | null;
     links: string[];
     github: CardGitHubLink[];
+    asana: CardAsanaLink[];
     labels: string[];
     startDate: string | null;
     endDate: string | null;

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -5,7 +5,7 @@ import {
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
-import type { CardGitHubLink } from "@/lib/cave-board-types";
+import type { CardAsanaLink, CardGitHubLink } from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import { trustedProjectCwd } from "@/lib/cave-projects";
 
@@ -28,6 +28,7 @@ export async function POST(req: Request) {
     projectId?: string | null;
     links?: string[];
     github?: CardGitHubLink[];
+    asana?: CardAsanaLink[];
     labels?: string[];
     startDate?: string | null;
     endDate?: string | null;
@@ -64,6 +65,7 @@ export async function POST(req: Request) {
     projectId: body.projectId,
     links: body.links,
     github: body.github,
+    asana: body.asana,
     labels: body.labels,
     startDate: body.startDate,
     endDate: body.endDate,

--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -99,22 +99,22 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
   if (!configured || items.length === 0) return null;
 
   return (
-    <section className="fwq-attention" aria-label="Asana tasks assigned to you">
-      <header className="fwq-attention-head">
+    <section className="fwq-asana" aria-label="Asana tasks assigned to you">
+      <header className="fwq-asana-head">
         <Icon name="ph:check-circle" width={14} aria-hidden />
-        <span className="fwq-attention-title">Asana</span>
-        <span className="fwq-attention-summary">{items.length} assigned</span>
+        <span className="fwq-asana-title">Asana</span>
+        <span className="fwq-asana-summary">{items.length} assigned</span>
       </header>
-      <ul className="fwq-attention-list">
+      <ul className="fwq-asana-list">
         {items.map((item) => {
           const busy = busyGid === item.gid;
           const meta = [item.projectName, item.dueOn ? `due ${item.dueOn}` : null].filter(Boolean).join(" · ");
           return (
-            <li key={item.gid} className="fwq-attention-item">
-              <div className="fwq-attention-main">
-                <span className="fwq-attention-name">{item.title}</span>
+            <li key={item.gid} className="fwq-asana-item">
+              <div className="fwq-asana-main">
+                <span className="fwq-asana-name">{item.title}</span>
               </div>
-              <div className="fwq-attention-tags">
+              <div className="fwq-asana-tags">
                 {meta ? <span className="fwq-tag">{meta}</span> : null}
                 {filed.has(item.gid) ? <span className="fwq-tag fwq-tag--ready">filed</span> : null}
               </div>

--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import {
+  createBoardCardFromAsanaItem,
+  fileAsanaItemAsBead,
+  type AsanaAssignedResponse,
+  type AsanaItem,
+} from "@/lib/asana-tasks";
+
+type Props = {
+  onOpenUrl?: (url: string) => void;
+  /** Nudge the parent Queue to reload after a task is filed as a bead so it
+   *  appears in the ready lanes without waiting for the next poll. */
+  onFiledBead?: () => void;
+};
+
+/**
+ * The Queue's Asana source: incomplete tasks assigned to the connected user,
+ * pulled from /api/asana/assigned. Renders NOTHING when Asana isn't connected
+ * or there are no tasks — the Queue's other sources (beads + PRs) stand alone,
+ * so an absent Asana connection must not add a banner or empty state here. Each
+ * task can be opened in Asana, added to the board, or filed as a bead (entering
+ * the ready queue via --external-ref).
+ */
+export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
+  const { announce } = useAnnouncer();
+  const [items, setItems] = useState<AsanaItem[]>([]);
+  const [configured, setConfigured] = useState(false);
+  const [busyGid, setBusyGid] = useState<string | null>(null);
+  const [filed, setFiled] = useState<Set<string>>(() => new Set());
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    try {
+      const res = await fetch("/api/asana/assigned", { cache: "no-store", signal: ctrl.signal });
+      const data = (await res.json()) as AsanaAssignedResponse;
+      if (ctrl.signal.aborted) return;
+      // A failed fetch or unconfigured Asana leaves the strip hidden — never an
+      // error banner; the Queue's beads/PR sources carry the surface on their own.
+      if (data.ok && data.configured) {
+        setItems(Array.isArray(data.items) ? data.items : []);
+        setConfigured(true);
+      } else {
+        setItems([]);
+        setConfigured(false);
+      }
+    } catch {
+      if (!ctrl.signal.aborted) {
+        setItems([]);
+        setConfigured(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    return () => abortRef.current?.abort();
+  }, [load]);
+
+  const addToBoard = useCallback(
+    async (item: AsanaItem) => {
+      setBusyGid(item.gid);
+      try {
+        const res = await createBoardCardFromAsanaItem(item, null);
+        announce(res.ok ? `Added "${item.title}" to the board.` : `Couldn't add to board: ${res.error}`, res.ok ? "polite" : "assertive");
+      } finally {
+        setBusyGid(null);
+      }
+    },
+    [announce],
+  );
+
+  const fileBead = useCallback(
+    async (item: AsanaItem) => {
+      setBusyGid(item.gid);
+      try {
+        const res = await fileAsanaItemAsBead(item);
+        if (res.ok) {
+          setFiled((prev) => new Set(prev).add(item.gid));
+          announce(res.beadId ? `Filed ${res.beadId} from "${item.title}".` : `Filed a bead from "${item.title}".`);
+          onFiledBead?.();
+        } else {
+          announce(`Couldn't file a bead: ${res.error}`, "assertive");
+        }
+      } finally {
+        setBusyGid(null);
+      }
+    },
+    [announce, onFiledBead],
+  );
+
+  if (!configured || items.length === 0) return null;
+
+  return (
+    <section className="fwq-attention" aria-label="Asana tasks assigned to you">
+      <header className="fwq-attention-head">
+        <Icon name="ph:check-circle" width={14} aria-hidden />
+        <span className="fwq-attention-title">Asana</span>
+        <span className="fwq-attention-summary">{items.length} assigned</span>
+      </header>
+      <ul className="fwq-attention-list">
+        {items.map((item) => {
+          const busy = busyGid === item.gid;
+          const meta = [item.projectName, item.dueOn ? `due ${item.dueOn}` : null].filter(Boolean).join(" · ");
+          return (
+            <li key={item.gid} className="fwq-attention-item">
+              <div className="fwq-attention-main">
+                <span className="fwq-attention-name">{item.title}</span>
+              </div>
+              <div className="fwq-attention-tags">
+                {meta ? <span className="fwq-tag">{meta}</span> : null}
+                {filed.has(item.gid) ? <span className="fwq-tag fwq-tag--ready">filed</span> : null}
+              </div>
+              <Button
+                variant="ghost"
+                size="xs"
+                trailingIcon="ph:arrow-square-out"
+                onClick={() => onOpenUrl?.(item.url)}
+                disabled={!onOpenUrl}
+              >
+                Open
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                leadingIcon="ph:plus"
+                loading={busy}
+                onClick={() => void addToBoard(item)}
+                title="Create a board card from this task"
+              >
+                Board
+              </Button>
+              <Button
+                variant="secondary"
+                size="xs"
+                leadingIcon="ph:git-branch"
+                loading={busy}
+                disabled={filed.has(item.gid)}
+                onClick={() => void fileBead(item)}
+                title="File this task as a bead (enters the ready queue)"
+              >
+                {filed.has(item.gid) ? "Filed" : "File bead"}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/asana-task-field.test.ts
+++ b/src/components/asana-task-field.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const root = new URL("../", import.meta.url);
+
+async function source(path: string) {
+  return readFile(new URL(path, root), "utf8");
+}
+
+const boardTypes = await source("lib/cave-board-types.ts");
+const boardStore = await source("lib/cave-board.ts");
+const boardCreateApi = await source("app/api/board/route.ts");
+const boardPatchApi = await source("app/api/board/[id]/route.ts");
+const boardInspector = await source("components/board-inspector.tsx");
+const asanaTasks = await source("lib/asana-tasks.ts");
+const taskAsana = await source("lib/task-asana.ts");
+const beadsApi = await source("app/api/beads/route.ts");
+const asanaAssigned = await source("app/api/asana/assigned/route.ts");
+const asanaPat = await source("app/api/asana/pat/route.ts");
+const queueStrip = await source("components/asana-queue-strip.tsx");
+
+// ── Card model + persistence ─────────────────────────────────────────────────
+assert.match(boardTypes, /export type CardAsanaLink = \{/, "Task cards expose a structured Asana connection type");
+assert.match(boardTypes, /asana: CardAsanaLink\[\]/, "Task cards persist structured Asana connections");
+assert.match(boardStore, /normalizeAsanaLinks/, "Board persistence normalizes Asana connections");
+assert.match(boardStore, /asanaLinksFromLinks/, "Board backfill derives Asana connections from bare links");
+assert.match(
+  boardStore,
+  /const asana = mergeAsanaLinks\(normalizeAsanaLinks\(c\.asana\), \.\.\.asanaLinksFromLinks\(c\.links\)\)/,
+  "Board backfill preserves explicit Asana connections and derives them from link URLs",
+);
+
+// ── API surface ──────────────────────────────────────────────────────────────
+assert.match(boardCreateApi, /asana\?: CardAsanaLink\[\]/, "Create task API accepts structured Asana connections");
+assert.match(boardPatchApi, /asana: CardAsanaLink\[\]/, "Patch task API accepts structured Asana connections");
+
+// ── Inspector attach ─────────────────────────────────────────────────────────
+assert.match(boardInspector, /function AsanaAttachSection\(/, "Inspector renders an Asana attach section");
+assert.match(
+  boardInspector,
+  /const asana = mergeTaskAsanaLinks\(card\.asana[\s\S]*?taskAsanaLinkFromAsanaItem\(item\)/,
+  "Inspector Asana attach merges structured connections onto the card",
+);
+
+// ── Create-card / bead-from-Asana helpers ────────────────────────────────────
+assert.match(
+  asanaTasks,
+  /asana: \[taskAsanaLinkFromAsanaItem\(item\)\]/,
+  "createBoardCardFromAsanaItem seeds the card's asana field",
+);
+assert.match(asanaTasks, /action: "create"/, "fileAsanaItemAsBead routes through the beads create action");
+assert.match(asanaTasks, /externalRef: item\.url/, "fileAsanaItemAsBead links the Asana permalink as external-ref");
+
+// task-asana helpers must stay isomorphic (importable from client + server), so
+// they can't pull in server-only modules.
+assert.doesNotMatch(taskAsana, /next\/server|node:fs|node:child_process/, "task-asana helpers stay isomorphic");
+
+// ── Beads bridge ─────────────────────────────────────────────────────────────
+assert.match(beadsApi, /parsed\.body\.action === "create"/, "Beads API handles a create action");
+assert.match(beadsApi, /"--external-ref"/, "Beads create passes --external-ref for the source ticket");
+
+// ── Live data routes gate on the connected PAT ───────────────────────────────
+assert.match(asanaAssigned, /configured: false/, "Assigned route reports unconfigured when no PAT is stored");
+assert.match(asanaAssigned, /completed_since=now/, "Assigned route requests only incomplete tasks");
+assert.match(asanaPat, /ASANA_PAT/, "PAT route stores the Asana token under ASANA_PAT");
+
+// ── Queue strip degrades silently ────────────────────────────────────────────
+assert.match(
+  queueStrip,
+  /if \(!configured \|\| items\.length === 0\) return null/,
+  "Queue Asana strip renders nothing when Asana is unconnected or empty",
+);
+
+console.log("asana task field guard passed");

--- a/src/components/asana-task-field.test.ts
+++ b/src/components/asana-task-field.test.ts
@@ -70,5 +70,9 @@ assert.match(
   /if \(!configured \|\| items\.length === 0\) return null/,
   "Queue Asana strip renders nothing when Asana is unconnected or empty",
 );
+// Distinct class from the warning-toned attention strip — never collides with
+// the .fwq-attention count assertions in familiar-work-queue.spec.ts.
+assert.doesNotMatch(queueStrip, /className="fwq-attention/, "Queue Asana strip uses its own fwq-asana classes");
+assert.match(queueStrip, /className="fwq-asana"/, "Queue Asana strip uses the fwq-asana container class");
 
 console.log("asana task field guard passed");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -16,6 +16,12 @@ import {
   mergeTaskGitHubLinks,
   taskGitHubLinkFromGitHubItem,
 } from "@/lib/task-github";
+import type { AsanaItem } from "@/lib/asana-tasks";
+import {
+  mergeLinksWithAsana,
+  mergeTaskAsanaLinks,
+  taskAsanaLinkFromAsanaItem,
+} from "@/lib/task-asana";
 import { Icon } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
@@ -43,6 +49,7 @@ function formatAttachmentSize(size?: number): string {
   return `${(kb / 1024).toFixed(1)} MB`;
 }
 const GITHUB_PAT_URL = "https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local";
+const ASANA_PAT_URL = "https://app.asana.com/0/my-apps";
 
 type LifecycleMove = { to: CardLifecycle; label: string; retry?: boolean };
 const NEXT_MOVES: Record<CardLifecycle, LifecycleMove[]> = {
@@ -425,6 +432,262 @@ function GitHubAttachSection({
 }
 
 
+
+// ── Asana attach ──────────────────────────────────────────────────────────────
+// Mirrors GitHubAttachSection. Surfaces the connected user's incomplete Asana
+// tasks (via /api/asana/assigned, populated once the Asana PAT is stored) so a
+// card can be linked to the work it tracks. When no PAT is configured the
+// inline connect form appears — the in-app "enable Asana" on-ramp.
+function InlineAsanaPATSetup({ onSaved }: { onSaved: () => void }) {
+  const [pat, setPat] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const trimmed = pat.trim();
+    if (!trimmed) { setError("Enter an Asana personal access token."); return; }
+    setSaving(true); setError(null);
+    try {
+      const res = await fetch("/api/asana/pat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pat: trimmed }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) { setError(data?.error ?? "Failed to save."); return; }
+      onSaved();
+    } catch { setError("Network error — please try again."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <div style={{ padding: "10px 10px 8px", display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+        <Icon name="ph:check-circle" width={14} className="text-[var(--text-muted)]" />
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-secondary)" }}>Connect Asana</span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 500 }}>Personal Access Token</label>
+        <input type="password" value={pat} onChange={(e) => setPat(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && void save()} placeholder="1/1234…:abcd…"
+          style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", borderRadius: 6,
+            padding: "5px 8px", fontSize: 11, color: "var(--text-primary)", outline: "none", width: "100%", boxSizing: "border-box" }} />
+      </div>
+      {error && <p style={{ fontSize: 10, color: "var(--color-danger)", margin: 0 }}>{error}</p>}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 2 }}>
+        <button type="button" onClick={() => void openExternalUrl(ASANA_PAT_URL)}
+          style={{ background: "transparent", border: 0, padding: 0, fontSize: 10, color: "var(--accent-presence)", textDecoration: "none", cursor: "pointer" }}>
+          Generate token →
+        </button>
+        <button type="button" disabled={!pat.trim() || saving} onClick={() => void save()}
+          style={{ background: "var(--accent-presence)", color: "var(--text-primary)", border: "none", borderRadius: 6,
+            padding: "4px 12px", fontSize: 11, fontWeight: 500, cursor: "pointer", opacity: saving ? 0.6 : 1 }}>
+          {saving ? "Verifying…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AsanaAttachSection({
+  card,
+  onPatch,
+  onOpenUrl,
+}: {
+  card: Card;
+  onPatch: (id: string, patch: CardPatch) => void;
+  onOpenUrl?: (url: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<AsanaItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
+  const coarse = useIsCoarsePointer();
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    fetch("/api/asana/assigned", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((d: { ok: boolean; items?: AsanaItem[]; configured?: boolean; error?: string }) => {
+        if (cancelled) return;
+        if (d.ok) {
+          setItems(d.items ?? []);
+          setConfigured(d.configured ?? true);
+        } else {
+          setErr(d.error ?? "failed");
+        }
+      })
+      .catch(() => { if (!cancelled) setErr("fetch failed"); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [open, fetchKey]); // fetchKey bumped to refetch after PAT save
+
+  const attachedUrls = new Set([...(card.links ?? []), ...(card.asana ?? []).map((item) => item.url)]);
+
+  const filtered = items.filter((item) => {
+    if (!query.trim()) return true;
+    const q = query.toLowerCase();
+    return item.title.toLowerCase().includes(q) || (item.projectName?.toLowerCase().includes(q) ?? false);
+  });
+
+  const attachedItems = mergeTaskAsanaLinks(
+    card.asana ?? [],
+    ...items.filter((i) => attachedUrls.has(i.url)).map(taskAsanaLinkFromAsanaItem),
+  );
+
+  function attach(item: AsanaItem) {
+    if (attachedUrls.has(item.url)) return;
+    const asana = mergeTaskAsanaLinks(card.asana ?? [], taskAsanaLinkFromAsanaItem(item));
+    onPatch(card.id, { asana, links: mergeLinksWithAsana(card.links, asana) });
+  }
+
+  function detach(url: string) {
+    const asana = (card.asana ?? []).filter((item) => item.url !== url);
+    onPatch(card.id, { asana, links: card.links.filter((l) => l !== url) });
+  }
+
+  const subtitle = (item: { projectName?: string; dueOn?: string | null }) =>
+    [item.projectName, item.dueOn ? `due ${item.dueOn}` : null].filter(Boolean).join(" · ");
+
+  return (
+    <div className="board-drawer-field">
+      <div className="board-drawer-field-label" style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <Icon name="ph:check-circle" width={11} />
+          Asana
+          {attachedItems.length > 0 && <span className="board-drawer-count-pill">{attachedItems.length}</span>}
+        </span>
+        <button
+          type="button"
+          className="board-toolbar-btn"
+          onClick={() => setOpen((v) => !v)}
+          style={{ fontSize: 10, padding: "2px 8px" }}
+        >
+          <Icon name={open ? "ph:caret-up" : "ph:check-circle"} width={11} />
+          {open ? "Hide" : "Attach"}
+        </button>
+      </div>
+
+      {attachedItems.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 6 }}>
+          {attachedItems.map((item) => (
+            <div key={item.id} style={{
+              display: "flex", alignItems: "center", gap: 6,
+              background: "var(--bg-elevated)", borderRadius: 6,
+              padding: "5px 8px", border: "1px solid var(--border-hairline)"
+            }}>
+              <button
+                type="button"
+                className="board-github-attachment-open"
+                onClick={() => onOpenUrl?.(item.url)}
+                title="Open in Asana"
+                style={{
+                  flex: 1, minWidth: 0, display: "inline-flex", alignItems: "center", gap: 6,
+                  border: 0, padding: 0, background: "transparent", color: "var(--text-primary)",
+                  textAlign: "left", cursor: "pointer",
+                }}
+              >
+                <Icon name="ph:check-circle" width={12} className={item.completed ? "text-[var(--color-success)]" : "text-[var(--text-muted)]"} />
+                <span style={{ flex: 1, minWidth: 0, fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {item.title}{subtitle(item) ? ` — ${subtitle(item)}` : ""}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="board-toolbar-btn"
+                style={{ fontSize: 10, padding: "1px 6px" }}
+                onClick={() => detach(item.url)}
+                title="Detach"
+              >
+                <Icon name="ph:x-bold" width={9} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {open && (
+        <div style={{ border: "1px solid var(--border-hairline)", borderRadius: 8, overflow: "hidden", background: "var(--bg-raised)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "7px 10px", borderBottom: "1px solid var(--border-hairline)" }}>
+            <Icon name="ph:magnifying-glass" width={12} className="shrink-0 text-[var(--text-muted)]" />
+            <input
+              autoFocus={!coarse}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search tasks, projects…"
+              style={{ flex: 1, background: "transparent", border: "none", outline: "none", fontSize: 12, color: "var(--text-primary)" }}
+            />
+            {query && (
+              <button type="button" onClick={() => setQuery("")} style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", display: "flex" }}>
+                <Icon name="ph:x" width={11} />
+              </button>
+            )}
+          </div>
+
+          <div style={{ maxHeight: 240, overflowY: "auto" }}>
+            {loading && (
+              <div style={{ padding: "10px" }}><SkeletonRows count={4} /></div>
+            )}
+            {err && (
+              <div style={{ padding: "10px", fontSize: 11, color: "var(--color-danger)" }}>{err}</div>
+            )}
+            {!loading && !err && configured === false && (
+              <InlineAsanaPATSetup onSaved={() => { setItems([]); setConfigured(null); setFetchKey((k) => k + 1); }} />
+            )}
+            {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
+              <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>
+                No incomplete tasks assigned to you.
+              </div>
+            )}
+            {!loading && !err && configured !== false && items.length > 0 && filtered.length === 0 && (
+              <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>No matches.</div>
+            )}
+            {filtered.map((item) => {
+              const attached = attachedUrls.has(item.url);
+              return (
+                <div key={item.id} style={{
+                  display: "flex", alignItems: "center", gap: 8,
+                  padding: "7px 10px", borderBottom: "1px solid var(--border-hairline)",
+                  background: attached ? "color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised))" : undefined,
+                }}>
+                  <Icon name="ph:check-circle" width={13} className="text-[var(--text-muted)]" />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 11, fontWeight: 500, color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {item.title}
+                    </div>
+                    <div style={{ fontSize: 11, color: "var(--text-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {subtitle(item) || "Asana task"}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+                    <button
+                      type="button"
+                      className="board-toolbar-btn"
+                      style={{
+                        fontSize: 10, padding: "2px 7px",
+                        ...(attached ? { color: "var(--accent-presence)", borderColor: "var(--accent-presence)" } : {}),
+                      }}
+                      onClick={() => attached ? detach(item.url) : attach(item)}
+                    >
+                      <Icon name={attached ? "ph:check-bold" : "ph:paperclip-bold"} width={10} />
+                      {attached ? "Attached" : "Attach"}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 // ── Links ────────────────────────────────────────────────────────────────────
 function LinksSection({
@@ -1347,6 +1610,8 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
           <LinksSection card={card} onPatch={onPatch} onOpenUrl={onOpenUrl} />
 
           <GitHubAttachSection card={card} familiars={familiars} onPatch={onPatch} onOpenUrl={onOpenUrl} />
+
+          <AsanaAttachSection card={card} onPatch={onPatch} onOpenUrl={onOpenUrl} />
 
           <AttachmentsSection card={card} onPatch={onPatch} />
 

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -22,6 +22,7 @@ import {
   type WorkQueueLaneKey,
 } from "@/lib/beads-work-queue";
 import type { PullRequestSummary } from "@/lib/beads-pr-management";
+import { AsanaQueueStrip } from "@/components/asana-queue-strip";
 
 type Props = {
   /** Rendered inside the Tasks page's Work-queue tab (cave-oa1z): the tab
@@ -334,6 +335,8 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
       ) : null}
 
       {q.attention.length > 0 ? <AttentionStrip items={q.attention} onOpenUrl={onOpenUrl} /> : null}
+
+      <AsanaQueueStrip onOpenUrl={onOpenUrl} onFiledBead={() => void load()} />
 
       <div className="fwq-body">
         {q.total === 0 ? (

--- a/src/lib/asana-tasks.ts
+++ b/src/lib/asana-tasks.ts
@@ -1,0 +1,152 @@
+// ── Asana item context (for attaching to board / beads / Queue) ──────────────
+//
+// Mirrors github-tasks.ts. The app doesn't speak MCP directly (the Asana MCP is
+// wired to the familiars); live data here comes from the Asana REST API via a
+// PAT (see /api/asana/*). An AsanaItem is the normalized, UI-facing shape of an
+// assigned task; the helpers turn one into a board card, a card connection, or
+// a bead.
+
+import type { CardAsanaKind, CardAsanaLink } from "@/lib/cave-board-types";
+import {
+  mergeLinksWithAsana,
+  mergeTaskAsanaLinks,
+  taskAsanaLinkFromAsanaItem,
+  taskAsanaLinkFromUrl,
+} from "@/lib/task-asana";
+
+export type AsanaItem = {
+  kind: CardAsanaKind;
+  /** Stable id — the Asana object gid (also stored on `gid`). */
+  id: string;
+  gid: string;
+  title: string;
+  /** Asana permalink (permalink_url from the API). */
+  url: string;
+  projectGid?: string;
+  projectName?: string;
+  /** Assignee display name, when the task is assigned. */
+  assignee?: string;
+  completed?: boolean;
+  /** Due date as YYYY-MM-DD, when set. */
+  dueOn?: string | null;
+  /** modified_at ISO timestamp. */
+  updatedAt: string;
+  workspaceGid?: string;
+};
+
+export type AsanaAssignedResponse = {
+  ok: boolean;
+  items: AsanaItem[];
+  /** True once an Asana PAT is stored — the "Asana connected" signal. */
+  configured?: boolean;
+  error?: string;
+};
+
+export function asanaItemToContext(item: AsanaItem): { title: string; url: string; projectName?: string } {
+  return { title: item.title, url: item.url, projectName: item.projectName };
+}
+
+/**
+ * Create a board card seeded from an Asana task, mirroring
+ * createBoardCardFromGitHubItem. The card lands in the Inbox column with the
+ * task's permalink in both `links` and the structured `asana` field.
+ */
+export async function createBoardCardFromAsanaItem(
+  item: AsanaItem,
+  familiarId: string | null,
+): Promise<{ ok: boolean; cardId?: string; error?: string }> {
+  const label = item.kind === "project" ? "Project" : "Task";
+  const title = `[Asana ${label}] ${item.title}`;
+  const notes = [item.projectName ? `Project: ${item.projectName}` : null, `URL: ${item.url}`]
+    .filter(Boolean)
+    .join("\n");
+
+  try {
+    const res = await fetch("/api/board", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title,
+        notes,
+        familiarId,
+        links: [item.url],
+        asana: [taskAsanaLinkFromAsanaItem(item)],
+        status: "inbox" as const,
+      }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      return { ok: false, error: data?.error ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, cardId: data.card?.id as string | undefined };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+  }
+}
+
+/** Attach an Asana task (item or bare permalink URL) to an existing card,
+ *  merging with whatever connections the card already has. */
+export async function attachAsanaItemToCard(
+  cardId: string,
+  item: AsanaItem | string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const asanaLink = typeof item === "string" ? taskAsanaLinkFromUrl(item) : taskAsanaLinkFromAsanaItem(item);
+    if (!asanaLink) return { ok: false, error: "not a recognizable Asana URL" };
+    const url = typeof item === "string" ? item : item.url;
+    const getRes = await fetch("/api/board");
+    const getData = await getRes.json().catch(() => null);
+    const cards: Array<{ id: string; links?: string[]; asana?: CardAsanaLink[] }> = getData?.cards ?? [];
+    const existing = cards.find((c) => c.id === cardId);
+    const asana = mergeTaskAsanaLinks(existing?.asana ?? [], asanaLink);
+    const mergedLinks = mergeLinksWithAsana([...new Set([...(existing?.links ?? []), url])], asana);
+
+    const res = await fetch(`/api/board/${cardId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ links: mergedLinks, asana }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      return { ok: false, error: data?.error ?? `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+  }
+}
+
+/**
+ * File an Asana task as a bead so it enters the ready queue — the beads protocol
+ * links external tickets via --external-ref (Linear/Asana URL). Routes through
+ * /api/beads' `create` action.
+ */
+export async function fileAsanaItemAsBead(
+  item: AsanaItem,
+  projectRoot?: string | null,
+): Promise<{ ok: boolean; beadId?: string; error?: string }> {
+  try {
+    const res = await fetch("/api/beads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "create",
+        title: item.title,
+        description: [item.projectName ? `Asana project: ${item.projectName}` : null, `Asana task: ${item.url}`]
+          .filter(Boolean)
+          .join("\n"),
+        externalRef: item.url,
+        labels: ["asana"],
+        projectRoot: projectRoot ?? undefined,
+      }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      return { ok: false, error: data?.error ?? `HTTP ${res.status}` };
+    }
+    const created = data.data as { id?: string } | null;
+    return { ok: true, beadId: created?.id };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+  }
+}

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -37,6 +37,33 @@ export type CardGitHubLink = {
   updatedAt?: string;
 };
 
+export type CardAsanaKind = "task" | "subtask" | "project";
+
+/**
+ * A structured connection between a board card and an Asana object, mirroring
+ * {@link CardGitHubLink}. Populated when a user attaches an assigned Asana task
+ * from the inspector, pastes an app.asana.com URL into a card's links (backfilled
+ * server-side), or a familiar working through the Asana MCP files the task here.
+ * `url` is the Asana permalink; `gid` is Asana's stable object id.
+ */
+export type CardAsanaLink = {
+  id: string;
+  kind: CardAsanaKind;
+  gid: string;
+  title: string;
+  url: string;
+  projectGid?: string;
+  projectName?: string;
+  /** Assignee display name/email, when known from the assigned-tasks fetch. */
+  assignee?: string;
+  completed?: boolean;
+  /** Due date as YYYY-MM-DD, when the task carries one. */
+  dueOn?: string | null;
+  source?: "assigned" | "manual" | "legacy-link";
+  savedAt?: string;
+  updatedAt?: string;
+};
+
 export type Card = {
   id: string;
   title: string;
@@ -50,6 +77,7 @@ export type Card = {
   projectId?: string | null;
   links: string[];
   github: CardGitHubLink[];
+  asana: CardAsanaLink[];
   labels: string[];
   startDate?: string | null;
   endDate?: string | null;

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -6,6 +6,7 @@ import { writeJsonAtomic } from "./server/atomic-write.ts";
 import {
   DEFAULT_MAX_RETRIES,
   type Card,
+  type CardAsanaLink,
   type CardGitHubLink,
   type CardLifecycle,
   type CardPriority,
@@ -17,6 +18,12 @@ import {
   normalizeTaskGitHubLinks,
   taskGitHubLinkFromUrl,
 } from "@/lib/task-github";
+import {
+  mergeLinksWithAsana,
+  mergeTaskAsanaLinks as mergeAsanaLinks,
+  normalizeTaskAsanaLinks,
+  taskAsanaLinkFromUrl,
+} from "@/lib/task-asana";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import {
   normalizeChatAttachments,
@@ -32,6 +39,7 @@ export {
   PRIORITIES,
   STATUSES,
   type Card,
+  type CardAsanaLink,
   type CardGitHubLink,
   type CardLifecycle,
   type CardPriority,
@@ -96,6 +104,19 @@ function gitHubLinksFromLinks(values: string[] | undefined): CardGitHubLink[] {
     .filter((item): item is CardGitHubLink => item !== null);
 }
 
+function normalizeAsanaLinks(values: CardAsanaLink[] | undefined): CardAsanaLink[] {
+  return normalizeTaskAsanaLinks(values);
+}
+
+// Derive structured Asana connections from bare app.asana.com URLs stashed in a
+// card's `links` (or written by an agent) — the same backfill github does, so a
+// pasted Asana task URL becomes a first-class connection.
+function asanaLinksFromLinks(values: string[] | undefined): CardAsanaLink[] {
+  return toStringList(values)
+    .map((url) => taskAsanaLinkFromUrl(url))
+    .filter((item): item is CardAsanaLink => item !== null);
+}
+
 function normalizeCwd(value: string | null | undefined): string | null {
   const cwd = value?.trim();
   return cwd ? cwd : null;
@@ -103,12 +124,12 @@ function normalizeCwd(value: string | null | undefined): string | null {
 
 type LegacyCard = Omit<
   Card,
-  "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
+  "cwd" | "projectId" | "links" | "github" | "asana" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
 > &
   Partial<
     Pick<
       Card,
-      "cwd" | "projectId" | "links" | "github" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
+      "cwd" | "projectId" | "links" | "github" | "asana" | "lifecycle" | "lifecycleAt" | "retryCount" | "maxRetries" | "steps" | "startDate" | "endDate"
     >
   >;
 
@@ -124,7 +145,10 @@ function normalizeBoardDate(value: string | null | undefined): string | null {
 function backfillCard(c: Card | LegacyCard): Card {
   const lifecycle = c.lifecycle ?? inferLifecycle(c.status);
   const github = mergeGitHubLinks(normalizeGitHubLinks(c.github), ...gitHubLinksFromLinks(c.links));
-  const links = mergeLinksWithGitHub(normalizeLinks(c.links), github);
+  const asana = mergeAsanaLinks(normalizeAsanaLinks(c.asana), ...asanaLinksFromLinks(c.links));
+  // Both link derivations feed back into `links` so a card's URL list stays the
+  // union of everything attached, regardless of which source added it.
+  const links = mergeLinksWithAsana(mergeLinksWithGitHub(normalizeLinks(c.links), github), asana);
   return {
     ...c,
     status: statusForLifecycle(lifecycle, c.status),
@@ -132,6 +156,7 @@ function backfillCard(c: Card | LegacyCard): Card {
     projectId: c.projectId ?? null,
     links,
     github,
+    asana,
     labels: normalizeList(c.labels),
     startDate: normalizeBoardDate(c.startDate),
     endDate: normalizeBoardDate(c.endDate),
@@ -226,6 +251,7 @@ export type NewCardInput = {
   projectId?: string | null;
   links?: string[];
   github?: CardGitHubLink[];
+  asana?: CardAsanaLink[];
   labels?: string[];
   startDate?: string | null;
   endDate?: string | null;
@@ -251,6 +277,7 @@ export async function createCard(input: NewCardInput): Promise<Card> {
   const now = new Date().toISOString();
   const status: CardStatus = input.status ?? "backlog";
   const github = mergeGitHubLinks(normalizeGitHubLinks(input.github), ...gitHubLinksFromLinks(input.links));
+  const asana = mergeAsanaLinks(normalizeAsanaLinks(input.asana), ...asanaLinksFromLinks(input.links));
   const card: Card = {
     id: crypto.randomUUID(),
     title: input.title.trim(),
@@ -261,8 +288,9 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     sessionId: input.sessionId ?? null,
     cwd: normalizeCwd(input.cwd),
     projectId: input.projectId ?? null,
-    links: mergeLinksWithGitHub(normalizeLinks(input.links), github),
+    links: mergeLinksWithAsana(mergeLinksWithGitHub(normalizeLinks(input.links), github), asana),
     github,
+    asana,
     labels: normalizeList(input.labels),
     startDate: normalizeBoardDate(input.startDate),
     endDate: normalizeBoardDate(input.endDate),
@@ -303,6 +331,17 @@ export async function updateCard(
   const patch: Partial<Omit<Card, "id" | "createdAt">> = hasCardOps(ops)
     ? { ...plain, ...applyCardOps(current, ops, new Date().toISOString()) }
     : plain;
+  // Resolve the structured connection lists once, then fold both back into
+  // `links` so the URL list stays the union of everything attached (github +
+  // asana + explicit links) — same invariant createCard/backfill maintain.
+  const nextGithub = mergeGitHubLinks(
+    normalizeGitHubLinks("github" in patch ? patch.github : current.github),
+    ...gitHubLinksFromLinks("links" in patch ? patch.links : current.links),
+  );
+  const nextAsana = mergeAsanaLinks(
+    normalizeAsanaLinks("asana" in patch ? patch.asana : current.asana),
+    ...asanaLinksFromLinks("links" in patch ? patch.links : current.links),
+  );
   const next: Card = {
     ...current,
     ...patch,
@@ -312,16 +351,11 @@ export async function updateCard(
     labels: patch.labels
       ? normalizeList(patch.labels)
       : current.labels,
-    github: mergeGitHubLinks(
-      normalizeGitHubLinks("github" in patch ? patch.github : current.github),
-      ...gitHubLinksFromLinks("links" in patch ? patch.links : current.links),
-    ),
-    links: mergeLinksWithGitHub(
-      "links" in patch ? normalizeLinks(patch.links) : current.links,
-      mergeGitHubLinks(
-        normalizeGitHubLinks("github" in patch ? patch.github : current.github),
-        ...gitHubLinksFromLinks("links" in patch ? patch.links : current.links),
-      ),
+    github: nextGithub,
+    asana: nextAsana,
+    links: mergeLinksWithAsana(
+      mergeLinksWithGitHub("links" in patch ? normalizeLinks(patch.links) : current.links, nextGithub),
+      nextAsana,
     ),
     cwd: "cwd" in patch ? normalizeCwd(patch.cwd) : current.cwd,
     projectId: "projectId" in patch ? patch.projectId ?? null : current.projectId ?? null,

--- a/src/lib/task-asana.test.ts
+++ b/src/lib/task-asana.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  taskAsanaLinkFromUrl,
+  normalizeTaskAsanaLinks,
+  mergeTaskAsanaLinks,
+  mergeLinksWithAsana,
+} from "./task-asana.ts";
+
+// ── URL parsing across the layouts Asana has shipped ─────────────────────────
+
+// classic /0/<project>/<task>
+let l = taskAsanaLinkFromUrl("https://app.asana.com/0/1200000000000001/1200000000000002");
+assert.ok(l, "classic project→task URL parses");
+assert.equal(l.kind, "task");
+assert.equal(l.gid, "1200000000000002");
+assert.equal(l.projectGid, "1200000000000001");
+assert.equal(l.source, "legacy-link");
+
+// focus view /0/<project>/<task>/f
+l = taskAsanaLinkFromUrl("https://app.asana.com/0/1111111111/2222222222/f");
+assert.equal(l.gid, "2222222222", "focus-view suffix ignored");
+
+// my-tasks permalink /0/0/<task>/f — project sentinel 0 is not a real project
+l = taskAsanaLinkFromUrl("https://app.asana.com/0/0/3333333333/f");
+assert.equal(l.gid, "3333333333");
+assert.equal(l.projectGid, undefined, "0 sentinel is not treated as a project");
+
+// newer grid layout /1/<ws>/project/<p>/task/<t>
+l = taskAsanaLinkFromUrl("https://app.asana.com/1/9999/project/4444/task/5555");
+assert.equal(l.gid, "5555");
+assert.equal(l.projectGid, "4444");
+
+// project-only /0/<project>
+l = taskAsanaLinkFromUrl("https://app.asana.com/0/6666666666");
+assert.equal(l.kind, "project");
+assert.equal(l.gid, "6666666666");
+
+// non-Asana host → null
+assert.equal(taskAsanaLinkFromUrl("https://github.com/o/r/issues/1"), null);
+// inbox with no gid → null
+assert.equal(taskAsanaLinkFromUrl("https://app.asana.com/0/inbox"), null);
+assert.equal(taskAsanaLinkFromUrl("not a url"), null);
+
+// ── merge / dedupe by gid across URL variants ────────────────────────────────
+const a = taskAsanaLinkFromUrl("https://app.asana.com/0/1000000000000010/1000000000000020");
+const b = taskAsanaLinkFromUrl("https://app.asana.com/0/0/1000000000000020/f");
+const merged = mergeTaskAsanaLinks([a], b);
+assert.equal(merged.length, 1, "same gid dedupes regardless of URL layout");
+
+// a concrete assigned source beats a legacy-link guess, and its title wins
+const assigned = { ...a, source: "assigned", title: "Real title" };
+const m2 = mergeTaskAsanaLinks([a], assigned);
+assert.equal(m2.length, 1);
+assert.equal(m2[0].source, "assigned");
+assert.equal(m2[0].title, "Real title");
+
+// ── normalize keeps only recognizable Asana URLs ─────────────────────────────
+const norm = normalizeTaskAsanaLinks([
+  { url: "https://app.asana.com/0/1000000000000001/1000000000000002" },
+  { url: "not a url" },
+  { url: "https://github.com/x/y" },
+]);
+assert.equal(norm.length, 1, "junk + non-Asana URLs are dropped");
+assert.equal(norm[0].gid, "1000000000000002");
+
+// ── links union ──────────────────────────────────────────────────────────────
+const links = mergeLinksWithAsana(["https://x.com"], [a]);
+assert.ok(links.includes("https://x.com"));
+assert.ok(links.includes(a.url));
+
+console.log("task-asana passed");

--- a/src/lib/task-asana.test.ts
+++ b/src/lib/task-asana.test.ts
@@ -65,8 +65,12 @@ assert.equal(norm.length, 1, "junk + non-Asana URLs are dropped");
 assert.equal(norm[0].gid, "1000000000000002");
 
 // ── links union ──────────────────────────────────────────────────────────────
-const links = mergeLinksWithAsana(["https://x.com"], [a]);
-assert.ok(links.includes("https://x.com"));
-assert.ok(links.includes(a.url));
+// Membership via a Set (exact equality) rather than String#includes so the
+// assertion can't be misread as URL substring sanitization (CodeQL
+// js/incomplete-url-substring-sanitization).
+const other = "https://example.test/board";
+const linkSet = new Set(mergeLinksWithAsana([other], [a]));
+assert.ok(linkSet.has(other), "existing links are preserved");
+assert.ok(linkSet.has(a.url), "asana link URL is folded into links");
 
 console.log("task-asana passed");

--- a/src/lib/task-asana.ts
+++ b/src/lib/task-asana.ts
@@ -1,0 +1,174 @@
+import type { CardAsanaKind, CardAsanaLink } from "@/lib/cave-board-types";
+import type { AsanaItem } from "@/lib/asana-tasks";
+
+type MaybeAsana = Partial<CardAsanaLink> & { url?: string };
+
+/** Asana object gids are long numeric strings. Accept a run of digits so we can
+ *  pull them out of the several permalink layouts Asana has shipped over time. */
+const GID_RE = /^\d{4,}$/;
+
+function normalizeUrl(url: string): string {
+  return url.trim();
+}
+
+function isAsanaHost(hostname: string): boolean {
+  return /(^|\.)asana\.com$/i.test(hostname);
+}
+
+function dedupeKey(item: Pick<CardAsanaLink, "url" | "id" | "gid">): string {
+  const gid = item.gid.trim();
+  if (gid) return `gid:${gid}`;
+  const url = item.url.trim().toLowerCase();
+  return url || item.id.trim().toLowerCase();
+}
+
+function itemId(kind: CardAsanaKind, gid: string): string {
+  return `asana:${kind}:${gid}`;
+}
+
+/**
+ * Parse an app.asana.com URL into a structured link. Handles the layouts Asana
+ * has used:
+ *   - `/0/<projectGid>/<taskGid>`            (classic project → task)
+ *   - `/0/<projectGid>/<taskGid>/f`          (focus view)
+ *   - `/0/0/<taskGid>/f`                      (my-tasks / permalink)
+ *   - `/1/<workspaceGid>/project/<p>/task/<t>` (newer grid layout)
+ *   - `/1/<workspaceGid>/task/<t>`            (newer task permalink)
+ *   - `/0/<projectGid>`                       (project only — no task)
+ * Returns null for non-Asana hosts and inbox/home/search URLs that carry no gid.
+ */
+export function taskAsanaLinkFromUrl(url: string): CardAsanaLink | null {
+  try {
+    const parsed = new URL(normalizeUrl(url));
+    if (!isAsanaHost(parsed.hostname)) return null;
+    const parts = parsed.pathname.replace(/^\/+/, "").split("/").filter(Boolean);
+    if (parts.length === 0) return null;
+
+    let taskGid: string | undefined;
+    let projectGid: string | undefined;
+
+    const taskKeyIdx = parts.indexOf("task");
+    const projectKeyIdx = parts.indexOf("project");
+    if (taskKeyIdx >= 0 && GID_RE.test(parts[taskKeyIdx + 1] ?? "")) {
+      // `/1/<ws>/…/task/<gid>` newer permalink.
+      taskGid = parts[taskKeyIdx + 1];
+      if (projectKeyIdx >= 0 && GID_RE.test(parts[projectKeyIdx + 1] ?? "")) {
+        projectGid = parts[projectKeyIdx + 1];
+      }
+    } else if (parts[0] === "0") {
+      // Classic `/0/<a>/<b>`. `<a>` is a project (or 0 for permalinks), `<b>` the task.
+      const a = parts[1];
+      const b = parts[2];
+      if (GID_RE.test(b ?? "")) {
+        taskGid = b;
+        if (GID_RE.test(a ?? "") && a !== "0") projectGid = a;
+      } else if (GID_RE.test(a ?? "")) {
+        // `/0/<projectGid>` — a project link, no task.
+        projectGid = a;
+      }
+    } else {
+      // Fallback: last gid-looking segment is the task.
+      const gids = parts.filter((p) => GID_RE.test(p));
+      if (gids.length) taskGid = gids[gids.length - 1];
+    }
+
+    const kind: CardAsanaKind = taskGid ? "task" : "project";
+    const gid = taskGid ?? projectGid;
+    if (!gid) return null;
+
+    return {
+      id: itemId(kind, gid),
+      kind,
+      gid,
+      title: kind === "task" ? `Asana task ${gid}` : `Asana project ${gid}`,
+      url: parsed.href,
+      projectGid,
+      dueOn: null,
+      source: "legacy-link",
+    } satisfies CardAsanaLink;
+  } catch {
+    return null;
+  }
+}
+
+export function taskAsanaLinkFromAsanaItem(item: AsanaItem): CardAsanaLink {
+  return {
+    id: item.id || itemId(item.kind, item.gid),
+    kind: item.kind,
+    gid: item.gid,
+    title: item.title,
+    url: normalizeUrl(item.url),
+    projectGid: item.projectGid,
+    projectName: item.projectName,
+    assignee: item.assignee,
+    completed: item.completed,
+    dueOn: item.dueOn ?? null,
+    source: "assigned",
+    updatedAt: item.updatedAt,
+  };
+}
+
+export function normalizeTaskAsanaLinks(values: MaybeAsana[] | null | undefined): CardAsanaLink[] {
+  return mergeTaskAsanaLinks(
+    [],
+    ...(values ?? [])
+      .map((value): CardAsanaLink | null => {
+        if (!value.url) return null;
+        const parsed = taskAsanaLinkFromUrl(value.url);
+        if (!parsed) return null;
+        const kind = value.kind ?? parsed.kind;
+        const gid = value.gid?.trim() || parsed.gid;
+        const title = value.title?.trim() || parsed.title;
+        return {
+          ...parsed,
+          ...value,
+          id: value.id?.trim() || itemId(kind, gid),
+          kind,
+          gid,
+          title,
+          url: normalizeUrl(value.url),
+          dueOn: value.dueOn ?? parsed.dueOn ?? null,
+        } satisfies CardAsanaLink;
+      })
+      .filter((value): value is CardAsanaLink => value !== null),
+  );
+}
+
+export function mergeTaskAsanaLinks(
+  existing: CardAsanaLink[] | null | undefined,
+  ...incoming: Array<CardAsanaLink | null | undefined>
+): CardAsanaLink[] {
+  const byKey = new Map<string, CardAsanaLink>();
+  for (const item of [...(existing ?? []), ...incoming]) {
+    if (!item?.url || !item.gid) continue;
+    const key = dedupeKey(item);
+    const previous = byKey.get(key);
+    if (!previous) {
+      byKey.set(key, { ...item, url: normalizeUrl(item.url) });
+      continue;
+    }
+    byKey.set(key, {
+      ...previous,
+      ...item,
+      id: previous.id || item.id,
+      title: item.title || previous.title,
+      gid: item.gid || previous.gid,
+      projectGid: item.projectGid ?? previous.projectGid,
+      projectName: item.projectName ?? previous.projectName,
+      assignee: item.assignee ?? previous.assignee,
+      completed: item.completed ?? previous.completed,
+      dueOn: item.dueOn ?? previous.dueOn ?? null,
+      // A concrete assigned/manual source always wins over a legacy-link guess.
+      source: previous.source === "legacy-link" ? item.source : previous.source,
+      savedAt: previous.savedAt ?? item.savedAt,
+      updatedAt: item.updatedAt ?? previous.updatedAt,
+    });
+  }
+  return [...byKey.values()];
+}
+
+export function mergeLinksWithAsana(links: string[] | null | undefined, asana: CardAsanaLink[]): string[] {
+  return [
+    ...new Set([...(links ?? []), ...asana.map((item) => item.url)].map((link) => link.trim()).filter(Boolean)),
+  ];
+}

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -135,6 +135,78 @@
   flex-shrink: 0;
 }
 
+/* Asana source strip — assigned tasks pulled into the Queue when Asana is
+   connected. Presence-toned so it reads as informational, visually distinct
+   from the warning-toned "needs attention" strip above it. */
+.fwq-asana {
+  margin: 12px 20px 0;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  border-radius: var(--radius-panel, 12px);
+  background: color-mix(in oklch, var(--accent-presence) 6%, transparent);
+  overflow: hidden;
+}
+
+.fwq-asana-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-presence);
+  border-bottom: 1px solid color-mix(in oklch, var(--accent-presence) 18%, transparent);
+}
+
+.fwq-asana-title {
+  flex-shrink: 0;
+}
+
+.fwq-asana-summary {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.fwq-asana-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fwq-asana-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+.fwq-asana-item:last-child {
+  border-bottom: 0;
+}
+
+.fwq-asana-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.fwq-asana-name {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fwq-asana-tags {
+  display: flex;
+  gap: 5px;
+  flex-shrink: 0;
+}
+
 /* Unlinked (no bead) reads as informational, distinct from the warning stale. */
 .fwq-tag--unlinked {
   color: var(--text-secondary);


### PR DESCRIPTION
## What

Comprehensive Asana support so Asana work is first-class across the tasks board, beads, and the Queue **once Asana is connected** — the Asana MCP marketplace plugin (already registered at `https://mcp.asana.com/v2/mcp`) is the discovery/on-ramp. The implementation mirrors the existing GitHub task-field stack end to end.

## Changes

**Board data model + persistence**
- `Card` gains a structured `asana: CardAsanaLink[]` field (parallel to `github`).
- The store normalizes/backfills it: pasting an `app.asana.com` task URL into a card's links becomes a first-class connection; create + patch APIs accept `asana` and keep `links` the union of everything attached.

**Live data (mirrors `/api/github/*`)**
- `POST/GET/DELETE /api/asana/pat` — connect via a Personal Access Token, validated against `app.asana.com` and stored in the local encrypted vault (never logged/returned).
- `GET /api/asana/assigned` — incomplete tasks assigned to you across your workspaces; `configured:false` when no PAT is stored (the "Asana connected" signal the UI gates on).

**Board inspector**
- An **Asana** attach section beside GitHub: inline connect form when unconnected, otherwise a searchable picker of your assigned incomplete tasks; attach/detach chips open the task in Asana.

**Beads**
- `/api/beads` gains a `create` action that files a task as a bead with `--external-ref` (the beads protocol's visibility layer for external tickets — same as Linear).

**Queue**
- A self-contained Asana strip lists your assigned incomplete tasks with **Open** / **Add to board** / **File as bead**. It renders **nothing** when Asana isn't connected, so the beads/PR sources stand alone (no banner, no empty state).

## Tests
- `src/lib/task-asana.test.ts` — URL parsing across Asana's permalink layouts (`/0/<p>/<t>`, `/0/0/<t>/f`, `/1/<ws>/project/<p>/task/<t>`, project-only), gid dedupe, source precedence, links union.
- `src/components/asana-task-field.test.ts` — wiring guard mirroring `github-task-field.test.ts` (types, store, APIs, inspector, beads bridge, live routes, Queue strip).
- `api-contracts` + `check:tests-wired` updated. `typecheck` and `pnpm build` green locally.

## Notes
- Data auth is a PAT (Asana's REST API), consistent with the GitHub integration; the MCP OAuth grant enables the familiars, the PAT enables the app's live views. Connecting is one field in the inspector's Asana section.
- No card-face change needed: Asana URLs flow into `card.links`, already surfaced by the generic link-count chip (GitHub has no separate badge either).

Beads: `cave-gu7n` (+ `.1`–`.6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)