### PR TITLE
feat(ios): honest reconnect pill — keep tabs mounted through connection drops (cave-y482 part 2)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -31,7 +31,17 @@ final class AppModel {
     }
 
     var connection: CaveConnection?
-    var connectionState: ConnectionState = .unconfigured
+    /// Stamped the moment the state LEAVES `.connected` — the last instant the
+    /// desktop was known reachable — so the reconnect pill can say
+    /// "last seen 2 min ago" honestly during a drop.
+    private(set) var lastConnectedAt: Date?
+    var connectionState: ConnectionState = .unconfigured {
+        didSet {
+            if oldValue == .connected, connectionState != .connected {
+                lastConnectedAt = Date()
+            }
+        }
+    }
     private let connectionMonitor = NWPathMonitor()
     private let connectionMonitorQueue = DispatchQueue(label: "ai.opencoven.cave.connection-monitor")
     private var connectionMonitorStarted = false
@@ -671,14 +681,22 @@ final class AppModel {
         connectionMonitor.start(queue: connectionMonitorQueue)
     }
 
+    /// Quiet: the state only changes on an outcome, so a healthy path change
+    /// (Wi-Fi ↔ LTE) doesn't blink the UI through `.checking` — which would
+    /// flash the reconnect pill over perfectly good tabs.
     func recoverConnectionInBackground() async {
         guard connection != nil else { connectionState = .unconfigured; return }
-        await refreshConnection(reloadLoadedSurfaces: true)
+        await refreshConnection(reloadLoadedSurfaces: true, quiet: true)
     }
 
-    private var shouldReloadLoadedSurfaces: Bool {
+    /// Any surface holds real data — the tab tree is worth keeping mounted
+    /// through a connection drop (RootView shows the reconnect pill over it
+    /// instead of tearing down to the Connect screen).
+    var hasLoadedSurfaces: Bool {
         !familiars.isEmpty || sessionsLoaded || tasksLoaded || remindersLoaded || projectsLoaded || journalLoaded
     }
+
+    private var shouldReloadLoadedSurfaces: Bool { hasLoadedSurfaces }
 
     private func pairingMessage() -> String {
         CaveConnection.accessToken == nil

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -101,7 +101,8 @@ private struct ReconnectPill: View {
         .buttonStyle(.plain)
         .glass(.elevated, in: Capsule())
         .padding(.top, 6)
-        .accessibilityLabel(Text("Reconnecting to your desktop. Tap to retry now."))
+        .accessibilityLabel(label)
+        .accessibilityHint(Text("Tap to retry now."))
     }
 
     /// `Text(_:style:)` renders an auto-updating relative clock ("2 min"),

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -3,19 +3,51 @@ import SwiftUI
 struct RootView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         @Bindable var app = app
         Group {
             switch app.connectionState {
-            case .unconfigured:
+            case .unconfigured, .needsAuth:
+                // No endpoint, or the desktop is up but demands pairing —
+                // only the user can fix either, so the Connect screen takes
+                // over fully.
                 ConnectionView()
-            case .checking where app.connection != nil && app.familiars.isEmpty:
+            case .checking where app.connection != nil && !app.hasLoadedSurfaces:
                 ConnectingView()
-            case .unreachable, .needsAuth:
+            case .unreachable where !app.hasLoadedSurfaces:
+                // Never got in this session — nothing to keep on screen.
                 ConnectionView()
             default:
+                // Connected — or a transient drop AFTER surfaces loaded. Keep
+                // the tab tree mounted (cached data stays usable, offline
+                // compose keeps queueing) and narrate recovery with the pill
+                // instead of tearing down to the Connect screen.
                 MainTabView()
+            }
+        }
+        .overlay(alignment: .top) {
+            if showsReconnectPill {
+                ReconnectPill(lastSeenAt: app.lastConnectedAt) {
+                    Task { await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true) }
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.snappy(duration: 0.25), value: showsReconnectPill)
+        // While the pill is up over the tabs, quietly re-probe so a desktop
+        // that comes back (restarted, woke from sleep) reconnects on its own.
+        // The Connect screen has its own ticker for the pre-surfaces case;
+        // the hasLoadedSurfaces guard keeps the two from double-probing.
+        // Keyed on scenePhase so backgrounding stops the timer.
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(10))
+                guard app.hasLoadedSurfaces,
+                      case .unreachable = app.connectionState else { continue }
+                await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
             }
         }
         .background(chrome.bgBase.ignoresSafeArea())
@@ -30,6 +62,52 @@ struct RootView: View {
         .fullScreenCover(isPresented: $app.diaryPresented) {
             DiaryView()
         }
+    }
+
+    /// The tabs are mounted but the desktop is out of reach (or a recovery
+    /// probe is in flight) — show the honest "Reconnecting…" pill.
+    private var showsReconnectPill: Bool {
+        guard app.hasLoadedSurfaces else { return false }
+        switch app.connectionState {
+        case .unreachable, .checking: return true
+        default: return false
+        }
+    }
+}
+
+/// Floating "Reconnecting… · last seen Xm" capsule shown over the mounted tab
+/// tree during a connection drop. Tapping it fires an immediate quiet probe
+/// instead of waiting out the 10s ticker.
+private struct ReconnectPill: View {
+    @Environment(\.chrome) private var chrome
+    var lastSeenAt: Date?
+    var retry: () -> Void
+
+    var body: some View {
+        Button(action: retry) {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(chrome.textSecondary)
+                label
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(chrome.textPrimary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .glass(.elevated, in: Capsule())
+        .padding(.top, 6)
+        .accessibilityLabel(Text("Reconnecting to your desktop. Tap to retry now."))
+    }
+
+    /// `Text(_:style:)` renders an auto-updating relative clock ("2 min"),
+    /// so the pill's age counts up without a timer.
+    private var label: Text {
+        guard let lastSeenAt else { return Text("Reconnecting…") }
+        return Text("Reconnecting… · last seen \(Text(lastSeenAt, style: .relative)) ago")
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -45,6 +45,7 @@ struct RootView: View {
             guard scenePhase == .active else { return }
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(10))
+                if Task.isCancelled { return }
                 guard app.hasLoadedSurfaces,
                       case .unreachable = app.connectionState else { continue }
                 await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)

--- a/scripts/ios-reconnect-pill.test.mjs
+++ b/scripts/ios-reconnect-pill.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Honest reconnect UX (bead cave-y482 part 2): once any surface has loaded,
+// a connection drop must NOT tear the tab tree down to the Connect screen.
+// The tabs stay mounted (cached data usable, offline compose keeps queueing)
+// with a "Reconnecting… · last seen Xm" pill narrating recovery. Full-screen
+// Connect is reserved for unconfigured / needsAuth / never-connected.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const root = await read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+
+// --- RootView: teardown only when there's nothing worth keeping -------------
+assert.match(
+  root,
+  /case \.unconfigured, \.needsAuth:\s*\n[\s\S]*?ConnectionView\(\)/,
+  "unconfigured and needsAuth take the full Connect screen — only the user can fix those",
+);
+assert.match(
+  root,
+  /case \.unreachable where !app\.hasLoadedSurfaces:\s*\n[\s\S]*?ConnectionView\(\)/,
+  "unreachable falls to the Connect screen ONLY before any surface has loaded",
+);
+assert.match(
+  root,
+  /case \.checking where app\.connection != nil && !app\.hasLoadedSurfaces:\s*\n\s*ConnectingView\(\)/,
+  "the Connecting screen is a cold-launch state, not a reconnect state",
+);
+
+// --- The pill: shown over mounted tabs during a drop, tap = retry now --------
+assert.match(
+  root,
+  /private var showsReconnectPill: Bool \{[\s\S]*?guard app\.hasLoadedSurfaces else \{ return false \}[\s\S]*?case \.unreachable, \.checking: return true/,
+  "the pill shows for unreachable/checking only once surfaces are loaded",
+);
+assert.match(
+  root,
+  /ReconnectPill\(lastSeenAt: app\.lastConnectedAt\) \{\s*\n\s*Task \{ await app\.refreshConnection\(reloadLoadedSurfaces: true, quiet: true\) \}/,
+  "tapping the pill fires an immediate quiet probe",
+);
+assert.match(
+  root,
+  /struct ReconnectPill: View[\s\S]*?Text\(lastSeenAt, style: \.relative\)/,
+  "the pill shows an auto-updating 'last seen' relative clock",
+);
+assert.match(
+  root,
+  /struct ReconnectPill: View[\s\S]*?\.glass\(\.elevated, in: Capsule\(\)\)/,
+  "the pill uses the shared elevated glass capsule (theme + accessibility aware)",
+);
+assert.match(
+  root,
+  /struct ReconnectPill: View[\s\S]*?accessibilityLabel/,
+  "the pill announces itself to VoiceOver",
+);
+
+// --- While the pill is up, something must actually retry ---------------------
+// The Connect screen's own 10s ticker no longer runs for unreachable-with-
+// surfaces (that screen isn't mounted), so RootView carries its own quiet
+// re-probe, mutually exclusive via the hasLoadedSurfaces guard.
+assert.match(
+  root,
+  /\.task\(id: scenePhase\) \{[\s\S]*?guard app\.hasLoadedSurfaces,\s*\n\s*case \.unreachable = app\.connectionState else \{ continue \}[\s\S]*?await app\.refreshConnection\(reloadLoadedSurfaces: true, quiet: true\)/,
+  "RootView quietly re-probes while the pill covers an unreachable desktop",
+);
+
+// --- AppModel: honest 'last seen' + shared surfaces gate ---------------------
+assert.match(
+  model,
+  /private\(set\) var lastConnectedAt: Date\?/,
+  "AppModel tracks when the desktop was last known reachable",
+);
+assert.match(
+  model,
+  /didSet \{\s*\n\s*if oldValue == \.connected, connectionState != \.connected \{\s*\n\s*lastConnectedAt = Date\(\)/,
+  "lastConnectedAt is stamped the moment the state LEAVES .connected — the last instant the desktop was seen",
+);
+assert.match(
+  model,
+  /var hasLoadedSurfaces: Bool \{\s*\n\s*!familiars\.isEmpty \|\| sessionsLoaded \|\| tasksLoaded \|\| remindersLoaded \|\| projectsLoaded \|\| journalLoaded/,
+  "hasLoadedSurfaces is the single gate for 'the tab tree holds real data'",
+);
+
+console.log("ios-reconnect-pill: OK");

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -32,8 +32,8 @@ assert.match(
 assert.match(model, /func recoverConnectionInBackground\(\) async/, "AppModel should expose background recovery");
 assert.match(
   model,
-  /func recoverConnectionInBackground[\s\S]*?await refreshConnection\(reloadLoadedSurfaces: true\)/,
-  "background recovery should ask refreshConnection to reload opened surfaces",
+  /func recoverConnectionInBackground[\s\S]*?await refreshConnection\(reloadLoadedSurfaces: true, quiet: true\)/,
+  "background recovery should reload opened surfaces quietly (no .checking blink → no pill flash on healthy path changes)",
 );
 assert.match(
   model,

--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -35,8 +35,13 @@ assert.match(libRs, /WebviewUrl::App\("index\.html"\.into\(\)\)/);
 const swiftRootView = read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
 assert.match(
   swiftRootView,
-  /case \.unreachable, \.needsAuth:\s*\n\s*ConnectionView\(\)/,
-  "native SwiftUI app should return unreachable AND pairing-required hosts to the connection screen",
+  /case \.unconfigured, \.needsAuth:\s*\n[\s\S]*?ConnectionView\(\)/,
+  "native SwiftUI app should return pairing-required hosts to the connection screen",
+);
+assert.match(
+  swiftRootView,
+  /case \.unreachable where !app\.hasLoadedSurfaces:\s*\n[\s\S]*?ConnectionView\(\)/,
+  "unreachable returns to the connection screen only before surfaces load — after that the reconnect pill covers it (see ios-reconnect-pill.test.mjs)",
 );
 
 const swiftChatThread = read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -795,6 +795,7 @@ export const SUITES = {
     "scripts/ios-auto-reconnect.test.mjs",
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connection-stability.test.mjs",
+    "scripts/ios-reconnect-pill.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",
     "scripts/ios-offline-compose.test.mjs",
     "scripts/ios-operator-profile.test.mjs",


### PR DESCRIPTION
Part 2 of bead **cave-y482** (follows #2933, which persisted the mobile secret).

## What

Once any surface has loaded, a connection drop no longer tears the tab tree down to the Connect screen. The tabs stay mounted — cached data stays usable and offline compose keeps queueing — with a **"Reconnecting… · last seen Xm"** glass pill narrating recovery. Full-screen Connect is reserved for `unconfigured` / `needsAuth` / never-connected-this-session.

## How

- **RootView**: `.unreachable`/`.checking` only fall to Connect/Connecting screens when `!hasLoadedSurfaces`; otherwise `MainTabView` stays mounted with the pill overlaid. The pill taps through to an immediate quiet probe, and RootView carries its own 10s quiet re-probe ticker (the Connect screen's ticker isn't mounted in this state; the `hasLoadedSurfaces` guard keeps the two mutually exclusive).
- **AppModel**: `lastConnectedAt` stamped via `didSet` the moment the state *leaves* `.connected` — the honest "last seen" instant. `hasLoadedSurfaces` exposed as the single gate for "the tab tree holds real data".
- **Quiet background recovery**: `recoverConnectionInBackground` now probes with `quiet: true`, so a healthy Wi-Fi↔LTE path change doesn't blink `.checking` → pill flash over perfectly good tabs.
- **Pill**: shared `.glass(.elevated, in: Capsule())` (theme + Reduce Transparency aware), auto-updating relative clock via `Text(_, style: .relative)` (no timer), VoiceOver label.

## Verification

- New pin suite `scripts/ios-reconnect-pill.test.mjs` (registered in the mobile group).
- `ios-self-healing-sync` pin updated for the quiet probe; full `scripts/ios-*.test.mjs` sweep green (60/60).
- Local swiftc/xcodebuild blocked in the session sandbox — CI + pin suite are the verification, same as part 1.

Remaining on the bead: part 3 (CaveConnection bare-host discovery ports 3000-3010).
