### PR TITLE
fix(inspector): open memory files via server-resolved path, not a hardcoded dev home

### DIFF
--- a/src/components/inspector-pane-surface.test.ts
+++ b/src/components/inspector-pane-surface.test.ts
@@ -22,4 +22,11 @@ assert.match(
   "nested MemoryTab mode shell should paint the base background behind Coven and Files empty states",
 );
 
+// Memory "open file" affordance must use the SERVER-resolved, allow-listed path —
+// never a hardcoded developer home dir (which broke on every non-dev machine).
+assert.doesNotMatch(source, /\/Users\/[a-z]/i, "no hardcoded developer home path in the inspector");
+assert.doesNotMatch(source, /NEXT_PUBLIC_COVEN_MEMORY_ROOT/, "no client-side memory-root path guessing");
+assert.match(source, /setOpenPath\(e\.fullPath!?\)/, "the memory open-file button opens the server-resolved fullPath");
+assert.match(source, /\{e\.fullPath \? \(/, "the open-file affordance only renders when the server attached an allow-listed fullPath");
+
 console.log("inspector-pane-surface.test.ts OK");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -584,6 +584,10 @@ type CovenMemoryEntry = {
   familiar_id: string;
   title: string;
   path: string;
+  /** Server-resolved absolute path, attached by /api/coven-memory only when the
+   *  entry passes the memory allow-list. Absent otherwise (then no open-file
+   *  affordance is shown). Never guessed on the client. */
+  fullPath?: string;
   updated_at: string;
   excerpt?: string;
 };
@@ -830,19 +834,21 @@ function MemoryTab({
                   {e.excerpt}
                 </p>
               ) : null}
-              <button
-                onClick={() => {
-                  // Open the underlying file in the redacted file viewer if it
-                  // sits inside one of our allowed memory roots.
-                  const guessed = e.path.startsWith("/")
-                    ? e.path
-                    : `${process.env.NEXT_PUBLIC_COVEN_MEMORY_ROOT ?? "/Users/buns/.coven/memory"}/${e.path}`;
-                  setOpenPath(guessed);
-                }}
-                className="mt-1 text-[10px] text-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
-              >
-                open file →
-              </button>
+              {e.fullPath ? (
+                <button
+                  onClick={() => {
+                    // Open the underlying file in the redacted file viewer via the
+                    // SERVER-resolved absolute path — /api/coven-memory attaches
+                    // `fullPath` only when the entry passes the memory allow-list.
+                    // No client-side home-directory guessing (which hardcoded one
+                    // developer's ~/.coven path and broke on every other machine).
+                    setOpenPath(e.fullPath!);
+                  }}
+                  className="mt-1 text-[10px] text-[var(--accent-presence)] hover:text-[var(--accent-presence)]"
+                >
+                  open file →
+                </button>
+              ) : null}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Production defect (all distributions)
The inspector's memory-tab **"open file"** button built the file path on the client, falling back to a hardcoded **`/Users/buns/.coven/memory`**. On any machine that isn't that developer's — i.e. **every packaged distribution and every real user** — it constructed a path that doesn't exist, so the affordance was broken.

## Fix
Use the server-attached `fullPath`. `/api/coven-memory` already resolves it via `resolveCovenMemoryFullPath` against the memory allow-list and attaches it **only** when the entry passes. The button now:
- renders only when `e.fullPath` is present (an allow-listed absolute path), and
- opens exactly that path — no client-side home-directory guessing, no `NEXT_PUBLIC_COVEN_MEMORY_ROOT` fallback.

Found during a production-readiness audit of `main` (typecheck clean, no stray `console.log`/`debugger`, no other hardcoded dev paths — the remaining `/Users/` references are comments in path-*normalization* helpers that strip such paths from the UI).

## Verification
- Guard pins added to `inspector-pane-surface.test.ts` (no `/Users/...`, no `NEXT_PUBLIC_COVEN_MEMORY_ROOT`, uses `e.fullPath`, gated render). All three inspector suites pass.
- `typecheck` clean · `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)