### PR TITLE
fix(rollout): seven P3 papercuts and dead-ends from the 100k-ft audit

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -77,7 +77,7 @@ const contracts: RouteContract[] = [
   { route: "/flows/webhook-test", methods: ["DELETE", "GET", "PATCH", "POST", "PUT"], kind: "json" },
   { route: "/flows/webhook-test/[...path]", methods: ["DELETE", "GET", "PATCH", "POST", "PUT"], kind: "json" },
   { route: "/flows/webhook-test/listen", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/hosts", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/hosts", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/github/comment", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/github/comments", methods: ["GET"], kind: "json" },
   { route: "/github/item", methods: ["GET"], kind: "json" },

--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -112,3 +112,31 @@ export async function POST(req: Request) {
   });
   return NextResponse.json({ ok: true, host: { host: candidate.host, cwd: candidate.cwd } });
 }
+
+/**
+ * DELETE /api/hosts — unregister a remote host (body: { host }). The route
+ * existed for GET/POST only, leaving no removal path anywhere (cave-4zdp).
+ * Conversations recorded on the removed host fail closed at send time with a
+ * re-pick error rather than silently running locally.
+ */
+export async function DELETE(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  let body: { host?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  const host = typeof body.host === "string" ? body.host.trim() : "";
+  if (!host) {
+    return NextResponse.json({ ok: false, error: "host is required" }, { status: 400 });
+  }
+  const config = await loadConfig();
+  if (!config.remoteHosts.some((entry) => entry.host === host)) {
+    return NextResponse.json({ ok: false, error: `host '${host}' is not registered` }, { status: 404 });
+  }
+  await saveConfig({ remoteHosts: config.remoteHosts.filter((entry) => entry.host !== host) });
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/backdrop-settings.tsx
+++ b/src/components/backdrop-settings.tsx
@@ -10,6 +10,7 @@ import {
   writeBackdropImage,
   writeBackdropPrefs,
 } from "@/lib/cave-backdrop";
+import { useArmedConfirm } from "@/lib/use-armed-confirm";
 
 /**
  * Settings → Appearance → Backdrop: pick an image that shows behind Home and
@@ -23,6 +24,8 @@ export function BackdropSettings() {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // Clearing discards the stored image with no undo — two-step (cave-5lsj).
+  const clearConfirm = useArmedConfirm();
   const urlRef = useRef<string | null>(null);
 
   // Thumbnail of whatever is stored — follows enable/replace/clear.
@@ -121,8 +124,14 @@ export function BackdropSettings() {
         </div>
         <div className="flex items-center gap-2">
           {previewUrl ? (
-            <Button size="xs" variant="ghost" leadingIcon="ph:x" onClick={() => void clearBackdrop()} disabled={busy}>
-              Clear
+            <Button
+              size="xs"
+              variant="ghost"
+              leadingIcon="ph:x"
+              onClick={() => clearConfirm.trigger(() => void clearBackdrop())}
+              disabled={busy}
+            >
+              {clearConfirm.armed ? "Really clear?" : "Clear"}
             </Button>
           ) : null}
         </div>

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -32,7 +32,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { HarnessFixActions } from "@/components/harness-fix-actions";
 import { parseHarnessFailure } from "@/lib/harness-failure";
-import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, markProjectsTabPending } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 import { openExternalUrl } from "@/lib/open-external";
 import { InlineAsanaPATSetup } from "@/components/asana-connect-inline";
@@ -63,6 +63,9 @@ const NEXT_MOVES: Record<CardLifecycle, LifecycleMove[]> = {
 };
 
 function openProjectsSurface() {
+  // Latch BEFORE the mode flip: a freshly-mounting ChatSurface consumes it on
+  // mount, so the Projects tab opens even when the event loses the race (cave-c2zf).
+  markProjectsTabPending();
   window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } }));
   window.setTimeout(() => {
     window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT));

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -98,6 +98,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   // only after the undo window, and Undo restores them (mirrors chat/projects).
   const { pending: deletePending, scheduleDelete: scheduleCardDelete, undo: undoCardDelete, commit: commitCardDelete } = useUndoDelete<Card[]>();
   const [error, setError] = useState<string | null>(null);
+  // Quiet-poll degradation: ≥2 consecutive background refresh failures while
+  // last-good cards stay rendered (cave-x6k5). Non-blocking strip, not `error`.
+  const [stale, setStale] = useState(false);
+  const quietFailStreakRef = useRef(0);
   // Distinguish "still loading" from "loaded and empty" so the empty-state
   // CTA doesn't flash on every open before the first GET resolves.
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -173,15 +177,26 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
         // as workspace.tsx's poll over this endpoint).
         setCards((prev) => (arrayContentEqual(prev, loaded) ? prev : loaded));
         setError(null);
+        quietFailStreakRef.current = 0;
+        setStale(false);
       } else if (!quiet) {
         setCards([]);
         setError(json.error ?? "load failed");
+      } else {
+        // Quiet polls used to swallow failures entirely — last-good cards
+        // stayed up with no freshness cue (cave-x6k5). Two consecutive
+        // failures flip a non-blocking "showing earlier data" strip.
+        quietFailStreakRef.current += 1;
+        if (quietFailStreakRef.current >= 2) setStale(true);
       }
     } catch (err) {
       if (ctl.signal.aborted) return; // aborted mid-flight — leave state to the newer load
       if (!quiet) {
         setCards([]);
         setError(err instanceof Error ? err.message : "load failed");
+      } else {
+        quietFailStreakRef.current += 1;
+        if (quietFailStreakRef.current >= 2) setStale(true);
       }
     } finally {
       if (!ctl.signal.aborted) setHasLoaded(true);
@@ -931,6 +946,20 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           <span className="flex min-w-0 items-center gap-1.5">
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
             <span className="min-w-0 truncate">{error}</span>
+          </span>
+          <Button variant="secondary" size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
+            Retry
+          </Button>
+        </div>
+      )}
+      {!error && stale && (
+        <div
+          role="status"
+          className="flex items-center justify-between gap-3 border-b border-[color-mix(in_oklch,var(--color-warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_12%,var(--bg-base))] px-5 py-1.5 text-xs text-[var(--color-warning)]"
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <Icon name="ph:clock-countdown" width={13} className="shrink-0" aria-hidden />
+            <span className="min-w-0 truncate">Refresh is failing — showing earlier data.</span>
           </span>
           <Button variant="secondary" size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
             Retry

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -79,6 +79,10 @@ type Props = {
    *  "no chats yet" empty state. Defaults true for callers that load
    *  sessions before mounting. */
   sessionsLoaded?: boolean;
+  /** The last session-list load failed. With no rows this swaps the "Ready
+   *  for a new thread" empty state for a can't-load state — a failed list is
+   *  not evidence there are no chats (cave-x6k5). */
+  sessionsError?: boolean;
   /** When true, hides the project sidebar rail so the list fits in a narrow
    *  companion panel (e.g. the Browser right-rail). */
   compact?: boolean;
@@ -233,7 +237,7 @@ function ChatListSection({
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, compact = false }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, sessionsLoaded = true, sessionsError = false, compact = false }: Props) {
   useMinuteTick(); // keep the "Xm ago" timestamps current without a data refresh
   // Scope the project rail to what the active familiar is granted; with no
   // active familiar (all-familiars view) this loads every project as before.
@@ -942,6 +946,19 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                 </span>
               </div>
             ))}
+          </div>
+        ) : sessionsError && !hasAny ? (
+          /* The session list FAILED to load — existing chats may be intact but
+             unreadable. "Ready for a new thread" here read as "your chats are
+             gone" (cave-x6k5). The 4s poll retries automatically. */
+          <div className="flex h-full flex-col justify-between px-4 py-4">
+            <EmptyState
+              compact
+              className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35"
+              icon="ph:plugs"
+              headline="Can't load chats right now"
+              subtitle="Your chats are safe — the list didn't load. Retrying automatically; check the daemon banner if this persists."
+            />
           </div>
         ) : !hasAny ? (
           /* Empty state */

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -44,6 +44,8 @@ type Props = {
   onSessionStarted?: () => void;
   onSessionsChanged?: () => void;
   sessionsLoaded?: boolean;
+  /** Last session-list load failed — forwarded to ChatList (cave-x6k5). */
+  sessionsError?: boolean;
   familiarsLoaded?: boolean;
   /** Last roster-load failure. With an empty roster this swaps the "summon
    *  your first familiar" empty state for a can't-reach + Retry state — the
@@ -101,6 +103,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onSessionStarted,
     onSessionsChanged,
     sessionsLoaded,
+    sessionsError,
     familiarsLoaded,
     familiarsError,
     onRetryFamiliars,
@@ -432,6 +435,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         sessions={sessions}
         daemonRunning={daemonRunning}
         sessionsLoaded={sessionsLoaded}
+        sessionsError={sessionsError}
         compact={compact}
         onSessionsChanged={onSessionsChanged}
         onOpen={(sessionId, familiarId, findQuery) => {

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -7,7 +7,7 @@ import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
 import { ProjectsView } from "@/components/projects-view";
 import { GroupChatView } from "@/components/group-chat-view";
 import { InspectorPane } from "@/components/inspector-pane";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending, consumeProjectsTabPending } from "@/lib/chat-tab-events";
 import { DebugPane } from "@/components/debug-pane";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { WorkspaceRail } from "@/components/workspace-rail";
@@ -68,6 +68,8 @@ type Props = {
   daemonRunning: boolean;
   routerRef: RefObject<ChatRouterHandle | null>;
   sessionsLoaded?: boolean;
+  /** Last session-list load failed — chat list shows a can't-load state (cave-x6k5). */
+  sessionsError?: boolean;
   familiarsLoaded?: boolean;
   /** Roster-load failure + retry, forwarded to ChatRouter's empty state (cave-atzv). */
   familiarsError?: string | null;
@@ -198,6 +200,7 @@ export function ChatSurface({
   daemonRunning,
   routerRef,
   sessionsLoaded,
+  sessionsError,
   familiarsLoaded,
   familiarsError,
   onRetryFamiliars,
@@ -601,6 +604,11 @@ export function ChatSurface({
   }
 
   useEffect(() => {
+    // Board→Projects handoffs fire the event from a surface where this
+    // listener isn't mounted yet — consume the retained latch on mount so the
+    // Projects tab opens even when the event loses the race (cave-c2zf; same
+    // shape as the coven-tab latch below).
+    if (consumeProjectsTabPending()) setScope("projects");
     const open = () => setScope("projects");
     window.addEventListener(CHAT_OPEN_PROJECTS_EVENT, open);
     return () => window.removeEventListener(CHAT_OPEN_PROJECTS_EVENT, open);
@@ -723,6 +731,7 @@ export function ChatSurface({
                   sessions={sessions}
                   daemonRunning={daemonRunning}
                   sessionsLoaded={sessionsLoaded}
+                  sessionsError={sessionsError}
                   familiarsLoaded={familiarsLoaded}
                   familiarsError={familiarsError}
                   onRetryFamiliars={onRetryFamiliars}

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -183,11 +183,12 @@ assert.match(
   /intent:\s*\{ kind: "open-project", root: p\.root \}/,
   "an open-project row carries the project root",
 );
-// Consumer: workspace opens the Projects tab then focuses the chosen project.
+// Consumer: workspace latches the Projects tab (fresh-mount race, cave-c2zf),
+// opens it, then focuses the chosen project.
 assert.match(
   workspace,
-  /intent\.kind === "open-project"[\s\S]{0,320}?CHAT_OPEN_PROJECTS_EVENT[\s\S]{0,200}?CHAT_FOCUS_PROJECT_EVENT, \{ detail: \{ root \} \}/,
-  "workspace opens the Projects tab then focuses the chosen project",
+  /intent\.kind === "open-project"[\s\S]{0,200}?markProjectsTabPending\(\)[\s\S]{0,320}?CHAT_OPEN_PROJECTS_EVENT[\s\S]{0,200}?CHAT_FOCUS_PROJECT_EVENT, \{ detail: \{ root \} \}/,
+  "workspace latches then opens the Projects tab and focuses the chosen project",
 );
 
 // Board view-switch: the palette offers "Board: Kanban/Table/Gantt" rows that

--- a/src/components/composer-host-chip.tsx
+++ b/src/components/composer-host-chip.tsx
@@ -7,7 +7,7 @@
 // current value and receives picks. Selection semantics stay the parent's
 // concern (per-session, fail-closed server-side resolution — see #2337).
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
@@ -122,6 +122,8 @@ export function ConnectHostDialog({ onClose, onConnected }: { onClose: () => voi
 export function useComposerHosts(value: string): {
   options: ChatHostOption[];
   load: (force?: boolean) => Promise<void>;
+  /** Unregister a host (DELETE /api/hosts) and refresh the list (cave-4zdp). */
+  removeHost: (host: string) => Promise<void>;
 } {
   const [hosts, setHosts] = useState<ChatHostOption[] | null>(null);
   const loading = useRef(false);
@@ -139,6 +141,19 @@ export function useComposerHosts(value: string): {
     }
   }, []);
 
+  const removeHost = useCallback(async (host: string) => {
+    try {
+      await fetch("/api/hosts", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ host }),
+      });
+    } catch {
+      /* refresh below shows the surviving registry either way */
+    }
+    await load(true);
+  }, [load]);
+
   const options = useMemo<ChatHostOption[]>(() => {
     const base: ChatHostOption[] = hosts ?? [
       { id: LOCAL_HOST_ID, kind: "local", label: "This machine", online: true },
@@ -148,7 +163,7 @@ export function useComposerHosts(value: string): {
       : [...base, { id: value, kind: "ssh", label: value, online: null }];
   }, [hosts, value]);
 
-  return { options, load };
+  return { options, load, removeHost };
 }
 
 /**
@@ -163,20 +178,30 @@ export function ComposerHostChoices({
   value,
   onPick,
   onConnectNew,
+  onRemoveHost,
 }: {
   options: ChatHostOption[];
   value: string;
   onPick: (id: string) => void;
   onConnectNew: () => void;
+  /** Unregister an ssh host. Optional: pickers without registry authority
+   *  (or before wiring) simply don't render the remove affordance. */
+  onRemoveHost?: (host: string) => void;
 }) {
+  // Per-row two-step: first tap arms ("Remove?"), second fires (cave-4zdp).
+  const [armedRemoveId, setArmedRemoveId] = useState<string | null>(null);
+  useEffect(() => {
+    if (armedRemoveId === null) return;
+    const t = window.setTimeout(() => setArmedRemoveId(null), 4000);
+    return () => window.clearTimeout(t);
+  }, [armedRemoveId]);
   return (
     <div className="cave-host-choices" role="radiogroup" aria-label="Run this chat on">
       {options.map((option) => {
         const optionStatus = hostStatusKind(option);
         const checked = option.id === value;
-        return (
+        const row = (
           <button
-            key={option.id}
             type="button"
             role="radio"
             aria-checked={checked}
@@ -190,6 +215,31 @@ export function ComposerHostChoices({
               {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
             </span>
           </button>
+        );
+        if (option.kind !== "ssh" || !onRemoveHost) {
+          return <div key={option.id} className="cave-host-choice-row">{row}</div>;
+        }
+        const armed = armedRemoveId === option.id;
+        return (
+          <div key={option.id} className="cave-host-choice-row">
+            {row}
+            <button
+              type="button"
+              className={`cave-host-remove focus-ring${armed ? " is-armed" : ""}`}
+              aria-label={armed ? `Really remove host ${option.label}? Click again to confirm` : `Remove host ${option.label}`}
+              title={armed ? "Click again to remove" : "Remove this host from the registry"}
+              onClick={() => {
+                if (armed) {
+                  setArmedRemoveId(null);
+                  onRemoveHost(option.id);
+                } else {
+                  setArmedRemoveId(option.id);
+                }
+              }}
+            >
+              {armed ? "Remove?" : <Icon name="ph:x" width={11} aria-hidden />}
+            </button>
+          </div>
         );
       })}
       <button
@@ -217,7 +267,7 @@ export function ComposerHostChip({
   const [open, setOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const { options, load } = useComposerHosts(value);
+  const { options, load, removeHost } = useComposerHosts(value);
 
   const current = options.find((option) => option.id === value);
   const label = current?.label ?? value;
@@ -257,6 +307,7 @@ export function ComposerHostChip({
           <ComposerHostChoices
             options={options}
             value={value}
+            onRemoveHost={(host) => void removeHost(host)}
             onPick={(id) => {
               onPick(id);
               setOpen(false);

--- a/src/components/composer-options-menu.tsx
+++ b/src/components/composer-options-menu.tsx
@@ -109,7 +109,7 @@ export function ComposerOptionsMenu({
   const [open, setOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
   const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const { options: hostOptions, load } = useComposerHosts(hostValue);
+  const { options: hostOptions, load, removeHost } = useComposerHosts(hostValue);
 
   const showDot = Boolean(indicator) || hostValue !== LOCAL_HOST_ID;
 
@@ -174,6 +174,7 @@ export function ComposerOptionsMenu({
             <ComposerHostChoices
               options={hostOptions}
               value={hostValue}
+              onRemoveHost={(host) => void removeHost(host)}
               onPick={onHostPick}
               onConnectNew={() => {
                 setOpen(false);

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -39,18 +39,14 @@ function timed<C>(name: string, loader: () => Promise<C>): () => Promise<C> {
   };
 }
 
-export const ComuxView = dynamic(
-  timed("comux", () => import("@/components/comux-view").then((m) => m.ComuxView)),
-  { ssr: false, loading: SurfaceFallback },
-);
+// (cave-gg5d) ComuxView and FlowView lazy exports removed: nothing imported
+// them — the standalone Code surface is retired and the Flow experience lives
+// on feature/automations-flow. The component sources remain for now; full
+// deletion is tracked separately (ComuxView.removeSession is the app's only
+// pty-kill site, so the rail-terminal PTY lifecycle must be settled first).
 
 export const GitHubView = dynamic(
   timed("github", () => import("@/components/github-view").then((m) => m.GitHubView)),
-  { ssr: false, loading: SurfaceFallback },
-);
-
-export const FlowView = dynamic(
-  timed("flow", () => import("@/components/flow/flow-view").then((m) => m.FlowView)),
   { ssr: false, loading: SurfaceFallback },
 );
 

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -72,8 +72,8 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
-  "Sidebar rows derive their highlight (including the marketplace aliasing) from sidebarRowState",
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes, \{ grimoireView: props\.grimoireView \}\)\}/,
+  "Sidebar rows derive their highlight (marketplace aliasing + the Journal/Grimoire tab split, cave-s9p6) from sidebarRowState",
 );
 
 // Settings: no separate plugins section, and the roles add-on toggle is gone

--- a/src/components/settings-profile.tsx
+++ b/src/components/settings-profile.tsx
@@ -5,6 +5,7 @@ import { SettingsOverview } from "@/components/settings-overview";
 import { SettingsGroup } from "@/components/ui/settings-group";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { useArmedConfirm } from "@/lib/use-armed-confirm";
 import { FAMILIAR_IMAGE_ACCEPT, prepareFamiliarImage } from "@/lib/familiar-image-upload";
 import { Icon } from "@/lib/icon";
 import {
@@ -80,6 +81,14 @@ export function ProfileSection() {
   const [linkHint, setLinkHint] = useState<string | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
   const [avatarBusy, setAvatarBusy] = useState(false);
+  // One-click removals with no undo → two-step (cave-5lsj). Links arm per-row.
+  const avatarRemoveConfirm = useArmedConfirm();
+  const [armedLinkIndex, setArmedLinkIndex] = useState<number | null>(null);
+  useEffect(() => {
+    if (armedLinkIndex === null) return;
+    const t = window.setTimeout(() => setArmedLinkIndex(null), 4000);
+    return () => window.clearTimeout(t);
+  }, [armedLinkIndex]);
   const [legacySvgAvatar, setLegacySvgAvatar] = useState(false);
   useEffect(() => {
     if (snapshot?.avatar.present) {
@@ -288,9 +297,9 @@ export function ProfileSection() {
                   variant="secondary"
                   size="sm"
                   disabled={avatarBusy}
-                  onClick={() => void removeAvatar()}
+                  onClick={() => avatarRemoveConfirm.trigger(() => void removeAvatar())}
                 >
-                  Remove
+                  {avatarRemoveConfirm.armed ? "Really remove?" : "Remove"}
                 </Button>
               ) : null}
             </div>
@@ -383,9 +392,16 @@ export function ProfileSection() {
                     variant="secondary"
                     size="sm"
                     disabled={disabled}
-                    onClick={() => void removeLink(index)}
+                    onClick={() => {
+                      if (armedLinkIndex === index) {
+                        setArmedLinkIndex(null);
+                        void removeLink(index);
+                      } else {
+                        setArmedLinkIndex(index);
+                      }
+                    }}
                   >
-                    Remove
+                    {armedLinkIndex === index ? "Really remove?" : "Remove"}
                   </Button>
                 </div>
                 {rowIncomplete ? (

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -157,12 +157,15 @@ assert.match(
   /aria-current=\{section === s\.id && !showPicker \? "page" : undefined\}/,
   "the active settings section is marked aria-current",
 );
-// The custom-theme reset button is labelled with the actual theme name.
+// The custom-theme discard button is labelled with the actual theme name and
+// is two-step: first click arms, second confirms (cave-5lsj — an imported
+// theme is unrecoverable once cleared).
 assert.match(
   source,
-  /aria-label=\{`Reset \$\{customData\.name\}`\}/,
-  "the custom-theme reset button names the theme it resets",
+  /aria-label=\{resetCustomArmed \? `Really discard \$\{customData\.name\}\? Click again to confirm` : `Discard \$\{customData\.name\}`\}/,
+  "the custom-theme discard button names the theme and confirms via a second click",
 );
+assert.match(source, /setResetCustomArmed\(false\), 4000\)/, "arming auto-disarms after a beat");
 
 assert.match(source, /className="max-w-none space-y-6"/, "settings pages fill the full pane width (no narrow max-w-2xl column on desktop)");
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1653,7 +1653,21 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
     return () => mq.removeEventListener("change", onChange);
   }, [mode, activeTheme, customData]);
 
+  // Two-step: an imported/tuned theme is unrecoverable once cleared (recovery
+  // = re-import from a remembered URL), and the trigger is a ~14px X. First
+  // click arms, second confirms; arming auto-disarms after a beat (cave-5lsj).
+  const [resetCustomArmed, setResetCustomArmed] = useState(false);
+  useEffect(() => {
+    if (!resetCustomArmed) return;
+    const t = window.setTimeout(() => setResetCustomArmed(false), 4000);
+    return () => window.clearTimeout(t);
+  }, [resetCustomArmed]);
   const handleResetCustom = () => {
+    if (!resetCustomArmed) {
+      setResetCustomArmed(true);
+      return;
+    }
+    setResetCustomArmed(false);
     clearCustomTheme();
     setActiveTheme("coven");
     setCustomData(null);
@@ -1767,14 +1781,20 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
               <button
                 type="button"
                 onClick={handleResetCustom}
-                className="focus-ring ml-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full opacity-70 hover:opacity-100"
-                aria-label={`Reset ${customData.name}`}
+                className={`focus-ring ml-1 inline-flex items-center justify-center rounded-full ${
+                  resetCustomArmed
+                    ? "h-auto w-auto px-1.5 text-[10px] font-semibold text-[var(--color-danger)]"
+                    : "h-3.5 w-3.5 opacity-70 hover:opacity-100"
+                }`}
+                aria-label={resetCustomArmed ? `Really discard ${customData.name}? Click again to confirm` : `Discard ${customData.name}`}
               >
-                <Icon name="ph:x-bold" width={9} />
+                {resetCustomArmed ? "Discard?" : <Icon name="ph:x-bold" width={9} />}
               </button>
             </span>
             <span className="text-[11px] text-[var(--text-muted)]">
-              Active — presets below will override.
+              {resetCustomArmed
+                ? "Click again to discard — re-importing needs the original URL."
+                : "Active — presets below will override."}
             </span>
           </div>
         )}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -472,8 +472,8 @@ assert.match(
 );
 assert.match(
   source,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
-  "each row derives active/split/idle from mode + open split pages",
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes, \{ grimoireView: props\.grimoireView \}\)\}/,
+  "each row derives active/split/idle from mode + open split pages + the Grimoire tab (Journal row, cave-s9p6)",
 );
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -61,6 +61,9 @@ export type SidebarMinimalProps = {
    *  Their rows get a lighter "open in split" wash instead of the active fill,
    *  so the highlight stays honest when a page renders beside the primary. */
   splitPageModes?: readonly string[];
+  /** Grimoire's current tab — lights the Journal row (not Grimoire) while the
+   *  Journal tab is up, since `mode` is never "journal" (cave-s9p6). */
+  grimoireView?: string;
   /** Role Surface rooms visible for the active familiar. Registry-driven —
    *  rendered as their own cluster; empty/omitted hides the cluster. */
   roleSurfaces?: readonly SidebarRoleSurfaceRow[];
@@ -289,7 +292,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             // Active follows the primary mode (Roles/Capabilities keep the
             // Marketplace hub lit); pages open as split tiles get a lighter
             // "open in split" state instead. Derivation in lib/sidebar-nav-state.
-            state={sidebarRowState(fm.id, mode, props.splitPageModes)}
+            state={sidebarRowState(fm.id, mode, props.splitPageModes, { grimoireView: props.grimoireView })}
             badge={fm.badge?.(props)}
             kbd={fm.kbd}
             description={fm.description}

--- a/src/components/snooze-menu.test.ts
+++ b/src/components/snooze-menu.test.ts
@@ -59,8 +59,11 @@ assert.match(
 );
 
 // ── Workspace inbox callbacks (calendar et al) announce too ──────────────────
-assert.match(ws, /void fetch\(`\/api\/inbox\/\$\{id\}\/done`, \{ method: "POST" \}\);\s*\n\s*announce\("Marked done\."\);/, "complete announces");
-assert.match(ws, /void fetch\(`\/api\/inbox\/\$\{id\}\/dismiss`, \{ method: "POST" \}\);\s*\n\s*announce\("Dismissed\."\);/, "dismiss announces");
+// The writes are now VERIFIED (cave-x6k5): failure re-syncs from the server
+// and corrects the announcement instead of leaving the optimistic state lying.
+assert.match(ws, /verifyInboxWrite\(fetch\(`\/api\/inbox\/\$\{id\}\/done`, \{ method: "POST" \}\), "Couldn't mark done — restored\."\);\s*\n\s*announce\("Marked done\."\);/, "complete announces and verifies");
+assert.match(ws, /verifyInboxWrite\(fetch\(`\/api\/inbox\/\$\{id\}\/dismiss`, \{ method: "POST" \}\), "Couldn't dismiss — restored\."\);\s*\n\s*announce\("Dismissed\."\);/, "dismiss announces and verifies");
 assert.match(ws, /announce\("Snoozed\."\);/, "snooze announces");
+assert.match(ws, /void refreshInbox\(\);/, "a failed write re-syncs the inbox from the server");
 
 console.log("snooze-menu.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -127,6 +127,7 @@ function openReleasePageInBrowser(): void {
 
 type Resolved =
   | { kind: "current" }
+  | { kind: "unknown"; message: string }
   | { kind: "native"; version: string; update: TauriUpdate }
   | { kind: "native-unavailable"; version: string; url: string; message: string }
   | { kind: "fallback"; version: string; url: string };
@@ -144,6 +145,11 @@ async function resolveUpdate(): Promise<Resolved> {
       return { kind: "native-unavailable", version: fb.latest, url, message: native.message };
     }
     return { kind: "fallback", version: fb.latest, url };
+  }
+  if (native.kind === "failed" && !fb) {
+    // BOTH checks failed (true offline): currency is unknowable. Affirming
+    // "Up to date" here sent offline users away confident (cave-lsk4).
+    return { kind: "unknown", message: native.message };
   }
   return { kind: "current" };
 }
@@ -172,7 +178,10 @@ export function UpdateBannerTrigger() {
     const runCheck = () => {
       if (installing) return;
       void resolveUpdate().then((r) => {
-        if (cancelled || installing || r.kind === "current") return;
+        // "unknown" (both checks unreachable) stays quiet here — the periodic
+        // banner must not nag about connectivity; the Settings row reports it
+        // honestly on an explicit check (cave-lsk4).
+        if (cancelled || installing || r.kind === "current" || r.kind === "unknown") return;
         if (isDismissed(r.version)) return;
 
         pushBanner({
@@ -234,6 +243,7 @@ export function UpdateBannerTrigger() {
 type RowState =
   | { phase: "checking" }
   | { phase: "current" }
+  | { phase: "unknown"; message: string }
   | { phase: "available"; r: Extract<Resolved, { kind: "native" | "fallback" }> }
   | { phase: "native-unavailable"; r: Extract<Resolved, { kind: "native-unavailable" }> }
   | { phase: "downloading"; version: string; pct: number }
@@ -255,6 +265,7 @@ export function UpdateSettingsRow() {
     void resolveUpdate().then((r) => {
       if (!mounted.current) return;
       if (r.kind === "current") setState({ phase: "current" });
+      else if (r.kind === "unknown") setState({ phase: "unknown", message: r.message });
       else if (r.kind === "native-unavailable") setState({ phase: "native-unavailable", r });
       else setState({ phase: "available", r });
     });
@@ -360,6 +371,24 @@ export function UpdateSettingsRow() {
         >
           Open release page in Browser
         </Button>
+        <Button
+          variant="secondary"
+          size="xs"
+          onClick={check}
+          className={secondaryBtn}
+        >
+          Retry
+        </Button>
+      </>
+    );
+  } else if (state.phase === "unknown") {
+    // Both the native check and the fallback fetch failed — we could not
+    // verify anything, so don't claim currency (cave-lsk4).
+    control = (
+      <>
+        <span className="text-[12px] text-[var(--color-warning)]" title={state.message}>
+          Couldn&apos;t check — you may be offline
+        </span>
         <Button
           variant="secondary"
           size="xs"

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -633,12 +633,10 @@ export function WorkspaceSidebar({
                       ) : null}
                       <button
                         type="button"
-                        onClick={() => {
-                          if (group.projectRoot) {
-                            window.dispatchEvent(new CustomEvent("cave:code-select-project", { detail: { root: group.projectRoot } }));
-                          }
-                          onNewChat(group.projectRoot);
-                        }}
+                        // (cave-gg5d) A "cave:code-select-project" dispatch used
+                        // to precede this — its only listener lived in the
+                        // unmounted ComuxView; onNewChat does the real work.
+                        onClick={() => onNewChat(group.projectRoot)}
                         title={`New chat in ${label}`}
                         aria-label={`New chat in ${label}`}
                         className="cnav__icon-btn focus-ring"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -44,7 +44,6 @@ import {
 } from "@/lib/familiar-memory";
 import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
-import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import type { BrowserPaneHandle } from "@/components/browser-pane";
 // Heavy, mode-gated surfaces are code-split via @/components/lazy-surfaces so
 // their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
@@ -59,7 +58,7 @@ import {
 } from "@/components/lazy-surfaces";
 import { WorkspaceSidebar } from "@/components/workspace-sidebar";
 import { OpenCovenSubmissionPage } from "@/components/opencoven-submission-page";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending, markProjectsTabPending } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";
 import { MobileHandoffModal } from "@/components/mobile-handoff-modal";
@@ -298,6 +297,8 @@ export function Workspace() {
   // false until the first /api/sessions/list fetch settles — lets the chat
   // list show a skeleton instead of flashing its empty state on boot.
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
+  // The last session-list load failed (cave-x6k5) — see loadSessions.
+  const [sessionsError, setSessionsError] = useState(false);
   // Monotonic sequence guard for loadSessions (see its definition): the list is
   // scoped to the active familiar, and loadSessions re-fires on every scope
   // change, so a stale in-flight load must not paint the previous familiar's
@@ -441,7 +442,6 @@ export function Workspace() {
   const [editingReminder, setEditingReminder] = useState<InboxItem | null>(null);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
-  const [addChooserOpen, setAddChooserOpen] = useState(false);
   const [mobileHandoffOpen, setMobileHandoffOpen] = useState(false);
   // Continue-on-phone (cave-i74f): the chat id riding the next handoff QR.
   const [mobileHandoffChatId, setMobileHandoffChatId] = useState<string | null>(null);
@@ -858,8 +858,15 @@ export function Workspace() {
         const sessionsResult = await fetch(`/api/sessions/list${scope}`, { cache: "no-store" });
         const json = await sessionsResult.json();
         if (!isCurrent()) return; // superseded by a newer load / scope change
-        if (!json.ok) return;
+        if (!json.ok) {
+          // A failed list is NOT "no chats" — flag it so the chat list can
+          // render a truthful can't-load state instead of the first-run
+          // empty state (cave-x6k5). The 4s poll retries.
+          setSessionsError(true);
+          return;
+        }
 
+        setSessionsError(false);
         const baseSessions = (json.sessions ?? []) as SessionRow[];
         // The 4s poll rebuilds a fresh array each tick; keep the previous
         // reference when nothing changed so an unchanged list doesn't re-render
@@ -880,7 +887,7 @@ export function Workspace() {
           });
         }
       } catch {
-        /* transient */
+        if (isCurrent()) setSessionsError(true); // transient — poll retries
       } finally {
         if (!baseSessionsApplied && isCurrent()) setSessionsLoaded(true);
       }
@@ -1260,43 +1267,61 @@ export function Workspace() {
     }
   }, []);
 
-  // Calendar item actions — optimistic local update + fire-and-forget POST;
-  // the /api/inbox/stream SSE reconciles authoritative state (same pattern as
-  // dismissToast/snoozeToast). The optimistic update is invisible to AT, so
-  // each action announces its outcome (generic on purpose: the callbacks are
-  // [] -deps'd and only carry the id — no stale-closure title lookups).
+  // Calendar item actions — optimistic local update + verified POST; the
+  // /api/inbox/stream SSE reconciles authoritative state on SUCCESS, but a
+  // FAILED write emits no SSE event, so each action now re-syncs from the
+  // server and corrects the announcement when its request fails — the old
+  // fire-and-forget left items visually done and told AT "Marked done."
+  // regardless (cave-x6k5). Announcements stay generic on purpose: the
+  // callbacks are [] -deps'd and only carry the id.
   const { announce } = useAnnouncer();
+  const verifyInboxWrite = useCallback((req: Promise<Response>, failureNote: string) => {
+    void req
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      })
+      .catch(() => {
+        announce(failureNote, "assertive");
+        void refreshInbox();
+      });
+  }, [announce, refreshInbox]);
   const completeInboxItem = useCallback((id: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "done" } : it)));
-    void fetch(`/api/inbox/${id}/done`, { method: "POST" });
+    verifyInboxWrite(fetch(`/api/inbox/${id}/done`, { method: "POST" }), "Couldn't mark done — restored.");
     announce("Marked done.");
-  }, [announce]);
+  }, [announce, verifyInboxWrite]);
   const dismissInboxItem = useCallback((id: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "dismissed" } : it)));
-    void fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
+    verifyInboxWrite(fetch(`/api/inbox/${id}/dismiss`, { method: "POST" }), "Couldn't dismiss — restored.");
     announce("Dismissed.");
-  }, [announce]);
+  }, [announce, verifyInboxWrite]);
   const snoozeInboxItem = useCallback((id: string, untilIso: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "snoozed", snoozeUntil: untilIso } : it)));
-    void fetch(`/api/inbox/${id}/snooze`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ untilIso }),
-    });
+    verifyInboxWrite(
+      fetch(`/api/inbox/${id}/snooze`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ untilIso }),
+      }),
+      "Couldn't snooze — restored.",
+    );
     announce("Snoozed.");
-  }, [announce]);
+  }, [announce, verifyInboxWrite]);
   // Drag-to-reschedule from the calendar: move the item to a new fireAt and make
-  // it pending there (clearing any snooze). Optimistic; the SSE stream reconciles.
+  // it pending there (clearing any snooze). Optimistic; verified like the rest.
   const rescheduleInboxItem = useCallback((id: string, fireAtIso: string) => {
     setInboxItems((prev) =>
       prev.map((it) => (it.id === id ? { ...it, fireAt: fireAtIso, status: "pending", snoozeUntil: null } : it)),
     );
-    void fetch(`/api/inbox/${id}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ fireAt: fireAtIso, status: "pending", snoozeUntil: null }),
-    });
-  }, []);
+    verifyInboxWrite(
+      fetch(`/api/inbox/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fireAt: fireAtIso, status: "pending", snoozeUntil: null }),
+      }),
+      "Couldn't reschedule — restored.",
+    );
+  }, [verifyInboxWrite]);
 
   // Poll Inbox for unresolved-escalations count — drives the
   // sidebar/daemon-bar Inbox badge. Cheap GET every 30s; the route
@@ -1535,6 +1560,10 @@ export function Workspace() {
       window.location.hash = `card-${link.ref}`;
     } else if (link.kind === "session") {
       openFamiliarSession(link.ref);
+    } else if (link.kind === "memory") {
+      // LinkRef supported "memory" but this fell through silently — a visible
+      // Link button that did nothing (cave-gg5d). Grimoire is the memory reader.
+      openGrimoireDoc("memory", link.ref);
     }
   }, [nextRouter, openFamiliarSession]);
 
@@ -1618,6 +1647,7 @@ export function Workspace() {
         // ⌘9 -> Projects tab inside chat surface (no SURFACE_ORDER lookup needed)
         if (e.key === "9") {
           e.preventDefault();
+          markProjectsTabPending(); // latch beats the fresh-mount race (cave-c2zf)
           setMode("chat");
           window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT)), 0);
           return;
@@ -1776,20 +1806,14 @@ export function Workspace() {
     [addSplitTarget, mode],
   );
 
+  // (cave-gg5d) The old "cave:salem-undock" dispatches here had NO listener
+  // anywhere — SalemChatPanel's unmount does the real teardown.
   const closeSplit = useCallback(() => {
-    // Tell Salem it's undocking so it can pause, mirroring the old rail teardown.
-    setSplitTargets((prev) => {
-      if (prev.some((target) => target.kind === "salem")) window.dispatchEvent(new CustomEvent("cave:salem-undock"));
-      return [];
-    });
+    setSplitTargets([]);
   }, []);
 
   const closeSplitTile = useCallback((id: string) => {
-    setSplitTargets((prev) => {
-      const closing = prev.find((target) => splitTargetKey(target) === id);
-      if (closing?.kind === "salem") window.dispatchEvent(new CustomEvent("cave:salem-undock"));
-      return removeSecondaryWorkspaceTile(prev, id, splitTargetKey);
-    });
+    setSplitTargets((prev) => removeSecondaryWorkspaceTile(prev, id, splitTargetKey));
   }, []);
 
   // Promote a split tile to the sole surface (its divider was dragged past the
@@ -1860,6 +1884,7 @@ export function Workspace() {
     if (intent.kind === "open-project") {
       // Open the Chat surface's Projects tab, then ask it to expand + scroll the
       // chosen project into view once it has mounted.
+      markProjectsTabPending(); // latch beats the fresh-mount race (cave-c2zf)
       setMode("chat");
       shellRef.current?.dismissNavMobile();
       const root = intent.root;
@@ -1932,7 +1957,7 @@ export function Workspace() {
         setMode("board");
         return true;
       case "/journal":
-        setMode("journal"); // redirects to Settings → Familiars → Journal
+        setMode("journal"); // opens the Grimoire on its Journal tab (see setMode)
         return true;
       case "/canvas":
         // The Canvas page moved to feature/journal-canvas-surface. /canvas is
@@ -1965,6 +1990,7 @@ export function Workspace() {
         setShortcutsOpen(true);
         return true;
       case "/projects":
+        markProjectsTabPending(); // latch beats the fresh-mount race (cave-c2zf)
         setMode("chat");
         window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT)), 0);
         return true;
@@ -2177,6 +2203,7 @@ export function Workspace() {
     <SidebarMinimal
       mode={mode}
       splitPageModes={splitPageModes}
+      grimoireView={grimoireView}
       // Registered Role Surfaces visible for the active familiar — rendered by
       // the sidebar as generic rows (rooms), never named in shell code.
       roleSurfaces={roleSurfaceSession.visibleSurfaces.map((surface) => ({
@@ -2307,6 +2334,7 @@ export function Workspace() {
         routerRef={routerRef}
         hideThreadRail
         sessionsLoaded={sessionsLoaded}
+        sessionsError={sessionsError}
         familiarsLoaded={familiarsLoaded}
         familiarsError={familiarsError}
         onRetryFamiliars={() => void loadFamiliars()}
@@ -2664,39 +2692,6 @@ export function Workspace() {
         open={glyphPickerFor !== null}
         familiar={glyphPickerFor}
         onClose={() => setGlyphPickerFor(null)}
-      />
-
-      <ChooserModal
-        open={addChooserOpen}
-        onClose={() => setAddChooserOpen(false)}
-        breadcrumb={["CovenCave", "Add"]}
-        options={
-          [
-            {
-              id: "reminder",
-              icon: "ph:alarm-bold",
-              title: "Reminder",
-              description: "Schedule a reminder to fire at a specific time.",
-            },
-            {
-              id: "board-card",
-              icon: "ph:kanban",
-              title: "Board card",
-              description: "Queue work for a familiar on the board.",
-            },
-            {
-              id: "familiar",
-              icon: "ph:sparkle",
-              title: "Familiar",
-              description: "Run setup to scaffold a new familiar.",
-            },
-          ] as ChooserOption[]
-        }
-        onPick={(id) => {
-          if (id === "reminder") openReminderModal();
-          else if (id === "board-card") setMode("board");
-          else if (id === "familiar") openOnboarding();
-        }}
       />
 
       <MobileHandoffModal

--- a/src/lib/chat-hosts.test.ts
+++ b/src/lib/chat-hosts.test.ts
@@ -78,8 +78,16 @@ assert.deepEqual(
   { ok: true, runtime: { kind: "ssh", host: "vm-1", cwd: "/srv/elsewhere", command: "coven" } },
   "resume re-pins the conversation's host AND its recorded cwd",
 );
-// …but a host that has since been unregistered falls back to the binding.
-assert.deepEqual(resolve(null, "ssh:gone-host:/srv"), { ok: true, runtime: null });
+// …but a host that has since been unregistered FAILS CLOSED: silently falling
+// back to the (local) binding lost the remote context and surprise-relocated
+// execution (cave-4zdp). The error names the host and the re-pick path.
+{
+  const gone = resolve(null, "ssh:gone-host:/srv");
+  assert.equal(gone.ok, false, "recorded-host-gone refuses, not silently local");
+  assert.match(gone.error, /gone-host/, "names the missing host");
+  assert.match(gone.error, /no longer registered/, "explains why");
+  assert.match(gone.error, /host chip/i, "points at the re-pick affordance");
+}
 assert.deepEqual(resolve(null, "local:/Users/val/repo"), { ok: true, runtime: null }, "local conversations defer to the binding");
 assert.deepEqual(resolve(null, null), { ok: true, runtime: null });
 

--- a/src/lib/chat-hosts.ts
+++ b/src/lib/chat-hosts.ts
@@ -141,6 +141,15 @@ export function resolveRequestedRuntime(args: {
     // Re-pin the conversation's host, keeping its recorded cwd (the harness
     // session store on the remote is cwd-scoped, same as local resume).
     if (match) return { ok: true, runtime: { ...match, cwd: recorded.cwd || match.cwd } };
+    // The recorded host is GONE from the registry. Falling through to the
+    // familiar's (local) binding silently continued the chat as a FRESH LOCAL
+    // session — remote context lost, execution surprise-relocated (cave-4zdp).
+    // Fail closed like an explicit unregistered pick; the host chip lets the
+    // user deliberately re-pick Local or another host.
+    return {
+      ok: false,
+      error: `this chat ran on host '${recorded.host}', which is no longer registered — pick a host (or Local) from the chat's host chip to continue`,
+    };
   }
   return { ok: true, runtime: null };
 }

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -25,3 +25,17 @@ export function consumeCovenTabPending(): boolean {
   covenTabPending = false;
   return pending;
 }
+
+// Same latch for the Projects tab: board→Projects handoffs (board-inspector,
+// ⌘9, /projects) dispatched CHAT_OPEN_PROJECTS_EVENT on a 0ms timeout while
+// ChatSurface — the only listener — was still mounting; a lost race landed on
+// Chat without the Projects tab (cave-c2zf).
+let projectsTabPending = false;
+export function markProjectsTabPending(): void {
+  projectsTabPending = true;
+}
+export function consumeProjectsTabPending(): boolean {
+  const pending = projectsTabPending;
+  projectsTabPending = false;
+  return pending;
+}

--- a/src/lib/sidebar-nav-state.test.ts
+++ b/src/lib/sidebar-nav-state.test.ts
@@ -35,3 +35,32 @@ test("no split modes provided behaves like an empty list", () => {
   assert.equal(sidebarRowState("board", "home"), "idle");
   assert.equal(sidebarRowState("board", "home", []), "idle");
 });
+
+test("deep-linkable modes hosted by another surface light the host row (cave-s9p6)", () => {
+  assert.equal(sidebarRowState("inbox", "calendar"), "active", "calendar renders on Schedules");
+  assert.equal(sidebarRowState("board", "familiar-work-queue"), "active", "the Queue is a Tasks-hub tab");
+  assert.equal(sidebarRowState("inbox", "flow"), "active", "retired flow remaps to Schedules");
+});
+
+test("the Journal row keys off the Grimoire tab, not the mode (cave-s9p6)", () => {
+  assert.equal(
+    sidebarRowState("journal", "grimoire", undefined, { grimoireView: "journal" }),
+    "active",
+    "Journal tab up → Journal row lights",
+  );
+  assert.equal(
+    sidebarRowState("grimoire", "grimoire", undefined, { grimoireView: "journal" }),
+    "idle",
+    "Journal tab up → Grimoire row yields",
+  );
+  assert.equal(
+    sidebarRowState("grimoire", "grimoire", undefined, { grimoireView: "docs" }),
+    "active",
+    "other Grimoire tabs keep the Grimoire row",
+  );
+  assert.equal(
+    sidebarRowState("journal", "grimoire"),
+    "idle",
+    "no view provided → unchanged legacy behavior",
+  );
+});

--- a/src/lib/sidebar-nav-state.ts
+++ b/src/lib/sidebar-nav-state.ts
@@ -19,6 +19,12 @@ export type SidebarRowState = "active" | "split" | "idle";
 const MODE_ALIASES: Record<string, string> = {
   roles: "marketplace",
   capabilities: "marketplace",
+  // Deep-linkable modes that render inside another surface left every row
+  // idle (cave-s9p6): the calendar lives on Schedules, the Queue is a tab of
+  // the Tasks hub, and retired "flow" remaps to Schedules in setMode.
+  calendar: "inbox",
+  "familiar-work-queue": "board",
+  flow: "inbox",
 };
 
 function normalizeMode(mode: string): string {
@@ -29,8 +35,18 @@ export function sidebarRowState(
   rowId: string,
   activeMode: string,
   splitPageModes?: readonly string[],
+  opts?: {
+    /** The Grimoire surface's current tab. `mode` is never "journal" (setMode
+     *  remaps it to grimoire+journal tab), so without this the Journal row
+     *  could never light — Grimoire lit instead (cave-s9p6). */
+    grimoireView?: string;
+  },
 ): SidebarRowState {
-  if (normalizeMode(activeMode) === rowId) return "active";
+  const effectiveActive =
+    activeMode === "grimoire" && opts?.grimoireView === "journal"
+      ? "journal"
+      : normalizeMode(activeMode);
+  if (effectiveActive === rowId) return "active";
   if (splitPageModes?.some((m) => normalizeMode(m) === rowId)) return "split";
   return "idle";
 }

--- a/src/lib/use-armed-confirm.ts
+++ b/src/lib/use-armed-confirm.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Two-step destructive click: the first click arms (caller swaps the label to
+ * a "Really …?" variant), the second fires. Arming auto-disarms after `ms`.
+ * For one-click removals that have neither confirm nor undo (cave-5lsj) in an
+ * app that otherwise trains users to expect undo.
+ */
+export function useArmedConfirm(ms = 4000): {
+  armed: boolean;
+  /** First call arms; a second call within the window disarms and runs `fire`. */
+  trigger: (fire: () => void) => void;
+  disarm: () => void;
+} {
+  const [armed, setArmed] = useState(false);
+  const armedRef = useRef(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const t = window.setTimeout(() => {
+      armedRef.current = false;
+      setArmed(false);
+    }, ms);
+    return () => window.clearTimeout(t);
+  }, [armed, ms]);
+
+  const trigger = useCallback((fire: () => void) => {
+    if (armedRef.current) {
+      armedRef.current = false;
+      setArmed(false);
+      fire();
+      return;
+    }
+    armedRef.current = true;
+    setArmed(true);
+  }, []);
+
+  const disarm = useCallback(() => {
+    armedRef.current = false;
+    setArmed(false);
+  }, []);
+
+  return { armed, trigger, disarm };
+}

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -78,6 +78,34 @@
 .cave-host-choice--connect { color: var(--text-muted); }
 .cave-host-choice--connect:hover { color: var(--text-primary); }
 
+/* Row wrapper: the radio row plus (for ssh hosts) a small remove affordance —
+   the registry had no removal path anywhere (cave-4zdp). Two-step: the button
+   swaps to a "Remove?" confirm before firing. */
+.cave-host-choice-row { display: flex; align-items: center; gap: 4px; }
+.cave-host-choice-row .cave-host-choice { flex: 1; min-width: 0; }
+.cave-host-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 4px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  cursor: pointer;
+}
+.cave-host-remove:hover { background: var(--bg-raised); color: var(--color-danger); }
+.cave-host-remove.is-armed {
+  border-color: color-mix(in oklch, var(--color-danger) 42%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 10%, transparent);
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
 /* Connect-new-host dialog */
 .cave-connect-host { display: flex; flex-direction: column; gap: 12px; }
 .cave-connect-host__hint { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-muted); }


### PR DESCRIPTION
Final batch from the 2026-07-09 pre-rollout UX audit (P1s: #2884, P2s: #2888).

## Fixes

**cave-s9p6 — sidebar highlight misses.** `calendar`/`familiar-work-queue`/`flow` now alias to their host rows (Schedules / Tasks); the Journal row lights while the Grimoire's Journal tab is up (new `grimoireView` option on `sidebarRowState`, threaded from the workspace). Unit tests added.

**cave-c2zf — board→Projects handoff race.** `markProjectsTabPending`/`consumeProjectsTabPending` (same shape as the coven-tab latch) wired at all three emitters and consumed on ChatSurface mount.

**cave-lsk4 — updater offline lie.** When BOTH the native check and the fallback release fetch fail, the Settings row says "Couldn't check — you may be offline" with Retry instead of "Up to date"; the periodic banner deliberately stays quiet on unknown. (The PAT-save network-vs-invalid half of this bead shipped in #2884.)

**cave-x6k5 — truthful-degradation stragglers.** Inbox complete/dismiss/snooze/reschedule verify their POSTs — failure re-syncs from the server and announces "Couldn't … — restored." assertively; a failed `/api/sessions/list` renders "Can't load chats right now" (threaded `sessionsError` workspace→ChatList) instead of "Ready for a new thread"; two consecutive failed board quiet polls surface a non-blocking "showing earlier data" strip with Retry.

**cave-4zdp — remote-host silent local fallback.** A conversation recorded on an unregistered host now fails closed naming the host and pointing at the host chip (unit-tested); `/api/hosts` gains DELETE (api-contracts updated); both host pickers get a two-step per-row Remove affordance.

**cave-5lsj — one-click destructive settings.** Custom-theme discard (with explanation copy), backdrop Clear, avatar Remove, and per-link Remove are all two-step armed confirms via a new `use-armed-confirm` hook (auto-disarms after 4s).

**cave-gg5d — dead-code sweep (safe parts).** ComuxView/FlowView lazy exports removed; no-listener `cave:salem-undock` and `cave:code-select-project` dispatches dropped; the unopenable workspace Add ChooserModal deleted; reminder `memory` links now open the Grimoire instead of no-oping; stale `/journal` comment fixed. Full source deletion is tracked in cave-c3yt (blocked on the rail-terminal PTY-kill lifecycle decision — ComuxView.removeSession is the app's only pty_stop site).

## Validation
- `pnpm typecheck` ✓ · `test:app` 600 files ✓ · `test:api` 131 ✓ · `test:mobile` 75 ✓ · `check:tests-wired` (802) ✓ · `pnpm build` + bundle budget ✓
- Updated pins to assert the new behavior: roles-tools-navigation, sidebar-minimal, command-palette, snooze-menu, settings-shell-polish, api-contracts (/hosts methods), chat-hosts unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)