### PR TITLE
feat(quick-chat): attachments, message queueing, and companion composer upgrades

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -304,6 +304,7 @@ export const SUITES = {
     "src/lib/prompt-placeholders.test.ts",
     "src/lib/prompt-prefs.test.ts",
     "src/lib/use-prompt-enhance.test.ts",
+    "src/lib/reply-recommendation.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/code-lang.test.ts",
     "src/lib/home-digest.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11864,6 +11864,117 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: 999px;
 }
 
+/* Reply recommendation — a proposed next reply offered above the composer,
+ * Tab-to-autofill once a familiar has replied (shared overlay + tray). */
+.quick-chat-reco {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  border-radius: var(--radius-control);
+  border: 1px solid color-mix(in oklch, var(--accent) 30%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent) 6%, var(--bg-raised));
+}
+.quick-chat-reco__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--accent-presence, var(--accent));
+}
+.quick-chat-reco__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  text-align: left;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--fg-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.quick-chat-reco__text--preview {
+  color: var(--fg-muted);
+}
+.quick-chat-reco__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.quick-chat-reco__kbd {
+  font-size: 10px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  padding: 1px 5px;
+  border-radius: 5px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  color: var(--fg-muted);
+}
+.quick-chat-reco__shimmer {
+  flex: 1 1 auto;
+  height: 12px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklch, var(--fg-muted) 12%, transparent) 25%,
+    color-mix(in oklch, var(--fg-muted) 22%, transparent) 50%,
+    color-mix(in oklch, var(--fg-muted) 12%, transparent) 75%
+  );
+  background-size: 200% 100%;
+  animation: quick-chat-reco-shimmer 1.2s ease-in-out infinite;
+}
+@keyframes quick-chat-reco-shimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .quick-chat-reco__shimmer {
+    animation: none;
+  }
+}
+
+/* Next-path suggestions — the agent's parseable trailer surfaced as tap-to-fill
+ * chips on the latest familiar reply (shared overlay + tray). Same accent-tint
+ * language as the main chat's .cave-next-path, sized for the compact tray.
+ * `.ui-btn.` specificity: the chips ride the shared Button primitive, so the
+ * base .ui-btn geometry (32px, nowrap) must lose here. */
+.quick-chat-next-paths {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.ui-btn.quick-chat-next-path {
+  height: auto;
+  min-height: 24px;
+  padding: 3px 10px;
+  justify-content: flex-start;
+  text-align: left;
+  white-space: normal;
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  border-radius: var(--radius-control);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--text-secondary);
+}
+.ui-btn.quick-chat-next-path:hover {
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  border-color: var(--accent-presence);
+  color: var(--text-primary);
+}
+
 /* Composer — textarea + action row pinned to the bottom (shared overlay + tray). */
 .quick-chat-overlay__composer {
   display: flex;
@@ -11906,6 +12017,97 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-overlay__actions button:not(:disabled):hover {
   filter: brightness(1.06);
+}
+
+/* Drag-and-drop attachments — the composer footer is the drop target; the
+ * counted enter/leave handlers (shared useAttachmentStaging) keep this veil
+ * steady while the drag crosses child elements. */
+.quick-chat-overlay__composer--drop {
+  outline: 1.5px dashed var(--accent-presence, var(--accent));
+  outline-offset: -4px;
+}
+.quick-chat-dropzone {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-presence, var(--accent));
+  background: color-mix(in oklch, var(--bg-base) 78%, transparent);
+  border-radius: inherit;
+  pointer-events: none;
+}
+/* Staged-file chips (above the actions row) and the paperclip line a sent
+ * user turn keeps in its bubble. */
+.quick-chat-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.quick-chat-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  padding: 2px 4px 2px 8px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.quick-chat-attachment-chip__name {
+  min-width: 0;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.quick-chat-bubble__files {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Queued messages — parked while a reply streams, auto-send on settle. The
+ * tinted border echoes the reply-recommendation strip: "held, not lost". */
+.quick-chat-queued {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.quick-chat-queued__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 2px 4px 2px 8px;
+  border-radius: var(--radius-control);
+  border: 1px dashed color-mix(in oklch, var(--accent-presence, var(--accent)) 45%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence, var(--accent)) 6%, transparent);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+.quick-chat-queued__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.quick-chat-queued__count {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--fg-muted);
 }
 
 /* ======================================================================

--- a/src/components/composer-enhance.test.ts
+++ b/src/components/composer-enhance.test.ts
@@ -59,6 +59,42 @@ assert.match(
   "accent marks presence only — the sparkle tints while loading, never at rest",
 );
 
+// ── EnhanceControl: one combined rectangle, not two floating rounds ──────────
+// The sparkle + caret live inside a single hairline control-radius rectangle
+// split by a hairline divider — minimal, and height-matched to the hosting
+// composer's Send button via the size prop.
+assert.match(
+  source,
+  /inline-flex items-stretch overflow-hidden rounded-\[var\(--radius-control\)\] border border-\[var\(--border-hairline\)\]/,
+  "the control is one bordered control-radius rectangle wrapping both segments",
+);
+assert.match(
+  source,
+  /border-l border-\[var\(--border-hairline\)\]/,
+  "the caret segment joins through a hairline divider, not its own outline",
+);
+{
+  const controlSrc = source.slice(
+    source.indexOf("export function EnhanceControl"),
+    source.indexOf("export function EnhanceStrip"),
+  );
+  assert.doesNotMatch(
+    controlSrc,
+    /rounded-full/,
+    "no rounded-full inside the control — the pill geometry belongs to the strip only",
+  );
+}
+assert.match(
+  source,
+  /size = "md",/,
+  "the height prop defaults to the 30px composer rows; quick chat opts into sm",
+);
+assert.match(
+  source,
+  /size === "sm" \? "h-\[26px\]" : "h-\[30px\]"/,
+  'sm matches the 26px Button size="sm" Send; md the 30px icon-button rows',
+);
+
 // ── EnhanceStrip: one status row, four phases ────────────────────────────────
 assert.match(source, /if \(state\.phase === "idle"\) return null/, "the strip renders nothing at rest");
 assert.match(source, /role="status"/, "the strip is a status live region");

--- a/src/components/composer-enhance.tsx
+++ b/src/components/composer-enhance.tsx
@@ -12,19 +12,26 @@ import type { PromptEnhanceState } from "@/lib/use-prompt-enhance";
 
 const LONG_PRESS_MS = 420;
 
-/** Sparkle split-control in the composer's 30px round-button language.
- *  Click = smart enhance; the chevron (or ArrowDown / long-press on the main
- *  button) opens the intent menu. Accent shows only while loading. */
+/** Sparkle split-control: one minimal rectangle (control-radius, hairline
+ *  border) holding the sparkle segment and the caret segment — a single
+ *  combined control, not two floating round buttons.
+ *  Click = smart enhance; the caret (or ArrowDown / long-press on the main
+ *  segment) opens the intent menu. Accent shows only while loading. */
 export function EnhanceControl({
   state,
   onEnhance,
   onCancel,
   disabled,
+  size = "md",
 }: {
   state: PromptEnhanceState;
   onEnhance: (intent: EnhanceIntent) => void;
   onCancel: () => void;
   disabled?: boolean;
+  /** Height language of the hosting composer — "md" sits with the 30px
+   *  icon-button rows (home, chat); "sm" matches the 26px `Button size="sm"`
+   *  Send button (quick chat). */
+  size?: "sm" | "md";
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const mainRef = useRef<HTMLButtonElement | null>(null);
@@ -37,15 +44,21 @@ export function EnhanceControl({
   }, []);
   useEffect(() => clearPress, [clearPress]);
 
-  const baseBtn =
-    "cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40";
+  // Both segments share one hairline rectangle — borderless inside, split by
+  // a hairline divider, height matched to the composer's Send button. They use
+  // their own segment class (NOT cave-composer-icon-button): the mobile
+  // touch-target override turns that class into 44px circles, which blew the
+  // segments out of the rectangle. Here the rectangle itself is the control —
+  // two flat rectangles inside it, the sparkle wider than the caret.
+  const heightClass = size === "sm" ? "h-[26px]" : "h-[30px]";
+  const segmentBtn = `composer-enhance-control__segment focus-ring grid ${heightClass} place-items-center hover:bg-[var(--bg-raised)] disabled:opacity-40`;
 
   return (
-    <span className="composer-enhance-control inline-flex items-center gap-0.5">
+    <span className="composer-enhance-control inline-flex items-stretch overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)]">
       <button
         ref={mainRef}
         type="button"
-        className={baseBtn}
+        className={`${segmentBtn} px-2`}
         title="Enhance prompt"
         aria-label="Enhance prompt"
         disabled={disabled && !loading}
@@ -81,7 +94,7 @@ export function EnhanceControl({
       </button>
       <button
         type="button"
-        className="cave-composer-icon-button focus-ring grid h-[30px] w-4 place-items-center rounded-full text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-40"
+        className={`${segmentBtn} w-[18px] border-l border-[var(--border-hairline)] text-[var(--text-muted)] hover:text-[var(--text-primary)]`}
         aria-label="Enhance options"
         aria-haspopup="menu"
         aria-expanded={menuOpen}

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -11,7 +11,7 @@ assert.match(source, /renderValue=/, "quick-chat select helper should keep its c
 // Shared conversation thread — used by both the in-app dropdown and the tray.
 assert.match(source, /export function QuickChatThread/, "controls export the shared multi-turn thread renderer");
 assert.match(source, /import \{ MarkdownBlock \} from "@\/components\/message-bubble"/, "familiar replies render markdown via the shared MarkdownBlock");
-assert.match(source, /copyText\(message\.text\)/, "each familiar reply can be copied to the clipboard");
+assert.match(source, /copyText\(visible\)/, "each familiar reply can be copied to the clipboard — the visible text, not the raw next-paths trailer");
 assert.match(source, /aria-live="polite"/, "the thread is a polite live region so streamed replies are announced");
 assert.match(source, /quick-chat-caret|quick-chat-typing/, "streaming turns show a caret / thinking affordance");
 
@@ -47,6 +47,21 @@ assert.match(
 );
 assert.match(
   source,
+  /showFamiliarPicker \? \(\s*<QuickChatSelect[\s\S]*label="Familiar"/,
+  "agent selection is conditional — shown only when the host asks for it (new-chat + flow)",
+);
+assert.match(
+  source,
+  /<QuickChatSelect[\s\S]*label="Project"[\s\S]*onChange=\{\(next\) => onPickProjectRoot\(/,
+  "the shared controls row includes project selection for quick chat",
+);
+assert.match(
+  source,
+  /projectsLoading && projects\.length === 0[\s\S]*label: "Loading projects…"/,
+  "project select shows a loading placeholder while scoped projects are fetching",
+);
+assert.match(
+  source,
   /CONTROL_SELECT_CLASS =\s*\n?\s*"[^"]*rounded-\[var\(--radius-control\)\]/,
   "selector controls use the shared control radius token",
 );
@@ -70,6 +85,30 @@ assert.match(
   source,
   /requestAnimationFrame\(\(\) => composerRef\.current\?\.focus\(\)\)/,
   "picking a suggestion moves the caret into the composer (both surfaces, via useSuggestionPicker)",
+);
+
+// ── Reply recommendation: Tab-to-autofill a suggested next reply ──────────────
+// After a familiar turn settles, the shared hook proposes the user's next
+// message and offers it above the composer; Tab (empty composer) or the Use
+// button autofills it.
+assert.match(
+  source,
+  /export function ReplyRecommendationStrip/,
+  "controls export the shared recommended-reply strip",
+);
+assert.ok(
+  source.includes("import { useReplyRecommendation"),
+  "the composer mounts the shared reply-recommendation hook for zero-wiring parity with Enhance",
+);
+assert.match(
+  source,
+  /event\.key === "Tab"[\s\S]*recommendation\.suggestion[\s\S]*!draft\.trim\(\)/,
+  "Tab accepts a ready recommendation only into the empty composer (else it falls through to focus traversal)",
+);
+assert.match(
+  source,
+  /<ReplyRecommendationStrip/,
+  "the composer renders the recommendation strip above the input",
 );
 
 // ── Thread auto-scroll must not fight the user ────────────────────────────────
@@ -110,5 +149,161 @@ assert.match(
   /setTimeout\(\(\) => setCopied\(false\), 1500\)/,
   "the copied ✓ hands the button back to copy after a beat (it used to stick forever)",
 );
+
+// ── Next-path suggestions — the agent trailer as tap-to-fill chips ────────────
+// Familiar replies carry a parseable <coven:next-paths> trailer (see
+// lib/next-paths.ts). The quick chat strips it from EVERY turn (streaming-safe:
+// the half-open block hides too) and renders the suggestions as chips on the
+// LATEST settled reply only — a compact tray can't afford stale chip rows.
+assert.match(
+  source,
+  /import \{ extractNextPaths \} from "@\/lib\/next-paths"/,
+  "the thread parses the shared next-paths trailer format — no bespoke parser",
+);
+assert.match(
+  source,
+  /message\.role === "assistant"\s*\?\s*extractNextPaths\(message\.text\)/,
+  "the trailer is stripped from familiar turns (never shown raw)",
+);
+assert.match(
+  source,
+  /isLastAssistant && !streaming && onSuggestion && suggestions\.length > 0/,
+  "chips render only on the latest settled reply, and only when a composer can accept them",
+);
+assert.match(
+  source,
+  /className="quick-chat-next-path"[\s\S]*?onClick=\{\(\) => onSuggestion\(suggestion\)\}/,
+  "clicking a chip fills the composer through the shared suggestion path (fill, not send)",
+);
+assert.match(
+  source,
+  /aria-label="Suggested next steps"/,
+  "the chip row is a labelled group",
+);
+
+// ── Enhance control matches the Send button's height language ────────────────
+assert.match(
+  source,
+  /<EnhanceControl[\s\S]*?size="sm"/,
+  "quick chat mounts the compact enhance control — same 26px height as its Send button",
+);
+
+// ── Attachments: drag-and-drop + paste, shared staging hook ──────────────────
+// Same capture behavior as the home/chat composers (useAttachmentStaging): the
+// composer footer is the drop target, the textarea takes paste-to-attach, and
+// the send strips the chip-row-local id before handing files to the hook.
+assert.ok(
+  source.includes('import { useAttachmentStaging } from "@/lib/use-attachment-staging"'),
+  "quick chat stages files through the shared hook — no bespoke drag state",
+);
+assert.match(
+  source,
+  /<footer[\s\S]*?\{\.\.\.dropHandlers\}/,
+  "the composer footer is the drop target (counted enter/leave handlers)",
+);
+assert.match(source, /onPaste=\{handlePaste\}/, "the textarea accepts paste-to-attach (screenshots)");
+assert.match(
+  source,
+  /dropActive \?[\s\S]*?quick-chat-dropzone/,
+  "an active file drag shows the drop veil",
+);
+assert.match(
+  source,
+  /onSend\(attachments\.map\(\(\{ id: _id, \.\.\.attachment \}\) => attachment\)\);\s*\n\s*clearAttachments\(\)/,
+  "send strips the local chip id and clears staging (mirrors the chat composer)",
+);
+assert.match(
+  source,
+  /const canSend = Boolean\(draft\.trim\(\) \|\| attachments\.length > 0\)/,
+  "attachment-only sends are allowed — files with no text still go",
+);
+assert.match(
+  source,
+  /aria-label="Attached files"[\s\S]*?attachmentIcon\(attachment\)/,
+  "staged files render as a labelled chip group with type icons",
+);
+assert.match(
+  source,
+  /aria-label=\{`Remove \$\{attachment\.name\}`\}/,
+  "each staged file is individually removable",
+);
+assert.match(
+  source,
+  /message\.attachments\?\.length \?[\s\S]*?quick-chat-bubble__files/,
+  "a sent user turn keeps its paperclip line in the bubble",
+);
+
+// ── Message queueing: sends during a stream park, then auto-send ─────────────
+assert.match(
+  source,
+  /if \(!disabled && canSend\) send\(\);/,
+  "Enter while a reply streams still dispatches — the hook queues it instead of dropping it",
+);
+assert.match(
+  source,
+  /\{sending \? "Queue" : "Send"\}/,
+  "the Send button relabels to Queue while a reply streams (and stays enabled)",
+);
+assert.doesNotMatch(
+  source,
+  /disabled=\{sending \|\| disabled \|\| !draft\.trim\(\)\}/,
+  "the old sending-disables-Send guard stays gone — sending now queues",
+);
+assert.match(
+  source,
+  /aria-label="Queued messages"[\s\S]*?onRemoveQueued\(item\.id\)/,
+  "queued messages render as a labelled chip list with per-item remove",
+);
+
+// ── The hook side of queueing + attachments (use-quick-chat) ─────────────────
+{
+  const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
+  assert.match(
+    hook,
+    /if \(abortRef\.current\) \{[\s\S]*?queuedRef\.current = \[\.\.\.queuedRef\.current, item\]/,
+    "a send during an in-flight turn queues instead of silently dropping",
+  );
+  assert.match(
+    hook,
+    /if \(status === "done"\) \{[\s\S]*?sendTextRef\.current\(next\.text, next\.attachments \?\? \[\]\)/,
+    "the queue drains only on NATURAL completion — Stop and failures park it",
+  );
+  assert.match(
+    hook,
+    /target\.error && !\(target\.familiarId && attachments\.length > 0\)/,
+    "only the empty-prompt error is forgiven for attachment-only sends",
+  );
+  assert.match(
+    hook,
+    /stripPreviewOnlyAttachmentFieldsKeepingImages\(attachments\)/,
+    "outgoing files are stripped to send shape — image payloads kept, previews dropped",
+  );
+  assert.match(
+    hook,
+    /useProjects\(\{ familiarId: selectedFamiliarId \}\)/,
+    "quick chat loads project options scoped to the selected familiar",
+  );
+  assert.match(
+    hook,
+    /projectRoot: selectedProjectRoot \?\? undefined/,
+    "quick chat forwards the selected project root to the chat bridge",
+  );
+  assert.match(
+    hook,
+    /queuedRef\.current = \[\];\s*\n\s*setQueued\(\[\]\);/,
+    "newThread clears the parked queue with the rest of the thread",
+  );
+  assert.match(
+    hook,
+    /void deliver\(target, resume, lastUserAttachmentsRef\.current\)/,
+    "regenerate re-sends the last user turn's files, not just its text",
+  );
+  const stream = readFileSync(new URL("../lib/familiar-stream.ts", import.meta.url), "utf8");
+  assert.match(
+    stream,
+    /\.\.\.\(opts\.attachments\?\.length \? \{ attachments: opts\.attachments \} : \{\}\)/,
+    "streamFamiliarText forwards attachments to the chat bridge (native support)",
+  );
+}
 
 console.log("quick-chat-controls.test.ts OK");

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -1,23 +1,49 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+// The slash menu popover reuses the home composer's .hc-slash-* affordance —
+// this stylesheet is global-scoped, so importing it here makes the menu render
+// identically in the tray window (which never mounts the home composer).
+import "@/styles/home-composer.css";
 import {
   COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
   type CommandResponseSpeed,
   type CommandThinkingEffort,
 } from "@/lib/command-controls";
+import type { CaveProject } from "@/lib/cave-projects-types";
 import { Icon, type IconName } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
+import { useReplyRecommendation, type ReplyRecommendationState } from "@/lib/use-reply-recommendation";
 import { EnhanceControl, EnhanceStrip } from "@/components/composer-enhance";
 import { IconButton } from "@/components/ui/icon-button";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { copyText } from "@/lib/clipboard";
-import type { QuickChatMessage } from "@/lib/use-quick-chat";
+import { attachmentIcon, type ChatAttachment } from "@/lib/chat-attachments";
+import { useAttachmentStaging } from "@/lib/use-attachment-staging";
+import type { QueuedQuickChatMessage, QuickChatMessage } from "@/lib/use-quick-chat";
+import { extractNextPaths } from "@/lib/next-paths";
 import { useStickToBottom } from "@/lib/use-stick-to-bottom";
+import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
+import { HomeSlashMenu } from "@/components/home/home-slash-menu";
+import { SLASH_COMMANDS, canonicalize } from "@/lib/slash-commands";
+import { formatModelList, resolveModelArg } from "@/lib/slash-model";
+import {
+  buildSkillPrompt,
+  formatSkillList,
+  resolveSkillInvocation,
+  type SkillOption,
+} from "@/lib/slash-skill";
+import {
+  formatPromptList,
+  promptInsertion,
+  resolvePromptArg,
+  type PromptOption,
+} from "@/lib/slash-prompt";
+import { recordPromptRecent } from "@/lib/prompt-prefs";
 
 export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
 
@@ -27,6 +53,11 @@ export const QUICK_CHAT_SUGGESTIONS = [
   "Draft a short status update",
   "What changed recently?",
 ];
+
+// Stable empty reference so QuickChatComposer can pass `messages ?? EMPTY` to
+// the recommendation hook without spawning a fresh array (and effect churn)
+// every render.
+const EMPTY_MESSAGES: QuickChatMessage[] = [];
 
 function initials(familiar: Familiar): string {
   return (familiar.display_name || familiar.id)
@@ -134,38 +165,69 @@ export function QuickChatControlsRow({
   familiars,
   selectedFamiliarId,
   onPickFamiliar,
+  projects,
+  projectsLoading,
+  selectedProjectRoot,
+  onPickProjectRoot,
   thinkingEffort,
   onThinkingEffortChange,
   responseSpeed,
   onResponseSpeedChange,
   sending,
+  showFamiliarPicker = false,
 }: {
   loading: boolean;
   familiars: Familiar[];
   selectedFamiliarId: string | null;
   onPickFamiliar: (id: string | null) => void;
+  projects: CaveProject[];
+  projectsLoading: boolean;
+  selectedProjectRoot: string | null;
+  onPickProjectRoot: (root: string | null) => void;
   thinkingEffort: CommandThinkingEffort;
   onThinkingEffortChange: (value: CommandThinkingEffort) => void;
   responseSpeed: CommandResponseSpeed;
   onResponseSpeedChange: (value: CommandResponseSpeed) => void;
   sending: boolean;
+  showFamiliarPicker?: boolean;
 }) {
   return (
     <div className="quick-chat-overlay__controls">
+      {showFamiliarPicker ? (
+        <QuickChatSelect
+          label="Familiar"
+          value={selectedFamiliarId ?? ""}
+          onChange={(next) => onPickFamiliar(next || null)}
+          disabled={loading || familiars.length === 0}
+          className="flex-1"
+          options={
+            loading && familiars.length === 0
+              ? [{ value: "", label: "Loading…", disabled: true }]
+              : familiars.map((familiar) => ({
+                  value: familiar.id,
+                  label: familiar.display_name,
+                  leading: <FamiliarMark familiar={familiar} size="sm" />,
+                }))
+          }
+        />
+      ) : null}
       <QuickChatSelect
-        label="Familiar"
-        value={selectedFamiliarId ?? ""}
-        onChange={(next) => onPickFamiliar(next || null)}
-        disabled={loading || familiars.length === 0}
+        label="Project"
+        value={selectedProjectRoot ?? "__none__"}
+        onChange={(next) => onPickProjectRoot(next === "__none__" ? null : next)}
+        disabled={projectsLoading && projects.length === 0}
         className="flex-1"
         options={
-          loading && familiars.length === 0
-            ? [{ value: "", label: "Loading…", disabled: true }]
-            : familiars.map((familiar) => ({
-                value: familiar.id,
-                label: familiar.display_name,
-                leading: <FamiliarMark familiar={familiar} size="sm" />,
-              }))
+          projectsLoading && projects.length === 0
+            ? [{ value: "__none__", label: "Loading projects…", disabled: true }]
+            : [
+                { value: "__none__", label: "No project", icon: "ph:folder-simple-dashed" as IconName },
+                ...projects.map((project) => ({
+                  value: project.root,
+                  label: project.name,
+                  icon: "ph:folder" as IconName,
+                })),
+              ]
         }
       />
       <StandardSelect
@@ -188,10 +250,42 @@ export function QuickChatControlsRow({
   );
 }
 
+// ── Slash commands ───────────────────────────────────────────────────────────
+// Quick chat supports the subset of the shared catalog that makes sense in a
+// compact tray thread. Everything else gets a pointer to the full app.
+
+const QUICK_SLASH_SUPPORTED = new Set([
+  "/help",
+  "/clear",
+  "/new",
+  "/model",
+  "/skill",
+  "/skills",
+  "/prompt",
+  "/prompts",
+]);
+
+/** The /help note for quick chat — only the commands that work here, sourced
+ *  from the shared catalog so names/aliases/descriptions never drift. */
+export function quickChatSlashHelp(): string {
+  const lines = SLASH_COMMANDS.filter((c) => QUICK_SLASH_SUPPORTED.has(c.name)).map((c) => {
+    const names = [c.name, ...(c.aliases ?? [])].join(", ");
+    const arg = c.argPlaceholder ? ` <${c.argPlaceholder}>` : "";
+    return `  ${names}${arg} — ${c.description}`;
+  });
+  return [
+    "Quick chat commands:",
+    ...lines,
+    "",
+    "@name switches familiar · Enter sends · other /commands live in the full CovenCave chat.",
+  ].join("\n");
+}
+
 // ── Composer ─────────────────────────────────────────────────────────────────
 // Error slot + textarea + actions row, shared by both surfaces. Enter sends;
 // Shift+Enter inserts a newline; ⌘/Ctrl+Enter always sends; IME composition is
-// left alone.
+// left alone. When the slash handlers are wired (tray), a leading `/` opens
+// the shared command menu (with /model, /skill and /prompt pickers).
 
 export function QuickChatComposer({
   error,
@@ -206,11 +300,21 @@ export function QuickChatComposer({
   composerRef,
   autoFocus,
   leading,
+  messages,
+  active = true,
+  onNewThread,
+  onLocalNote,
+  onSendText,
+  modelOverride,
+  onModelOverrideChange,
+  queued,
+  onRemoveQueued,
 }: {
   error: string | null;
   draft: string;
   onDraftChange: (value: string) => void;
-  onSend: () => void;
+  /** Send the trimmed draft with the staged files (already id-stripped). */
+  onSend: (attachments: ChatAttachment[]) => void;
   onCancel: () => void;
   sending: boolean;
   /** Blocks sending while true (e.g. the roster is still loading). */
@@ -221,6 +325,27 @@ export function QuickChatComposer({
   autoFocus?: boolean;
   /** Left slot of the actions row — a hint in the tray, Open-in-full-chat in the overlay. */
   leading?: React.ReactNode;
+  /** The conversation so far. When provided, a recommended next reply is
+   *  generated after each familiar turn and offered for Tab-to-autofill. */
+  messages?: QuickChatMessage[];
+  /** Whether this composer's pane is the foreground tab — gates recommendation
+   *  generation so background tabs don't burn model calls. */
+  active?: boolean;
+  // Slash commands (all three of onNewThread/onLocalNote/onSendText must be
+  // wired to enable them — the tray passes the useQuickChat methods through).
+  /** /clear · /new — reset the thread. */
+  onNewThread?: () => void;
+  /** Append a local assistant-styled note (slash output like /help). */
+  onLocalNote?: (text: string) => void;
+  /** Send an explicit text through the quick-chat pipeline (skill runs). */
+  onSendText?: (text: string) => void;
+  /** Current /model override (for the bare `/model` listing). */
+  modelOverride?: string | null;
+  /** /model pick — set the thread's model override. */
+  onModelOverrideChange?: (id: string | null) => void;
+  /** Messages parked behind the in-flight turn (chips above the actions row). */
+  queued?: QueuedQuickChatMessage[];
+  onRemoveQueued?: (id: string) => void;
 }) {
   // Prompt enhancement (cave-b6c2): the shared model-backed hook, mounted
   // internally so every quick-chat surface (dropdown, tray tab, standalone
@@ -232,43 +357,416 @@ export function QuickChatComposer({
     mode: "chat",
     disabled: sending,
   });
+  // Reply recommendation (cave reply-reco): after a familiar turn settles, the
+  // shared hook proposes the user's most useful next message. Mounted here so
+  // every quick-chat surface gets Tab-to-autofill with zero consumer wiring —
+  // exactly like Enhance above.
+  const recommendation = useReplyRecommendation({
+    messages: messages ?? EMPTY_MESSAGES,
+    familiarId: familiar?.id ?? null,
+    familiarName: familiar?.display_name ?? null,
+    draft,
+    enabled: messages != null && active && !sending && !disabled,
+  });
+  const acceptRecommendation = useCallback(() => {
+    const text = recommendation.accept();
+    if (text == null) return;
+    onDraftChange(text);
+    requestAnimationFrame(() => composerRef?.current?.focus());
+  }, [recommendation.accept, onDraftChange, composerRef]);
+
+  // Attachment staging (shared hook — same capture behavior as the home/chat
+  // composers): drag-and-drop anywhere on the composer footer, paste-to-attach
+  // on the textarea, paperclip-free (drop/paste only) at 10 files max.
+  const {
+    attachments,
+    removeAttachment,
+    clearAttachments,
+    handlePaste,
+    dropActive,
+    dropHandlers,
+  } = useAttachmentStaging({
+    focus: () => composerRef?.current?.focus(),
+  });
+
+  // Slash commands are live only when the host wires all three handlers (the
+  // tray does); otherwise a leading "/" just sends as plain text, as before.
+  const slashEnabled = Boolean(onNewThread && onLocalNote && onSendText);
+  const modelHarness = familiar?.harness ?? "claude";
+  // Shared inline menus (/command listbox + Skills group, /model, /skill,
+  // /prompt pickers) — same hook as the home/chat composers so the keyboard
+  // grammar transfers. The pick callbacks reference the helpers declared just
+  // below; the hook latest-refs its opts, so the late binding is safe (same
+  // pattern as home-composer's invokeSkill).
+  const menu = useInlineSlashMenus({
+    text: draft,
+    setText: onDraftChange,
+    modelHarness,
+    onPickModel: (id) => {
+      onModelOverrideChange?.(id);
+      onLocalNote?.(`Model set to \`${id}\` for this thread.`);
+      onDraftChange("");
+    },
+    onPickSkill: (s) => invokeSkillOption(s),
+    onInsertPrompt: (p) => insertPromptTemplate(p),
+    onRunCommand: (cmd) => runSlash(cmd.name),
+    onNoMatchEnter: () => {
+      if (!disabled && draft.trim()) send();
+    },
+  });
+
+  // Drop a prompt template into the composer for editing — never a send.
+  // Selects the first {{placeholder}} so typing replaces it (mirrors home).
+  const insertPromptTemplate = useCallback(
+    (p: PromptOption) => {
+      const ins = promptInsertion(p);
+      recordPromptRecent(p.id);
+      onDraftChange(ins.text);
+      requestAnimationFrame(() => {
+        const el = composerRef?.current;
+        if (!el) return;
+        el.focus();
+        if (ins.selectStart !== undefined && ins.selectEnd !== undefined) {
+          el.setSelectionRange(ins.selectStart, ins.selectEnd);
+        } else {
+          el.setSelectionRange(ins.text.length, ins.text.length);
+        }
+      });
+    },
+    [onDraftChange, composerRef],
+  );
+
+  // Invoke a skill in-thread: the harness owns Skill execution, so this sends
+  // the shared invocation prompt through the quick-chat pipeline. A skill with
+  // an argument-hint autofills `/skill <id> ` for argument editing first —
+  // picking again (or a hint-less skill) sends (mirrors home's invokeSkill).
+  const invokeSkillOption = useCallback(
+    (skill: SkillOption, args = "") => {
+      const filled = `/skill ${skill.id}`;
+      if (skill.argumentHint && !args && draft.trim().toLowerCase() !== filled.toLowerCase()) {
+        onDraftChange(`${filled} `);
+        composerRef?.current?.focus();
+        return;
+      }
+      onDraftChange("");
+      onSendText?.(buildSkillPrompt(skill, args));
+    },
+    [draft, onDraftChange, composerRef, onSendText],
+  );
+
+  // Slash dispatch — the quick-chat subset. Supported commands act locally or
+  // send through the pipeline; recognized-but-unsupported commands (e.g.
+  // /board) get a pointer to the full app; typos keep the draft for fixing.
+  const runSlash = useCallback(
+    (prompt: string) => {
+      const [rawCmd = "", ...rest] = prompt.split(/\s+/);
+      const command = canonicalize(rawCmd) ?? rawCmd;
+      const args = rest.join(" ").trim();
+      switch (command) {
+        case "/help":
+          onDraftChange("");
+          onLocalNote?.(quickChatSlashHelp());
+          return;
+        case "/clear":
+        case "/new":
+          onDraftChange("");
+          onNewThread?.();
+          return;
+        case "/model": {
+          onDraftChange("");
+          if (!args) {
+            onLocalNote?.(formatModelList(modelHarness, modelOverride ?? null));
+            return;
+          }
+          const id = resolveModelArg(args, modelHarness);
+          if (!id) {
+            onLocalNote?.(`Unknown model "${args}".`);
+            return;
+          }
+          onModelOverrideChange?.(id);
+          onLocalNote?.(`Model set to \`${id}\` for this thread.`);
+          return;
+        }
+        case "/skill":
+        case "/skills": {
+          if (!args) {
+            onDraftChange("");
+            onLocalNote?.(formatSkillList(menu.skills));
+            return;
+          }
+          const invocation = resolveSkillInvocation(args, menu.skills);
+          if (!invocation) {
+            onDraftChange("");
+            onLocalNote?.(`Unknown skill "${args}".`);
+            return;
+          }
+          invokeSkillOption(invocation.skill, invocation.args);
+          return;
+        }
+        case "/prompt":
+        case "/prompts": {
+          if (!args) {
+            onDraftChange("");
+            onLocalNote?.(formatPromptList(menu.prompts));
+            return;
+          }
+          const template = resolvePromptArg(args, menu.prompts);
+          if (!template) {
+            onDraftChange("");
+            onLocalNote?.(`Unknown prompt "${args}".`);
+            return;
+          }
+          insertPromptTemplate(template);
+          return;
+        }
+        default:
+          if (canonicalize(rawCmd)) {
+            onDraftChange("");
+            onLocalNote?.(`${command} isn't available in quick chat — open CovenCave for it. Type /help for what works here.`);
+          } else {
+            // Keep the draft — likely a typo the user wants to fix in place.
+            onLocalNote?.(`Unknown command ${rawCmd}. Type /help for quick-chat commands.`);
+          }
+      }
+    },
+    [
+      onDraftChange,
+      onLocalNote,
+      onNewThread,
+      onModelOverrideChange,
+      modelHarness,
+      modelOverride,
+      menu.skills,
+      menu.prompts,
+      invokeSkillOption,
+      insertPromptTemplate,
+    ],
+  );
+
   const send = useCallback(() => {
+    // A leading slash is a command, never a message — same contract as the
+    // home/chat composers (only when the host wired the slash handlers).
+    // Staged files stay staged across a command (e.g. /model then send).
+    const trimmed = draft.trim();
+    if (slashEnabled && trimmed.startsWith("/")) {
+      runSlash(trimmed);
+      return;
+    }
     // The strip belongs to the draft being sent — don't leave it hanging
     // over the emptied composer.
     promptEnhance.reset();
-    onSend();
-  }, [onSend, promptEnhance.reset]);
+    // ComposerAttachment carries a local `id` for the chip row — strip it from
+    // the outgoing payload (mirrors the chat composer's send).
+    onSend(attachments.map(({ id: _id, ...attachment }) => attachment));
+    clearAttachments();
+  }, [draft, slashEnabled, runSlash, onSend, promptEnhance.reset, attachments, clearAttachments]);
+  // Sendable = something to say (text or files). While a reply streams the
+  // same action QUEUES — the hook parks it and auto-sends on settle.
+  const canSend = Boolean(draft.trim() || attachments.length > 0);
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // The inline slash menus (Esc-dismiss, ↑↓/Tab/Enter across the pickers)
+      // take priority while one is open — shared hook, same ordering as the
+      // home/chat composers. Disjoint from the recommendation's Tab-accept:
+      // the menus only open on a leading "/", the recommendation only offers
+      // Tab on an empty draft.
+      if (slashEnabled && menu.handleKeyDown(event)) return;
+      // Tab accepts a ready recommendation into the empty composer (it falls
+      // through to normal focus traversal when there's nothing to accept, or
+      // the user has already started typing their own reply).
+      if (
+        event.key === "Tab" &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        recommendation.suggestion &&
+        !draft.trim()
+      ) {
+        event.preventDefault();
+        acceptRecommendation();
+        return;
+      }
       const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
       const plainEnter =
         event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
       if (cmdEnter || plainEnter) {
         event.preventDefault();
-        if (!sending && draft.trim()) send();
+        // Enter while a reply streams queues the message (the hook parks it);
+        // `disabled` (roster loading) still blocks.
+        if (!disabled && canSend) send();
       }
     },
-    [draft, send, sending],
+    [acceptRecommendation, canSend, disabled, draft, recommendation.suggestion, send, slashEnabled, menu.handleKeyDown],
   );
 
+  const slashMenuOpen = slashEnabled && menu.menuOpen;
+
   return (
-    <footer className="quick-chat-overlay__composer">
+    // `relative` anchors the slash popover (.hc-slash-menu is absolute,
+    // bottom-anchored) so it floats above the composer, over the thread. The
+    // footer is also the drop target for file attachments — the enter/leave
+    // counted handlers keep the overlay steady across child elements.
+    <footer
+      className={`quick-chat-overlay__composer relative${dropActive ? " quick-chat-overlay__composer--drop" : ""}`}
+      {...dropHandlers}
+    >
+      {dropActive ? (
+        <div className="quick-chat-dropzone" aria-hidden>
+          <Icon name="ph:paperclip" width={14} aria-hidden />
+          Drop files to attach
+        </div>
+      ) : null}
+      {/* Slash suggestion popover — shared .hc-slash-* affordance, compact
+          (no skill detail preview: the tray is too narrow for the side panel). */}
+      {slashEnabled && menu.modelMenuActive && menu.modelOptions ? (
+        <HomeSlashMenu
+          listboxId={menu.slashListboxId}
+          ariaLabel="Models"
+          items={menu.modelOptions.map((m) => ({ key: m.id, name: m.label, desc: m.id }))}
+          activeIndex={menu.slashIdx}
+          footer="↑↓ navigate · Enter switch · Esc cancel"
+          onHover={menu.setSlashIdx}
+          onPick={(i) => {
+            const m = menu.modelOptions?.[i];
+            if (!m) return;
+            onModelOverrideChange?.(m.id);
+            onLocalNote?.(`Model set to \`${m.id}\` for this thread.`);
+            onDraftChange("");
+            composerRef?.current?.focus();
+          }}
+        />
+      ) : slashEnabled && menu.skillMenuActive && menu.skillOptions ? (
+        <HomeSlashMenu
+          listboxId={menu.slashListboxId}
+          ariaLabel="Skills"
+          items={menu.skillOptions.map((s) => ({ key: s.id, name: s.name, desc: s.description || s.id }))}
+          activeIndex={menu.slashIdx}
+          footer="↑↓ navigate · Enter run · Tab complete · Esc cancel"
+          onHover={menu.setSlashIdx}
+          onPick={(i) => {
+            const s = menu.skillOptions?.[i];
+            if (s) invokeSkillOption(s);
+          }}
+        />
+      ) : slashEnabled && menu.promptMenuActive && menu.promptOptions ? (
+        <HomeSlashMenu
+          listboxId={menu.slashListboxId}
+          ariaLabel="Prompts"
+          items={menu.promptOptions.map((p) => ({ key: p.id, name: p.name, desc: p.description || p.id }))}
+          activeIndex={menu.slashIdx}
+          footer="↑↓ navigate · Enter insert · Tab complete · Esc cancel"
+          onHover={menu.setSlashIdx}
+          onPick={(i) => {
+            const p = menu.promptOptions?.[i];
+            if (p) insertPromptTemplate(p);
+          }}
+        />
+      ) : slashEnabled && (menu.slashSuggestions.length > 0 || menu.skillCommandRows.length > 0) ? (
+        <HomeSlashMenu
+          listboxId={menu.slashListboxId}
+          ariaLabel="Slash commands"
+          items={[
+            ...menu.slashSuggestions.map((cmd) => ({
+              key: cmd.name,
+              name: cmd.name,
+              desc: cmd.description,
+              arg: cmd.argPlaceholder || undefined,
+            })),
+            // Matching skills ride under the commands — one list, one index.
+            ...menu.skillCommandRows.map((s) => ({
+              key: `skill-${s.id}`,
+              name: s.name,
+              desc: `Skill · ${s.description || s.id}`,
+              arg: s.argumentHint || undefined,
+            })),
+          ]}
+          activeIndex={menu.slashIdx}
+          footer="↑↓ navigate · Enter run · Tab complete · type space to dismiss"
+          onHover={menu.setSlashIdx}
+          onPick={(i) => {
+            const cmd = menu.slashSuggestions[i];
+            const s = menu.skillCommandRows[i - menu.slashSuggestions.length];
+            if (cmd) {
+              onDraftChange(cmd.name + (cmd.argPlaceholder ? " " : ""));
+              composerRef?.current?.focus();
+            } else if (s) {
+              invokeSkillOption(s);
+            }
+          }}
+        />
+      ) : null}
       {error ? (
         <p className="quick-chat-overlay__error" role="alert">
           {error}
         </p>
       ) : null}
+      <ReplyRecommendationStrip
+        state={recommendation.state}
+        onUse={acceptRecommendation}
+        onDismiss={recommendation.dismiss}
+        onRegenerate={recommendation.regenerate}
+      />
       <textarea
         ref={composerRef}
         id={inputId}
         value={draft}
         autoFocus={autoFocus}
         aria-label="Message"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={slashMenuOpen}
+        aria-controls={slashMenuOpen ? menu.slashListboxId : undefined}
+        aria-activedescendant={slashMenuOpen ? `${menu.slashListboxId}-opt-${menu.slashIdx}` : undefined}
         onChange={(event) => onDraftChange(event.target.value)}
         onKeyDown={onKeyDown}
+        onPaste={handlePaste}
         placeholder={familiar ? `Message @${familiar.id}…` : "@sage summarize what needs attention"}
         className="quick-chat-overlay__input"
       />
+      {attachments.length > 0 ? (
+        <div className="quick-chat-attachments" role="group" aria-label="Attached files">
+          {attachments.map((attachment) => (
+            <span key={attachment.id} className="quick-chat-attachment-chip" title={attachment.name}>
+              <Icon name={attachmentIcon(attachment)} width={11} aria-hidden />
+              <span className="quick-chat-attachment-chip__name">{attachment.name}</span>
+              <IconButton
+                icon="ph:x"
+                size="xs"
+                aria-label={`Remove ${attachment.name}`}
+                title={`Remove ${attachment.name}`}
+                onClick={() => removeAttachment(attachment.id)}
+              />
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {queued && queued.length > 0 ? (
+        <div className="quick-chat-queued" role="group" aria-label="Queued messages">
+          {queued.map((item) => (
+            <span key={item.id} className="quick-chat-queued__chip" title={item.text}>
+              <Icon name="ph:clock" width={11} aria-hidden />
+              <span className="quick-chat-queued__text">
+                {item.text.trim() ||
+                  `${item.attachments?.length ?? 0} file${(item.attachments?.length ?? 0) === 1 ? "" : "s"}`}
+              </span>
+              {item.attachments?.length && item.text.trim() ? (
+                <span className="quick-chat-queued__count">📎{item.attachments.length}</span>
+              ) : null}
+              {onRemoveQueued ? (
+                <IconButton
+                  icon="ph:x"
+                  size="xs"
+                  aria-label="Remove queued message"
+                  title="Remove from queue"
+                  onClick={() => onRemoveQueued(item.id)}
+                />
+              ) : null}
+            </span>
+          ))}
+        </div>
+      ) : null}
       <EnhanceStrip
         state={promptEnhance.state}
         onApply={promptEnhance.apply}
@@ -284,6 +782,7 @@ export function QuickChatComposer({
             onEnhance={promptEnhance.enhance}
             onCancel={promptEnhance.cancel}
             disabled={sending || !draft.trim()}
+            size="sm"
           />
           {sending ? (
             <Button variant="secondary" size="sm" onClick={onCancel}>
@@ -295,13 +794,84 @@ export function QuickChatComposer({
             size="sm"
             leadingIcon="ph:sparkle"
             onClick={send}
-            disabled={sending || disabled || !draft.trim()}
+            disabled={disabled || !canSend}
+            title={sending ? "Queues — sends when the reply finishes" : undefined}
           >
-            Send
+            {sending ? "Queue" : "Send"}
           </Button>
         </div>
       </div>
     </footer>
+  );
+}
+
+// ── Reply recommendation strip ───────────────────────────────────────────────
+// Renders above the composer input once a familiar has replied: a shimmer while
+// the suggestion streams, then the proposed reply with a Tab affordance. Click
+// (or Tab in the empty composer) autofills it; refresh asks for another;
+// dismiss retires it for this turn.
+
+export function ReplyRecommendationStrip({
+  state,
+  onUse,
+  onDismiss,
+  onRegenerate,
+}: {
+  state: ReplyRecommendationState;
+  onUse: () => void;
+  onDismiss: () => void;
+  onRegenerate: () => void;
+}) {
+  if (state.phase === "idle") return null;
+  const loading = state.phase === "loading";
+  return (
+    <div className="quick-chat-reco" role="group" aria-label="Recommended reply">
+      <span className="quick-chat-reco__label">
+        <Icon name="ph:sparkle" width={12} aria-hidden />
+        {loading ? "Recommending a reply…" : "Recommended reply"}
+      </span>
+      {loading ? (
+        state.preview ? (
+          <p className="quick-chat-reco__text quick-chat-reco__text--preview">
+            {state.preview}
+            <span className="quick-chat-caret" aria-hidden />
+          </p>
+        ) : (
+          <span className="quick-chat-reco__shimmer" aria-hidden />
+        )
+      ) : (
+        <>
+          <p className="quick-chat-reco__text">{state.text}</p>
+          <span className="quick-chat-reco__actions">
+            <kbd className="quick-chat-reco__kbd" aria-hidden>
+              Tab
+            </kbd>
+            <Button
+              size="xs"
+              variant="secondary"
+              onClick={onUse}
+              title="Use this reply (Tab)"
+            >
+              Use
+            </Button>
+            <IconButton
+              icon="ph:arrow-clockwise"
+              size="xs"
+              aria-label="Suggest another reply"
+              title="Suggest another"
+              onClick={onRegenerate}
+            />
+            <IconButton
+              icon="ph:x"
+              size="xs"
+              aria-label="Dismiss recommended reply"
+              title="Dismiss"
+              onClick={onDismiss}
+            />
+          </span>
+        </>
+      )}
+    </div>
   );
 }
 
@@ -329,11 +899,15 @@ function QuickChatBubble({
   familiar,
   isLastAssistant,
   onRegenerate,
+  onSuggestion,
 }: {
   message: QuickChatMessage;
   familiar: Familiar | null;
   isLastAssistant: boolean;
   onRegenerate?: () => void;
+  /** Fills the composer (caret in) — next-path chips ride the same path as the
+   *  empty-state starters. */
+  onSuggestion?: (value: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -344,18 +918,35 @@ function QuickChatBubble({
     return () => window.clearTimeout(timer);
   }, [copied]);
 
+  // Next-path suggestions (the agent's parseable trailer) never render as raw
+  // text: the block is stripped from every familiar turn — streaming-safe, the
+  // half-open block hides too — and surfaced as chips on the latest turn only,
+  // so stale suggestions don't stack up the compact tray.
+  const { visible, suggestions } =
+    message.role === "assistant"
+      ? extractNextPaths(message.text)
+      : { visible: message.text, suggestions: [] };
+
   if (message.role === "user") {
     return (
       <div className="quick-chat-turn quick-chat-turn--user">
         <div className="quick-chat-bubble quick-chat-bubble--user">
-          <p className="whitespace-pre-wrap break-words leading-6">{message.text}</p>
+          {message.text ? (
+            <p className="whitespace-pre-wrap break-words leading-6">{message.text}</p>
+          ) : null}
+          {message.attachments?.length ? (
+            <p className="quick-chat-bubble__files" title={message.attachments.map((a) => a.name).join(", ")}>
+              <Icon name="ph:paperclip" width={11} aria-hidden />
+              {message.attachments.map((a) => a.name).join(" · ")}
+            </p>
+          ) : null}
         </div>
       </div>
     );
   }
 
   const streaming = message.pending;
-  const canAct = !streaming && message.text.length > 0;
+  const canAct = !streaming && visible.length > 0;
   return (
     <div className="quick-chat-turn quick-chat-turn--familiar">
       {familiar ? (
@@ -366,17 +957,17 @@ function QuickChatBubble({
         </span>
       )}
       <div className="quick-chat-bubble quick-chat-bubble--familiar">
-        {message.text ? (
+        {visible ? (
           streaming ? (
             // Render partial text plainly while it streams — re-parsing markdown
             // per token is wasteful and flashes half-open code fences.
             <p className="whitespace-pre-wrap break-words leading-6">
-              {message.text}
+              {visible}
               <span className="quick-chat-caret" aria-hidden />
             </p>
           ) : (
             <div className="quick-chat-md">
-              <MarkdownBlock text={message.text} />
+              <MarkdownBlock text={visible} />
             </div>
           )
         ) : streaming ? (
@@ -401,7 +992,8 @@ function QuickChatBubble({
               aria-label={copied ? "Copied" : "Copy reply"}
               title="Copy reply"
               onClick={() => {
-                void copyText(message.text).then((ok) => {
+                // Copy what the user sees — the next-paths trailer stays out.
+                void copyText(visible).then((ok) => {
                   if (ok) setCopied(true);
                 });
               }}
@@ -415,6 +1007,24 @@ function QuickChatBubble({
                 onClick={onRegenerate}
               />
             ) : null}
+          </div>
+        ) : null}
+
+        {/* Suggested follow-ups render LAST — tap-to-fill, so they sit closest
+            to the composer, mirroring the main chat's next-path row. */}
+        {isLastAssistant && !streaming && onSuggestion && suggestions.length > 0 ? (
+          <div className="quick-chat-next-paths" role="group" aria-label="Suggested next steps">
+            {suggestions.map((suggestion, i) => (
+              <Button
+                key={i}
+                size="xs"
+                variant="secondary"
+                className="quick-chat-next-path"
+                onClick={() => onSuggestion(suggestion)}
+              >
+                {suggestion}
+              </Button>
+            ))}
           </div>
         ) : null}
       </div>
@@ -462,7 +1072,9 @@ export function QuickChatThread({
 
   const lastAssistantId = (() => {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === "assistant") return messages[i].id;
+      // Local notes (slash output like /help) are assistant-styled but not
+      // familiar replies — never the regenerate / next-paths anchor.
+      if (messages[i].role === "assistant" && !messages[i].local) return messages[i].id;
     }
     return null;
   })();
@@ -500,6 +1112,7 @@ export function QuickChatThread({
             familiar={familiar}
             isLastAssistant={message.id === lastAssistantId}
             onRegenerate={onRegenerate}
+            onSuggestion={onSuggestion}
           />
         ))
       )}

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -35,8 +35,8 @@ assert.match(
 );
 assert.match(
   hook,
-  /resolveQuickChatTarget\(draft, familiars, selectedFamiliarId\)/,
-  "quick chat resolves @familiar mentions before sending",
+  /resolveQuickChatTarget\(raw, familiars, selectedFamiliarId\)/,
+  "quick chat resolves @familiar mentions before sending (sendText pipeline)",
 );
 assert.match(
   hook,
@@ -51,6 +51,16 @@ assert.match(
   component,
   /const inherited = reportsRef\.current\[activeIdRef\.current\]\?\.familiar\?\.id \?\? null/,
   "a new tab inherits the active tab's selected familiar",
+);
+assert.match(
+  component,
+  /useState<TabDescriptor\[]>\(\[\{ id: 1, initialFamiliarId: null, showAgentPicker: false \}\]\)/,
+  "the boot tab starts with compact controls (agent picker hidden)",
+);
+assert.match(
+  component,
+  /setTabs\(\(prev\) => \[\.\.\.prev, \{ id, initialFamiliarId: inherited, showAgentPicker: true \}\]\)/,
+  "clicking + opens a new chat with the agent picker visible",
 );
 assert.match(component, /aria-label="New chat"/, "the header exposes an add-chat button");
 assert.match(
@@ -142,6 +152,16 @@ assert.match(
 
 // ── Shared pieces (one source of truth with the overlay-era components) ─────
 assert.match(component, /<QuickChatControlsRow/, "tray renders the shared controls row");
+assert.match(
+  component,
+  /showFamiliarPicker=\{showAgentPicker && !pickerDismissed && messages\.length === 0\}/,
+  "agent selection is only shown for fresh + chats (hidden once the thread starts)",
+);
+assert.match(
+  component,
+  /if \(id\) setPickerDismissed\(true\)/,
+  "picking a familiar dismisses the agent picker — the selection UI goes away once the choice is made",
+);
 assert.match(component, /<QuickChatComposer/, "tray renders the shared composer");
 assert.match(
   controls,

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -35,6 +35,8 @@ type TabDescriptor = {
   id: number;
   /** Familiar the tab opens on — inherited from the active tab at creation. */
   initialFamiliarId: string | null;
+  /** New chats opened from "+" start with agent selection visible. */
+  showAgentPicker: boolean;
 };
 
 type TabReport = {
@@ -65,7 +67,7 @@ export function TrayQuickChat() {
   }, []);
 
   const seqRef = useRef(2);
-  const [tabs, setTabs] = useState<TabDescriptor[]>([{ id: 1, initialFamiliarId: null }]);
+  const [tabs, setTabs] = useState<TabDescriptor[]>([{ id: 1, initialFamiliarId: null, showAgentPicker: false }]);
   const [activeId, setActiveId] = useState(1);
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
@@ -86,7 +88,7 @@ export function TrayQuickChat() {
   const addTab = useCallback(() => {
     const inherited = reportsRef.current[activeIdRef.current]?.familiar?.id ?? null;
     const id = seqRef.current++;
-    setTabs((prev) => [...prev, { id, initialFamiliarId: inherited }]);
+    setTabs((prev) => [...prev, { id, initialFamiliarId: inherited, showAgentPicker: true }]);
     setActiveId(id);
   }, []);
 
@@ -101,7 +103,7 @@ export function TrayQuickChat() {
     if (next.length === 0) {
       // Closing the last chat closes the quick chat itself; a fresh tab
       // (keeping the familiar) waits behind it for the next summon.
-      const fresh = { id: seqRef.current++, initialFamiliarId: dropped?.familiar?.id ?? null };
+      const fresh = { id: seqRef.current++, initialFamiliarId: dropped?.familiar?.id ?? null, showAgentPicker: false };
       setTabs([fresh]);
       setActiveId(fresh.id);
       void hideTrayWindow();
@@ -202,6 +204,7 @@ export function TrayQuickChat() {
             tabId={tab.id}
             active={tab.id === activeId}
             initialFamiliarId={tab.initialFamiliarId}
+            showAgentPicker={tab.showAgentPicker}
             onReport={handleReport}
           />
         ))}
@@ -217,11 +220,13 @@ function QuickChatTabPane({
   tabId,
   active,
   initialFamiliarId,
+  showAgentPicker,
   onReport,
 }: {
   tabId: number;
   active: boolean;
   initialFamiliarId: string | null;
+  showAgentPicker: boolean;
   onReport: (id: number, report: TabReport) => void;
 }) {
   const {
@@ -229,6 +234,10 @@ function QuickChatTabPane({
     selectedFamiliarId,
     setSelectedFamiliarId,
     selectedFamiliar,
+    projects,
+    projectsLoading,
+    selectedProjectRoot,
+    setSelectedProjectRoot,
     draft,
     setDraft,
     messages,
@@ -241,12 +250,31 @@ function QuickChatTabPane({
     responseSpeed,
     setResponseSpeed,
     send,
+    sendText,
+    queued,
+    removeQueued,
+    note,
+    modelOverride,
+    setModelOverride,
     cancel,
+    newThread,
     regenerate,
   } = useQuickChat({ preferredFamiliarId: initialFamiliarId });
 
   const sending = sendState === "sending";
   const { composerRef, pickSuggestion } = useSuggestionPicker(setDraft);
+
+  // The agent picker exists to choose a familiar — once the user picks one,
+  // the choice is made, so the picker dismisses instead of lingering until
+  // the first message.
+  const [pickerDismissed, setPickerDismissed] = useState(false);
+  const pickFamiliar = useCallback(
+    (id: string | null) => {
+      setSelectedFamiliarId(id);
+      if (id) setPickerDismissed(true);
+    },
+    [setSelectedFamiliarId],
+  );
 
   useEffect(() => {
     onReport(tabId, { familiar: selectedFamiliar, sessionId, sending });
@@ -282,12 +310,17 @@ function QuickChatTabPane({
         loading={loading}
         familiars={familiars}
         selectedFamiliarId={selectedFamiliarId}
-        onPickFamiliar={setSelectedFamiliarId}
+        onPickFamiliar={pickFamiliar}
+        projects={projects}
+        projectsLoading={projectsLoading}
+        selectedProjectRoot={selectedProjectRoot}
+        onPickProjectRoot={setSelectedProjectRoot}
         thinkingEffort={thinkingEffort}
         onThinkingEffortChange={setThinkingEffort}
         responseSpeed={responseSpeed}
         onResponseSpeedChange={setResponseSpeed}
         sending={sending}
+        showFamiliarPicker={showAgentPicker && !pickerDismissed && messages.length === 0}
       />
 
       <QuickChatThread
@@ -301,14 +334,25 @@ function QuickChatTabPane({
         error={error}
         draft={draft}
         onDraftChange={setDraft}
-        onSend={() => void send()}
+        onSend={(attachments) => void send(attachments)}
         onCancel={cancel}
         sending={sending}
         disabled={loading}
+        queued={queued}
+        onRemoveQueued={removeQueued}
         familiar={selectedFamiliar}
         inputId={`quick-chat-draft-${tabId}`}
         composerRef={composerRef}
         autoFocus={active}
+        messages={messages}
+        active={active}
+        // Slash commands (/help, /clear, /new, /model, /skill, /prompt) — the
+        // composer dispatches; these hand it the thread-owning hook methods.
+        onNewThread={newThread}
+        onLocalNote={note}
+        onSendText={(text) => void sendText(text)}
+        modelOverride={modelOverride}
+        onModelOverrideChange={setModelOverride}
         leading={
           <div className="flex min-w-0 items-center gap-1.5">
             <IconButton

--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -49,6 +49,20 @@ describe("streamFamiliarText", () => {
     assert.equal(JSON.parse(bodies[1]).sessionId, "sess-9", "resume run includes sessionId");
   });
 
+  it("includes projectRoot in the request body only when provided", async () => {
+    const bodies: string[] = [];
+    globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {
+      bodies.push(init.body ?? "");
+      return sseResponse([frame({ kind: "done" })]);
+    }) as typeof fetch;
+
+    await streamFamiliarText({ familiarId: "nova", prompt: "p" });
+    await streamFamiliarText({ familiarId: "nova", prompt: "p", projectRoot: "/tmp/project" });
+
+    assert.equal(JSON.parse(bodies[0]).projectRoot, undefined, "default quick chat omits projectRoot");
+    assert.equal(JSON.parse(bodies[1]).projectRoot, "/tmp/project", "project-scoped quick chat includes projectRoot");
+  });
+
   it("forwards command controls and model override fields when provided", async () => {
     let body = "";
     globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -1,3 +1,4 @@
+import type { ChatAttachment } from "./chat-attachments";
 import type { SessionOrigin } from "./types";
 // Client helper: stream a one-shot prompt to a familiar through the chat bridge
 // (`/api/chat/send`, SSE) and return the concatenated assistant text. This is the
@@ -14,7 +15,12 @@ import { parseSseFrame } from "@/lib/canvas-generate";
 export async function streamFamiliarText(opts: {
   familiarId: string;
   prompt: string;
+  /** Staged files riding with the prompt. The bridge owns composition (text
+   *  inlined, images written to temp files the harness can Read) — pass them
+   *  through pre-stripped (see stripPreviewOnlyAttachmentFieldsKeepingImages). */
+  attachments?: ChatAttachment[];
   sessionId?: string;
+  projectRoot?: string;
   reasoningEffort?: string;
   responseSpeed?: string;
   modelOverride?: string;
@@ -39,7 +45,9 @@ export async function streamFamiliarText(opts: {
       body: JSON.stringify({
         familiarId: opts.familiarId,
         prompt: opts.prompt,
+        ...(opts.attachments?.length ? { attachments: opts.attachments } : {}),
         ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
+        ...(opts.projectRoot ? { projectRoot: opts.projectRoot } : {}),
         ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
         ...(opts.responseSpeed ? { responseSpeed: opts.responseSpeed } : {}),
         ...(opts.modelOverride ? { modelOverride: opts.modelOverride } : {}),

--- a/src/lib/reply-recommendation.test.ts
+++ b/src/lib/reply-recommendation.test.ts
@@ -1,0 +1,99 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildRecommendationInstruction,
+  extractRecommendedReply,
+  hasReplyableTurn,
+} from "./reply-recommendation.ts";
+
+// ── hasReplyableTurn ──────────────────────────────────────────────────────────
+assert.equal(hasReplyableTurn([]), false, "a cold thread has nothing to recommend against");
+assert.equal(
+  hasReplyableTurn([{ role: "user", text: "hi" }]),
+  false,
+  "a trailing user turn means we're waiting on a reply, not ready to suggest one",
+);
+assert.equal(
+  hasReplyableTurn([
+    { role: "user", text: "hi" },
+    { role: "assistant", text: "hello there", pending: true },
+  ]),
+  false,
+  "a still-streaming assistant turn is not a valid anchor",
+);
+assert.equal(
+  hasReplyableTurn([
+    { role: "user", text: "hi" },
+    { role: "assistant", text: "hello there" },
+  ]),
+  true,
+  "a settled non-empty assistant turn is a valid anchor",
+);
+assert.equal(
+  hasReplyableTurn([{ role: "assistant", text: "   " }]),
+  false,
+  "an empty assistant turn is not a valid anchor",
+);
+
+// ── buildRecommendationInstruction ────────────────────────────────────────────
+const instruction = buildRecommendationInstruction({
+  messages: [
+    { role: "user", text: "can you deploy the app?" },
+    { role: "assistant", text: "Deployed to staging. Want production too?" },
+  ],
+  familiarName: "Sage",
+});
+assert.match(instruction, /<reply><\/reply>/, "instruction demands the reply be wrapped in <reply> tags");
+assert.match(instruction, /first-person voice/, "instruction asks for the user's own voice");
+assert.match(instruction, /Do not answer as the assistant/, "instruction forbids continuing as the assistant");
+assert.match(instruction, /User: can you deploy the app\?/, "transcript labels the user turn");
+assert.match(instruction, /Sage: Deployed to staging\./, "transcript labels the familiar by name");
+
+// Only the last few turns are included, and each is clipped.
+const many = Array.from({ length: 12 }, (_, i) => ({
+  role: i % 2 === 0 ? "user" : "assistant",
+  text: `turn number ${i}`,
+}));
+const trimmed = buildRecommendationInstruction({ messages: many, familiarName: null });
+assert.doesNotMatch(trimmed, /turn number 0\b/, "old turns fall out of the transcript window");
+assert.match(trimmed, /turn number 11\b/, "the newest turn is always present");
+assert.match(trimmed, /Familiar: turn number 11/, "a missing familiar name falls back to 'Familiar'");
+
+// ── extractRecommendedReply ───────────────────────────────────────────────────
+assert.deepEqual(
+  extractRecommendedReply("<reply>Ship it to production.</reply>"),
+  { partial: "Ship it to production.", complete: true },
+  "a closed tag extracts the complete reply",
+);
+assert.equal(
+  extractRecommendedReply("<reply>Ship it to prod").partial,
+  "Ship it to prod",
+  "an open tag mid-stream yields the body so far",
+);
+assert.equal(
+  extractRecommendedReply("<reply>Ship it</re").partial,
+  "Ship it",
+  "a trailing partial of the closing tag is trimmed off the preview",
+);
+assert.equal(
+  extractRecommendedReply("<rep").partial,
+  "",
+  "a partial opening tag renders nothing rather than tag noise",
+);
+assert.equal(
+  extractRecommendedReply("Just say yes and move on.").partial,
+  "Just say yes and move on.",
+  "a tagless stream is usable as-is",
+);
+assert.equal(
+  extractRecommendedReply('<reply>"Ship it now."</reply>').partial,
+  "Ship it now.",
+  "a stray wrapping quote pair is stripped",
+);
+assert.equal(
+  extractRecommendedReply("```\nDo the thing.\n```").partial,
+  "Do the thing.",
+  "stray code fences are trimmed from a tagless reply",
+);
+
+console.log("reply-recommendation.test.ts passed");

--- a/src/lib/reply-recommendation.ts
+++ b/src/lib/reply-recommendation.ts
@@ -1,0 +1,107 @@
+// Reply recommendation (quick chat): after a familiar replies, propose the
+// single most useful next message the *user* could send — a natural follow-up
+// or a concrete next-step directive — so it can be Tab-accepted straight into
+// the composer. These helpers are pure (no React, no imports) so the hook and
+// tests can exercise the protocol directly, mirroring prompt-enhancer.ts.
+
+/** The minimal shape a turn needs for a recommendation. QuickChatMessage
+ *  satisfies this structurally, so the hook passes its messages as-is without
+ *  coupling this pure module to the client hook. */
+export type RecommendationTurn = {
+  role: "user" | "assistant";
+  text: string;
+  /** An assistant turn still streaming in — not yet a valid anchor. */
+  pending?: boolean;
+  /** Local note (slash-command output) — assistant-styled but not a familiar
+   *  reply, so never a recommendation anchor. */
+  local?: boolean;
+};
+
+const OPEN = "<reply>";
+const CLOSE = "</reply>";
+
+// How many trailing turns to include, and the per-message character cap — the
+// recommendation only needs the recent arc, not the whole thread.
+const MAX_TURNS = 6;
+const MAX_CHARS = 600;
+
+function clip(text: string, max = MAX_CHARS): string {
+  const t = text.trim().replace(/\s+/g, " ");
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+}
+
+/** A recommendation only makes sense once a familiar has actually replied — a
+ *  cold thread (or one waiting on a reply) has nothing to build a next move on. */
+export function hasReplyableTurn(messages: RecommendationTurn[]): boolean {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== "assistant" || last.pending || last.local) return false;
+  return last.text.trim().length > 0;
+}
+
+/** The meta-prompt sent to the familiar. It must propose the user's next
+ *  message — never continue as the assistant — and return only that message
+ *  inside <reply> tags so streaming extraction has an unambiguous frame. */
+export function buildRecommendationInstruction({
+  messages,
+  familiarName,
+}: {
+  messages: RecommendationTurn[];
+  familiarName?: string | null;
+}): string {
+  const speaker = familiarName?.trim() || "Familiar";
+  const recent = messages
+    .filter((m) => m.text.trim().length > 0)
+    .slice(-MAX_TURNS)
+    .map((m) => `${m.role === "user" ? "User" : speaker}: ${clip(m.text)}`)
+    .join("\n");
+  return [
+    "You are helping the User decide what to send next in this conversation.",
+    "Propose the single most useful next message the User could send — either a natural follow-up reply or a concrete next-step directive.",
+    "Rules: write it in the User's first-person voice, ready to send as-is. Keep it to one or two sentences. Do not answer as the assistant, do not add commentary, do not address the User, do not wrap it in quotes.",
+    "Return ONLY the suggested message wrapped exactly in <reply></reply> tags — no preamble.",
+    "",
+    "Conversation so far:",
+    recent,
+  ].join("\n");
+}
+
+/** Streaming-safe extraction of the suggested reply. Mirrors
+ *  extractEnhancedPrompt: trims a trailing partial of the closing tag mid-stream
+ *  so it never flashes tag noise, falls back to the whole trimmed text when the
+ *  model ignores the wrapper, and strips a stray wrapping quote. */
+export function extractRecommendedReply(text: string): { partial: string; complete: boolean } {
+  const open = text.indexOf(OPEN);
+  if (open >= 0) {
+    const start = open + OPEN.length;
+    const close = text.indexOf(CLOSE, start);
+    if (close >= 0) return { partial: unquote(text.slice(start, close).trim()), complete: true };
+    // Mid-stream: drop a trailing partial of the closing tag (longest suffix of
+    // the body that is a prefix of "</reply>") so it never renders.
+    let body = text.slice(start);
+    for (let n = Math.min(CLOSE.length - 1, body.length); n > 0; n -= 1) {
+      if (body.endsWith(CLOSE.slice(0, n))) {
+        body = body.slice(0, body.length - n);
+        break;
+      }
+    }
+    return { partial: body.trimStart(), complete: false };
+  }
+  // No opening tag yet. If everything so far could still become the tag (a
+  // prefix of it, ignoring leading whitespace), show nothing.
+  const lead = text.trimStart();
+  if (lead.length < OPEN.length && OPEN.startsWith(lead)) return { partial: "", complete: false };
+  // A tagless stream is usable as-is once trimmed of stray code fences.
+  const cleaned = lead
+    .trim()
+    .replace(/^```[a-z]*\n?/, "")
+    .replace(/\n?```$/, "")
+    .trim();
+  return { partial: unquote(cleaned), complete: false };
+}
+
+/** Models occasionally wrap the suggestion in matching quotes despite the rule
+ *  — strip a single balanced pair so the draft doesn't inherit them. */
+function unquote(text: string): string {
+  const m = /^(["'“”‘’])([\s\S]*)\1$/.exec(text);
+  return m ? m[2].trim() : text;
+}

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -9,6 +9,11 @@
 // starts a fresh thread; `newThread()` clears the current one on demand.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CaveProject } from "@/lib/cave-projects-types";
+import {
+  stripPreviewOnlyAttachmentFieldsKeepingImages,
+  type ChatAttachment,
+} from "@/lib/chat-attachments";
 import {
   COMMAND_CONTROL_DEFAULTS,
   type CommandResponseSpeed,
@@ -17,6 +22,7 @@ import {
 import { resolveQuickChatTarget, type QuickChatTarget } from "@/lib/quick-chat";
 import { streamFamiliarText } from "@/lib/familiar-stream";
 import type { Familiar } from "@/lib/types";
+import { useProjects } from "@/lib/use-projects";
 
 const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
 
@@ -46,10 +52,24 @@ export type QuickChatMessage = {
   id: string;
   role: QuickChatRole;
   text: string;
+  /** Files that rode with a user turn (shown as a chip line in the bubble). */
+  attachments?: ChatAttachment[];
   /** Assistant turn still streaming in. */
   pending?: boolean;
   /** Per-turn error (the familiar failed / reported an error). */
   error?: string | null;
+  /** Local note (slash-command output like /help) — rendered as an assistant
+   *  turn but never sent to the daemon, never a regenerate anchor, and never
+   *  a reply-recommendation trigger. */
+  local?: boolean;
+};
+
+/** A message parked while a reply streams — auto-sent (in order) when the
+ *  in-flight turn settles naturally. Stop parks the queue. */
+export type QueuedQuickChatMessage = {
+  id: string;
+  text: string;
+  attachments?: ChatAttachment[];
 };
 
 export type UseQuickChat = {
@@ -57,6 +77,10 @@ export type UseQuickChat = {
   selectedFamiliarId: string | null;
   setSelectedFamiliarId: (id: string | null) => void;
   selectedFamiliar: Familiar | null;
+  projects: CaveProject[];
+  projectsLoading: boolean;
+  selectedProjectRoot: string | null;
+  setSelectedProjectRoot: (root: string | null) => void;
   draft: string;
   setDraft: (value: string) => void;
   /** The conversation so far — user + streamed familiar turns. */
@@ -71,7 +95,23 @@ export type UseQuickChat = {
   setThinkingEffort: (value: CommandThinkingEffort) => void;
   responseSpeed: CommandResponseSpeed;
   setResponseSpeed: (value: CommandResponseSpeed) => void;
-  send: () => Promise<void>;
+  /** Send the draft (plus any staged attachments). While a reply is already
+   *  streaming the message is QUEUED instead of dropped, and auto-sends when
+   *  the turn settles naturally. */
+  send: (attachments?: ChatAttachment[]) => Promise<void>;
+  /** Send an explicit text through the same pipeline as `send` (slash-command
+   *  dispatch — e.g. a resolved skill invocation). Clears the draft. */
+  sendText: (raw: string, attachments?: ChatAttachment[]) => Promise<void>;
+  /** Messages waiting behind the in-flight turn, in send order. */
+  queued: QueuedQuickChatMessage[];
+  removeQueued: (id: string) => void;
+  /** Append a local assistant-styled note (slash-command output). Never
+   *  touches the daemon session. */
+  note: (text: string) => void;
+  /** Per-thread model override set via /model; cleared by newThread and when
+   *  the thread's familiar changes. */
+  modelOverride: string | null;
+  setModelOverride: (id: string | null) => void;
   cancel: () => void;
   /** Clear the conversation (keeps the familiar + control choices). */
   newThread: () => void;
@@ -96,6 +136,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   const enabled = options?.enabled ?? true;
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
+  const [selectedProjectRoot, setSelectedProjectRoot] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [messages, setMessages] = useState<QuickChatMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -129,6 +170,8 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   // without threading it through a state updater.
   const selectedIdRef = useRef<string | null>(selectedFamiliarId);
   selectedIdRef.current = selectedFamiliarId;
+  const selectedProjectRootRef = useRef<string | null>(selectedProjectRoot);
+  selectedProjectRootRef.current = selectedProjectRoot;
   // Roster-load bookkeeping: fire once (latched on `enabled`), abort via the
   // effect's own cleanup. `rosterLoadedRef` marks a COMPLETED load so the
   // cleanup can tell "hide mid-fetch" (un-latch, the re-run must refetch)
@@ -137,6 +180,37 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   const rosterLoadedRef = useRef(false);
 
   const nextId = useCallback((prefix: string) => `${prefix}-${msgSeqRef.current++}`, []);
+  const { projects, loading: projectsLoading } = useProjects({ familiarId: selectedFamiliarId });
+
+  // Per-thread /model override — ref-mirrored so deliver() reads the latest
+  // without re-identity, cleared whenever the thread resets or swaps familiar
+  // (the override belongs to this thread's harness).
+  const [modelOverride, setModelOverrideState] = useState<string | null>(null);
+  const modelOverrideRef = useRef<string | null>(null);
+  const setModelOverride = useCallback((id: string | null) => {
+    modelOverrideRef.current = id;
+    setModelOverrideState(id);
+  }, []);
+
+  // Local assistant-styled note (slash-command output like /help). Marked
+  // `local` so it never anchors regenerate or a reply recommendation.
+  const note = useCallback(
+    (text: string) => {
+      setMessages((prev) => [...prev, { id: nextId("n"), role: "assistant" as const, text, local: true }]);
+    },
+    [nextId],
+  );
+
+  // Messages queued behind an in-flight turn (ref-mirrored: the drain runs
+  // inside the send chain, where state would be stale).
+  const [queued, setQueued] = useState<QueuedQuickChatMessage[]>([]);
+  const queuedRef = useRef<QueuedQuickChatMessage[]>([]);
+  const removeQueued = useCallback((id: string) => {
+    queuedRef.current = queuedRef.current.filter((item) => item.id !== id);
+    setQueued(queuedRef.current);
+  }, []);
+  // Files that rode with the last user turn, so regenerate() re-sends them.
+  const lastUserAttachmentsRef = useRef<ChatAttachment[]>([]);
 
   // Clear the conversation; keeps the familiar + control choices intact.
   const newThread = useCallback(() => {
@@ -145,6 +219,11 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     sessionIdRef.current = null;
     threadFamiliarRef.current = null;
     lastUserPromptRef.current = "";
+    lastUserAttachmentsRef.current = [];
+    modelOverrideRef.current = null;
+    queuedRef.current = [];
+    setQueued([]);
+    setModelOverrideState(null);
     setSessionId(null);
     setMessages([]);
     setError(null);
@@ -219,13 +298,25 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? familiars[0] ?? null,
     [familiars, selectedFamiliarId],
   );
+  useEffect(() => {
+    if (!selectedProjectRootRef.current) return;
+    if (projects.some((project) => project.root === selectedProjectRootRef.current)) return;
+    selectedProjectRootRef.current = null;
+    setSelectedProjectRoot(null);
+  }, [projects]);
 
   // Stream one reply for a resolved target, appending a pending assistant turn
   // and filling it as tokens arrive. `resume` continues the current daemon
-  // session so follow-ups keep their context.
+  // session so follow-ups keep their context. Returns how the turn ended so
+  // the send chain knows whether to drain the queue: "done" is a natural
+  // completion; "stopped" is an abort or a failure (both park the queue).
   const deliver = useCallback(
-    async (target: QuickChatTarget, resume: boolean) => {
-      if (!target.familiarId) return;
+    async (
+      target: QuickChatTarget,
+      resume: boolean,
+      attachments: ChatAttachment[] = [],
+    ): Promise<"done" | "stopped"> => {
+      if (!target.familiarId) return "stopped";
       const assistantId = nextId("a");
       const controller = new AbortController();
       abortRef.current = controller;
@@ -240,9 +331,21 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         result = await streamFamiliarText({
           familiarId: target.familiarId,
           prompt: target.prompt,
+          projectRoot: selectedProjectRoot ?? undefined,
+          // Staged files: the bridge composes the prompt (text inlined, image
+          // payloads written to temp files the harness can Read) — send-body
+          // stripping mirrors the main chat composer.
+          ...(attachments.length
+            ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(attachments) }
+            : {}),
           sessionId: resume ? sessionIdRef.current ?? undefined : undefined,
           reasoningEffort: thinkingEffort,
           responseSpeed,
+          // /model pick — session-scoped so the resumed thread stays on the
+          // chosen model (re-sent per turn; idempotent on the bridge).
+          ...(modelOverrideRef.current
+            ? { modelOverride: modelOverrideRef.current, modelOverrideScope: "session" as const }
+            : {}),
           signal: controller.signal,
           // Capture the backing session the moment the bridge announces it —
           // if the user stops the stream mid-turn, the thread stays resumable
@@ -271,7 +374,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
           ),
         );
         setSendState("idle");
-        return;
+        return "stopped";
       }
 
       if (abortRef.current === controller) abortRef.current = null;
@@ -283,41 +386,100 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         ),
       );
       setSendState("done");
+      return "done";
     },
-    [nextId, responseSpeed, thinkingEffort],
+    [nextId, responseSpeed, selectedProjectRoot, thinkingEffort],
   );
 
-  const send = useCallback(async () => {
-    // One turn in flight at a time — a second Send/Enter while streaming would
-    // race the abort bookkeeping and duplicate turns.
-    if (abortRef.current) return;
-    const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
-    setError(target.error);
-    if (target.error || !target.familiarId) return;
+  // Full send pipeline for an explicit text — `send()` feeds it the draft;
+  // slash dispatch (skill invocations) feeds it a built prompt directly.
+  // Self-reference (assigned below) so the queue drain re-enters the pipeline
+  // without a stale closure.
+  const sendTextRef = useRef<(raw: string, attachments?: ChatAttachment[]) => Promise<void>>(
+    async () => {},
+  );
+  const sendText = useCallback(
+    async (raw: string, attachments: ChatAttachment[] = []) => {
+      // A turn is already streaming: QUEUE the message instead of dropping it
+      // (the old behavior) — it auto-sends, in order, when the reply settles
+      // naturally. Stop parks the queue, so a cancel never fires a surprise
+      // follow-up; the next manual send resumes draining.
+      if (abortRef.current) {
+        if (!raw.trim() && attachments.length === 0) return;
+        const item: QueuedQuickChatMessage = {
+          id: nextId("q"),
+          text: raw,
+          ...(attachments.length ? { attachments } : {}),
+        };
+        queuedRef.current = [...queuedRef.current, item];
+        setQueued(queuedRef.current);
+        setDraft("");
+        return;
+      }
+      const target = resolveQuickChatTarget(raw, familiars, selectedFamiliarId);
+      // Attachment-only sends are legal — the bridge builds a "review the
+      // attached files" prompt server-side. Only the empty-prompt error is
+      // forgiven; an unknown @mention or an empty roster still surfaces.
+      const blocking =
+        target.error && !(target.familiarId && attachments.length > 0) ? target.error : null;
+      setError(blocking);
+      if (blocking || !target.familiarId) return;
 
-    // A leading @mention (or picker change) that swaps familiar starts a fresh
-    // thread — a resumed session belongs to the previous familiar.
-    const sameFamiliar = threadFamiliarRef.current === target.familiarId;
-    const resume = sameFamiliar && sessionIdRef.current != null;
-    if (!sameFamiliar) {
-      sessionIdRef.current = null;
-      setSessionId(null);
-      if (threadFamiliarRef.current) setMessages([]);
-    }
-    threadFamiliarRef.current = target.familiarId;
-    // Targeting a familiar by @mention is as deliberate as picking it in the
-    // dropdown — stop following the workspace-active familiar afterwards.
-    if (target.mention) userPickedRef.current = true;
+      // A leading @mention (or picker change) that swaps familiar starts a fresh
+      // thread — a resumed session belongs to the previous familiar.
+      const sameFamiliar = threadFamiliarRef.current === target.familiarId;
+      const resume = sameFamiliar && sessionIdRef.current != null;
+      if (!sameFamiliar) {
+        sessionIdRef.current = null;
+        setSessionId(null);
+        if (threadFamiliarRef.current) setMessages([]);
+        // A /model pick belongs to the previous thread's harness.
+        modelOverrideRef.current = null;
+        setModelOverrideState(null);
+      }
+      threadFamiliarRef.current = target.familiarId;
+      // Targeting a familiar by @mention is as deliberate as picking it in the
+      // dropdown — stop following the workspace-active familiar afterwards.
+      if (target.mention) userPickedRef.current = true;
 
-    const userText = draft.trim();
-    lastUserPromptRef.current = draft;
-    setDraft("");
-    setSelectedFamiliarId(target.familiarId);
-    writeLastFamiliar(target.familiarId);
-    setMessages((prev) => [...prev, { id: nextId("u"), role: "user", text: userText }]);
+      const userText = raw.trim();
+      lastUserPromptRef.current = raw;
+      lastUserAttachmentsRef.current = attachments;
+      setDraft("");
+      setSelectedFamiliarId(target.familiarId);
+      writeLastFamiliar(target.familiarId);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: nextId("u"),
+          role: "user",
+          text: userText,
+          ...(attachments.length ? { attachments } : {}),
+        },
+      ]);
 
-    await deliver(target, resume);
-  }, [deliver, draft, familiars, nextId, selectedFamiliarId]);
+      const status = await deliver(target, resume, attachments);
+      // Natural completion drains the next queued message; a Stop or a failed
+      // turn parks the queue (its chips stay visible for remove-or-resume).
+      if (status === "done") {
+        const [next, ...rest] = queuedRef.current;
+        if (next) {
+          queuedRef.current = rest;
+          setQueued(rest);
+          await sendTextRef.current(next.text, next.attachments ?? []);
+        }
+      }
+    },
+    [deliver, familiars, nextId, selectedFamiliarId],
+  );
+  sendTextRef.current = sendText;
+
+  const send = useCallback(
+    async (attachments: ChatAttachment[] = []) => {
+      await sendText(draft, attachments);
+    },
+    [draft, sendText],
+  );
 
   const regenerate = useCallback(() => {
     const prompt = lastUserPromptRef.current;
@@ -336,7 +498,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
       return prev.slice(0, cut);
     });
     const resume = threadFamiliarRef.current === target.familiarId && sessionIdRef.current != null;
-    void deliver(target, resume);
+    void deliver(target, resume, lastUserAttachmentsRef.current);
   }, [deliver, familiars, selectedFamiliarId, sendState]);
 
   const cancel = useCallback(() => {
@@ -358,12 +520,24 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     },
     [newThread],
   );
+  const pickProjectRoot = useCallback(
+    (root: string | null) => {
+      if (selectedProjectRootRef.current !== root) newThread();
+      selectedProjectRootRef.current = root;
+      setSelectedProjectRoot(root);
+    },
+    [newThread],
+  );
 
   return {
     familiars,
     selectedFamiliarId,
     setSelectedFamiliarId: pickFamiliar,
     selectedFamiliar,
+    projects,
+    projectsLoading,
+    selectedProjectRoot,
+    setSelectedProjectRoot: pickProjectRoot,
     draft,
     setDraft,
     messages,
@@ -377,6 +551,12 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     responseSpeed,
     setResponseSpeed,
     send,
+    sendText,
+    queued,
+    removeQueued,
+    note,
+    modelOverride,
+    setModelOverride,
     cancel,
     newThread,
     regenerate,

--- a/src/lib/use-reply-recommendation.ts
+++ b/src/lib/use-reply-recommendation.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { streamFamiliarText } from "@/lib/familiar-stream";
+import {
+  buildRecommendationInstruction,
+  extractRecommendedReply,
+  type RecommendationTurn,
+} from "@/lib/reply-recommendation";
+
+// Model-backed reply recommendation for quick chat. After a familiar's reply
+// settles, this proposes the user's most useful next message so it can be
+// Tab-accepted straight into the composer. It mirrors usePromptEnhance's
+// discipline — a generation counter makes stale completions inert, and a
+// per-turn ref fires the request exactly once per reply.
+//
+// Model path: streamFamiliarText as an ephemeral run — no sessionId, origin
+// "enhance" (hidden from chat lists), low effort + fast speed. On any error,
+// empty result, or a slow first token it fails quiet (idle) — a missing
+// suggestion is a non-event, never an error the user must clear.
+
+export const RECOMMEND_FIRST_TOKEN_TIMEOUT_MS = 9000;
+
+export type ReplyRecommendationState =
+  | { phase: "idle" }
+  | { phase: "loading"; preview: string }
+  | { phase: "ready"; text: string };
+
+export type UseReplyRecommendation = {
+  state: ReplyRecommendationState;
+  /** The ready suggestion, or null while idle/loading. */
+  suggestion: string | null;
+  loading: boolean;
+  /** Consume the ready suggestion: returns its text and goes idle. */
+  accept: () => string | null;
+  /** Drop a ready suggestion without using it (kept out for this turn). */
+  dismiss: () => void;
+  /** Ask for a different suggestion for the same turn. */
+  regenerate: () => void;
+};
+
+export function useReplyRecommendation({
+  messages,
+  familiarId,
+  familiarName,
+  draft,
+  enabled = true,
+}: {
+  messages: RecommendationTurn[];
+  familiarId: string | null | undefined;
+  familiarName?: string | null;
+  /** The composer draft — a non-empty draft suppresses the recommendation
+   *  (the user is already writing their own reply). */
+  draft: string;
+  /** Gate generation (pane inactive / sending). Flipping off cancels in-flight. */
+  enabled?: boolean;
+}): UseReplyRecommendation {
+  const [state, setState] = useState<ReplyRecommendationState>({ phase: "idle" });
+
+  const generationRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  // The assistant turn we last generated (or are generating) a suggestion for,
+  // so the auto-trigger fires exactly once per reply.
+  const servedTurnRef = useRef<string | null>(null);
+  // Refs so completions/regenerate read the latest without re-subscribing.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const familiarNameRef = useRef(familiarName);
+  familiarNameRef.current = familiarName;
+  const familiarIdRef = useRef(familiarId);
+  familiarIdRef.current = familiarId;
+
+  // The valid recommendation anchor: a settled, non-empty assistant turn that
+  // is actually the last message (a trailing user turn means we're waiting on a
+  // reply, not ready to suggest the next one). Keyed by index so identical
+  // adjacent thread shapes still re-fire per new reply.
+  const lastIndex = messages.length - 1;
+  const last = lastIndex >= 0 ? messages[lastIndex] : null;
+  const anchorId =
+    last && last.role === "assistant" && !last.pending && !last.local && last.text.trim().length > 0
+      ? `${lastIndex}:${last.text.length}`
+      : null;
+  const anchorRef = useRef<string | null>(anchorId);
+  anchorRef.current = anchorId;
+
+  const cancel = useCallback(() => {
+    generationRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState({ phase: "idle" });
+  }, []);
+
+  const run = useCallback((turnId: string) => {
+    const familiar = familiarIdRef.current;
+    if (!familiar) return;
+    servedTurnRef.current = turnId;
+    generationRef.current += 1;
+    const gen = generationRef.current;
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setState({ phase: "loading", preview: "" });
+
+    let sawToken = false;
+    const timer = setTimeout(() => {
+      if (!sawToken && gen === generationRef.current) {
+        controller.abort();
+        setState({ phase: "idle" });
+      }
+    }, RECOMMEND_FIRST_TOKEN_TIMEOUT_MS);
+
+    void streamFamiliarText({
+      familiarId: familiar,
+      prompt: buildRecommendationInstruction({
+        messages: messagesRef.current,
+        familiarName: familiarNameRef.current,
+      }),
+      origin: "enhance",
+      reasoningEffort: "low",
+      responseSpeed: "fast",
+      signal: controller.signal,
+      onText: (text) => {
+        if (gen !== generationRef.current) return;
+        sawToken = true;
+        const { partial } = extractRecommendedReply(text);
+        setState((prev) => (prev.phase === "loading" ? { ...prev, preview: partial } : prev));
+      },
+    })
+      .then(({ text, error }) => {
+        clearTimeout(timer);
+        if (gen !== generationRef.current) return;
+        const { partial } = extractRecommendedReply(text);
+        // Fail quiet: no suggestion is a non-event, and if the user started
+        // typing their own reply mid-stream, don't nag them with one.
+        if (error || !partial.trim() || draftRef.current.trim()) {
+          setState({ phase: "idle" });
+          return;
+        }
+        setState({ phase: "ready", text: partial.trim() });
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        if (gen === generationRef.current) setState({ phase: "idle" });
+      });
+  }, []);
+
+  // Auto-trigger: one suggestion per settled reply, only while enabled and the
+  // composer is empty. servedTurnRef guards against re-firing for the same turn
+  // (including after the state settles or the draft is cleared again).
+  useEffect(() => {
+    if (!enabled || !familiarId) return;
+    if (draft.trim()) return;
+    if (!anchorId || servedTurnRef.current === anchorId) return;
+    run(anchorId);
+  }, [enabled, familiarId, draft, anchorId, run]);
+
+  // Typing over a live suggestion retires it — the user is writing their own
+  // reply. servedTurnRef stays set, so clearing the draft won't auto-regenerate
+  // (they can ask again with the refresh control).
+  useEffect(() => {
+    if (draft.trim() && stateRef.current.phase !== "idle") cancel();
+  }, [draft, cancel]);
+
+  // Going inactive / sending cancels any in-flight or ready suggestion.
+  useEffect(() => {
+    if (!enabled && stateRef.current.phase !== "idle") cancel();
+  }, [enabled, cancel]);
+
+  // Abort any in-flight stream on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const accept = useCallback((): string | null => {
+    const prev = stateRef.current;
+    if (prev.phase !== "ready") return null;
+    setState({ phase: "idle" });
+    return prev.text;
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setState((prev) => (prev.phase === "ready" ? { phase: "idle" } : prev));
+  }, []);
+
+  const regenerate = useCallback(() => {
+    if (anchorRef.current) run(anchorRef.current);
+  }, [run]);
+
+  return {
+    state,
+    suggestion: state.phase === "ready" ? state.text : null,
+    loading: state.phase === "loading",
+    accept,
+    dismiss,
+    regenerate,
+  };
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2466,6 +2466,18 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-primary);
 }
 
+/* Enhance split-control segments (composer-enhance.tsx) — the same tint family
+   as the icon buttons, but a dedicated class: the mobile touch-target override
+   inflates .cave-composer-icon-button into 44px circles, which blew the
+   sparkle + caret out of their shared hairline rectangle. These segments must
+   always render as two flat rectangles filling that rectangle (sparkle wider
+   than the caret) — the rectangle itself is the touch target. */
+.composer-enhance-control__segment {
+  background: color-mix(in oklch, var(--bg-surface) 52%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
+  color: var(--text-primary);
+}
+
 /* Base control pill — still used by the standalone ComposerHostChip. */
 .cave-composer-select {
   height: 30px;


### PR DESCRIPTION
## What

**Attachments + queueing** (core):
- Drag-and-drop / paste file staging on the quick-chat composer, "Attached files" chip row, attachment-only sends allowed.
- `familiar-stream` passes staged attachments through to `/api/chat/send` (bridge composes natively; images via temp files), pre-stripped like the main chat composer.
- Send-while-streaming **queues** instead of dropping: drains in order only on natural "done"; Stop/error parks the queue. Queued chips removable; Send/Queue button flip; regenerate re-sends last attachments; newThread clears the queue.

**Companion quick-chat work on the same surface** (interleaved in the same functions; not separable):
- `sendText` pipeline + local notes + per-thread `/model` override for slash dispatch.
- Project-root picker plumbing (projects -> controls -> stream body).
- Reply recommendation after a familiar turn (Tab-accept), pure protocol module + hook.
- Tray: `+` opens a new chat with the agent picker visible; picking dismisses it.
- EnhanceControl: dedicated `__segment` class (mobile 44px-circle override was blowing the sparkle/caret out of the rectangle) + `sm` size.

## Verification
- `tsc --noEmit`: 0 errors
- `node scripts/run-tests.mjs app`: **594/594**
- api suite: green except pre-existing macOS-only `sidecar-runtime-closure` /var-symlink failure (fails identically on a clean checkout; CI is Linux)

Scoped file-level out of a shared dirty checkout; unrelated pending work (chat-split, boundary sentinel, memory/config/board changes) was left behind.
