### PR TITLE
chore(release): stamp v0.0.174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.174] - 2026-07-11
+
+> 💬 **Copilot chats natively, cleaner Windows packaging, and the Grimoire becomes Memories.** Copilot (and other manifest adapters) now render their replies correctly in chat, the packaged Windows sidecar runtime is pruned and MSI publication is gated, and the knowledge surface is renamed Memories.
+
+Rolls up on top of v0.0.172 — this release also carries the v0.0.173-stamped work below (board/palette project-scoping, chat/board polish, rollout-audit hardening, and the MSI sidecar collapse), which was stamped but never cut as its own release. **Windows note:** the v0.0.172 → v0.0.174 upgrade is the one-time legacy bridge that removes v0.0.172's expanded sidecar tree; archive-to-archive upgrades after this are the fast path.
+
+### Features
+- **Analytics: thread signals become a scrollable, task-promoting data table** spanning both columns (#2920, cave-bhh2).
+
+### Fixes
+- **Chat: Copilot (and other manifest adapters) render replies natively** — external adapters pipe raw CLI stdout without codex/claude output shapes, so the assistant filter was eating whole replies; they now pass through verbatim (with CRLF/backspace handling). Plus the code rail fills wide panels and the sidenav "Grimoire" is renamed **Memories** (#2927, cave-ns35).
+- **Projects: drop stale scope on refetch; gate the palette project fetch until open** — prevents a mid-refetch pick from reaching a project the new familiar can't access (board chat-launch 403) (#2918).
+- **Board: Tasks|Queue segment tabs standardized to the group-toggle footprint** (#2921).
+
+### Windows runtime
+- **Prune the packaged sidecar runtime closure** — traced dep closure instead of the whole tree, with file/size budgets (#2922, by @romgenie).
+- **Gate MSI publication + upgrade diagnostics** — an MSI can't publish before its budget passes (#2923, by @romgenie).
+
+### Internal
+- **Runtimes: one label authority** — consolidated runtime label resolution, alias + merge-label fixes (#2919).
+
+
 ## [0.0.173] - 2026-07-10
 
 > Board & palette project-scoping correctness, chat/board polish, and rollout-audit hardening.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.173"
+version = "0.0.174"
 dependencies = [
  "flate2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.173"
+version = "0.0.174"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.174 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs`.

**Rolls up everything landed since the last actual release (v0.0.172).** v0.0.173 was stamped (#2910) but never tagged/released, so v0.0.174 carries both that work and the branch-sweep PRs on top:
- Chat: Copilot renders natively + Grimoire→Memories rename (#2927)
- Windows runtime: sidecar closure prune (#2922) + MSI-publication gating (#2923) — by @romgenie, via CodeQL-enabled mirrors
- Analytics thread-signals table (#2920), projects scope-refetch fix (#2918), board tab footprint (#2921), runtime label authority (#2919)
- Plus the never-released 0.0.173 work (board/palette scoping, chat/board polish, rollout hardening, MSI collapse).

After merge: tag `v0.0.174` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)