### PR TITLE
docs(settings): credit original preference-persistence author

### DIFF
--- a/docs/settings-persistence.md
+++ b/docs/settings-persistence.md
@@ -74,4 +74,4 @@ store.
 The preference-persistence system in this document was designed and
 implemented by Timothy Wayne Gregg ([@romgenie](https://github.com/romgenie))
 in [#2952](https://github.com/OpenCoven/coven-cave/pull/2952), re-homed and
-merged via #2971.
+merged via [#2971](https://github.com/OpenCoven/coven-cave/pull/2971).

--- a/docs/settings-persistence.md
+++ b/docs/settings-persistence.md
@@ -68,3 +68,10 @@ build once on an origin that still has the old data allows the best-effort
 migration; otherwise the old data remains untouched for manual/browser-level
 recovery. This limitation is why all covered settings now use the port-independent
 store.
+
+## Credits
+
+The preference-persistence system in this document was designed and
+implemented by Timothy Wayne Gregg ([@romgenie](https://github.com/romgenie))
+in [#2952](https://github.com/OpenCoven/coven-cave/pull/2952), re-homed and
+merged via #2971.


### PR DESCRIPTION
Adds a Credits section to `docs/settings-persistence.md` and carries a `Co-authored-by:` trailer for @romgenie so the preference-persistence work (originally #2952, merged via #2971) is reflected in git history and the **contributors graph**.

The squash-merge of #2971 dropped the original fork author's trailer (autofix bots' co-author lines were picked up instead). This lands his attribution durably.