### PR TITLE
feat(familiars): undo-safe Remove beside Archive — dual-track lifecycle (cave-ykwk)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -462,6 +462,7 @@ export const SUITES = {
     "src/lib/daemon-sync-status.test.ts",
     "src/lib/familiar-glyph.test.ts",
     "src/lib/familiar-memory.test.ts",
+    "src/lib/familiar-removal.test.ts",
     "src/lib/familiar-resolve.test.ts",
     "src/lib/familiar-studio-context.test.ts",
     "src/lib/html-sanitize.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -58,6 +58,8 @@ const contracts: RouteContract[] = [
   { route: "/familiars/[id]/self-reports/[sessionId]", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/self-reports", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/response-confidence", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
+  { route: "/familiars/[id]", methods: ["DELETE"], kind: "json", pathGuard: true },
+  { route: "/familiars/removed", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/familiars", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/feedback/message", methods: ["POST", "GET"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/fs-browse", methods: ["GET"], kind: "json", pathGuard: true, localOriginGuard: true },

--- a/src/app/api/familiars/[id]/route.ts
+++ b/src/app/api/familiars/[id]/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { loadConfig, saveConfig } from "@/lib/cave-config";
+import {
+  displayNameFromTomlBlock,
+  removeFamiliarBlockFromToml,
+} from "@/lib/familiar-removal";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { addTombstone } from "@/lib/server/familiar-tombstones";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Remove ("detach") a familiar — the undo-safe half of the dual-track
+ * lifecycle. Archive (client-side, cave-familiar-archive.ts) hides a familiar
+ * but leaves it registered; Remove strips its `[[familiar]]` block from
+ * ~/.coven/familiars.toml and drops its cave-config.json binding, which is
+ * what a mistaken OpenClaw-agent binding actually needs.
+ *
+ * Safety model:
+ * - Both the TOML block and the binding are snapshotted into the tombstone
+ *   store BEFORE anything is mutated, so POST /api/familiars/removed can
+ *   restore the entry exactly as it was for the whole restore window.
+ * - Nothing else is touched: the upstream OpenClaw agent instance, chat and
+ *   session history, and the familiar's workspace files (SOUL.md, memory,
+ *   avatars) all stay on disk. Re-registering the same id picks them back up.
+ */
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  if (!id || !isValidFamiliarId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  const familiarsToml = path.join(homedir(), ".coven", "familiars.toml");
+  let toml: string | null = null;
+  try {
+    toml = await readFile(familiarsToml, "utf8");
+  } catch {
+    /* absent — the familiar may still exist as a binding-only entry */
+  }
+
+  const surgery = toml === null ? null : removeFamiliarBlockFromToml(toml, id);
+  const config = await loadConfig();
+  const binding = config.familiars[id] ? { ...config.familiars[id] } : null;
+
+  if (!surgery?.removed && !binding) {
+    return NextResponse.json(
+      { ok: false, error: `No familiar "${id}" to remove.` },
+      { status: 404 },
+    );
+  }
+
+  // Snapshot before mutating — never destroy the only copy of the entry.
+  await addTombstone({
+    id,
+    displayName: (surgery?.removed ? displayNameFromTomlBlock(surgery.removed) : null) ?? id,
+    removedAt: new Date().toISOString(),
+    tomlBlock: surgery?.removed ?? null,
+    binding: binding as Record<string, unknown> | null,
+  });
+
+  if (surgery?.removed && toml !== null) {
+    await writeFile(familiarsToml, surgery.toml, "utf8");
+  }
+  if (binding) {
+    await saveConfig({ familiars: { [id]: null } });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    id,
+    removedFromToml: Boolean(surgery?.removed),
+    hadBinding: binding !== null,
+  });
+}

--- a/src/app/api/familiars/removed/route.ts
+++ b/src/app/api/familiars/removed/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { saveConfig, type FamiliarBinding } from "@/lib/cave-config";
+import { buildFamiliarsToml, familiarsTomlContainsId } from "@/lib/onboarding-familiars";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { readTombstones, takeTombstone } from "@/lib/server/familiar-tombstones";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * The "Recently removed" shelf backing the undo-safe familiar Remove flow.
+ *
+ *   GET  /api/familiars/removed        → { ok, removed: [{ id, displayName, removedAt }] }
+ *   POST /api/familiars/removed {id}   → restore the tombstoned familiar
+ *
+ * Restore re-appends the snapshotted `[[familiar]]` block to
+ * ~/.coven/familiars.toml and re-saves the cave-config.json binding, so the
+ * familiar comes back exactly as removed (workspace files never moved).
+ */
+export async function GET() {
+  const removed = (await readTombstones()).map(({ id, displayName, removedAt }) => ({
+    id,
+    displayName,
+    removedAt,
+  }));
+  return NextResponse.json({ ok: true, removed });
+}
+
+export async function POST(req: Request) {
+  let body: { id?: unknown };
+  try {
+    body = (await req.json()) as { id?: unknown };
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id || !isValidFamiliarId(id)) {
+    return NextResponse.json({ ok: false, error: "A familiar id is required." }, { status: 400 });
+  }
+
+  const entry = (await readTombstones()).find((tombstone) => tombstone.id === id);
+  if (!entry) {
+    return NextResponse.json(
+      { ok: false, error: `Nothing to restore for "${id}".` },
+      { status: 404 },
+    );
+  }
+
+  const familiarsToml = path.join(homedir(), ".coven", "familiars.toml");
+  let existing = "";
+  try {
+    existing = await readFile(familiarsToml, "utf8");
+  } catch {
+    /* absent — restore recreates the file */
+  }
+
+  // Conflict-check BEFORE consuming the tombstone: if the id was re-created in
+  // the meantime, appending the snapshot would register a duplicate block (the
+  // daemon only reads the first) and the binding write would clobber the new
+  // familiar's. Leave both the tombstone and the newcomer intact instead.
+  if (entry.tomlBlock && familiarsTomlContainsId(existing, id)) {
+    return NextResponse.json(
+      { ok: false, error: `A familiar with id "${id}" already exists — cannot restore over it.` },
+      { status: 409 },
+    );
+  }
+
+  await takeTombstone(id);
+
+  if (entry.tomlBlock) {
+    const base = existing || buildFamiliarsToml(null);
+    const separator = base.endsWith("\n") ? "\n" : "\n\n";
+    await writeFile(familiarsToml, `${base}${separator}${entry.tomlBlock}\n`, "utf8");
+  }
+  if (entry.binding) {
+    await saveConfig({
+      familiars: { [id]: entry.binding as unknown as Partial<FamiliarBinding> },
+    });
+  }
+
+  return NextResponse.json({ ok: true, id });
+}

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/onboarding-familiars";
 import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
 import { scaffoldFamiliarContractFiles } from "@/lib/server/familiar-contract-files";
+import { removedFamiliarIds, takeTombstone } from "@/lib/server/familiar-tombstones";
 
 export const dynamic = "force-dynamic";
 
@@ -29,11 +30,12 @@ export type DaemonFamiliar = {
 };
 
 export async function GET() {
-  const [res, config] = await Promise.all([
+  const [res, config, removedIds] = await Promise.all([
     callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
       path: "/api/v1/familiars",
     }),
     loadConfig(),
+    removedFamiliarIds().catch(() => new Set<string>()),
   ]);
   if (!res.ok) {
     return NextResponse.json(
@@ -49,8 +51,14 @@ export async function GET() {
   // when one exists, cache-busted by file mtime plus renderer format so both
   // content changes and server-side encoding changes refetch in desktop
   // WebViews. Familiars with no on-disk avatar omit it and render the glyph.
+  //
+  // A removed familiar (DELETE /api/familiars/[id]) can linger in the daemon's
+  // in-memory roster until it re-reads familiars.toml — hide tombstoned ids so
+  // Remove takes effect immediately in every client.
   const familiars = await Promise.all(
-    (res.data ?? []).map(async (f) => {
+    (res.data ?? [])
+      .filter((f) => !removedIds.has(f.id))
+      .map(async (f) => {
       const configEntry = config.familiars[f.id] ?? {};
       const binding = bindingFor(config, f.id);
       const avatar = await resolveFamiliarAvatar(f.id);
@@ -157,6 +165,10 @@ export async function POST(req: Request) {
   } else {
     await writeFile(familiarsToml, buildFamiliarsToml(draft), "utf8");
   }
+
+  // Re-creating a removed id must clear its tombstone: the roster GET hides
+  // tombstoned ids, so a stale entry would make the new familiar invisible.
+  await takeTombstone(draft.id).catch(() => {});
 
   // Scaffold the harness adapter manifest if it's missing (parity with
   // onboarding) so a familiar bound to a not-yet-configured harness still works.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7153,6 +7153,21 @@ a.mobile-handoff__link:hover {
 .familiar-studio-lifecycle__row-action { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 4px; background: transparent; border: none; color: var(--text-secondary); cursor: pointer; }
 .familiar-studio-lifecycle__row-action:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-base); }
 .familiar-studio-lifecycle__row-action:disabled { opacity: 0.25; cursor: not-allowed; }
+.familiar-studio-lifecycle__row-action--danger:hover:not(:disabled) { color: var(--color-danger); background: color-mix(in oklch, var(--color-danger) 12%, transparent); }
+
+/* Remove-confirm strip: detach semantics spelled out inline before scheduling
+   the undo-safe delete (danger tint recipe: solid text / 6% fill / 35% border). */
+.familiar-studio-lifecycle__confirm { display: flex; flex-direction: column; gap: 8px; margin: 2px 0 6px 28px; padding: 10px 12px; border: 1px solid color-mix(in oklch, var(--color-danger) 35%, transparent); border-radius: 8px; background: color-mix(in oklch, var(--color-danger) 6%, var(--bg-raised)); }
+.familiar-studio-lifecycle__confirm-title { margin: 0; font-size: 12px; font-weight: 600; color: var(--text-primary); }
+.familiar-studio-lifecycle__confirm-copy { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-secondary); }
+.familiar-studio-lifecycle__confirm-warn { color: var(--color-warning); }
+.familiar-studio-lifecycle__confirm-actions { display: flex; gap: 8px; }
+
+/* Recently removed shelf (restore from tombstones). */
+.familiar-studio-lifecycle__removed-row { display: flex; align-items: center; gap: 8px; padding: 4px 6px; border-radius: 6px; }
+.familiar-studio-lifecycle__removed-row:hover { background: var(--bg-raised); }
+.familiar-studio-lifecycle__removed-name { flex: 1; font-size: 13px; color: var(--text-primary); }
+.familiar-studio-lifecycle__removed-when { font-size: 11px; color: var(--text-muted); }
 
 /* Familiar Contract adherence tab. */
 .familiar-studio-contract { display: flex; flex-direction: column; gap: 18px; }

--- a/src/components/delete-undo-surfaces.test.ts
+++ b/src/components/delete-undo-surfaces.test.ts
@@ -10,6 +10,7 @@ for (const rel of [
   "./vault-panel.tsx",
   "./automations-view.tsx",
   "./journal/journal-entries.tsx",
+  "./familiar-studio-lifecycle-tab.tsx",
 ]) {
   const src = read(rel);
   assert.match(src, /import \{ useUndoDelete \} from "@\/lib\/use-undo-delete"/, `${rel} imports useUndoDelete`);
@@ -38,6 +39,13 @@ for (const rel of [
 {
   const src = read("./journal/journal-entries.tsx");
   assert.match(src, /day\?\.date !== deletePending\?\.item/, "journal treats the pending day as empty during the undo window");
+}
+
+// Familiar lifecycle: a familiar pending removal hides from BOTH the active and
+// archived lists during the undo window (the toast is its only handle).
+{
+  const src = read("./familiar-studio-lifecycle-tab.tsx");
+  assert.match(src, /f\.id === pendingRemoveId/, "lifecycle tab hides the pending familiar row during the undo window");
 }
 
 console.log("delete-undo-surfaces.test.ts OK");

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -26,6 +26,8 @@ type Props = {
    *  end of the familiar picker — the create action lives with the roster it
    *  extends instead of floating above the panel. */
   onSummon?: () => void;
+  /** Re-fetch the roster after the Lifecycle tab removes/restores a familiar. */
+  onRosterChanged?: () => void;
 };
 
 const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
@@ -54,7 +56,7 @@ const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
  * tab-body components as the drawer. The Settings provider instance is isolated
  * from the Workspace one, so selecting here never auto-opens the drawer there.
  */
-export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon }: Props) {
+export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRosterChanged }: Props) {
   const { activeFamiliarId, activeTab, setActiveTab, openFamiliarStudio } = useFamiliarStudio();
   const daemonSync = useDaemonSyncStatus();
 
@@ -189,7 +191,11 @@ export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon }: Pro
               ) : null}
               {activeTab === "brain" ? <FamiliarStudioBrainTab familiar={familiar} /> : null}
               {activeTab === "lifecycle" ? (
-                <FamiliarStudioLifecycleTab familiar={familiar} allResolved={resolved} />
+                <FamiliarStudioLifecycleTab
+                  familiar={familiar}
+                  allResolved={resolved}
+                  onRosterChanged={onRosterChanged}
+                />
               ) : null}
               {activeTab === "memory" ? (
                 <FamiliarStudioMemoryTab familiar={familiar} allFamiliars={familiars} />

--- a/src/components/familiar-studio-lifecycle-tab.test.ts
+++ b/src/components/familiar-studio-lifecycle-tab.test.ts
@@ -36,4 +36,85 @@ assert.match(source, /arrayMove\(ids, oldIndex, newIndex\)/, "drag reorder moves
 assert.match(source, /avatar strip's pinned order/, "lifecycle hint disambiguates roster order from pin order");
 assert.match(source, /window\.location\.hash = "appearance"/, "lifecycle hint links to Appearance");
 
+// ── Dual-track lifecycle (cave-ykwk): Remove = undo-safe detach ─────────────
+// Archive stays the reversible hide; Remove detaches a mistaken binding. These
+// pins hold the safety-critical seams of that flow.
+
+// Remove defers through the shared undo hook — nothing hits the server while
+// the toast's undo window is open.
+assert.match(source, /import \{ useUndoDelete \} from "@\/lib\/use-undo-delete"/);
+assert.match(source, /import \{ UndoToast \} from "@\/components\/ui\/undo-toast"/);
+assert.match(source, /useUndoDelete<ResolvedFamiliar>/);
+assert.match(
+  source,
+  /fetch\(`\/api\/familiars\/\$\{encodeURIComponent\(f\.id\)\}`, \{ method: "DELETE" \}\)/,
+  "remove commits as DELETE /api/familiars/[id]",
+);
+
+// Every row (active AND archived) exposes Remove as a distinct action beside
+// Archive/Unarchive, with an inline confirm strip that spells out detach
+// semantics: what is cleared vs. what survives, plus the active-session warning.
+assert.match(source, /aria-label=\{`Remove \$\{familiar\.display_name\}`\}/);
+assert.match(source, /aria-label=\{`Archive \$\{familiar\.display_name\}`\}/);
+assert.match(source, /roster entry and agent binding/, "confirm copy explains what is cleared");
+assert.match(source, /stay on\s+your disk/, "confirm copy explains what survives");
+assert.match(source, /active_sessions/, "confirm warns using the daemon session count");
+assert.match(source, /keep\s+running until they finish/);
+assert.match(source, /Archive hides a familiar/, "archive-vs-remove semantics are explained in-product");
+
+// Restore path: Recently removed shelf + POST restore + announcer feedback,
+// then a roster re-fetch threaded from Settings.
+assert.match(source, /Recently removed/);
+assert.match(source, /fetch\("\/api\/familiars\/removed"/);
+assert.match(source, /useAnnouncer/);
+assert.match(source, /"assertive"/, "failures announce assertively");
+assert.match(source, /onRosterChanged\?\.\(\)/);
+
+// Remove never touches the client-side archive store — archive and remove are
+// independent tracks, so an archived familiar restores as archived.
+{
+  const removeFlow = source.slice(
+    source.indexOf("function performRemove"),
+    source.indexOf("async function restoreRemoved"),
+  );
+  assert.ok(removeFlow.length > 0, "performRemove flow present before restoreRemoved");
+  assert.doesNotMatch(removeFlow, /archiveFamiliar|unarchiveFamiliar/, "remove leaves the archive store alone");
+}
+
+// ── Route seams ──────────────────────────────────────────────────────────────
+{
+  const path = await import("node:path");
+  const apiDir = path.join(process.cwd(), "src", "app", "api", "familiars");
+  const deleteRoute = readFileSync(path.join(apiDir, "[id]", "route.ts"), "utf8");
+  const removedRoute = readFileSync(path.join(apiDir, "removed", "route.ts"), "utf8");
+  const rosterRoute = readFileSync(path.join(apiDir, "route.ts"), "utf8");
+
+  // Tombstone-before-mutate: the snapshot must land on disk before
+  // familiars.toml or cave-config.json are touched — never destroy the only
+  // copy of the entry.
+  const tombstoneAt = deleteRoute.indexOf("await addTombstone(");
+  assert.ok(tombstoneAt > 0, "delete route snapshots a tombstone");
+  assert.ok(
+    tombstoneAt < deleteRoute.indexOf("writeFile(familiarsToml"),
+    "tombstone is written before familiars.toml is mutated",
+  );
+  assert.ok(
+    tombstoneAt < deleteRoute.indexOf("saveConfig("),
+    "tombstone is written before the binding is dropped",
+  );
+  assert.match(deleteRoute, /status: 404/, "nothing-to-remove is a 404, not a silent ok");
+
+  // The roster GET hides tombstoned ids (the daemon may not have re-read
+  // familiars.toml yet) and create clears a reused id's tombstone so the new
+  // familiar isn't invisible.
+  assert.match(rosterRoute, /removedFamiliarIds/);
+  assert.match(rosterRoute, /\.filter\(\(f\) => !removedIds\.has\(f\.id\)\)/);
+  assert.match(rosterRoute, /takeTombstone\(draft\.id\)/);
+
+  // Restore refuses to clobber a re-created id (duplicate [[familiar]] blocks —
+  // the daemon only reads the first) and keeps the tombstone for later.
+  assert.match(removedRoute, /familiarsTomlContainsId/);
+  assert.match(removedRoute, /status: 409/);
+}
+
 console.log("familiar-studio-lifecycle-tab.test.ts: ok");

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -20,6 +20,8 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { UndoToast } from "@/components/ui/undo-toast";
+import { useAnnouncer } from "@/components/ui/live-region";
 import {
   archiveFamiliar,
   unarchiveFamiliar,
@@ -29,25 +31,50 @@ import { clearAllFamiliarOverrides } from "@/lib/cave-familiar-overrides";
 import { clearGlyphOverride } from "@/lib/cave-glyph-overrides";
 import { clearFamiliarImage } from "@/lib/cave-familiar-images";
 import { setFamiliarOrder } from "@/lib/cave-familiar-order";
+import { relativeTime } from "@/lib/relative-time";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
+import { useUndoDelete } from "@/lib/use-undo-delete";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type Props = {
   familiar: ResolvedFamiliar | null;
   allResolved: ResolvedFamiliar[];
+  /** Re-fetch the roster after a remove/restore lands server-side. */
+  onRosterChanged?: () => void;
 };
 
-export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
+type RemovedFamiliarSummary = { id: string; displayName: string; removedAt: string };
+
+export function FamiliarStudioLifecycleTab({ familiar, allResolved, onRosterChanged }: Props) {
   const archived = useArchivedFamiliars();
   const { openFamiliarStudio } = useFamiliarStudio();
+  const { announce } = useAnnouncer();
   const [confirmReset, setConfirmReset] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState<ResolvedFamiliar | null>(null);
+  const [removedEntries, setRemovedEntries] = useState<RemovedFamiliarSummary[]>([]);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+  // Ids whose DELETE has committed but whose roster refresh hasn't landed yet —
+  // keeps the row from flashing back between commit and re-fetch.
+  const [removedLocally, setRemovedLocally] = useState<Set<string>>(new Set());
+  const {
+    pending: pendingRemove,
+    scheduleDelete,
+    undo: undoRemove,
+    commit: commitRemove,
+  } = useUndoDelete<ResolvedFamiliar>();
 
   // The full roster (active + archived) with reorder + archive — this is the
   // manager that used to live in the standalone "Manage familiars" page. It now
   // renders here so Settings → Familiars is the single source of truth, with the
   // selected familiar's per-familiar controls (reset) below it.
-  const active = allResolved.filter((f) => !(f.id in archived));
-  const archivedList = allResolved.filter((f) => f.id in archived);
+  //
+  // A familiar pending removal hides from BOTH lists during the undo window —
+  // the UndoToast is its only handle until the delete commits or is undone
+  // (same optimistic pattern as board/vault/journal).
+  const pendingRemoveId = pendingRemove?.item.id ?? null;
+  const hidden = (f: ResolvedFamiliar) => f.id === pendingRemoveId || removedLocally.has(f.id);
+  const active = allResolved.filter((f) => !(f.id in archived) && !hidden(f));
+  const archivedList = allResolved.filter((f) => f.id in archived && !hidden(f));
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -103,8 +130,95 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
     setConfirmReset(false);
   }
 
+  const removedCtlRef = useRef<AbortController | null>(null);
+  const loadRemoved = useCallback(async () => {
+    removedCtlRef.current?.abort();
+    const ctl = new AbortController();
+    removedCtlRef.current = ctl;
+    try {
+      const res = await fetch("/api/familiars/removed", { cache: "no-store", signal: ctl.signal });
+      const json = await res.json().catch(() => null);
+      if (ctl.signal.aborted) return;
+      if (json?.ok) setRemovedEntries((json.removed ?? []) as RemovedFamiliarSummary[]);
+    } catch {
+      /* transient (or aborted) — keep the last list */
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRemoved();
+    return () => removedCtlRef.current?.abort();
+  }, [loadRemoved]);
+
+  // Remove ≠ Archive: it detaches the familiar server-side (roster entry +
+  // agent binding), while chats, memory, and workspace files stay on disk.
+  // The DELETE is deferred through useUndoDelete, so Undo/⌘Z during the toast
+  // window means nothing was ever sent.
+  function performRemove(f: ResolvedFamiliar) {
+    setConfirmRemove(null);
+    scheduleDelete(f, f.display_name, async () => {
+      setRemovedLocally((prev) => new Set(prev).add(f.id));
+      try {
+        const res = await fetch(`/api/familiars/${encodeURIComponent(f.id)}`, { method: "DELETE" });
+        const json = await res.json().catch(() => null);
+        if (!res.ok || json?.ok === false) {
+          throw new Error(typeof json?.error === "string" ? json.error : `remove failed (${res.status})`);
+        }
+        announce(`Removed ${f.display_name}. Restore it from Recently removed.`);
+      } catch (err) {
+        setRemovedLocally((prev) => {
+          const next = new Set(prev);
+          next.delete(f.id);
+          return next;
+        });
+        announce(
+          `Could not remove ${f.display_name}: ${err instanceof Error ? err.message : "unknown error"}`,
+          "assertive",
+        );
+      } finally {
+        void loadRemoved();
+        onRosterChanged?.();
+      }
+    });
+  }
+
+  async function restoreRemoved(entry: RemovedFamiliarSummary) {
+    setRestoringId(entry.id);
+    try {
+      const res = await fetch("/api/familiars/removed", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: entry.id }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || json?.ok === false) {
+        throw new Error(typeof json?.error === "string" ? json.error : `restore failed (${res.status})`);
+      }
+      setRemovedLocally((prev) => {
+        const next = new Set(prev);
+        next.delete(entry.id);
+        return next;
+      });
+      announce(`Restored ${entry.displayName}.`);
+      onRosterChanged?.();
+    } catch (err) {
+      announce(
+        `Could not restore ${entry.displayName}: ${err instanceof Error ? err.message : "unknown error"}`,
+        "assertive",
+      );
+    } finally {
+      setRestoringId(null);
+      void loadRemoved();
+    }
+  }
+
   return (
     <div className="familiar-studio-lifecycle">
+      <p className="familiar-studio-lifecycle__hint">
+        Archive hides a familiar from switchers but keeps it bound — unarchive anytime. Remove
+        detaches it from your Cave; chats, memory, and workspace files stay on disk, and a removal
+        can be undone from Recently removed.
+      </p>
       <section>
         <h3 className="familiar-studio-lifecycle__heading">Active</h3>
         <p className="familiar-studio-lifecycle__hint">
@@ -129,17 +243,26 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
         >
           <SortableContext items={active.map((f) => f.id)} strategy={verticalListSortingStrategy}>
             {active.map((f, i) => (
-              <SortableFamiliarRow
-                key={f.id}
-                familiar={f}
-                canMoveUp={i > 0}
-                canMoveDown={i < active.length - 1}
-                onSelect={() => openFamiliarStudio(f.id, "identity")}
-                onArchive={() => archiveFamiliar(f.id)}
-                onUnarchive={() => unarchiveFamiliar(f.id)}
-                onMoveUp={() => move(f.id, "up")}
-                onMoveDown={() => move(f.id, "down")}
-              />
+              <Fragment key={f.id}>
+                <SortableFamiliarRow
+                  familiar={f}
+                  canMoveUp={i > 0}
+                  canMoveDown={i < active.length - 1}
+                  onSelect={() => openFamiliarStudio(f.id, "identity")}
+                  onArchive={() => archiveFamiliar(f.id)}
+                  onUnarchive={() => unarchiveFamiliar(f.id)}
+                  onRemove={() => setConfirmRemove(f)}
+                  onMoveUp={() => move(f.id, "up")}
+                  onMoveDown={() => move(f.id, "down")}
+                />
+                {confirmRemove?.id === f.id ? (
+                  <RemoveConfirm
+                    familiar={f}
+                    onConfirm={() => performRemove(f)}
+                    onCancel={() => setConfirmRemove(null)}
+                  />
+                ) : null}
+              </Fragment>
             ))}
           </SortableContext>
         </DndContext>
@@ -147,19 +270,58 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
       {archivedList.length > 0 ? (
         <section>
           <h3 className="familiar-studio-lifecycle__heading">Archived</h3>
+          <p className="familiar-studio-lifecycle__hint">
+            Hidden from switchers, still bound to their runtimes and memory.
+          </p>
           {archivedList.map((f) => (
-            <FamiliarRow
-              key={f.id}
-              familiar={f}
-              isArchived={true}
-              canMoveUp={false}
-              canMoveDown={false}
-              onSelect={() => openFamiliarStudio(f.id, "identity")}
-              onArchive={() => archiveFamiliar(f.id)}
-              onUnarchive={() => unarchiveFamiliar(f.id)}
-              onMoveUp={() => { /* no-op */ }}
-              onMoveDown={() => { /* no-op */ }}
-            />
+            <Fragment key={f.id}>
+              <FamiliarRow
+                familiar={f}
+                isArchived={true}
+                canMoveUp={false}
+                canMoveDown={false}
+                onSelect={() => openFamiliarStudio(f.id, "identity")}
+                onArchive={() => archiveFamiliar(f.id)}
+                onUnarchive={() => unarchiveFamiliar(f.id)}
+                onRemove={() => setConfirmRemove(f)}
+                onMoveUp={() => { /* no-op */ }}
+                onMoveDown={() => { /* no-op */ }}
+              />
+              {confirmRemove?.id === f.id ? (
+                <RemoveConfirm
+                  familiar={f}
+                  onConfirm={() => performRemove(f)}
+                  onCancel={() => setConfirmRemove(null)}
+                />
+              ) : null}
+            </Fragment>
+          ))}
+        </section>
+      ) : null}
+
+      {removedEntries.length > 0 ? (
+        <section className="familiar-studio-lifecycle__section">
+          <h3 className="familiar-studio-lifecycle__heading">Recently removed</h3>
+          <p className="familiar-studio-lifecycle__hint">
+            Removed familiars keep their chats, memory, and files on disk. Restore re-registers one
+            exactly as it was — kept for 30 days.
+          </p>
+          {removedEntries.map((entry) => (
+            <div key={entry.id} className="familiar-studio-lifecycle__removed-row">
+              <span className="familiar-studio-lifecycle__removed-name">{entry.displayName}</span>
+              <span className="familiar-studio-lifecycle__removed-when">
+                removed {relativeTime(entry.removedAt)}
+              </span>
+              <button
+                type="button"
+                onClick={() => void restoreRemoved(entry)}
+                disabled={restoringId !== null}
+                className="familiar-studio-lifecycle__btn"
+              >
+                <Icon name="ph:arrow-counter-clockwise" width={12} />
+                {restoringId === entry.id ? "Restoring…" : "Restore"}
+              </button>
+            </div>
           ))}
         </section>
       ) : null}
@@ -180,6 +342,64 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
           </button>
         </section>
       ) : null}
+
+      {pendingRemove ? (
+        <UndoToast
+          key={pendingRemove.id}
+          message={<>Removed <strong>{pendingRemove.label}</strong></>}
+          undoAriaLabel={`Undo removing ${pendingRemove.label}`}
+          onUndo={undoRemove}
+          onDismiss={commitRemove}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// The destructive half of the remove flow: an inline confirm strip that spells
+// out detach semantics (what is cleared vs. what survives) before anything is
+// scheduled — required in-product copy for the safety constraints of removal.
+function RemoveConfirm({
+  familiar,
+  onConfirm,
+  onCancel,
+}: {
+  familiar: ResolvedFamiliar;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const sessions = familiar.active_sessions ?? 0;
+  return (
+    <div
+      className="familiar-studio-lifecycle__confirm"
+      role="group"
+      aria-label={`Confirm removing ${familiar.display_name}`}
+    >
+      <p className="familiar-studio-lifecycle__confirm-title">Remove {familiar.display_name}?</p>
+      <p className="familiar-studio-lifecycle__confirm-copy">
+        This detaches {familiar.display_name} from your Cave — its roster entry and agent binding
+        are cleared. The agent itself, past chats, and memory files stay on
+        your disk, and you can restore it from Recently removed.
+      </p>
+      {sessions > 0 ? (
+        <p className="familiar-studio-lifecycle__confirm-copy familiar-studio-lifecycle__confirm-warn">
+          {familiar.display_name} has {sessions} active session{sessions === 1 ? "" : "s"} — they keep
+          running until they finish.
+        </p>
+      ) : null}
+      <div className="familiar-studio-lifecycle__confirm-actions">
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="familiar-studio-lifecycle__btn familiar-studio-lifecycle__btn--danger familiar-studio-lifecycle__btn--confirm"
+        >
+          <Icon name="ph:trash" width={14} />
+          Remove familiar
+        </button>
+        <button type="button" onClick={onCancel} className="familiar-studio-lifecycle__btn">
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }
@@ -193,6 +413,7 @@ function SortableFamiliarRow(props: {
   onSelect: () => void;
   onArchive: () => void;
   onUnarchive: () => void;
+  onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
 }) {
@@ -223,6 +444,7 @@ function FamiliarRow({
   onSelect,
   onArchive,
   onUnarchive,
+  onRemove,
   onMoveUp,
   onMoveDown,
   dragRef,
@@ -237,6 +459,7 @@ function FamiliarRow({
   onSelect: () => void;
   onArchive: () => void;
   onUnarchive: () => void;
+  onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
   dragRef?: (node: HTMLElement | null) => void;
@@ -286,14 +509,32 @@ function FamiliarRow({
         </>
       ) : null}
       {isArchived ? (
-        <button onClick={onUnarchive} aria-label="Unarchive" className="familiar-studio-lifecycle__row-action">
+        <button
+          onClick={onUnarchive}
+          aria-label={`Unarchive ${familiar.display_name}`}
+          title="Unarchive — return to the active roster"
+          className="familiar-studio-lifecycle__row-action"
+        >
           <Icon name="ph:arrow-counter-clockwise" width={12} />
         </button>
       ) : (
-        <button onClick={onArchive} aria-label="Archive" className="familiar-studio-lifecycle__row-action">
+        <button
+          onClick={onArchive}
+          aria-label={`Archive ${familiar.display_name}`}
+          title="Archive — hide from switchers; stays bound, unarchive anytime"
+          className="familiar-studio-lifecycle__row-action"
+        >
           <Icon name="ph:archive" width={12} />
         </button>
       )}
+      <button
+        onClick={onRemove}
+        aria-label={`Remove ${familiar.display_name}`}
+        title="Remove — detach from your Cave (undo-safe); chats and memory stay on disk"
+        className="familiar-studio-lifecycle__row-action familiar-studio-lifecycle__row-action--danger"
+      >
+        <Icon name="ph:trash" width={12} />
+      </button>
     </div>
   );
 }

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -939,6 +939,7 @@ function FamiliarsSection({
         familiars={rawFamiliars}
         resolved={familiars}
         onSummon={() => setCreateOpen(true)}
+        onRosterChanged={() => void load()}
       />
       {createDialog}
     </>

--- a/src/lib/familiar-removal.test.ts
+++ b/src/lib/familiar-removal.test.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+const {
+  removeFamiliarBlockFromToml,
+  displayNameFromTomlBlock,
+  pruneTombstones,
+  normalizeTombstones,
+  TOMBSTONE_MAX_ENTRIES,
+} = await import("./familiar-removal.ts");
+
+const HEADER = "# User familiars for this Coven.\n";
+const block = (id, name) =>
+  `[[familiar]]\nid = "${id}"\ndisplay_name = "${name}"\nrole = "Familiar"\nharness = "codex"\nmodel = "gpt-5.2-codex"\n`;
+const THREE = `${HEADER}\n${block("ada", "Ada")}\n${block("bel", "Bel")}\n${block("cyra", "Cyra")}`;
+
+// Remove the middle block: neighbors and the header survive byte-for-byte order.
+{
+  const { toml, removed } = removeFamiliarBlockFromToml(THREE, "bel");
+  assert.match(removed, /^\[\[familiar\]\]/);
+  assert.match(removed, /id = "bel"/);
+  assert.match(removed, /display_name = "Bel"/);
+  assert.doesNotMatch(toml, /"bel"/);
+  assert.match(toml, /id = "ada"/);
+  assert.match(toml, /id = "cyra"/);
+  assert.ok(toml.startsWith(HEADER), "header comment survives");
+  assert.ok(toml.endsWith("\n"), "document keeps its trailing newline");
+  assert.doesNotMatch(toml, /\n{3,}/, "no widening gap at the seam");
+}
+
+// Remove the first and last blocks.
+{
+  const first = removeFamiliarBlockFromToml(THREE, "ada");
+  assert.match(first.removed, /id = "ada"/);
+  assert.doesNotMatch(first.toml, /"ada"/);
+  assert.match(first.toml, /id = "bel"/);
+
+  const last = removeFamiliarBlockFromToml(THREE, "cyra");
+  assert.match(last.removed, /id = "cyra"/);
+  assert.doesNotMatch(last.toml, /"cyra"/);
+  assert.match(last.toml, /id = "bel"/);
+  assert.ok(last.toml.endsWith("\n"));
+}
+
+// Removing the sole familiar leaves the header, no dangling block.
+{
+  const { toml, removed } = removeFamiliarBlockFromToml(`${HEADER}\n${block("ada", "Ada")}`, "ada");
+  assert.match(removed, /id = "ada"/);
+  assert.doesNotMatch(toml, /\[\[familiar\]\]/);
+  assert.ok(toml.startsWith("# User familiars"), "header survives a full clear-out");
+}
+
+// Unknown id: untouched document, null removal.
+{
+  const { toml, removed } = removeFamiliarBlockFromToml(THREE, "nobody");
+  assert.equal(removed, null);
+  assert.equal(toml, THREE);
+}
+
+// An unrelated `[table]` after the target block must survive the cut — the
+// block ends at the NEXT header of any kind, not just `[[familiar]]`.
+{
+  const doc = `${HEADER}\n[[familiar]]\nid = "ada"\n\n[other.section]\nkey = "v"\n`;
+  const { toml, removed } = removeFamiliarBlockFromToml(doc, "ada");
+  assert.match(removed, /id = "ada"/);
+  assert.doesNotMatch(removed, /other\.section/);
+  assert.match(toml, /\[other\.section\]/);
+  assert.match(toml, /key = "v"/);
+}
+
+// Round-trip: re-appending the removed block registers the id again (the
+// restore route's append path).
+{
+  const cut = removeFamiliarBlockFromToml(THREE, "bel");
+  const restored = `${cut.toml}\n${cut.removed}\n`;
+  const again = removeFamiliarBlockFromToml(restored, "bel");
+  assert.match(again.removed, /display_name = "Bel"/, "restored block is removable again");
+  assert.match(again.toml, /id = "ada"/);
+  assert.match(again.toml, /id = "cyra"/);
+}
+
+// Display-name extraction, including escaped quotes; absent → null.
+{
+  assert.equal(displayNameFromTomlBlock(block("ada", "Ada")), "Ada");
+  assert.equal(
+    displayNameFromTomlBlock('[[familiar]]\nid = "x"\ndisplay_name = "The \\"Best\\""\n'),
+    'The "Best"',
+  );
+  assert.equal(displayNameFromTomlBlock('[[familiar]]\nid = "x"\n'), null);
+}
+
+// Tombstone pruning: age out past the window, cap the list, newest first.
+{
+  const now = Date.parse("2026-07-09T12:00:00.000Z");
+  const day = 24 * 60 * 60 * 1000;
+  const entry = (id, daysAgo) => ({
+    id,
+    displayName: id,
+    removedAt: new Date(now - daysAgo * day).toISOString(),
+    tomlBlock: null,
+    binding: null,
+  });
+
+  const pruned = pruneTombstones([entry("old", 31), entry("young", 1), entry("mid", 10)], now);
+  assert.deepEqual(pruned.map((e) => e.id), ["young", "mid"], "31-day-old entry ages out, newest first");
+
+  const many = Array.from({ length: TOMBSTONE_MAX_ENTRIES + 5 }, (_, i) => entry(`f${i}`, i / 100));
+  assert.equal(pruneTombstones(many, now).length, TOMBSTONE_MAX_ENTRIES, "list caps at the max");
+
+  const bad = pruneTombstones([{ ...entry("x", 1), removedAt: "not-a-date" }], now);
+  assert.equal(bad.length, 0, "unparseable timestamps drop");
+}
+
+// Store-file normalization tolerates junk shapes and defaults displayName.
+{
+  const parsed = normalizeTombstones({
+    entries: [
+      { id: "ada", removedAt: "2026-07-09T00:00:00.000Z", tomlBlock: 42, binding: [] },
+      { id: "", removedAt: "2026-07-09T00:00:00.000Z" },
+      { removedAt: "2026-07-09T00:00:00.000Z" },
+      "garbage",
+      { id: "bel", removedAt: "2026-07-09T00:00:00.000Z", displayName: "Bel", binding: { harness: "openclaw" } },
+    ],
+  });
+  assert.equal(parsed.length, 2);
+  assert.equal(parsed[0].displayName, "ada", "displayName defaults to the id");
+  assert.equal(parsed[0].tomlBlock, null, "non-string block coerces to null");
+  assert.equal(parsed[0].binding, null, "array binding coerces to null");
+  assert.deepEqual(parsed[1].binding, { harness: "openclaw" });
+  assert.deepEqual(normalizeTombstones(null), []);
+  assert.deepEqual(normalizeTombstones({ entries: "nope" }), []);
+}
+
+console.log("familiar-removal.test.ts OK");

--- a/src/lib/familiar-removal.ts
+++ b/src/lib/familiar-removal.ts
@@ -1,0 +1,119 @@
+/**
+ * Familiar removal — the detach half of the dual-track lifecycle (Archive, in
+ * cave-familiar-archive.ts, is the hide half). Pure helpers shared by the
+ * DELETE /api/familiars/[id] and /api/familiars/removed routes: `[[familiar]]`
+ * block surgery on familiars.toml, plus tombstone bookkeeping for the
+ * undo/restore path. No filesystem access here — the on-disk store lives in
+ * src/lib/server/familiar-tombstones.ts.
+ */
+
+export type RemovedFamiliarTombstone = {
+  id: string;
+  /** Roster label at removal time — drives "Recently removed" copy. */
+  displayName: string;
+  /** ISO timestamp of the removal. */
+  removedAt: string;
+  /** Verbatim `[[familiar]]` block removed from familiars.toml (null when the
+   *  familiar only existed as a cave-config binding). Restore re-appends it. */
+  tomlBlock: string | null;
+  /** The cave-config.json binding entry at removal time. */
+  binding: Record<string, unknown> | null;
+};
+
+/** Tombstones stay restorable for 30 days, capped at 20 entries (newest win). */
+export const TOMBSTONE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+export const TOMBSTONE_MAX_ENTRIES = 20;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Remove the `[[familiar]]` block whose `id` matches from a familiars.toml
+ * document. Returns the new document plus the removed block verbatim (trimmed)
+ * so callers can tombstone it; `removed` is null (and the document unchanged)
+ * when no block matches.
+ */
+export function removeFamiliarBlockFromToml(
+  toml: string,
+  id: string,
+): { toml: string; removed: string | null } {
+  const lines = toml.split("\n");
+  const idLine = new RegExp(`^\\s*id\\s*=\\s*"${escapeRegExp(id)}"\\s*$`);
+
+  for (let start = 0; start < lines.length; start++) {
+    if (!/^\s*\[\[familiar\]\]\s*$/.test(lines[start])) continue;
+    // A block runs to the next table header — another `[[familiar]]` OR an
+    // unrelated `[table]`, both of which must survive the cut — or EOF. Blank
+    // lines in between travel with the block so the survivors don't accumulate
+    // a widening gap.
+    let end = start + 1;
+    while (end < lines.length && !/^\s*\[/.test(lines[end])) end++;
+    const block = lines.slice(start, end);
+    if (!block.some((line) => idLine.test(line))) {
+      start = end - 1; // skip past the scanned block
+      continue;
+    }
+
+    const removed = block.join("\n").trim();
+    const rest = [...lines.slice(0, start), ...lines.slice(end)];
+    // Drop blank lines left dangling at EOF (loop, not /\n+$/ — anchored
+    // quantifier replaces have burned us in CodeQL polynomial-ReDoS review).
+    while (rest.length > 0 && rest[rest.length - 1].trim() === "") rest.pop();
+    let next = rest.join("\n");
+    if (next && !next.endsWith("\n")) next += "\n";
+    return { toml: next, removed };
+  }
+
+  return { toml, removed: null };
+}
+
+/** Best-effort `display_name` out of a `[[familiar]]` block, for toast copy. */
+export function displayNameFromTomlBlock(block: string): string | null {
+  const match = /^\s*display_name\s*=\s*"((?:[^"\\]|\\.)*)"\s*$/m.exec(block);
+  if (!match) return null;
+  const unescaped = match[1].replace(/\\(["\\])/g, "$1");
+  return unescaped || null;
+}
+
+/** Age out tombstones past the restore window and cap the list, newest first. */
+export function pruneTombstones(
+  entries: RemovedFamiliarTombstone[],
+  nowMs: number,
+): RemovedFamiliarTombstone[] {
+  const fresh = entries.filter((entry) => {
+    const removed = Date.parse(entry.removedAt);
+    return Number.isFinite(removed) && nowMs - removed <= TOMBSTONE_MAX_AGE_MS;
+  });
+  fresh.sort((a, b) => Date.parse(b.removedAt) - Date.parse(a.removedAt));
+  return fresh.slice(0, TOMBSTONE_MAX_ENTRIES);
+}
+
+/** Parse an untrusted store file value into well-formed tombstones. */
+export function normalizeTombstones(value: unknown): RemovedFamiliarTombstone[] {
+  const list =
+    value && typeof value === "object" && Array.isArray((value as { entries?: unknown }).entries)
+      ? ((value as { entries: unknown[] }).entries)
+      : [];
+  const out: RemovedFamiliarTombstone[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== "object") continue;
+    const entry = item as Record<string, unknown>;
+    if (typeof entry.id !== "string" || entry.id === "") continue;
+    if (typeof entry.removedAt !== "string") continue;
+    out.push({
+      id: entry.id,
+      displayName:
+        typeof entry.displayName === "string" && entry.displayName !== ""
+          ? entry.displayName
+          : entry.id,
+      removedAt: entry.removedAt,
+      tomlBlock: typeof entry.tomlBlock === "string" ? entry.tomlBlock : null,
+      binding:
+        entry.binding && typeof entry.binding === "object" && !Array.isArray(entry.binding)
+          ? (entry.binding as Record<string, unknown>)
+          : null,
+    });
+  }
+  return out;
+}

--- a/src/lib/server/familiar-tombstones.ts
+++ b/src/lib/server/familiar-tombstones.ts
@@ -1,0 +1,57 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { writeJsonAtomic } from "./atomic-write";
+import {
+  normalizeTombstones,
+  pruneTombstones,
+  type RemovedFamiliarTombstone,
+} from "@/lib/familiar-removal";
+
+/**
+ * ~/.coven/cave-removed-familiars.json — tombstones for removed familiars.
+ * DELETE /api/familiars/[id] snapshots an entry here BEFORE mutating
+ * familiars.toml / cave-config.json; POST /api/familiars/removed restores
+ * from it, and the roster GET hides tombstoned ids until the daemon has
+ * re-read familiars.toml.
+ */
+function storePath(): string {
+  return path.join(homedir(), ".coven", "cave-removed-familiars.json");
+}
+
+export async function readTombstones(now = Date.now()): Promise<RemovedFamiliarTombstone[]> {
+  let raw: string;
+  try {
+    raw = await readFile(storePath(), "utf8");
+  } catch {
+    return []; // absent — nothing removed yet
+  }
+  try {
+    return pruneTombstones(normalizeTombstones(JSON.parse(raw)), now);
+  } catch {
+    return []; // corrupt store reads as empty; the next write repairs it
+  }
+}
+
+async function writeTombstones(entries: RemovedFamiliarTombstone[]): Promise<void> {
+  await mkdir(path.dirname(storePath()), { recursive: true });
+  await writeJsonAtomic(storePath(), { entries });
+}
+
+export async function addTombstone(entry: RemovedFamiliarTombstone): Promise<void> {
+  const rest = (await readTombstones()).filter((existing) => existing.id !== entry.id);
+  await writeTombstones(pruneTombstones([entry, ...rest], Date.now()));
+}
+
+/** Remove and return the tombstone for `id`, or null when none exists. */
+export async function takeTombstone(id: string): Promise<RemovedFamiliarTombstone | null> {
+  const entries = await readTombstones();
+  const entry = entries.find((existing) => existing.id === id) ?? null;
+  if (entry) await writeTombstones(entries.filter((existing) => existing.id !== id));
+  return entry;
+}
+
+/** Ids the roster GET must hide until the daemon re-reads familiars.toml. */
+export async function removedFamiliarIds(): Promise<Set<string>> {
+  return new Set((await readTombstones()).map((entry) => entry.id));
+}


### PR DESCRIPTION
## Problem

Source feedback: **"Mac OS: Cannot Remove Familiars"** (Chris Thomas, 2026-06-25). A familiar bound to the wrong OpenClaw agent instance could only be **archived** — but archive is a client-side hide (`cave:familiar-archive:v1`) that never touches `familiars.toml`, so the mistaken binding stayed registered with the daemon forever. There was no delete path at all.

## Lifecycle model (decided on bead cave-ykwk)

**Dual-track:** Archive stays the reversible hide; **Remove** is a new undo-safe detach for mistaken bindings.

| | Archive | Remove |
|---|---|---|
| What it does | Hides from switchers, stays bound | Strips the `[[familiar]]` TOML block + drops the cave-config binding |
| Reversal | Unarchive, anytime | Undo toast (⌘Z, 4s) before anything is sent; then **Recently removed** shelf restores exactly-as-was for 30 days |
| Never touched | — | Upstream OpenClaw agent, chats/sessions, workspace files (SOUL.md, memory, avatars) |

## Safety mechanics

- **Tombstone-before-mutate**: `DELETE /api/familiars/[id]` snapshots the TOML block + binding into `~/.coven/cave-removed-familiars.json` *before* mutating either file (pinned by test).
- **Daemon-cache gap closed**: the roster GET filters tombstoned ids (the daemon may not re-read `familiars.toml` immediately); POST create drops a reused id's tombstone so a re-created familiar isn't invisible.
- **Restore conflicts**: restoring an id that was re-created meanwhile returns 409 and keeps the tombstone (never clobbers the newcomer).
- **In-product copy**: the confirm strip spells out what is cleared vs. what survives, warns when the familiar has active sessions, and the tab header explains archive-vs-remove semantics. Announcer feedback on remove/restore/failure.
- Archive and Remove are independent stores — an archived familiar restores as archived.

## Verification

- `test:app` (595 files) ✓ · `test:api` ✓ · `tsc --noEmit` ✓ · `check:tests-wired` ✓ · api-contracts (157 routes incl. 2 new) ✓
- New behavioral tests: TOML block surgery (first/middle/last/sole/unknown id, unrelated `[table]` survives, round-trip), tombstone prune/normalize.
- Route handlers exercised end-to-end under a fake `$HOME`: 403/404 guards, remove strips both stores w/ snapshot, restore round-trip, double-restore 404, re-create conflict 409, create-drops-tombstone, binding-only familiars — all green.
- In-app (prod build + Playwright): Lifecycle tab renders trash actions on every row; confirm strip shows the safety copy; Cancel dismisses.

Closes bead `cave-ykwk` (openclaw-workboard 6687f992).

🤖 Generated with [Claude Code](https://claude.com/claude-code)