### PR TITLE
chore(release): stamp v0.0.174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.174] - 2026-07-11
+
+> Copilot familiars work in native chat, the code rail fills wide windows, and the sidenav gains Memories.
+
+Patch release on top of v0.0.173.
+
+### Changes
+- fix(cave): copilot runs in native chat · code rail fills wide panels · sidenav Memories rename (cave-ns35) (#2927)
+- fix(windows): gate MSI publication and add upgrade diagnostics (#2923)
+- perf(windows): prune the packaged sidecar runtime closure (#2922)
+- fix(board): standardize Tasks|Queue segment tabs to the group-toggle footprint (#2921)
+- refactor(runtimes): one label authority, alias + merge-label fixes, hoisted rank map (#2919)
+- feat(analytics): thread signals span both columns with a scrollable, task-promoting data table (cave-bhh2) (#2920)
+- fix(projects): drop stale scope on refetch; gate palette project fetch on open (#2918)
+- fix(windows): collapse MSI sidecar payload (#2911)
+
+
 ## [0.0.173] - 2026-07-10
 
 > Board & palette project-scoping correctness, chat/board polish, and rollout-audit hardening.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.173"
+version = "0.0.174"
 dependencies = [
  "flate2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.173"
+version = "0.0.174"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.173</string>
+	<string>0.0.174</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamp v0.0.174 across the seven version locations + CHANGELOG.

Headline: copilot familiars work in native chat (#2927), the code rail fills wide windows, and the sidenav's Grimoire is now Memories (Journal row folded into it). Also carries the Windows MSI/runtime hardening batch (#2911–#2923), analytics thread signals (#2920), and project-scope fixes (#2918).

Note: the v0.0.173 tag exists but its release build never triggered (no release.yml run for it) — v0.0.174 supersedes it; the updater targets latest.

After merge: push the v0.0.174 tag at the squash commit to trigger release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)