### PR TITLE
ui(chat): visible rename button beside the chat title (cave-jk3h)

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -651,10 +651,15 @@ assert.match(
   /addEventListener\("cave:chat-rename", onRename\)[\s\S]{0,80}setEditing\(true\)|onRename = \(\) => setEditing\(true\)/,
   "ChatTitleEditable enters edit mode when the overflow menu fires cave:chat-rename",
 );
-assert.doesNotMatch(
+assert.match(
   source,
-  /aria-label="Rename chat"/,
-  "The persistent pencil button is removed — the title is clean, rename is one click away in the menu",
+  /aria-label="Rename chat"[\s\S]{0,200}setEditing\(true\)/,
+  "Chat title carries an explicit, labeled rename button — click-to-rename and the overflow item alone are not discoverable",
+);
+assert.match(
+  source,
+  /aria-label="Rename chat"[\s\S]{0,400}ph:pencil-simple/,
+  "The title's rename button uses the same pencil icon as the overflow menu item",
 );
 
 // — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1300,9 +1300,9 @@ function ChatTitleEditable({
     inputRef.current?.select();
   }, [editing]);
 
-  // The rename affordance now lives in the session overflow menu (Codex/ChatGPT
-  // idiom — a clean title, secondary actions one click away). The menu fires
-  // this event; clicking the title itself still enters edit mode directly.
+  // Rename has three entry points into the same edit mode: the pencil button
+  // beside the title, clicking the title text, and the session overflow menu —
+  // which lives outside this component and reaches it via this window event.
   useEffect(() => {
     const onRename = () => setEditing(true);
     window.addEventListener("cave:chat-rename", onRename);
@@ -1340,9 +1340,12 @@ function ChatTitleEditable({
     ? "cave-chat-title-input min-w-0 flex-1 rounded-sm bg-transparent text-[13px] font-semibold uppercase tracking-[0.12em] leading-tight text-[var(--text-primary)] outline-none"
     : "cave-chat-title-input min-w-0 flex-1 rounded-sm bg-transparent text-[14px] font-semibold leading-tight text-[var(--text-primary)] outline-none";
 
+  // No flex-1 on the title button itself — the wrapper carries the stretch so
+  // the pencil sits flush against the title text instead of drifting to the
+  // far edge of the free space.
   const buttonClassName = headline
-    ? "block w-full truncate text-left text-[13px] font-semibold uppercase tracking-[0.12em] leading-tight text-[var(--text-primary)] transition-colors hover:text-[color-mix(in_oklch,var(--accent-presence)_70%,var(--text-primary))]"
-    : "min-w-0 flex-1 truncate text-left text-[14px] font-semibold leading-tight text-[var(--text-primary)] transition-colors hover:text-[color-mix(in_oklch,var(--accent-presence)_70%,var(--text-primary))]";
+    ? "min-w-0 flex-1 truncate text-left text-[13px] font-semibold uppercase tracking-[0.12em] leading-tight text-[var(--text-primary)] transition-colors hover:text-[color-mix(in_oklch,var(--accent-presence)_70%,var(--text-primary))]"
+    : "min-w-0 truncate text-left text-[14px] font-semibold leading-tight text-[var(--text-primary)] transition-colors hover:text-[color-mix(in_oklch,var(--accent-presence)_70%,var(--text-primary))]";
 
   if (editing) {
     return (
@@ -1371,17 +1374,34 @@ function ChatTitleEditable({
   }
 
   return (
-    <button
-      type="button"
-      className={buttonClassName}
-      title={`${display} — click to rename`}
-      onClick={(e) => {
-        e.stopPropagation();
-        setEditing(true);
-      }}
-    >
-      {display}
-    </button>
+    <span className={headline ? "flex w-full min-w-0 items-center gap-1.5" : "flex min-w-0 flex-1 items-center gap-1"}>
+      <button
+        type="button"
+        className={buttonClassName}
+        title={`${display} — click to rename`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setEditing(true);
+        }}
+      >
+        {display}
+      </button>
+      {/* Explicit rename affordance — click-to-rename on the title alone is
+          invisible; the pencil makes renaming discoverable without opening
+          the overflow menu. */}
+      <button
+        type="button"
+        title="Rename chat"
+        aria-label="Rename chat"
+        onClick={(e) => {
+          e.stopPropagation();
+          setEditing(true);
+        }}
+        className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-60 transition-all hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] hover:opacity-100"
+      >
+        <Icon name="ph:pencil-simple" width={11} aria-hidden />
+      </button>
+    </span>
   );
 }
 

--- a/tests/chat-rename.spec.ts
+++ b/tests/chat-rename.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// The chat header carries an explicit, labeled rename button beside the title
+// (aria-label "Rename chat"). Clicking it opens the inline title editor;
+// Enter persists via PATCH /api/sessions/:id and the header reflects the new
+// name. Self-contained per the daemon-less E2E constraint: sessions and the
+// conversation come from route mocks, and the PATCH is intercepted so the
+// mock session list can echo the rename back like the daemon would.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+
+const SESSION = {
+  id: "s-rename",
+  title: "Quarterly plan",
+  status: "complete",
+  origin: "chat",
+  project_root: "/Users/dev/Documents/GitHub/OpenCoven/coven-cave",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local:/Users/dev/Documents/GitHub/OpenCoven/coven-cave",
+  exit_code: 0,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+async function setup(page: Page): Promise<{ patched: () => unknown }> {
+  // The PATCH body lands here; the sessions/list mock serves the patched
+  // title afterwards so the UI round-trip mirrors the real daemon.
+  let currentTitle = SESSION.title;
+  let patchedBody: unknown;
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3", "1");
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3.two-pane", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [{ ...SESSION, title: currentTitle }] } }),
+  );
+  await page.route("**/api/sessions/s-rename", (route) => {
+    if (route.request().method() !== "PATCH") return route.continue();
+    patchedBody = route.request().postDataJSON();
+    currentTitle = (patchedBody as { title: string }).title;
+    return route.fulfill({ json: { ok: true, title: currentTitle } });
+  });
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: "t1", role: "assistant", text: "Plan drafted.", createdAt: ISO }] },
+        context: { task: null, github: [] },
+      },
+    }),
+  );
+  await page.goto("/");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("Meta+2");
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+
+  return { patched: () => patchedBody };
+}
+
+test("header rename button opens the title editor and persists the new name", async ({ page }) => {
+  const { patched } = await setup(page);
+
+  // Open the mocked chat from the chat-mode sidebar.
+  await page.locator(".chat-sidebar").getByText("Quarterly plan", { exact: false }).first().click();
+
+  // The explicit affordance: a labeled button next to the title — not just
+  // click-to-rename on the text or the overflow-menu item.
+  const renameBtn = page.getByRole("button", { name: "Rename chat", exact: true });
+  await expect(renameBtn).toBeVisible({ timeout: 30_000 });
+
+  await renameBtn.click();
+  const input = page.getByRole("textbox", { name: "Chat title" });
+  await expect(input).toBeVisible();
+  await expect(input).toBeFocused();
+  await expect(input).toHaveValue("Quarterly plan");
+
+  const patchDone = page.waitForResponse(
+    (r) => r.url().includes("/api/sessions/s-rename") && r.request().method() === "PATCH",
+  );
+  await input.fill("Roadmap review");
+  await input.press("Enter");
+  await patchDone;
+
+  expect(patched()).toEqual({ title: "Roadmap review" });
+
+  // The editor closes and the header shows the persisted name.
+  await expect(input).toHaveCount(0);
+  await expect(
+    page.locator(".cave-chat-meta-line").getByRole("button", { name: /Roadmap review/ }),
+  ).toBeVisible({ timeout: 15_000 });
+});


### PR DESCRIPTION
## Summary

Renaming a chat had no visible affordance: click-to-rename on the title text is invisible, and the **Rename chat** overflow item is hidden behind the kebab. This re-adds the explicit pencil button beside the header title — the #382 idiom that #847 removed in favor of menu-only — wired to the same `ChatTitleEditable` edit mode (Enter saves via `PATCH /api/sessions/:id`, Esc cancels). All three entry points (pencil, title click, overflow item) share one edit path.

One placement improvement over the original: the title button no longer carries `flex-1` (the wrapper does), so the pencil hugs the title text instead of drifting across the free space toward the meta cluster.

## Test plan

- `chat-view-polish.test.ts`: the "pencil is removed" `doesNotMatch` pin flips to two positive pins (labeled `Rename chat` button wired to `setEditing(true)` + pencil icon); overflow-menu and event-listener pins unchanged
- **New e2e** `tests/chat-rename.spec.ts` (self-contained, route-mocked per the daemon-less CI constraint): pencil → focused pre-filled editor → Enter → asserts PATCH body `{title:"Roadmap review"}` → header shows the persisted name
- `pnpm test:app`, `tsc --noEmit`, `pnpm build` all pass; spec live-verified on the desktop project; screenshot-checked placement
- Commit SSH-signed

Closes bead `cave-jk3h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)