### PR TITLE
Stabilize craft draft generation

### DIFF
--- a/src/app/api/marketplace/crafts/drafts/route.ts
+++ b/src/app/api/marketplace/crafts/drafts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { buildCraftDraftFromRoles } from "@/lib/craft-draft";
+import { buildCraftDraftFromRoles, compareCraftDraftRoles } from "@/lib/craft-draft";
 import { readCraftDrafts, saveCraftDraft } from "@/lib/server/craft-drafts";
 import { loadRoleEntries } from "@/lib/server/role-entries";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
   const roleIdSet = new Set(roleIds);
   const roles = (await loadRoleEntries()).filter((role) => (
     role.familiar === familiar && roleIdSet.has(role.id)
-  ));
+  )).sort(compareCraftDraftRoles);
   if (roles.length === 0) {
     return NextResponse.json({ ok: false, error: "no matching roles" }, { status: 404 });
   }

--- a/src/lib/craft-draft.test.ts
+++ b/src/lib/craft-draft.test.ts
@@ -1,59 +1,67 @@
 import assert from "node:assert/strict";
 import { buildCraftDraftFromRoles } from "./craft-draft.ts";
 
+const roleInputs = [
+  {
+    id: "implementer",
+    name: "Implementation",
+    description: "Ships focused patches.",
+    familiar: "cody",
+    skills: ["test-driven-development", "using-git-worktrees"],
+    tools: ["read_files", "write_files", "shell"],
+    mcpServers: ["github"],
+    plugins: ["filesystem"],
+    workflows: ["review-fix-verify"],
+    effective: {
+      skills: [
+        { id: "test-driven-development", origin: "direct", originLabel: "Direct" },
+        { id: "receiving-code-review", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" },
+      ],
+      tools: [
+        { id: "read_files", origin: "direct", originLabel: "Direct" },
+        { id: "write_files", origin: "direct", originLabel: "Direct" },
+        { id: "shell", origin: "direct", originLabel: "Direct" },
+      ],
+      mcpServers: [{ id: "github", origin: "direct", originLabel: "Direct" }],
+      plugins: [{ id: "filesystem", origin: "direct", originLabel: "Direct" }],
+      workflows: [{ id: "review-fix-verify", origin: "direct", originLabel: "Direct" }],
+      prompts: [{ id: "review-install-plan", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" }],
+      capabilities: [
+        { id: "code_review", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" },
+        { id: "write_files", origin: "direct", originLabel: "Direct" },
+      ],
+    },
+  },
+  {
+    id: "reviewer",
+    name: "Review",
+    familiar: "cody",
+    skills: ["receiving-code-review"],
+    tools: ["read_files"],
+    mcpServers: [],
+    plugins: ["github"],
+    workflows: [],
+    effective: {
+      skills: [{ id: "receiving-code-review", origin: "direct", originLabel: "Direct" }],
+      tools: [{ id: "read_files", origin: "direct", originLabel: "Direct" }],
+      mcpServers: [],
+      plugins: [{ id: "github", origin: "direct", originLabel: "Direct" }],
+      workflows: [],
+      prompts: [],
+      capabilities: [{ id: "code_review", origin: "direct", originLabel: "Direct" }],
+    },
+  },
+] satisfies Parameters<typeof buildCraftDraftFromRoles>[0]["roles"];
+
 const draft = buildCraftDraftFromRoles({
   familiar: "cody",
-  roles: [
-    {
-      id: "implementer",
-      name: "Implementation",
-      description: "Ships focused patches.",
-      familiar: "cody",
-      skills: ["test-driven-development", "using-git-worktrees"],
-      tools: ["read_files", "write_files", "shell"],
-      mcpServers: ["github"],
-      plugins: ["filesystem"],
-      workflows: ["review-fix-verify"],
-      effective: {
-        skills: [
-          { id: "test-driven-development", origin: "direct", originLabel: "Direct" },
-          { id: "receiving-code-review", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" },
-        ],
-        tools: [
-          { id: "read_files", origin: "direct", originLabel: "Direct" },
-          { id: "write_files", origin: "direct", originLabel: "Direct" },
-          { id: "shell", origin: "direct", originLabel: "Direct" },
-        ],
-        mcpServers: [{ id: "github", origin: "direct", originLabel: "Direct" }],
-        plugins: [{ id: "filesystem", origin: "direct", originLabel: "Direct" }],
-        workflows: [{ id: "review-fix-verify", origin: "direct", originLabel: "Direct" }],
-        prompts: [{ id: "review-install-plan", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" }],
-        capabilities: [
-          { id: "code_review", origin: "craft", originLabel: "via Reviewer's Lens", craftId: "reviewers-lens" },
-          { id: "write_files", origin: "direct", originLabel: "Direct" },
-        ],
-      },
-    },
-    {
-      id: "reviewer",
-      name: "Review",
-      familiar: "cody",
-      skills: ["receiving-code-review"],
-      tools: ["read_files"],
-      mcpServers: [],
-      plugins: ["github"],
-      workflows: [],
-      effective: {
-        skills: [{ id: "receiving-code-review", origin: "direct", originLabel: "Direct" }],
-        tools: [{ id: "read_files", origin: "direct", originLabel: "Direct" }],
-        mcpServers: [],
-        plugins: [{ id: "github", origin: "direct", originLabel: "Direct" }],
-        workflows: [],
-        prompts: [],
-        capabilities: [{ id: "code_review", origin: "direct", originLabel: "Direct" }],
-      },
-    },
-  ],
+  roles: roleInputs,
+  now: "2026-07-12T09:00:00.000Z",
+});
+
+const reversedDraft = buildCraftDraftFromRoles({
+  familiar: "cody",
+  roles: [...roleInputs].reverse(),
   now: "2026-07-12T09:00:00.000Z",
 });
 
@@ -80,6 +88,9 @@ assert.equal(draft.plugin.craft?.provenance.source, "local-familiar:cody");
 assert.equal(draft.plugin.craft?.provenance.commit, "local-draft");
 assert.equal(draft.extraction.generatedAt, "2026-07-12T09:00:00.000Z");
 assert.deepEqual(draft.extraction.roles.map((role) => role.id), ["implementer", "reviewer"]);
+assert.equal(reversedDraft.id, draft.id);
+assert.equal(reversedDraft.plugin.displayName, draft.plugin.displayName);
+assert.deepEqual(reversedDraft.extraction.roles.map((role) => role.id), ["implementer", "reviewer"]);
 assert.equal(draft.extraction.ledger.skills.length, 3);
 assert.equal(draft.extraction.ledger.capabilities.length, 4);
 

--- a/src/lib/craft-draft.ts
+++ b/src/lib/craft-draft.ts
@@ -50,6 +50,18 @@ export type CraftDraft = {
 
 type MutableLedger = Map<string, { roles: Set<string>; origins: Set<string> }>;
 
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export function compareCraftDraftRoles(a: CraftDraftRoleInput, b: CraftDraftRoleInput): number {
+  const aName = (a.name.trim() || a.id).toLowerCase();
+  const bName = (b.name.trim() || b.id).toLowerCase();
+  return compareStrings(aName, bName) || compareStrings(a.id.toLowerCase(), b.id.toLowerCase());
+}
+
 function titleCase(value: string): string {
   return value
     .replace(/[-_]+/g, " ")
@@ -139,9 +151,10 @@ export function buildCraftDraftFromRoles({
   const cleanFamiliar = familiar.trim();
   if (!cleanFamiliar) throw new Error("familiar is required");
   if (roles.length === 0) throw new Error("select at least one role");
+  const orderedRoles = [...roles].sort(compareCraftDraftRoles);
 
-  const roleNames = roles.map((role) => role.name.trim() || role.id);
-  const roleIds = roles.map((role) => role.id.trim()).filter(Boolean);
+  const roleNames = orderedRoles.map((role) => role.name.trim() || role.id);
+  const roleIds = orderedRoles.map((role) => role.id.trim()).filter(Boolean);
   const displayName = `${titleCase(cleanFamiliar)} ${roleNames.join(" + ")}`;
   const id = slugify(`${cleanFamiliar}-${roleNames.join("-")}`);
 
@@ -153,7 +166,7 @@ export function buildCraftDraftFromRoles({
     capabilities: new Map<string, { roles: Set<string>; origins: Set<string> }>(),
   };
 
-  for (const role of roles) {
+  for (const role of orderedRoles) {
     const roleName = role.name.trim() || role.id;
     addEffective(ledgers.skills, role.effective.skills, roleName);
     addDirect(ledgers.skills, role.skills, roleName);
@@ -229,7 +242,7 @@ export function buildCraftDraftFromRoles({
     extraction: {
       familiar: cleanFamiliar,
       generatedAt: now,
-      roles: roles.map((role) => ({
+      roles: orderedRoles.map((role) => ({
         id: role.id,
         name: role.name,
         ...(role.description ? { description: role.description } : {}),

--- a/src/lib/craft-draft.ts
+++ b/src/lib/craft-draft.ts
@@ -57,9 +57,10 @@ function compareStrings(a: string, b: string): number {
 }
 
 export function compareCraftDraftRoles(a: CraftDraftRoleInput, b: CraftDraftRoleInput): number {
-  const aName = (a.name.trim() || a.id).toLowerCase();
-  const bName = (b.name.trim() || b.id).toLowerCase();
-  return compareStrings(aName, bName) || compareStrings(a.id.toLowerCase(), b.id.toLowerCase());
+  const aName = (a.name.trim() || a.id.trim()).toLowerCase();
+  const bName = (b.name.trim() || b.id.trim()).toLowerCase();
+  return compareStrings(aName, bName)
+    || compareStrings(a.id.trim().toLowerCase(), b.id.trim().toLowerCase());
 }
 
 function titleCase(value: string): string {

--- a/src/lib/server/craft-drafts.test.ts
+++ b/src/lib/server/craft-drafts.test.ts
@@ -43,7 +43,11 @@ try {
     JSON.stringify({
       schemaVersion: "opencoven.craft-draft.v1",
       id: "broken",
-      plugin: { id: "broken", kind: "craft", draft: true },
+      plugin: {
+        ...draft.plugin,
+        id: "broken",
+        draftId: "broken",
+      },
     }),
   );
   const drafts = await readCraftDrafts({ covenHome: root });

--- a/src/lib/server/craft-drafts.test.ts
+++ b/src/lib/server/craft-drafts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { readCraftDrafts, saveCraftDraft } from "./craft-drafts.ts";
@@ -38,6 +38,14 @@ try {
   });
 
   await saveCraftDraft(draft, { covenHome: root });
+  await writeFile(
+    path.join(root, "craft-drafts", "broken.json"),
+    JSON.stringify({
+      schemaVersion: "opencoven.craft-draft.v1",
+      id: "broken",
+      plugin: { id: "broken", kind: "craft", draft: true },
+    }),
+  );
   const drafts = await readCraftDrafts({ covenHome: root });
 
   assert.equal(drafts.length, 1);

--- a/src/lib/server/craft-drafts.ts
+++ b/src/lib/server/craft-drafts.ts
@@ -25,10 +25,19 @@ function draftPath(id: string, opts: CraftDraftStoreOptions = {}): string {
 function isCraftDraft(value: unknown): value is CraftDraft {
   if (!value || typeof value !== "object") return false;
   const draft = value as CraftDraft;
+  const plugin = draft.plugin;
   return draft.schemaVersion === "opencoven.craft-draft.v1"
     && typeof draft.id === "string"
-    && Boolean(draft.plugin?.draft)
-    && draft.plugin.kind === "craft";
+    && typeof plugin === "object"
+    && plugin !== null
+    && plugin.draft === true
+    && plugin.kind === "craft"
+    && plugin.id === draft.id
+    && typeof plugin.draftId === "string"
+    && plugin.draftId === draft.id
+    && typeof plugin.displayName === "string"
+    && plugin.displayName.trim().length > 0
+    && typeof plugin.description === "string";
 }
 
 export async function readCraftDrafts(opts: CraftDraftStoreOptions = {}): Promise<CraftDraft[]> {

--- a/src/lib/server/craft-drafts.ts
+++ b/src/lib/server/craft-drafts.ts
@@ -26,6 +26,8 @@ function isCraftDraft(value: unknown): value is CraftDraft {
   if (!value || typeof value !== "object") return false;
   const draft = value as CraftDraft;
   const plugin = draft.plugin;
+  const extraction = draft.extraction;
+  const extractionRoles = extraction?.roles;
   return draft.schemaVersion === "opencoven.craft-draft.v1"
     && typeof draft.id === "string"
     && typeof plugin === "object"
@@ -37,7 +39,22 @@ function isCraftDraft(value: unknown): value is CraftDraft {
     && plugin.draftId === draft.id
     && typeof plugin.displayName === "string"
     && plugin.displayName.trim().length > 0
-    && typeof plugin.description === "string";
+    && typeof plugin.description === "string"
+    && typeof extraction === "object"
+    && extraction !== null
+    && typeof extraction.familiar === "string"
+    && extraction.familiar.trim().length > 0
+    && typeof extraction.generatedAt === "string"
+    && Array.isArray(extractionRoles)
+    && extractionRoles.every((role) => (
+      typeof role === "object"
+      && role !== null
+      && typeof role.id === "string"
+      && role.id.trim().length > 0
+      && typeof role.name === "string"
+      && role.name.trim().length > 0
+      && (role.description === undefined || typeof role.description === "string")
+    ));
 }
 
 export async function readCraftDrafts(opts: CraftDraftStoreOptions = {}): Promise<CraftDraft[]> {

--- a/src/lib/server/role-entries.ts
+++ b/src/lib/server/role-entries.ts
@@ -26,12 +26,23 @@ export type RoleEntry = {
   activatedAt?: string;
 };
 
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 export async function loadRoleEntries(): Promise<RoleEntry[]> {
   const roles: RoleEntry[] = [];
   const cfg = await loadConfig();
   const roleConfigMap = new Map(cfg.roles.map((r) => [`${r.familiar}:${r.id}`, r]));
+  const roleFiles = (await discoverRoleFiles()).sort((a, b) => (
+    compareStrings(a.familiar, b.familiar)
+    || compareStrings(a.id, b.id)
+    || compareStrings(a.path, b.path)
+  ));
 
-  for (const roleFile of await discoverRoleFiles()) {
+  for (const roleFile of roleFiles) {
     try {
       const text = await readFile(roleFile.path, "utf8");
       const fm = parseRoleFrontmatter(text);


### PR DESCRIPTION
## Summary
- Sort discovered role files before loading role entries so `/api/roles` ordering is deterministic.
- Canonicalize draft role ordering at the route and builder boundary to keep draft ids/display names stable.
- Tighten the local Craft draft type guard so malformed draft JSON is ignored instead of breaking Marketplace reads.

## Context
Follow-up for Copilot review threads on #2974, which was merged before this correction commit landed on the PR branch.

## Verification
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- git diff --check origin/main...HEAD