### PR TITLE
chore(release): stamp v0.0.173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.173] - 2026-07-10
+
+> _One-line teaser — edit before merge._
+
+Patch release on top of v0.0.172.
+
+### Changes
+- fix(projects): drop stale scope on refetch; gate palette project fetch on open (#2908)
+- docs: iOS onboarding + constant connection + cloud persistence — review & plan (cave-rku9) (#2909)
+- fix(rollout): five P3s from the evening re-audit (#2907)
+- feat(cave): chat/board polish batch — palette, pickers, header row, review fixes (#2906)
+- fix(rollout): three P2s from the evening re-audit (#2904)
+
+
 ## [0.0.172] - 2026-07-10
 
 > Analytics & daily-report polish, marketplace Crafts and Grimoire Stitches, plus cross-platform production hardening.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ breaking config changes; patch releases stay additive.
 
 ## [0.0.173] - 2026-07-10
 
-> _One-line teaser — edit before merge._
+> Board & palette project-scoping correctness, chat/board polish, and rollout-audit hardening.
 
 Patch release on top of v0.0.172.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.172"
+version = "0.0.173"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.172"
+version = "0.0.173"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.172</string>
+	<string>0.0.173</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.172</string>
+	<string>0.0.173</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.172</string>
+	<string>0.0.173</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.172</string>
+	<string>0.0.173</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.172",
+  "version": "0.0.173",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamped by `scripts/stamp-release.mjs`. Edit the CHANGELOG teaser/grouping before merge.

```
## [0.0.173] - 2026-07-10

> _One-line teaser — edit before merge._

Patch release on top of v0.0.172.

### Changes
- fix(projects): drop stale scope on refetch; gate palette project fetch on open (#2908)
- docs: iOS onboarding + constant connection + cloud persistence — review & plan (cave-rku9) (#2909)
- fix(rollout): five P3s from the evening re-audit (#2907)
- feat(cave): chat/board polish batch — palette, pickers, header row, review fixes (#2906)
- fix(rollout): three P2s from the evening re-audit (#2904)

```