### PR TITLE
fix(runtimes): second review pass — build-metadata precedence, un-persisted checkout token

### DIFF
--- a/.github/workflows/sync-runtimes.yml
+++ b/.github/workflows/sync-runtimes.yml
@@ -40,6 +40,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Never persist the workflow GITHUB_TOKEN into git config: its
+          # preemptive auth extraheader would override the PAT-embedded remote
+          # URL below, so the push would authenticate as GITHUB_TOKEN — 403
+          # under this job's contents:read, and even with write it would
+          # recreate the "bot PR triggers no CI" problem the PAT exists to fix.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 

--- a/scripts/sync-runtimes.mjs
+++ b/scripts/sync-runtimes.mjs
@@ -40,7 +40,9 @@ const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
  *  lose the tie. */
 export function compareSemver(a, b) {
   const parse = (v) => {
-    const [core, ...pre] = String(v).split("-");
+    // Build metadata is ignored for precedence (semver §10).
+    const [bare] = String(v).split("+");
+    const [core, ...pre] = bare.split("-");
     const nums = core.split(".").map((n) => Number.parseInt(n, 10) || 0);
     while (nums.length < 3) nums.push(0);
     return { nums, pre: pre.join("-") };

--- a/scripts/sync-runtimes.test.mjs
+++ b/scripts/sync-runtimes.test.mjs
@@ -25,6 +25,11 @@ assert.ok(compareSemver("1.0.0-beta.11", "1.0.0-beta.2") > 0, "beta.11 > beta.2"
 assert.ok(compareSemver("1.0.0-alpha", "1.0.0-alpha.1") < 0, "fewer identifiers lose the tie");
 assert.ok(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta") < 0, "numeric identifiers rank below alphanumeric");
 assert.ok(compareSemver("1.0.0-beta", "1.0.0-alpha") > 0, "alphanumeric identifiers compare lexically");
+// Build metadata is ignored for precedence (semver §10) — review finding:
+// "+x" leaked into identifier comparison and outranked numeric identifiers.
+assert.ok(compareSemver("1.0.0-rc.2", "1.0.0-rc.1+x") > 0, "build metadata never outranks a newer prerelease");
+assert.equal(compareSemver("1.0.0-rc.1+b", "1.0.0-rc.1"), 0, "build metadata is precedence-invisible");
+assert.equal(compareSemver("2.0.0+build.5", "2.0.0"), 0, "release build metadata is precedence-invisible");
 
 // ── latest non-yanked pick ───────────────────────────────────────────────────
 {


### PR DESCRIPTION
Fixes both findings from the code review of #2858:

1. **Build metadata corrupted prerelease precedence (semver §10).** `+build` wasn't stripped before the §11.4 identifier comparison, so `1.0.0-rc.1+x` outranked `1.0.0-rc.2` (the `+x` suffix made the identifier classify as alphanumeric) — the sync could ship an *older* adapter document. Build metadata is now stripped in `parse`; tests pin `rc.2 > rc.1+x`, `rc.1+b == rc.1`, `2.0.0+build.5 == 2.0.0`, and the reviewer's exact repros were re-run green against the fixed module.

2. **Persisted checkout credentials defeated the PAT push.** `actions/checkout` default-persists the `GITHUB_TOKEN` auth extraheader, which authenticates every github.com request *preemptively* — git never falls back to the PAT embedded in the remote URL. Result: the bot push would 403 under the job's `contents: read` (or with write, silently push as `GITHUB_TOKEN`, recreating the exact no-CI-on-bot-PR problem #2858 fixed). Checkout now sets `persist-credentials: false`, making `SYNC_RUNTIMES_TOKEN` the sole push credential.

Also confirmed by review: #2844's no-op removal is behavior-identical; no leak of the PAT into logs.

Validation: sync test suite green (3 new §10 assertions); `--check` confirms the committed gen module unchanged; workflow YAML lints.