### PR TITLE
fix(shell): keep headers adaptive across screen sizes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5388,7 +5388,10 @@ button:active > .edge-rail-chip {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  width: min(480px, 42vw);
+  /* Stay geometrically centered, but reserve equal room on both sides for the
+     normal 204px action cluster plus breathing room. Basing the third cap on
+     this bar's own width makes compact native windows shrink gracefully. */
+  width: min(480px, 42vw, calc(100% - 432px));
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -5400,6 +5403,13 @@ button:active > .edge-rail-chip {
   transition: border-color var(--duration-fast) var(--ease-standard),
     background var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard);
+}
+
+/* Enrichment progress is intentionally visible text, so its action grows
+   beyond the icon-only baseline. Contract the centered search only while that
+   live label exists; wide windows still keep the 480px search cap. */
+.menu-bar:has(.menu-bar__task-label--live) .menu-bar__search {
+  width: min(480px, 42vw, calc(100% - 564px));
 }
 
 .menu-bar__search:hover,
@@ -5615,6 +5625,7 @@ button:active > .edge-rail-chip {
 
 .top-bar {
   display: none;
+  width: 100%;
   grid-template-columns: 1fr minmax(auto, 560px) 1fr;
   align-items: center;
   gap: 12px;
@@ -7388,6 +7399,10 @@ a.mobile-handoff__link:hover {
   .top-bar__actions .top-bar__mobile-toggle {
     border: 1px solid var(--border-hairline);
   }
+  .top-bar__actions .top-bar__tasks > .ui-icon-btn {
+    width: var(--touch-target);
+    height: var(--touch-target);
+  }
   .top-bar__account {
     background: transparent;
   }
@@ -7428,6 +7443,16 @@ a.mobile-handoff__link:hover {
       width: 100%;
       height: 100%;
       border-radius: calc(var(--radius-control) - 1px);
+    }
+  }
+  /* Below 456px, five global actions leave search under 120px even before its
+     text is considered. Chat and Board already live in the bottom destination
+     bar, so demote their duplicate top-row shortcuts while keeping search,
+     familiar scope, notifications, and account settings. */
+  @media (max-width: 455px) {
+    .top-bar__actions [data-quick-chat-trigger],
+    .top-bar__actions .top-bar__tasks {
+      display: none;
     }
   }
   .notification-bell__popover {

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -23,6 +23,16 @@ assert.match(css, /\.top-bar \{[\s\S]*?background:\s*var\(--bg-base\)[\s\S]*?bor
 // Search is centered in the bar with its pill border always visible (user
 // override of the earlier ghost-at-rest treatment) — Codex-style landmark.
 assert.match(css, /\.menu-bar__search \{[\s\S]*?position:\s*absolute[\s\S]*?left:\s*50%[\s\S]*?translateX\(-50%\)/, "search is absolutely centered in the title bar");
+assert.match(
+  css,
+  /\.menu-bar__search \{[\s\S]*?width:\s*min\(480px, 42vw, calc\(100% - 432px\)\)/,
+  "centered search reserves symmetric room for the normal desktop action group",
+);
+assert.match(
+  css,
+  /\.menu-bar:has\(\.menu-bar__task-label--live\) \.menu-bar__search \{[^}]*width:\s*min\(480px, 42vw, calc\(100% - 564px\)\)/,
+  "centered search contracts further while live enrichment progress widens the desktop actions",
+);
 assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid var\(--border-hairline\)/, "search border is always visible at rest");
 assert.match(css, /\.shell-top-history \{/, "history Back/Forward pair has its grouping styles");
 assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -104,6 +104,12 @@ assert.match(
 
 assert.match(
   globals,
+  /\.top-bar\s*\{(?=[^}]*display:\s*none;)[^}]*width:\s*100%;/,
+  "Adaptive top bar should fill its flex host so search can expand and actions stay pinned to the trailing edge",
+);
+
+assert.match(
+  globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__search\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Mobile search button should meet the 44px touch target",
 );
@@ -135,6 +141,18 @@ assert.match(
   globals,
   /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__actions \.notification-bell__trigger,[\s\S]*\.top-bar__account\s*\{[\s\S]*width:\s*var\(--touch-target\)[\s\S]*height:\s*var\(--touch-target\)/,
   "Mobile top-bar notification and account buttons should meet the 44px touch target",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\) \{[\s\S]*\.top-bar__actions \.top-bar__tasks > \.ui-icon-btn\s*\{[^}]*width:\s*var\(--touch-target\);[^}]*height:\s*var\(--touch-target\);/,
+  "Mobile top-bar task overflow should meet the same 44px touch target as adjacent actions",
+);
+
+assert.match(
+  globals,
+  /@media \(max-width: 455px\) \{[\s\S]*\.top-bar__actions \[data-quick-chat-trigger\],[\s\S]*\.top-bar__actions \.top-bar__tasks\s*\{[^}]*display:\s*none;/,
+  "Compact phones should demote Quick Chat and task shortcuts so primary header controls preserve a usable search field",
 );
 
 assert.match(

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -81,6 +81,20 @@ assert.match(projectsCss, /\.projects-hub\[data-pane="detail"\] \.projects-hub__
 assert.match(projectDetailSource, /aria-label="Back to project list"/, "the narrow detail pane has a labeled back affordance");
 assert.match(projectsView, /onBack=\{\(\) => setPane\("list"\)\}/, "back returns to the list pane");
 
+// The Projects header must respond to its actual pane width: split tiles can
+// be phone-narrow even inside a desktop viewport. Compact panes stack the
+// summary/sort row above the actions instead of letting the two groups overlap.
+assert.match(projectsViewSource, /className="projects-view flex h-full min-w-0 flex-col/, "the full Projects surface owns a named size container");
+assert.match(projectsViewToolbar, /className="projects-toolbar__row flex items-center justify-between gap-3"/, "the toolbar row exposes a stable responsive hook");
+assert.match(projectsViewToolbar, /className="projects-toolbar__controls flex min-w-0 items-center gap-2\.5"/, "summary and sort controls expose a responsive group hook");
+assert.match(projectsViewToolbar, /className="projects-toolbar__actions flex items-center gap-2"/, "Refresh and New project expose a responsive action-group hook");
+assert.match(projectsCss, /\.projects-view\s*\{[^}]*container:\s*projects-view \/ inline-size;/, "the whole surface queries its pane width, not the viewport");
+assert.match(
+  projectsCss,
+  /@container projects-view \(max-width: 640px\)\s*\{[\s\S]*\.projects-toolbar__row\s*\{[^}]*flex-wrap:\s*wrap;[\s\S]*\.projects-toolbar__controls\s*\{[^}]*flex:\s*1 1 100%;[^}]*flex-wrap:\s*wrap;[\s\S]*\.projects-toolbar__actions\s*\{[^}]*flex:\s*1 1 100%;[^}]*justify-content:\s*flex-end;/,
+  "compact Projects panes stack toolbar groups while keeping actions trailing-aligned",
+);
+
 // ── List pane rows ───────────────────────────────────────────────────────────
 assert.match(projectListSource, /role="listbox" aria-label="Projects"/, "the list pane is a labeled listbox");
 assert.match(projectListSource, /role="option"[\s\S]{0,80}?aria-selected=\{selected\}/, "each project row is an option reporting selection");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -486,10 +486,10 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   };
 
   return (
-    <div className="flex h-full min-w-0 flex-col bg-[var(--bg-base)]">
-      <header className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-2.5 sm:px-6">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-2.5">
+    <div className="projects-view flex h-full min-w-0 flex-col bg-[var(--bg-base)]">
+      <header className="projects-toolbar shrink-0 border-b border-[var(--border-hairline)] px-4 py-2.5 sm:px-6">
+        <div className="projects-toolbar__row flex items-center justify-between gap-3">
+          <div className="projects-toolbar__controls flex min-w-0 items-center gap-2.5">
             <span className="shrink-0 text-[12px] text-[var(--text-muted)]">
               {query.trim() && visibleProjects.length !== projects.length ? (
                 `${visibleProjects.length} of ${projects.length} projects`
@@ -562,7 +562,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
               </div>
             ) : null}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="projects-toolbar__actions flex items-center gap-2">
             <Button
               variant="secondary"
               size="sm"

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -11,6 +11,10 @@
    rules only match against an ANCESTOR container, so `.projects-hub { … }`
    inside `@container projects` would silently never apply if the hub were the
    container. */
+.projects-view {
+  container: projects-view / inline-size;
+}
+
 .projects-shell {
   display: flex;
   flex: 1;
@@ -152,6 +156,26 @@
 
 /* Back to the list — only exists under the narrow single-pane collapse. */
 .projects-detail-back { display: none; }
+
+/* The toolbar responds to the Projects pane itself, not the window: split
+   tiles can be phone-narrow on a desktop viewport. Give summary/sort and the
+   action pair separate rows before either group can compress or overlap. */
+@container projects-view (max-width: 640px) {
+  .projects-toolbar__row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .projects-toolbar__controls {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+  .projects-toolbar__actions {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+  }
+}
 
 /* ── Session chips (shared with the old table; canonical home is now here) ── */
 .projects-session-count { display: inline-flex; align-items: center; gap: 5px; flex: none; white-space: nowrap; color: var(--text-secondary); font-size: 12px; font-variant-numeric: tabular-nums; font-weight: 500; }

--- a/tests/projects-toolbar-responsive.spec.ts
+++ b/tests/projects-toolbar-responsive.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const NOW = new Date().toISOString();
+
+const PROJECTS = Array.from({ length: 12 }, (_, index) => ({
+  id: `project-${index + 1}`,
+  name: `Project ${index + 1}`,
+  root: `/workspace/project-${index + 1}`,
+  createdAt: NOW,
+  updatedAt: NOW,
+}));
+
+const SESSIONS = PROJECTS.slice(0, 5).map((project, index) => ({
+  id: `session-${index + 1}`,
+  project_root: project.root,
+  harness: "codex",
+  title: `Active session ${index + 1}`,
+  status: "idle",
+  exit_code: null,
+  archived_at: null,
+  created_at: NOW,
+  updated_at: NOW,
+  familiarId: "nova",
+}));
+
+type Rect = { left: number; top: number; right: number; bottom: number; width: number };
+
+async function rect(locator: Locator): Promise<Rect> {
+  return locator.evaluate((element) => {
+    const box = element.getBoundingClientRect();
+    return { left: box.left, top: box.top, right: box.right, bottom: box.bottom, width: box.width };
+  });
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.left < b.right - 1 && a.right > b.left + 1 && a.top < b.bottom - 1 && a.bottom > b.top + 1;
+}
+
+async function openPopulatedProjects(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) => route.fulfill({
+    json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] },
+  }));
+  await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: SESSIONS } }));
+  await page.route("**/api/projects**", (route) => route.fulfill({ json: { ok: true, projects: PROJECTS } }));
+  await page.goto("/?mode=chat");
+  await page.getByRole("tab", { name: "Projects" }).click();
+  await expect(page.locator(".projects-view")).toBeVisible();
+  await expect(page.getByRole("group", { name: "Filter by activity" })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Sort projects" })).toBeVisible();
+}
+
+test("populated Projects toolbar fits continuously through narrow split-pane widths", async ({ page }) => {
+  await openPopulatedProjects(page);
+
+  const surface = page.locator(".projects-view");
+  const toolbar = page.locator(".projects-toolbar");
+  const controls = page.locator(".projects-toolbar__controls");
+  const actions = page.locator(".projects-toolbar__actions");
+
+  for (const width of [521, 540, 560, 640, 641]) {
+    await surface.evaluate((element, nextWidth) => {
+      const html = element as HTMLElement;
+      html.style.width = `${nextWidth}px`;
+      html.style.flex = `0 0 ${nextWidth}px`;
+    }, width);
+
+    await expect.poll(async () => Math.round((await rect(surface)).width)).toBe(width);
+
+    const [toolbarRect, controlsRect, actionsRect] = await Promise.all([
+      rect(toolbar),
+      rect(controls),
+      rect(actions),
+    ]);
+
+    expect(overlaps(controlsRect, actionsRect), `${width}px controls and actions must not overlap`).toBe(false);
+    expect(controlsRect.left, `${width}px controls stay inside toolbar`).toBeGreaterThanOrEqual(toolbarRect.left - 1);
+    expect(actionsRect.right, `${width}px actions stay inside toolbar`).toBeLessThanOrEqual(toolbarRect.right + 1);
+
+    const stacked = Math.abs(controlsRect.top - actionsRect.top) > 1;
+    expect(stacked, `${width}px toolbar row placement`).toBe(width <= 640);
+  }
+});


### PR DESCRIPTION
## Summary

- make the adaptive top bar fill its native/web host and keep search/actions balanced across desktop, tablet, and phone widths
- reserve symmetric desktop search space for normal and live-enrichment action clusters
- preserve 44px mobile targets while demoting duplicate Chat/Board shortcuts below 456px
- make the Projects toolbar respond to its pane width and stack populated controls through the 640px collapse boundary
- add source contracts and a rendered Playwright regression at 521, 540, 560, 640, and 641px

## Why

The sub-1024 header shrink-wrapped instead of using the available shell width, while the centered desktop search did not reserve enough room for its trailing action cluster. The Projects toolbar also stacked below its true intrinsic-width requirement, leaving a 521–560px overlap gap in split panes.

This keeps the primary header usable and visually balanced across native window sizes and prevents Projects controls from colliding in narrow tiles.

## Validation

- 597 app test files
- 75 mobile test files
- 799 test files wired into CI
- TypeScript typecheck
- production build and bundle budgets (447KB / 650KB shell; 992KB / 2400KB largest chunk)
- Playwright populated Projects toolbar geometry at 521/540/560/640/641px
- eight rendered shell geometries from 320px phone through 1440px desktop, including macOS Tauri simulation
- real Tauri dev shell compiled and launched in a 1320×820 native window
- independent review: no remaining Critical or Important issues

Bead: `cave-1h82`