### PR TITLE
fix(chat): right sidebar mirrors the left panel's glass — flush fit, no far-right gap, whole tab labels

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3829,7 +3829,8 @@ textarea.required-inputs-control {
   background: var(--bg-hover);
 }
 
-/* Open tab bar (sits at top of the open aside) */
+/* Open tab bar (sits at top of the open aside) — translucent so the aside's
+   glass shows through, mirroring the left sidebar's chrome. */
 .right-panel-tabs {
   display: flex;
   align-items: center;
@@ -3838,7 +3839,7 @@ textarea.required-inputs-control {
   flex-shrink: 0;
   min-width: 0;
   border-bottom: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
+  background: transparent;
   padding: 0 4px;
 }
 
@@ -3890,6 +3891,28 @@ textarea.required-inputs-control {
   width: 100%;
 }
 
+/* Chat right sidebar (Inspector / Debug / Changes) — the mirrored twin of the
+   left .shell-nav: the same translucent glass and blur, with the hairline
+   flipped to its left edge, sitting flush against the window's right edge so
+   the backdrop never opens a dark gap at the far right. Inner panes stay
+   transparent; the aside owns the panel chrome. */
+.chat-right-aside {
+  border-left: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .chat-right-aside { background: var(--bg-raised); }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .chat-right-aside {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 .right-panel-pane {
   display: flex;
   flex-direction: column;
@@ -3908,7 +3931,8 @@ textarea.required-inputs-control {
   flex-shrink: 0;
   min-width: 0;
   border-bottom: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
+  /* Translucent over the aside's glass, like .right-panel-tabs. */
+  background: transparent;
   padding: 0 10px;
 }
 

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -218,7 +218,7 @@ assert.match(
 
 assert.match(
   chatSurface,
-  /<aside role="region" aria-label="Session panels" className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-\[var\(--border-hairline\)\]">/,
+  /<aside role="region" aria-label="Session panels" className="chat-right-aside relative flex h-full min-h-0 min-w-0 flex-1 flex-col">/,
   "ChatSurface right side panel should be height-bounded so its body can scroll vertically (and read as a named region, not a nested complementary landmark — CHAT-D13-05)",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -124,8 +124,9 @@ function RightPanel({
   return (
     // CHAT-D13-05: this panel renders inside the shell's <main>, where a
     // complementary landmark is invalid (axe landmark-complementary-is-top-level)
-    // — expose it as a named region instead.
-    <aside role="region" aria-label="Session panels" className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col border-l border-[var(--border-hairline)]">
+    // — expose it as a named region instead. .chat-right-aside mirrors the left
+    // sidebar's glass (fit + translucency owned in globals.css).
+    <aside role="region" aria-label="Session panels" className="chat-right-aside relative flex h-full min-h-0 min-w-0 flex-1 flex-col">
       <Group className="right-panel-split" orientation="vertical">
         <Panel id="right-panel-primary" className="right-panel-pane min-h-0" defaultSize="50%" minSize="25%">
           <div className="right-panel-tabs">
@@ -725,17 +726,18 @@ export function ChatSurface({
             </Panel>
             {showRightSidebar && (
               <>
-                {/* Defaults to 230px (mirrors the internal left rail, chat-thread-rail
-                    is w-[230px]) but is drag-resizable via the handle below, clamped
-                    to a sane band so the chat thread keeps its 45% minSize. */}
+                {/* Defaults to 260px — wide enough that the Inspector's three
+                    section tabs (Familiar/Analytics/Automations) fit without
+                    shredding, still drag-resizable via the handle below and
+                    clamped so the chat thread keeps its 45% minSize. */}
                 <Separator className="shell-separator hidden lg:flex">
                   <SeparatorHandle orientation="col" />
                 </Separator>
                 <Panel
                   id="right-sidebar"
                   className="hidden min-h-0 min-w-0 lg:flex"
-                  defaultSize="230px"
-                  minSize="200px"
+                  defaultSize="260px"
+                  minSize="220px"
                   maxSize="480px"
                 >
                   <RightPanel

--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -7,10 +7,13 @@ import { dirname, resolve } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(resolve(here, "./inspector-pane.tsx"), "utf8");
 
-test("outer tab nav uses the shared underline Tabs, labelled + filled", () => {
-  assert.match(src, /<Tabs[\s\S]{0,240}ariaLabel="Inspector sections"/, "outer nav uses shared Tabs");
+test("outer tab nav uses the shared underline Tabs, labelled, natural-width", () => {
+  assert.match(src, /<Tabs[\s\S]{0,420}ariaLabel="Inspector sections"/, "outer nav uses shared Tabs");
   assert.match(src, /variant="underline"/, "outer nav is underline");
-  assert.match(src, /\bfill\b/, "outer tabs stretch to fill the row");
+  // Natural-width sm tabs: `fill` split the 260px sidebar into equal thirds
+  // and shredded "Automations" — content-hugging tabs keep every label whole.
+  assert.match(src, /<Tabs[\s\S]{0,420}size="sm"/, "outer tabs use compact density");
+  assert.doesNotMatch(src, /<Tabs\s*\n\s*variant="underline"\s*\n\s*fill\b/, "outer tabs no longer stretch-fill the row");
 });
 
 test("inbox badge is softened from danger to warning tone", () => {

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -156,14 +156,20 @@ export function InspectorPane({
 
   const shellClassName = compact
     ? "flex h-full min-h-0 flex-col bg-[var(--bg-base)]"
-    : "flex h-full min-h-0 flex-col border-l border-[var(--border-hairline)] bg-[var(--bg-raised)]/40";
+    : // Non-compact renders inside the chat right sidebar (.chat-right-aside),
+      // which owns the panel chrome — border + glass — so the pane itself stays
+      // transparent instead of double-tinting/double-bordering the glass.
+      "flex h-full min-h-0 flex-col";
 
   return (
     <aside className={shellClassName}>
       {!compact && (
         <Tabs
           variant="underline"
-          fill
+          // Natural-width tabs (no fill): the three section labels hug their
+          // content like the left rail's tabs instead of splitting the track
+          // into equal thirds and shredding "Automations" at narrow widths.
+          size="sm"
           idPrefix="inspector"
           ariaLabel="Inspector sections"
           value={tab}

--- a/src/components/right-sidebar-fit.test.ts
+++ b/src/components/right-sidebar-fit.test.ts
@@ -8,8 +8,8 @@ const projectSidebar = await readFile(new URL("./chat-project-sidebar.tsx", impo
 
 assert.match(
   chatSurface,
-  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="230px"[\s\S]*minSize="200px"[\s\S]*maxSize="480px"/,
-  "ChatSurface right sidebar should default to 230px but be drag-resizable within a 200–480px band",
+  /Panel[\s\S]*id="right-sidebar"[\s\S]*defaultSize="260px"[\s\S]*minSize="220px"[\s\S]*maxSize="480px"/,
+  "ChatSurface right sidebar should default to 260px (Inspector section tabs fit untruncated) but be drag-resizable within a 220–480px band",
 );
 
 // Drag-to-resize: an outer separator with a col handle sits before the right
@@ -38,7 +38,25 @@ assert.match(
 assert.match(
   projectSidebar,
   /chat-thread-rail[\s\S]*w-\[230px\]/,
-  "The internal left rail is 230px — the width the right sidebar mirrors",
+  "The internal left rail stays 230px (the right sidebar runs slightly wider at 260px so Inspector tabs fit)",
+);
+
+// The aside mirrors the left sidebar's glass chrome: translucent bg + blur,
+// with reduced-transparency and no-backdrop-filter fallbacks.
+assert.match(
+  globals,
+  /\.chat-right-aside\s*\{[\s\S]*?border-left:\s*1px solid var\(--border-hairline\)[\s\S]*?color-mix\(in oklch, var\(--bg-raised\) 88%, transparent\)[\s\S]*?backdrop-filter: blur/,
+  "The chat right aside should carry the left sidebar's glass chrome (hairline + translucent blur)",
+);
+assert.match(
+  globals,
+  /@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\)\s*\{\s*\.chat-right-aside \{ background: var\(--bg-raised\); \}/,
+  "The glass aside must fall back to a solid raised background without backdrop-filter support",
+);
+assert.match(
+  globals,
+  /@media \(prefers-reduced-transparency: reduce\)\s*\{\s*\.chat-right-aside \{[\s\S]*?background: var\(--bg-raised\);[\s\S]*?backdrop-filter: none;/,
+  "The glass aside must respect prefers-reduced-transparency",
 );
 
 assert.match(


### PR DESCRIPTION
Fixes the chat Inspector/Debug/Changes sidebar (bead `cave-wc78`): the intermittent dark gap at the far right, the opaque mismatched chrome, and the shredded section tabs.

## Before
- The aside had **no background of its own** — fully transparent over the page, so with a backdrop set the far right sometimes read as a dark hole
- Header bands (`.right-panel-tabs`, Changes header) painted opaque `bg-raised`; the InspectorPane inside added a **second** border + tint
- `md` fill-tabs at the 230px default width truncated to "Analyt…" / "Autom…"

## After — the mirrored twin of the left `.shell-nav`
- **`.chat-right-aside`** owns the panel chrome: identical glass (`color-mix(in oklch, var(--bg-raised) 88%, transparent)` + `blur(14px) saturate(140%)`), hairline **flipped to the panel's left edge**, flush against the window's right edge — with `@supports` + `prefers-reduced-transparency` fallbacks
- Tab bar + Changes header go translucent; InspectorPane's non-compact shell drops its own border/tint (single source of chrome)
- Sidebar defaults to **260px** (min 220px, still drag-resizable); Inspector section tabs become **natural-width `sm`** — Familiar/Analytics/Automations all render whole

## Verified (running app, measured)
- aside computes the *exact same* glass color as `.shell-nav` (`oklch(…)/0.88`) ✓
- `border-left: 1px` hairline ✓ · **0px gap** to the viewport edge ✓
- all three tabs untruncated at default width (61/69/86px natural) ✓ · screenshots inspected
- typecheck ✓ · `pnpm test:app` **594** ✓ (source-assertion tests updated: aside className, 260px band, glass + fallbacks pinned)