### PR TITLE
feat(avatars): shared AvatarLightbox primitive (cave-ocy8)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -554,6 +554,7 @@ export const SUITES = {
     "src/components/ui/undo-toast.test.ts",
     "src/components/ui/search-input.test.ts",
     "src/components/ui/modal.test.ts",
+    "src/components/ui/avatar-lightbox.test.ts",
     "src/components/ui/confirm-dialog.test.ts",
     "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3065,6 +3065,26 @@ textarea.required-inputs-control {
   font-variant-numeric: tabular-nums;
 }
 
+/* ---- AvatarLightbox trigger -------------------------------- */
+/* Shared reset for the "click to enlarge" avatar button (AvatarLightbox). The
+   caller owns the inline avatar inside; this strips all button chrome so the
+   avatar looks identical whether or not it is expandable, and only adds the
+   zoom cursor. Focus styling comes from the composed `.focus-ring` utility. */
+.cave-avatar-lightbox-trigger {
+  display: inline-flex;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  line-height: 0;
+  border-radius: inherit;
+  cursor: zoom-in;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* ---- ThinkingIndicator ------------------------------------- */
 .ui-thinking {
   display: inline-flex;

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
-import { Modal } from "./ui/modal";
+import { AvatarLightbox } from "./ui/avatar-lightbox";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type Size = "sm" | "md" | "lg" | "xl";
@@ -35,7 +35,6 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
     [familiar.avatarImage, familiar.avatarImageFallback],
   );
   const [srcIdx, setSrcIdx] = useState(0);
-  const [enlarged, setEnlarged] = useState(false);
   useEffect(() => {
     setSrcIdx(0);
   }, [familiar.avatarImage, familiar.avatarImageFallback]);
@@ -64,33 +63,9 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
 
   if (expandable && hasImage) {
     return (
-      <>
-        <button
-          type="button"
-          onClick={() => setEnlarged(true)}
-          className="cursor-zoom-in"
-          aria-label={`Enlarge ${familiar.display_name} avatar`}
-          title="Click to enlarge"
-        >
-          {imgEl}
-        </button>
-        {enlarged ? (
-          <Modal
-            open
-            onClose={() => setEnlarged(false)}
-            breadcrumb={[familiar.display_name, "Avatar"]}
-            ariaLabel={`${familiar.display_name} avatar`}
-          >
-            <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
-              <img
-                src={currentSrc}
-                alt={`${familiar.display_name} avatar`}
-                className="h-full w-full object-cover"
-              />
-            </div>
-          </Modal>
-        ) : null}
-      </>
+      <AvatarLightbox src={currentSrc} label={familiar.display_name}>
+        {imgEl}
+      </AvatarLightbox>
     );
   }
 

--- a/src/components/ui/avatar-lightbox.test.ts
+++ b/src/components/ui/avatar-lightbox.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./avatar-lightbox.tsx", import.meta.url), "utf8");
+
+assert.match(src, /export function AvatarLightbox/, "Must export AvatarLightbox");
+
+// The primitive reuses the shared Modal for the enlarged view — it must NOT
+// hand-roll its own portal / focus-trap. Keeping the lightbox on one Modal is
+// the whole point of extracting this primitive.
+assert.match(src, /from "\.\/modal"/, "must reuse the shared Modal, not a hand-rolled dialog");
+assert.doesNotMatch(src, /createPortal|useFocusTrap/, "focus-trap/portal must stay owned by Modal");
+
+// Click enlarges: a button trigger toggles the enlarged state open.
+assert.match(src, /type="button"/, "trigger must be a real button for keyboard + a11y");
+assert.match(src, /onClick=\{\(\) => setEnlarged\(true\)\}/, "clicking the trigger opens the lightbox");
+assert.match(src, /cave-avatar-lightbox-trigger/, "trigger carries the shared reset class");
+assert.match(src, /focus-ring/, "trigger composes the shared focus-ring utility");
+
+// Accessible naming: the trigger announces the subject + noun, and the enlarged
+// image carries alt text (never a decorative empty alt in the lightbox).
+assert.match(src, /aria-label=\{`Enlarge \$\{label\} \$\{noun\}`\}/, "trigger aria-label names the subject");
+assert.match(src, /alt=\{`\$\{label\} \$\{noun\}`\}/, "enlarged img has descriptive alt text");
+assert.match(src, /breadcrumb=\{\[label, category\]\}/, "Modal is named via its breadcrumb");
+
+// The operator-avatar decision (click = expand; settings becomes a modal link)
+// rides on this optional footer slot — it must be forwarded to the Modal.
+assert.match(src, /footerActions=\{footerActions\}/, "footerActions passes through to the Modal footer");
+
+console.log("avatar-lightbox.test.ts: ok");

--- a/src/components/ui/avatar-lightbox.tsx
+++ b/src/components/ui/avatar-lightbox.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Modal } from "./modal";
+
+type AvatarLightboxProps = {
+  /** The small inline avatar to render as the clickable trigger (an <img> or
+   *  monogram tile). The caller owns its markup and sizing — this only adds the
+   *  zoom affordance and the enlarged view. */
+  children: ReactNode;
+  /** Full-resolution image src shown enlarged inside the lightbox. */
+  src: string;
+  /** Subject name — drives the trigger aria-label, breadcrumb, and alt text
+   *  (e.g. "Nova", a project name, or the operator's display name). */
+  label: string;
+  /** Breadcrumb tail and alt qualifier. Defaults to "Avatar". */
+  category?: string;
+  /** Optional footer actions inside the modal — e.g. an "Edit in Settings →"
+   *  link for the operator avatar, whose click previously navigated to
+   *  settings. Keeps that path discoverable without stealing the primary
+   *  click, which now enlarges like every other avatar surface. */
+  footerActions?: ReactNode;
+};
+
+/**
+ * Shared "peek at the avatar" lightbox. Wrap any avatar image in this to make a
+ * click enlarge it into a focus-trapped Modal (Esc / backdrop dismiss handled
+ * by Modal). One gesture across every avatar surface — familiar, project, and
+ * the operator's own — so behaviour and a11y stay identical everywhere. This is
+ * the single home for the pattern; callers must not hand-roll their own
+ * button + Modal.
+ */
+export function AvatarLightbox({
+  children,
+  src,
+  label,
+  category = "Avatar",
+  footerActions,
+}: AvatarLightboxProps) {
+  const [enlarged, setEnlarged] = useState(false);
+  const noun = category.toLowerCase();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setEnlarged(true)}
+        className="cave-avatar-lightbox-trigger focus-ring"
+        aria-label={`Enlarge ${label} ${noun}`}
+        title="Click to enlarge"
+      >
+        {children}
+      </button>
+      {enlarged ? (
+        <Modal
+          open
+          onClose={() => setEnlarged(false)}
+          breadcrumb={[label, category]}
+          footerActions={footerActions}
+        >
+          <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
+            <img src={src} alt={`${label} ${noun}`} className="h-full w-full object-cover" />
+          </div>
+        </Modal>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## What

Introduces a reusable **`<AvatarLightbox>`** primitive so any inline avatar can zoom-to-enlarge on click, and proves it by migrating `FamiliarAvatar` — the original home of the pattern — onto it.

Scopes the first step of **cave-ocy8** (*Expand avatar into a lightbox on tap*): reuse, don't rebuild. The `expandable`→`Modal` lightbox that already lived inside `FamiliarAvatar` is lifted into a shared component; focus-trap / Esc / backdrop dismiss stay owned by the existing `Modal`.

## Changes

- **`src/components/ui/avatar-lightbox.tsx`** — `<AvatarLightbox src label category? footerActions?>`. Wraps an inline avatar in a zoom-to-enlarge trigger + shared `Modal`. The `footerActions` slot is where the operator-avatar **"Edit in Settings →"** link plugs in (per the decision recorded on the bead).
- **`src/components/ui/avatar-lightbox.test.ts`** — co-located source-scan test: asserts it reuses `Modal`, doesn't hand-roll portal/focus-trap, names the trigger + enlarged img, and forwards `footerActions`.
- **`src/app/globals.css`** — `.cave-avatar-lightbox-trigger` reset (strips button chrome, `cursor: zoom-in`, composes shared `.focus-ring`).
- **`src/components/familiar-avatar.tsx`** — migrated onto the primitive; deletes the inline button + `Modal` + `enlarged` state. Image-source logic (the part its pinned test covers) is untouched.
- **`scripts/run-tests.mjs`** — registers the new test in the suite.

## Validation

- `avatar-lightbox.test` ok · `familiar-avatar.test` ok
- `check:tests-wired` ok (801 files, new test registered)
- `typecheck` exit 0

## Follow-ups (not in this PR)

- Wire `ProjectAvatar` onto the primitive (`expandable` for project tiles).
- Wire `UserChatAvatar` with the settings footer link.

Refs cave-ocy8

🤖 Generated with [Claude Code](https://claude.com/claude-code)