### PR TITLE
fix(prod): cross-platform path bug, silent quick-add failure, app error boundaries

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -160,6 +160,7 @@ export const SUITES = {
     "src/lib/dashboard-analytics.test.ts",
     "src/lib/coven-analytics.test.ts",
     "src/app/dashboard-page.test.ts",
+    "src/app/prod-hardening.test.ts",
     "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/lib/daily-summary-refresh.test.ts",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Route-level error boundary. Catches render/runtime errors thrown anywhere in
+ * the workspace subtree so one broken component recovers gracefully instead of
+ * white-screening the whole surface. Deliberately dependency-light — the UI that
+ * crashed must not be required to render this fallback.
+ */
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Diagnostics: `digest` ties a client-visible error to the server logs.
+    console.error("Cave surface error:", error);
+  }, [error]);
+
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+        background: "var(--bg-base, #0a0a0a)",
+        color: "var(--text-primary, #e8e8ec)",
+        fontFamily: "var(--font-sans), system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 420,
+          width: "100%",
+          textAlign: "center",
+          padding: "28px 28px 24px",
+          borderRadius: 16,
+          border: "1px solid var(--border-hairline, rgba(255,255,255,0.1))",
+          background: "var(--bg-raised, #141414)",
+        }}
+      >
+        <div style={{ fontSize: 34, lineHeight: 1, marginBottom: 12 }} aria-hidden>
+          ⚠️
+        </div>
+        <h1 style={{ margin: "0 0 6px", fontSize: 18, fontWeight: 600 }}>Something went wrong</h1>
+        <p style={{ margin: "0 0 20px", fontSize: 13, color: "var(--text-muted, #9a9a9a)" }}>
+          This surface hit an unexpected error. You can retry it, or reload the app — your work is
+          saved as you go.
+        </p>
+        <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 8,
+              border: "none",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 500,
+              color: "var(--accent-fg, #fff)",
+              background: "var(--accent-presence, #7c6cf0)",
+            }}
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 8,
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 500,
+              color: "var(--text-primary, #e8e8ec)",
+              background: "transparent",
+              border: "1px solid var(--border-strong, rgba(255,255,255,0.18))",
+            }}
+          >
+            Reload app
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Root error boundary — the last line of defense. Catches errors thrown in the
+ * root layout itself (where the normal `error.tsx` can't help), so a fatal error
+ * still shows a recoverable page instead of a blank white screen on any
+ * distribution. It replaces the whole document, so it renders its own
+ * <html>/<body> and uses hardcoded neutral-dark colors: the theme stylesheet may
+ * not have loaded when the layout is what failed.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Cave fatal error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "grid",
+          placeItems: "center",
+          background: "#0a0a0a",
+          color: "#e8e8ec",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        <div style={{ maxWidth: 400, textAlign: "center", padding: 28 }}>
+          <div style={{ fontSize: 34, marginBottom: 12 }} aria-hidden>
+            ⚠️
+          </div>
+          <h1 style={{ margin: "0 0 6px", fontSize: 18, fontWeight: 600 }}>The app hit a snag</h1>
+          <p style={{ margin: "0 0 20px", fontSize: 13, color: "#9a9a9a" }}>
+            CovenCave ran into an unexpected error while starting this view. Reloading usually
+            clears it.
+          </p>
+          <button
+            type="button"
+            onClick={() => reset()}
+            style={{
+              padding: "8px 18px",
+              borderRadius: 8,
+              border: "none",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 500,
+              color: "#fff",
+              background: "#7c6cf0",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/prod-hardening.test.ts
+++ b/src/app/prod-hardening.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+// [1] Windows path normalization must use a SINGLE backslash. The prior
+// `replace(/\//g, "\\\\")` emitted doubled backslashes, producing malformed
+// paths that broke the spawn cwd + the allow-list comparison on Windows.
+const scope = read("../lib/chat-runtime-scope.ts");
+assert.doesNotMatch(scope, /\\{4,}/, "chat-runtime-scope has no doubled-backslash Windows path replacement");
+assert.match(scope, /SINGLE backslash/, "the Windows path fix documents single-backslash normalization");
+
+// [2] Board quick-add create() must surface failures, not silently drop them
+// (the caller `void`s the promise). It guards the parse and shows the banner.
+const board = read("../components/board-view.tsx");
+assert.match(
+  board,
+  /const create = async \(draft[\s\S]*?try \{[\s\S]*?setActionError\(/,
+  "board create() surfaces errors via the inline error banner",
+);
+assert.match(board, /res\.json\(\)\.catch\(/, "board create() guards the response parse against non-JSON");
+
+// [3] App-level error boundaries so a thrown component recovers instead of
+// white-screening the app on any distribution.
+for (const f of ["./error.tsx", "./global-error.tsx"]) {
+  const s = read(f);
+  assert.match(s, /"use client";/, `${f} is a client component`);
+  assert.match(s, /export default function/, `${f} exports a default error boundary`);
+  assert.match(s, /reset\(\)/, `${f} offers a reset/recovery action`);
+}
+assert.match(read("./global-error.tsx"), /<html/, "global-error renders its own document (root-layout failures)");
+
+console.log("prod-hardening guard passed");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -447,11 +447,24 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   };
 
   const create = async (draft: NewCardDraft) => {
-    const res = await fetch("/api/board", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(draft) });
-    const json = await res.json();
-    if (!json.ok) throw new Error(json.error ?? "create failed");
-    announce(`Created task '${draft.title.trim()}'.`);
-    await load();
+    try {
+      const res = await fetch("/api/board", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(draft) });
+      // Guard the parse: a 500/HTML error page is not JSON and would otherwise
+      // throw an opaque parse error into the caller (which quick-add `void`s,
+      // silently dropping the failure).
+      const json = await res.json().catch(() => ({ ok: false, error: "the server returned an unreadable response" }));
+      if (!json.ok) throw new Error(json.error ?? "create failed");
+      setActionError(null);
+      announce(`Created task '${draft.title.trim()}'.`);
+      await load();
+    } catch (err) {
+      // Surface to the board's inline error banner so a failed quick-add is
+      // never silent; rethrow so the New-card modal path can react too.
+      setActionError(
+        err instanceof Error ? `Couldn't create the task — ${err.message}` : "Couldn't create the task.",
+      );
+      throw err;
+    }
   };
 
   // Inline quick-add from a kanban column: title-only card in that column's

--- a/src/lib/chat-runtime-scope.ts
+++ b/src/lib/chat-runtime-scope.ts
@@ -31,7 +31,11 @@ export type RuntimeScope =
 function normalizePath(p: string): string {
   if (process.platform === "win32") {
     if (/^[a-zA-Z]:$/.test(p)) return p + "\\";
-    return p.replace(/\//g, "\\\\");
+    // Convert forward slashes to a SINGLE backslash. The earlier replacement
+    // used an escaped-backslash literal that expanded to TWO backslashes per
+    // slash, producing malformed Windows paths that broke the spawn cwd and the
+    // allow-list path comparison.
+    return p.replace(/\//g, "\\");
   }
   return p;
 }


### PR DESCRIPTION
Production-readiness hardening from a **full audit** across three dimensions (cross-platform correctness, runtime robustness, distribution/native config). Three concrete, adversarially-verified fixes here; the rest of the audit is documented below.

## Fixes in this PR
1. **Windows path bug (cross-platform blocker)** — `chat-runtime-scope.ts` `normalizePath` replaced `/` with **two** backslashes (an escaped-backslash literal), producing malformed paths like `C:\\Users\\x`. This fed the **harness spawn cwd** and the **allow-list path comparison**, so remote/local runtime scoping was broken on Windows. → single backslash.
2. **Silent quick-add failure (robustness)** — board `create()` left `res.json()` unguarded and threw into a caller that `void`s the promise, so a failed task-create showed **no feedback** (looks like nothing happened). → guards the parse + surfaces the error via the board's inline banner, still rethrows for the New-card modal path.
3. **No app-level error recovery (robustness, all distributions)** — a thrown component **white-screened the whole app** (no `error.tsx`/`global-error.tsx`). → adds route-level `src/app/error.tsx` + a self-contained root `global-error.tsx` with a reset/reload recovery UI.

Guard test `src/app/prod-hardening.test.ts` pins all three (wired into the runner, 812 files). `typecheck` + `pnpm build` green. No score/behaviour changes beyond the fixes.

## Full audit — baseline
`origin/main` is otherwise healthy: typecheck clean, **0** stray `console.log`/`debugger`, **no other hardcoded dev paths** (the one — `/Users/buns/.coven/memory` — was already fixed in #2889), version stamps consistent (`0.0.171`), required CI green. Platform branching (`which`/`where`, `.exe`/`.cmd`, registry PATH, `path.join`/`path.sep`, `\r?\n`) is broadly correct.

## Deferred findings (tracked in beads `cave-vcyh`) — intentional/risky or blocked
- **iOS `NSAllowsArbitraryLoads=true`** — disables ATS; *likely intentional* for local-HTTP-over-Tailscale (iOS↔desktop). Needs an owner decision (scope to `NSExceptionDomains`), **not flipped blindly** here to avoid breaking connectivity. (`cave-vcyh.1`)
- **Windows shell PATH fallback** hardcodes `/bin/zsh` (`coven-bin.ts`, `mobile-handoff.ts`) — degraded, not broken (try/catch → system PATH); guard on platform. (`cave-vcyh.2`)
- **Windows MSI unsigned** — SmartScreen warning; blocked on a code-signing cert. (`cave-vcyh.3`)
- Minor/cosmetic (not filed): macOS-only path `existsSync` probes on Win/Linux (guarded, just wasted stats); Rust `.expect()` on a poisoned sidecar mutex (rare); CSP disabled (plausibly intentional for the loopback webview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)