### PR TITLE
fix(marketplace): preserve Craft transaction diagnostics

### DIFF
--- a/src/lib/server/craft-install.test.ts
+++ b/src/lib/server/craft-install.test.ts
@@ -83,7 +83,7 @@ type StoreHarness = {
   removals: string[];
 };
 
-function memoryStore(options: { failRecord?: boolean } = {}): StoreHarness {
+function memoryStore(options: { failRecord?: boolean; failRemove?: boolean } = {}): StoreHarness {
   const entries = new Map<string, CraftInstallationRecord>();
   const writes: CraftInstallationRecord[] = [];
   const removals: string[] = [];
@@ -103,6 +103,7 @@ function memoryStore(options: { failRecord?: boolean } = {}): StoreHarness {
         return saved;
       },
       async remove(id) {
+        if (options.failRemove) throw new Error("disk delete failed");
         entries.delete(id);
         removals.push(id);
       },
@@ -492,6 +493,32 @@ try {
     assert.equal(error.diagnostic.rollback?.succeeded, false, "rollback verifies the Craft is absent");
   }
 
+  // A failed rollback list command is a verification failure, not a second
+  // removal failure. The original install error remains the transaction code,
+  // while the bounded rollback diagnostic identifies the failing phase.
+  {
+    const harness = memoryStore();
+    let listCalls = 0;
+    const runner: CraftCommandRunner = async (_command, args) => {
+      const key = commandKey(args);
+      if (key === "plugin marketplace list --json") return { stdout: marketplaceList(), stderr: "" };
+      if (key === "plugin list --json") {
+        listCalls += 1;
+        if (listCalls === 1) return { stdout: pluginList(false), stderr: "" };
+        throw new Error("list failed");
+      }
+      if (key === `plugin add ${TARGET} --json`) return { stdout: "not-json", stderr: "" };
+      if (key === `plugin remove ${TARGET} --json`) return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      assert.fail(`unexpected command: ${key}`);
+    };
+    const error = await expectTransactionError(
+      service(runner, harness.store, codexHome).install(craft.id),
+      "malformed_json",
+    );
+    assert.equal(error.diagnostic.rollback?.succeeded, false);
+    assert.match(error.diagnostic.rollback?.message ?? "", /expected Craft installation state/i);
+  }
+
   // Same-Craft concurrent requests serialize; the second observes the verified
   // installation and cannot launch a duplicate add process.
   {
@@ -612,6 +639,43 @@ try {
       "plugin list --json",
     ]);
     assert.deepEqual(harness.removals, [craft.id]);
+  }
+
+  // Cave state deletion failures retain a stable structured classification
+  // whether Codex was already absent or Cave removed and verified it now.
+  {
+    const harness = memoryStore({ failRemove: true });
+    const runner: CraftCommandRunner = async (_command, args) => {
+      const key = commandKey(args);
+      if (key === "plugin marketplace list --json") return { stdout: marketplaceList(), stderr: "" };
+      if (key === "plugin list --json") return { stdout: pluginList(false), stderr: "" };
+      assert.fail(`unexpected command: ${key}`);
+    };
+    const error = await expectTransactionError(
+      service(runner, harness.store, codexHome).uninstall(craft.id),
+      "persistence_failed",
+    );
+    assert.equal(error.diagnostic.step, "persist");
+  }
+
+  {
+    const harness = memoryStore({ failRemove: true });
+    let installed = true;
+    const runner: CraftCommandRunner = async (_command, args) => {
+      const key = commandKey(args);
+      if (key === "plugin marketplace list --json") return { stdout: marketplaceList(), stderr: "" };
+      if (key === "plugin list --json") return { stdout: pluginList(installed), stderr: "" };
+      if (key === `plugin remove ${TARGET} --json`) {
+        installed = false;
+        return { stdout: JSON.stringify({ ok: true }), stderr: "" };
+      }
+      assert.fail(`unexpected command: ${key}`);
+    };
+    const error = await expectTransactionError(
+      service(runner, harness.store, codexHome).uninstall(craft.id),
+      "persistence_failed",
+    );
+    assert.equal(error.diagnostic.step, "persist");
   }
 
   console.log("craft-install.test.ts: ok");

--- a/src/lib/server/craft-install.ts
+++ b/src/lib/server/craft-install.ts
@@ -246,8 +246,10 @@ function commandFailureCode(step: CommandStep, error: unknown): CraftTransaction
     return "unsupported_runtime";
   }
   if (step === "marketplace-check" || step === "preflight") return "marketplace_check_failed";
-  if (step === "verification" || step === "uninstall-verification") return "verification_failed";
-  if (step === "uninstall" || step === "rollback" || step === "rollback-verification") {
+  if (step === "verification" || step === "uninstall-verification" || step === "rollback-verification") {
+    return "verification_failed";
+  }
+  if (step === "uninstall" || step === "rollback") {
     return "uninstall_failed";
   }
   return "install_failed";
@@ -522,6 +524,18 @@ export function createCraftInstallService(options: CraftInstallServiceOptions): 
     }
   }
 
+  async function removePersisted(id: string): Promise<void> {
+    try {
+      await options.store.remove(id);
+    } catch {
+      const message = publicFailureMessage("persistence_failed");
+      throw new CraftTransactionError("persistence_failed", message, {
+        step: "persist",
+        message,
+      });
+    }
+  }
+
   async function rollback(definition: CraftDefinition): Promise<CraftRollbackDiagnostic> {
     try {
       await runJson("rollback", ["plugin", "remove", `${definition.id}@${CODEX_MARKETPLACE_NAME}`, "--json"]);
@@ -563,9 +577,7 @@ export function createCraftInstallService(options: CraftInstallServiceOptions): 
       };
     }
 
-    let attemptedInstall = false;
     try {
-      attemptedInstall = true;
       await runJson("install", ["plugin", "add", plan.installTarget, "--json"]);
       const after = await runJson("verification", ["plugin", "list", "--json"]);
       if (!pluginIsVerified(after, definition)) {
@@ -590,7 +602,7 @@ export function createCraftInstallService(options: CraftInstallServiceOptions): 
       const failure = error instanceof CraftTransactionError
         ? error
         : commandError("install", error, env);
-      if (!attemptedInstall || priorInstallPresent) throw failure;
+      if (priorInstallPresent) throw failure;
       if (failure.code === "persistence_failed") {
         await options.store.remove(definition.id).catch(() => {});
       }
@@ -606,7 +618,7 @@ export function createCraftInstallService(options: CraftInstallServiceOptions): 
     await confirmMarketplace();
     const before = await runJson("preflight", ["plugin", "list", "--json"]);
     if (!pluginIsPresent(before, definition)) {
-      await options.store.remove(definition.id);
+      await removePersisted(definition.id);
       return {
         ok: true,
         installed: false,
@@ -630,7 +642,7 @@ export function createCraftInstallService(options: CraftInstallServiceOptions): 
         message,
       });
     }
-    await options.store.remove(definition.id);
+    await removePersisted(definition.id);
     return {
       ok: true,
       installed: false,


### PR DESCRIPTION
## Summary

- classify rollback plugin-list failures as verification failures
- convert both Craft uninstall persistence failures into stable `persistence_failed` transaction errors
- remove unreachable install-attempt state
- add regressions for rollback diagnostics and both uninstall persistence paths

## Context

PR #2886 merged its green pre-review head while the review-fix force update was in flight. This focused follow-up contains only the two-file reviewed delta, rebased on the merged #2886 tree.

## Verification

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/craft-install.test.ts`
- `pnpm typecheck`
- `git diff --check`

Bead: `cave-rprf.2`