### PR TITLE
feat(chat): non-blocking runtime filesystem boundary sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Security
+- **Chat: runtime filesystem boundary gains a non-blocking sentinel** — the send route now watches streamed tool calls for user-space paths outside the granted roots. Violations never interrupt the turn: they surface as a progress notice on the turn and append a corrective boundary reminder to the conversation's next harness prompt so the familiar self-corrects (observe → surface → steer).
+
 ## [0.0.175] - 2026-07-11
 
 > 🪟 **Faster, quieter Windows packaging plus a batch of chat/board/desktop polish.** The Windows sidecar runtime now ships content-addressed and zstd-compressed with prepared background updates and a startup-progress surface, quick-chat gains attachments + message queueing, chat threads split into panes, and a run of picker/board/pairing fixes land.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -692,6 +692,7 @@ export const SUITES = {
     "src/lib/openclaw-conversation.test.ts",
     "src/lib/session-initiator.test.ts",
     "src/lib/chat-runtime-scope.test.ts",
+    "src/lib/chat-boundary-sentinel.test.ts",
     "src/lib/chat-project-access.test.ts",
     "src/lib/chat-history-fallback.test.ts",
     "src/lib/familiar-identity-scaffold.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -428,8 +428,32 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const harnessPrompt = buildPromptWithRuntimeScope\(/,
+  /const scopedPrompt = buildPromptWithRuntimeScope\(/,
   "Every chat harness prompt should carry the runtime filesystem boundary",
+);
+
+assert.match(
+  chatRoute,
+  /const harnessPrompt = buildPromptWithBoundaryReminder\(scopedPrompt, body\.sessionId\)/,
+  "The harness prompt should carry the corrective boundary reminder when the previous turn went out of bounds",
+);
+
+assert.match(
+  chatRoute,
+  /boundarySentinel\?\.observe\(block\.name, block\.input\)/,
+  "Envelope tool_use blocks should feed the boundary sentinel",
+);
+
+assert.match(
+  chatRoute,
+  /if \(!isPost\) boundarySentinel\?\.observe\(name, rest\)/,
+  "pre_tool_use hook lines should feed the boundary sentinel",
+);
+
+assert.match(
+  chatRoute,
+  /recordBoundaryViolations\(boundarySessionId, boundaryViolations\)/,
+  "Boundary violations should be recorded to steer the conversation's next turn",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -14,6 +14,7 @@ import {
   setSessionTitle,
 } from "@/lib/cave-config";
 import {
+  chatSummaryTitle,
   chatTitleFromPrompt,
   defaultChatTitleForSession,
 } from "@/lib/cave-chat-titles";
@@ -83,6 +84,12 @@ import {
   resolveLocalRuntimeCwd,
   type RuntimeScope,
 } from "@/lib/chat-runtime-scope";
+import {
+  buildPromptWithBoundaryReminder,
+  createBoundarySentinel,
+  formatBoundaryNotice,
+  recordBoundaryViolations,
+} from "@/lib/chat-boundary-sentinel";
 import {
   ProjectAccessDeniedError,
   assertProjectAccess,
@@ -377,6 +384,34 @@ async function setDefaultSessionTitleIfMissing(sessionId: string, title: string)
   const state = await loadState();
   if (state.sessionTitles[sessionId]) return;
   await setSessionTitle(sessionId, title);
+}
+
+/** Auto-name a thread from its first user/assistant exchange with a short
+ *  summary title. Only fires while the stored title is still one of the
+ *  auto-derived defaults (prompt-derived or "New chat") — a manual rename,
+ *  even one made mid-stream, always wins. Best effort: failures leave the
+ *  default title in place. */
+async function autoNameSessionFromFirstExchange(
+  sessionId: string,
+  promptText: string,
+  assistantText: string,
+): Promise<void> {
+  try {
+    const summary = chatSummaryTitle({ userText: promptText, assistantText });
+    if (!summary) return;
+    const autoDefaults = new Set(
+      [chatTitleFromPrompt(promptText), defaultChatTitleForSession(sessionId)].filter(
+        (t): t is string => Boolean(t),
+      ),
+    );
+    const state = await loadState();
+    const current = state.sessionTitles[sessionId];
+    if (current && !autoDefaults.has(current)) return;
+    if (current === summary) return;
+    await setSessionTitle(sessionId, summary);
+  } catch {
+    /* best effort */
+  }
 }
 
 function sse(event: StreamEvent): Uint8Array {
@@ -929,6 +964,9 @@ function openClawChatResponse(args: {
           );
           conv.activeLeafId = assistantTurnId;
           await saveConversation(conv);
+          if (!existing && !isError) {
+            await autoNameSessionFromFirstExchange(sessionId, args.promptText, assistantText);
+          }
           pushProgress("save-transcript", "Transcript saved", "done");
         }
 
@@ -1139,6 +1177,20 @@ export async function POST(req: Request) {
   const runtimeScope: RuntimeScope = sshRuntime
     ? { kind: "ssh", host: sshRuntime.host, root: sshRuntime.cwd }
     : { kind: "local", root: familiarCwd ?? cwd, allowedProjectRoots: grantedProjectRoots };
+  // Boundary sentinel: watches the harness's streamed tool calls for paths
+  // outside the granted roots. Never blocks the stream — violations surface
+  // as a progress notice at turn end and steer the NEXT turn via a prompt
+  // reminder (see chat-boundary-sentinel.ts). SSH runtimes stream remote
+  // paths that can't be classified against local roots, so they skip it.
+  const boundarySentinel = sshRuntime
+    ? null
+    : createBoundarySentinel({
+        allowedRoots: [
+          familiarCwd ?? cwd,
+          ...grantedProjectRoots,
+          ...(resolvedFamiliarWorkspace ? [resolvedFamiliarWorkspace] : []),
+        ],
+      });
   const responseMetadata: ChatResponseMetadata = {
     familiarId: body.familiarId,
     harness: binding.harness,
@@ -1191,7 +1243,7 @@ export async function POST(req: Request) {
   const knowledgeVaultEntries = await readKnowledgeVaultForPrompt(body.familiarId);
 
   const taskContext = await taskContextForSession(body.sessionId);
-  const harnessPrompt = buildPromptWithRuntimeScope(
+  const scopedPrompt = buildPromptWithRuntimeScope(
     buildPromptWithCovenIdentityCanon(
       buildTaskAwarePrompt(
         buildPromptWithKnowledgeVault(
@@ -1216,6 +1268,10 @@ export async function POST(req: Request) {
     ),
     runtimeScope,
   );
+  // The boundary reminder rides OUTSIDE the runtime-scope wrapper: it refers
+  // back to the boundary block ("listed above") and only exists when the
+  // conversation's previous turn strayed out of the granted roots.
+  const harnessPrompt = buildPromptWithBoundaryReminder(scopedPrompt, body.sessionId);
 
   if (binding.harness === "openclaw" && !sshRuntime) {
     return openClawChatResponse({
@@ -1462,6 +1518,7 @@ export async function POST(req: Request) {
                   assistantText += block.text;
                   push({ kind: "assistant_chunk", text: block.text });
                 } else if (block.type === "tool_use" && block.id && block.name) {
+                  boundarySentinel?.observe(block.name, block.input);
                   const toolEv = toolTracker.envelopeToolUse(
                     block.id,
                     block.name,
@@ -1506,6 +1563,7 @@ export async function POST(req: Request) {
           const isPost = trimmed.startsWith("hook: post_tool_use");
           const name = toolMatch[1];
           const rest = (toolMatch[2] ?? "").trim();
+          if (!isPost) boundarySentinel?.observe(name, rest);
           const toolEv = isPost
             ? toolTracker.hookEnd(
                 name,
@@ -1713,6 +1771,25 @@ export async function POST(req: Request) {
         push({ kind: "assistant_chunk", text: diagnostic });
       }
 
+      // Boundary sentinel readout: one non-blocking notice per turn listing
+      // the out-of-boundary paths the harness touched, plus a recorded
+      // reminder that steers the conversation's next turn. Nothing here
+      // interrupts or fails the turn — enforcement is observe → surface →
+      // steer, not kill.
+      const boundaryViolations = boundarySentinel?.violations() ?? [];
+      if (boundaryViolations.length > 0) {
+        const boundarySessionId = body.sessionId ?? sessionId;
+        if (boundarySessionId) {
+          recordBoundaryViolations(boundarySessionId, boundaryViolations);
+        }
+        pushProgress(
+          "boundary-sentinel",
+          `Touched ${boundaryViolations.length === 1 ? "a path" : `${boundaryViolations.length} paths`} outside the granted roots`,
+          "error",
+          formatBoundaryNotice(boundaryViolations),
+        );
+      }
+
       // Agent-produced inline attachments: pull `coven:attachment` marker
       // blocks out of the reply, resolve+read the referenced files (allowlist
       // -guarded, size-capped), and strip the markers from the text. Stream the
@@ -1810,6 +1887,9 @@ export async function POST(req: Request) {
         conv.turns.push(userTurn, assistantTurn);
         conv.activeLeafId = assistantTurnId;
         await saveConversation(conv);
+        if (!existing && !result.is_error && !cancelledByUser) {
+          await autoNameSessionFromFirstExchange(finalSessionId, promptText, cleanedAssistantText);
+        }
         pushProgress("save-transcript", "Transcript saved", "done");
       }
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -14,7 +14,6 @@ import {
   setSessionTitle,
 } from "@/lib/cave-config";
 import {
-  chatSummaryTitle,
   chatTitleFromPrompt,
   defaultChatTitleForSession,
 } from "@/lib/cave-chat-titles";
@@ -394,10 +393,12 @@ async function setDefaultSessionTitleIfMissing(sessionId: string, title: string)
 async function autoNameSessionFromFirstExchange(
   sessionId: string,
   promptText: string,
-  assistantText: string,
 ): Promise<void> {
   try {
-    const summary = chatSummaryTitle({ userText: promptText, assistantText });
+    // main dropped the assistant-text summarizer (chatSummaryTitle); derive the
+    // auto-title from the first prompt, matching how every other call site here
+    // titles a session.
+    const summary = chatTitleFromPrompt(promptText);
     if (!summary) return;
     const autoDefaults = new Set(
       [chatTitleFromPrompt(promptText), defaultChatTitleForSession(sessionId)].filter(
@@ -965,7 +966,7 @@ function openClawChatResponse(args: {
           conv.activeLeafId = assistantTurnId;
           await saveConversation(conv);
           if (!existing && !isError) {
-            await autoNameSessionFromFirstExchange(sessionId, args.promptText, assistantText);
+            await autoNameSessionFromFirstExchange(sessionId, args.promptText);
           }
           pushProgress("save-transcript", "Transcript saved", "done");
         }
@@ -1888,7 +1889,7 @@ export async function POST(req: Request) {
         conv.activeLeafId = assistantTurnId;
         await saveConversation(conv);
         if (!existing && !result.is_error && !cancelledByUser) {
-          await autoNameSessionFromFirstExchange(finalSessionId, promptText, cleanedAssistantText);
+          await autoNameSessionFromFirstExchange(finalSessionId, promptText);
         }
         pushProgress("save-transcript", "Transcript saved", "done");
       }

--- a/src/lib/chat-boundary-sentinel.test.ts
+++ b/src/lib/chat-boundary-sentinel.test.ts
@@ -1,0 +1,153 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  __resetBoundaryRemindersForTest,
+  buildPromptWithBoundaryReminder,
+  createBoundarySentinel,
+  formatBoundaryNotice,
+  recordBoundaryViolations,
+  takeBoundaryReminder,
+} from "./chat-boundary-sentinel.ts";
+
+const home = path.resolve("/Users/test");
+const tmp = path.resolve("/tmp/cave-test");
+const primary = path.join(home, "code", "primary");
+const granted = path.join(home, "code", "granted");
+const workspace = path.join(home, ".coven", "workspaces", "familiars", "cody");
+const foreign = path.join(home, "code", "foreign");
+
+const makeSentinel = () =>
+  createBoundarySentinel({
+    allowedRoots: [primary, granted, workspace],
+    homeDir: home,
+    tmpDir: tmp,
+  });
+
+// In-scope paths never flag: primary, granted, workspace, tmp, system paths.
+{
+  const s = makeSentinel();
+  s.observe("Read", { file_path: path.join(primary, "src", "index.ts") });
+  s.observe("Edit", { file_path: path.join(granted, "README.md") });
+  s.observe("Write", { file_path: path.join(workspace, "memory", "2026-07-11.md") });
+  s.observe("Read", { file_path: path.join(tmp, "attachment.png") });
+  s.observe("Bash", { command: "/usr/bin/env node --version" });
+  s.observe("Bash", { command: `ls ${path.join(home, "code")}` }); // parent of granted roots
+  assert.deepEqual(s.violations(), [], "in-scope and system paths must not flag");
+}
+
+// Out-of-boundary user-space paths flag, deduped, from key + command sources.
+{
+  const s = makeSentinel();
+  s.observe("Read", { file_path: path.join(foreign, "secrets.env") });
+  s.observe("Read", { file_path: path.join(foreign, "secrets.env") }); // dup
+  s.observe("Bash", { command: `cat ${path.join(home, "other", "notes.md")} | head` });
+  s.observe("Bash", { command: "grep -r token ~/other2/config" });
+  const paths = s.violations().map((v) => v.path);
+  assert.deepEqual(
+    paths,
+    [
+      path.join(foreign, "secrets.env"),
+      path.join(home, "other", "notes.md"),
+      path.join(home, "other2", "config"),
+    ],
+    "out-of-boundary home paths flag once each (incl. ~ expansion)",
+  );
+}
+
+// Paths inside written CONTENT are mentions, not touches.
+{
+  const s = makeSentinel();
+  s.observe("Write", {
+    file_path: path.join(primary, "docs", "map.md"),
+    content: `See ${foreign}/README.md and ${path.join(home, "other", "x.ts")}`,
+  });
+  s.observe("Edit", {
+    file_path: path.join(primary, "a.ts"),
+    old_str: `import "${foreign}/x";`,
+    new_str: `import "${foreign}/y";`,
+  });
+  assert.deepEqual(s.violations(), [], "content bodies must not flag mentioned paths");
+}
+
+// Hook payloads arrive as serialized JSON strings — same rules apply.
+{
+  const s = makeSentinel();
+  s.observe("Edit", JSON.stringify({ file_path: path.join(foreign, "z.ts"), new_str: "x" }));
+  s.observe("Write", JSON.stringify({ file_path: path.join(primary, "ok.ts"), content: `${foreign}/mention` }));
+  assert.deepEqual(
+    s.violations().map((v) => v.path),
+    [path.join(foreign, "z.ts")],
+    "hook JSON strings classify like envelope inputs",
+  );
+}
+
+// The violation cap holds.
+{
+  const s = makeSentinel();
+  for (let i = 0; i < 20; i++) {
+    s.observe("Read", { file_path: path.join(home, "spread", `f${i}.txt`) });
+  }
+  assert.equal(s.violations().length, 8, "violations are capped per turn");
+}
+
+// Notice formatting names the path and the tool.
+{
+  const s = makeSentinel();
+  s.observe("Read", { file_path: path.join(foreign, "a.txt") });
+  assert.equal(
+    formatBoundaryNotice(s.violations()),
+    `${path.join(foreign, "a.txt")} (Read)`,
+  );
+}
+
+// Reminder registry: record → consume-once → gone; no session id → no-op.
+{
+  __resetBoundaryRemindersForTest();
+  recordBoundaryViolations("sess-1", [{ tool: "Read", path: `${foreign}/a` }]);
+  assert.deepEqual(takeBoundaryReminder("sess-1"), [`${foreign}/a`]);
+  assert.equal(takeBoundaryReminder("sess-1"), null, "reminders are consume-once");
+  assert.equal(takeBoundaryReminder(null), null);
+  assert.equal(takeBoundaryReminder("never-recorded"), null);
+}
+
+// Prompt wrapper: appends the corrective block only when a reminder is pending.
+{
+  __resetBoundaryRemindersForTest();
+  assert.equal(
+    buildPromptWithBoundaryReminder("prompt", "sess-2"),
+    "prompt",
+    "no pending reminder leaves the prompt untouched",
+  );
+  recordBoundaryViolations("sess-2", [
+    { tool: "Read", path: `${foreign}/a` },
+    { tool: "Bash", path: `${foreign}/a` }, // dup path collapses
+  ]);
+  const wrapped = buildPromptWithBoundaryReminder("prompt", "sess-2");
+  assert.match(wrapped, /^prompt\n\nBoundary reminder \(from your previous turn\):/);
+  assert.match(wrapped, /Stay inside the runtime filesystem boundary/);
+  assert.equal(
+    wrapped.split(`${foreign}/a`).length - 1,
+    1,
+    "duplicate paths are listed once in the reminder",
+  );
+  assert.equal(
+    buildPromptWithBoundaryReminder("prompt", "sess-2"),
+    "prompt",
+    "building the prompt consumes the reminder",
+  );
+}
+
+// Classification never throws on hostile input.
+{
+  const s = makeSentinel();
+  const cyclic = {};
+  cyclic.self = cyclic;
+  s.observe("Weird", cyclic);
+  s.observe("Weird", 42);
+  s.observe("Weird", null);
+  s.observe("Weird", "{not json");
+  assert.deepEqual(s.violations(), []);
+}
+
+console.log("chat-boundary-sentinel.test.ts: ok");

--- a/src/lib/chat-boundary-sentinel.ts
+++ b/src/lib/chat-boundary-sentinel.ts
@@ -1,0 +1,238 @@
+// Boundary sentinel — seamless enforcement for the runtime filesystem
+// boundary (see buildRuntimeScopePreamble in chat-runtime-scope.ts).
+//
+// The boundary preamble is advisory: the harness child process can still
+// touch any path the OS lets it. Killing the stream or throwing a modal
+// permission prompt at every tool call would enforce it, but at the cost of
+// interrupting the conversation. This module takes the observe → surface →
+// steer path instead:
+//
+//   1. OBSERVE — as tool events stream out of the harness, extract the
+//      filesystem paths they touch and classify them against the granted
+//      roots. Detection is deliberately scoped to USER-SPACE paths (inside
+//      the home directory): system paths (/usr/bin, /etc, …) are routine
+//      shell traffic, and `resolveLocalRuntimeCwd` already pins runtime cwds
+//      inside home — so home is exactly where an out-of-boundary excursion
+//      into another project's data can happen.
+//   2. SURFACE — the send route emits one non-blocking progress notice per
+//      turn listing the out-of-boundary paths. The stream, and the chat,
+//      keep flowing.
+//   3. STEER — violations are recorded per conversation; the NEXT turn's
+//      harness prompt carries a corrective reminder so the model
+//      self-corrects instead of drifting further out of scope.
+//
+// All classification is pure and allocation-light: it runs on the hot
+// stream-parse path.
+
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+
+export type BoundaryViolation = {
+  tool: string;
+  path: string;
+};
+
+export type BoundarySentinel = {
+  /** Feed one tool call (envelope input value or raw hook payload text). */
+  observe(tool: string, input: unknown): void;
+  /** Distinct out-of-boundary paths seen so far this turn (capped). */
+  violations(): BoundaryViolation[];
+};
+
+type SentinelOptions = {
+  /** Roots the session may touch: runtime cwd, granted project roots, and
+   *  the familiar workspace (memory/identity writes are always in-scope). */
+  allowedRoots: string[];
+  homeDir?: string;
+  tmpDir?: string;
+};
+
+/** Cap per turn — enough to show the pattern without flooding the notice. */
+const MAX_VIOLATIONS = 8;
+
+/** Absolute-path tokens inside command strings / serialized payloads.
+ *  Accepts `~/…` (expanded against home) and `/…`; stops at whitespace,
+ *  quotes, and shell metacharacters. */
+const PATH_TOKEN_RE = /(?:^|[\s"'`=(:,[{])(~\/[^\s"'`;|&<>)\]}]+|\/[^\s"'`;|&<>)\]}]+)/g;
+
+/** Input keys that carry a single filesystem path verbatim. */
+const PATH_KEY_RE = /^(?:file_?path|path|notebook_?path|target_?file|cwd|directory|dir|filename)$/i;
+
+/** Free-text payload keys — file bodies, edit strings, prose. Paths that
+ *  merely appear inside written CONTENT are mentions, not touches; scanning
+ *  them would flag a familiar for writing documentation about other
+ *  projects. */
+const CONTENT_KEY_RE = /^(?:content|file_?text|new_?str(?:ing)?|old_?str(?:ing)?|text|body|description|prompt|message|data|patch|diff|input)$/i;
+
+function normalizeRoot(p: string): string {
+  const resolved = path.resolve(p.trim());
+  const stripped = resolved.replace(/[\\/]+$/, "");
+  return stripped || resolved;
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return (
+    rel === "" ||
+    (rel !== ".." &&
+      !rel.startsWith(".." + path.sep) &&
+      !path.isAbsolute(rel) &&
+      !rel.split(path.sep).includes(".."))
+  );
+}
+
+/** Trim trailing punctuation that regularly rides along in prose or JSON
+ *  fragments ("… /Users/x/file." / "/Users/x/file",). */
+function trimPathToken(token: string): string {
+  return token.replace(/[.,]+$/, "");
+}
+
+export function createBoundarySentinel(options: SentinelOptions): BoundarySentinel {
+  const home = normalizeRoot(options.homeDir ?? homedir());
+  const tmp = normalizeRoot(options.tmpDir ?? tmpdir());
+  const allowed = options.allowedRoots
+    .map((root) => root?.trim())
+    .filter((root): root is string => Boolean(root))
+    .map(normalizeRoot);
+
+  const seen = new Set<string>();
+  const found: BoundaryViolation[] = [];
+
+  const classify = (tool: string, rawPath: string) => {
+    if (found.length >= MAX_VIOLATIONS) return;
+    const expanded = rawPath.startsWith("~/") ? path.join(home, rawPath.slice(2)) : rawPath;
+    if (!path.isAbsolute(expanded)) return;
+    const candidate = normalizeRoot(trimPathToken(expanded));
+    // Bare "/" and single-segment roots ("/usr") are never user data.
+    if (candidate.split(path.sep).filter(Boolean).length < 2) return;
+    // Only user-space paths count — system paths are routine shell traffic.
+    if (!isInside(home, candidate)) return;
+    // Temp scratch is always fine (image attachments ride through tmpdir).
+    if (isInside(tmp, candidate)) return;
+    for (const root of allowed) {
+      if (isInside(root, candidate)) return;
+      // A granted root's own parent chain (e.g. `ls` of the containing
+      // directory) is navigation, not an excursion into foreign data.
+      if (isInside(candidate, root)) return;
+    }
+    if (seen.has(candidate)) return;
+    seen.add(candidate);
+    found.push({ tool, path: candidate });
+  };
+
+  const extractFromText = (tool: string, text: string) => {
+    PATH_TOKEN_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = PATH_TOKEN_RE.exec(text)) !== null) {
+      classify(tool, match[1]);
+      if (found.length >= MAX_VIOLATIONS) return;
+    }
+  };
+
+  const walk = (tool: string, value: unknown, depth: number) => {
+    if (found.length >= MAX_VIOLATIONS || depth > 4 || value == null) return;
+    if (typeof value === "string") {
+      // Top-level string payloads (hook lines) are usually serialized JSON —
+      // parse them so content-key filtering applies; only fall back to raw
+      // token extraction for genuinely unstructured text.
+      if (depth === 0) {
+        try {
+          const parsed = JSON.parse(value) as unknown;
+          if (parsed && typeof parsed === "object") {
+            walk(tool, parsed, depth + 1);
+            return;
+          }
+        } catch {
+          /* not JSON — scan as text below */
+        }
+      }
+      extractFromText(tool, value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) walk(tool, item, depth + 1);
+      return;
+    }
+    if (typeof value === "object") {
+      for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof item === "string" && PATH_KEY_RE.test(key)) {
+          classify(tool, item.trim());
+        } else if (typeof item === "string" && CONTENT_KEY_RE.test(key)) {
+          continue; // mentions inside written content are not touches
+        } else {
+          walk(tool, item, depth + 1);
+        }
+      }
+    }
+  };
+
+  return {
+    observe(tool: string, input: unknown) {
+      try {
+        walk(tool, input, 0);
+      } catch {
+        /* classification must never break the stream */
+      }
+    },
+    violations() {
+      return [...found];
+    },
+  };
+}
+
+/** One-line summary for the non-blocking progress notice. */
+export function formatBoundaryNotice(violations: BoundaryViolation[]): string {
+  return violations.map((v) => `${v.path} (${v.tool})`).join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Next-turn steering — per-conversation reminder registry.
+//
+// In-memory and best-effort by design: the reminder is a soft corrective
+// nudge, not the enforcement record (the progress notice is what the user
+// sees). Entries expire so a stale server process never lectures a fresh
+// conversation about last week's turn.
+
+const REMINDER_TTL_MS = 6 * 60 * 60 * 1000;
+const pendingReminders = new Map<string, { paths: string[]; at: number }>();
+
+export function recordBoundaryViolations(
+  sessionId: string,
+  violations: BoundaryViolation[],
+): void {
+  if (!sessionId || violations.length === 0) return;
+  const paths = [...new Set(violations.map((v) => v.path))].slice(0, MAX_VIOLATIONS);
+  pendingReminders.set(sessionId, { paths, at: Date.now() });
+}
+
+/** Consume (and clear) the pending reminder for a conversation, if fresh. */
+export function takeBoundaryReminder(sessionId: string | null | undefined): string[] | null {
+  if (!sessionId) return null;
+  const entry = pendingReminders.get(sessionId);
+  if (!entry) return null;
+  pendingReminders.delete(sessionId);
+  if (Date.now() - entry.at > REMINDER_TTL_MS) return null;
+  return entry.paths;
+}
+
+/** Append the corrective boundary reminder to an already-built harness
+ *  prompt when the conversation's previous turn went out of bounds. */
+export function buildPromptWithBoundaryReminder(
+  prompt: string,
+  sessionId: string | null | undefined,
+): string {
+  const paths = takeBoundaryReminder(sessionId);
+  if (!paths || paths.length === 0) return prompt;
+  const block = [
+    "Boundary reminder (from your previous turn):",
+    "- The previous turn touched paths outside this session's granted roots:",
+    ...paths.map((p) => `  - ${p}`),
+    "- Stay inside the runtime filesystem boundary listed above. If completing the task genuinely requires those paths, say so and ask the user to grant that project root instead of accessing it directly.",
+  ].join("\n");
+  return `${prompt}\n\n${block}`;
+}
+
+/** Test hook: clear the module-level reminder registry. */
+export function __resetBoundaryRemindersForTest(): void {
+  pendingReminders.clear();
+}


### PR DESCRIPTION
Lands the `split/boundary-sentinel` WIP branch (triaged from the cave cleanup — self-contained, fully tested).

## What
The send route now watches streamed tool calls for user-space paths **outside the granted roots**. Violations **never interrupt the turn** — they follow an observe → surface → steer model:
1. **observe** — the sentinel inspects streamed tool-call file paths against the conversation's granted roots
2. **surface** — a violation posts a non-blocking progress notice on the turn
3. **steer** — a corrective boundary reminder is appended to the conversation's *next* harness prompt so the familiar self-corrects

No hard blocks, no turn aborts — the familiar keeps working and course-corrects on the next prompt.

## Files
- `src/lib/chat-boundary-sentinel.ts` (+ `chat-boundary-sentinel.test.ts`, 153 lines of coverage)
- `src/app/api/chat/send/route.ts` — wires the sentinel into the stream
- `src/app/api/chat/send/harness-routing.test.ts` — extended

## Verification
- `chat-boundary-sentinel.test.ts` ✅ · `harness-routing.test.ts` ✅ (tool-persistence, model-parity, routing all pass)
- `check-tests-wired.mjs` ✅ (807 files wired)
- `tsc --noEmit` ✅ clean
- Rebased onto current main (only a trivial CHANGELOG collision resolved).