### PR TITLE
Fix mobile chat scroll anchoring

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -24,11 +24,21 @@ struct ConnectionView: View {
                     addressField
 
                     if case .unreachable(let message) = app.connectionState {
-                        connectionRecoveryCallout(message: message, systemImage: "exclamationmark.triangle.fill")
+                        connectionRecoveryCallout(
+                            title: "Tailscale disconnected?",
+                            message: message,
+                            guidance: "Open Tailscale on this phone and make sure it says Connected. If it is connected, check that Cave is running on the desktop.",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
                     } else if case .needsAuth(let message) = app.connectionState {
                         // The desktop is alive but token-gated — say how to
                         // pair instead of the generic unreachable shrug.
-                        connectionRecoveryCallout(message: message, systemImage: "qrcode.viewfinder")
+                        connectionRecoveryCallout(
+                            title: "Pairing needed",
+                            message: message,
+                            guidance: "Open Cave on your desktop and scan the latest QR code.",
+                            systemImage: "qrcode.viewfinder"
+                        )
                     }
 
                     actions
@@ -213,21 +223,26 @@ struct ConnectionView: View {
         }
     }
 
-    private func connectionRecoveryCallout(message: String, systemImage: String) -> some View {
+    private func connectionRecoveryCallout(
+        title: String,
+        message: String,
+        guidance: String,
+        systemImage: String
+    ) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: systemImage)
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(.orange)
                 .frame(width: 28)
             VStack(alignment: .leading, spacing: 4) {
-                Text("Pairing needed")
+                Text(title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(chrome.textPrimary)
                 Text(message)
                     .font(.footnote)
                     .foregroundStyle(chrome.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
-                Text("Open Cave on your desktop and scan the latest QR code.")
+                Text(guidance)
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.orange)
             }

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -29,8 +29,20 @@ assert.match(
 
 assert.match(
   src,
-  /private func connectionRecoveryCallout\(message: String, systemImage: String\) -> some View \{[\s\S]*?Open Cave on your desktop and scan the latest QR code/,
+  /else if case \.needsAuth\(let message\) = app\.connectionState \{[\s\S]*?title: "Pairing needed"[\s\S]*?Open Cave on your desktop and scan the latest QR code/,
   "pairing-required state should render as a clear recovery callout",
+);
+
+assert.match(
+  src,
+  /if case \.unreachable\(let message\) = app\.connectionState \{[\s\S]*?connectionRecoveryCallout\(\s*title: "Tailscale disconnected\?",[\s\S]*?guidance: "Open Tailscale on this phone and make sure it says Connected/,
+  "unreachable state should explicitly point at Tailscale being disconnected before asking the user to re-pair",
+);
+
+assert.match(
+  src,
+  /else if case \.needsAuth\(let message\) = app\.connectionState \{[\s\S]*?connectionRecoveryCallout\(\s*title: "Pairing needed",[\s\S]*?guidance: "Open Cave on your desktop and scan the latest QR code/,
+  "auth failures should keep the pairing-needed QR guidance",
 );
 
 assert.match(

--- a/src/components/chat-view-scroll-pin.test.ts
+++ b/src/components/chat-view-scroll-pin.test.ts
@@ -46,14 +46,32 @@ assert.match(
 
 assert.match(
   src,
-  /new ResizeObserver\(\(\) => \{\s*if \(followingRef\.current\) schedulePin\(\);\s*\}\)/,
-  "a ResizeObserver re-pins on size changes ONLY while following — a released reader is never moved",
+  /new ResizeObserver\(\(\) => \{\s*if \(followingRef\.current\) \{\s*schedulePin\(\);\s*return;\s*\}\s*restoreReleasedScrollAnchor\(\);\s*\}\)/,
+  "a ResizeObserver re-pins while following and restores the released scroll anchor otherwise",
 );
 
 assert.match(
   src,
   /ro\.observe\(scroller\);\s*const thread = threadRef\.current;\s*if \(thread\) ro\.observe\(thread\);/,
   "the observer watches both the scroller (composer/window resizes) and the thread (content growth)",
+);
+
+assert.match(
+  src,
+  /const releasedScrollAnchorRef = useRef<\{ turnId: string \| null; node: HTMLElement \| null; top: number \} \| null>\(null\);/,
+  "released readers keep a DOM anchor so late layout above the viewport can be corrected",
+);
+
+assert.match(
+  src,
+  /const captureReleasedScrollAnchor = useCallback\(\(\) => \{[\s\S]*?querySelectorAll<HTMLElement>\("\[data-turn-id\]"\)[\s\S]*?getBoundingClientRect\(\)[\s\S]*?releasedScrollAnchorRef\.current = candidate/,
+  "released anchor capture records the first visible turn before async content changes height",
+);
+
+assert.match(
+  src,
+  /const restoreReleasedScrollAnchor = useCallback\(\(\) => \{[\s\S]*?scroller\.scrollTop \+= delta;[\s\S]*?captureReleasedScrollAnchor\(\);/,
+  "released anchor restore offsets scrollTop by the anchor delta and refreshes the anchor",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2398,21 +2398,75 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Distance-from-bottom captured at the instant of expansion so the prepended
   // older rows don't visually shove the viewport (restored in a layout effect).
   const expandAnchorRef = useRef<number | null>(null);
+  const releasedScrollAnchorRef = useRef<{ turnId: string | null; node: HTMLElement | null; top: number } | null>(null);
+  const releasedAnchorFrameRef = useRef<number | null>(null);
+  const captureReleasedScrollAnchor = useCallback(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) {
+      releasedScrollAnchorRef.current = null;
+      return;
+    }
+    const viewport = scroller.getBoundingClientRect();
+    let candidate: HTMLElement | null = null;
+    for (const node of scroller.querySelectorAll<HTMLElement>("[data-turn-id]")) {
+      const rect = node.getBoundingClientRect();
+      if (rect.bottom > viewport.top + 1 && rect.top < viewport.bottom - 1) {
+        candidate = node;
+        break;
+      }
+    }
+    releasedScrollAnchorRef.current = candidate
+      ? { turnId: candidate.dataset.turnId ?? null, node: candidate, top: candidate.getBoundingClientRect().top }
+      : null;
+  }, []);
+  const restoreReleasedScrollAnchor = useCallback(() => {
+    if (followingRef.current) return;
+    if (releasedAnchorFrameRef.current !== null) return;
+    releasedAnchorFrameRef.current = requestAnimationFrame(() => {
+      releasedAnchorFrameRef.current = null;
+      if (followingRef.current) return;
+      const scroller = scrollRef.current;
+      const anchor = releasedScrollAnchorRef.current;
+      if (!scroller || !anchor) {
+        captureReleasedScrollAnchor();
+        return;
+      }
+      const anchoredNode =
+        anchor.node?.isConnected
+          ? anchor.node
+          : Array.from(scroller.querySelectorAll<HTMLElement>("[data-turn-id]")).find(
+              (node) => node.dataset.turnId === anchor.turnId,
+            ) ?? null;
+      if (!anchoredNode) {
+        captureReleasedScrollAnchor();
+        return;
+      }
+      const delta = anchoredNode.getBoundingClientRect().top - anchor.top;
+      if (Math.abs(delta) >= 0.5) scroller.scrollTop += delta;
+      captureReleasedScrollAnchor();
+    });
+  }, [captureReleasedScrollAnchor]);
   const updateFollowing = useCallback((next: boolean) => {
     followingRef.current = next;
     setFollowing(next);
     if (next) {
       // Reset count when returning to the bottom
       setNewTurnsCount(0);
+      releasedScrollAnchorRef.current = null;
+      if (releasedAnchorFrameRef.current !== null) {
+        cancelAnimationFrame(releasedAnchorFrameRef.current);
+        releasedAnchorFrameRef.current = null;
+      }
     } else if (!historyExpandedRef.current) {
       // Leaving the bottom (wheel/touch/keys/find-jump all funnel here) — mount
       // the full transcript and anchor the scroll so older rows slide in above
       // the current view instead of jumping it.
       const el = scrollRef.current;
       expandAnchorRef.current = el ? el.scrollHeight - el.scrollTop : null;
+      captureReleasedScrollAnchor();
       setHistoryExpanded(true);
     }
-  }, []);
+  }, [captureReleasedScrollAnchor]);
 
   // Restore the pre-expansion distance-from-bottom once the full transcript has
   // mounted, so revealing the older rows doesn't jump the reader's viewport.
@@ -2422,8 +2476,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     expandAnchorRef.current = null;
     if (anchor == null) return;
     const el = scrollRef.current;
-    if (el) el.scrollTop = Math.max(0, el.scrollHeight - anchor);
-  }, [historyExpanded]);
+    if (el) {
+      el.scrollTop = Math.max(0, el.scrollHeight - anchor);
+      captureReleasedScrollAnchor();
+    }
+  }, [captureReleasedScrollAnchor, historyExpanded]);
 
   // `shouldApply` lets a caller (the effect below) veto the setState after the
   // await — a fetch that resolves after a thread switch must not overwrite the
@@ -3426,19 +3483,24 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // bottom while `following` is still true ("the chat scrolled up by
   // itself"). While following, ANY size change of the thread (content
   // growth) or the scroller (composer/window resize) re-pins through the
-  // same coalesced rAF; while released it does nothing, so a reader's place
-  // is never disturbed.
+  // same coalesced rAF. While released, late async layout above the viewport
+  // preserves the first visible turn's screen position, which stands in for
+  // native scroll anchoring in WKWebView.
   useEffect(() => {
     const scroller = scrollRef.current;
     if (!scroller || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(() => {
-      if (followingRef.current) schedulePin();
+      if (followingRef.current) {
+        schedulePin();
+        return;
+      }
+      restoreReleasedScrollAnchor();
     });
     ro.observe(scroller);
     const thread = threadRef.current;
     if (thread) ro.observe(thread);
     return () => ro.disconnect();
-  }, [schedulePin]);
+  }, [restoreReleasedScrollAnchor, schedulePin]);
 
   useEffect(() => () => {
     if (pinFrameRef.current !== null) {
@@ -3448,6 +3510,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       // guard in schedulePin, and no pin ever runs again for the lifetime of
       // the component — the "chat opens at the top and never follows" bug.
       pinFrameRef.current = null;
+    }
+    if (releasedAnchorFrameRef.current !== null) {
+      cancelAnimationFrame(releasedAnchorFrameRef.current);
+      releasedAnchorFrameRef.current = null;
     }
   }, []);
 
@@ -3459,6 +3525,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     updateFollowing(true);
     setHistoryExpanded(false);
     expandAnchorRef.current = null;
+    releasedScrollAnchorRef.current = null;
   }, [sessionId, updateFollowing]);
 
   // Release on intent: only USER input events detach following. Programmatic
@@ -3536,12 +3603,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (!el) return;
     const onScroll = () => {
       if (followingRef.current) return;
+      captureReleasedScrollAnchor();
       const gap = el.scrollHeight - el.scrollTop - el.clientHeight;
       if (gap <= 4) updateFollowing(true);
     };
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
-  }, [updateFollowing]);
+  }, [captureReleasedScrollAnchor, updateFollowing]);
 
   useEffect(() => {
     inputRef.current?.focus();


### PR DESCRIPTION
## Summary
- Preserve a released chat reader's first visible turn while async markdown, highlighting, Mermaid, and image layout changes resize content above the viewport.
- Clarify the native iOS unreachable state as a likely Tailscale-disconnected condition, while keeping pairing/auth guidance separate.

## Test plan
- `pnpm test:app`
- `pnpm test:mobile`
- `pnpm typecheck`
- `git diff --check HEAD~1..HEAD`

Bead: cave-22il
