### PR TITLE
fix(projects): dedupe projects by normalized root at load time

### DIFF
--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -33,10 +33,21 @@ function projectTimestamp(project: CaveProject): number {
   return Number.isFinite(createdAt) ? createdAt : Number.NEGATIVE_INFINITY;
 }
 
-export function dedupeProjectsByRoot(projects: CaveProject[]): CaveProject[] {
+/**
+ * Collapse the list to one project per path. The normalized root is the
+ * identity for dedupe purposes — ids are random and can diverge across
+ * duplicate rows, but two entries pointing at the same path are the same
+ * project. Newest record (by updatedAt, then createdAt) wins. Callers may
+ * pass a stricter normalizer (e.g. the server-side tilde-expanding one) so
+ * `~/code/app` and its absolute twin collapse too.
+ */
+export function dedupeProjectsByRoot(
+  projects: CaveProject[],
+  normalizeRoot: (root: string) => string = normalizeProjectRoot,
+): CaveProject[] {
   const byRoot = new Map<string, CaveProject>();
   for (const project of projects) {
-    const root = normalizeProjectRoot(project.root);
+    const root = normalizeRoot(project.root);
     const existing = byRoot.get(root);
     if (!existing || projectTimestamp(project) > projectTimestamp(existing)) {
       byRoot.set(root, project);

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -125,6 +125,74 @@ try {
   await seedDefaultProjectsIfEmpty();
   assert.equal((await loadProjects()).length, 0, "calling seed twice remains a no-op");
 
+  // Paths are the source of truth for identity: duplicate rows already on disk
+  // (persisted before the one-per-root guard, or written by hand) collapse at
+  // load time, so server consumers (projectById/trustedProjectCwd) can never
+  // resolve an entry the UI hides. Newest record wins; ~ expands like the
+  // server normalizer so a tilde row and its absolute twin are one project.
+  const { writeFile } = await import("node:fs/promises");
+  const homeAbs = path.join(os.homedir(), "dupe-home").replace(/\\/g, "/");
+  await writeFile(
+    process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+    JSON.stringify({
+      version: 1,
+      projects: [
+        {
+          id: "disk-old",
+          name: "Old",
+          root: "/tmp/dupe",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "disk-new",
+          name: "New",
+          root: "/tmp/dupe/",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        },
+        {
+          id: "tilde-row",
+          name: "Tilde",
+          root: "~/dupe-home",
+          createdAt: "2026-01-03T00:00:00.000Z",
+          updatedAt: "2026-01-03T00:00:00.000Z",
+        },
+        {
+          id: "abs-row",
+          name: "Absolute",
+          root: homeAbs,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  const dedupedLoad = await loadProjects();
+  assert.deepEqual(
+    dedupedLoad.map((entry) => entry.id).sort(),
+    ["disk-new", "tilde-row"],
+    "loadProjects collapses on-disk duplicates by normalized path, newest wins",
+  );
+  assert.equal(
+    projectForRoot("/tmp/dupe/", dedupedLoad)?.id,
+    "disk-new",
+    "path lookups resolve to the surviving (newest) duplicate",
+  );
+  // The next mutation persists the deduped list — the file self-heals.
+  assert.equal(await deleteProject("tilde-row"), true);
+  const healed = JSON.parse(
+    await readFile(process.env.CAVE_PROJECTS_PATH_OVERRIDE, "utf8"),
+  );
+  assert.deepEqual(
+    healed.projects.map((entry) => entry.id),
+    ["disk-new"],
+    "a write after load persists the deduped list, dropping stale duplicate rows",
+  );
+  assert.equal(await deleteProject("disk-new"), true);
+  assert.deepEqual(await loadProjects(), []);
+
   assert.deepEqual(
     sortProjectsAlphabetically([
       { id: "z", name: "Zed", root: "/work/zed", createdAt: "", updatedAt: "" },

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -10,6 +10,7 @@ export {
   sortProjectsAlphabetically,
 } from "./cave-projects-types.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
+import { dedupeProjectsByRoot as dedupeByRoot } from "./cave-projects-types.ts";
 
 type ProjectsFile = {
   version: 1;
@@ -73,7 +74,15 @@ export async function loadProjects(): Promise<CaveProject[]> {
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw) as Partial<ProjectsFile>;
-    return Array.isArray(parsed.projects) ? parsed.projects : [];
+    if (!Array.isArray(parsed.projects)) return [];
+    // Dedupe at the source of truth: the normalized path IS the project
+    // identity. createProject/patchProject keep new writes one-per-root, but
+    // duplicates persisted before that guard (or written by hand) would
+    // otherwise leak into every server consumer (projectById,
+    // trustedProjectCwd, permission filtering) while the UI hid them via
+    // dedupeProjectsByRoot — a client/server divergence. Newest record wins;
+    // the next mutation persists the deduped list, self-healing the file.
+    return dedupeByRoot(parsed.projects, normalizeRoot);
   } catch {
     return [];
   }


### PR DESCRIPTION
## What

`loadProjects()` now collapses duplicate project rows at load time, keyed by the server-side tilde-expanding normalized root. Newest record (`updatedAt`, then `createdAt`) wins; the next mutation persists the deduped list, so the file self-heals.

## Why

Duplicate rows already on disk (persisted before the one-per-root guard, or written by hand) leaked into every server consumer — `projectById`, `trustedProjectCwd`, permission filtering — while the UI hid them via `dedupeProjectsByRoot`. That client/server divergence meant lookups could resolve an entry the UI never shows.

## How

- `dedupeProjectsByRoot` gains an optional `normalizeRoot` parameter (default unchanged) so the server can pass its stricter tilde-expanding normalizer — `~/code/app` and its absolute twin collapse to one project.
- `loadProjects()` runs the dedupe on parse.
- Tests: on-disk duplicates (trailing slash + tilde/absolute twins) collapse at load, path lookups resolve to the surviving newest record, and a subsequent write persists the deduped list.

## Verification

- `node --test src/lib/cave-projects.test.ts` — pass
- `pnpm exec tsc --noEmit` — clean