### PR TITLE
fix(rollout): eight P2 dead-ends and papercuts from the 100k-ft audit

### DIFF
--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -45,6 +45,7 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const shellRef = useRef<HTMLDivElement | null>(null);
   const refineRef = useRef<HTMLTextAreaElement | null>(null);
+  const refineAbortRef = useRef<AbortController | null>(null);
 
   // Context-aware ideas derived from the artifact itself; recomputed only when
   // the code/kind changes (cheap string scans). Paired with the static defaults
@@ -71,6 +72,10 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
   // contentWindow passes, so a hostile embedder of the app can never spoof
   // sandbox-error events. (Audits keep flagging the "missing" origin check —
   // it's deliberate.)
+  // Abort an in-flight refine when the viewer unmounts — nothing should keep
+  // streaming into a dead component (cave-v35w).
+  useEffect(() => () => refineAbortRef.current?.abort(), []);
+
   useEffect(() => {
     setRuntimeError(null);
     function onMessage(e: MessageEvent) {
@@ -105,23 +110,39 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
     if (!ask || !familiarId || generating) return;
     setGenerating(true);
     setRuntimeError(null);
-    const result = await generateArtifactCode({
-      prompt: buildRefinePrompt(code, ask, kind),
-      familiarId,
-    });
-    setGenerating(false);
-    if (result.code) {
-      setCode(clampArtifactCode(result.code));
-      if (result.kind) setKind(result.kind);
-      setRefineText("");
-      setRefineOpen(false);
-      setEditing(false);
-      setTab("canvas");
-      setSaveState("idle");
-    } else {
-      setRuntimeError(result.error || "Refine failed — try a different description.");
+    const ctrl = new AbortController();
+    refineAbortRef.current = ctrl;
+    try {
+      const result = await generateArtifactCode({
+        prompt: buildRefinePrompt(code, ask, kind),
+        familiarId,
+        signal: ctrl.signal,
+      });
+      if (result.code) {
+        setCode(clampArtifactCode(result.code));
+        if (result.kind) setKind(result.kind);
+        setRefineText("");
+        setRefineOpen(false);
+        setEditing(false);
+        setTab("canvas");
+        setSaveState("idle");
+      } else if (result.error !== "cancelled") {
+        setRuntimeError(result.error || "Refine failed — try a different description.");
+      }
+    } catch (err) {
+      // generateArtifactCode converts stream failures to results, but keep a
+      // belt here — an uncaught rejection used to wedge "Refining…" forever
+      // with every control disabled (cave-v35w).
+      setRuntimeError((err as Error)?.message ?? "Refine failed — the connection dropped.");
+    } finally {
+      refineAbortRef.current = null;
+      setGenerating(false);
     }
   }, [refineText, familiarId, generating, code, kind]);
+
+  const cancelRefine = useCallback(() => {
+    refineAbortRef.current?.abort();
+  }, []);
 
   const openRefine = useCallback(() => {
     if (!familiarId) return;
@@ -328,8 +349,12 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
           <div className="chat-artifact__refine-foot">
             <span className="chat-artifact__refine-hint">⌘↵ to refine</span>
             <span className="chat-artifact__spacer" />
-            <button type="button" className="chat-artifact__btn chat-artifact__btn--text" onClick={() => setRefineOpen(false)}>
-              Cancel
+            <button
+              type="button"
+              className="chat-artifact__btn chat-artifact__btn--text"
+              onClick={() => (generating ? cancelRefine() : setRefineOpen(false))}
+            >
+              {generating ? "Stop" : "Cancel"}
             </button>
             <button
               type="button"

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -10,6 +10,7 @@ import { resolveFileRefTarget, type FileRef } from "@/lib/file-ref";
 import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
 import { segmentTurn } from "@/lib/turn-segments";
+import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
 import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
@@ -17,7 +18,7 @@ import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/ch
 import { canonicalize, formatHelp } from "@/lib/slash-commands";
 import { Icon, type IconName } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
-import { parseHarnessFailure } from "@/lib/harness-failure";
+import { parseHarnessFailure, parseHarnessAuthFailure, type HarnessAuthFailure } from "@/lib/harness-failure";
 import { HarnessFixActions } from "@/components/harness-fix-actions";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useKeySymbols } from "@/lib/platform-keys";
@@ -512,7 +513,9 @@ function ChatErrorStrip({
   addProjectLabel,
   addingProject,
   onAddProject,
+  onOpenProjects,
   onUseHarness,
+  harnessId,
 }: {
   message: string;
   code?: string;
@@ -528,8 +531,14 @@ function ChatErrorStrip({
   addProjectLabel?: string;
   addingProject?: boolean;
   onAddProject?: () => void;
+  /** When set, the chat's project folder is gone (project_root_unavailable):
+   *  render a primary action that opens the Projects tab to re-point it (cave-ivcc). */
+  onOpenProjects?: () => void;
   /** Switch the familiar to this harness and retry (harness-failure fix row). */
   onUseHarness?: (harnessId: string) => void | Promise<void>;
+  /** The runtime the failing send used — lets the auth-failure fix row name
+   *  it and offer its exact login command (cave-f6ol). */
+  harnessId?: string | null;
 }) {
   const { copied, copy } = useCopy();
   const erroredTools = (failingTurn?.tools ?? []).filter((t) => t.status === "error");
@@ -560,6 +569,13 @@ function ChatErrorStrip({
   // Harness/runtime failures get an inline fix row (switch adapter / copy the
   // quoted `coven adapter …` commands) instead of ending at the message.
   const harnessFailure = useMemo(() => parseHarnessFailure(detailText), [detailText]);
+  // Sign-in failures land here at the FIRST message (the wizard greens on
+  // install, never auth) — surface the runtime's login command instead of
+  // ending at raw stderr (cave-f6ol).
+  const authFailure = useMemo(
+    () => parseHarnessAuthFailure(detailText, harnessId),
+    [detailText, harnessId],
+  );
 
   const btn =
     "focus-ring inline-flex shrink-0 items-center gap-1 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_42%,transparent)] bg-[var(--bg-base)]/35 px-2 py-1 text-[11px] font-medium text-[var(--color-warning)] transition-colors hover:bg-[var(--bg-raised)] disabled:opacity-40";
@@ -605,6 +621,16 @@ function ChatErrorStrip({
               {addingProject ? "Adding…" : (addProjectLabel ?? "Add project")}
             </button>
           ) : null}
+          {onOpenProjects ? (
+            <button
+              type="button"
+              onClick={onOpenProjects}
+              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--accent-presence)]/50 bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] px-2 py-1 text-[11px] font-semibold text-[var(--accent-presence)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_24%,transparent)]"
+            >
+              <Icon name="ph:folders-bold" width={11} aria-hidden />
+              Open projects
+            </button>
+          ) : null}
           {canRetry ? (
             <button type="button" onClick={onRetry} disabled={busy} className={btn}>
               <Icon name="ph:arrow-clockwise" width={11} aria-hidden />
@@ -624,6 +650,9 @@ function ChatErrorStrip({
           buttonClassName={btn}
           className="px-5 pb-2"
         />
+      ) : null}
+      {!harnessFailure && authFailure ? (
+        <AuthFixRow failure={authFailure} buttonClassName={btn} />
       ) : null}
       {hasDetail && open ? (
         <div className="max-h-48 overflow-auto border-t border-[color-mix(in_oklch,var(--color-warning)_22%,transparent)] px-5 py-2">
@@ -648,6 +677,44 @@ function ChatErrorStrip({
             </div>
           ) : null}
         </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Runtime sign-in fix row (cave-f6ol): names the runtime, gives the exact
+ *  login command to run in a terminal, and copies it — the predictable
+ *  first-message failure for a user who skipped the wizard's login prose. */
+function AuthFixRow({
+  failure,
+  buttonClassName,
+}: {
+  failure: HarnessAuthFailure;
+  buttonClassName: string;
+}) {
+  const { copied, copy } = useCopy();
+  const runtime = failure.harnessLabel ?? "The runtime";
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-5 pb-2 text-[11px]">
+      <span className="min-w-0">
+        {runtime} isn&apos;t signed in.
+        {failure.loginCommand ? (
+          <>
+            {" "}Run{" "}
+            <code className="rounded bg-[var(--bg-base)]/40 px-1 py-0.5 font-mono text-[10px]">
+              {failure.loginCommand}
+            </code>{" "}
+            in a terminal, then retry.
+          </>
+        ) : (
+          " Sign in from a terminal, then retry."
+        )}
+      </span>
+      {failure.loginCommand ? (
+        <button type="button" onClick={() => copy(failure.loginCommand!)} className={buttonClassName}>
+          <Icon name={copied ? "ph:check-bold" : "ph:copy"} width={11} aria-hidden />
+          {copied ? "Copied" : "Copy command"}
+        </button>
       ) : null}
     </div>
   );
@@ -1289,7 +1356,9 @@ function metaLineSegments(args: {
   // reads as a folder.
   const runtime = formatRuntime(args.runtime) ?? formatRuntime(args.projectRoot ? `local:${args.projectRoot}` : null);
   if (args.state === "offline") {
-    segs.push("daemon offline · check Coven");
+    // "check Coven" named nothing findable — the banner's Start-daemon action
+    // is the actual remedy (cave-7jzq).
+    segs.push("daemon offline · start it from the banner above");
   } else if (args.state === "failed") {
     if (args.model) segs.push(shortModelLabel(args.model));
     if (runtime) segs.push({ dir: runtime });
@@ -2210,6 +2279,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // a chat whose cwd sits outside every registered project the familiar can
   // reach. Drives the error strip's "Add project" recovery action.
   const [projectAccessRoot, setProjectAccessRoot] = useState<string | null>(null);
+  // The chat's project folder no longer exists on disk (moved/deleted): the
+  // send 400s with code project_root_unavailable and Retry can never succeed —
+  // the recovery is re-pointing the project, not retrying (cave-ivcc).
+  const [projectRootMissing, setProjectRootMissing] = useState(false);
   const [addingProject, setAddingProject] = useState(false);
   const [voiceCallOpen, setVoiceCallOpen] = useState(false);
   const [expandedAvatarTurnId, setExpandedAvatarTurnId] = useState<string | null>(null);
@@ -3679,6 +3752,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setDebugError(null);
     setLastFailedSend(null);
     setProjectAccessRoot(null);
+    setProjectRootMissing(false);
     const initialLiveSessionId = currentSessionRef.current;
     liveSessionIdRef.current = initialLiveSessionId;
     setHistoryState("loaded");
@@ -3797,6 +3871,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         if (res.status === 403 && /project access denied|not registered/i.test(message)) {
           const failingRoot = (activeProjectRoot || session?.project_root || projectRoot || "").trim();
           setProjectAccessRoot(failingRoot || null);
+        }
+        // A 400 with project_root_unavailable means the folder itself is gone
+        // (moved/deleted). The server's internal phrasing ("refusing to start a
+        // homedir-scoped fallback session") is jargon, and Retry can never
+        // succeed — swap in actionable copy + an Open-projects fix (cave-ivcc).
+        if (res.status === 400 && /project_root_unavailable|projectRoot does not exist/i.test(message)) {
+          const missingRoot = (activeProjectRoot || session?.project_root || projectRoot || "").trim();
+          setProjectRootMissing(true);
+          setError(
+            missingRoot
+              ? `This chat's project folder is missing (${missingRoot}) — it may have been moved or deleted. Open Projects to fix its path, or pick a different project for this chat.`
+              : "This chat's project folder is missing — it may have been moved or deleted. Open Projects to fix its path, or pick a different project for this chat.",
+          );
         }
         upsertTurnProgress(assistantId, {
           id: "connect",
@@ -5028,15 +5115,22 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onRetry={retryLastSend}
           onOpenDebug={openDebug}
           onUseHarness={lastFailedSend ? handleUseHarnessFix : undefined}
+          harnessId={familiar.harness ?? null}
           addProjectLabel={
             projectAccessRoot ? `Add "${projectNameForRoot(projectAccessRoot)}" as project` : undefined
           }
           addingProject={addingProject}
           onAddProject={projectAccessRoot ? handleAddProject : undefined}
+          onOpenProjects={
+            projectRootMissing
+              ? () => window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT))
+              : undefined
+          }
           onDismiss={() => {
             setError(null);
             setDebugError(null);
             setProjectAccessRoot(null);
+            setProjectRootMissing(false);
           }}
         />
       ) : null}

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -390,8 +390,8 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
             headline="Queue is clear"
             subtitle={
               beadsDegraded
-                ? "No open PRs need attention. Bead lanes are unavailable right now."
-                : "No open PRs need attention and no ready beads are waiting to ship."
+                ? "No open PRs need attention. Bead lanes (beads are the queue's tracked tasks) are unavailable right now."
+                : "No open PRs need attention and no ready beads — the queue's tracked tasks — are waiting to ship."
             }
           />
         ) : visibleLanes.length === 0 ? (

--- a/src/components/familiars-memory-row.tsx
+++ b/src/components/familiars-memory-row.tsx
@@ -64,7 +64,7 @@ export function MemoryRowItem({
           </span>
         </span>
       </button>
-      <div className="flex items-center gap-1 pr-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover/row:opacity-100">
+      <div className="touch-always-visible flex items-center gap-1 pr-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover/row:opacity-100">
         <button
           type="button"
           onClick={onExpand}

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -462,7 +462,7 @@ function FamiliarsEmptyState({
       className="familiars-view__empty mx-auto my-16 max-w-md"
       icon="ph:sparkle"
       headline="The circle awaits"
-      subtitle="No familiars yet — summon your first: it can run on this machine, on a remote host over SSH, or bridge an OpenClaw agent you already keep."
+      subtitle="A familiar is an AI agent with its own identity, memory, and runtime. Summon your first — it can run on this machine, on a remote host over SSH, or bridge an OpenClaw agent you already keep."
       actions={
         <div className="flex items-center gap-2">
           <Button variant="primary" leadingIcon="ph:magic-wand-fill" onClick={onCreate}>

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -736,8 +736,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     </button>
                     <button
                       type="button"
-                      className="focus-ring absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover/coven:opacity-100"
-                      title="Delete coven"
+                      className="focus-ring touch-always-visible absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover/coven:opacity-100"
+                      title="Delete coven — removes this group chat only"
                       aria-label={`Delete ${g.name}`}
                       onClick={() => void requestDeleteGroup(g.id, g.name)}
                     >

--- a/src/components/harness-fix-actions.test.ts
+++ b/src/components/harness-fix-actions.test.ts
@@ -47,13 +47,18 @@ import { readFile } from "node:fs/promises";
   const source = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
   assert.match(
     source,
-    /import \{ parseHarnessFailure \} from "@\/lib\/harness-failure"/,
-    "chat-view should parse harness failures from the shared lib",
+    /import \{ parseHarnessFailure, parseHarnessAuthFailure, type HarnessAuthFailure \} from "@\/lib\/harness-failure"/,
+    "chat-view should parse harness failures (and auth failures, cave-f6ol) from the shared lib",
   );
   assert.match(
     source,
     /parseHarnessFailure\(detailText\)/,
     "ChatErrorStrip should parse the full detail text (message + code + tool/step output)",
+  );
+  assert.match(
+    source,
+    /parseHarnessAuthFailure\(detailText, harnessId\)/,
+    "ChatErrorStrip should detect runtime sign-in failures with the failing send's runtime (cave-f6ol)",
   );
   assert.match(
     source,

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -559,13 +559,25 @@ export function JournalEntries({
           aria-busy={generating}
           disabled={!canGenerate || generating || selected !== today || Boolean(outOfScopeBy)}
           onClick={generate}
-          title={Boolean(outOfScopeBy) ? `Today's entry was written by ${outOfScopeBy}` : selected !== today ? "Select today to generate" : undefined}
+          title={
+            !canGenerate
+              ? "Summon a familiar first — the journal is written by one of your familiars"
+              : Boolean(outOfScopeBy)
+                ? `Today's entry was written by ${outOfScopeBy}`
+                : selected !== today
+                  ? "Select today to generate"
+                  : undefined
+          }
         >
           <Icon name="ph:sparkle" aria-hidden />
           {generating ? "Reflecting…" : "Generate today's entry"}
           {/* The disabled reason lived only in title= (hover-only) — AT and
-              keyboard users get it in the accessible name too (cave-t1ou). */}
-          {!generating && Boolean(outOfScopeBy) ? (
+              keyboard users get it in the accessible name too (cave-t1ou).
+              The zero-familiar case had NO reason anywhere: the cold-start
+              empty state pointed at a button that was silently inert (cave-7jzq). */}
+          {!generating && !canGenerate ? (
+            <span className="sr-only">, unavailable — summon a familiar first</span>
+          ) : !generating && Boolean(outOfScopeBy) ? (
             <span className="sr-only">, unavailable — today's entry was written by {outOfScopeBy}</span>
           ) : !generating && selected !== today ? (
             <span className="sr-only">, unavailable — select today to generate</span>
@@ -590,7 +602,11 @@ export function JournalEntries({
         {!daysLoaded && days.length === 0 ? (
           <SkeletonRows count={4} className="journal-list__loading" />
         ) : days.length === 0 ? (
-          <div className="journal-empty">No journal entries yet. Generate today's above.</div>
+          <div className="journal-empty">
+            {canGenerate
+              ? "No journal entries yet. Generate today's above."
+              : "No journal entries yet. The journal is written by a familiar — summon one first, then generate today's entry above."}
+          </div>
         ) : filteredDays.length === 0 ? (
           <div className="journal-empty">No entries match “{filter.trim()}”.</div>
         ) : (

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -602,7 +602,7 @@ function TreeRow({
             className={`ml-auto mr-1 shrink-0 rounded-[var(--radius-control)] px-1.5 py-0.5 text-[10px] font-medium transition-opacity ${
               added
                 ? "text-[var(--accent-presence)]"
-                : "text-[var(--text-muted)] opacity-0 hover:bg-[var(--bg-base)] group-hover:opacity-100"
+                : "touch-always-visible text-[var(--text-muted)] opacity-0 hover:bg-[var(--bg-base)] group-hover:opacity-100 group-focus-within:opacity-100"
             }`}
           >
             {added ? "Added" : "Use"}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -597,7 +597,7 @@ function DaemonSection() {
       <SettingsGroup label="Connection">
         <SettingControlRow
           label="Runtime target"
-          hint={status?.target?.mode === "hub" ? `Connected through ${status.target.url ?? "server hub"}` : "Use the local sidecar daemon or a server hub on your private network."}
+          hint={status?.target?.mode === "hub" ? `Connected through ${status.target.url ?? "server hub"}` : "Local runs everything on this machine (the default). Server hub connects to a shared daemon on another machine."}
         >
           <Segmented
             options={["local", "hub"] as const}
@@ -618,7 +618,7 @@ function DaemonSection() {
             className="w-full min-w-[260px] max-w-md rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none disabled:opacity-50"
           />
         </SettingControlRow>
-        <SettingControlRow label="Executor addresses" hint="Optional executor nodes, one per line.">
+        <SettingControlRow label="Executor addresses" hint="Advanced, optional: addresses of extra machines that can run familiar sessions, one per line. Leave empty unless you run a multi-machine setup.">
           <textarea
             value={executorText}
             onChange={(event) => setExecutorText(event.target.value)}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -342,6 +342,15 @@ export function Workspace() {
       setModeRaw("grimoire");
       return;
     }
+    if (next === "flow") {
+      // FlowView is retired (lives on feature/automations-flow); "flow" has no
+      // render branch, so an unremapped request fell through to Home with the
+      // wrong sr-title and no nav highlight (cave-hyor). The remap lives HERE —
+      // the single choke point — so ?mode=flow deep links, cave:navigate-mode,
+      // and last-mode restore all land on Schedules.
+      setModeRaw("inbox");
+      return;
+    }
     setModeRaw(next);
   }, []);
   // Chat mode swaps the left nav for the ChatSidebar (project-grouped threads).
@@ -665,6 +674,17 @@ export function Workspace() {
     if (!target) return;
     setMode(target);
     clearModeParam();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // `/#card-<id>` deep link (daily-report pages, dashboard action inbox):
+  // BoardView is the only consumer of the card hash and it never mounts on
+  // the boot-default Chat surface, so external card links opened the app and
+  // silently dropped the card (cave-qnh2). Switch to the board; BoardView's
+  // hash effect re-applies once cards load.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (/^#card-/.test(window.location.hash)) setMode("board");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -75,33 +75,43 @@ export async function generateArtifactCode(opts: {
   let sessionId: string | null = null;
   let error: string | null = null;
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    let idx;
-    while ((idx = buffer.indexOf("\n\n")) >= 0) {
-      const frame = buffer.slice(0, idx);
-      buffer = buffer.slice(idx + 2);
-      const ev = parseSseFrame(frame);
-      if (!ev) continue;
-      switch (ev.kind) {
-        case "assistant_chunk":
-          text += ev.text ?? "";
-          opts.onText?.(text);
-          break;
-        case "session":
-          sessionId = ev.sessionId ?? sessionId;
-          break;
-        case "done":
-          if (ev.sessionId) sessionId = ev.sessionId;
-          if (ev.isError) error = error ?? "the familiar reported an error";
-          break;
-        case "error":
-          error = ev.message ?? "generation error";
-          break;
+  // A mid-stream network drop (or an abort) makes reader.read() REJECT — an
+  // unguarded loop turned that into a rejected promise that wedged callers'
+  // "generating" state forever (cave-v35w). Convert to a normal error result
+  // and keep any partial text.
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx;
+      while ((idx = buffer.indexOf("\n\n")) >= 0) {
+        const frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        const ev = parseSseFrame(frame);
+        if (!ev) continue;
+        switch (ev.kind) {
+          case "assistant_chunk":
+            text += ev.text ?? "";
+            opts.onText?.(text);
+            break;
+          case "session":
+            sessionId = ev.sessionId ?? sessionId;
+            break;
+          case "done":
+            if (ev.sessionId) sessionId = ev.sessionId;
+            if (ev.isError) error = error ?? "the familiar reported an error";
+            break;
+          case "error":
+            error = ev.message ?? "generation error";
+            break;
+        }
       }
     }
+  } catch (err) {
+    error = opts.signal?.aborted
+      ? "cancelled"
+      : (err as Error)?.message ?? "the connection dropped mid-generation";
   }
 
   const extracted = extractArtifact(text);

--- a/src/lib/dashboard-analytics.ts
+++ b/src/lib/dashboard-analytics.ts
@@ -303,7 +303,10 @@ const SPACE_ACTIONS: Record<string, { href: string; label: string }> = {
   memory: { href: "/?mode=agents", label: "Manage memory" },
   knowledge: { href: "/?mode=agents", label: "Open vault" },
   journal: { href: "/?mode=journal", label: "Open journal" },
-  flows: { href: "/?mode=flow", label: "Open flows" },
+  // FlowView is retired; flow data is managed from the Schedules surface.
+  // ?mode=flow now remaps to inbox in setMode anyway (cave-hyor) — link the
+  // real destination directly.
+  flows: { href: "/?mode=inbox", label: "Open schedules" },
   prompts: { href: "/?mode=marketplace", label: "Manage prompts" },
   skills: { href: "/?mode=marketplace", label: "Manage skills" },
 };

--- a/src/lib/harness-failure.test.ts
+++ b/src/lib/harness-failure.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   harnessFixCommand,
   harnessSwitchTargets,
+  parseHarnessAuthFailure,
   parseHarnessFailure,
 } from "./harness-failure.ts";
 
@@ -103,6 +104,34 @@ import {
   assert.equal(failure.harness, "mystery", "unknown harness ids pass through raw");
   assert.equal(failure.harnessLabel, "mystery", "unknown ids label as themselves");
   assert.deepEqual(failure.configured, ["codex", "claude"], "untrusted entries and dupes drop out");
+}
+
+// ── Runtime auth failures (cave-f6ol) ─────────────────────────────────────────
+{
+  const auth = parseHarnessAuthFailure("Error: not logged in. Please run /login to continue.", "claude");
+  assert.ok(auth, "claude sign-in failure detected");
+  assert.equal(auth.harness, "claude");
+  assert.equal(auth.loginCommand, "claude /login", "claude login command offered");
+
+  const codex = parseHarnessAuthFailure("stream error: invalid API key — run `codex login`", "codex");
+  assert.ok(codex);
+  assert.equal(codex.loginCommand, "codex login");
+
+  const unknownRuntime = parseHarnessAuthFailure("authentication required", "mystery-harness");
+  assert.ok(unknownRuntime, "auth failure still detected without a known runtime");
+  assert.equal(unknownRuntime.harness, null, "unknown runtime ids don't map");
+  assert.equal(unknownRuntime.loginCommand, null, "no command invented for unknown runtimes");
+
+  assert.equal(
+    parseHarnessAuthFailure("request failed (401): unauthorized", "claude"),
+    null,
+    "a bare access-gate 'unauthorized' is NOT a runtime sign-in failure",
+  );
+  assert.equal(
+    parseHarnessAuthFailure("spawn claude ENOENT", "claude"),
+    null,
+    "a missing binary is a harness failure, not an auth failure",
+  );
 }
 
 console.log("harness-failure.test.ts: ok");

--- a/src/lib/harness-failure.ts
+++ b/src/lib/harness-failure.ts
@@ -136,6 +136,59 @@ export function parseHarnessFailure(
   };
 }
 
+// ── Runtime auth failures ─────────────────────────────────────────────────────
+// The onboarding wizard greens a runtime the moment its binary installs — it
+// never verifies login — so an unauthenticated runtime fails at the user's
+// FIRST MESSAGE with raw stderr (cave-f6ol). Recognize the common sign-in
+// failure shapes and hand surfaces a copyable login command. Patterns are
+// deliberately conservative: a bare "unauthorized" is NOT matched (the app's
+// own access-gate 401s use that word and are not a runtime-login problem).
+
+export type HarnessAuthFailure = {
+  /** Canonical id of the runtime needing login, when the caller knows it. */
+  harness: string | null;
+  harnessLabel: string | null;
+  /** Copyable terminal command that starts the sign-in flow, when known. */
+  loginCommand: string | null;
+};
+
+const AUTH_FAILURE_PATTERNS: RegExp[] = [
+  /\bnot (?:signed|logged) in\b/i,
+  /\bplease (?:run )?[`'"]?\/?login\b/i,
+  /\brun [`'"]?(?:codex login|claude \/login|copilot \/login|gh auth login)[`'"]?/i,
+  /\binvalid api key\b/i,
+  /\bapi key (?:not set|missing|not found|expired)\b/i,
+  /\bauthentication (?:error|failed|required)\b/i,
+  /\bcredentials? (?:missing|not found|expired|invalid|required)\b/i,
+  /\bauthentication[_-]error\b/i,
+];
+
+/** Terminal sign-in command per runtime (mirrors the onboarding install prose). */
+const LOGIN_COMMANDS: Record<string, string> = {
+  claude: "claude /login",
+  codex: "codex login",
+  copilot: "copilot /login",
+};
+
+/**
+ * Detect a runtime sign-in failure in error text. `harnessId` is the runtime
+ * the failing send used (the stderr rarely names it) — pass it when known so
+ * the fix can name the runtime and its exact login command.
+ */
+export function parseHarnessAuthFailure(
+  text: string | null | undefined,
+  harnessId?: string | null,
+): HarnessAuthFailure | null {
+  if (!text || typeof text !== "string") return null;
+  if (!AUTH_FAILURE_PATTERNS.some((re) => re.test(text))) return null;
+  const harness = knownAdapterId(harnessId);
+  return {
+    harness,
+    harnessLabel: harness ? adapterLabel(harness) : null,
+    loginCommand: harness ? LOGIN_COMMANDS[harness] ?? null : null,
+  };
+}
+
 /**
  * The harnesses a fix UI should offer to switch to: the configured list when
  * the error names one, otherwise every other chat-supported adapter. Capped so

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -9,16 +9,21 @@
  *
  * Keep this list truthful: every entry must correspond to a binding that
  * actually exists in code —
- *   - panels/terminal: src/components/shell.tsx keydown handlers
+ *   - panels: src/components/shell.tsx keydown handlers
  *   - palette, surfaces, familiars, new chat, this sheet: src/components/workspace.tsx
  *   - composer + slash menu: src/components/chat-view.tsx onComposerKey and
  *     src/components/home-composer.tsx handleKeyDown
  *   - "/" search focus: each surface's view (familiars-view, projects-view,
  *     capabilities-view, chat-list); "⌘F" sessions search: chat-list.tsx
- *   - terminal & panes: src/components/comux-view.tsx keydown handlers
  *   - browser pane: src/components/browser-pane.tsx (⌘L / ⌘K / [)
  *   - ⌘S save: familiar-daily-notes.tsx;
  *     artifact refine ⌘↵: chat-artifact-viewer.tsx
+ *
+ * (cave-7c9i) The sheet used to advertise ⌘6–⌘8 / a retired "Code" surface,
+ * a ⌃` terminal toggle whose Shell `bottom` slot the Workspace never passes,
+ * and a whole "Terminal & panes" group implemented only in the unmounted
+ * ComuxView. Advertised-but-dead shortcuts erode trust in the whole sheet —
+ * if a binding lands, add it here in the same change that wires it.
  */
 
 export type ShortcutEntry = {
@@ -28,7 +33,7 @@ export type ShortcutEntry = {
 };
 
 export type ShortcutGroup = {
-  id: "panels" | "terminal" | "browser" | "composer" | "slash-menu" | "other";
+  id: "panels" | "browser" | "composer" | "slash-menu" | "other";
   label: string;
   entries: ShortcutEntry[];
 };
@@ -41,8 +46,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘K", description: "Open the command palette" },
       { keys: "⌘B", description: "Toggle the left sidebar" },
       { keys: "⌘\\", description: "Toggle the list panel" },
-      { keys: "⌃`", description: "Toggle the integrated terminal (desktop app)" },
-      { keys: "⌘1–⌘8", description: "Jump to a sidebar surface (Home … Code)" },
+      { keys: "⌘1–⌘5", description: "Jump to a surface (Home, Chat, Tasks, Schedules, Browser)" },
       { keys: "⌘9", description: "Jump to Projects (Chat surface)" },
       { keys: "⌘[ / ⌘]", description: "Previous / next surface" },
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
@@ -50,19 +54,6 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌘N", description: "New chat (on the Chat surface)" },
       { keys: "/", description: "Focus the search (Familiars, Projects, Capabilities, Sessions)" },
       { keys: "⌘F", description: "Focus the sessions search" },
-    ],
-  },
-  {
-    id: "terminal",
-    label: "Terminal & panes",
-    entries: [
-      { keys: "⌘N", description: "New terminal session" },
-      { keys: "⌘W", description: "Close the focused pane" },
-      { keys: "⌘⌥←→↑↓", description: "Focus the pane in that direction" },
-      { keys: "⌘[ / ⌘]", description: "Cycle to the previous / next pane" },
-      { keys: "⌘1–⌘9", description: "Jump to pane N" },
-      { keys: "⌘↵", description: "Zoom the focused pane (toggle)" },
-      { keys: "⌘⇧B", description: "Broadcast input to every visible pane" },
     ],
   },
   {

--- a/tests/keyboard-shortcuts.spec.ts
+++ b/tests/keyboard-shortcuts.spec.ts
@@ -25,7 +25,9 @@ async function gotoApp(page: Page) {
 // so match the dialog by its accessible name rather than an aria-label attr.
 const sheet = (page: Page) => page.getByRole("dialog", { name: /Keyboard shortcuts/ });
 
-const GROUPS = ["Panels & navigation", "Terminal & panes", "Browser", "Composer", "Slash menu", "Other"];
+// "Terminal & panes" was removed from the catalog — its bindings lived only in
+// the unmounted ComuxView, and the sheet stays truthful (cave-7c9i).
+const GROUPS = ["Panels & navigation", "Browser", "Composer", "Slash menu", "Other"];
 
 test.describe("keyboard shortcuts sheet", () => {
   test("opens with ?, lists every catalog group, closes with Escape", async ({ page }) => {
@@ -40,7 +42,9 @@ test.describe("keyboard shortcuts sheet", () => {
     }
     // Representative rows, including one from the #1605 additions.
     await expect(sheet(page).getByText("Open the command palette")).toBeVisible();
-    await expect(sheet(page).getByText("Broadcast input to every visible pane")).toBeVisible();
+    await expect(sheet(page).getByText("Recall prompt history (home composer, empty input)")).toBeVisible();
+    // Removed-with-the-group row must NOT resurface (cave-7c9i).
+    await expect(sheet(page).getByText("Broadcast input to every visible pane")).toBeHidden();
 
     await page.keyboard.press("Escape");
     await expect(sheet(page)).toBeHidden();


### PR DESCRIPTION
Fixes the eight P2 beads from the 2026-07-09 pre-rollout UX audit (follow-up to the P1 batch in #2884).

## Fixes

**cave-qnh2 — external `/#card-` links dropped the card.** BoardView is the only card-hash consumer and never mounts on the boot-default Chat surface. A boot effect now switches to the board when the hash matches; BoardView's existing hash effect applies the selection once cards load.

**cave-7c9i — shortcuts sheet advertised dead shortcuts.** ⌘1–⌘8 → the real ⌘1–⌘5 with true surface names; the no-op ⌃` terminal toggle and the entire "Terminal & panes" group (implemented only in unmounted ComuxView) removed; header comment now warns against advertising unwired bindings.

**cave-hyor — `?mode=flow` rendered Home mislabeled.** The flow→Schedules remap moved into `setMode` (the single choke point covering deep links, navigate-mode, and last-mode restore); the dashboard space panel's "Open flows" now links `/?mode=inbox` as "Open schedules".

**cave-v35w — Refine wedged forever on mid-stream failure.** `generateArtifactCode`'s read loop converts stream failures (and aborts) into error results keeping partial text; the viewer resets `generating` in `finally`, the panel's Cancel becomes **Stop** (aborts) while refining, and unmount aborts in-flight work.

**cave-f6ol — first-chat auth failures were raw stderr.** New `parseHarnessAuthFailure` in harness-failure.ts (conservative patterns; bare "unauthorized" deliberately ignored to avoid access-gate false positives) + an `AuthFixRow` in the chat error strip naming the runtime and offering its copyable login command (`claude /login` / `codex login` / `copilot /login`). Unit-tested.

**cave-ivcc — deleted project folder produced jargon + a Retry that can't succeed.** The 400 `project_root_unavailable` now renders "This chat's project folder is missing (path)…" plus an **Open projects** action (via `CHAT_OPEN_PROJECTS_EVENT`).

**cave-8taz — touch-invisible hover controls.** `.touch-always-visible` added to the group-chat delete overlay, memory-row actions, and project-tree "Use" (which also gains a focus-visible reveal it never had).

**cave-7jzq — first-contact jargon.** "Familiar" defined on the circle empty state; beads glossed as "the queue's tracked tasks" in Queue empty states; "Delete coven" title scoped ("removes this group chat only"); daemon settings hints rewritten in plain language (local vs server hub, executors marked advanced); chat meta "daemon offline · check Coven" → "start it from the banner above"; journal's disabled Generate finally explains the zero-familiar case (title + sr-only + empty-state copy).

## Validation
- `pnpm typecheck` ✓ · `test:app` 597 files ✓ · `test:api` 131 ✓ · `test:mobile` 75 ✓ · `check:tests-wired` (799) ✓ · `pnpm build` + bundle budget ✓
- New unit coverage: `harness-failure.test.ts` auth-failure cases (incl. the access-gate false-positive guard). Updated pin: `harness-fix-actions.test.ts` import + auth-parse assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)