### PR TITLE
feat(analytics): thread signals span both columns with a scrollable, task-promoting data table (cave-bhh2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11135,6 +11135,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   margin: 0;
   padding: 0;
   list-style: none;
+  /* The queue is a triage strip, not the page — long summaries scroll. */
+  max-height: 240px;
+  overflow-y: auto;
 }
 .fa-thread-review-list li {
   min-width: 0;
@@ -11256,8 +11259,33 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-color: color-mix(in oklch, var(--color-warning) 50%, var(--border-hairline));
   color: var(--color-warning);
 }
+.fa-thread-table-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.fa-thread-table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+.fa-thread-table__select-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
 .fa-thread-table-wrap {
   min-width: 0;
+  /* Scrollable data table: the section spans both analytics columns, so the
+     table caps its height and scrolls under its sticky header instead of
+     stretching the page. */
+  max-height: 420px;
   overflow: auto;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
@@ -11270,11 +11298,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   table-layout: fixed;
   font-size: 13px;
 }
-.fa-thread-table__col-signal { width: 25%; }
-.fa-thread-table__col-type { width: 18%; }
-.fa-thread-table__col-state { width: 15%; }
-.fa-thread-table__col-detail { width: 34%; }
-.fa-thread-table__col-count { width: 8%; }
+.fa-thread-table__col-select { width: 34px; }
+.fa-thread-table__col-signal { width: 23%; }
+.fa-thread-table__col-type { width: 15%; }
+.fa-thread-table__col-state { width: 13%; }
+.fa-thread-table__col-detail { width: 33%; }
+.fa-thread-table__col-count { width: 9%; }
+.fa-thread-table__col-actions { width: 84px; }
 .fa-thread-table thead th {
   position: sticky;
   top: 0;
@@ -11400,6 +11430,49 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-table__empty td {
   color: var(--text-muted);
   font-size: 12px;
+}
+/* Sortable header buttons — quiet text that inherits the th typography. */
+.fa-thread-table thead th .fa-thread-table__sort {
+  height: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 500;
+}
+.fa-thread-table thead th .fa-thread-table__sort:hover {
+  color: var(--text-primary);
+}
+.fa-thread-table__select {
+  text-align: center;
+}
+.fa-thread-table__select input[type="checkbox"],
+.fa-thread-table__select-all input[type="checkbox"] {
+  accent-color: var(--accent-presence);
+  cursor: pointer;
+}
+.fa-thread-table__select input[type="checkbox"]:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+.fa-thread-table__actions {
+  text-align: right;
+  white-space: nowrap;
+}
+.fa-thread-table__actions-head {
+  text-align: right;
+}
+/* Signals already promoted to board cards read as settled rows. */
+.fa-thread-table__row--added td {
+  opacity: 0.62;
+}
+.fa-thread-table__added {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--color-success, var(--accent-presence));
+  font-size: 11px;
 }
 .fa-contract-grid {
   display: grid;

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -686,6 +686,9 @@ export function FamiliarAnalyticsContent({
         <FaSection
           id="fa-thread-signals"
           title="Thread signals"
+          // The signals data table earns full width only when there are
+          // reports — an empty state shouldn't claim both columns.
+          wide={model.threadReports.length > 0}
           count={`${model.threadReports.length} ${model.threadReports.length === 1 ? "report" : "reports"}`}
         >
           <ThreadSignalsSection familiarId={model.familiarId} reports={model.threadReports} />

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -5,6 +5,8 @@ import { aggregateThreadSignals, buildThreadSignalReviewQueue, THREAD_SIGNALS_EM
 import type { ThreadSelfReport } from "@/lib/thread-self-report";
 
 const source = readFileSync(new URL("./thread-signals-section.tsx", import.meta.url), "utf8");
+const analyticsSource = readFileSync(new URL("./familiar-analytics-view.tsx", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
 assert.match(source, /import \{ Button \}/, "ThreadSignalsSection review actions use the shared Button primitive");
 assert.doesNotMatch(source, /<button\b/, "ThreadSignalsSection should not hand-roll button controls");
@@ -141,7 +143,46 @@ describe("aggregateThreadSignals", () => {
     assert.match(source, /className="board-table-group-row fa-thread-table__group"/, "sections render as task-style grouped rows");
     assert.match(source, /className="fa-thread-table__col-detail"/, "column sizing classes stay separate from cell content classes");
     assert.match(source, /No access gaps\./, "empty category states remain visible inside the table");
-    assert.match(source, /<th>Signal<\/th>[\s\S]*<th>Type<\/th>[\s\S]*<th>Status<\/th>[\s\S]*<th>Detail<\/th>[\s\S]*<th>Reports<\/th>/, "table exposes scan-friendly columns");
+    assert.match(source, /\{ key: "signal", label: "Signal" \}[\s\S]*\{ key: "type", label: "Type" \}[\s\S]*\{ key: "state", label: "Status" \}/, "table exposes scan-friendly columns");
+    assert.match(source, /<th>Detail<\/th>/, "detail stays a plain column");
+  });
+
+  it("is a real data table: sortable columns with an accessible sort state", () => {
+    assert.match(source, /aria-sort=\{sortKey === column\.key \? \(sortDir === "asc" \? "ascending" : "descending"\) : undefined\}/, "sorted column exposes aria-sort");
+    assert.match(source, /onClick=\{\(\) => toggleSort\(column\.key\)\}/, "headers toggle sorting");
+    assert.match(source, /setSortKey\(null\)/, "third press returns to the default category grouping");
+    assert.match(source, /localeCompare/, "text columns compare locale-aware");
+    assert.match(source, /toggleSort\("count"\)/, "report count is sortable too");
+  });
+
+  it("mutates signal rows into board tasks", () => {
+    assert.match(source, /fetch\("\/api\/board"/, "row promotion posts to the board API");
+    assert.match(source, /taskDraftFromRow/, "rows are shaped into task drafts");
+    assert.match(source, /title: `\$\{row\.type\}: \$\{row\.signal\}`/, "task titles carry the signal identity");
+    assert.match(source, /labels: \["thread-signal"\]/, "created cards are labeled for provenance");
+    assert.match(source, /critical: "urgent",[\s\S]*warning: "high",[\s\S]*info: "medium",/, "severity maps to card priority");
+    assert.match(source, /type="checkbox"/, "rows are selectable");
+    assert.match(source, /aria-label="Select all signals"/, "bulk selection has an accessible control");
+    assert.match(source, /useAnnouncer/, "task creation results are announced to screen readers");
+    assert.match(source, /fa-thread-table__row--added/, "promoted rows read as settled");
+  });
+
+  it("spans both analytics columns and scrolls under a max height", () => {
+    assert.match(
+      analyticsSource,
+      /id="fa-thread-signals"[\s\S]*?wide=\{model\.threadReports\.length > 0\}/,
+      "the Thread signals section spans both fa-grid columns when it has data",
+    );
+    assert.match(
+      globals,
+      /\.fa-thread-table-wrap \{[^}]*max-height: 420px;[^}]*overflow: auto;/,
+      "the signal table caps its height and scrolls",
+    );
+    assert.match(
+      globals,
+      /\.fa-thread-review-list \{[^}]*max-height: 240px;[^}]*overflow-y: auto;/,
+      "the review queue caps its height and scrolls",
+    );
   });
 
   it("lets you select a review item to unlock a discussion on the topic", () => {

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Fragment } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { Icon } from "@/lib/icon";
 import {
   aggregateThreadSignals,
   buildThreadSignalReviewQueue,
@@ -30,6 +32,15 @@ type ThreadSignalTableSection = {
   title: string;
   empty: string;
   rows: ThreadSignalTableRow[];
+};
+
+type SortKey = "signal" | "type" | "state" | "count";
+type SortDir = "asc" | "desc";
+
+const SEVERITY_TO_PRIORITY: Record<"critical" | "warning" | "info", "urgent" | "high" | "medium"> = {
+  critical: "urgent",
+  warning: "high",
+  info: "medium",
 };
 
 function ScoreBar({ label, value }: { label: string; value: number }) {
@@ -150,6 +161,286 @@ function discussReviewItem(familiarId: string, item: ThreadSignalReviewItem) {
   );
 }
 
+/** Shape a signal row into the task card the board API accepts. */
+function taskDraftFromRow(familiarId: string, row: ThreadSignalTableRow) {
+  return {
+    title: `${row.type}: ${row.signal}`,
+    notes: `${row.detail}\n\nSource: thread signals for familiar ${familiarId}${row.count ? ` (reported ${row.count}x)` : ""}.`,
+    priority: SEVERITY_TO_PRIORITY[row.severity ?? "info"],
+    familiarId,
+    labels: ["thread-signal"],
+  };
+}
+
+function compareRows(a: ThreadSignalTableRow, b: ThreadSignalTableRow, key: SortKey, dir: SortDir): number {
+  let cmp = 0;
+  if (key === "count") {
+    cmp = (a.count ?? 0) - (b.count ?? 0);
+  } else {
+    cmp = a[key].localeCompare(b[key], undefined, { sensitivity: "base" });
+  }
+  return dir === "asc" ? cmp : -cmp;
+}
+
+const TABLE_COLUMNS: { key: SortKey; label: string }[] = [
+  { key: "signal", label: "Signal" },
+  { key: "type", label: "Type" },
+  { key: "state", label: "Status" },
+];
+
+/**
+ * The signal summary as a real data table: sortable columns, row selection,
+ * and per-row / bulk conversion of signals into task cards on the board
+ * (POST /api/board). Grouped by category by default; picking a sort column
+ * flattens the groups into one comparable list.
+ */
+function ThreadSignalsTable({
+  familiarId,
+  sections,
+}: {
+  familiarId: string;
+  sections: ThreadSignalTableSection[];
+}) {
+  const { announce } = useAnnouncer();
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+  const [added, setAdded] = useState<ReadonlySet<string>>(new Set());
+
+  const allRows = useMemo(() => sections.flatMap((section) => section.rows), [sections]);
+  const sortedRows = useMemo(() => {
+    if (!sortKey) return null;
+    return [...allRows].sort((a, b) => compareRows(a, b, sortKey, sortDir));
+  }, [allRows, sortKey, sortDir]);
+
+  const selectableIds = useMemo(
+    () => allRows.map((row) => row.id).filter((id) => !added.has(id)),
+    [allRows, added],
+  );
+  const selectedCount = selectableIds.filter((id) => selected.has(id)).length;
+  const allSelected = selectableIds.length > 0 && selectedCount === selectableIds.length;
+
+  function toggleSort(key: SortKey) {
+    if (sortKey !== key) {
+      setSortKey(key);
+      setSortDir("asc");
+    } else if (sortDir === "asc") {
+      setSortDir("desc");
+    } else {
+      // Third press returns to the default category grouping.
+      setSortKey(null);
+      setSortDir("asc");
+    }
+  }
+
+  function toggleRow(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(selectableIds));
+  }
+
+  async function createTasks(rows: ThreadSignalTableRow[]) {
+    const targets = rows.filter((row) => !added.has(row.id) && !pending.has(row.id));
+    if (targets.length === 0) return;
+    setPending((prev) => new Set([...prev, ...targets.map((row) => row.id)]));
+    const succeeded: string[] = [];
+    for (const row of targets) {
+      try {
+        const res = await fetch("/api/board", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(taskDraftFromRow(familiarId, row)),
+        });
+        const json = await res.json().catch(() => ({ ok: false }));
+        if (res.ok && json.ok) succeeded.push(row.id);
+      } catch {
+        // Failed rows stay actionable; the announce below reports the shortfall.
+      }
+    }
+    setPending((prev) => {
+      const next = new Set(prev);
+      for (const row of targets) next.delete(row.id);
+      return next;
+    });
+    if (succeeded.length > 0) {
+      setAdded((prev) => new Set([...prev, ...succeeded]));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const id of succeeded) next.delete(id);
+        return next;
+      });
+    }
+    if (succeeded.length === targets.length) {
+      announce(succeeded.length === 1 ? "Added 1 task to the board." : `Added ${succeeded.length} tasks to the board.`);
+    } else {
+      announce(`Added ${succeeded.length} of ${targets.length} tasks — the rest failed, try again.`);
+    }
+  }
+
+  function renderRow(row: ThreadSignalTableRow, alt: boolean) {
+    const isAdded = added.has(row.id);
+    const isPending = pending.has(row.id);
+    return (
+      <tr
+        key={row.id}
+        className={[alt ? "board-table-row--alt" : "", isAdded ? "fa-thread-table__row--added" : ""].filter(Boolean).join(" ") || undefined}
+      >
+        <td className="fa-thread-table__select">
+          <input
+            type="checkbox"
+            checked={selected.has(row.id)}
+            disabled={isAdded || isPending}
+            onChange={() => toggleRow(row.id)}
+            aria-label={`Select ${row.signal}`}
+          />
+        </td>
+        <td>
+          <span className="fa-thread-table__signal-cell">
+            <span className={`fa-thread-table__severity fa-thread-table__severity--${row.severity ?? "info"}`} aria-hidden />
+            <span className="board-table-title" title={row.signal}>{row.signal}</span>
+          </span>
+        </td>
+        <td><span className="board-table-muted">{row.type}</span></td>
+        <td><span className={`fa-thread-table__state fa-thread-table__state--${row.severity ?? "info"}`}>{row.state}</span></td>
+        <td><span className="fa-thread-table__detail">{row.detail}</span></td>
+        <td><span className="board-table-cell-time">{row.count ? `${row.count}x` : "-"}</span></td>
+        <td className="fa-thread-table__actions">
+          {isAdded ? (
+            <span className="fa-thread-table__added" title="A task card exists on the board for this signal">
+              <Icon name="ph:check-circle" width={13} aria-hidden /> Task
+            </span>
+          ) : (
+            <Button
+              variant="ghost"
+              size="xs"
+              loading={isPending}
+              leadingIcon="ph:plus"
+              onClick={() => void createTasks([row])}
+              aria-label={`Add task for ${row.signal}`}
+              title="Create a task card on the board from this signal"
+            >
+              Task
+            </Button>
+          )}
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <div className="fa-thread-table-shell">
+      <div className="fa-thread-table-toolbar">
+        <label className="fa-thread-table__select-all">
+          <input
+            type="checkbox"
+            checked={allSelected}
+            disabled={selectableIds.length === 0}
+            onChange={toggleAll}
+            aria-label="Select all signals"
+          />
+          {selectedCount > 0 ? `${selectedCount} selected` : "Select signals"}
+        </label>
+        <Button
+          variant="secondary"
+          size="xs"
+          leadingIcon="ph:kanban"
+          disabled={selectedCount === 0}
+          onClick={() => void createTasks(allRows.filter((row) => selected.has(row.id)))}
+          title="Create board task cards from the selected signals"
+        >
+          Add {selectedCount > 0 ? selectedCount : ""} as tasks
+        </Button>
+      </div>
+      <div className="fa-thread-table-wrap">
+        <table className="board-table board-table--grid fa-thread-table" aria-label="Thread signal summary">
+          <colgroup>
+            <col className="fa-thread-table__col-select" />
+            <col className="fa-thread-table__col-signal" />
+            <col className="fa-thread-table__col-type" />
+            <col className="fa-thread-table__col-state" />
+            <col className="fa-thread-table__col-detail" />
+            <col className="fa-thread-table__col-count" />
+            <col className="fa-thread-table__col-actions" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th className="fa-thread-table__select" aria-label="Selection" />
+              {TABLE_COLUMNS.map((column) => (
+                <th
+                  key={column.key}
+                  aria-sort={sortKey === column.key ? (sortDir === "asc" ? "ascending" : "descending") : undefined}
+                >
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className="fa-thread-table__sort"
+                    onClick={() => toggleSort(column.key)}
+                    trailingIcon={sortKey === column.key ? (sortDir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"}
+                    title={`Sort by ${column.label.toLowerCase()}`}
+                  >
+                    {column.label}
+                  </Button>
+                </th>
+              ))}
+              <th>Detail</th>
+              <th aria-sort={sortKey === "count" ? (sortDir === "asc" ? "ascending" : "descending") : undefined}>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="fa-thread-table__sort"
+                  onClick={() => toggleSort("count")}
+                  trailingIcon={sortKey === "count" ? (sortDir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"}
+                  title="Sort by report count"
+                >
+                  Reports
+                </Button>
+              </th>
+              <th className="fa-thread-table__actions-head">Task</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows ? (
+              sortedRows.length === 0 ? (
+                <tr className="fa-thread-table__empty">
+                  <td colSpan={7}>No signals reported.</td>
+                </tr>
+              ) : (
+                sortedRows.map((row, index) => renderRow(row, index % 2 === 1))
+              )
+            ) : (
+              sections.map((section) => (
+                <Fragment key={section.id}>
+                  <tr className="board-table-group-row fa-thread-table__group">
+                    <td colSpan={7}>
+                      {section.title}
+                      <span className="board-table-group-badge">{section.rows.length}</span>
+                    </td>
+                  </tr>
+                  {section.rows.length === 0 ? (
+                    <tr className="fa-thread-table__empty">
+                      <td colSpan={7}>{section.empty}</td>
+                    </tr>
+                  ) : (
+                    section.rows.map((row, index) => renderRow(row, index % 2 === 1))
+                  )}
+                </Fragment>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 export function ThreadSignalsSection({ familiarId, reports }: { familiarId: string; reports: ThreadSelfReport[] }) {
   if (reports.length === 0) {
     return (
@@ -212,58 +503,7 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
           </span>
         ))}
       </div>
-      <div className="fa-thread-table-wrap">
-        <table className="board-table board-table--grid fa-thread-table" aria-label="Thread signal summary">
-          <colgroup>
-            <col className="fa-thread-table__col-signal" />
-            <col className="fa-thread-table__col-type" />
-            <col className="fa-thread-table__col-state" />
-            <col className="fa-thread-table__col-detail" />
-            <col className="fa-thread-table__col-count" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>Signal</th>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Detail</th>
-              <th>Reports</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sections.map((section) => (
-              <Fragment key={section.id}>
-                <tr className="board-table-group-row fa-thread-table__group">
-                  <td colSpan={5}>
-                    {section.title}
-                    <span className="board-table-group-badge">{section.rows.length}</span>
-                  </td>
-                </tr>
-                {section.rows.length === 0 ? (
-                  <tr className="fa-thread-table__empty">
-                    <td colSpan={5}>{section.empty}</td>
-                  </tr>
-                ) : (
-                  section.rows.map((row, index) => (
-                    <tr key={row.id} className={index % 2 === 1 ? "board-table-row--alt" : undefined}>
-                      <td>
-                        <span className="fa-thread-table__signal-cell">
-                          <span className={`fa-thread-table__severity fa-thread-table__severity--${row.severity ?? "info"}`} aria-hidden />
-                          <span className="board-table-title" title={row.signal}>{row.signal}</span>
-                        </span>
-                      </td>
-                      <td><span className="board-table-muted">{row.type}</span></td>
-                      <td><span className={`fa-thread-table__state fa-thread-table__state--${row.severity ?? "info"}`}>{row.state}</span></td>
-                      <td><span className="fa-thread-table__detail">{row.detail}</span></td>
-                      <td><span className="board-table-cell-time">{row.count ? `${row.count}x` : "-"}</span></td>
-                    </tr>
-                  ))
-                )}
-              </Fragment>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <ThreadSignalsTable familiarId={familiarId} sections={sections} />
     </div>
   );
 }


### PR DESCRIPTION
Parked branch landed for review (1 commit, 4 files). Thread signals span both columns as a scrollable data table that can promote a signal to a task.

🤖 Worked through by Claude Code (branch-cleanup goal)