### PR TITLE
docs: credit Windows native freeze fix contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,16 @@ improvements.
 
 ## Community Contributors
 
+### Timothy Wayne Gregg ([@romgenie](https://github.com/romgenie))
+
+Timothy diagnosed and contributed the Windows native Browser callback, focus,
+and shutdown hardening that keeps Cave controls responsive after opening links,
+isolates ConPTY startup from WebView2 callbacks, and preserves a bounded native
+close path when renderers stall. His fork contribution was re-landed through an
+origin branch for required CI and CodeQL coverage.
+(proposed in [#2962](https://github.com/OpenCoven/coven-cave/pull/2962),
+shipped in [#2963](https://github.com/OpenCoven/coven-cave/pull/2963))
+
 ### Jiachen LIU ([@AmberLJC](https://github.com/AmberLJC))
 
 Jiachen authored the two MIT-licensed research-ideation skills adapted for the


### PR DESCRIPTION
## Summary

Follow-up contributor-credit correction for #2963.

- records Timothy Wayne Gregg ([@romgenie](https://github.com/romgenie)) in `CONTRIBUTORS.md` for the substantial Windows native Browser callback/focus/shutdown fix proposed in #2962 and re-landed in #2963
- includes the repository-required numeric GitHub no-reply trailer so the human contribution is linked correctly
- does not change runtime code or the tested build

The #2963 squash commit inadvertently retained the unlinked local `Codex <codex@opencoven.local>` trailer rather than the human contributor trailer requested before merge. Git history cannot be amended on protected `main`, so this follow-up supplies the durable project credit and linked contribution.

@BunsDev please review/re-home this docs-only correction if the same fork CodeQL restriction requires an origin branch.