### PR TITLE
fix(chat): render captured Codex output events

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -900,6 +900,12 @@ assert.match(
 );
 
 assert.match(
+  chatRoute,
+  /ev\.type === "output" && typeof ev\.text === "string"[\s\S]*?assistantFilter\.push\(cleaned\)[\s\S]*?kind: "assistant_chunk", text: filtered/,
+  "Coven stream-json output events must pass through the Codex assistant filter instead of being discarded as handled JSON",
+);
+
+assert.match(
   streamEvents,
   /kind: "done";[\s\S]*?usage\?: TurnUsage;[\s\S]*?costUsd\?: number;/,
   "The done StreamEvent must carry optional usage and costUsd fields (CHAT-D12-02)",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -906,6 +906,12 @@ assert.match(
 );
 
 assert.match(
+  chatRoute,
+  /ev\.type === "output" && typeof ev\.text === "string"[\s\S]*?recordStdoutErrorTail\(cleaned\)[\s\S]*?assistantFilter\.push\(cleaned\)/,
+  "Coven stream-json output events must preserve error-looking stdout text for empty-response diagnostics before filtering",
+);
+
+assert.match(
   streamEvents,
   /kind: "done";[\s\S]*?usage\?: TurnUsage;[\s\S]*?costUsd\?: number;/,
   "The done StreamEvent must carry optional usage and costUsd fields (CHAT-D12-02)",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1528,6 +1528,7 @@ export async function POST(req: Request) {
               is_error?: boolean;
               total_cost_usd?: number;
               usage?: unknown;
+              text?: string;
               message?: {
                 content?: Array<{
                   type?: string;
@@ -1576,6 +1577,18 @@ export async function POST(req: Request) {
                 usage: parseStreamJsonUsage(ev.usage),
                 costUsd: parseCostUsd(ev.total_cost_usd),
               };
+            } else if (ev.type === "output" && typeof ev.text === "string") {
+              // Coven's Windows captured-piped Codex path wraps transcript
+              // bytes as stream-json `output` events so stdout remains a
+              // valid JSONL protocol. Preserve the original chunk boundaries:
+              // AssistantFilter buffers partial lines and exposes only the
+              // assistant phase after stripping Codex's startup transcript.
+              const cleaned = resolveBackspaces(stripAnsi(ev.text));
+              const filtered = assistantFilter.push(cleaned);
+              if (filtered) {
+                assistantText += filtered;
+                push({ kind: "assistant_chunk", text: filtered });
+              }
             } else if (
               ev.type === "assistant" &&
               Array.isArray(ev.message?.content)

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1498,6 +1498,14 @@ export async function POST(req: Request) {
       const STDOUT_ERR_KEEP = 10;
       const ERR_LINE_RE =
         /\b(error|failed|denied|unauthori[sz]ed|invalid|refused|missing|not found|401|403|500)\b/i;
+      const recordStdoutErrorTail = (text: string) => {
+        for (const part of text.split(/\r?\n/)) {
+          const trimmed = part.trim();
+          if (!trimmed || !ERR_LINE_RE.test(trimmed)) continue;
+          stdoutErrTail.push(trimmed);
+          if (stdoutErrTail.length > STDOUT_ERR_KEEP) stdoutErrTail.shift();
+        }
+      };
 
       // Set to true when the harness reports its resume failed (rollout DB
       // miss). Triggers a single transparent retry without --continue.
@@ -1584,6 +1592,7 @@ export async function POST(req: Request) {
               // AssistantFilter buffers partial lines and exposes only the
               // assistant phase after stripping Codex's startup transcript.
               const cleaned = resolveBackspaces(stripAnsi(ev.text));
+              recordStdoutErrorTail(cleaned);
               const filtered = assistantFilter.push(cleaned);
               if (filtered) {
                 assistantText += filtered;
@@ -1635,12 +1644,9 @@ export async function POST(req: Request) {
           }
         }
         const cleaned = resolveBackspaces(stripAnsi(line));
-        // Snapshot error-looking stdout lines for the empty-response diagnostic.
         const trimmed = cleaned.trim();
-        if (trimmed && ERR_LINE_RE.test(trimmed)) {
-          stdoutErrTail.push(trimmed);
-          if (stdoutErrTail.length > STDOUT_ERR_KEEP) stdoutErrTail.shift();
-        }
+        // Snapshot error-looking stdout lines for the empty-response diagnostic.
+        recordStdoutErrorTail(cleaned);
         // Surface tool-use hook lines as structured events so the chat can
         // render a tool block. Hooks are still discarded by AssistantFilter
         // below, so this is purely additive.


### PR DESCRIPTION
## Summary
- restore rendering/persistence for captured Codex `type: "output"` stream-json events, carrying forward the closed fork PR #2976
- preserve error-looking output text in the empty-response diagnostic tail before AssistantFilter suppression
- add harness-routing source contracts for both the output-event path and diagnostic capture

## Context
- Replaces closed, unmerged fork PR #2976 because maintainer edits were disabled.
- Companion runtime fix: OpenCoven/coven#337.

## Verification
- `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app`
- `git diff --check origin/main...HEAD`