### PR TITLE
fix(board): reveal the still-selected card after a view-mode switch (cave-iote)

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -431,6 +431,16 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
   }, [cards, groupMode, ownerName, projectName, familiarColor]);
   const unscheduledCount = unscheduledCards.length;
 
+  // A selected card without dates lives only in the (default-closed)
+  // unscheduled tray, so the BoardView view-switch scroll pass would find no
+  // node for it (cave-iote). Reveal the tray whenever the selection lands on
+  // an unscheduled card; a manual re-collapse afterwards is left alone.
+  const selectedUnscheduled =
+    selectedCardId !== null && unscheduledCards.some((c) => c.id === selectedCardId);
+  useEffect(() => {
+    if (selectedUnscheduled) setShowUnscheduled(true);
+  }, [selectedUnscheduled]);
+
   // Auto-center on today once the timeline can be drawn (keyed on the clock +
   // zoom). centerOnTodayRef is assigned during render below; retry until it
   // succeeds (scroller mounted, today in range), then latch so we never fight a
@@ -497,7 +507,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
         {showUnscheduled ? (
           <ul style={{ listStyle: "none", margin: "6px 0 0", padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
             {unscheduledCards.map((c) => (
-              <li key={c.id} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
+              <li key={c.id} data-card-id={c.id} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8 }}>
                 <button
                   type="button"
                   draggable={!!onPatch}

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -175,6 +175,25 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
 
   const sorted = useMemo(() => sortCards(cards, sortKey, sortDir, familiars), [cards, sortKey, sortDir, familiars]);
   const groups = useMemo(() => groupCards(sorted, groupBy, familiars, projects), [sorted, groupBy, familiars, projects]);
+
+  // The "done" group is collapsed by default, so a still-selected done card
+  // can mount with no row for the BoardView view-switch scroll pass to find
+  // (cave-iote). Reveal the group holding the selection once at mount; later
+  // manual collapses are the user's call and are never fought.
+  useEffect(() => {
+    if (!selectedCardId) return;
+    const holder = groups.find((g) => g.cards.some((c) => c.id === selectedCardId));
+    if (!holder) return;
+    setCollapsed((prev) => {
+      if (!prev.has(holder.key)) return prev;
+      const next = new Set(prev);
+      next.delete(holder.key);
+      return next;
+    });
+    // Mount-only by design — reruns would reopen groups the user closed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // The familiar options are identical for every row, so build them once instead
   // of rebuilding the option data per row on each render.
   const familiarOptions = useMemo(

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -254,6 +254,13 @@ assert.match(table, /selectedGroupKey === "done" \? new Set<string>\(\) : new Se
 assert.match(table, /sel \? cardGroupKey\(sel, groupBy\) : null/, "the selection's group is derived through the same cardGroupKey the grouper uses");
 assert.match(table, /const key = cardGroupKey\(c, by\);/, "groupCards shares cardGroupKey — the two can never disagree on a card's group");
 assert.match(table, /\}, \[selectedGroupKey\]\);/, "the expand effect keys on the selection's group only — a manual collapse sticks until the selection moves");
+// ── cave-iote remainder: the view-switch scroll no-ops when the selection's
+// node doesn't exist in the freshly mounted view — reveal it, then retry once.
+assert.match(view, /if \(attempts\+\+ === 0\) frame = requestAnimationFrame\(locate\);/, "a missing card node gets exactly one more frame (a reveal effect may still be mounting it)");
+assert.match(table, /groups\.find\(\(g\) => g\.cards\.some\(\(c\) => c\.id === selectedCardId\)\)/, "the table locates the group holding the selection");
+assert.match(table, /next\.delete\(holder\.key\);/, "the table un-collapses the selection's group at mount (done is collapsed by default)");
+assert.match(gantt, /if \(selectedUnscheduled\) setShowUnscheduled\(true\);/, "the gantt reveals the unscheduled tray when the selection has no dates");
+assert.match(gantt, /<li key=\{c\.id\} data-card-id=\{c\.id\}/, "unscheduled tray items carry data-card-id so the scroll pass can reach them");
 
 // ── Bulk-op patch failures reconcile ONCE, after the batch settles (cave-381s):
 // a failed patchCard used to `await load()` immediately, reverting the

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -349,10 +349,17 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const switched = prevViewModeRef.current !== viewMode;
     prevViewModeRef.current = viewMode;
     if (!switched || !selectedCardId) return;
-    const frame = requestAnimationFrame(() => {
-      viewAreaRef.current
-        ?.querySelector<HTMLElement>(`[data-card-id="${selectedCardId}"]`)
-        ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    // Two-frame retry: the mounted view may still be revealing the
+    // default-collapsed group / unscheduled tray that holds the selection
+    // (cave-iote), so a missing node gets exactly one more frame to appear.
+    let attempts = 0;
+    let frame = requestAnimationFrame(function locate() {
+      const el = viewAreaRef.current?.querySelector<HTMLElement>(`[data-card-id="${selectedCardId}"]`);
+      if (el) {
+        el.scrollIntoView({ block: "nearest", inline: "nearest" });
+        return;
+      }
+      if (attempts++ === 0) frame = requestAnimationFrame(locate);
     });
     return () => cancelAnimationFrame(frame);
   }, [viewMode, selectedCardId]);


### PR DESCRIPTION
## What

Closes the **P1-6 remainder** from the 2026-07-03 UX heuristic audit (bead `cave-iote`): after a board view-mode switch, the still-selected card could sit off-screen (or have no DOM node at all) while the inspector showed it.

## Why the #2684 fix wasn't enough

The existing view-switch `scrollIntoView` pass runs one rAF after the switch and silently no-ops when the selection has **no node in the freshly mounted view**:

- **Table** — a selected *done* card mounts inside the default-collapsed "done" group → no row.
- **Gantt** — a selected *unscheduled* card lives only in the default-closed unscheduled tray → no node (tray items also lacked `data-card-id`).

## Fix

- `board-table.tsx` — mount-only effect un-collapses the group holding `selectedCardId`; later manual collapses are never fought.
- `board-gantt.tsx` — reveal the unscheduled tray when the selection is unscheduled; tray `<li>`s now carry `data-card-id`.
- `board-view.tsx` — locate pass retries exactly one extra frame so the reveal effects can mount the row before scrolling.

## Verification

- `tsc --noEmit`: 0 errors
- `pnpm test`: **594/594** app test files green
- 5 new pins in `board-ux-polish.test.ts`

Bead: `cave-iote`