### PR TITLE
docs(changelog): record the quick-chat attachments + queueing release note (#2937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ breaking config changes; patch releases stay additive.
 ## [Unreleased]
 
 ### Features
-- **Quick chat: drag-and-drop/paste attachments, message queueing, and companion composer upgrades** — the tray/overlay composer stages files via drag-drop or paste as chips (attachment-only sends allowed, bridge composes natively), send-while-streaming queues the message and drains it in order on a natural done (Stop/error keep it parked), plus slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and Enhance sparkle/caret segments that stay inside their rectangle on mobile (#2937).
+- **Quick chat: drag-and-drop/paste attachments, message queueing, and companion composer upgrades** — the tray/overlay composer stages files via drag-and-drop or paste as chips (attachment-only sends allowed, bridge composes natively), send-while-streaming queues the message and drains it in order on a natural done (Stop/error keeps it parked), plus slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and Enhance sparkle/caret segments that stay inside their rectangle on mobile (#2937).
 
 ## [0.0.174] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Features
+- **Quick chat: drag-and-drop/paste attachments, message queueing, and companion composer upgrades** — the tray/overlay composer stages files via drag-drop or paste as chips (attachment-only sends allowed, bridge composes natively), send-while-streaming queues the message and drains it in order on a natural done (Stop/error keep it parked), plus slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and Enhance sparkle/caret segments that stay inside their rectangle on mobile (#2937).
+
 ## [0.0.174] - 2026-07-11
 
 > 💬 **Copilot chats natively, cleaner Windows packaging, and the Grimoire becomes Memories.** Copilot (and other manifest adapters) now render their replies correctly in chat, the packaged Windows sidecar runtime is pruned and MSI publication is gated, and the knowledge surface is renamed Memories.


### PR DESCRIPTION
## What

Adds the missing `[Unreleased]` CHANGELOG entry for the quick-chat work that landed in #2937 (drag-and-drop/paste attachments, message queueing, slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and the Enhance segment fix).

## Why

#2937 merged without a release note. This session had prepared the same feature lane in parallel (branch `feat/quick-chat-slash-attachments-queue`, since deleted as superseded — its code diff vs main was empty after the merge); the CHANGELOG entry was the one useful remaining delta, re-cut cleanly off current `main`.

## Verification

- Docs-only change; `[Unreleased]` section, Keep-a-Changelog format matched to neighboring entries.