### PR TITLE
feat(windows): prepare updates and show startup progress

### DIFF
--- a/docs/windows-update-preparation.md
+++ b/docs/windows-update-preparation.md
@@ -1,0 +1,24 @@
+# Windows update preparation and first launch
+
+The desktop updater separates preparation from installation:
+
+1. `Update.download()` downloads the signed updater artifact while the current app remains usable.
+2. The updater verifies the artifact signature before the promise resolves. The UI reports this as a separate verification phase and does not show the update as ready beforehand.
+3. The user explicitly selects **Restart & install**. On Windows, the updater starts `msiexec`, exits CovenCave, and the MSI relaunches the new version.
+4. The new version immediately paints the bundled `startup.html` page. Runtime verification/extraction and sidecar startup run on a worker thread. The page reports preparation, service startup, readiness, diagnostics, cancellation where safe, and retry.
+
+Prepared sidecar caches are reused by the existing archive marker checks. A failed or cancelled startup leaves a complete prepared cache intact, and stale-cache cleanup still retains the previous complete runtime for rollback.
+
+## Updater constraints
+
+Tauri updater 2.10.1 keeps the downloaded MSI in a native in-memory resource. It does not expose its bytes or a network abort handle to application JavaScript. The MSI is also opaque until installation. Therefore:
+
+- cancellation during download is cooperative: the current app stays usable, the request is allowed to settle, and the native bytes are released without installing;
+- CovenCave cannot safely pre-extract the next sidecar from the MSI before restart;
+- true cross-version sidecar prewarming would require publishing a separately signed runtime asset and is intentionally outside this independently mergeable change.
+
+The first-launch page permits cancellation only after the non-interruptible archive operation completes. Cancelling during sidecar readiness stops and reaps the process tree. Retry reuses any complete prepared cache.
+
+## Verification
+
+The release-runtime test asserts that Windows creates the local startup window before dispatching background preparation. Rust unit tests cover progress serialization, duplicate-worker prevention, cancellation reset, loopback-only quick chat navigation, and cancellable readiness polling. The update test uses a mocked native updater to verify that preparation never installs, signature verification remains distinct from download progress, and cancellation releases the prepared resource exactly once.

--- a/src-tauri/frontend-stub/startup.html
+++ b/src-tauri/frontend-stub/startup.html
@@ -1,0 +1,232 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Starting CovenCave</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        background: #090909;
+        color: #f7f7f2;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: grid;
+        place-items: center;
+        padding: 32px;
+        background:
+          radial-gradient(circle at 22% 12%, rgba(255, 255, 255, 0.1), transparent 34%),
+          linear-gradient(155deg, #111 0%, #080808 58%, #18120d 100%);
+      }
+
+      main {
+        width: min(100%, 520px);
+        display: grid;
+        gap: 18px;
+      }
+
+      .mark {
+        width: 48px;
+        height: 48px;
+        display: grid;
+        place-items: center;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        background: rgba(255, 255, 255, 0.07);
+        font-size: 26px;
+        font-weight: 700;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 28px;
+        line-height: 1.15;
+      }
+
+      p {
+        margin: 0;
+        color: rgba(247, 247, 242, 0.7);
+        font-size: 14px;
+        line-height: 1.5;
+      }
+
+      .progress-track {
+        height: 8px;
+        overflow: hidden;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+      }
+
+      .progress-value {
+        width: 0;
+        height: 100%;
+        border-radius: inherit;
+        background: #f7f7f2;
+        transition: width 180ms ease;
+      }
+
+      .phase {
+        min-height: 22px;
+        color: rgba(247, 247, 242, 0.86);
+        font-size: 14px;
+      }
+
+      .actions {
+        display: flex;
+        gap: 10px;
+      }
+
+      button {
+        min-height: 40px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 8px;
+        padding: 0 14px;
+        background: #f7f7f2;
+        color: #090909;
+        font: inherit;
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      button.secondary {
+        background: transparent;
+        color: #f7f7f2;
+      }
+
+      button[hidden] {
+        display: none;
+      }
+
+      button:disabled {
+        opacity: 0.55;
+      }
+
+      details {
+        color: #ffb4a8;
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      pre {
+        max-height: 180px;
+        overflow: auto;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        color: rgba(247, 247, 242, 0.72);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="mark" aria-hidden="true">C</div>
+      <h1>Starting CovenCave</h1>
+      <p>
+        The application runtime is being verified and prepared. The first start after an update can
+        take longer; later starts reuse the prepared runtime.
+      </p>
+      <div
+        class="progress-track"
+        id="progress"
+        role="progressbar"
+        aria-label="CovenCave startup progress"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0"
+      >
+        <div class="progress-value" id="progress-value"></div>
+      </div>
+      <div class="phase" id="phase" role="status" aria-live="polite">Preparing startup…</div>
+      <div class="actions">
+        <button id="retry" type="button" hidden>Retry</button>
+        <button class="secondary" id="cancel" type="button" hidden>Cancel startup</button>
+      </div>
+      <details id="diagnostics" hidden>
+        <summary>Startup diagnostics</summary>
+        <pre id="diagnostic-message"></pre>
+      </details>
+    </main>
+
+    <script>
+      (() => {
+        const eventName = "sidecar-startup-progress";
+        const progress = document.getElementById("progress");
+        const progressValue = document.getElementById("progress-value");
+        const phase = document.getElementById("phase");
+        const retry = document.getElementById("retry");
+        const cancel = document.getElementById("cancel");
+        const diagnostics = document.getElementById("diagnostics");
+        const diagnosticMessage = document.getElementById("diagnostic-message");
+
+        function render(status) {
+          const value = Math.max(0, Math.min(100, Number(status?.progress) || 0));
+          progress.setAttribute("aria-valuenow", String(value));
+          progressValue.style.width = `${value}%`;
+          phase.textContent = status?.message || "Preparing CovenCave";
+          retry.hidden = !status?.canRetry;
+          retry.disabled = false;
+          cancel.hidden = !status?.canCancel;
+          cancel.disabled = false;
+          const failed = status?.phase === "failed";
+          diagnostics.hidden = !failed;
+          diagnosticMessage.textContent = failed ? status.message : "";
+        }
+
+        async function invoke(command) {
+          const api = window.__TAURI__;
+          if (!api?.core?.invoke) throw new Error("Native startup API is unavailable");
+          return api.core.invoke(command);
+        }
+
+        retry.addEventListener("click", async () => {
+          retry.disabled = true;
+          diagnostics.hidden = true;
+          try {
+            await invoke("retry_sidecar_startup");
+          } catch (error) {
+            render({
+              phase: "failed",
+              progress: 0,
+              message: error instanceof Error ? error.message : String(error),
+              canRetry: true,
+              canCancel: false,
+            });
+          }
+        });
+
+        cancel.addEventListener("click", async () => {
+          cancel.disabled = true;
+          try {
+            await invoke("cancel_sidecar_startup");
+          } catch (error) {
+            phase.textContent = error instanceof Error ? error.message : String(error);
+            cancel.disabled = false;
+          }
+        });
+
+        async function initialize() {
+          const api = window.__TAURI__;
+          if (!api?.event?.listen) throw new Error("Native startup events are unavailable");
+          await api.event.listen(eventName, (event) => render(event.payload));
+          render(await invoke("sidecar_startup_status"));
+        }
+
+        initialize().catch((error) => {
+          render({
+            phase: "failed",
+            progress: 0,
+            message: error instanceof Error ? error.message : String(error),
+            canRetry: false,
+            canCancel: false,
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -17,4 +17,7 @@ permissions = [
   "allow-browser-report-title",
   "allow-browser-report-scroll",
   "allow-shell-open",
+  "allow-sidecar-startup-status",
+  "allow-retry-sidecar-startup",
+  "allow-cancel-sidecar-startup",
 ]

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -41,6 +41,9 @@ const requiredPermissionIds = [
   "allow-browser-close-all",
   "allow-browser-reload",
   "allow-shell-open",
+  "allow-sidecar-startup-status",
+  "allow-retry-sidecar-startup",
+  "allow-cancel-sidecar-startup",
 ];
 
 const requiredCommands = [
@@ -58,6 +61,9 @@ const requiredCommands = [
   "browser_close_all",
   "browser_reload",
   "shell_open",
+  "sidecar_startup_status",
+  "retry_sidecar_startup",
+  "cancel_sidecar_startup",
 ];
 
 // Node 22 (CI's runtime) has no global URLPattern, so match capability
@@ -207,6 +213,9 @@ test("packaged sidecar loopback origins can use browser commands and main-webvie
   assertCapabilityDoesNotGrant(loopbackBrowserCapability, [
     "default",
     "allow-shell-open",
+    "allow-sidecar-startup-status",
+    "allow-retry-sidecar-startup",
+    "allow-cancel-sidecar-startup",
   ]);
 });
 
@@ -370,17 +379,21 @@ test("the trusted main loopback webview can run the native in-app updater", () =
     "grant exactly check/download/install (updater:default), relaunch, and the platform/arch reads used to pick installer fallbacks — nothing else (no process:allow-exit)",
   );
 
-  // The web side must actually drive the native path: check() from
-  // plugin-updater, downloadAndInstall on the returned update, and relaunch()
-  // from plugin-process. If a refactor drops any of these the capability
-  // grant is dead weight and users silently regress to browser downloads.
+  // The web side must actually drive the native path: check(), prepare the
+  // signed download while the old app remains usable, explicitly install,
+  // and relaunch. If a refactor drops these the capability grant is dead.
   assert.ok(
     updateAvailable.includes('await import("@tauri-apps/plugin-updater")'),
     "update-available.tsx must check for updates through the native plugin-updater",
   );
   assert.ok(
+    updateAvailable.includes("prepareNativeUpdate") && updateAvailable.includes("installPreparedUpdate"),
+    "update-available.tsx must separate signed download preparation from explicit install",
+  );
+  assert.equal(
     updateAvailable.includes("downloadAndInstall"),
-    "update-available.tsx must install through the native updater download",
+    false,
+    "update preparation must not exit the old app as soon as download finishes",
   );
   assert.ok(
     updateAvailable.includes('await import("@tauri-apps/plugin-process")'),

--- a/src-tauri/permissions/pty.toml
+++ b/src-tauri/permissions/pty.toml
@@ -77,3 +77,18 @@ commands.allow = ["browser_report_title"]
 identifier = "allow-browser-report-scroll"
 description = "Allows child browser webviews to report scroll position via Rust."
 commands.allow = ["browser_report_scroll"]
+
+[[permission]]
+identifier = "allow-sidecar-startup-status"
+description = "Allows the bundled local startup page to read sidecar preparation status."
+commands.allow = ["sidecar_startup_status"]
+
+[[permission]]
+identifier = "allow-retry-sidecar-startup"
+description = "Allows the bundled local startup page to retry sidecar preparation."
+commands.allow = ["retry_sidecar_startup"]
+
+[[permission]]
+identifier = "allow-cancel-sidecar-startup"
+description = "Allows the bundled local startup page to cancel sidecar preparation at a safe boundary."
+commands.allow = ["cancel_sidecar_startup"]

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -149,7 +149,7 @@ test("packaged sidecar bootstraps mobile handoff tokens", async () => {
   );
   assert.match(
     launcher,
-    /\?covenCaveToken=\{\}&coven_access_token=\{\}/,
+    /\?covenCaveToken=\{auth_token\}&coven_access_token=\{mobile_access_token\}/,
     "desktop webview should bootstrap both sidecar auth and mobile access cookies",
   );
 });
@@ -169,8 +169,13 @@ test("macOS tray exposes quick chat as a separate floating window", async () => 
   );
   assert.match(
     launcher,
-    /show_quick_chat_window\(app, &quick_chat_url_for_menu\)/,
-    "the Quick Chat menu item must open the dedicated quick chat window",
+    /"quick_chat" => show_quick_chat_from_main\(app\)/,
+    "the Quick Chat menu item must resolve the ready main sidecar before opening",
+  );
+  assert.match(
+    launcher,
+    /fn quick_chat_url_from_main[\s\S]*trusted_loopback[\s\S]*url\.set_path\("\/quick-chat"\)/,
+    "quick chat must not open against the local startup page or an untrusted origin",
   );
   assert.match(
     launcher,
@@ -209,8 +214,46 @@ test("Windows packaged sidecar starts without a console window", async () => {
   );
   assert.match(
     launcher,
-    /cmd\.creation_flags\(0x08000000\)/,
+    /command\.creation_flags\(0x08000000\)/,
     "Windows launcher must use CREATE_NO_WINDOW for the Node sidecar process",
+  );
+});
+
+test("Windows first launch paints progress and supports recovery while the sidecar starts", async () => {
+  const [launcher, startupPage] = await Promise.all([
+    readFile(new URL("./src/lib.rs", import.meta.url), "utf8"),
+    readFile(new URL("./frontend-stub/startup.html", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(
+    launcher,
+    /WebviewUrl::App\("startup\.html"\.into\(\)\)/,
+    "Windows release startup must create a local window before runtime preparation",
+  );
+  assert.match(
+    launcher,
+    /thread::Builder::new\(\)[\s\S]*coven-sidecar-startup[\s\S]*start_sidecar_runtime/,
+    "runtime preparation and sidecar readiness must run off the UI thread",
+  );
+  assert.match(
+    launcher,
+    /retry_sidecar_startup[\s\S]*cancel_sidecar_startup/,
+    "startup must expose retry and cancellation commands",
+  );
+  assert.match(
+    startupPage,
+    /role="progressbar"[\s\S]*aria-live="polite"/,
+    "startup page must expose accessible progress",
+  );
+  assert.match(
+    startupPage,
+    /sidecar-startup-progress/,
+    "startup page must listen for native phase changes",
+  );
+  assert.match(
+    startupPage,
+    /Startup diagnostics[\s\S]*retry_sidecar_startup/,
+    "startup failures must surface diagnostics and an in-window retry",
   );
 });
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@
 // Android. Mobile binaries are thin shells: webview only, no sidecar.
 #[cfg(desktop)]
 use rand::{rngs::OsRng, RngCore};
+#[cfg(all(desktop, target_os = "windows"))]
+use serde::Serialize;
 #[cfg(desktop)]
 use std::net::TcpListener;
 #[cfg(all(desktop, target_os = "windows"))]
@@ -12,6 +14,8 @@ use std::os::windows::process::CommandExt;
 use std::path::{Path, PathBuf};
 #[cfg(desktop)]
 use std::process::{Child, Command, Stdio};
+#[cfg(all(desktop, target_os = "windows"))]
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(desktop)]
 use std::sync::{Arc, Mutex};
 #[cfg(desktop)]
@@ -25,7 +29,6 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Listener, Manager, Url, WebviewUrl, WebviewWindowBuilder,
 };
-
 #[cfg(desktop)]
 const QUICK_CHAT_WINDOW_LABEL: &str = "quick-chat";
 #[cfg(desktop)]
@@ -79,9 +82,37 @@ fn quick_chat_position(app: &tauri::AppHandle) -> (f64, f64) {
         let screen_x = position.x as f64 / scale;
         let screen_y = position.y as f64 / scale;
         let screen_w = size.width as f64 / scale;
-        return (screen_x + screen_w - QUICK_CHAT_WIDTH - 14.0, screen_y + 34.0);
+        return (
+            screen_x + screen_w - QUICK_CHAT_WIDTH - 14.0,
+            screen_y + 34.0,
+        );
     }
     (24.0, 40.0)
+}
+
+#[cfg(desktop)]
+fn quick_chat_url_from_main(mut url: Url) -> Option<Url> {
+    let trusted_loopback = url.scheme() == "http"
+        && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
+        && url.port().is_some();
+    if !trusted_loopback {
+        return None;
+    }
+    url.set_path("/quick-chat");
+    Some(url)
+}
+
+#[cfg(desktop)]
+fn show_quick_chat_from_main(app: &tauri::AppHandle) {
+    let Some(url) = app
+        .get_webview_window("main")
+        .and_then(|window| window.url().ok())
+        .and_then(quick_chat_url_from_main)
+    else {
+        focus_main_window(app);
+        return;
+    };
+    show_quick_chat_window(app, &url);
 }
 
 #[cfg(desktop)]
@@ -230,7 +261,9 @@ fn fatal_exit(msg: &str) -> ! {
 fn check_app_translocation() {
     #[cfg(target_os = "macos")]
     {
-        let Ok(exe) = std::env::current_exe() else { return };
+        let Ok(exe) = std::env::current_exe() else {
+            return;
+        };
         let path = exe.to_string_lossy().to_string();
         if !path.contains("/AppTranslocation/") && !path.contains("/Volumes/") {
             return;
@@ -277,8 +310,7 @@ fn find_node(resource_dir: &Path) -> Option<PathBuf> {
         let home = std::env::var("USERPROFILE").unwrap_or_default();
 
         // nvm-windows stores versions under %APPDATA%\nvm\v<version>\node.exe
-        let nvm_root =
-            PathBuf::from(std::env::var("APPDATA").unwrap_or_default()).join("nvm");
+        let nvm_root = PathBuf::from(std::env::var("APPDATA").unwrap_or_default()).join("nvm");
         if let Ok(entries) = std::fs::read_dir(&nvm_root) {
             let mut versions: Vec<PathBuf> = entries
                 .filter_map(|e| e.ok())
@@ -297,8 +329,7 @@ fn find_node(resource_dir: &Path) -> Option<PathBuf> {
         // Standard / tool-manager install locations
         let candidates = [
             PathBuf::from(
-                std::env::var("ProgramFiles")
-                    .unwrap_or_else(|_| "C:\\Program Files".into()),
+                std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".into()),
             )
             .join("nodejs")
             .join("node.exe"),
@@ -411,7 +442,10 @@ fn find_coven() -> Option<PathBuf> {
                 return Some(c.clone());
             }
         }
-        if let Ok(out) = std::process::Command::new("where.exe").arg("coven").output() {
+        if let Ok(out) = std::process::Command::new("where.exe")
+            .arg("coven")
+            .output()
+        {
             let path = String::from_utf8_lossy(&out.stdout)
                 .lines()
                 .next()
@@ -487,6 +521,162 @@ fn sidecar_auth_token() -> String {
 struct SidecarState(Arc<Mutex<Option<Child>>>);
 
 #[cfg(desktop)]
+#[derive(Clone, Copy)]
+enum SidecarStartupStep {
+    PreparingRuntime,
+    StartingService,
+    WaitingForService,
+}
+
+#[cfg(desktop)]
+enum SidecarStartError {
+    Cancelled,
+    Failed(String),
+}
+
+#[cfg(desktop)]
+enum PortWaitResult {
+    Ready,
+    Cancelled,
+    TimedOut,
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+const SIDECAR_STARTUP_EVENT: &str = "sidecar-startup-progress";
+
+#[cfg(all(desktop, target_os = "windows"))]
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SidecarStartupStatus {
+    phase: &'static str,
+    progress: u8,
+    message: String,
+    can_retry: bool,
+    can_cancel: bool,
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+impl SidecarStartupStatus {
+    fn preparing() -> Self {
+        Self {
+            phase: "preparing",
+            progress: 10,
+            message: "Verifying and preparing the application runtime".to_string(),
+            can_retry: false,
+            can_cancel: false,
+        }
+    }
+
+    fn starting() -> Self {
+        Self {
+            phase: "starting",
+            progress: 70,
+            message: "Starting local services".to_string(),
+            can_retry: false,
+            can_cancel: true,
+        }
+    }
+
+    fn waiting() -> Self {
+        Self {
+            phase: "waiting",
+            progress: 85,
+            message: "Waiting for CovenCave to become ready".to_string(),
+            can_retry: false,
+            can_cancel: true,
+        }
+    }
+
+    fn ready() -> Self {
+        Self {
+            phase: "ready",
+            progress: 100,
+            message: "CovenCave is ready".to_string(),
+            can_retry: false,
+            can_cancel: false,
+        }
+    }
+
+    fn failed(message: String) -> Self {
+        Self {
+            phase: "failed",
+            progress: 0,
+            message,
+            can_retry: true,
+            can_cancel: false,
+        }
+    }
+
+    fn cancelled() -> Self {
+        Self {
+            phase: "cancelled",
+            progress: 0,
+            message: "Startup was cancelled. The prepared runtime is safe to reuse.".to_string(),
+            can_retry: true,
+            can_cancel: false,
+        }
+    }
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+struct SidecarStartupControl {
+    status: Mutex<SidecarStartupStatus>,
+    running: AtomicBool,
+    cancel_requested: AtomicBool,
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+impl SidecarStartupControl {
+    fn new() -> Self {
+        Self {
+            status: Mutex::new(SidecarStartupStatus::preparing()),
+            running: AtomicBool::new(false),
+            cancel_requested: AtomicBool::new(false),
+        }
+    }
+
+    fn begin(&self) -> Result<(), String> {
+        self.running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| "sidecar startup is already running".to_string())?;
+        self.cancel_requested.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn finish(&self) {
+        self.running.store(false, Ordering::Release);
+    }
+
+    fn request_cancel(&self) -> Result<(), String> {
+        if !self.running.load(Ordering::Acquire) {
+            return Err("sidecar startup is not running".to_string());
+        }
+        self.cancel_requested.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel_requested.load(Ordering::Acquire)
+    }
+
+    fn status(&self) -> Result<SidecarStartupStatus, String> {
+        self.status
+            .lock()
+            .map(|status| status.clone())
+            .map_err(|_| "sidecar startup status lock is poisoned".to_string())
+    }
+
+    fn set_status(&self, status: SidecarStartupStatus) -> Result<(), String> {
+        let mut current = self
+            .status
+            .lock()
+            .map_err(|_| "sidecar startup status lock is poisoned".to_string())?;
+        *current = status;
+        Ok(())
+    }
+}
+
+#[cfg(desktop)]
 struct SidecarCleanupGuard(Arc<Mutex<Option<Child>>>);
 
 #[cfg(desktop)]
@@ -509,55 +699,61 @@ impl SidecarState {
             .0
             .lock()
             .map_err(|_| "sidecar process lock is poisoned".to_string())?;
-        let Some(mut child) = guard.take() else {
+        let Some(child) = guard.take() else {
             return Ok(());
         };
-        if child
-            .try_wait()
-            .map_err(|error| format!("could not inspect sidecar process: {error}"))?
-            .is_some()
-        {
-            return Ok(());
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            let pid = child.id().to_string();
-            let mut taskkill = Command::new(windows_system32_binary("taskkill.exe"));
-            taskkill
-                .args(["/PID", &pid, "/T", "/F"])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .creation_flags(0x08000000);
-            match taskkill.status() {
-                Ok(status) if status.success() => {}
-                Ok(status) => log::warn!(
-                    "[cave] taskkill could not stop sidecar process tree {} (status {}); falling back to direct termination",
-                    pid,
-                    status
-                ),
-                Err(error) => log::warn!(
-                    "[cave] taskkill could not start for sidecar process tree {}: {}; falling back to direct termination",
-                    pid,
-                    error
-                ),
-            }
-        }
-
-        if child
-            .try_wait()
-            .map_err(|error| format!("could not inspect terminated sidecar: {error}"))?
-            .is_none()
-        {
-            child
-                .kill()
-                .map_err(|error| format!("could not stop sidecar process: {error}"))?;
-        }
-        child
-            .wait()
-            .map_err(|error| format!("could not wait for sidecar process shutdown: {error}"))?;
-        Ok(())
+        drop(guard);
+        stop_sidecar_child(child)
     }
+}
+
+#[cfg(desktop)]
+fn stop_sidecar_child(mut child: Child) -> Result<(), String> {
+    if child
+        .try_wait()
+        .map_err(|error| format!("could not inspect sidecar process: {error}"))?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let pid = child.id().to_string();
+        let mut taskkill = Command::new(windows_system32_binary("taskkill.exe"));
+        taskkill
+            .args(["/PID", &pid, "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(0x08000000);
+        match taskkill.status() {
+            Ok(status) if status.success() => {}
+            Ok(status) => log::warn!(
+                "[cave] taskkill could not stop sidecar process tree {} (status {}); falling back to direct termination",
+                pid,
+                status
+            ),
+            Err(error) => log::warn!(
+                "[cave] taskkill could not start for sidecar process tree {}: {}; falling back to direct termination",
+                pid,
+                error
+            ),
+        }
+    }
+
+    if child
+        .try_wait()
+        .map_err(|error| format!("could not inspect terminated sidecar: {error}"))?
+        .is_none()
+    {
+        child
+            .kill()
+            .map_err(|error| format!("could not stop sidecar process: {error}"))?;
+    }
+    child
+        .wait()
+        .map_err(|error| format!("could not wait for sidecar process shutdown: {error}"))?;
+    Ok(())
 }
 
 #[cfg(desktop)]
@@ -604,18 +800,20 @@ fn live_dev_server_url(app: &tauri::App) -> Option<tauri::Url> {
 }
 
 #[cfg(desktop)]
-fn wait_for_port(port: u16, timeout: Duration) -> bool {
-    use std::net::TcpStream;
-    let addr = format!("127.0.0.1:{}", port);
-    let parsed = addr.parse().expect("valid sidecar addr");
+fn wait_for_port(port: u16, timeout: Duration, should_cancel: impl Fn() -> bool) -> PortWaitResult {
+    use std::net::{SocketAddr, TcpStream};
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&parsed, Duration::from_millis(200)).is_ok() {
-            return true;
+        if should_cancel() {
+            return PortWaitResult::Cancelled;
+        }
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+            return PortWaitResult::Ready;
         }
         thread::sleep(Duration::from_millis(150));
     }
-    false
+    PortWaitResult::TimedOut
 }
 
 #[cfg(all(desktop, target_os = "windows"))]
@@ -635,6 +833,375 @@ fn node_arg_path(path: &Path) -> PathBuf {
     path.to_path_buf()
 }
 
+#[cfg(desktop)]
+fn start_sidecar_runtime(
+    app: &tauri::AppHandle,
+    mut on_step: impl FnMut(SidecarStartupStep),
+    should_cancel: impl Fn() -> bool,
+) -> Result<Url, SidecarStartError> {
+    on_step(SidecarStartupStep::PreparingRuntime);
+    let resource_dir = app.path().resource_dir().map_err(|error| {
+        SidecarStartError::Failed(format!("could not resolve resource dir: {error}"))
+    })?;
+
+    #[cfg(target_os = "windows")]
+    let server_dir_root =
+        sidecar_archive::prepare_sidecar_runtime(app, &resource_dir).map_err(|error| {
+            SidecarStartError::Failed(format!("could not prepare sidecar runtime: {error}"))
+        })?;
+    #[cfg(not(target_os = "windows"))]
+    let server_dir_root = resource_dir.join("resources").join("server");
+
+    if should_cancel() {
+        return Err(SidecarStartError::Cancelled);
+    }
+
+    let server_mjs = server_dir_root.join("server.mjs");
+    let server_js = server_dir_root.join("server.js");
+    let server_entry = if server_mjs.exists() {
+        server_mjs
+    } else if server_js.exists() {
+        log::warn!(
+            "[cave] bundle has no server.mjs - terminal websocket bridge unavailable in this build"
+        );
+        server_js
+    } else {
+        return Err(SidecarStartError::Failed(format!(
+            "standalone server not found at {}",
+            server_js.display()
+        )));
+    };
+
+    let port = find_free_port()
+        .ok_or_else(|| SidecarStartError::Failed("no free local port available".to_string()))?;
+    let auth_token = sidecar_auth_token();
+    let mobile_access_token = sidecar_auth_token();
+    log::info!("[cave] starting sidecar on port {port}");
+
+    let node = find_node(&resource_dir).ok_or_else(|| {
+        SidecarStartError::Failed(
+            "Could not find a `node` binary. Install Node.js from https://nodejs.org and re-launch CovenCave."
+                .to_string(),
+        )
+    })?;
+    log::info!("[cave] using node at {}", node.display());
+
+    // Capture sidecar logs so startup failures can be surfaced in the local
+    // preparation window instead of leaving a blank webview.
+    let log_dir = {
+        #[cfg(target_os = "macos")]
+        {
+            std::env::var("HOME")
+                .map(|home| PathBuf::from(home).join("Library/Logs/CovenCave"))
+                .unwrap_or_else(|_| std::env::temp_dir())
+        }
+        #[cfg(target_os = "windows")]
+        {
+            PathBuf::from(
+                std::env::var("APPDATA")
+                    .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into()),
+            )
+            .join("CovenCave")
+            .join("logs")
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        {
+            std::env::var("HOME")
+                .map(|home| PathBuf::from(home).join(".local/share/CovenCave/logs"))
+                .unwrap_or_else(|_| std::env::temp_dir())
+        }
+    };
+    if let Err(error) = std::fs::create_dir_all(&log_dir) {
+        log::warn!(
+            "[cave] could not create sidecar log directory {}: {error}",
+            log_dir.display()
+        );
+    }
+    let log_path = log_dir.join("sidecar.log");
+    log::info!("[cave] sidecar log -> {}", log_path.display());
+    let stdout_log = std::fs::File::create(&log_path).ok();
+    let stderr_log = stdout_log.as_ref().and_then(|file| file.try_clone().ok());
+
+    let server_dir = server_entry.parent().ok_or_else(|| {
+        SidecarStartError::Failed("server entry has no parent directory".to_string())
+    })?;
+    let server_js_arg = node_arg_path(&server_entry);
+    let server_dir_arg = node_arg_path(server_dir);
+
+    let path_sep = if cfg!(target_os = "windows") {
+        ";"
+    } else {
+        ":"
+    };
+    let default_path = if cfg!(target_os = "windows") {
+        std::env::var("PATH").unwrap_or_else(|_| "C:\\Windows\\system32;C:\\Windows".into())
+    } else {
+        std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin:/usr/sbin:/sbin".into())
+    };
+    let mut augmented_path = default_path;
+    if let Some(directory) = node.parent() {
+        augmented_path = format!("{}{}{}", directory.display(), path_sep, augmented_path);
+    }
+    match find_coven() {
+        Some(coven) => {
+            log::info!("[cave] using coven at {}", coven.display());
+            if let Some(directory) = coven.parent() {
+                augmented_path = format!("{}{}{}", directory.display(), path_sep, augmented_path);
+            }
+        }
+        None => log::warn!("[cave] `coven` CLI not found on disk - onboarding will prompt install"),
+    }
+
+    on_step(SidecarStartupStep::StartingService);
+    if should_cancel() {
+        return Err(SidecarStartError::Cancelled);
+    }
+
+    let mut command = Command::new(&node);
+    command
+        .arg(&server_js_arg)
+        .current_dir(&server_dir_arg)
+        .env("PATH", &augmented_path)
+        .env("PORT", port.to_string())
+        .env("HOSTNAME", "127.0.0.1")
+        .env("NODE_ENV", "production")
+        .env("COVEN_CAVE_BUNDLE", "1")
+        .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
+        .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token);
+
+    if let Some(output) = stdout_log {
+        command.stdout(Stdio::from(output));
+    } else {
+        command.stdout(Stdio::null());
+    }
+    if let Some(error_output) = stderr_log {
+        command.stderr(Stdio::from(error_output));
+    } else {
+        command.stderr(Stdio::null());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let child = command.spawn().map_err(|error| {
+        SidecarStartError::Failed(format!("failed to spawn node sidecar: {error}"))
+    })?;
+    let sidecar_state = app.state::<SidecarState>();
+    match sidecar_state.0.lock() {
+        Ok(mut sidecar) => *sidecar = Some(child),
+        Err(_) => {
+            let cleanup = stop_sidecar_child(child)
+                .err()
+                .map(|error| format!("; cleanup also failed: {error}"))
+                .unwrap_or_default();
+            return Err(SidecarStartError::Failed(format!(
+                "sidecar process lock is poisoned{cleanup}"
+            )));
+        }
+    }
+
+    on_step(SidecarStartupStep::WaitingForService);
+    let sidecar_start_timeout = if cfg!(target_os = "windows") {
+        Duration::from_secs(90)
+    } else {
+        Duration::from_secs(20)
+    };
+    match wait_for_port(port, sidecar_start_timeout, &should_cancel) {
+        PortWaitResult::Ready => {}
+        PortWaitResult::Cancelled => return Err(SidecarStartError::Cancelled),
+        PortWaitResult::TimedOut => {
+            let tail = std::fs::read_to_string(&log_path)
+                .ok()
+                .map(|contents| {
+                    let lines: Vec<&str> = contents.lines().rev().take(8).collect();
+                    let mut tail = lines.into_iter().rev().collect::<Vec<_>>().join("\n");
+                    if tail.is_empty() {
+                        tail.push_str("(no output captured)");
+                    }
+                    tail
+                })
+                .unwrap_or_else(|| "(could not read sidecar log)".to_string());
+            return Err(SidecarStartError::Failed(format!(
+                "Sidecar (node {}) did not become ready on port {} within {}s.\n\nLast lines from {}:\n{}",
+                node.display(),
+                port,
+                sidecar_start_timeout.as_secs(),
+                log_path.display(),
+                tail
+            )));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    sidecar_archive::cleanup_stale_sidecar_runtimes(&server_dir_root);
+
+    format!(
+        "http://127.0.0.1:{port}/?covenCaveToken={auth_token}&coven_access_token={mobile_access_token}"
+    )
+    .parse()
+    .map_err(|error| SidecarStartError::Failed(format!("could not build sidecar URL: {error}")))
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+fn publish_sidecar_startup_status(
+    app: &tauri::AppHandle,
+    control: &SidecarStartupControl,
+    status: SidecarStartupStatus,
+) -> Result<(), String> {
+    control.set_status(status.clone())?;
+    app.emit_to("main", SIDECAR_STARTUP_EVENT, status)
+        .map_err(|error| format!("could not publish sidecar startup status: {error}"))
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+fn spawn_sidecar_startup(
+    app: tauri::AppHandle,
+    control: Arc<SidecarStartupControl>,
+) -> Result<(), String> {
+    control.begin()?;
+    if let Err(error) =
+        publish_sidecar_startup_status(&app, &control, SidecarStartupStatus::preparing())
+    {
+        control.finish();
+        return Err(error);
+    }
+
+    let thread_control = Arc::clone(&control);
+    let worker_app = app.clone();
+    let spawn_result = thread::Builder::new()
+        .name("coven-sidecar-startup".to_string())
+        .spawn(move || {
+            let app = worker_app;
+            let progress_app = app.clone();
+            let progress_control = Arc::clone(&thread_control);
+            let cancel_control = Arc::clone(&thread_control);
+            let result = start_sidecar_runtime(
+                &app,
+                move |step| {
+                    let status = match step {
+                        SidecarStartupStep::PreparingRuntime => SidecarStartupStatus::preparing(),
+                        SidecarStartupStep::StartingService => SidecarStartupStatus::starting(),
+                        SidecarStartupStep::WaitingForService => SidecarStartupStatus::waiting(),
+                    };
+                    if let Err(error) = publish_sidecar_startup_status(
+                        &progress_app,
+                        &progress_control,
+                        status,
+                    ) {
+                        log::warn!("[cave] {error}");
+                    }
+                },
+                move || cancel_control.is_cancelled(),
+            );
+
+            let final_status = match result {
+                Ok(_url) if thread_control.is_cancelled() => {
+                    if let Some(sidecar) = app.try_state::<SidecarState>() {
+                        if let Err(error) = sidecar.stop() {
+                            log::warn!("[cave] could not stop cancelled sidecar: {error}");
+                        }
+                    }
+                    SidecarStartupStatus::cancelled()
+                }
+                Ok(url) => {
+                    pty::trust_main_origin(&url);
+                    let navigation = app
+                        .get_webview_window("main")
+                        .ok_or_else(|| "startup window is unavailable".to_string())
+                        .and_then(|window| {
+                            window
+                                .navigate(url)
+                                .map_err(|error| format!("could not open CovenCave: {error}"))
+                        });
+                    match navigation {
+                        Ok(()) => SidecarStartupStatus::ready(),
+                        Err(error) => {
+                            if let Some(sidecar) = app.try_state::<SidecarState>() {
+                                if let Err(stop_error) = sidecar.stop() {
+                                    log::warn!(
+                                        "[cave] could not stop sidecar after navigation failure: {stop_error}"
+                                    );
+                                }
+                            }
+                            SidecarStartupStatus::failed(error)
+                        }
+                    }
+                }
+                Err(SidecarStartError::Cancelled) => {
+                    if let Some(sidecar) = app.try_state::<SidecarState>() {
+                        if let Err(error) = sidecar.stop() {
+                            log::warn!("[cave] could not stop cancelled sidecar: {error}");
+                        }
+                    }
+                    SidecarStartupStatus::cancelled()
+                }
+                Err(SidecarStartError::Failed(error)) => {
+                    if let Some(sidecar) = app.try_state::<SidecarState>() {
+                        if let Err(stop_error) = sidecar.stop() {
+                            log::warn!(
+                                "[cave] could not stop sidecar after startup failure: {stop_error}"
+                            );
+                        }
+                    }
+                    SidecarStartupStatus::failed(error)
+                }
+            };
+
+            if let Err(error) =
+                publish_sidecar_startup_status(&app, &thread_control, final_status)
+            {
+                log::warn!("[cave] {error}");
+            }
+            thread_control.finish();
+        });
+
+    if let Err(error) = spawn_result {
+        control.finish();
+        let message = format!("could not start sidecar preparation worker: {error}");
+        let _ = publish_sidecar_startup_status(
+            &app,
+            &control,
+            SidecarStartupStatus::failed(message.clone()),
+        );
+        return Err(message);
+    }
+
+    Ok(())
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+#[tauri::command]
+fn sidecar_startup_status(
+    state: tauri::State<'_, Arc<SidecarStartupControl>>,
+) -> Result<SidecarStartupStatus, String> {
+    state.status()
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+#[tauri::command]
+fn retry_sidecar_startup(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<SidecarStartupControl>>,
+) -> Result<(), String> {
+    spawn_sidecar_startup(app, Arc::clone(state.inner()))
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+#[tauri::command]
+fn cancel_sidecar_startup(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<SidecarStartupControl>>,
+) -> Result<(), String> {
+    state.request_cancel()?;
+    let mut status = state.status()?;
+    status.phase = "cancelling";
+    status.message = "Finishing the current operation before cancelling".to_string();
+    status.can_cancel = false;
+    publish_sidecar_startup_status(&app, state.inner(), status)
+}
+
 #[cfg(all(test, desktop))]
 mod tests {
     #[allow(unused_imports)]
@@ -646,6 +1213,67 @@ mod tests {
 
         assert_eq!(token.len(), 64);
         assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn quick_chat_url_requires_a_loopback_sidecar_origin() {
+        let sidecar = Url::parse("http://127.0.0.1:43123/?token=secret").expect("sidecar URL");
+        let quick_chat = quick_chat_url_from_main(sidecar).expect("trusted quick chat URL");
+
+        assert_eq!(quick_chat.path(), "/quick-chat");
+        assert_eq!(quick_chat.query(), Some("token=secret"));
+        assert!(quick_chat_url_from_main(
+            Url::parse("https://example.test/").expect("external URL")
+        )
+        .is_none());
+        assert!(quick_chat_url_from_main(
+            Url::parse("tauri://localhost/startup.html").expect("local startup URL")
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn sidecar_port_wait_is_cancellable_and_detects_readiness() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind readiness fixture");
+        let port = listener.local_addr().expect("fixture address").port();
+        assert!(matches!(
+            wait_for_port(port, Duration::from_secs(1), || false),
+            PortWaitResult::Ready
+        ));
+        drop(listener);
+
+        assert!(matches!(
+            wait_for_port(port, Duration::from_secs(1), || true),
+            PortWaitResult::Cancelled
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn startup_control_prevents_concurrent_workers_and_resets_cancellation() {
+        let control = SidecarStartupControl::new();
+
+        control.begin().expect("first worker starts");
+        assert!(control.begin().is_err());
+        control.request_cancel().expect("running worker cancels");
+        assert!(control.is_cancelled());
+        control.finish();
+
+        control.begin().expect("retry starts after completion");
+        assert!(!control.is_cancelled());
+        control.finish();
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn startup_status_uses_frontend_field_names() {
+        let value = serde_json::to_value(SidecarStartupStatus::waiting())
+            .expect("serialize startup status");
+
+        assert_eq!(value["phase"], "waiting");
+        assert_eq!(value["progress"], 85);
+        assert_eq!(value["canRetry"], false);
+        assert_eq!(value["canCancel"], true);
     }
 
     #[test]
@@ -743,8 +1371,8 @@ fn validate_shell_open_path(path: &str) -> Result<PathBuf, String> {
         return Err("shell_open_path requires an absolute path".to_string());
     }
 
-    let metadata = std::fs::metadata(&path)
-        .map_err(|_| "shell_open_path path does not exist".to_string())?;
+    let metadata =
+        std::fs::metadata(&path).map_err(|_| "shell_open_path path does not exist".to_string())?;
     if !metadata.is_dir() {
         return Err("shell_open_path only opens directories".to_string());
     }
@@ -800,8 +1428,7 @@ fn set_traffic_lights_visible(window: tauri::WebviewWindow, visible: bool) {
                 let ns_window = ns_ptr as *mut AnyObject;
                 // NSWindowButton: close = 0, miniaturize = 1, zoom = 2.
                 for kind in 0u64..=2u64 {
-                    let button: *mut AnyObject =
-                        msg_send![&*ns_window, standardWindowButton: kind];
+                    let button: *mut AnyObject = msg_send![&*ns_window, standardWindowButton: kind];
                     if !button.is_null() {
                         let _: () = msg_send![&*button, setHidden: !visible];
                     }
@@ -911,7 +1538,11 @@ fn shell_pick_directory() -> Result<Option<String>, String> {
             .map_err(|e| e.to_string())?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            return Err(if stderr.is_empty() { "folder picker failed".to_string() } else { stderr });
+            return Err(if stderr.is_empty() {
+                "folder picker failed".to_string()
+            } else {
+                stderr
+            });
         }
         return normalize_picked_directory(&String::from_utf8_lossy(&output.stdout));
     }
@@ -919,7 +1550,12 @@ fn shell_pick_directory() -> Result<Option<String>, String> {
     #[cfg(target_os = "linux")]
     {
         let zenity = std::process::Command::new("zenity")
-            .args(["--file-selection", "--directory", "--title", "Choose a folder for CovenCave"])
+            .args([
+                "--file-selection",
+                "--directory",
+                "--title",
+                "Choose a folder for CovenCave",
+            ])
             .output();
         if let Ok(output) = zenity {
             if output.status.success() {
@@ -966,7 +1602,9 @@ mod shell_open_tests {
         let path = super::windows_system32_binary("rundll32.exe");
         let path = path.to_string_lossy();
         assert!(path.starts_with(r"C:\") || path.contains(r":\"));
-        assert!(path.ends_with(r"System32\rundll32.exe") || path.ends_with("System32/rundll32.exe"));
+        assert!(
+            path.ends_with(r"System32\rundll32.exe") || path.ends_with("System32/rundll32.exe")
+        );
     }
 
     #[test]
@@ -980,7 +1618,11 @@ mod shell_open_tests {
     #[test]
     fn normalizes_only_absolute_existing_picked_directories() {
         let current = std::env::current_dir().expect("current dir");
-        assert!(super::normalize_picked_directory(&current.to_string_lossy()).unwrap().is_some());
+        assert!(
+            super::normalize_picked_directory(&current.to_string_lossy())
+                .unwrap()
+                .is_some()
+        );
         assert_eq!(super::normalize_picked_directory("").unwrap(), None);
         assert!(super::normalize_picked_directory("relative/path").is_err());
         assert!(super::normalize_picked_directory(&file!()).is_err());
@@ -1101,7 +1743,7 @@ pub fn run() {
     #[cfg(desktop)]
     let sidecar_process = Arc::new(Mutex::new(None));
     #[cfg(desktop)]
-    builder
+    let builder = builder
         .invoke_handler(tauri::generate_handler![
             pty::pty_start,
             pty::pty_write,
@@ -1124,8 +1766,18 @@ pub fn run() {
             shell_open_path,
             shell_pick_directory,
             set_traffic_lights_visible,
+            #[cfg(target_os = "windows")]
+            sidecar_startup_status,
+            #[cfg(target_os = "windows")]
+            retry_sidecar_startup,
+            #[cfg(target_os = "windows")]
+            cancel_sidecar_startup,
         ])
-        .manage(SidecarState(Arc::clone(&sidecar_process)))
+        .manage(SidecarState(Arc::clone(&sidecar_process)));
+    #[cfg(all(desktop, target_os = "windows"))]
+    let builder = builder.manage(Arc::new(SidecarStartupControl::new()));
+    #[cfg(desktop)]
+    builder
         .setup(move |app| {
             // The updater's Windows pre-exit path clears the application
             // resource table after validating the package and before starting
@@ -1175,266 +1827,83 @@ pub fn run() {
             // checkout could not boot `pnpm dev:app` at all — and when a
             // stale bundle did exist, the dev app silently rendered an old
             // production build instead of live code.
-            let main_url: tauri::Url = if let Some(dev_url) = live_dev_server_url(app) {
-                dev_url
+            let main_url: Option<tauri::Url> = if let Some(dev_url) = live_dev_server_url(app) {
+                Some(dev_url)
             } else {
-            let resource_dir = match app.path().resource_dir() {
-                Ok(d) => d,
-                Err(e) => fatal_exit(&format!("could not resolve resource dir: {}", e)),
-            };
-            // Prefer the custom server (server.ts → server.mjs): it carries
-            // the /api/pty-ws terminal websocket bridge. server.js is Next's
-            // generated standalone entrypoint, kept as a fallback for old
-            // bundles — it serves the app but has no terminal bridge.
-            #[cfg(target_os = "windows")]
-            let server_dir_root = match sidecar_archive::prepare_sidecar_runtime(app, &resource_dir)
-            {
-                Ok(path) => path,
-                Err(error) => fatal_exit(&format!("could not prepare sidecar runtime: {error}")),
-            };
-            #[cfg(not(target_os = "windows"))]
-            let server_dir_root = resource_dir.join("resources").join("server");
-            let server_mjs = server_dir_root.join("server.mjs");
-            let server_js = server_dir_root.join("server.js");
-            let server_entry = if server_mjs.exists() {
-                server_mjs
-            } else if server_js.exists() {
-                log::warn!(
-                    "[cave] bundle has no server.mjs — terminal websocket bridge unavailable in this build"
-                );
-                server_js
-            } else {
-                fatal_exit(&format!(
-                    "standalone server not found at {}",
-                    server_js.display()
-                ));
-            };
-
-            let port = match find_free_port() {
-                Some(p) => p,
-                None => fatal_exit("no free local port available"),
-            };
-            let auth_token = sidecar_auth_token();
-            let mobile_access_token = sidecar_auth_token();
-            log::info!("[cave] starting sidecar on port {}", port);
-
-            let node = match find_node(&resource_dir) {
-                Some(p) => p,
-                None => fatal_exit(
-                    "Could not find a `node` binary. Install Node.js from \
-                     https://nodejs.org and re-launch CovenCave.",
-                ),
-            };
-            log::info!("[cave] using node at {}", node.display());
-
-            // Capture sidecar logs so we can show what went wrong if it never
-            // becomes ready. Platform-specific log directory:
-            //   macOS:   ~/Library/Logs/CovenCave/sidecar.log
-            //   Windows: %APPDATA%\CovenCave\logs\sidecar.log
-            //   Linux:   ~/.local/share/CovenCave/logs/sidecar.log
-            let log_dir = {
-                #[cfg(target_os = "macos")]
-                {
-                    std::env::var("HOME")
-                        .map(|h| PathBuf::from(h).join("Library/Logs/CovenCave"))
-                        .unwrap_or_else(|_| std::env::temp_dir())
-                }
                 #[cfg(target_os = "windows")]
                 {
-                    PathBuf::from(
-                        std::env::var("APPDATA")
-                            .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into()),
-                    )
-                    .join("CovenCave")
-                    .join("logs")
+                    WebviewWindowBuilder::new(app, "main", WebviewUrl::App("startup.html".into()))
+                        .title("CovenCave")
+                        .inner_size(1320.0, 820.0)
+                        .min_inner_size(960.0, 600.0)
+                        .resizable(true)
+                        .disable_drag_drop_handler()
+                        .build()?;
+
+                    let startup_control =
+                        Arc::clone(app.state::<Arc<SidecarStartupControl>>().inner());
+                    spawn_sidecar_startup(app.handle().clone(), startup_control)?;
+                    None
                 }
-                #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                #[cfg(not(target_os = "windows"))]
                 {
-                    std::env::var("HOME")
-                        .map(|h| PathBuf::from(h).join(".local/share/CovenCave/logs"))
-                        .unwrap_or_else(|_| std::env::temp_dir())
-                }
-            };
-            let _ = std::fs::create_dir_all(&log_dir);
-            let log_path = log_dir.join("sidecar.log");
-            log::info!("[cave] sidecar log → {}", log_path.display());
-
-            let stdout_log = std::fs::File::create(&log_path).ok();
-            let stderr_log = stdout_log
-                .as_ref()
-                .and_then(|f| f.try_clone().ok());
-
-            // Crucially, run from the directory that contains the server
-            // entrypoint so Next.js can locate its sibling .next/ and public/.
-            let server_dir = server_entry
-                .parent()
-                .ok_or("server entry has no parent dir")?;
-            let server_js_arg = node_arg_path(&server_entry);
-            let server_dir_arg = node_arg_path(server_dir);
-
-            // GUI launches often inherit a stripped PATH. Prepend the
-            // directories holding `node` and `coven` so the sidecar's API
-            // routes can spawn them by name. Missing `coven` is non-fatal —
-            // onboarding surfaces it.
-            //
-            // PATH separator is ':' on Unix and ';' on Windows.
-            let path_sep = if cfg!(target_os = "windows") { ";" } else { ":" };
-            let default_path = if cfg!(target_os = "windows") {
-                std::env::var("PATH").unwrap_or_else(|_| "C:\\Windows\\system32;C:\\Windows".into())
-            } else {
-                std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin:/usr/sbin:/sbin".into())
-            };
-            let mut augmented_path = default_path;
-            if let Some(dir) = node.parent() {
-                augmented_path = format!("{}{}{}", dir.display(), path_sep, augmented_path);
-            }
-            match find_coven() {
-                Some(coven) => {
-                    log::info!("[cave] using coven at {}", coven.display());
-                    if let Some(dir) = coven.parent() {
-                        augmented_path =
-                            format!("{}{}{}", dir.display(), path_sep, augmented_path);
-                    }
-                }
-                None => log::warn!(
-                    "[cave] `coven` CLI not found on disk — onboarding will prompt install"
-                ),
-            }
-
-            let mut cmd = Command::new(&node);
-            cmd.arg(&server_js_arg)
-                .current_dir(&server_dir_arg)
-                .env("PATH", &augmented_path)
-                .env("PORT", port.to_string())
-                .env("HOSTNAME", "127.0.0.1")
-                .env("NODE_ENV", "production")
-                .env("COVEN_CAVE_BUNDLE", "1")
-                .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
-                .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token);
-
-            if let Some(out) = stdout_log {
-                cmd.stdout(Stdio::from(out));
-            } else {
-                cmd.stdout(Stdio::null());
-            }
-            if let Some(err) = stderr_log {
-                cmd.stderr(Stdio::from(err));
-            } else {
-                cmd.stderr(Stdio::null());
-            }
-
-            #[cfg(target_os = "windows")]
-            {
-                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-            }
-
-            let child = match cmd.spawn() {
-                Ok(c) => c,
-                Err(e) => fatal_exit(&format!("failed to spawn node sidecar: {}", e)),
-            };
-
-            let sidecar_state = app.state::<SidecarState>();
-            let mut sidecar = match sidecar_state.0.lock() {
-                Ok(sidecar) => sidecar,
-                Err(_) => fatal_exit("sidecar process lock is poisoned"),
-            };
-            *sidecar = Some(child);
-            drop(sidecar);
-
-            let sidecar_start_timeout = if cfg!(target_os = "windows") {
-                Duration::from_secs(90)
-            } else {
-                Duration::from_secs(20)
-            };
-            if !wait_for_port(port, sidecar_start_timeout) {
-                // Read the tail of the sidecar log to give the user a clue.
-                let tail = std::fs::read_to_string(&log_path)
-                    .ok()
-                    .map(|s| {
-                        let lines: Vec<&str> = s.lines().rev().take(8).collect();
-                        let mut tail = lines
-                            .into_iter()
-                            .rev()
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        if tail.is_empty() {
-                            tail.push_str("(no output captured)");
+                    let sidecar_url = match start_sidecar_runtime(app.handle(), |_| {}, || false) {
+                        Ok(url) => url,
+                        Err(SidecarStartError::Cancelled) => {
+                            fatal_exit("sidecar startup was cancelled")
                         }
-                        tail
-                    })
-                    .unwrap_or_else(|| "(could not read sidecar log)".to_string());
-                fatal_exit(&format!(
-                    "Sidecar (node {}) did not become ready on port {} within {}s.\n\nLast lines from {}:\n{}",
-                    node.display(),
-                    port,
-                    sidecar_start_timeout.as_secs(),
-                    log_path.display(),
-                    tail
-                ));
-            }
-
-            // Only retire older complete caches after the new runtime has
-            // actually booted. Keep one previous version for rollback.
-            #[cfg(target_os = "windows")]
-            sidecar_archive::cleanup_stale_sidecar_runtimes(&server_dir_root);
-
-            format!(
-                "http://127.0.0.1:{}/?covenCaveToken={}&coven_access_token={}",
-                port, auth_token, mobile_access_token
-            )
-            .parse()
-            .expect("valid url")
+                        Err(SidecarStartError::Failed(error)) => fatal_exit(&error),
+                    };
+                    Some(sidecar_url)
+                }
             };
 
-            pty::trust_main_origin(&main_url);
-            let mut quick_chat_url = main_url.clone();
-            quick_chat_url.set_path("/quick-chat");
-            let mut main_window = WebviewWindowBuilder::new(
-                app,
-                "main",
-                WebviewUrl::External(main_url),
-            )
-            .title("CovenCave")
-            .inner_size(1320.0, 820.0)
-            .min_inner_size(960.0, 600.0)
-            .resizable(true)
-            // Required for HTML5 drag-and-drop (Coven Board card moves) to
-            // work in the webview — otherwise Tauri's OS-level file-drop
-            // handler intercepts dragenter/dragover/drop before the DOM sees
-            // them.
-            .disable_drag_drop_handler();
-            // macOS: dissolve the seam between the native title bar and the
-            // app's top toolbar. `Overlay` lets the webview content fill to the
-            // very top (the traffic-light buttons float over it) and
-            // `hidden_title` drops the centered "CovenCave" label, so the
-            // toolbar reads as one continuous strip. The web side reserves room
-            // for the traffic lights (`[data-tauri-titlebar]` in globals.css)
-            // and marks the bar `data-tauri-drag-region="deep"`; the drag is
-            // an ACL-gated IPC call, granted to this loopback origin by
-            // capabilities/loopback-window-drag.json. No-op on Windows/Linux.
-            #[cfg(target_os = "macos")]
-            {
-                main_window = main_window
-                    .title_bar_style(tauri::TitleBarStyle::Overlay)
-                    .hidden_title(true);
-            }
-            // Dev-only automation hook: WKWebView has no external driver
-            // protocol, so dev tooling (terminal e2e checks, screenshots)
-            // can inject a script that runs before the page loads. No-op in
-            // release builds.
-            if cfg!(debug_assertions) {
-                if let Ok(script) = std::env::var("COVEN_CAVE_DEV_INIT_SCRIPT") {
-                    if !script.is_empty() {
-                        log::info!(
-                            "[cave] injecting COVEN_CAVE_DEV_INIT_SCRIPT ({} bytes)",
-                            script.len()
-                        );
-                        main_window = main_window.initialization_script(&script);
+            if let Some(main_url) = main_url {
+                pty::trust_main_origin(&main_url);
+                let mut main_window =
+                    WebviewWindowBuilder::new(app, "main", WebviewUrl::External(main_url))
+                        .title("CovenCave")
+                        .inner_size(1320.0, 820.0)
+                        .min_inner_size(960.0, 600.0)
+                        .resizable(true)
+                        // Required for HTML5 drag-and-drop (Coven Board card moves) to
+                        // work in the webview — otherwise Tauri's OS-level file-drop
+                        // handler intercepts dragenter/dragover/drop before the DOM sees
+                        // them.
+                        .disable_drag_drop_handler();
+                // macOS: dissolve the seam between the native title bar and the
+                // app's top toolbar. `Overlay` lets the webview content fill to the
+                // very top (the traffic-light buttons float over it) and
+                // `hidden_title` drops the centered "CovenCave" label, so the
+                // toolbar reads as one continuous strip. The web side reserves room
+                // for the traffic lights (`[data-tauri-titlebar]` in globals.css)
+                // and marks the bar `data-tauri-drag-region="deep"`; the drag is
+                // an ACL-gated IPC call, granted to this loopback origin by
+                // capabilities/loopback-window-drag.json. No-op on Windows/Linux.
+                #[cfg(target_os = "macos")]
+                {
+                    main_window = main_window
+                        .title_bar_style(tauri::TitleBarStyle::Overlay)
+                        .hidden_title(true);
+                }
+                // Dev-only automation hook: WKWebView has no external driver
+                // protocol, so dev tooling (terminal e2e checks, screenshots)
+                // can inject a script that runs before the page loads. No-op in
+                // release builds.
+                if cfg!(debug_assertions) {
+                    if let Ok(script) = std::env::var("COVEN_CAVE_DEV_INIT_SCRIPT") {
+                        if !script.is_empty() {
+                            log::info!(
+                                "[cave] injecting COVEN_CAVE_DEV_INIT_SCRIPT ({} bytes)",
+                                script.len()
+                            );
+                            main_window = main_window.initialization_script(&script);
+                        }
                     }
                 }
-            }
-            if let Err(e) = main_window.build() {
-                fatal_exit(&format!("failed to build main window: {}", e));
+                if let Err(e) = main_window.build() {
+                    fatal_exit(&format!("failed to build main window: {}", e));
+                }
             }
 
             // Status bar / system-tray menu — quick access to inbox + reminder
@@ -1443,13 +1912,8 @@ pub fn run() {
             // WebView listens for.
             let open_inbox =
                 MenuItem::with_id(app, "open_inbox", "Open Inbox", true, None::<&str>)?;
-            let new_reminder = MenuItem::with_id(
-                app,
-                "new_reminder",
-                "New Reminder…",
-                true,
-                None::<&str>,
-            )?;
+            let new_reminder =
+                MenuItem::with_id(app, "new_reminder", "New Reminder…", true, None::<&str>)?;
             let quick_chat =
                 MenuItem::with_id(app, "quick_chat", "Quick Chat…", true, None::<&str>)?;
             let show_app =
@@ -1472,7 +1936,6 @@ pub fn run() {
             // `icon_as_template(true)` is a macOS-only concept (renders the
             // icon as a template image so the system can adapt it to dark/light
             // menu bar). On other platforms the call doesn't exist — guard it.
-            let quick_chat_url_for_menu = quick_chat_url.clone();
             let tray_builder = TrayIconBuilder::with_id("cave-tray")
                 .icon(coven_tray_icon())
                 .menu(&tray_menu)
@@ -1487,7 +1950,7 @@ pub fn run() {
                         focus_main_window(app);
                         let _ = app.emit("tray:new-reminder", ());
                     }
-                    "quick_chat" => show_quick_chat_window(app, &quick_chat_url_for_menu),
+                    "quick_chat" => show_quick_chat_from_main(app),
                     "show_app" => focus_main_window(app),
                     "quit" => app.exit(0),
                     _ => {}
@@ -1514,10 +1977,9 @@ pub fn run() {
             {
                 let previous_hook = std::panic::take_hook();
                 std::panic::set_hook(Box::new(|_| {}));
-                let tray_result =
-                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        tray_builder.build(app)
-                    }));
+                let tray_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    tray_builder.build(app)
+                }));
                 std::panic::set_hook(previous_hook);
 
                 match tray_result {
@@ -1544,7 +2006,9 @@ pub fn run() {
                 if window.label() == "main" {
                     if let Some(state) = window.app_handle().try_state::<SidecarState>() {
                         if let Err(error) = state.stop() {
-                            log::warn!("[cave] could not stop sidecar during window teardown: {error}");
+                            log::warn!(
+                                "[cave] could not stop sidecar during window teardown: {error}"
+                            );
                         }
                     }
                 }

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -502,7 +502,7 @@ pub(crate) fn cleanup_stale_sidecar_runtimes(current: &Path) {
 }
 
 pub(crate) fn prepare_sidecar_runtime(
-    app: &tauri::App,
+    app: &tauri::AppHandle,
     resource_dir: &Path,
 ) -> Result<PathBuf, String> {
     let archive_dir = resource_dir.join("resources").join("server-archive");

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -1,8 +1,16 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { prepareNativeUpdate } from "../lib/native-update-preparation.ts";
+import {
+  adoptNativeUpdateResult,
+  NativeUpdateCoordinator,
+} from "../lib/native-update-coordinator.ts";
 
-const src = await readFile(new URL("./update-available.tsx", import.meta.url), "utf8");
+const [src, preparationSrc] = await Promise.all([
+  readFile(new URL("./update-available.tsx", import.meta.url), "utf8"),
+  readFile(new URL("../lib/native-update-preparation.ts", import.meta.url), "utf8"),
+]);
 
 // Desktop-only: both surfaces gate on the Tauri desktop hook.
 assert.match(src, /useIsTauriDesktop/, "gates the update UI to the Tauri desktop build");
@@ -14,11 +22,16 @@ assert.doesNotMatch(
   "update row controls should use tokenized radii instead of hard-coded rounded classes",
 );
 
-// Native updater path: check() → downloadAndInstall() → relaunch().
+// Native updater path: check() → download/signature verification → explicit
+// install/relaunch. The old app remains usable until restart is chosen.
 assert.match(src, /@tauri-apps\/plugin-updater/, "uses the native Tauri updater plugin");
-assert.match(src, /downloadAndInstall/, "installs via the native updater");
+assert.match(preparationSrc, /update\.download\(/, "downloads through the native updater");
+assert.match(src, /update\.install\(\)/, "installs the prepared native update");
+assert.doesNotMatch(src, /downloadAndInstall/, "does not combine download with immediate process exit");
 assert.match(src, /@tauri-apps\/plugin-process/, "relaunches via the process plugin");
 assert.match(src, /relaunch\(\)/, "relaunches the app after install");
+assert.match(preparationSrc, /phase: "verifying"/, "shows signature verification as a distinct phase");
+assert.match(preparationSrc, /update\.close\(\)/, "releases cancelled or discarded update resources");
 
 // Graceful fallback when no updater-enabled release exists yet.
 assert.match(src, /\/api\/app\/latest-release/, "falls back to the server release check");
@@ -47,7 +60,7 @@ assert.match(src, /kind:\s*"native-unavailable"/, "preserves native updater chec
 assert.match(src, /message:\s*native\.message/, "native updater check failures carry the underlying error message");
 assert.doesNotMatch(
   src,
-  /async function checkNativeUpdate\([\s\S]*?catch\s*\{\s*return null;[\s\S]*?async function installNativeUpdate/,
+  /async function checkNativeUpdate\([\s\S]*?catch\s*\{\s*return null;[\s\S]*?async function prepareNativeUpdate/,
   "native updater check failures must not be silently collapsed into the browser fallback path",
 );
 
@@ -57,7 +70,7 @@ assert.match(src, /setInterval\(runCheck, RECHECK_INTERVAL_MS\)/, "banner re-che
 assert.match(src, /clearInterval\(interval\)/, "banner re-check interval is torn down on unmount");
 assert.match(
   src,
-  /if \(installing\) return;/,
+  /if \(busy\) return;/,
   "a periodic re-check must not clobber an in-flight install's progress banner",
 );
 
@@ -67,13 +80,18 @@ assert.match(src, /cave:update:dismissed:/, "persists dismissal keyed by version
 assert.match(src, /onDismiss:\s*\(\)\s*=>\s*markDismissed/, "dismissing the banner records it for that version");
 assert.match(
   src,
-  /installNativeUpdate\(r\.update,\s*\(pct\) => \{[\s\S]*Downloading update v\$\{r\.version\}… \$\{pct\}%/,
-  "banner native install should surface download progress instead of a static loading state",
+  /prepareNativeUpdate\([\s\S]*Downloading update v\$\{r\.version\}… \$\{pct\}%/,
+  "banner native preparation should surface download progress instead of a static loading state",
 );
+assert.match(src, /label: "Cancel"/, "banner exposes cooperative cancellation");
+assert.match(src, /Update v\$\{r\.version\} is verified and ready/, "banner waits for verification before install");
 
 // Settings row exposes install / in-app fallback / progress / manual recheck.
-assert.match(src, /Install &amp; restart/, "native path offers install + restart");
+assert.match(src, /Download update/, "native path prepares the update without exiting the app");
 assert.match(src, /Downloading…/, "shows download progress");
+assert.match(src, /Verifying signature…/, "shows signature verification progress");
+assert.match(src, /Restart &amp; install/, "prepared update offers an explicit restart action");
+assert.match(src, />\s*Cancel\s*</, "settings row allows preparation cancellation");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
 assert.match(src, /Open installer in Browser/, "fallback keeps installer recovery inside Cave's Browser surface");
 assert.match(src, /Native updater unavailable/, "settings row distinguishes native updater failure from a normal installer fallback");
@@ -101,5 +119,401 @@ assert.doesNotMatch(
 );
 assert.doesNotMatch(src, /download manually/i, "failed updater copy should not imply leaving the app for manual recovery");
 assert.match(src, />\s*Retry\s*</, "failed state offers a retry");
+
+{
+  const progress = [];
+  let closeCalls = 0;
+  let installCalls = 0;
+  const update = {
+    version: "9.9.9",
+    async download(onEvent) {
+      onEvent?.({ event: "Started", data: { contentLength: 100 } });
+      onEvent?.({ event: "Progress", data: { chunkLength: 50 } });
+      onEvent?.({ event: "Finished" });
+    },
+    async install() {
+      installCalls += 1;
+    },
+    async close() {
+      closeCalls += 1;
+    },
+  };
+
+  const result = await prepareNativeUpdate(update, (event) => progress.push(event), {
+    cancelled: false,
+  });
+  assert.equal(result, "ready", "a verified download becomes ready without installing");
+  assert.deepEqual(
+    progress,
+    [
+      { phase: "downloading", pct: 0 },
+      { phase: "downloading", pct: 50 },
+      { phase: "verifying", pct: 99 },
+    ],
+    "download and signature verification progress stay distinct",
+  );
+  assert.equal(installCalls, 0, "preparation must not install or exit the running app");
+  assert.equal(closeCalls, 0, "ready bytes remain available for explicit install");
+}
+
+{
+  const cancellation = { cancelled: false };
+  let closeCalls = 0;
+  const update = {
+    version: "9.9.9",
+    async download(onEvent) {
+      onEvent?.({ event: "Started", data: { contentLength: 10 } });
+      cancellation.cancelled = true;
+      onEvent?.({ event: "Finished" });
+    },
+    async install() {},
+    async close() {
+      closeCalls += 1;
+    },
+  };
+
+  const result = await prepareNativeUpdate(update, () => undefined, cancellation);
+  assert.equal(result, "cancelled", "cooperative cancellation settles deterministically");
+  assert.equal(closeCalls, 1, "cancelled verified bytes are released exactly once");
+}
+
+{
+  let closeCalls = 0;
+  const update = {
+    version: "9.9.9",
+    async download() {
+      throw new Error("network interrupted");
+    },
+    async install() {},
+    async close() {
+      closeCalls += 1;
+    },
+  };
+
+  await assert.rejects(
+    prepareNativeUpdate(update, () => undefined, { cancelled: false }),
+    /network interrupted/,
+    "real download failures remain actionable errors",
+  );
+  assert.equal(closeCalls, 0, "the caller owns cleanup for a non-cancellation failure");
+}
+
+function mockUpdate(version = "9.9.9") {
+  let closeCalls = 0;
+  return {
+    handle: {
+      version,
+      async download() {},
+      async install() {},
+      async close() {
+        closeCalls += 1;
+      },
+    },
+    closeCalls: () => closeCalls,
+  };
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("dismissed-banner");
+  const update = mockUpdate();
+  await coordinator.adopt(banner, update.handle);
+  await coordinator.release(banner);
+  await coordinator.release(banner);
+  assert.equal(update.closeCalls(), 1, "a dismissed banner releases its native handle exactly once");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const settings = Symbol("available-settings-row");
+  const update = mockUpdate();
+  await coordinator.adopt(settings, update.handle);
+  await coordinator.release(settings);
+  assert.equal(update.closeCalls(), 1, "unmounting an available Settings row releases its native handle");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("banner");
+  const settings = Symbol("settings");
+  const primary = mockUpdate();
+  const duplicate = mockUpdate();
+  const bannerHandle = await coordinator.adopt(banner, primary.handle);
+  const settingsHandle = await coordinator.adopt(settings, duplicate.handle);
+
+  assert.equal(settingsHandle, bannerHandle, "both surfaces share one retained native update");
+  assert.equal(duplicate.closeCalls(), 1, "the redundant native check resource is closed immediately");
+  assert.equal(coordinator.beginAction(banner, bannerHandle), true);
+  assert.equal(
+    coordinator.beginAction(settings, settingsHandle),
+    false,
+    "only one surface may prepare or install the shared update",
+  );
+  await coordinator.release(settings);
+  assert.equal(primary.closeCalls(), 0, "a participating surface cannot close another surface's action");
+  await coordinator.finishAction(banner);
+  await coordinator.release(banner);
+  assert.equal(primary.closeCalls(), 1, "the shared handle closes when its final owner releases it");
+  await coordinator.invalidate(primary.handle);
+  assert.equal(primary.closeCalls(), 1, "invalidation remains close-once after release");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("racing-banner");
+  const settings = Symbol("racing-settings");
+  const primary = mockUpdate();
+  let finishDuplicateClose;
+  const duplicate = {
+    version: "9.9.9",
+    async download() {},
+    async install() {},
+    async close() {
+      await new Promise((resolve) => {
+        finishDuplicateClose = resolve;
+      });
+    },
+  };
+  await coordinator.adopt(banner, primary.handle);
+  const adoptingSettings = coordinator.adopt(settings, duplicate);
+  await Promise.resolve();
+  await coordinator.release(banner);
+  finishDuplicateClose();
+  assert.equal(
+    await adoptingSettings,
+    primary.handle,
+    "a lease acquired during redundant-resource disposal keeps the shared handle alive",
+  );
+  assert.equal(primary.closeCalls(), 0);
+  await coordinator.release(settings);
+  assert.equal(primary.closeCalls(), 1);
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("version-banner");
+  const settings = Symbol("version-settings");
+  const v1 = mockUpdate("1.0.0");
+  const duplicateV1 = mockUpdate("1.0.0");
+  const v2 = mockUpdate("2.0.0");
+  const snapshots = [];
+  coordinator.subscribe((snapshot) => snapshots.push(snapshot.update?.version ?? null));
+  await coordinator.adopt(banner, v1.handle);
+  await coordinator.adopt(settings, duplicateV1.handle);
+
+  assert.equal(await coordinator.adopt(settings, v2.handle), v2.handle);
+  assert.equal(v1.closeCalls(), 1, "replacing v1 closes the retained old handle once");
+  assert.equal(duplicateV1.closeCalls(), 1, "the redundant v1 check also closes once");
+  assert.deepEqual(snapshots, ["2.0.0"], "both surfaces are notified to replace stale v1 CTAs");
+  await coordinator.release(banner);
+  assert.equal(v2.closeCalls(), 0, "v2 remains while Settings still owns it");
+  await coordinator.release(settings);
+  assert.equal(v2.closeCalls(), 1);
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const fastSurface = Symbol("fast-newer-check");
+  const slowSurface = Symbol("slow-stale-check");
+  const v2 = mockUpdate("2.0.0");
+  const staleV1 = mockUpdate("1.0.0");
+  await coordinator.adopt(fastSurface, v2.handle);
+  assert.equal(
+    await coordinator.adopt(slowSurface, staleV1.handle),
+    v2.handle,
+    "a slower stale check cannot replace a newer retained release",
+  );
+  assert.equal(staleV1.closeCalls(), 1);
+  assert.equal(v2.closeCalls(), 0);
+  await coordinator.release(fastSurface);
+  await coordinator.release(slowSurface);
+  assert.equal(v2.closeCalls(), 1);
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("current-banner");
+  const settings = Symbol("current-settings");
+  const v1 = mockUpdate("1.0.0");
+  const duplicateV1 = mockUpdate("1.0.0");
+  const snapshots = [];
+  coordinator.subscribe((snapshot) => snapshots.push(snapshot.update?.version ?? null));
+  await coordinator.adopt(banner, v1.handle);
+  await coordinator.adopt(settings, duplicateV1.handle);
+  await coordinator.reportCurrent();
+
+  assert.equal(v1.closeCalls(), 1, "a no-update recheck releases the formerly available handle");
+  assert.equal(duplicateV1.closeCalls(), 1);
+  assert.deepEqual(snapshots, [null], "all mounted surfaces are told to remove stale update CTAs");
+  await coordinator.release(banner);
+  await coordinator.release(settings);
+  assert.equal(v1.closeCalls(), 1, "later surface cleanup does not double-close v1");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const banner = Symbol("active-banner");
+  const settings = Symbol("active-settings");
+  const v1 = mockUpdate("1.0.0");
+  const duplicateV1 = mockUpdate("1.0.0");
+  const v2 = mockUpdate("2.0.0");
+  const snapshots = [];
+  coordinator.subscribe((snapshot) => snapshots.push(snapshot.update?.version ?? null));
+  const retainedV1 = await coordinator.adopt(banner, v1.handle);
+  await coordinator.adopt(settings, duplicateV1.handle);
+  assert.equal(coordinator.beginAction(banner, retainedV1), true);
+
+  assert.equal(
+    await coordinator.adopt(settings, v2.handle),
+    retainedV1,
+    "a newer candidate is deferred while v1 preparation/install owns the action",
+  );
+  assert.equal(v1.closeCalls(), 0);
+  assert.equal(v2.closeCalls(), 0, "the deferred v2 resource remains available for promotion");
+  assert.deepEqual(snapshots, []);
+
+  await coordinator.finishAction(banner);
+  assert.equal(v1.closeCalls(), 1);
+  assert.equal(v2.closeCalls(), 0);
+  assert.deepEqual(snapshots, ["2.0.0"], "v2 promotion invalidates stale v1 CTAs after the action");
+  await coordinator.release(banner);
+  await coordinator.release(settings);
+  assert.equal(v1.closeCalls(), 1);
+  assert.equal(v2.closeCalls(), 1, "the promoted handle closes exactly once after final release");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const staleCurrentSurface = Symbol("slow-current-check");
+  const newerSurface = Symbol("fast-newer-check");
+  const staleCurrentEpoch = coordinator.beginCheck();
+  const newerEpoch = coordinator.beginCheck();
+  const v2 = mockUpdate("2.0.0");
+
+  await coordinator.adopt(newerSurface, v2.handle, newerEpoch);
+  await coordinator.reportCurrent(staleCurrentEpoch);
+
+  assert.equal(v2.closeCalls(), 0, "a stale no-update result cannot clear a newer adopted release");
+  assert.equal(
+    coordinator.beginAction(newerSurface, v2.handle),
+    true,
+    "the newer release remains actionable after the stale result settles",
+  );
+  await coordinator.finishAction(newerSurface);
+  await coordinator.release(newerSurface);
+  await coordinator.release(staleCurrentSurface);
+  assert.equal(v2.closeCalls(), 1);
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const staleAvailableSurface = Symbol("slow-available-check");
+  const staleAvailableEpoch = coordinator.beginCheck();
+  const newerCurrentEpoch = coordinator.beginCheck();
+  const staleV2 = mockUpdate("2.0.0");
+
+  await coordinator.reportCurrent(newerCurrentEpoch);
+  assert.equal(
+    await coordinator.adopt(staleAvailableSurface, staleV2.handle, staleAvailableEpoch),
+    null,
+    "an older available result is rejected after a newer no-update result settles",
+  );
+  assert.equal(staleV2.closeCalls(), 1, "the rejected native handle closes exactly once");
+  await coordinator.invalidate(staleV2.handle);
+  assert.equal(staleV2.closeCalls(), 1, "later invalidation cannot double-close the stale handle");
+  assert.equal(
+    coordinator.beginAction(staleAvailableSurface, staleV2.handle),
+    false,
+    "the stale available result never becomes actionable",
+  );
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const staleBanner = Symbol("stale-banner-result");
+  const newerSettings = Symbol("newer-settings-result");
+  const staleEpoch = coordinator.beginCheck();
+  const newerEpoch = coordinator.beginCheck();
+  const staleV1 = mockUpdate("1.0.0");
+  const v2 = mockUpdate("2.0.0");
+  await coordinator.adopt(newerSettings, v2.handle, newerEpoch);
+
+  const uiResult = await adoptNativeUpdateResult(
+    coordinator,
+    staleBanner,
+    staleV1.handle,
+    staleEpoch,
+  );
+
+  assert.equal(uiResult.kind, "available", "the stale UI check still observes retained availability");
+  assert.equal(
+    uiResult.update,
+    v2.handle,
+    "the component receives the retained newer handle instead of rendering Up to date",
+  );
+  assert.equal(staleV1.closeCalls(), 1, "the rejected stale candidate closes exactly once");
+  await coordinator.release(newerSettings);
+  assert.equal(v2.closeCalls(), 0, "the stale caller owns the retained newer handle it observes");
+  await coordinator.release(staleBanner);
+  assert.equal(v2.closeCalls(), 1, "the retained handle closes after the UI caller releases ownership");
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const activeSurface = Symbol("active-v1-surface");
+  const newerSurface = Symbol("pending-v2-surface");
+  const v1 = mockUpdate("1.0.0");
+  const v2 = mockUpdate("2.0.0");
+  const retainedV1 = await coordinator.adopt(activeSurface, v1.handle);
+  assert.equal(coordinator.beginAction(activeSurface, retainedV1), true);
+  const staleCurrentEpoch = coordinator.beginCheck();
+  const newerEpoch = coordinator.beginCheck();
+
+  await coordinator.adopt(newerSurface, v2.handle, newerEpoch);
+  await coordinator.reportCurrent(staleCurrentEpoch);
+  await coordinator.finishAction(activeSurface);
+
+  assert.equal(v1.closeCalls(), 1, "finishing the active action retires v1 once");
+  assert.equal(v2.closeCalls(), 0, "a stale no-update result cannot discard deferred v2");
+  assert.equal(
+    coordinator.beginAction(newerSurface, v2.handle),
+    true,
+    "the deferred newer release is promoted after the active action",
+  );
+  await coordinator.finishAction(newerSurface);
+  await coordinator.release(activeSurface);
+  await coordinator.release(newerSurface);
+  assert.equal(v2.closeCalls(), 1);
+}
+
+{
+  const coordinator = new NativeUpdateCoordinator();
+  const activeSurface = Symbol("active-current-wins");
+  const staleAvailableSurface = Symbol("stale-pending-available");
+  const v1 = mockUpdate("1.0.0");
+  const staleV2 = mockUpdate("2.0.0");
+  const retainedV1 = await coordinator.adopt(activeSurface, v1.handle);
+  assert.equal(coordinator.beginAction(activeSurface, retainedV1), true);
+  const staleAvailableEpoch = coordinator.beginCheck();
+  const newerCurrentEpoch = coordinator.beginCheck();
+
+  await coordinator.reportCurrent(newerCurrentEpoch);
+  assert.equal(
+    await coordinator.adopt(staleAvailableSurface, staleV2.handle, staleAvailableEpoch),
+    null,
+    "an older available result cannot override a newer deferred no-update result",
+  );
+  assert.equal(staleV2.closeCalls(), 1, "the stale deferred candidate closes exactly once");
+  await coordinator.finishAction(activeSurface);
+  assert.equal(v1.closeCalls(), 1, "the newer no-update result clears v1 after its action finishes");
+  assert.equal(
+    coordinator.beginAction(staleAvailableSurface, staleV2.handle),
+    false,
+    "the rejected candidate is never promoted after the action",
+  );
+  await coordinator.release(activeSurface);
+  await coordinator.release(staleAvailableSurface);
+  assert.equal(staleV2.closeCalls(), 1);
+}
 
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -6,6 +6,17 @@ import { isTauri, useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useShellBanners } from "@/lib/shell-banners";
 import { openInAppBrowserUrl } from "@/lib/open-external";
 import { pickDownloadUrl, type UpdateStatus } from "@/lib/app-update";
+import {
+  prepareNativeUpdate,
+  releasePreparedUpdate,
+  type CancellationSignal,
+  type NativeUpdateHandle,
+  type PreparationProgress,
+} from "@/lib/native-update-preparation";
+import {
+  adoptNativeUpdateResult,
+  nativeUpdateCoordinator,
+} from "@/lib/native-update-coordinator";
 
 const BANNER_ID = "update-available";
 const RELEASES_PAGE = "https://github.com/OpenCoven/coven-cave/releases/latest";
@@ -29,19 +40,8 @@ function markDismissed(version: string): void {
   }
 }
 
-// Minimal shape of the plugin-updater Update we depend on.
-type TauriUpdate = {
-  version: string;
-  available?: boolean;
-  downloadAndInstall: (onEvent?: (e: DownloadEvent) => void) => Promise<void>;
-};
-type DownloadEvent =
-  | { event: "Started"; data?: { contentLength?: number } }
-  | { event: "Progress"; data?: { chunkLength?: number } }
-  | { event: "Finished" };
-
 type NativeCheckResult =
-  | { kind: "available"; update: TauriUpdate }
+  | { kind: "available"; update: NativeUpdateHandle }
   | { kind: "current" }
   | { kind: "failed"; message: string };
 
@@ -54,37 +54,33 @@ function errorMessage(err: unknown, fallback: string): string {
  * distinguish "native updater unavailable" from the intentional browser
  * installer fallback.
  */
-async function checkNativeUpdate(): Promise<NativeCheckResult> {
+async function checkNativeUpdate(owner: symbol): Promise<NativeCheckResult> {
   if (!isTauri()) return { kind: "current" };
+  const checkEpoch = nativeUpdateCoordinator.beginCheck();
   try {
     const { check } = await import("@tauri-apps/plugin-updater");
-    const update = (await check()) as TauriUpdate | null;
-    if (!update) return { kind: "current" };
+    const update = (await check()) as NativeUpdateHandle | null;
+    if (!update) {
+      await nativeUpdateCoordinator.reportCurrent(checkEpoch);
+      return { kind: "current" };
+    }
     // Older plugin versions expose `.available`; newer return null when none.
-    if (update.available === false) return { kind: "current" };
-    return { kind: "available", update };
+    if (update.available === false) {
+      await releasePreparedUpdate(update);
+      await nativeUpdateCoordinator.reportCurrent(checkEpoch);
+      return { kind: "current" };
+    }
+    return await adoptNativeUpdateResult(nativeUpdateCoordinator, owner, update, checkEpoch);
   } catch (err) {
     return { kind: "failed", message: errorMessage(err, "Native updater check failed") };
   }
 }
 
-/** Download + install a native update, reporting 0–100 progress, then relaunch. */
-async function installNativeUpdate(
-  update: TauriUpdate,
-  onProgress: (pct: number) => void,
-): Promise<void> {
-  let total = 0;
-  let received = 0;
-  await update.downloadAndInstall((e) => {
-    if (e.event === "Started") {
-      total = e.data?.contentLength ?? 0;
-    } else if (e.event === "Progress") {
-      received += e.data?.chunkLength ?? 0;
-      if (total > 0) onProgress(Math.min(99, Math.round((received / total) * 100)));
-    } else if (e.event === "Finished") {
-      onProgress(100);
-    }
-  });
+/** Install an already downloaded and verified update, then relaunch where supported. */
+async function installPreparedUpdate(update: NativeUpdateHandle): Promise<void> {
+  await update.install();
+  // Windows exits inside install() and AUTOLAUNCHAPP handles restart. Other
+  // desktop platforms return and need an explicit relaunch.
   const { relaunch } = await import("@tauri-apps/plugin-process");
   await relaunch();
 }
@@ -128,13 +124,13 @@ function openReleasePageInBrowser(): void {
 type Resolved =
   | { kind: "current" }
   | { kind: "unknown"; message: string }
-  | { kind: "native"; version: string; update: TauriUpdate }
+  | { kind: "native"; version: string; update: NativeUpdateHandle }
   | { kind: "native-unavailable"; version: string; url: string; message: string }
   | { kind: "fallback"; version: string; url: string };
 
 /** Native-first, then fallback. Used by both the banner and the settings row. */
-async function resolveUpdate(): Promise<Resolved> {
-  const native = await checkNativeUpdate();
+async function resolveUpdate(owner: symbol): Promise<Resolved> {
+  const native = await checkNativeUpdate(owner);
   if (native.kind === "available") {
     return { kind: "native", version: native.update.version, update: native.update };
   }
@@ -167,22 +163,33 @@ const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 export function UpdateBannerTrigger() {
   const isDesktop = useIsTauriDesktop();
   const { pushBanner, dismissBanner } = useShellBanners();
+  const owner = useRef(Symbol("update-banner")).current;
 
   useEffect(() => {
     if (!isDesktop) return;
     let cancelled = false;
-    // While an install is downloading, a periodic re-check must not clobber
-    // the progress banner (they share BANNER_ID) with a fresh "available" one.
-    let installing = false;
+    let busy = false;
+    let activeCancellation: CancellationSignal | null = null;
+    let preparedUpdate: NativeUpdateHandle | null = null;
 
     const runCheck = () => {
-      if (installing) return;
-      void resolveUpdate().then((r) => {
+      if (busy) return;
+      void resolveUpdate(owner).then((r) => {
         // "unknown" (both checks unreachable) stays quiet here — the periodic
         // banner must not nag about connectivity; the Settings row reports it
         // honestly on an explicit check (cave-lsk4).
-        if (cancelled || installing || r.kind === "current" || r.kind === "unknown") return;
-        if (isDismissed(r.version)) return;
+        if (cancelled) {
+          if (r.kind === "native") void nativeUpdateCoordinator.release(owner);
+          return;
+        }
+        if (busy || r.kind === "current" || r.kind === "unknown") {
+          if (r.kind === "native") void nativeUpdateCoordinator.release(owner);
+          return;
+        }
+        if (isDismissed(r.version)) {
+          if (r.kind === "native") void nativeUpdateCoordinator.release(owner);
+          return;
+        }
 
         pushBanner({
           id: BANNER_ID,
@@ -192,20 +199,111 @@ export function UpdateBannerTrigger() {
               ? `Native updater unavailable — v${r.version}`
               : `Update available — v${r.version}`,
           cta: {
-            label: r.kind === "native" ? "Install & restart" : "Open installer in Browser",
+            label: r.kind === "native" ? "Download update" : "Open installer in Browser",
             onClick: () => {
               if (r.kind === "native") {
-                installing = true;
-                pushBanner({ id: BANNER_ID, severity: "info", title: `Preparing update v${r.version}…` });
-                void installNativeUpdate(r.update, (pct) => {
+                if (busy) return;
+                if (!nativeUpdateCoordinator.beginAction(owner, r.update)) {
                   pushBanner({
                     id: BANNER_ID,
                     severity: "info",
-                    title: `Downloading update v${r.version}… ${pct}%`,
+                    title: `Update v${r.version} is already being prepared in Settings`,
                   });
-                }).catch((err) => {
-                  installing = false;
-                  const reason = err instanceof Error ? err.message : "";
+                  return;
+                }
+                busy = true;
+                const cancellation: CancellationSignal = { cancelled: false };
+                activeCancellation = cancellation;
+                const requestCancel = () => {
+                  cancellation.cancelled = true;
+                  pushBanner({
+                    id: BANNER_ID,
+                    severity: "info",
+                    title: `Cancelling update v${r.version} after verification…`,
+                  });
+                };
+                pushBanner({
+                  id: BANNER_ID,
+                  severity: "info",
+                  title: `Preparing update v${r.version}…`,
+                  cta: { label: "Cancel", onClick: requestCancel },
+                  onDismiss: requestCancel,
+                });
+                void prepareNativeUpdate(
+                  r.update,
+                  ({ phase, pct }) => {
+                    if (cancelled || cancellation.cancelled) return;
+                    pushBanner({
+                      id: BANNER_ID,
+                      severity: "info",
+                      title:
+                        phase === "verifying"
+                          ? `Verifying update v${r.version}…`
+                          : `Downloading update v${r.version}… ${pct}%`,
+                      cta: { label: "Cancel", onClick: requestCancel },
+                      onDismiss: requestCancel,
+                    });
+                  },
+                  cancellation,
+                ).then(async (result) => {
+                  activeCancellation = null;
+                  if (result === "cancelled" || cancelled) {
+                    await nativeUpdateCoordinator.finishAction(owner);
+                    await nativeUpdateCoordinator.invalidate(r.update);
+                    busy = false;
+                    markDismissed(r.version);
+                    if (!cancelled) dismissBanner(BANNER_ID);
+                    return;
+                  }
+
+                  preparedUpdate = r.update;
+                  pushBanner({
+                    id: BANNER_ID,
+                    severity: "info",
+                    title: `Update v${r.version} is verified and ready`,
+                    cta: {
+                      label: "Restart & install",
+                      onClick: () => {
+                        if (preparedUpdate !== r.update) return;
+                        preparedUpdate = null;
+                        pushBanner({
+                          id: BANNER_ID,
+                          severity: "info",
+                          title: `Installing update v${r.version}…`,
+                        });
+                        void installPreparedUpdate(r.update).catch(async (error) => {
+                          await nativeUpdateCoordinator.finishAction(owner);
+                          await nativeUpdateCoordinator.invalidate(r.update);
+                          busy = false;
+                          preparedUpdate = null;
+                          pushBanner({
+                            id: BANNER_ID,
+                            severity: "warning",
+                            title: `Update failed (${errorMessage(error, "install failed")})`,
+                            cta: {
+                              label: "Open release page in Browser",
+                              onClick: openReleasePageInBrowser,
+                            },
+                            onDismiss: () => markDismissed(r.version),
+                          });
+                        });
+                      },
+                    },
+                    onDismiss: () => {
+                      busy = false;
+                      preparedUpdate = null;
+                      markDismissed(r.version);
+                      void nativeUpdateCoordinator
+                        .finishAction(owner)
+                        .then(() => nativeUpdateCoordinator.invalidate(r.update));
+                    },
+                  });
+                }).catch(async (err) => {
+                  await nativeUpdateCoordinator.finishAction(owner);
+                  await nativeUpdateCoordinator.invalidate(r.update);
+                  activeCancellation = null;
+                  busy = false;
+                  const reason = errorMessage(err, "");
                   pushBanner({
                     id: BANNER_ID,
                     severity: "warning",
@@ -223,16 +321,34 @@ export function UpdateBannerTrigger() {
               }
             },
           },
-          onDismiss: () => markDismissed(r.version),
+          onDismiss: () => {
+            markDismissed(r.version);
+            if (r.kind === "native") void nativeUpdateCoordinator.release(owner);
+          },
         });
       });
     };
 
+    const unsubscribe = nativeUpdateCoordinator.subscribe(() => {
+      if (cancelled || busy) return;
+      dismissBanner(BANNER_ID);
+      runCheck();
+    });
     runCheck();
     const interval = window.setInterval(runCheck, RECHECK_INTERVAL_MS);
     return () => {
       cancelled = true;
+      if (activeCancellation) activeCancellation.cancelled = true;
+      if (preparedUpdate) {
+        const update = preparedUpdate;
+        void nativeUpdateCoordinator
+          .finishAction(owner)
+          .then(() => nativeUpdateCoordinator.invalidate(update));
+      } else if (!activeCancellation) {
+        void nativeUpdateCoordinator.release(owner);
+      }
       window.clearInterval(interval);
+      unsubscribe();
       dismissBanner(BANNER_ID);
     };
   }, [isDesktop, pushBanner, dismissBanner]);
@@ -246,24 +362,32 @@ type RowState =
   | { phase: "unknown"; message: string }
   | { phase: "available"; r: Extract<Resolved, { kind: "native" | "fallback" }> }
   | { phase: "native-unavailable"; r: Extract<Resolved, { kind: "native-unavailable" }> }
-  | { phase: "downloading"; version: string; pct: number }
-  | { phase: "failed"; version: string; message: string }
-  | { phase: "ready"; version: string };
+  | { phase: "preparing"; version: string; stage: PreparationProgress["phase"]; pct: number }
+  | { phase: "cancelling"; version: string }
+  | { phase: "prepared"; version: string; update: NativeUpdateHandle }
+  | { phase: "installing"; version: string }
+  | { phase: "failed"; version: string; message: string };
 
 /**
  * Desktop-only row for Settings ▸ About. Native updater when available
- * (Install & restart with progress), else opens the release installer in Cave's
- * Browser surface.
+ * (download + verify, then restart to install), else opens the release
+ * installer in Cave's Browser surface.
  */
 export function UpdateSettingsRow() {
   const isDesktop = useIsTauriDesktop();
   const [state, setState] = useState<RowState>({ phase: "checking" });
   const mounted = useRef(true);
+  const activeCancellation = useRef<CancellationSignal | null>(null);
+  const preparedUpdate = useRef<NativeUpdateHandle | null>(null);
+  const owner = useRef(Symbol("update-settings")).current;
 
   const check = useCallback(() => {
     setState({ phase: "checking" });
-    void resolveUpdate().then((r) => {
-      if (!mounted.current) return;
+    void resolveUpdate(owner).then((r) => {
+      if (!mounted.current) {
+        if (r.kind === "native") void nativeUpdateCoordinator.release(owner);
+        return;
+      }
       if (r.kind === "current") setState({ phase: "current" });
       else if (r.kind === "unknown") setState({ phase: "unknown", message: r.message });
       else if (r.kind === "native-unavailable") setState({ phase: "native-unavailable", r });
@@ -273,23 +397,71 @@ export function UpdateSettingsRow() {
 
   useEffect(() => {
     mounted.current = true;
+    const unsubscribe = nativeUpdateCoordinator.subscribe((snapshot) => {
+      if (!mounted.current || activeCancellation.current || preparedUpdate.current) return;
+      if (snapshot.update) {
+        setState({
+          phase: "available",
+          r: { kind: "native", version: snapshot.update.version, update: snapshot.update },
+        });
+      } else {
+        setState({ phase: "current" });
+      }
+    });
     if (isDesktop) check();
     return () => {
       mounted.current = false;
+      unsubscribe();
+      if (activeCancellation.current) activeCancellation.current.cancelled = true;
+      if (preparedUpdate.current) {
+        nativeUpdateCoordinator.finishAction(owner);
+        void nativeUpdateCoordinator.invalidate(preparedUpdate.current);
+      } else if (!activeCancellation.current) {
+        void nativeUpdateCoordinator.release(owner);
+      }
     };
   }, [isDesktop, check]);
 
   if (!isDesktop) return null;
 
-  const install = (update: TauriUpdate, version: string) => {
-    setState({ phase: "downloading", version, pct: 0 });
-    void installNativeUpdate(update, (pct) => {
-      if (mounted.current) setState({ phase: "downloading", version, pct });
-    })
-      .then(() => {
-        if (mounted.current) setState({ phase: "ready", version });
+  const prepare = (update: NativeUpdateHandle, version: string) => {
+    if (activeCancellation.current || preparedUpdate.current) return;
+    if (!nativeUpdateCoordinator.beginAction(owner, update)) {
+      setState({ phase: "failed", version, message: "Update preparation is active in another surface" });
+      return;
+    }
+    const cancellation: CancellationSignal = { cancelled: false };
+    activeCancellation.current = cancellation;
+    setState({ phase: "preparing", version, stage: "downloading", pct: 0 });
+    void prepareNativeUpdate(
+      update,
+      ({ phase, pct }) => {
+        if (mounted.current && !cancellation.cancelled) {
+          setState({ phase: "preparing", version, stage: phase, pct });
+        }
+      },
+      cancellation,
+    )
+      .then(async (result) => {
+        activeCancellation.current = null;
+        if (!mounted.current) {
+          await nativeUpdateCoordinator.finishAction(owner);
+          await nativeUpdateCoordinator.invalidate(update);
+          return;
+        }
+        if (result === "cancelled") {
+          await nativeUpdateCoordinator.finishAction(owner);
+          await nativeUpdateCoordinator.invalidate(update);
+          check();
+          return;
+        }
+        preparedUpdate.current = update;
+        setState({ phase: "prepared", version, update });
       })
-      .catch((err) => {
+      .catch(async (err) => {
+        await nativeUpdateCoordinator.finishAction(owner);
+        await nativeUpdateCoordinator.invalidate(update);
+        activeCancellation.current = null;
         if (mounted.current)
           setState({
             phase: "failed",
@@ -297,6 +469,29 @@ export function UpdateSettingsRow() {
             message: err instanceof Error ? err.message : "Update failed",
           });
       });
+  };
+
+  const cancelPreparation = (version: string) => {
+    if (!activeCancellation.current) return;
+    activeCancellation.current.cancelled = true;
+    setState({ phase: "cancelling", version });
+  };
+
+  const install = (update: NativeUpdateHandle, version: string) => {
+    if (preparedUpdate.current !== update) return;
+    preparedUpdate.current = null;
+    setState({ phase: "installing", version });
+    void installPreparedUpdate(update).catch(async (err) => {
+      await nativeUpdateCoordinator.finishAction(owner);
+      await nativeUpdateCoordinator.invalidate(update);
+      if (mounted.current) {
+        setState({
+          phase: "failed",
+          version,
+          message: errorMessage(err, "Update failed"),
+        });
+      }
+    });
   };
 
   const accentBtn =
@@ -307,18 +502,55 @@ export function UpdateSettingsRow() {
   let control: ReactNode;
   if (state.phase === "checking") {
     control = <span className="text-[12px] text-[var(--text-muted)]">Checking…</span>;
-  } else if (state.phase === "downloading") {
-    control = <span className="text-[12px] text-[var(--text-muted)]">Downloading… {state.pct}%</span>;
-  } else if (state.phase === "ready") {
-    control = <span className="text-[12px] font-medium text-[var(--text-primary)]">Restarting…</span>;
+  } else if (state.phase === "preparing") {
+    control = (
+      <>
+        <span className="text-[12px] text-[var(--text-muted)]">
+          {state.stage === "verifying" ? "Verifying signature…" : `Downloading… ${state.pct}%`}
+        </span>
+        <Button
+          variant="secondary"
+          size="xs"
+          onClick={() => cancelPreparation(state.version)}
+          className={secondaryBtn}
+        >
+          Cancel
+        </Button>
+      </>
+    );
+  } else if (state.phase === "cancelling") {
+    control = (
+      <span className="text-[12px] text-[var(--text-muted)]">
+        Cancelling after verification…
+      </span>
+    );
+  } else if (state.phase === "prepared") {
+    control = (
+      <>
+        <span className="text-[12px] font-medium text-[var(--text-primary)]">
+          v{state.version} verified
+        </span>
+        <Button
+          variant="primary"
+          size="xs"
+          onClick={() => install(state.update, state.version)}
+          className={accentBtn}
+          leadingIcon="ph:arrow-clockwise-bold"
+        >
+          Restart &amp; install
+        </Button>
+      </>
+    );
+  } else if (state.phase === "installing") {
+    control = <span className="text-[12px] font-medium text-[var(--text-primary)]">Installing…</span>;
   } else if (state.phase === "available") {
     const r = state.r; // narrowed to native | fallback
     control = (
       <>
         <span className="text-[12px] font-medium text-[var(--text-primary)]">v{r.version} available</span>
         {r.kind === "native" ? (
-          <Button variant="primary" size="xs" onClick={() => install(r.update, r.version)} className={accentBtn} leadingIcon="ph:arrow-down-bold">
-            Install &amp; restart
+          <Button variant="primary" size="xs" onClick={() => prepare(r.update, r.version)} className={accentBtn} leadingIcon="ph:arrow-down-bold">
+            Download update
           </Button>
         ) : (
           <Button variant="primary" size="xs" onClick={() => openInAppBrowserUrl(r.url)} className={accentBtn} leadingIcon="ph:arrow-square-out">

--- a/src/lib/native-update-coordinator.ts
+++ b/src/lib/native-update-coordinator.ts
@@ -1,0 +1,185 @@
+import { releasePreparedUpdate, type NativeUpdateHandle } from "./native-update-preparation.ts";
+
+export type NativeUpdateSnapshot = {
+  update: NativeUpdateHandle | null;
+  actionActive: boolean;
+};
+
+export type NativeUpdateCheckResult =
+  | { kind: "available"; update: NativeUpdateHandle }
+  | { kind: "current" };
+
+type Listener = (snapshot: NativeUpdateSnapshot) => void;
+
+function compareVersions(left: string, right: string): number {
+  const parse = (version: string) => {
+    const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(version);
+    return match
+      ? { core: match.slice(1, 4).map(Number), prerelease: match[4]?.split(".") ?? [] }
+      : null;
+  };
+  const a = parse(left);
+  const b = parse(right);
+  if (!a || !b) return left.localeCompare(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (a.core[index] !== b.core[index]) return a.core[index] - b.core[index];
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    return b.prerelease.length - a.prerelease.length;
+  }
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = a.prerelease[index];
+    const rightPart = b.prerelease[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+    const leftNumber = /^\d+$/.test(leftPart) ? Number(leftPart) : null;
+    const rightNumber = /^\d+$/.test(rightPart) ? Number(rightPart) : null;
+    if (leftNumber !== null && rightNumber !== null) return leftNumber - rightNumber;
+    if (leftNumber !== null) return -1;
+    if (rightNumber !== null) return 1;
+    return leftPart.localeCompare(rightPart);
+  }
+  return 0;
+}
+
+/** Shared native updater resource and action coordinator for all React surfaces. */
+export class NativeUpdateCoordinator {
+  private update: NativeUpdateHandle | null = null;
+  private pendingUpdate: NativeUpdateHandle | null = null;
+  private pendingCurrent = false;
+  private checkEpoch = 0;
+  private latestResultEpoch = 0;
+  private latestResultAvailable = false;
+  private readonly owners = new Set<symbol>();
+  private actionOwner: symbol | null = null;
+  private readonly listeners = new Set<Listener>();
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  beginCheck(): number {
+    this.checkEpoch += 1;
+    return this.checkEpoch;
+  }
+
+  private notify(): void {
+    const snapshot = { update: this.update, actionActive: this.actionOwner !== null };
+    for (const listener of this.listeners) listener(snapshot);
+  }
+
+  private async replaceCurrent(replacement: NativeUpdateHandle | null): Promise<void> {
+    const previous = this.update;
+    const changed = previous !== replacement;
+    this.update = replacement;
+    if (!replacement) this.owners.clear();
+    if (changed && previous) await releasePreparedUpdate(previous);
+    if (changed) this.notify();
+  }
+
+  async adopt(
+    owner: symbol,
+    candidate: NativeUpdateHandle,
+    epoch = this.beginCheck(),
+  ): Promise<NativeUpdateHandle | null> {
+    if (epoch < this.latestResultEpoch) {
+      await releasePreparedUpdate(candidate);
+      if (!this.latestResultAvailable) return null;
+      const retained = this.pendingUpdate ?? this.update;
+      if (retained) this.owners.add(owner);
+      return retained;
+    }
+    this.latestResultEpoch = epoch;
+    this.latestResultAvailable = true;
+    if (!this.update) {
+      this.update = candidate;
+      this.owners.add(owner);
+      return candidate;
+    }
+    if (compareVersions(candidate.version, this.update.version) <= 0) {
+      this.owners.add(owner);
+      if (this.update !== candidate) await releasePreparedUpdate(candidate);
+      return this.update;
+    }
+
+    this.owners.add(owner);
+    if (this.actionOwner) {
+      const replacedPending = this.pendingUpdate;
+      this.pendingUpdate = candidate;
+      this.pendingCurrent = false;
+      if (replacedPending && replacedPending !== candidate) {
+        await releasePreparedUpdate(replacedPending);
+      }
+      return this.update;
+    }
+
+    await this.replaceCurrent(candidate);
+    return candidate;
+  }
+
+  async reportCurrent(epoch = this.beginCheck()): Promise<void> {
+    if (epoch < this.latestResultEpoch) return;
+    this.latestResultEpoch = epoch;
+    this.latestResultAvailable = false;
+    if (this.actionOwner) {
+      this.pendingCurrent = true;
+      if (this.pendingUpdate) await releasePreparedUpdate(this.pendingUpdate);
+      this.pendingUpdate = null;
+      return;
+    }
+    await this.replaceCurrent(null);
+  }
+
+  beginAction(owner: symbol, update: NativeUpdateHandle): boolean {
+    if (this.update !== update || (this.actionOwner && this.actionOwner !== owner)) return false;
+    this.actionOwner = owner;
+    return true;
+  }
+
+  async finishAction(owner: symbol): Promise<void> {
+    if (this.actionOwner !== owner) return;
+    this.actionOwner = null;
+    if (this.pendingCurrent) {
+      this.pendingCurrent = false;
+      await this.replaceCurrent(null);
+      return;
+    }
+    if (this.pendingUpdate) {
+      const replacement = this.pendingUpdate;
+      this.pendingUpdate = null;
+      await this.replaceCurrent(replacement);
+      return;
+    }
+  }
+
+  async release(owner: symbol): Promise<void> {
+    this.owners.delete(owner);
+    if (this.actionOwner === owner) return;
+    if (this.owners.size === 0 && this.update) await this.replaceCurrent(null);
+  }
+
+  async invalidate(update: NativeUpdateHandle): Promise<void> {
+    if (this.update === update) {
+      this.update = null;
+      this.actionOwner = null;
+      this.owners.clear();
+      this.notify();
+    }
+    await releasePreparedUpdate(update);
+  }
+}
+
+export async function adoptNativeUpdateResult(
+  coordinator: NativeUpdateCoordinator,
+  owner: symbol,
+  candidate: NativeUpdateHandle,
+  epoch: number,
+): Promise<NativeUpdateCheckResult> {
+  const adopted = await coordinator.adopt(owner, candidate, epoch);
+  return adopted ? { kind: "available", update: adopted } : { kind: "current" };
+}
+
+export const nativeUpdateCoordinator = new NativeUpdateCoordinator();

--- a/src/lib/native-update-preparation.ts
+++ b/src/lib/native-update-preparation.ts
@@ -1,0 +1,74 @@
+export type NativeDownloadEvent =
+  | { event: "Started"; data?: { contentLength?: number } }
+  | { event: "Progress"; data?: { chunkLength?: number } }
+  | { event: "Finished" };
+
+export type NativeUpdateHandle = {
+  version: string;
+  available?: boolean;
+  download: (onEvent?: (event: NativeDownloadEvent) => void) => Promise<void>;
+  install: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+export type PreparationProgress = {
+  phase: "downloading" | "verifying";
+  pct: number;
+};
+
+export type CancellationSignal = { cancelled: boolean };
+
+const closedUpdates = new WeakSet<object>();
+
+/**
+ * Download and signature-verify an update while the current app remains usable.
+ * Tauri does not expose a network abort handle, so cancellation is cooperative:
+ * the verified bytes are released as soon as the in-flight request settles.
+ */
+export async function prepareNativeUpdate(
+  update: NativeUpdateHandle,
+  onProgress: (progress: PreparationProgress) => void,
+  cancellation: CancellationSignal,
+): Promise<"ready" | "cancelled"> {
+  let total = 0;
+  let received = 0;
+  try {
+    await update.download((event) => {
+      if (event.event === "Started") {
+        total = event.data?.contentLength ?? 0;
+        onProgress({ phase: "downloading", pct: 0 });
+      } else if (event.event === "Progress") {
+        received += event.data?.chunkLength ?? 0;
+        if (total > 0) {
+          onProgress({
+            phase: "downloading",
+            pct: Math.min(98, Math.round((received / total) * 100)),
+          });
+        }
+      } else if (event.event === "Finished") {
+        // The Rust plugin emits Finished before minisign verification.
+        onProgress({ phase: "verifying", pct: 99 });
+      }
+    });
+  } catch (error) {
+    if (!cancellation.cancelled) throw error;
+    await releasePreparedUpdate(update);
+    return "cancelled";
+  }
+
+  if (cancellation.cancelled) {
+    await releasePreparedUpdate(update);
+    return "cancelled";
+  }
+  return "ready";
+}
+
+export async function releasePreparedUpdate(update: NativeUpdateHandle): Promise<void> {
+  if (closedUpdates.has(update)) return;
+  closedUpdates.add(update);
+  try {
+    await update.close();
+  } catch {
+    // The installer may already have consumed and closed the resource.
+  }
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -135,4 +135,8 @@ assert.match(mobileDocsSource, /signed (?:expiring )?invites?/, "mobile docs sho
 assert.match(tauriSource, /sidecar_auth_token\(\)/, "Tauri sidecar should generate a per-launch token");
 assert.match(tauriSource, /\.env\("COVEN_CAVE_AUTH_TOKEN", &auth_token\)/, "Tauri sidecar should pass the token to Next.js");
 assert.match(tauriSource, /\.env\("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token\)/, "Tauri sidecar should pass the mobile access secret to Next.js");
-assert.match(tauriSource, /\?covenCaveToken=\{\}&coven_access_token=\{\}/, "Tauri app URL should bootstrap both tokens into the webview");
+assert.match(
+  tauriSource,
+  /\?covenCaveToken=\{auth_token\}&coven_access_token=\{mobile_access_token\}/,
+  "Tauri app URL should bootstrap both named tokens into the webview",
+);


### PR DESCRIPTION
Upstream mirror of #2916 (by @romgenie) so the required CodeQL check can run and the stack can land. Commits are romgenie's, unchanged; squash-merge will credit via Co-authored-by.

Reviewed as part of the Windows sidecar-runtime stack. Superseded fork PR: #2916.

🤖 Mirrored + landed by Claude Code