### PR TITLE
chore(release): stamp v0.0.168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.168] - 2026-07-09
+
+> _One-line teaser — edit before merge._
+
+Patch release on top of v0.0.167.
+
+### Changes
+- fix(release): updater tarball ships no AppleDouble entries — kills the macOS 'app is damaged' update error (cave-csl8) (#2864)
+- fix(shell): comprehensive title-bar fit + subtle titlebar glass (cave-y894) (#2862)
+- feat(cave): analytics model-performance votes, settings polish, composer/home refinements (#2860)
+
+
 ## [0.0.167] - 2026-07-09
 
 > 🪄 **Polish + hardening pass** — the marketplace's prompt-pack "Try it" becomes an unmissable bordered pill with a hand-off arrow instead of near-invisible ghost text, and the desktop title-bar controls stop hiding under the macOS traffic lights. Under the hood: a ReDoS-prone path regex is replaced with a plain `trimEnd`, and the runtime-sync tooling gets spec-correct prerelease semver plus CI-triggering bot PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ breaking config changes; patch releases stay additive.
 
 ## [0.0.168] - 2026-07-09
 
-> _One-line teaser — edit before merge._
+> In-app updates work again on macOS — the updater tarball no longer breaks the app's code seal — plus a comprehensive title-bar fit and subtle titlebar glass.
 
 Patch release on top of v0.0.167.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.167",
+  "version": "0.0.168",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.167"
+version = "0.0.168"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.167"
+version = "0.0.168"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.167</string>
+	<string>0.0.168</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.167</string>
+	<string>0.0.168</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.167</string>
+	<string>0.0.168</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.167</string>
+	<string>0.0.168</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.167",
+  "version": "0.0.168",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamped by `scripts/stamp-release.mjs`. Edit the CHANGELOG teaser/grouping before merge.

```
## [0.0.168] - 2026-07-09

> _One-line teaser — edit before merge._

Patch release on top of v0.0.167.

### Changes
- fix(release): updater tarball ships no AppleDouble entries — kills the macOS 'app is damaged' update error (cave-csl8) (#2864)
- fix(shell): comprehensive title-bar fit + subtle titlebar glass (cave-y894) (#2862)
- feat(cave): analytics model-performance votes, settings polish, composer/home refinements (#2860)

```