### PR TITLE
fix(chat): repair main typecheck (chatSummaryTitle) + Windows boundary-sentinel coverage

### DIFF
--- a/src/lib/cave-chat-titles.test.ts
+++ b/src/lib/cave-chat-titles.test.ts
@@ -1,10 +1,13 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import {
+  chatSummaryTitle,
   defaultChatTitleForSession,
   disambiguateSessionTitles,
+  MAX_SUMMARY_TITLE_LENGTH,
   mergeSessionTitleOverrides,
   normalizeChatTitle,
+  titleFromAssistantReply,
 } from "./cave-chat-titles.ts";
 
 const sessions = [
@@ -56,6 +59,53 @@ assert.deepEqual(
   ]);
   assert.equal(map.get("x"), "New chat", "no time => no suffix, no crash");
   assert.equal(map.get("y"), "New chat");
+}
+
+// chatSummaryTitle — auto-naming threads from the first exchange.
+{
+  // Short prompts pass through filler-cleaned, already title-shaped.
+  assert.equal(
+    chatSummaryTitle({ userText: "please fix the search bar" }),
+    "Fix the search bar",
+  );
+  // Long prompts fall back to an opening assistant heading when one exists.
+  const longAsk =
+    "I have been thinking about how our retry policy interacts with the queue " +
+    "backoff settings and I want to understand what the best configuration is " +
+    "for high-throughput consumers under sustained load";
+  assert.equal(
+    chatSummaryTitle({
+      userText: longAsk,
+      assistantText: "## Retry policy vs queue backoff\n\nHere is how they interact…",
+    }),
+    "Retry policy vs queue backoff",
+  );
+  // No usable heading → question lead-in stripped + word-boundary clamp.
+  const noHeading = chatSummaryTitle({
+    userText: "what's the best way to configure retry backoff for high-throughput queue consumers under sustained load",
+    assistantText: "They interact in a few ways.",
+  });
+  assert.ok(noHeading.length <= MAX_SUMMARY_TITLE_LENGTH, "clamped to summary length");
+  assert.match(noHeading, /^Best way to configure retry backoff/, "lead-in stripped, capitalized");
+  // Nothing meaningful → null (caller keeps the current title).
+  assert.equal(chatSummaryTitle({ userText: "   ", assistantText: "" }), null);
+  assert.equal(chatSummaryTitle({}), null);
+}
+
+// titleFromAssistantReply — only clean, early, plausible headings count.
+{
+  assert.equal(
+    titleFromAssistantReply("# **Fixing the parser** 🎉\nbody"),
+    "Fixing the parser",
+    "markdown syntax and edge emoji stripped",
+  );
+  assert.equal(titleFromAssistantReply("no headings here\njust text"), null);
+  assert.equal(
+    titleFromAssistantReply("line one\nline two\nline three\n# Too late"),
+    null,
+    "headings after the opening lines are ignored",
+  );
+  assert.equal(titleFromAssistantReply(null), null);
 }
 
 console.log("cave-chat-titles.test.ts ok");

--- a/src/lib/cave-chat-titles.ts
+++ b/src/lib/cave-chat-titles.ts
@@ -70,6 +70,69 @@ export function chatTitleFromPrompt(prompt: string | null | undefined): string |
   return `${trimmed.trimEnd()}…`;
 }
 
+// --- Auto-naming: short summary titles -------------------------------------
+
+export const MAX_SUMMARY_TITLE_LENGTH = 48;
+
+// Question/request lead-ins that frame a topic without being part of it.
+// Stripped once from the front of an already filler-cleaned prompt so
+// "What's the best way to cache sessions" → "Best way to cache sessions".
+// Anchored and conservative — if stripping leaves nothing meaningful the
+// caller keeps the unstripped text.
+const QUESTION_LEAD_IN_RE =
+  /^(?:what(?:['’]s| is| are)(?: the)?|how (?:do|can|would|should) (?:i|we|you)|how to|why (?:is|are|does|do|did)|where (?:is|are|can|do)|when (?:is|are|does|do|should)|who (?:is|are)|is there (?:a|any) way to|tell me about|explain(?: to me)?|show me(?: how to)?)\b[\s,:;\-–—]*/i;
+
+function clampAtWordBoundary(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  const slice = text.slice(0, maxLen - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const trimmed = lastSpace >= maxLen * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${trimmed.trimEnd().replace(/[,;:\-–—]$/, "")}…`;
+}
+
+/** First markdown heading (h1–h3) in the opening lines of an assistant reply,
+ *  cleaned of markdown syntax and edge emoji. Assistant headings are often a
+ *  genuine summary of a long ask ("# Retry policy options"). Null when the
+ *  reply doesn't open with a usable heading. */
+export function titleFromAssistantReply(assistantText: string | null | undefined): string | null {
+  if (typeof assistantText !== "string") return null;
+  const lines = assistantText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+  for (const line of lines) {
+    const match = /^#{1,3}\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const cleaned = stripLeadingTrailingEmoji(match[1].replace(/[*_`#]+/g, "").trim());
+    if (cleaned.length >= 3 && cleaned.length <= 80) {
+      return clampAtWordBoundary(cleaned, MAX_SUMMARY_TITLE_LENGTH);
+    }
+  }
+  return null;
+}
+
+/** Short summary title for a chat thread, derived from its first exchange.
+ *  Pure heuristic (no model call, matching the prompt-enhancer convention):
+ *  the filler-cleaned user prompt when it already fits; otherwise an opening
+ *  assistant heading when one exists; otherwise the cleaned prompt with its
+ *  question lead-in stripped, clamped at a word boundary. Null when nothing
+ *  meaningful can be derived — callers keep their current title. */
+export function chatSummaryTitle(input: {
+  userText?: string | null;
+  assistantText?: string | null;
+}): string | null {
+  const normalized = normalizeChatTitle(input.userText);
+  const cleaned = normalized ? cleanPromptForTitle(normalized) : null;
+  if (cleaned && cleaned.length <= MAX_SUMMARY_TITLE_LENGTH) return cleaned;
+  const fromReply = titleFromAssistantReply(input.assistantText);
+  if (fromReply) return fromReply;
+  if (!cleaned) return null;
+  const stripped = cleaned.replace(QUESTION_LEAD_IN_RE, "").trim();
+  const topic = stripped.length >= 3 ? stripped.charAt(0).toUpperCase() + stripped.slice(1) : cleaned;
+  return clampAtWordBoundary(topic, MAX_SUMMARY_TITLE_LENGTH);
+}
+
 // Matches the current header ("Coven identity canon:") and legacy variants
 // with a parenthetical before the colon ("Coven identity canon (binding):"),
 // which ~17 historical sessions still carry. A colon-less title like

--- a/src/lib/chat-boundary-sentinel.test.ts
+++ b/src/lib/chat-boundary-sentinel.test.ts
@@ -138,6 +138,34 @@ const makeSentinel = () =>
   );
 }
 
+// Windows path forms: drive-letter tokens in command strings and `~\`
+// expansion. Classification of these is meaningful only where the platform
+// path module is win32 (the sentinel guards the host the server runs on),
+// so the positive assertions run on Windows and POSIX asserts inertness.
+if (process.platform === "win32") {
+  const s = makeSentinel();
+  const foreignWin = path.join(home, "winproj", "secret.txt");
+  s.observe("Bash", { command: `type ${foreignWin}` }); // C:\… token in a command
+  s.observe("Bash", { command: "dir ~\\winother\\cfg" }); // ~\ expansion
+  const paths = s.violations().map((v) => v.path);
+  assert.ok(
+    paths.includes(path.resolve(foreignWin)),
+    `drive-letter command tokens classify on Windows: ${paths.join(", ")}`,
+  );
+  assert.ok(
+    paths.includes(path.join(home, "winother", "cfg")),
+    `~\\ tokens expand against home on Windows: ${paths.join(", ")}`,
+  );
+} else {
+  const s = makeSentinel();
+  s.observe("Bash", { command: "run C:\\Other\\place && dir C:/Other/too" });
+  assert.deepEqual(
+    s.violations(),
+    [],
+    "drive-letter tokens are inert on POSIX hosts (not absolute paths there)",
+  );
+}
+
 // Classification never throws on hostile input.
 {
   const s = makeSentinel();

--- a/src/lib/chat-boundary-sentinel.ts
+++ b/src/lib/chat-boundary-sentinel.ts
@@ -51,9 +51,13 @@ type SentinelOptions = {
 const MAX_VIOLATIONS = 8;
 
 /** Absolute-path tokens inside command strings / serialized payloads.
- *  Accepts `~/…` (expanded against home) and `/…`; stops at whitespace,
- *  quotes, and shell metacharacters. */
-const PATH_TOKEN_RE = /(?:^|[\s"'`=(:,[{])(~\/[^\s"'`;|&<>)\]}]+|\/[^\s"'`;|&<>)\]}]+)/g;
+ *  Accepts `~/…` / `~\…` (expanded against home), drive-letter paths
+ *  (`C:\…`, `C:/…`), and `/…`; stops at whitespace, quotes, and shell
+ *  metacharacters. Drive-letter tokens only classify on Windows hosts —
+ *  `path.isAbsolute` rejects them under POSIX, which is correct because the
+ *  sentinel guards the host the server runs on. */
+const PATH_TOKEN_RE =
+  /(?:^|[\s"'`=(:,[{])(~[\\/][^\s"'`;|&<>)\]}]+|[A-Za-z]:[\\/][^\s"'`;|&<>)\]}]+|\/[^\s"'`;|&<>)\]}]+)/g;
 
 /** Input keys that carry a single filesystem path verbatim. */
 const PATH_KEY_RE = /^(?:file_?path|path|notebook_?path|target_?file|cwd|directory|dir|filename)$/i;
@@ -100,7 +104,10 @@ export function createBoundarySentinel(options: SentinelOptions): BoundarySentin
 
   const classify = (tool: string, rawPath: string) => {
     if (found.length >= MAX_VIOLATIONS) return;
-    const expanded = rawPath.startsWith("~/") ? path.join(home, rawPath.slice(2)) : rawPath;
+    const expanded =
+      rawPath.startsWith("~/") || rawPath.startsWith("~\\")
+        ? path.join(home, rawPath.slice(2))
+        : rawPath;
     if (!path.isAbsolute(expanded)) return;
     const candidate = normalizeRoot(trimPathToken(expanded));
     // Bare "/" and single-segment roots ("/usr") are never user data.


### PR DESCRIPTION
## Summary

Repairs `main` after #2949 squash-merged red, and lands the Windows review follow-ups from that PR's open Copilot threads.

**Build repair:** `src/app/api/chat/send/route.ts` (merged in #2949) imports `chatSummaryTitle` from `@/lib/cave-chat-titles`, but the helper never made it into the split — `pnpm typecheck` fails on `main` right now (TS2305), which is why #2949's `Frontend build` and all three `Sidecar runtime` jobs were red at merge time. This PR ships the helper and its tests.

**Review follow-ups (from #2949's unresolved threads):**
- `PATH_TOKEN_RE` now matches drive-letter tokens (`C:\…`, `C:/…`) and `~\` alongside `~/` and `/…`, so command strings observed on Windows hosts get the same boundary coverage. Drive tokens stay inert on POSIX hosts, where `path.isAbsolute` rejects them — the sentinel guards the host the server runs on.
- `~` expansion handles `~\` as well as `~/`.
- Tests: win32-gated positive coverage for both forms (exercised by the `Cross-environment (windows-latest)` job); POSIX asserts drive tokens never flag.

## Verification

- `pnpm typecheck` — 0 (fails on current `main`)
- `pnpm test:app` — 597 test files pass (pre-rebase run on identical content; re-running post-rebase locally and in CI)
- CI on this PR is the authoritative gate for `Frontend build` / `Sidecar runtime` recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
