### PR TITLE
chore(release): stamp v0.0.177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.177] - 2026-07-12
+
+> 🗨️ **Chat context, discoverability, and durable settings.** The composer gains a live git context chip (branch · worktree · PR), chats get a visible rename button and smart chat→task autofill with promoted inspector tabs and AI project icons, granted project roots are now enforced at the harness level, and preferences survive sidecar port changes.
+
+### Features
+- **Chat: git context chip in the composer** — when the chat's project root is a git repo, the composer utility row shows the branch, uncommitted-change count, linked worktree, and the branch's PR; the PR segment opens in the in-app browser (#2967).
+- **Chat: smart chat→task autofill + promoted inspector tabs + AI project icons** — creating a task from a chat mines links, GitHub references, priority keywords, natural-language due dates, and plan-list subtasks into a full board draft; inspector sections are promoted into the right-panel tab strip, and projects gain AI-generated icons (#2970).
+- **Chat: visible rename button** — a pencil button beside the chat title opens the inline rename editor, making renaming discoverable; clicking the title and the overflow-menu item still work (#2968).
+
+### Fixes
+- **Chat: granted project roots enforced at the harness** — runtime grants are forwarded via `coven run --add-dir`, so familiars can actually read granted directories instead of failing on prompt-text-only grants (#2969).
+- **Settings: preferences persist across sidecar ports** — appearance, theme, backdrop, and reading settings are server-persisted and bootstrapped at startup, so they no longer reset when the app serves from a different port (#2971, supersedes #2952).
+
 ## [0.0.176] - 2026-07-11
 
 > 🪟 **Windows stability + chat robustness.** Native browser lockups and unresponsive shutdown are fixed, the send route gains a non-blocking filesystem boundary sentinel and a resilient chat-title helper, quick-chat gets a conversation cache, and mobile chat scroll anchoring is repaired.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.176",
+  "version": "0.0.177",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.176"
+version = "0.0.177"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.176"
+version = "0.0.177"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.176</string>
+	<string>0.0.177</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.176</string>
+	<string>0.0.177</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.176</string>
+	<string>0.0.177</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.176</string>
+	<string>0.0.177</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.176",
+  "version": "0.0.177",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Rolls up 5 PRs since v0.0.176: composer git context chip (branch · worktree · PR) (#2967), visible chat rename button (#2968), smart chat→task autofill + promoted inspector tabs + AI project icons (#2970), harness-level enforcement of granted project roots via `coven run --add-dir` (#2969), and server-persisted preferences that survive sidecar port changes (#2971).

Stamps all seven version locations (package.json, Cargo.toml, Cargo.lock app block, tauri.conf.json, both iOS plists ×2 lines) + the CHANGELOG.

## Test plan

- `src/lib/app-version.test.ts` (the seven-location enforcer) passes
- Full `pnpm test:app` green; commit SSH-signed
- After merge: tag the squash commit `v0.0.177` to kick the release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)