### PR TITLE
fix(chat): forward granted project roots to the harness via coven run --add-dir (cave-hbp3)

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -1146,6 +1146,40 @@ assert.ok(
   "--model must be pushed before the -- prompt separator",
 );
 
+// ── Directory grants (gated --add-dir passthrough) ─────────────────────────
+// Granted project roots must be forwarded to the harness or they stay
+// prompt-text-only: the runtime-scope preamble describes the grants, but a
+// harness that only trusts its cwd denies every access to them.
+assert.match(
+  chatRoute,
+  /covenRunSupportsAddDirFlag/,
+  "--add-dir forwarding must gate on the coven run capability probe",
+);
+assert.match(
+  chatRoute,
+  /binding\.harness !== "openclaw" && \(await covenRunSupportsAddDir\(\)\)/,
+  "OpenClaw never forwards --add-dir; every other harness gates on the probe",
+);
+assert.match(
+  chatRoute,
+  /addDirForwardingEnabled && !sshRuntime/,
+  "--add-dir forwarding is local-only; SSH runtimes own their remote filesystem",
+);
+assert.match(
+  chatRoute,
+  /for \(const dir of forwardAddDirs\) a\.push\("--add-dir", dir\);/,
+  "Local argv should push each granted root via the repeatable --add-dir flag",
+);
+assert.ok(
+  localArgvBlock[0].indexOf('a.push("--add-dir"') < localArgvBlock[0].indexOf('a.push("--", prompt)'),
+  "--add-dir must be pushed before the -- prompt separator",
+);
+assert.match(
+  chatRoute,
+  /\.filter\(\(root\) => root && root !== spawnRoot\)/,
+  "The spawn cwd is already trusted and must not be re-forwarded",
+);
+
 assert.match(
   chatRoute,
   /responseMetadata\.confirmedModel = confirmedModel;/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -64,7 +64,7 @@ import {
   resolveOpenClawAgentBinding,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
-import { isTrustedChatHarness, covenRunSupportsModelFlag, covenRunSupportsPermissionFlag, canonicalHarnessId } from "@/lib/harness-adapters";
+import { isTrustedChatHarness, covenRunSupportsModelFlag, covenRunSupportsPermissionFlag, covenRunSupportsAddDirFlag, canonicalHarnessId } from "@/lib/harness-adapters";
 import {
   type ConversationFile,
   type ChatTurn,
@@ -605,6 +605,54 @@ function covenRunSupportsPermission(): Promise<boolean> {
   return covenRunPermissionFlagProbe;
 }
 
+// Same gated probe for `coven run --add-dir <DIR>` (repeatable). Granted
+// project roots must be trusted by the spawned harness itself — the
+// runtime-scope preamble only DESCRIBES the grants, and a harness that trusts
+// nothing but its cwd denies every access to them (non-interactive sessions
+// cannot re-request permission mid-turn). Cached; failures resolve false.
+let covenRunAddDirFlagProbe: Promise<boolean> | null = null;
+function covenRunSupportsAddDir(): Promise<boolean> {
+  if (!covenRunAddDirFlagProbe) {
+    covenRunAddDirFlagProbe = new Promise<boolean>((resolve) => {
+      let out = "";
+      let settled = false;
+      const done = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+      try {
+        const { command, fixedArgs } = covenLaunchCommand();
+        const child = spawn(command, [...fixedArgs, "run", "--help"], {
+          env: covenSpawnEnv(),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        child.stdout.on("data", (d) => (out += d.toString()));
+        child.stderr.on("data", (d) => (out += d.toString()));
+        const t = setTimeout(() => {
+          try {
+            child.kill("SIGTERM");
+          } catch {
+            /* ignore */
+          }
+          done(false);
+        }, 2500);
+        child.on("close", () => {
+          clearTimeout(t);
+          done(covenRunSupportsAddDirFlag(out));
+        });
+        child.on("error", () => {
+          clearTimeout(t);
+          done(false);
+        });
+      } catch {
+        done(false);
+      }
+    });
+  }
+  return covenRunAddDirFlagProbe;
+}
+
 function resolveSendModelMetadata(args: {
   body: SendBody;
   config: CaveConfig;
@@ -1068,6 +1116,11 @@ export async function POST(req: Request) {
   // its own default sandbox instead of being widened to danger-full-access.
   const permissionForwardingEnabled =
     binding.harness !== "openclaw" && (await covenRunSupportsPermission());
+  // Same gating for directory grants (`--add-dir`). Without forwarding, the
+  // granted roots listed in the runtime-scope preamble are prompt-text-only
+  // and the harness denies every access to them.
+  const addDirForwardingEnabled =
+    binding.harness !== "openclaw" && (await covenRunSupportsAddDir());
   const { desiredModel, modelState } = resolveSendModelMetadata({
     body,
     config,
@@ -1295,6 +1348,25 @@ export async function POST(req: Request) {
     modelForwardingEnabled && cleanModelId(desiredModel) ? desiredModel : null;
   const forwardPermission =
     permissionForwardingEnabled && body.permissionMode === "read" ? "read-only" : null;
+  // Directory grants: forward every granted project root — plus the familiar's
+  // own workspace when it isn't the spawn cwd — so the harness actually trusts
+  // the roots the runtime-scope preamble grants. The spawn cwd is already
+  // trusted implicitly, so it's excluded. Gated on the `--add-dir` probe and
+  // local runtimes only (SSH runtimes own their remote filesystem).
+  const spawnRoot = familiarCwd ?? cwd;
+  const forwardAddDirs =
+    addDirForwardingEnabled && !sshRuntime
+      ? Array.from(
+          new Set(
+            [
+              ...grantedProjectRoots,
+              ...(resolvedFamiliarWorkspace ? [resolvedFamiliarWorkspace] : []),
+            ]
+              .map((root) => root.trim())
+              .filter((root) => root && root !== spawnRoot),
+          ),
+        )
+      : [];
   // `promptOverride` lets the transparent resume-retry (below) prime a fresh
   // harness session with replayed conversation history — without it the retry
   // forks a context-free session and the familiar loses the thread.
@@ -1320,6 +1392,8 @@ export async function POST(req: Request) {
     // `coven run --permission read-only` (codex --sandbox read-only / claude
     // --permission-mode plan). Gated on the CLI advertising the flag.
     if (forwardPermission) a.push("--permission", forwardPermission);
+    // Trust each granted root at the harness level; repeatable flag.
+    for (const dir of forwardAddDirs) a.push("--add-dir", dir);
     // Inject identity preamble. coven-cli renders this through the best
     // available identity channel for the chosen harness. Without this, the
     // harness answers as its generic CLI identity instead of as the familiar.

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -8,6 +8,7 @@ import {
   adapterManifestScaffoldForHarness,
   covenHelpSupportsAdapterList,
   covenRunSupportsModelFlag,
+  covenRunSupportsAddDirFlag,
   isTrustedChatHarness,
   isTrustedOnboardingHarness,
   openClawAdapterReport,
@@ -46,6 +47,35 @@ assert.equal(
   covenRunSupportsModelFlag("see also --model-context-protocol for MCP"),
   false,
   "A substring like --model-context-protocol must not be mistaken for --model",
+);
+
+// Directory-grant gating probe: forwarding `--add-dir` must stay off until the
+// installed `coven run` advertises the flag.
+assert.equal(
+  covenRunSupportsAddDirFlag(`Usage: coven run [OPTIONS] <HARNESS> [PROMPT]...
+
+Options:
+      --stream-json  Emit stream-json events
+      --add-dir <DIR>  Additional directory the harness may access (repeatable)
+`),
+  true,
+  "Help text advertising --add-dir should enable forwarding",
+);
+assert.equal(
+  covenRunSupportsAddDirFlag(`Usage: coven run [OPTIONS] <HARNESS> [PROMPT]...
+
+Options:
+      --stream-json  Emit stream-json events
+`),
+  false,
+  "Help text without --add-dir should keep forwarding off",
+);
+assert.equal(covenRunSupportsAddDirFlag(""), false, "Empty help text never enables --add-dir forwarding");
+assert.equal(covenRunSupportsAddDirFlag(undefined), false, "Non-string help text never enables --add-dir forwarding");
+assert.equal(
+  covenRunSupportsAddDirFlag("see also --add-dir-recursive for nested grants"),
+  false,
+  "A longer flag like --add-dir-recursive must not be mistaken for --add-dir",
 );
 
 const curatedIds = ["codex", "claude", "copilot", "hermes", "openclaw"];

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -223,6 +223,16 @@ export function covenRunSupportsPermissionFlag(helpText: string): boolean {
   return /(^|\s)--permission(?![\w-])/m.test(helpText);
 }
 
+// Gated-forwarding probe for `coven run --add-dir <DIR>` (repeatable). Granted
+// project roots are only real grants if the spawned harness also trusts those
+// directories — the runtime-scope preamble alone leaves the harness denying
+// every access outside its cwd. Forwarding stays a no-op on CLIs that predate
+// the flag, since `coven run` rejects unknown flags.
+export function covenRunSupportsAddDirFlag(helpText: string): boolean {
+  if (typeof helpText !== "string" || !helpText) return false;
+  return /(^|\s)--add-dir(?![\w-])/m.test(helpText);
+}
+
 export function mergeAdapterReports(
   localReports: Array<
     Partial<AdapterReport> & {


### PR DESCRIPTION
## Problem

Runtime grants for familiar workspaces are **prompt-text-only**. `/api/chat/send` lists `grantedProjectRoots` in the runtime-scope boundary preamble, but never authorizes those directories at the harness level. The spawned harness trusts only its cwd, so every access to a granted root fails with `Permission denied and could not request permission from user` in non-interactive sessions.

Observed live: a Sage session granted `~/.coven/workspaces/familiars/sage` (and sibling project roots) could not read any of them — the grants in the preamble were unenforceable text.

## Fix

Forward each granted project root — plus the familiar's workspace when it isn't already the spawn cwd — through a repeatable `coven run --add-dir <DIR>` passthrough:

- **Gated on a capability probe** (`coven run --help` advertising `--add-dir`), exactly mirroring the existing `--model` / `--permission` forwarding pattern. No-op until the companion CLI ships the flag.
- **Local runtimes only** — SSH runtimes own their remote filesystem; OpenClaw bypasses `coven run`.
- Spawn cwd excluded (already implicitly trusted); roots deduped.
- Flags emitted before the `--` prompt separator like every other flag.

## Tests

- `covenRunSupportsAddDirFlag` unit tests (advertised / absent / empty / non-string / longer-flag false-positive guard) in `harness-adapters.test.ts`
- Route-shape assertions in `harness-routing.test.ts`: probe gating, OpenClaw exclusion, SSH exclusion, repeatable push before `--`, spawn-cwd exclusion

## Verification

- `pnpm typecheck` clean
- `pnpm test` — 604/604 app test files pass

## Follow-up

Companion CLI change in `coven` to implement `coven run --add-dir` (mapping to each harness's native trust flag, e.g. `copilot --add-dir`, `claude --add-dir`). Tracked in bead cave-hbp3.

Bead: cave-hbp3