### PR TITLE
perf(windows): optimize runtime extraction and lifecycle diagnostics

### DIFF
--- a/docs/windows-sidecar-compression.md
+++ b/docs/windows-sidecar-compression.md
@@ -1,0 +1,112 @@
+# Windows sidecar compression benchmark
+
+The Windows runtime archive uses zstd level 3. The comparison uses the exact
+tar payload that the production extractor consumes, so both formats contain
+the same paths, metadata, hardlinks, and expanded bytes.
+
+## Current production closure
+
+Measured on the Windows reference machine on 2026-07-10. The source is the
+v0.0.173-style production runtime from PR #2911: 24,293 files, 4,018
+directories, and 549,137,534 expanded bytes. Compression streamed the same
+563,394,560-byte tar through Python 3.14's standard gzip and zstd codecs.
+Extraction used Windows inbox bsdtar 3.8.4 with libzstd 1.5.7. Runs were
+alternated to reduce filesystem-cache and Defender ordering bias.
+
+| Format | Level | Archive bytes | Compression | Extraction run 1 | Extraction run 2 | Mean extraction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| gzip | 6 | 144,750,679 | 14.207s | 61.161s | 44.013s | 52.587s |
+| zstd | 3 | 126,098,931 | 4.890s | 34.473s | 43.290s | 38.882s |
+
+Every extraction produced exactly 24,293 files, 4,018 directories, and
+549,137,534 bytes. Zstd was 12.9% smaller, 2.9x faster to compress, and 26.1%
+faster to extract on the two-run mean. File creation and real-time scanning
+still dominate warm extraction, which is why the runtime records file counts,
+per-phase timings, staging estimates, and observable Defender process context.
+Cache disk diagnostics sum the logical bytes actually present before
+preparation, then add the manifest-sized staging estimate for a conservative
+peak. Failure records retain completed phase timings, the active failed phase,
+cache/generation context, and Defender process context for extraction-related
+failures. The latest diagnostics file is replaced atomically on Windows.
+
+## Pruned runtime closure
+
+The final PR2-pruned runtime was measured separately after native `sharp` and
+`node-pty` loading passed: 4,942 files, 1,348 directories, and 102,580,489
+expanded bytes. The authoritative input was the 32,090,079-byte gzip artifact
+with SHA-256 `47344a0e280436a0287975f0ef8c71c7814091e5209f8bf7b1838bf5630c018e`.
+It was decompressed once, then the identical 107,253,760-byte tar payload was
+recompressed with gzip level 6 and zstd level 3. Extraction used the same
+Windows inbox bsdtar and alternated formats over six runs each to expose
+filesystem-cache and real-time-scanning variance.
+
+| Format | Level | Archive bytes | Compression | Extraction mean | Extraction median | Six extraction runs |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| gzip | 6 | 32,536,779 | 2.495s | 5.044s | 4.749s | 4.670, 4.828, 6.469, 5.060, 4.669, 4.568s |
+| zstd | 3 | 29,077,557 | 0.786s | 5.044s | 4.940s | 5.140, 4.555, 5.821, 4.868, 4.919, 4.961s |
+
+Every extraction produced exactly 4,942 files, 1,348 directories, and
+102,580,489 bytes. Extraction is effectively tied on this pruned payload
+(the means differ by less than 0.001% while gzip's median is 3.9% lower), confirming
+that file creation and scanning dominate decompression. Zstd is still the
+measured overall winner: it is 10.6% smaller and 3.2x faster to compress with
+no mean extraction penalty. The runtime's split decompression/file-creation
+timings preserve that distinction on release machines instead of attributing
+the full extraction interval to the codec.
+
+## Decision
+
+Use `server.tar.zst` at zstd level 3. Windows' inbox bsdtar creates the release
+archive without an extra runner dependency, and the Rust launcher decodes it
+in-process. The manifest identifies `tar.zst` explicitly and retains the same
+SHA-256, expanded-byte, file-count, and directory-count integrity checks.
+
+The cache key and current-plus-one-previous retention policy are unchanged.
+
+## Evidence provenance and reproduction
+
+The tables above are the retained record from the 2026-07-10 Windows terminal
+session. The individual measurements were transcribed when each command
+completed, but the raw console transcript was not retained. No synthetic raw
+log is checked in because it would imply provenance that does not exist.
+
+To reproduce the comparison, first materialize the production sidecar payload
+with `TAURI_PLATFORM=windows bash scripts/sidecar-bundle.sh`, then extract
+`server.tar.zst` once and create one canonical, uncompressed tar from that
+directory. Compress that same tar at gzip level 6 and zstd level 3. For each
+format, alternate extraction order and use a new empty destination per run:
+
+```powershell
+$tar = "$env:SystemRoot\System32\tar.exe"
+$payload = Resolve-Path .\sidecar-payload
+& $tar -cf .\sidecar.tar -C $payload .
+python -c "import gzip,shutil,sys; i=open(sys.argv[1],'rb'); o=gzip.open(sys.argv[2],'wb',compresslevel=6); shutil.copyfileobj(i,o); o.close(); i.close()" .\sidecar.tar .\sidecar.tar.gz
+python -c "import compression.zstd as zstd,shutil,sys; i=open(sys.argv[1],'rb'); o=zstd.open(sys.argv[2],'wb',level=3); shutil.copyfileobj(i,o); o.close(); i.close()" .\sidecar.tar .\sidecar.tar.zst
+
+1..6 | ForEach-Object {
+    foreach ($archive in @('.\sidecar.tar.gz', '.\sidecar.tar.zst')) {
+        $destination = Join-Path $env:TEMP ([Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $destination | Out-Null
+        $elapsed = Measure-Command { & $tar -xf $archive -C $destination }
+        [pscustomobject]@{ archive = $archive; run = $_; seconds = $elapsed.TotalSeconds }
+        Remove-Item -LiteralPath $destination -Recurse -Force
+    }
+}
+```
+
+Before comparing timings, hash the canonical tar used for both formats and
+verify that every extracted tree has identical file count, directory count,
+logical byte count, and per-file SHA-256 values. Record the Windows tar version
+and whether `MsMpEng.exe` was running so later measurements remain comparable.
+
+## Integration contract
+
+This independently based compression change reserves manifest schema 3 for
+the combined runtime-cache implementation. When this work is semantically
+merged with the schema-2 content-addressed cache change, schema 3 must retain
+its canonical payload and full-tree digests, payload-derived cache key,
+interprocess `fs2` lock, free-space preflight, full-file warm validation, and
+atomic recovery behavior while changing the archive transport to `tar.zst`.
+The branches intentionally remain non-stacked and may require conflict
+resolution; schema 3 prevents either incompatible wire format from being
+mistaken for the other during that integration.

--- a/scripts/sidecar-archive-manifest.mjs
+++ b/scripts/sidecar-archive-manifest.mjs
@@ -53,13 +53,17 @@ async function treeMetrics(root) {
 }
 
 export async function writeSidecarArchiveManifest(sourceRoot, archivePath, outputPath) {
+  if (!archivePath.toLowerCase().endsWith(".tar.zst")) {
+    throw new Error(`sidecar archive must use the measured tar.zst format: ${archivePath}`);
+  }
   const [{ size: archiveBytes }, metrics, archiveSha256] = await Promise.all([
     stat(archivePath),
     treeMetrics(sourceRoot),
     sha256File(archivePath),
   ]);
   const manifest = {
-    schemaVersion: 1,
+    schemaVersion: 3,
+    archiveFormat: "tar.zst",
     archiveSha256,
     archiveBytes,
     ...metrics,

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -101,9 +101,16 @@ assert.ok(
   baseConfig.bundle.resources.includes("resources/server/**/*"),
   "non-Windows bundles must retain the expanded tree for nested native signing",
 );
-assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.gz archive");
+assert.match(src, /server\.tar\.zst/, "Windows sidecar must be emitted as a zstd-compressed tar archive");
+assert.match(src, /System32\/tar\.exe/, "Windows bundling must use the inbox libzstd-enabled bsdtar");
+assert.match(src, /-acf "\$WINDOWS_ARCHIVE"/, "archive suffix must select zstd compression");
+assert.match(src, /zstd:compression-level=3/, "release archive must use the measured zstd level 3");
+assert.doesNotMatch(src, /server\.tar\.gz/, "Windows must not retain the slower gzip archive path");
 assert.match(src, /sidecar-archive-manifest\.mjs/, "archive generation must emit its integrity and size manifest");
 assert.match(manifestSource, /archiveBytes: 256 \* 1024 \* 1024/, "archive size must have a 256 MiB hard budget");
+assert.match(manifestSource, /schemaVersion: 3/, "zstd archive format must use the non-colliding combined manifest schema");
+assert.match(manifestSource, /archiveFormat: "tar\.zst"/, "manifest must identify the selected compression format");
+assert.match(manifestSource, /endsWith\("\.tar\.zst"\)/, "manifest writer must reject a misleading archive suffix");
 assert.match(manifestSource, /unpackedBytes: 768 \* 1024 \* 1024/, "expanded runtime must have a 768 MiB hard budget");
 assert.match(manifestSource, /fileCount: 50_000/, "archive entry count must have a hard budget");
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -24,7 +24,7 @@ esac
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/src-tauri/resources/server"
 WINDOWS_ARCHIVE_DIR="$ROOT/src-tauri/resources/server-archive"
-WINDOWS_ARCHIVE="$WINDOWS_ARCHIVE_DIR/server.tar.gz"
+WINDOWS_ARCHIVE="$WINDOWS_ARCHIVE_DIR/server.tar.zst"
 WINDOWS_ARCHIVE_MANIFEST="$WINDOWS_ARCHIVE_DIR/manifest.json"
 BUNDLED_NODE_DIR="$ROOT/src-tauri/resources/node"
 STATIC="$ROOT/.next/static"
@@ -217,13 +217,23 @@ write_windows_sidecar_archive() {
     mv "$materialized" "$link"
   done < <(find "$DEST" -type l -print0)
 
-  echo "==> archiving Windows sidecar -> $WINDOWS_ARCHIVE"
-  if [ "$(uname -s)" = "Darwin" ]; then
-    COPYFILE_DISABLE=1 tar --no-mac-metadata --no-xattrs \
-      -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
-  else
-    tar -czf "$WINDOWS_ARCHIVE" -C "$DEST" .
+  # Git for Windows ships GNU tar, whose --zstd mode requires a separate
+  # zstd.exe that is not installed on GitHub runners. Windows' inbox bsdtar
+  # links libzstd directly, so use it explicitly and let -a select zstd from
+  # the .tar.zst suffix.
+  if [ -z "${SYSTEMROOT:-}" ] || ! command -v cygpath >/dev/null 2>&1; then
+    echo "ERROR: Windows zstd archive generation requires Git Bash and SYSTEMROOT" >&2
+    exit 1
   fi
+  windows_tar="$(cygpath -u "$SYSTEMROOT/System32/tar.exe")"
+  if [ ! -x "$windows_tar" ] || ! "$windows_tar" --version 2>&1 | grep -q 'libzstd'; then
+    echo "ERROR: Windows inbox tar does not expose libzstd: $windows_tar" >&2
+    exit 1
+  fi
+
+  echo "==> archiving Windows sidecar with zstd -> $WINDOWS_ARCHIVE"
+  "$windows_tar" -acf "$WINDOWS_ARCHIVE" \
+    --options 'zstd:compression-level=3' -C "$DEST" .
 
   node "$ROOT/scripts/sidecar-archive-manifest.mjs" \
     "$DEST" "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST"

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -94,14 +94,16 @@ async function main() {
   let sidecarRoot = stagedSidecarRoot;
   if (process.platform === "win32") {
     const archiveDir = path.join(root, "src-tauri", "resources", "server-archive");
-    const archive = path.join(archiveDir, "server.tar.gz");
+    const archive = path.join(archiveDir, "server.tar.zst");
     const manifest = JSON.parse(await readFile(path.join(archiveDir, "manifest.json"), "utf8"));
-    assert.equal(manifest.schemaVersion, 1);
+    assert.equal(manifest.schemaVersion, 3);
+    assert.equal(manifest.archiveFormat, "tar.zst");
     assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 50_000);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 256 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes <= 768 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));
-    const extraction = spawnSync("tar", ["-xzf", archive, "-C", extractedSidecarRoot], {
+    const windowsTar = path.join(process.env.SystemRoot || "C:\\Windows", "System32", "tar.exe");
+    const extraction = spawnSync(windowsTar, ["-xf", archive, "-C", extractedSidecarRoot], {
       encoding: "utf8",
     });
     if (extraction.status !== 0) {

--- a/scripts/uninstall-app.sh
+++ b/scripts/uninstall-app.sh
@@ -26,6 +26,7 @@ Default mode is a dry run.
 Removes CovenCave application artifacts:
   - installed app bundles / desktop entries
   - Tauri app support, cache, WebKit, preferences, saved state
+  - extracted Windows sidecar runtime cache
   - CovenCave sidecar logs
   - mobile Tailscale runner state
   - known launch-agent entries and plists
@@ -238,6 +239,10 @@ remove_windows_artifacts() {
 
   if [[ -n "$local_appdata" ]]; then
     remove_path "${local_appdata}/Programs/${APP_NAME}"
+    # The extracted Windows sidecar is a reproducible cache, not user data.
+    # Name it explicitly so uninstall diagnostics prove it was considered;
+    # the containing Tauri app-data directory is removed immediately after.
+    remove_path "${local_appdata}/${APP_ID}/sidecar-runtime"
     remove_path "${local_appdata}/${APP_ID}"
   else
     log "skip: LOCALAPPDATA is not set"

--- a/scripts/uninstall-app.test.mjs
+++ b/scripts/uninstall-app.test.mjs
@@ -1,12 +1,34 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 const scriptUrl = new URL("./uninstall-app.sh", import.meta.url);
+const wixCleanupUrl = new URL(
+  "../src-tauri/windows/fragments/sidecar-cache-cleanup.wxs",
+  import.meta.url,
+);
+const nativeScriptPath = fileURLToPath(scriptUrl);
+function toBashPath(value) {
+  return process.platform === "win32"
+    ? value.replace(/^([A-Za-z]):[\\/]/, (_, drive) => `/${drive.toLowerCase()}/`).replaceAll("\\", "/")
+    : value;
+}
+const bashScriptPath = process.platform === "win32"
+  ? toBashPath(nativeScriptPath)
+  : nativeScriptPath;
+const windowsGitBash = [
+  process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Git", "bin", "bash.exe"),
+  process.env["ProgramFiles(x86)"] && path.join(process.env["ProgramFiles(x86)"], "Git", "bin", "bash.exe"),
+].find((candidate) => candidate && existsSync(candidate));
+const bashExecutable = process.platform === "win32" && windowsGitBash
+  ? windowsGitBash
+  : "bash";
 const source = await readFile(scriptUrl, "utf8");
+const wixCleanup = await readFile(wixCleanupUrl, "utf8");
 
 assert.match(source, /APP_ID="ai\.opencoven\.cave"/, "uninstaller should target the Tauri app identifier");
 assert.match(source, /--execute/, "uninstaller should be dry-run by default and require --execute");
@@ -32,13 +54,27 @@ assert.match(source, /XDG_DATA_HOME/, "Linux app data should be removed");
 assert.match(source, /XDG_CONFIG_HOME/, "Linux config should be removed");
 assert.match(source, /XDG_CACHE_HOME/, "Linux cache should be removed");
 assert.match(source, /LOCALAPPDATA/, "Windows app install/data paths should be covered");
+assert.match(
+  source,
+  /LOCALAPPDATA[\s\S]*\$\{local_appdata\}\/\$\{APP_ID\}\/sidecar-runtime/,
+  "Windows uninstall diagnostics must explicitly cover the extracted sidecar cache",
+);
 assert.match(source, /skip: LOCALAPPDATA is not set/, "Windows cleanup should not form root-relative paths from missing env vars");
+assert.match(wixCleanup, /if defined LOCALAPPDATA/, "MSI cleanup must refuse a missing LOCALAPPDATA root");
+assert.match(wixCleanup, /Impersonate="yes"/, "MSI cleanup must target the interactive user's cache");
+assert.match(wixCleanup, /Execute="commit"/, "MSI cleanup must wait until uninstall commits");
+assert.match(
+  wixCleanup,
+  /\(REMOVE = "ALL"\) AND NOT UPGRADINGPRODUCTCODE/,
+  "MSI cleanup must run only for a full uninstall, not a major upgrade",
+);
 
 function run(args, env = {}) {
-  const result = spawnSync("bash", [scriptUrl.pathname, ...args], {
+  const result = spawnSync(bashExecutable, [bashScriptPath, ...args], {
     encoding: "utf8",
     env: {
       ...process.env,
+      COVEN_HOME: "",
       ...env,
     },
   });
@@ -82,8 +118,8 @@ function run(args, env = {}) {
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, new RegExp(`${stateRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/coven-cave`));
-  assert.match(result.stdout, new RegExp(`${covenHome.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(result.stdout, /\.state[\\/]coven-cave/);
+  assert.match(result.stdout, /\.coven/);
   assert.doesNotMatch(result.stdout, /preserve: .*\.coven/);
 }
 
@@ -106,6 +142,60 @@ function run(args, env = {}) {
 }
 
 {
+  const home = mkdtempSync(path.join(tmpdir(), "coven-cave-uninstall-home-"));
+  const localAppData = path.join(home, "LocalAppData");
+  const sidecarCache = path.join(localAppData, "ai.opencoven.cave", "sidecar-runtime");
+  const unrelatedUserData = path.join(localAppData, "coven-user-data");
+  mkdirSync(sidecarCache, { recursive: true });
+  mkdirSync(unrelatedUserData, { recursive: true });
+  writeFileSync(path.join(sidecarCache, ".complete.json"), "{}");
+  writeFileSync(path.join(unrelatedUserData, "keep.txt"), "keep");
+
+  const result = run(["--execute"], {
+    HOME: home,
+    OSTYPE: "msys",
+    LOCALAPPDATA: localAppData,
+    APPDATA: "",
+    PROGRAMDATA: "",
+    USERPROFILE: "",
+    TMPDIR: path.join(home, "tmp"),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /ai\.opencoven\.cave\/sidecar-runtime/);
+  await assert.rejects(access(sidecarCache), "sidecar cache should be removed on execute");
+  await access(path.join(unrelatedUserData, "keep.txt"));
+}
+
+if (process.platform === "win32") {
+  const localAppData = mkdtempSync(path.join(tmpdir(), "coven-cave-msi-cleanup-"));
+  const sidecarCache = path.join(localAppData, "ai.opencoven.cave", "sidecar-runtime");
+  const unrelatedUserData = path.join(localAppData, "unrelated-user-data");
+  mkdirSync(sidecarCache, { recursive: true });
+  mkdirSync(unrelatedUserData, { recursive: true });
+  writeFileSync(path.join(sidecarCache, ".complete.json"), "{}");
+  writeFileSync(path.join(unrelatedUserData, "keep.txt"), "keep");
+
+  const result = spawnSync(
+    "cmd.exe",
+    [
+      "/D",
+      "/C",
+      "if defined LOCALAPPDATA if exist \"%LOCALAPPDATA%\\ai.opencoven.cave\\sidecar-runtime\" rmdir /S /Q \"%LOCALAPPDATA%\\ai.opencoven.cave\\sidecar-runtime\"",
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, LOCALAPPDATA: localAppData },
+      windowsVerbatimArguments: true,
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  await assert.rejects(access(sidecarCache), "MSI command should remove only the sidecar cache");
+  await access(path.join(unrelatedUserData, "keep.txt"));
+}
+
+if (process.platform !== "win32") {
   const home = mkdtempSync(path.join(tmpdir(), "coven-cave-uninstall-home-"));
   const bin = path.join(home, "bin");
   const copiedDiagnostics = path.join(home, "copied-diagnostics.txt");

--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -104,7 +104,7 @@ try {
         )
         $script:installedFileBytes += [long]$size
         $longName = ($name -split '\|')[-1]
-        if ($longName -eq "server.tar.gz") {
+        if ($longName -eq "server.tar.zst") {
             $script:serverArchiveRows += 1
         }
     }
@@ -142,7 +142,7 @@ try {
         }
     }
     if ($serverArchiveRows -ne 1) {
-        $violations += "expected exactly one server.tar.gz File row; found $serverArchiveRows"
+        $violations += "expected exactly one server.tar.zst File row; found $serverArchiveRows"
     }
     if ($violations.Count -gt 0) {
         throw "Windows MSI budget failed: $($violations -join '; ')"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -79,7 +79,6 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.0.173"
 dependencies = [
- "flate2",
  "log",
  "objc2",
  "once_cell",
@@ -98,6 +97,8 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "window-vibrancy",
+ "windows-sys 0.61.2",
+ "zstd",
 ]
 
 [[package]]
@@ -555,6 +556,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2071,6 +2074,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
 ]
 
 [[package]]
@@ -6080,6 +6093,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,9 +58,10 @@ tauri-plugin-process = "2"
 # Windows packages the large Next.js sidecar as one archive instead of one
 # WiX component per file. The launcher verifies and extracts it on first use.
 [target.'cfg(target_os = "windows")'.dependencies]
-flate2 = "1"
 sha2 = "0.10"
 tar = "0.4"
+zstd = "0.13"
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 # OS-level glass for the quick-chat tray window: NSVisualEffectView vibrancy
 # behind the transparent webview on macOS (the only platform we apply it on;

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -126,7 +126,71 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
   }
   assert.match(budget, /\$rowBudget = 64/);
   assert.match(budget, /\$byteBudget = 256MB/);
-  assert.match(budget, /expected exactly one server\.tar\.gz File row/);
+  assert.match(budget, /expected exactly one server\.tar\.zst File row/);
+});
+
+test("Windows runtime uses measured zstd extraction diagnostics and uninstall cleanup", async () => {
+  const [archiveRuntime, bundleScript, manifestWriter, smoke, uninstaller, windowsConfig, wixCleanup, compressionGuide] = await Promise.all([
+    readFile(new URL("./src/sidecar_archive.rs", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/sidecar-bundle.sh", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/sidecar-archive-manifest.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/sidecar-runtime-smoke.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/uninstall-app.sh", import.meta.url), "utf8"),
+    readFile(new URL("./tauri.windows.conf.json", import.meta.url), "utf8"),
+    readFile(new URL("./windows/fragments/sidecar-cache-cleanup.wxs", import.meta.url), "utf8"),
+    readFile(new URL("../docs/windows-sidecar-compression.md", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(bundleScript, /server\.tar\.zst/);
+  assert.match(bundleScript, /System32\/tar\.exe[\s\S]*libzstd/);
+  assert.doesNotMatch(bundleScript, /server\.tar\.gz/);
+  assert.match(archiveRuntime, /ZstdDecoder::new/);
+  assert.match(archiveRuntime, /const ARCHIVE_FORMAT: &str = "tar\.zst"/);
+  assert.match(archiveRuntime, /const MANIFEST_SCHEMA_VERSION: u32 = 3/);
+  assert.match(manifestWriter, /schemaVersion: 3/);
+  for (const field of [
+    "cache_outcome",
+    "compressed_bytes",
+    "expanded_bytes",
+    "file_count",
+    "directory_count",
+    "defender_relevant_file_entries",
+    "windows_defender_process_detected",
+    "staging_disk_bytes_estimate",
+    "existing_cache_logical_bytes_before",
+    "peak_cache_logical_bytes_estimate",
+    "archive_decompression_ms",
+    "file_creation_ms",
+    "archive_extract_ms",
+    "tree_verify_ms",
+    "total_ms",
+  ]) {
+    assert.match(archiveRuntime, new RegExp(field), `runtime diagnostics must include ${field}`);
+  }
+  assert.match(archiveRuntime, /sidecar-runtime-latest\.json/);
+  assert.match(archiveRuntime, /"cacheOutcome": "error"/);
+  assert.match(archiveRuntime, /"failedPhase": context\.failed_phase/);
+  assert.match(smoke, /server\.tar\.zst/);
+  assert.match(smoke, /System32", "tar\.exe"/);
+  assert.match(uninstaller, /\$\{local_appdata\}\/\$\{APP_ID\}\/sidecar-runtime/);
+  assert.match(windowsConfig, /sidecar-cache-cleanup\.wxs/);
+  assert.match(windowsConfig, /SidecarRuntimeCleanupAnchor/);
+  assert.match(wixCleanup, /Execute="commit"/);
+  assert.match(wixCleanup, /Impersonate="yes"/);
+  assert.match(wixCleanup, /if defined LOCALAPPDATA/);
+  assert.match(wixCleanup, /%LOCALAPPDATA%\\ai\.opencoven\.cave\\sidecar-runtime/);
+  assert.match(wixCleanup, /\(REMOVE = "ALL"\) AND NOT UPGRADINGPRODUCTCODE/);
+  for (const invariant of [
+    "canonical payload",
+    "full-tree digests",
+    "payload-derived cache key",
+    "fs2",
+    "free-space preflight",
+    "full-file warm validation",
+    "atomic recovery",
+  ]) {
+    assert.match(compressionGuide, new RegExp(invariant), `schema 3 integration contract must preserve ${invariant}`);
+  }
 });
 
 test("packaged app does not override Coven workspace with OpenClaw workspace", async () => {

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -1,13 +1,22 @@
-use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File};
-use std::io::Read;
+use std::io::{self, Read};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
+use zstd::stream::read::Decoder as ZstdDecoder;
 
-const MANIFEST_SCHEMA_VERSION: u32 = 1;
+const MANIFEST_SCHEMA_VERSION: u32 = 3;
+const COMPLETION_MARKER_SCHEMA_VERSION: u32 = 1;
+const DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+const ARCHIVE_FORMAT: &str = "tar.zst";
+const ARCHIVE_FILE_NAME: &str = "server.tar.zst";
+const DIAGNOSTICS_FILE_NAME: &str = "sidecar-runtime-latest.json";
 const MAX_ARCHIVE_BYTES: u64 = 256 * 1024 * 1024;
 const MAX_UNPACKED_BYTES: u64 = 768 * 1024 * 1024;
 const MAX_FILE_COUNT: u64 = 50_000;
@@ -26,6 +35,7 @@ const REQUIRED_RUNTIME_PATHS: [&str; 7] = [
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct SidecarArchiveManifest {
     schema_version: u32,
+    archive_format: String,
     archive_sha256: String,
     archive_bytes: u64,
     unpacked_bytes: u64,
@@ -39,6 +49,111 @@ struct CompletionMarker {
     schema_version: u32,
     package_version: String,
     archive_sha256: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimePhaseDiagnostics {
+    manifest_read_ms: f64,
+    cache_lookup_ms: f64,
+    archive_metadata_ms: f64,
+    archive_hash_ms: f64,
+    recovery_cleanup_ms: f64,
+    staging_create_ms: f64,
+    archive_decompression_ms: f64,
+    file_creation_ms: f64,
+    archive_extract_ms: f64,
+    tree_verify_ms: f64,
+    marker_write_ms: f64,
+    activation_ms: f64,
+    total_ms: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SidecarRuntimeDiagnostics {
+    schema_version: u32,
+    archive_format: &'static str,
+    package_version: String,
+    cache_outcome: &'static str,
+    cache_path: String,
+    archive_path: String,
+    archive_hash_verified: bool,
+    compressed_bytes: u64,
+    expanded_bytes: u64,
+    file_count: u64,
+    directory_count: u64,
+    defender_relevant_file_entries: u64,
+    windows_defender_process_detected: Option<bool>,
+    defender_probe_ms: f64,
+    existing_complete_generations_before: u64,
+    existing_cache_logical_bytes_before: u64,
+    staging_disk_bytes_estimate: u64,
+    peak_cache_logical_bytes_estimate: u64,
+    phases: RuntimePhaseDiagnostics,
+}
+
+#[derive(Debug)]
+struct PreparedSidecarRuntime {
+    path: PathBuf,
+    diagnostics: SidecarRuntimeDiagnostics,
+}
+
+struct ExtractionDiagnostics {
+    archive_decompression_ms: f64,
+    file_creation_ms: f64,
+    archive_extract_ms: f64,
+    tree_verify_ms: f64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct FailureContext {
+    failed_phase: &'static str,
+    phases: RuntimePhaseDiagnostics,
+    cache_path: String,
+    existing_complete_generations_before: u64,
+    existing_cache_logical_bytes_before: u64,
+}
+
+fn record_phase_context(
+    context: &Mutex<FailureContext>,
+    failed_phase: &'static str,
+    phases: &RuntimePhaseDiagnostics,
+) {
+    if let Ok(mut context) = context.lock() {
+        context.failed_phase = failed_phase;
+        context.phases = phases.clone();
+    }
+}
+
+struct TimedRead<R> {
+    inner: R,
+    read_elapsed: Duration,
+}
+
+impl<R: Read> Read for TimedRead<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let started = Instant::now();
+        let result = self.inner.read(buffer);
+        self.read_elapsed = self.read_elapsed.saturating_add(started.elapsed());
+        result
+    }
+}
+
+struct RuntimeDiagnosticsInput<'a> {
+    package_version: &'a str,
+    archive_path: &'a Path,
+    cache_path: &'a Path,
+    cache_outcome: &'static str,
+    archive_hash_verified: bool,
+    existing_complete_generations_before: u64,
+    existing_cache_logical_bytes_before: u64,
+    staging_disk_bytes_estimate: u64,
+    phases: RuntimePhaseDiagnostics,
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1_000.0
 }
 
 fn read_manifest(path: &Path) -> Result<SidecarArchiveManifest, String> {
@@ -55,6 +170,12 @@ fn read_manifest(path: &Path) -> Result<SidecarArchiveManifest, String> {
         return Err(format!(
             "unsupported sidecar manifest schema {}",
             manifest.schema_version
+        ));
+    }
+    if manifest.archive_format != ARCHIVE_FORMAT {
+        return Err(format!(
+            "unsupported sidecar archive format {}",
+            manifest.archive_format
         ));
     }
     if manifest.archive_sha256.len() != 64
@@ -144,11 +265,127 @@ fn cache_is_ready(destination: &Path, package_version: &str, archive_sha256: &st
     };
     match serde_json::from_str::<CompletionMarker>(&marker) {
         Ok(marker) => {
-            marker.schema_version == MANIFEST_SCHEMA_VERSION
+            marker.schema_version == COMPLETION_MARKER_SCHEMA_VERSION
                 && marker.package_version == package_version
                 && marker.archive_sha256 == archive_sha256
         }
         Err(_) => false,
+    }
+}
+
+fn complete_cache_generation_count(cache_root: &Path) -> u64 {
+    let Ok(entries) = fs::read_dir(cache_root) else {
+        return 0;
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir() && has_complete_marker(&entry.path()))
+        .count() as u64
+}
+
+fn cache_logical_bytes(cache_root: &Path) -> u64 {
+    let mut total = 0_u64;
+    let mut pending = vec![cache_root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let Ok(metadata) = fs::symlink_metadata(entry.path()) else {
+                continue;
+            };
+            if metadata.is_dir() && !metadata.file_type().is_symlink() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    total
+}
+
+fn defender_process_context() -> (Option<bool>, f64) {
+    let started = Instant::now();
+    let mut command = Command::new(super::windows_system32_binary("tasklist.exe"));
+    command
+        .args(["/FI", "IMAGENAME eq MsMpEng.exe", "/NH"])
+        .creation_flags(0x08000000);
+    let detected = match command.output() {
+        Ok(output) if output.status.success() => Some(
+            String::from_utf8_lossy(&output.stdout)
+                .to_ascii_lowercase()
+                .contains("msmpeng.exe"),
+        ),
+        Ok(_) | Err(_) => None,
+    };
+    (detected, elapsed_ms(started))
+}
+
+fn write_diagnostics(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("diagnostics path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "could not create sidecar diagnostics directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|error| format!("could not serialize sidecar diagnostics: {error}"))?;
+    let temporary = parent.join(format!(
+        ".{DIAGNOSTICS_FILE_NAME}.{}-{}.tmp",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::write(&temporary, format!("{json}\n")).map_err(|error| {
+        format!(
+            "could not write sidecar diagnostics staging file {}: {error}",
+            temporary.display()
+        )
+    })?;
+    atomic_replace_file(&temporary, path).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        format!(
+            "could not activate sidecar diagnostics {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn atomic_replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    if !destination.exists() {
+        return fs::rename(temporary, destination);
+    }
+    let destination_wide: Vec<u16> = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let temporary_wide: Vec<u16> = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: both path buffers are NUL-terminated and remain alive for the
+    // call; backup, exclude, and reserved pointers are intentionally null.
+    let replaced = unsafe {
+        windows_sys::Win32::Storage::FileSystem::ReplaceFileW(
+            destination_wide.as_ptr(),
+            temporary_wide.as_ptr(),
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 
@@ -204,15 +441,21 @@ fn extract_archive(
     archive_path: &Path,
     staging: &Path,
     manifest: &SidecarArchiveManifest,
-) -> Result<(), String> {
+) -> Result<ExtractionDiagnostics, String> {
+    let extraction_started = Instant::now();
     let archive_file = File::open(archive_path).map_err(|error| {
         format!(
             "could not open sidecar archive {}: {error}",
             archive_path.display()
         )
     })?;
-    let decoder = GzDecoder::new(archive_file);
-    let mut archive = tar::Archive::new(decoder);
+    let decoder = ZstdDecoder::new(archive_file)
+        .map_err(|error| format!("could not initialize sidecar zstd decoder: {error}"))?;
+    let timed_decoder = TimedRead {
+        inner: decoder,
+        read_elapsed: Duration::ZERO,
+    };
+    let mut archive = tar::Archive::new(timed_decoder);
     let entries = archive
         .entries()
         .map_err(|error| format!("could not read sidecar archive: {error}"))?;
@@ -313,6 +556,14 @@ fn extract_archive(
             manifest.file_count, manifest.directory_count
         ));
     }
+    let archive_extract_ms = elapsed_ms(extraction_started);
+    let archive_decompression_ms = archive.into_inner().read_elapsed.as_secs_f64() * 1_000.0;
+    // Extraction streams decompressed tar bytes directly into filesystem
+    // writes. The residual captures tar parsing, path creation, and file I/O;
+    // keeping both values exposes whether CPU decompression or filesystem/
+    // real-time scanning dominates a release-machine cold launch.
+    let file_creation_ms = (archive_extract_ms - archive_decompression_ms).max(0.0);
+    let verification_started = Instant::now();
     let (file_count, directory_count, unpacked_bytes) = tree_metrics(staging)?;
     if file_count != manifest.file_count
         || directory_count != manifest.directory_count
@@ -324,27 +575,119 @@ fn extract_archive(
         return Err("sidecar archive is missing required runtime files".to_string());
     }
 
-    Ok(())
+    Ok(ExtractionDiagnostics {
+        archive_decompression_ms,
+        file_creation_ms,
+        archive_extract_ms,
+        tree_verify_ms: elapsed_ms(verification_started),
+    })
 }
 
+fn runtime_diagnostics(
+    manifest: &SidecarArchiveManifest,
+    input: RuntimeDiagnosticsInput<'_>,
+) -> SidecarRuntimeDiagnostics {
+    SidecarRuntimeDiagnostics {
+        schema_version: DIAGNOSTICS_SCHEMA_VERSION,
+        archive_format: ARCHIVE_FORMAT,
+        package_version: input.package_version.to_string(),
+        cache_outcome: input.cache_outcome,
+        cache_path: input.cache_path.to_string_lossy().into_owned(),
+        archive_path: input.archive_path.to_string_lossy().into_owned(),
+        archive_hash_verified: input.archive_hash_verified,
+        compressed_bytes: manifest.archive_bytes,
+        expanded_bytes: manifest.unpacked_bytes,
+        file_count: manifest.file_count,
+        directory_count: manifest.directory_count,
+        defender_relevant_file_entries: manifest
+            .file_count
+            .saturating_add(manifest.directory_count),
+        windows_defender_process_detected: None,
+        defender_probe_ms: 0.0,
+        existing_complete_generations_before: input.existing_complete_generations_before,
+        existing_cache_logical_bytes_before: input.existing_cache_logical_bytes_before,
+        staging_disk_bytes_estimate: input.staging_disk_bytes_estimate,
+        peak_cache_logical_bytes_estimate: input
+            .existing_cache_logical_bytes_before
+            .saturating_add(input.staging_disk_bytes_estimate),
+        phases: input.phases,
+    }
+}
+
+#[cfg(test)]
 fn prepare_runtime_from_files(
     archive_path: &Path,
     manifest_path: &Path,
     cache_root: &Path,
     package_version: &str,
-) -> Result<PathBuf, String> {
+) -> Result<PreparedSidecarRuntime, String> {
+    let failure_context = Mutex::new(FailureContext::default());
+    prepare_runtime_from_files_with_context(
+        archive_path,
+        manifest_path,
+        cache_root,
+        package_version,
+        &failure_context,
+    )
+}
+
+fn prepare_runtime_from_files_with_context(
+    archive_path: &Path,
+    manifest_path: &Path,
+    cache_root: &Path,
+    package_version: &str,
+    failure_context: &Mutex<FailureContext>,
+) -> Result<PreparedSidecarRuntime, String> {
+    let total_started = Instant::now();
+    let mut phases = RuntimePhaseDiagnostics::default();
+
+    record_phase_context(failure_context, "manifest-read", &phases);
+    let phase_started = Instant::now();
     let manifest = read_manifest(manifest_path)?;
+    phases.manifest_read_ms = elapsed_ms(phase_started);
     let destination = cache_root.join(cache_key(package_version, &manifest.archive_sha256));
-    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
-        return Ok(destination);
+    let existing_complete_generations = complete_cache_generation_count(cache_root);
+    let existing_cache_bytes = cache_logical_bytes(cache_root);
+    if let Ok(mut context) = failure_context.lock() {
+        context.cache_path = destination.to_string_lossy().into_owned();
+        context.existing_complete_generations_before = existing_complete_generations;
+        context.existing_cache_logical_bytes_before = existing_cache_bytes;
     }
 
+    record_phase_context(failure_context, "cache-lookup", &phases);
+    let phase_started = Instant::now();
+    if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
+        phases.cache_lookup_ms = elapsed_ms(phase_started);
+        phases.total_ms = elapsed_ms(total_started);
+        return Ok(PreparedSidecarRuntime {
+            diagnostics: runtime_diagnostics(
+                &manifest,
+                RuntimeDiagnosticsInput {
+                    package_version,
+                    archive_path,
+                    cache_path: &destination,
+                    cache_outcome: "hit",
+                    archive_hash_verified: false,
+                    existing_complete_generations_before: existing_complete_generations,
+                    existing_cache_logical_bytes_before: existing_cache_bytes,
+                    staging_disk_bytes_estimate: 0,
+                    phases,
+                },
+            ),
+            path: destination,
+        });
+    }
+    phases.cache_lookup_ms = elapsed_ms(phase_started);
+
+    record_phase_context(failure_context, "archive-metadata", &phases);
+    let phase_started = Instant::now();
     let metadata = fs::metadata(archive_path).map_err(|error| {
         format!(
             "could not inspect sidecar archive {}: {error}",
             archive_path.display()
         )
     })?;
+    phases.archive_metadata_ms = elapsed_ms(phase_started);
     if metadata.len() != manifest.archive_bytes {
         return Err(format!(
             "sidecar archive size does not match manifest ({}/{})",
@@ -352,7 +695,11 @@ fn prepare_runtime_from_files(
             manifest.archive_bytes
         ));
     }
+
+    record_phase_context(failure_context, "archive-hash", &phases);
+    let phase_started = Instant::now();
     let actual_sha256 = sha256_file(archive_path)?;
+    phases.archive_hash_ms = elapsed_ms(phase_started);
     if actual_sha256 != manifest.archive_sha256 {
         return Err("sidecar archive SHA-256 does not match its manifest".to_string());
     }
@@ -363,16 +710,43 @@ fn prepare_runtime_from_files(
             cache_root.display()
         )
     })?;
+
+    let phase_started = Instant::now();
     if cache_is_ready(&destination, package_version, &manifest.archive_sha256) {
-        return Ok(destination);
+        phases.cache_lookup_ms += elapsed_ms(phase_started);
+        phases.total_ms = elapsed_ms(total_started);
+        return Ok(PreparedSidecarRuntime {
+            diagnostics: runtime_diagnostics(
+                &manifest,
+                RuntimeDiagnosticsInput {
+                    package_version,
+                    archive_path,
+                    cache_path: &destination,
+                    cache_outcome: "hit-after-validation-race",
+                    archive_hash_verified: true,
+                    existing_complete_generations_before: existing_complete_generations,
+                    existing_cache_logical_bytes_before: existing_cache_bytes,
+                    staging_disk_bytes_estimate: 0,
+                    phases,
+                },
+            ),
+            path: destination,
+        });
     }
+    phases.cache_lookup_ms += elapsed_ms(phase_started);
+
+    let mut cache_outcome = "miss";
     if destination.exists() {
+        record_phase_context(failure_context, "recovery-cleanup", &phases);
+        let phase_started = Instant::now();
         fs::remove_dir_all(&destination).map_err(|error| {
             format!(
                 "could not replace incomplete sidecar cache {}: {error}",
                 destination.display()
             )
         })?;
+        phases.recovery_cleanup_ms = elapsed_ms(phase_started);
+        cache_outcome = "recovered-incomplete";
     }
 
     let nonce = SystemTime::now()
@@ -384,17 +758,27 @@ fn prepare_runtime_from_files(
         std::process::id(),
         cache_key(package_version, &manifest.archive_sha256)
     ));
+    record_phase_context(failure_context, "staging-create", &phases);
+    let phase_started = Instant::now();
     fs::create_dir(&staging).map_err(|error| {
         format!(
             "could not create sidecar staging directory {}: {error}",
             staging.display()
         )
     })?;
+    phases.staging_create_ms = elapsed_ms(phase_started);
 
+    record_phase_context(failure_context, "archive-extract", &phases);
     let extraction = (|| -> Result<(), String> {
-        extract_archive(archive_path, &staging, &manifest)?;
+        let extraction = extract_archive(archive_path, &staging, &manifest)?;
+        phases.archive_decompression_ms = extraction.archive_decompression_ms;
+        phases.file_creation_ms = extraction.file_creation_ms;
+        phases.archive_extract_ms = extraction.archive_extract_ms;
+        phases.tree_verify_ms = extraction.tree_verify_ms;
+        record_phase_context(failure_context, "marker-write", &phases);
+        let marker_started = Instant::now();
         let marker = CompletionMarker {
-            schema_version: MANIFEST_SCHEMA_VERSION,
+            schema_version: COMPLETION_MARKER_SCHEMA_VERSION,
             package_version: package_version.to_string(),
             archive_sha256: manifest.archive_sha256.clone(),
         };
@@ -402,6 +786,7 @@ fn prepare_runtime_from_files(
             .map_err(|error| format!("could not serialize sidecar completion marker: {error}"))?;
         fs::write(staging.join(".complete.json"), format!("{marker_json}\n"))
             .map_err(|error| format!("could not write sidecar completion marker: {error}"))?;
+        phases.marker_write_ms = elapsed_ms(marker_started);
         Ok(())
     })();
     if let Err(error) = extraction {
@@ -409,20 +794,42 @@ fn prepare_runtime_from_files(
         return Err(error);
     }
 
-    match fs::rename(&staging, &destination) {
-        Ok(()) => Ok(destination),
+    record_phase_context(failure_context, "activation", &phases);
+    let phase_started = Instant::now();
+    let activated_path = match fs::rename(&staging, &destination) {
+        Ok(()) => destination.clone(),
         Err(_error) if cache_is_ready(&destination, package_version, &manifest.archive_sha256) => {
             let _ = fs::remove_dir_all(&staging);
-            Ok(destination)
+            cache_outcome = "hit-after-activation-race";
+            destination.clone()
         }
         Err(error) => {
             let _ = fs::remove_dir_all(&staging);
-            Err(format!(
+            return Err(format!(
                 "could not activate extracted sidecar cache {}: {error}",
                 destination.display()
-            ))
+            ));
         }
-    }
+    };
+    phases.activation_ms = elapsed_ms(phase_started);
+    phases.total_ms = elapsed_ms(total_started);
+    Ok(PreparedSidecarRuntime {
+        diagnostics: runtime_diagnostics(
+            &manifest,
+            RuntimeDiagnosticsInput {
+                package_version,
+                archive_path,
+                cache_path: &activated_path,
+                cache_outcome,
+                archive_hash_verified: true,
+                existing_complete_generations_before: existing_complete_generations,
+                existing_cache_logical_bytes_before: existing_cache_bytes,
+                staging_disk_bytes_estimate: manifest.unpacked_bytes,
+                phases,
+            },
+        ),
+        path: activated_path,
+    })
 }
 
 fn has_complete_marker(runtime: &Path) -> bool {
@@ -434,7 +841,7 @@ fn has_complete_marker(runtime: &Path) -> bool {
     };
     match serde_json::from_str::<CompletionMarker>(&contents) {
         Ok(marker) => {
-            marker.schema_version == MANIFEST_SCHEMA_VERSION
+            marker.schema_version == COMPLETION_MARKER_SCHEMA_VERSION
                 && marker.archive_sha256.len() == 64
                 && marker
                     .archive_sha256
@@ -506,32 +913,99 @@ pub(crate) fn prepare_sidecar_runtime(
     resource_dir: &Path,
 ) -> Result<PathBuf, String> {
     let archive_dir = resource_dir.join("resources").join("server-archive");
-    let archive_path = archive_dir.join("server.tar.gz");
+    let archive_path = archive_dir.join(ARCHIVE_FILE_NAME);
     let manifest_path = archive_dir.join("manifest.json");
     let cache_root = app
         .path()
         .app_local_data_dir()
         .map_err(|error| format!("could not resolve sidecar cache directory: {error}"))?
         .join("sidecar-runtime");
+    let diagnostics_path = app
+        .path()
+        .app_log_dir()
+        .ok()
+        .map(|directory| directory.join(DIAGNOSTICS_FILE_NAME));
     let started = Instant::now();
-    let runtime = prepare_runtime_from_files(
+    let failure_context = Mutex::new(FailureContext::default());
+    let prepared = match prepare_runtime_from_files_with_context(
         &archive_path,
         &manifest_path,
         &cache_root,
         &app.package_info().version.to_string(),
-    )?;
+        &failure_context,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            if let Some(path) = diagnostics_path.as_deref() {
+                let mut context = failure_context
+                    .lock()
+                    .map(|context| context.clone())
+                    .unwrap_or_default();
+                context.phases.total_ms = elapsed_ms(started);
+                let defender_relevant = matches!(
+                    context.failed_phase,
+                    "archive-hash"
+                        | "staging-create"
+                        | "archive-extract"
+                        | "marker-write"
+                        | "activation"
+                );
+                let (defender_detected, defender_probe_ms) = if defender_relevant {
+                    defender_process_context()
+                } else {
+                    (None, 0.0)
+                };
+                let failure = serde_json::json!({
+                    "schemaVersion": DIAGNOSTICS_SCHEMA_VERSION,
+                    "archiveFormat": ARCHIVE_FORMAT,
+                    "cacheOutcome": "error",
+                    "cachePath": context.cache_path,
+                    "archivePath": archive_path.to_string_lossy(),
+                    "failedPhase": context.failed_phase,
+                    "existingCompleteGenerationsBefore": context.existing_complete_generations_before,
+                    "existingCacheLogicalBytesBefore": context.existing_cache_logical_bytes_before,
+                    "windowsDefenderProcessDetected": defender_detected,
+                    "defenderProbeMs": defender_probe_ms,
+                    "phases": context.phases,
+                    "totalMs": elapsed_ms(started),
+                    "error": &error,
+                });
+                if let Err(diagnostic_error) = write_diagnostics(path, &failure) {
+                    log::warn!(
+                        "[cave] could not persist sidecar failure diagnostics: {diagnostic_error}"
+                    );
+                }
+            }
+            return Err(error);
+        }
+    };
+    let mut diagnostics = prepared.diagnostics;
+    if diagnostics.cache_outcome != "hit" {
+        let (defender_detected, defender_probe_ms) = defender_process_context();
+        diagnostics.windows_defender_process_detected = defender_detected;
+        diagnostics.defender_probe_ms = defender_probe_ms;
+    }
+    if let Some(path) = diagnostics_path.as_deref() {
+        if let Err(error) = write_diagnostics(path, &diagnostics) {
+            log::warn!("[cave] could not persist sidecar runtime diagnostics: {error}");
+        }
+    }
+    if let Ok(json) = serde_json::to_string(&diagnostics) {
+        log::info!("[cave] sidecar_runtime_diagnostics={json}");
+    }
     log::info!(
         "[cave] Windows sidecar runtime ready at {} in {:.2?}",
-        runtime.display(),
+        prepared.path.display(),
         started.elapsed()
     );
-    Ok(runtime)
+    Ok(prepared.path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flate2::{write::GzEncoder, Compression};
+    use std::thread;
+    use zstd::stream::write::Encoder as ZstdEncoder;
 
     fn test_root(name: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
@@ -569,19 +1043,20 @@ mod tests {
             fs::write(destination, contents).expect("write fixture file");
         }
 
-        let archive_path = root.join("server.tar.gz");
+        let archive_path = root.join(ARCHIVE_FILE_NAME);
         let archive_file = File::create(&archive_path).expect("create archive");
-        let encoder = GzEncoder::new(archive_file, Compression::default());
+        let encoder = ZstdEncoder::new(archive_file, 3).expect("create zstd encoder");
         let mut archive = tar::Builder::new(encoder);
         archive
             .append_dir_all(".", &source)
             .expect("append fixture tree");
         let encoder = archive.into_inner().expect("finish tar");
-        encoder.finish().expect("finish gzip");
+        encoder.finish().expect("finish zstd");
         let (file_count, directory_count, unpacked_bytes) =
             tree_metrics(&source).expect("fixture metrics");
         let manifest = SidecarArchiveManifest {
             schema_version: MANIFEST_SCHEMA_VERSION,
+            archive_format: ARCHIVE_FORMAT.to_string(),
             archive_sha256: sha256_file(&archive_path).expect("fixture digest"),
             archive_bytes: fs::metadata(&archive_path).expect("archive metadata").len(),
             unpacked_bytes,
@@ -593,6 +1068,7 @@ mod tests {
             &manifest_path,
             serde_json::to_vec(&serde_json::json!({
                 "schemaVersion": manifest.schema_version,
+                "archiveFormat": manifest.archive_format.clone(),
                 "archiveSha256": manifest.archive_sha256.clone(),
                 "archiveBytes": manifest.archive_bytes,
                 "unpackedBytes": manifest.unpacked_bytes,
@@ -610,16 +1086,56 @@ mod tests {
         let root = test_root("extract");
         let (archive, manifest, _) = write_fixture(&root);
         let cache = root.join("cache");
-        let runtime = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
+        let cold = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
             .expect("extract runtime");
-        assert!(runtime.join("server.mjs").is_file());
-        assert!(runtime.join(".complete.json").is_file());
+        assert!(cold.path.join("server.mjs").is_file());
+        assert!(cold.path.join(".complete.json").is_file());
+        assert_eq!(cold.diagnostics.archive_format, ARCHIVE_FORMAT);
+        assert_eq!(cold.diagnostics.cache_outcome, "miss");
+        assert!(cold.diagnostics.archive_hash_verified);
+        assert!(cold.diagnostics.compressed_bytes > 0);
+        assert!(cold.diagnostics.expanded_bytes > 0);
+        assert_eq!(
+            cold.diagnostics.defender_relevant_file_entries,
+            cold.diagnostics
+                .file_count
+                .saturating_add(cold.diagnostics.directory_count)
+        );
+        assert_eq!(
+            cold.diagnostics.staging_disk_bytes_estimate,
+            cold.diagnostics.expanded_bytes
+        );
+        assert!(cold.diagnostics.phases.archive_decompression_ms > 0.0);
+        assert!(cold.diagnostics.phases.file_creation_ms >= 0.0);
+        assert!(
+            (cold.diagnostics.phases.archive_decompression_ms
+                + cold.diagnostics.phases.file_creation_ms
+                - cold.diagnostics.phases.archive_extract_ms)
+                .abs()
+                < 0.01
+        );
+        assert!(
+            cold.diagnostics.peak_cache_logical_bytes_estimate
+                >= cold.diagnostics.staging_disk_bytes_estimate
+        );
+        let diagnostics_path = root.join(DIAGNOSTICS_FILE_NAME);
+        write_diagnostics(&diagnostics_path, &cold.diagnostics).expect("persist cold diagnostics");
+        let persisted: serde_json::Value = serde_json::from_slice(
+            &fs::read(&diagnostics_path).expect("read persisted diagnostics"),
+        )
+        .expect("parse persisted diagnostics");
+        assert_eq!(persisted["cacheOutcome"], "miss");
+        assert_eq!(persisted["archiveFormat"], "tar.zst");
+        let runtime_path = cold.path.clone();
 
         fs::remove_file(&archive).expect("remove archive after first extraction");
-        assert_eq!(
-            prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3").expect("reuse cache"),
-            runtime
-        );
+        let warm =
+            prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3").expect("reuse cache");
+        assert_eq!(warm.path, runtime_path);
+        assert_eq!(warm.diagnostics.cache_outcome, "hit");
+        assert!(!warm.diagnostics.archive_hash_verified);
+        assert_eq!(warm.diagnostics.staging_disk_bytes_estimate, 0);
+        assert_eq!(warm.diagnostics.phases.archive_extract_ms, 0.0);
         fs::remove_dir_all(root).expect("remove test root");
     }
 
@@ -635,8 +1151,10 @@ mod tests {
 
         let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache, "1.2.3")
             .expect("replace incomplete cache");
-        assert!(!runtime.join("partial").exists());
-        assert!(runtime.join("server.mjs").is_file());
+        assert!(!runtime.path.join("partial").exists());
+        assert!(runtime.path.join("server.mjs").is_file());
+        assert_eq!(runtime.diagnostics.cache_outcome, "recovered-incomplete");
+        assert!(runtime.diagnostics.phases.recovery_cleanup_ms >= 0.0);
         fs::remove_dir_all(root).expect("remove test root");
     }
 
@@ -644,7 +1162,7 @@ mod tests {
     fn rejects_a_corrupt_archive_without_activating_it() {
         let root = test_root("corrupt");
         let (archive, manifest, _) = write_fixture(&root);
-        fs::write(&archive, b"not a gzip archive").expect("corrupt archive");
+        fs::write(&archive, b"not a zstd archive").expect("corrupt archive");
         let cache = root.join("cache");
         let error = prepare_runtime_from_files(&archive, &manifest, &cache, "1.2.3")
             .expect_err("corrupt archive must fail");
@@ -673,11 +1191,128 @@ mod tests {
     }
 
     #[test]
+    fn manifest_rejects_an_unexpected_compression_format() {
+        let root = test_root("format");
+        let (_, manifest_path, _) = write_fixture(&root);
+        let mut value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+                .expect("parse manifest");
+        value["archiveFormat"] = serde_json::json!("tar.gz");
+        fs::write(
+            &manifest_path,
+            serde_json::to_vec(&value).expect("serialize wrong-format manifest"),
+        )
+        .expect("write wrong-format manifest");
+        assert!(read_manifest(&manifest_path)
+            .expect_err("unexpected archive format must fail")
+            .contains("archive format"));
+        fs::remove_dir_all(root).expect("remove format root");
+    }
+
+    #[test]
+    fn diagnostics_replace_existing_file_atomically() {
+        let root = test_root("diagnostics-replace");
+        let diagnostics = root.join(DIAGNOSTICS_FILE_NAME);
+        fs::write(&diagnostics, "old\n").expect("write old diagnostics");
+        write_diagnostics(&diagnostics, &serde_json::json!({ "value": "new" }))
+            .expect("replace diagnostics");
+        let contents = fs::read_to_string(&diagnostics).expect("read diagnostics");
+        assert!(contents.contains("new"));
+        assert!(!contents.contains("old"));
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn logical_cache_bytes_sum_actual_generation_files() {
+        let root = test_root("logical-cache-bytes");
+        fs::create_dir(root.join("a")).expect("create first generation");
+        fs::create_dir(root.join("b")).expect("create second generation");
+        fs::write(root.join("a/one"), b"123").expect("write first file");
+        fs::write(root.join("b/two"), b"12345").expect("write second file");
+        assert_eq!(cache_logical_bytes(&root), 8);
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[test]
+    fn failure_context_records_explicit_phase_and_cache_usage() {
+        let root = test_root("failure-context");
+        let (archive, manifest_path, _) = write_fixture(&root);
+        let cache = root.join("cache");
+        fs::create_dir_all(&cache).expect("create cache");
+        fs::write(cache.join("existing"), b"1234").expect("write existing cache file");
+        fs::write(&archive, b"corrupt").expect("corrupt archive");
+        let context = Mutex::new(FailureContext::default());
+        let result = prepare_runtime_from_files_with_context(
+            &archive,
+            &manifest_path,
+            &cache,
+            "1.2.3",
+            &context,
+        );
+        assert!(result.is_err(), "corrupt archive must fail");
+        let context = context.lock().expect("read failure context");
+        assert_eq!(context.failed_phase, "archive-metadata");
+        assert_eq!(context.existing_cache_logical_bytes_before, 4);
+        assert!(context.cache_path.contains("1.2.3-"));
+        fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    fn write_complete_runtime(
+        cache: &Path,
+        name: &str,
+        version: &str,
+        digest_byte: char,
+    ) -> PathBuf {
+        let runtime = cache.join(name);
+        fs::create_dir(&runtime).expect("create complete runtime");
+        for (path, contents) in fixture_files() {
+            let destination = runtime.join(path);
+            fs::create_dir_all(destination.parent().expect("runtime fixture parent"))
+                .expect("create runtime fixture parent");
+            fs::write(destination, contents).expect("write runtime fixture");
+        }
+        let marker = CompletionMarker {
+            schema_version: COMPLETION_MARKER_SCHEMA_VERSION,
+            package_version: version.to_string(),
+            archive_sha256: std::iter::repeat(digest_byte).take(64).collect(),
+        };
+        fs::write(
+            runtime.join(".complete.json"),
+            serde_json::to_vec(&marker).expect("serialize complete marker"),
+        )
+        .expect("write complete marker");
+        runtime
+    }
+
+    #[test]
+    fn cleanup_preserves_current_and_one_previous_complete_runtime() {
+        let root = test_root("cleanup");
+        let cache = root.join("cache");
+        fs::create_dir(&cache).expect("create cleanup cache");
+        let oldest = write_complete_runtime(&cache, "oldest", "1.0.0", 'a');
+        thread::sleep(Duration::from_millis(25));
+        let previous = write_complete_runtime(&cache, "previous", "1.1.0", 'b');
+        thread::sleep(Duration::from_millis(25));
+        let current = write_complete_runtime(&cache, "current", "1.2.0", 'c');
+        let incomplete = cache.join("incomplete");
+        fs::create_dir(&incomplete).expect("create incomplete cache");
+        fs::write(incomplete.join("partial"), b"partial").expect("write incomplete cache");
+
+        cleanup_stale_sidecar_runtimes(&current);
+
+        assert!(current.is_dir());
+        assert!(previous.is_dir());
+        assert!(!oldest.exists());
+        assert!(!incomplete.exists());
+        fs::remove_dir_all(root).expect("remove cleanup root");
+    }
+
+    #[test]
     fn extracts_the_built_windows_archive_when_available() {
         let archive_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("resources")
             .join("server-archive");
-        let archive = archive_dir.join("server.tar.gz");
+        let archive = archive_dir.join(ARCHIVE_FILE_NAME);
         let manifest = archive_dir.join("manifest.json");
         if !archive.is_file() || !manifest.is_file() {
             // Plain cargo test/check runs do not build release resources. The
@@ -687,7 +1322,8 @@ mod tests {
         let root = test_root("built-archive");
         let runtime = prepare_runtime_from_files(&archive, &manifest, &root, "ci-fixture")
             .expect("extract built Windows archive with production code");
-        assert!(runtime_has_required_files(&runtime));
+        assert!(runtime_has_required_files(&runtime.path));
+        assert_eq!(runtime.diagnostics.archive_format, "tar.zst");
         fs::remove_dir_all(root).expect("remove built archive fixture");
     }
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,6 +4,16 @@
     "resources": [
       "resources/server-archive/**/*",
       "resources/node/**/*"
-    ]
+    ],
+    "windows": {
+      "wix": {
+        "fragmentPaths": [
+          "./windows/fragments/sidecar-cache-cleanup.wxs"
+        ],
+        "componentRefs": [
+          "SidecarRuntimeCleanupAnchor"
+        ]
+      }
+    }
   }
 }

--- a/src-tauri/windows/fragments/sidecar-cache-cleanup.wxs
+++ b/src-tauri/windows/fragments/sidecar-cache-cleanup.wxs
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <!--
+      Tauri's MSI is per-machine, but the extracted runtime belongs to the
+      interactive user. Run the cleanup impersonated so LOCALAPPDATA resolves
+      to that user, and skip major upgrades so rollback generations survive.
+    -->
+    <DirectoryRef Id="INSTALLDIR">
+      <Component
+        Id="SidecarRuntimeCleanupAnchor"
+        Guid="{5E1942A7-C665-472F-9EAA-508566D2FC7A}"
+        KeyPath="yes"
+      />
+    </DirectoryRef>
+    <!-- Declare the standard system directory so the deferred action always
+         has an existing working directory after INSTALLDIR is removed. -->
+    <DirectoryRef Id="TARGETDIR">
+      <Directory Id="SystemFolder" />
+    </DirectoryRef>
+
+    <CustomAction
+      Id="RemoveSidecarRuntimeCache"
+      Directory="SystemFolder"
+      Execute="commit"
+      Impersonate="yes"
+      Return="ignore"
+      ExeCommand="cmd.exe /D /C if defined LOCALAPPDATA if exist &quot;%LOCALAPPDATA%\ai.opencoven.cave\sidecar-runtime&quot; rmdir /S /Q &quot;%LOCALAPPDATA%\ai.opencoven.cave\sidecar-runtime&quot;"
+    />
+
+    <InstallExecuteSequence>
+      <Custom Action="RemoveSidecarRuntimeCache" Before="InstallFinalize">
+        (REMOVE = "ALL") AND NOT UPGRADINGPRODUCTCODE
+      </Custom>
+    </InstallExecuteSequence>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
Upstream mirror of #2917 (by @romgenie) so the required CodeQL check can run and the stack can land. Commits are romgenie's, unchanged; squash-merge will credit via Co-authored-by.

Reviewed as part of the Windows sidecar-runtime stack. Superseded fork PR: #2917.

🤖 Mirrored + landed by Claude Code