### PR TITLE
fix(desktop): foreground the folder picker (#2614) and keep failed sends in-chat (#2618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breaking config changes; patch releases stay additive.
 - **Quick chat: drag-and-drop/paste attachments, message queueing, and companion composer upgrades** — the tray/overlay composer stages files via drag-and-drop or paste as chips (attachment-only sends allowed, bridge composes natively), send-while-streaming queues the message and drains it in order on a natural done (Stop/error keeps it parked), plus slash-dispatch send path, project-root picker plumbing, Tab-accept reply recommendations, and Enhance sparkle/caret segments that stay inside their rectangle on mobile (#2937).
 - **Chat: split panes** — drag a conversation from the thread rail onto the chat surface to snap it left / right / above / below the current chat as a resizable pane. Each secondary pane carries a slim header (title · open as main · ✕); opening a pane's thread as the primary chat collapses it back out of the strip. Desktop full-width chat only.
 
+### Fixes
+- **Folder picker is summoned to the foreground** — the native "choose a folder" dialog no longer opens hidden behind the window. On Windows the `FolderBrowserDialog` now gets a `TopMost` owner form so it comes forward focused; macOS activates System Events before `choose folder`; Linux runs zenity modal (#2614).
+- **A failed chat send keeps you in the conversation** — when the coven CLI can't be resolved from the app's environment, the send failure now surfaces as an inline error strip with your message preserved for one-click Retry and a soft "Open Setup" link (wizard overlay, not a hard navigation) instead of eating the message and bouncing to Setup (#2618).
+
 ## [0.0.174] - 2026-07-11
 
 > 💬 **Copilot chats natively, cleaner Windows packaging, and the Grimoire becomes Memories.** Copilot (and other manifest adapters) now render their replies correctly in chat, the packaged Windows sidecar runtime is pruned and MSI publication is gated, and the knowledge surface is renamed Memories.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1646,8 +1646,12 @@ fn shell_open_path(path: String) -> Result<(), String> {
 fn shell_pick_directory() -> Result<Option<String>, String> {
     #[cfg(target_os = "macos")]
     {
+        // `tell app "System Events" ... activate` pulls the picker to the
+        // foreground so it isn't summoned behind Cave's window (issue #2614b).
         let output = std::process::Command::new("osascript")
             .args([
+                "-e",
+                "tell application \"System Events\" to activate",
                 "-e",
                 "POSIX path of (choose folder with prompt \"Choose a folder for CovenCave\")",
             ])
@@ -1666,7 +1670,12 @@ fn shell_pick_directory() -> Result<Option<String>, String> {
 
     #[cfg(target_os = "windows")]
     {
-        let script = r#"Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.Description = 'Choose a folder for CovenCave'; if ($d.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Write($d.SelectedPath) }"#;
+        // A bare FolderBrowserDialog has no owner window, so Windows opens it
+        // *behind* every other window, unfocused, with no taskbar entry — it
+        // looks like the click did nothing (issue #2614b). Give it a TopMost,
+        // ShowInTaskbar owner form (created off-screen) and pass that form as
+        // the ShowDialog owner so the picker is summoned to the foreground.
+        let script = r#"Add-Type -AssemblyName System.Windows.Forms; $owner = New-Object System.Windows.Forms.Form; $owner.TopMost = $true; $owner.ShowInTaskbar = $false; $owner.StartPosition = 'Manual'; $owner.Location = New-Object System.Drawing.Point(-32000, -32000); $owner.Size = New-Object System.Drawing.Size(1, 1); $owner.Show(); $owner.Activate(); $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.Description = 'Choose a folder for CovenCave'; $result = $d.ShowDialog($owner); $owner.Close(); if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Write($d.SelectedPath) }"#;
         let output = std::process::Command::new("powershell.exe")
             .args(["-NoProfile", "-Sta", "-Command", script])
             .output()
@@ -1688,6 +1697,7 @@ fn shell_pick_directory() -> Result<Option<String>, String> {
             .args([
                 "--file-selection",
                 "--directory",
+                "--modal",
                 "--title",
                 "Choose a folder for CovenCave",
             ])
@@ -1761,6 +1771,30 @@ mod shell_open_tests {
         assert_eq!(super::normalize_picked_directory("").unwrap(), None);
         assert!(super::normalize_picked_directory("relative/path").is_err());
         assert!(super::normalize_picked_directory(&file!()).is_err());
+    }
+
+    // #2614b: the native folder picker must be summoned to the foreground, not
+    // opened behind Cave's window. Guard the parenting/activation on each
+    // platform's picker invocation so a future edit can't silently regress it.
+    #[test]
+    fn folder_picker_is_summoned_to_the_foreground() {
+        let src = include_str!("lib.rs");
+        // Windows: the FolderBrowserDialog gets a TopMost owner form passed to
+        // ShowDialog so it can't open buried/unfocused.
+        assert!(
+            src.contains("$owner.TopMost = $true") && src.contains("$d.ShowDialog($owner)"),
+            "the Windows folder picker must own its dialog with a TopMost form (foreground)",
+        );
+        // macOS: activate before `choose folder` so it comes to the front.
+        assert!(
+            src.contains("tell application \\\"System Events\\\" to activate"),
+            "the macOS folder picker must activate System Events before choosing",
+        );
+        // Linux: the zenity picker runs modal.
+        assert!(
+            src.contains("--file-selection") && src.contains("--modal"),
+            "the Linux (zenity) folder picker must run modal",
+        );
     }
 }
 

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -181,3 +181,27 @@ assert.doesNotMatch(
   /projectRoot: activeProjectRoot,/,
   "ChatView must not echo the raw activeProjectRoot (session cwd) as an explicit projectRoot",
 );
+
+// ── #2618: a failed chat send keeps the user in-chat with the message preserved,
+// and the coven-CLI-missing case offers a soft "Open Setup" link (overlay, not a
+// hard navigation to the wizard). ──────────────────────────────────────────────
+assert.match(
+  source,
+  /setLastFailedSend\(request\);/,
+  "a failed send preserves the request so the composer message can be retried",
+);
+assert.match(
+  source,
+  /const covenMissing = useMemo\(\s*\(\) => \/coven CLI not found on PATH\/i\.test\(message\) \|\| code === "ENOENT"/,
+  "the error strip detects the coven-CLI-missing failure class",
+);
+assert.match(
+  source,
+  /onOpenSetup=\{\(\) => window\.dispatchEvent\(new CustomEvent\("cave:onboarding-open"\)\)\}/,
+  "Open Setup opens the wizard as a soft overlay event, never a route change",
+);
+assert.doesNotMatch(
+  source,
+  /router\.(push|replace)\([`"'][^`"']*onboard/i,
+  "a send failure must never hard-navigate the router to onboarding",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -509,6 +509,7 @@ function ChatErrorStrip({
   busy,
   onRetry,
   onOpenDebug,
+  onOpenSetup,
   onDismiss,
   addProjectLabel,
   addingProject,
@@ -536,6 +537,9 @@ function ChatErrorStrip({
   onOpenProjects?: () => void;
   /** Switch the familiar to this harness and retry (harness-failure fix row). */
   onUseHarness?: (harnessId: string) => void | Promise<void>;
+  /** Open the Setup wizard overlay (soft, not a route change) when the coven
+   *  CLI is unresolvable — the composer message is preserved for retry (#2618). */
+  onOpenSetup?: () => void;
   /** The runtime the failing send used — lets the auth-failure fix row name
    *  it and offer its exact login command (cave-f6ol). */
   harnessId?: string | null;
@@ -575,6 +579,14 @@ function ChatErrorStrip({
   const authFailure = useMemo(
     () => parseHarnessAuthFailure(detailText, harnessId),
     [detailText, harnessId],
+  );
+  // The coven CLI couldn't be resolved from the app's spawn environment
+  // (the #2610 class of failure). Rather than a bare error + generic Retry,
+  // offer a soft "Open Setup" link (overlay, not a hard nav) — the message
+  // stays in the composer for retry (#2618).
+  const covenMissing = useMemo(
+    () => /coven CLI not found on PATH/i.test(message) || code === "ENOENT",
+    [message, code],
   );
 
   const btn =
@@ -653,6 +665,18 @@ function ChatErrorStrip({
       ) : null}
       {!harnessFailure && authFailure ? (
         <AuthFixRow failure={authFailure} buttonClassName={btn} />
+      ) : null}
+      {!harnessFailure && !authFailure && covenMissing ? (
+        <div className="flex flex-wrap items-center gap-2 px-5 pb-2 text-[11px]">
+          <span className="min-w-0">
+            The coven CLI isn&apos;t resolvable from this app&apos;s environment. Open Setup to install
+            or repair it, then retry — your message is kept.
+          </span>
+          <button type="button" onClick={onOpenSetup} className={btn}>
+            <Icon name="ph:wrench" width={11} aria-hidden />
+            Open Setup
+          </button>
+        </div>
       ) : null}
       {hasDetail && open ? (
         <div className="max-h-48 overflow-auto border-t border-[color-mix(in_oklch,var(--color-warning)_22%,transparent)] px-5 py-2">
@@ -5121,6 +5145,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onRetry={retryLastSend}
           onOpenDebug={openDebug}
           onUseHarness={lastFailedSend ? handleUseHarnessFix : undefined}
+          onOpenSetup={() => window.dispatchEvent(new CustomEvent("cave:onboarding-open"))}
           harnessId={familiar.harness ?? null}
           addProjectLabel={
             projectAccessRoot ? `Add "${projectNameForRoot(projectAccessRoot)}" as project` : undefined


### PR DESCRIPTION
Takes the two escalated Windows-onboarding issues the optimal, low-risk way.

## #2614 — folder picker opens behind the window
Chose **parent + foreground the existing native dialogs** over adding `@tauri-apps/plugin-dialog`. Rationale: the `isTauri()`-false concern in the original report is **already resolved** — the repo now ships `loopback-*` capabilities (`remote.urls` grants the localhost origin scoped IPC), so `invoke("shell_pick_directory")` reaches the backend. The only live symptom left is (b), the unparented dialog. Parenting it is self-contained Rust with **zero new Cargo deps, capability grants, or CSP surface** — strictly safer than wiring dialog IPC to an http://localhost origin.

- **Windows:** `FolderBrowserDialog` gets a `TopMost`, off-screen owner `Form` passed to `ShowDialog($owner)` → comes forward, focused.
- **macOS:** `tell application "System Events" to activate` before `choose folder`.
- **Linux:** zenity picker runs `--modal`.
- Guarded by a new Rust source-scan test (`folder_picker_is_summoned_to_the_foreground`).

## #2618 — failed send eats the message + bounces to Setup
The hard-redirect behavior **no longer exists** — the send path already does `setError()` + `setLastFailedSend()` with **no router navigation**, landing in the mature `ChatErrorStrip` (inline, retry, preserved composer). The one gap was that the coven-CLI-missing case had no actionable fix-row. Added a soft **"Open Setup"** row that fires the `cave:onboarding-open` **overlay** event (not a route change), matching the existing harness/auth/project fix-row pattern. Message stays in the composer for one-click Retry.
- Guarded by new `chat-view.test.ts` assertions (detects the failure class, opens Setup via overlay event, asserts no `router.push(onboard*)`).

Closes #2614. Closes #2618.

**Verification:** `cargo check` clean, `cargo test shell_open_tests::folder_picker` green, `tsc --noEmit` clean, `chat-view.test.ts` green.