### PR TITLE
fix(test): drop no-op replace in browser-polish.test.ts

### DIFF
--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -233,7 +233,7 @@ assert.match(pane, /const navigationArgs = withNativeBrowserSequence\([\s\S]{0,5
 for (const command of ["browser_set_bounds", "browser_hide", "browser_close", "browser_deactivate_all", "browser_reload"]) {
   assert.match(
     pane + nativeLifecycle,
-    new RegExp(`${command.replace("_", "_")}[\\s\\S]{0,220}withNativeBrowserSequence|withNativeBrowserSequence[\\s\\S]{0,220}${command}`),
+    new RegExp(`${command}[\\s\\S]{0,220}withNativeBrowserSequence|withNativeBrowserSequence[\\s\\S]{0,220}${command}`),
     `${command} includes a lifecycle sequence`,
   );
 }


### PR DESCRIPTION
Re-home of #2953 (the Copilot-authored branch was gated behind bot-run approval, so CI never ran the required checks).

CodeQL flagged `command.replace("_", "_")` as a useless string replacement — it replaces `_` with `_`. The `command` tokens are used verbatim in the lifecycle-sequence regex, so this just interpolates `${command}` directly. Pure no-op cleanup, zero behavior change.

Verified: `browser-polish.test.ts` passes locally.

Closes #2953.