### PR TITLE
fix(windows): gate MSI publication and add upgrade diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,20 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo test --manifest-path src-tauri/Cargo.toml --locked sidecar_archive
 
+      # The updater clears Tauri's resource table immediately before
+      # launching msiexec. Exercise the native Drop guard on Windows so an
+      # update cannot strand the packaged Node process tree.
+      - name: Test Windows updater sidecar cleanup
+        if: matrix.os == 'windows-latest'
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --locked --lib tests::sidecar_cleanup_is_idempotent_when_no_child_is_running -- --exact --nocapture
+          cargo test --manifest-path src-tauri/Cargo.toml --locked --lib tests::dropping_application_cleanup_guard_stops_and_reaps_sidecar -- --exact --nocapture
+
+      - name: Test Windows upgrade diagnostics fixture
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: .\scripts\windows-upgrade-diagnostics.test.ps1
+
   sidecar-runtime-required:
     name: Sidecar runtime required
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,14 +220,8 @@ jobs:
 
       - name: Build with tauri-action
         if: >-
-          (
-            matrix.family == 'linux' &&
-            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
-          ) ||
-          (
-            matrix.family == 'windows' &&
-            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
-          )
+          matrix.family == 'linux' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
         uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -244,6 +238,17 @@ jobs:
           # latest.json is built by the dedicated `updater-manifest` job after
           # all platforms upload their signed artifacts — per-job generation
           # here would clobber the manifest with a single platform.
+          includeUpdaterJson: false
+          args: ${{ matrix.args }}
+
+      # Build without release inputs so tauri-action cannot publish the MSI
+      # before its component/size budget has passed.
+      - name: Build Windows MSI without publishing
+        if: >-
+          matrix.family == 'windows' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+        uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
+        with:
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
@@ -271,6 +276,41 @@ jobs:
           path: ${{ runner.temp }}/windows-msi-metrics.json
           if-no-files-found: warn
           compression-level: 0
+
+      - name: Publish validated Windows MSI
+        if: >-
+          matrix.family == 'windows' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+        shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $msis = @(Get-ChildItem -Path src-tauri/target/release/bundle/msi -Filter *.msi -File)
+          if ($msis.Count -ne 1) {
+            throw "Expected exactly one budget-approved MSI, found $($msis.Count)"
+          }
+
+          gh release view $env:RELEASE_TAG *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create $env:RELEASE_TAG `
+              --verify-tag `
+              --title "CovenCave $env:RELEASE_TAG" `
+              --notes "Release artifacts are still being assembled by the release workflow."
+            if ($LASTEXITCODE -ne 0) {
+              # Another matrix leg may have created the release concurrently.
+              Start-Sleep -Seconds 5
+              gh release view $env:RELEASE_TAG *> $null
+              if ($LASTEXITCODE -ne 0) {
+                throw "Could not create or find release $env:RELEASE_TAG"
+              }
+            }
+          }
+
+          gh release upload $env:RELEASE_TAG $msis[0].FullName --clobber
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not publish budget-approved MSI"
+          }
 
       - name: Sign Linux/Windows updater artifact
         if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ breaking config changes; patch releases stay additive.
 
 Patch release on top of v0.0.172.
 
+> **Windows upgrade note:** v0.0.172 → v0.0.173 is the one-time legacy bridge. Windows Installer must still remove v0.0.172's expanded sidecar tree; archive-to-archive upgrades after v0.0.173 are the representative fast path.
+
 ### Changes
+- fix(windows): collapse the MSI sidecar payload into one verified runtime archive, reducing per-file upgrade work (#2911)
 - fix(projects): drop stale scope on refetch; gate palette project fetch on open (#2908)
 - docs: iOS onboarding + constant connection + cloud persistence — review & plan (cave-rku9) (#2909)
 - fix(rollout): five P3s from the evening re-audit (#2907)

--- a/docs/windows-upgrade-benchmark.md
+++ b/docs/windows-upgrade-benchmark.md
@@ -1,0 +1,62 @@
+# Windows upgrade benchmark
+
+`scripts/windows-upgrade-diagnostics.ps1` captures one Windows MSI upgrade as
+a reproducible diagnostic bundle. It records the candidate's MSI metadata and
+SHA-256, installed versions, MSI action evidence, CPU and I/O counter samples,
+MSI Installer and Restart Manager events, relevant process trees, sidecar
+readiness, interactive readiness, and an atomic `summary.json`.
+
+The default invocation is a non-mutating preflight:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows-upgrade-diagnostics.ps1 `
+  -CandidateMsiPath C:\path\to\CovenCave_0.0.173_x64_en-US.msi `
+  -OutputDirectory C:\temp\coven-upgrade-0172-0173
+```
+
+Review `summary.json`, then run the measured upgrade from an elevated
+PowerShell. Both expected versions and explicit installation authorization are
+required:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows-upgrade-diagnostics.ps1 `
+  -CandidateMsiPath C:\path\to\CovenCave_0.0.173_x64_en-US.msi `
+  -OutputDirectory C:\temp\coven-upgrade-0172-0173 `
+  -ExpectedFromVersion 0.0.172 `
+  -ExpectedToVersion 0.0.173 `
+  -AllowInstall
+```
+
+An HTTPS `-CandidateUrl` may be used instead of a local path. The downloaded
+MSI is retained beside the diagnostics and hashed before execution.
+
+## Measurement boundaries
+
+The v0.0.172 to v0.0.173 measurement is classified as
+`legacy-expanded-msi-bridge`. It includes removal of v0.0.172's roughly 24,000
+expanded sidecar components, so it is not a steady-state result. Use a
+v0.0.173-or-newer source and the next candidate to measure the representative
+`archive-to-archive` path.
+
+The harness invokes only `msiexec /i` with `/passive`, `/norestart`,
+`REBOOT=ReallySuppress`, and `/L*V`. It does not uninstall the product, delete
+application data, or stop application processes itself. On timeout it records
+a partial summary and deliberately leaves Windows Installer running so the MSI
+engine can complete or roll back safely. Run the benchmark on a machine where
+an update and application relaunch are acceptable.
+
+After a successful MSI transaction, the harness starts the installed app when
+Restart Manager has not already done so. Sidecar readiness is the first
+listening socket owned by a packaged Node descendant. Interactive readiness is
+the first responsive CovenCave process with a main window. Pass
+`-SkipReadiness` only when measuring the MSI transaction in isolation.
+
+Process command lines and event messages are redacted for CovenCave access
+tokens before being written. Review the bundle before sharing it because paths,
+process identifiers, and Windows event messages can still identify the host.
+
+The deterministic fixture test is safe to run at any time:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows-upgrade-diagnostics.test.ps1
+```

--- a/scripts/windows-upgrade-diagnostics.ps1
+++ b/scripts/windows-upgrade-diagnostics.ps1
@@ -1,0 +1,975 @@
+[CmdletBinding(DefaultParameterSetName = "Local")]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = "Local")]
+    [string]$CandidateMsiPath,
+
+    [Parameter(Mandatory = $true, ParameterSetName = "Url")]
+    [string]$CandidateUrl,
+
+    [Parameter(Mandatory = $true, ParameterSetName = "Fixture")]
+    [string]$FixturePath,
+
+    [string]$OutputDirectory = "windows-upgrade-diagnostics",
+    [string]$ExpectedFromVersion,
+    [string]$ExpectedToVersion,
+    [ValidateRange(1, 240)]
+    [int]$TimeoutMinutes = 60,
+    [ValidateRange(1, 60)]
+    [int]$SampleIntervalSeconds = 5,
+    [ValidateRange(10, 900)]
+    [int]$ReadyTimeoutSeconds = 300,
+    [string]$LaunchPath,
+    [switch]$AllowInstall,
+    [switch]$SkipReadiness
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+function ConvertTo-RedactedText {
+    param([AllowNull()][string]$Text)
+
+    if ($null -eq $Text) {
+        return $null
+    }
+    $redacted = $Text
+    $redacted = $redacted -replace '(?i)(covenCaveToken=)[^&\s"'']+', '$1[REDACTED]'
+    $redacted = $redacted -replace '(?i)(coven_access_token=)[^&\s"'']+', '$1[REDACTED]'
+    $redacted = $redacted -replace '(?i)(COVEN_CAVE_(?:SIDECAR|ACCESS)_TOKEN[=:]\s*)[^\s"'']+', '$1[REDACTED]'
+    return $redacted
+}
+
+function Write-JsonAtomic {
+    param(
+        [Parameter(Mandatory = $true)]$Value,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 16
+    $temporaryPath = "$Path.tmp"
+    [System.IO.File]::WriteAllText($temporaryPath, "$json`n", [System.Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+}
+
+function Get-OptionalProperty {
+    param(
+        [Parameter(Mandatory = $true)]$Value,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        if ($Value.Contains($Name)) {
+            return $Value[$Name]
+        }
+        return $null
+    }
+
+    $property = $Value.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+    return $property.Value
+}
+
+function Get-MsiMetadata {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $installer = $null
+    $database = $null
+    try {
+        $installer = New-Object -ComObject WindowsInstaller.Installer
+        $database = $installer.GetType().InvokeMember(
+            "OpenDatabase",
+            [System.Reflection.BindingFlags]::InvokeMethod,
+            $null,
+            $installer,
+            @($Path, 0)
+        )
+        $properties = [ordered]@{}
+        foreach ($propertyName in @("ProductName", "ProductVersion", "ProductCode", "UpgradeCode")) {
+            $view = $null
+            $record = $null
+            try {
+                $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = '$propertyName'"
+                $view = $database.GetType().InvokeMember(
+                    "OpenView",
+                    [System.Reflection.BindingFlags]::InvokeMethod,
+                    $null,
+                    $database,
+                    @($query)
+                )
+                $view.GetType().InvokeMember(
+                    "Execute",
+                    [System.Reflection.BindingFlags]::InvokeMethod,
+                    $null,
+                    $view,
+                    $null
+                ) | Out-Null
+                $record = $view.GetType().InvokeMember(
+                    "Fetch",
+                    [System.Reflection.BindingFlags]::InvokeMethod,
+                    $null,
+                    $view,
+                    $null
+                )
+                $properties[$propertyName] = if ($null -eq $record) {
+                    $null
+                }
+                else {
+                    $record.GetType().InvokeMember(
+                        "StringData",
+                        [System.Reflection.BindingFlags]::GetProperty,
+                        $null,
+                        $record,
+                        @(1)
+                    )
+                }
+            }
+            finally {
+                if ($null -ne $record) {
+                    [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($record)
+                }
+                if ($null -ne $view) {
+                    $view.GetType().InvokeMember(
+                        "Close",
+                        [System.Reflection.BindingFlags]::InvokeMethod,
+                        $null,
+                        $view,
+                        $null
+                    ) | Out-Null
+                    [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($view)
+                }
+            }
+        }
+        return [ordered]@{
+            source = $Path
+            path = $Path
+            sha256 = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+            bytes = (Get-Item -LiteralPath $Path).Length
+            productName = $properties.ProductName
+            productVersion = $properties.ProductVersion
+            productCode = $properties.ProductCode
+            upgradeCode = $properties.UpgradeCode
+        }
+    }
+    finally {
+        if ($null -ne $database) {
+            [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($database)
+        }
+        if ($null -ne $installer) {
+            [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($installer)
+        }
+    }
+}
+
+function Get-InstalledCovenCaveRecord {
+    $records = @()
+    foreach ($root in @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*",
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )) {
+        $records += @(Get-ItemProperty -Path $root -ErrorAction SilentlyContinue | Where-Object {
+            (Get-OptionalProperty -Value $_ -Name "DisplayName") -eq "CovenCave"
+        })
+    }
+    $record = $records | Sort-Object -Property @{
+        Expression = {
+            try {
+                [Version](Get-OptionalProperty -Value $_ -Name "DisplayVersion")
+            }
+            catch {
+                [Version]"0.0.0"
+            }
+        }
+        Descending = $true
+    } | Select-Object -First 1
+    if ($null -eq $record) {
+        return $null
+    }
+    return [ordered]@{
+        displayName = Get-OptionalProperty -Value $record -Name "DisplayName"
+        version = Get-OptionalProperty -Value $record -Name "DisplayVersion"
+        installLocation = Get-OptionalProperty -Value $record -Name "InstallLocation"
+        displayIcon = Get-OptionalProperty -Value $record -Name "DisplayIcon"
+        uninstallString = ConvertTo-RedactedText -Text (Get-OptionalProperty -Value $record -Name "UninstallString")
+    }
+}
+
+function Get-AllProcesses {
+    return @(Get-CimInstance -ClassName Win32_Process | Select-Object `
+        ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine, CreationDate, `
+        KernelModeTime, UserModeTime, ReadTransferCount, WriteTransferCount)
+}
+
+function Get-DescendantIds {
+    param(
+        [Parameter(Mandatory = $true)]$Processes,
+        [Parameter(Mandatory = $true)][int[]]$RootIds
+    )
+
+    $selected = @($RootIds | Select-Object -Unique)
+    $changed = $true
+    while ($changed) {
+        $changed = $false
+        foreach ($process in $Processes) {
+            $id = [int]$process.ProcessId
+            if (($selected -contains [int]$process.ParentProcessId) -and -not ($selected -contains $id)) {
+                $selected += $id
+                $changed = $true
+            }
+        }
+    }
+    return @($selected)
+}
+
+function ConvertTo-ProcessRecord {
+    param([Parameter(Mandatory = $true)]$Process)
+
+    return [ordered]@{
+        processId = [int]$Process.ProcessId
+        parentProcessId = [int]$Process.ParentProcessId
+        name = $Process.Name
+        executablePath = $Process.ExecutablePath
+        commandLine = ConvertTo-RedactedText -Text $Process.CommandLine
+        creationDate = if ($null -eq $Process.CreationDate) { $null } else { ([DateTimeOffset]$Process.CreationDate).ToUniversalTime().ToString("o") }
+    }
+}
+
+function Test-SameExecutablePath {
+    param(
+        [AllowNull()][string]$Left,
+        [AllowNull()][string]$Right
+    )
+
+    if (-not $Left -or -not $Right) {
+        return $false
+    }
+    try {
+        $normalizedLeft = [System.IO.Path]::GetFullPath(($Left -replace '^\\\\\?\\', ''))
+        $normalizedRight = [System.IO.Path]::GetFullPath(($Right -replace '^\\\\\?\\', ''))
+        return $normalizedLeft.Equals($normalizedRight, [StringComparison]::OrdinalIgnoreCase)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Get-ApplicationRootIds {
+    param(
+        [Parameter(Mandatory = $true)]$Processes,
+        [Parameter(Mandatory = $true)][string]$Executable
+    )
+
+    return @($Processes | Where-Object {
+        Test-SameExecutablePath -Left $_.ExecutablePath -Right $Executable
+    } | ForEach-Object { [int]$_.ProcessId })
+}
+
+function Get-CovenProcessSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [int[]]$TrackedProcessIds = @()
+    )
+
+    $processes = Get-AllProcesses
+    $rootIds = @(Get-ApplicationRootIds -Processes $processes -Executable $Executable)
+    $selectedIds = @($TrackedProcessIds | Select-Object -Unique)
+    if ($rootIds.Count -gt 0) {
+        $selectedIds += Get-DescendantIds -Processes $processes -RootIds $rootIds
+    }
+    $selectedIds = @($selectedIds | Select-Object -Unique)
+    if ($selectedIds.Count -eq 0) {
+        return @()
+    }
+    return @($processes | Where-Object { $selectedIds -contains [int]$_.ProcessId } | ForEach-Object {
+        ConvertTo-ProcessRecord -Process $_
+    })
+}
+
+function Get-InstallerPerformanceSample {
+    param(
+        [Parameter(Mandatory = $true)][int]$ClientProcessId,
+        [Parameter(Mandatory = $true)][DateTimeOffset]$TransactionStartedAt
+    )
+
+    $processes = Get-AllProcesses
+    $descendantIds = Get-DescendantIds -Processes $processes -RootIds @($ClientProcessId)
+    # Windows Installer normally transfers work from the launched client to a
+    # service-hosted msiexec process. The live path refuses to start while any
+    # msiexec already exists, so every installer process created after this
+    # transaction began belongs to this measurement.
+    $newInstallers = @($processes | Where-Object {
+        if ($_.Name -ine "msiexec.exe") {
+            return $false
+        }
+        $created = if ($null -eq $_.CreationDate) { $null } else { [DateTimeOffset]$_.CreationDate }
+        return $descendantIds -contains [int]$_.ProcessId -or (
+            $null -ne $created -and $created -ge $TransactionStartedAt.AddSeconds(-1)
+        )
+    })
+    $installers = @($newInstallers | Where-Object {
+        $descendantIds -contains [int]$_.ProcessId -or
+        $_.CommandLine -match '(?i)\bmsiexec(?:\.exe)?"?\s+/V\b'
+    })
+    $unattributed = @($newInstallers | Where-Object {
+        $candidateId = [int]$_.ProcessId
+        -not @($installers | Where-Object { [int]$_.ProcessId -eq $candidateId }).Count
+    })
+    [long]$cpu100ns = 0
+    [long]$readBytes = 0
+    [long]$writeBytes = 0
+    foreach ($process in $installers) {
+        $cpu100ns += [long]$process.KernelModeTime + [long]$process.UserModeTime
+        $readBytes += [long]$process.ReadTransferCount
+        $writeBytes += [long]$process.WriteTransferCount
+    }
+    return [ordered]@{
+        capturedAtUtc = [DateTimeOffset]::UtcNow.ToString("o")
+        clientProcessId = $ClientProcessId
+        processIds = @($installers | ForEach-Object { [int]$_.ProcessId })
+        processes = @($installers | ForEach-Object {
+            [ordered]@{
+                processId = [int]$_.ProcessId
+                parentProcessId = [int]$_.ParentProcessId
+                relationship = if ([int]$_.ProcessId -eq $ClientProcessId) {
+                    "launched-client"
+                }
+                elseif ($descendantIds -contains [int]$_.ProcessId) {
+                    "client-descendant"
+                }
+                else {
+                    "transaction-service"
+                }
+                commandLine = ConvertTo-RedactedText -Text $_.CommandLine
+                creationDate = if ($null -eq $_.CreationDate) { $null } else { ([DateTimeOffset]$_.CreationDate).ToUniversalTime().ToString("o") }
+                cpuMilliseconds = [math]::Round(([long]$_.KernelModeTime + [long]$_.UserModeTime) / 10000.0, 3)
+                readBytes = [long]$_.ReadTransferCount
+                writeBytes = [long]$_.WriteTransferCount
+            }
+        })
+        unattributedProcesses = @($unattributed | ForEach-Object {
+            ConvertTo-ProcessRecord -Process $_
+        })
+        cpuMilliseconds = [math]::Round($cpu100ns / 10000.0, 3)
+        readBytes = $readBytes
+        writeBytes = $writeBytes
+    }
+}
+
+function Get-UpgradeAcceptance {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$BeforeProcesses,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$AfterInstallerProcesses,
+        [Parameter(Mandatory = $true)]$Events,
+        [Parameter(Mandatory = $true)]$MsiLog,
+        [AllowNull()][object]$InstallerExitCode
+    )
+
+    $beforeSidecarIds = @($BeforeProcesses | Where-Object { $_.name -ieq "node.exe" } | ForEach-Object { [int]$_.processId })
+    $orphanedSidecarIds = @($AfterInstallerProcesses | Where-Object {
+        $_.name -ieq "node.exe" -and $beforeSidecarIds -contains [int]$_.processId
+    } | ForEach-Object { [int]$_.processId })
+    $rebootPattern = '(?i)(restart|reboot).{0,40}(required|necessary|initiated|scheduled)|(required|necessary).{0,40}(restart|reboot)'
+    $rebootWarningEvidence = @()
+    if ($InstallerExitCode -in @(1641, 3010)) {
+        $rebootWarningEvidence += [ordered]@{
+            source = "installer-exit-code"
+            exitCode = [int]$InstallerExitCode
+        }
+    }
+    $rebootWarningEvidence += @($Events.restartManager | Where-Object {
+        (Get-OptionalProperty -Value $_ -Name "id") -eq 10005 -or
+        (Get-OptionalProperty -Value $_ -Name "message") -match $rebootPattern
+    })
+    $rebootWarningEvidence += @($MsiLog.restartManagerEvidence | Where-Object {
+        $_ -match $rebootPattern
+    })
+    return [ordered]@{
+        orphanedSidecarProcessIds = $orphanedSidecarIds
+        noOrphanedSidecar = $orphanedSidecarIds.Count -eq 0
+        rebootWarningEvidence = $rebootWarningEvidence
+        noRebootWarning = $rebootWarningEvidence.Count -eq 0
+    }
+}
+
+function Get-MsiLogEvidence {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return [ordered]@{
+            path = $Path
+            exists = $false
+            bytes = 0
+            sha256 = $null
+            actions = @()
+            completionEvidence = @()
+            restartManagerEvidence = @()
+            errors = @()
+        }
+    }
+
+    $actions = @()
+    $completion = @()
+    $restartManager = @()
+    $errors = @()
+    try {
+        foreach ($line in Get-Content -LiteralPath $Path -ErrorAction Stop) {
+            if ($line -match 'Action (start|ended) (?<time>\d{2}:\d{2}:\d{2}):\s*(?<action>[^.]+)\.?(?: Return value (?<return>\d+)\.)?') {
+                $actions += [ordered]@{
+                    phase = $Matches[1]
+                    clockTime = $Matches.time
+                    action = $Matches.action.Trim()
+                    returnValue = if ($Matches.ContainsKey("return") -and $Matches.return) { [int]$Matches.return } else { $null }
+                    line = ConvertTo-RedactedText -Text $line
+                }
+            }
+            if ($line -match 'MainEngineThread is returning 0|Installation operation completed successfully|Installation completed successfully') {
+                $completion += ConvertTo-RedactedText -Text $line
+            }
+            if ($line -match '(?i)Restart Manager|RM session|RMSession|RMShutdown') {
+                $restartManager += ConvertTo-RedactedText -Text $line
+            }
+            if ($line -match 'Return value 3|(?i)error\s+1[0-9]{3}|MainEngineThread is returning [1-9]') {
+                $errors += ConvertTo-RedactedText -Text $line
+            }
+        }
+    }
+    catch {
+        return [ordered]@{
+            path = $Path
+            exists = $true
+            bytes = (Get-Item -LiteralPath $Path).Length
+            sha256 = $null
+            actions = @()
+            completionEvidence = @()
+            restartManagerEvidence = @()
+            errors = @()
+            readError = $_.Exception.Message
+        }
+    }
+    return [ordered]@{
+        path = $Path
+        exists = $true
+        bytes = (Get-Item -LiteralPath $Path).Length
+        sha256 = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+        actions = $actions
+        completionEvidence = $completion
+        restartManagerEvidence = $restartManager
+        errors = $errors
+    }
+}
+
+function Get-WindowsInstallerEvents {
+    param(
+        [Parameter(Mandatory = $true)][DateTime]$StartTime,
+        [Parameter(Mandatory = $true)][DateTime]$EndTime
+    )
+
+    $msiEvents = @()
+    $restartEvents = @()
+    try {
+        $events = @(Get-WinEvent -FilterHashtable @{
+            LogName = "Application"
+            StartTime = $StartTime
+            EndTime = $EndTime
+        } -ErrorAction Stop | Where-Object {
+            $_.ProviderName -in @("MsiInstaller", "Microsoft-Windows-MsiInstaller", "Microsoft-Windows-RestartManager")
+        } | Select-Object -First 1000)
+        foreach ($event in $events) {
+            $record = [ordered]@{
+                timeCreatedUtc = if ($null -eq $event.TimeCreated) { $null } else { ([DateTimeOffset]$event.TimeCreated).ToUniversalTime().ToString("o") }
+                providerName = $event.ProviderName
+                id = $event.Id
+                level = $event.LevelDisplayName
+                message = ConvertTo-RedactedText -Text $event.Message
+            }
+            if ($event.ProviderName -match 'RestartManager') {
+                $restartEvents += $record
+            }
+            else {
+                $msiEvents += $record
+            }
+        }
+    }
+    catch {
+        $msiEvents += [ordered]@{ queryError = $_.Exception.Message }
+    }
+
+    try {
+        $restartLog = Get-WinEvent -ListLog "Microsoft-Windows-RestartManager/Operational" -ErrorAction Stop
+        if ($restartLog.IsEnabled) {
+            foreach ($event in @(Get-WinEvent -FilterHashtable @{
+                LogName = "Microsoft-Windows-RestartManager/Operational"
+                StartTime = $StartTime
+                EndTime = $EndTime
+            } -ErrorAction Stop | Select-Object -First 1000)) {
+                $restartEvents += [ordered]@{
+                    timeCreatedUtc = if ($null -eq $event.TimeCreated) { $null } else { ([DateTimeOffset]$event.TimeCreated).ToUniversalTime().ToString("o") }
+                    providerName = $event.ProviderName
+                    id = $event.Id
+                    level = $event.LevelDisplayName
+                    message = ConvertTo-RedactedText -Text $event.Message
+                }
+            }
+        }
+    }
+    catch {
+        $restartEvents += [ordered]@{ queryError = $_.Exception.Message }
+    }
+
+    return [ordered]@{
+        msiInstaller = $msiEvents
+        restartManager = $restartEvents
+    }
+}
+
+function Get-MigrationInfo {
+    param(
+        [AllowNull()][string]$FromVersion,
+        [AllowNull()][string]$ToVersion
+    )
+
+    $legacyBridge = $false
+    if ($FromVersion -eq "0.0.172" -and $ToVersion) {
+        try {
+            $legacyBridge = ([Version]$ToVersion) -ge ([Version]"0.0.173")
+        }
+        catch {
+            $legacyBridge = $false
+        }
+    }
+    return [ordered]@{
+        fromVersion = $FromVersion
+        toVersion = $ToVersion
+        kind = if ($legacyBridge) { "legacy-expanded-msi-bridge" } elseif ($FromVersion -and $ToVersion) { "archive-to-archive" } else { "unknown" }
+        legacyBridge = $legacyBridge
+        note = if ($legacyBridge) {
+            "v0.0.172 still owns roughly 24,000 expanded sidecar components; this one-time bridge measures their removal, not steady-state archive upgrades."
+        }
+        else {
+            "Archive-to-archive upgrades are the representative steady-state path after v0.0.173."
+        }
+    }
+}
+
+function Get-DurationMilliseconds {
+    param(
+        [AllowNull()][string]$Start,
+        [AllowNull()][string]$End
+    )
+
+    if (-not $Start -or -not $End) {
+        return $null
+    }
+    return [math]::Round((([DateTimeOffset]$End) - ([DateTimeOffset]$Start)).TotalMilliseconds, 3)
+}
+
+function Resolve-CovenExecutable {
+    param($InstalledRecord)
+
+    if ($LaunchPath) {
+        return (Resolve-Path -LiteralPath $LaunchPath).Path
+    }
+    if ($null -ne $InstalledRecord -and $InstalledRecord.installLocation) {
+        foreach ($name in @("app.exe", "CovenCave.exe")) {
+            $candidate = Join-Path $InstalledRecord.installLocation $name
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return (Resolve-Path -LiteralPath $candidate).Path
+            }
+        }
+    }
+    if ($null -ne $InstalledRecord -and $InstalledRecord.displayIcon) {
+        $iconPath = ($InstalledRecord.displayIcon -replace '^"|"$' -replace ',\d+$', '').Trim('"')
+        if (Test-Path -LiteralPath $iconPath -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $iconPath).Path
+        }
+    }
+    foreach ($candidate in @(
+        (Join-Path $env:ProgramFiles "CovenCave\app.exe"),
+        (Join-Path $env:ProgramFiles "CovenCave\CovenCave.exe"),
+        (Join-Path $env:LOCALAPPDATA "CovenCave\app.exe"),
+        (Join-Path $env:LOCALAPPDATA "CovenCave\CovenCave.exe")
+    )) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+    throw "Could not resolve the installed CovenCave executable; pass -LaunchPath"
+}
+
+function Wait-ForCovenReadiness {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $runningRoots = @(Get-ApplicationRootIds -Processes (Get-AllProcesses) -Executable $Executable)
+    if ($runningRoots.Count -eq 0) {
+        Start-Process -FilePath $Executable | Out-Null
+    }
+
+    $started = [DateTimeOffset]::UtcNow
+    $sidecarReady = $null
+    $interactiveReady = $null
+    $deadline = $started.AddSeconds($TimeoutSeconds)
+    while ([DateTimeOffset]::UtcNow -lt $deadline -and ($null -eq $sidecarReady -or $null -eq $interactiveReady)) {
+        $all = Get-AllProcesses
+        $appIds = @(Get-ApplicationRootIds -Processes $all -Executable $Executable)
+        if ($appIds.Count -gt 0) {
+            $descendants = Get-DescendantIds -Processes $all -RootIds $appIds
+            $nodeIds = @($all | Where-Object {
+                $_.Name -ieq "node.exe" -and $descendants -contains [int]$_.ProcessId
+            } | ForEach-Object { [int]$_.ProcessId })
+            if ($null -eq $sidecarReady -and $nodeIds.Count -gt 0) {
+                try {
+                    $listeners = @(Get-NetTCPConnection -State Listen -ErrorAction Stop | Where-Object {
+                        $nodeIds -contains [int]$_.OwningProcess
+                    })
+                    if ($listeners.Count -gt 0) {
+                        $sidecarReady = [DateTimeOffset]::UtcNow.ToString("o")
+                    }
+                }
+                catch {
+                    # Keep polling; the final summary still records a timeout.
+                }
+            }
+            if ($null -eq $interactiveReady) {
+                foreach ($process in @(Get-Process -Id $appIds -ErrorAction SilentlyContinue)) {
+                    if ($process.Responding -and $process.MainWindowHandle -ne 0) {
+                        $interactiveReady = [DateTimeOffset]::UtcNow.ToString("o")
+                        break
+                    }
+                }
+            }
+        }
+        if ($null -eq $sidecarReady -or $null -eq $interactiveReady) {
+            Start-Sleep -Milliseconds 250
+        }
+    }
+    return [ordered]@{
+        monitoringStartedAtUtc = $started.ToString("o")
+        sidecarReadyAtUtc = $sidecarReady
+        interactiveReadyAtUtc = $interactiveReady
+        timedOut = $null -eq $sidecarReady -or $null -eq $interactiveReady
+    }
+}
+
+$resolvedOutput = [System.IO.Path]::GetFullPath($OutputDirectory)
+[System.IO.Directory]::CreateDirectory($resolvedOutput) | Out-Null
+$summaryPath = Join-Path $resolvedOutput "summary.json"
+
+if ($PSCmdlet.ParameterSetName -eq "Fixture") {
+    $resolvedFixture = (Resolve-Path -LiteralPath $FixturePath).Path
+    $fixture = Get-Content -Raw -LiteralPath $resolvedFixture | ConvertFrom-Json
+    $fixtureRoot = Split-Path -Parent $resolvedFixture
+    $fixtureLog = if ([System.IO.Path]::IsPathRooted($fixture.msiLogPath)) {
+        $fixture.msiLogPath
+    }
+    else {
+        Join-Path $fixtureRoot $fixture.msiLogPath
+    }
+    $retainedLog = Join-Path $resolvedOutput "msi-verbose.log"
+    Copy-Item -LiteralPath $fixtureLog -Destination $retainedLog -Force
+    $logEvidence = Get-MsiLogEvidence -Path $retainedLog
+    $fixtureProcessSelection = Get-OptionalProperty -Value $fixture -Name "processSelection"
+    $summary = [ordered]@{
+        schemaVersion = 1
+        mode = "fixture"
+        generatedAtUtc = [DateTimeOffset]::UtcNow.ToString("o")
+        candidate = $fixture.candidate
+        installedBefore = $fixture.installedBefore
+        installedAfter = $fixture.installedAfter
+        migration = Get-MigrationInfo -FromVersion $fixture.installedBefore.version -ToVersion $fixture.candidate.productVersion
+        installer = $fixture.installer
+        timeline = [ordered]@{
+            startedAtUtc = $fixture.timeline.startedAtUtc
+            installerStartedAtUtc = $fixture.timeline.installerStartedAtUtc
+            installerEndedAtUtc = $fixture.timeline.installerEndedAtUtc
+            sidecarReadyAtUtc = $fixture.timeline.sidecarReadyAtUtc
+            interactiveReadyAtUtc = $fixture.timeline.interactiveReadyAtUtc
+            installerDurationMilliseconds = Get-DurationMilliseconds -Start $fixture.timeline.installerStartedAtUtc -End $fixture.timeline.installerEndedAtUtc
+            sidecarReadyAfterInstallerMilliseconds = Get-DurationMilliseconds -Start $fixture.timeline.installerEndedAtUtc -End $fixture.timeline.sidecarReadyAtUtc
+            interactiveReadyAfterInstallerMilliseconds = Get-DurationMilliseconds -Start $fixture.timeline.installerEndedAtUtc -End $fixture.timeline.interactiveReadyAtUtc
+        }
+        processSnapshots = $fixture.processSnapshots
+        processSelection = if ($null -eq $fixtureProcessSelection) {
+            $null
+        }
+        else {
+            [ordered]@{
+                executable = $fixtureProcessSelection.executable
+                selectedRootProcessIds = Get-ApplicationRootIds `
+                    -Processes $fixtureProcessSelection.processes `
+                    -Executable $fixtureProcessSelection.executable
+            }
+        }
+        performanceSamples = $fixture.performanceSamples
+        events = $fixture.events
+        msiLog = $logEvidence
+        acceptance = Get-UpgradeAcceptance `
+            -BeforeProcesses $fixture.processSnapshots.before `
+            -AfterInstallerProcesses $fixture.processSnapshots.afterInstaller `
+            -Events $fixture.events `
+            -MsiLog $logEvidence `
+            -InstallerExitCode $fixture.installer.exitCode
+        safety = [ordered]@{
+            userDataDeletionInvoked = $false
+            userDataPathsModifiedDirectly = $false
+            uninstallInvoked = $false
+            forcedInstallerTermination = $false
+            rebootSuppressed = $true
+        }
+    }
+    Write-JsonAtomic -Value $summary -Path $summaryPath
+    Write-Host "Windows upgrade diagnostics fixture: $summaryPath"
+    return
+}
+
+$candidateSource = if ($PSCmdlet.ParameterSetName -eq "Url") { $CandidateUrl } else { $CandidateMsiPath }
+if ($PSCmdlet.ParameterSetName -eq "Url") {
+    $uri = [Uri]$CandidateUrl
+    if (-not $uri.IsAbsoluteUri -or $uri.Scheme -ne "https") {
+        throw "CandidateUrl must be an absolute HTTPS URL"
+    }
+    # Signed download URLs can carry credentials in their query string. Keep
+    # only the stable path in diagnostics.
+    $candidateSource = $uri.GetLeftPart([UriPartial]::Path)
+    $downloadPath = Join-Path $resolvedOutput "candidate.msi"
+    Invoke-WebRequest -Uri $uri -OutFile $downloadPath -UseBasicParsing
+    $resolvedCandidate = $downloadPath
+}
+else {
+    $resolvedCandidate = (Resolve-Path -LiteralPath $CandidateMsiPath).Path
+}
+
+$candidate = Get-MsiMetadata -Path $resolvedCandidate
+$candidate.source = $candidateSource
+$installedBefore = Get-InstalledCovenCaveRecord
+$fromVersion = if ($null -eq $installedBefore) { $null } else { $installedBefore.version }
+
+if ($ExpectedFromVersion -and $fromVersion -ne $ExpectedFromVersion) {
+    throw "Installed version '$fromVersion' does not match -ExpectedFromVersion '$ExpectedFromVersion'"
+}
+if ($ExpectedToVersion -and $candidate.productVersion -ne $ExpectedToVersion) {
+    throw "Candidate version '$($candidate.productVersion)' does not match -ExpectedToVersion '$ExpectedToVersion'"
+}
+$installedExecutable = if ($null -eq $installedBefore) {
+    $null
+}
+else {
+    Resolve-CovenExecutable -InstalledRecord $installedBefore
+}
+
+if (-not $AllowInstall) {
+    $summary = [ordered]@{
+        schemaVersion = 1
+        mode = "preflight"
+        generatedAtUtc = [DateTimeOffset]::UtcNow.ToString("o")
+        candidate = $candidate
+        installedBefore = $installedBefore
+        installedAfter = $installedBefore
+        migration = Get-MigrationInfo -FromVersion $fromVersion -ToVersion $candidate.productVersion
+        installer = [ordered]@{ status = "not-started"; reason = "-AllowInstall was not supplied" }
+        timeline = $null
+        processSnapshots = [ordered]@{
+            before = if ($installedExecutable) {
+                Get-CovenProcessSnapshot -Executable $installedExecutable
+            }
+            else {
+                @()
+            }
+        }
+        performanceSamples = @()
+        events = [ordered]@{ msiInstaller = @(); restartManager = @() }
+        msiLog = [ordered]@{ exists = $false; status = "not-started" }
+        safety = [ordered]@{
+            userDataDeletionInvoked = $false
+            userDataPathsModifiedDirectly = $false
+            uninstallInvoked = $false
+            forcedInstallerTermination = $false
+            rebootSuppressed = $true
+        }
+    }
+    Write-JsonAtomic -Value $summary -Path $summaryPath
+    Write-Host "Preflight only; pass -AllowInstall with both expected versions to run the upgrade: $summaryPath"
+    return
+}
+
+if (-not $ExpectedFromVersion -or -not $ExpectedToVersion) {
+    throw "Live installation requires -ExpectedFromVersion and -ExpectedToVersion"
+}
+if ($null -eq $installedBefore) {
+    throw "CovenCave is not registered as installed; this harness measures upgrades, not clean installs"
+}
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run an elevated PowerShell for a repeatable MSI upgrade benchmark"
+}
+
+$captureStarted = [DateTimeOffset]::UtcNow
+$installerStarted = $null
+$installerEnded = $null
+$installerExitCode = $null
+$timedOut = $false
+$failure = $null
+$samples = @()
+$beforeProcesses = @(Get-CovenProcessSnapshot -Executable $installedExecutable)
+$afterInstallerProcesses = @()
+$afterReadyProcesses = @()
+$readiness = [ordered]@{
+    monitoringStartedAtUtc = $null
+    sidecarReadyAtUtc = $null
+    interactiveReadyAtUtc = $null
+    timedOut = $false
+    skipped = [bool]$SkipReadiness
+}
+$verboseLogPath = Join-Path $resolvedOutput "msi-verbose.log"
+$installerProcess = $null
+
+try {
+    $preexistingInstallers = @(Get-AllProcesses | Where-Object { $_.Name -ieq "msiexec.exe" })
+    if ($preexistingInstallers.Count -gt 0) {
+        $ids = ($preexistingInstallers | ForEach-Object { [string]$_.ProcessId }) -join ", "
+        throw "Refusing to mix this benchmark with existing Windows Installer activity (msiexec PIDs: $ids)"
+    }
+    $installerArguments = @(
+        "/i",
+        "`"$resolvedCandidate`"",
+        "/passive",
+        "/norestart",
+        "REBOOT=ReallySuppress",
+        "/L*V",
+        "`"$verboseLogPath`""
+    )
+    $installerStarted = [DateTimeOffset]::UtcNow
+    $installerProcess = Start-Process -FilePath (Join-Path $env:SystemRoot "System32\msiexec.exe") `
+        -ArgumentList $installerArguments -PassThru
+    $deadline = $installerStarted.AddMinutes($TimeoutMinutes)
+    while (-not $installerProcess.HasExited) {
+        $samples += Get-InstallerPerformanceSample `
+            -ClientProcessId $installerProcess.Id `
+            -TransactionStartedAt $installerStarted
+        if ([DateTimeOffset]::UtcNow -ge $deadline) {
+            $timedOut = $true
+            $failure = "MSI exceeded the $TimeoutMinutes minute diagnostic timeout; it was not forcibly terminated so Windows Installer can complete or roll back safely"
+            break
+        }
+        Start-Sleep -Seconds $SampleIntervalSeconds
+        $installerProcess.Refresh()
+    }
+    if (-not $timedOut) {
+        $installerProcess.WaitForExit()
+        $installerEnded = [DateTimeOffset]::UtcNow
+        $installerExitCode = $installerProcess.ExitCode
+        $samples += Get-InstallerPerformanceSample `
+            -ClientProcessId $installerProcess.Id `
+            -TransactionStartedAt $installerStarted
+        if ($installerExitCode -ne 0) {
+            $failure = "msiexec returned $installerExitCode"
+        }
+    }
+    $trackedBeforeIds = @($beforeProcesses | ForEach-Object { [int]$_.processId })
+    $afterInstallerProcesses = @(Get-CovenProcessSnapshot `
+        -Executable $installedExecutable `
+        -TrackedProcessIds $trackedBeforeIds)
+
+    if (-not $timedOut -and $installerExitCode -eq 0 -and -not $SkipReadiness) {
+        $installedAfterForLaunch = Get-InstalledCovenCaveRecord
+        $executable = Resolve-CovenExecutable -InstalledRecord $installedAfterForLaunch
+        $readiness = Wait-ForCovenReadiness -Executable $executable -TimeoutSeconds $ReadyTimeoutSeconds
+        $readiness.skipped = $false
+        $afterReadyProcesses = @(Get-CovenProcessSnapshot `
+            -Executable $executable `
+            -TrackedProcessIds $trackedBeforeIds)
+        if ($readiness.timedOut -and -not $failure) {
+            $failure = "CovenCave did not reach both sidecar and interactive readiness within $ReadyTimeoutSeconds seconds"
+        }
+    }
+}
+catch {
+    $failure = $_.Exception.Message
+}
+
+$captureEnded = [DateTimeOffset]::UtcNow
+$installedAfter = Get-InstalledCovenCaveRecord
+$events = Get-WindowsInstallerEvents -StartTime $captureStarted.LocalDateTime -EndTime $captureEnded.LocalDateTime
+$logEvidence = Get-MsiLogEvidence -Path $verboseLogPath
+if (-not $timedOut -and $installerExitCode -eq 0 -and -not $logEvidence.exists -and -not $failure) {
+    $failure = "msiexec returned success but /L*V did not create $verboseLogPath"
+}
+$acceptance = Get-UpgradeAcceptance `
+    -BeforeProcesses $beforeProcesses `
+    -AfterInstallerProcesses $afterInstallerProcesses `
+    -Events $events `
+    -MsiLog $logEvidence `
+    -InstallerExitCode $installerExitCode
+if (-not $failure -and -not $acceptance.noOrphanedSidecar) {
+    $failure = "The upgrade left packaged sidecar process IDs running: $($acceptance.orphanedSidecarProcessIds -join ', ')"
+}
+if (-not $failure -and -not $acceptance.noRebootWarning) {
+    $failure = "The upgrade emitted reboot-required evidence"
+}
+$unattributedInstallers = @($samples | ForEach-Object { @($_.unattributedProcesses) } | Where-Object { $null -ne $_ })
+if (-not $failure -and $unattributedInstallers.Count -gt 0) {
+    $failure = "Unrelated Windows Installer activity started during the benchmark; CPU/I/O attribution is not isolated"
+}
+
+$summary = [ordered]@{
+    schemaVersion = 1
+    mode = "install"
+    generatedAtUtc = [DateTimeOffset]::UtcNow.ToString("o")
+    candidate = $candidate
+    installedBefore = $installedBefore
+    installedAfter = $installedAfter
+    migration = Get-MigrationInfo -FromVersion $fromVersion -ToVersion $candidate.productVersion
+    installer = [ordered]@{
+        processId = if ($null -eq $installerProcess) { $null } else { $installerProcess.Id }
+        exitCode = $installerExitCode
+        timedOut = $timedOut
+        timeoutMinutes = $TimeoutMinutes
+        failure = $failure
+        arguments = @("/i", "[candidate MSI]", "/passive", "/norestart", "REBOOT=ReallySuppress", "/L*V", "[diagnostic log]")
+    }
+    timeline = [ordered]@{
+        startedAtUtc = $captureStarted.ToString("o")
+        installerStartedAtUtc = if ($null -eq $installerStarted) { $null } else { $installerStarted.ToString("o") }
+        installerEndedAtUtc = if ($null -eq $installerEnded) { $null } else { $installerEnded.ToString("o") }
+        sidecarReadyAtUtc = $readiness.sidecarReadyAtUtc
+        interactiveReadyAtUtc = $readiness.interactiveReadyAtUtc
+        installerDurationMilliseconds = Get-DurationMilliseconds `
+            -Start $(if ($null -eq $installerStarted) { $null } else { $installerStarted.ToString("o") }) `
+            -End $(if ($null -eq $installerEnded) { $null } else { $installerEnded.ToString("o") })
+        sidecarReadyAfterInstallerMilliseconds = Get-DurationMilliseconds `
+            -Start $(if ($null -eq $installerEnded) { $null } else { $installerEnded.ToString("o") }) `
+            -End $readiness.sidecarReadyAtUtc
+        interactiveReadyAfterInstallerMilliseconds = Get-DurationMilliseconds `
+            -Start $(if ($null -eq $installerEnded) { $null } else { $installerEnded.ToString("o") }) `
+            -End $readiness.interactiveReadyAtUtc
+        captureEndedAtUtc = $captureEnded.ToString("o")
+    }
+    processSnapshots = [ordered]@{
+        before = $beforeProcesses
+        afterInstaller = $afterInstallerProcesses
+        afterReadiness = $afterReadyProcesses
+    }
+    performanceSamples = $samples
+    events = $events
+    msiLog = $logEvidence
+    readiness = $readiness
+    acceptance = $acceptance
+    safety = [ordered]@{
+        userDataDeletionInvoked = $false
+        userDataPathsModifiedDirectly = $false
+        uninstallInvoked = $false
+        forcedInstallerTermination = $false
+        rebootSuppressed = $true
+    }
+}
+Write-JsonAtomic -Value $summary -Path $summaryPath
+Write-Host "Windows upgrade diagnostics: $summaryPath"
+
+if ($failure) {
+    throw "$failure (diagnostics retained at $summaryPath)"
+}

--- a/scripts/windows-upgrade-diagnostics.test.ps1
+++ b/scripts/windows-upgrade-diagnostics.test.ps1
@@ -1,0 +1,181 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Message)
+    if ($Actual -ne $Expected) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("coven-upgrade-diagnostics-test-" + [Guid]::NewGuid().ToString("N"))
+$fixtureRoot = Join-Path $testRoot "fixture"
+$outputRoot = Join-Path $testRoot "output"
+[System.IO.Directory]::CreateDirectory($fixtureRoot) | Out-Null
+
+try {
+    $harnessSource = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot "windows-upgrade-diagnostics.ps1")
+    Assert-True ($harnessSource -match 'CovenCave\\app\.exe') "readiness must resolve the installed app.exe binary"
+    Assert-True ($harnessSource -match '@\("app\.exe", "CovenCave\.exe"\)') "process snapshots must track the installed app.exe process"
+    Assert-True ($harnessSource -match '\[AllowEmptyCollection\(\)\]\[object\[\]\]\$AfterInstallerProcesses') "acceptance must allow a clean empty post-installer process snapshot"
+    Assert-True ($harnessSource -match '\$beforeProcesses = @\(Get-CovenProcessSnapshot') "live pre-installer snapshots must preserve empty arrays instead of binding null"
+    Assert-True ($harnessSource -match '\$afterInstallerProcesses = @\(Get-CovenProcessSnapshot') "live post-installer snapshots must preserve empty arrays instead of binding null"
+    Assert-True ($harnessSource -match '\$Value -is \[System\.Collections\.IDictionary\]') "live ordered event records must expose dictionary keys to reboot detection"
+
+    $parseErrors = $null
+    $tokens = $null
+    $harnessAst = [System.Management.Automation.Language.Parser]::ParseInput(
+        $harnessSource,
+        [ref]$tokens,
+        [ref]$parseErrors
+    )
+    Assert-Equal $parseErrors.Count 0 "diagnostic harness must parse before production functions are exercised"
+    $productionFunctions = @($harnessAst.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -in @("Get-OptionalProperty", "Get-UpgradeAcceptance")
+    }, $true))
+    Assert-Equal $productionFunctions.Count 2 "acceptance regression must execute both production functions"
+    foreach ($function in $productionFunctions) {
+        Invoke-Expression $function.Extent.Text
+    }
+    $orderedDictionaryAcceptance = Get-UpgradeAcceptance `
+        -BeforeProcesses @() `
+        -AfterInstallerProcesses @() `
+        -Events ([ordered]@{
+            restartManager = @([ordered]@{ id = 10005; message = "A machine restart is necessary" })
+        }) `
+        -MsiLog ([ordered]@{ restartManagerEvidence = @() }) `
+        -InstallerExitCode 0
+    Assert-True (-not $orderedDictionaryAcceptance.noRebootWarning) "production acceptance must detect an OrderedDictionary Restart Manager warning"
+    Assert-Equal $orderedDictionaryAcceptance.rebootWarningEvidence.Count 1 "OrderedDictionary warning evidence must be retained exactly once"
+
+    $log = @'
+=== Verbose logging started ===
+MSI (s) (10:20) [14:00:00:001]: Action start 14:00:00: InstallValidate.
+MSI (s) (10:20) [14:00:01:001]: RESTART MANAGER: Session opened.
+MSI (s) (10:20) [14:00:02:001]: Action ended 14:00:02: InstallValidate. Return value 1.
+MSI (s) (10:20) [14:00:03:001]: Action start 14:00:03: InstallFinalize.
+MSI (s) (10:20) [14:00:10:001]: Action ended 14:00:10: InstallFinalize. Return value 1.
+MSI (s) (10:20) [14:00:10:100]: Product: CovenCave -- Installation operation completed successfully.
+MSI (s) (10:20) [14:00:10:200]: MainEngineThread is returning 0
+'@
+    [System.IO.File]::WriteAllText((Join-Path $fixtureRoot "bridge-msi.log"), $log)
+
+    $fixture = [ordered]@{
+        schemaVersion = 1
+        candidate = [ordered]@{
+            source = "fixture://candidate.msi"
+            path = "C:\fixture\CovenCave_0.0.173_x64_en-US.msi"
+            sha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+            bytes = 181293056
+            productName = "CovenCave"
+            productVersion = "0.0.173"
+            productCode = "{11111111-1111-1111-1111-111111111111}"
+            upgradeCode = "{22222222-2222-2222-2222-222222222222}"
+        }
+        installedBefore = [ordered]@{ displayName = "CovenCave"; version = "0.0.172" }
+        installedAfter = [ordered]@{ displayName = "CovenCave"; version = "0.0.173" }
+        installer = [ordered]@{ processId = 4100; exitCode = 0; timedOut = $false }
+        timeline = [ordered]@{
+            startedAtUtc = "2026-07-10T18:00:00.0000000+00:00"
+            installerStartedAtUtc = "2026-07-10T18:00:01.0000000+00:00"
+            installerEndedAtUtc = "2026-07-10T18:02:01.0000000+00:00"
+            sidecarReadyAtUtc = "2026-07-10T18:02:31.0000000+00:00"
+            interactiveReadyAtUtc = "2026-07-10T18:02:36.0000000+00:00"
+        }
+        processSnapshots = [ordered]@{
+            before = @([ordered]@{ processId = 100; name = "CovenCave.exe" })
+            afterInstaller = @()
+            afterReadiness = @([ordered]@{ processId = 200; name = "CovenCave.exe" })
+        }
+        processSelection = [ordered]@{
+            executable = "C:\Program Files\CovenCave\app.exe"
+            processes = @(
+                [ordered]@{ ProcessId = 410; ExecutablePath = "C:\Program Files\CovenCave\app.exe" },
+                [ordered]@{ ProcessId = 411; ExecutablePath = "C:\OtherProduct\app.exe" },
+                [ordered]@{ ProcessId = 412; ExecutablePath = "C:\Program Files\CovenCave\CovenCave.exe" }
+            )
+        }
+        performanceSamples = @(
+            [ordered]@{ capturedAtUtc = "2026-07-10T18:00:01Z"; clientProcessId = 4100; processIds = @(4100); processes = @([ordered]@{ processId = 4100; relationship = "launched-client" }); cpuMilliseconds = 100; readBytes = 1024; writeBytes = 2048 },
+            [ordered]@{ capturedAtUtc = "2026-07-10T18:02:01Z"; clientProcessId = 4100; processIds = @(4100, 4200); processes = @([ordered]@{ processId = 4100; relationship = "launched-client" }, [ordered]@{ processId = 4200; relationship = "transaction-service" }); cpuMilliseconds = 1000; readBytes = 4096; writeBytes = 8192 }
+        )
+        events = [ordered]@{
+            msiInstaller = @([ordered]@{ id = 11707; providerName = "MsiInstaller" })
+            restartManager = @([ordered]@{ id = 10000; providerName = "Microsoft-Windows-RestartManager" })
+        }
+        msiLogPath = "bridge-msi.log"
+    }
+    $fixturePath = Join-Path $fixtureRoot "fixture.json"
+    [System.IO.File]::WriteAllText($fixturePath, ($fixture | ConvertTo-Json -Depth 10))
+
+    & (Join-Path $PSScriptRoot "windows-upgrade-diagnostics.ps1") `
+        -FixturePath $fixturePath `
+        -OutputDirectory $outputRoot
+
+    $summaryPath = Join-Path $outputRoot "summary.json"
+    Assert-True (Test-Path -LiteralPath $summaryPath -PathType Leaf) "fixture run must write summary.json"
+    $summary = Get-Content -Raw -LiteralPath $summaryPath | ConvertFrom-Json
+
+    Assert-Equal $summary.schemaVersion 1 "summary schema must be versioned"
+    Assert-Equal $summary.mode "fixture" "fixture mode must be explicit"
+    Assert-Equal $summary.migration.kind "legacy-expanded-msi-bridge" "0.0.172 to 0.0.173 must not be reported as steady state"
+    Assert-True $summary.migration.legacyBridge "legacy bridge flag must be true"
+    Assert-Equal $summary.timeline.installerDurationMilliseconds 120000 "installer duration must be derived from timestamps"
+    Assert-Equal $summary.timeline.sidecarReadyAfterInstallerMilliseconds 30000 "sidecar readiness must be separate from MSI duration"
+    Assert-Equal $summary.timeline.interactiveReadyAfterInstallerMilliseconds 35000 "interactive readiness must be separate from sidecar readiness"
+    Assert-True $summary.msiLog.exists "/L*V fixture log must be retained and verified"
+    Assert-Equal $summary.msiLog.actions.Count 4 "MSI action evidence must retain starts and endings"
+    Assert-Equal $summary.msiLog.actions[0].action "InstallValidate" "MSI action parser must preserve action names"
+    Assert-True ($summary.msiLog.completionEvidence.Count -ge 1) "successful completion evidence must be parsed"
+    Assert-True ($summary.msiLog.restartManagerEvidence.Count -ge 1) "Restart Manager log evidence must be parsed"
+    Assert-Equal $summary.events.msiInstaller.Count 1 "MSI event evidence must be retained"
+    Assert-Equal $summary.events.restartManager.Count 1 "Restart Manager events must be retained"
+    Assert-True $summary.acceptance.noOrphanedSidecar "fixture must prove no packaged sidecar was orphaned"
+    Assert-True $summary.acceptance.noRebootWarning "fixture must prove no reboot warning remained"
+    Assert-Equal $summary.performanceSamples.Count 2 "CPU and I/O samples must be retained"
+    $selectedFixtureRoots = @($summary.processSelection.selectedRootProcessIds)
+    Assert-Equal $selectedFixtureRoots.Count 1 "only the resolved installed executable may seed the process tree"
+    Assert-Equal $selectedFixtureRoots[0] 410 "an unrelated app.exe must not satisfy readiness"
+    Assert-Equal $summary.performanceSamples[1].processes[1].relationship "transaction-service" "installer client/service attribution must be retained"
+    Assert-True (-not $summary.safety.userDataDeletionInvoked) "harness must never delete user data"
+    Assert-True (-not $summary.safety.userDataPathsModifiedDirectly) "harness must not modify user-data paths directly"
+    Assert-True (-not $summary.safety.forcedInstallerTermination) "timeout policy must never force-kill Windows Installer"
+    Assert-True $summary.safety.rebootSuppressed "benchmark installs must suppress restarts"
+
+    $negativeOutput = Join-Path $testRoot "negative-output"
+    $fixture.installer.exitCode = 3010
+    $fixture.processSnapshots.before = @([ordered]@{ processId = 501; name = "node.exe" })
+    $fixture.processSnapshots.afterInstaller = @([ordered]@{ processId = 501; name = "node.exe" })
+    $fixture.events.restartManager = @([ordered]@{
+        id = 10005
+        providerName = "Microsoft-Windows-RestartManager"
+        message = "A machine restart is necessary"
+    })
+    [System.IO.File]::WriteAllText($fixturePath, ($fixture | ConvertTo-Json -Depth 10))
+    & (Join-Path $PSScriptRoot "windows-upgrade-diagnostics.ps1") `
+        -FixturePath $fixturePath `
+        -OutputDirectory $negativeOutput
+    $negative = Get-Content -Raw -LiteralPath (Join-Path $negativeOutput "summary.json") | ConvertFrom-Json
+    Assert-True (-not $negative.acceptance.noOrphanedSidecar) "retained sidecar PID must fail orphan acceptance"
+    Assert-Equal $negative.acceptance.orphanedSidecarProcessIds[0] 501 "orphan evidence must retain the PID"
+    Assert-True (-not $negative.acceptance.noRebootWarning) "3010/RM evidence must fail reboot acceptance"
+    Assert-True ($negative.acceptance.rebootWarningEvidence.Count -ge 2) "exit code and Restart Manager warning must both be retained"
+
+    Write-Host "windows-upgrade-diagnostics fixture test passed"
+}
+finally {
+    $resolvedTemp = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+    $resolvedTest = [System.IO.Path]::GetFullPath($testRoot)
+    if ($resolvedTest.StartsWith($resolvedTemp, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $resolvedTest -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -127,6 +127,55 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
   assert.match(budget, /\$rowBudget = 64/);
   assert.match(budget, /\$byteBudget = 256MB/);
   assert.match(budget, /expected exactly one server\.tar\.gz File row/);
+  assert.match(
+    workflow,
+    /Build Windows MSI without publishing[\s\S]*Measure and enforce Windows MSI budget[\s\S]*Publish validated Windows MSI/,
+    "the MSI must pass its budget before it becomes a release asset",
+  );
+  const buildOnlyStart = workflow.indexOf("- name: Build Windows MSI without publishing");
+  const budgetStart = workflow.indexOf("- name: Measure and enforce Windows MSI budget");
+  const windowsBuildBlock = workflow.slice(buildOnlyStart, budgetStart);
+  assert.doesNotMatch(
+    windowsBuildBlock,
+    /tagName:|releaseName:|releaseId:/,
+    "the pre-budget Windows build must not give tauri-action release upload inputs",
+  );
+});
+
+test("Windows upgrade diagnostics preserve the legacy-bridge evidence", async () => {
+  const [harness, fixtureTest, workflow, changelog, guide] = await Promise.all([
+    readFile(new URL("../scripts/windows-upgrade-diagnostics.ps1", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/windows-upgrade-diagnostics.test.ps1", import.meta.url), "utf8"),
+    readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+    readFile(new URL("../CHANGELOG.md", import.meta.url), "utf8"),
+    readFile(new URL("../docs/windows-upgrade-benchmark.md", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(harness, /ParameterSetName = "Fixture"/);
+  assert.match(harness, /CandidateMsiPath[\s\S]*CandidateUrl/);
+  assert.match(harness, /AllowInstall/);
+  assert.match(harness, /Live installation requires -ExpectedFromVersion and -ExpectedToVersion/);
+  assert.match(harness, /Get-FileHash[\s\S]*SHA256/);
+  assert.match(harness, /performanceSamples/);
+  assert.match(harness, /Get-WindowsInstallerEvents/);
+  assert.match(harness, /Microsoft-Windows-RestartManager/);
+  assert.match(harness, /processSnapshots/);
+  assert.match(harness, /sidecarReadyAtUtc[\s\S]*interactiveReadyAtUtc/);
+  assert.match(harness, /"\/L\*V"/);
+  assert.match(harness, /forcedInstallerTermination = \$false/);
+  assert.doesNotMatch(
+    harness,
+    /Stop-Process|\.Kill\(/,
+    "the timeout path must leave Windows Installer in control of completion or rollback",
+  );
+  assert.match(fixtureTest, /legacy-expanded-msi-bridge/);
+  assert.match(fixtureTest, /msiLog\.actions/);
+  assert.match(workflow, /Test Windows updater sidecar cleanup[\s\S]*cargo test[^\n]*cleanup/);
+  assert.match(workflow, /Test Windows upgrade diagnostics fixture/);
+  assert.match(changelog, /\[0\.0\.173\][\s\S]*#2911/);
+  assert.match(changelog, /v0\.0\.172.*v0\.0\.173 is the one-time legacy bridge/);
+  assert.match(guide, /archive-to-archive/);
+  assert.match(guide, /does not uninstall the product, delete[\s\S]*application data/);
 });
 
 test("packaged app does not override Coven workspace with OpenClaw workspace", async () => {


### PR DESCRIPTION
Upstream mirror of #2913 (by @romgenie) so the required CodeQL check can run and the stack can land. Commits are romgenie's, unchanged; squash-merge will credit via Co-authored-by.

Reviewed as part of the Windows sidecar-runtime stack. Superseded fork PR: #2913.

🤖 Mirrored + landed by Claude Code