### PR TITLE
feat(chat): git context chip in the composer — branch · worktree · PR

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -220,6 +220,7 @@ export const SUITES = {
     "src/components/message-bubble-file-links.test.ts",
     "src/components/chat-view-polish.test.ts",
     "src/components/composer-runtime-chip.test.ts",
+    "src/components/composer-git-chip.test.ts",
     "src/components/chat-empty-state.test.ts",
     "src/components/user-chat-avatar.test.ts",
     "src/components/user-profile-invariants.test.ts",

--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -26,8 +26,29 @@ assert.match(
 );
 assert.match(
   source,
-  /NextResponse\.json\(\{ ok: true, repo: true, repoRoot, branch, files \}\)/,
-  "the change-list response includes the branch field",
+  /NextResponse\.json\(\{ ok: true, repo: true, repoRoot, branch, worktree, files \}\)/,
+  "the change-list response includes the branch and worktree fields",
+);
+
+// Linked-worktree detection compares --git-dir with --git-common-dir (they
+// only differ in a `git worktree` checkout) — never a path-name heuristic.
+assert.match(
+  source,
+  /\["rev-parse", "--git-dir", "--git-common-dir"\]/,
+  "worktreeName resolves worktree-ness from git itself",
+);
+
+// PR context (?pr=1) goes through ghCli (execFile, no shell) and the branch
+// PR's URL must match the pinned github.com PR shape before it is returned.
+assert.match(
+  source,
+  /ghCli\(repoRoot, \[\s*"pr", "view", branch, "--json", "number,url,state,isDraft",\s*\]\)/,
+  "branchPr reads the branch PR via the gh CLI helper",
+);
+assert.match(
+  source,
+  /PR_URL_RE\.test\(parsed\.url\)/,
+  "branchPr validates the PR URL shape before returning it",
 );
 
 console.log("changes route.test.ts: ok");

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -77,6 +77,22 @@ async function currentBranch(repoRoot: string): Promise<string> {
   return stdout.trim();
 }
 
+/** Linked-worktree name (the checkout dir's basename) when repoRoot is a
+ *  `git worktree` checkout rather than the primary clone, else null. A linked
+ *  worktree's --git-dir (.git/worktrees/<name>) differs from its
+ *  --git-common-dir (the primary clone's .git). */
+async function worktreeName(repoRoot: string): Promise<string | null> {
+  try {
+    const { stdout } = await git(repoRoot, ["rev-parse", "--git-dir", "--git-common-dir"]);
+    const [gitDir, commonDir] = stdout.trim().split("\n");
+    if (!gitDir || !commonDir) return null;
+    if (path.resolve(repoRoot, gitDir) === path.resolve(repoRoot, commonDir)) return null;
+    return path.basename(repoRoot);
+  } catch {
+    return null;
+  }
+}
+
 /** The repo's default branch: origin/HEAD when known, else main/master, else main. */
 async function defaultBranch(repoRoot: string): Promise<string> {
   try {
@@ -248,7 +264,49 @@ async function listChanges(repoRoot: string): Promise<NextResponse> {
     /* no HEAD yet */
   }
 
-  return NextResponse.json({ ok: true, repo: true, repoRoot, branch, files });
+  // Linked-worktree name rides along too (composer git chip) — null in the
+  // primary checkout, the checkout dir's basename in a `git worktree`.
+  const worktree = await worktreeName(repoRoot);
+
+  return NextResponse.json({ ok: true, repo: true, repoRoot, branch, worktree, files });
+}
+
+/** PR context for the current branch (composer git chip): the open/merged pull
+ *  request heading this branch, via `gh pr view` — null when there is no PR,
+ *  no branch (detached/unborn HEAD), or `gh` is unavailable/unauthenticated.
+ *  Read-only and network-bound, so it's a separate `?pr=1` query the client
+ *  fetches once per branch instead of riding the 5s status poll. */
+async function branchPr(repoRoot: string): Promise<NextResponse> {
+  let branch: string | null = null;
+  try {
+    branch = await currentBranch(repoRoot);
+  } catch {
+    /* no HEAD yet */
+  }
+  if (!branch || branch === "HEAD") return NextResponse.json({ ok: true, branch, pr: null });
+  try {
+    const { stdout } = await ghCli(repoRoot, [
+      "pr", "view", branch, "--json", "number,url,state,isDraft",
+    ]);
+    const parsed = JSON.parse(stdout) as {
+      number?: number; url?: string; state?: string; isDraft?: boolean;
+    };
+    if (typeof parsed.number === "number" && typeof parsed.url === "string" && PR_URL_RE.test(parsed.url)) {
+      return NextResponse.json({
+        ok: true,
+        branch,
+        pr: {
+          number: parsed.number,
+          url: parsed.url,
+          state: typeof parsed.state === "string" ? parsed.state : "OPEN",
+          isDraft: parsed.isDraft === true,
+        },
+      });
+    }
+  } catch {
+    /* no PR for this branch, or gh missing/unauthenticated — a clean null */
+  }
+  return NextResponse.json({ ok: true, branch, pr: null });
 }
 
 async function diffFile(repoRoot: string, relPath: string, absPath: string): Promise<NextResponse> {
@@ -286,6 +344,7 @@ export async function GET(req: NextRequest) {
   const filePath = req.nextUrl.searchParams.get("path");
   const wantCheckpoints = req.nextUrl.searchParams.get("checkpoints");
   const checkpointName = req.nextUrl.searchParams.get("checkpoint");
+  const wantPr = req.nextUrl.searchParams.get("pr");
   if (!projectRoot) {
     return NextResponse.json({ ok: false, error: "missing projectRoot param" }, { status: 400 });
   }
@@ -319,6 +378,7 @@ export async function GET(req: NextRequest) {
         truncated,
       });
     }
+    if (wantPr !== null) return await branchPr(root.repoRoot);
     if (filePath === null) return await listChanges(root.repoRoot);
     const abs = resolveContainedFile(root.repoRoot, filePath);
     if (!abs) return pathNotAllowed();

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -134,6 +134,7 @@ import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
 import { ComposerRuntimeChip } from "@/components/composer-runtime-chip";
+import { ComposerGitChip } from "@/components/composer-git-chip";
 import { resolveActivePath, buildSiblingIndex, childLeaf } from "@/lib/conversation-tree";
 import { appendCollapsingNewlines } from "@/lib/stream-text";
 import { stripStepMarkers } from "@/lib/workflow-step-progress";
@@ -5681,6 +5682,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     onPickModel={handleSelectModel}
                     disabled={busy}
                   />
+                  {/* Git context — branch · dirty count · worktree · PR — for
+                      chats rooted in a git repo (hidden otherwise). */}
+                  <ComposerGitChip projectRoot={activeProjectRoot} onOpenUrl={onOpenUrl} />
                 </div>
                 <div className="cave-composer-submit-row">
                   <EnhanceControl

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+// Source pins for the composer git chip: chats rooted in a git repo show
+// branch · dirty count · worktree · PR context in the composer control row,
+// like a modern coding CLI's status line; git-less chats show nothing.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const chip = readFileSync(new URL("./composer-git-chip.tsx", import.meta.url), "utf8");
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const summary = readFileSync(new URL("../lib/use-changes-summary.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/composer-git-chip.css", import.meta.url), "utf8");
+
+// ── The chat composer renders the chip from the chat's active project root ──
+assert.match(
+  chatView,
+  /<ComposerGitChip projectRoot=\{activeProjectRoot\} onOpenUrl=\{onOpenUrl\} \/>/,
+  "the chat composer renders the git chip wired to the resolved project root",
+);
+
+// ── Git-less chats render nothing — the chip gates on a loaded repo status ──
+assert.match(
+  chip,
+  /if \(!root \|\| !loaded \|\| notARepo \|\| !branch\) return null;/,
+  "the chip only appears for chats whose root is a git repo with a branch",
+);
+
+// ── Status rides the existing /api/changes poll, not a new endpoint ─────────
+assert.match(
+  chip,
+  /useChangesSummary\(root, Boolean\(root\)\)/,
+  "branch/worktree/dirty state come from the shared changes-summary hook",
+);
+assert.match(
+  summary,
+  /worktree: string \| null;/,
+  "the changes summary carries the linked-worktree name",
+);
+
+// ── PR lookup is once-per-(root, branch), never on the 5s poll ──────────────
+assert.match(
+  chip,
+  /const key = `\$\{projectRoot\}\\n\$\{branch\}`;\s*\n\s*if \(fetchedKey\.current === key\) return;/,
+  "the PR fetch is keyed by (projectRoot, branch) so the status poll can't re-trigger it",
+);
+assert.match(
+  chip,
+  /\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}&pr=1/,
+  "the PR context comes from the changes route's ?pr=1 query",
+);
+
+// ── The PR segment is the interactive part: opens in-app, window.open shim ──
+assert.match(
+  chip,
+  /if \(onOpenUrl\) onOpenUrl\(pr\.url\);\s*\n\s*else window\.open\(pr\.url, "_blank", "noopener,noreferrer"\);/,
+  "clicking the PR opens it via the app's URL handler with a safe window.open fallback",
+);
+
+// ── Long branch names ellipsize instead of blowing up the control row ───────
+assert.match(
+  css,
+  /\.cave-composer-git-chip__label \{[\s\S]*?text-overflow: ellipsis;/,
+  "branch/worktree labels truncate with an ellipsis",
+);
+
+console.log("composer-git-chip.test.ts: ok");

--- a/src/components/composer-git-chip.tsx
+++ b/src/components/composer-git-chip.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+// ComposerGitChip — the chat composer's git context strip: when the chat's
+// project root is a git repo, show the current branch, a dirty-file count, a
+// linked-worktree marker, and (when one exists) the branch's pull request —
+// the same at-a-glance context a modern coding CLI prints in its status line.
+//
+// Branch / worktree / dirty count ride the existing /api/changes status poll
+// via useChangesSummary (5s, visibility-gated, single-flight). The PR lookup
+// is network-bound (`gh pr view`), so it's fetched once per (root, branch)
+// through the separate `?pr=1` query instead of riding the poll. Chats whose
+// root isn't a repo (or have no project root at all) render nothing.
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { useChangesSummary } from "@/lib/use-changes-summary";
+import "@/styles/composer-git-chip.css";
+
+type BranchPr = {
+  number: number;
+  url: string;
+  /** gh's PR state: OPEN | MERGED | CLOSED. */
+  state: string;
+  isDraft: boolean;
+};
+
+type PrResponse = { ok?: boolean; pr?: BranchPr | null };
+
+/** The branch's PR, fetched once per (projectRoot, branch) — null when the
+ *  branch has no PR (or gh is unavailable), undefined while unresolved. */
+function useBranchPr(projectRoot: string | undefined, branch: string | null): BranchPr | null {
+  const [pr, setPr] = useState<BranchPr | null>(null);
+  // One fetch per (root, branch) pair — a branch switch refetches, the 5s
+  // status poll does not.
+  const fetchedKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!projectRoot || !branch || branch === "HEAD") {
+      fetchedKey.current = null;
+      setPr(null);
+      return;
+    }
+    const key = `${projectRoot}\n${branch}`;
+    if (fetchedKey.current === key) return;
+    fetchedKey.current = key;
+    setPr(null);
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}&pr=1`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as PrResponse;
+        if (cancelled) return;
+        const got = json.ok && json.pr && typeof json.pr.number === "number" ? json.pr : null;
+        setPr(got);
+      } catch {
+        /* transient — leave as no-PR */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectRoot, branch]);
+
+  return pr;
+}
+
+export function ComposerGitChip({
+  projectRoot,
+  onOpenUrl,
+}: {
+  /** The chat's active project root ("" / undefined when no project). */
+  projectRoot: string | undefined;
+  /** Opens the PR in the app's browser pane; falls back to window.open. */
+  onOpenUrl?: (url: string) => void;
+}) {
+  const root = projectRoot?.trim() ? projectRoot : undefined;
+  const { loaded, notARepo, branch, count, worktree } = useChangesSummary(root, Boolean(root));
+  const pr = useBranchPr(root, branch);
+
+  // Git-less chats (no project, or a non-repo root) show nothing — the chip
+  // only appears once the repo status has actually loaded.
+  if (!root || !loaded || notARepo || !branch) return null;
+
+  const dirtyLabel = count > 0 ? `${count} uncommitted change${count === 1 ? "" : "s"}` : "clean";
+  const title = [
+    `Branch: ${branch}`,
+    worktree ? `Worktree: ${worktree}` : null,
+    dirtyLabel,
+    pr ? `PR #${pr.number} (${pr.isDraft ? "draft" : pr.state.toLowerCase()})` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div className="cave-composer-git-chip" title={title} data-testid="composer-git-chip">
+      <span className="cave-composer-git-chip__branch">
+        <Icon name="ph:git-branch" width={12} aria-hidden />
+        <span className="cave-composer-git-chip__label" aria-label={`Branch: ${branch}`}>
+          {branch}
+        </span>
+        {count > 0 ? (
+          <span className="cave-composer-git-chip__dirty" aria-label={dirtyLabel}>
+            +{count}
+          </span>
+        ) : null}
+      </span>
+      {worktree ? (
+        <span className="cave-composer-git-chip__worktree" aria-label={`Worktree: ${worktree}`}>
+          <Icon name="ph:tree-structure" width={11} aria-hidden />
+          <span className="cave-composer-git-chip__label">{worktree}</span>
+        </span>
+      ) : null}
+      {pr ? (
+        <button
+          type="button"
+          className="cave-composer-git-chip__pr"
+          data-pr-state={pr.isDraft ? "draft" : pr.state.toLowerCase()}
+          title={`Open PR #${pr.number} (${pr.isDraft ? "draft" : pr.state.toLowerCase()})`}
+          aria-label={`Open pull request #${pr.number}`}
+          onClick={() => {
+            if (onOpenUrl) onOpenUrl(pr.url);
+            else window.open(pr.url, "_blank", "noopener,noreferrer");
+          }}
+        >
+          <Icon name="ph:git-pull-request" width={11} aria-hidden />
+          <span>#{pr.number}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -25,6 +25,8 @@ type ChangesSummary = {
   notARepo: boolean;
   /** Current branch (null before load, when not a repo, or on an unborn HEAD). */
   branch: string | null;
+  /** Linked-worktree name (checkout dir basename) — null in the primary checkout. */
+  worktree: string | null;
 };
 
 type ChangesResponse = {
@@ -32,6 +34,7 @@ type ChangesResponse = {
   repo?: boolean;
   files?: unknown[];
   branch?: string | null;
+  worktree?: string | null;
 };
 
 export function useChangesSummary(
@@ -42,6 +45,7 @@ export function useChangesSummary(
   const [loaded, setLoaded] = useState(false);
   const [notARepo, setNotARepo] = useState(false);
   const [branch, setBranch] = useState<string | null>(null);
+  const [worktree, setWorktree] = useState<string | null>(null);
   const inFlight = useRef(false);
 
   useEffect(() => {
@@ -63,6 +67,7 @@ export function useChangesSummary(
           setNotARepo(json.repo === false);
           setCount(Array.isArray(json.files) ? json.files.length : 0);
           setBranch(typeof json.branch === "string" ? json.branch : null);
+          setWorktree(typeof json.worktree === "string" ? json.worktree : null);
         }
       } catch {
         /* transient — keep the last known summary */
@@ -85,5 +90,5 @@ export function useChangesSummary(
     };
   }, [projectRoot, active]);
 
-  return { count, loaded, notARepo, branch };
+  return { count, loaded, notARepo, branch, worktree };
 }

--- a/src/styles/composer-git-chip.css
+++ b/src/styles/composer-git-chip.css
@@ -1,0 +1,92 @@
+/* Composer git chip — branch · worktree · PR context in the chat composer's
+   control row. A passive status strip (the PR segment is the one interactive
+   part), pill-shaped to sit with the runtime chip and icon-button family
+   (composer-runtime-chip.css is the styling reference). */
+
+.cave-composer-git-chip {
+  display: inline-flex;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  max-width: 240px;
+  height: 30px;
+  padding: 0 11px;
+  font-size: 11px;
+  line-height: 1;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
+  color: var(--text-secondary);
+}
+
+.cave-composer-git-chip__branch,
+.cave-composer-git-chip__worktree {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+}
+
+.cave-composer-git-chip svg {
+  flex-shrink: 0;
+  color: var(--composer-pill-gold, oklch(0.81 0.105 83));
+}
+
+.cave-composer-git-chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Worktree segment reads quieter than the branch it duplicates context with. */
+.cave-composer-git-chip__worktree .cave-composer-git-chip__label {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.cave-composer-git-chip__dirty {
+  flex: 0 0 auto;
+  color: var(--color-warning, oklch(0.75 0.15 75));
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.cave-composer-git-chip__pr {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 3px;
+  margin: 0 -4px 0 0;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.cave-composer-git-chip__pr:hover {
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.cave-composer-git-chip__pr[data-pr-state="merged"] svg {
+  color: var(--accent-presence);
+}
+.cave-composer-git-chip__pr[data-pr-state="draft"] svg,
+.cave-composer-git-chip__pr[data-pr-state="closed"] svg {
+  color: var(--text-muted);
+}
+
+/* Narrow composers (mobile / slim side panels): the branch name is the
+   highest-value token — drop the worktree segment first. */
+@media (max-width: 640px) {
+  .cave-composer-git-chip__worktree {
+    display: none;
+  }
+}


### PR DESCRIPTION
When a chat's project root is a git repo, the composer control row now shows the branch, uncommitted-change count, linked-worktree name, and the branch's PR — the status-line context a modern coding CLI prints. Chats without git show nothing.

## What changed
- **/api/changes GET** listing carries `worktree` (linked-worktree name via `--git-dir` vs `--git-common-dir` — git's own answer, not a path heuristic). New `?pr=1` query resolves the current branch's PR through `gh pr view` (execFile helper, no shell); returns `pr: null` when there's no PR, detached/unborn HEAD, or `gh` is unavailable.
- **useChangesSummary** now exposes `worktree` alongside `branch`/`count` — same 5s visibility-gated single-flight poll, no new endpoint for status.
- **ComposerGitChip** (new): renders in the composer utility row next to the runtime chip, gated on a loaded `repo: true` status. PR segment is the interactive part — opens via `onOpenUrl` (in-app browser) with a safe `window.open` fallback. PR lookup fetches once per (root, branch), never per poll. Long branch names ellipsize; the worktree segment drops first on narrow widths.

## Verification
- `pnpm typecheck` clean; `check:tests-wired` green.
- `node scripts/run-tests.mjs app api` — 744 test files pass (includes new `composer-git-chip.test.ts` pins and updated `changes/route.test.ts` pins).
- Live dev-server check: listing returns `worktree: "composer-git-chip"` from the linked worktree and `worktree: null` from the primary checkout; `?pr=1` returns `pr: null` for a branch with no PR (~1.2s).