### PR TITLE
fix(windows): collapse MSI sidecar into a versioned runtime archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
   sidecar-runtime:
     name: Sidecar runtime (${{ matrix.os }})
     # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (windows runner is the flaky/slow one).
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -197,6 +197,14 @@ jobs:
         with:
           node-version: 22
 
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+        if: matrix.os == 'windows-latest'
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: matrix.os == 'windows-latest'
+        with:
+          workspaces: src-tauri -> target
+
       - run: pnpm install --frozen-lockfile
 
       # Slice B runtime proof for #1990: build the OS-specific packaged Node
@@ -209,6 +217,12 @@ jobs:
         run: bash scripts/sidecar-bundle.sh
 
       - run: pnpm test:sidecar-runtime
+
+      # Exercise the production archive verifier/extractor on its actual OS;
+      # the Node smoke above intentionally treats the archive as a black box.
+      - name: Test Windows sidecar cache extraction
+        if: matrix.os == 'windows-latest'
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked sidecar_archive
 
   sidecar-runtime-required:
     name: Sidecar runtime required

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,31 @@ jobs:
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
+      - name: Measure and enforce Windows MSI budget
+        if: >-
+          matrix.family == 'windows' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+        shell: powershell
+        run: |
+          $msis = @(Get-ChildItem -Path src-tauri/target/release/bundle/msi -Filter *.msi -File)
+          if ($msis.Count -ne 1) {
+            throw "Expected exactly one built MSI, found $($msis.Count)"
+          }
+          & .\scripts\windows-msi-budget.ps1 `
+            -MsiPath $msis[0].FullName `
+            -OutputPath "$env:RUNNER_TEMP\windows-msi-metrics.json"
+
+      - name: Retain Windows MSI diagnostics
+        if: >-
+          always() && matrix.family == 'windows' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-msi-diagnostics-${{ env.RELEASE_VERSION }}
+          path: ${{ runner.temp }}/windows-msi-metrics.json
+          if-no-files-found: warn
+          compression-level: 0
+
       - name: Sign Linux/Windows updater artifact
         if: >-
           (

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ next-env.d.ts
 # placeholder in each tree so Tauri's resource globs validate on clean CI.
 src-tauri/resources/server/*
 !src-tauri/resources/server/placeholder.txt
+src-tauri/resources/server-archive/*
+!src-tauri/resources/server-archive/placeholder.txt
 src-tauri/resources/node/*
 !src-tauri/resources/node/placeholder.txt
 

--- a/scripts/sidecar-archive-manifest.mjs
+++ b/scripts/sidecar-archive-manifest.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SIDECAR_ARCHIVE_BUDGETS = Object.freeze({
+  archiveBytes: 256 * 1024 * 1024,
+  unpackedBytes: 768 * 1024 * 1024,
+  fileCount: 50_000,
+});
+
+async function sha256File(file) {
+  return await new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const input = createReadStream(file);
+    input.on("data", (chunk) => hash.update(chunk));
+    input.on("error", reject);
+    input.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function treeMetrics(root) {
+  let fileCount = 0;
+  let directoryCount = 0;
+  let unpackedBytes = 0;
+  const pending = [root];
+
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      const metadata = await lstat(entryPath);
+      if (metadata.isSymbolicLink()) {
+        throw new Error(`sidecar archive input must not contain symlinks: ${entryPath}`);
+      }
+      if (metadata.isDirectory()) {
+        directoryCount += 1;
+        pending.push(entryPath);
+      } else if (metadata.isFile()) {
+        fileCount += 1;
+        unpackedBytes += metadata.size;
+      } else {
+        throw new Error(`sidecar archive input contains an unsupported entry: ${entryPath}`);
+      }
+    }
+  }
+
+  return { fileCount, directoryCount, unpackedBytes };
+}
+
+export async function writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath) {
+  const [{ size: archiveBytes }, metrics, archiveSha256] = await Promise.all([
+    stat(archivePath),
+    treeMetrics(sourceRoot),
+    sha256File(archivePath),
+  ]);
+  const manifest = {
+    schemaVersion: 1,
+    archiveSha256,
+    archiveBytes,
+    ...metrics,
+  };
+
+  for (const [metric, budget] of Object.entries(SIDECAR_ARCHIVE_BUDGETS)) {
+    if (manifest[metric] > budget) {
+      throw new Error(`sidecar ${metric} ${manifest[metric]} exceeds budget ${budget}`);
+    }
+  }
+
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifest;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [sourceRoot, archivePath, outputPath] = process.argv.slice(2);
+  if (!sourceRoot || !archivePath || !outputPath) {
+    console.error("usage: sidecar-archive-manifest.mjs <source-root> <archive> <manifest>");
+    process.exit(2);
+  }
+  const manifest = await writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath);
+  console.log(
+    `==> Windows sidecar archive: ${manifest.fileCount} files, ${manifest.unpackedBytes} bytes expanded, ${manifest.archiveBytes} bytes compressed`,
+  );
+}

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -6,7 +6,14 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const src = await readFile(new URL("./sidecar-bundle.sh", import.meta.url), "utf8");
+const [src, baseConfigSource, windowsConfigSource, manifestSource] = await Promise.all([
+  readFile(new URL("./sidecar-bundle.sh", import.meta.url), "utf8"),
+  readFile(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+  readFile(new URL("../src-tauri/tauri.windows.conf.json", import.meta.url), "utf8"),
+  readFile(new URL("./sidecar-archive-manifest.mjs", import.meta.url), "utf8"),
+]);
+const baseConfig = JSON.parse(baseConfigSource);
+const windowsConfig = JSON.parse(windowsConfigSource);
 
 // Must use locked pnpm install (frozen lockfile prevents supply chain attacks)
 assert.match(src, /pnpm install --prod --frozen-lockfile/, "sidecar must install from locked pnpm lockfile");
@@ -80,6 +87,30 @@ assert.doesNotMatch(
   src,
   /sharp_pkg="@img\/sharp-/,
   "sidecar must NOT hard-code @img/sharp package names — they come from sidecar-target.mjs (#1990)",
+);
+
+// Windows must not hand WiX the expanded 20k-file server tree. macOS/Linux
+// retain it because their release pipeline signs nested native modules after
+// Tauri assembles the app.
+assert.deepEqual(
+  windowsConfig.bundle.resources,
+  ["resources/server-archive/**/*", "resources/node/**/*"],
+  "Windows resources must replace the expanded sidecar with its bounded archive",
+);
+assert.ok(
+  baseConfig.bundle.resources.includes("resources/server/**/*"),
+  "non-Windows bundles must retain the expanded tree for nested native signing",
+);
+assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.gz archive");
+assert.match(src, /sidecar-archive-manifest\.mjs/, "archive generation must emit its integrity and size manifest");
+assert.match(manifestSource, /archiveBytes: 256 \* 1024 \* 1024/, "archive size must have a 256 MiB hard budget");
+assert.match(manifestSource, /unpackedBytes: 768 \* 1024 \* 1024/, "expanded runtime must have a 768 MiB hard budget");
+assert.match(manifestSource, /fileCount: 50_000/, "archive entry count must have a hard budget");
+assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");
+assert.match(
+  src,
+  /write_windows_sidecar_archive\(\)[\s\S]*find "\$DEST" -type l[\s\S]*rm -rf "\$DEST"[\s\S]*placeholder\.txt/,
+  "Windows bundling must materialize links and remove the expanded resource payload",
 );
 
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Build + assemble the Next.js standalone server with a flat, complete
-# node_modules so it can boot from inside the Tauri .app bundle without any
-# pnpm symlink magic. Output: src-tauri/resources/server/.
+# node_modules so it can boot without any pnpm symlink magic. macOS/Linux
+# package the expanded tree; Windows packages a bounded archive that the
+# launcher expands into its versioned local runtime cache.
 #
 # Mobile-Tauri builds: skip entirely. iOS and Android sandboxes can't spawn
 # a child Node.js process, the resulting IPA / APK would balloon by ~100MB
@@ -22,11 +23,17 @@ esac
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/src-tauri/resources/server"
+WINDOWS_ARCHIVE_DIR="$ROOT/src-tauri/resources/server-archive"
+WINDOWS_ARCHIVE="$WINDOWS_ARCHIVE_DIR/server.tar.gz"
+WINDOWS_ARCHIVE_MANIFEST="$WINDOWS_ARCHIVE_DIR/manifest.json"
 BUNDLED_NODE_DIR="$ROOT/src-tauri/resources/node"
 STATIC="$ROOT/.next/static"
 PUBLIC="$ROOT/public"
 PNPM_STAGE="$(mktemp -d "${TMPDIR:-/tmp}/coven-cave-sidecar-pnpm.XXXXXX")"
-trap 'rm -rf "$PNPM_STAGE"' EXIT
+cleanup_staging() {
+  rm -rf "$PNPM_STAGE"
+}
+trap cleanup_staging EXIT
 
 fix_node_pty_spawn_helpers() {
   local base="$1"
@@ -192,6 +199,42 @@ copy_node_shared_runtime() {
   echo "==> bundled Node shared runtime $lib_name"
 }
 
+write_windows_sidecar_archive() {
+  mkdir -p "$WINDOWS_ARCHIVE_DIR"
+  rm -f "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"
+
+  # The standalone output can retain valid pnpm symlinks. Materialize those
+  # few links in place instead of copying the entire 500+ MiB tree a second
+  # time. The manifest and runtime both reject any link that survives.
+  while IFS= read -r -d '' link; do
+    if [ ! -e "$link" ]; then
+      echo "ERROR: dangling sidecar symlink cannot be archived: $link" >&2
+      exit 1
+    fi
+    materialized="${link}.materialized.$$"
+    cp -aL "$link" "$materialized"
+    rm -f "$link"
+    mv "$materialized" "$link"
+  done < <(find "$DEST" -type l -print0)
+
+  echo "==> archiving Windows sidecar -> $WINDOWS_ARCHIVE"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs \
+      -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
+  else
+    tar -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
+  fi
+
+  node "$ROOT/scripts/sidecar-archive-manifest.mjs" \
+    "$DEST" "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"
+
+  # Keep the expanded tree out of the Windows build workspace as a second
+  # guard against accidentally reintroducing thousands of WiX components.
+  rm -rf "$DEST"
+  mkdir -p "$DEST"
+  printf "generated at release build time\n" > "$DEST/placeholder.txt"
+}
+
 echo "==> next build"
 (cd "$ROOT" && pnpm build) >&2
 
@@ -340,6 +383,10 @@ if ! (cd "$DEST" && node -e "require('sharp')") >&2 2>&1; then
   echo "==> ! sharp failed to load from sidecar bundle — raster avatars will 404 (#2010)" >&2
   echo "    expected @img/sharp-<build-target> native binary under $DEST/node_modules/@img" >&2
   exit 1
+fi
+
+if [ "${TAURI_PLATFORM:-}" = "windows" ] || [ "${OS:-}" = "Windows_NT" ]; then
+  write_windows_sidecar_archive
 fi
 
 echo "==> sidecar bundle ready ($(du -sh "$DEST" | cut -f1))"

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
-import { access, mkdir, mkdtemp } from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -9,8 +9,7 @@ import { fileURLToPath } from "node:url";
 import sharp from "sharp";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const sidecarRoot = path.join(root, "src-tauri", "resources", "server");
-const sidecarServer = path.join(sidecarRoot, "server.mjs");
+const stagedSidecarRoot = path.join(root, "src-tauri", "resources", "server");
 const bundledNode = path.join(
   root,
   "src-tauri",
@@ -57,7 +56,7 @@ async function requestAvatar(baseUrl, output) {
 }
 
 async function waitForAvatar(baseUrl, output) {
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + (process.platform === "win32" ? 90_000 : 30_000);
   while (Date.now() < deadline) {
     const res = await requestAvatar(baseUrl, output);
     if (!res) {
@@ -91,8 +90,39 @@ function attachOutput(child) {
 }
 
 async function main() {
+  let extractedSidecarRoot = null;
+  let sidecarRoot = stagedSidecarRoot;
+  if (process.platform === "win32") {
+    const archiveDir = path.join(root, "src-tauri", "resources", "server-archive");
+    const archive = path.join(archiveDir, "server.tar.gz");
+    const manifest = JSON.parse(await readFile(path.join(archiveDir, "manifest.json"), "utf8"));
+    assert.equal(manifest.schemaVersion, 1);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 50_000);
+    assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 256 * 1024 * 1024);
+    assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes <= 768 * 1024 * 1024);
+    extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));
+    const extraction = spawnSync("tar", ["-xzf", archive, "-C", extractedSidecarRoot], {
+      encoding: "utf8",
+    });
+    if (extraction.status !== 0) {
+      throw new Error(`could not extract Windows sidecar archive: ${extraction.stderr || extraction.error}`);
+    }
+    sidecarRoot = extractedSidecarRoot;
+  }
+  const sidecarServer = path.join(sidecarRoot, "server.mjs");
   await access(sidecarServer);
   await access(bundledNode);
+
+  const nativeModules = spawnSync(
+    bundledNode,
+    ["-e", "require('sharp'); require('node-pty')"],
+    { cwd: sidecarRoot, encoding: "utf8" },
+  );
+  assert.equal(
+    nativeModules.status,
+    0,
+    `packaged native modules must load from the sidecar runtime: ${nativeModules.stderr || nativeModules.error}`,
+  );
 
   const covenHome = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-"));
   const avatarDir = path.join(covenHome, "workspaces", "familiars", "smoke", "avatars");
@@ -151,6 +181,10 @@ async function main() {
       waitForExit(child),
       new Promise((resolve) => setTimeout(resolve, 2_000)),
     ]);
+    await rm(covenHome, { recursive: true, force: true });
+    if (extractedSidecarRoot) {
+      await rm(extractedSidecarRoot, { recursive: true, force: true });
+    }
   }
 }
 

--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -1,0 +1,158 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MsiPath,
+
+    [string]$OutputPath = "windows-msi-metrics.json"
+)
+
+$ErrorActionPreference = "Stop"
+$rowBudget = 64
+$byteBudget = 256MB
+$resolvedMsi = (Resolve-Path -LiteralPath $MsiPath).Path
+$resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)
+$installer = $null
+$database = $null
+
+function Open-MsiView {
+    param([Parameter(Mandatory = $true)][string]$Query)
+
+    $view = $database.GetType().InvokeMember(
+        "OpenView",
+        [System.Reflection.BindingFlags]::InvokeMethod,
+        $null,
+        $database,
+        @($Query)
+    )
+    $view.GetType().InvokeMember(
+        "Execute",
+        [System.Reflection.BindingFlags]::InvokeMethod,
+        $null,
+        $view,
+        $null
+    ) | Out-Null
+    return $view
+}
+
+function Read-MsiRows {
+    param(
+        [Parameter(Mandatory = $true)][string]$Query,
+        [Parameter(Mandatory = $true)][scriptblock]$OnRow
+    )
+
+    $view = Open-MsiView -Query $Query
+    $count = 0
+    try {
+        while ($count -le $rowBudget) {
+            $record = $view.GetType().InvokeMember(
+                "Fetch",
+                [System.Reflection.BindingFlags]::InvokeMethod,
+                $null,
+                $view,
+                $null
+            )
+            if ($null -eq $record) {
+                break
+            }
+            $count += 1
+            if ($count -le $rowBudget) {
+                & $OnRow $record
+            }
+            [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($record)
+        }
+    }
+    finally {
+        $view.GetType().InvokeMember(
+            "Close",
+            [System.Reflection.BindingFlags]::InvokeMethod,
+            $null,
+            $view,
+            $null
+        ) | Out-Null
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($view)
+    }
+    return $count
+}
+
+try {
+    $installer = New-Object -ComObject WindowsInstaller.Installer
+    $database = $installer.GetType().InvokeMember(
+        "OpenDatabase",
+        [System.Reflection.BindingFlags]::InvokeMethod,
+        $null,
+        $installer,
+        @($resolvedMsi, 0)
+    )
+
+    [long]$installedFileBytes = 0
+    [int]$serverArchiveRows = 0
+    $fileRows = Read-MsiRows -Query 'SELECT `FileSize`, `FileName` FROM `File`' -OnRow {
+        param($record)
+        $size = $record.GetType().InvokeMember(
+            "IntegerData",
+            [System.Reflection.BindingFlags]::GetProperty,
+            $null,
+            $record,
+            @(1)
+        )
+        $name = $record.GetType().InvokeMember(
+            "StringData",
+            [System.Reflection.BindingFlags]::GetProperty,
+            $null,
+            $record,
+            @(2)
+        )
+        $script:installedFileBytes += [long]$size
+        $longName = ($name -split '\|')[-1]
+        if ($longName -eq "server.tar.gz") {
+            $script:serverArchiveRows += 1
+        }
+    }
+    $componentRows = Read-MsiRows -Query 'SELECT `Component` FROM `Component`' -OnRow { param($record) }
+    $createFolderRows = Read-MsiRows -Query 'SELECT `Directory_` FROM `CreateFolder`' -OnRow { param($record) }
+    $directoryRows = Read-MsiRows -Query 'SELECT `Directory` FROM `Directory`' -OnRow { param($record) }
+
+    $metrics = [ordered]@{
+        schemaVersion = 1
+        msiPath = $resolvedMsi
+        msiBytes = (Get-Item -LiteralPath $resolvedMsi).Length
+        installedFileBytes = $installedFileBytes
+        fileRows = $fileRows
+        componentRows = $componentRows
+        createFolderRows = $createFolderRows
+        directoryRows = $directoryRows
+        serverArchiveRows = $serverArchiveRows
+        rowBudget = $rowBudget
+        byteBudget = $byteBudget
+    }
+    $json = $metrics | ConvertTo-Json
+    [System.IO.File]::WriteAllText($resolvedOutput, "$json`n")
+    $metrics | Format-List | Out-String | Write-Host
+    Write-Host "MSI metrics JSON: $resolvedOutput"
+
+    $violations = @()
+    foreach ($metric in @("fileRows", "componentRows", "createFolderRows", "directoryRows")) {
+        if ($metrics[$metric] -gt $rowBudget) {
+            $violations += "$metric exceeds $rowBudget"
+        }
+    }
+    foreach ($metric in @("msiBytes", "installedFileBytes")) {
+        if ($metrics[$metric] -gt $byteBudget) {
+            $violations += "$metric exceeds $byteBudget bytes"
+        }
+    }
+    if ($serverArchiveRows -ne 1) {
+        $violations += "expected exactly one server.tar.gz File row; found $serverArchiveRows"
+    }
+    if ($violations.Count -gt 0) {
+        throw "Windows MSI budget failed: $($violations -join '; ')"
+    }
+}
+finally {
+    if ($null -ne $database) {
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($database)
+    }
+    if ($null -ne $installer) {
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($installer)
+    }
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -79,6 +79,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.0.172"
 dependencies = [
+ "flate2",
  "log",
  "objc2",
  "once_cell",
@@ -87,6 +88,8 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "sha2",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,13 @@ portable-pty = "0.8"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 
+# Windows packages the large Next.js sidecar as one archive instead of one
+# WiX component per file. The launcher verifies and extracts it on first use.
+[target.'cfg(target_os = "windows")'.dependencies]
+flate2 = "1"
+sha2 = "0.10"
+tar = "0.4"
+
 # OS-level glass for the quick-chat tray window: NSVisualEffectView vibrancy
 # behind the transparent webview on macOS (the only platform we apply it on;
 # the crate compiles everywhere and the call sites are cfg(target_os) gated).

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -3,8 +3,9 @@ import { access, readFile } from "node:fs/promises";
 import test from "node:test";
 
 test("release bundle includes and prefers a bundled Node runtime", async () => {
-  const [tauriConfig, bundleScript, launcher] = await Promise.all([
+  const [tauriConfig, windowsConfig, bundleScript, launcher] = await Promise.all([
     readFile(new URL("./tauri.conf.json", import.meta.url), "utf8"),
+    readFile(new URL("./tauri.windows.conf.json", import.meta.url), "utf8"),
     readFile(new URL("../scripts/sidecar-bundle.sh", import.meta.url), "utf8"),
     readFile(new URL("./src/lib.rs", import.meta.url), "utf8"),
   ]);
@@ -13,6 +14,16 @@ test("release bundle includes and prefers a bundled Node runtime", async () => {
     tauriConfig,
     /"resources\/node\/\*\*\/\*"/,
     "Tauri resources must include the bundled Node runtime",
+  );
+  assert.match(
+    windowsConfig,
+    /"resources\/server-archive\/\*\*\/\*"/,
+    "Windows must package the sidecar archive instead of thousands of server files",
+  );
+  assert.doesNotMatch(
+    windowsConfig,
+    /"resources\/server\/\*\*\/\*"/,
+    "Windows platform config must not retain the expanded sidecar resource glob",
   );
   assert.match(
     tauriConfig,
@@ -39,6 +50,11 @@ test("release bundle includes and prefers a bundled Node runtime", async () => {
     /resources[\s\S]*node[\s\S]*bin[\s\S]*node/,
     "launcher must know the bundled Node resource path",
   );
+  assert.match(
+    launcher,
+    /sidecar_archive::prepare_sidecar_runtime\(app, &resource_dir\)/,
+    "Windows launcher must prepare the verified runtime cache before starting Node",
+  );
 });
 
 test("clean release runners have resource glob placeholders", async () => {
@@ -46,6 +62,7 @@ test("clean release runners have resource glob placeholders", async () => {
 
   await Promise.all([
     access(new URL("./resources/server/placeholder.txt", import.meta.url)),
+    access(new URL("./resources/server-archive/placeholder.txt", import.meta.url)),
     access(new URL("./resources/node/placeholder.txt", import.meta.url)),
   ]);
 
@@ -56,9 +73,60 @@ test("clean release runners have resource glob placeholders", async () => {
   );
   assert.match(
     gitignore,
+    /!src-tauri\/resources\/server-archive\/placeholder\.txt/,
+    "server archive placeholder must be tracked so the Windows resource glob matches in clean CI",
+  );
+  assert.match(
+    gitignore,
     /!src-tauri\/resources\/node\/placeholder\.txt/,
     "node placeholder must be tracked so resources/node/**/* matches in clean CI",
   );
+});
+
+test("native updater cleanup stops the sidecar before Windows exits", async () => {
+  const launcher = await readFile(new URL("./src/lib.rs", import.meta.url), "utf8");
+
+  assert.match(
+    launcher,
+    /struct SidecarCleanupGuard[\s\S]*impl Drop for SidecarCleanupGuard[\s\S]*state\.stop\(\)/,
+    "application resource cleanup must stop and reap the owned sidecar",
+  );
+  assert.match(
+    launcher,
+    /resources_table\(\)[\s\S]*\.add\(SidecarCleanupGuard/,
+    "sidecar cleanup guard must live in the application resource table cleared by the updater",
+  );
+  assert.match(
+    launcher,
+    /fn stop\(&self\)[\s\S]*guard\.take\(\)[\s\S]*child[\s\S]*\.wait\(\)/,
+    "sidecar cleanup must be idempotent and wait for process termination",
+  );
+  assert.match(
+    launcher,
+    /msi-upgrade-from-/,
+    "updater MSI logs must be versioned per running app",
+  );
+  assert.match(
+    launcher,
+    /installer_args\(\[[\s\S]*OsString::from\("\/L\*V"\)/,
+    "updater-driven MSI installs must retain a verbose per-run diagnostic log",
+  );
+});
+
+test("Windows release reports and enforces bounded MSI tables", async () => {
+  const [workflow, budget] = await Promise.all([
+    readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/windows-msi-budget.ps1", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(workflow, /Measure and enforce Windows MSI budget/);
+  assert.match(workflow, /windows-msi-metrics\.json/);
+  for (const table of ["File", "Component", "CreateFolder", "Directory"]) {
+    assert.match(budget, new RegExp("FROM `" + table + "`"), `budget must inspect MSI ${table} rows`);
+  }
+  assert.match(budget, /\$rowBudget = 64/);
+  assert.match(budget, /\$byteBudget = 256MB/);
+  assert.match(budget, /expected exactly one server\.tar\.gz File row/);
 });
 
 test("packaged app does not override Coven workspace with OpenClaw workspace", async () => {

--- a/src-tauri/resources/server-archive/placeholder.txt
+++ b/src-tauri/resources/server-archive/placeholder.txt
@@ -1,0 +1,1 @@
+generated at release build time

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 #[cfg(desktop)]
 use std::process::{Child, Command, Stdio};
 #[cfg(desktop)]
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 #[cfg(desktop)]
 use std::thread;
 #[cfg(desktop)]
@@ -484,7 +484,81 @@ fn sidecar_auth_token() -> String {
 }
 
 #[cfg(desktop)]
-struct SidecarState(Mutex<Option<Child>>);
+struct SidecarState(Arc<Mutex<Option<Child>>>);
+
+#[cfg(desktop)]
+struct SidecarCleanupGuard(Arc<Mutex<Option<Child>>>);
+
+#[cfg(desktop)]
+impl tauri::Resource for SidecarCleanupGuard {}
+
+#[cfg(desktop)]
+impl Drop for SidecarCleanupGuard {
+    fn drop(&mut self) {
+        let state = SidecarState(Arc::clone(&self.0));
+        if let Err(error) = state.stop() {
+            log::warn!("[cave] could not stop sidecar during application cleanup: {error}");
+        }
+    }
+}
+
+#[cfg(desktop)]
+impl SidecarState {
+    fn stop(&self) -> Result<(), String> {
+        let mut guard = self
+            .0
+            .lock()
+            .map_err(|_| "sidecar process lock is poisoned".to_string())?;
+        let Some(mut child) = guard.take() else {
+            return Ok(());
+        };
+        if child
+            .try_wait()
+            .map_err(|error| format!("could not inspect sidecar process: {error}"))?
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let pid = child.id().to_string();
+            let mut taskkill = Command::new(windows_system32_binary("taskkill.exe"));
+            taskkill
+                .args(["/PID", &pid, "/T", "/F"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .creation_flags(0x08000000);
+            match taskkill.status() {
+                Ok(status) if status.success() => {}
+                Ok(status) => log::warn!(
+                    "[cave] taskkill could not stop sidecar process tree {} (status {}); falling back to direct termination",
+                    pid,
+                    status
+                ),
+                Err(error) => log::warn!(
+                    "[cave] taskkill could not start for sidecar process tree {}: {}; falling back to direct termination",
+                    pid,
+                    error
+                ),
+            }
+        }
+
+        if child
+            .try_wait()
+            .map_err(|error| format!("could not inspect terminated sidecar: {error}"))?
+            .is_none()
+        {
+            child
+                .kill()
+                .map_err(|error| format!("could not stop sidecar process: {error}"))?;
+        }
+        child
+            .wait()
+            .map_err(|error| format!("could not wait for sidecar process shutdown: {error}"))?;
+        Ok(())
+    }
+}
 
 #[cfg(desktop)]
 fn find_free_port() -> Option<u16> {
@@ -574,6 +648,41 @@ mod tests {
         assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
+    #[test]
+    fn sidecar_cleanup_is_idempotent_when_no_child_is_running() {
+        let state = SidecarState(Arc::new(Mutex::new(None)));
+
+        state.stop().expect("first empty cleanup");
+        state.stop().expect("second empty cleanup");
+    }
+
+    #[test]
+    fn dropping_application_cleanup_guard_stops_and_reaps_sidecar() {
+        #[cfg(target_os = "windows")]
+        let mut command = {
+            let mut command = Command::new(windows_system32_binary("ping.exe"));
+            command.args(["127.0.0.1", "-n", "30"]);
+            command.creation_flags(0x08000000);
+            command
+        };
+        #[cfg(not(target_os = "windows"))]
+        let mut command = {
+            let mut command = Command::new("sleep");
+            command.arg("30");
+            command
+        };
+        let child = command
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cleanup fixture");
+        let slot = Arc::new(Mutex::new(Some(child)));
+
+        drop(SidecarCleanupGuard(Arc::clone(&slot)));
+
+        assert!(slot.lock().expect("sidecar slot").is_none());
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn node_arg_path_strips_windows_extended_prefix() {
@@ -609,6 +718,8 @@ mod tests {
 mod browser;
 #[cfg(desktop)]
 mod pty;
+#[cfg(all(desktop, target_os = "windows"))]
+mod sidecar_archive;
 
 #[cfg(desktop)]
 fn validate_shell_open_url(url: &str) -> Result<(), String> {
@@ -988,6 +1099,8 @@ pub fn run() {
     // tray icon. Everything below this point is gated to `cfg(desktop)`
     // by the imports at the top of the file.
     #[cfg(desktop)]
+    let sidecar_process = Arc::new(Mutex::new(None));
+    #[cfg(desktop)]
     builder
         .invoke_handler(tauri::generate_handler![
             pty::pty_start,
@@ -1012,8 +1125,15 @@ pub fn run() {
             shell_pick_directory,
             set_traffic_lights_visible,
         ])
-        .manage(SidecarState(Mutex::new(None)))
-        .setup(|app| {
+        .manage(SidecarState(Arc::clone(&sidecar_process)))
+        .setup(move |app| {
+            // The updater's Windows pre-exit path clears the application
+            // resource table after validating the package and before starting
+            // msiexec. Dropping this guard stops/reaps the sidecar even though
+            // std::process::exit bypasses window destruction and RunEvent.
+            let _ = app
+                .resources_table()
+                .add(SidecarCleanupGuard(Arc::clone(&sidecar_process)));
             if cfg!(debug_assertions) {
                 app.handle().plugin(
                     tauri_plugin_log::Builder::default()
@@ -1026,7 +1146,23 @@ pub fn run() {
 
             // Desktop auto-update: updater checks/downloads/installs signed
             // release artifacts; process provides relaunch() after install.
-            app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
+            let updater_builder = tauri_plugin_updater::Builder::new();
+            #[cfg(target_os = "windows")]
+            let updater_builder = {
+                let log_dir = app.path().app_log_dir()?;
+                std::fs::create_dir_all(&log_dir)?;
+                let log_path = log_dir.join(format!(
+                    "msi-upgrade-from-{}-{}.log",
+                    app.package_info().version,
+                    std::process::id()
+                ));
+                log::info!("[cave] updater MSI log -> {}", log_path.display());
+                updater_builder.installer_args([
+                    std::ffi::OsString::from("/L*V"),
+                    std::ffi::OsString::from(format!("\"{}\"", log_path.display())),
+                ])
+            };
+            app.handle().plugin(updater_builder.build())?;
             app.handle().plugin(tauri_plugin_process::init())?;
 
             check_app_translocation();
@@ -1050,6 +1186,13 @@ pub fn run() {
             // the /api/pty-ws terminal websocket bridge. server.js is Next's
             // generated standalone entrypoint, kept as a fallback for old
             // bundles — it serves the app but has no terminal bridge.
+            #[cfg(target_os = "windows")]
+            let server_dir_root = match sidecar_archive::prepare_sidecar_runtime(app, &resource_dir)
+            {
+                Ok(path) => path,
+                Err(error) => fatal_exit(&format!("could not prepare sidecar runtime: {error}")),
+            };
+            #[cfg(not(target_os = "windows"))]
             let server_dir_root = resource_dir.join("resources").join("server");
             let server_mjs = server_dir_root.join("server.mjs");
             let server_js = server_dir_root.join("server.js");
@@ -1190,13 +1333,20 @@ pub fn run() {
                 Err(e) => fatal_exit(&format!("failed to spawn node sidecar: {}", e)),
             };
 
-            *app
-                .state::<SidecarState>()
-                .0
-                .lock()
-                .expect("sidecar lock") = Some(child);
+            let sidecar_state = app.state::<SidecarState>();
+            let mut sidecar = match sidecar_state.0.lock() {
+                Ok(sidecar) => sidecar,
+                Err(_) => fatal_exit("sidecar process lock is poisoned"),
+            };
+            *sidecar = Some(child);
+            drop(sidecar);
 
-            if !wait_for_port(port, Duration::from_secs(20)) {
+            let sidecar_start_timeout = if cfg!(target_os = "windows") {
+                Duration::from_secs(90)
+            } else {
+                Duration::from_secs(20)
+            };
+            if !wait_for_port(port, sidecar_start_timeout) {
                 // Read the tail of the sidecar log to give the user a clue.
                 let tail = std::fs::read_to_string(&log_path)
                     .ok()
@@ -1214,13 +1364,19 @@ pub fn run() {
                     })
                     .unwrap_or_else(|| "(could not read sidecar log)".to_string());
                 fatal_exit(&format!(
-                    "Sidecar (node {}) did not become ready on port {} within 20s.\n\nLast lines from {}:\n{}",
+                    "Sidecar (node {}) did not become ready on port {} within {}s.\n\nLast lines from {}:\n{}",
                     node.display(),
                     port,
+                    sidecar_start_timeout.as_secs(),
                     log_path.display(),
                     tail
                 ));
             }
+
+            // Only retire older complete caches after the new runtime has
+            // actually booted. Keep one previous version for rollback.
+            #[cfg(target_os = "windows")]
+            sidecar_archive::cleanup_stale_sidecar_runtimes(&server_dir_root);
 
             format!(
                 "http://127.0.0.1:{}/?covenCaveToken={}&coven_access_token={}",
@@ -1387,9 +1543,8 @@ pub fn run() {
             if let tauri::WindowEvent::Destroyed = event {
                 if window.label() == "main" {
                     if let Some(state) = window.app_handle().try_state::<SidecarState>() {
-                        if let Some(mut child) = state.0.lock().expect("sidecar lock").take() {
-                            let _ = child.kill();
-                            let _ = child.wait();
+                        if let Err(error) = state.stop() {
+                            log::warn!("[cave] could not stop sidecar during window teardown: {error}");
                         }
                     }
                 }

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -1,0 +1,693 @@
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::Manager;
+
+const MANIFEST_SCHEMA_VERSION: u32 = 1;
+const MAX_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_UNPACKED_BYTES: u64 = 768 * 1024 * 1024;
+const MAX_FILE_COUNT: u64 = 50_000;
+const STALE_EXTRACTION_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const REQUIRED_RUNTIME_PATHS: [&str; 7] = [
+    "server.mjs",
+    ".next/required-server-files.json",
+    ".next/BUILD_ID",
+    "node_modules/@next/env/package.json",
+    "node_modules/@swc/helpers/_",
+    "node_modules/node-pty/package.json",
+    "node_modules/sharp/package.json",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SidecarArchiveManifest {
+    schema_version: u32,
+    archive_sha256: String,
+    archive_bytes: u64,
+    unpacked_bytes: u64,
+    file_count: u64,
+    directory_count: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CompletionMarker {
+    schema_version: u32,
+    package_version: String,
+    archive_sha256: String,
+}
+
+fn read_manifest(path: &Path) -> Result<SidecarArchiveManifest, String> {
+    let contents = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "could not read sidecar manifest {}: {error}",
+            path.display()
+        )
+    })?;
+    let manifest: SidecarArchiveManifest = serde_json::from_str(&contents)
+        .map_err(|error| format!("invalid sidecar manifest {}: {error}", path.display()))?;
+
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported sidecar manifest schema {}",
+            manifest.schema_version
+        ));
+    }
+    if manifest.archive_sha256.len() != 64
+        || !manifest
+            .archive_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("sidecar manifest has an invalid SHA-256 digest".to_string());
+    }
+    if manifest.archive_bytes == 0 || manifest.archive_bytes > MAX_ARCHIVE_BYTES {
+        return Err(format!(
+            "sidecar archive size {} is outside the supported range",
+            manifest.archive_bytes
+        ));
+    }
+    if manifest.unpacked_bytes == 0 || manifest.unpacked_bytes > MAX_UNPACKED_BYTES {
+        return Err(format!(
+            "sidecar expanded size {} is outside the supported range",
+            manifest.unpacked_bytes
+        ));
+    }
+    if manifest.file_count == 0 || manifest.file_count > MAX_FILE_COUNT {
+        return Err(format!(
+            "sidecar file count {} is outside the supported range",
+            manifest.file_count
+        ));
+    }
+    if manifest.directory_count > MAX_FILE_COUNT {
+        return Err(format!(
+            "sidecar directory count {} is outside the supported range",
+            manifest.directory_count
+        ));
+    }
+
+    Ok(manifest)
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = File::open(path)
+        .map_err(|error| format!("could not open sidecar archive {}: {error}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| format!("could not hash sidecar archive: {error}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn cache_key(package_version: &str, archive_sha256: &str) -> String {
+    let version: String = package_version
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("{version}-{}", &archive_sha256[..16])
+}
+
+fn runtime_has_required_files(root: &Path) -> bool {
+    REQUIRED_RUNTIME_PATHS
+        .iter()
+        .all(|relative| root.join(relative).exists())
+}
+
+fn cache_is_ready(destination: &Path, package_version: &str, archive_sha256: &str) -> bool {
+    if !runtime_has_required_files(destination) {
+        return false;
+    }
+    let marker = match fs::read_to_string(destination.join(".complete.json")) {
+        Ok(contents) => contents,
+        Err(_) => return false,
+    };
+    match serde_json::from_str::<CompletionMarker>(&marker) {
+        Ok(marker) => {
+            marker.schema_version == MANIFEST_SCHEMA_VERSION
+                && marker.package_version == package_version
+                && marker.archive_sha256 == archive_sha256
+        }
+        Err(_) => false,
+    }
+}
+
+fn tree_metrics(root: &Path) -> Result<(u64, u64, u64), String> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut file_count = 0_u64;
+    let mut directory_count = 0_u64;
+    let mut unpacked_bytes = 0_u64;
+
+    while let Some(directory) = pending.pop() {
+        let entries = fs::read_dir(&directory).map_err(|error| {
+            format!(
+                "could not inspect extracted sidecar directory {}: {error}",
+                directory.display()
+            )
+        })?;
+        for entry in entries {
+            let entry =
+                entry.map_err(|error| format!("could not inspect sidecar entry: {error}"))?;
+            let metadata = fs::symlink_metadata(entry.path())
+                .map_err(|error| format!("could not inspect sidecar metadata: {error}"))?;
+            if metadata.file_type().is_symlink() {
+                return Err(format!(
+                    "extracted sidecar contains a forbidden symlink: {}",
+                    entry.path().display()
+                ));
+            }
+            if metadata.is_dir() {
+                directory_count = directory_count
+                    .checked_add(1)
+                    .ok_or_else(|| "sidecar directory count overflow".to_string())?;
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                file_count = file_count
+                    .checked_add(1)
+                    .ok_or_else(|| "sidecar file count overflow".to_string())?;
+                unpacked_bytes = unpacked_bytes
+                    .checked_add(metadata.len())
+                    .ok_or_else(|| "sidecar expanded size overflow".to_string())?;
+            } else {
+                return Err(format!(
+                    "extracted sidecar contains an unsupported entry: {}",
+                    entry.path().display()
+                ));
+            }
+        }
+    }
+
+    Ok((file_count, directory_count, unpacked_bytes))
+}
+
+fn extract_archive(
+    archive_path: &Path,
+    staging: &Path,
+    manifest: &SidecarArchiveManifest,
+) -> Result<(), String> {
+    let archive_file = File::open(archive_path).map_err(|error| {
+        format!(
+            "could not open sidecar archive {}: {error}",
+            archive_path.display()
+        )
+    })?;
+    let decoder = GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("could not read sidecar archive: {error}"))?;
+    let mut archive_file_count = 0_u64;
+    let mut archive_directory_count = 0_u64;
+    let mut archive_bytes = 0_u64;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|error| format!("invalid sidecar archive entry: {error}"))?;
+        let relative = entry
+            .path()
+            .map_err(|error| format!("invalid sidecar archive path: {error}"))?
+            .into_owned();
+        if relative.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        }) {
+            return Err(format!(
+                "sidecar archive path escapes its runtime root: {}",
+                relative.display()
+            ));
+        }
+
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_file() || entry_type.is_hard_link() {
+            archive_file_count = archive_file_count
+                .checked_add(1)
+                .ok_or_else(|| "sidecar archive file count overflow".to_string())?;
+            if entry_type.is_file() {
+                archive_bytes = archive_bytes
+                    .checked_add(
+                        entry
+                            .header()
+                            .size()
+                            .map_err(|error| format!("invalid sidecar entry size: {error}"))?,
+                    )
+                    .ok_or_else(|| "sidecar archive expanded size overflow".to_string())?;
+            } else {
+                let target = entry
+                    .link_name()
+                    .map_err(|error| format!("invalid sidecar hardlink target: {error}"))?
+                    .ok_or_else(|| "sidecar hardlink is missing its target".to_string())?;
+                if target.components().any(|component| {
+                    matches!(
+                        component,
+                        Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                    )
+                }) {
+                    return Err(format!(
+                        "sidecar hardlink target escapes its runtime root: {}",
+                        target.display()
+                    ));
+                }
+            }
+            if archive_file_count > MAX_FILE_COUNT
+                || archive_bytes > manifest.unpacked_bytes
+                || archive_bytes > MAX_UNPACKED_BYTES
+            {
+                return Err("sidecar archive exceeds extraction safety limits".to_string());
+            }
+        } else if entry_type.is_dir() {
+            let is_archive_root = relative
+                .components()
+                .all(|component| component == Component::CurDir);
+            if !is_archive_root {
+                archive_directory_count = archive_directory_count
+                    .checked_add(1)
+                    .ok_or_else(|| "sidecar archive directory count overflow".to_string())?;
+                if archive_directory_count > MAX_FILE_COUNT {
+                    return Err("sidecar archive exceeds directory safety limits".to_string());
+                }
+            }
+        } else {
+            return Err(format!(
+                "sidecar archive contains a forbidden non-file entry: {}",
+                relative.display()
+            ));
+        }
+
+        let unpacked = entry
+            .unpack_in(staging)
+            .map_err(|error| format!("could not extract {}: {error}", relative.display()))?;
+        if !unpacked {
+            return Err(format!(
+                "sidecar archive refused unsafe path {}",
+                relative.display()
+            ));
+        }
+    }
+
+    if archive_file_count != manifest.file_count
+        || archive_directory_count != manifest.directory_count
+    {
+        return Err(format!(
+            "sidecar archive metrics do not match manifest (files {archive_file_count}/{}, directories {archive_directory_count}/{})",
+            manifest.file_count, manifest.directory_count
+        ));
+    }
+    let (file_count, directory_count, unpacked_bytes) = tree_metrics(staging)?;
+    if file_count != manifest.file_count
+        || directory_count != manifest.directory_count
+        || unpacked_bytes != manifest.unpacked_bytes
+    {
+        return Err("extracted sidecar metrics do not match manifest".to_string());
+    }
+    if !runtime_has_required_files(staging) {
+        return Err("sidecar archive is missing required runtime files".to_string());
+    }
+
+    Ok(())
+}
+
+fn prepare_runtime_from_files(
+    archive_path: &Path,
+    manifest_path: &Path,
+    cache_root: &Path,
+    package_version: &str,
+) -> Result<PathBuf, String> {
+    let manifest = read_manifest(manifest_path)?;
+    let destination = cache_root.join(cache_key(package_version, &manifest.archive_sha256));
+    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
+        return Ok(destination);
+    }
+
+    let metadata = fs::metadata(archive_path).map_err(|error| {
+        format!(
+            "could not inspect sidecar archive {}: {error}",
+            archive_path.display()
+        )
+    })?;
+    if metadata.len() != manifest.archive_bytes {
+        return Err(format!(
+            "sidecar archive size does not match manifest ({}/{})",
+            metadata.len(),
+            manifest.archive_bytes
+        ));
+    }
+    let actual_sha256 = sha256_file(archive_path)?;
+    if actual_sha256 != manifest.archive_sha256 {
+        return Err("sidecar archive SHA-256 does not match its manifest".to_string());
+    }
+
+    fs::create_dir_all(cache_root).map_err(|error| {
+        format!(
+            "could not create sidecar cache {}: {error}",
+            cache_root.display()
+        )
+    })?;
+    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
+        return Ok(destination);
+    }
+    if destination.exists() {
+        fs::remove_dir_all(&destination).map_err(|error| {
+            format!(
+                "could not replace incomplete sidecar cache {}: {error}",
+                destination.display()
+            )
+        })?;
+    }
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let staging = cache_root.join(format!(
+        ".extract-{}-{}-{nonce}",
+        std::process::id(),
+        cache_key(package_version, &manifest.archive_sha256)
+    ));
+    fs::create_dir(&staging).map_err(|error| {
+        format!(
+            "could not create sidecar staging directory {}: {error}",
+            staging.display()
+        )
+    })?;
+
+    let extraction = (|| -> Result<(), String> {
+        extract_archive(archive_path, &staging, &manifest)?;
+        let marker = CompletionMarker {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            package_version: package_version.to_string(),
+            archive_sha256: manifest.archive_sha256.clone(),
+        };
+        let marker_json = serde_json::to_string_pretty(&marker)
+            .map_err(|error| format!("could not serialize sidecar completion marker: {error}"))?;
+        fs::write(staging.join(".complete.json"), format!("{marker_json}\n"))
+            .map_err(|error| format!("could not write sidecar completion marker: {error}"))?;
+        Ok(())
+    })();
+    if let Err(error) = extraction {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+
+    match fs::rename(&staging, &destination) {
+        Ok(()) => Ok(destination),
+        Err(_error) if cache_is_ready(&destination, package_version, &manifest.archive_sha256) => {
+            let _ = fs::remove_dir_all(&staging);
+            Ok(destination)
+        }
+        Err(error) => {
+            let _ = fs::remove_dir_all(&staging);
+            Err(format!(
+                "could not activate extracted sidecar cache {}: {error}",
+                destination.display()
+            ))
+        }
+    }
+}
+
+fn has_complete_marker(runtime: &Path) -> bool {
+    if !runtime_has_required_files(runtime) {
+        return false;
+    }
+    let Ok(contents) = fs::read_to_string(runtime.join(".complete.json")) else {
+        return false;
+    };
+    match serde_json::from_str::<CompletionMarker>(&contents) {
+        Ok(marker) => {
+            marker.schema_version == MANIFEST_SCHEMA_VERSION
+                && marker.archive_sha256.len() == 64
+                && marker
+                    .archive_sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit())
+        }
+        Err(_) => false,
+    }
+}
+
+pub(crate) fn cleanup_stale_sidecar_runtimes(current: &Path) {
+    let Some(cache_root) = current.parent() else {
+        return;
+    };
+    let Ok(entries) = fs::read_dir(cache_root) else {
+        return;
+    };
+    let mut previous = Vec::new();
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_dir() || path == current {
+            continue;
+        }
+        if entry.file_name().to_string_lossy().starts_with(".extract-") {
+            let stale = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .ok()
+                .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+                .is_some_and(|age| age >= STALE_EXTRACTION_AGE);
+            if stale {
+                let _ = fs::remove_dir_all(path);
+            }
+            continue;
+        }
+        if has_complete_marker(&path) {
+            previous.push(entry);
+        } else if let Err(error) = fs::remove_dir_all(&path) {
+            log::warn!(
+                "[cave] could not remove incomplete sidecar cache {}: {}",
+                path.display(),
+                error
+            );
+        }
+    }
+    previous.sort_by_key(|entry| {
+        entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(UNIX_EPOCH)
+    });
+    previous.reverse();
+
+    // Keep one previous complete runtime for rollback and for a concurrently
+    // running older app. Older generations are best-effort cache cleanup.
+    for entry in previous.into_iter().skip(1) {
+        if let Err(error) = fs::remove_dir_all(entry.path()) {
+            log::warn!(
+                "[cave] could not remove stale sidecar cache {}: {}",
+                entry.path().display(),
+                error
+            );
+        }
+    }
+}
+
+pub(crate) fn prepare_sidecar_runtime(
+    app: &tauri::App,
+    resource_dir: &Path,
+) -> Result<PathBuf, String> {
+    let archive_dir = resource_dir.join("resources").join("server-archive");
+    let archive_path = archive_dir.join("server.tar.gz");
+    let manifest_path = archive_dir.join("manifest.json");
+    let cache_root = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("could not resolve sidecar cache directory: {error}"))?
+        .join("sidecar-runtime");
+    let started = Instant::now();
+    let runtime = prepare_runtime_from_files(
+        &archive_path,
+        &manifest_path,
+        &cache_root,
+        &app.package_info().version.to_string(),
+    )?;
+    log::info!(
+        "[cave] Windows sidecar runtime ready at {} in {:.2?}",
+        runtime.display(),
+        started.elapsed()
+    );
+    Ok(runtime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::{write::GzEncoder, Compression};
+
+    fn test_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "covencave-sidecar-{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("test clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create test root");
+        root
+    }
+
+    fn fixture_files() -> Vec<(&'static str, &'static [u8])> {
+        vec![
+            ("server.mjs", b"console.log('fixture')"),
+            (".next/required-server-files.json", b"{}"),
+            (".next/BUILD_ID", b"fixture-build"),
+            ("node_modules/@next/env/package.json", b"{}"),
+            ("node_modules/@swc/helpers/_/index", b"fixture"),
+            ("node_modules/node-pty/package.json", b"{}"),
+            ("node_modules/sharp/package.json", b"{}"),
+        ]
+    }
+
+    fn write_fixture(root: &Path) -> (PathBuf, PathBuf, SidecarArchiveManifest) {
+        let source = root.join("source");
+        fs::create_dir(&source).expect("create fixture source");
+        let files = fixture_files();
+        for (path, contents) in &files {
+            let destination = source.join(path);
+            fs::create_dir_all(destination.parent().expect("fixture parent"))
+                .expect("create fixture parent");
+            fs::write(destination, contents).expect("write fixture file");
+        }
+
+        let archive_path = root.join("server.tar.gz");
+        let archive_file = File::create(&archive_path).expect("create archive");
+        let encoder = GzEncoder::new(archive_file, Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        archive
+            .append_dir_all(".", &source)
+            .expect("append fixture tree");
+        let encoder = archive.into_inner().expect("finish tar");
+        encoder.finish().expect("finish gzip");
+        let (file_count, directory_count, unpacked_bytes) =
+            tree_metrics(&source).expect("fixture metrics");
+        let manifest = SidecarArchiveManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            archive_sha256: sha256_file(&archive_path).expect("fixture digest"),
+            archive_bytes: fs::metadata(&archive_path).expect("archive metadata").len(),
+            unpacked_bytes,
+            file_count,
+            directory_count,
+        };
+        let manifest_path = root.join("manifest.json");
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&serde_json::json!({
+                "schemaVersion": manifest.schema_version,
+                "archiveSha256": manifest.archive_sha256.clone(),
+                "archiveBytes": manifest.archive_bytes,
+                "unpackedBytes": manifest.unpacked_bytes,
+                "fileCount": manifest.file_count,
+                "directoryCount": manifest.directory_count,
+            }))
+            .expect("serialize manifest"),
+        )
+        .expect("write manifest");
+        (archive_path, manifest_path, manifest)
+    }
+
+    #[test]
+    fn extracts_atomically_and_reuses_complete_cache() {
+        let root = test_root("extract");
+        let (archive, manifest, _) = write_fixture(&root);
+        let cache = root.join("cache");
+        let runtime = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
+            .expect("extract runtime");
+        assert!(runtime.join("server.mjs").is_file());
+        assert!(runtime.join(".complete.json").is_file());
+
+        fs::remove_file(&archive).expect("remove archive after first extraction");
+        assert_eq!(
+            prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3").expect("reuse cache"),
+            runtime
+        );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn replaces_an_incomplete_destination() {
+        let root = test_root("incomplete");
+        let (archive, manifest_path, manifest) = write_fixture(&root);
+        let cache = root.join("cache");
+        fs::create_dir_all(&cache).expect("create cache");
+        let destination = cache.join(cache_key("1.2.3", &manifest.archive_sha256));
+        fs::create_dir(&destination).expect("create incomplete destination");
+        fs::write(destination.join("partial"), b"partial").expect("write partial file");
+
+        let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache, "1.2.3")
+            .expect("replace incomplete cache");
+        assert!(!runtime.join("partial").exists());
+        assert!(runtime.join("server.mjs").is_file());
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn rejects_a_corrupt_archive_without_activating_it() {
+        let root = test_root("corrupt");
+        let (archive, manifest, _) = write_fixture(&root);
+        fs::write(&archive, b"not a gzip archive").expect("corrupt archive");
+        let cache = root.join("cache");
+        let error = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
+            .expect_err("corrupt archive must fail");
+        assert!(error.contains("size does not match") || error.contains("SHA-256"));
+        assert!(!cache.exists() || fs::read_dir(&cache).expect("read cache").next().is_none());
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn manifest_limits_are_enforced_before_extraction() {
+        let root = test_root("limits");
+        let (_, manifest_path, _) = write_fixture(&root);
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+                .expect("parse manifest");
+        value["fileCount"] = serde_json::json!(MAX_FILE_COUNT + 1);
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&value).expect("serialize oversized manifest"),
+        )
+        .expect("write oversized manifest");
+        assert!(read_manifest(&manifest_path)
+            .expect_err("oversized manifest must fail")
+            .contains("file count"));
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn extracts_the_built_windows_archive_when_available() {
+        let archive_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("resources")
+            .join("server-archive");
+        let archive = archive_dir.join("server.tar.gz");
+        let manifest = archive_dir.join("manifest.json");
+        if !archive.is_file() || !manifest.is_file() {
+            // Plain cargo test/check runs do not build release resources. The
+            // Windows sidecar-runtime CI leg builds them before this test.
+            return;
+        }
+        let root = test_root("built-archive");
+        let runtime = prepare_runtime_from_files(&archive, &manifest, &root, "ci-fixture")
+            .expect("extract built Windows archive with production code");
+        assert!(runtime_has_required_files(&runtime));
+        fs::remove_dir_all(root).expect("remove built archive fixture");
+    }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": [
+      "resources/server-archive/**/*",
+      "resources/node/**/*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Replace the expanded Windows sidecar resource tree with one verified archive, reducing the WiX/MSI component graph by more than 99.9% while preserving the complete packaged runtime. Also stop the sidecar before updater exit and retain verbose MSI upgrade logs.

Fixes #2892.

## Why

The 35m17s upgrade in #2892 was dominated by Windows Installer servicing 24,219 components and 24,215 files. Nearly all came from recursively packaging the 24k-file Next.js/Node sidecar tree as individual WiX components.

This keeps the same runtime payload but moves its internal file expansion to a versioned LocalAppData cache, outside MSI's component transaction.

## Changes

- Add a Windows-only Tauri resource override containing `server.tar.gz`, its manifest, and bundled Node; macOS/Linux keep the expanded tree for existing native signing.
- Materialize package symlinks, enforce compressed/expanded/file-count budgets, and emit SHA-256 metadata during bundling.
- Verify and safely extract the archive to an atomic `<version>-<digest>` cache on first launch; reuse complete caches and retain the current plus one prior runtime.
- Reject traversal, symlink, device, and unconfined hardlink entries; validate counts, sizes, digest, and required native/runtime paths.
- Register a native resource cleanup guard so Tauri updater exit stops and reaps the Node process tree before `msiexec` starts.
- Enable `/L*V` updater logs under the app log directory.
- Measure release MSI tables with the Windows Installer COM API and fail above 64 rows or 256 MiB; upload the JSON diagnostics.
- Exercise archive extraction, native `sharp`/`node-pty` loading, server startup, cache recovery, and cleanup behavior in CI/tests.

## Verification

Production Windows artifact diagnostics:

| Metric | #2892 baseline | Candidate |
|---|---:|---:|
| MSI `File` rows | 24,215 | 6 |
| MSI `Component` rows | 24,219 | 10 |
| MSI `CreateFolder` rows | 24,214 | 5 |
| MSI `Directory` rows | 3,598 | 10 |

- Archive: 24,293 files, 4,018 directories, 549,137,534 bytes expanded, 142,153,657 bytes compressed.
- MSI: 181,293,056 bytes; summed installed `FileSize`: 249,352,404 bytes; exactly one `server.tar.gz` row.
- Cold production Rust extraction of the full archive: 144.11s.
- Full extracted-runtime smoke with bundled Node, `sharp`, `node-pty`, server boot, and avatar request: 141.7s.

Passed:

- `bash scripts/sidecar-bundle.sh`
- `pnpm test:sidecar-runtime`
- `pnpm exec tauri build --bundles msi --config .tmp-tauri-msi-config.json` (temporary config disabled only a duplicate prebuild)
- `powershell -File scripts/windows-msi-budget.ps1 -MsiPath <candidate.msi>`
- `cargo check --locked --all-targets` on the rebased v0.0.172 tree
- `cargo test --locked sidecar_archive -- --nocapture` (5 passed)
- `cargo test --locked cleanup -- --nocapture` (2 passed)
- `node scripts/sidecar-bundle.test.mjs`
- `node scripts/sidecar-bundle-deps.test.mjs`
- `node src-tauri/release-runtime.test.mjs` (11 passed)
- `node src-tauri/permissions/desktop-permissions.test.mjs` (11 passed)
- `node src/components/update-available.test.ts`
- `node scripts/check-tests-wired.mjs` (797 suites wired)
- `pnpm typecheck`
- `git diff --check origin/main...HEAD`

Known baseline/environment failures:

- `cargo clippy --locked --all-targets -- -D warnings`: pre-existing `too_many_arguments` in `src/browser.rs` and `needless_return` in `src/pty.rs` plus the unrelated folder-picker path in `src/lib.rs`.
- `cargo test --locked --lib`: 21 passed; existing `pty::tests::pty_diagnose_spawns_shell_and_reads_output` failed with empty output, matching the pre-change baseline.
- `pnpm test:app`: stopped at the existing Windows Store Python alias error in `scripts/sync-marketplace.test.mjs` (exit 9009).
- `pnpm test:api`: stopped because plain `bash` resolves to a broken local WSL installation; the touched shell tests passed through Git Bash.

## Risk + rollout notes

- This intentionally shifts sidecar file I/O from MSI upgrade to first launch. Cold extraction stayed below five minutes on the diagnostic machine; warm cache reuse is tested but not separately benchmarked.
- Cache contents are user-writable LocalAppData. Initial extraction verifies the signed bundle archive; warm reuse validates the completion marker and required paths rather than rehashing all 24k files.
- Cleanup retains one prior complete cache. Cache residue after uninstall and a narrow concurrent incomplete-cache replacement race remain.
- Host tar metadata is not reproducible, so same-version rebuilds can produce a different digest/cache key.
- The release budget currently runs after `tauri-action`; a failing budget can occur after the action has uploaded its artifact.
- A real previous-version-to-candidate timed upgrade was not run because the local installed/candidate versions did not provide a valid consecutive-version test. This draft should remain unmerged until reference Windows hardware confirms the upgrade is under five minutes and Restart Manager leaves no sidecar process.
