### PR TITLE
feat(chat): split panes — drag a conversation from the thread rail onto the chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ breaking config changes; patch releases stay additive.
 
 ### Features
 - **Quick chat: drag-and-drop/paste attachments, message queueing, and companion composer upgrades** — the tray/overlay composer stages files via drag-and-drop or paste as chips (attachment-only sends allowed, bridge composes natively), send-while-streaming queues the message and drains it in order on a natural done (Stop/error keeps it parked), plus slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and Enhance sparkle/caret segments that stay inside their rectangle on mobile (#2937).
+- **Chat: split panes** — drag a conversation from the thread rail onto the chat surface to snap it left / right / above / below the current chat as a resizable pane. Each secondary pane carries a slim header (title · open as main · ✕); opening a pane's thread as the primary chat collapses it back out of the strip. Desktop full-width chat only.
 
 ## [0.0.174] - 2026-07-11
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -200,6 +200,8 @@ export const SUITES = {
     "src/components/chat-list-collapse.test.ts",
     "src/components/chat-router-hide-archived.test.ts",
     "src/components/chat-router-switching.test.ts",
+    "src/components/chat-split-host.test.ts",
+    "src/lib/chat-split.test.ts",
     "src/components/chat-thread-rail.test.ts",
     "src/components/chat-rail-modern-redesign.test.ts",
     "src/components/message-bubble-markdown.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12374,8 +12374,129 @@ details[open] > .cave-edit-card__summary::before {
   pointer-events: none;
 }
 
+/* ── Chat split panes — drag a conversation from the thread rail onto the
+      chat and snap it left / right / above / below (chat-split-host). ── */
+.chat-split__group {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+.chat-split__pane-panel {
+  min-width: 0;
+  min-height: 0;
+}
+.chat-split__tile {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-base);
+}
+.chat-split__pane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 0 6px 0 10px;
+  border-bottom: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
+}
+.chat-split__pane-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.chat-split__pane-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-split__pane-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.chat-split__pane-btn {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.chat-split__pane-btn:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+.chat-split__pane-close:hover {
+  color: var(--color-danger, #e5484d);
+}
+.chat-split__pane-body {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+.chat-split__pane-body > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Drop overlay: one live layer over the chat — the snap preview tracks the
+   pointer's nearest edge and glows over the half the pane will occupy. */
+.chat-split__dropzone {
+  position: absolute;
+  inset: 0;
+  z-index: 7;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklch, var(--bg-base) 35%, transparent);
+}
+.chat-split__preview {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  padding: 10px;
+  border: 2px solid var(--accent);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  transition: left 0.12s ease, top 0.12s ease, width 0.12s ease, height 0.12s ease;
+  pointer-events: none;
+}
+.chat-split__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 80%;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
+  border: 1px solid var(--border-hairline);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
+}
+.chat-split__hint--idle {
+  color: var(--text-muted);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .split-host__guide { transition: none; }
+  .chat-split__preview { transition: none; }
 }
 
 @media (max-width: 1023px) {

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type CSSProperties, type DragEvent as ReactDragEvent, type ReactNode } from "react";
 import type { SessionRow } from "@/lib/types";
 import { type ChatProjectGroup } from "@/lib/chat-projects";
 import { selectionKey, type ProjectSelection } from "@/lib/chat-project-selection";
@@ -23,6 +23,11 @@ import {
 } from "@/lib/chat-session-order";
 import { Icon, type IconName } from "@/lib/icon";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import {
+  CHAT_SESSION_DRAG_MIME,
+  emitChatSessionDragEnd,
+  emitChatSessionDragStart,
+} from "@/lib/chat-split";
 import {
   DndContext,
   PointerSensor,
@@ -89,6 +94,28 @@ function repoLabel(group: ChatProjectGroup): string {
     group.projectName ??
     (group.projectRoot?.replace(/\\/g, "/").split("/").filter(Boolean).at(-1) ?? "No project")
   );
+}
+
+// Native HTML5 drag props for a thread row: dragging the row *body* carries the
+// conversation to the chat surface's split drop zone (chat-split-host). The
+// dnd-kit reorder handle is exempted — a native dragstart from inside it is
+// cancelled so the pointer-driven reorder keeps sole ownership of that slot.
+function sessionDragProps(sessionId: string, title: string) {
+  return {
+    draggable: true,
+    onDragStart: (e: ReactDragEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest?.("[data-thread-drag-handle]")) {
+        e.preventDefault();
+        return;
+      }
+      e.dataTransfer.setData(CHAT_SESSION_DRAG_MIME, sessionId);
+      e.dataTransfer.setData("text/plain", title);
+      e.dataTransfer.effectAllowed = "copyMove";
+      emitChatSessionDragStart({ sessionId, title });
+    },
+    onDragEnd: () => emitChatSessionDragEnd(),
+  };
 }
 
 
@@ -158,6 +185,7 @@ function ThreadRow({
         onKeyDown={(e) => {
           if (e.key === "Enter") onOpen();
         }}
+        {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
         className={[
           "focus-ring-inset relative flex min-h-[36px] w-full items-center gap-1.5 py-2 pl-2 pr-1.5 text-left text-[12px] transition-colors",
@@ -178,6 +206,7 @@ function ThreadRow({
             type="button"
             {...attributes}
             {...listeners}
+            data-thread-drag-handle=""
             onClick={(e) => e.stopPropagation()}
             title="Drag to reorder"
             aria-label={`Reorder ${title}`}
@@ -261,6 +290,7 @@ function FolderChatRow({
         onKeyDown={(e) => {
           if (e.key === "Enter") onOpen();
         }}
+        {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
         className={[
           "relative flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-2 pr-2 text-left text-[12px] transition-colors",
@@ -281,6 +311,7 @@ function FolderChatRow({
             type="button"
             {...attributes}
             {...listeners}
+            data-thread-drag-handle=""
             onClick={(e) => e.stopPropagation()}
             title="Drag to reorder or move to another project"
             aria-label={`Move ${title}`}

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -38,8 +38,10 @@ assert.match(
 
 assert.match(
   source,
-  /<ChatProjectSidebar[\s\S]*activeSessionId=\{view\.kind === "chat" \? view\.sessionId : null\}[\s\S]*<ChatView/,
-  "ChatRouter should render the projects sidebar next to ChatView while a chat is open",
+  // The chat surface renders through ChatSplitHost (multi-pane chat); the
+  // sidebar still sits beside it while a chat is open.
+  /<ChatProjectSidebar[\s\S]*activeSessionId=\{view\.kind === "chat" \? view\.sessionId : null\}[\s\S]*<ChatSplitHost/,
+  "ChatRouter should render the projects sidebar next to the chat surface while a chat is open",
 );
 
 assert.match(

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRe
 import { ChatList } from "@/components/chat-list";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import { ChatView } from "@/components/chat-view";
+import { ChatSplitHost, type ChatSplitTile } from "@/components/chat-split-host";
 import { NewChatLaunch } from "@/components/new-chat-launch";
 import { FamiliarChatoutCodexSurface } from "@/components/familiar-chatout-codex";
 import { caveChatoutCodex } from "@/lib/feature-flags";
@@ -15,6 +16,14 @@ import {
 } from "@/lib/chat-projects";
 import { applyProjectOverrides } from "@/lib/chat-project-overrides";
 import type { ChatAttachment } from "@/lib/chat-attachments";
+import {
+  CHAT_SPLIT_PRIMARY,
+  dropSessionIntoChatSplit,
+  emptyChatSplitLayout,
+  removeChatSplitPane,
+  type ChatDropZone,
+} from "@/lib/chat-split";
+import { sessionRailTitle } from "@/lib/session-rail-title";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
@@ -119,6 +128,11 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   ref,
 ) {
   const [view, setView] = useState<View>({ kind: "list" });
+  // ── Multi-pane split (drag a convo from the thread rail onto the chat) ────
+  // The primary chat is one pane; dropped conversations open beside/above/
+  // below it. Pure layout rules live in @/lib/chat-split; panes for deleted
+  // sessions are filtered at render (the id simply stops resolving).
+  const [split, setSplit] = useState(() => emptyChatSplitLayout());
   // Set when a conversation-search hit asks the opened chat to jump to a query;
   // handed to ChatView (nonce-keyed) so it opens in-thread find on the match.
   const [pendingFind, setPendingFind] = useState<{ query: string; nonce: number } | null>(null);
@@ -249,6 +263,27 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       : familiar ?? fallbackFamiliar;
     if (next) onSetActiveFamiliar?.(next.id);
     return next;
+  }
+
+  // A conversation opened as the primary chat leaves the split — the same
+  // thread twice would stream twice. (Also how "open as main" collapses the
+  // promoted pane: promotion just opens it as primary.)
+  const primarySessionId = view.kind === "chat" ? view.sessionId : null;
+  useEffect(() => {
+    if (!primarySessionId) return;
+    setSplit((prev) => removeChatSplitPane(prev, primarySessionId));
+  }, [primarySessionId]);
+
+  function handleDropSession(sessionId: string, zone: ChatDropZone) {
+    if (sessionId === primarySessionId) return; // already the open chat
+    if (!sessions.some((entry) => entry.id === sessionId)) return;
+    setSplit((prev) => dropSessionIntoChatSplit(prev, sessionId, zone));
+  }
+
+  function handlePromotePane(sessionId: string) {
+    const session = sessions.find((entry) => entry.id === sessionId);
+    const next = selectFamiliarForChat(session?.familiarId ?? null);
+    setView({ kind: "chat", sessionId, familiarId: next?.id ?? session?.familiarId ?? null });
   }
 
   useEffect(() => {
@@ -480,6 +515,79 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     );
   }
 
+  const primaryChat = caveChatoutCodex() ? (
+    <FamiliarChatoutCodexSurface />
+  ) : (
+    <ChatView
+      ref={viewHandle}
+      familiar={chatFamiliar}
+      sessionId={view.sessionId}
+      session={activeSession}
+      projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
+      initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
+      initialAttachments={view.kind === "chat" ? view.initialAttachments : undefined}
+      initialControls={view.kind === "chat" ? view.initialControls : undefined}
+      origin={view.kind === "chat" ? view.origin : undefined}
+      openFindQuery={pendingFind?.query}
+      openFindNonce={pendingFind?.nonce}
+      daemonRunning={daemonRunning}
+      sessions={sessions}
+      onSessionsChanged={onSessionsChanged}
+      onBack={() => setView({ kind: "list" })}
+      onSessionStarted={(sid) => {
+        // Only promote the sessionId in the view state when the current chat
+        // has no session yet (null). If a session is already set, leave the
+        // view alone — updating it would re-mount ChatView and lose the live
+        // currentSessionRef, breaking follow-up messages.
+        setView((prev) =>
+          prev.kind === "chat" && prev.sessionId === null
+            ? { kind: "chat", sessionId: sid, projectRoot: prev.projectRoot, familiarId: prev.familiarId }
+            : prev,
+        );
+        onSessionStarted?.();
+      }}
+      onSlashCommand={onSlashFromChat}
+      onOpenOnboarding={onOpenOnboarding}
+      onOpenTask={onOpenTask}
+      onOpenUrl={onOpenUrl}
+      onProjectRootChange={syncSidebarProjectRoot}
+    />
+  );
+
+  // Split panes only render on the full-width desktop chat: the compact
+  // companion rail and mobile have no room, and the Codex surface is its own
+  // world. Panes whose session vanished (deleted) resolve to nothing here —
+  // the layout state simply stops matching and the strip collapses.
+  const enableSplit = !compact && !isMobile && !caveChatoutCodex();
+  const splitPaneTiles: ChatSplitTile[] = (enableSplit ? split.panes : [CHAT_SPLIT_PRIMARY]).flatMap(
+    (paneId): ChatSplitTile[] => {
+      if (paneId === CHAT_SPLIT_PRIMARY) {
+        return [{ id: paneId, title: "Current chat", content: primaryChat }];
+      }
+      const paneSession = sessions.find((entry) => entry.id === paneId);
+      if (!paneSession) return [];
+      const paneFamiliar = familiars.find((entry) => entry.id === paneSession.familiarId) ?? chatFamiliar;
+      return [
+        {
+          id: paneId,
+          title: sessionRailTitle(paneSession),
+          content: (
+            <ChatView
+              familiar={paneFamiliar}
+              sessionId={paneId}
+              session={paneSession}
+              daemonRunning={daemonRunning}
+              sessions={sessions}
+              onSessionsChanged={onSessionsChanged}
+              onOpenTask={onOpenTask}
+              onOpenUrl={onOpenUrl}
+            />
+          ),
+        },
+      ];
+    },
+  );
+
   return (
     <div className="flex h-full min-w-0">
       {!compact && (
@@ -515,45 +623,15 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         onOpenProjectsTab={openProjectsTab}
       />
       )}
-      <div className="min-h-0 min-w-0 flex-1">
-        {caveChatoutCodex() ? (
-          <FamiliarChatoutCodexSurface />
-        ) : (
-          <ChatView
-            ref={viewHandle}
-            familiar={chatFamiliar}
-            sessionId={view.sessionId}
-            session={activeSession}
-            projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
-            initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
-            initialAttachments={view.kind === "chat" ? view.initialAttachments : undefined}
-            initialControls={view.kind === "chat" ? view.initialControls : undefined}
-            origin={view.kind === "chat" ? view.origin : undefined}
-            openFindQuery={pendingFind?.query}
-            openFindNonce={pendingFind?.nonce}
-            daemonRunning={daemonRunning}
-            sessions={sessions}
-            onSessionsChanged={onSessionsChanged}
-            onBack={() => setView({ kind: "list" })}
-            onSessionStarted={(sid) => {
-              // Only promote the sessionId in the view state when the current chat
-              // has no session yet (null). If a session is already set, leave the
-              // view alone — updating it would re-mount ChatView and lose the live
-              // currentSessionRef, breaking follow-up messages.
-              setView((prev) =>
-                prev.kind === "chat" && prev.sessionId === null
-                  ? { kind: "chat", sessionId: sid, projectRoot: prev.projectRoot, familiarId: prev.familiarId }
-                  : prev,
-              );
-              onSessionStarted?.();
-            }}
-            onSlashCommand={onSlashFromChat}
-            onOpenOnboarding={onOpenOnboarding}
-            onOpenTask={onOpenTask}
-            onOpenUrl={onOpenUrl}
-            onProjectRootChange={syncSidebarProjectRoot}
-          />
-        )}
+      <div className="relative min-h-0 min-w-0 flex-1">
+        <ChatSplitHost
+          panes={splitPaneTiles}
+          axis={split.axis}
+          enableDrop={enableSplit}
+          onDropSession={handleDropSession}
+          onClosePane={(paneId) => setSplit((prev) => removeChatSplitPane(prev, paneId))}
+          onPromotePane={handlePromotePane}
+        />
       </div>
     </div>
   );

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -1,0 +1,109 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Multi-pane chat: drag a conversation from the thread rail onto the chat and
+// snap it left / right / above / below. Pins the wiring across the three
+// surfaces — drag source (chat-project-sidebar), drop host (chat-split-host),
+// and layout owner (chat-router) — plus the styles that make it visible.
+
+const host = await readFile(new URL("./chat-split-host.tsx", import.meta.url), "utf8");
+const router = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
+const sidebar = await readFile(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── Drop host ────────────────────────────────────────────────────────────────
+
+// The host coordinates with the drag source over the window-event protocol
+// (same idiom as page-drag → DetailSplitHost).
+assert.match(host, /CHAT_SESSION_DRAG_START/, "host listens for drag start");
+assert.match(host, /CHAT_SESSION_DRAG_END/, "host listens for drag end");
+assert.match(
+  host,
+  /getData\(CHAT_SESSION_DRAG_MIME\)/,
+  "drop reads the session id from the chat-session MIME type",
+);
+
+// The snap zone is resolved from the live pointer position (closest edge) and
+// previewed over the half the pane will occupy.
+assert.match(host, /resolveChatDropZone\(/, "zone comes from the closest-edge geometry");
+assert.match(host, /chatDropPreviewRect\(/, "the preview rect mirrors the resulting split");
+assert.match(host, /onDragOver=\{handleDragOver\}/, "overlay tracks dragover");
+assert.match(host, /className="chat-split__preview"/, "live snap preview renders");
+
+// Panes render in a resizable strip whose orientation follows the split axis.
+assert.match(
+  host,
+  /orientation=\{axis === "row" \? "horizontal" : "vertical"\}/,
+  "the pane group orientation follows the layout axis",
+);
+assert.match(
+  host,
+  /minSize=\{axis === "row" \? "280px" : "160px"\}/,
+  "panes keep a pixel floor so a divider can't crush a conversation",
+);
+// RRP re-layout bug guard (cave-hivd idiom): remount the group per pane set.
+assert.match(host, /key=\{`\$\{axis\}\|\$\{panes\.map/, "the group remounts on pane-set changes");
+
+// Secondary panes get chrome: close + open-as-main; the primary keeps its own
+// header (no double chrome).
+assert.match(host, /aria-label=\{`Close \$\{tile\.title\} pane`\}/, "panes can be closed");
+assert.match(host, /aria-label=\{`Open \$\{tile\.title\} as main chat`\}/, "panes can be promoted");
+assert.match(
+  host,
+  /tile\.id === CHAT_SPLIT_PRIMARY[\s\S]{0,220}<div className="chat-split__pane-body">\{tile\.content\}<\/div>/,
+  "the primary pane renders without extra chrome",
+);
+
+// ── Layout owner (chat-router) ───────────────────────────────────────────────
+
+assert.match(router, /<ChatSplitHost/, "the chat view area renders through the split host");
+assert.match(router, /dropSessionIntoChatSplit\(prev, sessionId, zone\)/, "drops feed the pure layout");
+assert.match(
+  router,
+  /if \(sessionId === primarySessionId\) return;/,
+  "dropping the already-open conversation is a no-op",
+);
+assert.match(
+  router,
+  /setSplit\(\(prev\) => removeChatSplitPane\(prev, primarySessionId\)\)/,
+  "a conversation opened as primary leaves the split (no double-streaming)",
+);
+assert.match(
+  router,
+  /const enableSplit = !compact && !isMobile && !caveChatoutCodex\(\);/,
+  "splits are desktop-only: compact rail, mobile and the Codex surface opt out",
+);
+assert.match(router, /onPromotePane=\{handlePromotePane\}/, "promote opens the pane as the primary chat");
+
+// ── Drag source (thread rail) ────────────────────────────────────────────────
+
+assert.match(sidebar, /function sessionDragProps\(/, "rows share one native-drag helper");
+assert.match(sidebar, /emitChatSessionDragStart\(\{ sessionId, title \}\)/, "row drag announces itself");
+assert.match(sidebar, /emitChatSessionDragEnd\(\)/, "row drag end clears the drop zone");
+// Both row flavors are draggable to the chat.
+assert.equal(
+  (sidebar.match(/\{\.\.\.sessionDragProps\(session\.id, title\)\}/g) ?? []).length,
+  2,
+  "search-result rows and folder rows are both drag sources",
+);
+// The dnd-kit reorder handle keeps sole ownership of its slot: a native drag
+// started from inside it is cancelled.
+assert.match(sidebar, /closest\?\.\("\[data-thread-drag-handle\]"\)/, "handle drags are exempted");
+assert.equal(
+  (sidebar.match(/data-thread-drag-handle=""/g) ?? []).length,
+  2,
+  "both reorder handles carry the exemption marker",
+);
+
+// ── Styles ───────────────────────────────────────────────────────────────────
+
+assert.match(css, /\.chat-split__dropzone \{/, "drop overlay styles exist");
+assert.match(css, /\.chat-split__preview \{/, "snap preview styles exist");
+assert.match(
+  css,
+  /\.chat-split__preview \{ transition: none; \}/,
+  "the preview respects prefers-reduced-motion",
+);
+
+console.log("chat-split-host.test.ts: ok");

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+/**
+ * ChatSplitHost — wraps the chat surface and adds two things:
+ *
+ *  1. A **drop zone**: while a thread-rail conversation is being dragged, the
+ *     chat area lights up with a live snap preview — the nearest edge (left /
+ *     right / above / below) is resolved from the pointer position and the
+ *     half the pane will occupy glows. Dropping opens that conversation there.
+ *  2. A **resizable pane strip**: dropped conversations render beside (row) or
+ *     stacked with (column) the primary chat in a react-resizable-panels group,
+ *     each secondary pane with its own slim header (title · open as main · ✕).
+ *
+ * The chat sibling of DetailSplitHost (workspace pages); geometry and layout
+ * rules live in `@/lib/chat-split`.
+ */
+
+import React from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
+import {
+  CHAT_SESSION_DRAG_END,
+  CHAT_SESSION_DRAG_MIME,
+  CHAT_SESSION_DRAG_START,
+  CHAT_SPLIT_PRIMARY,
+  chatDropPreviewRect,
+  chatDropZoneLabel,
+  resolveChatDropZone,
+  type ChatDropZone,
+  type ChatSessionDragDetail,
+  type ChatSplitAxis,
+} from "@/lib/chat-split";
+
+export type ChatSplitTile = {
+  /** CHAT_SPLIT_PRIMARY or a session id. */
+  id: string;
+  title: string;
+  content: React.ReactNode;
+};
+
+export type ChatSplitHostProps = {
+  /** Panes in layout order; must contain the primary tile. */
+  panes: ChatSplitTile[];
+  axis: ChatSplitAxis;
+  /** Enable the drag-to-split drop zone (desktop, full-width chat only). */
+  enableDrop: boolean;
+  /** A conversation was dropped on the given snap zone. */
+  onDropSession: (sessionId: string, zone: ChatDropZone) => void;
+  /** Close one dropped pane. */
+  onClosePane: (sessionId: string) => void;
+  /** Promote a dropped pane to be the primary chat. */
+  onPromotePane?: (sessionId: string) => void;
+};
+
+export function ChatSplitHost({
+  panes,
+  axis,
+  enableDrop,
+  onDropSession,
+  onClosePane,
+  onPromotePane,
+}: ChatSplitHostProps) {
+  const hasSplit = panes.length > 1;
+
+  // ---- Drag-to-split drop zone -------------------------------------------
+  const [drag, setDrag] = React.useState<ChatSessionDragDetail | null>(null);
+  const [zone, setZone] = React.useState<ChatDropZone | null>(null);
+  const overlayRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!enableDrop) return;
+    const onStart = (e: Event) => {
+      const detail = (e as CustomEvent<ChatSessionDragDetail>).detail;
+      if (detail?.sessionId) setDrag(detail);
+    };
+    const onEnd = () => {
+      setDrag(null);
+      setZone(null);
+    };
+    window.addEventListener(CHAT_SESSION_DRAG_START, onStart);
+    window.addEventListener(CHAT_SESSION_DRAG_END, onEnd);
+    return () => {
+      window.removeEventListener(CHAT_SESSION_DRAG_START, onStart);
+      window.removeEventListener(CHAT_SESSION_DRAG_END, onEnd);
+    };
+  }, [enableDrop]);
+
+  const zoneFromPointer = React.useCallback((e: React.DragEvent): ChatDropZone | null => {
+    const el = overlayRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return resolveChatDropZone(rect.width, rect.height, e.clientX - rect.left, e.clientY - rect.top);
+  }, []);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setZone(zoneFromPointer(e));
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const sessionId = e.dataTransfer.getData(CHAT_SESSION_DRAG_MIME) || drag?.sessionId || "";
+    const dropZone = zoneFromPointer(e) ?? zone;
+    setDrag(null);
+    setZone(null);
+    if (sessionId && dropZone) onDropSession(sessionId, dropZone);
+  };
+
+  const preview = zone ? chatDropPreviewRect(zone) : null;
+
+  const renderTile = (tile: ChatSplitTile) => {
+    if (tile.id === CHAT_SPLIT_PRIMARY) {
+      // The primary chat keeps its own header — no extra chrome.
+      return <div className="chat-split__pane-body">{tile.content}</div>;
+    }
+    return (
+      <section className="chat-split__tile" aria-label={`${tile.title} (split pane)`}>
+        <header className="chat-split__pane-head">
+          <span className="chat-split__pane-title" title={tile.title}>
+            <Icon name="ph:chats-circle" width={13} height={13} aria-hidden />
+            <span className="chat-split__pane-title-text">{tile.title}</span>
+          </span>
+          <span className="chat-split__pane-actions">
+            {onPromotePane ? (
+              <button
+                type="button"
+                className="chat-split__pane-btn"
+                title="Open as main chat"
+                aria-label={`Open ${tile.title} as main chat`}
+                onClick={() => onPromotePane(tile.id)}
+              >
+                <Icon
+                  name="ph:arrows-out-simple"
+                  width={CAVE_ICON_SIZE.shellToggle}
+                  height={CAVE_ICON_SIZE.shellToggle}
+                  aria-hidden
+                />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="chat-split__pane-btn chat-split__pane-close"
+              title="Close pane"
+              aria-label={`Close ${tile.title} pane`}
+              onClick={() => onClosePane(tile.id)}
+            >
+              <Icon
+                name="ph:x"
+                width={CAVE_ICON_SIZE.shellToggle}
+                height={CAVE_ICON_SIZE.shellToggle}
+                aria-hidden
+              />
+            </button>
+          </span>
+        </header>
+        <div className="chat-split__pane-body">{tile.content}</div>
+      </section>
+    );
+  };
+
+  return (
+    <>
+      {hasSplit ? (
+        <Group
+          // Remount on pane-set changes (mirrors DetailSplitHost, cave-hivd):
+          // RRP squeezes a panel added to a live group below its min — a fresh
+          // mount re-lays every pane out evenly.
+          key={`${axis}|${panes.map((tile) => tile.id).join("|")}`}
+          className="chat-split__group"
+          orientation={axis === "row" ? "horizontal" : "vertical"}
+        >
+          {panes.map((tile, i) => (
+            <React.Fragment key={tile.id}>
+              {i > 0 ? (
+                <Separator className="shell-separator chat-split__sep">
+                  <SeparatorHandle orientation={axis === "row" ? "col" : "row"} />
+                </Separator>
+              ) : null}
+              <Panel
+                id={`chat-split-${tile.id}`}
+                className="chat-split__pane-panel flex min-h-0 min-w-0"
+                // Pixel floors so a divider can't crush a conversation into
+                // letter soup; stacked panes need less than side-by-side ones.
+                minSize={axis === "row" ? "280px" : "160px"}
+              >
+                {renderTile(tile)}
+              </Panel>
+            </React.Fragment>
+          ))}
+        </Group>
+      ) : (
+        panes[0]?.content ?? null
+      )}
+
+      {enableDrop && drag ? (
+        <div
+          ref={overlayRef}
+          className="chat-split__dropzone"
+          data-zone={zone ?? undefined}
+          onDragOver={handleDragOver}
+          onDragLeave={(e) => {
+            // Only clear when actually leaving the overlay (not entering the
+            // pointer-events:none preview child).
+            if (e.currentTarget === e.target) setZone(null);
+          }}
+          onDrop={handleDrop}
+        >
+          {preview && zone ? (
+            <div
+              className="chat-split__preview"
+              style={{
+                left: `${preview.left}%`,
+                top: `${preview.top}%`,
+                width: `${preview.width}%`,
+                height: `${preview.height}%`,
+              }}
+              aria-hidden
+            >
+              <span className="chat-split__hint">
+                <Icon
+                  name={zone === "top" || zone === "bottom" ? "ph:rows" : "ph:columns"}
+                  width={16}
+                  height={16}
+                  aria-hidden
+                />
+                Open {drag.title} {chatDropZoneLabel(zone)}
+              </span>
+            </div>
+          ) : (
+            <span className="chat-split__hint chat-split__hint--idle">
+              <Icon name="ph:squares-four" width={16} height={16} aria-hidden />
+              Drag toward an edge to split
+            </span>
+          )}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/lib/chat-split.test.ts
+++ b/src/lib/chat-split.test.ts
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CHAT_SPLIT_PRIMARY,
+  MAX_CHAT_SPLIT_PANES,
+  chatDropPreviewRect,
+  chatDropZoneLabel,
+  chatSplitAxisForZone,
+  chatSplitSessionIds,
+  dropSessionIntoChatSplit,
+  emptyChatSplitLayout,
+  hasChatSplit,
+  removeChatSplitPane,
+  resolveChatDropZone,
+} from "./chat-split.ts";
+
+// ── resolveChatDropZone — closest-edge snap ──────────────────────────────────
+
+test("resolveChatDropZone snaps to the nearest edge", () => {
+  assert.equal(resolveChatDropZone(1000, 600, 50, 300), "left");
+  assert.equal(resolveChatDropZone(1000, 600, 950, 300), "right");
+  assert.equal(resolveChatDropZone(1000, 600, 500, 30), "top");
+  assert.equal(resolveChatDropZone(1000, 600, 500, 570), "bottom");
+});
+
+test("resolveChatDropZone uses normalized distance, not pixels", () => {
+  // 100px from the left of a 1000px-wide area (10%) vs 100px from the top of a
+  // 600px-tall area (~17%) — the left edge is nearer proportionally.
+  assert.equal(resolveChatDropZone(1000, 600, 100, 100), "left");
+  // Mirror on a tall narrow area: top wins.
+  assert.equal(resolveChatDropZone(600, 1000, 100, 100), "top");
+});
+
+test("resolveChatDropZone breaks dead-center ties horizontal-first", () => {
+  assert.equal(resolveChatDropZone(1000, 1000, 500, 500), "left");
+});
+
+test("resolveChatDropZone rejects points outside the rect and bad rects", () => {
+  assert.equal(resolveChatDropZone(1000, 600, -5, 300), null);
+  assert.equal(resolveChatDropZone(1000, 600, 500, 700), null);
+  assert.equal(resolveChatDropZone(0, 0, 0, 0), null);
+  assert.equal(resolveChatDropZone(Number.NaN, 600, 10, 10), null);
+});
+
+// ── Preview + labels ─────────────────────────────────────────────────────────
+
+test("chatDropPreviewRect highlights the half the pane will occupy", () => {
+  assert.deepEqual(chatDropPreviewRect("left"), { left: 0, top: 0, width: 50, height: 100 });
+  assert.deepEqual(chatDropPreviewRect("right"), { left: 50, top: 0, width: 50, height: 100 });
+  assert.deepEqual(chatDropPreviewRect("top"), { left: 0, top: 0, width: 100, height: 50 });
+  assert.deepEqual(chatDropPreviewRect("bottom"), { left: 0, top: 50, width: 100, height: 50 });
+});
+
+test("chatDropZoneLabel words vertical zones as above/below", () => {
+  assert.equal(chatDropZoneLabel("top"), "above");
+  assert.equal(chatDropZoneLabel("bottom"), "below");
+  assert.equal(chatDropZoneLabel("left"), "left");
+  assert.equal(chatDropZoneLabel("right"), "right");
+});
+
+// ── Layout state ─────────────────────────────────────────────────────────────
+
+test("the empty layout is a lone primary pane with no split", () => {
+  const layout = emptyChatSplitLayout();
+  assert.deepEqual(layout.panes, [CHAT_SPLIT_PRIMARY]);
+  assert.equal(hasChatSplit(layout), false);
+  assert.deepEqual(chatSplitSessionIds(layout), []);
+});
+
+test("the first drop sets the axis from the zone and lands on the drop edge", () => {
+  const right = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  assert.deepEqual(right, { axis: "row", panes: [CHAT_SPLIT_PRIMARY, "s1"] });
+  assert.equal(hasChatSplit(right), true);
+
+  const left = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "left");
+  assert.deepEqual(left.panes, ["s1", CHAT_SPLIT_PRIMARY]);
+
+  const top = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "top");
+  assert.deepEqual(top, { axis: "column", panes: ["s1", CHAT_SPLIT_PRIMARY] });
+
+  const bottom = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "bottom");
+  assert.deepEqual(bottom, { axis: "column", panes: [CHAT_SPLIT_PRIMARY, "s1"] });
+});
+
+test("chatSplitAxisForZone maps sides to row and top/bottom to column", () => {
+  assert.equal(chatSplitAxisForZone("left"), "row");
+  assert.equal(chatSplitAxisForZone("right"), "row");
+  assert.equal(chatSplitAxisForZone("top"), "column");
+  assert.equal(chatSplitAxisForZone("bottom"), "column");
+});
+
+test("re-dropping an open pane moves it to the drop edge, never duplicates", () => {
+  let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  layout = dropSessionIntoChatSplit(layout, "s2", "right");
+  assert.deepEqual(layout.panes, [CHAT_SPLIT_PRIMARY, "s1", "s2"]);
+  layout = dropSessionIntoChatSplit(layout, "s1", "left");
+  assert.deepEqual(layout.panes, ["s1", CHAT_SPLIT_PRIMARY, "s2"]);
+});
+
+test("a perpendicular drop reorients the whole strip", () => {
+  let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  assert.equal(layout.axis, "row");
+  layout = dropSessionIntoChatSplit(layout, "s2", "bottom");
+  assert.equal(layout.axis, "column");
+  assert.deepEqual(layout.panes, [CHAT_SPLIT_PRIMARY, "s1", "s2"]);
+});
+
+test("at the pane cap, the endmost secondary on the far edge is evicted", () => {
+  let layout = emptyChatSplitLayout();
+  layout = dropSessionIntoChatSplit(layout, "s1", "right");
+  layout = dropSessionIntoChatSplit(layout, "s2", "right");
+  layout = dropSessionIntoChatSplit(layout, "s3", "right");
+  assert.equal(layout.panes.length, MAX_CHAT_SPLIT_PANES);
+
+  // Drop at the end → the first secondary (nearest the start) is evicted.
+  const atEnd = dropSessionIntoChatSplit(layout, "s4", "right");
+  assert.deepEqual(atEnd.panes, [CHAT_SPLIT_PRIMARY, "s2", "s3", "s4"]);
+
+  // Drop at the start → the last secondary is evicted; primary survives.
+  const atStart = dropSessionIntoChatSplit(layout, "s4", "left");
+  assert.deepEqual(atStart.panes, ["s4", CHAT_SPLIT_PRIMARY, "s1", "s2"]);
+});
+
+test("the primary pane is never evicted even when it sits at the far edge", () => {
+  let layout = emptyChatSplitLayout();
+  layout = dropSessionIntoChatSplit(layout, "s1", "left");
+  layout = dropSessionIntoChatSplit(layout, "s2", "left");
+  layout = dropSessionIntoChatSplit(layout, "s3", "left");
+  assert.deepEqual(layout.panes, ["s3", "s2", "s1", CHAT_SPLIT_PRIMARY]);
+  const next = dropSessionIntoChatSplit(layout, "s4", "left");
+  assert.deepEqual(next.panes, ["s4", "s3", "s2", CHAT_SPLIT_PRIMARY]);
+});
+
+test("blank ids and the primary sentinel are rejected as drops", () => {
+  const layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  assert.equal(dropSessionIntoChatSplit(layout, "  ", "right"), layout);
+  assert.equal(dropSessionIntoChatSplit(layout, CHAT_SPLIT_PRIMARY, "right"), layout);
+});
+
+test("removeChatSplitPane closes a pane and collapses back to solo", () => {
+  let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  layout = dropSessionIntoChatSplit(layout, "s2", "right");
+  layout = removeChatSplitPane(layout, "s1");
+  assert.deepEqual(layout.panes, [CHAT_SPLIT_PRIMARY, "s2"]);
+  layout = removeChatSplitPane(layout, "s2");
+  assert.equal(hasChatSplit(layout), false);
+});
+
+test("removeChatSplitPane never removes the primary and no-ops on unknown ids", () => {
+  const layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  assert.equal(removeChatSplitPane(layout, CHAT_SPLIT_PRIMARY), layout);
+  assert.equal(removeChatSplitPane(layout, "nope"), layout);
+});
+
+test("chatSplitSessionIds lists dropped panes in layout order", () => {
+  let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  layout = dropSessionIntoChatSplit(layout, "s2", "left");
+  assert.deepEqual(chatSplitSessionIds(layout), ["s2", "s1"]);
+});

--- a/src/lib/chat-split.ts
+++ b/src/lib/chat-split.ts
@@ -1,0 +1,179 @@
+/**
+ * chat-split — the drag protocol + pure layout logic that lets a conversation
+ * be dragged from the thread rail onto the chat surface and *snapped* into a
+ * split pane (left / right / above / below).
+ *
+ * Mirrors the workspace page-drag idiom (`page-drag.ts` + DetailSplitHost):
+ * the drag *source* (a thread-rail row) and the drop *target* (the chat area)
+ * live in different components, so they coordinate over window CustomEvents +
+ * a DataTransfer MIME type rather than React props. All geometry/layout math
+ * lives here as pure functions so it is unit-testable without a DOM.
+ */
+
+/** DataTransfer type carried by a conversation drag (value = the session id). */
+export const CHAT_SESSION_DRAG_MIME = "application/x-cave-chat-session";
+
+/** Fired on the window when a thread-rail conversation drag starts. */
+export const CHAT_SESSION_DRAG_START = "cave:chat-session-drag-start";
+
+/** Fired on the window when a conversation drag ends (drop or cancel). */
+export const CHAT_SESSION_DRAG_END = "cave:chat-session-drag-end";
+
+export type ChatSessionDragDetail = {
+  /** The conversation/session id being dragged. */
+  sessionId: string;
+  /** Human label for the drop hint ("Open {title} …"). */
+  title: string;
+};
+
+export function emitChatSessionDragStart(detail: ChatSessionDragDetail): void {
+  window.dispatchEvent(new CustomEvent<ChatSessionDragDetail>(CHAT_SESSION_DRAG_START, { detail }));
+}
+
+export function emitChatSessionDragEnd(): void {
+  window.dispatchEvent(new Event(CHAT_SESSION_DRAG_END));
+}
+
+// ── Drop-zone geometry ───────────────────────────────────────────────────────
+
+export type ChatDropZone = "left" | "right" | "top" | "bottom";
+
+/** row = panes side by side · column = panes stacked. */
+export type ChatSplitAxis = "row" | "column";
+
+/**
+ * Resolve which snap zone the pointer is in, by the *closest edge* of the
+ * chat area — the "intelligent" part of the snap: the whole surface is live,
+ * and the nearest edge wins. Ties break horizontal-first (left, then right)
+ * because a side-by-side split is the common intent on a landscape surface.
+ * Returns null when the point is outside the rect or the rect is degenerate.
+ */
+export function resolveChatDropZone(
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+): ChatDropZone | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+  if (!Number.isFinite(x) || !Number.isFinite(y) || x < 0 || y < 0 || x > width || y > height) {
+    return null;
+  }
+  const nx = x / width;
+  const ny = y / height;
+  const dist: Array<[ChatDropZone, number]> = [
+    ["left", nx],
+    ["right", 1 - nx],
+    ["top", ny],
+    ["bottom", 1 - ny],
+  ];
+  let best = dist[0]!;
+  for (const entry of dist) if (entry[1] < best[1]) best = entry;
+  return best[0];
+}
+
+/**
+ * Where to draw the live snap preview for a zone, as percentages of the chat
+ * area (0..100). Each zone highlights the half the dropped conversation will
+ * occupy, so the drop reads exactly like the resulting split.
+ */
+export function chatDropPreviewRect(zone: ChatDropZone): {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+} {
+  switch (zone) {
+    case "left":
+      return { left: 0, top: 0, width: 50, height: 100 };
+    case "right":
+      return { left: 50, top: 0, width: 50, height: 100 };
+    case "top":
+      return { left: 0, top: 0, width: 100, height: 50 };
+    case "bottom":
+      return { left: 0, top: 50, width: 100, height: 50 };
+  }
+}
+
+/** Human wording for the drop hint ("Open {title} {label}"). */
+export function chatDropZoneLabel(zone: ChatDropZone): string {
+  if (zone === "top") return "above";
+  if (zone === "bottom") return "below";
+  return zone;
+}
+
+// ── Split layout state ───────────────────────────────────────────────────────
+
+/** Sentinel pane id for the live primary chat view. */
+export const CHAT_SPLIT_PRIMARY = "primary";
+
+/** Hard cap on visible chat panes (primary included) — mirrors workspace tiles. */
+export const MAX_CHAT_SPLIT_PANES = 4;
+
+export type ChatSplitLayout = {
+  axis: ChatSplitAxis;
+  /** Pane ids in layout order: CHAT_SPLIT_PRIMARY plus dropped session ids. */
+  panes: string[];
+};
+
+export function emptyChatSplitLayout(): ChatSplitLayout {
+  return { axis: "row", panes: [CHAT_SPLIT_PRIMARY] };
+}
+
+export function hasChatSplit(layout: ChatSplitLayout): boolean {
+  return layout.panes.length > 1;
+}
+
+export function chatSplitAxisForZone(zone: ChatDropZone): ChatSplitAxis {
+  return zone === "left" || zone === "right" ? "row" : "column";
+}
+
+/** The dropped-session pane ids, in layout order (primary excluded). */
+export function chatSplitSessionIds(layout: ChatSplitLayout): string[] {
+  return layout.panes.filter((id) => id !== CHAT_SPLIT_PRIMARY);
+}
+
+/**
+ * Drop a conversation into the split at `zone`.
+ *
+ *  - left/top insert the pane at the start of the strip, right/bottom at the
+ *    end — the pane lands exactly where the preview showed it.
+ *  - A session already open in a pane is *moved* to the drop edge (dedupe),
+ *    never duplicated.
+ *  - The first split sets the axis from the zone; a later drop on the
+ *    perpendicular orientation reorients the whole strip (one axis at a time —
+ *    honest and predictable rather than a nested tiling tree).
+ *  - At the MAX_CHAT_SPLIT_PANES cap, the endmost *secondary* pane on the far
+ *    edge (furthest from the drop) is evicted to make room; the primary pane
+ *    is never evicted.
+ */
+export function dropSessionIntoChatSplit(
+  layout: ChatSplitLayout,
+  sessionId: string,
+  zone: ChatDropZone,
+): ChatSplitLayout {
+  const sid = sessionId.trim();
+  if (!sid || sid === CHAT_SPLIT_PRIMARY) return layout;
+  let panes = layout.panes.filter((id) => id !== sid);
+  // The axis always follows the latest drop's orientation: the first split
+  // sets it, and a perpendicular drop reorients the existing strip.
+  const axis = chatSplitAxisForZone(zone);
+  const atStart = zone === "left" || zone === "top";
+  if (panes.length >= MAX_CHAT_SPLIT_PANES) {
+    // Evict the endmost secondary pane on the opposite edge from the drop.
+    const candidates = panes
+      .map((id, index) => ({ id, index }))
+      .filter((entry) => entry.id !== CHAT_SPLIT_PRIMARY);
+    const evict = atStart ? candidates.at(-1) : candidates[0];
+    if (!evict) return layout; // all-primary (impossible) — refuse rather than overflow
+    panes = panes.filter((_, index) => index !== evict.index);
+  }
+  return { axis, panes: atStart ? [sid, ...panes] : [...panes, sid] };
+}
+
+/** Close one dropped pane. The primary sentinel cannot be removed. */
+export function removeChatSplitPane(layout: ChatSplitLayout, sessionId: string): ChatSplitLayout {
+  if (sessionId === CHAT_SPLIT_PRIMARY) return layout;
+  const panes = layout.panes.filter((id) => id !== sessionId);
+  if (panes.length === layout.panes.length) return layout;
+  return { axis: layout.axis, panes };
+}


### PR DESCRIPTION
## What

Drag a conversation from the thread rail onto the chat surface to snap it **left / right / above / below** the current chat as a resizable split pane. While dragging, the chat area lights up with a live snap preview of the half the pane will occupy.

- Secondary panes render in a `react-resizable-panels` group, each with a slim header (title · **open as main** · ✕).
- Opening a pane's thread as the primary chat collapses it back out of the split — the same thread never streams twice.
- Split is gated to the full-width desktop chat (not compact rail / mobile / Codex surface). Panes whose session is deleted simply stop resolving and the strip collapses.

## How

- **NEW `src/lib/chat-split.ts`** — drag protocol (DataTransfer MIME + window CustomEvents, mirroring the workspace `page-drag` idiom) plus pure layout/geometry rules (drop-zone resolution, pane insert/remove, preview rects). Unit-tested without a DOM.
- **NEW `src/components/chat-split-host.tsx`** — drop zone + pane strip; chat sibling of `DetailSplitHost`.
- `chat-router.tsx` renders the chat surface through `ChatSplitHost`; primary-session effect removes a promoted/duplicated pane.
- `chat-project-sidebar.tsx` thread rows become native HTML5 drag sources; the dnd-kit reorder handle is exempted (`data-thread-drag-handle`) so pointer-driven reorder keeps sole ownership of that slot.
- `globals.css` chat-split styles (incl. reduced-motion opt-out); CHANGELOG entry.

## Verification

- `tsc --noEmit` clean
- `pnpm test` (app suite): **594/594** test files pass, including new `chat-split.test.ts` + `chat-split-host.test.ts` and the updated `chat-router-switching.test.ts` pins

Extracted from a shared checkout carrying unrelated in-flight work; this branch contains only the chat-split changes, rebuilt off current `origin/main`.