### PR TITLE
fix(composer): keep enhance sparkle/caret segments inside their rectangle

### DIFF
--- a/src/components/composer-enhance.test.ts
+++ b/src/components/composer-enhance.test.ts
@@ -59,6 +59,42 @@ assert.match(
   "accent marks presence only — the sparkle tints while loading, never at rest",
 );
 
+// ── EnhanceControl: one combined rectangle, not two floating rounds ──────────
+// The sparkle + caret live inside a single hairline control-radius rectangle
+// split by a hairline divider — minimal, and height-matched to the hosting
+// composer's Send button via the size prop.
+assert.match(
+  source,
+  /inline-flex items-stretch overflow-hidden rounded-\[var\(--radius-control\)\] border border-\[var\(--border-hairline\)\]/,
+  "the control is one bordered control-radius rectangle wrapping both segments",
+);
+assert.match(
+  source,
+  /border-l border-\[var\(--border-hairline\)\]/,
+  "the caret segment joins through a hairline divider, not its own outline",
+);
+{
+  const controlSrc = source.slice(
+    source.indexOf("export function EnhanceControl"),
+    source.indexOf("export function EnhanceStrip"),
+  );
+  assert.doesNotMatch(
+    controlSrc,
+    /rounded-full/,
+    "no rounded-full inside the control — the pill geometry belongs to the strip only",
+  );
+}
+assert.match(
+  source,
+  /size = "md",/,
+  "the height prop defaults to the 30px composer rows; quick chat opts into sm",
+);
+assert.match(
+  source,
+  /size === "sm" \? "h-\[26px\]" : "h-\[30px\]"/,
+  'sm matches the 26px Button size="sm" Send; md the 30px icon-button rows',
+);
+
 // ── EnhanceStrip: one status row, four phases ────────────────────────────────
 assert.match(source, /if \(state\.phase === "idle"\) return null/, "the strip renders nothing at rest");
 assert.match(source, /role="status"/, "the strip is a status live region");

--- a/src/components/composer-enhance.tsx
+++ b/src/components/composer-enhance.tsx
@@ -12,19 +12,26 @@ import type { PromptEnhanceState } from "@/lib/use-prompt-enhance";
 
 const LONG_PRESS_MS = 420;
 
-/** Sparkle split-control in the composer's 30px round-button language.
- *  Click = smart enhance; the chevron (or ArrowDown / long-press on the main
- *  button) opens the intent menu. Accent shows only while loading. */
+/** Sparkle split-control: one minimal rectangle (control-radius, hairline
+ *  border) holding the sparkle segment and the caret segment — a single
+ *  combined control, not two floating round buttons.
+ *  Click = smart enhance; the caret (or ArrowDown / long-press on the main
+ *  segment) opens the intent menu. Accent shows only while loading. */
 export function EnhanceControl({
   state,
   onEnhance,
   onCancel,
   disabled,
+  size = "md",
 }: {
   state: PromptEnhanceState;
   onEnhance: (intent: EnhanceIntent) => void;
   onCancel: () => void;
   disabled?: boolean;
+  /** Height language of the hosting composer — "md" sits with the 30px
+   *  icon-button rows (home, chat); "sm" matches the 26px `Button size="sm"`
+   *  Send button (quick chat). */
+  size?: "sm" | "md";
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const mainRef = useRef<HTMLButtonElement | null>(null);
@@ -37,15 +44,21 @@ export function EnhanceControl({
   }, []);
   useEffect(() => clearPress, [clearPress]);
 
-  const baseBtn =
-    "cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40";
+  // Both segments share one hairline rectangle — borderless inside, split by
+  // a hairline divider, height matched to the composer's Send button. They use
+  // their own segment class (NOT cave-composer-icon-button): the mobile
+  // touch-target override turns that class into 44px circles, which blew the
+  // segments out of the rectangle. Here the rectangle itself is the control —
+  // two flat rectangles inside it, the sparkle wider than the caret.
+  const heightClass = size === "sm" ? "h-[26px]" : "h-[30px]";
+  const segmentBtn = `composer-enhance-control__segment focus-ring grid ${heightClass} place-items-center hover:bg-[var(--bg-raised)] disabled:opacity-40`;
 
   return (
-    <span className="composer-enhance-control inline-flex items-center gap-0.5">
+    <span className="composer-enhance-control inline-flex items-stretch overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)]">
       <button
         ref={mainRef}
         type="button"
-        className={baseBtn}
+        className={`${segmentBtn} px-2`}
         title="Enhance prompt"
         aria-label="Enhance prompt"
         disabled={disabled && !loading}
@@ -81,7 +94,7 @@ export function EnhanceControl({
       </button>
       <button
         type="button"
-        className="cave-composer-icon-button focus-ring grid h-[30px] w-4 place-items-center rounded-full text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-40"
+        className={`${segmentBtn} w-[18px] border-l border-[var(--border-hairline)] text-[var(--text-muted)] hover:text-[var(--text-primary)]`}
         aria-label="Enhance options"
         aria-haspopup="menu"
         aria-expanded={menuOpen}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2466,6 +2466,18 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-primary);
 }
 
+/* Enhance split-control segments (composer-enhance.tsx) — the same tint family
+   as the icon buttons, but a dedicated class: the mobile touch-target override
+   inflates .cave-composer-icon-button into 44px circles, which blew the
+   sparkle + caret out of their shared hairline rectangle. These segments must
+   always render as two flat rectangles filling that rectangle (sparkle wider
+   than the caret) — the rectangle itself is the touch target. */
+.composer-enhance-control__segment {
+  background: color-mix(in oklch, var(--bg-surface) 52%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
+  color: var(--text-primary);
+}
+
 /* Base control pill — still used by the standalone ComposerHostChip. */
 .cave-composer-select {
   height: 30px;


### PR DESCRIPTION
## Problem
The `EnhanceControl` sparkle + caret segments reused `.cave-composer-icon-button`. The mobile touch-target override inflates that class into 44px circles, which blew both segments out of their shared hairline rectangle.

## Fix
- Dedicated `.composer-enhance-control__segment` class (`src/styles/cave-chat.css`) — same tint family as icon buttons, but rectangle-shaped; the rectangle itself is the touch target.
- The control is now one bordered `--radius-control` rectangle split by a hairline divider (no `rounded-full` inside the control).
- New `size` prop: `md` (default) sits with the 30px composer icon rows; `sm` matches the 26px `Button size="sm"` Send in quick chat (consumer wiring lands with the quick-chat feature branch).

## Verification
- `pnpm typecheck` — 0 errors
- `node scripts/run-tests.mjs app` — 593/593 green (includes new geometry pins in `composer-enhance.test.ts`)