### PR TITLE
chore(release): stamp v0.0.171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.171] - 2026-07-09
+
+> 🧹 **Tidier familiars, leaner chat header** — removing a familiar is now undo-safe (a distinct track from Archive), and the chat header slims to Find + a kebab with compact project selection.
+
+Patch release on top of v0.0.170.
+
+### Features
+- **Familiars: undo-safe Remove beside Archive** (#2873, cave-ykwk) — a dual-track lifecycle so Remove and Archive are distinct, and Remove can be undone.
+
+### Improvements
+- **Chat: the header slims to Find + a kebab menu** with compact project selection (#2874).
+
+
 ## [0.0.170] - 2026-07-09
 
 > 🧑‍🤝‍🧑 **Asana, assignable per familiar** — connect Asana once, then decide per agent whether (and in which workspace) it works with your tasks, right in Familiar Studio → Brain. The board and Queue show each agent only their scoped tasks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.170",
+  "version": "0.0.171",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.170"
+version = "0.0.171"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.170"
+version = "0.0.171"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.170</string>
+	<string>0.0.171</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.170</string>
+	<string>0.0.171</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.170</string>
+	<string>0.0.171</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.170</string>
+	<string>0.0.171</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.170",
+  "version": "0.0.171",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.171 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs`.

Patch release on top of v0.0.170 — 2 commits (no Asana; the full Asana experience already shipped in v0.0.170):
- **Familiars: undo-safe Remove beside Archive** (#2873, cave-ykwk)
- Chat: slim header to Find + kebab with compact project selection (#2874)

After merge: tag `v0.0.171` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)