### PR TITLE
fix(board): reconcile bulk patch failures once, after the batch settles (cave-381s)

### DIFF
--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -244,4 +244,24 @@ assert.match(view, /return \(\) => cancelAnimationFrame\(frame\);/, "the scroll 
 assert.doesNotMatch(view, /querySelector<HTMLElement>\(`\[data-card-id="\$\{selectedCardId\}"\]`\)\s*\?\.focus\(\)/, "view switches must not steal focus from the toggle the user clicked");
 assert.match(gantt, /data-card-id=\{row\.cardId\}/, "gantt rows carry data-card-id so the view-switch scroll finds them");
 
+// ── Bulk-op patch failures reconcile ONCE, after the batch settles (cave-381s):
+// a failed patchCard used to `await load()` immediately, reverting the
+// optimistic state of sibling patches still in flight.
+assert.match(view, /inFlightPatchesRef\.current \+= 1/, "every patch enters the in-flight counter");
+assert.match(
+  view,
+  /inFlightPatchesRef\.current -= 1;\s*\n\s*if \(inFlightPatchesRef\.current === 0 && reloadWhenPatchesSettleRef\.current\) \{\s*\n\s*reloadWhenPatchesSettleRef\.current = false;\s*\n\s*await load\(\);/,
+  "the reconciling reload waits for the whole batch and runs once",
+);
+assert.doesNotMatch(
+  view,
+  /setActionError\([^)]*Couldn't save changes[^)]*\);\s*\n\s*await load\(\);/,
+  "a patch failure must NOT reload immediately (it reverts in-flight siblings)",
+);
+assert.match(
+  view,
+  /return patchCard\(id, patch\);\s*\n\s*\};\s*\n\s*const create/,
+  "moveCardToStatus returns the patch promise so bulkMove's busy state waits for the batch",
+);
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -365,6 +365,12 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     return "queued" as const;
   };
 
+  // (cave-381s) In-flight PATCH counter + deferred-reconcile flag: a failed
+  // patch inside a parallel bulk batch must not reload the board out from
+  // under its still-in-flight siblings. See patchCard's finally block.
+  const inFlightPatchesRef = useRef(0);
+  const reloadWhenPatchesSettleRef = useRef(false);
+
   const patchCard = async (id: string, patch: CardPatch, armUndo = true) => {
     if ("cwd" in patch || "projectId" in patch) setChatLinkError(null);
     // A date-only patch is a gantt reschedule — snapshot the prior dates so it
@@ -398,6 +404,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
         ? { ...c, ...plain, ...applyCardOps(c, ops, new Date().toISOString()) }
         : { ...c, ...plain };
     }));
+    inFlightPatchesRef.current += 1;
     try {
       const res = await fetch(`/api/board/${id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(patch) });
       const json = await res.json();
@@ -405,14 +412,26 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
         // Revert to the server copy and tell the user — an optimistic change
         // that silently snaps back reads as a glitch.
         setActionError(json.error ? `Couldn't save changes — ${json.error}` : "Couldn't save changes — reverted to the server copy.");
-        await load();
+        reloadWhenPatchesSettleRef.current = true;
       } else {
         setActionError(null);
         if (json.card) setCards((prev) => prev.map((c) => (c.id === id ? (json.card as Card) : c)));
       }
     } catch {
       setActionError("Couldn't reach the server — your change was reverted.");
-      await load();
+      reloadWhenPatchesSettleRef.current = true;
+    } finally {
+      // (cave-381s) Bulk ops fire patchCard per id in parallel; a failure used
+      // to `await load()` IMMEDIATELY, which reverted the optimistic state of
+      // sibling patches still in flight (transient flicker as each settled and
+      // re-applied). The reconciling reload now waits for the whole batch:
+      // only the LAST settling patch runs it, once. A solo patch (count 1→0)
+      // still reloads right away — single-op behavior is unchanged.
+      inFlightPatchesRef.current -= 1;
+      if (inFlightPatchesRef.current === 0 && reloadWhenPatchesSettleRef.current) {
+        reloadWhenPatchesSettleRef.current = false;
+        await load();
+      }
     }
   };
 
@@ -421,7 +440,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     if (status === "running") (patch as Record<string, unknown>).runningSince = new Date().toISOString();
     const title = cards.find((c) => c.id === id)?.title;
     if (title) announce(`Moved '${title}' to ${status.charAt(0).toUpperCase()}${status.slice(1)}.`);
-    void patchCard(id, patch);
+    // Return the patch promise so bulkMove's Promise.all actually waits for
+    // the batch — bulkBusy used to clear while the PATCHes were still in
+    // flight (cave-381s). Fire-and-forget callers are unaffected.
+    return patchCard(id, patch);
   };
 
   const create = async (draft: NewCardDraft) => {


### PR DESCRIPTION
Last open bug from the 2026-07-09 rollout audit backlog (P4, filed pre-audit; was blocked by cave-6fqb whose PR #2684 merged 2026-07-08).

**Bug:** bulk ops fire `patchCard` per id in parallel; one failure ran `await load()` immediately, reloading all cards and reverting the optimistic state of the sibling patches still in flight (transient flicker as each settled and re-applied).

**Fix:** an in-flight counter brackets every PATCH; failures set a reload-when-settled flag, and only the last settling patch runs the single reconciling `load()`. Solo patches (count 1→0) reload immediately — single-op behavior unchanged. `moveCardToStatus` now returns the patch promise so `bulkMove`'s busy state waits for the real batch.

**Validation:** typecheck ✓ · test:app 605 ✓ · test:api 135 ✓ · test:mobile 75 ✓ · tests-wired (811) ✓ · build + bundle budget ✓ · new pins in `board-ux-polish.test.ts` (including a doesNotMatch guard on the old immediate-reload shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)