### PR TITLE
feat(asana): refresh the Queue Asana strip on the 30s poll

### DIFF
--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -4,12 +4,21 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import {
   createBoardCardFromAsanaItem,
   fileAsanaItemAsBead,
   type AsanaAssignedResponse,
   type AsanaItem,
 } from "@/lib/asana-tasks";
+
+// Content equality for the poll — the assigned list is a plain object graph, so a
+// serialized compare is exact. Keeping the previous array identity on a no-change
+// poll stops the 30s tick from re-rendering every row for an identical picture
+// (same discipline as the parent Queue's sameQueue guard).
+function sameItems(a: AsanaItem[], b: AsanaItem[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
 
 type Props = {
   onOpenUrl?: (url: string) => void;
@@ -45,10 +54,11 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
       // A failed fetch or unconfigured Asana leaves the strip hidden — never an
       // error banner; the Queue's beads/PR sources carry the surface on their own.
       if (data.ok && data.configured) {
-        setItems(Array.isArray(data.items) ? data.items : []);
+        const next = Array.isArray(data.items) ? data.items : [];
+        setItems((prev) => (sameItems(prev, next) ? prev : next));
         setConfigured(true);
       } else {
-        setItems([]);
+        setItems((prev) => (prev.length === 0 ? prev : []));
         setConfigured(false);
       }
     } catch {
@@ -63,6 +73,12 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
     void load();
     return () => abortRef.current?.abort();
   }, [load]);
+
+  // Refresh on the same 30s cadence as the Queue's beads/PR lanes so a task
+  // completed or reassigned in Asana doesn't linger here until remount. Paused
+  // while an input is focused and while the tab is hidden (usePausablePoll);
+  // kept at 30s — not tighter — to respect Asana's REST rate limits.
+  usePausablePoll(() => void load(), 30_000, { pauseWhileInputActive: true });
 
   const addToBoard = useCallback(
     async (item: AsanaItem) => {

--- a/src/components/asana-task-field.test.ts
+++ b/src/components/asana-task-field.test.ts
@@ -74,5 +74,9 @@ assert.match(
 // the .fwq-attention count assertions in familiar-work-queue.spec.ts.
 assert.doesNotMatch(queueStrip, /className="fwq-attention/, "Queue Asana strip uses its own fwq-asana classes");
 assert.match(queueStrip, /className="fwq-asana"/, "Queue Asana strip uses the fwq-asana container class");
+// Freshness: refreshes on the Queue's poll cadence (cave-m4h9) with an equality
+// guard so identical polls don't churn re-renders.
+assert.match(queueStrip, /usePausablePoll\(\(\) => void load\(\), 30_000/, "Queue Asana strip refreshes on the 30s poll");
+assert.match(queueStrip, /function sameItems\(/, "Queue Asana strip guards identical polls against re-render churn");
 
 console.log("asana task field guard passed");


### PR DESCRIPTION
## What
Follow-up to #2865 (bead `cave-m4h9`): the Queue's Asana strip loaded assigned tasks **once per mount** (+ after filing a bead), while the Queue's beads/PR lanes poll every 30s. A task completed or reassigned in Asana therefore lingered on the strip until remount.

## Change
- `AsanaQueueStrip` now calls `usePausablePoll(() => void load(), 30_000, { pauseWhileInputActive: true })` — the **same 30s cadence** as the parent Queue, paused while an input is focused or the tab is hidden.
- Kept at 30s (not tighter) to respect Asana's REST rate limits.
- Added a `sameItems` JSON-equality guard so an unchanged poll keeps the previous array identity — no re-render churn — mirroring the parent's `sameQueue` discipline.

## Tests
- `asana-task-field` guard extended to pin both the poll and the equality guard.
- `typecheck` clean · guard test passes · `pnpm build` green.

## Risk
Minimal. Behavior when Asana is unconnected is unchanged (strip still renders `null`; the poll just re-confirms `configured:false`). No new API surface.

Closes the one freshness inconsistency flagged in the #2865 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)