### PR TITLE
style(chrome): frost the opaque floating overlay chrome (cave-il65)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -210,7 +210,7 @@
      with blur(var(--glass-blur)); a see-through fill WITHOUT blur is
      unreadable, which is why the @supports fallback below restores the
      opaque tokens wherever backdrop-filter is unavailable. */
-  --glass-blur: 16px;
+  --glass-blur: 20px;
   --glass-saturate: 140%;
   --glass-elevated: color-mix(in oklch, var(--bg-elevated) 74%, transparent);
   --glass-raised: color-mix(in oklch, var(--bg-raised) 80%, transparent);
@@ -667,7 +667,12 @@ tr[role="checkbox"]:focus-visible {
   bottom: 0;
   width: 232px;
   z-index: 60;
-  background: var(--bg-raised);
+  /* Frosted glass: the peek floats over live content, so blur keeps it
+     legible without going fully opaque. Opaque fallbacks live in the shared
+     @supports / reduced-transparency blocks below. */
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-right: 1px solid var(--border-hairline);
   box-shadow: 0 12px 40px rgb(0 0 0 / 0.35);
   animation: shellNavPeekIn 0.13s ease;
@@ -2046,7 +2051,9 @@ textarea.required-inputs-control {
   bottom: var(--space-4);
   width: 440px;
   max-width: calc(100vw - 2 * var(--space-4));
-  background: var(--bg-raised);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   box-shadow: 0 16px 48px oklch(0 0 0 / 50%);
@@ -2807,11 +2814,22 @@ textarea.required-inputs-control {
  * unreadable soup — restore the opaque theme surfaces. */
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   .ui-popover,
-  .glass-overlay {
+  .glass-overlay,
+  .ui-tooltip,
+  .ui-undo-toast,
+  .familiar-switcher__popover {
     background: var(--bg-elevated);
   }
-  .ui-modal {
+  .ui-modal,
+  .ui-dock-chat,
+  .shell-nav-panel > .shell-nav--peek,
+  .cave-cal-detail-panel,
+  .familiar-studio__drawer {
     background: var(--bg-raised);
+  }
+  .quick-chat-overlay,
+  .quick-chat-overlay__caret {
+    background: var(--bg-panel);
   }
 }
 
@@ -2819,13 +2837,26 @@ textarea.required-inputs-control {
  * transparency get the opaque surfaces (and their compositor back). */
 @media (prefers-reduced-transparency: reduce) {
   .ui-popover,
-  .glass-overlay {
+  .glass-overlay,
+  .ui-tooltip,
+  .ui-undo-toast,
+  .familiar-switcher__popover {
     background: var(--bg-elevated);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }
-  .ui-modal {
+  .ui-modal,
+  .ui-dock-chat,
+  .shell-nav-panel > .shell-nav--peek,
+  .cave-cal-detail-panel,
+  .familiar-studio__drawer {
     background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .quick-chat-overlay,
+  .quick-chat-overlay__caret {
+    background: var(--bg-panel);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }
@@ -2912,7 +2943,9 @@ textarea.required-inputs-control {
 .ui-tooltip {
   position: fixed;
   z-index: 70;
-  background: var(--bg-elevated);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--text-primary);
   font-size: var(--text-2xs);
   padding: 4px 8px;
@@ -5845,7 +5878,9 @@ button:active > .edge-rail-chip {
   padding: 0;
   border-radius: 12px;
   border: 1px solid var(--border-hairline);
-  background: var(--bg-base);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: var(--shadow-popover, 0 8px 28px rgb(0 0 0 / 0.28));
   overflow: hidden;
 }
@@ -6674,7 +6709,9 @@ a.mobile-handoff__link:hover {
   width: min(320px, 100%);
   display: flex;
   flex-direction: column;
-  background: var(--bg-raised);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   box-shadow: -8px 0 24px color-mix(in oklch, var(--text-primary) 10%, transparent);
   z-index: 10;
@@ -6728,7 +6765,9 @@ a.mobile-handoff__link:hover {
   width: min(496px, 92vw);
   display: grid;
   grid-template-columns: max-content 1fr;
-  background: var(--bg-base);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   box-shadow: -12px 0 40px color-mix(in oklch, var(--text-primary) 16%, transparent);
   z-index: 45;
@@ -12092,7 +12131,9 @@ details[open] > .cave-edit-card__summary::before {
   flex-direction: column;
   border-radius: var(--radius-panel, 14px);
   border: 1px solid var(--border-hairline);
-  background: var(--bg-panel);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--fg-primary);
   /* Layered elevation: an inner top highlight + two soft drop shadows read as a
      crisp floating panel rather than one flat blur. */
@@ -12109,7 +12150,10 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-overlay__caret {
   width: 12px;
   height: 12px;
-  background: var(--bg-panel);
+  /* Matches the overlay's frosted fill so the caret doesn't read solid. */
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   border-top: 1px solid var(--border-hairline);
   border-top-left-radius: 3px;
@@ -13690,7 +13734,9 @@ details[open] > .cave-edit-card__summary::before {
   max-width: 420px;
   border-radius: 8px;
   border: 1px solid var(--border-strong);
-  background: var(--bg-elevated);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: 0 4px 24px rgb(0 0 0 / 35%);
   overflow: hidden;
   animation: ui-undo-toast-enter 0.18s var(--ease-decelerate, ease-out);

--- a/src/components/glass-overlay-chrome.test.ts
+++ b/src/components/glass-overlay-chrome.test.ts
@@ -69,4 +69,60 @@ assert.match(palette, /className="glass-overlay mt-\[12vh\]/, "the command palet
 assert.doesNotMatch(palette, /mt-\[12vh\][^"]*bg-\[var\(--bg-elevated\)\]/, "the palette's old opaque fill is gone");
 assert.match(bell, /notification-bell__popover glass-overlay/, "the notification bell popover is glass");
 
+// ── Frosted floating chrome (autopilot: "ultra opaque components → frosty") ──
+// Floating overlays that used to paint fully-solid theme fills now pair a
+// translucent glass fill with backdrop blur, and every one of them appears in
+// BOTH opaque-fallback blocks (@supports-not and reduced-transparency), so
+// nothing goes see-through where the blur can't render.
+const GLASS_RE = String.raw`background: var\(--glass-(?:elevated|raised)\);\s*\n\s*backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);\s*\n\s*-webkit-backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);`;
+const frostedGlobals = [
+  String.raw`\.shell-nav-panel > \.shell-nav--peek`,
+  String.raw`\.ui-dock-chat`,
+  String.raw`\.ui-tooltip`,
+  String.raw`\.familiar-switcher__popover`,
+  String.raw`\.cave-cal-detail-panel`,
+  String.raw`\.familiar-studio__drawer`,
+  String.raw`\.quick-chat-overlay`,
+  String.raw`\.ui-undo-toast`,
+];
+for (const sel of frostedGlobals) {
+  assert.match(
+    css,
+    new RegExp(`${sel} \\{[\\s\\S]{0,700}?${GLASS_RE}`),
+    `${sel} is frosted glass`,
+  );
+}
+// Both fallback blocks restore an opaque fill for every frosted global.
+const supportsBlock = css.match(/@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\) \{[\s\S]*?\n\}/)?.[0] ?? "";
+const reducedBlock = css.match(/@media \(prefers-reduced-transparency: reduce\) \{[\s\S]*?\n\}/)?.[0] ?? "";
+for (const sel of ["shell-nav--peek", "ui-dock-chat", "ui-tooltip", "familiar-switcher__popover", "cave-cal-detail-panel", "familiar-studio__drawer", "quick-chat-overlay", "ui-undo-toast"]) {
+  assert.ok(supportsBlock.includes(sel), `${sel} has an opaque no-backdrop-filter fallback`);
+  assert.ok(reducedBlock.includes(sel), `${sel} respects reduced transparency`);
+}
+
+// Feature stylesheets carry the same pairing + their own fallback blocks.
+const featureSheets: Array<[string, string[]]> = [
+  ["../styles/dashboard.css", ["dash-snooze__menu", "spark-tip"]],
+  ["../styles/cave-chat.css", ["cave-chat-model-popover", "voice-call-overlay__dialog", "cave-table-lightbox__panel"]],
+  ["../styles/flow.css", ["flow-ndv", "flow-template-overlay-panel"]],
+  ["../styles/home-composer.css", ["hc-slash-menu"]],
+  ["../styles/journal.css", ["journal-notice"]],
+  ["../styles/summoning-circle.css", ["summoning-dialog"]],
+  ["../styles/board.css", ["board-drawer", "gh-pat-dialog", "gh-action-popover", "gh-profile-card"]],
+];
+for (const [file, selectors] of featureSheets) {
+  const sheet = readFileSync(new URL(file, import.meta.url), "utf8");
+  const sheetSupports = sheet.match(/@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\) \{[\s\S]*?\n\}/g)?.join("\n") ?? "";
+  const sheetReduced = sheet.match(/@media \(prefers-reduced-transparency: reduce\) \{[\s\S]*?\n\}/g)?.join("\n") ?? "";
+  for (const sel of selectors) {
+    assert.match(
+      sheet,
+      new RegExp(`\\.${sel}(?::not\\([^)]*\\))? \\{[\\s\\S]{0,900}?backdrop-filter:\\s*blur\\(var\\(--glass-blur\\)\\) saturate\\(var\\(--glass-saturate\\)\\)`),
+      `${file} ${sel} is frosted glass`,
+    );
+    assert.ok(sheetSupports.includes(sel), `${file} ${sel} has an opaque no-backdrop-filter fallback`);
+    assert.ok(sheetReduced.includes(sel), `${file} ${sel} respects reduced transparency`);
+  }
+}
+
 console.log("glass-overlay-chrome.test.ts: ok");

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -55,8 +55,8 @@ assert.match(
 
 assert.match(
   styles,
-  /\.voice-call-overlay__dialog\s*\{[\s\S]*?background:\s*var\(--bg-raised\);[\s\S]*?box-shadow:/,
-  "voice overlay dialog has a styled raised surface",
+  /\.voice-call-overlay__dialog\s*\{[\s\S]*?background:\s*var\(--glass-raised\);[\s\S]*?backdrop-filter:\s*blur\(var\(--glass-blur\)\)[\s\S]*?box-shadow:/,
+  "voice overlay dialog is a frosted raised surface",
 );
 
 assert.match(

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -409,7 +409,7 @@
 
 .board-drawer-backdrop { position:fixed; inset:0; background:rgba(0,0,0,.30); z-index:300; animation:board-backdrop-in .18s ease; }
 @keyframes board-backdrop-in { from{opacity:0} to{opacity:1} }
-.board-drawer { position:fixed; top:0; right:0; bottom:0; width:480px; max-width:100vw; background:var(--bg-raised); border-left:1px solid var(--border-strong); z-index:301; display:flex; flex-direction:column; overflow:hidden; box-shadow:-8px 0 32px rgba(0,0,0,.20); animation:board-drawer-in .22s ease-out; }
+.board-drawer { position:fixed; top:0; right:0; bottom:0; width:480px; max-width:100vw; background:var(--glass-raised); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); border-left:1px solid var(--border-strong); z-index:301; display:flex; flex-direction:column; overflow:hidden; box-shadow:-8px 0 32px rgba(0,0,0,.20); animation:board-drawer-in .22s ease-out; }
 @keyframes board-drawer-in { from{transform:translateX(100%)} to{transform:translateX(0)} }
 .board-drawer--closing { animation:board-drawer-out .18s ease-in forwards; }
 @keyframes board-drawer-out { from{transform:translateX(0)} to{transform:translateX(100%)} }
@@ -646,7 +646,9 @@
   max-width:28rem;
   border-radius:var(--radius-panel);
   border:1px solid var(--border-hairline);
-  background:var(--bg-elevated);
+  background:var(--glass-elevated);
+  backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
   padding:1.5rem;
   box-shadow:var(--shadow-popover, 0 25px 50px -12px rgb(0 0 0 / .25));
 }
@@ -812,8 +814,8 @@
 .gh-actions.reveal-on-hover:has(.gh-action-error) { opacity:1; }
 .gh-action-wrap { position:relative; display:inline-flex; }
 .gh-action-error { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; margin-left:4px; border-radius:50%; background:var(--color-danger); color:#fff; font-size:10px; font-weight:700; }
-.gh-action-popover { position:absolute; top:calc(100% + 4px); right:0; z-index:60; min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--bg-elevated); box-shadow:0 12px 30px rgba(0,0,0,.18); }
-.gh-action-popover--wide { padding:0; min-width:280px; background:transparent; border:none; box-shadow:none; }
+.gh-action-popover { position:absolute; top:calc(100% + 4px); right:0; z-index:60; min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--glass-elevated); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); box-shadow:0 12px 30px rgba(0,0,0,.18); }
+.gh-action-popover--wide { padding:0; min-width:280px; background:transparent; border:none; box-shadow:none; backdrop-filter:none; -webkit-backdrop-filter:none; }
 .gh-action-popover-title { padding:0 4px 6px; font-size:11px; color:var(--text-muted); }
 .gh-action-popover-list { list-style:none; margin:0; padding:0; max-height:220px; overflow-y:auto; }
 .gh-action-popover-item { display:flex; align-items:center; gap:8px; width:100%; padding:5px 7px; border:none; background:transparent; color:var(--text-secondary); font-size:11.5px; text-align:left; cursor:pointer; border-radius:var(--radius-control); }
@@ -1400,7 +1402,9 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   padding:14px;
   border:1px solid var(--border-hairline);
   border-radius:14px;
-  background:var(--bg-elevated);
+  background:var(--glass-elevated);
+  backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow:0 16px 44px rgba(0,0,0,0.34);
   display:flex;
   flex-direction:column;
@@ -2168,3 +2172,27 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .cg-sw--pending { background: var(--color-warning); }
 .cg-sw--at-risk { background: var(--color-danger); }
 .cg-today-sw { width: 0; height: 12px; border-left: 2px solid var(--color-danger); display: inline-block; }
+
+/* ── Frosted-glass fallbacks ─────────────────────────────────────────────────
+   Glass needs a live blur behind it — restore the opaque surfaces wherever
+   backdrop-filter is unavailable or the OS asked for less transparency. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .board-drawer { background: var(--bg-raised); }
+  .gh-pat-dialog,
+  .gh-action-popover:not(.gh-action-popover--wide),
+  .gh-profile-card { background: var(--bg-elevated); }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .board-drawer {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .gh-pat-dialog,
+  .gh-action-popover:not(.gh-action-popover--wide),
+  .gh-profile-card {
+    background: var(--bg-elevated);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -311,7 +311,9 @@
   max-height: 90vh;
   border: 1px solid var(--border-strong);
   border-radius: 16px;
-  background: var(--bg-panel);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: 0 24px 70px color-mix(in oklch, black 45%, transparent);
   overflow: hidden;
 }
@@ -2877,7 +2879,9 @@ details[open] > .cave-tool-summary::before {
   width: min(320px, calc(100vw - 32px));
   border: 1px solid var(--border-strong);
   border-radius: 8px;
-  background: var(--bg-elevated);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   padding: 9px;
   box-shadow: 0 14px 34px color-mix(in oklch, var(--bg-base) 64%, transparent);
   color: var(--text-secondary);
@@ -3113,7 +3117,9 @@ details[open] > .cave-tool-summary::before {
   overflow: hidden;
   border: 1px solid var(--border-hairline);
   border-radius: 8px;
-  background: var(--bg-raised);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--text-primary);
   box-shadow: 0 24px 80px color-mix(in oklch, var(--bg-base) 76%, transparent);
 }
@@ -5352,11 +5358,29 @@ details[open] > .cave-tool-summary::before {
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   .workspace-rail-reopen,
 .chat-right-rail { background: var(--bg-raised); }
+  .cave-chat-model-popover { background: var(--bg-elevated); }
+  .voice-call-overlay__dialog { background: var(--bg-raised); }
+  .cave-table-lightbox__panel { background: var(--bg-panel); }
 }
 @media (prefers-reduced-transparency: reduce) {
   .workspace-rail-reopen,
 .chat-right-rail {
     background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .cave-chat-model-popover {
+    background: var(--bg-elevated);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .voice-call-overlay__dialog {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .cave-table-lightbox__panel {
+    background: var(--bg-panel);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -115,7 +115,9 @@
   min-width: 150px;
   padding: 4px;
   border-radius: 10px;
-  background: var(--bg-panel, var(--bg-base));
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong);
   box-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.45);
 }
@@ -178,12 +180,22 @@
     background:
       linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
   }
+  .dash-snooze__menu,
+  .spark-tip {
+    background: var(--bg-elevated);
+  }
 }
 
 @media (prefers-reduced-transparency: reduce) {
   .settings-shell__header {
     background:
       linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .dash-snooze__menu,
+  .spark-tip {
+    background: var(--bg-elevated);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
   }
@@ -531,7 +543,9 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .spark-tip { position: absolute; top: -7px; transform: translate(-50%, -100%);
   white-space: nowrap; pointer-events: none; z-index: 4;
   padding: 3px 7px; border-radius: 6px; font-size: 10.5px; line-height: 1.2;
-  color: var(--text-primary); background: var(--bg-elevated, var(--bg-raised));
+  color: var(--text-primary); background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong); box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
   font-variant-numeric: tabular-nums; }
 .spark-tip b { font-weight: 700; }

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -435,7 +435,7 @@
 .flow-catalog-item-desc { font-size: var(--text-xs); color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 /* ---- Node detail view --------------------------------------------------- */
-.flow-ndv { position: absolute; top: 0; right: 0; bottom: 0; z-index: 8; width: 332px; display: flex; flex-direction: column; background: var(--bg-raised); border-left: 1px solid var(--border-hairline); box-shadow: -10px 0 32px rgb(0 0 0 / 30%); }
+.flow-ndv { position: absolute; top: 0; right: 0; bottom: 0; z-index: 8; width: 332px; display: flex; flex-direction: column; background: var(--glass-raised); backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate)); -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate)); border-left: 1px solid var(--border-hairline); box-shadow: -10px 0 32px rgb(0 0 0 / 30%); }
 .flow-ndv-head { display: flex; align-items: center; gap: 8px; padding: var(--space-3); border-bottom: 1px solid var(--border-hairline); }
 .flow-ndv-icon { flex: none; display: grid; place-items: center; width: 28px; height: 28px; border-radius: 8px; color: #11131a; }
 .flow-ndv-name { flex: 1; min-width: 0; padding: 4px 6px; border: 1px solid transparent; border-radius: var(--radius-control); background: transparent; color: var(--text-primary); font-size: var(--text-md); font-weight: 600; outline: none; }
@@ -595,11 +595,33 @@
   max-height: min(700px, 90vh);
   display: flex;
   flex-direction: column;
-  background: var(--bg-elevated);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border);
   border-radius: var(--radius-panel);
   box-shadow: 0 24px 64px color-mix(in oklch, #000 45%, transparent);
   overflow: hidden;
+}
+
+/* Frosted glass needs a live blur behind it — restore the opaque surfaces
+   wherever backdrop-filter is unavailable or the OS asked for less
+   transparency. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .flow-ndv { background: var(--bg-raised); }
+  .flow-template-overlay-panel { background: var(--bg-elevated); }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .flow-ndv {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .flow-template-overlay-panel {
+    background: var(--bg-elevated);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 /* Gallery container — used both in the overlay and as the full empty-state */

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -699,10 +699,28 @@
   overflow: hidden;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-2xl, 14px);
-  background: var(--bg-base);
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow:
     0 14px 32px -16px color-mix(in oklch, var(--accent-presence) 22%, transparent),
     0 4px 18px -6px rgb(0 0 0 / 0.35);
+}
+
+/* Frosted glass needs a live blur behind it — restore the opaque surface
+   wherever backdrop-filter is unavailable or the OS asked for less
+   transparency. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .hc-slash-menu {
+    background: var(--bg-base);
+  }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .hc-slash-menu {
+    background: var(--bg-base);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 /* Skills picker: option list + detail preview side by side. */
 .hc-slash-body { display: flex; align-items: stretch; min-height: 0; }

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -422,11 +422,29 @@
   padding: 10px 12px 10px 13px;
   font-size: 12.5px;
   color: var(--text-primary);
-  background: var(--bg-elevated, var(--bg-raised));
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-strong));
   border-radius: 12px;
   box-shadow: 0 18px 50px -18px rgba(0, 0, 0, 0.6);
   animation: journal-notice-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* Frosted glass needs a live blur behind it — restore the opaque surface
+   wherever backdrop-filter is unavailable or the OS asked for less
+   transparency. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .journal-notice {
+    background: var(--bg-elevated, var(--bg-raised));
+  }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .journal-notice {
+    background: var(--bg-elevated, var(--bg-raised));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 @keyframes journal-notice-in {
   from { opacity: 0; transform: translate(-50%, 12px); }

--- a/src/styles/summoning-circle.css
+++ b/src/styles/summoning-circle.css
@@ -21,10 +21,28 @@
   width: min(940px, 100%);
   max-height: min(760px, calc(100vh - 2 * var(--space-4)));
   overflow: hidden;
-  background: var(--bg-raised);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   box-shadow: 0 24px 64px oklch(0 0 0 / 35%);
+}
+
+/* Frosted glass needs a live blur behind it — restore the opaque surface
+   wherever backdrop-filter is unavailable or the OS asked for less
+   transparency. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .summoning-dialog {
+    background: var(--bg-raised);
+  }
+}
+@media (prefers-reduced-transparency: reduce) {
+  .summoning-dialog {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 .summoning-body {


### PR DESCRIPTION
## What

Converts the floating overlay chrome that still painted **fully-solid theme fills** to the app's shared frosted-glass vocabulary: a translucent `--glass-elevated`/`--glass-raised` fill paired with `backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate))` (+ the `-webkit-` pair). `--glass-blur` steps **16px → 20px** for a frostier finish — easier to view over busy content without being too transparent (fills stay at the established 74/80% alphas).

## Converted surfaces

**globals.css:** `.ui-tooltip`, `.ui-undo-toast`, `.ui-dock-chat`, `.shell-nav--peek` (hover peek), `.familiar-switcher__popover`, `.cave-cal-detail-panel`, `.familiar-studio__drawer`, `.quick-chat-overlay` + caret

**Feature sheets:** board drawer, GitHub PAT dialog / action popover / profile card (board.css); chat model popover, voice-call dialog, table lightbox (cave-chat.css); flow node-detail panel + template overlay (flow.css); home slash menu; journal notice; summoning dialog; dash snooze menu + spark tip (dashboard.css)

## Fallbacks preserved

Every converted surface is listed in **both** opaque-fallback paths — `@supports not (backdrop-filter…)` and `@media (prefers-reduced-transparency: reduce)` — so nothing goes see-through where the blur can't render, and the OS accessibility setting still wins.

## Validation

- `glass-overlay-chrome.test.ts` extended: enforces the glass pairing **and** both fallback listings for all 20 converted selectors
- `voice-call-overlay.test.ts` updated for the frosted dialog
- Local: typecheck ✓, test:app 600 ✓, test:api 131 ✓, test:mobile 75 ✓, build + bundle budget ✓

Bead: cave-il65