### PR TITLE
fix(chat): pinned chats persist across surfaces — one shared subscribable pin store

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -82,16 +82,19 @@ assert.deepEqual(
 assert.equal(sorted[1], groups[1], "groups without pins keep their reference");
 assert.equal(sortPinnedFirst(groups, []), groups, "no pins → groups returned untouched");
 
-// ChatList wiring: persisted pin state drives a pinned-first ordering.
+// ChatList wiring: the shared cross-surface pin store drives a pinned-first
+// ordering. ChatList must NOT keep a private useState copy of the pin list —
+// that's the stale-clobber bug (pin in the thread rail, then pin here, and the
+// stale copy overwrote the first pin on write).
 assert.match(
   source,
-  /setPinnedIds\(readPinnedSessions\(\)\)/,
-  "ChatList should hydrate pinned ids from the localStorage store after mount",
+  /const pinnedIds = usePinnedSessions\(\)/,
+  "ChatList should read pinned ids from the shared subscribable store",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /window\.localStorage\.setItem\(PINNED_SESSIONS_KEY, JSON\.stringify\(pinnedIds\)\)/,
-  "ChatList should persist pin toggles back to the localStorage store",
+  /setPinnedIds/,
+  "ChatList must not hold a private pin-list state that can clobber other surfaces",
 );
 assert.match(
   source,
@@ -100,7 +103,7 @@ assert.match(
 );
 assert.match(
   source,
-  /togglePinnedSession\(prev, sessionId\)/,
+  /toggleStoredPinnedSession\(sessionId\)/,
   "ChatList pin action should toggle through the shared store helper",
 );
 assert.match(

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -36,12 +36,11 @@ import {
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
 import {
-  PINNED_SESSIONS_KEY,
   isSessionPinned,
-  readPinnedSessions,
   sortPinnedFirst,
-  togglePinnedSession,
+  toggleStoredPinnedSession,
 } from "@/lib/chat-session-prefs";
+import { usePinnedSessions } from "@/lib/use-pinned-sessions";
 import {
   applyManualOrder,
   mergeVisibleOrder,
@@ -261,9 +260,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     });
   }, []);
   const [unreadsOnly, setUnreadsOnly] = useState(false);
-  // Pins are Cave-local UI state (localStorage), same idiom as the project
-  // sidebar persistence below — the daemon never learns about them.
-  const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+  // Pins are Cave-local UI state (localStorage) shared across every chat
+  // surface through one subscribable store — the daemon never learns about
+  // them, and no surface holds a private copy that could clobber another's.
+  const pinnedIds = usePinnedSessions();
   const [sessionOrder, setSessionOrder] = useState<string[]>([]);
   // Archived rows are excluded server-side by /api/sessions/list; the toggle
   // opts into them with its own includeArchived fetch (the workspace's list
@@ -401,7 +401,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     );
     const storedSelection = readPersisted<unknown>(PROJECT_SIDEBAR_KEYS.selected, "all");
     setSelection(typeof storedSelection === "string" ? storedSelection : "all");
-    setPinnedIds(readPinnedSessions());
     setSessionOrder(readSessionOrder());
     setSidebarHydrated(true);
   }, [sessionsLoaded, sidebarGroups]);
@@ -418,9 +417,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.selected, JSON.stringify(selection));
   }, [sidebarHydrated, selection]);
-  useEffect(() => {
-    if (sidebarHydrated) window.localStorage.setItem(PINNED_SESSIONS_KEY, JSON.stringify(pinnedIds));
-  }, [sidebarHydrated, pinnedIds]);
 
   // Archived sessions only load while the toggle is on; archive/unarchive
   // bumps archiveNonce so the opt-in list refetches after each change.
@@ -603,7 +599,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   const togglePin = (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation();
-    setPinnedIds((prev) => togglePinnedSession(prev, sessionId));
+    toggleStoredPinnedSession(sessionId);
   };
 
   const setSessionArchived = async (e: React.MouseEvent, sessionId: string, archived: boolean) => {

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -10,11 +10,10 @@ import { sessionRailTitle } from "@/lib/session-rail-title";
 import { cancelHoverPrefetch, hoverPrefetchConversation } from "@/lib/conversation-cache";
 import { relativeTime } from "@/lib/relative-time";
 import {
-  PINNED_SESSIONS_KEY,
   isSessionPinned,
-  readPinnedSessions,
-  togglePinnedSession,
+  toggleStoredPinnedSession,
 } from "@/lib/chat-session-prefs";
+import { usePinnedSessions } from "@/lib/use-pinned-sessions";
 import {
   applyManualOrder,
   partitionPinnedFirst,
@@ -349,20 +348,16 @@ export function ChatProjectSidebar({
   onOpenProjectsTab,
 }: Props) {
   const [search, setSearch] = useState("");
-  const [pinnedIds, setPinnedIds] = useState<string[]>([]);
+  // Pins come from the shared cross-surface store; the manual drag order is
+  // still local (this rail is its only writer).
+  const pinnedIds = usePinnedSessions();
   const [order, setOrder] = useState<string[]>([]);
-  const [hydrated, setHydrated] = useState(false);
 
-  // UI prefs (pins + manual order) load after mount so SSR markup and the
-  // first client render agree — same idiom as the chat list's persistence.
+  // The manual order loads after mount so SSR markup and the first client
+  // render agree — same idiom as the chat list's persistence.
   useEffect(() => {
-    setPinnedIds(readPinnedSessions());
     setOrder(readSessionOrder());
-    setHydrated(true);
   }, []);
-  useEffect(() => {
-    if (hydrated) window.localStorage.setItem(PINNED_SESSIONS_KEY, JSON.stringify(pinnedIds));
-  }, [hydrated, pinnedIds]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -424,7 +419,7 @@ export function ChatProjectSidebar({
   }
 
   function togglePin(sessionId: string) {
-    setPinnedIds((prev) => togglePinnedSession(prev, sessionId));
+    toggleStoredPinnedSession(sessionId);
   }
 
   // Folder-tree DnD: reorder a chat within its project, or drop it onto another

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -74,9 +74,9 @@ assert.match(
   "Project folder headers read as headers: the label is bold",
 );
 
-// ── Pin toggle is Cave-local (shared localStorage key with the chat list) ────
-assert.match(source, /PINNED_SESSIONS_KEY/, "Rail pins share the chat list's localStorage key");
-assert.match(source, /togglePinnedSession/, "Rail toggles pins through the shared helper");
+// ── Pin toggle is Cave-local (shared cross-surface store with the chat list) ─
+assert.match(source, /usePinnedSessions\(\)/, "Rail pins read from the shared cross-surface pin store");
+assert.match(source, /toggleStoredPinnedSession/, "Rail toggles pins through the shared store helper");
 
 // ── Default floats pinned; once dragged, manual order wins (no tug-of-war) ───
 assert.match(

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -19,14 +19,13 @@ import {
   type ChatProjectGroup,
 } from "@/lib/chat-projects";
 import {
-  PINNED_SESSIONS_KEY,
   isSessionPinned,
-  readPinnedSessions,
-  togglePinnedSession,
+  toggleStoredPinnedSession,
   readChatSidebarView,
   writeChatSidebarView,
   type ChatSidebarView,
 } from "@/lib/chat-session-prefs";
+import { usePinnedSessions } from "@/lib/use-pinned-sessions";
 import { deriveChatRecencyBuckets } from "@/lib/chat-recency";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui/popover";
 import { addChatProject, projectNameForRoot } from "@/lib/chat-add-project";
@@ -224,8 +223,9 @@ export function WorkspaceSidebar({
   const [query, setQuery] = useState("");
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(() => new Set());
   const [showAllByKey, setShowAllByKey] = useState<Set<string>>(() => new Set());
-  const [pinnedIds, setPinnedIds] = useState<string[]>([]);
-  const [hydrated, setHydrated] = useState(false);
+  // Pins come from the shared cross-surface store (chat list + thread rail +
+  // this sidebar all read and write the same subscribable list).
+  const pinnedIds = usePinnedSessions();
   const [confirmingSessionId, setConfirmingSessionId] = useState<string | null>(null);
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null);
   const [registeringRoot, setRegisteringRoot] = useState<string | null>(null);
@@ -239,17 +239,11 @@ export function WorkspaceSidebar({
   // the GitHub action popover, #2288). Also hydrates the organize-view preference.
   useFocusTrap(menuOpen, menuBodyRef, { onEscape: () => setMenuOpen(false) });
 
-  // Pins and the organize-view preference load after mount so SSR and first
-  // client render agree (same idiom as the chat list). The store is shared
-  // with the chat surface's other lists.
+  // The organize-view preference loads after mount so SSR and first client
+  // render agree (same idiom as the chat list).
   useEffect(() => {
-    setPinnedIds(readPinnedSessions());
     setView(readChatSidebarView());
-    setHydrated(true);
   }, []);
-  useEffect(() => {
-    if (hydrated) window.localStorage.setItem(PINNED_SESSIONS_KEY, JSON.stringify(pinnedIds));
-  }, [hydrated, pinnedIds]);
 
   const visibleSessions = useMemo(
     () => filterVisibleChatSessions(sessions, activeFamiliarId ?? null),
@@ -327,7 +321,7 @@ export function WorkspaceSidebar({
   };
 
   const togglePin = (sessionId: string) => {
-    setPinnedIds((prev) => togglePinnedSession(prev, sessionId));
+    toggleStoredPinnedSession(sessionId);
   };
 
   const selectView = (next: ChatSidebarView) => {

--- a/src/lib/chat-session-prefs.test.ts
+++ b/src/lib/chat-session-prefs.test.ts
@@ -3,9 +3,14 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   CHAT_SIDEBAR_VIEW_KEY,
+  PINNED_SESSIONS_KEY,
+  getPinnedSessionsSnapshot,
   normalizeChatSidebarView,
   readChatSidebarView,
+  subscribePinnedSessions,
+  toggleStoredPinnedSession,
   writeChatSidebarView,
+  writePinnedSessions,
 } from "./chat-session-prefs.ts";
 
 test("normalize: only 'projects' opts out of the recent default", () => {
@@ -42,5 +47,96 @@ test("read/write round-trip through a stubbed localStorage", () => {
     assert.equal(readChatSidebarView(), "recent");
   } finally {
     delete globalThis.window;
+  }
+});
+
+// ── Shared pin store ─────────────────────────────────────────────────────────
+
+function withStubbedStorage(fn) {
+  const store = new Map();
+  globalThis.window = {
+    localStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => void store.set(k, String(v)),
+    },
+    addEventListener: () => {},
+  };
+  try {
+    fn(store);
+  } finally {
+    delete globalThis.window;
+    // Reset the module-level snapshot cache for the next test by writing a
+    // fresh empty list (window is gone, so this only touches the cache).
+    writePinnedSessions([]);
+  }
+}
+
+test("pin snapshot is SSR-safe and referentially stable", () => {
+  assert.equal(typeof window, "undefined");
+  assert.deepEqual(getPinnedSessionsSnapshot(), []);
+  withStubbedStorage(() => {
+    writePinnedSessions(["s1", "s2"]);
+    const a = getPinnedSessionsSnapshot();
+    const b = getPinnedSessionsSnapshot();
+    assert.equal(a, b, "unchanged store returns the same array reference");
+    assert.deepEqual(a, ["s1", "s2"]);
+  });
+});
+
+test("writes persist under the stable key, dedupe, and notify subscribers", () => {
+  withStubbedStorage((store) => {
+    let notified = 0;
+    const unsubscribe = subscribePinnedSessions(() => {
+      notified += 1;
+    });
+    writePinnedSessions(["s1", "s1", "", "s2"]);
+    assert.equal(store.get(PINNED_SESSIONS_KEY), JSON.stringify(["s1", "s2"]));
+    assert.equal(notified, 1, "each write notifies once");
+    unsubscribe();
+    writePinnedSessions(["s1"]);
+    assert.equal(notified, 1, "unsubscribed listeners stop firing");
+  });
+});
+
+test("two surfaces toggling through the store cannot clobber each other", () => {
+  // Regression: chat list, thread rail and workspace sidebar each held a
+  // private useState copy of the pin list and wrote the whole key on change.
+  // Pin in surface A, then pin in surface B → B persisted its stale copy and
+  // A's pin vanished. Through the shared store, sequential toggles from
+  // different surfaces accumulate.
+  withStubbedStorage((store) => {
+    toggleStoredPinnedSession("from-thread-rail");
+    toggleStoredPinnedSession("from-chat-list");
+    assert.deepEqual(
+      JSON.parse(store.get(PINNED_SESSIONS_KEY)),
+      ["from-thread-rail", "from-chat-list"],
+      "both surfaces' pins survive",
+    );
+    toggleStoredPinnedSession("from-thread-rail");
+    assert.deepEqual(
+      JSON.parse(store.get(PINNED_SESSIONS_KEY)),
+      ["from-chat-list"],
+      "unpin removes only the toggled id",
+    );
+  });
+});
+
+test("snapshot survives a localStorage write failure (in-memory fallback)", () => {
+  const store = new Map();
+  globalThis.window = {
+    localStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    },
+    addEventListener: () => {},
+  };
+  try {
+    writePinnedSessions(["s9"]);
+    assert.deepEqual(getPinnedSessionsSnapshot(), ["s9"], "pins stay live for this page");
+  } finally {
+    delete globalThis.window;
+    writePinnedSessions([]);
   }
 });

--- a/src/lib/chat-session-prefs.ts
+++ b/src/lib/chat-session-prefs.ts
@@ -5,12 +5,9 @@ import type { ChatProjectGroup } from "./chat-projects.ts";
  *  same way as the chat project sidebar state (see chat-project-selection). */
 export const PINNED_SESSIONS_KEY = "cave:chat:pinned-sessions";
 
-/** Read the pinned session ids; survives SSR (no window) and corrupt values. */
-export function readPinnedSessions(): string[] {
-  if (typeof window === "undefined") return [];
+function parsePinnedSessions(raw: string | null): string[] {
+  if (raw === null) return [];
   try {
-    const raw = window.localStorage.getItem(PINNED_SESSIONS_KEY);
-    if (raw === null) return [];
     const parsed: unknown = JSON.parse(raw);
     return Array.isArray(parsed)
       ? parsed.filter((v): v is string => typeof v === "string")
@@ -18,6 +15,97 @@ export function readPinnedSessions(): string[] {
   } catch {
     return [];
   }
+}
+
+/** Read the pinned session ids; survives SSR (no window) and corrupt values. */
+export function readPinnedSessions(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return parsePinnedSessions(window.localStorage.getItem(PINNED_SESSIONS_KEY));
+  } catch {
+    return [];
+  }
+}
+
+// ── Shared pin store ─────────────────────────────────────────────────────────
+// The chat list, the chat-surface thread rail, and the workspace sidebar all
+// show the same pins. Each used to hold its own useState copy and write the
+// whole key on change, so pinning in one surface and then pinning in another
+// clobbered the first (the second surface wrote its stale copy). One
+// subscribable store — same idiom as session-pins.ts — keeps every mounted
+// surface on the same list and persists exactly once per change.
+
+const pinListeners = new Set<() => void>();
+function notifyPinnedSessions(): void {
+  for (const fn of pinListeners) fn();
+}
+
+/** Subscribe to pin changes (useSyncExternalStore-compatible). */
+export function subscribePinnedSessions(fn: () => void): () => void {
+  pinListeners.add(fn);
+  return () => {
+    pinListeners.delete(fn);
+  };
+}
+
+// useSyncExternalStore requires a referentially-stable snapshot: getSnapshot
+// must return the SAME array while the underlying value is unchanged or React
+// re-renders every commit. Cache the parsed list keyed on the raw stored
+// string.
+const EMPTY_PINNED: string[] = [];
+let cachedPinnedRaw: string | null | undefined;
+let cachedPinned: string[] = EMPTY_PINNED;
+
+/** Referentially-stable snapshot of the pinned ids (SSR-safe: [] on server). */
+export function getPinnedSessionsSnapshot(): string[] {
+  if (typeof window === "undefined") return EMPTY_PINNED;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(PINNED_SESSIONS_KEY);
+  } catch {
+    return cachedPinned;
+  }
+  if (raw === cachedPinnedRaw) return cachedPinned;
+  cachedPinnedRaw = raw;
+  cachedPinned = parsePinnedSessions(raw);
+  return cachedPinned;
+}
+
+/** Persist a new pin list and notify every subscribed surface. */
+export function writePinnedSessions(ids: readonly string[]): void {
+  const unique = Array.from(new Set(ids.filter((id) => typeof id === "string" && id.length > 0)));
+  // Update the in-memory snapshot first so subscribers stay consistent even
+  // when localStorage is full/disabled (the pin just won't survive reload).
+  cachedPinnedRaw = JSON.stringify(unique);
+  cachedPinned = unique;
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(PINNED_SESSIONS_KEY, cachedPinnedRaw);
+    } catch {
+      // Storage rejected the write (full/disabled) — pins live for this page
+      // only. Key the cache on whatever storage still holds so the snapshot
+      // keeps serving the in-memory list instead of re-parsing the stale raw.
+      try {
+        cachedPinnedRaw = window.localStorage.getItem(PINNED_SESSIONS_KEY);
+      } catch {
+        /* getItem also failing routes snapshots to the cached list anyway */
+      }
+    }
+  }
+  notifyPinnedSessions();
+}
+
+/** Toggle a pin against the shared store (persists + notifies). */
+export function toggleStoredPinnedSession(sessionId: string): void {
+  writePinnedSessions(togglePinnedSession(getPinnedSessionsSnapshot(), sessionId));
+}
+
+// Cross-tab: another tab's pin write lands as a storage event; re-notify so
+// every surface here re-reads the fresh value.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === PINNED_SESSIONS_KEY) notifyPinnedSessions();
+  });
 }
 
 export function isSessionPinned(pinned: readonly string[], sessionId: string): boolean {

--- a/src/lib/use-pinned-sessions.ts
+++ b/src/lib/use-pinned-sessions.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { getPinnedSessionsSnapshot, subscribePinnedSessions } from "@/lib/chat-session-prefs";
+
+const EMPTY: string[] = [];
+
+/**
+ * Subscribe to the shared pinned-chat list (`cave:chat:pinned-sessions`).
+ * Every surface rendering pins — chat list, thread rail, workspace sidebar —
+ * reads through this hook so a pin toggled anywhere updates everywhere and no
+ * stale local copy can clobber the persisted list.
+ */
+export function usePinnedSessions(): string[] {
+  return useSyncExternalStore(subscribePinnedSessions, getPinnedSessionsSnapshot, () => EMPTY);
+}


### PR DESCRIPTION
## Problem — pinned chats vanish

Three surfaces render pins from `cave:chat:pinned-sessions`: the chat list (`chat-list.tsx`), the chat-surface thread rail (`chat-project-sidebar.tsx`), and the workspace sidebar (`workspace-sidebar.tsx`). Each held a **private `useState` copy** hydrated once on mount and wrote the whole key whenever its copy changed.

With two surfaces mounted at once (the chat list renders the thread rail alongside itself), pin in one → its copy + the key update, but the sibling's copy stays stale. Pin/unpin in the sibling next → it persists **its stale list**, and the first pin is gone. Pins appeared not to persist.

## Fix

- `chat-session-prefs.ts` gains a shared subscribable pin store (same proven idiom as `session-pins.ts`): referentially-stable snapshot for `useSyncExternalStore`, dedupe on write, notify-on-change, storage-event bridge for cross-tab, and an in-memory fallback when `localStorage` rejects writes.
- New `usePinnedSessions()` hook (`src/lib/use-pinned-sessions.ts`).
- All three surfaces drop their private state/read/write effects and go through the store; `toggleStoredPinnedSession()` is the single write path.
- Regression tests: cross-surface clobber, snapshot stability, dedupe/notify/unsubscribe, quota-failure fallback. Source-assertion tests updated; `chat-list-delete.test.ts` now asserts ChatList holds **no** private pin state.

## Ordering (second half of the request)

Most-recent-project-first chat rail ordering (recency beats alphabetical) already landed last night in #2961 (`deriveChatProjectGroups` sorts groups by latest chat activity, "No project" last) and is covered by `chat-projects.test.ts`. Verified intact here — no change needed.

## Verification

- `pnpm test` — 615 test files pass
- `tsc --noEmit` — clean
- `pnpm build` — green, bundle within budget

Bead: cave-md1i