### PR TITLE
chore(release): stamp v0.0.170

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.170] - 2026-07-09
+
+> 🧑‍🤝‍🧑 **Asana, assignable per familiar** — connect Asana once, then decide per agent whether (and in which workspace) it works with your tasks, right in Familiar Studio → Brain. The board and Queue show each agent only their scoped tasks.
+
+Patch release on top of v0.0.169.
+
+### Features
+- **Asana: seamless connect + per-agent assignment** (#2871, cave-vn19). One app-wide connection, then a per-familiar "Work with Asana tasks" toggle + optional workspace scope in the Brain tab. `/api/asana/assigned` honors each agent's assignment; the board inspector scopes to the card's familiar and the Queue strip to the active one (hidden for opted-out agents).
+
+### Improvements
+- **Asana: the Queue strip refreshes on the 30s poll** (#2870, cave-m4h9) with an equality guard against re-render churn.
+
+
 ## [0.0.169] - 2026-07-09
 
 > Mobile Cave reconnects cleanly over Tailscale when a stale dev server is in the way, Queue gains Asana-linked task context, and runtime sync gets its second review hardening pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.169",
+  "version": "0.0.170",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.169"
+version = "0.0.170"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.169"
+version = "0.0.170"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.169</string>
+	<string>0.0.170</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.169</string>
+	<string>0.0.170</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.169</string>
+	<string>0.0.170</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.169</string>
+	<string>0.0.170</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.169",
+  "version": "0.0.170",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.170 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs`.

Patch release on top of v0.0.169 — 2 commits:
- **Asana: seamless connect + per-agent assignment** (#2871, cave-vn19)
- Asana: Queue strip refreshes on the 30s poll (#2870, cave-m4h9)

After merge: tag `v0.0.170` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)