### PR TITLE
fix(stitches): review hardening — connect-time SSRF guard, sandboxed sew, fence-safe parse (cave-746p)

### DIFF
--- a/src/lib/server/pin-sources.test.ts
+++ b/src/lib/server/pin-sources.test.ts
@@ -6,6 +6,7 @@ import {
   githubApiTarget,
   htmlToText,
   isPrivateIp,
+  publicOnlyLookup,
 } from "./pin-sources.ts";
 
 describe("isPrivateIp — SSRF guard ranges", () => {
@@ -44,6 +45,20 @@ describe("isPrivateIp — SSRF guard ranges", () => {
   it("treats non-IP strings as blocked (resolve first)", () => {
     assert.equal(isPrivateIp("localhost"), true);
     assert.equal(isPrivateIp(""), true);
+  });
+});
+
+describe("publicOnlyLookup — connect-time SSRF guard", () => {
+  it("refuses hostnames that resolve to private addresses at CONNECT time", async () => {
+    // localhost resolves to loopback everywhere — the lookup handed to
+    // http(s).request must error instead of returning an address, so the
+    // socket can never reach it (closes the DNS-rebinding TOCTOU: the
+    // validated resolution IS the connection's resolution).
+    const err = await new Promise((resolve) => {
+      publicOnlyLookup("localhost", {}, (e) => resolve(e));
+    });
+    assert.ok(err instanceof Error, "lookup must error");
+    assert.match(err.message, /private address/);
   });
 });
 

--- a/src/lib/server/pin-sources.ts
+++ b/src/lib/server/pin-sources.ts
@@ -16,6 +16,9 @@
 
 import { readFile, stat } from "node:fs/promises";
 import { lookup } from "node:dns/promises";
+import type { LookupAddress, LookupOptions } from "node:dns";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import path from "node:path";
 import { loadConversation, isSafeConversationSessionId } from "../cave-conversations.ts";
@@ -74,22 +77,34 @@ export function isPrivateIp(addr: string): boolean {
   return true; // not an IP literal — callers resolve first
 }
 
-/** Resolve a hostname and reject when ANY address is private. */
-async function assertPublicHost(hostname: string): Promise<string | null> {
-  if (isIP(hostname)) {
-    return isPrivateIp(hostname) ? "URL resolves to a private address" : null;
-  }
-  let addresses: { address: string }[];
-  try {
-    addresses = await lookup(hostname, { all: true });
-  } catch {
-    return "URL hostname did not resolve";
-  }
-  if (addresses.length === 0) return "URL hostname did not resolve";
-  for (const { address } of addresses) {
-    if (isPrivateIp(address)) return "URL resolves to a private address";
-  }
-  return null;
+/**
+ * `dns.lookup`-shaped resolver handed to `http(s).request`: the address it
+ * returns IS the address the socket connects to, so validating here closes
+ * the DNS-rebinding TOCTOU that a check-then-fetch guard leaves open (a TTL-0
+ * host can answer the check with a public IP and the fetch with 127.0.0.1).
+ * Exported for tests.
+ */
+export function publicOnlyLookup(
+  hostname: string,
+  options: LookupOptions,
+  callback: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void,
+): void {
+  lookup(hostname, { all: true })
+    .then((addresses) => {
+      if (addresses.length === 0) {
+        callback(Object.assign(new Error("hostname did not resolve"), { code: "ENOTFOUND" }), "", 4);
+        return;
+      }
+      for (const { address } of addresses) {
+        if (isPrivateIp(address)) {
+          callback(Object.assign(new Error("URL resolves to a private address"), { code: "EACCES" }), "", 4);
+          return;
+        }
+      }
+      if (options?.all) callback(null, addresses);
+      else callback(null, addresses[0].address, addresses[0].family);
+    })
+    .catch((err) => callback(err as NodeJS.ErrnoException, "", 4));
 }
 
 // ── HTML → text ──────────────────────────────────────────────────────────────
@@ -202,6 +217,8 @@ export function githubApiTarget(url: URL): GitHubTarget | null {
 
 // ── Fetch plumbing ───────────────────────────────────────────────────────────
 
+/** Plain fetch for the FIXED GitHub hosts only (no user-controlled hostname —
+ *  no rebinding surface). URL pins go through `requestPublicUrl` instead. */
 async function fetchCapped(url: string, accept: string): Promise<Response> {
   return fetch(url, {
     redirect: "manual",
@@ -217,33 +234,83 @@ async function readBodyCapped(res: Response): Promise<string> {
   return text.length > FETCH_BYTE_CAP ? text.slice(0, FETCH_BYTE_CAP) : text;
 }
 
-/** Fetch a public URL following ≤3 redirects, re-validating EVERY hop. */
+type PlainResponse = { status: number; location: string | null; body: string };
+
+/** One http(s) request whose socket resolves through `publicOnlyLookup` —
+ *  the connection can only ever reach an address that passed the guard. */
+function requestOnce(url: URL): Promise<PlainResponse> {
+  return new Promise((resolve, reject) => {
+    const request = url.protocol === "https:" ? httpsRequest : httpRequest;
+    const req = request(
+      url,
+      {
+        method: "GET",
+        lookup: publicOnlyLookup,
+        headers: {
+          accept: "text/html, text/plain;q=0.9, */*;q=0.1",
+          "user-agent": "coven-cave-grimoire-stitch",
+        },
+        timeout: FETCH_TIMEOUT_MS,
+      },
+      (res) => {
+        const declared = Number(res.headers["content-length"] ?? "0");
+        if (declared > FETCH_BYTE_CAP) {
+          res.destroy();
+          reject(new Error("response too large"));
+          return;
+        }
+        let size = 0;
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => {
+          size += chunk.length;
+          if (size > FETCH_BYTE_CAP) {
+            res.destroy();
+            reject(new Error("response too large"));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            location: typeof res.headers.location === "string" ? res.headers.location : null,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+        res.on("error", reject);
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error("fetch timed out")));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/** Fetch a public URL following ≤3 redirects. Every hop's SOCKET is pinned to
+ *  guard-validated addresses via `publicOnlyLookup` (literal-IP hosts are
+ *  checked directly — node skips lookup for them). */
 async function fetchPublicUrl(startUrl: URL): Promise<{ finalUrl: URL; body: string } | { error: string }> {
   let current = startUrl;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    const hostError = await assertPublicHost(current.hostname);
-    if (hostError) return { error: hostError };
-    let res: Response;
+    if (isIP(current.hostname) && isPrivateIp(current.hostname)) {
+      return { error: "URL resolves to a private address" };
+    }
+    let res: PlainResponse;
     try {
-      res = await fetchCapped(current.toString(), "text/html, text/plain;q=0.9, */*;q=0.1");
-    } catch {
-      return { error: "fetch failed" };
+      res = await requestOnce(current);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "fetch failed";
+      return { error: /private address/.test(message) ? "URL resolves to a private address" : message };
     }
     if (res.status >= 300 && res.status < 400) {
-      const location = res.headers.get("location");
-      res.body?.cancel();
-      if (!location) return { error: "redirect without location" };
-      const next = parseSafeHttpUrl(new URL(location, current).toString());
+      if (!res.location) return { error: "redirect without location" };
+      const next = parseSafeHttpUrl(new URL(res.location, current).toString());
       if (!next) return { error: "redirected to an unsupported URL" };
       current = next;
       continue;
     }
-    if (!res.ok) return { error: `HTTP ${res.status}` };
-    try {
-      return { finalUrl: current, body: await readBodyCapped(res) };
-    } catch (err) {
-      return { error: err instanceof Error ? err.message : "read failed" };
-    }
+    if (res.status < 200 || res.status >= 300) return { error: `HTTP ${res.status}` };
+    return { finalUrl: current, body: res.body };
   }
   return { error: "too many redirects" };
 }

--- a/src/lib/server/stitch-sew.test.ts
+++ b/src/lib/server/stitch-sew.test.ts
@@ -25,7 +25,9 @@ try {
   delete process.env.COVEN_CODEX_BIN;
   let inv = buildSewInvocation(thread, "/tmp/last.txt");
   assert.equal(inv.command, "codex");
-  assert.deepEqual(inv.args, ["exec", "--output-last-message", "/tmp/last.txt", "-"]);
+  // --sandbox read-only pins the run's privileges: the prompt embeds
+  // attacker-influenceable remote content, and a distillation needs no tools.
+  assert.deepEqual(inv.args, ["exec", "--sandbox", "read-only", "--output-last-message", "/tmp/last.txt", "-"]);
   assert.match(inv.stdinPrompt, /TITLE: <entry title/);
   assert.match(inv.stdinPrompt, /Use 5 retries\./);
 

--- a/src/lib/server/stitch-sew.ts
+++ b/src/lib/server/stitch-sew.ts
@@ -29,12 +29,18 @@ export type SewInvocation = {
 
 const SEW_TIMEOUT_MS = 180_000;
 
-/** Pure: how to invoke `codex exec` for a sew. Unit-tested. */
+/** Pure: how to invoke `codex exec` for a sew. Unit-tested.
+ *
+ *  Unlike automation runs (user-authored prompts), the sew prompt embeds
+ *  attacker-influenceable remote content (fetched pages, GitHub bodies), so
+ *  the invocation pins its own privileges instead of inheriting the user's
+ *  codex config: a distillation needs no tools, so `--sandbox read-only`
+ *  overrides any permissive default while the run distills. */
 export function buildSewInvocation(thread: Pick<StitchThread, "title" | "pins">, lastMessagePath: string): SewInvocation {
   const command = process.env.COVEN_CODEX_BIN?.trim() || "codex";
   return {
     command,
-    args: ["exec", "--output-last-message", lastMessagePath, "-"],
+    args: ["exec", "--sandbox", "read-only", "--output-last-message", lastMessagePath, "-"],
     stdinPrompt: buildSewPrompt(thread),
   };
 }
@@ -104,7 +110,9 @@ export async function runAgenticSew(thread: StitchThread): Promise<SewRunResult>
           resolve(value);
         }
       };
-      const child = spawn(inv.command, inv.args, { stdio: ["pipe", "ignore", "ignore"] });
+      // Neutral cwd: the sew's temp dir, not the server checkout — even a
+      // read-only sandbox shouldn't be pointed at the repo as its workspace.
+      const child = spawn(inv.command, inv.args, { cwd: dir, stdio: ["pipe", "ignore", "ignore"] });
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
         settle({ code: null, error: "sew timed out" });

--- a/src/lib/stitch.test.ts
+++ b/src/lib/stitch.test.ts
@@ -121,6 +121,21 @@ describe("sew prompt and output contract", () => {
     assert.deepEqual(out, { title: "T", tags: [], body: "Body" });
   });
 
+  it("never strips code fences INSIDE the body (only a whole-response wrap)", () => {
+    // A correct, unfenced response whose body contains a fenced code block
+    // must come through byte-identical — a line-anchored lazy unfence used to
+    // eat the body's fences (review finding on #2891).
+    const body = "Intro\n```js\nconsole.log(1)\n```\nAfter";
+    const out = parseSewOutput(`TITLE: Foo\nTAGS: a, b\n---\n${body}`);
+    assert.equal(out?.body, body);
+
+    // A fully-fenced response with an internal code block unwraps ONLY the
+    // outer pair (greedy match to the final closing fence).
+    const fenced = "```\nTITLE: Foo\nTAGS: a\n---\nIntro\n```js\nconsole.log(1)\n```\nAfter\n```";
+    const outFenced = parseSewOutput(fenced);
+    assert.equal(outFenced?.body, "Intro\n```js\nconsole.log(1)\n```\nAfter");
+  });
+
   it("rejects malformed output instead of guessing", () => {
     assert.equal(parseSewOutput("Sure! Here's your entry: ..."), null);
     assert.equal(parseSewOutput("TITLE: X\nTAGS: a\n---\n"), null);

--- a/src/lib/stitch.ts
+++ b/src/lib/stitch.ts
@@ -198,8 +198,11 @@ export type SewOutput = {
  *  callers surface that as a retryable failure instead of writing garbage. */
 export function parseSewOutput(text: string): SewOutput | null {
   const trimmed = text.trim();
-  // Tolerate a fenced response even though the prompt forbids it.
-  const unfenced = trimmed.replace(/^```[a-z]*\r?\n([\s\S]*?)\r?\n```$/m, "$1").trim();
+  // Tolerate the WHOLE response being fenced even though the prompt forbids
+  // it. Anchored to the full string (no `m` flag) and greedy: a line-anchored
+  // lazy match would pair a code fence INSIDE the body and strip it, silently
+  // corrupting sewn entries that contain code blocks.
+  const unfenced = trimmed.replace(/^```[a-z]*\r?\n([\s\S]*)\r?\n```$/, "$1").trim();
   const match = unfenced.match(/^TITLE:\s*(.+)\r?\nTAGS:\s*(.*)\r?\n---\r?\n([\s\S]*)$/);
   if (!match) return null;
   const title = match[1].trim();


### PR DESCRIPTION
## Summary

Code-review hardening for Grimoire Stitches (#2891) — three high-confidence findings from the `/review` pass:

1. **Fence-safe sew-output parse** — `parseSewOutput`'s whole-response unfence used a line-anchored lazy match (`/m` flag), which paired a code fence *inside* the body and stripped it: every agentic sew of content containing a code block silently lost its first fence pair. Now anchored to the full string, greedy to the final closing fence, with regression tests for both shapes.

2. **Connect-time SSRF guard (rebinding TOCTOU closed)** — the guard resolved DNS separately from the fetch's own resolution, so a TTL-0 host could answer the check with a public IP and the connect with `127.0.0.1`. URL pins now go through `node:http(s).request` with a custom `lookup` that validates every address at **connect** time — the checked resolution is the socket's resolution. Redirect hops inherit the same lookup; literal-IP hosts (which skip lookup) are checked inline. GitHub pins keep plain fetch (fixed hosts).

3. **Sandboxed agentic sew** — the sew prompt embeds attacker-influenceable remote content but the `codex exec` spawn inherited the user's codex config and the server's cwd. The invocation now pins its own privileges: `--sandbox read-only` plus a neutral temp-dir cwd — a distillation needs no tools.

## Verification

- 135 api + 606 app test files green; tsc clean
- New/updated unit tests: fence regression (unfenced + fully-fenced bodies with internal code blocks), `publicOnlyLookup` refusing loopback at connect time, sandboxed invocation args
- Live smoke test against the dev server: `https://example.com` pin captures with title; `http://localhost:3715/` and `http://169.254.169.254/` both refused with "URL resolves to a private address"

Bead: cave-746p
