### PR TITLE
perf(windows): prune the packaged sidecar runtime closure

### DIFF
--- a/scripts/build-sandbox-runtime.mjs
+++ b/scripts/build-sandbox-runtime.mjs
@@ -53,7 +53,7 @@ export async function buildSandboxRuntime() {
 }
 
 // Run when invoked directly (not when imported by the test).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   buildSandboxRuntime()
     .then(() => console.log(`sandbox assets → ${path.relative(root, OUTDIR)}/{react-runtime,tailwind}.js`))
     .catch((err) => {

--- a/scripts/build-sandbox-runtime.test.mjs
+++ b/scripts/build-sandbox-runtime.test.mjs
@@ -1,11 +1,22 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import { buildSandboxRuntime, OUTFILE, TAILWIND_OUTFILE } from "./build-sandbox-runtime.mjs";
 
 // Build the sandbox runtime and assert it produced a self-contained browser
 // bundle with React + sucrase inlined and the runtime's public surface intact.
 // (Functional render is covered by a Playwright check run outside CI.)
+
+const scriptPath = fileURLToPath(new URL("./build-sandbox-runtime.mjs", import.meta.url));
+const cli = spawnSync(process.execPath, [scriptPath], { encoding: "utf8" });
+assert.equal(cli.status, 0, `direct sandbox build failed: ${cli.stderr || cli.error}`);
+assert.match(
+  cli.stdout,
+  /sandbox assets/,
+  "direct execution must work when process.argv[1] is a native Windows path",
+);
 
 await buildSandboxRuntime();
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -740,6 +740,7 @@ export const SUITES = {
     "src/app/api/launch/route.test.ts",
     "scripts/sidecar-bundle.test.mjs",
     "scripts/sidecar-bundle-deps.test.mjs",
+    "scripts/sidecar-runtime-closure.test.mjs",
     "scripts/tray-icon.test.mjs",
     "src/app/api/sessions/[id]/events/route.test.ts",
     "src/app/api/sessions/prune/prune-response.test.ts",

--- a/scripts/sidecar-archive-manifest.mjs
+++ b/scripts/sidecar-archive-manifest.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { lstat, readdir, stat, writeFile } from "node:fs/promises";
+import { lstat, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const SIDECAR_ARCHIVE_BUDGETS = Object.freeze({
-  archiveBytes: 256 * 1024 * 1024,
-  unpackedBytes: 768 * 1024 * 1024,
-  fileCount: 50_000,
+  archiveBytes: 80 * 1024 * 1024,
+  unpackedBytes: 200 * 1024 * 1024 - 1,
+  fileCount: 4_999,
 });
 
 async function sha256File(file) {
@@ -75,13 +75,42 @@ export async function writeSidecarArchiveManifest(sourceRoot, archivePath, outpu
   return manifest;
 }
 
+export async function publishSidecarArchive(
+  sourceRoot,
+  temporaryArchivePath,
+  archivePath,
+  manifestPath,
+  temporaryManifestPath = `${manifestPath}.${process.pid}.tmp`,
+) {
+  try {
+    const manifest = await writeSidecarArchiveManifest(sourceRoot, temporaryArchivePath, temporaryManifestPath);
+    // Both files are fully written, hashed, and budgeted before either public
+    // path changes. Publish the manifest last so readers never accept a new
+    // archive using stale integrity metadata.
+    await rename(temporaryArchivePath, archivePath);
+    await rename(temporaryManifestPath, manifestPath);
+    return manifest;
+  } catch (error) {
+    await Promise.all([
+      rm(temporaryArchivePath, { force: true }),
+      rm(temporaryManifestPath, { force: true }),
+    ]);
+    throw error;
+  }
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const [sourceRoot, archivePath, outputPath] = process.argv.slice(2);
-  if (!sourceRoot || !archivePath || !outputPath) {
-    console.error("usage: sidecar-archive-manifest.mjs <source-root> <archive> <manifest>");
+  const publish = process.argv[2] === "--publish";
+  const args = process.argv.slice(publish ? 3 : 2);
+  if (args.length !== (publish ? 5 : 3)) {
+    console.error(
+      "usage: sidecar-archive-manifest.mjs [--publish] <source-root> <temporary-archive> [archive] <manifest> [temporary-manifest]",
+    );
     process.exit(2);
   }
-  const manifest = await writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath);
+  const manifest = publish
+    ? await publishSidecarArchive(args[0], args[1], args[2], args[3], args[4])
+    : await writeSidecarArchiveManifest(args[0], args[1], args[2]);
   console.log(
     `==> Windows sidecar archive: ${manifest.fileCount} files, ${manifest.unpackedBytes} bytes expanded, ${manifest.archiveBytes} bytes compressed`,
   );

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -6,11 +6,12 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const [src, baseConfigSource, windowsConfigSource, manifestSource] = await Promise.all([
+const [src, baseConfigSource, windowsConfigSource, manifestSource, closureSource] = await Promise.all([
   readFile(new URL("./sidecar-bundle.sh", import.meta.url), "utf8"),
   readFile(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"),
   readFile(new URL("../src-tauri/tauri.windows.conf.json", import.meta.url), "utf8"),
   readFile(new URL("./sidecar-archive-manifest.mjs", import.meta.url), "utf8"),
+  readFile(new URL("./sidecar-runtime-closure.mjs", import.meta.url), "utf8"),
 ]);
 const baseConfig = JSON.parse(baseConfigSource);
 const windowsConfig = JSON.parse(windowsConfigSource);
@@ -18,17 +19,49 @@ const windowsConfig = JSON.parse(windowsConfigSource);
 // Must use locked pnpm install (frozen lockfile prevents supply chain attacks)
 assert.match(src, /pnpm install --prod --frozen-lockfile/, "sidecar must install from locked pnpm lockfile");
 
-// Must dereference symlinks when copying node_modules (-L flag)
-assert.match(src, /cp -aL.*node_modules/, "node_modules copy must dereference symlinks (-aL) to prevent symlink attacks");
-
 // Must NOT use npm install (unlocked, not reproducible)
 assert.doesNotMatch(src, /(?<!p)npm install(?! --lockfile-version)/, "sidecar must not use unlocked npm install");
 
 // PNPM_STAGE must be used as the source for the final node_modules
 assert.match(src, /PNPM_STAGE.*node_modules/, "final node_modules must come from PNPM_STAGE (locked install)");
 
-// Security: must not blindly copy symlinks from STANDALONE into bundle
-assert.match(src, /cp -aL/, "all node_modules copies must dereference symlinks");
+// Security: dependency links are resolved only when their target remains in
+// the locked workspace/staging roots. The resulting runtime must contain no
+// links before it reaches the archive or platform signer.
+assert.match(closureSource, /realpath\(source\)/, "dependency links must be resolved before copying");
+assert.match(closureSource, /sidecar dependency link escapes its allowed roots/, "dependency links must be confined");
+assert.match(closureSource, /sidecar runtime must not contain links/, "assembled runtime must reject surviving links");
+
+// Runtime size: assemble the union of Next's NFT traces and explicit dynamic
+// packages/data, never the standalone repository root or full prod install.
+assert.match(src, /sidecar-runtime-closure\.mjs/, "sidecar must use the traced runtime closure assembler");
+assert.doesNotMatch(src, /cp -aL "\$PNPM_STAGE\/node_modules" "\$DEST\/node_modules"/, "sidecar must not graft every production dependency");
+assert.match(closureSource, /\.nft\.json/, "runtime closure must consume Next file traces");
+for (const runtimeRoot of [
+  ".agents/skills",
+  "marketplace/catalog.json",
+  "marketplace/exports",
+  "marketplace/marketplace.json",
+  "marketplace/plugins",
+  "public",
+  "workflows",
+  "vault.yaml",
+]) {
+  assert.match(closureSource, new RegExp(runtimeRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime allowlist must retain ${runtimeRoot}`);
+}
+for (const forbiddenRoot of [
+  ".beads",
+  ".claude",
+  ".codex",
+  "marketplace/craft-sources",
+  "screenshots",
+  "src",
+  "tests",
+]) {
+  assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
+}
+assert.match(closureSource, /fileCount: 4_999/, "runtime closure must stay below 5,000 files");
+assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
 // useful only while developing or debugging the build machine.
@@ -103,9 +136,12 @@ assert.ok(
 );
 assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.gz archive");
 assert.match(src, /sidecar-archive-manifest\.mjs/, "archive generation must emit its integrity and size manifest");
-assert.match(manifestSource, /archiveBytes: 256 \* 1024 \* 1024/, "archive size must have a 256 MiB hard budget");
-assert.match(manifestSource, /unpackedBytes: 768 \* 1024 \* 1024/, "expanded runtime must have a 768 MiB hard budget");
-assert.match(manifestSource, /fileCount: 50_000/, "archive entry count must have a hard budget");
+assert.match(src, /\.server\.tar\.gz\.\$\$\.tmp/, "archive generation must use a same-directory staging path");
+assert.match(src, /sidecar-archive-manifest\.mjs" --publish/, "verified archive publication must use the atomic publisher");
+assert.match(manifestSource, /rename\(temporaryArchivePath, archivePath\)[\s\S]*rename\(temporaryManifestPath, manifestPath\)/, "archive must publish only after verification and manifest must publish last");
+assert.match(manifestSource, /archiveBytes: 80 \* 1024 \* 1024/, "archive size must stay within the 80 MiB target");
+assert.match(manifestSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "expanded runtime must stay strictly below the 200 MiB target");
+assert.match(manifestSource, /fileCount: 4_999/, "archive must stay below 5,000 files");
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");
 assert.match(
   src,

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Build + assemble the Next.js standalone server with a flat, complete
-# node_modules so it can boot without any pnpm symlink magic. macOS/Linux
-# package the expanded tree; Windows packages a bounded archive that the
-# launcher expands into its versioned local runtime cache.
+# Build + assemble the Next.js standalone server from its emitted file traces
+# plus Cave's explicit runtime data. macOS/Linux package the expanded tree;
+# Windows packages a bounded archive that the launcher expands into its
+# versioned local runtime cache.
 #
 # Mobile-Tauri builds: skip entirely. iOS and Android sandboxes can't spawn
 # a child Node.js process, the resulting IPA / APK would balloon by ~100MB
@@ -26,12 +26,13 @@ DEST="$ROOT/src-tauri/resources/server"
 WINDOWS_ARCHIVE_DIR="$ROOT/src-tauri/resources/server-archive"
 WINDOWS_ARCHIVE="$WINDOWS_ARCHIVE_DIR/server.tar.gz"
 WINDOWS_ARCHIVE_MANIFEST="$WINDOWS_ARCHIVE_DIR/manifest.json"
+WINDOWS_ARCHIVE_TEMP="$WINDOWS_ARCHIVE_DIR/.server.tar.gz.$$.tmp"
+WINDOWS_ARCHIVE_MANIFEST_TEMP="$WINDOWS_ARCHIVE_DIR/.manifest.json.$$.tmp"
 BUNDLED_NODE_DIR="$ROOT/src-tauri/resources/node"
-STATIC="$ROOT/.next/static"
-PUBLIC="$ROOT/public"
 PNPM_STAGE="$(mktemp -d "${TMPDIR:-/tmp}/coven-cave-sidecar-pnpm.XXXXXX")"
 cleanup_staging() {
   rm -rf "$PNPM_STAGE"
+  rm -f "$WINDOWS_ARCHIVE_TEMP" "$WINDOWS_ARCHIVE_MANIFEST_TEMP"
 }
 trap cleanup_staging EXIT
 
@@ -139,12 +140,18 @@ prune_sidecar_nonruntime_files() {
     "$dest/node_modules/@playwright" \
     "$dest/node_modules/@types" \
     "$dest/node_modules/playwright" \
-    "$dest/node_modules/playwright-core"
+    "$dest/node_modules/playwright-core" \
+    "$dest/node_modules/node-pty/deps" \
+    "$dest/node_modules/node-pty/scripts" \
+    "$dest/node_modules/node-pty/src" \
+    "$dest/node_modules/node-pty/typings"
 
   find "$dest" -type f \( \
     -name '*.map' -o \
     -name '*.d.ts' -o \
-    -name '*.d.ts.map' \
+    -name '*.d.ts.map' -o \
+    -name '*.pdb' -o \
+    -name '*.test.js' \
   \) -delete
 }
 
@@ -201,7 +208,13 @@ copy_node_shared_runtime() {
 
 write_windows_sidecar_archive() {
   mkdir -p "$WINDOWS_ARCHIVE_DIR"
-  rm -f "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"
+  # A killed prior build must not leave unbounded staging files. Final archive
+  # and manifest paths remain untouched until the replacement passes all
+  # integrity and size gates.
+  find "$WINDOWS_ARCHIVE_DIR" -maxdepth 1 -type f -mmin +1440 \( \
+    -name '.server.tar.gz.*.tmp' -o \
+    -name '.manifest.json.*.tmp' \
+  \) -delete
 
   # The standalone output can retain valid pnpm symlinks. Materialize those
   # few links in place instead of copying the entire 500+ MiB tree a second
@@ -217,16 +230,18 @@ write_windows_sidecar_archive() {
     mv "$materialized" "$link"
   done < <(find "$DEST" -type l -print0)
 
-  echo "==> archiving Windows sidecar -> $WINDOWS_ARCHIVE"
+  echo "==> archiving Windows sidecar -> $WINDOWS_ARCHIVE_TEMP"
   if [ "$(uname -s)" = "Darwin" ]; then
     COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs \
-      -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
+      -czf "$WINDOWS_ARCHIVE_TEMP" -C "$DEST" .
   else
-    tar -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
+    tar -czf "$WINDOWS_ARCHIVE_TEMP" -C "$DEST" .
   fi
 
-  node "$ROOT/scripts/sidecar-archive-manifest.mjs" \
-    "$DEST" "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"
+  node "$ROOT/scripts/sidecar-archive-manifest.mjs" --publish \
+    "$DEST" "$WINDOWS_ARCHIVE_TEMP" \
+    "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST" \
+    "$WINDOWS_ARCHIVE_MANIFEST_TEMP"
 
   # Keep the expanded tree out of the Windows build workspace as a second
   # guard against accidentally reintroducing thousands of WiX components.
@@ -281,90 +296,16 @@ fi
 prune_foreign_native_packages "$PNPM_STAGE/node_modules"
 fix_node_pty_spawn_helpers "$PNPM_STAGE/node_modules"
 
-echo "==> copying standalone tree → $DEST"
-rm -rf "$DEST"
-mkdir -p "$DEST"
-# Skip the standalone's broken pnpm-style node_modules; we'll bring in the
-# locked, dereferenced pnpm one instead.
-(cd "$STANDALONE" && find . -mindepth 1 -maxdepth 1 ! -name node_modules \
-   -exec cp -a {} "$DEST/" \;)
+echo "==> assembling traced sidecar runtime → $DEST"
+node "$ROOT/scripts/sidecar-runtime-closure.mjs" \
+  "$ROOT" "$STANDALONE" "$PNPM_STAGE/node_modules" "$DEST"
 
-echo "==> grafting locked node_modules → $DEST/node_modules"
-cp -aL "$PNPM_STAGE/node_modules" "$DEST/node_modules"
+echo "==> pruning sidecar runtime for the release target"
+prune_foreign_native_packages "$DEST/node_modules"
 fix_node_pty_spawn_helpers "$DEST/node_modules"
 
-# The standalone tree's server.js is Next's generated entrypoint — it serves
-# the app but has no /api/pty-ws websocket bridge, so the terminal cannot
-# reach a shell through the sidecar. Ship the custom server (server.ts →
-# server.mjs, produced by `pnpm build:server` inside `pnpm build` above);
-# the Tauri launcher prefers server.mjs when present.
-echo "==> shipping custom PTY-bridge server → $DEST/server.mjs"
-if [ ! -f "$ROOT/server.mjs" ]; then
-  echo "ERROR: $ROOT/server.mjs missing after build — build:server should have produced it" >&2
-  exit 1
-fi
-cp "$ROOT/server.mjs" "$DEST/server.mjs"
-
-# But Next.js's compiled server.js can require the standalone's own internal
-# next package layout. Merge any package the standalone shipped that the
-# locked production install did not include (rare, but cheap to do).
-if [ -d "$STANDALONE/node_modules" ]; then
-  echo "==> backfilling any pnpm-only packages from standalone"
-  (cd "$STANDALONE/node_modules" && find . -maxdepth 2 -mindepth 1 -type d \
-     ! -path "./.pnpm*" -print0 2>/dev/null \
-     | while IFS= read -r -d '' pkg; do
-        rel="${pkg#./}"
-        if [ ! -e "$DEST/node_modules/$rel" ]; then
-          mkdir -p "$DEST/node_modules/$(dirname "$rel")"
-          cp -aL "$STANDALONE/node_modules/$rel" \
-            "$DEST/node_modules/$rel" 2>/dev/null || true
-        fi
-      done)
-fi
-
-if [ -d "$STATIC" ]; then
-  mkdir -p "$DEST/.next/static"
-  echo "==> copying .next/static → $DEST/.next/static"
-  cp -a "$STATIC/." "$DEST/.next/static/"
-fi
-
-# Next.js + pnpm also drops symlinks under .next/node_modules/ that point at
-# ../../node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg> (e.g. shiki,
-# oniguruma-to-es). After we swap in the locked top-level node_modules
-# above, those symlinks dangle, and Tauri's resource glob rejects the bundle
-# with `resource path doesn't exist`. Resolve each into a real directory.
-if [ -d "$DEST/.next/node_modules" ]; then
-  echo "==> resolving dangling pnpm symlinks in .next/node_modules"
-  while IFS= read -r link; do
-    # Only patch dangling symlinks (non-dangling ones are fine as-is).
-    if [ -e "$link" ]; then
-      continue
-    fi
-    # Strip the trailing -<16hex> webpack-content-hash suffix
-    pkg="$(basename "$link" | sed -E 's/-[a-f0-9]{16}$//')"
-    src=""
-    if [ -d "$PNPM_STAGE/node_modules/$pkg" ]; then
-      src="$PNPM_STAGE/node_modules/$pkg"
-    elif [ -d "$ROOT/node_modules/$pkg" ]; then
-      src="$ROOT/node_modules/$pkg"
-    fi
-    if [ -n "$src" ] && [ -d "$src" ]; then
-      rm -f "$link"
-      cp -aL "$src" "$link"
-      echo "    resolved $(basename "$link") ← $pkg"
-    else
-      echo "    ! could not resolve $(basename "$link") (pkg=$pkg)" >&2
-    fi
-  done < <(find "$DEST/.next/node_modules" -mindepth 1 -maxdepth 1 -type l)
-fi
-
-if [ -d "$PUBLIC" ]; then
-  mkdir -p "$DEST/public"
-  echo "==> copying public/ → $DEST/public"
-  cp -a "$PUBLIC/." "$DEST/public/"
-fi
-
 prune_sidecar_nonruntime_files "$DEST"
+node "$ROOT/scripts/sidecar-runtime-closure.mjs" --verify "$DEST"
 
 # Sanity check
 for must in node_modules/@next/env node_modules/@swc/helpers/_; do

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+import { copyFile, lstat, mkdir, readFile, readdir, realpath, rm, stat, writeFile, chmod } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SIDECAR_RUNTIME_ROOTS = Object.freeze([
+  ".agents/skills",
+  "marketplace/catalog.json",
+  "marketplace/exports",
+  "marketplace/marketplace.json",
+  "marketplace/plugins",
+  "public",
+  "workflows",
+  "vault.yaml",
+]);
+
+export const SIDECAR_FORBIDDEN_ROOTS = Object.freeze([
+  ".beads",
+  ".claude",
+  ".codex",
+  "apps",
+  "docs",
+  "marketplace/craft-sources",
+  "screenshots",
+  "scripts",
+  "src",
+  "tests",
+]);
+
+export const SIDECAR_DYNAMIC_PACKAGES = Object.freeze([
+  "@next/env",
+  "@swc/helpers",
+  "node-pty",
+  "sharp",
+  "ws",
+]);
+
+export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
+  fileCount: 4_999,
+  unpackedBytes: 200 * 1024 * 1024 - 1,
+});
+
+const PACKAGE_NAME_RE = /^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+$/i;
+const PLATFORM_OPTIONAL_PACKAGE_RE = /^(?:@img\/sharp-|@next\/swc-)/;
+
+function isInside(root, candidate) {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
+function packageParts(relativePath) {
+  const parts = relativePath.split(path.sep);
+  if (parts[0] !== "node_modules") return null;
+
+  const nodeModulesIndex = parts.lastIndexOf("node_modules");
+  let packageEnd = nodeModulesIndex + 2;
+  if (parts[nodeModulesIndex + 1]?.startsWith("@")) packageEnd += 1;
+  if (packageEnd > parts.length) return null;
+
+  const packageName = parts.slice(nodeModulesIndex + 1, packageEnd).join("/");
+  if (!packageName || packageName === ".pnpm") return null;
+  if (!PACKAGE_NAME_RE.test(packageName)) {
+    throw new Error(`invalid package name in Next trace: ${packageName}`);
+  }
+  return {
+    packageName,
+    packageRoot: parts.slice(0, packageEnd).join(path.sep),
+  };
+}
+
+function shouldSkipPackageEntry(relativePath, entryName, _isDirectory) {
+  if (entryName === "node_modules") return true;
+  if (entryName.endsWith(".map") || entryName.endsWith(".d.ts") || entryName.endsWith(".d.ts.map")) return true;
+
+  const normalized = relativePath.split(path.sep).join("/");
+  if (/^node-pty\/(?:deps|scripts|src|typings)(?:\/|$)/.test(normalized)) return true;
+  if (/^node-pty\/lib\/.*\.test\.js$/.test(normalized)) return true;
+  if (/^node-pty\/.*\.pdb$/i.test(normalized)) return true;
+  return false;
+}
+
+async function copyResolvedEntry(source, destination, options, relativePath = "") {
+  if (!options.allowedLinkRoots.some((root) => isInside(root, source))) {
+    throw new Error(`sidecar runtime input escapes its allowed roots: ${source}`);
+  }
+  const metadata = await lstat(source);
+  let resolvedSource = source;
+  let resolvedMetadata = metadata;
+
+  if (metadata.isSymbolicLink()) {
+    if (!options.followLinks) {
+      throw new Error(`sidecar runtime input must not contain links: ${source}`);
+    }
+    resolvedSource = await realpath(source);
+    if (!options.allowedLinkRoots.some((root) => isInside(root, resolvedSource))) {
+      throw new Error(`sidecar dependency link escapes its allowed roots: ${source} -> ${resolvedSource}`);
+    }
+    resolvedMetadata = await stat(resolvedSource);
+  }
+
+  if (resolvedMetadata.isDirectory()) {
+    await mkdir(destination, { recursive: true });
+    const entries = await readdir(resolvedSource, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const childRelative = relativePath ? path.join(relativePath, entry.name) : entry.name;
+      if (options.filter?.(childRelative, entry.name, entry.isDirectory())) continue;
+      await copyResolvedEntry(
+        path.join(resolvedSource, entry.name),
+        path.join(destination, entry.name),
+        options,
+        childRelative,
+      );
+    }
+    return;
+  }
+
+  if (!resolvedMetadata.isFile()) {
+    throw new Error(`sidecar runtime input contains an unsupported entry: ${source}`);
+  }
+  await mkdir(path.dirname(destination), { recursive: true });
+  await copyFile(resolvedSource, destination);
+  await chmod(destination, resolvedMetadata.mode & 0o777);
+}
+
+async function walkFiles(root, predicate, skipDirectory = () => false) {
+  const found = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!skipDirectory(entryPath, entry.name)) pending.push(entryPath);
+      } else if (predicate(entryPath, entry.name)) {
+        found.push(entryPath);
+      }
+    }
+  }
+  return found;
+}
+
+export async function collectTracedDependencies(projectRoot) {
+  const nextRoot = path.join(projectRoot, ".next");
+  const traceFiles = await walkFiles(
+    nextRoot,
+    (_entryPath, name) => name.endsWith(".nft.json"),
+    (entryPath, name) => name === "cache" || name === "standalone" || isInside(path.join(nextRoot, "standalone"), entryPath),
+  );
+  if (traceFiles.length === 0) {
+    throw new Error(`Next build emitted no .nft.json traces under ${nextRoot}`);
+  }
+
+  const packageRoots = new Map();
+  const resolvedPackageRoots = new Map();
+  for (const traceFile of traceFiles) {
+    const trace = JSON.parse(await readFile(traceFile, "utf8"));
+    if (!Array.isArray(trace.files)) {
+      throw new Error(`invalid Next trace file list: ${traceFile}`);
+    }
+    for (const tracedPath of trace.files) {
+      if (typeof tracedPath !== "string") {
+        throw new Error(`invalid Next trace entry in ${traceFile}`);
+      }
+      const source = path.resolve(path.dirname(traceFile), tracedPath);
+      if (!isInside(projectRoot, source)) {
+        throw new Error(`Next trace escapes the project root: ${traceFile} -> ${tracedPath}`);
+      }
+      const relativeSource = path.relative(projectRoot, source);
+      const parts = packageParts(relativeSource);
+      if (!parts) continue;
+
+      const sourcePackageRoot = path.join(projectRoot, parts.packageRoot);
+      let resolvedPackageRoot = resolvedPackageRoots.get(sourcePackageRoot);
+      if (!resolvedPackageRoot) {
+        resolvedPackageRoot = await realpath(sourcePackageRoot);
+        resolvedPackageRoots.set(sourcePackageRoot, resolvedPackageRoot);
+      }
+      if (!isInside(path.join(projectRoot, "node_modules"), resolvedPackageRoot)) {
+        throw new Error(`traced dependency resolves outside node_modules: ${sourcePackageRoot} -> ${resolvedPackageRoot}`);
+      }
+      const previousRoot = packageRoots.get(parts.packageName);
+      if (previousRoot && previousRoot !== resolvedPackageRoot) {
+        throw new Error(
+          `Next trace resolves multiple versions of ${parts.packageName}: ${previousRoot} and ${resolvedPackageRoot}`,
+        );
+      }
+      packageRoots.set(parts.packageName, resolvedPackageRoot);
+    }
+  }
+
+  return {
+    traceFileCount: traceFiles.length,
+    packageNames: [...packageRoots.keys()].sort(),
+    packages: [...packageRoots.entries()]
+      .map(([packageName, sourceRoot]) => ({ packageName, sourceRoot }))
+      .sort((left, right) => left.packageName.localeCompare(right.packageName)),
+  };
+}
+
+async function copyDynamicPackage(packageName, dependencyRoot, destination, allowedLinkRoots) {
+  if (!PACKAGE_NAME_RE.test(packageName)) {
+    throw new Error(`invalid dynamic sidecar package name: ${packageName}`);
+  }
+  const destinationPackage = path.join(destination, "node_modules", ...packageName.split("/"));
+  const source = path.join(dependencyRoot, ...packageName.split("/"));
+  const packageJson = path.join(source, "package.json");
+  try {
+    await stat(packageJson);
+  } catch (error) {
+    try {
+      await stat(path.join(destinationPackage, "package.json"));
+      return;
+    } catch (destinationError) {
+      if (destinationError.code !== "ENOENT") throw destinationError;
+    }
+    throw new Error(`required dynamic sidecar package is missing: ${packageName} (${error.message})`);
+  }
+  await copyResolvedEntry(source, destinationPackage, {
+    followLinks: true,
+    allowedLinkRoots,
+    filter: (relativePath, name, isDirectory) =>
+      shouldSkipPackageEntry(path.join(packageName, relativePath), name, isDirectory),
+  });
+}
+
+async function copyDynamicNativePackages(dependencyRoot, destination, allowedLinkRoots) {
+  const scopeRoot = path.join(dependencyRoot, "@img");
+  let entries;
+  try {
+    entries = await readdir(scopeRoot, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
+  }
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.name.startsWith("sharp-")) continue;
+    await copyDynamicPackage(`@img/${entry.name}`, dependencyRoot, destination, allowedLinkRoots);
+  }
+}
+
+async function copyNextAliases(standaloneRoot, destination, allowedLinkRoots) {
+  const aliasesRoot = path.join(standaloneRoot, ".next", "node_modules");
+  let aliases;
+  try {
+    aliases = await readdir(aliasesRoot, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
+  }
+
+  for (const alias of aliases.sort((left, right) => left.name.localeCompare(right.name))) {
+    const aliasSource = path.join(aliasesRoot, alias.name);
+    const resolvedAlias = await realpath(aliasSource);
+    const packageJson = JSON.parse(await readFile(path.join(resolvedAlias, "package.json"), "utf8"));
+    if (typeof packageJson.name !== "string" || !PACKAGE_NAME_RE.test(packageJson.name)) {
+      throw new Error(`Next runtime alias has no package name: ${aliasSource}`);
+    }
+    const packageSource = path.join(destination, "node_modules", ...packageJson.name.split("/"));
+    await copyResolvedEntry(packageSource, path.join(destination, ".next", "node_modules", alias.name), {
+      followLinks: true,
+      allowedLinkRoots: [...allowedLinkRoots, destination],
+      filter: (relativePath, name, isDirectory) =>
+        shouldSkipPackageEntry(path.join(packageJson.name, relativePath), name, isDirectory),
+    });
+  }
+}
+
+export async function assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination) {
+  const roots = [projectRoot, standaloneRoot, dependencyRoot].map((root) => path.resolve(root));
+  [projectRoot, standaloneRoot, dependencyRoot, destination] = [
+    path.resolve(projectRoot),
+    path.resolve(standaloneRoot),
+    path.resolve(dependencyRoot),
+    path.resolve(destination),
+  ];
+  if (isInside(projectRoot, destination) && !isInside(path.join(projectRoot, "src-tauri", "resources"), destination)) {
+    throw new Error(`refusing to replace a sidecar destination outside src-tauri/resources: ${destination}`);
+  }
+
+  const traced = await collectTracedDependencies(projectRoot);
+  for (const requiredPackage of ["next", "react", "react-dom"]) {
+    if (!traced.packageNames.includes(requiredPackage)) {
+      throw new Error(`Next trace is missing required server package: ${requiredPackage}`);
+    }
+  }
+
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(destination, { recursive: true });
+
+  await copyResolvedEntry(path.join(standaloneRoot, ".next"), path.join(destination, ".next"), {
+    followLinks: false,
+    allowedLinkRoots: roots,
+    filter: (relativePath, name, isDirectory) => {
+      if (relativePath.split(path.sep)[0] === "node_modules") return true;
+      return name.endsWith(".map") || name.endsWith(".nft.json") || (isDirectory && name === "cache");
+    },
+  });
+  await copyResolvedEntry(path.join(projectRoot, ".next", "static"), path.join(destination, ".next", "static"), {
+    followLinks: false,
+    allowedLinkRoots: roots,
+  });
+  await copyResolvedEntry(path.join(standaloneRoot, "server.js"), path.join(destination, "server.js"), {
+    followLinks: false,
+    allowedLinkRoots: roots,
+  });
+  await copyResolvedEntry(path.join(projectRoot, "server.mjs"), path.join(destination, "server.mjs"), {
+    followLinks: false,
+    allowedLinkRoots: roots,
+  });
+
+  const projectPackage = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
+  await writeFile(
+    path.join(destination, "package.json"),
+    `${JSON.stringify({ name: "coven-cave-sidecar", version: projectPackage.version, private: true, type: "module" }, null, 2)}\n`,
+    "utf8",
+  );
+
+  for (const runtimeRoot of SIDECAR_RUNTIME_ROOTS) {
+    await copyResolvedEntry(path.join(projectRoot, runtimeRoot), path.join(destination, runtimeRoot), {
+      followLinks: false,
+      allowedLinkRoots: roots,
+    });
+  }
+
+  for (const { packageName, sourceRoot } of traced.packages) {
+    const sparseSource = path.join(standaloneRoot, path.relative(projectRoot, sourceRoot));
+    const stagedSource = path.join(dependencyRoot, ...packageName.split("/"));
+    let source = sparseSource;
+    try {
+      if (!(await stat(sparseSource)).isDirectory()) {
+        throw new Error("not a directory");
+      }
+    } catch {
+      source = stagedSource;
+      try {
+        if (!(await stat(stagedSource)).isDirectory()) throw new Error("not a directory");
+      } catch (error) {
+        if (error.code === "ENOENT" && PLATFORM_OPTIONAL_PACKAGE_RE.test(packageName)) continue;
+        throw new Error(
+          `traced sidecar package is missing from the build output and locked production install: ${packageName} (${error.message})`,
+        );
+      }
+    }
+    await copyResolvedEntry(source, path.join(destination, "node_modules", ...packageName.split("/")), {
+      followLinks: true,
+      allowedLinkRoots: roots,
+      filter: (relativePath, name, isDirectory) =>
+        shouldSkipPackageEntry(path.join(packageName, relativePath), name, isDirectory),
+    });
+  }
+
+  for (const packageName of SIDECAR_DYNAMIC_PACKAGES) {
+    await copyDynamicPackage(packageName, dependencyRoot, destination, roots);
+  }
+  await copyDynamicNativePackages(dependencyRoot, destination, roots);
+  await copyNextAliases(standaloneRoot, destination, roots);
+
+  return traced;
+}
+
+export async function sidecarRuntimeMetrics(root) {
+  let fileCount = 0;
+  let directoryCount = 0;
+  let unpackedBytes = 0;
+  const pending = [path.resolve(root)];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      const metadata = await lstat(entryPath);
+      if (metadata.isSymbolicLink()) throw new Error(`sidecar runtime must not contain links: ${entryPath}`);
+      if (metadata.isDirectory()) {
+        directoryCount += 1;
+        pending.push(entryPath);
+      } else if (metadata.isFile()) {
+        fileCount += 1;
+        unpackedBytes += metadata.size;
+      } else {
+        throw new Error(`sidecar runtime contains an unsupported entry: ${entryPath}`);
+      }
+    }
+  }
+  return { fileCount, directoryCount, unpackedBytes };
+}
+
+export async function verifySidecarRuntime(root) {
+  root = path.resolve(root);
+  const required = [
+    ".next/BUILD_ID",
+    ".next/required-server-files.json",
+    "marketplace/catalog.json",
+    "marketplace/marketplace.json",
+    "node_modules/@next/env/package.json",
+    "node_modules/@swc/helpers/package.json",
+    "node_modules/next/package.json",
+    "node_modules/node-pty/package.json",
+    "node_modules/react/package.json",
+    "node_modules/react-dom/package.json",
+    "node_modules/sharp/package.json",
+    "node_modules/ws/package.json",
+    "package.json",
+    "public/sandbox/react-runtime.js",
+    "server.js",
+    "server.mjs",
+    "vault.yaml",
+  ];
+  for (const relativePath of required) await stat(path.join(root, relativePath));
+  for (const forbiddenRoot of SIDECAR_FORBIDDEN_ROOTS) {
+    try {
+      await stat(path.join(root, forbiddenRoot));
+      throw new Error(`development-only root leaked into sidecar runtime: ${forbiddenRoot}`);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+
+  const metrics = await sidecarRuntimeMetrics(root);
+  for (const [metric, budget] of Object.entries(SIDECAR_RUNTIME_BUDGETS)) {
+    if (metrics[metric] > budget) {
+      throw new Error(`sidecar runtime ${metric} ${metrics[metric]} exceeds target ${budget}`);
+    }
+  }
+  return metrics;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (process.argv[2] === "--verify") {
+    const root = process.argv[3];
+    if (!root) throw new Error("usage: sidecar-runtime-closure.mjs --verify <runtime-root>");
+    const metrics = await verifySidecarRuntime(root);
+    console.log(
+      `==> sidecar runtime closure: ${metrics.fileCount} files, ${metrics.directoryCount} directories, ${metrics.unpackedBytes} bytes`,
+    );
+  } else {
+    const [projectRoot, standaloneRoot, dependencyRoot, destination] = process.argv.slice(2);
+    if (!projectRoot || !standaloneRoot || !dependencyRoot || !destination) {
+      throw new Error(
+        "usage: sidecar-runtime-closure.mjs <project-root> <standalone-root> <dependency-root> <destination>",
+      );
+    }
+    const traced = await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
+    console.log(
+      `==> assembled sidecar from ${traced.traceFileCount} Next traces and ${traced.packageNames.length} traced packages`,
+    );
+  }
+}

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  assembleSidecarRuntime,
+  collectTracedDependencies,
+  SIDECAR_FORBIDDEN_ROOTS,
+  SIDECAR_RUNTIME_BUDGETS,
+  verifySidecarRuntime,
+} from "./sidecar-runtime-closure.mjs";
+import { publishSidecarArchive } from "./sidecar-archive-manifest.mjs";
+
+async function write(root, relativePath, contents = "fixture\n") {
+  const output = path.join(root, relativePath);
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, contents, "utf8");
+}
+
+async function packageFixture(root, packageName, extra = {}) {
+  const packageRoot = path.join(root, "node_modules", ...packageName.split("/"));
+  await write(packageRoot, "package.json", `${JSON.stringify({ name: packageName, version: "1.0.0" })}\n`);
+  await write(packageRoot, "index.js", `module.exports = ${JSON.stringify(packageName)};\n`);
+  for (const [relativePath, contents] of Object.entries(extra)) await write(packageRoot, relativePath, contents);
+}
+
+async function missing(target) {
+  try {
+    await access(target);
+    return false;
+  } catch (error) {
+    if (error.code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+const fixture = await mkdtemp(path.join(os.tmpdir(), "coven-sidecar-closure-"));
+const projectRoot = path.join(fixture, "project");
+const standaloneRoot = path.join(projectRoot, ".next", "standalone");
+const dependencyRoot = path.join(fixture, "locked-production", "node_modules");
+const destination = path.join(fixture, "output");
+
+try {
+  await write(projectRoot, "package.json", '{"name":"fixture","version":"9.8.7"}\n');
+  await write(projectRoot, "server.mjs", "export {};\n");
+  await write(projectRoot, "vault.yaml", "{}\n");
+  await write(projectRoot, ".agents/skills/runtime/SKILL.md", "# Runtime skill\n");
+  await write(projectRoot, "marketplace/catalog.json", "{}\n");
+  await write(projectRoot, "marketplace/exports/mcp/mcp.json", "{}\n");
+  await write(projectRoot, "marketplace/marketplace.json", "{}\n");
+  await write(projectRoot, "marketplace/plugins/example/plugin.json", "{}\n");
+  await write(projectRoot, "public/sandbox/react-runtime.js", "runtime\n");
+  await write(projectRoot, "public/sandbox/tailwind.js", "tailwind\n");
+  await write(projectRoot, "workflows/example.yaml", "id: example\n");
+  for (const forbiddenRoot of SIDECAR_FORBIDDEN_ROOTS) {
+    await write(projectRoot, `${forbiddenRoot}/must-not-ship.txt`, "development only\n");
+  }
+
+  await write(projectRoot, ".next/static/chunk.js", "chunk\n");
+  await write(standaloneRoot, ".next/BUILD_ID", "fixture-build\n");
+  await write(standaloneRoot, ".next/required-server-files.json", "{}\n");
+  await write(standaloneRoot, ".next/server/route.js", "route\n");
+  await write(standaloneRoot, ".next/server/route.js.map", "build-only map\n");
+  await write(standaloneRoot, "server.js", "require('next');\n");
+
+  for (const packageName of [
+    "@next/env",
+    "@swc/helpers",
+    "@img/sharp-win32-x64",
+    "foo",
+    "next",
+    "node-pty",
+    "react",
+    "react-dom",
+    "sharp",
+    "ws",
+  ]) {
+    await packageFixture(projectRoot, packageName);
+    await packageFixture(path.dirname(dependencyRoot), packageName);
+  }
+  await write(projectRoot, "node_modules/@img/sharp-win32-x64/lib/libvips-42.dll", "native dependency\n");
+  await write(dependencyRoot, "@img/sharp-win32-x64/lib/libvips-42.dll", "native dependency\n");
+  await write(projectRoot, "node_modules/foo/node_modules/evil/index.js", "must not be copied\n");
+
+  const tracePath = path.join(projectRoot, ".next", "server", "route.js.nft.json");
+  const traceEntries = ["foo", "next", "react", "react-dom"].map(
+    (packageName) => `../../node_modules/${packageName}/index.js`,
+  );
+  traceEntries.push("../../src/development-only.ts");
+  await write(projectRoot, ".next/server/route.js.nft.json", `${JSON.stringify({ version: 1, files: traceEntries })}\n`);
+
+  const trace = await collectTracedDependencies(projectRoot);
+  assert.equal(trace.traceFileCount, 1);
+  assert.deepEqual(trace.packageNames, ["foo", "next", "react", "react-dom"]);
+
+  await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
+  const metrics = await verifySidecarRuntime(destination);
+  assert.ok(metrics.fileCount < 5_000);
+  assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
+  assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
+    fileCount: 4_999,
+    unpackedBytes: 200 * 1024 * 1024 - 1,
+  });
+
+  assert.equal(JSON.parse(await readFile(path.join(destination, "package.json"), "utf8")).version, "9.8.7");
+  assert.equal(await readFile(path.join(destination, "marketplace/catalog.json"), "utf8"), "{}\n");
+  assert.equal(await readFile(path.join(destination, "marketplace/plugins/example/plugin.json"), "utf8"), "{}\n");
+  assert.equal(await readFile(path.join(destination, "workflows/example.yaml"), "utf8"), "id: example\n");
+  assert.equal(await readFile(path.join(destination, "public/sandbox/tailwind.js"), "utf8"), "tailwind\n");
+  assert.equal(await readFile(path.join(destination, "node_modules/foo/index.js"), "utf8"), 'module.exports = "foo";\n');
+  assert.equal(
+    await readFile(path.join(destination, "node_modules/@img/sharp-win32-x64/lib/libvips-42.dll"), "utf8"),
+    "native dependency\n",
+  );
+  assert.ok(await missing(path.join(destination, "node_modules/foo/node_modules/evil/index.js")));
+  assert.ok(await missing(path.join(destination, ".next/server/route.js.map")));
+  for (const forbiddenRoot of SIDECAR_FORBIDDEN_ROOTS) {
+    assert.ok(await missing(path.join(destination, forbiddenRoot)), `${forbiddenRoot} must be excluded`);
+  }
+
+  const optionalPackage = "@next/swc-linux-x64-gnu";
+  await packageFixture(projectRoot, optionalPackage);
+  await writeFile(
+    tracePath,
+    `${JSON.stringify({
+      version: 1,
+      files: [...traceEntries, `../../node_modules/${optionalPackage}/index.js`],
+    })}\n`,
+    "utf8",
+  );
+  await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
+  assert.ok(
+    await missing(path.join(destination, "node_modules", ...optionalPackage.split("/"))),
+    "a traced platform-optional package absent from this target's locked install may be skipped",
+  );
+
+  await writeFile(tracePath, `${JSON.stringify({ version: 1, files: traceEntries })}\n`, "utf8");
+  for (const requiredPackage of ["sharp", "node-pty", "ws"]) {
+    const requiredRoot = path.join(dependencyRoot, requiredPackage);
+    await rm(requiredRoot, { recursive: true, force: true });
+    await assert.rejects(
+      assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+      new RegExp(`required dynamic sidecar package is missing: ${requiredPackage}`),
+      `missing required dynamic package ${requiredPackage} must fail closed`,
+    );
+    await packageFixture(path.dirname(dependencyRoot), requiredPackage);
+  }
+
+  const externalPackageRoot = path.join(fixture, "outside-allowed-roots", "sharp");
+  await write(externalPackageRoot, "package.json", '{"name":"sharp","version":"1.0.0"}\n');
+  await write(externalPackageRoot, "index.js", "module.exports = 'outside';\n");
+  await rm(path.join(dependencyRoot, "sharp"), { recursive: true, force: true });
+  try {
+    await symlink(
+      externalPackageRoot,
+      path.join(dependencyRoot, "sharp"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await assert.rejects(
+      assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+      /sidecar dependency link escapes its allowed roots/,
+      "dependency links must not escape the locked production root",
+    );
+  } catch (error) {
+    if (!["EPERM", "EACCES", "ENOSYS"].includes(error.code)) throw error;
+    console.warn(`sidecar-runtime-closure.test: symlink confinement skipped (${error.code})`);
+  } finally {
+    await rm(path.join(dependencyRoot, "sharp"), { recursive: true, force: true });
+    await packageFixture(path.dirname(dependencyRoot), "sharp");
+  }
+
+  const publishedArchive = path.join(fixture, "published", "server.tar.gz");
+  const publishedManifest = path.join(fixture, "published", "manifest.json");
+  const interruptedArchive = path.join(fixture, "published", ".server.tar.gz.interrupted.tmp");
+  await mkdir(path.dirname(publishedArchive), { recursive: true });
+  await writeFile(publishedArchive, "previous archive\n");
+  await writeFile(publishedManifest, "previous manifest\n");
+  await writeFile(interruptedArchive, "candidate archive\n");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(fixture, "missing-runtime"),
+      interruptedArchive,
+      publishedArchive,
+      publishedManifest,
+    ),
+    /ENOENT/,
+    "failed verification must interrupt publication",
+  );
+  assert.equal(await readFile(publishedArchive, "utf8"), "previous archive\n");
+  assert.equal(await readFile(publishedManifest, "utf8"), "previous manifest\n");
+  assert.ok(await missing(interruptedArchive), "failed publication must remove its staged archive");
+
+  const verifiedArchive = path.join(fixture, "published", ".server.tar.gz.verified.tmp");
+  await writeFile(verifiedArchive, "verified candidate archive\n");
+  const published = await publishSidecarArchive(
+    path.join(projectRoot, "public"),
+    verifiedArchive,
+    publishedArchive,
+    publishedManifest,
+  );
+  assert.equal(await readFile(publishedArchive, "utf8"), "verified candidate archive\n");
+  assert.deepEqual(JSON.parse(await readFile(publishedManifest, "utf8")), published);
+  assert.ok(await missing(verifiedArchive), "successful publication must consume its staged archive");
+
+  await writeFile(tracePath, `${JSON.stringify({ version: 1, files: ["../../../outside.txt"] })}\n`, "utf8");
+  await assert.rejects(
+    collectTracedDependencies(projectRoot),
+    /Next trace escapes the project root/,
+    "trace input must not copy arbitrary files from outside the project",
+  );
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}
+
+console.log("sidecar-runtime-closure.test.mjs: ok");

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -97,9 +97,9 @@ async function main() {
     const archive = path.join(archiveDir, "server.tar.gz");
     const manifest = JSON.parse(await readFile(path.join(archiveDir, "manifest.json"), "utf8"));
     assert.equal(manifest.schemaVersion, 1);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 50_000);
-    assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 256 * 1024 * 1024);
-    assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes <= 768 * 1024 * 1024);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount < 5_000);
+    assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
+    assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));
     const extraction = spawnSync("tar", ["-xzf", archive, "-C", extractedSidecarRoot], {
       encoding: "utf8",
@@ -110,6 +110,33 @@ async function main() {
     sidecarRoot = extractedSidecarRoot;
   }
   const sidecarServer = path.join(sidecarRoot, "server.mjs");
+  for (const requiredPath of [
+    ".agents/skills/run-cave-app/SKILL.md",
+    ".next/BUILD_ID",
+    "marketplace/catalog.json",
+    "marketplace/marketplace.json",
+    "marketplace/plugins/github/plugin.json",
+    "marketplace/plugins/prompt-pack-essentials/plugin.json",
+    "public/sandbox/react-runtime.js",
+    "public/sandbox/tailwind.js",
+    "vault.yaml",
+    "workflows/release-review.yaml",
+  ]) {
+    await access(path.join(sidecarRoot, requiredPath));
+  }
+  for (const forbiddenRoot of [
+    ".beads",
+    ".claude",
+    ".codex",
+    "apps",
+    "docs",
+    "marketplace/craft-sources",
+    "screenshots",
+    "src",
+    "tests",
+  ]) {
+    await assert.rejects(access(path.join(sidecarRoot, forbiddenRoot)), { code: "ENOENT" });
+  }
   await access(sidecarServer);
   await access(bundledNode);
 
@@ -171,6 +198,60 @@ async function main() {
     assert.equal(meta.format, "png");
     assert.equal(meta.width, 256, "avatar should be downscaled to the packaged route max dimension");
     assert.equal(meta.height, 128, "avatar should preserve aspect ratio during sidecar transcode");
+
+    const marketplaceResponse = await fetch(`${baseUrl}/api/marketplace`, {
+      headers: { "x-coven-cave-token": token },
+    });
+    assert.equal(marketplaceResponse.status, 200, "packaged marketplace API must load its bundled catalog");
+    const marketplace = await marketplaceResponse.json();
+    assert.ok(marketplace.ok && marketplace.plugins.length > 0, "packaged marketplace catalog must not be empty");
+
+    const promptPackResponse = await fetch(`${baseUrl}/api/marketplace/pack-prompts?id=prompt-pack-essentials`, {
+      headers: { "x-coven-cave-token": token },
+    });
+    assert.equal(promptPackResponse.status, 200, "packaged prompt packs must resolve from marketplace/plugins");
+    const promptPack = await promptPackResponse.json();
+    assert.ok(promptPack.ok && promptPack.prompts.length > 0, "packaged prompt pack content must not be empty");
+
+    const installResponse = await fetch(`${baseUrl}/api/marketplace/install`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: baseUrl,
+        "x-coven-cave-token": token,
+      },
+      body: JSON.stringify({ id: "github" }),
+    });
+    assert.equal(installResponse.status, 200, "packaged marketplace install must read the retained plugin manifest");
+    assert.equal((await installResponse.json()).ok, true);
+    const uninstallResponse = await fetch(`${baseUrl}/api/marketplace/uninstall`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: baseUrl,
+        "x-coven-cave-token": token,
+      },
+      body: JSON.stringify({ id: "github" }),
+    });
+    assert.equal(uninstallResponse.status, 200, "packaged marketplace uninstall must resolve the retained catalog");
+    assert.equal((await uninstallResponse.json()).ok, true);
+
+    const craftPlanResponse = await fetch(`${baseUrl}/api/marketplace/crafts/plan?id=seekers-lens`, {
+      headers: { "x-coven-cave-token": token },
+    });
+    assert.equal(craftPlanResponse.status, 200, "craft install planning must not depend on excluded craft sources");
+    assert.equal((await craftPlanResponse.json()).ok, true);
+
+    const workflowsResponse = await fetch(`${baseUrl}/api/workflows`, {
+      headers: { "x-coven-cave-token": token },
+    });
+    assert.equal(workflowsResponse.status, 200, "packaged workflows API must load its bundled seeds");
+    const workflows = await workflowsResponse.json();
+    assert.ok(workflows.ok && workflows.workflows.length > 0, "packaged workflow seeds must not be empty");
+
+    const sandboxResponse = await fetch(`${baseUrl}/sandbox/react-runtime.js`);
+    assert.equal(sandboxResponse.status, 200, "packaged sandbox runtime must be served from public assets");
+    assert.match(await sandboxResponse.text(), /generated; do not edit/);
     console.log(`sidecar-runtime-smoke: ok on ${process.platform}/${process.arch} (${baseUrl})`);
   } catch (err) {
     console.error(output.dump());

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -140,7 +140,13 @@ assert.equal(
 const sidecarBundle = readFileSync(new URL("../scripts/sidecar-bundle.sh", import.meta.url), "utf8");
 assert.match(
   sidecarBundle,
-  /cp "\$ROOT\/server\.mjs" "\$DEST\/server\.mjs"/,
+  /node "\$ROOT\/scripts\/sidecar-runtime-closure\.mjs"/,
+  "sidecar bundle delegates packaging to the traced runtime assembler",
+);
+const sidecarClosure = readFileSync(new URL("../scripts/sidecar-runtime-closure.mjs", import.meta.url), "utf8");
+assert.match(
+  sidecarClosure,
+  /copyResolvedEntry\(path\.join\(projectRoot, "server\.mjs"\), path\.join\(destination, "server\.mjs"\)/,
   "sidecar bundle ships the custom PTY-bridge server next to the standalone tree",
 );
 const tauriLib = readFileSync(new URL("../src-tauri/src/lib.rs", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

Replace the full production dependency graft with an explicit, traced, tested Windows sidecar runtime closure below the file and size budgets.

## Why

Refs #2912.

The previous sidecar contained roughly 24,000 files. The packaged runtime needs traced Next.js dependencies, explicit dynamic/native packages, and known runtime data?not the complete production dependency tree.

## Changes

- Assemble from Next.js NFT traces and an explicit runtime-data allowlist.
- Preserve skills, marketplace/plugins, public assets, workflows, crafts, Sharp, `node-pty`, and the packaged server.
- Source fallback dependencies only from the frozen production install.
- Reject escaping or surviving links and exclude development/test/source-only content.
- Enforce fewer than 5,000 files, fewer than 200 MiB expanded, and at most 80 MiB compressed.
- Publish archive and manifest only after hashing and budget validation.
- Extend packaged smokes across server, Sharp, `node-pty`, marketplace, crafts, workflows, and public assets.

This PR is independently mergeable and does not depend on the diagnostics, cache, UX, or compression PRs.

## Verification

- `node scripts/sidecar-runtime-closure.test.mjs` ? passed.
- `node scripts/sidecar-bundle-deps.test.mjs` ? passed.
- `node scripts/build-sandbox-runtime.test.mjs` ? passed.
- `node --experimental-strip-types src/server-pty-ws.test.ts` ? passed the traced-assembler packaging contract.
- `node scripts/check-tests-wired.mjs` ? all 799 test files wired.
- `node scripts/sidecar-runtime-smoke.mjs` ? passed on Windows x64.
- `pnpm typecheck` ? passed.
- `git diff --check origin/main...HEAD` ? passed.
- Independent gzip artifact: 4,942 files, 1,348 directories, 102,580,489 expanded bytes, 32,090,079 compressed bytes, SHA-256 `47344a0e280436a0287975f0ef8c71c7814091e5209f8bf7b1838bf5630c018e`.
- Combined release artifact: 4,942 files, 102,605,244 expanded bytes, 29,081,705 zstd bytes; packaged feature smoke passed.
- Combined MSI: 68,886,528 bytes, File 6, Component 11, CreateFolder 6, Directory 11, exactly one runtime archive.

## Risk + rollout notes

- The explicit dynamic-package allowlist is the primary review surface; packaged smokes cover all known consumers.
- Later cache/compression PRs touch shared packaging files but this PR has no dependency on them.
- `pnpm test:app` passed 61 files before the existing Windows Microsoft Store Python alias stopped `sync-marketplace.test.mjs`; focused tests and typecheck pass.
- Required `CodeQL` was not scheduled for this fork-based PR; an OpenCoven maintainer must mirror the head to an upstream branch (or otherwise run the required aggregate check) before merge.

