### PR TITLE
feat(settings): scalable familiar picker

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -599,6 +599,7 @@ export const SUITES = {
     "src/app/daily-report-page.test.ts",
     "src/lib/icon-subset.test.ts",
     "src/lib/panel-shortcuts.test.ts",
+    "src/lib/settings-familiar-picker.test.ts",
     "src/components/familiar-studio-inline.test.ts",
     "src/lib/session-rail-title.test.ts",
     "src/lib/familiar-card-data.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6430,83 +6430,212 @@ a.mobile-handoff__link:hover {
   text-transform: uppercase;
   color: var(--text-muted);
 }
-/* Avatar-chip picker — WRAPS so every familiar stays visible (the old
-   horizontal scroll silently clipped the roster's tail); the Summon
-   invitation chip rides the end of the flow. */
-.familiar-studio-inline__picker-row {
-  display: flex;
-  align-items: flex-start;
-  min-width: 0;
-}
-.familiar-studio-inline__picker {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: var(--space-2);
-  min-width: 0;
-  flex: 1 1 auto;
-}
-.familiar-studio-inline__chip {
+/* A coven can grow without making the Settings header grow with it. The active
+   familiar's color is spent once: a quiet seam on the trigger/selected row. */
+.familiar-studio-picker__trigger {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  flex: 0 0 auto;
-  max-width: 220px;
-  padding: 6px 14px 6px 8px;
+  width: 100%;
+  min-height: 48px;
+  min-width: 0;
+  gap: 10px;
+  padding: 7px 10px 7px 7px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
-  color: var(--text-secondary);
+  color: var(--text-primary);
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 72%, transparent);
   cursor: pointer;
-  scroll-snap-align: start;
-  transition: background var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
+  text-align: left;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
 }
-.familiar-studio-inline__chip:hover:not([data-active="true"]) {
+.familiar-studio-picker__trigger:hover {
   background: var(--bg-raised);
   border-color: var(--border-strong);
-  color: var(--text-primary);
 }
-.familiar-studio-inline__chip[data-active="true"] {
-  border-color: color-mix(in oklch, var(--chip-accent, var(--accent-presence)) 60%, var(--border-hairline));
-  background: color-mix(in oklch, var(--chip-accent, var(--accent-presence)) 14%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--chip-accent, var(--accent-presence)) 32%, transparent);
-  color: var(--text-primary);
+.familiar-studio-picker__trigger:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 2px;
 }
-.familiar-studio-inline__chip:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--ring-focus); }
-/* Summon — the dashed invitation chip (design language: dashed = invitation).
-   It matches the roster chips' shape so the create action reads as "the next
-   member of this row", quiet until hovered. */
-.familiar-studio-inline__chip--summon {
-  border-style: dashed;
-  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
-  background: transparent;
-  color: var(--text-secondary);
-}
-.familiar-studio-inline__chip--summon:hover {
-  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
-  border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
-  color: var(--text-primary);
-}
-.familiar-studio-inline__summon-glyph {
+.familiar-studio-picker__trigger-avatar,
+.familiar-studio-picker__option-avatar {
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
   flex: 0 0 auto;
-  border-radius: 999px;
-  color: var(--accent-presence);
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
-.familiar-studio-inline__chip-text { display: flex; flex-direction: column; gap: 0; min-width: 0; text-align: left; }
-.familiar-studio-inline__chip-name {
-  font-size: var(--text-sm); font-weight: 550; color: var(--text-primary);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+.familiar-studio-picker__trigger-copy,
+.familiar-studio-picker__option-copy {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
 }
-.familiar-studio-inline__chip-role {
-  font-size: var(--text-2xs); color: var(--text-muted);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+.familiar-studio-picker__trigger-name,
+.familiar-studio-picker__option-name {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.familiar-studio-picker__trigger-role,
+.familiar-studio-picker__option-meta {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.familiar-studio-picker__option-meta span {
+  font-family: var(--font-mono), ui-monospace, monospace;
+}
+.familiar-studio-picker__trigger-count {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+}
+.familiar-studio-picker__trigger-caret {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+.familiar-studio-picker__popover {
+  display: flex;
+  flex-direction: column;
+  width: min(360px, calc(100vw - 16px));
+  max-width: calc(100vw - 16px);
+  background: var(--bg-elevated);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  overflow-x: hidden;
+  padding: 0;
+}
+.familiar-studio-picker {
+  display: grid;
+  flex: 1 1 auto;
+  max-height: inherit;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+}
+.familiar-studio-picker__search-shell {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 8px 8px 4px;
+  padding: 0 9px;
+  min-height: 36px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-muted);
+}
+.familiar-studio-picker__search-shell:focus-within {
+  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
+  box-shadow: 0 0 0 2px var(--ring-focus-soft);
+}
+.familiar-studio-picker__search {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-sm);
+}
+.familiar-studio-picker__search::placeholder { color: var(--text-muted); }
+.familiar-studio-picker__search::-webkit-search-cancel-button { opacity: 0.6; }
+.familiar-studio-picker__result-summary {
+  padding: 3px 11px 5px;
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+}
+.familiar-studio-picker__results {
+  max-height: min(320px, 45vh);
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 3px 5px 6px;
+  list-style: none;
+  scrollbar-gutter: stable;
+}
+.familiar-studio-picker__option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  gap: 9px;
+  padding: 5px 8px 5px 6px;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+}
+.familiar-studio-picker__option[data-highlighted] {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.familiar-studio-picker__option[data-selected] {
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 13%, transparent);
+  box-shadow: inset 2px 0 0 var(--familiar-accent, var(--accent-presence));
+  color: var(--text-primary);
+}
+.familiar-studio-picker__option[data-selected][data-highlighted] {
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 18%, var(--bg-hover));
+}
+.familiar-studio-picker__option:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: -2px;
+}
+.familiar-studio-picker__empty {
+  padding: 24px 12px;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  text-align: center;
+}
+.familiar-studio-picker__footer {
+  padding: 7px;
+  border-top: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
+}
+.familiar-studio-picker__summon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 36px;
+  gap: 7px;
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 48%, var(--border-hairline));
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+}
+.familiar-studio-picker__summon:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 70%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--text-primary);
+}
+.familiar-studio-picker__summon:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 .familiar-studio-inline__detail {
   display: grid;
@@ -6516,9 +6645,37 @@ a.mobile-handoff__link:hover {
 }
 .familiar-studio-inline__body { max-height: 62vh; }
 
+/* When a short window or on-screen keyboard leaves only the popover's 120px
+   safety floor, preserve one complete 44px result without sacrificing the
+   fixed search and Summon controls. data-compact comes from Popover's
+   visual-viewport-aware height calculation (CSS media height still sees the
+   larger layout viewport on mobile). The count remains live for AT while its
+   visible copy yields the scarce vertical space. */
+.familiar-studio-picker__popover[data-compact] .familiar-studio-picker__search-shell {
+  min-height: 28px;
+  margin: 1px 5px;
+}
+.familiar-studio-picker__popover[data-compact] .familiar-studio-picker__result-summary {
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+  line-height: 0;
+  opacity: 0;
+}
+.familiar-studio-picker__popover[data-compact] .familiar-studio-picker__results {
+  gap: 1px;
+  padding: 0 4px;
+}
+.familiar-studio-picker__popover[data-compact] .familiar-studio-picker__footer {
+  padding: 0 5px;
+  border-top: 0;
+}
+
 @media (max-width: 640px) {
   .familiar-studio-inline { grid-template-columns: 1fr; min-height: 0; }
   .familiar-studio-inline__selector { padding: var(--space-3); }
+  .familiar-studio-picker__summon { min-height: 44px; }
   .familiar-studio-inline__body { max-height: none; }
 }
 .familiar-studio-identity { display: flex; flex-direction: column; gap: var(--space-4); }

--- a/src/components/familiar-studio-inline.test.ts
+++ b/src/components/familiar-studio-inline.test.ts
@@ -1,28 +1,95 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./familiar-studio-inline.tsx", import.meta.url), "utf8");
+const pickerUrl = new URL("./settings-familiar-picker.tsx", import.meta.url);
+const pickerExists = existsSync(pickerUrl);
+const picker = pickerExists ? readFileSync(pickerUrl, "utf8") : "";
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const inlineStyles = globals.slice(
+  globals.indexOf("/* Inline Familiar Studio"),
+  globals.indexOf(".familiar-studio-identity"),
+);
 
 assert.match(source, /export function FamiliarStudioInlinePanel/, "Must export the inline panel");
 
-// Master-detail shell: a compact horizontal avatar-chip picker + detail pane.
-assert.match(source, /familiar-studio-inline__selector/, "Renders the familiar picker header");
-assert.match(source, /familiar-studio-inline__picker/, "Renders the horizontal chip picker");
-assert.match(source, /role="radiogroup"/, "Picker is a radiogroup");
-assert.match(source, /aria-label="Choose familiar to edit"/, "Settings familiar picker is labelled");
-assert.match(source, /FamiliarAvatar/, "Each chip shows the familiar's avatar");
-assert.match(source, /familiar-studio-inline__detail/, "Renders the detail pane");
-
-// Reuses the Studio context for selection + tab persistence, NOT local state,
-// so deep-link openFamiliarStudio(id, tab) and last-tab memory carry over.
-assert.match(source, /useFamiliarStudio\(\)/, "Uses the Familiar Studio context for selection");
+// Master-detail shell delegates roster scale + interaction to one focused,
+// controlled picker instead of growing a wrapping chip wall without bound.
+assert.equal(pickerExists, true, "Settings has a dedicated scalable familiar picker");
+assert.match(source, /SettingsFamiliarPicker/, "Renders the scalable familiar picker");
+assert.match(source, /familiars=\{resolved\}/, "Picker receives the resolved roster in daemon order");
+assert.match(source, /value=\{activeFamiliarId\}/, "Picker is controlled by Familiar Studio selection");
 assert.match(
   source,
-  /onClick=\{\(\) => openFamiliarStudio\(f\.id, activeTab\)\}/,
-  "Picking a chip opens that familiar at the current tab",
+  /onChange=\{\(id\) => openFamiliarStudio\(id, activeTab\)\}/,
+  "Picker selection opens the familiar at the current Studio tab",
 );
-assert.match(source, /aria-checked=\{active\}/, "The active familiar chip is marked checked");
+assert.match(source, /onSummon=\{onSummon\}/, "Summoning stays attached to familiar selection");
+assert.doesNotMatch(source, /role="radiogroup"/, "The unbounded chip radiogroup is retired");
+assert.doesNotMatch(source, /familiar-studio-inline__chip/, "Inline panel no longer owns roster chips");
+assert.match(source, /familiar-studio-inline__detail/, "Renders the detail pane");
+
+// Reuses the Studio context for selection + tab persistence, NOT selection
+// state inside the picker, so deep links and last-tab memory carry over.
+assert.match(source, /useFamiliarStudio\(\)/, "Uses the Familiar Studio context for selection");
+
+// The popup is a searchable, bounded combobox/listbox. Keyboard highlight is
+// separate from the committed aria-selected familiar.
+assert.match(picker, /aria-haspopup="dialog"/, "Picker trigger identifies its popover");
+assert.match(picker, /aria-expanded=\{open\}/, "Picker trigger exposes expanded state");
+assert.match(picker, /role="combobox"/, "Search field uses editable combobox semantics");
+assert.match(picker, /aria-autocomplete="list"/, "Combobox announces list autocomplete");
+assert.match(picker, /aria-controls=\{LISTBOX_ID\}/, "Combobox controls the result listbox");
+assert.match(picker, /aria-activedescendant=/, "Combobox exposes the keyboard-highlighted option");
+assert.match(picker, /role="listbox"/, "Filtered familiar results are a listbox");
+assert.match(picker, /role="option"/, "Each familiar result is an option");
+assert.match(picker, /aria-selected=\{selected\}/, "Committed familiar selection is announced");
+assert.match(
+  picker,
+  /role="option"[\s\S]{0,180}tabIndex=\{-1\}/,
+  "Listbox options use active-descendant navigation instead of adding one Tab stop per familiar",
+);
+assert.match(
+  picker,
+  /scrollStrategy="content"/,
+  "The picker keeps search and Summon fixed while its result list owns scrolling",
+);
+assert.match(
+  picker,
+  /compactAtHeight=\{184\}/,
+  "Picker compaction follows the Popover's visual-viewport-aware available height",
+);
+assert.match(picker, /moveFamiliarPickerIndex/, "Arrow navigation uses the tested index helper");
+assert.match(picker, /event\.key === "Enter"/, "Enter commits the highlighted familiar");
+assert.match(picker, /aria-live="polite"/, "Search result changes are announced");
+
+const resultsPosition = picker.indexOf('className="familiar-studio-picker__results"');
+const footerPosition = picker.indexOf('className="familiar-studio-picker__footer"');
+assert.ok(resultsPosition >= 0, "Picker renders a dedicated scrollable results region");
+assert.ok(footerPosition > resultsPosition, "Summon footer stays outside and after the results scroller");
+assert.match(picker, /Summon familiar/, "Summon remains reachable from the picker footer");
+assert.match(
+  inlineStyles,
+  /\.familiar-studio-picker__trigger\s*\{[\s\S]*?width:\s*100%[\s\S]*?min-height:\s*48px/,
+  "Picker trigger is one constant-height row",
+);
+assert.match(
+  inlineStyles,
+  /\.familiar-studio-picker__results\s*\{[\s\S]*?max-height:[\s\S]*?overflow-y:\s*auto/,
+  "Large rosters scroll inside a bounded result list",
+);
+assert.match(
+  inlineStyles,
+  /\.familiar-studio-picker__popover\s*\{[\s\S]*?background:\s*var\(--bg-elevated\)/,
+  "Dense familiar rows use an opaque elevated surface instead of unreadable glass",
+);
+assert.match(
+  inlineStyles,
+  /@media \(max-width: 640px\)[\s\S]*?\.familiar-studio-picker__summon\s*\{[\s\S]*?min-height:\s*44px/,
+  "The summon action keeps a touch-sized target in narrow Settings layouts",
+);
+assert.doesNotMatch(inlineStyles, /\.familiar-studio-inline__picker\s*\{/, "Wrapping roster CSS is retired");
 
 // Non-modal: it must NOT render the drawer chrome (scrim / fixed drawer root).
 assert.doesNotMatch(source, /familiar-studio__scrim/, "Inline panel must not render the modal scrim");
@@ -30,7 +97,7 @@ assert.doesNotMatch(source, /familiar-studio__drawer/, "Inline panel must not re
 
 // Familiar-specific studio tabs are wired with the same prop shapes the drawer uses.
 for (const tab of ["Identity", "Look", "Brain", "Lifecycle", "Memory"]) {
-  assert.match(source, new RegExp(`FamiliarStudio${tab}Tab`), `Wires the ${tab} tab body`);
+  assert.match(source, new RegExp("FamiliarStudio" + tab + "Tab"), "Wires the " + tab + " tab body");
 }
 assert.match(source, /<FamiliarStudioLookTab familiar=\{familiar\} allFamiliars=\{resolved\} \/>/, "Look tab gets all resolved familiars for group colors");
 assert.match(source, /<FamiliarStudioMemoryTab familiar=\{familiar\} allFamiliars=\{familiars\} \/>/, "Memory tab gets the raw roster");

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -13,7 +13,7 @@ import { FamiliarStudioLifecycleTab } from "./familiar-studio-lifecycle-tab";
 import { FamiliarStudioMemoryTab } from "./familiar-studio-memory-tab";
 import { FamiliarStudioProjectsTab } from "./familiar-studio-projects-tab";
 import { FamiliarStudioJournalTab } from "./familiar-studio-journal-tab";
-import { FamiliarAvatar } from "./familiar-avatar";
+import { SettingsFamiliarPicker } from "./settings-familiar-picker";
 import { VaultPanel } from "./vault-panel";
 import type { Familiar } from "@/lib/types";
 
@@ -22,9 +22,7 @@ type Props = {
   familiars: Familiar[];
   /** Resolved roster (cave overrides applied) — drives the master list + tab bodies. */
   resolved: ResolvedFamiliar[];
-  /** Opens the summoning circle. Renders as a dashed invitation chip riding the
-   *  end of the familiar picker — the create action lives with the roster it
-   *  extends instead of floating above the panel. */
+  /** Opens the summoning circle from the familiar picker's fixed footer. */
   onSummon?: () => void;
   /** Re-fetch the roster after the Lifecycle tab removes/restores a familiar. */
   onRosterChanged?: () => void;
@@ -101,61 +99,12 @@ export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRos
       className="familiar-studio-inline"
       style={familiar ? ({ ["--familiar-accent"]: familiar.color } as CSSProperties) : undefined}
     >
-      <div className="familiar-studio-inline__selector">
-        <span className="familiar-studio-inline__selector-label" id="settings-familiar-picker-label">
-          Familiar
-        </span>
-        <div className="familiar-studio-inline__picker-row">
-          <div
-            className="familiar-studio-inline__picker"
-            role="radiogroup"
-            aria-label="Choose familiar to edit"
-            aria-labelledby="settings-familiar-picker-label"
-          >
-            {resolved.map((f) => {
-              const active = f.id === familiar?.id;
-              return (
-                <button
-                  key={f.id}
-                  type="button"
-                  role="radio"
-                  aria-checked={active}
-                  onClick={() => openFamiliarStudio(f.id, activeTab)}
-                  className="familiar-studio-inline__chip"
-                  data-active={active ? "true" : undefined}
-                  style={{ ["--chip-accent"]: f.color } as CSSProperties}
-                  title={f.role ? `${f.display_name} — ${f.role}` : f.display_name}
-                >
-                  <FamiliarAvatar familiar={f} size="md" />
-                  <span className="familiar-studio-inline__chip-text">
-                    <span className="familiar-studio-inline__chip-name">{f.display_name}</span>
-                    {f.role ? <span className="familiar-studio-inline__chip-role">{f.role}</span> : null}
-                  </span>
-                </button>
-              );
-            })}
-            {/* Summon rides the roster it extends — a dashed invitation chip
-                (outside the radiogroup semantics: it creates, not selects). */}
-            {onSummon ? (
-              <button
-                type="button"
-                onClick={onSummon}
-                className="familiar-studio-inline__chip familiar-studio-inline__chip--summon"
-                title="Summon a new familiar"
-                aria-label="Summon a new familiar"
-              >
-                <span className="familiar-studio-inline__summon-glyph" aria-hidden>
-                  <Icon name="ph:magic-wand-fill" width={14} />
-                </span>
-                <span className="familiar-studio-inline__chip-text">
-                  <span className="familiar-studio-inline__chip-name">Summon</span>
-                  <span className="familiar-studio-inline__chip-role">New familiar</span>
-                </span>
-              </button>
-            ) : null}
-          </div>
-        </div>
-      </div>
+      <SettingsFamiliarPicker
+        familiars={resolved}
+        value={activeFamiliarId}
+        onChange={(id) => openFamiliarStudio(id, activeTab)}
+        onSummon={onSummon}
+      />
 
       <div className="familiar-studio-inline__detail">
         {familiar ? (

--- a/src/components/settings-familiar-picker.tsx
+++ b/src/components/settings-familiar-picker.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+} from "react";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { Popover } from "@/components/ui/popover";
+import { Icon } from "@/lib/icon";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import {
+  familiarRosterCountLabel,
+  filterSettingsFamiliars,
+  moveFamiliarPickerIndex,
+} from "@/lib/settings-familiar-picker";
+
+type Props = {
+  familiars: ResolvedFamiliar[];
+  value: string | null;
+  onChange: (id: string) => void;
+  onSummon?: () => void;
+};
+
+const LISTBOX_ID = "settings-familiar-picker-listbox";
+const OPTION_ID_PREFIX = "settings-familiar-picker-option-";
+
+function optionId(index: number): string {
+  return OPTION_ID_PREFIX + index;
+}
+
+export function SettingsFamiliarPicker({ familiars, value, onChange, onSummon }: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const active = useMemo(
+    () => familiars.find((familiar) => familiar.id === value) ?? null,
+    [familiars, value],
+  );
+  const filtered = useMemo(
+    () => filterSettingsFamiliars(familiars, query),
+    [familiars, query],
+  );
+  const rosterCount = familiarRosterCountLabel(familiars.length);
+
+  const resetAndClose = () => {
+    setOpen(false);
+    setQuery("");
+    setHighlightedIndex(-1);
+  };
+
+  const updateOpen = (next: boolean) => {
+    if (!next) {
+      resetAndClose();
+      return;
+    }
+    setQuery("");
+    const selectedIndex = familiars.findIndex((familiar) => familiar.id === value);
+    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : familiars.length > 0 ? 0 : -1);
+    setOpen(true);
+  };
+
+  const selectFamiliar = (id: string) => {
+    onChange(id);
+    resetAndClose();
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    searchRef.current?.focus({ preventScroll: true });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlightedIndex((current) => {
+      if (filtered.length === 0) return -1;
+      if (current < 0) return 0;
+      return Math.min(current, filtered.length - 1);
+    });
+  }, [filtered.length, open]);
+
+  useEffect(() => {
+    if (!open || highlightedIndex < 0) return;
+    optionRefs.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [filtered, highlightedIndex, open]);
+
+  const handleQueryChange = (nextQuery: string) => {
+    setQuery(nextQuery);
+    const nextFiltered = filterSettingsFamiliars(familiars, nextQuery);
+    const selectedIndex = nextFiltered.findIndex((familiar) => familiar.id === value);
+    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : nextFiltered.length > 0 ? 0 : -1);
+  };
+
+  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const key = event.key;
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((current) =>
+        moveFamiliarPickerIndex(current, key, filtered.length),
+      );
+      return;
+    }
+    if (event.key === "Enter") {
+      const familiar = filtered[highlightedIndex];
+      if (!familiar) return;
+      event.preventDefault();
+      selectFamiliar(familiar.id);
+    }
+  };
+
+  const activeDescendant =
+    highlightedIndex >= 0 && filtered[highlightedIndex]
+      ? optionId(highlightedIndex)
+      : undefined;
+  const triggerLabel = active
+    ? "Choose familiar to edit. Current: " + active.display_name + ". " + rosterCount + "."
+    : "Choose familiar to edit. " + rosterCount + ".";
+  const resultSummary = query.trim()
+    ? filtered.length + " of " + rosterCount
+    : rosterCount;
+
+  return (
+    <div className="familiar-studio-inline__selector">
+      <span className="familiar-studio-inline__selector-label" id="settings-familiar-picker-label">
+        Familiar
+      </span>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="familiar-studio-picker__trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={triggerLabel}
+        onClick={() => updateOpen(!open)}
+        style={
+          active
+            ? ({ ["--familiar-accent"]: active.color } as CSSProperties)
+            : undefined
+        }
+      >
+        <span className="familiar-studio-picker__trigger-avatar" aria-hidden>
+          {active ? (
+            <FamiliarAvatar familiar={active} size="md" />
+          ) : (
+            <Icon name="ph:sparkle" width={16} />
+          )}
+        </span>
+        <span className="familiar-studio-picker__trigger-copy">
+          <span className="familiar-studio-picker__trigger-name">
+            {active?.display_name ?? "Select a familiar"}
+          </span>
+          <span className="familiar-studio-picker__trigger-role">
+            {active?.role || active?.id || "Choose who to edit"}
+          </span>
+        </span>
+        <span className="familiar-studio-picker__trigger-count">{rosterCount}</span>
+        <Icon
+          name="ph:caret-up-down-bold"
+          width={12}
+          className="familiar-studio-picker__trigger-caret"
+          aria-hidden
+        />
+      </button>
+
+      <Popover
+        open={open}
+        onOpenChange={updateOpen}
+        anchorRef={triggerRef}
+        placement="bottom-start"
+        minWidth={240}
+        scrollStrategy="content"
+        compactAtHeight={184}
+        className="familiar-studio-picker__popover"
+        ariaLabel="Choose familiar to edit"
+      >
+        <div className="familiar-studio-picker">
+          <div className="familiar-studio-picker__search-shell">
+            <Icon name="ph:magnifying-glass" width={14} aria-hidden />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(event) => handleQueryChange(event.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              role="combobox"
+              aria-label="Search familiars"
+              aria-expanded={open}
+              aria-autocomplete="list"
+              aria-controls={LISTBOX_ID}
+              aria-activedescendant={activeDescendant}
+              autoComplete="off"
+              placeholder="Search name, role, or ID…"
+              className="familiar-studio-picker__search"
+            />
+          </div>
+          <div className="familiar-studio-picker__result-summary" aria-live="polite">
+            {resultSummary}
+          </div>
+
+          <ul
+            id={LISTBOX_ID}
+            className="familiar-studio-picker__results"
+            role="listbox"
+            aria-label="Familiars"
+          >
+            {filtered.map((familiar, index) => {
+              const selected = familiar.id === value;
+              const highlighted = index === highlightedIndex;
+              return (
+                <li key={familiar.id} role="presentation">
+                  <button
+                    ref={(node) => {
+                      optionRefs.current[index] = node;
+                    }}
+                    id={optionId(index)}
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    tabIndex={-1}
+                    data-selected={selected || undefined}
+                    data-highlighted={highlighted || undefined}
+                    className="familiar-studio-picker__option"
+                    style={{ ["--familiar-accent"]: familiar.color } as CSSProperties}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                    onClick={() => selectFamiliar(familiar.id)}
+                    title={familiar.display_name + " — " + (familiar.role || familiar.id)}
+                  >
+                    <span className="familiar-studio-picker__option-avatar" aria-hidden>
+                      <FamiliarAvatar familiar={familiar} size="sm" />
+                    </span>
+                    <span className="familiar-studio-picker__option-copy">
+                      <span className="familiar-studio-picker__option-name">
+                        {familiar.display_name}
+                      </span>
+                      <span className="familiar-studio-picker__option-meta">
+                        {familiar.role ? familiar.role + " · " : ""}
+                        <span>{familiar.id}</span>
+                      </span>
+                    </span>
+                    {selected ? <Icon name="ph:check-bold" width={13} aria-hidden /> : null}
+                  </button>
+                </li>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <li className="familiar-studio-picker__empty" role="presentation">
+                No familiars match “{query.trim()}”.
+              </li>
+            ) : null}
+          </ul>
+
+          {onSummon ? (
+            <div className="familiar-studio-picker__footer">
+              <button
+                type="button"
+                className="familiar-studio-picker__summon"
+                onClick={() => {
+                  resetAndClose();
+                  onSummon();
+                }}
+              >
+                <Icon name="ph:magic-wand-fill" width={14} aria-hidden />
+                Summon familiar
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -933,8 +933,8 @@ function FamiliarsSection({
 
   return (
     <>
-      {/* Summon lives inside the panel's familiar picker (dashed invitation
-          chip at the roster's end) — no floating action above the card. */}
+      {/* Summon lives in the familiar picker's fixed footer, alongside the
+          roster it extends instead of floating above the Studio. */}
       <FamiliarStudioInlinePanel
         familiars={rawFamiliars}
         resolved={familiars}

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -21,6 +21,30 @@ assert.match(src, /spaceBelow|spaceAbove/, "compares room below vs above the anc
 assert.match(src, /Math\.min\(r\.left/, "clamps the left edge within the viewport");
 assert.match(src, /maxHeight/, "caps height (with overflowY:auto) so neither side overflows");
 
+// Complex pickers can keep their own header/footer fixed and give scrolling to
+// an inner results region. That must be opt-in so existing simple menus retain
+// the shared popover's default outer scrolling behavior.
+assert.match(
+  src,
+  /scrollStrategy\?: "popover" \| "content"/,
+  "popover exposes an opt-in inner-content scrolling strategy",
+);
+assert.match(
+  src,
+  /scrollStrategy === "content" \? "hidden" : "auto"/,
+  "content-owned scrolling disables the outer popover scroll container",
+);
+assert.match(
+  src,
+  /compactAtHeight\?: number/,
+  "composite children can react to the popover's computed visual-viewport height",
+);
+assert.match(
+  src,
+  /data-compact=\{compact \|\| undefined\}/,
+  "the popover exposes its computed compact state to descendant CSS",
+);
+
 // Visual-viewport awareness: the on-screen keyboard (iOS) shrinks the visible band
 // without changing window.innerHeight. The popover must measure against
 // window.visualViewport so it clamps inside the visible area instead of hiding

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -23,6 +23,17 @@ export type PopoverProps = {
   offset?: number;
   /** Optional minimum width override; defaults to anchor width. */
   minWidth?: number;
+  /**
+   * Which layer owns vertical scrolling when content exceeds the available
+   * viewport height. "popover" preserves the simple-menu default; "content"
+   * lets a composite child keep its own header/footer fixed around a scroller.
+   */
+  scrollStrategy?: "popover" | "content";
+  /**
+   * Adds data-compact when the visual-viewport-aware available height is at or
+   * below this pixel threshold, so composite children can tighten fixed chrome.
+   */
+  compactAtHeight?: number;
   className?: string;
   /** Accessible name for the dialog. role="dialog" requires a name; without one
    *  screen readers announce the popover with no title. */
@@ -42,12 +53,15 @@ export function Popover({
   placement = "bottom-start",
   offset = 6,
   minWidth,
+  scrollStrategy = "popover",
+  compactAtHeight,
   className,
   ariaLabel,
   children,
 }: PopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [style, setStyle] = useState<CSSProperties>({});
+  const [compact, setCompact] = useState(false);
 
   const compute = useCallback(() => {
     const a = anchorRef.current;
@@ -83,14 +97,19 @@ export function Popover({
       : popH > spaceBelow && spaceAbove > spaceBelow;
     const isEnd = placement.endsWith("end");
 
+    const availableHeight = Math.round(
+      Math.max(Math.min(isTop ? spaceAbove : spaceBelow, viewH - 2 * MARGIN), 120),
+    );
+    setCompact(compactAtHeight !== undefined && availableHeight <= compactAtHeight);
+
     const next: CSSProperties = {
       position: "absolute",
       minWidth: minWidth ?? r.width,
       // Never exceed the chosen side's visible space; scroll inside if it must. Floor
       // low (120px) rather than 160 so a keyboard-shrunk viewport still clamps inside
       // the visible band instead of disappearing under the keyboard.
-      maxHeight: `${Math.round(Math.max(Math.min(isTop ? spaceAbove : spaceBelow, viewH - 2 * MARGIN), 120))}px`,
-      overflowY: "auto",
+      maxHeight: `${availableHeight}px`,
+      overflowY: scrollStrategy === "content" ? "hidden" : "auto",
     };
     if (isTop) {
       next.bottom = window.innerHeight - r.top + offset;
@@ -104,7 +123,7 @@ export function Popover({
       next.left = Math.max(MARGIN, Math.min(r.left, viewLeft + viewW - popW - MARGIN));
     }
     setStyle(next);
-  }, [anchorRef, placement, offset, minWidth]);
+  }, [anchorRef, placement, offset, minWidth, scrollStrategy, compactAtHeight]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -176,6 +195,7 @@ export function Popover({
         // "dialog" never floats astray while Tab walks the page behind it.
         role="dialog"
         aria-label={ariaLabel}
+        data-compact={compact || undefined}
         tabIndex={-1}
         onBlur={(e) => {
           const next = e.relatedTarget as Node | null;

--- a/src/lib/settings-familiar-picker.test.ts
+++ b/src/lib/settings-familiar-picker.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  familiarRosterCountLabel,
+  filterSettingsFamiliars,
+  moveFamiliarPickerIndex,
+  type SettingsFamiliarSearchItem,
+} from "./settings-familiar-picker.ts";
+
+const roster: SettingsFamiliarSearchItem[] = [
+  { id: "sage-main", display_name: "Sage", role: "Code review" },
+  { id: "nova-research", display_name: "Nova", role: "Research" },
+  { id: "cody-build", display_name: "Cody", role: "Build engineer" },
+];
+
+test("an empty query preserves daemon roster order", () => {
+  assert.deepEqual(
+    filterSettingsFamiliars(roster, "   ").map((familiar) => familiar.id),
+    ["sage-main", "nova-research", "cody-build"],
+  );
+});
+
+test("search is case-insensitive across display name, role, and id", () => {
+  assert.deepEqual(filterSettingsFamiliars(roster, "SAGE").map((familiar) => familiar.id), ["sage-main"]);
+  assert.deepEqual(filterSettingsFamiliars(roster, "research").map((familiar) => familiar.id), ["nova-research"]);
+  assert.deepEqual(filterSettingsFamiliars(roster, "CODY-BUILD").map((familiar) => familiar.id), ["cody-build"]);
+});
+
+test("every query token can match a different familiar field", () => {
+  assert.deepEqual(
+    filterSettingsFamiliars(roster, "sage review main").map((familiar) => familiar.id),
+    ["sage-main"],
+  );
+});
+
+test("filtering a large roster stays ordered and finds a stable id", () => {
+  const largeRoster: SettingsFamiliarSearchItem[] = Array.from({ length: 250 }, (_, index) => ({
+    id: `familiar-${index}`,
+    display_name: `Familiar ${index}`,
+    role: index % 10 === 0 ? "Release wrangler" : "Generalist",
+  }));
+
+  assert.deepEqual(
+    filterSettingsFamiliars(largeRoster, "release familiar-240").map((familiar) => familiar.id),
+    ["familiar-240"],
+  );
+  assert.deepEqual(
+    filterSettingsFamiliars(largeRoster, "release").slice(0, 4).map((familiar) => familiar.id),
+    ["familiar-0", "familiar-10", "familiar-20", "familiar-30"],
+  );
+});
+
+test("roster count copy uses singular only for one familiar", () => {
+  assert.equal(familiarRosterCountLabel(0), "0 familiars");
+  assert.equal(familiarRosterCountLabel(1), "1 familiar");
+  assert.equal(familiarRosterCountLabel(250), "250 familiars");
+});
+
+test("arrow navigation has no highlight when there are no results", () => {
+  assert.equal(moveFamiliarPickerIndex(-1, "ArrowDown", 0), -1);
+  assert.equal(moveFamiliarPickerIndex(0, "ArrowUp", 0), -1);
+});
+
+test("arrow navigation starts at an edge and wraps across the result list", () => {
+  assert.equal(moveFamiliarPickerIndex(-1, "ArrowDown", 3), 0);
+  assert.equal(moveFamiliarPickerIndex(-1, "ArrowUp", 3), 2);
+  assert.equal(moveFamiliarPickerIndex(2, "ArrowDown", 3), 0);
+  assert.equal(moveFamiliarPickerIndex(0, "ArrowUp", 3), 2);
+  assert.equal(moveFamiliarPickerIndex(1, "ArrowDown", 3), 2);
+});
+

--- a/src/lib/settings-familiar-picker.ts
+++ b/src/lib/settings-familiar-picker.ts
@@ -1,0 +1,36 @@
+export type SettingsFamiliarSearchItem = {
+  id: string;
+  display_name: string;
+  role?: string | null;
+};
+
+export function filterSettingsFamiliars<T extends SettingsFamiliarSearchItem>(
+  familiars: readonly T[],
+  query: string,
+): T[] {
+  const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [...familiars];
+
+  return familiars.filter((familiar) => {
+    const searchable = [familiar.id, familiar.display_name, familiar.role ?? ""]
+      .join(" ")
+      .toLocaleLowerCase();
+    return tokens.every((token) => searchable.includes(token));
+  });
+}
+
+export function familiarRosterCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "familiar" : "familiars"}`;
+}
+
+export function moveFamiliarPickerIndex(
+  current: number,
+  key: "ArrowDown" | "ArrowUp",
+  count: number,
+): number {
+  if (count <= 0) return -1;
+  if (key === "ArrowDown") {
+    return current < 0 || current >= count - 1 ? 0 : current + 1;
+  }
+  return current <= 0 || current >= count ? count - 1 : current - 1;
+}

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const FAMILIARS = Array.from({ length: 60 }, (_, index) => ({
+  id: `familiar-${String(index + 1).padStart(2, "0")}`,
+  display_name: `Familiar ${String(index + 1).padStart(2, "0")}`,
+  role: index % 2 === 0 ? "Builder" : "Researcher",
+  color: index % 2 === 0 ? "#8b7cf6" : "#57b8a6",
+  icon: index % 2 === 0 ? "ph:sparkle-fill" : "ph:owl-fill",
+  status: "active",
+}));
+
+async function gotoFamiliarSettings(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars", (route) =>
+    route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
+  );
+  await page.goto("/settings#familiars");
+  await expect(page.locator(".familiar-studio-picker__trigger")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+async function emulateVisualViewport(page: Page, width: number, height: number) {
+  await page.addInitScript(
+    ({ visualWidth, visualHeight }) => {
+      const viewport = Object.assign(new EventTarget(), {
+        width: visualWidth,
+        height: visualHeight,
+        offsetTop: 0,
+        offsetLeft: 0,
+        pageTop: 0,
+        pageLeft: 0,
+        scale: 1,
+      });
+      Object.defineProperty(window, "visualViewport", {
+        configurable: true,
+        value: viewport,
+      });
+    },
+    { visualWidth: width, visualHeight: height },
+  );
+}
+
+async function expectContained(inner: Locator, outer: Locator) {
+  const [innerBox, outerBox] = await Promise.all([
+    inner.boundingBox(),
+    outer.boundingBox(),
+  ]);
+  expect(innerBox, "inner control has layout bounds").not.toBeNull();
+  expect(outerBox, "popover has layout bounds").not.toBeNull();
+  expect(innerBox!.y, "control top stays inside the popover").toBeGreaterThanOrEqual(
+    outerBox!.y - 1,
+  );
+  expect(
+    innerBox!.y + innerBox!.height,
+    "control bottom stays inside the popover",
+  ).toBeLessThanOrEqual(outerBox!.y + outerBox!.height + 1);
+}
+
+test("a keyboard-shrunk visual viewport keeps fixed controls and one full result", async ({ page }) => {
+  // Mobile keyboards can shrink visualViewport without changing the CSS layout
+  // viewport. Keep the latter tall so a max-height media query cannot make this
+  // pass accidentally; Popover must propagate its computed available height.
+  await page.setViewportSize({ width: 390, height: 720 });
+  // 270px puts both sides of the anchor below Popover's 120px safety floor.
+  await emulateVisualViewport(page, 390, 270);
+  await gotoFamiliarSettings(page);
+
+  await page.locator(".familiar-studio-picker__trigger").click();
+  const popover = page.locator(".familiar-studio-picker__popover");
+  const search = page.getByRole("combobox", { name: "Search familiars" });
+  const summon = page.getByRole("button", { name: "Summon familiar" });
+  const results = page.getByRole("listbox", { name: "Familiars" });
+  await expect(popover).toBeVisible();
+  await expect.poll(() => popover.evaluate((element) => element.style.maxHeight)).toBe("120px");
+
+  await expectContained(search, popover);
+  await expectContained(summon, popover);
+
+  // Wrapping from the first result to the last scrolls the result list. It must
+  // not scroll the containing dialog and carry the still-focused search field
+  // out of view (the failure mode seen with mobile keyboards / short windows).
+  await search.press("ArrowUp");
+  await expect(search).toBeFocused();
+  await expect(search).toHaveAttribute(
+    "aria-activedescendant",
+    "settings-familiar-picker-option-59",
+  );
+  await expectContained(search, popover);
+  await expectContained(summon, popover);
+  const highlighted = page.locator(".familiar-studio-picker__option[data-highlighted]");
+  await expect(highlighted).toContainText("Familiar 60");
+  const resultsBox = await results.boundingBox();
+  expect(resultsBox, "the result scroller has layout bounds").not.toBeNull();
+  expect(resultsBox!.height, "the exact floor preserves a full 44px option").toBeGreaterThanOrEqual(44);
+  await expectContained(highlighted, results);
+
+  const scrollState = await popover.evaluate((element) => ({
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+  }));
+  expect(scrollState.scrollTop, "the outer dialog must stay fixed").toBe(0);
+  expect(
+    scrollState.scrollHeight - scrollState.clientHeight,
+    "the outer dialog itself must not be the scrolling region",
+  ).toBeLessThanOrEqual(1);
+});
+
+test("a 60-familiar roster stays compact, searchable, and keyboard-selectable", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await gotoFamiliarSettings(page);
+
+  const trigger = page.locator(".familiar-studio-picker__trigger");
+  await expect(trigger).toContainText("60 familiars");
+  const triggerBox = await trigger.boundingBox();
+  expect(triggerBox, "the familiar trigger has layout bounds").not.toBeNull();
+  expect(triggerBox!.height, "roster size must not grow the Settings header").toBeLessThanOrEqual(50);
+
+  await trigger.click();
+  const results = page.getByRole("listbox", { name: "Familiars" });
+  await expect(results.getByRole("option")).toHaveCount(60);
+  const resultsScroll = await results.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(resultsScroll.clientHeight, "the roster has a bounded viewport").toBeLessThanOrEqual(320);
+  expect(resultsScroll.scrollHeight, "large rosters scroll inside the popup").toBeGreaterThan(
+    resultsScroll.clientHeight,
+  );
+
+  const search = page.getByRole("combobox", { name: "Search familiars" });
+  await search.fill("Researcher familiar-60");
+  const match = results.getByRole("option");
+  await expect(match).toHaveCount(1);
+  await expect(match).toContainText("Familiar 60");
+  await expect(match).toContainText("Researcher");
+  await expect(match).toContainText("familiar-60");
+
+  await search.press("Enter");
+  await expect(page.locator(".familiar-studio-picker__popover")).toHaveCount(0);
+  await expect(trigger).toContainText("Familiar 60");
+});


### PR DESCRIPTION
Lands the `feat/settings-familiar-picker-scale` WIP branch (triaged from cave cleanup — clean rebase, fully tested).

## What
A dedicated **settings familiar picker** surface with a scalable grid, extracted out of the inline `familiar-studio` path so the picker can grow independently. Includes popover refinements it depends on.

## Files
- `src/lib/settings-familiar-picker.ts` (+ tests, 7/7 pass)
- `src/components/settings-familiar-picker.tsx` (278 lines)
- `src/components/familiar-studio-inline.tsx` — slimmed (picker logic extracted)
- `src/components/ui/popover.tsx` — refinements (+ tests)
- `tests/settings-familiar-picker.spec.ts` — Playwright coverage
- `src/app/globals.css` — picker grid styles

## Verification
- `settings-familiar-picker.test.ts` 7/7 ✅ · `familiar-studio-inline.test.ts` ✅ · `popover.test.ts` ✅
- `check-tests-wired.mjs` ✅ (807 files) · `tsc --noEmit` ✅
- Clean rebase onto current main (no conflicts).