### PR TITLE
fix(board): anchor detail-panel action popover left so it isn't clipped

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -834,7 +834,6 @@
 /* Detail-panel actions sit at the panel's LEFT edge, so a right-anchored popover
    extends into the scroll container's unreachable left overflow and gets clipped.
    Anchor to the actions row itself (wrap goes static) and open from the left. */
-.gh-glass-actions .gh-action-wrap { position:static; }
 .gh-glass-actions .gh-action-popover { left:0; right:auto; max-width:100%; }
 
 .gh-glass-panel {

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -831,6 +831,11 @@
 .gh-action-popover-item:disabled { opacity:.55; cursor:wait; }
 .gh-action-popover-item-title { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .gh-action-popover-item-familiar { color:var(--text-muted); font-size:10.5px; }
+/* Detail-panel actions sit at the panel's LEFT edge, so a right-anchored popover
+   extends into the scroll container's unreachable left overflow and gets clipped.
+   Anchor to the actions row itself (wrap goes static) and open from the left. */
+.gh-glass-actions .gh-action-wrap { position:static; }
+.gh-glass-actions .gh-action-popover { left:0; right:auto; max-width:100%; }
 
 .gh-glass-panel {
   position:relative;


### PR DESCRIPTION
The `gh-glass-actions` row sits at the detail panel's LEFT edge, so the right-anchored `.gh-action-popover` extended into the scroll container's unreachable left overflow and got clipped.

Fix: make `.gh-action-wrap` static inside `.gh-glass-actions` so the popover anchors to the actions row itself, and open it from the left (`left:0; right:auto; max-width:100%`).

CSS-only, scoped to the detail-panel actions; the board-card popovers keep their existing right-anchored behavior.