### PR TITLE
fix(chat): render captured Codex output events

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -900,6 +900,12 @@ assert.match(
 );
 
 assert.match(
+  chatRoute,
+  /ev\.type === "output" && typeof ev\.text === "string"[\s\S]*?assistantFilter\.push\(cleaned\)[\s\S]*?kind: "assistant_chunk", text: filtered/,
+  "Coven stream-json output events must pass through the Codex assistant filter instead of being discarded as handled JSON",
+);
+
+assert.match(
   streamEvents,
   /kind: "done";[\s\S]*?usage\?: TurnUsage;[\s\S]*?costUsd\?: number;/,
   "The done StreamEvent must carry optional usage and costUsd fields (CHAT-D12-02)",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1528,6 +1528,7 @@ export async function POST(req: Request) {
               is_error?: boolean;
               total_cost_usd?: number;
               usage?: unknown;
+              text?: string;
               message?: {
                 content?: Array<{
                   type?: string;
@@ -1576,6 +1577,18 @@ export async function POST(req: Request) {
                 usage: parseStreamJsonUsage(ev.usage),
                 costUsd: parseCostUsd(ev.total_cost_usd),
               };
+            } else if (ev.type === "output" && typeof ev.text === "string") {
+              // Coven's Windows captured-piped Codex path wraps transcript
+              // bytes as stream-json `output` events so stdout remains a
+              // valid JSONL protocol. Preserve the original chunk boundaries:
+              // AssistantFilter buffers partial lines and exposes only the
+              // assistant phase after stripping Codex's startup transcript.
+              const cleaned = resolveBackspaces(stripAnsi(ev.text));
+              const filtered = assistantFilter.push(cleaned);
+              if (filtered) {
+                assistantText += filtered;
+                push({ kind: "assistant_chunk", text: filtered });
+              }
             } else if (
               ev.type === "assistant" &&
               Array.isArray(ev.message?.content)


### PR DESCRIPTION
## What changed

- parse Coven stream-JSON `type: "output"` events in the chat send route
- feed captured Codex chunks through the existing assistant transcript filter
- preserve partial chunk boundaries so startup banners stay suppressed and assistant prose streams normally
- pin the integration contract in the harness-routing test

## Root cause

The Windows captured-piped Coven path emits Codex transcript bytes as structured `output` events to keep stdout valid JSONL. Cave recognized those lines as JSON but handled only `result`, Claude `assistant`, and tool-result events. It then returned without consuming `output.text`, so a successful Codex run was synthesized as ?completed but produced no output.?

## Impact

Windows Codex responses now render and persist in Cave instead of becoming false authentication diagnostics.

## Validation

- `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`
- `pnpm typecheck`
- `git diff --check`
- end-to-end `/api/chat/send` with the patched Coven binary:
  - session `8461a585-4ae2-4b43-ab65-38fa74d5ea6d`
  - status `completed`
  - exit code `0`
  - assistant text persisted
  - `isError: false`

Companion runtime fix: OpenCoven/coven#337

Bead: `cave-178`.
