### PR TITLE
feat(marketplace): add Craft schema and Seeker's Lens

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,14 @@ improvements.
 
 ## Community Contributors
 
+### Jiachen LIU ([@AmberLJC](https://github.com/AmberLJC))
+
+Jiachen authored the two MIT-licensed research-ideation skills adapted for the
+Seeker's Lens reference Craft: structured research brainstorming and
+cognitive-science-based creative thinking. The Craft pins the original content
+and provenance at Orchestra Research commit
+[`773a529`](https://github.com/orchestra-research/AI-Research-SKILLs/commit/773a52944ba4747a18bd4ae9ade53fff041adcbc).
+
 ### CodeDoes ([@CodeDoes](https://github.com/CodeDoes))
 
 CodeDoes contributed the single-build Linux AppImage GLib-strip release flow,

--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -2541,6 +2541,121 @@
       }
     },
     {
+      "name": "seekers-lens",
+      "displayName": "Seeker's Lens",
+      "kind": "craft",
+      "visibility": "hidden",
+      "version": "0.1.0",
+      "description": "Discovery and ideation for bounded research work, from broad exploration through a reviewable pilot direction.",
+      "category": "Research Crafts",
+      "license": "MIT",
+      "keywords": [
+        "research",
+        "ideation",
+        "discovery",
+        "brainstorming",
+        "craft"
+      ],
+      "capabilities": [
+        "research",
+        "ideation",
+        "workflows"
+      ],
+      "sourceRefs": [
+        "https://github.com/orchestra-research/AI-Research-SKILLs/tree/773a52944ba4747a18bd4ae9ade53fff041adcbc/21-research-ideation"
+      ],
+      "trust": "official-local",
+      "craft": {
+        "schemaVersion": "opencoven.craft.v1",
+        "components": {
+          "required": [
+            "fetch",
+            "filesystem",
+            "memory",
+            "sequential-thinking"
+          ],
+          "optional": [
+            "exa",
+            "tavily",
+            "firecrawl",
+            "searxng",
+            "research-ingestion"
+          ]
+        },
+        "bundled": {
+          "skills": [
+            {
+              "id": "brainstorming-research-ideas",
+              "sourcePath": "craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md",
+              "upstreamPath": "21-research-ideation/brainstorming-research-ideas/SKILL.md",
+              "contentHash": "sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46",
+              "modifications": [
+                "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+                "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+                "Added a Coven boundary that keeps ideation advisory until execution is separately authorized."
+              ]
+            },
+            {
+              "id": "creative-thinking-for-research",
+              "sourcePath": "craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md",
+              "upstreamPath": "21-research-ideation/creative-thinking-for-research/SKILL.md",
+              "contentHash": "sha256:ec111f9236d7f9d72c895cebbf0f534ac93f4249172607559ad4bf92aefc5310",
+              "modifications": [
+                "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+                "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+                "Added a Coven boundary that labels speculation and requires separate authorization before execution."
+              ]
+            }
+          ],
+          "prompts": [
+            {
+              "id": "open-a-research-space",
+              "name": "Open a research space",
+              "description": "Generate, challenge, and rank bounded research directions.",
+              "body": "Open the research space around {{topic}}. Use both Seeker's Lens ideation skills to generate distinct directions, label assumptions and unknowns, then rank the strongest three by novelty, impact, evidence gap, and feasibility. Stop with a proposed checkpoint; do not begin experiments."
+            },
+            {
+              "id": "stress-test-a-research-idea",
+              "name": "Stress-test a research idea",
+              "description": "Probe a candidate direction before committing resources.",
+              "body": "Stress-test {{research idea}}. Reformulate it at three abstraction levels, identify the strongest contradiction or boundary case, compare a simpler baseline, and state the evidence that would change the recommendation. End with a bounded pilot and a human go/no-go checkpoint."
+            }
+          ],
+          "workflows": [
+            {
+              "id": "diverge-converge-refine",
+              "name": "Diverge, converge, refine",
+              "description": "Move from a broad topic to a reviewable pilot without starting execution.",
+              "steps": [
+                "Define the research space, stakeholders, constraints, and explicit resource bounds.",
+                "Generate diverse candidate directions with multiple ideation lenses.",
+                "Challenge candidates with contradiction, boundary, simplicity, and feasibility checks.",
+                "Rank the strongest directions and expose assumptions, evidence gaps, and likely objections.",
+                "Draft one bounded pilot and stop at a human go/no-go checkpoint."
+              ]
+            }
+          ]
+        },
+        "requiredCapabilities": [
+          "filesystem.read",
+          "network.http",
+          "memory.local",
+          "reasoning.sequential"
+        ],
+        "recommendedRoles": [
+          "researcher",
+          "strategist",
+          "analyst"
+        ],
+        "provenance": {
+          "source": "https://github.com/orchestra-research/AI-Research-SKILLs",
+          "commit": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+          "license": "MIT",
+          "licensePath": "craft-sources/orchestra-research/LICENSE"
+        }
+      }
+    },
+    {
       "name": "skill-scanner",
       "displayName": "Skill Scanner",
       "version": "0.1.0",

--- a/marketplace/craft-sources/orchestra-research/LICENSE
+++ b/marketplace/craft-sources/orchestra-research/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Claude AI Research Skills Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/marketplace/craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md
+++ b/marketplace/craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: brainstorming-research-ideas
+description: Guides researchers through structured ideation frameworks to discover high-impact research directions. Use when exploring new problem spaces, pivoting between projects, or seeking novel angles on existing work.
+license: MIT
+---
+
+# Research Idea Brainstorming
+
+Structured frameworks for discovering the next research idea. This skill provides ten complementary ideation lenses that help researchers move from vague curiosity to concrete, defensible research proposals. Each framework targets a different cognitive mode—use them individually or combine them for comprehensive exploration.
+
+## Coven Boundary
+
+- Treat every direction as a proposal for the researcher to accept, revise, or reject.
+- Do not start experiments, spend money or compute, alter repositories, or publish results unless the user separately requests that work.
+- State assumptions and define a checkpoint before handing an idea to an execution workflow.
+
+## When to Use This Skill
+
+- Starting a new research direction and need structured exploration
+- Feeling stuck on a current project and want fresh angles
+- Evaluating whether a half-formed idea has real potential
+- Preparing for a brainstorming session with collaborators
+- Transitioning between research areas and seeking high-leverage entry points
+- Reviewing a field and looking for underexplored gaps
+
+**Do NOT use this skill when**:
+- You already have a well-defined research question and need execution guidance
+- You need help with experimental design or methodology (use domain-specific skills)
+- You want a literature review (hand off to an available literature-review or research-ingestion capability)
+
+---
+
+## Core Ideation Frameworks
+
+### 1. Problem-First vs. Solution-First Thinking
+
+Research ideas originate from two distinct modes. Knowing which mode you are in prevents a common failure: building solutions that lack real problems, or chasing problems without feasible approaches.
+
+**Problem-First** (pain point → method):
+- Start with a concrete failure, bottleneck, or unmet need
+- Naturally yields impactful work because the motivation is intrinsic
+- Risk: may converge on incremental fixes rather than paradigm shifts
+
+**Solution-First** (new capability → application):
+- Start with a new tool, insight, or technique seeking application
+- Often drives breakthroughs by unlocking previously impossible approaches
+- Risk: "hammer looking for a nail"—solution may lack genuine demand
+
+**Workflow**:
+1. Write down your idea in one sentence
+2. Classify it: Is this problem-first or solution-first?
+3. If problem-first → verify the problem matters (who suffers? how much?)
+4. If solution-first → identify at least two genuine problems it addresses
+5. For either mode, articulate the gap: what cannot be done today that this enables?
+
+**Self-Check**:
+- [ ] Can I name a specific person or community who needs this?
+- [ ] Is the problem I am solving actually unsolved (not just under-marketed)?
+- [ ] If solution-first, does the solution create new capability or just replicate existing ones?
+
+---
+
+### 2. The Abstraction Ladder
+
+Every research problem sits at a particular level of abstraction. Deliberately moving up or down the ladder reveals ideas invisible at your current level.
+
+| Direction | Action | Outcome |
+|-----------|--------|---------|
+| **Move Up** (generalize) | Turn a specific result into a broader principle | Framework papers, theoretical contributions |
+| **Move Down** (instantiate) | Test a general paradigm under concrete constraints | Empirical papers, surprising failure analyses |
+| **Move Sideways** (analogize) | Apply same abstraction level to adjacent domain | Cross-pollination, transfer papers |
+
+**Workflow**:
+1. State your current research focus in one sentence
+2. Move UP: What is the general principle behind this? What class of problems does this belong to?
+3. Move DOWN: What is the most specific, constrained instance of this? What happens at the extreme?
+4. Move SIDEWAYS: Where else does this pattern appear in a different field?
+5. For each new level, ask: Is this a publishable contribution on its own?
+
+**Example**:
+- **Current**: "Improving retrieval accuracy for RAG systems"
+- **Up**: "What makes context selection effective for any augmented generation system?"
+- **Down**: "How does retrieval accuracy degrade when documents are adversarially perturbed?"
+- **Sideways**: "Database query optimization uses similar relevance ranking—what can we borrow?"
+
+---
+
+### 3. Tension and Contradiction Hunting
+
+Breakthroughs often come from resolving tensions between widely accepted but seemingly conflicting goals. These contradictions are not bugs—they are the research opportunity.
+
+**Common Research Tensions**:
+
+| Tension Pair | Research Opportunity |
+|-------------|---------------------|
+| Performance ↔ Efficiency | Can we match SOTA with 10x less compute? |
+| Privacy ↔ Utility | Can federated/encrypted methods close the accuracy gap? |
+| Generality ↔ Specialization | When does fine-tuning beat prompting, and why? |
+| Safety ↔ Capability | Can alignment improve rather than tax capability? |
+| Interpretability ↔ Performance | Do mechanistic insights enable better architectures? |
+| Scale ↔ Accessibility | Can small models replicate emergent behaviors? |
+
+**Workflow**:
+1. Pick your research area
+2. List the top 3-5 desiderata (things everyone wants)
+3. Identify pairs that are commonly treated as trade-offs
+4. For each pair, ask: Is this trade-off fundamental or an artifact of current methods?
+5. If artifact → the reconciliation IS your research contribution
+6. If fundamental → characterizing the Pareto frontier is itself valuable
+
+**Self-Check**:
+- [ ] Have I confirmed this tension is real (not just assumed)?
+- [ ] Can I point to papers that optimize for each side independently?
+- [ ] Is my proposed reconciliation technically plausible, not just aspirational?
+
+---
+
+### 4. Cross-Pollination (Analogy Transfer)
+
+Borrowing structural ideas from other disciplines is one of the most generative research heuristics. Many foundational techniques emerged this way—attention mechanisms draw from cognitive science, genetic algorithms from biology, adversarial training from game theory.
+
+**Requirements for a Valid Analogy**:
+- **Structural fidelity**: The mapping must hold at the level of underlying mechanisms, not just surface similarity
+- **Non-obvious connection**: If the link is well-known, the novelty is gone
+- **Testable predictions**: The analogy should generate concrete hypotheses
+
+**High-Yield Source Fields for ML Research**:
+
+| Source Field | Transferable Concepts |
+|-------------|----------------------|
+| Neuroscience | Attention, memory consolidation, hierarchical processing |
+| Physics | Energy-based models, phase transitions, renormalization |
+| Economics | Mechanism design, auction theory, incentive alignment |
+| Ecology | Population dynamics, niche competition, co-evolution |
+| Linguistics | Compositionality, pragmatics, grammatical induction |
+| Control Theory | Feedback loops, stability, adaptive regulation |
+
+**Workflow**:
+1. Describe your problem in domain-agnostic language (strip the jargon)
+2. Ask: What other field solves a structurally similar problem?
+3. Study that field's solution at the mechanism level
+4. Map the solution back to your domain, preserving structural relationships
+5. Generate testable predictions from the analogy
+6. Validate: Does the borrowed idea actually improve outcomes?
+
+---
+
+### 5. The "What Changed?" Principle
+
+Strong ideas often come from revisiting old problems under new conditions. Advances in hardware, scale, data availability, or regulations can invalidate prior assumptions and make previously impractical approaches viable.
+
+**Categories of Change to Monitor**:
+
+| Change Type | Example | Research Implication |
+|------------|---------|---------------------|
+| **Compute** | GPUs 10x faster | Methods dismissed as too expensive become feasible |
+| **Scale** | Trillion-token datasets | Statistical arguments that failed at small scale may now hold |
+| **Regulation** | EU AI Act, GDPR | Creates demand for compliant alternatives |
+| **Tooling** | New frameworks, APIs | Reduces implementation barrier for complex methods |
+| **Failure** | High-profile system failures | Exposes gaps in existing approaches |
+| **Cultural** | New user behaviors | Shifts what problems matter most |
+
+**Workflow**:
+1. Pick a well-known negative result or abandoned approach (3-10 years old)
+2. List the assumptions that led to its rejection
+3. For each assumption, ask: Is this still true today?
+4. If any assumption has been invalidated → re-run the idea under new conditions
+5. Frame the contribution: "X was previously impractical because Y, but Z has changed"
+
+---
+
+### 6. Failure Analysis and Boundary Probing
+
+Understanding where a method breaks is often as valuable as showing where it works. Boundary probing systematically exposes the conditions under which accepted techniques fail.
+
+**Types of Boundaries to Probe**:
+- **Distributional**: What happens with out-of-distribution inputs?
+- **Scale**: Does the method degrade at 10x or 0.1x the typical scale?
+- **Adversarial**: Can the method be deliberately broken?
+- **Compositional**: Does performance hold when combining multiple capabilities?
+- **Temporal**: Does the method degrade over time (concept drift)?
+
+**Workflow**:
+1. Select a widely-used method with strong reported results
+2. Identify the implicit assumptions in its evaluation (dataset, scale, domain)
+3. Systematically violate each assumption
+4. Document where and how the method breaks
+5. Diagnose the root cause of each failure
+6. Propose a fix or explain why the failure is fundamental
+
+**Self-Check**:
+- [ ] Am I probing genuine boundaries, not just confirming known limitations?
+- [ ] Can I explain WHY the method fails, not just THAT it fails?
+- [ ] Does my analysis suggest a constructive path forward?
+
+---
+
+### 7. The Simplicity Test
+
+Before accepting complexity, ask whether a simpler approach suffices. Fields sometimes over-index on elaborate solutions when a streamlined baseline performs competitively.
+
+**Warning Signs of Unnecessary Complexity**:
+- The method has many hyperparameters with narrow optimal ranges
+- Ablations show most components contribute marginally
+- A simple baseline was never properly tuned or evaluated
+- The improvement over baselines is within noise on most benchmarks
+
+**Workflow**:
+1. Identify the current SOTA method for your problem
+2. Strip it to its simplest possible core (what is the one key idea?)
+3. Build that minimal version with careful engineering
+4. Compare fairly: same compute budget, same tuning effort
+5. If the gap is small → the contribution is the simplicity itself
+6. If the gap is large → you now understand what the complexity buys
+
+**Contribution Framing**:
+- "We show that [simple method] with [one modification] matches [complex SOTA]"
+- "We identify [specific component] as the critical driver, not [other components]"
+
+---
+
+### 8. Stakeholder Rotation
+
+Viewing a system from multiple perspectives reveals distinct classes of research questions. Each stakeholder sees different friction, risk, and opportunity.
+
+**Stakeholder Perspectives**:
+
+| Stakeholder | Key Questions |
+|-------------|---------------|
+| **End User** | Is this usable? What errors are unacceptable? What is the latency tolerance? |
+| **Developer** | Is this debuggable? What is the maintenance burden? How does it compose? |
+| **Theorist** | Why does this work? What are the formal guarantees? Where are the gaps? |
+| **Adversary** | How can this be exploited? What are the attack surfaces? |
+| **Ethicist** | Who is harmed? What biases are embedded? Who is excluded? |
+| **Regulator** | Is this auditable? Can decisions be explained? Is there accountability? |
+| **Operator** | What is the cost? How does it scale? What is the failure mode? |
+
+**Workflow**:
+1. Describe your system or method in one paragraph
+2. Assume each stakeholder perspective in turn (spend 5 minutes per role)
+3. For each perspective, list the top 3 concerns or questions
+4. Identify which concerns are unaddressed by existing work
+5. The unaddressed concern with the broadest impact is your research question
+
+---
+
+### 9. Composition and Decomposition
+
+Novelty often emerges from recombination or modularization. Innovation frequently lies not in new primitives, but in how components are arranged or separated.
+
+**Composition** (combining existing techniques):
+- Identify two methods that solve complementary subproblems
+- Ask: What emergent capability arises from combining them?
+- Example: RAG + Chain-of-Thought → retrieval-augmented reasoning
+
+**Decomposition** (breaking apart monolithic systems):
+- Identify a complex system with entangled components
+- Ask: Which component is the actual bottleneck?
+- Example: Decomposing "fine-tuning" into data selection, optimization, and regularization reveals that data selection often matters most
+
+**Workflow**:
+1. List the 5-10 key components or techniques in your area
+2. **Compose**: Pick pairs and ask what happens when you combine them
+3. **Decompose**: Pick a complex method and isolate each component's contribution
+4. For compositions: Does the combination create emergent capabilities?
+5. For decompositions: Does isolation reveal a dominant or redundant component?
+
+---
+
+### 10. The "Explain It to Someone" Test
+
+A strong research idea should be defensible in two sentences to a smart non-expert. This test enforces clarity of purpose and sharpens the value proposition.
+
+**The Two-Sentence Template**:
+> **Sentence 1** (Problem): "[Domain] currently struggles with [specific problem], which matters because [concrete consequence]."
+> **Sentence 2** (Insight): "We [approach] by [key mechanism], which works because [reason]."
+
+**If You Cannot Fill This Template**:
+- The problem may not be well-defined yet → return to Framework 1
+- The insight may not be clear yet → return to Framework 7 (simplify)
+- The significance may not be established → return to Framework 3 (find the tension)
+
+**Calibration Questions**:
+- Would a smart colleague outside your subfield understand why this matters?
+- Does the explanation stand without jargon?
+- Can you predict what a skeptic's first objection would be?
+
+---
+
+## Integrated Brainstorming Workflow
+
+Use this end-to-end workflow to go from blank page to ranked research ideas.
+
+### Phase 1: Diverge (Generate Candidates)
+
+**Goal**: Produce 10-20 candidate ideas without filtering.
+
+1. **Scan for tensions** (Framework 3): List 5 trade-offs in your field
+2. **Check what changed** (Framework 5): List 3 recent shifts (compute, data, regulation)
+3. **Probe boundaries** (Framework 6): Pick 2 popular methods and find where they break
+4. **Cross-pollinate** (Framework 4): Pick 1 idea from an adjacent field
+5. **Compose/decompose** (Framework 9): Combine 2 existing techniques or split 1 apart
+6. **Climb the abstraction ladder** (Framework 2): For each candidate, generate up/down/sideways variants
+
+### Phase 2: Converge (Filter and Rank)
+
+**Goal**: Narrow to 3-5 strongest ideas.
+
+Apply these filters to each candidate:
+
+| Filter | Question | Kill Criterion |
+|--------|----------|----------------|
+| **Explain-It Test** (F10) | Can I state this in two sentences? | If no → idea is not yet clear |
+| **Problem-First Check** (F1) | Is the problem genuine and important? | If no one suffers from this → drop it |
+| **Simplicity Test** (F7) | Is the complexity justified? | If a simpler approach works → simplify or drop |
+| **Stakeholder Check** (F8) | Who benefits? Who might object? | If no clear beneficiary → drop it |
+| **Feasibility** | Can I execute this with available resources? | If clearly infeasible → park it for later |
+
+### Phase 3: Refine (Sharpen the Winner)
+
+**Goal**: Turn the top idea into a concrete research plan.
+
+1. Write the two-sentence pitch (Framework 10)
+2. Identify the core tension being resolved (Framework 3)
+3. Specify the abstraction level (Framework 2)
+4. List 3 concrete experiments that would validate the idea
+5. Anticipate the strongest objection and prepare a response
+6. Define a 2-week pilot that would provide signal on feasibility
+
+**Completion Checklist**:
+- [ ] Two-sentence pitch is clear and compelling
+- [ ] Problem is genuine (problem-first check passed)
+- [ ] Approach is justified (simplicity test passed)
+- [ ] At least one stakeholder clearly benefits
+- [ ] Core experiments are specified
+- [ ] Feasibility pilot is defined
+- [ ] Strongest objection has a response
+
+---
+
+## Framework Selection Guide
+
+Not sure which framework to start with? Use this decision guide:
+
+| Your Situation | Start With |
+|---------------|------------|
+| "I don't know what area to work in" | Tension Hunting (F3) → What Changed (F5) |
+| "I have a vague area but no specific idea" | Abstraction Ladder (F2) → Failure Analysis (F6) |
+| "I have an idea but I'm not sure it's good" | Explain-It Test (F10) → Simplicity Test (F7) |
+| "I have a good idea but need a fresh angle" | Cross-Pollination (F4) → Stakeholder Rotation (F8) |
+| "I want to combine existing work into something new" | Composition/Decomposition (F9) |
+| "I found a cool technique and want to apply it" | Problem-First Check (F1) → Stakeholder Rotation (F8) |
+| "I want to challenge conventional wisdom" | Failure Analysis (F6) → Simplicity Test (F7) |
+
+---
+
+## Common Pitfalls in Research Ideation
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Novelty without impact** | "No one has done X" but no one needs X | Apply Problem-First Check (F1) |
+| **Incremental by default** | Idea is +2% on a benchmark | Climb the Abstraction Ladder (F2) |
+| **Complexity worship** | Method has 8 components, each helping marginally | Apply Simplicity Test (F7) |
+| **Echo chamber** | All ideas come from reading the same 10 papers | Use Cross-Pollination (F4) |
+| **Stale assumptions** | "This was tried and didn't work" (5 years ago) | Apply What Changed (F5) |
+| **Single-perspective bias** | Only considering the ML engineer's view | Use Stakeholder Rotation (F8) |
+| **Premature convergence** | Committed to first idea without exploring alternatives | Run full Diverge phase |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help brainstorming research ideas:
+
+1. **Identify their starting point**: Are they exploring a new area, stuck on a current project, or evaluating an existing idea?
+2. **Select appropriate frameworks**: Use the Framework Selection Guide to pick 2-3 relevant lenses
+3. **Walk through frameworks interactively**: Apply each framework step-by-step, asking the researcher for domain-specific inputs
+4. **Generate candidates**: Aim for 10-20 raw ideas across frameworks
+5. **Filter and rank**: Apply the Converge phase filters to narrow to top 3-5
+6. **Refine the winner**: Help articulate the two-sentence pitch and define concrete next steps
+
+**Key Principles**:
+- Push for specificity—vague ideas ("improve efficiency") are not actionable
+- Challenge assumptions—ask "why?" at least three times
+- Maintain a written list of all candidates, even rejected ones (they may recombine later)
+- The researcher makes the final call on which ideas to pursue; the agent facilitates structured thinking

--- a/marketplace/craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md
+++ b/marketplace/craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: creative-thinking-for-research
+description: Applies cognitive science frameworks for creative thinking to CS and AI research ideation. Use when seeking genuinely novel research directions by leveraging combinatorial creativity, analogical reasoning, constraint manipulation, and other empirically grounded creative strategies.
+license: MIT
+---
+
+# Creative Thinking for Research
+
+Eight empirically grounded frameworks from cognitive science, applied to computer science and AI research. Unlike ad-hoc brainstorming, each framework here is backed by decades of creativity research — from Koestler's bisociation to Kauffman's adjacent possible. They target distinct cognitive operations: combining, reformulating, analogizing, constraining, inverting, abstracting, exploring boundaries, and holding contradictions.
+
+## Coven Boundary
+
+- Treat creative directions as advisory candidates, not authorization to execute them.
+- Do not start experiments, spend money or compute, alter repositories, or publish results unless the user separately requests that work.
+- Mark speculative claims, state assumptions, and define a human checkpoint before moving from ideation to execution.
+
+## When to Use This Skill
+
+- Generating genuinely novel ideas, not incremental extensions of prior work
+- Feeling trapped in a local optimum of thinking within a single subfield
+- Wanting to systematically apply creativity heuristics rather than waiting for inspiration
+- Preparing for a research retreat or PhD-level ideation session
+- Bridging between fields and seeking structural (not superficial) connections
+
+**Do NOT use this skill when**:
+- You need structured project-level brainstorming workflows (use `brainstorming-research-ideas`)
+- You have a well-defined problem and need execution help (use domain-specific skills)
+- You need a literature survey (hand off to an available literature-review or research-ingestion capability)
+
+**Relationship to Brainstorm skill**: The brainstorm skill provides operational workflows (diverge → converge → refine) and practical filters. This skill provides the deeper cognitive engines that power creative leaps. Use them together: creative-thinking to generate raw insight, brainstorm to structure and evaluate it.
+
+---
+
+## Framework 1: Combinatorial Creativity (Bisociation)
+
+Novel ideas arise from combining existing concepts in unexpected ways. Arthur Koestler called this **bisociation** — connecting two previously unrelated frames of reference, as distinct from routine association within a single frame.
+
+**Why it works**: Meta-research consistently shows that breadth of knowledge is a precursor to creative output. People who read across disciplines produce more novel work. The combination itself is the creative act.
+
+**In CS Research**:
+- Biological evolution → optimization (genetic algorithms)
+- Game theory → networking (mechanism design for routing)
+- Statistical physics → machine learning (Boltzmann machines, energy-based models)
+- Linguistics → programming (type theory, formal grammars)
+
+**Systematic Bisociation Workflow**:
+
+1. **Select two domains** you have at least passing familiarity with
+2. **List core primitives** in each domain (5-10 fundamental concepts per domain)
+3. **Create a cross-product matrix**: row = concepts from Domain A, column = concepts from Domain B
+4. **For each cell**, ask: "What would it mean to apply A's concept to B's problem?"
+5. **Filter**: Which combinations produce a non-trivial, testable research question?
+6. **Validate structural depth**: Is the connection mechanistic or merely metaphorical?
+
+**Cross-Product Example**:
+
+| | Caching | Load Balancing | Fault Tolerance |
+|---|---------|---------------|-----------------|
+| **Natural Selection** | Evict least-fit entries | Adaptive allocation via fitness | Population-level redundancy |
+| **Immune Memory** | Learned threat signatures | Distributed detection | Self/non-self discrimination |
+| **Symbiosis** | Cooperative prefetching | Mutualistic resource sharing | Co-dependent resilience |
+
+**Quality Test**: A strong bisociation is not a surface metaphor ("the network is like a brain") but a structural mapping where the mechanism transfers ("attention mechanisms implement a form of selective gating analogous to cognitive attention filtering").
+
+**Self-Check**:
+- [ ] Is the connection structural (mechanisms map) or merely verbal (labels map)?
+- [ ] Does the combination generate testable predictions?
+- [ ] Would an expert in both fields find the connection non-obvious but sound?
+
+---
+
+## Framework 2: Problem Reformulation (Representational Change)
+
+Gestalt psychologists identified that breakthroughs often come not from solving the problem as stated, but from **re-representing the problem itself**. Kaplan and Simon's work on insight shows that changing the problem space — the constraints, the abstraction level, the formalism — is often where creativity lives.
+
+**The Key Shift**: From "How do I solve this problem?" to "Am I even thinking about this problem correctly?"
+
+**Reformulation Strategies**:
+
+| Strategy | Example |
+|----------|---------|
+| **Change the objective** | "Make the algorithm faster" → "Eliminate the need for this computation" |
+| **Change the formalism** | Graph problem → linear algebra problem (spectral methods) |
+| **Change the granularity** | Per-token prediction → per-span prediction |
+| **Change the agent** | "How should the model learn?" → "How should the data teach?" (curriculum learning) |
+| **Change the timescale** | Real-time optimization → amortized inference |
+| **Invert the direction** | Forward simulation → inverse problem (learning from observations) |
+
+**Workflow**:
+
+1. State your current problem in one sentence
+2. Identify the **hidden assumptions** in that statement:
+   - What formalism are you using? (Could you use a different one?)
+   - What is the objective? (Is it the right objective?)
+   - What level of granularity? (Could you go coarser or finer?)
+   - Who is the agent? (Could you shift perspective?)
+3. For each assumption, **generate the alternative**: "What if [opposite assumption]?"
+4. For each alternative, ask: "Does this reformulation make the problem easier, harder, or different in a useful way?"
+5. A reformulation that makes a hard problem easy is often a publishable insight on its own
+
+**Classic CS Examples**:
+- **PageRank**: Reformulated "find important web pages" from content analysis to graph eigenvalue problem
+- **Dropout**: Reformulated "prevent overfitting" from regularization to approximate ensemble
+- **Attention**: Reformulated "handle long sequences" from remembering everything to selectively querying
+
+---
+
+## Framework 3: Analogical Reasoning (Structure-Mapping)
+
+Dedre Gentner's **structure-mapping theory** and Kevin Dunbar's studies of real scientists show that analogy is the core engine of scientific creativity. The critical finding: surface-level analogies are common but weak; **structural or relational analogies** — where the deep causal/relational structure maps across domains — produce the most powerful insights.
+
+**Dunbar's Finding**: In the most successful labs, analogies from distant domains drove the most important discoveries. Nearby analogies refined ideas; distant analogies generated them.
+
+**Levels of Analogical Depth**:
+
+| Level | Description | Value | Example |
+|-------|-------------|-------|---------|
+| **Surface** | Things look similar | Low | "A neural network is like a brain" |
+| **Relational** | Relationships between entities match | Medium | "Attention allocation in models parallels resource allocation in economics" |
+| **Structural** | Deep causal mechanisms map | High | "Diffusion models reverse a thermodynamic process; the math of non-equilibrium stat-mech directly applies" |
+
+**Structure-Mapping Workflow**:
+
+1. **Describe your problem** using only relational/causal language (strip domain-specific nouns)
+   - Bad: "We need to improve transformer attention efficiency"
+   - Good: "We have a system that must selectively aggregate information from a large set, where relevance is context-dependent and the cost scales quadratically with set size"
+2. **Search for structural matches**: What other systems selectively aggregate from large sets?
+   - Database query optimization, visual attention in neuroscience, information retrieval, resource allocation
+3. **Pick the most distant match** with genuine structural fidelity
+4. **Map the solution mechanism**: How does the source domain solve this?
+5. **Transfer and adapt**: What changes when you bring that mechanism into your domain?
+6. **Generate predictions**: The analogy should tell you something you didn't already know
+
+**Validation Checklist**:
+- [ ] Does the mapping preserve causal/relational structure (not just labels)?
+- [ ] Can I identify at least one prediction the analogy makes in my domain?
+- [ ] Would an expert in the source domain confirm the mechanism is correctly understood?
+- [ ] Is the analogy non-obvious to my target audience?
+
+---
+
+## Framework 4: Constraint Manipulation (Boden's Framework)
+
+Margaret Boden's framework distinguishes three forms of creativity based on how they interact with constraints:
+
+| Type | Operation | CS Example |
+|------|-----------|------------|
+| **Exploratory** | Search within the existing conceptual space | Hyperparameter tuning, architecture search within a fixed paradigm |
+| **Combinational** | Combine elements from different spaces | Multi-task learning, neuro-symbolic methods |
+| **Transformational** | Change the rules of the space itself | Dropping the assumption that training requires labels (self-supervised learning) |
+
+**Transformational creativity is the rarest and highest-impact.** It happens when you change what is even considered a valid solution.
+
+**Constraint Analysis Workflow**:
+
+1. **List the constraints** of your current approach (5-10 constraints):
+   - Computational: "Must fit in GPU memory"
+   - Methodological: "Requires labeled data"
+   - Architectural: "Uses fixed-length context"
+   - Evaluative: "Measured by accuracy on benchmark X"
+2. **Classify each constraint**:
+   - **Hard**: Physically or logically necessary (cannot violate)
+   - **Soft**: Convention or historical accident (can question)
+   - **Hidden**: Not stated but implicitly assumed (most fertile for innovation)
+3. **For each soft/hidden constraint**, ask:
+   - What if we relaxed it? (streaming algorithms from relaxing "fits in memory")
+   - What if we tightened it? (efficiency research from tightening compute budgets)
+   - What if we replaced it with a different constraint entirely?
+4. **The most productive move** is often exposing and dropping a hidden constraint
+
+**Classic Examples of Constraint Transformation**:
+- "Data must fit in memory" → dropped → streaming algorithms, external memory
+- "Training requires human labels" → dropped → self-supervised learning
+- "Models must be deterministic" → dropped → variational methods, diffusion
+- "Inference must happen in one pass" → dropped → iterative refinement, chain-of-thought
+
+---
+
+## Framework 5: Negation and Inversion
+
+Take a core assumption in your field and negate it. This is formalized in De Bono's lateral thinking and the **TRIZ methodology** from engineering.
+
+**The Pattern**: "What if [widely held assumption] is wrong, unnecessary, or invertible?"
+
+**Systematic Negation Workflow**:
+
+1. **List 5-10 core assumptions** in your subfield (the things "everyone knows")
+2. **Negate each one** and ask: What system would you build?
+3. **Evaluate each negation**:
+   - Incoherent → discard
+   - Already explored → check if conditions have changed (see brainstorm skill, Framework 5)
+   - Unexplored and coherent → potential research direction
+
+**Negation Hall of Fame in CS**:
+
+| Assumption | Negation | Result |
+|-----------|----------|--------|
+| "We need strong consistency" | What if we don't? | Eventual consistency, CRDTs |
+| "We need exact answers" | What if approximate is fine? | Sketches, LSH, approximate nearest neighbors |
+| "Labels are necessary" | What if we learn without them? | Self-supervised learning, contrastive methods |
+| "More parameters = more compute" | What if we don't use all parameters? | Mixture of Experts, sparse models |
+| "Training and inference are separate" | What if the model keeps learning? | Online learning, test-time training |
+| "Errors must be prevented" | What if we embrace and correct them? | Speculative decoding, self-correction |
+
+**TRIZ-Inspired Principles for CS**:
+
+| TRIZ Principle | CS Application |
+|---------------|----------------|
+| **Inversion** | Reverse the process (generative vs. discriminative) |
+| **Segmentation** | Break monolithic into modular (microservices, mixture of experts) |
+| **Merging** | Combine separate steps (end-to-end learning) |
+| **Universality** | One component serves multiple functions (multi-task models) |
+| **Nesting** | Place one system inside another (meta-learning) |
+| **Dynamization** | Make static things adaptive (dynamic architectures, adaptive computation) |
+
+---
+
+## Framework 6: Abstraction and Generalization Laddering
+
+Moving up and down the abstraction ladder is a fundamental creative act. Polya's heuristics formalize this: *"Can you solve a more general problem? A more specific one? An analogous one?"*
+
+**Three Moves**:
+
+| Move | Question | Outcome |
+|------|----------|---------|
+| **Generalize** | "Is my solution a special case of something broader?" | Framework papers, unifying theories |
+| **Specialize** | "What happens when I add extreme constraints?" | Niche applications, surprising edge cases |
+| **Analogize** | "Where else does this abstract pattern appear?" | Cross-domain transfer (see Framework 3) |
+
+**Generalization Workflow**:
+1. State your specific result
+2. Replace each specific element with a variable: "ResNet works for ImageNet" → "Architecture X works for distribution Y"
+3. Ask: Under what conditions does this hold? What is the general principle?
+4. If the general principle is novel → that is the contribution
+
+**Specialization Workflow**:
+1. Take a general method
+2. Add extreme constraints: tiny data, huge dimensionality, adversarial inputs, real-time requirements
+3. Ask: Does the method still work? If not, why not?
+4. The failure case often reveals the method's true assumptions
+
+**When to Generalize vs. Specialize**:
+- Generalize when you have results but no explanation
+- Specialize when you have theory but no grounding
+- Analogize when you are stuck in either direction
+
+---
+
+## Framework 7: The Adjacent Possible (Kauffman / Johnson)
+
+Stuart Kauffman's concept, popularized by Steven Johnson: innovation happens at the boundary of what is currently reachable — the **adjacent possible**. New ideas become thinkable once their prerequisites exist. This explains why simultaneous independent discovery is so common — multiple people reach the same boundary.
+
+**Practical Implication**: Map what has recently become possible and explore the space those enablers open.
+
+**Adjacent Possible Mapping Workflow**:
+
+1. **List recent enablers** (last 1-3 years):
+   - New hardware capabilities (longer context, faster inference, new accelerators)
+   - New datasets or benchmarks
+   - New open-source tools or frameworks
+   - New theoretical results
+   - New regulatory or social conditions
+2. **For each enabler, ask**: "What was previously impossible or impractical that this now permits?"
+3. **Combine enablers**: The most powerful adjacent possibles arise from the intersection of multiple new enablers
+4. **Check for competition**: If many people can see the same adjacent possible, speed or a unique angle matters
+
+**Current Adjacent Possibles (2025-2026)**:
+
+| Enabler | Newly Possible |
+|---------|---------------|
+| 1M+ token context windows | Full-codebase reasoning, book-length analysis |
+| Inference cost drops (100x in 2 years) | Real-time agentic loops, always-on AI assistants |
+| Open-weight models at GPT-4 level | Reproducible research on frontier capabilities |
+| Multimodal models (vision + language + audio) | Unified perception-reasoning systems |
+| Synthetic data at scale | Training data for domains with no natural data |
+| Tool-using models | Research automation, self-improving systems |
+
+**Timing Signal**: If your idea requires technology that doesn't exist yet, it's beyond the adjacent possible — park it. If your idea could have been done 5 years ago, someone probably did — check the literature. The sweet spot is ideas that became feasible in the last 6-18 months.
+
+---
+
+## Framework 8: Janusian and Dialectical Thinking
+
+Albert Rothenberg's studies of eminent creators found that **holding two contradictory ideas simultaneously** is a hallmark of creative thinking. Named after Janus, the two-faced Roman god, this mode of thinking doesn't resolve contradictions by choosing a side — it generates new frameworks that transcend the opposition.
+
+**In CS**: The most influential results often emerge from tensions previously thought irreconcilable.
+
+| Contradiction | Resolution | Impact |
+|--------------|------------|--------|
+| Consistency AND Availability (distributed systems) | CAP theorem: formalized the trade-off, then Raft/CRDTs found practical middle grounds | Foundation of distributed systems theory |
+| Security AND Usability | Zero-knowledge proofs: prove knowledge without revealing it | Enabled private computation |
+| Expressiveness AND Tractability | Probabilistic programming: express complex models, automate inference | New programming paradigm |
+| Memorization AND Generalization | Grokking: models memorize first, then generalize with more training | New understanding of learning dynamics |
+| Compression AND Quality | Neural codecs that compress beyond information-theoretic limits via learned priors | Redefined compression research |
+
+**Dialectical Thinking Workflow**:
+
+1. **Identify a binary** in your field: A vs. B (two approaches, goals, or paradigms treated as opposites)
+2. **Resist choosing a side**. Instead ask:
+   - "What would a system look like that achieves both A and B?"
+   - "Under what conditions is the A-B trade-off not fundamental?"
+   - "Is the opposition an artifact of how we formalized the problem?"
+3. **Seek synthesis**: The resolution often requires a new abstraction that reframes the relationship
+4. **Test the synthesis**: Can you demonstrate empirically that both goals are achievable?
+
+**Self-Check**:
+- [ ] Am I holding the contradiction genuinely (not prematurely resolving it)?
+- [ ] Is the synthesis a new idea, not just a compromise (splitting the difference)?
+- [ ] Does the resolution change how people think about the problem, not just the solution?
+
+---
+
+## Combining Frameworks: A Creative Thinking Protocol
+
+These frameworks are most powerful in combination. Here is a systematic protocol for a deep creative thinking session:
+
+### Phase 1: Map the Space (15 min)
+1. **Constraint Manipulation** (F4): List all constraints of the current paradigm. Mark which are hard, soft, hidden.
+2. **Adjacent Possible** (F7): List recent enablers that change the feasibility landscape.
+
+### Phase 2: Generate Disruptions (30 min)
+3. **Negation** (F5): Negate 3 soft/hidden constraints. What systems emerge?
+4. **Bisociation** (F1): Pick a distant field and create a cross-product matrix with your domain.
+5. **Problem Reformulation** (F2): Restate your problem 3 different ways (change objective, formalism, agent).
+
+### Phase 3: Deepen Promising Leads (30 min)
+6. **Analogical Reasoning** (F3): For each promising idea, find a structural analogy and extract predictions.
+7. **Abstraction Laddering** (F6): Move each idea up (generalize) and down (specialize).
+8. **Janusian Thinking** (F8): Identify any tensions. Can you synthesize rather than choose?
+
+### Phase 4: Evaluate (15 min)
+Apply the two-sentence test (from the brainstorm skill):
+> "**[Domain] currently struggles with [problem] because [reason].** We [approach] by [mechanism], which works because [insight]."
+
+Any idea that survives all four phases and passes the two-sentence test is worth pursuing.
+
+---
+
+## Common Creative Blocks and Unblocking Strategies
+
+| Block | Symptom | Framework to Apply |
+|-------|---------|-------------------|
+| **Fixation** | Cannot stop thinking about the problem one way | Problem Reformulation (F2) — force a different representation |
+| **Tunnel vision** | All ideas come from the same subfield | Bisociation (F1) or Analogical Reasoning (F3) — import from elsewhere |
+| **Self-censoring** | Dismissing ideas as "too weird" before exploring | Negation (F5) — weird is the point; evaluate after generating |
+| **Incrementalism** | Every idea is "+2% on benchmark X" | Constraint Manipulation (F4) — change the rules, not the parameters |
+| **Analysis paralysis** | Too many options, cannot commit | Adjacent Possible (F7) — what is feasible right now? |
+| **False dichotomy** | Stuck choosing between two approaches | Janusian Thinking (F8) — seek synthesis, not selection |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help with creative thinking or novel ideation:
+
+1. **Assess the block**: What kind of thinking are they stuck in? (See Common Creative Blocks table)
+2. **Select 2-3 frameworks** based on the block type
+3. **Walk through each framework interactively**, asking the researcher to supply domain-specific content
+4. **Push for structural depth**: If an analogy or combination is surface-level, probe deeper
+5. **Maintain a running list** of all generated ideas, even unusual ones
+6. **Apply the two-sentence test** to candidates that survive exploration
+7. **Hand off to the brainstorm skill** for systematic evaluation (diverge → converge → refine)
+
+**Key Principles**:
+- Generative mode first, evaluative mode second — do not filter prematurely
+- Distant analogies are more valuable than nearby ones, but require more validation
+- The researcher's domain expertise is essential — the agent provides the cognitive scaffolding, not the domain knowledge
+- Encourage the researcher to sit with contradictions rather than resolve them quickly

--- a/marketplace/plugins/seekers-lens/.codex-plugin/plugin.json
+++ b/marketplace/plugins/seekers-lens/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "seekers-lens",
+  "version": "0.1.0",
+  "description": "Discovery and ideation for bounded research work, from broad exploration through a reviewable pilot direction.",
+  "author": {
+    "name": "OpenCoven",
+    "url": "https://github.com/OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "ideation",
+    "discovery",
+    "brainstorming",
+    "craft"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Seeker's Lens",
+    "shortDescription": "Discovery and ideation for bounded research work, from broad exploration through a reviewable pilot direction.",
+    "longDescription": "Discovery and ideation for bounded research work, from broad exploration through a reviewable pilot direction.",
+    "developerName": "OpenCoven",
+    "category": "Research Crafts",
+    "capabilities": [
+      "filesystem.read",
+      "network.http",
+      "memory.local",
+      "reasoning.sequential"
+    ],
+    "websiteURL": "https://opencoven.ai",
+    "defaultPrompt": [
+      "Use Seeker's Lens to open a bounded research direction."
+    ]
+  }
+}

--- a/marketplace/plugins/seekers-lens/assets/THIRD_PARTY_NOTICES.md
+++ b/marketplace/plugins/seekers-lens/assets/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,28 @@
+# Third-party notices for Seeker's Lens
+
+Upstream: https://github.com/orchestra-research/AI-Research-SKILLs
+Pinned commit: 773a52944ba4747a18bd4ae9ade53fff041adcbc
+License: MIT
+
+## Bundled skills
+
+### brainstorming-research-ideas
+
+- Upstream path: `21-research-ideation/brainstorming-research-ideas/SKILL.md`
+- Upstream content hash: `sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46`
+- Coven modifications:
+  - Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.
+  - Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.
+  - Added a Coven boundary that keeps ideation advisory until execution is separately authorized.
+
+### creative-thinking-for-research
+
+- Upstream path: `21-research-ideation/creative-thinking-for-research/SKILL.md`
+- Upstream content hash: `sha256:ec111f9236d7f9d72c895cebbf0f534ac93f4249172607559ad4bf92aefc5310`
+- Coven modifications:
+  - Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.
+  - Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.
+  - Added a Coven boundary that labels speculation and requires separate authorization before execution.
+
+The upstream material is redistributed under the license named above.
+See the pinned source repository for the complete license text.

--- a/marketplace/plugins/seekers-lens/assets/UPSTREAM_LICENSE.txt
+++ b/marketplace/plugins/seekers-lens/assets/UPSTREAM_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Claude AI Research Skills Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/marketplace/plugins/seekers-lens/assets/craft.json
+++ b/marketplace/plugins/seekers-lens/assets/craft.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": "opencoven.craft.v1",
+  "components": {
+    "required": [
+      "fetch",
+      "filesystem",
+      "memory",
+      "sequential-thinking"
+    ],
+    "optional": [
+      "exa",
+      "tavily",
+      "firecrawl",
+      "searxng",
+      "research-ingestion"
+    ]
+  },
+  "bundled": {
+    "skills": [
+      {
+        "id": "brainstorming-research-ideas",
+        "sourcePath": "craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md",
+        "upstreamPath": "21-research-ideation/brainstorming-research-ideas/SKILL.md",
+        "contentHash": "sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46",
+        "modifications": [
+          "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+          "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+          "Added a Coven boundary that keeps ideation advisory until execution is separately authorized."
+        ]
+      },
+      {
+        "id": "creative-thinking-for-research",
+        "sourcePath": "craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md",
+        "upstreamPath": "21-research-ideation/creative-thinking-for-research/SKILL.md",
+        "contentHash": "sha256:ec111f9236d7f9d72c895cebbf0f534ac93f4249172607559ad4bf92aefc5310",
+        "modifications": [
+          "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+          "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+          "Added a Coven boundary that labels speculation and requires separate authorization before execution."
+        ]
+      }
+    ],
+    "prompts": [
+      {
+        "id": "open-a-research-space",
+        "name": "Open a research space",
+        "description": "Generate, challenge, and rank bounded research directions.",
+        "body": "Open the research space around {{topic}}. Use both Seeker's Lens ideation skills to generate distinct directions, label assumptions and unknowns, then rank the strongest three by novelty, impact, evidence gap, and feasibility. Stop with a proposed checkpoint; do not begin experiments."
+      },
+      {
+        "id": "stress-test-a-research-idea",
+        "name": "Stress-test a research idea",
+        "description": "Probe a candidate direction before committing resources.",
+        "body": "Stress-test {{research idea}}. Reformulate it at three abstraction levels, identify the strongest contradiction or boundary case, compare a simpler baseline, and state the evidence that would change the recommendation. End with a bounded pilot and a human go/no-go checkpoint."
+      }
+    ],
+    "workflows": [
+      {
+        "id": "diverge-converge-refine",
+        "name": "Diverge, converge, refine",
+        "description": "Move from a broad topic to a reviewable pilot without starting execution.",
+        "steps": [
+          "Define the research space, stakeholders, constraints, and explicit resource bounds.",
+          "Generate diverse candidate directions with multiple ideation lenses.",
+          "Challenge candidates with contradiction, boundary, simplicity, and feasibility checks.",
+          "Rank the strongest directions and expose assumptions, evidence gaps, and likely objections.",
+          "Draft one bounded pilot and stop at a human go/no-go checkpoint."
+        ]
+      }
+    ]
+  },
+  "requiredCapabilities": [
+    "filesystem.read",
+    "network.http",
+    "memory.local",
+    "reasoning.sequential"
+  ],
+  "recommendedRoles": [
+    "researcher",
+    "strategist",
+    "analyst"
+  ],
+  "provenance": {
+    "source": "https://github.com/orchestra-research/AI-Research-SKILLs",
+    "commit": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+    "license": "MIT",
+    "licensePath": "craft-sources/orchestra-research/LICENSE"
+  }
+}

--- a/marketplace/plugins/seekers-lens/plugin.json
+++ b/marketplace/plugins/seekers-lens/plugin.json
@@ -1,0 +1,130 @@
+{
+  "name": "seekers-lens",
+  "version": "0.1.0",
+  "description": "Discovery and ideation for bounded research work, from broad exploration through a reviewable pilot direction.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "ideation",
+    "discovery",
+    "brainstorming",
+    "craft"
+  ],
+  "capabilities": [
+    "research",
+    "ideation",
+    "workflows"
+  ],
+  "marketplaceId": "opencoven/seekers-lens",
+  "x-coven": {
+    "displayName": "Seeker's Lens",
+    "category": "Research Crafts",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/orchestra-research/AI-Research-SKILLs/tree/773a52944ba4747a18bd4ae9ade53fff041adcbc/21-research-ideation"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  },
+  "kind": "craft",
+  "craft": {
+    "schemaVersion": "opencoven.craft.v1",
+    "components": {
+      "required": [
+        "fetch",
+        "filesystem",
+        "memory",
+        "sequential-thinking"
+      ],
+      "optional": [
+        "exa",
+        "tavily",
+        "firecrawl",
+        "searxng",
+        "research-ingestion"
+      ]
+    },
+    "bundled": {
+      "skills": [
+        {
+          "id": "brainstorming-research-ideas",
+          "sourcePath": "craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md",
+          "upstreamPath": "21-research-ideation/brainstorming-research-ideas/SKILL.md",
+          "contentHash": "sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46",
+          "modifications": [
+            "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+            "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+            "Added a Coven boundary that keeps ideation advisory until execution is separately authorized."
+          ]
+        },
+        {
+          "id": "creative-thinking-for-research",
+          "sourcePath": "craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md",
+          "upstreamPath": "21-research-ideation/creative-thinking-for-research/SKILL.md",
+          "contentHash": "sha256:ec111f9236d7f9d72c895cebbf0f534ac93f4249172607559ad4bf92aefc5310",
+          "modifications": [
+            "Normalized frontmatter to Codex-supported name, description, and license fields while retaining the instructional body.",
+            "Replaced the unavailable scientific-skills literature-review reference with a capability-neutral handoff.",
+            "Added a Coven boundary that labels speculation and requires separate authorization before execution."
+          ]
+        }
+      ],
+      "prompts": [
+        {
+          "id": "open-a-research-space",
+          "name": "Open a research space",
+          "description": "Generate, challenge, and rank bounded research directions.",
+          "body": "Open the research space around {{topic}}. Use both Seeker's Lens ideation skills to generate distinct directions, label assumptions and unknowns, then rank the strongest three by novelty, impact, evidence gap, and feasibility. Stop with a proposed checkpoint; do not begin experiments."
+        },
+        {
+          "id": "stress-test-a-research-idea",
+          "name": "Stress-test a research idea",
+          "description": "Probe a candidate direction before committing resources.",
+          "body": "Stress-test {{research idea}}. Reformulate it at three abstraction levels, identify the strongest contradiction or boundary case, compare a simpler baseline, and state the evidence that would change the recommendation. End with a bounded pilot and a human go/no-go checkpoint."
+        }
+      ],
+      "workflows": [
+        {
+          "id": "diverge-converge-refine",
+          "name": "Diverge, converge, refine",
+          "description": "Move from a broad topic to a reviewable pilot without starting execution.",
+          "steps": [
+            "Define the research space, stakeholders, constraints, and explicit resource bounds.",
+            "Generate diverse candidate directions with multiple ideation lenses.",
+            "Challenge candidates with contradiction, boundary, simplicity, and feasibility checks.",
+            "Rank the strongest directions and expose assumptions, evidence gaps, and likely objections.",
+            "Draft one bounded pilot and stop at a human go/no-go checkpoint."
+          ]
+        }
+      ]
+    },
+    "requiredCapabilities": [
+      "filesystem.read",
+      "network.http",
+      "memory.local",
+      "reasoning.sequential"
+    ],
+    "recommendedRoles": [
+      "researcher",
+      "strategist",
+      "analyst"
+    ],
+    "provenance": {
+      "source": "https://github.com/orchestra-research/AI-Research-SKILLs",
+      "commit": "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+      "license": "MIT",
+      "licensePath": "craft-sources/orchestra-research/LICENSE"
+    }
+  }
+}

--- a/marketplace/plugins/seekers-lens/prompts/open-a-research-space.md
+++ b/marketplace/plugins/seekers-lens/prompts/open-a-research-space.md
@@ -1,0 +1,6 @@
+---
+name: Open a research space
+description: Generate, challenge, and rank bounded research directions.
+---
+
+Open the research space around {{topic}}. Use both Seeker's Lens ideation skills to generate distinct directions, label assumptions and unknowns, then rank the strongest three by novelty, impact, evidence gap, and feasibility. Stop with a proposed checkpoint; do not begin experiments.

--- a/marketplace/plugins/seekers-lens/prompts/stress-test-a-research-idea.md
+++ b/marketplace/plugins/seekers-lens/prompts/stress-test-a-research-idea.md
@@ -1,0 +1,6 @@
+---
+name: Stress-test a research idea
+description: Probe a candidate direction before committing resources.
+---
+
+Stress-test {{research idea}}. Reformulate it at three abstraction levels, identify the strongest contradiction or boundary case, compare a simpler baseline, and state the evidence that would change the recommendation. End with a bounded pilot and a human go/no-go checkpoint.

--- a/marketplace/plugins/seekers-lens/skills/brainstorming-research-ideas/SKILL.md
+++ b/marketplace/plugins/seekers-lens/skills/brainstorming-research-ideas/SKILL.md
@@ -1,0 +1,386 @@
+---
+name: brainstorming-research-ideas
+description: Guides researchers through structured ideation frameworks to discover high-impact research directions. Use when exploring new problem spaces, pivoting between projects, or seeking novel angles on existing work.
+license: MIT
+---
+
+# Research Idea Brainstorming
+
+Structured frameworks for discovering the next research idea. This skill provides ten complementary ideation lenses that help researchers move from vague curiosity to concrete, defensible research proposals. Each framework targets a different cognitive mode—use them individually or combine them for comprehensive exploration.
+
+## Coven Boundary
+
+- Treat every direction as a proposal for the researcher to accept, revise, or reject.
+- Do not start experiments, spend money or compute, alter repositories, or publish results unless the user separately requests that work.
+- State assumptions and define a checkpoint before handing an idea to an execution workflow.
+
+## When to Use This Skill
+
+- Starting a new research direction and need structured exploration
+- Feeling stuck on a current project and want fresh angles
+- Evaluating whether a half-formed idea has real potential
+- Preparing for a brainstorming session with collaborators
+- Transitioning between research areas and seeking high-leverage entry points
+- Reviewing a field and looking for underexplored gaps
+
+**Do NOT use this skill when**:
+- You already have a well-defined research question and need execution guidance
+- You need help with experimental design or methodology (use domain-specific skills)
+- You want a literature review (hand off to an available literature-review or research-ingestion capability)
+
+---
+
+## Core Ideation Frameworks
+
+### 1. Problem-First vs. Solution-First Thinking
+
+Research ideas originate from two distinct modes. Knowing which mode you are in prevents a common failure: building solutions that lack real problems, or chasing problems without feasible approaches.
+
+**Problem-First** (pain point → method):
+- Start with a concrete failure, bottleneck, or unmet need
+- Naturally yields impactful work because the motivation is intrinsic
+- Risk: may converge on incremental fixes rather than paradigm shifts
+
+**Solution-First** (new capability → application):
+- Start with a new tool, insight, or technique seeking application
+- Often drives breakthroughs by unlocking previously impossible approaches
+- Risk: "hammer looking for a nail"—solution may lack genuine demand
+
+**Workflow**:
+1. Write down your idea in one sentence
+2. Classify it: Is this problem-first or solution-first?
+3. If problem-first → verify the problem matters (who suffers? how much?)
+4. If solution-first → identify at least two genuine problems it addresses
+5. For either mode, articulate the gap: what cannot be done today that this enables?
+
+**Self-Check**:
+- [ ] Can I name a specific person or community who needs this?
+- [ ] Is the problem I am solving actually unsolved (not just under-marketed)?
+- [ ] If solution-first, does the solution create new capability or just replicate existing ones?
+
+---
+
+### 2. The Abstraction Ladder
+
+Every research problem sits at a particular level of abstraction. Deliberately moving up or down the ladder reveals ideas invisible at your current level.
+
+| Direction | Action | Outcome |
+|-----------|--------|---------|
+| **Move Up** (generalize) | Turn a specific result into a broader principle | Framework papers, theoretical contributions |
+| **Move Down** (instantiate) | Test a general paradigm under concrete constraints | Empirical papers, surprising failure analyses |
+| **Move Sideways** (analogize) | Apply same abstraction level to adjacent domain | Cross-pollination, transfer papers |
+
+**Workflow**:
+1. State your current research focus in one sentence
+2. Move UP: What is the general principle behind this? What class of problems does this belong to?
+3. Move DOWN: What is the most specific, constrained instance of this? What happens at the extreme?
+4. Move SIDEWAYS: Where else does this pattern appear in a different field?
+5. For each new level, ask: Is this a publishable contribution on its own?
+
+**Example**:
+- **Current**: "Improving retrieval accuracy for RAG systems"
+- **Up**: "What makes context selection effective for any augmented generation system?"
+- **Down**: "How does retrieval accuracy degrade when documents are adversarially perturbed?"
+- **Sideways**: "Database query optimization uses similar relevance ranking—what can we borrow?"
+
+---
+
+### 3. Tension and Contradiction Hunting
+
+Breakthroughs often come from resolving tensions between widely accepted but seemingly conflicting goals. These contradictions are not bugs—they are the research opportunity.
+
+**Common Research Tensions**:
+
+| Tension Pair | Research Opportunity |
+|-------------|---------------------|
+| Performance ↔ Efficiency | Can we match SOTA with 10x less compute? |
+| Privacy ↔ Utility | Can federated/encrypted methods close the accuracy gap? |
+| Generality ↔ Specialization | When does fine-tuning beat prompting, and why? |
+| Safety ↔ Capability | Can alignment improve rather than tax capability? |
+| Interpretability ↔ Performance | Do mechanistic insights enable better architectures? |
+| Scale ↔ Accessibility | Can small models replicate emergent behaviors? |
+
+**Workflow**:
+1. Pick your research area
+2. List the top 3-5 desiderata (things everyone wants)
+3. Identify pairs that are commonly treated as trade-offs
+4. For each pair, ask: Is this trade-off fundamental or an artifact of current methods?
+5. If artifact → the reconciliation IS your research contribution
+6. If fundamental → characterizing the Pareto frontier is itself valuable
+
+**Self-Check**:
+- [ ] Have I confirmed this tension is real (not just assumed)?
+- [ ] Can I point to papers that optimize for each side independently?
+- [ ] Is my proposed reconciliation technically plausible, not just aspirational?
+
+---
+
+### 4. Cross-Pollination (Analogy Transfer)
+
+Borrowing structural ideas from other disciplines is one of the most generative research heuristics. Many foundational techniques emerged this way—attention mechanisms draw from cognitive science, genetic algorithms from biology, adversarial training from game theory.
+
+**Requirements for a Valid Analogy**:
+- **Structural fidelity**: The mapping must hold at the level of underlying mechanisms, not just surface similarity
+- **Non-obvious connection**: If the link is well-known, the novelty is gone
+- **Testable predictions**: The analogy should generate concrete hypotheses
+
+**High-Yield Source Fields for ML Research**:
+
+| Source Field | Transferable Concepts |
+|-------------|----------------------|
+| Neuroscience | Attention, memory consolidation, hierarchical processing |
+| Physics | Energy-based models, phase transitions, renormalization |
+| Economics | Mechanism design, auction theory, incentive alignment |
+| Ecology | Population dynamics, niche competition, co-evolution |
+| Linguistics | Compositionality, pragmatics, grammatical induction |
+| Control Theory | Feedback loops, stability, adaptive regulation |
+
+**Workflow**:
+1. Describe your problem in domain-agnostic language (strip the jargon)
+2. Ask: What other field solves a structurally similar problem?
+3. Study that field's solution at the mechanism level
+4. Map the solution back to your domain, preserving structural relationships
+5. Generate testable predictions from the analogy
+6. Validate: Does the borrowed idea actually improve outcomes?
+
+---
+
+### 5. The "What Changed?" Principle
+
+Strong ideas often come from revisiting old problems under new conditions. Advances in hardware, scale, data availability, or regulations can invalidate prior assumptions and make previously impractical approaches viable.
+
+**Categories of Change to Monitor**:
+
+| Change Type | Example | Research Implication |
+|------------|---------|---------------------|
+| **Compute** | GPUs 10x faster | Methods dismissed as too expensive become feasible |
+| **Scale** | Trillion-token datasets | Statistical arguments that failed at small scale may now hold |
+| **Regulation** | EU AI Act, GDPR | Creates demand for compliant alternatives |
+| **Tooling** | New frameworks, APIs | Reduces implementation barrier for complex methods |
+| **Failure** | High-profile system failures | Exposes gaps in existing approaches |
+| **Cultural** | New user behaviors | Shifts what problems matter most |
+
+**Workflow**:
+1. Pick a well-known negative result or abandoned approach (3-10 years old)
+2. List the assumptions that led to its rejection
+3. For each assumption, ask: Is this still true today?
+4. If any assumption has been invalidated → re-run the idea under new conditions
+5. Frame the contribution: "X was previously impractical because Y, but Z has changed"
+
+---
+
+### 6. Failure Analysis and Boundary Probing
+
+Understanding where a method breaks is often as valuable as showing where it works. Boundary probing systematically exposes the conditions under which accepted techniques fail.
+
+**Types of Boundaries to Probe**:
+- **Distributional**: What happens with out-of-distribution inputs?
+- **Scale**: Does the method degrade at 10x or 0.1x the typical scale?
+- **Adversarial**: Can the method be deliberately broken?
+- **Compositional**: Does performance hold when combining multiple capabilities?
+- **Temporal**: Does the method degrade over time (concept drift)?
+
+**Workflow**:
+1. Select a widely-used method with strong reported results
+2. Identify the implicit assumptions in its evaluation (dataset, scale, domain)
+3. Systematically violate each assumption
+4. Document where and how the method breaks
+5. Diagnose the root cause of each failure
+6. Propose a fix or explain why the failure is fundamental
+
+**Self-Check**:
+- [ ] Am I probing genuine boundaries, not just confirming known limitations?
+- [ ] Can I explain WHY the method fails, not just THAT it fails?
+- [ ] Does my analysis suggest a constructive path forward?
+
+---
+
+### 7. The Simplicity Test
+
+Before accepting complexity, ask whether a simpler approach suffices. Fields sometimes over-index on elaborate solutions when a streamlined baseline performs competitively.
+
+**Warning Signs of Unnecessary Complexity**:
+- The method has many hyperparameters with narrow optimal ranges
+- Ablations show most components contribute marginally
+- A simple baseline was never properly tuned or evaluated
+- The improvement over baselines is within noise on most benchmarks
+
+**Workflow**:
+1. Identify the current SOTA method for your problem
+2. Strip it to its simplest possible core (what is the one key idea?)
+3. Build that minimal version with careful engineering
+4. Compare fairly: same compute budget, same tuning effort
+5. If the gap is small → the contribution is the simplicity itself
+6. If the gap is large → you now understand what the complexity buys
+
+**Contribution Framing**:
+- "We show that [simple method] with [one modification] matches [complex SOTA]"
+- "We identify [specific component] as the critical driver, not [other components]"
+
+---
+
+### 8. Stakeholder Rotation
+
+Viewing a system from multiple perspectives reveals distinct classes of research questions. Each stakeholder sees different friction, risk, and opportunity.
+
+**Stakeholder Perspectives**:
+
+| Stakeholder | Key Questions |
+|-------------|---------------|
+| **End User** | Is this usable? What errors are unacceptable? What is the latency tolerance? |
+| **Developer** | Is this debuggable? What is the maintenance burden? How does it compose? |
+| **Theorist** | Why does this work? What are the formal guarantees? Where are the gaps? |
+| **Adversary** | How can this be exploited? What are the attack surfaces? |
+| **Ethicist** | Who is harmed? What biases are embedded? Who is excluded? |
+| **Regulator** | Is this auditable? Can decisions be explained? Is there accountability? |
+| **Operator** | What is the cost? How does it scale? What is the failure mode? |
+
+**Workflow**:
+1. Describe your system or method in one paragraph
+2. Assume each stakeholder perspective in turn (spend 5 minutes per role)
+3. For each perspective, list the top 3 concerns or questions
+4. Identify which concerns are unaddressed by existing work
+5. The unaddressed concern with the broadest impact is your research question
+
+---
+
+### 9. Composition and Decomposition
+
+Novelty often emerges from recombination or modularization. Innovation frequently lies not in new primitives, but in how components are arranged or separated.
+
+**Composition** (combining existing techniques):
+- Identify two methods that solve complementary subproblems
+- Ask: What emergent capability arises from combining them?
+- Example: RAG + Chain-of-Thought → retrieval-augmented reasoning
+
+**Decomposition** (breaking apart monolithic systems):
+- Identify a complex system with entangled components
+- Ask: Which component is the actual bottleneck?
+- Example: Decomposing "fine-tuning" into data selection, optimization, and regularization reveals that data selection often matters most
+
+**Workflow**:
+1. List the 5-10 key components or techniques in your area
+2. **Compose**: Pick pairs and ask what happens when you combine them
+3. **Decompose**: Pick a complex method and isolate each component's contribution
+4. For compositions: Does the combination create emergent capabilities?
+5. For decompositions: Does isolation reveal a dominant or redundant component?
+
+---
+
+### 10. The "Explain It to Someone" Test
+
+A strong research idea should be defensible in two sentences to a smart non-expert. This test enforces clarity of purpose and sharpens the value proposition.
+
+**The Two-Sentence Template**:
+> **Sentence 1** (Problem): "[Domain] currently struggles with [specific problem], which matters because [concrete consequence]."
+> **Sentence 2** (Insight): "We [approach] by [key mechanism], which works because [reason]."
+
+**If You Cannot Fill This Template**:
+- The problem may not be well-defined yet → return to Framework 1
+- The insight may not be clear yet → return to Framework 7 (simplify)
+- The significance may not be established → return to Framework 3 (find the tension)
+
+**Calibration Questions**:
+- Would a smart colleague outside your subfield understand why this matters?
+- Does the explanation stand without jargon?
+- Can you predict what a skeptic's first objection would be?
+
+---
+
+## Integrated Brainstorming Workflow
+
+Use this end-to-end workflow to go from blank page to ranked research ideas.
+
+### Phase 1: Diverge (Generate Candidates)
+
+**Goal**: Produce 10-20 candidate ideas without filtering.
+
+1. **Scan for tensions** (Framework 3): List 5 trade-offs in your field
+2. **Check what changed** (Framework 5): List 3 recent shifts (compute, data, regulation)
+3. **Probe boundaries** (Framework 6): Pick 2 popular methods and find where they break
+4. **Cross-pollinate** (Framework 4): Pick 1 idea from an adjacent field
+5. **Compose/decompose** (Framework 9): Combine 2 existing techniques or split 1 apart
+6. **Climb the abstraction ladder** (Framework 2): For each candidate, generate up/down/sideways variants
+
+### Phase 2: Converge (Filter and Rank)
+
+**Goal**: Narrow to 3-5 strongest ideas.
+
+Apply these filters to each candidate:
+
+| Filter | Question | Kill Criterion |
+|--------|----------|----------------|
+| **Explain-It Test** (F10) | Can I state this in two sentences? | If no → idea is not yet clear |
+| **Problem-First Check** (F1) | Is the problem genuine and important? | If no one suffers from this → drop it |
+| **Simplicity Test** (F7) | Is the complexity justified? | If a simpler approach works → simplify or drop |
+| **Stakeholder Check** (F8) | Who benefits? Who might object? | If no clear beneficiary → drop it |
+| **Feasibility** | Can I execute this with available resources? | If clearly infeasible → park it for later |
+
+### Phase 3: Refine (Sharpen the Winner)
+
+**Goal**: Turn the top idea into a concrete research plan.
+
+1. Write the two-sentence pitch (Framework 10)
+2. Identify the core tension being resolved (Framework 3)
+3. Specify the abstraction level (Framework 2)
+4. List 3 concrete experiments that would validate the idea
+5. Anticipate the strongest objection and prepare a response
+6. Define a 2-week pilot that would provide signal on feasibility
+
+**Completion Checklist**:
+- [ ] Two-sentence pitch is clear and compelling
+- [ ] Problem is genuine (problem-first check passed)
+- [ ] Approach is justified (simplicity test passed)
+- [ ] At least one stakeholder clearly benefits
+- [ ] Core experiments are specified
+- [ ] Feasibility pilot is defined
+- [ ] Strongest objection has a response
+
+---
+
+## Framework Selection Guide
+
+Not sure which framework to start with? Use this decision guide:
+
+| Your Situation | Start With |
+|---------------|------------|
+| "I don't know what area to work in" | Tension Hunting (F3) → What Changed (F5) |
+| "I have a vague area but no specific idea" | Abstraction Ladder (F2) → Failure Analysis (F6) |
+| "I have an idea but I'm not sure it's good" | Explain-It Test (F10) → Simplicity Test (F7) |
+| "I have a good idea but need a fresh angle" | Cross-Pollination (F4) → Stakeholder Rotation (F8) |
+| "I want to combine existing work into something new" | Composition/Decomposition (F9) |
+| "I found a cool technique and want to apply it" | Problem-First Check (F1) → Stakeholder Rotation (F8) |
+| "I want to challenge conventional wisdom" | Failure Analysis (F6) → Simplicity Test (F7) |
+
+---
+
+## Common Pitfalls in Research Ideation
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Novelty without impact** | "No one has done X" but no one needs X | Apply Problem-First Check (F1) |
+| **Incremental by default** | Idea is +2% on a benchmark | Climb the Abstraction Ladder (F2) |
+| **Complexity worship** | Method has 8 components, each helping marginally | Apply Simplicity Test (F7) |
+| **Echo chamber** | All ideas come from reading the same 10 papers | Use Cross-Pollination (F4) |
+| **Stale assumptions** | "This was tried and didn't work" (5 years ago) | Apply What Changed (F5) |
+| **Single-perspective bias** | Only considering the ML engineer's view | Use Stakeholder Rotation (F8) |
+| **Premature convergence** | Committed to first idea without exploring alternatives | Run full Diverge phase |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help brainstorming research ideas:
+
+1. **Identify their starting point**: Are they exploring a new area, stuck on a current project, or evaluating an existing idea?
+2. **Select appropriate frameworks**: Use the Framework Selection Guide to pick 2-3 relevant lenses
+3. **Walk through frameworks interactively**: Apply each framework step-by-step, asking the researcher for domain-specific inputs
+4. **Generate candidates**: Aim for 10-20 raw ideas across frameworks
+5. **Filter and rank**: Apply the Converge phase filters to narrow to top 3-5
+6. **Refine the winner**: Help articulate the two-sentence pitch and define concrete next steps
+
+**Key Principles**:
+- Push for specificity—vague ideas ("improve efficiency") are not actionable
+- Challenge assumptions—ask "why?" at least three times
+- Maintain a written list of all candidates, even rejected ones (they may recombine later)
+- The researcher makes the final call on which ideas to pursue; the agent facilitates structured thinking

--- a/marketplace/plugins/seekers-lens/skills/creative-thinking-for-research/SKILL.md
+++ b/marketplace/plugins/seekers-lens/skills/creative-thinking-for-research/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: creative-thinking-for-research
+description: Applies cognitive science frameworks for creative thinking to CS and AI research ideation. Use when seeking genuinely novel research directions by leveraging combinatorial creativity, analogical reasoning, constraint manipulation, and other empirically grounded creative strategies.
+license: MIT
+---
+
+# Creative Thinking for Research
+
+Eight empirically grounded frameworks from cognitive science, applied to computer science and AI research. Unlike ad-hoc brainstorming, each framework here is backed by decades of creativity research — from Koestler's bisociation to Kauffman's adjacent possible. They target distinct cognitive operations: combining, reformulating, analogizing, constraining, inverting, abstracting, exploring boundaries, and holding contradictions.
+
+## Coven Boundary
+
+- Treat creative directions as advisory candidates, not authorization to execute them.
+- Do not start experiments, spend money or compute, alter repositories, or publish results unless the user separately requests that work.
+- Mark speculative claims, state assumptions, and define a human checkpoint before moving from ideation to execution.
+
+## When to Use This Skill
+
+- Generating genuinely novel ideas, not incremental extensions of prior work
+- Feeling trapped in a local optimum of thinking within a single subfield
+- Wanting to systematically apply creativity heuristics rather than waiting for inspiration
+- Preparing for a research retreat or PhD-level ideation session
+- Bridging between fields and seeking structural (not superficial) connections
+
+**Do NOT use this skill when**:
+- You need structured project-level brainstorming workflows (use `brainstorming-research-ideas`)
+- You have a well-defined problem and need execution help (use domain-specific skills)
+- You need a literature survey (hand off to an available literature-review or research-ingestion capability)
+
+**Relationship to Brainstorm skill**: The brainstorm skill provides operational workflows (diverge → converge → refine) and practical filters. This skill provides the deeper cognitive engines that power creative leaps. Use them together: creative-thinking to generate raw insight, brainstorm to structure and evaluate it.
+
+---
+
+## Framework 1: Combinatorial Creativity (Bisociation)
+
+Novel ideas arise from combining existing concepts in unexpected ways. Arthur Koestler called this **bisociation** — connecting two previously unrelated frames of reference, as distinct from routine association within a single frame.
+
+**Why it works**: Meta-research consistently shows that breadth of knowledge is a precursor to creative output. People who read across disciplines produce more novel work. The combination itself is the creative act.
+
+**In CS Research**:
+- Biological evolution → optimization (genetic algorithms)
+- Game theory → networking (mechanism design for routing)
+- Statistical physics → machine learning (Boltzmann machines, energy-based models)
+- Linguistics → programming (type theory, formal grammars)
+
+**Systematic Bisociation Workflow**:
+
+1. **Select two domains** you have at least passing familiarity with
+2. **List core primitives** in each domain (5-10 fundamental concepts per domain)
+3. **Create a cross-product matrix**: row = concepts from Domain A, column = concepts from Domain B
+4. **For each cell**, ask: "What would it mean to apply A's concept to B's problem?"
+5. **Filter**: Which combinations produce a non-trivial, testable research question?
+6. **Validate structural depth**: Is the connection mechanistic or merely metaphorical?
+
+**Cross-Product Example**:
+
+| | Caching | Load Balancing | Fault Tolerance |
+|---|---------|---------------|-----------------|
+| **Natural Selection** | Evict least-fit entries | Adaptive allocation via fitness | Population-level redundancy |
+| **Immune Memory** | Learned threat signatures | Distributed detection | Self/non-self discrimination |
+| **Symbiosis** | Cooperative prefetching | Mutualistic resource sharing | Co-dependent resilience |
+
+**Quality Test**: A strong bisociation is not a surface metaphor ("the network is like a brain") but a structural mapping where the mechanism transfers ("attention mechanisms implement a form of selective gating analogous to cognitive attention filtering").
+
+**Self-Check**:
+- [ ] Is the connection structural (mechanisms map) or merely verbal (labels map)?
+- [ ] Does the combination generate testable predictions?
+- [ ] Would an expert in both fields find the connection non-obvious but sound?
+
+---
+
+## Framework 2: Problem Reformulation (Representational Change)
+
+Gestalt psychologists identified that breakthroughs often come not from solving the problem as stated, but from **re-representing the problem itself**. Kaplan and Simon's work on insight shows that changing the problem space — the constraints, the abstraction level, the formalism — is often where creativity lives.
+
+**The Key Shift**: From "How do I solve this problem?" to "Am I even thinking about this problem correctly?"
+
+**Reformulation Strategies**:
+
+| Strategy | Example |
+|----------|---------|
+| **Change the objective** | "Make the algorithm faster" → "Eliminate the need for this computation" |
+| **Change the formalism** | Graph problem → linear algebra problem (spectral methods) |
+| **Change the granularity** | Per-token prediction → per-span prediction |
+| **Change the agent** | "How should the model learn?" → "How should the data teach?" (curriculum learning) |
+| **Change the timescale** | Real-time optimization → amortized inference |
+| **Invert the direction** | Forward simulation → inverse problem (learning from observations) |
+
+**Workflow**:
+
+1. State your current problem in one sentence
+2. Identify the **hidden assumptions** in that statement:
+   - What formalism are you using? (Could you use a different one?)
+   - What is the objective? (Is it the right objective?)
+   - What level of granularity? (Could you go coarser or finer?)
+   - Who is the agent? (Could you shift perspective?)
+3. For each assumption, **generate the alternative**: "What if [opposite assumption]?"
+4. For each alternative, ask: "Does this reformulation make the problem easier, harder, or different in a useful way?"
+5. A reformulation that makes a hard problem easy is often a publishable insight on its own
+
+**Classic CS Examples**:
+- **PageRank**: Reformulated "find important web pages" from content analysis to graph eigenvalue problem
+- **Dropout**: Reformulated "prevent overfitting" from regularization to approximate ensemble
+- **Attention**: Reformulated "handle long sequences" from remembering everything to selectively querying
+
+---
+
+## Framework 3: Analogical Reasoning (Structure-Mapping)
+
+Dedre Gentner's **structure-mapping theory** and Kevin Dunbar's studies of real scientists show that analogy is the core engine of scientific creativity. The critical finding: surface-level analogies are common but weak; **structural or relational analogies** — where the deep causal/relational structure maps across domains — produce the most powerful insights.
+
+**Dunbar's Finding**: In the most successful labs, analogies from distant domains drove the most important discoveries. Nearby analogies refined ideas; distant analogies generated them.
+
+**Levels of Analogical Depth**:
+
+| Level | Description | Value | Example |
+|-------|-------------|-------|---------|
+| **Surface** | Things look similar | Low | "A neural network is like a brain" |
+| **Relational** | Relationships between entities match | Medium | "Attention allocation in models parallels resource allocation in economics" |
+| **Structural** | Deep causal mechanisms map | High | "Diffusion models reverse a thermodynamic process; the math of non-equilibrium stat-mech directly applies" |
+
+**Structure-Mapping Workflow**:
+
+1. **Describe your problem** using only relational/causal language (strip domain-specific nouns)
+   - Bad: "We need to improve transformer attention efficiency"
+   - Good: "We have a system that must selectively aggregate information from a large set, where relevance is context-dependent and the cost scales quadratically with set size"
+2. **Search for structural matches**: What other systems selectively aggregate from large sets?
+   - Database query optimization, visual attention in neuroscience, information retrieval, resource allocation
+3. **Pick the most distant match** with genuine structural fidelity
+4. **Map the solution mechanism**: How does the source domain solve this?
+5. **Transfer and adapt**: What changes when you bring that mechanism into your domain?
+6. **Generate predictions**: The analogy should tell you something you didn't already know
+
+**Validation Checklist**:
+- [ ] Does the mapping preserve causal/relational structure (not just labels)?
+- [ ] Can I identify at least one prediction the analogy makes in my domain?
+- [ ] Would an expert in the source domain confirm the mechanism is correctly understood?
+- [ ] Is the analogy non-obvious to my target audience?
+
+---
+
+## Framework 4: Constraint Manipulation (Boden's Framework)
+
+Margaret Boden's framework distinguishes three forms of creativity based on how they interact with constraints:
+
+| Type | Operation | CS Example |
+|------|-----------|------------|
+| **Exploratory** | Search within the existing conceptual space | Hyperparameter tuning, architecture search within a fixed paradigm |
+| **Combinational** | Combine elements from different spaces | Multi-task learning, neuro-symbolic methods |
+| **Transformational** | Change the rules of the space itself | Dropping the assumption that training requires labels (self-supervised learning) |
+
+**Transformational creativity is the rarest and highest-impact.** It happens when you change what is even considered a valid solution.
+
+**Constraint Analysis Workflow**:
+
+1. **List the constraints** of your current approach (5-10 constraints):
+   - Computational: "Must fit in GPU memory"
+   - Methodological: "Requires labeled data"
+   - Architectural: "Uses fixed-length context"
+   - Evaluative: "Measured by accuracy on benchmark X"
+2. **Classify each constraint**:
+   - **Hard**: Physically or logically necessary (cannot violate)
+   - **Soft**: Convention or historical accident (can question)
+   - **Hidden**: Not stated but implicitly assumed (most fertile for innovation)
+3. **For each soft/hidden constraint**, ask:
+   - What if we relaxed it? (streaming algorithms from relaxing "fits in memory")
+   - What if we tightened it? (efficiency research from tightening compute budgets)
+   - What if we replaced it with a different constraint entirely?
+4. **The most productive move** is often exposing and dropping a hidden constraint
+
+**Classic Examples of Constraint Transformation**:
+- "Data must fit in memory" → dropped → streaming algorithms, external memory
+- "Training requires human labels" → dropped → self-supervised learning
+- "Models must be deterministic" → dropped → variational methods, diffusion
+- "Inference must happen in one pass" → dropped → iterative refinement, chain-of-thought
+
+---
+
+## Framework 5: Negation and Inversion
+
+Take a core assumption in your field and negate it. This is formalized in De Bono's lateral thinking and the **TRIZ methodology** from engineering.
+
+**The Pattern**: "What if [widely held assumption] is wrong, unnecessary, or invertible?"
+
+**Systematic Negation Workflow**:
+
+1. **List 5-10 core assumptions** in your subfield (the things "everyone knows")
+2. **Negate each one** and ask: What system would you build?
+3. **Evaluate each negation**:
+   - Incoherent → discard
+   - Already explored → check if conditions have changed (see brainstorm skill, Framework 5)
+   - Unexplored and coherent → potential research direction
+
+**Negation Hall of Fame in CS**:
+
+| Assumption | Negation | Result |
+|-----------|----------|--------|
+| "We need strong consistency" | What if we don't? | Eventual consistency, CRDTs |
+| "We need exact answers" | What if approximate is fine? | Sketches, LSH, approximate nearest neighbors |
+| "Labels are necessary" | What if we learn without them? | Self-supervised learning, contrastive methods |
+| "More parameters = more compute" | What if we don't use all parameters? | Mixture of Experts, sparse models |
+| "Training and inference are separate" | What if the model keeps learning? | Online learning, test-time training |
+| "Errors must be prevented" | What if we embrace and correct them? | Speculative decoding, self-correction |
+
+**TRIZ-Inspired Principles for CS**:
+
+| TRIZ Principle | CS Application |
+|---------------|----------------|
+| **Inversion** | Reverse the process (generative vs. discriminative) |
+| **Segmentation** | Break monolithic into modular (microservices, mixture of experts) |
+| **Merging** | Combine separate steps (end-to-end learning) |
+| **Universality** | One component serves multiple functions (multi-task models) |
+| **Nesting** | Place one system inside another (meta-learning) |
+| **Dynamization** | Make static things adaptive (dynamic architectures, adaptive computation) |
+
+---
+
+## Framework 6: Abstraction and Generalization Laddering
+
+Moving up and down the abstraction ladder is a fundamental creative act. Polya's heuristics formalize this: *"Can you solve a more general problem? A more specific one? An analogous one?"*
+
+**Three Moves**:
+
+| Move | Question | Outcome |
+|------|----------|---------|
+| **Generalize** | "Is my solution a special case of something broader?" | Framework papers, unifying theories |
+| **Specialize** | "What happens when I add extreme constraints?" | Niche applications, surprising edge cases |
+| **Analogize** | "Where else does this abstract pattern appear?" | Cross-domain transfer (see Framework 3) |
+
+**Generalization Workflow**:
+1. State your specific result
+2. Replace each specific element with a variable: "ResNet works for ImageNet" → "Architecture X works for distribution Y"
+3. Ask: Under what conditions does this hold? What is the general principle?
+4. If the general principle is novel → that is the contribution
+
+**Specialization Workflow**:
+1. Take a general method
+2. Add extreme constraints: tiny data, huge dimensionality, adversarial inputs, real-time requirements
+3. Ask: Does the method still work? If not, why not?
+4. The failure case often reveals the method's true assumptions
+
+**When to Generalize vs. Specialize**:
+- Generalize when you have results but no explanation
+- Specialize when you have theory but no grounding
+- Analogize when you are stuck in either direction
+
+---
+
+## Framework 7: The Adjacent Possible (Kauffman / Johnson)
+
+Stuart Kauffman's concept, popularized by Steven Johnson: innovation happens at the boundary of what is currently reachable — the **adjacent possible**. New ideas become thinkable once their prerequisites exist. This explains why simultaneous independent discovery is so common — multiple people reach the same boundary.
+
+**Practical Implication**: Map what has recently become possible and explore the space those enablers open.
+
+**Adjacent Possible Mapping Workflow**:
+
+1. **List recent enablers** (last 1-3 years):
+   - New hardware capabilities (longer context, faster inference, new accelerators)
+   - New datasets or benchmarks
+   - New open-source tools or frameworks
+   - New theoretical results
+   - New regulatory or social conditions
+2. **For each enabler, ask**: "What was previously impossible or impractical that this now permits?"
+3. **Combine enablers**: The most powerful adjacent possibles arise from the intersection of multiple new enablers
+4. **Check for competition**: If many people can see the same adjacent possible, speed or a unique angle matters
+
+**Current Adjacent Possibles (2025-2026)**:
+
+| Enabler | Newly Possible |
+|---------|---------------|
+| 1M+ token context windows | Full-codebase reasoning, book-length analysis |
+| Inference cost drops (100x in 2 years) | Real-time agentic loops, always-on AI assistants |
+| Open-weight models at GPT-4 level | Reproducible research on frontier capabilities |
+| Multimodal models (vision + language + audio) | Unified perception-reasoning systems |
+| Synthetic data at scale | Training data for domains with no natural data |
+| Tool-using models | Research automation, self-improving systems |
+
+**Timing Signal**: If your idea requires technology that doesn't exist yet, it's beyond the adjacent possible — park it. If your idea could have been done 5 years ago, someone probably did — check the literature. The sweet spot is ideas that became feasible in the last 6-18 months.
+
+---
+
+## Framework 8: Janusian and Dialectical Thinking
+
+Albert Rothenberg's studies of eminent creators found that **holding two contradictory ideas simultaneously** is a hallmark of creative thinking. Named after Janus, the two-faced Roman god, this mode of thinking doesn't resolve contradictions by choosing a side — it generates new frameworks that transcend the opposition.
+
+**In CS**: The most influential results often emerge from tensions previously thought irreconcilable.
+
+| Contradiction | Resolution | Impact |
+|--------------|------------|--------|
+| Consistency AND Availability (distributed systems) | CAP theorem: formalized the trade-off, then Raft/CRDTs found practical middle grounds | Foundation of distributed systems theory |
+| Security AND Usability | Zero-knowledge proofs: prove knowledge without revealing it | Enabled private computation |
+| Expressiveness AND Tractability | Probabilistic programming: express complex models, automate inference | New programming paradigm |
+| Memorization AND Generalization | Grokking: models memorize first, then generalize with more training | New understanding of learning dynamics |
+| Compression AND Quality | Neural codecs that compress beyond information-theoretic limits via learned priors | Redefined compression research |
+
+**Dialectical Thinking Workflow**:
+
+1. **Identify a binary** in your field: A vs. B (two approaches, goals, or paradigms treated as opposites)
+2. **Resist choosing a side**. Instead ask:
+   - "What would a system look like that achieves both A and B?"
+   - "Under what conditions is the A-B trade-off not fundamental?"
+   - "Is the opposition an artifact of how we formalized the problem?"
+3. **Seek synthesis**: The resolution often requires a new abstraction that reframes the relationship
+4. **Test the synthesis**: Can you demonstrate empirically that both goals are achievable?
+
+**Self-Check**:
+- [ ] Am I holding the contradiction genuinely (not prematurely resolving it)?
+- [ ] Is the synthesis a new idea, not just a compromise (splitting the difference)?
+- [ ] Does the resolution change how people think about the problem, not just the solution?
+
+---
+
+## Combining Frameworks: A Creative Thinking Protocol
+
+These frameworks are most powerful in combination. Here is a systematic protocol for a deep creative thinking session:
+
+### Phase 1: Map the Space (15 min)
+1. **Constraint Manipulation** (F4): List all constraints of the current paradigm. Mark which are hard, soft, hidden.
+2. **Adjacent Possible** (F7): List recent enablers that change the feasibility landscape.
+
+### Phase 2: Generate Disruptions (30 min)
+3. **Negation** (F5): Negate 3 soft/hidden constraints. What systems emerge?
+4. **Bisociation** (F1): Pick a distant field and create a cross-product matrix with your domain.
+5. **Problem Reformulation** (F2): Restate your problem 3 different ways (change objective, formalism, agent).
+
+### Phase 3: Deepen Promising Leads (30 min)
+6. **Analogical Reasoning** (F3): For each promising idea, find a structural analogy and extract predictions.
+7. **Abstraction Laddering** (F6): Move each idea up (generalize) and down (specialize).
+8. **Janusian Thinking** (F8): Identify any tensions. Can you synthesize rather than choose?
+
+### Phase 4: Evaluate (15 min)
+Apply the two-sentence test (from the brainstorm skill):
+> "**[Domain] currently struggles with [problem] because [reason].** We [approach] by [mechanism], which works because [insight]."
+
+Any idea that survives all four phases and passes the two-sentence test is worth pursuing.
+
+---
+
+## Common Creative Blocks and Unblocking Strategies
+
+| Block | Symptom | Framework to Apply |
+|-------|---------|-------------------|
+| **Fixation** | Cannot stop thinking about the problem one way | Problem Reformulation (F2) — force a different representation |
+| **Tunnel vision** | All ideas come from the same subfield | Bisociation (F1) or Analogical Reasoning (F3) — import from elsewhere |
+| **Self-censoring** | Dismissing ideas as "too weird" before exploring | Negation (F5) — weird is the point; evaluate after generating |
+| **Incrementalism** | Every idea is "+2% on benchmark X" | Constraint Manipulation (F4) — change the rules, not the parameters |
+| **Analysis paralysis** | Too many options, cannot commit | Adjacent Possible (F7) — what is feasible right now? |
+| **False dichotomy** | Stuck choosing between two approaches | Janusian Thinking (F8) — seek synthesis, not selection |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help with creative thinking or novel ideation:
+
+1. **Assess the block**: What kind of thinking are they stuck in? (See Common Creative Blocks table)
+2. **Select 2-3 frameworks** based on the block type
+3. **Walk through each framework interactively**, asking the researcher to supply domain-specific content
+4. **Push for structural depth**: If an analogy or combination is surface-level, probe deeper
+5. **Maintain a running list** of all generated ideas, even unusual ones
+6. **Apply the two-sentence test** to candidates that survive exploration
+7. **Hand off to the brainstorm skill** for systematic evaluation (diverge → converge → refine)
+
+**Key Principles**:
+- Generative mode first, evaluative mode second — do not filter prematurely
+- Distant analogies are more valuable than nearby ones, but require more validation
+- The researcher's domain expertise is essential — the agent provides the cognitive scaffolding, not the domain knowledge
+- Encourage the researcher to sit with contradictions rather than resolve them quickly

--- a/marketplace/plugins/seekers-lens/workflows/diverge-converge-refine.json
+++ b/marketplace/plugins/seekers-lens/workflows/diverge-converge-refine.json
@@ -1,0 +1,12 @@
+{
+  "id": "diverge-converge-refine",
+  "name": "Diverge, converge, refine",
+  "description": "Move from a broad topic to a reviewable pilot without starting execution.",
+  "steps": [
+    "Define the research space, stakeholders, constraints, and explicit resource bounds.",
+    "Generate diverse candidate directions with multiple ideation lenses.",
+    "Challenge candidates with contradiction, boundary, simplicity, and feasibility checks.",
+    "Rank the strongest directions and expose assumptions, evidence gaps, and likely objections.",
+    "Draft one bounded pilot and stop at a human go/no-go checkpoint."
+  ]
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -82,6 +82,7 @@ export const SUITES = {
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/chat-add-project.test.ts",
     "src/lib/session-project-scope.test.ts",
+    "scripts/sync-marketplace.test.mjs",
     "src/lib/marketplace-catalog.test.ts",
     "src/lib/rss.test.ts",
     "src/lib/home-feed.test.ts",

--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import re
 import sys
@@ -533,12 +534,16 @@ def remove_unexpected_managed_files(files: dict[Path, str], managed_roots: set[P
         for directory in sorted(directories, key=lambda value: len(value.parts), reverse=True):
             try:
                 directory.rmdir()
-            except OSError:
-                pass
+            except OSError as exc:
+                # Cleanup is best-effort for non-empty or concurrently removed directories.
+                if exc.errno not in {errno.ENOTEMPTY, errno.EEXIST, errno.ENOENT}:
+                    raise
         try:
             root.rmdir()
-        except OSError:
-            pass
+        except OSError as exc:
+            # A managed root can remain when it still contains expected generated files.
+            if exc.errno not in {errno.ENOTEMPTY, errno.EEXIST, errno.ENOENT}:
+                raise
 
 
 def write_files(files: dict[Path, str], managed_roots: set[Path] | None = None) -> None:

--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -15,16 +16,192 @@ MARKETPLACE = ROOT / "marketplace"
 CATALOG = MARKETPLACE / "catalog.json"
 PLUGIN_ROOT = MARKETPLACE / "plugins"
 EXPORT_ROOT = MARKETPLACE / "exports"
+CRAFT_SCHEMA_VERSION = "opencoven.craft.v1"
+SUPPORTED_CRAFT_LICENSES = {
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+}
+RESOURCE_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+CONTENT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
-def load_catalog() -> dict[str, Any]:
-    with CATALOG.open("r", encoding="utf-8") as handle:
-        catalog = json.load(handle)
-    names = [plugin["name"] for plugin in catalog["plugins"]]
+def _string_list(value: Any, label: str, *, allow_empty: bool = False) -> list[str]:
+    if not isinstance(value, list) or (not value and not allow_empty):
+        suffix = "" if allow_empty else " and must not be empty"
+        raise ValueError(f"{label} must be a list of strings{suffix}")
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ValueError(f"{label} must contain non-empty strings")
+    if len(value) != len(set(value)):
+        raise ValueError(f"{label} contains duplicate ids")
+    return value
+
+
+def _safe_relative_path(value: Any, label: str, *, required_prefix: str | None = None) -> PurePosixPath:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"unsafe {label}: {value!r}")
+    candidate = PurePosixPath(value)
+    if candidate.is_absolute() or any(part in {"", ".", ".."} for part in candidate.parts):
+        raise ValueError(f"unsafe {label}: {value!r}")
+    if required_prefix and (not candidate.parts or candidate.parts[0] != required_prefix):
+        raise ValueError(f"unsafe {label}: {value!r}")
+    return candidate
+
+
+def _require_text(mapping: dict[str, Any], key: str, label: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label}.{key} must be a non-empty string")
+    return value
+
+
+def validate_craft(
+    plugin: dict[str, Any],
+    plugins_by_name: dict[str, dict[str, Any]],
+    marketplace_dir: Path,
+) -> None:
+    name = plugin.get("name", "<unnamed>")
+    craft = plugin.get("craft")
+    if not isinstance(craft, dict):
+        raise ValueError(f'Craft "{name}" is missing its craft specification')
+    if craft.get("schemaVersion") != CRAFT_SCHEMA_VERSION:
+        raise ValueError(f'Craft "{name}" must use schemaVersion {CRAFT_SCHEMA_VERSION}')
+    if plugin.get("license") not in SUPPORTED_CRAFT_LICENSES:
+        raise ValueError(f'unsupported Craft license "{plugin.get("license")}"')
+
+    components = craft.get("components")
+    if not isinstance(components, dict):
+        raise ValueError(f'Craft "{name}" components must be an object')
+    required = _string_list(components.get("required"), f'Craft "{name}" required components')
+    optional = _string_list(
+        components.get("optional", []),
+        f'Craft "{name}" optional components',
+        allow_empty=True,
+    )
+    overlap = sorted(set(required) & set(optional))
+    if overlap:
+        raise ValueError(f'Craft "{name}" repeats components as required and optional: {", ".join(overlap)}')
+    for component_id in [*required, *optional]:
+        component = plugins_by_name.get(component_id)
+        if component is None:
+            raise ValueError(f'Craft "{name}" references missing component plugin "{component_id}"')
+        if component.get("kind") == "craft":
+            raise ValueError(f'Craft "{name}" contains nested Craft component "{component_id}"')
+
+    bundled = craft.get("bundled")
+    if not isinstance(bundled, dict):
+        raise ValueError(f'Craft "{name}" bundled resources must be an object')
+    skills = bundled.get("skills")
+    prompts = bundled.get("prompts", [])
+    workflows = bundled.get("workflows", [])
+    if not isinstance(skills, list) or not skills:
+        raise ValueError(f'Craft "{name}" must bundle at least one skill')
+    if not isinstance(prompts, list) or not isinstance(workflows, list):
+        raise ValueError(f'Craft "{name}" prompts and workflows must be lists')
+
+    seen_resource_ids: set[str] = set()
+    for resource_type, resources in (("skill", skills), ("prompt", prompts), ("workflow", workflows)):
+        for resource in resources:
+            if not isinstance(resource, dict):
+                raise ValueError(f'Craft "{name}" {resource_type} resources must be objects')
+            resource_id = _require_text(resource, "id", f'Craft "{name}" {resource_type}')
+            if not RESOURCE_ID_RE.fullmatch(resource_id):
+                raise ValueError(f'invalid Craft resource id "{resource_id}"')
+            if resource_id in seen_resource_ids:
+                raise ValueError(f'duplicate Craft resource id "{resource_id}"')
+            seen_resource_ids.add(resource_id)
+
+            if resource_type == "skill":
+                source_path = _safe_relative_path(
+                    resource.get("sourcePath"),
+                    "Craft source path",
+                    required_prefix="craft-sources",
+                )
+                source_file = (marketplace_dir / Path(*source_path.parts)).resolve()
+                source_root = (marketplace_dir / "craft-sources").resolve()
+                try:
+                    source_file.relative_to(source_root)
+                except ValueError as exc:
+                    raise ValueError(f'unsafe Craft source path: {resource.get("sourcePath")!r}') from exc
+                if not source_file.is_file():
+                    raise ValueError(f'Craft source file does not exist: {resource.get("sourcePath")}')
+                _safe_relative_path(resource.get("upstreamPath"), "Craft upstream path")
+                content_hash = _require_text(resource, "contentHash", f'Craft "{name}" skill "{resource_id}"')
+                if not CONTENT_HASH_RE.fullmatch(content_hash):
+                    raise ValueError(f'Craft skill "{resource_id}" has an invalid sha256 content hash')
+                _string_list(
+                    resource.get("modifications"),
+                    f'Craft skill "{resource_id}" modification notes',
+                )
+            elif resource_type == "prompt":
+                _require_text(resource, "name", f'Craft "{name}" prompt "{resource_id}"')
+                _require_text(resource, "body", f'Craft "{name}" prompt "{resource_id}"')
+            else:
+                _require_text(resource, "name", f'Craft "{name}" workflow "{resource_id}"')
+                _string_list(
+                    resource.get("steps"),
+                    f'Craft workflow "{resource_id}" steps',
+                )
+
+    _string_list(craft.get("requiredCapabilities"), f'Craft "{name}" required capabilities')
+    _string_list(craft.get("recommendedRoles"), f'Craft "{name}" recommended roles')
+    provenance = craft.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError(f'Craft "{name}" provenance must be an object')
+    source = _require_text(provenance, "source", f'Craft "{name}" provenance')
+    if not source.startswith("https://"):
+        raise ValueError(f'Craft "{name}" provenance source must be https')
+    commit = _require_text(provenance, "commit", f'Craft "{name}" provenance')
+    if not COMMIT_RE.fullmatch(commit):
+        raise ValueError(f'Craft "{name}" provenance commit must be a full 40-character hash')
+    license_id = _require_text(provenance, "license", f'Craft "{name}" provenance')
+    if license_id not in SUPPORTED_CRAFT_LICENSES:
+        raise ValueError(f'unsupported Craft license "{license_id}"')
+    license_path = _safe_relative_path(
+        provenance.get("licensePath"),
+        "Craft license path",
+        required_prefix="craft-sources",
+    )
+    license_file = (marketplace_dir / Path(*license_path.parts)).resolve()
+    source_root = (marketplace_dir / "craft-sources").resolve()
+    try:
+        license_file.relative_to(source_root)
+    except ValueError as exc:
+        raise ValueError(f'unsafe Craft license path: {provenance.get("licensePath")!r}') from exc
+    if not license_file.is_file():
+        raise ValueError(f'Craft license file does not exist: {provenance.get("licensePath")}')
+    if craft.get("mcpServers") is not None and not isinstance(craft.get("mcpServers"), dict):
+        raise ValueError(f'Craft "{name}" mcpServers must be an object')
+    if plugin.get("visibility", "public") not in {"public", "hidden"}:
+        raise ValueError(f'Craft "{name}" visibility must be public or hidden')
+
+
+def validate_catalog(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) -> dict[str, Any]:
+    plugins = catalog.get("plugins")
+    if not isinstance(plugins, list):
+        raise ValueError("Marketplace catalog plugins must be a list")
+    names = [plugin.get("name") for plugin in plugins if isinstance(plugin, dict)]
+    if len(names) != len(plugins) or any(not isinstance(name, str) or not name for name in names):
+        raise ValueError("Every marketplace plugin needs a non-empty name")
     duplicates = sorted({name for name in names if names.count(name) > 1})
     if duplicates:
         raise ValueError(f"Duplicate marketplace plugin names: {', '.join(duplicates)}")
+    plugins_by_name = {plugin["name"]: plugin for plugin in plugins}
+    for plugin in plugins:
+        if plugin.get("kind") == "craft":
+            validate_craft(plugin, plugins_by_name, marketplace_dir)
+        elif plugin.get("craft") is not None:
+            raise ValueError(f'Plugin "{plugin["name"]}" has Craft metadata without kind "craft"')
     return catalog
+
+
+def load_catalog(catalog_path: Path = CATALOG, marketplace_dir: Path = MARKETPLACE) -> dict[str, Any]:
+    with catalog_path.open("r", encoding="utf-8") as handle:
+        catalog = json.load(handle)
+    return validate_catalog(catalog, marketplace_dir)
 
 
 def dump_json(value: Any) -> str:
@@ -79,6 +256,41 @@ def prompt_markdown(prompt: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def craft_notice(plugin: dict[str, Any]) -> str:
+    craft = plugin["craft"]
+    provenance = craft["provenance"]
+    lines = [
+        f"# Third-party notices for {plugin['displayName']}",
+        "",
+        f"Upstream: {provenance['source']}",
+        f"Pinned commit: {provenance['commit']}",
+        f"License: {provenance['license']}",
+        "",
+        "## Bundled skills",
+        "",
+    ]
+    for skill in craft["bundled"]["skills"]:
+        lines.extend(
+            [
+                f"### {skill['id']}",
+                "",
+                f"- Upstream path: `{skill['upstreamPath']}`",
+                f"- Upstream content hash: `{skill['contentHash']}`",
+                "- Coven modifications:",
+                *(f"  - {note}" for note in skill["modifications"]),
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "The upstream material is redistributed under the license named above.",
+            "See the pinned source repository for the complete license text.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
     manifest: dict[str, Any] = {
         "name": plugin["name"],
@@ -87,7 +299,7 @@ def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
         "author": {"name": "OpenCoven"},
         "homepage": "https://opencoven.ai",
             "repository": "https://github.com/OpenCoven/coven-cave",
-        "license": "GPL-3.0",
+        "license": plugin.get("license", "GPL-3.0"),
         "keywords": plugin.get("keywords", []),
         "capabilities": plugin.get("capabilities", []),
         "marketplaceId": f"opencoven/{plugin['name']}",
@@ -112,10 +324,44 @@ def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
         manifest["userConfig"] = plugin["userConfig"]
     if plugin.get("prompts"):
         manifest["prompts"] = [prompt["id"] for prompt in plugin["prompts"]]
+    if plugin.get("kind") == "craft":
+        manifest["kind"] = "craft"
+        manifest["craft"] = plugin["craft"]
+        if plugin["craft"].get("mcpServers"):
+            manifest["mcpServers"] = plugin["craft"]["mcpServers"]
     return manifest
 
 
 def codex_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
+    if plugin.get("kind") == "craft":
+        craft = plugin["craft"]
+        manifest: dict[str, Any] = {
+            "name": plugin["name"],
+            "version": plugin["version"],
+            "description": plugin["description"],
+            "author": {
+                "name": "OpenCoven",
+                "url": "https://github.com/OpenCoven",
+            },
+            "homepage": "https://opencoven.ai",
+            "repository": "https://github.com/OpenCoven/coven-cave",
+            "license": plugin.get("license", craft["provenance"]["license"]),
+            "keywords": plugin.get("keywords", []),
+            "skills": "./skills/",
+            "interface": {
+                "displayName": plugin["displayName"],
+                "shortDescription": plugin["description"],
+                "longDescription": plugin["description"],
+                "developerName": "OpenCoven",
+                "category": plugin["category"],
+                "capabilities": craft["requiredCapabilities"],
+                "websiteURL": "https://opencoven.ai",
+                "defaultPrompt": [f"Use {plugin['displayName']} to open a bounded research direction."],
+            },
+        }
+        if craft.get("mcpServers"):
+            manifest["mcpServers"] = "./.mcp.json"
+        return manifest
     return {
         "name": plugin["name"],
         "version": plugin["version"],
@@ -134,11 +380,29 @@ def codex_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def package_files(catalog: dict[str, Any]) -> dict[Path, str]:
+def package_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) -> dict[Path, str]:
     files: dict[Path, str] = {}
+    plugin_root = marketplace_dir / "plugins"
     for plugin in catalog["plugins"]:
-        package_dir = PLUGIN_ROOT / plugin["name"]
+        package_dir = plugin_root / plugin["name"]
         files[package_dir / "plugin.json"] = dump_json(coven_manifest(plugin))
+        if plugin.get("kind") == "craft":
+            craft = plugin["craft"]
+            for skill in craft["bundled"]["skills"]:
+                source = marketplace_dir / Path(*PurePosixPath(skill["sourcePath"]).parts)
+                files[package_dir / "skills" / skill["id"] / "SKILL.md"] = source.read_text(encoding="utf-8")
+            for prompt in craft["bundled"].get("prompts", []):
+                files[package_dir / "prompts" / f"{prompt['id']}.md"] = prompt_markdown(prompt)
+            for workflow in craft["bundled"].get("workflows", []):
+                files[package_dir / "workflows" / f"{workflow['id']}.json"] = dump_json(workflow)
+            files[package_dir / "assets" / "craft.json"] = dump_json(craft)
+            files[package_dir / "assets" / "THIRD_PARTY_NOTICES.md"] = craft_notice(plugin)
+            license_source = marketplace_dir / Path(*PurePosixPath(craft["provenance"]["licensePath"]).parts)
+            files[package_dir / "assets" / "UPSTREAM_LICENSE.txt"] = license_source.read_text(encoding="utf-8")
+            if craft.get("mcpServers"):
+                files[package_dir / ".mcp.json"] = dump_json({"mcpServers": craft["mcpServers"]})
+            files[package_dir / ".codex-plugin" / "plugin.json"] = dump_json(codex_manifest(plugin))
+            continue
         # Some marketplace skill packs carry hand-authored, long-form SKILL.md
         # files that should remain the source of truth. Their manifests and
         # exports are still generated from catalog.json, but sync must not
@@ -152,8 +416,8 @@ def package_files(catalog: dict[str, Any]) -> dict[Path, str]:
     return files
 
 
-def marketplace_files(catalog: dict[str, Any]) -> dict[Path, str]:
-    plugins = catalog["plugins"]
+def marketplace_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) -> dict[Path, str]:
+    plugins = [plugin for plugin in catalog["plugins"] if plugin.get("visibility", "public") != "hidden"]
     root_marketplace = {
         "schemaVersion": "opencoven.marketplace.v1",
         "name": catalog["name"],
@@ -162,7 +426,7 @@ def marketplace_files(catalog: dict[str, Any]) -> dict[Path, str]:
             "description": catalog["description"],
         },
         "plugins": [
-            {
+            ({
                 "name": plugin["name"],
                 "displayName": plugin["displayName"],
                 "category": plugin["category"],
@@ -173,7 +437,8 @@ def marketplace_files(catalog: dict[str, Any]) -> dict[Path, str]:
                 },
                 "trust": plugin["trust"],
                 "roleAffinity": plugin.get("roleAffinity", []),
-            }
+                **({"kind": "craft", "craft": plugin["craft"]} if plugin.get("kind") == "craft" else {}),
+            })
             for plugin in plugins
         ],
     }
@@ -195,7 +460,10 @@ def marketplace_files(catalog: dict[str, Any]) -> dict[Path, str]:
     }
     mcp_servers: dict[str, Any] = {}
     for plugin in plugins:
-        for name, server in plugin.get("mcpServers", {}).items():
+        plugin_servers = plugin.get("mcpServers", {})
+        if plugin.get("kind") == "craft":
+            plugin_servers = plugin["craft"].get("mcpServers", {})
+        for name, server in plugin_servers.items():
             mcp_servers[name] = server
     role_affinity = {
         plugin["name"]: plugin.get("roleAffinity", [])
@@ -203,54 +471,131 @@ def marketplace_files(catalog: dict[str, Any]) -> dict[Path, str]:
         if plugin.get("roleAffinity")
     }
     return {
-        MARKETPLACE / "marketplace.json": dump_json(root_marketplace),
-        EXPORT_ROOT / "codex" / "marketplace.json": dump_json(codex_marketplace),
-        EXPORT_ROOT / "mcp" / "mcp.json": dump_json({"mcpServers": mcp_servers}),
-        EXPORT_ROOT / "roles" / "role-affinity.json": dump_json(role_affinity),
+        marketplace_dir / "marketplace.json": dump_json(root_marketplace),
+        marketplace_dir / "exports" / "codex" / "marketplace.json": dump_json(codex_marketplace),
+        marketplace_dir / "exports" / "mcp" / "mcp.json": dump_json({"mcpServers": mcp_servers}),
+        marketplace_dir / "exports" / "roles" / "role-affinity.json": dump_json(role_affinity),
     }
 
 
-def expected_files(catalog: dict[str, Any]) -> dict[Path, str]:
-    files = package_files(catalog)
-    files.update(marketplace_files(catalog))
+def expected_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) -> dict[Path, str]:
+    files = package_files(catalog, marketplace_dir)
+    files.update(marketplace_files(catalog, marketplace_dir))
     return files
 
 
-def write_files(files: dict[Path, str]) -> None:
+def managed_craft_roots(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) -> set[Path]:
+    """Craft packages are fully generated, so their file sets are authoritative.
+
+    Include previously generated Craft roots no longer present in the catalog;
+    their root Cave manifest identifies them without treating legacy/manual
+    plugin packages as generator-owned.
+    """
+    plugin_root = marketplace_dir / "plugins"
+    roots = {
+        plugin_root / plugin["name"]
+        for plugin in catalog["plugins"]
+        if plugin.get("kind") == "craft"
+    }
+    if plugin_root.is_dir():
+        for candidate in plugin_root.iterdir():
+            if not candidate.is_dir() or candidate.is_symlink():
+                continue
+            manifest_path = candidate / "plugin.json"
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(manifest, dict) and manifest.get("kind") == "craft":
+                roots.add(candidate)
+    return roots
+
+
+def unexpected_managed_files(files: dict[Path, str], managed_roots: set[Path]) -> list[Path]:
+    expected = set(files)
+    unexpected: list[Path] = []
+    for root in sorted(managed_roots):
+        if not root.is_dir() or root.is_symlink():
+            continue
+        for path in root.rglob("*"):
+            if (path.is_file() or path.is_symlink()) and path not in expected:
+                unexpected.append(path)
+    return sorted(unexpected)
+
+
+def remove_unexpected_managed_files(files: dict[Path, str], managed_roots: set[Path]) -> None:
+    for path in unexpected_managed_files(files, managed_roots):
+        path.unlink()
+    for root in sorted(managed_roots):
+        if not root.is_dir() or root.is_symlink():
+            continue
+        directories = [path for path in root.rglob("*") if path.is_dir() and not path.is_symlink()]
+        for directory in sorted(directories, key=lambda value: len(value.parts), reverse=True):
+            try:
+                directory.rmdir()
+            except OSError:
+                pass
+        try:
+            root.rmdir()
+        except OSError:
+            pass
+
+
+def write_files(files: dict[Path, str], managed_roots: set[Path] | None = None) -> None:
+    remove_unexpected_managed_files(files, managed_roots or set())
     for path, content in sorted(files.items()):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
 
-def check_files(files: dict[Path, str]) -> list[str]:
+def check_files(
+    files: dict[Path, str],
+    display_root: Path = ROOT,
+    managed_roots: set[Path] | None = None,
+) -> list[str]:
     problems: list[str] = []
     for path, expected in sorted(files.items()):
+        try:
+            display_path = path.relative_to(display_root)
+        except ValueError:
+            display_path = path
         if not path.exists():
-            problems.append(f"missing {path.relative_to(ROOT)}")
+            problems.append(f"missing {display_path}")
             continue
         actual = path.read_text(encoding="utf-8")
         if actual != expected:
-            problems.append(f"stale {path.relative_to(ROOT)}")
+            problems.append(f"stale {display_path}")
+    for path in unexpected_managed_files(files, managed_roots or set()):
+        try:
+            display_path = path.relative_to(display_root)
+        except ValueError:
+            display_path = path
+        problems.append(f"unexpected {display_path}")
     return problems
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--check", action="store_true", help="verify generated marketplace files are up to date")
+    parser.add_argument("--catalog", type=Path, help="catalog path (defaults to marketplace/catalog.json)")
+    parser.add_argument("--marketplace-root", type=Path, help="marketplace output/source root")
     args = parser.parse_args()
 
     try:
-        catalog = load_catalog()
-        files = expected_files(catalog)
+        marketplace_dir = (args.marketplace_root or MARKETPLACE).resolve()
+        catalog_path = (args.catalog or (marketplace_dir / "catalog.json")).resolve()
+        catalog = load_catalog(catalog_path, marketplace_dir)
+        files = expected_files(catalog, marketplace_dir)
+        craft_roots = managed_craft_roots(catalog, marketplace_dir)
         if args.check:
-            problems = check_files(files)
+            problems = check_files(files, marketplace_dir.parent, craft_roots)
             if problems:
                 for problem in problems:
                     print(problem, file=sys.stderr)
                 return 1
             print(f"marketplace_ok files={len(files)} plugins={len(catalog['plugins'])}")
             return 0
-        write_files(files)
+        write_files(files, craft_roots)
         print(f"marketplace_synced files={len(files)} plugins={len(catalog['plugins'])}")
         return 0
     except Exception as exc:

--- a/scripts/sync-marketplace.test.mjs
+++ b/scripts/sync-marketplace.test.mjs
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SYNC = path.join(ROOT, "scripts", "sync-marketplace.py");
+
+function legacyPlugin(name) {
+  return {
+    name,
+    displayName: name,
+    version: "0.1.0",
+    description: `${name} component`,
+    category: "Research",
+    keywords: [name],
+    capabilities: [],
+    sourceRefs: ["https://github.com/OpenCoven/coven-cave"],
+    trust: "official-local",
+    skill: {
+      description: `${name} component skill`,
+      useCases: ["Test component resolution"],
+      guardrails: ["Stay inside the test fixture"],
+    },
+  };
+}
+
+function provenance(upstreamPath, hash = "a".repeat(64)) {
+  return {
+    upstreamPath,
+    contentHash: `sha256:${hash}`,
+    modifications: ["Normalized frontmatter for Codex plugin packaging."],
+  };
+}
+
+function validCraft(overrides = {}) {
+  const craft = {
+    schemaVersion: "opencoven.craft.v1",
+    components: {
+      required: ["fetch", "filesystem"],
+      optional: ["exa"],
+    },
+    bundled: {
+      skills: [
+        {
+          id: "brainstorming-research-ideas",
+          sourcePath: "craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md",
+          ...provenance("21-research-ideation/brainstorming-research-ideas/SKILL.md"),
+        },
+        {
+          id: "creative-thinking-for-research",
+          sourcePath: "craft-sources/seekers-lens/creative-thinking-for-research/SKILL.md",
+          ...provenance("21-research-ideation/creative-thinking-for-research/SKILL.md", "b".repeat(64)),
+        },
+      ],
+      prompts: [
+        {
+          id: "open-a-research-space",
+          name: "Open a research space",
+          description: "Generate and rank bounded research directions.",
+          body: "Explore {{topic}} with divergent and convergent research lenses.",
+        },
+      ],
+      workflows: [
+        {
+          id: "diverge-converge-refine",
+          name: "Diverge, converge, refine",
+          description: "Turn a broad topic into a bounded pilot.",
+          steps: ["Generate candidate directions", "Rank with evidence", "Define a pilot"],
+        },
+      ],
+    },
+    requiredCapabilities: ["filesystem.read", "network.http", "reasoning.sequential"],
+    recommendedRoles: ["researcher", "strategist"],
+    provenance: {
+      source: "https://github.com/orchestra-research/AI-Research-SKILLs",
+      commit: "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+      license: "MIT",
+      licensePath: "craft-sources/orchestra-research/LICENSE",
+    },
+    mcpServers: {
+      "local-search": { command: "research-search", args: ["--stdio"], type: "stdio" },
+    },
+    ...overrides,
+  };
+  return {
+    name: "seekers-lens",
+    displayName: "Seeker's Lens",
+    kind: "craft",
+    visibility: "public",
+    version: "0.1.0",
+    description: "Discovery and ideation for bounded research work.",
+    category: "Research Crafts",
+    keywords: ["research", "ideation"],
+    capabilities: ["research"],
+    sourceRefs: ["https://github.com/orchestra-research/AI-Research-SKILLs"],
+    trust: "official-local",
+    license: "MIT",
+    craft,
+  };
+}
+
+function fixtureCatalog(craft = validCraft(), extra = []) {
+  return {
+    schemaVersion: "opencoven.marketplace.catalog.v1",
+    name: "opencoven-first-party",
+    displayName: "OpenCoven First-Party Marketplace",
+    description: "test catalog",
+    version: "0.1.0",
+    generatedBy: "scripts/sync-marketplace.py",
+    plugins: [legacyPlugin("fetch"), legacyPlugin("filesystem"), legacyPlugin("exa"), ...extra, craft],
+  };
+}
+
+function writeFixture(catalog, sourcePaths = true) {
+  const dir = mkdtempSync(path.join(tmpdir(), "coven-craft-sync-"));
+  const marketplace = path.join(dir, "marketplace");
+  mkdirSync(marketplace, { recursive: true });
+  const catalogPath = path.join(marketplace, "catalog.json");
+  writeFileSync(catalogPath, JSON.stringify(catalog, null, 2) + "\n");
+  if (sourcePaths) {
+    for (const skill of catalog.plugins.find((p) => p.kind === "craft")?.craft?.bundled?.skills ?? []) {
+      const target = path.join(marketplace, skill.sourcePath);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, `---\nname: ${skill.id}\ndescription: Fixture skill.\nlicense: MIT\n---\n\n# ${skill.id}\n`);
+    }
+    const provenance = catalog.plugins.find((p) => p.kind === "craft")?.craft?.provenance;
+    if (provenance?.licensePath) {
+      const license = path.join(marketplace, provenance.licensePath);
+      mkdirSync(path.dirname(license), { recursive: true });
+      writeFileSync(license, "MIT License\n\nCopyright fixture\n");
+    }
+  }
+  return { dir, marketplace, catalogPath };
+}
+
+function runSync(fixture, extraArgs = []) {
+  return spawnSync(
+    "python3",
+    [SYNC, "--catalog", fixture.catalogPath, "--marketplace-root", fixture.marketplace, ...extraArgs],
+    { cwd: ROOT, encoding: "utf8" },
+  );
+}
+
+function generatedDigest(root) {
+  const out = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (full !== path.join(root, "catalog.json")) {
+        const rel = path.relative(root, full).split(path.sep).join("/");
+        const hash = createHash("sha256").update(readFileSync(full)).digest("hex");
+        out.push(`${rel}:${hash}`);
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+function expectRejected(catalog, pattern, sourcePaths = true) {
+  const fixture = writeFixture(catalog, sourcePaths);
+  try {
+    const result = runSync(fixture);
+    assert.notEqual(result.status, 0, `invalid catalog unexpectedly passed: ${result.stdout}`);
+    assert.match(result.stderr, pattern);
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+}
+
+const fixture = writeFixture(fixtureCatalog());
+try {
+  const first = runSync(fixture);
+  assert.equal(first.status, 0, first.stderr);
+
+  const pluginRoot = path.join(fixture.marketplace, "plugins", "seekers-lens");
+  const manifest = JSON.parse(readFileSync(path.join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"));
+  assert.equal(manifest.name, "seekers-lens");
+  assert.equal(manifest.version, "0.1.0");
+  assert.equal(manifest.skills, "./skills/");
+  assert.equal(manifest.mcpServers, "./.mcp.json");
+  assert.ok(Array.isArray(manifest.interface.defaultPrompt));
+  assert.equal(manifest.interface.defaultPrompt.length, 1);
+  assert.equal(manifest.license, "MIT");
+
+  for (const skill of ["brainstorming-research-ideas", "creative-thinking-for-research"]) {
+    assert.match(readFileSync(path.join(pluginRoot, "skills", skill, "SKILL.md"), "utf8"), new RegExp(`name: ${skill}`));
+  }
+  assert.match(readFileSync(path.join(pluginRoot, "prompts", "open-a-research-space.md"), "utf8"), /Open a research space/);
+  assert.deepEqual(
+    JSON.parse(readFileSync(path.join(pluginRoot, "workflows", "diverge-converge-refine.json"), "utf8")).steps,
+    ["Generate candidate directions", "Rank with evidence", "Define a pilot"],
+  );
+  assert.equal(
+    JSON.parse(readFileSync(path.join(pluginRoot, ".mcp.json"), "utf8")).mcpServers["local-search"].command,
+    "research-search",
+  );
+  const portableSpec = JSON.parse(readFileSync(path.join(pluginRoot, "assets", "craft.json"), "utf8"));
+  assert.equal(portableSpec.schemaVersion, "opencoven.craft.v1");
+  assert.equal(portableSpec.provenance.license, "MIT");
+  assert.match(readFileSync(path.join(pluginRoot, "assets", "UPSTREAM_LICENSE.txt"), "utf8"), /MIT License/);
+
+  const caveManifest = JSON.parse(readFileSync(path.join(pluginRoot, "plugin.json"), "utf8"));
+  assert.equal(caveManifest.kind, "craft");
+  assert.deepEqual(caveManifest.craft.components.required, ["fetch", "filesystem"]);
+
+  const marketplace = JSON.parse(readFileSync(path.join(fixture.marketplace, "marketplace.json"), "utf8"));
+  const entry = marketplace.plugins.find((p) => p.name === "seekers-lens");
+  assert.equal(entry.kind, "craft");
+  assert.equal(entry.craft.schemaVersion, "opencoven.craft.v1");
+  const codexMarketplace = JSON.parse(readFileSync(path.join(fixture.marketplace, "exports", "codex", "marketplace.json"), "utf8"));
+  assert.equal(codexMarketplace.plugins.find((p) => p.name === "seekers-lens").category, "Research Crafts");
+
+  const before = generatedDigest(fixture.marketplace);
+  const second = runSync(fixture);
+  assert.equal(second.status, 0, second.stderr);
+  assert.deepEqual(generatedDigest(fixture.marketplace), before, "generation should be deterministic");
+
+  writeFileSync(path.join(pluginRoot, "prompts", "open-a-research-space.md"), "stale\n");
+  const stale = runSync(fixture, ["--check"]);
+  assert.notEqual(stale.status, 0);
+  assert.match(stale.stderr, /stale marketplace\/plugins\/seekers-lens\/prompts\/open-a-research-space\.md/);
+  const repaired = runSync(fixture);
+  assert.equal(repaired.status, 0, repaired.stderr);
+
+  const orphan = path.join(pluginRoot, "prompts", "removed-resource.md");
+  writeFileSync(orphan, "this resource is no longer declared\n");
+  const orphaned = runSync(fixture, ["--check"]);
+  assert.notEqual(orphaned.status, 0);
+  assert.match(orphaned.stderr, /unexpected marketplace\/plugins\/seekers-lens\/prompts\/removed-resource\.md/);
+  const cleaned = runSync(fixture);
+  assert.equal(cleaned.status, 0, cleaned.stderr);
+  assert.equal(existsSync(orphan), false, "sync removes undeclared files from fully managed Craft packages");
+} finally {
+  rmSync(fixture.dir, { recursive: true, force: true });
+}
+
+const hiddenFixture = writeFixture(fixtureCatalog({ ...validCraft(), visibility: "hidden" }));
+try {
+  const hidden = runSync(hiddenFixture);
+  assert.equal(hidden.status, 0, hidden.stderr);
+  assert.ok(readFileSync(path.join(hiddenFixture.marketplace, "plugins", "seekers-lens", "plugin.json"), "utf8"));
+  const browseIds = JSON.parse(readFileSync(path.join(hiddenFixture.marketplace, "marketplace.json"), "utf8")).plugins.map((p) => p.name);
+  assert.ok(!browseIds.includes("seekers-lens"), "hidden Crafts must not become generally browsable");
+} finally {
+  rmSync(hiddenFixture.dir, { recursive: true, force: true });
+}
+
+expectRejected(
+  fixtureCatalog(validCraft({ ...validCraft().craft, components: { required: ["missing"], optional: [] } })),
+  /missing component plugin "missing"/i,
+);
+
+const duplicate = validCraft();
+duplicate.craft.bundled.prompts[0].id = duplicate.craft.bundled.skills[0].id;
+expectRejected(fixtureCatalog(duplicate), /duplicate Craft resource id "brainstorming-research-ideas"/i);
+
+const unsafe = validCraft();
+unsafe.craft.bundled.skills[0].sourcePath = "../outside/SKILL.md";
+expectRejected(fixtureCatalog(unsafe), /unsafe Craft source path/i, false);
+
+const unsupported = validCraft();
+unsupported.craft.provenance.license = "GPL-3.0";
+expectRejected(fixtureCatalog(unsupported), /unsupported Craft license "GPL-3.0"/i);
+
+const nestedComponent = validCraft();
+nestedComponent.name = "nested-craft";
+const nested = validCraft({ ...validCraft().craft, components: { required: ["nested-craft"], optional: [] } });
+expectRejected(fixtureCatalog(nested, [nestedComponent]), /nested Craft component "nested-craft"/i);
+
+// Production reference Craft: present and fully generated, but intentionally
+// absent from browse/install exports until the final enablement slice.
+const productionCatalog = JSON.parse(readFileSync(path.join(ROOT, "marketplace", "catalog.json"), "utf8"));
+const productionSeeker = productionCatalog.plugins.find((plugin) => plugin.name === "seekers-lens");
+assert.ok(productionSeeker, "the production catalog includes Seeker's Lens");
+assert.equal(productionSeeker.kind, "craft");
+assert.equal(productionSeeker.visibility, "hidden");
+assert.deepEqual(productionSeeker.craft.components.required, ["fetch", "filesystem", "memory", "sequential-thinking"]);
+assert.deepEqual(productionSeeker.craft.components.optional, ["exa", "tavily", "firecrawl", "searxng", "research-ingestion"]);
+assert.deepEqual(
+  productionSeeker.craft.bundled.skills.map((skill) => [skill.id, skill.contentHash]),
+  [
+    ["brainstorming-research-ideas", "sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46"],
+    ["creative-thinking-for-research", "sha256:ec111f9236d7f9d72c895cebbf0f534ac93f4249172607559ad4bf92aefc5310"],
+  ],
+);
+assert.equal(productionSeeker.craft.provenance.commit, "773a52944ba4747a18bd4ae9ade53fff041adcbc");
+assert.equal(productionSeeker.craft.provenance.license, "MIT");
+
+const productionRoot = path.join(ROOT, "marketplace", "plugins", "seekers-lens");
+const productionManifest = JSON.parse(readFileSync(path.join(productionRoot, ".codex-plugin", "plugin.json"), "utf8"));
+assert.ok(Array.isArray(productionManifest.interface.defaultPrompt));
+assert.equal(productionManifest.skills, "./skills/");
+assert.equal(existsSync(path.join(productionRoot, ".mcp.json")), false, "components stay separate plugins; the Craft does not duplicate MCP config");
+for (const skill of productionSeeker.craft.bundled.skills) {
+  assert.ok(existsSync(path.join(productionRoot, "skills", skill.id, "SKILL.md")), `${skill.id} is bundled`);
+}
+const productionBrowse = JSON.parse(readFileSync(path.join(ROOT, "marketplace", "marketplace.json"), "utf8"));
+assert.ok(!productionBrowse.plugins.some((plugin) => plugin.name === "seekers-lens"));
+const productionCheck = spawnSync("python3", [SYNC, "--check"], { cwd: ROOT, encoding: "utf8" });
+assert.equal(productionCheck.status, 0, productionCheck.stderr);
+
+console.log("sync-marketplace.test.mjs: ok");

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -191,7 +191,33 @@ assert.equal(deriveKind({ prompts: ["debug-this"] }), "prompt");
 assert.equal(deriveKind({ prompts: [] }), "skill"); // empty pack -> not a prompt kind
 // An MCP server wins over shipped prompts — the server defines the runtime shape.
 assert.equal(deriveKind({ prompts: ["a"], mcpServers: { x: { command: "npx" } } }), "mcp");
+assert.equal(
+  deriveKind({ kind: "craft", mcpServers: { x: { command: "npx" } } }),
+  "craft",
+  "an explicit Craft kind wins over its bundled runtime components",
+);
 assert.equal(merged.find((p) => p.id === "legacy").kind, "skill"); // no manifest -> skill
+
+const craftSpec = {
+  schemaVersion: "opencoven.craft.v1",
+  components: { required: ["fetch"], optional: ["exa"] },
+  bundled: { skills: [{ id: "brainstorming-research-ideas" }], prompts: [], workflows: [] },
+  requiredCapabilities: ["network.http"],
+  recommendedRoles: ["researcher"],
+  provenance: {
+    source: "https://github.com/orchestra-research/AI-Research-SKILLs",
+    commit: "773a52944ba4747a18bd4ae9ade53fff041adcbc",
+    license: "MIT",
+    licensePath: "craft-sources/orchestra-research/LICENSE",
+  },
+};
+const craftMerged = mergeCatalog(
+  [{ name: "seekers-lens", displayName: "Seeker's Lens", kind: "craft", category: "Research Crafts", policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" } }],
+  { "seekers-lens": { kind: "craft", version: "0.1.0", craft: craftSpec, mcpServers: { local: { command: "research-search" } } } },
+  {},
+);
+assert.equal(craftMerged[0].kind, "craft");
+assert.deepEqual(craftMerged[0].craft, craftSpec, "Craft metadata is exposed through the marketplace model");
 
 // --- filterPlugins: kind + ids ---
 assert.deepEqual(filterPlugins(merged, { kind: "mcp" }).map((p) => p.id), ["fetch", "github"]);
@@ -201,14 +227,15 @@ assert.deepEqual(filterPlugins(merged, { ids: ["github", "legacy"] }).map((p) =>
 assert.deepEqual(filterPlugins(merged, { ids: ["github"], kind: "skill" }).map((p) => p.id), []);
 
 // --- countByKind ---
-assert.deepEqual(countByKind(merged), { api: 1, mcp: 2, skill: 1, prompt: 0 });
+assert.deepEqual(countByKind(merged), { api: 1, mcp: 2, skill: 1, prompt: 0, craft: 0 });
+assert.deepEqual(countByKind(craftMerged), { api: 0, mcp: 0, skill: 0, prompt: 0, craft: 1 });
 
 // --- groupPluginsByCategory ---
 const groups = groupPluginsByCategory(merged);
 assert.deepEqual(groups.map((g) => g.category), ["Developer Tools", "Other", "Web"]);
 assert.deepEqual(groups[0].plugins.map((p) => p.id), ["fetch", "github"]);
-assert.deepEqual(groups[0].counts, { api: 0, mcp: 2, skill: 0, prompt: 0 });
-assert.deepEqual(groups.find((g) => g.category === "Web")?.counts, { api: 1, mcp: 0, skill: 0, prompt: 0 });
+assert.deepEqual(groups[0].counts, { api: 0, mcp: 2, skill: 0, prompt: 0, craft: 0 });
+assert.deepEqual(groups.find((g) => g.category === "Web")?.counts, { api: 1, mcp: 0, skill: 0, prompt: 0, craft: 0 });
 
 // --- sortPlugins (returns a new array, never mutates) ---
 const before = merged.map((p) => p.id);

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -201,7 +201,17 @@ assert.equal(merged.find((p) => p.id === "legacy").kind, "skill"); // no manifes
 const craftSpec = {
   schemaVersion: "opencoven.craft.v1",
   components: { required: ["fetch"], optional: ["exa"] },
-  bundled: { skills: [{ id: "brainstorming-research-ideas" }], prompts: [], workflows: [] },
+  bundled: {
+    skills: [{
+      id: "brainstorming-research-ideas",
+      sourcePath: "craft-sources/seekers-lens/brainstorming-research-ideas/SKILL.md",
+      upstreamPath: "21-research-ideation/brainstorming-research-ideas/SKILL.md",
+      contentHash: "sha256:8422a1a6dc0a88d05f02b9fbe0f8c2ae06a77024856d18125efa13d19d855d46",
+      modifications: ["Normalized frontmatter for Codex."],
+    }],
+    prompts: [],
+    workflows: [],
+  },
   requiredCapabilities: ["network.http"],
   recommendedRoles: ["researcher"],
   provenance: {
@@ -213,7 +223,7 @@ const craftSpec = {
 };
 const craftMerged = mergeCatalog(
   [{ name: "seekers-lens", displayName: "Seeker's Lens", kind: "craft", category: "Research Crafts", policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" } }],
-  { "seekers-lens": { kind: "craft", version: "0.1.0", craft: craftSpec, mcpServers: { local: { command: "research-search" } } } },
+  { "seekers-lens": { kind: "craft", version: "0.1.0", craft: craftSpec, mcpServers: { local: { command: "research-search", args: ["--stdio"] } } } },
   {},
 );
 assert.equal(craftMerged[0].kind, "craft");

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -82,7 +82,7 @@ export type PluginManifest = {
   keywords?: string[];
   capabilities?: string[];
   userConfig?: Record<string, PluginUserConfigField>;
-  mcpServers?: Record<string, { url?: string; type?: string; command?: string }>;
+  mcpServers?: Record<string, { url?: string; type?: string; command?: string; args?: string[] }>;
   craft?: CraftSpecification;
   /** Prompt-template ids shipped by this plugin (a prompt pack). The files
    *  live at marketplace/plugins/<id>/prompts/<pid>.md and are resolved by

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -12,9 +12,53 @@ export type MarketplaceJsonPlugin = {
   name: string;
   displayName?: string;
   category?: string;
+  kind?: PluginKind;
   trust?: string;
   policy?: { installation?: string; authentication?: string };
   roleAffinity?: RoleAffinity[];
+};
+
+export type CraftProvenance = {
+  source: string;
+  commit: string;
+  license: string;
+  licensePath: string;
+};
+
+export type CraftSourcedResource = {
+  id: string;
+  sourcePath: string;
+  upstreamPath: string;
+  contentHash: string;
+  modifications: string[];
+};
+
+export type CraftPromptResource = {
+  id: string;
+  name: string;
+  description?: string;
+  body: string;
+};
+
+export type CraftWorkflowResource = {
+  id: string;
+  name: string;
+  description?: string;
+  steps: string[];
+};
+
+export type CraftSpecification = {
+  schemaVersion: "opencoven.craft.v1";
+  components: { required: string[]; optional: string[] };
+  bundled: {
+    skills: CraftSourcedResource[];
+    prompts: CraftPromptResource[];
+    workflows: CraftWorkflowResource[];
+  };
+  requiredCapabilities: string[];
+  recommendedRoles: string[];
+  provenance: CraftProvenance;
+  mcpServers?: Record<string, { url?: string; type?: string; command?: string; args?: string[] }>;
 };
 
 export type PluginUserConfigField = {
@@ -29,6 +73,7 @@ export type PluginUserConfigField = {
 };
 
 export type PluginManifest = {
+  kind?: PluginKind;
   version?: string;
   description?: string;
   author?: { name?: string } | string;
@@ -38,6 +83,7 @@ export type PluginManifest = {
   capabilities?: string[];
   userConfig?: Record<string, PluginUserConfigField>;
   mcpServers?: Record<string, { url?: string; type?: string; command?: string }>;
+  craft?: CraftSpecification;
   /** Prompt-template ids shipped by this plugin (a prompt pack). The files
    *  live at marketplace/plugins/<id>/prompts/<pid>.md and are resolved by
    *  /api/prompts at scan time once the pack is installed. */
@@ -87,7 +133,7 @@ export function remoteUrlFromManifest(manifest: PluginManifest): string | undefi
 
 export type InstalledMap = Record<string, { version: string; source: string; installedAt: string }>;
 
-export type PluginKind = "api" | "mcp" | "skill" | "prompt";
+export type PluginKind = "api" | "mcp" | "skill" | "prompt" | "craft";
 
 export type MarketplacePlugin = {
   id: string;
@@ -112,6 +158,8 @@ export type MarketplacePlugin = {
   remoteUrl?: string;
   /** Prompt-template ids for kind "prompt" packs (listed in the detail pane). */
   prompts?: string[];
+  /** Versioned composition and provenance for kind "craft" entries. */
+  craft?: CraftSpecification;
 };
 
 /**
@@ -122,6 +170,7 @@ export type MarketplacePlugin = {
  * without an external server.
  */
 export function deriveKind(manifest: PluginManifest): PluginKind {
+  if (manifest.kind === "craft") return "craft";
   const servers = manifest.mcpServers ?? {};
   if (Object.keys(servers).length > 0) return "mcp";
   if ((manifest.prompts?.length ?? 0) > 0) return "prompt";
@@ -194,7 +243,7 @@ export function mergeCatalog(
         homepage: manifest.homepage,
         repository: manifest.repository,
         roleAffinity: p.roleAffinity ?? [],
-        kind: deriveKind(manifest),
+        kind: p.kind === "craft" ? "craft" : deriveKind(manifest),
         version: manifest.version ?? "0.0.0",
         installed: Boolean(installed[p.name]),
         requiresSetup: requiredConfig.length > 0,
@@ -203,6 +252,7 @@ export function mergeCatalog(
         configured: false,
         remoteUrl: remoteUrlFromManifest(manifest),
         ...(manifest.prompts?.length ? { prompts: manifest.prompts } : {}),
+        ...(manifest.craft ? { craft: manifest.craft } : {}),
       };
     })
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
@@ -275,24 +325,28 @@ export function sortPlugins(plugins: MarketplacePlugin[], sort: SortKey): Market
   );
 }
 
-export function countByKind(plugins: MarketplacePlugin[]): { api: number; mcp: number; skill: number; prompt: number } {
+export type PluginKindCounts = { api: number; mcp: number; skill: number; prompt: number; craft: number };
+
+export function countByKind(plugins: MarketplacePlugin[]): PluginKindCounts {
   let api = 0;
   let mcp = 0;
   let skill = 0;
   let prompt = 0;
+  let craft = 0;
   for (const p of plugins) {
     if (p.kind === "api") api += 1;
     else if (p.kind === "mcp") mcp += 1;
     else if (p.kind === "prompt") prompt += 1;
+    else if (p.kind === "craft") craft += 1;
     else skill += 1;
   }
-  return { api, mcp, skill, prompt };
+  return { api, mcp, skill, prompt, craft };
 }
 
 export type MarketplaceCategoryGroup = {
   category: string;
   plugins: MarketplacePlugin[];
-  counts: { api: number; mcp: number; skill: number; prompt: number };
+  counts: PluginKindCounts;
 };
 
 export function groupPluginsByCategory(plugins: MarketplacePlugin[]): MarketplaceCategoryGroup[] {


### PR DESCRIPTION
## Summary

- add the versioned `opencoven.craft.v1` catalog schema, parser types, validation, and deterministic Codex plugin generation
- add hidden Seeker’s Lens reference Craft with audited, pinned MIT-licensed research ideation skills and credential-free core components
- manage generated Craft package roots, provenance notices, stale exports, and invalid/nested component rejection

## Test plan

- [x] `pnpm test:app` (596 test files)
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `python3 scripts/sync-marketplace.py --check`
- [x] plugin-creator validation for `marketplace/plugins/seekers-lens`
- [x] `pnpm build`
- [x] `git diff origin/main...HEAD --check`

Bead: `cave-rprf.1`

Upstream research skills are adapted from Orchestra Research’s AI Research Skills at pinned commit `773a52944ba4747a18bd4ae9ade53fff041adcbc`. Attribution and the MIT license are included in the generated package and contributor credit is preserved in the commit.
