### PR TITLE
fix(rollout): three P2s from the evening re-audit

### DIFF
--- a/src/app/dashboard/familiars/growth/page.tsx
+++ b/src/app/dashboard/familiars/growth/page.tsx
@@ -13,7 +13,9 @@ export default function FamiliarGrowthDashboardPage() {
             Dashboard
           </a>
           <span className="dr-crumb-sep" aria-hidden>/</span>
-          <a className="dr-back" href="/#familiars">
+          {/* ?mode= is the SPA's deep-link param; a bare #familiars hash has
+              no consumer and landed on the boot surface (cave-aka2). */}
+          <a className="dr-back" href="/?mode=agents">
             Familiars
           </a>
           <span className="dr-crumb-sep" aria-hidden>/</span>

--- a/src/components/familiar-inline-card.tsx
+++ b/src/components/familiar-inline-card.tsx
@@ -19,36 +19,48 @@ import {
   type RawMemoryEntry,
 } from "@/lib/familiar-card-data";
 
-let familiarsCache: Promise<Record<string, FamiliarStatusInfo>> | null = null;
-function loadFamiliarStatus(): Promise<Record<string, FamiliarStatusInfo>> {
+// Module-level caches keep repeated card opens cheap, but a FAILED load must
+// not be cached for the app's lifetime — that turned one transient error into
+// a permanent "No memory yet" on every card until a full reload (cave-2ex2).
+// Failures resolve to null AND clear the cache so the next mount retries.
+let familiarsCache: Promise<Record<string, FamiliarStatusInfo> | null> | null = null;
+function loadFamiliarStatus(): Promise<Record<string, FamiliarStatusInfo> | null> {
   if (!familiarsCache) {
     familiarsCache = fetch("/api/familiars", { cache: "no-store" })
       .then((r) => r.json())
       .then((j) => {
+        if (!j?.ok || !Array.isArray(j.familiars)) throw new Error("familiars load failed");
         const map: Record<string, FamiliarStatusInfo> = {};
-        if (j?.ok && Array.isArray(j.familiars)) {
-          for (const f of j.familiars) {
-            map[f.id] = {
-              status: f.status,
-              lastSeen: f.last_seen ?? null,
-              activeSessions: f.active_sessions,
-            };
-          }
+        for (const f of j.familiars) {
+          map[f.id] = {
+            status: f.status,
+            lastSeen: f.last_seen ?? null,
+            activeSessions: f.active_sessions,
+          };
         }
         return map;
       })
-      .catch(() => ({}));
+      .catch(() => {
+        familiarsCache = null;
+        return null;
+      });
   }
   return familiarsCache;
 }
 
-let memoryCache: Promise<RawMemoryEntry[]> | null = null;
-function loadMemoryEntries(): Promise<RawMemoryEntry[]> {
+let memoryCache: Promise<RawMemoryEntry[] | null> | null = null;
+function loadMemoryEntries(): Promise<RawMemoryEntry[] | null> {
   if (!memoryCache) {
     memoryCache = fetch("/api/memory", { cache: "no-store" })
       .then((r) => r.json())
-      .then((j) => (j?.ok && Array.isArray(j.entries) ? (j.entries as RawMemoryEntry[]) : []))
-      .catch(() => []);
+      .then((j) => {
+        if (!j?.ok || !Array.isArray(j.entries)) throw new Error("memory load failed");
+        return j.entries as RawMemoryEntry[];
+      })
+      .catch(() => {
+        memoryCache = null;
+        return null;
+      });
   }
   return memoryCache;
 }
@@ -60,7 +72,7 @@ function useFamiliarStatus(id: string): { info: FamiliarStatusInfo | null; faile
     let alive = true;
     loadFamiliarStatus().then((map) => {
       if (!alive) return;
-      if (map[id]) setInfo(map[id]);
+      if (map?.[id]) setInfo(map[id]);
       else setFailed(true);
     });
     return () => {
@@ -70,22 +82,27 @@ function useFamiliarStatus(id: string): { info: FamiliarStatusInfo | null; faile
   return { info, failed };
 }
 
-function useFamiliarMemory(id: string): { entries: MemoryPeekEntry[]; loading: boolean } {
+function useFamiliarMemory(id: string): { entries: MemoryPeekEntry[]; loading: boolean; failed: boolean } {
   const [entries, setEntries] = useState<MemoryPeekEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
   useEffect(() => {
     let alive = true;
     setLoading(true);
+    setFailed(false);
     loadMemoryEntries().then((all) => {
       if (!alive) return;
-      setEntries(pickFamiliarMemory(all, id, 3));
+      // null = the load FAILED — an error is not evidence of an empty memory
+      // (the old path rendered "No memory yet" over it; cave-2ex2).
+      if (all === null) setFailed(true);
+      else setEntries(pickFamiliarMemory(all, id, 3));
       setLoading(false);
     });
     return () => {
       alive = false;
     };
   }, [id]);
-  return { entries, loading };
+  return { entries, loading, failed };
 }
 
 export function FamiliarInlineCard({
@@ -108,8 +125,8 @@ export function FamiliarInlineCard({
   });
 
   const { openFamiliarStudio } = useFamiliarStudio();
-  const { info, failed } = useFamiliarStatus(familiar.id);
-  const { entries, loading } = useFamiliarMemory(familiar.id);
+  const { info, failed: statusFailed } = useFamiliarStatus(familiar.id);
+  const { entries, loading, failed: memoryFailed } = useFamiliarMemory(familiar.id);
 
   const meta = statusMeta(info?.status);
 
@@ -137,7 +154,9 @@ export function FamiliarInlineCard({
 
       <div className="familiar-inline-card__status">
         {!info ? (
-          <span className="familiar-inline-card__status-muted">status unavailable</span>
+          <span className="familiar-inline-card__status-muted">
+            {statusFailed ? "status unavailable — reopen to retry" : "checking status…"}
+          </span>
         ) : (
           <>
             <span
@@ -189,6 +208,10 @@ export function FamiliarInlineCard({
         </div>
         {loading ? (
           <SkeletonRows count={3} className="familiar-inline-card__memory-loading" />
+        ) : memoryFailed ? (
+          // A failed load is NOT an empty memory (cave-2ex2). The cache
+          // self-clears on failure, so reopening the card retries.
+          <div className="familiar-inline-card__memory-muted">Memory unavailable right now — reopen to retry</div>
         ) : entries.length === 0 ? (
           <div className="familiar-inline-card__memory-muted">No memory yet</div>
         ) : (

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -828,9 +828,21 @@ function StageVessel({
           {harnesses === null ? (
             <p className="text-[11px] text-[var(--text-muted)]">Looking for installed runtimes…</p>
           ) : installedHarnesses.length === 0 ? (
-            <p className="text-[11px] text-[var(--color-warning)]">
-              No chat-capable runtime found. Install one (Codex, Claude Code, Copilot, Hermes…) from Settings, then return to the circle.
-            </p>
+            // Runtime installs live in the SETUP WIZARD, not Settings — the old
+            // copy pointed at a Settings section that doesn't exist, looping
+            // users between the circle and Settings (cave-tpji).
+            <div className="flex flex-col items-start gap-1.5">
+              <p className="text-[11px] text-[var(--color-warning)]">
+                No chat-capable runtime found. Run setup to install one (Codex, Claude Code, Copilot…), then return to the circle.
+              </p>
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent("cave:onboarding-open"))}
+                className="focus-ring rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-elevated)]"
+              >
+                Run setup
+              </button>
+            </div>
           ) : (
             <div role="radiogroup" aria-label="Runtime" className="summoning-chiprow">
               {installedHarnesses.map((h) => (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -681,10 +681,14 @@ export function Workspace() {
   // BoardView is the only consumer of the card hash and it never mounts on
   // the boot-default Chat surface, so external card links opened the app and
   // silently dropped the card (cave-qnh2). Switch to the board; BoardView's
-  // hash effect re-applies once cards load.
+  // hash effect re-applies once cards load. Same treatment for `/#grimoire:`
+  // (memory/knowledge/journal doc links from daily-report pages and shared
+  // URLs): GrimoireView reads its hash on mount, so it only needs the mode
+  // switch here (cave-aka2).
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (/^#card-/.test(window.location.hash)) setMode("board");
+    else if (window.location.hash.startsWith("#grimoire:")) setMode("grimoire");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/daily-report.test.ts
+++ b/src/lib/daily-report.test.ts
@@ -69,7 +69,8 @@ function item(overrides) {
   assert.equal(itemHref(item({ link: { kind: "session", ref: "s1" } })), "/#chat-s1");
   assert.equal(
     itemHref(item({ link: { kind: "memory", ref: "a/b c" } })),
-    "/#memory:a%2Fb%20c",
+    // Memory rides the Grimoire hash — `#memory:` never had a consumer (cave-aka2).
+    "/#grimoire:memory:a%2Fb%20c",
   );
   assert.equal(itemHref(item({ link: { kind: "url", ref: "https://x" } })), "https://x");
   assert.equal(itemHref(item({ sessionId: "sess9", link: null })), "/#chat-sess9");

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -116,9 +116,11 @@ export const KIND_ICON: Record<ItemKind, string> = {
 
 /**
  * Turn an inbox item into an href the standalone routes can use. In-app
- * targets resolve to `/#<hash>` so the workspace deep-link listeners
- * (`#card-`, `#chat-`, `#memory:`) re-enter the right surface; bare urls pass
- * through. Items with no actionable target return `/` (the home shell).
+ * targets resolve to `/#<hash>` so the workspace boot deep-link handlers
+ * (`#card-`, `#chat-`, `#grimoire:`) re-enter the right surface; bare urls
+ * pass through. Items with no actionable target return `/` (the home shell).
+ * (`#memory:` never had a consumer — memory links ride the Grimoire hash,
+ * whose reader is the app's memory viewer; cave-aka2.)
  */
 export function itemHref(item: InboxItem): string {
   const link: LinkRef | null | undefined = item.link;
@@ -129,7 +131,7 @@ export function itemHref(item: InboxItem): string {
       case "session":
         return `/#chat-${link.ref}`;
       case "memory":
-        return `/#memory:${encodeURIComponent(link.ref)}`;
+        return `/#grimoire:memory:${encodeURIComponent(link.ref)}`;
       case "url":
         return link.ref || "/";
     }


### PR DESCRIPTION
The evening re-audit (after the 23-fix arc #2884–#2901) verified 35/36 fix-items hold and surfaced three new/remaining P2s — fixed here.

**cave-tpji — summoning circle dead pointer.** The no-runtime state told users to install a runtime "from Settings" — Settings has no install section (found in the morning audit but never filed). Now: "Run setup to install one (Codex, Claude Code, Copilot…)" plus a **Run setup** button dispatching `cave:onboarding-open` — runtime installs are exactly what the wizard does. (This also legitimately re-employs the listener the dead-code sweep had flagged as orphaned.)

**cave-aka2 — deep-link stragglers.** `daily-report.ts` still emitted dead `/#memory:` hrefs for memory-linked inbox items (the sibling emitter the cave-ce7y fix missed) → now `/#grimoire:memory:<path>`; `#grimoire:` hashes get a cold-boot `setMode("grimoire")` beside the `#card-` handler (GrimoireView reads its hash on mount), so shared/reloaded Grimoire links survive; the growth-dashboard "Familiars" breadcrumb targets `/?mode=agents` instead of the consumerless `/#familiars`. Doc comment corrected; `daily-report.test.ts` pin updated to the working hash.

**cave-2ex2 — forever-cached failures.** The familiar inline card's module-level `familiarsCache`/`memoryCache` cached a *failed* fetch for the app's lifetime, so one transient error made every card show a false "No memory yet" until full reload. Failures now resolve `null` **and self-clear the cache** (next card open retries); the memory panel renders "Memory unavailable right now — reopen to retry" and the status line distinguishes "checking status…" from "status unavailable — reopen to retry".

**Validation:** typecheck ✓ · test:app 591 ✓ · test:api 135 ✓ · test:mobile 75 ✓ · tests-wired 797 ✓ · build + bundle budget ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)