### PR TITLE
refactor(runtimes): one label authority, alias + merge-label fixes, hoisted rank map

### DIFF
--- a/src/components/capabilities-normalize.test.ts
+++ b/src/components/capabilities-normalize.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   filterCapabilityItems,
+  harnessLabel,
   normalizeCapabilities,
 } from "./capabilities-normalize.ts";
 
@@ -125,5 +126,17 @@ assert.deepEqual(
   filterCapabilityItems(view.items, { harnessId: "codex", status: "disabled" }).map((item) => item.id),
   ["codex:mcp:filesystem"],
 );
+
+// harnessLabel delegates to the shared runtime label authority — every Coven
+// adapter id resolves to real display copy (openclaw/hermes used to fall
+// through to the raw lowercase id / a drifted registry label), while
+// non-adapter editor harnesses keep their local labels.
+assert.equal(harnessLabel("openclaw"), "OpenClaw");
+assert.equal(harnessLabel("hermes"), "Hermes");
+assert.equal(harnessLabel("copilot"), "Copilot");
+assert.equal(harnessLabel("opencode"), "OpenCode");
+assert.equal(harnessLabel("cursor"), "Cursor");
+assert.equal(harnessLabel("gemini"), "Gemini CLI");
+assert.equal(harnessLabel("unknown-thing"), "unknown-thing");
 
 console.log("capabilities-normalize.test.ts: ok");

--- a/src/components/capabilities-normalize.ts
+++ b/src/components/capabilities-normalize.ts
@@ -1,5 +1,5 @@
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
-import { REGISTRY_RUNTIMES } from "../lib/runtime-registry.gen.ts";
+import { runtimeDisplayLabel } from "../lib/harness-adapters.ts";
 
 export type CovenSkill = {
   id: string;
@@ -63,20 +63,16 @@ export type CapabilityFilters = {
   status?: CapabilityStatus | "all" | null;
 };
 
-const HARNESS_LABEL: Record<string, string> = {
-  codex: "Codex",
-  claude: "Claude Code",
+// Labels for harness ids that appear in capability manifests but are NOT
+// Coven runtime adapters (editor agents etc.) — everything else delegates to
+// the shared runtime label authority in harness-adapters.
+const NON_ADAPTER_HARNESS_LABEL: Record<string, string> = {
   cursor: "Cursor",
   gemini: "Gemini CLI",
-  opencode: "OpenCode",
-  "coven-code": "Coven Code",
-  copilot: "GitHub Copilot",
 };
 
 export function harnessLabel(id: string): string {
-  if (HARNESS_LABEL[id]) return HARNESS_LABEL[id];
-  const registry = REGISTRY_RUNTIMES.find((entry) => entry.id === id);
-  return registry?.label ?? id;
+  return NON_ADAPTER_HARNESS_LABEL[id] ?? runtimeDisplayLabel(id);
 }
 
 function skillSourcePath(skillPath?: string): string | undefined {

--- a/src/components/runtime-logo.tsx
+++ b/src/components/runtime-logo.tsx
@@ -8,7 +8,7 @@
 // like Icon does.
 
 import { Icon, type IconName } from "@/lib/icon";
-import { REGISTRY_RUNTIMES } from "../lib/runtime-registry.gen.ts";
+import { runtimeDisplayLabel } from "../lib/harness-adapters.ts";
 
 const OPENAI_PATH =
   "M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z";
@@ -33,23 +33,8 @@ const GLYPH_FALLBACKS: Record<string, IconName> = {
 };
 
 export function runtimeDisplayName(runtime: string): string {
-  switch (runtime) {
-    case "codex":
-      return "Codex";
-    case "claude":
-      return "Claude Code";
-    case "copilot":
-      return "Copilot";
-    case "hermes":
-      return "Hermes";
-    case "openclaw":
-      return "OpenClaw";
-    default: {
-      // Registry-synced runtimes carry their accepted label.
-      const registry = REGISTRY_RUNTIMES.find((entry) => entry.id === runtime);
-      return registry?.label ?? runtime;
-    }
-  }
+  // Single label authority: curated adapter copy → registry label → raw id.
+  return runtimeDisplayLabel(runtime);
 }
 
 export function RuntimeLogo({ runtime, size = 13 }: { runtime: string; size?: number }) {

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -12,6 +12,7 @@ import {
   isTrustedOnboardingHarness,
   openClawAdapterReport,
   canonicalHarnessId,
+  runtimeDisplayLabel,
 } from "./harness-adapters.ts";
 
 // Model-parity gating probe: forwarding `--model` must stay off until the
@@ -133,6 +134,27 @@ assert.equal(
   merged.find((adapter) => adapter.id === "hermes")?.source,
   "manifest",
 );
+// A daemon manifest label ("Hermes Agent") only applies when Cave has no
+// local report for that id; a local (curated) label always wins so a
+// registry-scaffolded manifest can't flip the adapters list copy.
+assert.equal(merged.find((adapter) => adapter.id === "hermes")?.label, "Hermes Agent", "daemon label used when no local report exists");
+assert.equal(merged.find((adapter) => adapter.id === "codex")?.label, "Codex");
+{
+  const labelMerge = mergeAdapterReports(
+    [{ id: "copilot", label: "Copilot", binary: "copilot", installed: true, path: null, version: null }],
+    [{ id: "copilot", label: "GitHub Copilot CLI", executable: "copilot", available: true, install_hint: "", source: "manifest" }],
+  );
+  assert.equal(labelMerge[0].label, "Copilot", "curated label survives a registry-manifest daemon report");
+}
+
+// Single label authority: curated copy → registry label → raw id; aliases
+// canonicalize first.
+assert.equal(runtimeDisplayLabel("copilot"), "Copilot");
+assert.equal(runtimeDisplayLabel("opencode"), "OpenCode", "registry runtimes use their accepted label");
+assert.equal(runtimeDisplayLabel("opencode-ai"), "OpenCode", "npm package alias canonicalizes (chat trust gate parity)");
+assert.equal(runtimeDisplayLabel("openclaw"), "OpenClaw");
+assert.equal(runtimeDisplayLabel("mystery"), "mystery", "unknown ids label as themselves");
+assert.ok(isTrustedChatHarness("opencode-ai"), "package alias passes the chat trust gate");
 assert.equal(
   merged.find((adapter) => adapter.id === "hermes")?.manifestPath,
   "/tmp/adapters.json",

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -149,6 +149,8 @@ const HARNESS_ALIASES: Record<string, string> = {
   "openai-codex": "codex",
   "github-copilot": "copilot",
   "copilot-cli": "copilot",
+  // OpenCode's npm package is `opencode-ai` (its binary is `opencode`).
+  "opencode-ai": "opencode",
 };
 
 export function canonicalHarnessId(harness: string): string {
@@ -167,18 +169,34 @@ export function isTrustedChatHarness(harness: string): boolean {
   return TRUSTED_CHAT_HARNESSES.has(canonicalHarnessId(harness));
 }
 
+// The single display-label authority for runtime/harness ids: curated Cave
+// copy wins, then the synced registry's accepted label, then the raw id.
+// UI surfaces (runtime logo, capabilities map, adapter rows) should delegate
+// here instead of keeping their own label tables, which have drifted before
+// ("Copilot" vs "GitHub Copilot" vs the registry's "GitHub Copilot CLI").
+export function runtimeDisplayLabel(runtime: string): string {
+  const id = canonicalHarnessId(runtime);
+  const curated = COMPATIBILITY_ADAPTERS.find((adapter) => adapter.id === id);
+  if (curated) return curated.label;
+  const registry = REGISTRY_RUNTIMES.find((entry) => entry.id === id);
+  return registry?.label ?? runtime;
+}
+
 export function openClawAdapterReport(openclawAgentCount: number): AdapterReport {
+  // Identity/copy comes from the curated entry — the two used to be
+  // copy-pasted twins and drifted one edit at a time.
+  const curated = CURATED_ADAPTERS.find((adapter) => adapter.id === "openclaw")!;
   return {
-    id: "openclaw",
-    label: "OpenClaw",
-    binary: "openclaw",
-    chatSupported: true,
+    id: curated.id,
+    label: curated.label,
+    binary: curated.binary,
+    chatSupported: curated.chatSupported,
     installed: openclawAgentCount > 0,
     path: null,
     version: openclawAgentCount > 0
       ? `${openclawAgentCount} agent${openclawAgentCount === 1 ? "" : "s"}`
       : null,
-    installHint: "Install OpenClaw with `npm install -g openclaw@latest`, then connect or create an agent under ~/.openclaw/agents.",
+    installHint: curated.installHint,
     source: "openclaw",
     manifestPath: null,
   };
@@ -239,7 +257,10 @@ export function mergeAdapterReports(
     const existing = merged.get(coven.id);
     merged.set(coven.id, {
       id: coven.id,
-      label: coven.label,
+      // Cave's curated label wins over the daemon manifest's — otherwise a
+      // registry-scaffolded manifest ("GitHub Copilot CLI") silently flips
+      // the adapters list away from Cave's copy ("Copilot").
+      label: existing?.label ?? coven.label,
       binary: coven.executable,
       chatSupported: existing?.chatSupported ?? isTrustedChatHarness(coven.id),
       installed: coven.available || existing?.installed === true,
@@ -251,13 +272,14 @@ export function mergeAdapterReports(
     });
   }
 
-  return [...merged.values()].sort((a, b) => {
-    // Curated adapters keep their seed order; registry additions follow
-    // alphabetically (COMPATIBILITY_ADAPTERS already encodes both).
-    const rankById = new Map(COMPATIBILITY_ADAPTERS.map((adapter, index) => [adapter.id, index]));
-    const rank = (id: string) => rankById.get(id) ?? COMPATIBILITY_ADAPTERS.length;
-    return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
-  });
+  // Curated adapters keep their seed order; registry additions follow
+  // alphabetically (COMPATIBILITY_ADAPTERS already encodes both). Built once
+  // per merge — not inside the comparator, which runs O(n log n) times.
+  const rankById = new Map(COMPATIBILITY_ADAPTERS.map((adapter, index) => [adapter.id, index]));
+  const rank = (id: string) => rankById.get(id) ?? COMPATIBILITY_ADAPTERS.length;
+  return [...merged.values()].sort(
+    (a, b) => rank(a.id) - rank(b.id) || a.label.localeCompare(b.label),
+  );
 }
 
 export function adapterSetupState(reports: AdapterReport[]): AdapterSetupState {


### PR DESCRIPTION
Parked branch landed for review (1 commit, 5 files). Consolidates runtime label resolution to one authority, fixes alias + merge-label handling, and hoists the rank map.

🤖 Worked through by Claude Code (branch-cleanup goal)