### PR TITLE
fix(board): never mount the table with the selected card's group collapsed (cave-iote)

### DIFF
--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -42,14 +42,20 @@ function sortCards(cards: Card[], key: SortKey, dir: SortDir, familiars: Familia
 
 const NO_PROJECT_KEY = "__noproject__";
 
+/** The group a card lands in for a given grouping — shared by the grouper and
+ *  the keep-selection-visible logic so the two can never disagree. */
+function cardGroupKey(c: Card, by: GroupBy): string {
+  return by === "status"
+    ? c.status
+    : by === "familiar"
+      ? (c.familiarId ?? "__unassigned__")
+      : (c.projectId ?? NO_PROJECT_KEY);
+}
+
 function groupCards(cards: Card[], by: GroupBy, familiars: Familiar[], projects: CaveProject[]): { key: string; label: string; cards: Card[] }[] {
   const map = new Map<string, Card[]>();
   for (const c of cards) {
-    const key = by === "status"
-      ? c.status
-      : by === "familiar"
-        ? (c.familiarId ?? "__unassigned__")
-        : (c.projectId ?? NO_PROJECT_KEY);
+    const key = cardGroupKey(c, by);
     if (!map.has(key)) map.set(key, []);
     map.get(key)!.push(c);
   }
@@ -120,7 +126,36 @@ type Props = {
 export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, selectMode = false, isSelected, onToggleSelect, onPatch }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["done"]));
+
+  // Which group holds the current selection (null when nothing is selected).
+  const selectedGroupKey = useMemo(() => {
+    const sel = selectedCardId ? cards.find((c) => c.id === selectedCardId) : undefined;
+    return sel ? cardGroupKey(sel, groupBy) : null;
+  }, [cards, selectedCardId, groupBy]);
+
+  // "Done" starts collapsed to keep the table short — but never at the cost of
+  // hiding the still-selected card the open inspector describes (cave-iote,
+  // P1-6 remainder): a kanban/gantt selection that lives in "done" must have a
+  // mounted row in the very first commit, or BoardView's view-switch
+  // scrollIntoView finds nothing and silently no-ops. Lazy init, not an
+  // effect, so there's no collapsed→expanded flash to race that scroll.
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () => (selectedGroupKey === "done" ? new Set<string>() : new Set(["done"])),
+  );
+
+  // A selection that later arrives in (or regroups into) a collapsed group
+  // would have no row to show — expand that group. Keyed on the selection's
+  // group only, NOT on `collapsed`: collapsing a group by hand must stick
+  // until the selection actually moves.
+  useEffect(() => {
+    if (!selectedGroupKey) return;
+    setCollapsed((prev) => {
+      if (!prev.has(selectedGroupKey)) return prev;
+      const next = new Set(prev);
+      next.delete(selectedGroupKey);
+      return next;
+    });
+  }, [selectedGroupKey]);
 
   // Column arrangement state (reorder + resize). Defaults match COLS for SSR;
   // the persisted layout is hydrated after mount to avoid a hydration mismatch.

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -244,6 +244,17 @@ assert.match(view, /return \(\) => cancelAnimationFrame\(frame\);/, "the scroll 
 assert.doesNotMatch(view, /querySelector<HTMLElement>\(`\[data-card-id="\$\{selectedCardId\}"\]`\)\s*\?\.focus\(\)/, "view switches must not steal focus from the toggle the user clicked");
 assert.match(gantt, /data-card-id=\{row\.cardId\}/, "gantt rows carry data-card-id so the view-switch scroll finds them");
 
+// ── …and the table never mounts with the selection hidden (cave-iote, the
+// P1-6 remainder): "done" collapses by default, so switching to table with a
+// done card selected used to leave no row for the anchor scroll to find — the
+// inspector described an invisible card. The collapse initializer must be
+// selection-aware, and a later selection must expand its own collapsed group
+// without un-sticking manual collapses.
+assert.match(table, /selectedGroupKey === "done" \? new Set<string>\(\) : new Set\(\["done"\]\)/, "the default 'done' collapse yields when the selection lives there (lazy init — no flash, nothing to race the view-switch scroll)");
+assert.match(table, /sel \? cardGroupKey\(sel, groupBy\) : null/, "the selection's group is derived through the same cardGroupKey the grouper uses");
+assert.match(table, /const key = cardGroupKey\(c, by\);/, "groupCards shares cardGroupKey — the two can never disagree on a card's group");
+assert.match(table, /\}, \[selectedGroupKey\]\);/, "the expand effect keys on the selection's group only — a manual collapse sticks until the selection moves");
+
 // ── Bulk-op patch failures reconcile ONCE, after the batch settles (cave-381s):
 // a failed patchCard used to `await load()` immediately, reverting the
 // optimistic state of sibling patches still in flight.


### PR DESCRIPTION
## What

Completes the P1-6 remainder (bead **cave-iote**): the view-switch scroll-anchor from bb86b5c3 finds the still-selected card by `data-card-id` after a kanban↔table↔gantt switch — but **BoardTable mounts with the `done` group collapsed**, so switching to table with a done card selected left no row in the DOM. The anchor scroll silently no-oped and the inspector kept describing a card the table didn't show.

## How

- **Selection-aware collapse initializer** (lazy `useState` init): if the selection lives in `done`, the table mounts with it expanded — the row exists in the very first commit, so nothing races BoardView's rAF `scrollIntoView` and there's no collapsed→expanded flash.
- **Expand-on-selection effect**: a selection that later arrives in (or is regrouped into) a collapsed group expands that group. Keyed on the selection's group only — a manual collapse sticks until the selection actually moves.
- **One `cardGroupKey` authority** shared by `groupCards` and the new logic, so the grouper and the keep-visible logic can never disagree.
- Pinned in `board-ux-polish.test.ts` next to the existing P1-6 asserts.

## Verification

- `pnpm exec tsc --noEmit` — 0 errors
- `pnpm test` — 594/594 test files pass

Bead: cave-iote (P1-6 remainder, 2026-07-03 heuristic audit)