### PR TITLE
refactor(chat): slim the chat header to Find + kebab with compact project selection

### DIFF
--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -104,9 +104,10 @@ assert.doesNotMatch(
   "Standalone lifecycle status bar CSS is removed (folded into meta line)",
 );
 
-// In-chat delete lives ONLY in the header trash button now — it opens a confirm
-// popover, the explicit Delete commits via deleteChat, and success refreshes the
-// session list and navigates back. The overflow menu no longer carries delete.
+// In-chat delete lives ONLY in the session overflow (kebab) menu now — the
+// danger "Delete chat…" item swaps the menu body to a confirm view, the
+// explicit Delete commits via deleteChat, and success refreshes the session
+// list and navigates back. No standalone header trash button remains.
 assert.match(
   source,
   /const deleteChat = async[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(sessionId\)\}`, \{ method: "DELETE" \}\)/,
@@ -118,33 +119,48 @@ assert.match(
   "Successful delete refreshes sessions and navigates back to the list",
 );
 
-// A standalone delete (trash) button sits at the top of the session, beside the
-// overflow menu, opening a confirm popover before it commits via deleteChat.
+// The kebab's delete is a two-step guard: the danger item arms a confirm view
+// (Delete this chat permanently? / Cancel / Delete chat) inside the popover.
 assert.match(
   source,
-  /function HeaderDeleteButton[\s\S]*?aria-label="Delete chat"[\s\S]*?Delete this chat permanently\?[\s\S]*?disabled=\{deleting\} onSelect=\{\(\) => onDelete\(\)\}/,
-  "HeaderDeleteButton renders a guarded trash trigger that confirms before deleting",
+  /function SessionOverflowMenu[\s\S]*?confirmingDelete \? \([\s\S]*?Delete this chat permanently\?[\s\S]*?disabled=\{deleting\} onSelect=\{\(\) => onDelete\(\)\}[\s\S]*?Delete chat…/,
+  "SessionOverflowMenu guards delete behind an in-popover confirm view",
 );
 assert.match(
   source,
-  /function HeaderDebugButton[\s\S]*?aria-label="Debug chat"[\s\S]*?<Icon name="ph:bug-bold"/,
-  "HeaderDebugButton renders a visible bug trigger for the debug panel",
+  /onSelect=\{\(\) => setConfirmingDelete\(true\)\}/,
+  "the danger Delete chat… item arms the confirm view instead of deleting outright",
 );
+// Closing the kebab disarms the confirm so it never reopens pre-armed.
 assert.match(
   source,
-  /<HeaderDebugButton onOpenDebug=\{openDebug\} \/>[\s\S]*?<HeaderDeleteButton key=\{sessionId\} onDelete=\{\(\) => void deleteChat\(\)\} deleting=\{deleting\} \/>/,
-  "the chat header mounts the visible debug bug immediately before the standalone delete button",
+  /const close = \(\) => \{\s*setOpen\(false\);\s*setConfirmingDelete\(false\);\s*\};/,
+  "closing the overflow menu resets the armed delete confirm",
 );
-// The overflow (kebab) menu no longer offers delete — it's header-only.
+// The standalone header debug/delete buttons are gone — the header's only
+// always-visible controls are Find and the kebab.
+assert.doesNotMatch(
+  source,
+  /function HeaderDebugButton|function HeaderDeleteButton|function HeaderThinkingToggle|function HeaderReflectButton/,
+  "the standalone header icon buttons are folded into the overflow menu",
+);
 assert.doesNotMatch(
   source,
   /onConfirmDeleteChange/,
-  "the overflow menu's two-step delete wiring is removed",
+  "the old overflow two-step delete wiring stays removed",
+);
+
+// Project selection is one compact row in the kebab that opens the shared
+// searchable ProjectPickerPopover — not an inline list of every project.
+assert.match(
+  source,
+  /function SessionOverflowMenu[\s\S]*?Project: \{activeProject \? activeProject\.name : "No project"\}[\s\S]*?<ProjectPickerPopover/,
+  "the kebab shows a single Project row that opens the shared picker popover",
 );
 assert.doesNotMatch(
   source,
-  /Confirm delete/,
-  "no 'Confirm delete' item remains in the overflow menu",
+  /projects\.map\(\(entry\) => \(\s*<PopoverItem/,
+  "the kebab no longer inlines the full project list",
 );
 
 // ── Collapsed tool rows show a one-line arg summary (CHAT-D4-02) ─────────────

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -92,8 +92,8 @@ assert.match(
 );
 assert.match(
   source,
-  /function HeaderThinkingToggle[\s\S]*useShowThinking\(\)[\s\S]*aria-pressed=\{showThinking\}/,
-  "A header toggle flips the global Show-thinking preference",
+  /function SessionOverflowMenu[\s\S]*useShowThinking\(\)[\s\S]*checked=\{showThinking\}[\s\S]*\{showThinking \? "Hide thinking" : "Show thinking"\}/,
+  "The session overflow menu carries the global Show-thinking toggle",
 );
 
 assert.match(
@@ -501,10 +501,13 @@ assert.match(
   "Open chat header should be compressed for a streamlined session UI",
 );
 
-assert.match(
+// The standalone header icon buttons (thinking/debug/reflect/delete) are gone —
+// their chrome went with them; the kebab and find affordance are the only
+// always-visible session actions.
+assert.doesNotMatch(
   styles,
-  /\.cave-chat-icon-button\s*\{[\s\S]*border:\s*1px solid transparent;[\s\S]*background:\s*transparent;/,
-  "Open chat header icon buttons should be chromeless until hover/focus",
+  /\.cave-chat-icon-button/,
+  "Dead standalone icon-button chrome is removed with the buttons",
 );
 
 // Ultra-minimal header: at rest only the ⋮ kebab shows; the quick actions

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -60,16 +60,16 @@ assert.match(
 
 assert.match(
   source,
-  /HeaderReflectButton[\s\S]*Reflect on this thread[\s\S]*ph:sparkle-bold/,
-  "ChatView should expose a Reflect action in the chat header",
+  /Reflect on this thread[\s\S]{0,600}ph:phone/,
+  "ChatView should expose a Reflect action in the session overflow menu",
 );
 // Reflect must not reuse the thinking toggle's brain — two identical brains
-// in one header row made the actions indistinguishable. Sparkle matches the
-// daily note's Reflection section where reflections land.
-assert.doesNotMatch(
+// in one menu made the actions indistinguishable. Sparkle matches the daily
+// note's Reflection section where reflections land.
+assert.match(
   source,
-  /function HeaderReflectButton[\s\S]{0,900}ph:brain/,
-  "the Reflect header button must stay visually distinct from the thinking toggle's brain",
+  /reflecting \? "ph:circle-notch-bold" : "ph:sparkle-bold"/,
+  "the Reflect action keeps its sparkle (spinner while reflecting), distinct from the thinking brain",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -119,7 +119,7 @@ import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
 import { SaveTemplateModal } from "@/components/save-template-modal";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
-import { ProjectPicker, useAddProjectFlow } from "@/components/project-picker";
+import { ProjectPickerPopover, useAddProjectFlow } from "@/components/project-picker";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolVisual } from "@/lib/tool-visual";
 import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
@@ -791,11 +791,14 @@ function splitReasoning(text: string): { visible: string; reasoning: string } {
 // view arms/executes its "Start a task" card-follows-chat flow (see
 // handleEvent's "session" case).
 
-/** Codex/ChatGPT-style overflow menu. Collapses the session's secondary
- *  controls — project switch, voice call, debug — into a single kebab so the
- *  header reads as title + quiet metadata instead of a row of competing icons.
- *  Find and Delete stay inline (one-click); everything else lives one click away
- *  here. */
+/** Codex/ChatGPT-style overflow menu. Collapses ALL of the session's secondary
+ *  controls — project selection, thinking toggle, reflect, voice call, debug,
+ *  delete — into a single kebab so the header reads as title + quiet metadata
+ *  plus Find, instead of a row of competing icons. Project selection is one
+ *  compact "Project: <name>" row that opens the shared searchable picker
+ *  (anchored to the same kebab trigger), not an inline list of every project.
+ *  Delete keeps its two-step guard: the danger item swaps the menu body to a
+ *  confirm view before anything commits. */
 function SessionOverflowMenu({
   projects,
   projectId,
@@ -803,9 +806,14 @@ function SessionOverflowMenu({
   onAddProject,
   familiar,
   sessionId,
+  hasTurns,
   voiceActive,
   onOpenVoice,
   onOpenDebug,
+  reflecting,
+  onReflect,
+  deleting,
+  onDelete,
 }: {
   projects: CaveProject[];
   projectId: string | null;
@@ -815,11 +823,21 @@ function SessionOverflowMenu({
   familiar: Familiar;
   /** Active conversation id — powers "Continue on phone" (cave-i74f). */
   sessionId?: string | null;
+  /** Gates the Show-thinking toggle — pointless on an empty transcript. */
+  hasTurns: boolean;
   voiceActive: boolean;
   onOpenVoice: () => void;
   onOpenDebug: () => void;
+  /** Reflect-on-thread (absent when the familiar has no id). */
+  reflecting: boolean;
+  onReflect?: () => void;
+  deleting: boolean;
+  onDelete: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [showThinking, setShowThinking] = useShowThinking();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const activeProject =
     projectId === NO_PROJECT_ID
@@ -827,7 +845,10 @@ function SessionOverflowMenu({
       : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
   const voiceConfigured = Boolean(familiar.voiceProvider);
 
-  const close = () => setOpen(false);
+  const close = () => {
+    setOpen(false);
+    setConfirmingDelete(false);
+  };
 
   return (
     <>
@@ -839,7 +860,7 @@ function SessionOverflowMenu({
         aria-haspopup="menu"
         aria-expanded={open}
         title="Session options"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => (open ? close() : setOpen(true))}
       >
         <Icon name="ph:dots-three-vertical" width={15} aria-hidden />
       </button>
@@ -851,208 +872,121 @@ function SessionOverflowMenu({
         minWidth={216}
         ariaLabel="Chat options"
       >
-        <PopoverBody>
-          {sessionId ? (
+        {confirmingDelete ? (
+          <PopoverBody>
+            <PopoverLabel>Delete this chat permanently?</PopoverLabel>
+            <PopoverItem icon="ph:x" onSelect={() => setConfirmingDelete(false)}>
+              Cancel
+            </PopoverItem>
+            <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
+              {deleting ? "Deleting…" : "Delete chat"}
+            </PopoverItem>
+          </PopoverBody>
+        ) : (
+          <PopoverBody>
+            {sessionId ? (
+              <PopoverItem
+                icon="ph:device-mobile"
+                onSelect={() => {
+                  close();
+                  // Golden path 5: hand off the MOMENT — the pairing modal's QR
+                  // carries #chat-<id> so one scan opens this conversation.
+                  window.dispatchEvent(
+                    new CustomEvent("cave:continue-on-phone", { detail: { chatId: sessionId } }),
+                  );
+                }}
+              >
+                Continue on phone
+              </PopoverItem>
+            ) : null}
             <PopoverItem
-              icon="ph:device-mobile"
+              icon="ph:pencil-simple"
               onSelect={() => {
+                window.dispatchEvent(new Event("cave:chat-rename"));
                 close();
-                // Golden path 5: hand off the MOMENT — the pairing modal's QR
-                // carries #chat-<id> so one scan opens this conversation.
-                window.dispatchEvent(
-                  new CustomEvent("cave:continue-on-phone", { detail: { chatId: sessionId } }),
-                );
               }}
             >
-              Continue on phone
+              Rename chat
             </PopoverItem>
-          ) : null}
-          <PopoverItem
-            icon="ph:pencil-simple"
-            onSelect={() => {
-              window.dispatchEvent(new Event("cave:chat-rename"));
-              close();
-            }}
-          >
-            Rename chat
-          </PopoverItem>
-          <PopoverSeparator />
-          {projects.length > 0 || onAddProject ? (
-            <>
-              <PopoverLabel>Project</PopoverLabel>
-              {projects.length > 0 ? (
-                <>
-                  <PopoverItem
-                    icon={activeProject ? "ph:folder" : "ph:check"}
-                    active={!activeProject}
-                    onSelect={() => {
-                      onProjectChange(NO_PROJECT_ID);
-                      close();
-                    }}
-                  >
-                    No project
-                  </PopoverItem>
-                  {projects.map((entry) => (
-                    <PopoverItem
-                      key={entry.id}
-                      icon={entry.id === activeProject?.id ? "ph:check" : "ph:folder"}
-                      active={entry.id === activeProject?.id}
-                      onSelect={() => {
-                        onProjectChange(entry.id);
-                        close();
-                      }}
-                    >
-                      {entry.name}
-                    </PopoverItem>
-                  ))}
-                </>
-              ) : null}
-              {onAddProject ? (
-                <PopoverItem
-                  icon="ph:plus"
-                  onSelect={() => {
-                    onAddProject();
-                    close();
-                  }}
-                >
-                  Add project…
-                </PopoverItem>
-              ) : null}
-              <PopoverSeparator />
-            </>
-          ) : null}
-          <PopoverItem
-            icon="ph:phone"
-            disabled={!voiceConfigured || voiceActive}
-            onSelect={() => {
-              onOpenVoice();
-              close();
-            }}
-          >
-            {voiceConfigured ? `Call ${familiar.display_name}` : "Voice — set up in Studio"}
-          </PopoverItem>
-          <PopoverItem
-            icon="ph:bug-bold"
-            onSelect={() => {
-              onOpenDebug();
-              close();
-            }}
-          >
-            Debug session
-          </PopoverItem>
-        </PopoverBody>
+            {projects.length > 0 || onAddProject ? (
+              <PopoverItem
+                icon="ph:folder"
+                title={activeProject?.root ?? "No project"}
+                onSelect={() => {
+                  // Chain popovers: the kebab closes on this click; the picker
+                  // mounts after it, so its outside-click listener misses the
+                  // same mousedown and it stays open on the shared anchor.
+                  close();
+                  setProjectPickerOpen(true);
+                }}
+              >
+                Project: {activeProject ? activeProject.name : "No project"}
+              </PopoverItem>
+            ) : null}
+            <PopoverSeparator />
+            {hasTurns ? (
+              <PopoverItem
+                icon={showThinking ? "ph:brain-bold" : "ph:brain"}
+                checked={showThinking}
+                title={showThinking ? "Hide reasoning blocks" : "Show reasoning blocks"}
+                onSelect={() => {
+                  setShowThinking(!showThinking);
+                  close();
+                }}
+              >
+                {showThinking ? "Hide thinking" : "Show thinking"}
+              </PopoverItem>
+            ) : null}
+            {onReflect ? (
+              <PopoverItem
+                icon={reflecting ? "ph:circle-notch-bold" : "ph:sparkle-bold"}
+                disabled={reflecting}
+                onSelect={() => {
+                  close();
+                  onReflect();
+                }}
+              >
+                {reflecting ? "Reflecting…" : "Reflect on this thread"}
+              </PopoverItem>
+            ) : null}
+            <PopoverItem
+              icon="ph:phone"
+              disabled={!voiceConfigured || voiceActive}
+              onSelect={() => {
+                onOpenVoice();
+                close();
+              }}
+            >
+              {voiceConfigured ? `Call ${familiar.display_name}` : "Voice — set up in Studio"}
+            </PopoverItem>
+            <PopoverItem
+              icon="ph:bug-bold"
+              onSelect={() => {
+                onOpenDebug();
+                close();
+              }}
+            >
+              Debug session
+            </PopoverItem>
+            <PopoverSeparator />
+            <PopoverItem icon="ph:trash" danger onSelect={() => setConfirmingDelete(true)}>
+              Delete chat…
+            </PopoverItem>
+          </PopoverBody>
+        )}
       </Popover>
-    </>
-  );
-}
-
-/** Header toggle for the global "Show thinking" preference — flips every
- *  reasoning disclosure in the transcript open/closed at once. */
-function HeaderThinkingToggle() {
-  const [showThinking, setShowThinking] = useShowThinking();
-  return (
-    <button
-      type="button"
-      className={`focus-ring cave-chat-icon-button${showThinking ? " cave-chat-icon-button--active" : ""}`}
-      aria-label={showThinking ? "Hide thinking" : "Show thinking"}
-      aria-pressed={showThinking}
-      title={showThinking ? "Hide reasoning blocks" : "Show reasoning blocks"}
-      onClick={() => setShowThinking(!showThinking)}
-    >
-      <Icon name={showThinking ? "ph:brain-bold" : "ph:brain"} width={15} aria-hidden />
-    </button>
-  );
-}
-
-function HeaderDebugButton({ onOpenDebug }: { onOpenDebug: () => void }) {
-  return (
-    <button
-      type="button"
-      className="focus-ring cave-chat-icon-button"
-      aria-label="Debug chat"
-      title="Debug chat"
-      onClick={onOpenDebug}
-    >
-      <Icon name="ph:bug-bold" width={15} aria-hidden />
-    </button>
-  );
-}
-
-function HeaderReflectButton({
-  reflecting,
-  onReflect,
-}: {
-  reflecting: boolean;
-  onReflect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      className="focus-ring cave-chat-icon-button"
-      aria-label="Reflect on this thread"
-      title="Reflect on this thread"
-      disabled={reflecting}
-      onClick={onReflect}
-    >
-      {/* Sparkle, not brain: reflections land in the daily note's Reflection
-          section (iconed ph:sparkle), and the brain belongs to the thinking
-          toggle two buttons away — two identical brains in one header row. */}
-      <Icon
-        name={reflecting ? "ph:circle-notch-bold" : "ph:sparkle-bold"}
-        width={15}
-        className={reflecting ? "animate-spin" : undefined}
-        aria-hidden
-      />
-    </button>
-  );
-}
-
-/** Standalone delete control for the chat header — a one-click trash button that
- *  opens a small confirm popover before committing. Mirrors the overflow menu's
- *  two-step guard, but surfaced at the top of the session for quick access. Uses
- *  its own open state so it never collides with the kebab's armed state; the
- *  in-flight `deleting` flag and the actual delete are shared via props. */
-function HeaderDeleteButton({
-  onDelete,
-  deleting,
-}: {
-  onDelete: () => void;
-  deleting: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="focus-ring cave-chat-delete-trigger"
-        aria-label="Delete chat"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title="Delete chat"
-        onClick={() => setOpen((v) => !v)}
-      >
-        <Icon name="ph:trash" width={15} aria-hidden />
-      </button>
-      <Popover
-        open={open}
-        onOpenChange={setOpen}
+      <ProjectPickerPopover
+        open={projectPickerOpen}
+        onOpenChange={setProjectPickerOpen}
         anchorRef={triggerRef}
+        projects={projects}
+        value={projectId}
+        onChange={onProjectChange}
+        allowNoProject
+        onAddProject={onAddProject}
         placement="bottom-end"
-        minWidth={216}
-        ariaLabel="Delete chat"
-      >
-        <PopoverBody>
-          <PopoverLabel>Delete this chat permanently?</PopoverLabel>
-          <PopoverItem icon="ph:x" onSelect={() => setOpen(false)}>
-            Cancel
-          </PopoverItem>
-          <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
-            {deleting ? "Deleting…" : "Delete chat"}
-          </PopoverItem>
-        </PopoverBody>
-      </Popover>
+        ariaLabel="Project for this chat"
+      />
     </>
   );
 }
@@ -2284,7 +2218,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Two-step delete via the header trash button: it opens a confirm popover and
   // only the explicit Delete commits (HeaderDeleteButton owns the armed state).
   const [deleting, setDeleting] = useState(false);
-  const { projects, createProject, reload: reloadProjects } = useProjects();
+  // Scope the picker to the projects THIS familiar has been granted access to —
+  // the chat-send route enforces the same grant (assertProjectAccess → 403), so
+  // an unscoped list would offer projects that fail on send.
+  const { projects, createProject, reload: reloadProjects } = useProjects({ familiarId: familiar.id });
   const firstProject = projects[0] ?? null;
   const [projectIdDraft, setProjectIdDraft] = useState<string | null>(null);
   // A session whose recorded cwd maps to no registered project resolves to
@@ -4807,30 +4744,26 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onPrev={findPrev}
               />
             ) : null}
-            {turns.length > 0 ? <HeaderThinkingToggle /> : null}
-            {sessionId && (
-              <HeaderDebugButton onOpenDebug={openDebug} />
-            )}
-            {sessionId && (
-              <HeaderDeleteButton key={sessionId} onDelete={() => void deleteChat()} deleting={deleting} />
-            )}
             {sessionId && (
               <SessionOverflowMenu
+                key={sessionId}
                 projects={projects}
                 projectId={projectIdDraft}
                 onProjectChange={setProjectIdDraft}
                 onAddProject={overflowAddProject.beginAddProject}
                 familiar={familiar}
                 sessionId={sessionId}
+                hasTurns={turns.length > 0}
                 voiceActive={voiceCallOpen}
                 onOpenVoice={() => setVoiceCallOpen(true)}
                 onOpenDebug={openDebug}
+                reflecting={reflecting}
+                onReflect={familiar.id ? () => void reflectOnThread() : undefined}
+                deleting={deleting}
+                onDelete={() => void deleteChat()}
               />
             )}
             {overflowAddProject.addProjectModal}
-            {sessionId && familiar.id ? (
-              <HeaderReflectButton reflecting={reflecting} onReflect={() => void reflectOnThread()} />
-            ) : null}
             {!hasLinkedChips ? linkedContextRow : null}
           </div>
         </MetaLine>

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -91,6 +91,142 @@ export function useAddProjectFlow(args: {
   return { beginAddProject, addProjectModal, adding, addError };
 }
 
+/** Resolve the effective selection: NO_PROJECT_ID → none; null → first project. */
+function selectedProject(value: string | null, sorted: CaveProject[]): CaveProject | null {
+  return value === NO_PROJECT_ID
+    ? null
+    : (value ? sorted.find((project) => project.id === value) ?? sorted[0] : sorted[0]) ?? null;
+}
+
+/**
+ * Controlled popover half of the shared project picker — the filterable list,
+ * No-project row, and optional Add-project row, anchored to any caller-owned
+ * trigger. ProjectPicker mounts it behind its chip; the chat session kebab
+ * anchors it to the kebab trigger so switching projects is one compact row
+ * instead of a full inline list.
+ */
+export function ProjectPickerPopover({
+  open,
+  onOpenChange,
+  anchorRef,
+  projects,
+  value,
+  onChange,
+  allowNoProject = false,
+  onAddProject,
+  addingProject = false,
+  placement = "bottom-start",
+  ariaLabel,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  projects: CaveProject[];
+  /** Project id, NO_PROJECT_ID, or null (null falls back to the first project). */
+  value: string | null;
+  onChange: (id: string) => void;
+  allowNoProject?: boolean;
+  /** Presence enables the "Add project…" row. */
+  onAddProject?: () => void;
+  addingProject?: boolean;
+  placement?: "bottom-start" | "bottom-end";
+  ariaLabel: string;
+}) {
+  const [query, setQuery] = useState("");
+  const sortedProjects = useMemo(() => sortProjectsAlphabetically(projects), [projects]);
+  const selected = selectedProject(value, sortedProjects);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sortedProjects;
+    return sortedProjects.filter(
+      (project) =>
+        project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q),
+    );
+  }, [sortedProjects, query]);
+
+  const close = () => {
+    onOpenChange(false);
+    setQuery("");
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+      anchorRef={anchorRef}
+      placement={placement}
+      minWidth={260}
+      className="cave-project-picker__popover"
+      ariaLabel={ariaLabel}
+    >
+      <PopoverBody>
+        {projects.length > 6 ? (
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter projects…"
+            aria-label="Filter projects"
+            className="cave-project-picker__filter focus-ring-inset"
+          />
+        ) : null}
+        <PopoverLabel>Project</PopoverLabel>
+        {allowNoProject ? (
+          <PopoverItem
+            icon="ph:folder"
+            checked={!selected}
+            active={!selected}
+            onSelect={() => {
+              onChange(NO_PROJECT_ID);
+              close();
+            }}
+          >
+            No project
+          </PopoverItem>
+        ) : null}
+        {visible.map((entry) => (
+          <PopoverItem
+            key={entry.id}
+            leading={
+              <ProjectAvatar name={entry.name} root={entry.root} color={entry.color} size="sm" />
+            }
+            checked={entry.id === selected?.id}
+            active={entry.id === selected?.id}
+            onSelect={() => {
+              onChange(entry.id);
+              close();
+            }}
+          >
+            <span className="cave-project-picker__option">
+              <span className="cave-project-picker__option-name">{entry.name}</span>
+              <span className="cave-project-picker__option-root">{entry.root}</span>
+            </span>
+          </PopoverItem>
+        ))}
+        {query.trim() && visible.length === 0 ? (
+          <div className="cave-project-picker__none">No projects match</div>
+        ) : null}
+        {onAddProject ? (
+          <>
+            <PopoverSeparator />
+            <PopoverItem
+              icon="ph:plus"
+              disabled={addingProject}
+              onSelect={() => {
+                close();
+                onAddProject();
+              }}
+            >
+              {addingProject ? "Adding project…" : "Add project…"}
+            </PopoverItem>
+          </>
+        ) : null}
+      </PopoverBody>
+    </Popover>
+  );
+}
+
 /**
  * Shared project picker: one trigger chip + popover for every surface that
  * lets the user choose the project a conversation runs in. Replaces the
@@ -122,29 +258,9 @@ export function ProjectPicker({
   className?: string;
 }) {
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const sortedProjects = useMemo(() => sortProjectsAlphabetically(projects), [projects]);
-
-  const selected =
-    value === NO_PROJECT_ID
-      ? null
-      : (value ? sortedProjects.find((project) => project.id === value) ?? sortedProjects[0] : sortedProjects[0]) ??
-        null;
-
-  const visible = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return sortedProjects;
-    return sortedProjects.filter(
-      (project) =>
-        project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q),
-    );
-  }, [sortedProjects, query]);
-
-  const close = () => {
-    setOpen(false);
-    setQuery("");
-  };
+  const selected = selectedProject(value, sortedProjects);
 
   const addFlow = useAddProjectFlow({
     familiarId,
@@ -159,7 +275,7 @@ export function ProjectPicker({
         ref={triggerRef}
         variant="ghost"
         className={`cave-project-picker__trigger focus-ring${className ? ` ${className}` : ""}`}
-        onClick={() => (open ? close() : setOpen(true))}
+        onClick={() => setOpen((v) => !v)}
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label={ariaLabel}
@@ -176,79 +292,18 @@ export function ProjectPicker({
         </span>
         <Icon name="ph:caret-up-down-bold" width={10} aria-hidden />
       </Button>
-      <Popover
+      <ProjectPickerPopover
         open={open}
-        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        onOpenChange={setOpen}
         anchorRef={triggerRef}
-        placement="bottom-start"
-        minWidth={260}
-        className="cave-project-picker__popover"
+        projects={projects}
+        value={value}
+        onChange={onChange}
+        allowNoProject={allowNoProject}
+        onAddProject={createProject ? addFlow.beginAddProject : undefined}
+        addingProject={addFlow.adding}
         ariaLabel={ariaLabel}
-      >
-        <PopoverBody>
-          {projects.length > 6 ? (
-            <input
-              type="text"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Filter projects…"
-              aria-label="Filter projects"
-              className="cave-project-picker__filter focus-ring-inset"
-            />
-          ) : null}
-          <PopoverLabel>Project</PopoverLabel>
-          {allowNoProject ? (
-            <PopoverItem
-              icon="ph:folder"
-              checked={!selected}
-              active={!selected}
-              onSelect={() => {
-                onChange(NO_PROJECT_ID);
-                close();
-              }}
-            >
-              No project
-            </PopoverItem>
-          ) : null}
-          {visible.map((entry) => (
-            <PopoverItem
-              key={entry.id}
-              leading={
-                <ProjectAvatar name={entry.name} root={entry.root} color={entry.color} size="sm" />
-              }
-              checked={entry.id === selected?.id}
-              active={entry.id === selected?.id}
-              onSelect={() => {
-                onChange(entry.id);
-                close();
-              }}
-            >
-              <span className="cave-project-picker__option">
-                <span className="cave-project-picker__option-name">{entry.name}</span>
-                <span className="cave-project-picker__option-root">{entry.root}</span>
-              </span>
-            </PopoverItem>
-          ))}
-          {query.trim() && visible.length === 0 ? (
-            <div className="cave-project-picker__none">No projects match</div>
-          ) : null}
-          {createProject ? (
-            <>
-              <PopoverSeparator />
-              <PopoverItem
-                icon="ph:plus"
-                disabled={addFlow.adding}
-                onSelect={() => {
-                  close();
-                  addFlow.beginAddProject();
-                }}
-              >
-                {addFlow.adding ? "Adding project…" : "Add project…"}
-              </PopoverItem>
-            </>
-          ) : null}
-        </PopoverBody>
-      </Popover>
+      />
       {addFlow.addError ? (
         <span className="cave-project-picker__error" role="alert">
           {addFlow.addError}

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -34,8 +34,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chatView,
-  /<PopoverLabel>Project<\/PopoverLabel>[\s\S]*?onProjectChange\(NO_PROJECT_ID\);[\s\S]*?No project[\s\S]*?projects\.map\(\(entry\) => \(/,
-  "The overflow menu offers an explicit No-project row so a workspace session can stay (or become) project-less",
+  /function SessionOverflowMenu[\s\S]*?<ProjectPickerPopover[\s\S]*?allowNoProject/,
+  "The overflow menu's picker offers an explicit No-project choice so a workspace session can stay (or become) project-less",
 );
 assert.match(
   chatView,
@@ -59,8 +59,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /function SessionOverflowMenu[\s\S]*projects\.map\(\(entry\) => \([\s\S]*onSelect=\{\(\) => \{\s*onProjectChange\(entry\.id\)/,
-  "Active chats expose project switching through the session overflow menu",
+  /function SessionOverflowMenu[\s\S]*<ProjectPickerPopover[\s\S]*value=\{projectId\}[\s\S]*onChange=\{onProjectChange\}/,
+  "Active chats expose project switching through the shared picker popover in the session overflow menu",
 );
 assert.match(
   chatView,

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2793,44 +2793,6 @@ details[open] > .cave-tool-summary::before {
   box-shadow: 0 0 0 2px color-mix(in oklch, currentColor 14%, transparent);
 }
 
-.cave-chat-icon-button {
-  display: inline-grid;
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  place-items: center;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-muted);
-  transition:
-    background var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
-}
-
-.cave-chat-icon-button:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--border-strong) 74%, transparent);
-  background: color-mix(in oklch, var(--bg-hover) 72%, transparent);
-  color: var(--text-primary);
-}
-
-.cave-chat-icon-button:disabled {
-  opacity: 0.45;
-}
-
-.cave-chat-icon-button--active {
-  border-color: color-mix(in oklch, var(--accent-presence) 45%, transparent);
-  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
-  color: var(--accent-presence);
-}
-
-.cave-chat-icon-button--active:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
-  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
-  color: var(--accent-presence);
-}
-
 .cave-chat-back-button {
   width: 24px;
   height: 24px;
@@ -3096,24 +3058,15 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-primary);
 }
 
-/* The header delete trigger reads as destructive on hover/open. */
-.cave-chat-session-actions > .cave-chat-delete-trigger:hover:not(:disabled),
-.cave-chat-session-actions > .cave-chat-delete-trigger[aria-expanded="true"] {
-  border-color: color-mix(in oklch, var(--color-danger) 55%, transparent);
-  background: color-mix(in oklch, var(--color-danger) 14%, transparent);
-  color: var(--color-danger);
-}
-
 .cave-chat-session-actions .voice-call-button:disabled {
   opacity: 0.45;
 }
 
 /* Ultra-minimal header (pointer devices): at rest only the ⋮ kebab and the
- * find affordance show; the quick actions (thinking, debug, delete, reflect)
- * and the lone "link a task" + reveal on header hover or keyboard focus. They
- * keep their layout slot (no reflow on reveal). Touch devices — which have no
- * hover — skip this and show everything. The kebab still holds every action,
- * so nothing becomes hover-only. */
+ * find affordance show; the lone "link a task" chip reveals on header hover or
+ * keyboard focus, keeping its layout slot (no reflow on reveal). Touch devices
+ * — which have no hover — skip this and show everything. The kebab holds every
+ * secondary action, so nothing becomes hover-only. */
 @media (hover: hover) and (pointer: fine) {
   .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find),
   .cave-chat-linked-context .cave-chat-linked-chip--link-task {


### PR DESCRIPTION
## What

Slims the open-chat header from seven competing controls down to **Find + the ⋮ kebab** (plus the hover-reveal "link a task" chip).

### Before
Find · thinking toggle · debug (duplicated in kebab) · delete · kebab (with a full inline list of every project) · reflect · link-task

### After
- **Find + kebab only** stay inline. Thinking toggle, reflect, debug, and delete all live in `SessionOverflowMenu`; delete keeps its two-step guard as an in-popover confirm view that disarms when the menu closes.
- **Project selection is one compact row** — `Project: <name>` — that opens the shared searchable picker anchored to the kebab trigger, replacing the inline list of every registered project.
- Extracted a controlled `ProjectPickerPopover` from `ProjectPicker` (public API unchanged; home composer and chat empty state untouched).
- Removed dead `.cave-chat-icon-button` / `.cave-chat-delete-trigger` CSS.

## Testing

- Updated source-shape tests: `chat-header-row`, `chat-view-polish`, `chat-view`, `task-chat-cwd`; `project-picker` + `chat-surface-polish` pass unchanged.
- `tsc --noEmit` clean; full `pnpm test:app` green (594 test files).
- No e2e selectors reference the removed controls.

Out of scope: mobile header, MetaLine, empty-state/home-composer pickers.