### PR TITLE
fix(prod): short-circuit the POSIX login-shell PATH probe on Windows

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -454,6 +454,7 @@ export const SUITES = {
     "src/lib/chat-attachments.test.ts",
     "src/lib/codex-automations.test.ts",
     "src/lib/coven-spawn-error.test.ts",
+    "src/lib/login-shell-win32-guard.test.ts",
     "src/lib/daemon-sync-status.test.ts",
     "src/lib/familiar-glyph.test.ts",
     "src/lib/familiar-memory.test.ts",

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -116,6 +116,9 @@ export function pickWindowsLauncher(lines: string[]): string | null {
 }
 
 function loginShellPath(): string | null {
+  // Windows has no POSIX login shell to source — the `-ilc` probe below would
+  // always fail. Skip it (callers fall back to the registry/system PATH).
+  if (process.platform === "win32") return null;
   // Read SHELL through a deliberately opaque accessor so Turbopack's static
   // analysis can't union the value with a string literal like "/bin/zsh"
   // and treat it as a file pattern that matches the whole project tree.

--- a/src/lib/login-shell-win32-guard.test.ts
+++ b/src/lib/login-shell-win32-guard.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+// Windows has no POSIX login shell to source, so the interactive `-ilc` PATH
+// probe (which falls back to /bin/zsh) always fails there. loginShellPath must
+// short-circuit on win32 instead of attempting the doomed spawn — callers fall
+// back to the Windows registry / system PATH.
+for (const f of ["./coven-bin.ts", "./mobile-handoff.ts"]) {
+  assert.match(
+    read(f),
+    /function loginShellPath\(\): string \| null \{[\s\S]*?process\.platform === "win32"\) return null/,
+    `${f}: loginShellPath short-circuits on Windows`,
+  );
+}
+
+console.log("login-shell-win32-guard passed");

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -64,6 +64,9 @@ function executableExists(candidate: string) {
 }
 
 function loginShellPath(): string | null {
+  // Windows has no POSIX login shell to source — skip the `-ilc` probe (which
+  // would try /bin/zsh and always fail) and fall back to the system PATH.
+  if (process.platform === "win32") return null;
   const env = process.env as Record<string, string | undefined>;
   const shell = env["SHELL"] ?? ["/bin", "zsh"].join("/");
   try {


### PR DESCRIPTION
Resolves the safely-fixable deferred item from the production-readiness audit (`cave-vcyh.2`).

## Fix
`loginShellPath()` (in `coven-bin.ts` and `mobile-handoff.ts`) read `$SHELL`, fell back to `/bin/zsh`, and ran `<shell> -ilc 'echo $PATH'` to capture the interactive-shell PATH. On **Windows** `$SHELL` is unset, so it tried to spawn `/bin/zsh` — which always fails (caught → returns `null`). Now it **short-circuits on `process.platform === "win32"`**: Windows has no POSIX login shell to source, and callers already fall back to the Windows registry / system PATH. This avoids a doomed spawn and makes the intent explicit.

Guard test `src/lib/login-shell-win32-guard.test.ts` pins the win32 short-circuit in both files (wired into the runner). `typecheck` + `pnpm build` green; existing `coven-bin`/`mobile-handoff` suites pass.

## Disposition of the other deferred audit items (updated in beads `cave-vcyh`)
- **iOS `NSAllowsArbitraryLoads` (`cave-vcyh.1`) — kept, by design.** Verified **load-bearing**: iOS connects to the desktop over Tailscale, and per `apps/ios/.../README.md` a bare host/IP defaults to **cleartext `http://<host>:3000`** (only `.ts.net` MagicDNS uses HTTPS). ATS blocks cleartext, and `NSAllowsLocalNetworking` does **not** cover Tailscale's `100.64.0.0/10` CGNAT range — so tightening it would **break IP-based pairing**, the documented core flow. The real fix is a product decision (HTTPS-only via MagicDNS) requiring on-device verification; tracked as such, not a code defect.
- **Windows MSI signing (`cave-vcyh.3`) — externally blocked.** Needs a Windows code-signing certificate before a signing step can be added to `release.yml`; can't be resolved in-repo without the cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)