### PR TITLE
fix(board): standardize Tasks|Queue segment tabs to the group-toggle footprint

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -38,6 +38,14 @@
 
 .board-clear-confirm { display:flex; gap:6px; }
 
+/* Tasks|Queue segment tabs (shared Tabs, variant=segment) — standardized to the
+   group-toggle footprint: same total height (control + 1px borders) and the
+   same 10px/12px button metrics as .board-group-toggle-btn, while keeping the
+   segment aesthetic (hairline container, rounded active pill). Same recipe as
+   .gh-compact-tabs below. */
+.board-header-tabs { flex:0 0 auto; height:calc(var(--board-control-h,28px) + 2px); padding:2px; }
+.board-header-tabs [role="tab"] { height:100%; padding:0 10px; font-size:12px; }
+
 .board-group-toggle { display:flex; border:1px solid var(--border-strong); border-radius:var(--radius-control); overflow:hidden; }
 /* Leading zoom glyph so the compact D/W/M reads as a timeline zoom, not a range filter. */
 .board-group-toggle .cg-zoom-cell { display:flex; align-items:center; padding:0 4px 0 8px; background:var(--bg-raised); color:var(--text-muted); border-right:1px solid var(--border-strong); }


### PR DESCRIPTION
## What

The Tasks|Queue tabs in the board header (shared `Tabs`, `variant=segment`) rendered at their Tailwind-default ~34px height with 11px labels, next to the 28px Status|Familiar|Project group toggle inside the 40px compact header band — visibly off-height and off-scale.

This applies the existing `.gh-compact-tabs` standardization recipe to `.board-header-tabs`:

- Tablist height keys off the same `--board-control-h` variable the group toggle uses (`calc(26px + 2px)` = 28px total, matching the toggle's 26px buttons + 1px borders), so any future header re-sizing keeps them in sync.
- Tab buttons get the group-toggle button metrics: `height: 100%`, `padding: 0 10px`, `font-size: 12px`.
- The segment aesthetic is untouched: hairline-bordered rounded container, gap between pills, raised active pill with strong border.

## Verification

Built and ran the app in a throwaway worktree, measured the DOM: `.board-header-tabs`, `.board-group-toggle`, and `.board-view-toggle` all report exactly 28px tall at the same y-position, with 12px/10px button metrics across both components ("Tasks" pill 55.4px vs "Status" 56.5px). Screenshot of the header band confirms one consistent control row. The two tests that pin these classes (`board-grouping`, `board-schedule-window`) pass; full `pnpm build` green within bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)