### PR TITLE
chore(release): stamp v0.0.176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.176] - 2026-07-11
+
+> 🪟 **Windows stability + chat robustness.** Native browser lockups and unresponsive shutdown are fixed, the send route gains a non-blocking filesystem boundary sentinel and a resilient chat-title helper, quick-chat gets a conversation cache, and mobile chat scroll anchoring is repaired.
+
+### Features
+- **Chat: conversation cache + quick-chat UX** — recently viewed conversations are cached so quick-chat and thread switches feel instant, with the composer/UX polish that shipped alongside it (#2961).
+- **Settings: scalable familiar picker** — the familiar picker scales cleanly across window sizes instead of clipping or overflowing (#2950).
+- **Cross-platform UI consistency program (Phase 0)** — shared field primitives land as the foundation for consistent form/input styling across desktop, mobile, and web (#2951).
+
+### Fixes
+- **Windows: native browser lockups and unresponsive shutdown** — the WebView2 environment callback work is isolated so a slow or hung callback can no longer freeze the main thread, plus a close watchdog and offscreen-at-full-size child realization prevent the shutdown hang (#2947, #2963).
+- **Mobile: chat scroll anchoring** — the conversation no longer jumps or loses its anchor while streaming on mobile (#2946).
+- **Chat: resilient conversation-title helper** — the `chatSummaryTitle` helper is restored with Windows path coverage so title derivation works consistently across platforms (#2955).
+
 ### Security
-- **Chat: runtime filesystem boundary gains a non-blocking sentinel** — the send route now watches streamed tool calls for user-space paths outside the granted roots. Violations never interrupt the turn: they surface as a progress notice on the turn and append a corrective boundary reminder to the conversation's next harness prompt so the familiar self-corrects (observe → surface → steer).
+- **Chat: runtime filesystem boundary gains a non-blocking sentinel** — the send route now watches streamed tool calls for user-space paths outside the granted roots. Violations never interrupt the turn: they surface as a progress notice on the turn and append a corrective boundary reminder to the conversation's next harness prompt so the familiar self-corrects (observe → surface → steer) (#2949).
 
 ## [0.0.175] - 2026-07-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.175",
+  "version": "0.0.176",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.175"
+version = "0.0.176"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.175"
+version = "0.0.176"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.175</string>
+	<string>0.0.176</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.175</string>
+	<string>0.0.176</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.175</string>
+	<string>0.0.176</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.175</string>
+	<string>0.0.176</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.175",
+  "version": "0.0.176",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Rolls up **10 PRs** since v0.0.175.

Stamps all six version locations (`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, `src-tauri/Info.ios.plist`, `src-tauri/gen/apple/app_iOS/Info.plist`) 0.0.175 → 0.0.176, and adds the `## [0.0.176]` CHANGELOG section.

### Highlights
- **fix(windows):** native browser lockups + unresponsive shutdown (#2947, #2963)
- **security(chat):** non-blocking filesystem boundary sentinel (#2949)
- **fix(chat):** resilient chatSummaryTitle helper + Windows path coverage (#2955)
- **feat(chat):** conversation cache + quick-chat UX (#2961)
- **feat(settings):** scalable familiar picker (#2950)
- **feat(ui):** cross-platform consistency Phase 0 (#2951)
- **fix(mobile):** chat scroll anchoring (#2946)

Tag `v0.0.176` will be pushed once this merges.