### PR TITLE
fix(artifact-comments): clamp Comment fab x so wide selections don't clip it offscreen

### DIFF
--- a/src/components/artifact-comments.test.ts
+++ b/src/components/artifact-comments.test.ts
@@ -17,6 +17,12 @@ assert.match(
 assert.match(comp, /document\.addEventListener\("mouseup", onMouseUp\)/, "detects selection on mouseup");
 assert.match(comp, /window\.getSelection\(\)/, "reads the live text selection");
 assert.match(comp, /className="cave-artifact-comment-fab"/, "shows a floating Comment affordance on selection");
+// The fab's x is clamped so wide selections can't push it off the viewport edge.
+assert.match(
+  comp,
+  /clampFabX\(rect\.left \+ rect\.width \/ 2, window\.innerWidth\)/,
+  "clamps the fab position to the viewport so it never clips offscreen",
+);
 // The comments are folded into a prompt and sent via the chat send path.
 assert.match(comp, /buildCommentsPrompt\(comments/, "builds the revision prompt from the collected comments");
 assert.match(comp, /onRequest\(prompt\)/, "submits the synthesized prompt to the agent");

--- a/src/components/artifact-comments.tsx
+++ b/src/components/artifact-comments.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import {
   buildCommentsPrompt,
+  clampFabX,
   normalizeExcerpt,
   readComments,
   writeComments,
@@ -76,7 +77,8 @@ export function ArtifactComments({
           return;
         }
         const rect = selection.getRangeAt(0).getBoundingClientRect();
-        setSel({ text, x: rect.left + rect.width / 2, y: rect.top });
+        // Clamp so the pill never clips off either viewport edge on wide selections.
+        setSel({ text, x: clampFabX(rect.left + rect.width / 2, window.innerWidth), y: rect.top });
       }, 0);
     };
     const onSelectionChange = () => {

--- a/src/lib/artifact-comments.test.ts
+++ b/src/lib/artifact-comments.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildCommentsPrompt, normalizeExcerpt, commentsStorageKey } from "./artifact-comments.ts";
+import { buildCommentsPrompt, clampFabX, normalizeExcerpt, commentsStorageKey } from "./artifact-comments.ts";
 
 // ── normalizeExcerpt collapses whitespace and clamps long selections ─────────
 assert.equal(normalizeExcerpt("  hello   world\n\nfoo "), "hello world foo");
@@ -37,5 +37,15 @@ assert.match(labeled, /on the spec\./, "honours a custom document label");
 
 // ── storage key is namespaced per turn ───────────────────────────────────────
 assert.equal(commentsStorageKey("t_123"), "cave:artifact-comments:v1:t_123");
+
+// ── clampFabX keeps the fab pill fully inside the viewport ───────────────────
+assert.equal(clampFabX(500, 1000), 500, "mid-viewport positions pass through");
+assert.equal(clampFabX(990, 1000), 940, "right-edge positions are pulled in (margin + half-width)");
+assert.equal(clampFabX(1500, 1000), 940, "positions past the edge are clamped, not lost");
+assert.equal(clampFabX(10, 1000), 60, "left-edge positions are pulled in symmetrically");
+assert.equal(clampFabX(-50, 1000), 60, "negative positions are clamped");
+assert.equal(clampFabX(50, 100), 50, "degenerate narrow viewports fall back to center");
+assert.equal(clampFabX(300, 1000, 20, 10), 300, "honours custom half-width/margin");
+assert.equal(clampFabX(995, 1000, 20, 10), 970, "custom bounds clamp accordingly");
 
 console.log("artifact-comments.test.ts: ok");

--- a/src/lib/artifact-comments.ts
+++ b/src/lib/artifact-comments.ts
@@ -26,6 +26,28 @@ export function commentsStorageKey(turnId: string): string {
   return `${STORAGE_PREFIX}${turnId}`;
 }
 
+/** Approx. half the rendered fab pill width (icon + "Comment" label + padding). */
+export const FAB_HALF_WIDTH = 52;
+/** Minimum gap kept between the fab edge and the viewport edge. */
+export const FAB_EDGE_MARGIN = 8;
+
+/**
+ * Clamp the floating Comment fab's center-x so the pill (rendered with
+ * `translateX(-50%)`) stays fully inside the viewport. Wide selections put the
+ * selection midpoint near an edge, which otherwise clips the button offscreen.
+ */
+export function clampFabX(
+  x: number,
+  viewportWidth: number,
+  halfWidth: number = FAB_HALF_WIDTH,
+  margin: number = FAB_EDGE_MARGIN,
+): number {
+  const min = margin + halfWidth;
+  const max = viewportWidth - margin - halfWidth;
+  if (max <= min) return viewportWidth / 2;
+  return Math.min(max, Math.max(min, x));
+}
+
 /** Collapse whitespace and clamp a selected excerpt to a quotable length. */
 export function normalizeExcerpt(raw: string): string {
   const collapsed = raw.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
The floating Comment pill is positioned at the selection midpoint with `translateX(-50%)`, so selections reaching a viewport edge pushed the pill partly (or fully) offscreen.

- Add `clampFabX` (half-width + edge margin, center fallback for degenerate viewports) in `src/lib/artifact-comments.ts`
- Apply it in the mouseup selection handler in `artifact-comments.tsx`
- Unit tests added in both lib and component pins

Re-landing local commit `70d8f65e` from `main` via the PR path (push previously failed without network grants).