### PR TITLE
fix(marketplace): preserve Craft dialog focus fallback

### DIFF
--- a/src/components/marketplace/craft-detail.tsx
+++ b/src/components/marketplace/craft-detail.tsx
@@ -212,6 +212,7 @@ export function CraftDetail({
     <div className="fixed inset-0 z-50 flex justify-end bg-[var(--backdrop-scrim)]" onClick={onClose}>
       <div
         ref={dialogRef}
+        tabIndex={-1}
         role="dialog"
         aria-modal="true"
         aria-label={`${plugin.displayName} Craft details`}

--- a/src/components/marketplace/crafts-marketplace.test.ts
+++ b/src/components/marketplace/crafts-marketplace.test.ts
@@ -39,7 +39,7 @@ for (const heading of [
   "Equip Roles",
   "Effective capabilities",
 ]) {
-  assert.match(craftDetail, new RegExp(heading.replace(/[&]/g, "&")), `${heading} is visible in the Craft dossier`);
+  assert.match(craftDetail, new RegExp(heading), `${heading} is visible in the Craft dossier`);
 }
 assert.match(craftDetail, /plan\.commands\.install\.join\(" "\)/, "exact Codex install argv is shown before confirmation");
 assert.match(craftDetail, /plan\?\.runtime\.disclosure/, "user-scope routing-boundary disclosure is visible");
@@ -48,6 +48,7 @@ assert.match(craftDetail, /originLabel/, "effective Role capability chips retain
 assert.match(craftDetail, /affectedRoles/, "detach-first failure shows affected Roles");
 assert.match(craftDetail, /affectedRolesTruncated/, "bounded detach-first diagnostics disclose omitted Role counts");
 assert.match(craftDetail, /aria-live="polite"/, "plan and action state changes are announced");
+assert.match(craftDetail, /ref=\{dialogRef\}[\s\S]*tabIndex=\{-1\}/, "focus-trap container remains programmatically focusable for its fallback path");
 assert.doesNotMatch(craftDetail, /<label[^>]+className="craft-role-row"/, "Role rows do not nest a button inside a label");
 assert.match(craftDetail, /Install Craft/, "new Crafts expose an explicit install state");
 assert.match(craftDetail, /Update Craft/, "stale Crafts expose an explicit update state");


### PR DESCRIPTION
## Follow-up to #2893

Addresses the two review findings that arrived after the main Craft slice merged:

- add `tabIndex={-1}` to the Craft dossier dialog container so the shared focus trap can use its documented fallback path
- remove the no-op substring replacement in the Craft Marketplace source test that triggered CodeQL's replacement-of-substring-with-itself alert

Validation:

- focused Craft source test
- `pnpm typecheck`
- Craft Marketplace Playwright lifecycle specs (2 passed)
- `git diff --check`
- signed follow-up commit `41819142`