### PR TITLE
feat(asana): seamless connect + per-agent assignment (cave-vn19)

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -19,6 +19,7 @@ type RouteContract = {
 const contracts: RouteContract[] = [
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
   { route: "/asana/assigned", methods: ["GET"], kind: "json" },
+  { route: "/asana/workspaces", methods: ["GET"], kind: "json" },
   { route: "/asana/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/beads", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
   { route: "/beads/prs", methods: ["GET"], kind: "json", localOriginGuard: true, pathGuard: true },

--- a/src/app/api/asana/assigned/route.ts
+++ b/src/app/api/asana/assigned/route.ts
@@ -7,9 +7,10 @@
  * is false when no PAT is stored — the "Asana connected" signal the UI gates on.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import type { AsanaItem } from "@/lib/asana-tasks";
 import { resolveSecret } from "@/lib/vault";
+import { bindingFor, loadConfig } from "@/lib/cave-config";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -74,10 +75,28 @@ function toItem(task: RawAsanaTask, workspaceGid: string): AsanaItem {
   };
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const token = resolveAsanaToken();
   if (!token) {
     return NextResponse.json({ ok: true, items: [], configured: false });
+  }
+
+  // Per-agent assignment: when a familiarId is passed, the caller wants only
+  // the tasks THIS agent is assigned to work with. `asanaEnabled === false`
+  // opts the agent out (returns `assigned:false`); `asanaWorkspaceGid` scopes
+  // the fan-out to one workspace. No familiarId = the whole connected user.
+  const familiarId = req.nextUrl.searchParams.get("familiarId")?.trim() || null;
+  let scopeWorkspaceGid: string | null = null;
+  if (familiarId) {
+    try {
+      const binding = bindingFor(await loadConfig(), familiarId);
+      if (binding.asanaEnabled === false) {
+        return NextResponse.json({ ok: true, items: [], configured: true, assigned: false });
+      }
+      scopeWorkspaceGid = binding.asanaWorkspaceGid?.trim() || null;
+    } catch {
+      /* config unreadable — fall through to the unscoped (connected-user) view */
+    }
   }
 
   const headers = authHeaders(token);
@@ -95,9 +114,15 @@ export async function GET() {
     }
     const meData = (await meRes.json().catch(() => null)) as { data?: AsanaMe } | null;
     const me = meData?.data;
-    const workspaces = (me?.workspaces ?? []).slice(0, MAX_WORKSPACES);
+    let workspaces = (me?.workspaces ?? []).slice(0, MAX_WORKSPACES);
+    // Scope to the familiar's chosen workspace when set (and it's one the user
+    // actually belongs to — otherwise fall back to all, never an empty view).
+    if (scopeWorkspaceGid) {
+      const scoped = workspaces.filter((ws) => ws.gid === scopeWorkspaceGid);
+      if (scoped.length) workspaces = scoped;
+    }
     if (workspaces.length === 0) {
-      return NextResponse.json({ ok: true, items: [], configured: true });
+      return NextResponse.json({ ok: true, items: [], configured: true, assigned: true });
     }
 
     const perWorkspace = await Promise.all(
@@ -122,7 +147,7 @@ export async function GET() {
     }
     items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 
-    return NextResponse.json({ ok: true, items, configured: true });
+    return NextResponse.json({ ok: true, items, configured: true, assigned: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return NextResponse.json({ ok: false, error: message, items: [] }, { status: 502 });

--- a/src/app/api/asana/workspaces/route.ts
+++ b/src/app/api/asana/workspaces/route.ts
@@ -1,0 +1,55 @@
+/**
+ * /api/asana/workspaces
+ *
+ * Lists the connected user's Asana workspaces — the options for a familiar's
+ * per-agent workspace scope (Familiar Studio → Brain → Asana). Reads the same
+ * app-wide PAT as /api/asana/assigned; `configured:false` when none is stored.
+ */
+
+import { NextResponse } from "next/server";
+import type { AsanaWorkspace } from "@/lib/asana-tasks";
+import { resolveSecret } from "@/lib/vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const API = "https://app.asana.com/api/1.0";
+
+function resolveAsanaToken(): string | undefined {
+  return (
+    resolveSecret("ASANA_PAT") ??
+    process.env.ASANA_PAT?.trim() ??
+    process.env.ASANA_ACCESS_TOKEN?.trim()
+  );
+}
+
+export async function GET() {
+  const token = resolveAsanaToken();
+  if (!token) {
+    return NextResponse.json({ ok: true, configured: false, workspaces: [] });
+  }
+
+  try {
+    const res = await fetch(`${API}/users/me?opt_fields=workspaces.name`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return NextResponse.json(
+        { ok: false, configured: true, workspaces: [], error: `Asana API error: HTTP ${res.status}` },
+        { status: 502 },
+      );
+    }
+    const data = (await res.json().catch(() => null)) as {
+      data?: { workspaces?: Array<{ gid: string; name?: string }> };
+    } | null;
+    const workspaces: AsanaWorkspace[] = (data?.data?.workspaces ?? []).map((ws) => ({
+      gid: ws.gid,
+      name: ws.name?.trim() || ws.gid,
+    }));
+    return NextResponse.json({ ok: true, configured: true, workspaces });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ ok: false, configured: true, workspaces: [], error: message }, { status: 502 });
+  }
+}

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -70,6 +70,8 @@ export async function GET() {
         voiceModel: binding.voiceModel,
         voiceName: binding.voiceName,
         autoSelfReport: configEntry.autoSelfReport ?? false,
+        asanaEnabled: configEntry.asanaEnabled,
+        asanaWorkspaceGid: configEntry.asanaWorkspaceGid,
         avatarUrl: avatar
           ? `/api/familiars/${encodeURIComponent(f.id)}/avatar?v=${Math.round(avatar.mtimeMs)}&format=png`
           : undefined,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7008,6 +7008,36 @@ a.mobile-handoff__link:hover {
 .familiar-studio-brain__hint { margin: 6px 0 0; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
 .familiar-studio-brain__switch { align-self: flex-start; cursor: pointer; }
 .familiar-studio-brain__control { display: flex; min-width: 0; gap: 6px; align-items: flex-start; }
+
+/* Asana section (Familiar Studio → Brain): inline connect + per-agent controls. */
+.familiar-asana__connect { display: flex; flex-direction: column; gap: 8px; }
+.familiar-asana__connect-row { display: flex; gap: 8px; align-items: center; }
+.familiar-asana__input {
+  flex: 1;
+  min-width: 0;
+  height: 32px;
+  padding: 0 10px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+.familiar-asana__connect-btn {
+  flex: 0 0 auto;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--accent-presence);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.familiar-asana__connect-btn:disabled { opacity: 0.5; cursor: default; }
+.familiar-asana__gen-link { font-size: var(--text-2xs); color: var(--accent-presence); width: fit-content; }
+.familiar-asana__error { margin: 6px 0 0; font-size: var(--text-2xs); color: var(--color-danger); }
 .familiar-studio-brain__input {
   flex: 1;
   min-width: 0;

--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -25,6 +25,9 @@ type Props = {
   /** Nudge the parent Queue to reload after a task is filed as a bead so it
    *  appears in the ready lanes without waiting for the next poll. */
   onFiledBead?: () => void;
+  /** Scope the strip to one agent: shows only the Asana tasks that familiar is
+   *  assigned to work with, and hides entirely when the agent is opted out. */
+  familiarId?: string | null;
 };
 
 /**
@@ -35,7 +38,7 @@ type Props = {
  * task can be opened in Asana, added to the board, or filed as a bead (entering
  * the ready queue via --external-ref).
  */
-export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
+export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
   const { announce } = useAnnouncer();
   const [items, setItems] = useState<AsanaItem[]>([]);
   const [configured, setConfigured] = useState(false);
@@ -48,12 +51,16 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
     const ctrl = new AbortController();
     abortRef.current = ctrl;
     try {
-      const res = await fetch("/api/asana/assigned", { cache: "no-store", signal: ctrl.signal });
+      const url = familiarId
+        ? `/api/asana/assigned?familiarId=${encodeURIComponent(familiarId)}`
+        : "/api/asana/assigned";
+      const res = await fetch(url, { cache: "no-store", signal: ctrl.signal });
       const data = (await res.json()) as AsanaAssignedResponse;
       if (ctrl.signal.aborted) return;
-      // A failed fetch or unconfigured Asana leaves the strip hidden — never an
-      // error banner; the Queue's beads/PR sources carry the surface on their own.
-      if (data.ok && data.configured) {
+      // A failed fetch, unconfigured Asana, or an agent opted out (assigned ===
+      // false) leaves the strip hidden — never an error banner; the Queue's
+      // beads/PR sources carry the surface on their own.
+      if (data.ok && data.configured && data.assigned !== false) {
         const next = Array.isArray(data.items) ? data.items : [];
         setItems((prev) => (sameItems(prev, next) ? prev : next));
         setConfigured(true);
@@ -67,7 +74,7 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead }: Props) {
         setConfigured(false);
       }
     }
-  }, []);
+  }, [familiarId]);
 
   useEffect(() => {
     void load();

--- a/src/components/asana-task-field.test.ts
+++ b/src/components/asana-task-field.test.ts
@@ -79,4 +79,44 @@ assert.match(queueStrip, /className="fwq-asana"/, "Queue Asana strip uses the fw
 assert.match(queueStrip, /usePausablePoll\(\(\) => void load\(\), 30_000/, "Queue Asana strip refreshes on the 30s poll");
 assert.match(queueStrip, /function sameItems\(/, "Queue Asana strip guards identical polls against re-render churn");
 
+// ── Per-agent assignment (cave-vn19): connect once, assign per familiar ──────
+{
+  const caveConfig = await source("lib/cave-config.ts");
+  const familiarsRoute = await source("app/api/familiars/route.ts");
+  const familiarType = await source("lib/types.ts");
+  const brainTab = await source("components/familiar-studio-brain-tab.tsx");
+  const asanaSection = await source("components/familiar-asana-section.tsx");
+  const workspacesRoute = await source("app/api/asana/workspaces/route.ts");
+  const workQueueView = await source("components/familiar-work-queue-view.tsx");
+
+  // Data model: per-agent enablement + workspace scope ride FamiliarBinding.
+  assert.match(caveConfig, /asanaEnabled\?: boolean/, "FamiliarBinding carries per-agent Asana enablement");
+  assert.match(caveConfig, /asanaWorkspaceGid\?: string/, "FamiliarBinding carries a per-agent Asana workspace scope");
+  assert.match(caveConfig, /asanaEnabled: f\.asanaEnabled/, "bindingFor surfaces asanaEnabled");
+  assert.match(familiarType, /asanaEnabled\?: boolean/, "the Familiar type exposes asanaEnabled to the UI");
+  assert.match(familiarsRoute, /asanaEnabled: configEntry\.asanaEnabled/, "the familiars route maps asanaEnabled through");
+
+  // Assigned route honors the familiar's assignment: opt-out + workspace scope.
+  assert.match(asanaAssigned, /searchParams\.get\("familiarId"\)/, "assigned route accepts a familiarId scope");
+  assert.match(asanaAssigned, /bindingFor\(await loadConfig\(\)/, "assigned route reads the familiar's binding");
+  assert.match(asanaAssigned, /binding\.asanaEnabled === false[\s\S]{0,160}assigned: false/, "an opted-out agent gets assigned:false and no tasks");
+  assert.match(asanaAssigned, /binding\.asanaWorkspaceGid/, "a scoped agent's fan-out filters to its workspace");
+
+  // Workspaces route backs the scope picker.
+  assert.match(workspacesRoute, /export async function GET/, "the workspaces route exists for the scope picker");
+  assert.match(workspacesRoute, /workspaces\.name/, "the workspaces route lists the user's Asana workspaces");
+
+  // Brain tab hosts connect + assignment in one per-agent place.
+  assert.match(brainTab, /<FamiliarAsanaSection familiar=\{familiar\}/, "the Brain tab renders the per-agent Asana section");
+  assert.match(asanaSection, /\/api\/asana\/pat/, "the section connects the app-wide PAT inline (seamless)");
+  assert.match(asanaSection, /asanaEnabled: next \? null : false/, "the toggle opts the agent in (null=on) or out (false)");
+  assert.match(asanaSection, /asanaWorkspaceGid: gid \|\| null/, "the scope select persists the workspace gid");
+
+  // Board + Queue scope to the agent.
+  assert.match(boardInspector, /assigned\?familiarId=\$\{encodeURIComponent\(card\.familiarId\)\}/, "the inspector picker scopes to the card's familiar");
+  assert.match(queueStrip, /familiarId\?: string \| null/, "the Queue strip accepts a familiar scope");
+  assert.match(queueStrip, /data\.assigned !== false/, "the Queue strip hides for an opted-out agent");
+  assert.match(workQueueView, /familiarId=\{activeFamiliarId\}/, "the Queue view scopes the strip to the active familiar");
+}
+
 console.log("asana task field guard passed");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -512,7 +512,12 @@ function AsanaAttachSection({
     let cancelled = false;
     setLoading(true);
     setErr(null);
-    fetch("/api/asana/assigned", { cache: "no-store" })
+    // Scope to the card's familiar: the picker offers the Asana tasks THIS
+    // agent is assigned to work with (per-agent enablement + workspace scope).
+    const url = card.familiarId
+      ? `/api/asana/assigned?familiarId=${encodeURIComponent(card.familiarId)}`
+      : "/api/asana/assigned";
+    fetch(url, { cache: "no-store" })
       .then((r) => r.json())
       .then((d: { ok: boolean; items?: AsanaItem[]; configured?: boolean; error?: string }) => {
         if (cancelled) return;
@@ -526,7 +531,7 @@ function AsanaAttachSection({
       .catch(() => { if (!cancelled) setErr("fetch failed"); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [open, fetchKey]); // fetchKey bumped to refetch after PAT save
+  }, [open, fetchKey, card.familiarId]); // fetchKey bumped to refetch after PAT save
 
   const attachedUrls = new Set([...(card.links ?? []), ...(card.asana ?? []).map((item) => item.url)]);
 

--- a/src/components/familiar-asana-section.tsx
+++ b/src/components/familiar-asana-section.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import type { AsanaWorkspace, AsanaWorkspacesResponse } from "@/lib/asana-tasks";
+import { StandardSelect } from "@/components/ui/select";
+import {
+  reportDaemonSyncFailure,
+  reportDaemonSyncSuccess,
+} from "@/lib/daemon-sync-status";
+
+/**
+ * Familiar Studio → Brain → Asana. Connection and per-agent assignment live in
+ * one place: the PAT is app-wide (connect once, seamlessly, right here when it
+ * isn't set yet), and the toggle + workspace scope decide whether and how THIS
+ * familiar works with Asana tasks. Persists to the familiar's binding via
+ * /api/config, mirroring the Brain tab's other per-agent settings.
+ *
+ * `asanaEnabled` is undefined-means-on (the seamless default once connected);
+ * turning the agent off writes `false`, turning it back on deletes the key.
+ */
+export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar }) {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [login, setLogin] = useState<string | null>(null);
+  const [workspaces, setWorkspaces] = useState<AsanaWorkspace[]>([]);
+
+  // Per-agent drafts (optimistic; reverted on save failure).
+  const [enabled, setEnabled] = useState(familiar.asanaEnabled !== false);
+  const [workspaceGid, setWorkspaceGid] = useState(familiar.asanaWorkspaceGid ?? "");
+
+  // Inline connect form (shown only when the app has no PAT yet).
+  const [pat, setPat] = useState("");
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEnabled(familiar.asanaEnabled !== false);
+    setWorkspaceGid(familiar.asanaWorkspaceGid ?? "");
+  }, [familiar.id, familiar.asanaEnabled, familiar.asanaWorkspaceGid]);
+
+  const loadWorkspaces = useCallback(async () => {
+    try {
+      const res = await fetch("/api/asana/workspaces", { cache: "no-store" });
+      const json = (await res.json()) as AsanaWorkspacesResponse;
+      setWorkspaces(json.workspaces ?? []);
+    } catch {
+      setWorkspaces([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/asana/pat", { cache: "no-store" });
+        const json = (await res.json()) as { hasPat?: boolean; login?: string | null };
+        if (cancelled) return;
+        setConfigured(Boolean(json.hasPat));
+        setLogin(json.login ?? null);
+        if (json.hasPat) void loadWorkspaces();
+      } catch {
+        if (!cancelled) setConfigured(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [loadWorkspaces]);
+
+  async function saveBinding(patch: Record<string, unknown>, revert: () => void) {
+    try {
+      const res = await fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ familiars: { [familiar.id]: patch } }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(`Couldn't save: ${json.error ?? res.statusText}`);
+        reportDaemonSyncFailure(`cave-config write: ${json.error ?? res.statusText}`);
+        revert();
+      } else {
+        setError(null);
+        reportDaemonSyncSuccess();
+      }
+    } catch (err) {
+      setError(`Couldn't save: ${(err as Error).message}`);
+      revert();
+    }
+  }
+
+  async function connect() {
+    const token = pat.trim();
+    if (!token || connecting) return;
+    setConnecting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/asana/pat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ pat: token }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        setError(json.error ?? "Couldn't connect Asana");
+      } else {
+        setPat("");
+        setConfigured(true);
+        setLogin(json.login ?? null);
+        void loadWorkspaces();
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  function toggleEnabled() {
+    const next = !enabled;
+    setEnabled(next);
+    // undefined-means-on: turning ON deletes the key (null), OFF writes false.
+    void saveBinding({ asanaEnabled: next ? null : false }, () => setEnabled(!next));
+  }
+
+  function pickWorkspace(gid: string) {
+    const prev = workspaceGid;
+    setWorkspaceGid(gid);
+    void saveBinding({ asanaWorkspaceGid: gid || null }, () => setWorkspaceGid(prev));
+  }
+
+  return (
+    <section className="familiar-studio-brain__card" data-asana-section>
+      <h3 className="familiar-studio-brain__card-title">Asana</h3>
+
+      {configured === false ? (
+        // Seamless first connect — the PAT is app-wide, entered once, right here.
+        <div className="familiar-asana__connect">
+          <p className="familiar-studio-brain__hint">
+            Connect Asana once to let your familiars work with your tasks. The token is
+            stored encrypted and only ever sent to Asana.
+          </p>
+          <div className="familiar-asana__connect-row">
+            <input
+              type="password"
+              value={pat}
+              onChange={(e) => setPat(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") void connect(); }}
+              placeholder="Asana Personal Access Token"
+              aria-label="Asana Personal Access Token"
+              className="familiar-asana__input focus-ring"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              onClick={() => void connect()}
+              disabled={!pat.trim() || connecting}
+              className="familiar-asana__connect-btn focus-ring"
+            >
+              {connecting ? "Verifying…" : "Connect"}
+            </button>
+          </div>
+          <a
+            href="https://app.asana.com/0/my-apps"
+            target="_blank"
+            rel="noreferrer"
+            className="familiar-asana__gen-link"
+          >
+            Generate a token →
+          </a>
+        </div>
+      ) : (
+        <>
+          <div className="familiar-studio-brain__row">
+            <span className="familiar-studio-brain__label">Work with Asana tasks</span>
+            <div className="familiar-studio-brain__control">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                aria-label="Work with Asana tasks"
+                onClick={toggleEnabled}
+                className={`familiar-studio-brain__switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+                  enabled
+                    ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+                    : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
+                }`}
+              >
+                {enabled ? "On" : "Off"}
+              </button>
+            </div>
+          </div>
+
+          {enabled && workspaces.length > 1 ? (
+            <div className="familiar-studio-brain__row">
+              <span className="familiar-studio-brain__label">Workspace</span>
+              <div className="familiar-studio-brain__control">
+                <StandardSelect
+                  label="Asana workspace scope"
+                  value={workspaceGid}
+                  onChange={pickWorkspace}
+                  options={[
+                    { value: "", label: "All workspaces" },
+                    ...workspaces.map((ws) => ({ value: ws.gid, label: ws.name })),
+                  ]}
+                />
+              </div>
+            </div>
+          ) : null}
+
+          <p className="familiar-studio-brain__hint">
+            {enabled
+              ? `${familiar.display_name} sees your assigned Asana tasks${
+                  workspaceGid ? " in the selected workspace" : ""
+                } on the board and in the Queue.`
+              : `${familiar.display_name} is opted out of Asana. Other familiars keep their access.`}
+            {login ? ` · Connected as ${login}.` : ""}
+          </p>
+        </>
+      )}
+
+      {error ? <p className="familiar-asana__error" role="alert">{error}</p> : null}
+    </section>
+  );
+}

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -9,6 +9,7 @@ import {
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import { StandardSelect, type StandardSelectGroup } from "@/components/ui/select";
 import { catalogForRuntime } from "@/lib/runtime-models";
+import { FamiliarAsanaSection } from "@/components/familiar-asana-section";
 
 type Props = { familiar: ResolvedFamiliar };
 
@@ -338,6 +339,8 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
               Writes a self-report to memory when a chat closes or is archived.
             </p>
           </section>
+
+          <FamiliarAsanaSection familiar={familiar} />
 
           {harnessId ? (
             <details

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -30,6 +30,10 @@ type Props = {
   embedded?: boolean;
   familiars?: ResolvedFamiliar[];
   onOpenUrl?: (url: string) => void;
+  /** The workspace's active familiar scope. When set, the Asana strip shows
+   *  only that agent's assigned tasks; null/undefined = the whole connected
+   *  user (the "All familiars" scope). */
+  activeFamiliarId?: string | null;
 };
 
 const LANE_ICON: Record<WorkQueueLaneKey, IconName> = {
@@ -111,7 +115,7 @@ function sameQueue(a: WorkQueue, b: WorkQueue): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = false }: Props) {
+export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = false, activeFamiliarId }: Props) {
   const { announce } = useAnnouncer();
   const [queue, setQueue] = useState<WorkQueue | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -377,7 +381,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
 
       {q.attention.length > 0 ? <AttentionStrip items={q.attention} onOpenUrl={onOpenUrl} /> : null}
 
-      <AsanaQueueStrip onOpenUrl={onOpenUrl} onFiledBead={() => void load()} />
+      <AsanaQueueStrip onOpenUrl={onOpenUrl} onFiledBead={() => void load()} familiarId={activeFamiliarId} />
 
       <div className="fwq-body">
         {q.total === 0 ? (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2259,7 +2259,7 @@ export function Workspace() {
       <BoardView
         key={mode}
         initialTab={mode === "familiar-work-queue" ? "queue" : "tasks"}
-        queueSlot={<FamiliarWorkQueueView familiars={resolvedFamiliars} onOpenUrl={openUrlInAppBrowser} embedded />}
+        queueSlot={<FamiliarWorkQueueView familiars={resolvedFamiliars} onOpenUrl={openUrlInAppBrowser} embedded activeFamiliarId={activeId} />}
         familiars={familiars}
         sessions={sessions}
         activeFamiliarId={activeId}

--- a/src/lib/asana-tasks.ts
+++ b/src/lib/asana-tasks.ts
@@ -39,6 +39,19 @@ export type AsanaAssignedResponse = {
   items: AsanaItem[];
   /** True once an Asana PAT is stored — the "Asana connected" signal. */
   configured?: boolean;
+  /** When a familiarId was passed: false means this agent is opted out of Asana
+   *  (asanaEnabled === false). Absent/true otherwise. */
+  assigned?: boolean;
+  error?: string;
+};
+
+/** One of the connected user's Asana workspaces (for the per-agent scope picker). */
+export type AsanaWorkspace = { gid: string; name: string };
+
+export type AsanaWorkspacesResponse = {
+  ok: boolean;
+  configured?: boolean;
+  workspaces: AsanaWorkspace[];
   error?: string;
 };
 

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -84,6 +84,13 @@ export type FamiliarBinding = {
   voiceModel?: string;
   voiceName?: string;
   autoSelfReport?: boolean;
+  /** Per-agent Asana assignment. The PAT is app-wide (one connection); this
+   *  decides whether THIS familiar works with Asana tasks. Undefined = on when
+   *  the app is connected (the seamless default); false opts the agent out. */
+  asanaEnabled?: boolean;
+  /** Optional Asana workspace gid this familiar is scoped to (empty = all of
+   *  the connected user's workspaces). */
+  asanaWorkspaceGid?: string;
   runtime?: FamiliarRuntime;
 };
 
@@ -451,6 +458,8 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
     voiceModel: f.voiceModel,
     voiceName: f.voiceName,
     autoSelfReport: f.autoSelfReport ?? false,
+    asanaEnabled: f.asanaEnabled,
+    asanaWorkspaceGid: f.asanaWorkspaceGid,
     runtime: normalizeFamiliarRuntime(f.runtime ?? config.defaults.runtime),
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,11 @@ export type Familiar = {
   voiceModel?: string;
   voiceName?: string;
   autoSelfReport?: boolean;
+  /** Per-agent Asana assignment (see FamiliarBinding). Undefined = on when the
+   *  app is connected; false opts this familiar out. */
+  asanaEnabled?: boolean;
+  /** Optional Asana workspace gid this familiar is scoped to. */
+  asanaWorkspaceGid?: string;
 };
 
 export type DaemonStatus = {


### PR DESCRIPTION
## What

User request: make the Asana connection experience **seamless** and **assignable at an agent level**. Chosen model (Option A, confirmed): one app-wide Asana connection, plus per-familiar enablement + workspace scope. This mirrors how `FamiliarBinding` already carries per-agent model/harness/voice.

## How

- **Data model** — `FamiliarBinding` (+ the `Familiar` type) gain `asanaEnabled` (undefined = on when the app is connected — the seamless default; `false` opts the agent out) and `asanaWorkspaceGid` (optional scope). Mapped through `/api/familiars` and `bindingFor`, so the existing `/api/config` PATCH path persists them with no new plumbing.
- **Familiar Studio → Brain → Asana** (new `FamiliarAsanaSection`) — connection and assignment in one place per agent:
  - App has no PAT yet → inline **Connect** field (the app-wide token, entered once, stored encrypted) — seamless first connect without hunting through a board card.
  - Connected → a **"Work with Asana tasks"** toggle + an optional **workspace scope** select for that familiar.
- **Scoping honored across surfaces** — `/api/asana/assigned?familiarId=` reads the familiar's binding: an opted-out agent returns `assigned:false` + no tasks; a scoped agent's fan-out filters to its workspace (falling back to all if the gid isn't one the user belongs to, never an empty view). New `GET /api/asana/workspaces` backs the scope picker.
  - **Board inspector** scopes its attach picker to `card.familiarId`.
  - **Queue strip** scopes to the active familiar and hides entirely for an opted-out agent.

Credentials stay app-wide (one PAT, encrypted) — consistent with GitHub — so no per-agent credential burden. Multi-account per-agent identity is a clean future extension if ever needed.

Bead: cave-vn19

## Verification
- `tsc --noEmit` clean
- App suite ✓ 594 · API suite ✓ 131 (wiring pins added to `asana-task-field.test.ts`; `/asana/workspaces` added to `api-contracts.test.ts`)
- `pnpm build` within bundle budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)