### PR TITLE
chore(release): stamp v0.0.178

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.178] - 2026-07-12
+
+> 🪄 **Craft authoring, GitHub event subscriptions, and chat reliability.** Cave can now create local draft Crafts from familiar roles, subscribe to GitHub repository activity, keep pinned chats synchronized across surfaces, and render captured Codex output events reliably on the Windows harness path.
+
+Patch release on top of v0.0.177.
+
+### Features
+- **Crafts: create local draft Crafts from familiars** — the Crafts page can extract a reversible local draft from a familiar's selected roles, including direct and effective skills, tools/capabilities, MCP servers, plugins, prompts, workflows, origin labels, and a review ledger before save (#2974, #2975).
+- **GitHub: subscribe to repository events** — repository activity can now subscribe to opened PRs and CI completion events for Cave-side project awareness (#2978).
+- **Desktop: Coven logo menu-bar icon** — the menu-bar tray now uses the Coven logo so Cave is easier to recognize at a glance (#2979).
+
+### Fixes
+- **Chat: captured Codex output events render correctly** — Coven stream-json `output` events are routed through the assistant filter, persisted, and still preserve error-looking output text for empty-response diagnostics on the Windows captured-piped path (#2982).
+- **Chat: pinned chats persist across surfaces** — pinned chat state now flows through one shared subscribable store, so chat pins stay in sync between surfaces (#2980).
+
+### Docs
+- **Settings: attribution note** — the preference-persistence changelog credit now names the original author correctly (#2977).
+
+
 ## [0.0.177] - 2026-07-12
 
 > 🗨️ **Chat context, discoverability, and durable settings.** The composer gains a live git context chip (branch · worktree · PR), chats get a visible rename button and smart chat→task autofill with promoted inspector tabs and AI project icons, granted project roots are now enforced at the harness level, and preferences survive sidecar port changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -64,7 +64,7 @@ test("pre-v0.0.54 versions render the legacy single-DMG install block", () => {
   const body = render("v0.0.42");
   assert.match(
     body,
-    /download `CovenCave-v0\.0\.42\.dmg`/,
+    /download \[`CovenCave-v0\.0\.42\.dmg`\]\(https:\/\/github\.com\/OpenCoven\/coven-cave\/releases\/download\/v0\.0\.42\/CovenCave-v0\.0\.42\.dmg\)/,
     "legacy install block lists the un-suffixed DMG",
   );
   assert.doesNotMatch(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.177"
+version = "0.0.178"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.177"
+version = "0.0.178"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.177</string>
+	<string>0.0.178</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.177</string>
+	<string>0.0.178</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.177</string>
+	<string>0.0.178</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.177</string>
+	<string>0.0.178</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamped by `scripts/stamp-release.mjs`. Edit the CHANGELOG teaser/grouping before merge.

```
## [0.0.178] - 2026-07-12

> _One-line teaser — edit before merge._

Patch release on top of v0.0.177.

### Changes
- fix(chat): render captured Codex output events (#2982)
- fix(chat): pinned chats persist across surfaces — one shared subscribable pin store (#2980)
- Use the Coven logo as the menu-bar tray icon (#2979)
- feat(github): subscribe to repo events — opened PRs and CI completions (#2978)
- docs(settings): credit original preference-persistence author (#2977)
- Harden craft draft extraction validation
- Potential fix for pull request finding
- Stabilize craft draft generation
- Add local craft draft creation (#2974)

```