### PR TITLE
feat(analytics): give the standalone analytics route the left sidepanel

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -366,6 +366,7 @@ export const SUITES = {
     "src/app/api/familiar-self-report-route.test.ts",
     "src/components/familiar-analytics-view.test.ts",
     "src/components/familiar-analytics-navigation.test.ts",
+    "src/components/analytics-page-shell.test.ts",
     "src/lib/server/familiar-self-reports.test.ts",
     "src/components/thread-signal-card.test.ts",
     "src/components/thread-signals-section.test.ts",

--- a/src/app/dashboard/familiars/[id]/analytics/page.tsx
+++ b/src/app/dashboard/familiars/[id]/analytics/page.tsx
@@ -1,8 +1,13 @@
 import { FamiliarAnalyticsView } from "@/components/familiar-analytics-view";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 
 export const dynamic = "force-dynamic";
 
 export default async function FamiliarAnalyticsPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  return <FamiliarAnalyticsView familiarId={id} />;
+  return (
+    <AnalyticsPageShell>
+      <FamiliarAnalyticsView familiarId={id} />
+    </AnalyticsPageShell>
+  );
 }

--- a/src/app/familiars/[id]/analytics/page.tsx
+++ b/src/app/familiars/[id]/analytics/page.tsx
@@ -1,8 +1,13 @@
 import { FamiliarAnalyticsView } from "@/components/familiar-analytics-view";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 
 export const dynamic = "force-dynamic";
 
 export default async function FamiliarAnalyticsPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  return <FamiliarAnalyticsView familiarId={id} />;
+  return (
+    <AnalyticsPageShell>
+      <FamiliarAnalyticsView familiarId={id} />
+    </AnalyticsPageShell>
+  );
 }

--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const root = new URL("../", import.meta.url);
+async function source(path: string) {
+  return readFile(new URL(path, root), "utf8");
+}
+
+const routePage = await source("app/familiars/[id]/analytics/page.tsx");
+const dashPage = await source("app/dashboard/familiars/[id]/analytics/page.tsx");
+const shell = await source("components/analytics-page-shell.tsx");
+const css = await source("styles/analytics-page-shell.css");
+
+// ── Both standalone analytics routes wrap the view in the left-sidepanel shell ──
+for (const [name, page] of [
+  ["/familiars/[id]/analytics", routePage],
+  ["/dashboard/familiars/[id]/analytics", dashPage],
+]) {
+  assert.match(page, /import \{ AnalyticsPageShell \} from "@\/components\/analytics-page-shell"/, `${name} imports the shell`);
+  assert.match(
+    page,
+    /<AnalyticsPageShell>[\s\S]*<FamiliarAnalyticsView familiarId=\{id\} \/>[\s\S]*<\/AnalyticsPageShell>/,
+    `${name} renders the analytics view inside AnalyticsPageShell (left sidepanel)`,
+  );
+}
+
+// ── The shell renders a real left nav rail into the app's SPA surfaces ──────────
+assert.match(shell, /<nav className="aps-rail" aria-label="Primary">/, "shell renders a labelled left nav rail");
+assert.match(shell, /href: "\/\?mode=home"/, "rail deep-links Home into the SPA");
+assert.match(shell, /href: "\/\?mode=chat"/, "rail deep-links Chat");
+assert.match(shell, /href: "\/\?mode=board"/, "rail deep-links Tasks");
+assert.match(shell, /href="\/dashboard"/, "rail links to the Dashboard route");
+
+// ── Persistent at EVERY screen size — the rail must not be hidden on small widths ─
+assert.match(css, /\.aps-rail\s*\{/, "the rail has base styles");
+assert.doesNotMatch(css, /\.aps-rail[^{]*\{[^}]*display:\s*none/, "the rail is never display:none");
+assert.doesNotMatch(css, /@media[^{]*\{[^}]*\.aps-rail[^}]*display:\s*none/, "no media query hides the rail on small screens");
+
+console.log("analytics-page-shell guard passed");

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
+import "@/styles/analytics-page-shell.css";
+
+type RailDest = { href: string; label: string; icon: IconName };
+
+// Mirror the app's primary sidebar destinations (sidebar-minimal FOLDER_MODES)
+// as deep links the SPA resolves via `?mode=` (workspace readModeParam). Kept as
+// plain <a> links because this shell wraps STANDALONE routes that live outside
+// the SPA workspace which owns SidebarMinimal.
+const PRIMARY: RailDest[] = [
+  { href: "/?mode=home", label: "Home", icon: "ph:house-bold" },
+  { href: "/?mode=chat", label: "Chat", icon: "ph:chats" },
+  { href: "/?mode=board", label: "Tasks", icon: "ph:kanban" },
+  { href: "/?mode=inbox", label: "Schedules", icon: "ph:calendar-check" },
+  { href: "/?mode=journal", label: "Journal", icon: "ph:book-open" },
+  { href: "/?mode=grimoire", label: "Grimoire", icon: "ph:books" },
+  { href: "/?mode=marketplace", label: "Marketplace", icon: "ph:storefront-bold" },
+  { href: "/?mode=github", label: "GitHub", icon: "ph:github-logo" },
+];
+
+const NAV_ICON = CAVE_ICON_SIZE.sidePanelNav;
+
+/**
+ * Standalone-route left side-panel. The familiar-analytics route renders OUTSIDE
+ * the SPA workspace (which owns SidebarMinimal), so on its own it has no nav. This
+ * shell gives it the app's left rail at EVERY screen size (goal: the left
+ * sidepanel on analytics, all screens): a compact, always-visible icon column of
+ * the primary destinations (deep-linking back into the SPA) plus Dashboard — so
+ * you can navigate away from analytics without a browser Back.
+ */
+export function AnalyticsPageShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="aps">
+      <nav className="aps-rail" aria-label="Primary">
+        <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
+          <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+        </a>
+        <ul className="aps-rail-list">
+          {PRIMARY.map((d) => (
+            <li key={d.href}>
+              <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
+                <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
+              </a>
+            </li>
+          ))}
+        </ul>
+        <a className="aps-rail-link aps-rail-foot" href="/dashboard" aria-label="Dashboard" title="Dashboard">
+          <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+        </a>
+      </nav>
+      <main className="aps-main">{children}</main>
+    </div>
+  );
+}

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -1,0 +1,86 @@
+/* Standalone-route left side-panel (analytics-page-shell.tsx). A persistent icon
+   rail shown at EVERY screen size, so the familiar-analytics route carries the
+   app's left sidepanel even though it renders outside the SPA workspace. */
+
+.aps {
+  display: flex;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--bg-base);
+}
+
+.aps-rail {
+  flex: 0 0 auto;
+  width: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 0 12px;
+  border-right: 1px solid var(--border-hairline);
+  background: var(--bg-elevated);
+  /* Sticks to the viewport so the rail is always in reach as analytics scrolls. */
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
+  height: 100dvh;
+  /* Clear the native/Tauri title bar so the brand mark isn't under the traffic
+     lights on desktop; harmless (0) on web. */
+  padding-top: max(10px, env(safe-area-inset-top));
+}
+
+.aps-brand {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  color: var(--accent-presence);
+  margin-bottom: 8px;
+  flex-shrink: 0;
+}
+
+.aps-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+}
+
+.aps-rail-link {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.aps-rail-link:hover,
+.aps-rail-link:focus-visible {
+  background: color-mix(in oklch, var(--bg-hover) 72%, transparent);
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--border-strong) 60%, transparent);
+}
+
+.aps-rail-foot {
+  margin-top: auto;
+  flex-shrink: 0;
+}
+
+.aps-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100vh;
+  height: 100dvh;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## What
The familiar-analytics page renders as a **standalone Next route** (`/familiars/[id]/analytics` and `/dashboard/familiars/[id]/analytics`), outside the SPA workspace that owns `SidebarMinimal` — so it had **no left navigation**. This adds the app's left sidepanel to those routes, at **every screen size**.

## How
- New `AnalyticsPageShell` — a persistent, link-based left icon rail mirroring the app's primary destinations (Home · Chat · Tasks · Schedules · Journal · Grimoire · Marketplace · GitHub, deep-linking into the SPA via `/?mode=<id>`, plus Dashboard). Styled with semantic tokens; sticky full-height column.
- Both analytics route pages now wrap `<FamiliarAnalyticsView>` in it.
- Persistent at all widths — **no media query hides the rail** (guarded by a test).

Since these are standalone routes (not SPA surfaces), the rail navigates via real links rather than reproducing `SidebarMinimal`'s SPA-coupled state — keeping the change self-contained.

## Verification
- `typecheck` clean · `pnpm build` green · new `analytics-page-shell` wiring guard + `check:tests-wired` (798 files).
- Drove the running app to `/familiars/nova/analytics` and screenshotted **desktop (1440px)** and **mobile (390px)** — the rail renders identically at both (`display:flex`, 56px), 8 destinations + brand + Dashboard, no layout break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)