### PR TITLE
fix(projects): drop stale scope on refetch; gate palette project fetch on open

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -266,6 +266,7 @@ export const SUITES = {
     "src/components/vault-automations-filter.test.ts",
     "src/components/board-link-browser.test.ts",
     "src/components/new-card-modal.test.ts",
+    "src/lib/use-projects.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/components/calendar-agenda-redesign.test.ts",
     "src/lib/calendar-layout.test.ts",

--- a/src/components/board-project-picker.test.ts
+++ b/src/components/board-project-picker.test.ts
@@ -53,8 +53,8 @@ assert.match(
 );
 assert.match(
   newCard,
-  /<Field label="Project">[\s\S]{0,260}options=\{\[\s*\{ value: "", label: "No project" \},/,
-  "new-card modal renders a Project field with a No-project default",
+  /<Field label="Project">[\s\S]{0,600}label: projectsLoading \? "Loading projects…" : "No project" \}/,
+  "new-card modal renders a Project field whose default reads 'Loading projects…' while the scoped list is in flight, else 'No project'",
 );
 assert.match(
   newCard,

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -170,8 +170,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const \{ projects \} = useProjects\(\{ familiarId: activeFamiliarId \}\)/,
-  "palette scopes project navigation to the active familiar's granted projects",
+  /const \{ projects \} = useProjects\(\{ familiarId: activeFamiliarId, enabled: open \}\)/,
+  "palette scopes project navigation to the active familiar's granted projects and only fetches while open",
 );
 assert.match(
   source,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -242,7 +242,10 @@ export function CommandPalette({
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   // "Open project" rows jump into the Projects hub, which is itself scoped to
   // the active familiar — offer only projects that familiar can actually reach.
-  const { projects } = useProjects({ familiarId: activeFamiliarId });
+  // The palette is always mounted (it self-returns null when closed), so gate
+  // the fetch on `open`, or it re-requests /api/projects on every active-familiar
+  // change while the user can't even see the palette.
+  const { projects } = useProjects({ familiarId: activeFamiliarId, enabled: open });
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);
   const [cards, setCards] = useState<Card[]>([]);

--- a/src/components/new-card-modal.test.ts
+++ b/src/components/new-card-modal.test.ts
@@ -10,4 +10,24 @@ assert.doesNotMatch(modal, /<button\b/, "new-card modal should not hand-roll but
 assert.doesNotMatch(modal, /<select\b|<option\b/, "new-card modal should not use native select controls");
 assert.doesNotMatch(modal, /rounded-md/, "new-card modal should use control radius tokens instead of hard-coded rounded-md");
 
+// The project list is familiar-scoped and self-fetched (enabled: open), so while
+// a fetch is in flight the modal must NOT offer the previous familiar's retained
+// options — otherwise a mid-refetch pick reaches a project the new familiar can't
+// access and the board chat-launch 403s. Gate the options on the loading flag.
+assert.match(
+  modal,
+  /useProjects\(\{ familiarId, enabled: open \}\)/,
+  "new-card modal fetches projects scoped to the assigned familiar, only while open",
+);
+assert.match(
+  modal,
+  /loading: projectsLoading/,
+  "new-card modal reads the projects loading flag to gate the Project picker",
+);
+assert.match(
+  modal,
+  /projectsLoading \? \[\] : projects\.map/,
+  "new-card modal suppresses stale project options while the scoped list is loading",
+);
+
 console.log("new-card-modal.test.ts: ok");

--- a/src/components/new-card-modal.tsx
+++ b/src/components/new-card-modal.tsx
@@ -77,7 +77,7 @@ export function NewCardModal({
   // POST starts the card's chat under that familiar, which the server rejects
   // (403) for an ungranted project. Re-scopes when the Familiar picker below
   // changes; a null familiar ("Default familiar") loads the operator-wide list.
-  const { projects } = useProjects({ familiarId, enabled: open });
+  const { projects, loading: projectsLoading } = useProjects({ familiarId, enabled: open });
 
   useEffect(() => {
     if (!open) return;
@@ -249,8 +249,12 @@ export function NewCardModal({
             value={projectId ?? ""}
             onChange={(v) => setProjectId(v || null)}
             options={[
-              { value: "", label: "No project" },
-              ...projects.map((p) => ({ value: p.id, label: p.name })),
+              // While the familiar-scoped list is in flight, suppress the
+              // options entirely: the retained list belongs to the *previous*
+              // familiar, so offering it lets the user pick a project this
+              // familiar can't reach (the board chat-launch then 403s).
+              { value: "", label: projectsLoading ? "Loading projects…" : "No project" },
+              ...(projectsLoading ? [] : projects.map((p) => ({ value: p.id, label: p.name }))),
             ]}
           />
         </Field>

--- a/src/lib/use-projects.test.ts
+++ b/src/lib/use-projects.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./use-projects.ts", import.meta.url), "utf8");
+
+// When the scope (familiarId) changes or the hook re-enables, the previous
+// scope's list must be dropped before the refetch resolves. Otherwise a
+// familiar-scoped consumer (new-card modal, command palette) keeps showing —
+// and lets the user pick — another familiar's projects during the in-flight
+// request, which then 403s at the board chat-launch (assertProjectAccess).
+assert.match(
+  source,
+  /setProjects\(\[\]\);\s*\n\s*load\(\);/,
+  "useProjects clears the retained list before refetching on a scope/enable change",
+);
+
+// The clear must live in the [enabled, load] effect (load is memoized on
+// familiarId), NOT inside load() itself — a manual reload() after a mutation
+// calls load() directly and must not blank the list mid-refresh.
+assert.doesNotMatch(
+  source,
+  /setLoading\(true\);\s*\n\s*setError\(null\);\s*\n\s*setProjects\(\[\]\)/,
+  "the reset lives in the effect, not in load(), so in-place reload() never blanks the list",
+);
+
+console.log("use-projects.test.ts: ok");

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -71,6 +71,13 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
       return;
     }
 
+    // Drop the previous scope's list before refetching so a familiarId change
+    // (or a re-enable) never leaves another familiar's projects visible — and
+    // pickable — during the in-flight request. `load` is memoized on familiarId,
+    // so this effect only re-runs when the scope or `enabled` actually changes;
+    // a manual reload() after a mutation calls load() directly and is
+    // unaffected, so an in-place refresh never blanks the list.
+    setProjects([]);
     load();
     return () => abortRef.current?.abort();
   }, [enabled, load]);


### PR DESCRIPTION
Parked branch landed for review (2 commits, 8 files). Drops stale project scope on refetch and gates the palette project fetch until it's opened, plus a test pin update for the loading-gated Select.

🤖 Worked through by Claude Code (branch-cleanup goal)