### PR TITLE
perf(windows): add deterministic content-addressed runtime cache

### DIFF
--- a/docs/windows-runtime-cache.md
+++ b/docs/windows-runtime-cache.md
@@ -1,0 +1,35 @@
+# Windows runtime cache design
+
+The Windows runtime uses one deterministic, content-addressed archive layer.
+The cache key contains the archive schema and canonical payload digest, while a
+separate tree digest authenticates every activated file on reuse.
+
+## Layering decision
+
+Measurements taken before this change did not justify splitting stable
+dependencies from release-specific application files:
+
+| Payload | Files | Expanded bytes | Compressed bytes | Compression/build | Extraction |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Production runtime used for cache validation | 21,916 | 522,443,366 | 137,268,806 gzip | 123.97 s cold / 84.84 s warm archive build | not isolated in this PR |
+| Final pruned runtime closure | 4,942 | 102,580,489 | 32,090,079 source gzip; 29,077,557 zstd-3 candidate | 2.495 s gzip-6; 0.786 s zstd-3 | 5.044 s mean for both formats across six alternating runs |
+
+The final closure reduces the expanded payload by about 80 percent before
+introducing a second archive, manifest, activation transaction, rollback unit,
+or lock domain. There is not yet consecutive-release churn evidence showing
+that a dependency layer would avoid enough transfer or preparation work to
+offset that complexity. The current schema therefore keeps one atomic layer
+and reuses it across app versions whenever its payload digest is unchanged.
+
+Startup cleanup holds the shared cache lock and removes only incomplete
+generations and stale extraction staging directories. It retains every
+structurally complete content-addressed generation because, without explicit
+process leases, an older concurrently running app may still be loading files
+from any one of them. Explicit uninstall owns complete-cache reclamation; this
+trades bounded cache growth between uninstalls for safe rollback and concurrent
+upgrade behavior.
+
+Revisit the split only after consecutive production candidates measure stable
+dependency bytes separately from changed application bytes. A split must keep
+both layers deterministic, verified, atomically activated, rollback-safe, and
+covered by concurrent-launch and low-space tests.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -738,6 +738,7 @@ export const SUITES = {
     "src/app/api/salem/pathfinder/feedback/route.test.ts",
     "src/app/api/feedback/message/route.test.ts",
     "src/app/api/launch/route.test.ts",
+    "scripts/sidecar-archive-manifest.test.mjs",
     "scripts/sidecar-bundle.test.mjs",
     "scripts/sidecar-bundle-deps.test.mjs",
     "scripts/tray-icon.test.mjs",

--- a/scripts/sidecar-archive-manifest.mjs
+++ b/scripts/sidecar-archive-manifest.mjs
@@ -1,15 +1,30 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { lstat, readdir, stat, writeFile } from "node:fs/promises";
+import { once } from "node:events";
+import { createReadStream, createWriteStream } from "node:fs";
+import { lstat, mkdir, open, readdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { createGzip } from "node:zlib";
 
+export const SIDECAR_ARCHIVE_SCHEMA_VERSION = 2;
 export const SIDECAR_ARCHIVE_BUDGETS = Object.freeze({
   archiveBytes: 256 * 1024 * 1024,
   unpackedBytes: 768 * 1024 * 1024,
   fileCount: 50_000,
 });
+
+const TAR_BLOCK_BYTES = 512;
+const TAR_END_BYTES = TAR_BLOCK_BYTES * 2;
+const NORMALIZED_DIRECTORY_MODE = 0o755;
+const NORMALIZED_FILE_MODE = 0o644;
+const COMPLETION_MARKER_PATH = ".complete.json";
+
+// Windows runners expose different tar implementations over time. Keep this
+// small writer in-process so ordering and metadata are part of our format,
+// rather than host defaults. Ustar covers normal paths; GNU LongLink records
+// cover the long package paths and are consumed by both bsdtar and Rust `tar`.
 
 async function sha256File(file) {
   return await new Promise((resolve, reject) => {
@@ -21,52 +36,270 @@ async function sha256File(file) {
   });
 }
 
-async function treeMetrics(root) {
+function compareArchivePaths(left, right) {
+  return Buffer.compare(Buffer.from(left.archivePath, "utf8"), Buffer.from(right.archivePath, "utf8"));
+}
+
+async function collectArchiveEntries(root) {
+  const entries = [];
+  const pending = [{ absolutePath: root, archivePath: "" }];
   let fileCount = 0;
   let directoryCount = 0;
   let unpackedBytes = 0;
-  const pending = [root];
 
   while (pending.length > 0) {
     const directory = pending.pop();
-    const entries = await readdir(directory, { withFileTypes: true });
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      const entryPath = path.join(directory, entry.name);
-      const metadata = await lstat(entryPath);
+    const children = await readdir(directory.absolutePath, { withFileTypes: true });
+    children.sort((left, right) => Buffer.compare(Buffer.from(left.name), Buffer.from(right.name)));
+    for (const child of children) {
+      const absolutePath = path.join(directory.absolutePath, child.name);
+      const archivePath = directory.archivePath
+        ? `${directory.archivePath}/${child.name}`
+        : child.name;
+      if (archivePath === COMPLETION_MARKER_PATH) {
+        throw new Error(`${COMPLETION_MARKER_PATH} is reserved for runtime cache activation`);
+      }
+      const metadata = await lstat(absolutePath);
       if (metadata.isSymbolicLink()) {
-        throw new Error(`sidecar archive input must not contain symlinks: ${entryPath}`);
+        throw new Error(`sidecar archive input must not contain symlinks: ${absolutePath}`);
       }
       if (metadata.isDirectory()) {
         directoryCount += 1;
-        pending.push(entryPath);
+        entries.push({ absolutePath, archivePath, kind: "directory", mode: NORMALIZED_DIRECTORY_MODE, size: 0 });
+        pending.push({ absolutePath, archivePath });
       } else if (metadata.isFile()) {
         fileCount += 1;
         unpackedBytes += metadata.size;
+        entries.push({
+          absolutePath,
+          archivePath,
+          kind: "file",
+          mode: NORMALIZED_FILE_MODE,
+          size: metadata.size,
+        });
       } else {
-        throw new Error(`sidecar archive input contains an unsupported entry: ${entryPath}`);
+        throw new Error(`sidecar archive input contains an unsupported entry: ${absolutePath}`);
       }
     }
   }
 
-  return { fileCount, directoryCount, unpackedBytes };
+  entries.sort(compareArchivePaths);
+  return { entries, fileCount, directoryCount, unpackedBytes };
+}
+
+function updateTreeDigestHeader(hash, kind, archivePath, size = null) {
+  const encodedPath = Buffer.from(archivePath, "utf8");
+  const pathLength = Buffer.alloc(8);
+  pathLength.writeBigUInt64BE(BigInt(encodedPath.length));
+  hash.update(kind);
+  hash.update(pathLength);
+  hash.update(encodedPath);
+  if (size !== null) {
+    const encodedSize = Buffer.alloc(8);
+    encodedSize.writeBigUInt64BE(BigInt(size));
+    hash.update(encodedSize);
+  }
+}
+
+function writeOctal(header, offset, width, value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`invalid ${label} for deterministic sidecar archive: ${value}`);
+  }
+  const encoded = value.toString(8);
+  if (encoded.length > width - 1) {
+    throw new Error(`${label} does not fit in a ustar header: ${value}`);
+  }
+  header.fill(0x30, offset, offset + width - 1);
+  header.write(encoded, offset + width - 1 - encoded.length, encoded.length, "ascii");
+  header[offset + width - 1] = 0;
+}
+
+function writeUtf8(header, offset, width, value, label) {
+  const encoded = Buffer.from(value, "utf8");
+  if (encoded.length > width) {
+    throw new Error(`${label} does not fit in a ustar header: ${value}`);
+  }
+  encoded.copy(header, offset);
+}
+
+function splitUstarPath(archivePath) {
+  if (Buffer.byteLength(archivePath, "utf8") <= 100) {
+    return { name: archivePath, prefix: "" };
+  }
+  for (let split = archivePath.lastIndexOf("/"); split > 0; split = archivePath.lastIndexOf("/", split - 1)) {
+    const prefix = archivePath.slice(0, split);
+    const name = archivePath.slice(split + 1);
+    if (Buffer.byteLength(prefix, "utf8") <= 155 && Buffer.byteLength(name, "utf8") <= 100) {
+      return { name, prefix };
+    }
+  }
+  return null;
+}
+
+function createTarHeader(archivePath, { mode, size, type }) {
+  const split = splitUstarPath(archivePath);
+  if (!split) {
+    throw new Error(`deterministic sidecar archive path requires a GNU long-name record: ${archivePath}`);
+  }
+  const header = Buffer.alloc(TAR_BLOCK_BYTES);
+  writeUtf8(header, 0, 100, split.name, "path name");
+  writeOctal(header, 100, 8, mode, "mode");
+  writeOctal(header, 108, 8, 0, "uid");
+  writeOctal(header, 116, 8, 0, "gid");
+  writeOctal(header, 124, 12, size, "size");
+  writeOctal(header, 136, 12, 0, "mtime");
+  header.fill(0x20, 148, 156);
+  header[156] = type.charCodeAt(0);
+  writeUtf8(header, 257, 6, "ustar\0", "ustar magic");
+  writeUtf8(header, 263, 2, "00", "ustar version");
+  writeUtf8(header, 345, 155, split.prefix, "path prefix");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0).toString(8).padStart(6, "0");
+  if (checksum.length !== 6) {
+    throw new Error(`ustar checksum does not fit its header field: ${checksum}`);
+  }
+  header.write(`${checksum}\0 `, 148, 8, "ascii");
+  return header;
+}
+
+function paddingFor(size) {
+  const remainder = size % TAR_BLOCK_BYTES;
+  return remainder === 0 ? 0 : TAR_BLOCK_BYTES - remainder;
+}
+
+async function normalizeGzipHeader(archivePath) {
+  const archive = await open(archivePath, "r+");
+  try {
+    const header = Buffer.alloc(10);
+    const { bytesRead } = await archive.read(header, 0, header.length, 0);
+    if (
+      bytesRead !== header.length
+      || header[0] !== 0x1f
+      || header[1] !== 0x8b
+      || header[2] !== 8
+      || header[3] !== 0
+    ) {
+      throw new Error("sidecar archive writer produced an unsupported gzip header");
+    }
+    header.writeUInt32LE(0, 4);
+    header[9] = 0xff;
+    await archive.write(header, 0, header.length, 0);
+    await archive.sync();
+  } finally {
+    await archive.close();
+  }
+}
+
+export async function writeDeterministicSidecarArchive(sourceRoot, archivePath) {
+  const source = path.resolve(sourceRoot);
+  const metrics = await collectArchiveEntries(source);
+  await mkdir(path.dirname(archivePath), { recursive: true });
+  await rm(archivePath, { force: true });
+
+  // The payload digest covers the canonical uncompressed tar bytes. The
+  // archive digest separately authenticates the exact gzip resource.
+  const payloadHash = createHash("sha256");
+  const treeHash = createHash("sha256");
+  const gzip = createGzip({ level: 9 });
+  const output = createWriteStream(archivePath, { flags: "wx" });
+  const piping = pipeline(gzip, output);
+  const writeTar = async (chunk) => {
+    payloadHash.update(chunk);
+    if (!gzip.write(chunk)) {
+      await once(gzip, "drain");
+    }
+  };
+  const writePadding = async (size) => {
+    const padding = paddingFor(size);
+    if (padding > 0) {
+      await writeTar(Buffer.alloc(padding));
+    }
+  };
+
+  try {
+    for (const entry of metrics.entries) {
+      updateTreeDigestHeader(
+        treeHash,
+        entry.kind === "directory" ? "d" : "f",
+        entry.archivePath,
+        entry.kind === "file" ? entry.size : null,
+      );
+      const archivePathWithType = entry.kind === "directory" ? `${entry.archivePath}/` : entry.archivePath;
+      let headerPath = archivePathWithType;
+      if (!splitUstarPath(archivePathWithType)) {
+        const longName = Buffer.from(`${archivePathWithType}\0`, "utf8");
+        await writeTar(createTarHeader("././@LongLink", {
+          mode: NORMALIZED_FILE_MODE,
+          size: longName.length,
+          type: "L",
+        }));
+        await writeTar(longName);
+        await writePadding(longName.length);
+        headerPath = `long/${createHash("sha256").update(archivePathWithType).digest("hex").slice(0, 32)}`;
+      }
+
+      await writeTar(createTarHeader(headerPath, {
+        mode: entry.mode,
+        size: entry.size,
+        type: entry.kind === "directory" ? "5" : "0",
+      }));
+      if (entry.kind === "file") {
+        let bytesRead = 0;
+        for await (const chunk of createReadStream(entry.absolutePath)) {
+          bytesRead += chunk.length;
+          if (bytesRead > entry.size) {
+            throw new Error(`sidecar archive input changed while reading: ${entry.absolutePath}`);
+          }
+          await writeTar(chunk);
+          treeHash.update(chunk);
+        }
+        if (bytesRead !== entry.size) {
+          throw new Error(`sidecar archive input changed while reading: ${entry.absolutePath}`);
+        }
+        await writePadding(entry.size);
+      }
+    }
+    await writeTar(Buffer.alloc(TAR_END_BYTES));
+    gzip.end();
+    await piping;
+    await normalizeGzipHeader(archivePath);
+  } catch (error) {
+    gzip.destroy();
+    await piping.catch(() => {});
+    await rm(archivePath, { force: true });
+    throw error;
+  }
+
+  const [{ size: archiveBytes }, archiveSha256] = await Promise.all([
+    stat(archivePath),
+    sha256File(archivePath),
+  ]);
+  return {
+    payloadSha256: payloadHash.digest("hex"),
+    treeSha256: treeHash.digest("hex"),
+    archiveSha256,
+    archiveBytes,
+    fileCount: metrics.fileCount,
+    directoryCount: metrics.directoryCount,
+    unpackedBytes: metrics.unpackedBytes,
+  };
 }
 
 export async function writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath) {
-  const [{ size: archiveBytes }, metrics, archiveSha256] = await Promise.all([
-    stat(archivePath),
-    treeMetrics(sourceRoot),
-    sha256File(archivePath),
-  ]);
+  const archive = await writeDeterministicSidecarArchive(sourceRoot, archivePath);
   const manifest = {
-    schemaVersion: 1,
-    archiveSha256,
-    archiveBytes,
-    ...metrics,
+    schemaVersion: SIDECAR_ARCHIVE_SCHEMA_VERSION,
+    payloadSha256: archive.payloadSha256,
+    treeSha256: archive.treeSha256,
+    archiveSha256: archive.archiveSha256,
+    archiveBytes: archive.archiveBytes,
+    fileCount: archive.fileCount,
+    directoryCount: archive.directoryCount,
+    unpackedBytes: archive.unpackedBytes,
   };
 
   for (const [metric, budget] of Object.entries(SIDECAR_ARCHIVE_BUDGETS)) {
     if (manifest[metric] > budget) {
+      await rm(archivePath, { force: true });
       throw new Error(`sidecar ${metric} ${manifest[metric]} exceeds budget ${budget}`);
     }
   }
@@ -83,6 +316,6 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
   }
   const manifest = await writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath);
   console.log(
-    `==> Windows sidecar archive: ${manifest.fileCount} files, ${manifest.unpackedBytes} bytes expanded, ${manifest.archiveBytes} bytes compressed`,
+    `==> Windows sidecar archive: ${manifest.fileCount} files, ${manifest.unpackedBytes} bytes expanded, ${manifest.archiveBytes} bytes compressed, payload ${manifest.payloadSha256}`,
   );
 }

--- a/scripts/sidecar-archive-manifest.test.mjs
+++ b/scripts/sidecar-archive-manifest.test.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  SIDECAR_ARCHIVE_SCHEMA_VERSION,
+  writeSidecarArchiveManifest,
+} from "./sidecar-archive-manifest.mjs";
+
+const longRelativePath = path.join(
+  "node_modules",
+  `package-${"x".repeat(108)}`,
+  "nested",
+  "fixture.json",
+);
+const fixtureFiles = [
+  ["z-last.txt", "last\n"],
+  [path.join("a-first", "entry.txt"), "first\n"],
+  [longRelativePath, "long-name\n"],
+];
+
+async function createFixture(root, files, seconds) {
+  for (const [relative, contents] of files) {
+    const destination = path.join(root, relative);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await writeFile(destination, contents, "utf8");
+    await utimes(destination, seconds, seconds);
+  }
+}
+
+const temp = await mkdtemp(path.join(os.tmpdir(), "coven-sidecar-determinism-"));
+try {
+  const firstRoot = path.join(temp, "first");
+  const secondRoot = path.join(temp, "second");
+  await Promise.all([
+    createFixture(firstRoot, fixtureFiles, 1_700_000_000),
+    createFixture(secondRoot, [...fixtureFiles].reverse(), 1_800_000_000),
+  ]);
+  await chmod(path.join(secondRoot, "z-last.txt"), 0o755);
+
+  const firstArchive = path.join(temp, "first.tar.gz");
+  const secondArchive = path.join(temp, "second.tar.gz");
+  const firstManifestPath = path.join(temp, "first.json");
+  const secondManifestPath = path.join(temp, "second.json");
+  const [firstManifest, secondManifest] = await Promise.all([
+    writeSidecarArchiveManifest(firstRoot, firstArchive, firstManifestPath),
+    writeSidecarArchiveManifest(secondRoot, secondArchive, secondManifestPath),
+  ]);
+
+  assert.equal(firstManifest.schemaVersion, SIDECAR_ARCHIVE_SCHEMA_VERSION);
+  assert.equal(firstManifest.schemaVersion, 2);
+  assert.deepEqual(secondManifest, firstManifest, "metadata and creation order must not affect the manifest");
+  assert.deepEqual(
+    await readFile(secondArchive),
+    await readFile(firstArchive),
+    "metadata and creation order must not affect archive bytes",
+  );
+  assert.match(firstManifest.treeSha256, /^[a-f0-9]{64}$/);
+
+  const digestFixture = path.join(temp, "tree-digest-fixture");
+  await createFixture(digestFixture, [
+    [path.join("a-first", "entry.txt"), "first\n"],
+    ["z-last.txt", "last\n"],
+  ], 1_700_000_000);
+  const digestManifest = await writeSidecarArchiveManifest(
+    digestFixture,
+    path.join(temp, "tree-digest.tar.gz"),
+    path.join(temp, "tree-digest.json"),
+  );
+  assert.equal(
+    digestManifest.treeSha256,
+    "8b1ba9bbae7c87757dcb92c97532285d679785504c65a52af139e5457ca203a7",
+    "tree digest framing must stay interoperable with the Rust cache verifier",
+  );
+
+  const gzipHeader = (await readFile(firstArchive)).subarray(0, 10);
+  assert.equal(gzipHeader.subarray(4, 8).toString("hex"), "00000000", "gzip mtime must be zero");
+  assert.equal(gzipHeader[9], 0xff, "gzip OS byte must be normalized");
+
+  const tarBytes = gunzipSync(await readFile(firstArchive));
+  assert.equal(createHash("sha256").update(tarBytes).digest("hex"), firstManifest.payloadSha256);
+  for (let offset = 0; offset + 512 <= tarBytes.length; ) {
+    const header = tarBytes.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+    const octal = (start, width) => Number.parseInt(
+      header.subarray(start, start + width).toString("ascii").replace(/\0.*$/, "").trim() || "0",
+      8,
+    );
+    const type = String.fromCharCode(header[156]);
+    assert.equal(octal(108, 8), 0, "tar uid must be zero");
+    assert.equal(octal(116, 8), 0, "tar gid must be zero");
+    assert.equal(octal(136, 12), 0, "tar mtime must be zero");
+    assert.equal(octal(100, 8), type === "5" ? 0o755 : 0o644, "tar mode must be normalized");
+    const size = octal(124, 12);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+
+  const extracted = path.join(temp, "extracted");
+  await mkdir(extracted);
+  const extraction = spawnSync("tar", ["-xzf", firstArchive, "-C", extracted], { encoding: "utf8" });
+  assert.equal(extraction.status, 0, extraction.stderr || extraction.error?.message);
+  assert.equal(await readFile(path.join(extracted, longRelativePath), "utf8"), "long-name\n");
+
+  console.log(
+    `sidecar archive determinism: ok (${firstManifest.archiveSha256}, ${firstManifest.archiveBytes} bytes)`,
+  );
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -103,6 +103,20 @@ assert.ok(
 );
 assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.gz archive");
 assert.match(src, /sidecar-archive-manifest\.mjs/, "archive generation must emit its integrity and size manifest");
+assert.doesNotMatch(
+  src,
+  /tar -czf "\$WINDOWS_ARCHIVE"/,
+  "Windows archive bytes must not depend on the host tar implementation",
+);
+assert.match(manifestSource, /SIDECAR_ARCHIVE_SCHEMA_VERSION = 2/, "content-addressed manifests must use schema 2");
+assert.match(manifestSource, /entries\.sort\(compareArchivePaths\)/, "archive paths must have deterministic byte ordering");
+assert.match(manifestSource, /writeOctal\(header, 108, 8, 0, "uid"\)/, "archive uid must be normalized");
+assert.match(manifestSource, /writeOctal\(header, 116, 8, 0, "gid"\)/, "archive gid must be normalized");
+assert.match(manifestSource, /writeOctal\(header, 136, 12, 0, "mtime"\)/, "archive mtime must be normalized");
+assert.match(manifestSource, /kind: "file",[\s\S]*mode: NORMALIZED_FILE_MODE/, "archive file modes must be normalized");
+assert.match(manifestSource, /header\[9\] = 0xff/, "gzip host metadata must be normalized");
+assert.match(manifestSource, /payloadSha256/, "manifest must identify canonical payload content separately from gzip bytes");
+assert.match(manifestSource, /treeSha256/, "manifest must authenticate the activated runtime tree");
 assert.match(manifestSource, /archiveBytes: 256 \* 1024 \* 1024/, "archive size must have a 256 MiB hard budget");
 assert.match(manifestSource, /unpackedBytes: 768 \* 1024 \* 1024/, "expanded runtime must have a 768 MiB hard budget");
 assert.match(manifestSource, /fileCount: 50_000/, "archive entry count must have a hard budget");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -218,13 +218,9 @@ write_windows_sidecar_archive() {
   done < <(find "$DEST" -type l -print0)
 
   echo "==> archiving Windows sidecar -> $WINDOWS_ARCHIVE"
-  if [ "$(uname -s)" = "Darwin" ]; then
-    COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs \
-      -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
-  else
-    tar -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
-  fi
-
+  # The Node writer emits a canonical tar stream (byte-sorted paths, fixed
+  # uid/gid/mtime/modes) and normalizes the gzip header. Identical payloads
+  # therefore keep the same digest/cache key across release builds and hosts.
   node "$ROOT/scripts/sidecar-archive-manifest.mjs" \
     "$DEST" "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -96,7 +96,10 @@ async function main() {
     const archiveDir = path.join(root, "src-tauri", "resources", "server-archive");
     const archive = path.join(archiveDir, "server.tar.gz");
     const manifest = JSON.parse(await readFile(path.join(archiveDir, "manifest.json"), "utf8"));
-    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.schemaVersion, 2);
+    assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
+    assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
+    assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
     assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 50_000);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 256 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes <= 768 * 1024 * 1024);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,6 +80,7 @@ name = "app"
 version = "0.0.173"
 dependencies = [
  "flate2",
+ "fs2",
  "log",
  "objc2",
  "once_cell",
@@ -1224,6 +1225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,7 @@ tauri-plugin-process = "2"
 # WiX component per file. The launcher verifies and extracts it on first use.
 [target.'cfg(target_os = "windows")'.dependencies]
 flate2 = "1"
+fs2 = "0.4.3"
 sha2 = "0.10"
 tar = "0.4"
 

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -1,16 +1,21 @@
 use flate2::read::GzDecoder;
+use fs2::FileExt as Fs2FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
 
-const MANIFEST_SCHEMA_VERSION: u32 = 1;
+const MANIFEST_SCHEMA_VERSION: u32 = 2;
 const MAX_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_UNPACKED_BYTES: u64 = 768 * 1024 * 1024;
 const MAX_FILE_COUNT: u64 = 50_000;
+const MIN_FREE_SPACE_RESERVE_BYTES: u64 = 64 * 1024 * 1024;
+const CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const CACHE_LOCK_RETRY: Duration = Duration::from_millis(100);
 const STALE_EXTRACTION_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 const REQUIRED_RUNTIME_PATHS: [&str; 7] = [
     "server.mjs",
@@ -26,6 +31,8 @@ const REQUIRED_RUNTIME_PATHS: [&str; 7] = [
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct SidecarArchiveManifest {
     schema_version: u32,
+    payload_sha256: String,
+    tree_sha256: String,
     archive_sha256: String,
     archive_bytes: u64,
     unpacked_bytes: u64,
@@ -37,8 +44,67 @@ struct SidecarArchiveManifest {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct CompletionMarker {
     schema_version: u32,
-    package_version: String,
-    archive_sha256: String,
+    payload_sha256: String,
+    tree_sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredCompletionMarker {
+    schema_version: u32,
+    #[serde(default)]
+    payload_sha256: Option<String>,
+    #[serde(default)]
+    tree_sha256: Option<String>,
+    #[serde(default)]
+    package_version: Option<String>,
+    #[serde(default)]
+    archive_sha256: Option<String>,
+}
+
+struct HashingReader<R> {
+    inner: R,
+    hasher: Sha256,
+}
+
+impl<R> HashingReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn finish(self) -> String {
+        hex_digest(self.hasher.finalize())
+    }
+}
+
+impl<R: Read> Read for HashingReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buffer)?;
+        self.hasher.update(&buffer[..read]);
+        Ok(read)
+    }
+}
+
+struct CacheLock {
+    _file: File,
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    digest
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 fn read_manifest(path: &Path) -> Result<SidecarArchiveManifest, String> {
@@ -57,12 +123,13 @@ fn read_manifest(path: &Path) -> Result<SidecarArchiveManifest, String> {
             manifest.schema_version
         ));
     }
-    if manifest.archive_sha256.len() != 64
-        || !manifest
-            .archive_sha256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit())
-    {
+    if !is_sha256(&manifest.payload_sha256) {
+        return Err("sidecar manifest has an invalid payload SHA-256 digest".to_string());
+    }
+    if !is_sha256(&manifest.tree_sha256) {
+        return Err("sidecar manifest has an invalid tree SHA-256 digest".to_string());
+    }
+    if !is_sha256(&manifest.archive_sha256) {
         return Err("sidecar manifest has an invalid SHA-256 digest".to_string());
     }
     if manifest.archive_bytes == 0 || manifest.archive_bytes > MAX_ARCHIVE_BYTES {
@@ -107,25 +174,13 @@ fn sha256_file(path: &Path) -> Result<String, String> {
         }
         hasher.update(&buffer[..read]);
     }
-    Ok(hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect())
+    Ok(hex_digest(hasher.finalize()))
 }
 
-fn cache_key(package_version: &str, archive_sha256: &str) -> String {
-    let version: String = package_version
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    format!("{version}-{}", &archive_sha256[..16])
+fn cache_key(manifest: &SidecarArchiveManifest) -> String {
+    // Cache identity follows canonical payload content, not the app version or
+    // gzip envelope, so unchanged runtimes survive consecutive upgrades.
+    format!("v{}-{}", manifest.schema_version, manifest.payload_sha256)
 }
 
 fn runtime_has_required_files(root: &Path) -> bool {
@@ -134,7 +189,7 @@ fn runtime_has_required_files(root: &Path) -> bool {
         .all(|relative| root.join(relative).exists())
 }
 
-fn cache_is_ready(destination: &Path, package_version: &str, archive_sha256: &str) -> bool {
+fn cache_is_ready(destination: &Path, manifest: &SidecarArchiveManifest) -> bool {
     if !runtime_has_required_files(destination) {
         return false;
     }
@@ -142,18 +197,179 @@ fn cache_is_ready(destination: &Path, package_version: &str, archive_sha256: &st
         Ok(contents) => contents,
         Err(_) => return false,
     };
-    match serde_json::from_str::<CompletionMarker>(&marker) {
+    let marker_matches = match serde_json::from_str::<CompletionMarker>(&marker) {
         Ok(marker) => {
             marker.schema_version == MANIFEST_SCHEMA_VERSION
-                && marker.package_version == package_version
-                && marker.archive_sha256 == archive_sha256
+                && marker.payload_sha256 == manifest.payload_sha256
+                && marker.tree_sha256 == manifest.tree_sha256
         }
         Err(_) => false,
+    };
+    if !marker_matches {
+        return false;
+    }
+    tree_metrics(destination).is_ok_and(|(_, _, _, digest)| digest == manifest.tree_sha256)
+}
+
+fn lock_is_contended(error: &io::Error) -> bool {
+    let expected = fs2::lock_contended_error();
+    match (error.raw_os_error(), expected.raw_os_error()) {
+        (Some(actual), Some(expected)) => actual == expected,
+        _ => error.kind() == expected.kind(),
     }
 }
 
-fn tree_metrics(root: &Path) -> Result<(u64, u64, u64), String> {
+fn acquire_cache_lock(cache_root: &Path) -> Result<CacheLock, String> {
+    // Advisory OS locks are released when a crashed process closes its handle,
+    // unlike sentinel directories that can strand every later startup.
+    let lock_path = cache_root.join(".runtime-cache.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| {
+            format!(
+                "could not open sidecar cache lock {}: {error}",
+                lock_path.display()
+            )
+        })?;
+    let started = Instant::now();
+    loop {
+        match Fs2FileExt::try_lock_exclusive(&file) {
+            Ok(()) => return Ok(CacheLock { _file: file }),
+            Err(error) if lock_is_contended(&error) && started.elapsed() < CACHE_LOCK_TIMEOUT => {
+                thread::sleep(CACHE_LOCK_RETRY);
+            }
+            Err(error) if lock_is_contended(&error) => {
+                return Err(format!(
+                    "timed out waiting for another process to prepare the sidecar runtime after {} seconds",
+                    CACHE_LOCK_TIMEOUT.as_secs()
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "could not lock sidecar runtime cache {}: {error}",
+                    lock_path.display()
+                ));
+            }
+        }
+    }
+}
+
+fn try_acquire_cache_lock(cache_root: &Path) -> Result<Option<CacheLock>, String> {
+    let lock_path = cache_root.join(".runtime-cache.lock");
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| {
+            format!(
+                "could not open sidecar cache lock {}: {error}",
+                lock_path.display()
+            )
+        })?;
+    match Fs2FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(Some(CacheLock { _file: file })),
+        Err(error) if lock_is_contended(&error) => Ok(None),
+        Err(error) => Err(format!(
+            "could not lock sidecar runtime cache {}: {error}",
+            lock_path.display()
+        )),
+    }
+}
+
+fn required_free_space(manifest: &SidecarArchiveManifest) -> Result<u64, String> {
+    let reserve = MIN_FREE_SPACE_RESERVE_BYTES.max(manifest.unpacked_bytes / 10);
+    manifest
+        .unpacked_bytes
+        .checked_add(reserve)
+        .ok_or_else(|| "sidecar free-space requirement overflow".to_string())
+}
+
+fn remove_cache_path(path: &Path) -> Result<(), String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "could not inspect sidecar cache path {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    let removal = if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    };
+    removal.map_err(|error| {
+        format!(
+            "could not remove sidecar cache path {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn cleanup_staging_before_extraction(cache_root: &Path, key: &str) -> Result<(), String> {
+    let entries = fs::read_dir(cache_root).map_err(|error| {
+        format!(
+            "could not inspect sidecar cache {}: {error}",
+            cache_root.display()
+        )
+    })?;
+    let current_prefix = format!(".extract-{key}-");
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("could not inspect sidecar cache entry: {error}"))?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with(".extract-") {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+            .is_some_and(|age| age >= STALE_EXTRACTION_AGE);
+        if name.starts_with(&current_prefix) || stale {
+            remove_cache_path(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+fn create_staging_directory(cache_root: &Path, key: &str) -> Result<PathBuf, String> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    for attempt in 0..100_u32 {
+        let staging = cache_root.join(format!(
+            ".extract-{key}-{}-{nonce}-{attempt}",
+            std::process::id()
+        ));
+        match fs::create_dir(&staging) {
+            Ok(()) => return Ok(staging),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(format!(
+                    "could not create sidecar staging directory {}: {error}",
+                    staging.display()
+                ));
+            }
+        }
+    }
+    Err("could not allocate a unique sidecar staging directory".to_string())
+}
+
+fn tree_metrics(root: &Path) -> Result<(u64, u64, u64, String), String> {
     let mut pending = vec![root.to_path_buf()];
+    let mut paths = Vec::new();
     let mut file_count = 0_u64;
     let mut directory_count = 0_u64;
     let mut unpacked_bytes = 0_u64;
@@ -168,19 +384,35 @@ fn tree_metrics(root: &Path) -> Result<(u64, u64, u64), String> {
         for entry in entries {
             let entry =
                 entry.map_err(|error| format!("could not inspect sidecar entry: {error}"))?;
-            let metadata = fs::symlink_metadata(entry.path())
+            let entry_path = entry.path();
+            let metadata = fs::symlink_metadata(&entry_path)
                 .map_err(|error| format!("could not inspect sidecar metadata: {error}"))?;
             if metadata.file_type().is_symlink() {
                 return Err(format!(
                     "extracted sidecar contains a forbidden symlink: {}",
-                    entry.path().display()
+                    entry_path.display()
                 ));
+            }
+            let relative = entry_path
+                .strip_prefix(root)
+                .map_err(|error| format!("could not resolve sidecar relative path: {error}"))?
+                .components()
+                .map(|component| {
+                    component.as_os_str().to_str().ok_or_else(|| {
+                        format!("sidecar path is not valid UTF-8: {}", entry_path.display())
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .join("/");
+            if relative == ".complete.json" {
+                continue;
             }
             if metadata.is_dir() {
                 directory_count = directory_count
                     .checked_add(1)
                     .ok_or_else(|| "sidecar directory count overflow".to_string())?;
-                pending.push(entry.path());
+                pending.push(entry_path.clone());
+                paths.push((relative, entry_path, true, 0));
             } else if metadata.is_file() {
                 file_count = file_count
                     .checked_add(1)
@@ -188,16 +420,51 @@ fn tree_metrics(root: &Path) -> Result<(u64, u64, u64), String> {
                 unpacked_bytes = unpacked_bytes
                     .checked_add(metadata.len())
                     .ok_or_else(|| "sidecar expanded size overflow".to_string())?;
+                paths.push((relative, entry_path, false, metadata.len()));
             } else {
                 return Err(format!(
                     "extracted sidecar contains an unsupported entry: {}",
-                    entry.path().display()
+                    entry_path.display()
                 ));
             }
         }
     }
+    paths.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    for (relative, path, is_directory, size) in paths {
+        hasher.update(if is_directory { b"d" } else { b"f" });
+        hasher.update((relative.len() as u64).to_be_bytes());
+        hasher.update(relative.as_bytes());
+        if !is_directory {
+            hasher.update(size.to_be_bytes());
+            let mut file = File::open(&path).map_err(|error| {
+                format!(
+                    "could not open cached sidecar file {}: {error}",
+                    path.display()
+                )
+            })?;
+            loop {
+                let read = file.read(&mut buffer).map_err(|error| {
+                    format!(
+                        "could not hash cached sidecar file {}: {error}",
+                        path.display()
+                    )
+                })?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+        }
+    }
 
-    Ok((file_count, directory_count, unpacked_bytes))
+    Ok((
+        file_count,
+        directory_count,
+        unpacked_bytes,
+        hex_digest(hasher.finalize()),
+    ))
 }
 
 fn extract_archive(
@@ -212,7 +479,8 @@ fn extract_archive(
         )
     })?;
     let decoder = GzDecoder::new(archive_file);
-    let mut archive = tar::Archive::new(decoder);
+    let hashing_reader = HashingReader::new(decoder);
+    let mut archive = tar::Archive::new(hashing_reader);
     let entries = archive
         .entries()
         .map_err(|error| format!("could not read sidecar archive: {error}"))?;
@@ -305,6 +573,14 @@ fn extract_archive(
         }
     }
 
+    let mut hashing_reader = archive.into_inner();
+    io::copy(&mut hashing_reader, &mut io::sink())
+        .map_err(|error| format!("could not finish hashing sidecar payload: {error}"))?;
+    let payload_sha256 = hashing_reader.finish();
+    if payload_sha256 != manifest.payload_sha256 {
+        return Err("sidecar payload SHA-256 does not match its manifest".to_string());
+    }
+
     if archive_file_count != manifest.file_count
         || archive_directory_count != manifest.directory_count
     {
@@ -313,12 +589,15 @@ fn extract_archive(
             manifest.file_count, manifest.directory_count
         ));
     }
-    let (file_count, directory_count, unpacked_bytes) = tree_metrics(staging)?;
+    let (file_count, directory_count, unpacked_bytes, tree_sha256) = tree_metrics(staging)?;
     if file_count != manifest.file_count
         || directory_count != manifest.directory_count
         || unpacked_bytes != manifest.unpacked_bytes
     {
         return Err("extracted sidecar metrics do not match manifest".to_string());
+    }
+    if tree_sha256 != manifest.tree_sha256 {
+        return Err("extracted sidecar tree SHA-256 does not match its manifest".to_string());
     }
     if !runtime_has_required_files(staging) {
         return Err("sidecar archive is missing required runtime files".to_string());
@@ -331,12 +610,49 @@ fn prepare_runtime_from_files(
     archive_path: &Path,
     manifest_path: &Path,
     cache_root: &Path,
-    package_version: &str,
+) -> Result<PathBuf, String> {
+    prepare_runtime_from_files_with_space(archive_path, manifest_path, cache_root, &|path| {
+        fs2::available_space(path).map_err(|error| {
+            format!(
+                "could not determine free space for sidecar cache {}: {error}",
+                path.display()
+            )
+        })
+    })
+}
+
+fn prepare_runtime_from_files_with_space(
+    archive_path: &Path,
+    manifest_path: &Path,
+    cache_root: &Path,
+    available_space: &(dyn Fn(&Path) -> Result<u64, String> + Sync),
 ) -> Result<PathBuf, String> {
     let manifest = read_manifest(manifest_path)?;
-    let destination = cache_root.join(cache_key(package_version, &manifest.archive_sha256));
-    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
+    let key = cache_key(&manifest);
+    let destination = cache_root.join(&key);
+    if cache_is_ready(&destination, &manifest) {
         return Ok(destination);
+    }
+    fs::create_dir_all(cache_root).map_err(|error| {
+        format!(
+            "could not create sidecar cache {}: {error}",
+            cache_root.display()
+        )
+    })?;
+    let _lock = acquire_cache_lock(cache_root)?;
+    if cache_is_ready(&destination, &manifest) {
+        return Ok(destination);
+    }
+
+    cleanup_staging_before_extraction(cache_root, &key)?;
+    remove_cache_path(&destination)?;
+
+    let required_space = required_free_space(&manifest)?;
+    let free_space = available_space(cache_root)?;
+    if free_space < required_space {
+        return Err(format!(
+            "not enough free space to prepare the sidecar runtime: {free_space} bytes available, {required_space} required"
+        ));
     }
 
     let metadata = fs::metadata(archive_path).map_err(|error| {
@@ -357,66 +673,44 @@ fn prepare_runtime_from_files(
         return Err("sidecar archive SHA-256 does not match its manifest".to_string());
     }
 
-    fs::create_dir_all(cache_root).map_err(|error| {
-        format!(
-            "could not create sidecar cache {}: {error}",
-            cache_root.display()
-        )
-    })?;
-    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
-        return Ok(destination);
-    }
-    if destination.exists() {
-        fs::remove_dir_all(&destination).map_err(|error| {
-            format!(
-                "could not replace incomplete sidecar cache {}: {error}",
-                destination.display()
-            )
-        })?;
-    }
-
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let staging = cache_root.join(format!(
-        ".extract-{}-{}-{nonce}",
-        std::process::id(),
-        cache_key(package_version, &manifest.archive_sha256)
-    ));
-    fs::create_dir(&staging).map_err(|error| {
-        format!(
-            "could not create sidecar staging directory {}: {error}",
-            staging.display()
-        )
-    })?;
+    let staging = create_staging_directory(cache_root, &key)?;
 
     let extraction = (|| -> Result<(), String> {
         extract_archive(archive_path, &staging, &manifest)?;
         let marker = CompletionMarker {
             schema_version: MANIFEST_SCHEMA_VERSION,
-            package_version: package_version.to_string(),
-            archive_sha256: manifest.archive_sha256.clone(),
+            payload_sha256: manifest.payload_sha256.clone(),
+            tree_sha256: manifest.tree_sha256.clone(),
         };
         let marker_json = serde_json::to_string_pretty(&marker)
             .map_err(|error| format!("could not serialize sidecar completion marker: {error}"))?;
-        fs::write(staging.join(".complete.json"), format!("{marker_json}\n"))
+        let marker_path = staging.join(".complete.json");
+        let mut marker_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker_path)
+            .map_err(|error| format!("could not create sidecar completion marker: {error}"))?;
+        marker_file
+            .write_all(format!("{marker_json}\n").as_bytes())
             .map_err(|error| format!("could not write sidecar completion marker: {error}"))?;
+        marker_file
+            .sync_all()
+            .map_err(|error| format!("could not flush sidecar completion marker: {error}"))?;
         Ok(())
     })();
     if let Err(error) = extraction {
-        let _ = fs::remove_dir_all(&staging);
+        let _ = remove_cache_path(&staging);
         return Err(error);
     }
 
     match fs::rename(&staging, &destination) {
         Ok(()) => Ok(destination),
-        Err(_error) if cache_is_ready(&destination, package_version, &manifest.archive_sha256) => {
-            let _ = fs::remove_dir_all(&staging);
+        Err(_error) if cache_is_ready(&destination, &manifest) => {
+            let _ = remove_cache_path(&staging);
             Ok(destination)
         }
         Err(error) => {
-            let _ = fs::remove_dir_all(&staging);
+            let _ = remove_cache_path(&staging);
             Err(format!(
                 "could not activate extracted sidecar cache {}: {error}",
                 destination.display()
@@ -432,16 +726,20 @@ fn has_complete_marker(runtime: &Path) -> bool {
     let Ok(contents) = fs::read_to_string(runtime.join(".complete.json")) else {
         return false;
     };
-    match serde_json::from_str::<CompletionMarker>(&contents) {
-        Ok(marker) => {
-            marker.schema_version == MANIFEST_SCHEMA_VERSION
-                && marker.archive_sha256.len() == 64
-                && marker
-                    .archive_sha256
-                    .bytes()
-                    .all(|byte| byte.is_ascii_hexdigit())
+    match serde_json::from_str::<StoredCompletionMarker>(&contents) {
+        Ok(marker) if marker.schema_version == MANIFEST_SCHEMA_VERSION => {
+            marker.payload_sha256.as_deref().is_some_and(is_sha256)
+                && marker.tree_sha256.as_deref().is_some_and(is_sha256)
+        }
+        Ok(marker) if marker.schema_version == 1 => {
+            marker
+                .package_version
+                .as_deref()
+                .is_some_and(|version| !version.is_empty())
+                && marker.archive_sha256.as_deref().is_some_and(is_sha256)
         }
         Err(_) => false,
+        Ok(_) => false,
     }
 }
 
@@ -449,13 +747,28 @@ pub(crate) fn cleanup_stale_sidecar_runtimes(current: &Path) {
     let Some(cache_root) = current.parent() else {
         return;
     };
+    let _lock = match try_acquire_cache_lock(cache_root) {
+        Ok(Some(cache_lock)) => cache_lock,
+        Ok(None) => {
+            log::info!(
+                "[cave] skipping sidecar cache retirement while another process holds the cache lock"
+            );
+            return;
+        }
+        Err(error) => {
+            log::warn!("[cave] could not coordinate sidecar cache retirement: {error}");
+            return;
+        }
+    };
     let Ok(entries) = fs::read_dir(cache_root) else {
         return;
     };
-    let mut previous = Vec::new();
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
-        if !path.is_dir() || path == current {
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() || path == current {
             continue;
         }
         if entry.file_name().to_string_lossy().starts_with(".extract-") {
@@ -466,37 +779,22 @@ pub(crate) fn cleanup_stale_sidecar_runtimes(current: &Path) {
                 .and_then(|modified| SystemTime::now().duration_since(modified).ok())
                 .is_some_and(|age| age >= STALE_EXTRACTION_AGE);
             if stale {
-                let _ = fs::remove_dir_all(path);
+                let _ = remove_cache_path(&path);
             }
             continue;
         }
-        if has_complete_marker(&path) {
-            previous.push(entry);
-        } else if let Err(error) = fs::remove_dir_all(&path) {
-            log::warn!(
-                "[cave] could not remove incomplete sidecar cache {}: {}",
-                path.display(),
-                error
-            );
-        }
-    }
-    previous.sort_by_key(|entry| {
-        entry
-            .metadata()
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(UNIX_EPOCH)
-    });
-    previous.reverse();
-
-    // Keep one previous complete runtime for rollback and for a concurrently
-    // running older app. Older generations are best-effort cache cleanup.
-    for entry in previous.into_iter().skip(1) {
-        if let Err(error) = fs::remove_dir_all(entry.path()) {
-            log::warn!(
-                "[cave] could not remove stale sidecar cache {}: {}",
-                entry.path().display(),
-                error
-            );
+        // A complete content-addressed generation may still be serving an
+        // older concurrently running app. Without process leases there is no
+        // safe startup-time proof that it is unused, so explicit uninstall
+        // owns complete-generation reclamation.
+        if !has_complete_marker(&path) {
+            if let Err(error) = remove_cache_path(&path) {
+                log::warn!(
+                    "[cave] could not remove incomplete sidecar cache {}: {}",
+                    path.display(),
+                    error
+                );
+            }
         }
     }
 }
@@ -514,12 +812,7 @@ pub(crate) fn prepare_sidecar_runtime(
         .map_err(|error| format!("could not resolve sidecar cache directory: {error}"))?
         .join("sidecar-runtime");
     let started = Instant::now();
-    let runtime = prepare_runtime_from_files(
-        &archive_path,
-        &manifest_path,
-        &cache_root,
-        &app.package_info().version.to_string(),
-    )?;
+    let runtime = prepare_runtime_from_files(&archive_path, &manifest_path, &cache_root)?;
     log::info!(
         "[cave] Windows sidecar runtime ready at {} in {:.2?}",
         runtime.display(),
@@ -532,6 +825,10 @@ pub(crate) fn prepare_sidecar_runtime(
 mod tests {
     use super::*;
     use flate2::{write::GzEncoder, Compression};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier,
+    };
 
     fn test_root(name: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
@@ -578,10 +875,16 @@ mod tests {
             .expect("append fixture tree");
         let encoder = archive.into_inner().expect("finish tar");
         encoder.finish().expect("finish gzip");
-        let (file_count, directory_count, unpacked_bytes) =
+        let archive_file = File::open(&archive_path).expect("open archive for payload digest");
+        let mut payload_reader = HashingReader::new(GzDecoder::new(archive_file));
+        io::copy(&mut payload_reader, &mut io::sink()).expect("hash fixture payload");
+        let payload_sha256 = payload_reader.finish();
+        let (file_count, directory_count, unpacked_bytes, tree_sha256) =
             tree_metrics(&source).expect("fixture metrics");
         let manifest = SidecarArchiveManifest {
             schema_version: MANIFEST_SCHEMA_VERSION,
+            payload_sha256,
+            tree_sha256,
             archive_sha256: sha256_file(&archive_path).expect("fixture digest"),
             archive_bytes: fs::metadata(&archive_path).expect("archive metadata").len(),
             unpacked_bytes,
@@ -593,6 +896,8 @@ mod tests {
             &manifest_path,
             serde_json::to_vec(&serde_json::json!({
                 "schemaVersion": manifest.schema_version,
+                "payloadSha256": manifest.payload_sha256.clone(),
+                "treeSha256": manifest.tree_sha256.clone(),
                 "archiveSha256": manifest.archive_sha256.clone(),
                 "archiveBytes": manifest.archive_bytes,
                 "unpackedBytes": manifest.unpacked_bytes,
@@ -605,21 +910,134 @@ mod tests {
         (archive_path, manifest_path, manifest)
     }
 
+    fn create_required_runtime(root: &Path) {
+        for relative in REQUIRED_RUNTIME_PATHS {
+            let target = root.join(relative);
+            if relative.ends_with("/_") {
+                fs::create_dir_all(target).expect("create required runtime directory");
+            } else {
+                fs::create_dir_all(target.parent().expect("required runtime parent"))
+                    .expect("create required runtime parent");
+                fs::write(target, b"fixture").expect("write required runtime file");
+            }
+        }
+    }
+
     #[test]
     fn extracts_atomically_and_reuses_complete_cache() {
         let root = test_root("extract");
         let (archive, manifest, _) = write_fixture(&root);
         let cache = root.join("cache");
-        let runtime = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
-            .expect("extract runtime");
+        let runtime =
+            prepare_runtime_from_files(&archive, &manifest, &cache).expect("extract runtime");
         assert!(runtime.join("server.mjs").is_file());
         assert!(runtime.join(".complete.json").is_file());
 
         fs::remove_file(&archive).expect("remove archive after first extraction");
         assert_eq!(
-            prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3").expect("reuse cache"),
+            prepare_runtime_from_files(&archive, &manifest, &cache).expect("reuse cache"),
             runtime
         );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn same_payload_is_reused_across_package_versions() {
+        let root = test_root("cross-version");
+        let version_a = root.join("version-a");
+        let version_b = root.join("version-b");
+        fs::create_dir_all(&version_a).expect("create version a");
+        fs::create_dir_all(&version_b).expect("create version b");
+        let (archive_a, manifest_a, manifest) = write_fixture(&version_a);
+        let archive_b = version_b.join("server.tar.gz");
+        let manifest_b = version_b.join("manifest.json");
+        fs::copy(&archive_a, &archive_b).expect("copy archive to version b");
+        fs::copy(&manifest_a, &manifest_b).expect("copy manifest to version b");
+        let cache = root.join("cache");
+
+        let runtime_a = prepare_runtime_from_files(&archive_a, &manifest_a, &cache)
+            .expect("prepare version a runtime");
+        fs::remove_file(&archive_b).expect("remove version b archive to prove cache reuse");
+        let runtime_b = prepare_runtime_from_files(&archive_b, &manifest_b, &cache)
+            .expect("reuse payload cache for version b");
+
+        assert_eq!(runtime_b, runtime_a);
+        assert_eq!(
+            runtime_a.file_name().and_then(|name| name.to_str()),
+            Some(cache_key(&manifest).as_str())
+        );
+        assert!(!runtime_a.to_string_lossy().contains("version-a"));
+        assert!(!runtime_a.to_string_lossy().contains("version-b"));
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn concurrent_preparations_extract_once_under_the_process_lock() {
+        let root = test_root("concurrent");
+        let (archive, manifest, _) = write_fixture(&root);
+        let cache = root.join("cache");
+        let barrier = Arc::new(Barrier::new(8));
+        let probes = Arc::new(AtomicUsize::new(0));
+        let mut workers = Vec::new();
+        for _ in 0..8 {
+            let archive = archive.clone();
+            let manifest = manifest.clone();
+            let cache = cache.clone();
+            let barrier = Arc::clone(&barrier);
+            let probes = Arc::clone(&probes);
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                prepare_runtime_from_files_with_space(&archive, &manifest, &cache, &|_| {
+                    probes.fetch_add(1, Ordering::SeqCst);
+                    Ok(u64::MAX)
+                })
+            }));
+        }
+
+        let runtimes: Vec<PathBuf> = workers
+            .into_iter()
+            .map(|worker| {
+                worker
+                    .join()
+                    .expect("join preparation worker")
+                    .expect("prepare runtime")
+            })
+            .collect();
+        assert!(runtimes.iter().all(|runtime| runtime == &runtimes[0]));
+        assert_eq!(
+            probes.load(Ordering::SeqCst),
+            1,
+            "only the lock winner may extract"
+        );
+        assert_eq!(
+            fs::read_dir(&cache)
+                .expect("read cache")
+                .filter_map(Result::ok)
+                .filter(|entry| entry.path().is_dir())
+                .count(),
+            1
+        );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn low_space_preflight_fails_before_creating_staging() {
+        let root = test_root("low-space");
+        let (archive, manifest_path, manifest) = write_fixture(&root);
+        let cache = root.join("cache");
+        let required = required_free_space(&manifest).expect("required space");
+        let error =
+            prepare_runtime_from_files_with_space(&archive, &manifest_path, &cache, &|_| {
+                Ok(required - 1)
+            })
+            .expect_err("low free space must fail");
+
+        assert!(error.contains("not enough free space"));
+        assert!(!cache.join(cache_key(&manifest)).exists());
+        assert!(!fs::read_dir(&cache)
+            .expect("read cache")
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().starts_with(".extract-")));
         fs::remove_dir_all(root).expect("remove test root");
     }
 
@@ -629,14 +1047,69 @@ mod tests {
         let (archive, manifest_path, manifest) = write_fixture(&root);
         let cache = root.join("cache");
         fs::create_dir_all(&cache).expect("create cache");
-        let destination = cache.join(cache_key("1.2.3", &manifest.archive_sha256));
+        let destination = cache.join(cache_key(&manifest));
         fs::create_dir(&destination).expect("create incomplete destination");
         fs::write(destination.join("partial"), b"partial").expect("write partial file");
 
-        let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache, "1.2.3")
+        let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache)
             .expect("replace incomplete cache");
         assert!(!runtime.join("partial").exists());
         assert!(runtime.join("server.mjs").is_file());
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn recovers_a_damaged_cache_and_cleans_orphaned_staging() {
+        let root = test_root("recovery");
+        let (archive, manifest_path, manifest) = write_fixture(&root);
+        let cache = root.join("cache");
+        let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect("prepare initial runtime");
+        fs::remove_file(runtime.join("server.mjs")).expect("damage cached runtime");
+        let orphan = cache.join(format!(".extract-{}-orphan", cache_key(&manifest)));
+        fs::create_dir(&orphan).expect("create orphaned staging directory");
+        fs::write(orphan.join("partial"), b"partial").expect("write orphaned staging file");
+
+        let recovered = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect("recover damaged runtime");
+        assert_eq!(recovered, runtime);
+        assert!(recovered.join("server.mjs").is_file());
+        assert!(!orphan.exists());
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn recovers_same_size_corruption_outside_required_paths() {
+        let root = test_root("content-corruption");
+        let (archive, manifest_path, _) = write_fixture(&root);
+        let cache = root.join("cache");
+        let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect("prepare initial runtime");
+        let helper = runtime.join("node_modules/@swc/helpers/_/index");
+        fs::write(&helper, b"corrupt").expect("corrupt non-sentinel file with same byte length");
+
+        let recovered = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect("recover arbitrary cached-file corruption");
+        assert_eq!(
+            fs::read(recovered.join("node_modules/@swc/helpers/_/index"))
+                .expect("read recovered helper"),
+            b"fixture"
+        );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn tree_digest_matches_the_archive_writer_contract() {
+        let root = test_root("tree-digest-contract");
+        fs::create_dir_all(root.join("a-first")).expect("create digest fixture directory");
+        fs::write(root.join("a-first/entry.txt"), b"first\n").expect("write first fixture");
+        fs::write(root.join("z-last.txt"), b"last\n").expect("write last fixture");
+
+        let (_, _, _, digest) = tree_metrics(&root).expect("hash fixture tree");
+        assert_eq!(
+            digest,
+            "8b1ba9bbae7c87757dcb92c97532285d679785504c65a52af139e5457ca203a7"
+        );
         fs::remove_dir_all(root).expect("remove test root");
     }
 
@@ -646,10 +1119,120 @@ mod tests {
         let (archive, manifest, _) = write_fixture(&root);
         fs::write(&archive, b"not a gzip archive").expect("corrupt archive");
         let cache = root.join("cache");
-        let error = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
+        let error = prepare_runtime_from_files(&archive, &manifest, &cache)
             .expect_err("corrupt archive must fail");
         assert!(error.contains("size does not match") || error.contains("SHA-256"));
-        assert!(!cache.exists() || fs::read_dir(&cache).expect("read cache").next().is_none());
+        assert!(
+            !cache.exists()
+                || !fs::read_dir(&cache)
+                    .expect("read cache")
+                    .filter_map(Result::ok)
+                    .any(|entry| entry.path().is_dir())
+        );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn rejects_a_payload_digest_mismatch_without_activation() {
+        let root = test_root("payload-digest");
+        let (archive, manifest_path, _) = write_fixture(&root);
+        let mut manifest: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+                .expect("parse manifest");
+        manifest["payloadSha256"] = serde_json::json!("0".repeat(64));
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&manifest).expect("serialize mismatched manifest"),
+        )
+        .expect("write mismatched manifest");
+        let cache = root.join("cache");
+
+        let error = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect_err("payload digest mismatch must fail");
+        assert!(error.contains("payload SHA-256"));
+        assert!(!fs::read_dir(&cache)
+            .expect("read cache")
+            .filter_map(Result::ok)
+            .any(|entry| entry.path().is_dir()));
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn cleanup_retains_all_complete_generations_without_process_leases() {
+        let root = test_root("rollback");
+        let current = root.join("v2-current");
+        create_required_runtime(&current);
+        fs::write(
+            current.join(".complete.json"),
+            serde_json::to_vec(&CompletionMarker {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                payload_sha256: "a".repeat(64),
+                tree_sha256: "c".repeat(64),
+            })
+            .expect("serialize current marker"),
+        )
+        .expect("write current marker");
+
+        let older = root.join("v2-older");
+        create_required_runtime(&older);
+        fs::write(
+            older.join(".complete.json"),
+            serde_json::to_vec(&CompletionMarker {
+                schema_version: MANIFEST_SCHEMA_VERSION,
+                payload_sha256: "b".repeat(64),
+                tree_sha256: "d".repeat(64),
+            })
+            .expect("serialize older marker"),
+        )
+        .expect("write older marker");
+        thread::sleep(Duration::from_millis(20));
+
+        let legacy = root.join("legacy");
+        create_required_runtime(&legacy);
+        fs::write(
+            legacy.join(".complete.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "schemaVersion": 1,
+                "packageVersion": "0.0.173",
+                "archiveSha256": "c".repeat(64),
+            }))
+            .expect("serialize legacy marker"),
+        )
+        .expect("write legacy marker");
+
+        cleanup_stale_sidecar_runtimes(&current);
+        assert!(
+            legacy.exists(),
+            "legacy complete runtime must remain available for rollback"
+        );
+        assert!(
+            older.exists(),
+            "content-addressed generations may still serve running older apps"
+        );
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn cleanup_skips_retirement_while_cache_lock_is_held() {
+        let root = test_root("cleanup-lock");
+        let current = root.join("current");
+        let incomplete = root.join("incomplete");
+        create_required_runtime(&current);
+        fs::create_dir(&incomplete).expect("create incomplete cache");
+        let lock = acquire_cache_lock(&root).expect("hold cache lock");
+
+        cleanup_stale_sidecar_runtimes(&current);
+        assert!(
+            incomplete.exists(),
+            "contended cleanup must not mutate caches"
+        );
+
+        drop(lock);
+        cleanup_stale_sidecar_runtimes(&current);
+        assert!(
+            !incomplete.exists(),
+            "coordinated cleanup should resume after unlock"
+        );
         fs::remove_dir_all(root).expect("remove test root");
     }
 
@@ -685,7 +1268,7 @@ mod tests {
             return;
         }
         let root = test_root("built-archive");
-        let runtime = prepare_runtime_from_files(&archive, &manifest, &root, "ci-fixture")
+        let runtime = prepare_runtime_from_files(&archive, &manifest, &root)
             .expect("extract built Windows archive with production code");
         assert!(runtime_has_required_files(&runtime));
         fs::remove_dir_all(root).expect("remove built archive fixture");


### PR DESCRIPTION
Upstream mirror of #2915 (by @romgenie) so the required CodeQL check can run and the stack can land. Commits are romgenie's, unchanged; squash-merge will credit via Co-authored-by.

Reviewed as part of the Windows sidecar-runtime stack. Superseded fork PR: #2915.

🤖 Mirrored + landed by Claude Code