### PR TITLE
fix(rollout): six P1 UX dead-ends from the 100k-ft audit

### DIFF
--- a/src/app/api/asana/assigned/route.ts
+++ b/src/app/api/asana/assigned/route.ts
@@ -106,9 +106,18 @@ export async function GET(req: NextRequest) {
       headers,
       cache: "no-store",
     });
+    if (meRes.status === 401) {
+      // The stored PAT was revoked/expired. Distinct from "not configured":
+      // the UI must offer reconnect, not silently hide or show a raw 401
+      // forever (cave-d6zq).
+      return NextResponse.json(
+        { ok: false, error: "Asana rejected the stored token (revoked or expired).", items: [], configured: true, patInvalid: true },
+        { status: 200 },
+      );
+    }
     if (!meRes.ok) {
       return NextResponse.json(
-        { ok: false, error: `Asana API error: HTTP ${meRes.status}`, items: [] },
+        { ok: false, error: `Asana API error: HTTP ${meRes.status}`, items: [], configured: true },
         { status: 502 },
       );
     }

--- a/src/app/api/asana/pat/route.ts
+++ b/src/app/api/asana/pat/route.ts
@@ -37,7 +37,7 @@ function applyEnvUpdates(updates: Record<string, string | null>): void {
   writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
 }
 
-async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null }> {
+async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null; network?: boolean }> {
   try {
     const res = await fetch("https://app.asana.com/api/1.0/users/me", {
       headers: { Authorization: `Bearer ${pat}`, Accept: "application/json" },
@@ -48,7 +48,8 @@ async function validatePat(pat: string): Promise<{ valid: boolean; login: string
     const me = data?.data as { name?: string; email?: string } | undefined;
     return { valid: true, login: me?.name ?? me?.email ?? null };
   } catch {
-    return { valid: false, login: null };
+    // Asana unreachable — not evidence the token is bad (cave-d6zq).
+    return { valid: false, login: null, network: true };
   }
 }
 
@@ -84,6 +85,12 @@ export async function POST(req: NextRequest) {
 
   const result = await validatePat(pat);
   if (!result.valid) {
+    if (result.network) {
+      return NextResponse.json(
+        { ok: false, error: "Couldn't reach Asana to verify the token — check your connection and try again." },
+        { status: 503 },
+      );
+    }
     return NextResponse.json(
       { ok: false, error: "Asana PAT is invalid or expired" },
       { status: 422 },

--- a/src/app/api/github/activity/route.ts
+++ b/src/app/api/github/activity/route.ts
@@ -64,7 +64,11 @@ async function fetchPrChecks(repo: string, number: number, token: string | null)
 
 type ActivityResult = {
   ok: true;
-  authed: boolean;       // true = PAT used; false = public API
+  authed: boolean;       // true = a WORKING PAT was used; false = public API
+  /** The stored PAT was rejected by GitHub (revoked/expired). The client must
+   *  surface this — silently falling back rendered an authed-looking empty
+   *  state over a dead token (cave-cjgg). */
+  patInvalid?: boolean;
   login: string | null;
   items: GitHubItem[];
   rateLimit: { remaining: number; limit: number } | null;
@@ -85,22 +89,30 @@ async function ghFetch(path: string, token: string | null) {
 
 export async function GET() {
   // PAT is strictly local — read from env, never echoed back
-  const token = resolveSecret("GITHUB_PAT") ?? null;
+  const storedToken = resolveSecret("GITHUB_PAT") ?? null;
   const envLogin = resolveSecret("GITHUB_USERNAME") ?? null;
 
   // ── Resolve login ────────────────────────────────────────────────────────
   let login: string | null = envLogin;
   let rateInfo: { remaining: number; limit: number } | null = null;
+  let patInvalid = false;
 
-  if (token) {
+  if (storedToken) {
     try {
-      const { data, rateRemaining, rateLimit } = await ghFetch("/user", token);
+      const { res, data, rateRemaining, rateLimit } = await ghFetch("/user", storedToken);
+      if (res.status === 401) {
+        // GitHub rejected the stored PAT (revoked/expired). Flag it and stop
+        // sending it — every downstream search would just 401 into empty
+        // arrays, rendering a convincing "nothing open" (cave-cjgg).
+        patInvalid = true;
+      }
       login = data?.login ?? login;
       if (rateRemaining >= 0) rateInfo = { remaining: rateRemaining, limit: rateLimit };
     } catch {
-      // PAT might be invalid — fall through to public
+      // Network failure probing /user — transient; keep using the token.
     }
   }
+  const token = patInvalid ? null : storedToken;
 
   if (!login) {
     return NextResponse.json(
@@ -218,6 +230,7 @@ export async function GET() {
   const result: ActivityResult = {
     ok: true,
     authed: !!token,
+    patInvalid: patInvalid || undefined,
     login,
     items,
     rateLimit: rateInfo,

--- a/src/app/api/github/assigned/route.ts
+++ b/src/app/api/github/assigned/route.ts
@@ -67,6 +67,15 @@ export async function GET() {
         : !reviewRes.ok
           ? reviewRes.status
           : createdRes.status;
+      if (failedStatus === 401) {
+        // The stored PAT was rejected (revoked/expired) — flag it so the
+        // client reopens the connect form instead of pinning a raw 401
+        // against a form gated on configured===false (cave-cjgg/cave-d6zq).
+        return NextResponse.json(
+          { ok: false, error: "GitHub rejected the stored token (revoked or expired).", items: [], configured: true, patInvalid: true },
+          { status: 200 },
+        );
+      }
       return NextResponse.json(
         { ok: false, error: `GitHub API error: HTTP ${failedStatus}`, items: [] },
         { status: 502 },

--- a/src/app/api/github/pat/route.ts
+++ b/src/app/api/github/pat/route.ts
@@ -37,7 +37,7 @@ function applyEnvUpdates(updates: Record<string, string | null>): void {
   writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
 }
 
-async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null }> {
+async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null; network?: boolean }> {
   try {
     const res = await fetch("https://api.github.com/user", {
       headers: {
@@ -51,7 +51,29 @@ async function validatePat(pat: string): Promise<{ valid: boolean; login: string
     const data = await res.json().catch(() => null);
     return { valid: true, login: data?.login ?? null };
   } catch {
-    return { valid: false, login: null };
+    // GitHub unreachable — NOT evidence the token is bad. Telling an offline
+    // user their good token "is invalid" sent them token-regenerating for a
+    // network problem (cave-cjgg).
+    return { valid: false, login: null, network: true };
+  }
+}
+
+/** Best-effort existence check for a username-only setup. Only an explicit
+ *  404 rejects — rate limits / network failures must not brick setup, but a
+ *  typo'd username used to save silently and render a permanently empty
+ *  public view (cave-cjgg). */
+async function usernameExists(username: string): Promise<boolean> {
+  try {
+    const res = await fetch(`https://api.github.com/users/${encodeURIComponent(username)}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      cache: "no-store",
+    });
+    return res.status !== 404;
+  } catch {
+    return true;
   }
 }
 
@@ -91,9 +113,19 @@ export async function POST(req: NextRequest) {
   if (pat) {
     const result = await validatePat(pat);
     if (!result.valid) {
+      if (result.network) {
+        return NextResponse.json(
+          { ok: false, error: "Couldn't reach GitHub to verify the token — check your connection and try again." },
+          { status: 503 },
+        );
+      }
       return NextResponse.json({ ok: false, error: "PAT is invalid or lacks required scopes (needs read:user, repo)" }, { status: 422 });
     }
     login = result.login ?? login;
+  } else if (username) {
+    if (!(await usernameExists(username))) {
+      return NextResponse.json({ ok: false, error: `GitHub user "${username}" not found — check the spelling.` }, { status: 422 });
+    }
   }
 
   const updates: Record<string, string | null> = {};

--- a/src/components/asana-connect-inline.tsx
+++ b/src/components/asana-connect-inline.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * Compact inline "Connect Asana" form — POSTs the PAT to /api/asana/pat and
+ * reports back. Extracted from board-inspector's attach section so the Queue's
+ * Asana strip can offer the same reconnect path when a stored token is
+ * rejected (cave-d6zq) instead of dead-ending.
+ */
+
+import { useState } from "react";
+import { Icon } from "@/lib/icon";
+import { openExternalUrl } from "@/lib/open-external";
+
+export const ASANA_PAT_URL = "https://app.asana.com/0/my-apps";
+
+export function InlineAsanaPATSetup({ onSaved }: { onSaved: () => void }) {
+  const [pat, setPat] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const trimmed = pat.trim();
+    if (!trimmed) { setError("Enter an Asana personal access token."); return; }
+    setSaving(true); setError(null);
+    try {
+      const res = await fetch("/api/asana/pat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pat: trimmed }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.ok) { setError(data?.error ?? "Failed to save."); return; }
+      onSaved();
+    } catch { setError("Network error — please try again."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <div style={{ padding: "10px 10px 8px", display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+        <Icon name="ph:check-circle" width={14} className="text-[var(--text-muted)]" />
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-secondary)" }}>Connect Asana</span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <label style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 500 }}>Personal Access Token</label>
+        <input type="password" value={pat} onChange={(e) => setPat(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && void save()} placeholder="1/1234…:abcd…"
+          style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", borderRadius: 6,
+            padding: "5px 8px", fontSize: 11, color: "var(--text-primary)", outline: "none", width: "100%", boxSizing: "border-box" }} />
+      </div>
+      {error && <p style={{ fontSize: 10, color: "var(--color-danger)", margin: 0 }}>{error}</p>}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 2 }}>
+        <button type="button" onClick={() => void openExternalUrl(ASANA_PAT_URL)}
+          style={{ background: "transparent", border: 0, padding: 0, fontSize: 10, color: "var(--accent-presence)", textDecoration: "none", cursor: "pointer" }}>
+          Generate token →
+        </button>
+        <button type="button" disabled={!pat.trim() || saving} onClick={() => void save()}
+          style={{ background: "var(--accent-presence)", color: "var(--text-primary)", border: "none", borderRadius: 6,
+            padding: "4px 12px", fontSize: 11, fontWeight: 500, cursor: "pointer", opacity: saving ? 0.6 : 1 }}>
+          {saving ? "Verifying…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
+import { InlineAsanaPATSetup } from "@/components/asana-connect-inline";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import {
@@ -42,6 +43,8 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
   const { announce } = useAnnouncer();
   const [items, setItems] = useState<AsanaItem[]>([]);
   const [configured, setConfigured] = useState(false);
+  const [patInvalid, setPatInvalid] = useState(false);
+  const [reconnectOpen, setReconnectOpen] = useState(false);
   const [busyGid, setBusyGid] = useState<string | null>(null);
   const [filed, setFiled] = useState<Set<string>>(() => new Set());
   const abortRef = useRef<AbortController | null>(null);
@@ -59,14 +62,18 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
       if (ctrl.signal.aborted) return;
       // A failed fetch, unconfigured Asana, or an agent opted out (assigned ===
       // false) leaves the strip hidden — never an error banner; the Queue's
-      // beads/PR sources carry the surface on their own.
+      // beads/PR sources carry the surface on their own. The one exception is a
+      // REJECTED token (patInvalid): that's permanent-until-fixed, and hiding it
+      // made the strip vanish with no cue or way back (cave-d6zq).
       if (data.ok && data.configured && data.assigned !== false) {
         const next = Array.isArray(data.items) ? data.items : [];
         setItems((prev) => (sameItems(prev, next) ? prev : next));
         setConfigured(true);
+        setPatInvalid(false);
       } else {
         setItems((prev) => (prev.length === 0 ? prev : []));
         setConfigured(false);
+        setPatInvalid(data.patInvalid === true);
       }
     } catch {
       if (!ctrl.signal.aborted) {
@@ -118,6 +125,36 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
     },
     [announce, onFiledBead],
   );
+
+  if (patInvalid) {
+    return (
+      <section className="fwq-asana" aria-label="Asana connection">
+        <header className="fwq-asana-head">
+          <Icon name="ph:check-circle" width={14} aria-hidden />
+          <span className="fwq-asana-title">Asana</span>
+          <span className="fwq-asana-summary">token expired — assigned tasks are hidden</span>
+          <Button
+            variant="ghost"
+            size="xs"
+            leadingIcon="ph:plugs"
+            onClick={() => setReconnectOpen((v) => !v)}
+          >
+            {reconnectOpen ? "Cancel" : "Reconnect"}
+          </Button>
+        </header>
+        {reconnectOpen && (
+          <InlineAsanaPATSetup
+            onSaved={() => {
+              setReconnectOpen(false);
+              setPatInvalid(false);
+              announce("Asana reconnected.");
+              void load();
+            }}
+          />
+        )}
+      </section>
+    );
+  }
 
   if (!configured || items.length === 0) return null;
 

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -35,6 +35,7 @@ import { parseHarnessFailure } from "@/lib/harness-failure";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 import { openExternalUrl } from "@/lib/open-external";
+import { InlineAsanaPATSetup } from "@/components/asana-connect-inline";
 import { attachmentIcon, fileToAttachment, hasDraggedFiles } from "@/lib/chat-attachments";
 import type { CardPatch } from "@/lib/board-card-ops";
 import { sessionStatusTone, sessionStatusWord } from "@/lib/session-status";
@@ -49,7 +50,6 @@ function formatAttachmentSize(size?: number): string {
   return `${(kb / 1024).toFixed(1)} MB`;
 }
 const GITHUB_PAT_URL = "https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local";
-const ASANA_PAT_URL = "https://app.asana.com/0/my-apps";
 
 type LifecycleMove = { to: CardLifecycle; label: string; retry?: boolean };
 const NEXT_MOVES: Record<CardLifecycle, LifecycleMove[]> = {
@@ -208,6 +208,7 @@ function GitHubAttachSection({
   const [query, setQuery] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [configured, setConfigured] = useState<boolean | null>(null);
+  const [patRejected, setPatRejected] = useState(false);
   const [fetchKey, setFetchKey] = useState(0);
   const coarse = useIsCoarsePointer();
 
@@ -218,12 +219,19 @@ function GitHubAttachSection({
     setErr(null);
     fetch("/api/github/assigned", { cache: "no-store" })
       .then((r) => r.json())
-      .then((d: { ok: boolean; items?: GitHubItem[]; configured?: boolean; error?: string }) => {
+      .then((d: { ok: boolean; items?: GitHubItem[]; configured?: boolean; error?: string; patInvalid?: boolean }) => {
         // Drop a superseded/post-close response (open toggled or PAT re-saved).
         if (cancelled) return;
         if (d.ok) {
           setItems(d.items ?? []);
           setConfigured(d.configured ?? true);
+          setPatRejected(false);
+        } else if (d.patInvalid) {
+          // Rejected token: reopen the connect form (it was gated on
+          // configured===false, unreachable with a stored-but-dead PAT).
+          setItems([]);
+          setConfigured(false);
+          setPatRejected(true);
         } else {
           setErr(d.error ?? "failed");
         }
@@ -361,7 +369,14 @@ function GitHubAttachSection({
               <div style={{ padding: "10px", fontSize: 11, color: "var(--color-danger)" }}>{err}</div>
             )}
             {!loading && !err && configured === false && (
-              <InlinePATSetup onSaved={() => { setItems([]); setConfigured(null); setFetchKey((k) => k + 1); }} />
+              <>
+                {patRejected && (
+                  <div style={{ padding: "10px 10px 0", fontSize: 11, color: "var(--color-danger)" }}>
+                    GitHub rejected the stored token (revoked or expired) — reconnect below.
+                  </div>
+                )}
+                <InlinePATSetup onSaved={() => { setItems([]); setConfigured(null); setPatRejected(false); setFetchKey((k) => k + 1); }} />
+              </>
             )}
             {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
               <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>
@@ -438,57 +453,6 @@ function GitHubAttachSection({
 // tasks (via /api/asana/assigned, populated once the Asana PAT is stored) so a
 // card can be linked to the work it tracks. When no PAT is configured the
 // inline connect form appears — the in-app "enable Asana" on-ramp.
-function InlineAsanaPATSetup({ onSaved }: { onSaved: () => void }) {
-  const [pat, setPat] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function save() {
-    const trimmed = pat.trim();
-    if (!trimmed) { setError("Enter an Asana personal access token."); return; }
-    setSaving(true); setError(null);
-    try {
-      const res = await fetch("/api/asana/pat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pat: trimmed }),
-      });
-      const data = await res.json().catch(() => null);
-      if (!res.ok || !data?.ok) { setError(data?.error ?? "Failed to save."); return; }
-      onSaved();
-    } catch { setError("Network error — please try again."); }
-    finally { setSaving(false); }
-  }
-
-  return (
-    <div style={{ padding: "10px 10px 8px", display: "flex", flexDirection: "column", gap: 8 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
-        <Icon name="ph:check-circle" width={14} className="text-[var(--text-muted)]" />
-        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-secondary)" }}>Connect Asana</span>
-      </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-        <label style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 500 }}>Personal Access Token</label>
-        <input type="password" value={pat} onChange={(e) => setPat(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && void save()} placeholder="1/1234…:abcd…"
-          style={{ background: "var(--bg-base)", border: "1px solid var(--border-hairline)", borderRadius: 6,
-            padding: "5px 8px", fontSize: 11, color: "var(--text-primary)", outline: "none", width: "100%", boxSizing: "border-box" }} />
-      </div>
-      {error && <p style={{ fontSize: 10, color: "var(--color-danger)", margin: 0 }}>{error}</p>}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 2 }}>
-        <button type="button" onClick={() => void openExternalUrl(ASANA_PAT_URL)}
-          style={{ background: "transparent", border: 0, padding: 0, fontSize: 10, color: "var(--accent-presence)", textDecoration: "none", cursor: "pointer" }}>
-          Generate token →
-        </button>
-        <button type="button" disabled={!pat.trim() || saving} onClick={() => void save()}
-          style={{ background: "var(--accent-presence)", color: "var(--text-primary)", border: "none", borderRadius: 6,
-            padding: "4px 12px", fontSize: 11, fontWeight: 500, cursor: "pointer", opacity: saving ? 0.6 : 1 }}>
-          {saving ? "Verifying…" : "Save"}
-        </button>
-      </div>
-    </div>
-  );
-}
-
 function AsanaAttachSection({
   card,
   onPatch,
@@ -504,6 +468,7 @@ function AsanaAttachSection({
   const [query, setQuery] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [configured, setConfigured] = useState<boolean | null>(null);
+  const [patRejected, setPatRejected] = useState(false);
   const [fetchKey, setFetchKey] = useState(0);
   const coarse = useIsCoarsePointer();
 
@@ -519,11 +484,20 @@ function AsanaAttachSection({
       : "/api/asana/assigned";
     fetch(url, { cache: "no-store" })
       .then((r) => r.json())
-      .then((d: { ok: boolean; items?: AsanaItem[]; configured?: boolean; error?: string }) => {
+      .then((d: { ok: boolean; items?: AsanaItem[]; configured?: boolean; error?: string; patInvalid?: boolean }) => {
         if (cancelled) return;
         if (d.ok) {
           setItems(d.items ?? []);
           setConfigured(d.configured ?? true);
+          setPatRejected(false);
+        } else if (d.patInvalid) {
+          // Rejected token: reopen the connect form with an explanation. The
+          // raw 401 used to render here forever — and the form was gated on
+          // configured===false, which a stored-but-dead PAT never satisfies
+          // (cave-d6zq).
+          setItems([]);
+          setConfigured(false);
+          setPatRejected(true);
         } else {
           setErr(d.error ?? "failed");
         }
@@ -643,7 +617,14 @@ function AsanaAttachSection({
               <div style={{ padding: "10px", fontSize: 11, color: "var(--color-danger)" }}>{err}</div>
             )}
             {!loading && !err && configured === false && (
-              <InlineAsanaPATSetup onSaved={() => { setItems([]); setConfigured(null); setFetchKey((k) => k + 1); }} />
+              <>
+                {patRejected && (
+                  <div style={{ padding: "10px 10px 0", fontSize: 11, color: "var(--color-danger)" }}>
+                    Asana rejected the stored token (revoked or expired) — reconnect below.
+                  </div>
+                )}
+                <InlineAsanaPATSetup onSaved={() => { setItems([]); setConfigured(null); setPatRejected(false); setFetchKey((k) => k + 1); }} />
+              </>
             )}
             {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
               <div style={{ padding: "12px 10px", fontSize: 11, color: "var(--text-muted)", textAlign: "center" }}>

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -19,6 +19,7 @@ import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
   normalizeSelection,
   projectSelectionKeys,
@@ -44,6 +45,12 @@ type Props = {
   onSessionsChanged?: () => void;
   sessionsLoaded?: boolean;
   familiarsLoaded?: boolean;
+  /** Last roster-load failure. With an empty roster this swaps the "summon
+   *  your first familiar" empty state for a can't-reach + Retry state — the
+   *  familiars may exist but be unreadable right now (cave-atzv). */
+  familiarsError?: string | null;
+  /** Retry a failed roster load. */
+  onRetryFamiliars?: () => void;
   onSlashFromChat?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
   pendingProjectRoot?: string | null;
@@ -95,6 +102,8 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onSessionsChanged,
     sessionsLoaded,
     familiarsLoaded,
+    familiarsError,
+    onRetryFamiliars,
     onSlashFromChat,
     onOpenOnboarding,
     pendingProjectRoot,
@@ -351,36 +360,66 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         />
       );
     }
-    // Empty-state copy is mode-aware: on phones the nav/sidebar/agent panels
-    // are drawers behind a toggle, so "from the sidebar selector" / "left
-    // panel" reads as broken. Point users at the drawer or the setup CTA
-    // instead.
-    const heading = isMobile
-      ? "Choose a familiar to start chatting"
-      : "Choose a familiar from the sidebar selector";
+    // Roster failed to load: the familiars may exist but be unreadable right
+    // now (daemon flap, auth). First-run "summon" copy here would read as
+    // "your familiars were deleted" — offer Retry instead (cave-atzv).
+    if (familiarsError) {
+      return (
+        <section className="flex h-full flex-col items-center justify-center gap-4 bg-[var(--bg-base)] px-6 text-center text-sm text-[var(--text-muted)]">
+          <div>
+            <p className="text-[15px] font-medium text-[var(--text-secondary)]">
+              Can&apos;t reach your familiars
+            </p>
+            <p className="mt-1 text-[12px]">
+              {daemonRunning === false
+                ? "The daemon is offline, so the roster can't be read. Your familiars are safe."
+                : "The roster didn't load. Your familiars are safe — retry in a moment."}
+            </p>
+          </div>
+          {onRetryFamiliars ? (
+            <button
+              onClick={onRetryFamiliars}
+              className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+            >
+              Retry
+            </button>
+          ) : null}
+        </section>
+      );
+    }
+    // Loaded-and-empty: there is nothing to "choose" yet — the first familiar
+    // has to be summoned. Lead with the Summoning Circle (the wizard stops at
+    // infrastructure and cannot create familiars, cave-3em5); keep setup as
+    // the quieter escape hatch for genuinely unconfigured machines.
     const subline = pendingProjectRoot
-      ? "Selecting one will start this chat in the pending project."
-      : isMobile
-        ? "Open the menu to pick a familiar, or set one up below."
-        : "Pick who should handle the conversation from the left panel.";
+      ? "Summoning one will let this chat start in the pending project."
+      : "A familiar is an AI agent with its own identity and memory. Summon your first to start chatting.";
     return (
       <section className="flex h-full flex-col items-center justify-center gap-4 bg-[var(--bg-base)] px-6 text-center text-sm text-[var(--text-muted)]">
         <div>
           <p className="text-[15px] font-medium text-[var(--text-secondary)]">
-            {heading}
+            Summon your first familiar
           </p>
           <p className="mt-1 text-[12px]">
             {subline}
           </p>
         </div>
-        {onOpenOnboarding ? (
+        <div className="flex items-center gap-2">
           <button
-            onClick={onOpenOnboarding}
-            className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+            onClick={() => requestSummonFamiliar()}
+            className="rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[12px] font-medium text-[var(--bg-base)] hover:opacity-90"
           >
-            Open setup
+            Summon a familiar
           </button>
-        ) : null}
+          {onOpenOnboarding ? (
+            <button
+              onClick={onOpenOnboarding}
+              className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 text-[12px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+            >
+              Open setup
+            </button>
+          ) : null}
+        </div>
       </section>
     );
   }

--- a/src/components/chat-surface-polish.test.ts
+++ b/src/components/chat-surface-polish.test.ts
@@ -7,13 +7,16 @@ import { dirname, resolve } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 const read = (p: string) => readFileSync(resolve(here, p), "utf8");
 
-test("chat-router renders mobile-aware empty-state copy", () => {
+test("chat-router zero-roster empty state leads with the Summoning Circle", () => {
   const src = read("./chat-router.tsx");
-  assert.match(src, /useIsMobile/, "imports useIsMobile");
-  assert.match(src, /Choose a familiar to start chatting/, "mobile heading present");
-  assert.match(src, /Choose a familiar from the sidebar selector/, "desktop heading present");
-  assert.match(src, /Open the menu to pick a familiar/, "mobile subline present");
-  assert.match(src, /Pick who should handle the conversation from the left panel/, "desktop subline present");
+  // With zero familiars there is nothing to "choose" — the state summons
+  // instead of pointing at a selector that lists nothing (cave-3em5).
+  assert.match(src, /Summon your first familiar/, "summon heading present");
+  assert.match(src, /requestSummonFamiliar\(\)/, "primary CTA opens the Summoning Circle");
+  assert.doesNotMatch(src, /from the sidebar selector|from the left panel/, "no pointers at a selector that lists zero familiars");
+  // Roster-load failure must NOT render the first-run copy (cave-atzv).
+  assert.match(src, /Can&apos;t reach your familiars/, "roster-error state present");
+  assert.match(src, /onRetryFamiliars/, "roster-error state offers Retry");
 });
 
 // The right companion rail (which took suppressEmpty={mode === "chat"}) was

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -19,6 +19,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { openGrimoireDoc } from "@/lib/grimoire-link";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
@@ -68,6 +69,9 @@ type Props = {
   routerRef: RefObject<ChatRouterHandle | null>;
   sessionsLoaded?: boolean;
   familiarsLoaded?: boolean;
+  /** Roster-load failure + retry, forwarded to ChatRouter's empty state (cave-atzv). */
+  familiarsError?: string | null;
+  onRetryFamiliars?: () => void;
   inboxItems: InboxItem[];
   inspectorOpen: boolean;
   rightPanel?: RightPanelKind | null;
@@ -195,6 +199,8 @@ export function ChatSurface({
   routerRef,
   sessionsLoaded,
   familiarsLoaded,
+  familiarsError,
+  onRetryFamiliars,
   inboxItems,
   inspectorOpen,
   rightPanel: rightPanelProp,
@@ -676,8 +682,9 @@ export function ChatSurface({
             activeFamiliar={activeFamiliar}
             lockToFamiliar
             onOpenMemoryFile={(path) => {
-              setRightPanel("inspector");
-              window.location.hash = `memory:${encodeURIComponent(path)}`;
+              // Land on the Grimoire editor — the app's memory-file reader.
+              // (The old `#memory:` hash had no consumer anywhere; cave-ce7y.)
+              openGrimoireDoc("memory", path);
             }}
           />
         ) : scope === "projects" ? (
@@ -710,6 +717,8 @@ export function ChatSurface({
                   daemonRunning={daemonRunning}
                   sessionsLoaded={sessionsLoaded}
                   familiarsLoaded={familiarsLoaded}
+                  familiarsError={familiarsError}
+                  onRetryFamiliars={onRetryFamiliars}
                   compact={compactRail}
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}

--- a/src/components/familiar-asana-section.tsx
+++ b/src/components/familiar-asana-section.tsx
@@ -31,6 +31,7 @@ export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar 
   // Inline connect form (shown only when the app has no PAT yet).
   const [pat, setPat] = useState("");
   const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -111,6 +112,27 @@ export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar 
       setError((err as Error).message);
     } finally {
       setConnecting(false);
+    }
+  }
+
+  async function disconnect() {
+    if (disconnecting) return;
+    setDisconnecting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/asana/pat", { method: "DELETE" });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || json?.ok === false) {
+        setError(json?.error ?? "Couldn't disconnect Asana");
+      } else {
+        setConfigured(false);
+        setLogin(null);
+        setWorkspaces([]);
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setDisconnecting(false);
     }
   }
 
@@ -215,6 +237,23 @@ export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar 
               : `${familiar.display_name} is opted out of Asana. Other familiars keep their access.`}
             {login ? ` · Connected as ${login}.` : ""}
           </p>
+
+          {/* App-wide disconnect: removes the stored PAT (revoked tokens had
+              no in-app way out — only a hidden vault-key delete; cave-d6zq).
+              The connect form reappears for a fresh token. */}
+          <div className="familiar-studio-brain__row">
+            <span className="familiar-studio-brain__label">Connection</span>
+            <div className="familiar-studio-brain__control">
+              <button
+                type="button"
+                onClick={() => void disconnect()}
+                disabled={disconnecting}
+                className="focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:text-[var(--color-danger)]"
+              >
+                {disconnecting ? "Disconnecting…" : "Disconnect Asana"}
+              </button>
+            </div>
+          </div>
         </>
       )}
 

--- a/src/components/familiar-switcher.test.ts
+++ b/src/components/familiar-switcher.test.ts
@@ -103,8 +103,13 @@ assert.doesNotMatch(source, /togglePin|familiar-switcher__pin|useFamiliarPins/, 
 // view) and reorder as quieter actions beneath it (cave-6p5l).
 assert.match(
   source,
-  /new CustomEvent\("cave:onboarding-open"\)/,
-  "Summon routes to the summoning circle (familiars are daemon-owned)",
+  /requestSummonFamiliar\(\)/,
+  "Summon routes to the Summoning Circle on the Familiars surface (cave-3em5)",
+);
+assert.doesNotMatch(
+  source,
+  /cave:onboarding-open/,
+  "Summon must NOT open the onboarding wizard — it stops at infrastructure and cannot create familiars (cave-3em5)",
 );
 assert.match(
   source,

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -7,6 +7,7 @@ import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { computePresence, REMOTE_HARNESSES } from "@/lib/presence";
 import { Popover } from "@/components/ui/popover";
 import { setFamiliarOrder } from "@/lib/cave-familiar-order";
+import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
   DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter,
   type DragEndEvent,
@@ -83,13 +84,10 @@ export function FamiliarSwitcher({
     if (!multi) setOpen(false);
   };
 
-  // Familiars are daemon-owned — there is no cave-side create. "New familiar"
-  // routes to onboarding (the canonical create flow) via the window-event bus
-  // the Workspace listens on (see `cave:onboarding-open`).
+  // Creation lives in the Summoning Circle on the Familiars surface — the
+  // onboarding wizard stops at infrastructure and cannot summon (cave-3em5).
   const fireCreateFamiliar = () => {
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("cave:onboarding-open"));
-    }
+    requestSummonFamiliar();
   };
 
   const anyNeedsReply = useMemo(() => {

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -27,6 +27,7 @@ import {
   type CovenMemoryEntry,
 } from "@/components/familiars-view-stats";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
+import { SUMMON_FAMILIAR_EVENT, consumeSummonPending } from "@/lib/summon-events";
 
 type CovenMemoryResponse =
   | { ok: true; entries: CovenMemoryEntry[] }
@@ -53,6 +54,12 @@ type AgentsViewProps = {
   onOpenUrl: (url: string) => void;
   /** Refresh the roster after a familiar is created and focus the new one. */
   onFamiliarCreated?: (id: string) => void;
+  /** Last roster-load failure. When set with an empty roster the surface must
+   *  NOT show first-run copy — the familiars may exist but be unreadable
+   *  (daemon flap, auth) (cave-atzv). */
+  familiarsError?: string | null;
+  /** Retry a failed roster load. */
+  onRetryFamiliars?: () => void;
 };
 
 function familiarMatches(familiar: Familiar, query: string): boolean {
@@ -78,9 +85,20 @@ export function FamiliarsView({
   onOpenOnboarding,
   onOpenUrl,
   onFamiliarCreated,
+  familiarsError,
+  onRetryFamiliars,
 }: AgentsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [createOpen, setCreateOpen] = useState(false);
+  // Other surfaces request the Summoning Circle through summon-events: the
+  // retained latch covers the fresh-mount race (mode flip → this view mounts
+  // after the event fired); the event covers the already-mounted case.
+  useEffect(() => {
+    if (consumeSummonPending()) setCreateOpen(true);
+    const open = () => setCreateOpen(true);
+    window.addEventListener(SUMMON_FAMILIAR_EVENT, open);
+    return () => window.removeEventListener(SUMMON_FAMILIAR_EVENT, open);
+  }, []);
   // When set, the summoning circle opens as the Enhancement Rite for this familiar.
   const [enhanceTarget, setEnhanceTarget] = useState<ResolvedFamiliar | null>(null);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
@@ -302,10 +320,33 @@ export function FamiliarsView({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {familiars.length === 0 ? (
           <div className="p-4">
-            <FamiliarsEmptyState
-              onCreate={() => setCreateOpen(true)}
-              onOpenOnboarding={onOpenOnboarding}
-            />
+            {familiarsError ? (
+              // The roster failed to load — familiars may exist but be
+              // unreadable right now. First-run "summon your first" copy here
+              // would read as "your familiars were deleted" (cave-atzv).
+              <EmptyState
+                className="familiars-view__empty mx-auto my-16 max-w-md"
+                icon="ph:plugs"
+                headline="Can't reach your familiars"
+                subtitle={
+                  daemonRunning
+                    ? "The roster didn't load. Your familiars are safe — retry in a moment."
+                    : "The daemon is offline, so the roster can't be read. Your familiars are safe — start the daemon, then retry."
+                }
+                actions={
+                  onRetryFamiliars ? (
+                    <Button variant="primary" leadingIcon="ph:arrow-clockwise" onClick={onRetryFamiliars}>
+                      Retry
+                    </Button>
+                  ) : undefined
+                }
+              />
+            ) : (
+              <FamiliarsEmptyState
+                onCreate={() => setCreateOpen(true)}
+                onOpenOnboarding={onOpenOnboarding}
+              />
+            )}
           </div>
         ) : viewMode === "detail" && selectedFamiliar ? (
           <div className="familiars-view__detail flex h-full min-h-0">

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -62,6 +62,9 @@ import { openExternalUrl } from "@/lib/open-external";
 type ActivityResult = {
   ok: true;
   authed: boolean;
+  /** GitHub rejected the stored PAT (revoked/expired) — surface it, don't
+   *  render an authed-looking empty state over a dead token (cave-cjgg). */
+  patInvalid?: boolean;
   login: string | null;
   items: GitHubItem[];
   rateLimit: { remaining: number; limit: number } | null;
@@ -189,14 +192,19 @@ function PatSetupModal({
   onSaved,
   onClose,
   username,
+  hasPat = false,
 }: {
   onSaved: (login: string, hasPat: boolean) => void;
   onClose: () => void;
   username: string | null;
+  /** A PAT is currently stored — offers the remove path (the DELETE route
+   *  had no caller anywhere; cave-cjgg). */
+  hasPat?: boolean;
 }) {
   const [pat, setPat] = useState("");
   const [usernameInput, setUsernameInput] = useState(username ?? "");
   const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -346,6 +354,41 @@ function PatSetupModal({
             </Button>
           </div>
         </form>
+
+        {hasPat && (
+          <div className="mt-3 border-t border-[var(--border-hairline)] pt-3">
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={removing || saving}
+              onClick={() => {
+                if (removing) return;
+                setRemoving(true);
+                setError(null);
+                void (async () => {
+                  try {
+                    const res = await fetch("/api/github/pat", { method: "DELETE" });
+                    const data = await res.json().catch(() => null);
+                    if (!res.ok || data?.ok === false) {
+                      setError(data?.error ?? "Couldn't remove the token.");
+                      return;
+                    }
+                    onSaved(usernameInput.trim() || username || "", false);
+                  } catch {
+                    setError("Network error — please try again.");
+                  } finally {
+                    setRemoving(false);
+                  }
+                })();
+              }}
+            >
+              {removing ? "Removing…" : "Remove stored token"}
+            </Button>
+            <p className="mt-1 text-[10px] text-[var(--text-muted)]">
+              Drops back to public data for @{usernameInput.trim() || username || "…"}.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -2302,7 +2345,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
 
       const nextActivity = data as ActivityResult;
       setActivity((prev) =>
-        prev && prev.authed === nextActivity.authed && arrayContentEqual(prev.items, nextActivity.items)
+        prev && prev.authed === nextActivity.authed && prev.patInvalid === nextActivity.patInvalid && arrayContentEqual(prev.items, nextActivity.items)
           ? prev
           : nextActivity);
       setError(null);
@@ -2544,6 +2587,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       {showPatModal && (
         <PatSetupModal
           username={patStatus?.login ?? null}
+          hasPat={patStatus?.hasPat ?? false}
           onSaved={(login, hasPat) => {
             setPatStatus({ hasPat, login });
             setShowPatModal(false);
@@ -2560,7 +2604,17 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
             <span className="gh-compact-login">@{activity.login}</span>
           )}
 
-          {activity?.authed === false && (
+          {activity?.patInvalid && (
+            <button
+              type="button"
+              onClick={() => setShowPatModal(true)}
+              className="gh-compact-auth gh-compact-auth--invalid focus-ring"
+              title="GitHub rejected the stored token (revoked or expired) — update your PAT"
+            >
+              token rejected — update PAT
+            </button>
+          )}
+          {!activity?.patInvalid && activity?.authed === false && (
             <span
               className="gh-compact-auth gh-compact-auth--public"
               title="Public API — add a PAT for private repos + review requests"
@@ -2745,6 +2799,19 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                 icon="ph:magnifying-glass"
                 headline={`No items match “${query.trim()}”`}
                 subtitle="Try a shorter query, or clear the search to see everything."
+              />
+            ) : activity?.patInvalid ? (
+              // A dead PAT means this emptiness is unverifiable — an all-clear
+              // check mark here would be a lie (cave-cjgg).
+              <EmptyState
+                icon="ph:key"
+                headline="GitHub token rejected"
+                subtitle="The stored token was revoked or expired, so private repos and reviews can't be read. Update the PAT to restore the full view."
+                actions={
+                  <Button variant="primary" leadingIcon="ph:key" onClick={() => setShowPatModal(true)}>
+                    Update PAT
+                  </Button>
+                }
               />
             ) : (
               <EmptyState

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -19,6 +19,7 @@ import {
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { resolveModelArg } from "@/lib/slash-model";
+import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
   resolveSkillInvocation,
   buildSkillPrompt,
@@ -492,7 +493,13 @@ export function HomeComposer({
     try {
       switch (destination) {
         case "chat": {
-          if (!selectedFamiliarId) { onToast("No familiar selected — add one in Settings."); break; }
+          if (!selectedFamiliarId) {
+            // Walk them to the Summoning Circle instead of naming a two-hop
+            // Settings destination; the draft persists for their return (cave-3em5).
+            onToast("No familiar yet — summon one to send this. Your draft is saved.");
+            requestSummonFamiliar();
+            break;
+          }
           // Hand the prompt to ChatView, which owns the streaming send. Doing
           // the send here and canceling on the session event aborts the
           // request server-side — the harness is killed mid-run and the

--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -71,8 +71,8 @@ assert.doesNotMatch(
 
 assert.match(
   chatRouter,
-  /Choose a familiar from the sidebar selector/,
-  "ChatRouter should explain the new familiar selection path",
+  /Summon your first familiar/,
+  "ChatRouter's zero-roster empty state summons instead of pointing at a selector that lists nothing (cave-3em5)",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -30,6 +30,7 @@ import { Shell, type ShellHandle } from "@/components/shell";
 import type { DetailSplitTile } from "@/components/detail-split-host";
 import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
+import { openGrimoireDoc } from "@/lib/grimoire-link";
 import { FamiliarStudioProvider, openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { RailInspector } from "@/components/inspector-pane";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -355,6 +356,10 @@ export function Workspace() {
   // "running" doesn't flicker it away — it shows on the first failed poll and
   // only clears after the daemon is *consistently* healthy (see the streak ref).
   const [daemonOffline, setDaemonOffline] = useState(false);
+  // The access-token gate rejected our credential (401 on the status poll).
+  // Distinct from daemonOffline: the daemon may be fine — WE can't see it, and
+  // the fix is re-auth (reload to the gate page), not "Start daemon" (cave-wkp5).
+  const [authExpired, setAuthExpired] = useState(false);
   const daemonHealthyStreakRef = useRef(0);
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
 
@@ -534,33 +539,50 @@ export function Workspace() {
 
   const refreshDaemonStatus = useCallback(async (opts?: { trusted?: boolean }) => {
     let running = false;
+    let authRejected = false;
     try {
       const res = await fetch("/api/daemon/status", { cache: "no-store" });
-      const json = (await res.json()) as { running?: boolean };
-      running = json.running === true;
-      setDaemonRunning(running);
-    } catch {
-      setDaemonRunning(false);
-    } finally {
-      // Drive the sticky offline signal: any failed poll marks the daemon
-      // offline immediately, but a background poll takes two *consecutive*
-      // healthy polls to clear — otherwise a flapping zombie daemon keeps
-      // dismissing the banner.
-      if (running) {
-        daemonHealthyStreakRef.current += 1;
-        // A `trusted` refresh follows an explicit user-initiated start, so a
-        // healthy answer is enough to clear the banner immediately — without it
-        // the "Start daemon" banner lingered for a poll cycle (~5s) after the
-        // daemon was already up.
-        if (opts?.trusted) daemonHealthyStreakRef.current = 2;
-        if (daemonHealthyStreakRef.current >= 2) setDaemonOffline(false);
+      if (res.status === 401) {
+        // The access-token gate rejected US — the daemon may be perfectly
+        // healthy; we just can't see it. Attributing this to the daemon put
+        // users in front of a "Daemon offline" banner whose "Start daemon"
+        // CTA also 401s (cave-wkp5). Surface re-auth instead, and leave the
+        // daemon state untouched.
+        authRejected = true;
       } else {
-        daemonHealthyStreakRef.current = 0;
-        setDaemonOffline(true);
+        const json = (await res.json()) as { running?: boolean };
+        running = json.running === true;
+        setDaemonRunning(running);
+        // A real (non-401) answer proves the credential is accepted again.
+        setAuthExpired(false);
       }
-      // The first poll has now produced a real answer — only after this may the
-      // offline banner appear, so a fresh load doesn't flash it before we know.
-      setDaemonStatusResolved(true);
+    } catch {
+      if (!authRejected) setDaemonRunning(false);
+    } finally {
+      if (authRejected) {
+        setAuthExpired(true);
+        setDaemonStatusResolved(true);
+      } else {
+        // Drive the sticky offline signal: any failed poll marks the daemon
+        // offline immediately, but a background poll takes two *consecutive*
+        // healthy polls to clear — otherwise a flapping zombie daemon keeps
+        // dismissing the banner.
+        if (running) {
+          daemonHealthyStreakRef.current += 1;
+          // A `trusted` refresh follows an explicit user-initiated start, so a
+          // healthy answer is enough to clear the banner immediately — without it
+          // the "Start daemon" banner lingered for a poll cycle (~5s) after the
+          // daemon was already up.
+          if (opts?.trusted) daemonHealthyStreakRef.current = 2;
+          if (daemonHealthyStreakRef.current >= 2) setDaemonOffline(false);
+        } else {
+          daemonHealthyStreakRef.current = 0;
+          setDaemonOffline(true);
+        }
+        // The first poll has now produced a real answer — only after this may the
+        // offline banner appear, so a fresh load doesn't flash it before we know.
+        setDaemonStatusResolved(true);
+      }
     }
   }, []);
 
@@ -691,9 +713,11 @@ export function Workspace() {
   });
 
   // Push / dismiss the daemon-offline banner into the shared shell channel so
-  // it appears at the top of every surface, not just Chat.
+  // it appears at the top of every surface, not just Chat. While the access
+  // token is rejected the daemon state is unknowable — suppress this banner
+  // in favour of the re-auth one (cave-wkp5).
   useEffect(() => {
-    if (!daemonOffline) {
+    if (!daemonOffline || authExpired) {
       dismissBanner("daemon-offline");
       dismissBanner("daemon-start-error");
     } else if (daemonStatusResolved) {
@@ -711,26 +735,55 @@ export function Workspace() {
         },
       });
     }
-  }, [daemonOffline, daemonStatusResolved, pushBanner, dismissBanner, startDaemon]);
+  }, [daemonOffline, daemonStatusResolved, authExpired, pushBanner, dismissBanner, startDaemon]);
+
+  // Re-auth banner: the access-token gate is rejecting every request, so all
+  // surfaces are degrading at once. A reload lands on the gate page, which
+  // explains how to sign back in (paste a token / open the pairing link).
+  useEffect(() => {
+    if (!authExpired) {
+      dismissBanner("auth-expired");
+      return;
+    }
+    pushBanner({
+      id: "auth-expired",
+      severity: "error",
+      title: "Access expired — this session's token is no longer valid. Reload to sign in again.",
+      cta: {
+        label: "Reload",
+        onClick: () => {
+          window.location.reload();
+        },
+      },
+    });
+  }, [authExpired, pushBanner, dismissBanner]);
 
   const loadFamiliars = useCallback(async () => {
     try {
       const res = await fetch("/api/familiars", { cache: "no-store" });
       const json = await res.json();
       if (!json.ok) {
-        setFamiliars([]);
+        // Keep the last-known-good roster: a failed load means "can't see the
+        // familiars right now", not "there are none". Clearing here made three
+        // surfaces show first-run copy over an intact roster (cave-atzv).
         setFamiliarsError(json.error ?? "daemon offline");
         return;
       }
       setFamiliarsError(null);
       setFamiliars((json.familiars ?? []) as Familiar[]);
     } catch (err) {
-      setFamiliars([]);
       setFamiliarsError(err instanceof Error ? err.message : "fetch failed");
     } finally {
       setFamiliarsLoaded(true);
     }
   }, []);
+
+  // A roster load that failed (or raced the daemon's boot) self-heals once the
+  // daemon is reachable again — without this, one transient failure left the
+  // empty state up until an unrelated refresh event (cave-atzv).
+  useEffect(() => {
+    if (daemonRunning) void loadFamiliars();
+  }, [daemonRunning, loadFamiliars]);
 
   // Scope the view to a familiar. `null` clears to "All". With `opts.multi`
   // (⌘/Ctrl-click) the id is toggled in/out of the multiselect set; a plain
@@ -1835,8 +1888,10 @@ export function Workspace() {
       return;
     }
     if (intent.kind === "open-memory-file") {
-      setMode("agents");
-      window.location.hash = `memory:${encodeURIComponent(intent.path)}`;
+      // Land on the Grimoire editor with the file selected. (The old
+      // `#memory:` hash had no consumer anywhere — picking a memory result
+      // jumped to Familiars with nothing opened; cave-ce7y.)
+      openGrimoireDoc("memory", intent.path);
       return;
     }
     if (intent.kind === "slash") {
@@ -2209,7 +2264,9 @@ export function Workspace() {
         onStartChat={(familiarId) => startFamiliarChat(familiarId)}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
         onOpenMemoryFile={(path) => {
-          window.location.hash = `memory:${encodeURIComponent(path)}`;
+          // Grimoire editor is the memory-file reader — the old `#memory:`
+          // hash had no consumer (cave-ce7y).
+          openGrimoireDoc("memory", path);
         }}
         onOpenOnboarding={openOnboarding}
         onOpenUrl={openUrlInAppBrowser}
@@ -2217,6 +2274,8 @@ export function Workspace() {
           void loadFamiliars();
           selectFamiliar(id);
         }}
+        familiarsError={familiarsError}
+        onRetryFamiliars={() => void loadFamiliars()}
       />
     ) : mode === "chat" ? (
       <ChatSurface
@@ -2229,6 +2288,8 @@ export function Workspace() {
         hideThreadRail
         sessionsLoaded={sessionsLoaded}
         familiarsLoaded={familiarsLoaded}
+        familiarsError={familiarsError}
+        onRetryFamiliars={() => void loadFamiliars()}
         inboxItems={inboxItemsWithEphemeral}
         inspectorOpen={inspectorOpen}
         rightPanel={rightPanel}

--- a/src/lib/asana-tasks.ts
+++ b/src/lib/asana-tasks.ts
@@ -42,6 +42,9 @@ export type AsanaAssignedResponse = {
   /** When a familiarId was passed: false means this agent is opted out of Asana
    *  (asanaEnabled === false). Absent/true otherwise. */
   assigned?: boolean;
+  /** The stored PAT was rejected by Asana (revoked/expired) — the UI must
+   *  offer reconnect, not silently hide (cave-d6zq). */
+  patInvalid?: boolean;
   error?: string;
 };
 

--- a/src/lib/summon-events.ts
+++ b/src/lib/summon-events.ts
@@ -1,0 +1,41 @@
+"use client";
+
+/**
+ * Cross-surface request to open the Summoning Circle (familiar creation).
+ *
+ * Familiar creation lives in the Circle on the Familiars surface (#2635) —
+ * NOT in the onboarding wizard, which stops at infrastructure. Any surface
+ * that wants to offer "summon a familiar" routes through here so the wiring
+ * can't drift back to the wizard (cave-3em5: the switcher's Summon button
+ * dispatched `cave:onboarding-open` long after creation moved out of it).
+ *
+ * Mount race: when summoning is requested from a different surface, the
+ * Workspace flips to `agents` and FamiliarsView mounts fresh — a
+ * fire-and-forget event can race its listener subscription. Same shape as
+ * `markCovenTabPending` in chat-tab-events.ts: a retained latch set
+ * synchronously before the mode flips, consumed on mount; the event covers
+ * the already-mounted case.
+ */
+
+/** Window event asking a mounted Familiars surface to open the Circle. */
+export const SUMMON_FAMILIAR_EVENT = "cave:summon-familiar";
+
+let summonPending = false;
+
+export function markSummonPending(): void {
+  summonPending = true;
+}
+
+export function consumeSummonPending(): boolean {
+  const pending = summonPending;
+  summonPending = false;
+  return pending;
+}
+
+/** Navigate to the Familiars surface and open the Summoning Circle. */
+export function requestSummonFamiliar(): void {
+  if (typeof window === "undefined") return;
+  markSummonPending();
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "agents" } }));
+  window.dispatchEvent(new CustomEvent(SUMMON_FAMILIAR_EVENT));
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -602,6 +602,13 @@
   background:color-mix(in oklab,var(--color-success) 10%,transparent);
   color:var(--color-success);
 }
+/* Rejected/expired PAT: a clickable chip (opens the PAT modal) in danger tint. */
+.gh-compact-auth--invalid {
+  border-color:color-mix(in oklab,var(--color-danger) 42%,transparent);
+  background:color-mix(in oklab,var(--color-danger) 10%,transparent);
+  color:var(--color-danger);
+  cursor:pointer;
+}
 .gh-compact-rate {
   color:var(--text-muted);
   font-size:10px;


### PR DESCRIPTION
Fixes the six P1 bugs filed from the 2026-07-09 pre-rollout UX audit. Every finding was verified in source before fixing; all six are journey-level dead-ends a normal user can hit.

## Fixes

**cave-3em5 — Summon familiar misrouted to the infra wizard.** The switcher's always-visible "Summon familiar" dispatched `cave:onboarding-open`, but the wizard stops at infrastructure and cannot create familiars (creation moved to the Summoning Circle in #2635). New `src/lib/summon-events.ts` (`requestSummonFamiliar()` = latch + navigate + event, mirroring the coven-tab latch's mount-race fix) now backs the switcher, the chat zero-roster empty state (which also stops pointing at "the sidebar selector" when the roster lists nothing), and the home composer's no-familiar submit.

**cave-wkp5 — Expired access token masqueraded as "Daemon offline".** The status poll now recognizes a 401 as *our credential failing*, not the daemon: a distinct "Access expired — Reload to sign in again" error banner replaces the daemon-offline banner (whose "Start daemon" CTA also 401'd). Non-401 responses clear the flag.

**cave-atzv — Roster wipe on a failed familiars fetch.** `loadFamiliars` keeps the last-known-good roster on failure; the previously-dead `familiarsError` state now drives a "Can't reach your familiars" + Retry empty state on both chat and Familiars (instead of first-run "summon your first familiar" copy over an intact roster), and the roster reloads when the daemon comes back up.

**cave-ce7y — `#memory:` deep links had no consumer.** All four emitters (⌘K memory results, Familiars view, chat memory tab, workspace prop) now route through the working `openGrimoireDoc("memory", path)` — the Grimoire editor is the app's memory reader.

**cave-cjgg — Dead GitHub PAT showed a green "authenticated" chip.** `/api/github/activity` probes `/user`; a 401 sets `patInvalid`, stops sending the dead token (public fallback keeps working), and reports `authed:false`. The view renders a danger "token rejected — update PAT" chip and a truthful empty state with an Update-PAT action; `/api/github/assigned` flags the same so the board attach section reopens its connect form. PatSetupModal gains "Remove stored token" (first caller of the DELETE route); username-only setup 404-validates; PAT-save network failures return 503 "couldn't reach GitHub" instead of "invalid token".

**cave-d6zq — Revoked Asana PAT bricked the integration.** `/api/asana/assigned` flags `patInvalid` on 401; the Queue strip shows a compact "token expired — Reconnect" row (instead of vanishing forever); the board attach section reopens the inline connect form with an explanation (was gated on `configured===false`, unreachable with a stored-but-dead PAT); Familiar Studio's Asana section gains **Disconnect Asana** (first caller of that DELETE route). The inline connect form is extracted to `asana-connect-inline.tsx` for reuse.

## Validation
- `pnpm typecheck` ✓ · `pnpm test:app` 595 files ✓ · `test:api` 131 ✓ · `test:mobile` 75 ✓ · `check:tests-wired` ✓ · `pnpm build` + bundle budget ✓
- Updated pins: `familiar-switcher.test.ts` (now asserts the circle route and forbids `cave:onboarding-open`), `chat-surface-polish.test.ts`, `sidebar-familiar-filter.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)