### PR TITLE
fix(cave): copilot runs in native chat · code rail fills wide panels · sidenav Memories rename (cave-ns35)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
-import { stripAnsi } from "@/lib/ansi";
+import { resolveBackspaces, stripAnsi } from "@/lib/ansi";
 import {
   bindingFor,
   enqueueOfflineTravelItem,
@@ -1336,7 +1336,15 @@ export async function POST(req: Request) {
       push({ kind: "user", text: promptText });
 
       let sessionId: string | null = body.sessionId ?? null;
-      let assistantFilter = new AssistantFilter();
+      // The AssistantFilter's suppressions all key on codex/claude output
+      // shapes (marker lines, startup banners, exec echoes). External manifest
+      // adapters (copilot, opencode, hermes, …) pipe the CLI's raw stdout with
+      // none of those shapes — the phase gate ate whole replies ("completed
+      // but produced no output") and the banner heuristic ate bare-number
+      // answers — so their text passes through verbatim.
+      const rawStdoutHarness =
+        binding.harness !== "codex" && binding.harness !== "claude";
+      let assistantFilter = new AssistantFilter({ passthrough: rawStdoutHarness });
       let assistantText = "";
       let jsonBuf = "";
       let result: {
@@ -1372,7 +1380,11 @@ export async function POST(req: Request) {
       // model field arrives (older CLIs omit it → honest `pending`).
       let confirmedModel: string | null = null;
 
-      const handleLine = (line: string) => {
+      const handleLine = (rawLine: string) => {
+        // stdout is split on bare \n; external adapters (copilot) emit CRLF,
+        // and a trailing \r would both fail the endsWith("}") JSON sniff and
+        // leak into bubble text.
+        const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
         if (!line) return;
         if (RESUME_ERR_RE.test(line)) resumeFailed = true;
         const isJson = line.startsWith("{") && line.endsWith("}");
@@ -1479,7 +1491,7 @@ export async function POST(req: Request) {
             /* fall through to filter */
           }
         }
-        const cleaned = stripAnsi(line);
+        const cleaned = resolveBackspaces(stripAnsi(line));
         // Snapshot error-looking stdout lines for the empty-response diagnostic.
         const trimmed = cleaned.trim();
         if (trimmed && ERR_LINE_RE.test(trimmed)) {
@@ -1654,7 +1666,7 @@ export async function POST(req: Request) {
           "running",
         );
         sessionId = null;
-        assistantFilter = new AssistantFilter();
+        assistantFilter = new AssistantFilter({ passthrough: rawStdoutHarness });
         assistantText = "";
         jsonBuf = "";
         result = {};

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -16,7 +16,7 @@ const PRIMARY: RailDest[] = [
   { href: "/?mode=board", label: "Tasks", icon: "ph:kanban" },
   { href: "/?mode=inbox", label: "Schedules", icon: "ph:calendar-check" },
   { href: "/?mode=journal", label: "Journal", icon: "ph:book-open" },
-  { href: "/?mode=grimoire", label: "Grimoire", icon: "ph:books" },
+  { href: "/?mode=grimoire", label: "Memories", icon: "ph:books" },
   { href: "/?mode=marketplace", label: "Marketplace", icon: "ph:storefront-bold" },
   { href: "/?mode=github", label: "GitHub", icon: "ph:github-logo" },
 ];

--- a/src/components/familiar-studio-journal-tab.test.ts
+++ b/src/components/familiar-studio-journal-tab.test.ts
@@ -103,8 +103,10 @@ assert.doesNotMatch(ws, /mode === "journal" \?/, "no journal surface branch rema
 assert.doesNotMatch(ws, /cave:journal-set-tab/, "the journal tab event plumbing is gone");
 assert.match(ws, /case "\/journal":\s*\n\s*setMode\("journal"\)/, "/journal routes through the redirect");
 
-// ── Sidebar: the Journal row stays (redirects on click), minus sketches ─────
-assert.match(sidebar, /id: "journal", label: "Journal", iconName: "ph:book-open"/, "sidebar keeps the Journal row");
+// ── Sidebar: the Journal mode stays reachable (⌘K palette + deep links via
+// navHidden) even though its dedicated row is retired — it's a tab inside
+// Memories now. ─────
+assert.match(sidebar, /id: "journal", label: "Journal", iconName: "ph:book-open"/, "sidebar keeps the Journal FOLDER_MODES entry for the palette");
 assert.doesNotMatch(sidebar, /generated sketches/, "sidebar description no longer promises the canvas");
 
 // ── A redirect is not a page: journal can't be dragged into a split ─────────

--- a/src/components/familiars-memory-reader.tsx
+++ b/src/components/familiars-memory-reader.tsx
@@ -197,11 +197,11 @@ export function MemoryReaderPane({
             <button
               type="button"
               onClick={() => openGrimoireDoc("memory", row.contentPath!)}
-              title="Open in the Grimoire editor"
+              title="Open in the Memories editor"
               className="focus-ring inline-flex h-6 items-center gap-1 rounded border border-[var(--border-hairline)] px-1.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
             >
               <Icon name="ph:book-open" width={11} aria-hidden />
-              Grimoire
+              Memories
             </button>
           ) : null}
         </div>

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -10,13 +10,13 @@ const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.
 // ── Surface registration: mode, title, render branch, sidebar row ────────────
 
 assert.match(modeType, /\| "grimoire"/, "grimoire is a WorkspaceMode");
-assert.match(workspace, /grimoire: "Grimoire"/, "grimoire has a page title (sr-only h1)");
+assert.match(workspace, /grimoire: "Memories"/, "grimoire has a page title (sr-only h1) reading Memories");
 assert.match(workspace, /mode === "grimoire" \? \(\s*<GrimoireView\s+view=\{grimoireView\}/, "grimoire mode renders GrimoireView with the controlled view");
 // Journal is now a tab inside Grimoire: the nav/deep-link `journal` mode opens
 // Grimoire on its Journal tab instead of redirecting to Settings.
 assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*setModeRaw\("grimoire"\);/, "the journal mode routes into the Grimoire Journal tab");
 assert.match(sidebar, /\| "grimoire"/, "grimoire is a FolderMode");
-assert.match(sidebar, /id: "grimoire", label: "Grimoire"/, "grimoire has a sidebar row (and ⌘K palette entry via FOLDER_MODES)");
+assert.match(sidebar, /id: "grimoire", label: "Memories"/, "grimoire has a sidebar row labeled Memories (and ⌘K palette entry via FOLDER_MODES)");
 
 // ── Navigator: three sources, searchable, new-entry affordance ───────────────
 
@@ -171,7 +171,7 @@ assert.match(
   "the doc index maps memory entries by fullPath (the same path openDoc navigates to)",
 );
 assert.match(view, /onClick=\{\(\) => onOpen\(ref\)\}/, "a resolved chip navigates to its doc");
-assert.match(view, /title="No matching Grimoire doc"[\s\S]{0,600}border-dashed/, "an unresolved link renders dashed with a hint (tap shows why — cave-bkpj)");
+assert.match(view, /title="No matching Memories doc"[\s\S]{0,600}border-dashed/, "an unresolved link renders dashed with a hint (tap shows why — cave-bkpj)");
 assert.match(view, /<GrimoireDocLinks\b[\s\S]{0,280}onOpen=\{openDoc\}/, "the chip row is wired to openDoc for the active doc");
 
 // ── Backlinks: incoming mentions from the doc graph (cave-hand) ──────────────
@@ -195,7 +195,7 @@ assert.match(view, /const localGraph = useMemo\([\s\S]{0,200}buildDocGraph\(/, "
 assert.match(view, /markdown: k\.body/, "the fallback graph reads each knowledge body (already loaded)");
 assert.match(view, /const graph = scan\?\.graph \?\? localGraph/, "the server scan wins, the local graph stands in — never blank");
 assert.match(view, /if \(firstLoadDoneRef\.current\) refreshGraph\(\)/, "saves/deletes rescan the graph (mount already fetched)");
-assert.match(view, /aria-label="Grimoire view"/, "the Docs|Journal|Graph switch is a labelled control group");
+assert.match(view, /aria-label="Memories view"/, "the Docs|Journal|Graph switch is a labelled control group");
 assert.match(
   view,
   /aria-pressed=\{view === "docs"\}[\s\S]{0,900}aria-pressed=\{view === "journal"\}[\s\S]{0,900}aria-pressed=\{view === "graph"\}/,

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -688,7 +688,7 @@ function GrimoireDocLinks({
               <button
                 key={i}
                 type="button"
-                title="No matching Grimoire doc"
+                title="No matching Memories doc"
                 aria-expanded={unresolvedHint === display}
                 onClick={() => {
                   const hint = `“${display}” has no matching doc yet — create a stitch with that title to link it.`;
@@ -1308,11 +1308,11 @@ export function GrimoireView({
           Marketplace / Tasks): small title on the left, the surface verbs on the
           right. The rail keeps its own search (it filters the rail list). */}
       <header className="surface-compact-header">
-        <h1 className="surface-compact-title">Grimoire</h1>
+        <h1 className="surface-compact-title">Memories</h1>
         <div className="surface-compact-actions">
           <div
             role="group"
-            aria-label="Grimoire view"
+            aria-label="Memories view"
             className="inline-flex h-[26px] items-center gap-0.5 rounded-md border border-[var(--border-hairline)] p-0.5"
           >
             <button

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -471,8 +471,8 @@ function MemoryFileView({ path, file, reveal, totalRedactions, onRevealToggle, o
       <div className="flex-1 truncate font-mono text-[var(--text-secondary)]">{filename}</div>
       <button
         onClick={() => openGrimoireDoc("memory", path)}
-        title="Open in the Grimoire editor"
-        aria-label="Open in Grimoire"
+        title="Open in the Memories editor"
+        aria-label="Open in Memories"
         className="rounded p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
       >
         <Icon name="ph:book-open" width={13} />

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -72,8 +72,8 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes, \{ grimoireView: props\.grimoireView \}\)\}/,
-  "Sidebar rows derive their highlight (marketplace aliasing + the Journal/Grimoire tab split, cave-s9p6) from sidebarRowState",
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  "Sidebar rows derive their highlight (marketplace + journal aliasing, cave-s9p6) from sidebarRowState",
 );
 
 // Settings: no separate plugins section, and the roles add-on toggle is gone

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -421,21 +421,21 @@ assert.match(
 // Quiet cluster (§8): occasional destinations stay in the same flat list but
 // render muted-until-hover, with the first quiet row opening a spacing gap.
 // Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
-// ⌘-numbered daily set (Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4); Journal
-// and Grimoire lead the quiet cluster, followed by Marketplace/GitHub/Work Queue.
+// ⌘-numbered daily set (Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4); Memories
+// leads the quiet cluster, followed by Marketplace/GitHub/Work Queue.
 assert.match(
   source,
-  /\{ id: "journal",[^}]*quiet: true \}/,
-  "Journal is in the quiet cluster (cave-xsq.8)",
+  /\{ id: "journal",[^}]*navHidden: true \}/,
+  "Journal keeps no sidebar row — it's a tab inside Memories (palette/deep-link reachability stays via navHidden)",
 );
 assert.match(
   source,
-  /\{ id: "grimoire",[^}]*quiet: true \}/,
-  "Grimoire is in the quiet cluster (cave-xsq.8)",
+  /\{ id: "grimoire", label: "Memories",[^}]*quiet: true \}/,
+  "Memories (grimoire) is in the quiet cluster (cave-xsq.8)",
 );
 assert.match(
   source,
-  /id: "inbox",[\s\S]*?\{ id: "journal"/,
+  /id: "inbox",[\s\S]*?\{ id: "grimoire"/,
   "the ⌘-numbered prominent cluster (…Schedules) renders above the quiet cluster",
 );
 assert.match(
@@ -472,8 +472,8 @@ assert.match(
 );
 assert.match(
   source,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes, \{ grimoireView: props\.grimoireView \}\)\}/,
-  "each row derives active/split/idle from mode + open split pages + the Grimoire tab (Journal row, cave-s9p6)",
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  "each row derives active/split/idle from mode + open split pages",
 );
 assert.match(
   source,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -61,9 +61,6 @@ export type SidebarMinimalProps = {
    *  Their rows get a lighter "open in split" wash instead of the active fill,
    *  so the highlight stays honest when a page renders beside the primary. */
   splitPageModes?: readonly string[];
-  /** Grimoire's current tab — lights the Journal row (not Grimoire) while the
-   *  Journal tab is up, since `mode` is never "journal" (cave-s9p6). */
-  grimoireView?: string;
   /** Role Surface rooms visible for the active familiar. Registry-driven —
    *  rendered as their own cluster; empty/omitted hides the cluster. */
   roleSurfaces?: readonly SidebarRoleSurfaceRow[];
@@ -126,11 +123,15 @@ const FOLDER_MODES: Array<{
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and scheduled jobs in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
   // Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
   // ⌘-numbered daily destinations (Home · Chat · Tasks · Schedules — Schedules
-  // also carries the needs-you badge). Journal and Grimoire join the quiet
-  // cluster: same flat list, same reachability (rows, palette, deep links),
-  // just muted-until-hover so the conversation-first surfaces read first.
-  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in the Grimoire", quiet: true },
-  { id: "grimoire", label: "Grimoire", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
+  // also carries the needs-you badge). Memories joins the quiet cluster: same
+  // flat list, same reachability (rows, palette, deep links), just
+  // muted-until-hover so the conversation-first surfaces read first.
+  // Journal keeps no row of its own — it's a tab inside Memories, and a
+  // dedicated row double-listed the same surface. navHidden keeps the mode in
+  // the ⌘K palette and as a deep-link target (setMode remaps it to the
+  // Memories surface's Journal tab).
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in Memories", quiet: true, navHidden: true },
+  { id: "grimoire", label: "Memories", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
   // Browser is summoned on demand (a clicked link/URL opens it, plus ⌘5 and the
   // ⌘K palette) rather than navigated to daily, so it's kept in the list for
   // those launchers but hidden from the sidebar rows.
@@ -292,7 +293,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             // Active follows the primary mode (Roles/Capabilities keep the
             // Marketplace hub lit); pages open as split tiles get a lighter
             // "open in split" state instead. Derivation in lib/sidebar-nav-state.
-            state={sidebarRowState(fm.id, mode, props.splitPageModes, { grimoireView: props.grimoireView })}
+            state={sidebarRowState(fm.id, mode, props.splitPageModes)}
             badge={fm.badge?.(props)}
             kbd={fm.kbd}
             description={fm.description}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -171,7 +171,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   capabilities: "Capabilities",
   "familiar-work-queue": "Queue",
   journal: "Journal",
-  grimoire: "Grimoire",
+  grimoire: "Memories",
 };
 
 // Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
@@ -2206,7 +2206,6 @@ export function Workspace() {
     <SidebarMinimal
       mode={mode}
       splitPageModes={splitPageModes}
-      grimoireView={grimoireView}
       // Registered Role Surfaces visible for the active familiar — rendered by
       // the sidebar as generic rows (rooms), never named in shell code.
       roleSurfaces={roleSurfaceSession.visibleSurfaces.map((surface) => ({

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -5,6 +5,21 @@ export function stripAnsi(input: string): string {
   return input.replace(OSC_RE, "").replace(ANSI_RE, "");
 }
 
+// Apply terminal backspace semantics: "x\b" erases x. TTY-first CLIs piped
+// through `coven run` leave self-erasing artifacts in stdout — GitHub Copilot
+// CLI prints "^D\b\b" before each reply, which a terminal erases but a pipe
+// preserves — and those bytes would otherwise land verbatim in chat bubbles.
+// Leading backspaces (nothing left to erase) are dropped.
+export function resolveBackspaces(input: string): string {
+  if (!input.includes("\b")) return input;
+  const out: string[] = [];
+  for (const ch of input) {
+    if (ch === "\b") out.pop();
+    else out.push(ch);
+  }
+  return out.join("");
+}
+
 const PROMPT_PATTERNS: RegExp[] = [
   /\?\s*$/,
   /\?\s*\([^)]*\)\s*$/,

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -192,3 +192,33 @@ assert.equal(
   "Here are the options:\n---\nNote: pick the one that fits your budget.\n",
   "a horizontal rule followed by capitalized prose (Note:) is NOT skill frontmatter",
 );
+
+// ── passthrough: external manifest adapters (copilot, opencode, …) ──────────
+// Their CLIs pipe raw stdout with none of the codex/claude output shapes this
+// filter keys on: the default "pre" phase suppressed the entire reply
+// (observed as copilot chats ending "completed but produced no output"), and
+// BANNER_LINE_RE's token-count heuristic (a bare number) ate legitimate
+// numeric answers ("What is 2+3?" → "5" → suppressed).
+{
+  const external = new AssistantFilter({ passthrough: true });
+  let out = external.push("Here is the answer you asked for.\n");
+  out += external.push("5\n");
+  out += external.flush();
+  assert.equal(
+    out,
+    "Here is the answer you asked for.\n5\n",
+    "external-adapter stdout passes through verbatim — no marker gate, no banner heuristics",
+  );
+}
+assert.equal(
+  feed(["A bare line with no marker before it."]),
+  "",
+  "default construction still gates on the codex/claude markers",
+);
+assert.equal(
+  feed(["codex", "12,345"]),
+  "",
+  "default construction still suppresses codex token-count banner numbers",
+);
+
+console.log("chat-assistant-filter.test: ok (passthrough)");

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -103,6 +103,20 @@ export class AssistantFilter {
   private inExecEcho: "none" | "header" | "cmdline" | "output" = "none";
   private execEchoDepth = 0;
 
+  // Every suppression in this filter keys on codex/claude output shapes: the
+  // "pre" phase gates on their marker lines (CODEX_START_LINE /
+  // CLAUDE_ASSISTANT_RE), BANNER_LINE_RE matches their startup banners and
+  // token-count lines (a bare number!), and the exec-echo machine matches
+  // codex's tool-echo blocks. External manifest adapters (copilot, opencode,
+  // hermes, …) pipe their CLI's raw stdout with none of those shapes — the
+  // phase gate suppressed entire replies, and the banner heuristic ate
+  // legitimate numeric answers. Those callers get verbatim passthrough.
+  private passthrough = false;
+
+  constructor(opts?: { passthrough?: boolean }) {
+    this.passthrough = opts?.passthrough === true;
+  }
+
   push(chunk: string): string {
     this.buf += chunk;
     let out = "";
@@ -128,6 +142,7 @@ export class AssistantFilter {
 
   private processLine(rawLine: string): string {
     const line = rawLine.replace(/\r/g, "");
+    if (this.passthrough) return line + "\n";
     const trimmed = line.trim();
 
     if (trimmed === CODEX_START_LINE || CLAUDE_ASSISTANT_RE.test(trimmed)) {

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { covenLaunchCommandForBinary, pickWindowsLauncher, windowsPathFromRegQuery } from "./coven-bin.ts";
+import { covenAdapterDirsEnvValue, covenLaunchCommandForBinary, pickWindowsLauncher, windowsPathFromRegQuery } from "./coven-bin.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 
@@ -173,6 +173,37 @@ assert.match(
   source,
   /execFileSync\("where", \["coven"\][\s\S]*pickWindowsLauncher/,
   "covenBin falls back to `where` + launcher picking before the literal name on Windows",
+);
+
+// Released coven CLIs only auto-trust recipe-installed manifests inside
+// COVEN_HOME/adapters (hermes); Cave-scaffolded copilot/opencode manifests
+// there are ignored unless COVEN_HARNESS_ADAPTER_DIRS names the directory.
+// Every coven spawn must therefore carry the env var.
+const defaultAdapters = path.join(os.homedir(), ".coven", "adapters");
+assert.equal(
+  covenAdapterDirsEnvValue(undefined),
+  defaultAdapters,
+  "no user value → COVEN_HOME defaults to ~/.coven and adapters/ is named",
+);
+assert.equal(
+  covenAdapterDirsEnvValue(undefined, path.join(os.tmpdir(), "coven-home")),
+  path.join(os.tmpdir(), "coven-home", "adapters"),
+  "an explicit COVEN_HOME override wins over ~/.coven",
+);
+assert.equal(
+  covenAdapterDirsEnvValue("/opt/adapters"),
+  ["/opt/adapters", defaultAdapters].join(path.delimiter),
+  "a user-set value keeps priority; Cave's directory is appended",
+);
+assert.equal(
+  covenAdapterDirsEnvValue(defaultAdapters),
+  defaultAdapters,
+  "already-listed directory is not duplicated (dup adapter ids error in the CLI)",
+);
+assert.match(
+  source,
+  /COVEN_HARNESS_ADAPTER_DIRS = covenAdapterDirsEnvValue\(/,
+  "covenSpawnEnv wires the adapter dirs into every coven child process",
 );
 
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -300,6 +300,31 @@ export function covenLaunchCommand(): CovenLaunchCommand {
 }
 
 /**
+ * Value for COVEN_HARNESS_ADAPTER_DIRS in coven child processes: the user's
+ * own value (if any) with COVEN_HOME/adapters appended.
+ *
+ * Released coven CLIs (≤0.0.53) only auto-trust manifests in
+ * COVEN_HOME/adapters whose id matches a built-in install recipe (hermes
+ * today). The manifests Cave scaffolds there for other runtimes (copilot,
+ * opencode, …) are silently ignored, so `coven run copilot` failed with
+ * "unsupported harness" even though the manifest existed and parsed. The
+ * CLI's sanctioned path for other external harnesses is this env var, so
+ * every coven spawn points it at the directory Cave writes manifests into.
+ * The CLI dedups against recipe-trusted manifests and tolerates a missing
+ * directory. Exported for tests.
+ */
+export function covenAdapterDirsEnvValue(
+  existing: string | undefined,
+  covenHome?: string,
+): string {
+  const home = covenHome?.trim() || path.join(HOME, ".coven");
+  const adaptersDir = path.join(home, "adapters");
+  const dirs = (existing ?? "").split(path.delimiter).filter(Boolean);
+  if (dirs.includes(adaptersDir)) return dirs.join(path.delimiter);
+  return [...dirs, adaptersDir].join(path.delimiter);
+}
+
+/**
  * Augmented spawn env with PATH containing the user's interactive-shell PATH
  * plus the candidate dirs (in priority order), so subprocesses launched from
  * a Finder-spawned cave can still resolve nested tooling (codex, claude,
@@ -325,6 +350,10 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
     cachedPath = dedup.join(path.delimiter);
   }
   const env: NodeJS.ProcessEnv = { ...process.env, PATH: cachedPath };
+  env.COVEN_HARNESS_ADAPTER_DIRS = covenAdapterDirsEnvValue(
+    process.env.COVEN_HARNESS_ADAPTER_DIRS,
+    process.env.COVEN_HOME,
+  );
   for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
     delete env[key];
   }

--- a/src/lib/grimoire-link.test.ts
+++ b/src/lib/grimoire-link.test.ts
@@ -30,6 +30,6 @@ assert.match(lib, /window\.history\.replaceState/, "the hash is written before t
 assert.match(reader, /openGrimoireDoc\("memory", row\.contentPath/, "memory reader links its file to the Grimoire");
 assert.match(reader, /row\.contentPath \?/, "reader only offers the link when the file path resolved");
 assert.match(inspector, /openGrimoireDoc\("memory", path\)/, "chat inspector's memory file view links to the Grimoire");
-assert.match(inspector, /aria-label="Open in Grimoire"/, "inspector link is labelled");
+assert.match(inspector, /aria-label="Open in Memories"/, "inspector link is labelled");
 
 console.log("grimoire-link.test: ok");

--- a/src/lib/sidebar-nav-state.test.ts
+++ b/src/lib/sidebar-nav-state.test.ts
@@ -42,25 +42,18 @@ test("deep-linkable modes hosted by another surface light the host row (cave-s9p
   assert.equal(sidebarRowState("inbox", "flow"), "active", "retired flow remaps to Schedules");
 });
 
-test("the Journal row keys off the Grimoire tab, not the mode (cave-s9p6)", () => {
+test("Journal is a Memories tab — the Memories (grimoire) row hosts it", () => {
+  // The Journal sidebar row is retired (navHidden): the surface lives as a
+  // tab inside Memories, so the Memories row stays lit on either tab, and a
+  // "journal" deep-link mode lights the Memories row too.
   assert.equal(
-    sidebarRowState("journal", "grimoire", undefined, { grimoireView: "journal" }),
+    sidebarRowState("grimoire", "grimoire"),
     "active",
-    "Journal tab up → Journal row lights",
+    "Memories row lights for the grimoire mode regardless of tab",
   );
   assert.equal(
-    sidebarRowState("grimoire", "grimoire", undefined, { grimoireView: "journal" }),
-    "idle",
-    "Journal tab up → Grimoire row yields",
-  );
-  assert.equal(
-    sidebarRowState("grimoire", "grimoire", undefined, { grimoireView: "docs" }),
+    sidebarRowState("grimoire", "journal"),
     "active",
-    "other Grimoire tabs keep the Grimoire row",
-  );
-  assert.equal(
-    sidebarRowState("journal", "grimoire"),
-    "idle",
-    "no view provided → unchanged legacy behavior",
+    "a journal deep-link mode lights the Memories row",
   );
 });

--- a/src/lib/sidebar-nav-state.ts
+++ b/src/lib/sidebar-nav-state.ts
@@ -25,6 +25,9 @@ const MODE_ALIASES: Record<string, string> = {
   calendar: "inbox",
   "familiar-work-queue": "board",
   flow: "inbox",
+  // Journal has no sidebar row of its own anymore — it's a tab inside the
+  // Memories (grimoire) surface, so that row stays lit on either tab.
+  journal: "grimoire",
 };
 
 function normalizeMode(mode: string): string {
@@ -35,18 +38,8 @@ export function sidebarRowState(
   rowId: string,
   activeMode: string,
   splitPageModes?: readonly string[],
-  opts?: {
-    /** The Grimoire surface's current tab. `mode` is never "journal" (setMode
-     *  remaps it to grimoire+journal tab), so without this the Journal row
-     *  could never light — Grimoire lit instead (cave-s9p6). */
-    grimoireView?: string;
-  },
 ): SidebarRowState {
-  const effectiveActive =
-    activeMode === "grimoire" && opts?.grimoireView === "journal"
-      ? "journal"
-      : normalizeMode(activeMode);
-  if (effectiveActive === rowId) return "active";
+  if (normalizeMode(activeMode) === rowId) return "active";
   if (splitPageModes?.some((m) => normalizeMode(m) === rowId)) return "split";
   return "idle";
 }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4676,6 +4676,11 @@ details[open] > .cave-tool-summary::before {
 .workspace-rail {
   display: flex;
   flex-direction: row;
+  /* Fill the hosting panel. The code-rail Panel clamps at maxSize 560px while
+     the resizable layout can hand it more — without flex-grow the rail sat at
+     its content width and left a dead band between its right edge and the
+     collapsed Inspector rail on wide windows. */
+  flex: 1 1 auto;
   height: 100%;
   min-height: 0;
   min-width: 0;


### PR DESCRIPTION
## Copilot works in the cave (and every external adapter with it)

Chatting with a copilot-bound familiar (sage, charm) failed instantly with `unsupported harness 'copilot'` — and after fixing that, replies still arrived as *"completed but produced no output."* Three stacked root causes, all verified empirically:

1. **Released coven CLIs (≤0.0.53, the npm latest) never load Cave's scaffolded manifests.** `COVEN_HOME/adapters` is gated to the CLI's built-in recipe allowlist (only `hermes`); copilot/opencode manifests there are silently ignored. Proven by bisect: an unknown-id manifest in the default dir is skipped while the byte-identical file loads via `COVEN_HARNESS_ADAPTER_DIRS`. Fix: `covenSpawnEnv()` sets `COVEN_HARNESS_ADAPTER_DIRS=<COVEN_HOME>/adapters` on every coven spawn (appends to a user-set value, no duplicate entry, missing dir tolerated — new unit tests).
2. **`AssistantFilter` suppressed the entire reply.** Its `"pre"` phase gates on codex/claude marker lines that external adapters never emit, and `BANNER_LINE_RE`'s token-count heuristic (`\d[\d,]*\s*$`) ate legitimate bare-number answers. External adapters now get verbatim passthrough; codex/claude behavior is unchanged and still pinned.
3. **Copilot's raw stdout carries TTY artifacts** — a self-erasing `^D\b\b` prefix and CRLF line endings that a terminal hides but a pipe preserves. New `resolveBackspaces()` in `lib/ansi` + a trailing-`\r` trim in `handleLine` (which also protects the `endsWith("}")` JSON sniff).

**End-to-end proof** on the production build: `POST /api/chat/send` to sage (harness copilot, model `github/auto`) → `{"kind":"assistant_chunk","text":"5\n"}`, `isError:false`, model confirmed. `/api/harnesses` now reports the copilot/opencode manifests as loaded.

## Code rail: blank band on wide windows

`.workspace-rail` had no flex-grow, so when the resizable layout handed its Panel more width than the rail's content (Panel clamps at `maxSize` 560px), a dead backdrop band opened between the Files pane and the collapsed Inspector rail. Reproduced at a 2400px viewport (rail 332px inside a 560px panel); `flex: 1 1 auto` renders it flush — verified live before/after.

## Sidenav: Journal row retired, Grimoire → Memories

Journal is a tab inside the surface, so its row double-listed the destination — the entry is now `navHidden` (⌘K "Go to Journal" and `/journal` deep links still route onto the Journal tab), and `sidebarRowState` aliases `journal→grimoire` so the row stays lit on either tab. All user-facing "Grimoire" strings read **Memories** (sidebar row, page title, header h1, aria-labels, Open-in buttons, analytics shell). Mode ids/routes/component names keep the `grimoire` spelling; the Settings link to the external mind.opencoven.ai product is untouched.

Verified in-app: sidebar rows are `Home · Chat · Tasks · Schedules · Memories · Marketplace · GitHub`, the Memories row stays active on the Journal tab, and the surface header reads Memories.

Bead: cave-ns35. Full suite green (592 test files), `tsc --noEmit` clean, `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)