### PR TITLE
fix(chat): render tool calls on the copilot harness via its JSONL stream

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -685,6 +685,7 @@ export const SUITES = {
     "src/lib/coven-identity-canon.test.ts",
     "src/lib/familiar-runtime.test.ts",
     "src/lib/harness-adapters.test.ts",
+    "src/lib/copilot-stream.test.ts",
     "src/app/api/board/enrich-steps/route.test.ts",
     "src/app/api/board/[id]/chat/route.test.ts",
     "src/app/api/chat/send/harness-routing.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -1206,4 +1206,60 @@ assert.match(
 
 console.log("model parity routing tests passed");
 
+// ── Copilot JSONL stream wiring (cave-yesg) ──────────────────────────────────
+// `coven run copilot --stream-json` launches the CLI one-shot and pipes raw
+// prose, so tool calls never reach the chat. Copilot chats must spawn the CLI
+// directly with its manifest-declared stream args and parse its JSONL events;
+// every other adapter (and SSH runtimes) keeps the coven run path.
+
+assert.match(
+  chatRoute,
+  /import \{[\s\S]*?copilotStreamSpec,[\s\S]*?\} from "@\/lib\/copilot-stream";/,
+  "Chat send should source copilot stream wiring from the shared copilot-stream lib",
+);
+
+assert.match(
+  chatRoute,
+  /const copilotStream =\s*\n?\s*!sshRuntime && binding\.harness === "copilot" \? copilotStreamSpec\(\) : null;/,
+  "The copilot stream path is gated to local copilot chats and falls back to passthrough when the manifest stops declaring stream mode",
+);
+
+assert.match(
+  chatRoute,
+  /const \{ command, fixedArgs \} = copilotStream\s*\n?\s*\? \{ command: copilotStream\.executable, fixedArgs: \[\] as string\[\] \}\s*\n?\s*: covenLaunchCommand\(\);/,
+  "Copilot stream turns spawn the adapter binary directly; everything else spawns coven",
+);
+
+assert.match(
+  chatRoute,
+  /if \(copilotStream\) \{\s*\n\s*handleCopilotLine\(line, isJson\);\s*\n\s*return;/,
+  "Copilot stdout routes through the copilot JSONL handler, never the AssistantFilter (raw JSON frames must not leak into the bubble)",
+);
+
+assert.match(
+  chatRoute,
+  /copilotIdentityPreamble\(\s*\n?\s*body\.familiarId,/,
+  "The direct copilot spawn bypasses `coven run --familiar`, so the route must mirror coven's identity preamble itself",
+);
+
+assert.match(
+  chatRoute,
+  /No session, task, or name matched/,
+  "Copilot --resume misses (e.g. pre-stream conversations whose harnessSessionId lives in coven's store) must trigger the transparent fresh-session retry",
+);
+
+assert.match(
+  chatRoute,
+  /copilotText\.reset\(\);/,
+  "The resume retry must clear per-attempt copilot text-dedup state alongside the tracker",
+);
+
+assert.match(
+  chatRoute,
+  /const a = \["run", binding\.harness, "--stream-json"\];/,
+  "Adapters without a Cave-known stream protocol keep the coven run passthrough fallback",
+);
+
+console.log("copilot stream routing tests passed");
+
 console.log("harness-routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -35,6 +35,13 @@ import {
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
 import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
+import {
+  buildCopilotStreamArgs,
+  copilotIdentityPreamble,
+  copilotStreamSpec,
+  CopilotTextAssembler,
+  parseCopilotChatEvent,
+} from "@/lib/copilot-stream";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import {
   buildPromptWithKnowledgeVault,
@@ -1367,6 +1374,19 @@ export async function POST(req: Request) {
           ),
         )
       : [];
+  // Copilot tool visibility (cave-yesg): `coven run copilot --stream-json`
+  // launches the CLI one-shot (`-s -p`) and pipes raw prose, so tool calls
+  // never surface as structured events. When the registry manifest declares
+  // copilot's JSONL stream mode, spawn the CLI directly with those args and
+  // parse its event stream instead. Local runtimes only — SSH runtimes go
+  // through `coven run` on the remote host. Null keeps the passthrough
+  // fallback (and every other adapter keeps it unconditionally).
+  const copilotStream =
+    !sshRuntime && binding.harness === "copilot" ? copilotStreamSpec() : null;
+  // The copilot session id Cave chose for the CURRENT attempt: the resume
+  // target, or a pre-assigned fresh id (copilot events don't echo the id
+  // until the final result frame, so the stream handler announces this one).
+  let copilotSessionHint: string | null = null;
   // `promptOverride` lets the transparent resume-retry (below) prime a fresh
   // harness session with replayed conversation history — without it the retry
   // forks a context-free session and the familiar loses the thread.
@@ -1383,6 +1403,25 @@ export async function POST(req: Request) {
         prompt,
         sessionId: resumeSessionId,
         model: forwardModel,
+      });
+    }
+    if (copilotStream) {
+      copilotSessionHint = resumeSessionId ?? crypto.randomUUID();
+      // The direct spawn bypasses `coven run --familiar`, so mirror coven's
+      // identity preamble here — without it the familiar answers as the
+      // generic Copilot CLI.
+      const identity = copilotIdentityPreamble(
+        body.familiarId,
+        binding.display_name,
+        binding.role,
+      );
+      return buildCopilotStreamArgs({
+        spec: copilotStream,
+        prompt: identity ? `${identity}\n\n${prompt}` : prompt,
+        resumeSessionId,
+        newSessionId: resumeSessionId ? null : copilotSessionHint,
+        model: cleanModelId(desiredModel),
+        permissionMode: body.permissionMode === "read" ? "read" : "full",
       });
     }
     const a = ["run", binding.harness, "--stream-json"];
@@ -1418,10 +1457,13 @@ export async function POST(req: Request) {
   // "No conversation found with session ID: <uuid>" when the requested
   // conversation vanished from Claude's local store. Coven itself emits
   // "session <uuid> not found in local store" when the requested --continue
-  // id exists only in Cave's local transcript store. In these cases we retry
+  // id exists only in Cave's local transcript store. Copilot emits "No
+  // session, task, or name matched '<id>'" on `--resume` misses — including
+  // every conversation recorded before the direct-stream path existed, whose
+  // harnessSessionId lives only in coven's store. In these cases we retry
   // once without the resume flag so the chat starts fresh instead of erroring.
   const RESUME_ERR_RE =
-    /thread\/resume failed|no rollout found|code\s*-32600|Session ID \S+ is already in use|No conversation found with session ID|session\s+\S+\s+not found in local store/i;
+    /thread\/resume failed|no rollout found|code\s*-32600|Session ID \S+ is already in use|No conversation found with session ID|session\s+\S+\s+not found in local store|No session, task, or name matched/i;
 
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
@@ -1517,6 +1559,115 @@ export async function POST(req: Request) {
       // model field arrives (older CLIs omit it → honest `pending`).
       let confirmedModel: string | null = null;
 
+      // Dedups copilot's streamed text deltas against the full-content
+      // assistant.message frame that follows them.
+      const copilotText = new CopilotTextAssembler();
+
+      const announceSession = (id: string) => {
+        sessionId = id;
+        // The client tracks the STABLE conversation id — on resumed
+        // turns the harness mints a fresh internal id, which must not
+        // leak out as a "new session" (it fragmented every continued
+        // chat into one sidebar entry per turn).
+        const announcedId = body.sessionId ?? id;
+        push({ kind: "session", sessionId: announcedId });
+        // Title the session from the user's prompt as soon as the id
+        // exists. The daemon's own title derives from the harness
+        // prompt — i.e. the identity-canon preamble — and is what the
+        // UI would otherwise show until the transcript save runs.
+        void setDefaultSessionTitleIfMissing(
+          announcedId,
+          chatTitleFromPrompt(promptText) ?? defaultChatTitleForSession(announcedId),
+        ).catch(() => undefined);
+      };
+
+      // Copilot JSONL stream (cave-yesg): the CLI's own event schema, not
+      // claude stream-json. Text arrives as message deltas + a full-content
+      // message frame (deduped by CopilotTextAssembler); tool calls arrive as
+      // toolRequests / execution_start / execution_complete keyed on a native
+      // toolCallId, which maps onto the tracker's envelope lifecycle so live
+      // chips, textOffset interleaving, and persistedTools all work exactly
+      // as they do for claude. Non-JSON stdout is never assistant text on
+      // this protocol — it only feeds the empty-response diagnostic tail.
+      const handleCopilotLine = (line: string, isJson: boolean) => {
+        if (isJson) {
+          try {
+            const ev = parseCopilotChatEvent(JSON.parse(line));
+            if (!ev) return;
+            if (!confirmedModel && ev.kind !== "result") {
+              const echoed = cleanModelId(ev.model);
+              if (echoed) confirmedModel = echoed;
+            }
+            // Copilot only echoes the session id on the final result frame;
+            // announce the id Cave launched with as soon as the stream is
+            // live so the client can adopt the conversation immediately.
+            if (!sessionId && copilotSessionHint) announceSession(copilotSessionHint);
+            switch (ev.kind) {
+              case "text_delta": {
+                const text = copilotText.delta(ev.messageId, ev.text);
+                if (text) {
+                  assistantText += text;
+                  push({ kind: "assistant_chunk", text });
+                }
+                break;
+              }
+              case "message": {
+                const text = copilotText.message(ev.messageId, ev.content);
+                if (text) {
+                  assistantText += text;
+                  push({ kind: "assistant_chunk", text });
+                }
+                // Tool requests announce calls before execution starts; the
+                // tracker links the later execution_start onto the same id.
+                for (const req of ev.toolRequests) {
+                  boundarySentinel?.observe(req.name, req.input);
+                  const toolEv = toolTracker.envelopeToolUse(
+                    req.toolCallId,
+                    req.name,
+                    formatToolInputValue(req.input),
+                    assistantText.length,
+                  );
+                  if (toolEv) push({ kind: "tool_use", ...toolEv });
+                }
+                break;
+              }
+              case "tool_start": {
+                boundarySentinel?.observe(ev.toolName, ev.input);
+                const toolEv = toolTracker.envelopeToolUse(
+                  ev.toolCallId,
+                  ev.toolName,
+                  formatToolInputValue(ev.input),
+                  assistantText.length,
+                );
+                if (toolEv) push({ kind: "tool_use", ...toolEv });
+                break;
+              }
+              case "tool_end": {
+                const toolEv = toolTracker.envelopeToolResult(
+                  ev.toolCallId,
+                  ev.output,
+                  ev.isError,
+                );
+                if (toolEv) push({ kind: "tool_use", ...toolEv });
+                break;
+              }
+              case "result": {
+                if (!sessionId && ev.sessionId) announceSession(ev.sessionId);
+                result = {
+                  duration_ms: ev.durationMs,
+                  is_error: ev.isError,
+                };
+                break;
+              }
+            }
+            return;
+          } catch {
+            /* not valid JSON after all — fall through to the error tail */
+          }
+        }
+        recordStdoutErrorTail(resolveBackspaces(stripAnsi(line)));
+      };
+
       const handleLine = (rawLine: string) => {
         // stdout is split on bare \n; external adapters (copilot) emit CRLF,
         // and a trailing \r would both fail the endsWith("}") JSON sniff and
@@ -1525,6 +1676,10 @@ export async function POST(req: Request) {
         if (!line) return;
         if (RESUME_ERR_RE.test(line)) resumeFailed = true;
         const isJson = line.startsWith("{") && line.endsWith("}");
+        if (copilotStream) {
+          handleCopilotLine(line, isJson);
+          return;
+        }
         if (isJson) {
           try {
             const ev = JSON.parse(line) as {
@@ -1710,7 +1865,12 @@ export async function POST(req: Request) {
                 });
               })()
             : (() => {
-                const { command, fixedArgs } = covenLaunchCommand();
+                // Copilot stream turns spawn the adapter binary directly with
+                // its manifest-declared JSONL args; everything else goes
+                // through `coven run`.
+                const { command, fixedArgs } = copilotStream
+                  ? { command: copilotStream.executable, fixedArgs: [] as string[] }
+                  : covenLaunchCommand();
                 return spawn(command, [...fixedArgs, ...spawnArgs], {
                   // Spawn IN the familiar's workspace when no project root was
                   // supplied, so coven's project-root resolver picks that dir as
@@ -1768,7 +1928,9 @@ export async function POST(req: Request) {
                 message:
                   sshRuntime
                     ? "ssh CLI not found on PATH. Install OpenSSH or run this familiar locally."
-                    : "coven CLI not found on PATH. Open Setup to install it, then try again.",
+                    : copilotStream
+                      ? "copilot CLI not found on PATH. Install it with `npm install -g @github/copilot`, then try again."
+                      : "coven CLI not found on PATH. Open Setup to install it, then try again.",
               });
             } else {
               push({ kind: "error", message: err.message });
@@ -1821,6 +1983,7 @@ export async function POST(req: Request) {
         jsonBuf = "";
         result = {};
         toolTracker = new ToolCallTracker();
+        copilotText.reset();
         stderrTail.length = 0;
         stdoutErrTail.length = 0;
         resumeFailed = false;

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -1,0 +1,294 @@
+// Behavioral tests for the copilot JSONL stream wiring (cave-yesg): the
+// manifest-declared stream spec, the direct-spawn argv builder, and the
+// event parser feeding ToolCallTracker — the exact pipeline the chat send
+// route runs for copilot turns. The fixture below is a sanitized capture of
+// copilot CLI 1.0.70 `--output-format json --stream on -p …` running one
+// shell tool call and a follow-up text reply.
+
+import assert from "node:assert/strict";
+import {
+  buildCopilotStreamArgs,
+  copilotIdentityPreamble,
+  copilotStreamSpec,
+  CopilotTextAssembler,
+  parseCopilotChatEvent,
+} from "./copilot-stream.ts";
+import {
+  formatToolInputValue,
+  toPersistedTools,
+  ToolCallTracker,
+} from "./chat-tool-events.ts";
+
+// ── stream spec from the synced registry manifest ────────────────────────────
+
+const spec = copilotStreamSpec();
+assert.ok(spec, "registry manifest declares copilot stream mode");
+assert.equal(spec.executable, "copilot");
+assert.deepEqual(
+  spec.prefixArgs,
+  ["--output-format", "json", "--stream", "on", "-p"],
+  "stream prefix args come from the manifest's stream_args.prefix_args",
+);
+assert.equal(spec.sessionIdFlag, "--session-id");
+assert.equal(spec.resumeFlag, "--resume");
+assert.equal(spec.modelFlag, "--model");
+assert.deepEqual(spec.sandboxFullArgs, ["--allow-all"]);
+assert.deepEqual(spec.sandboxReadOnlyArgs, [
+  "--deny-tool",
+  "write",
+  "--deny-tool",
+  "shell",
+]);
+
+// ── argv builder ──────────────────────────────────────────────────────────────
+
+const freshArgs = buildCopilotStreamArgs({
+  spec,
+  prompt: "do the thing",
+  resumeSessionId: null,
+  newSessionId: "11111111-2222-4333-8444-555555555555",
+  model: "openai/gpt-5.5",
+  permissionMode: "full",
+});
+assert.deepEqual(
+  freshArgs,
+  [
+    "--session-id",
+    "11111111-2222-4333-8444-555555555555",
+    "--model",
+    "gpt-5.5",
+    "--allow-all",
+    "--output-format",
+    "json",
+    "--stream",
+    "on",
+    "-p",
+    "do the thing",
+  ],
+  "fresh turns pre-assign the session id, strip the model namespace, map full access to --allow-all, and trail the prompt after -p",
+);
+
+const resumeArgs = buildCopilotStreamArgs({
+  spec,
+  prompt: "continue",
+  resumeSessionId: "aaaa1111-2222-4333-8444-555555555555",
+  newSessionId: null,
+  model: null,
+  permissionMode: "read",
+});
+assert.deepEqual(
+  resumeArgs,
+  [
+    "--resume",
+    "aaaa1111-2222-4333-8444-555555555555",
+    "--deny-tool",
+    "write",
+    "--deny-tool",
+    "shell",
+    "--output-format",
+    "json",
+    "--stream",
+    "on",
+    "-p",
+    "continue",
+  ],
+  "resumed read-only turns use --resume and the manifest's deny-tool sandbox args",
+);
+
+// ── identity preamble (mirror of coven's FamiliarContext) ─────────────────────
+
+assert.equal(
+  copilotIdentityPreamble("nova", "Nova", "Queen / Orchestrator"),
+  "[Identity: You are Nova, a Queen / Orchestrator. Respond as Nova, not as the underlying tool.]",
+);
+assert.equal(
+  copilotIdentityPreamble("sage", "Sage"),
+  "[Identity: You are Sage. Respond as Sage, not as the underlying tool.]",
+);
+assert.equal(
+  copilotIdentityPreamble("charm"),
+  "[Identity: You are Charm. Respond as Charm, not as the underlying tool.]",
+  "missing display name falls back to the capitalized familiar id",
+);
+
+// ── fixture: sanitized copilot CLI 1.0.70 JSONL capture ──────────────────────
+
+const FIXTURE = [
+  `{"type":"session.mcp_servers_loaded","data":{"servers":[]},"id":"e1","timestamp":"2026-07-12T12:58:59.497Z","ephemeral":true}`,
+  `{"type":"user.message","data":{"content":"Run the shell command: echo hello-fixture."},"id":"e2","timestamp":"2026-07-12T12:59:00.015Z"}`,
+  `{"type":"assistant.turn_start","data":{"turnId":"0","model":"claude-fable-5"},"id":"e3","timestamp":"2026-07-12T12:59:04.660Z"}`,
+  `{"type":"assistant.tool_call_delta","data":{"toolCallId":"toolu_01","toolName":"bash","inputDelta":"{\\"c"},"id":"e4","timestamp":"2026-07-12T12:59:04.663Z","ephemeral":true}`,
+  `{"type":"assistant.message","data":{"messageId":"m1","model":"claude-fable-5","content":"","toolRequests":[{"toolCallId":"toolu_01","name":"bash","arguments":{"command":"echo hello-fixture","description":"Echo hello-fixture"},"type":"function"}],"turnId":"0"},"id":"e5","timestamp":"2026-07-12T12:59:04.672Z"}`,
+  `{"type":"tool.execution_start","data":{"toolCallId":"toolu_01","toolName":"bash","arguments":{"command":"echo hello-fixture","description":"Echo hello-fixture"},"model":"claude-fable-5","turnId":"0"},"id":"e6","timestamp":"2026-07-12T12:59:04.674Z"}`,
+  `{"type":"tool.execution_partial_result","data":{"toolCallId":"toolu_01","partialOutput":"hello-fixture\\n"},"id":"e7","timestamp":"2026-07-12T12:59:04.709Z","ephemeral":true}`,
+  `{"type":"tool.execution_complete","data":{"toolCallId":"toolu_01","model":"claude-fable-5","turnId":"0","success":true,"result":{"content":"hello-fixture\\n<shellId: 0 completed with exit code 0>"}},"id":"e8","timestamp":"2026-07-12T12:59:04.711Z"}`,
+  `{"type":"assistant.turn_end","data":{"turnId":"0","model":"claude-fable-5"},"id":"e9","timestamp":"2026-07-12T12:59:04.712Z"}`,
+  `{"type":"assistant.message_start","data":{"messageId":"m2"},"id":"e10","timestamp":"2026-07-12T12:59:08.059Z","ephemeral":true}`,
+  `{"type":"assistant.message_delta","data":{"messageId":"m2","deltaContent":"The command "},"id":"e11","timestamp":"2026-07-12T12:59:08.059Z","ephemeral":true}`,
+  `{"type":"assistant.message_delta","data":{"messageId":"m2","deltaContent":"printed hello-fixture."},"id":"e12","timestamp":"2026-07-12T12:59:08.060Z","ephemeral":true}`,
+  `{"type":"assistant.message","data":{"messageId":"m2","model":"claude-fable-5","content":"The command printed hello-fixture.","toolRequests":[],"turnId":"1"},"id":"e13","timestamp":"2026-07-12T12:59:08.063Z"}`,
+  `{"type":"assistant.idle","data":{},"id":"e14","timestamp":"2026-07-12T12:59:08.067Z","ephemeral":true}`,
+  `{"type":"result","timestamp":"2026-07-12T12:59:08.078Z","sessionId":"06b41838-31ab-4dc4-8481-96d85281bfa7","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":7931,"sessionDurationMs":9980}}`,
+];
+
+// ── parser unit shapes ────────────────────────────────────────────────────────
+
+assert.equal(
+  parseCopilotChatEvent(JSON.parse(FIXTURE[0])),
+  null,
+  "session noise frames parse to null",
+);
+assert.equal(
+  parseCopilotChatEvent(JSON.parse(FIXTURE[3])),
+  null,
+  "tool_call_delta frames (partial input JSON) parse to null",
+);
+assert.equal(
+  parseCopilotChatEvent(JSON.parse(FIXTURE[6])),
+  null,
+  "partial tool output frames parse to null",
+);
+assert.equal(parseCopilotChatEvent("not an object"), null);
+assert.equal(parseCopilotChatEvent({ type: 42 }), null);
+
+const resultEv = parseCopilotChatEvent(JSON.parse(FIXTURE[14]));
+assert.deepEqual(resultEv, {
+  kind: "result",
+  sessionId: "06b41838-31ab-4dc4-8481-96d85281bfa7",
+  isError: false,
+  durationMs: 9980,
+});
+assert.deepEqual(
+  parseCopilotChatEvent({ type: "result", exitCode: 1 }),
+  { kind: "result", sessionId: undefined, isError: true, durationMs: undefined },
+  "nonzero exit codes surface as errors",
+);
+
+// ── full pipeline: fixture → tracker + text assembly (what the route runs) ───
+
+{
+  const tracker = new ToolCallTracker(() => 1_000);
+  const text = new CopilotTextAssembler();
+  let assistantText = "";
+  const streamed: Array<{ id: string; status: string; output?: string }> = [];
+  let model: string | undefined;
+
+  for (const line of FIXTURE) {
+    const ev = parseCopilotChatEvent(JSON.parse(line));
+    if (!ev) continue;
+    if (ev.kind !== "result" && ev.model && !model) model = ev.model;
+    switch (ev.kind) {
+      case "text_delta": {
+        assistantText += text.delta(ev.messageId, ev.text);
+        break;
+      }
+      case "message": {
+        assistantText += text.message(ev.messageId, ev.content);
+        for (const req of ev.toolRequests) {
+          const toolEv = tracker.envelopeToolUse(
+            req.toolCallId,
+            req.name,
+            formatToolInputValue(req.input),
+            assistantText.length,
+          );
+          if (toolEv) streamed.push(toolEv);
+        }
+        break;
+      }
+      case "tool_start": {
+        const toolEv = tracker.envelopeToolUse(
+          ev.toolCallId,
+          ev.toolName,
+          formatToolInputValue(ev.input),
+          assistantText.length,
+        );
+        if (toolEv) streamed.push(toolEv);
+        break;
+      }
+      case "tool_end": {
+        const toolEv = tracker.envelopeToolResult(ev.toolCallId, ev.output, ev.isError);
+        if (toolEv) streamed.push(toolEv);
+        break;
+      }
+      case "result":
+        break;
+    }
+  }
+
+  assert.equal(model, "claude-fable-5", "the model echo is captured for parity");
+  assert.equal(
+    assistantText,
+    "The command printed hello-fixture.",
+    "delta frames stream text; the full-content message frame appends nothing new",
+  );
+
+  assert.equal(
+    streamed.length,
+    2,
+    "one running chip (from toolRequests; execution_start dedups onto it) and one settle",
+  );
+  assert.equal(streamed[0].id, "toolu_01");
+  assert.equal(streamed[0].status, "running");
+  assert.equal(streamed[1].id, "toolu_01", "start and settle merge on the native id");
+  assert.equal(streamed[1].status, "ok");
+  assert.match(streamed[1].output ?? "", /hello-fixture/);
+
+  const persisted = toPersistedTools(tracker.snapshot(), 0);
+  assert.ok(persisted, "the turn persists its tool rows");
+  assert.equal(persisted.length, 1);
+  assert.equal(persisted[0].name, "bash");
+  assert.equal(persisted[0].status, "ok");
+  assert.equal(persisted[0].textOffset, 0, "the call started before any text streamed");
+  assert.match(persisted[0].input ?? "", /echo hello-fixture/);
+}
+
+// ── failed tool call settles as error ────────────────────────────────────────
+
+{
+  const tracker = new ToolCallTracker(() => 1_000);
+  const start = parseCopilotChatEvent({
+    type: "tool.execution_start",
+    data: { toolCallId: "t9", toolName: "bash", arguments: { command: "false" } },
+  });
+  assert.ok(start && start.kind === "tool_start");
+  tracker.envelopeToolUse(start.toolCallId, start.toolName, undefined, 0);
+  const end = parseCopilotChatEvent({
+    type: "tool.execution_complete",
+    data: { toolCallId: "t9", success: false, result: { content: "boom" } },
+  });
+  assert.ok(end && end.kind === "tool_end");
+  assert.equal(end.isError, true);
+  const settled = tracker.envelopeToolResult(end.toolCallId, end.output, end.isError);
+  assert.equal(settled?.status, "error");
+  assert.equal(settled?.output, "boom");
+}
+
+// ── text assembler edge cases ────────────────────────────────────────────────
+
+{
+  const text = new CopilotTextAssembler();
+  assert.equal(
+    text.message("solo", "No deltas came first."),
+    "No deltas came first.",
+    "a message with no prior deltas contributes its full content",
+  );
+  assert.equal(text.message("solo", "No deltas came first."), "", "repeats add nothing");
+
+  assert.equal(text.delta("m", "Hello "), "Hello ");
+  assert.equal(text.delta("m", "world"), "world");
+  assert.equal(
+    text.message("m", "Hello world!"),
+    "!",
+    "a final message longer than its deltas contributes only the tail",
+  );
+  assert.equal(
+    text.message("m", "Hello"),
+    "",
+    "a final message shorter than its streamed deltas never duplicates",
+  );
+
+  text.reset();
+  assert.equal(text.message("m", "fresh"), "fresh", "reset clears per-attempt state");
+}
+
+console.log("copilot-stream: ok");

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -1,0 +1,324 @@
+// Copilot CLI JSONL stream wiring for native Cave chat (cave-yesg).
+//
+// Chats normally spawn `coven run <harness> --stream-json`, but for external
+// manifest adapters coven launches ONE-SHOT (`copilot -s -p …`) and pipes raw
+// prose — so tool calls never reach the chat as structured events and
+// persistedTools stays empty. The copilot adapter manifest already declares a
+// JSONL stream mode (`--output-format json --stream on -p` plus
+// `--session-id`/`--resume`); this module turns that declaration into a direct
+// spawn argv and parses the Copilot CLI's event stream into the shapes the
+// chat route feeds ToolCallTracker with.
+//
+// Scope note: this is deliberately copilot-only. Other registry adapters that
+// declare `stream_args` (e.g. coven-code) use a long-lived stdin-frame
+// protocol where a positional prompt is ignored — direct-spawning them with
+// these args would hang. Adapters without a Cave-known stream protocol keep
+// the existing `coven run` passthrough fallback.
+//
+// Event schema (verified against copilot CLI 1.0.70 `--output-format json
+// --stream on`):
+//   {"type":"assistant.message_delta","data":{"messageId","deltaContent"}}
+//   {"type":"assistant.message","data":{"messageId","content","toolRequests":
+//       [{"toolCallId","name","arguments"}],"model"}}
+//   {"type":"tool.execution_start","data":{"toolCallId","toolName","arguments"}}
+//   {"type":"tool.execution_complete","data":{"toolCallId","success",
+//       "result":{"content"}}}
+//   {"type":"result","sessionId","exitCode","usage":{"sessionDurationMs",…}}
+// plus session.* / assistant.turn_* / *_delta noise events that the chat
+// ignores. The final `result` frame is top-level (no `data` envelope).
+
+import { REGISTRY_RUNTIMES } from "./runtime-registry.gen.ts";
+
+export type CopilotStreamSpec = {
+  executable: string;
+  /** JSONL stream launch args; ends with the prompt flag (`-p`). */
+  prefixArgs: string[];
+  /** Pre-assign a fresh session id (`--session-id`). */
+  sessionIdFlag: string | null;
+  /** Resume an existing session (`--resume`). */
+  resumeFlag: string | null;
+  /** Native model flag (`--model`). */
+  modelFlag: string | null;
+  /** Full-access sandbox argv (`--allow-all`). */
+  sandboxFullArgs: string[];
+  /** Read-only sandbox argv (`--deny-tool write --deny-tool shell`). */
+  sandboxReadOnlyArgs: string[];
+};
+
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  if (!value.every((entry) => typeof entry === "string")) return null;
+  return value as string[];
+}
+
+/**
+ * Stream-launch material for the copilot adapter, sourced from the synced
+ * coven-runtimes registry (the same conformance-tested document Cave
+ * scaffolds into `$COVEN_HOME/adapters/copilot.json`). Returns null when the
+ * registry entry stops declaring a stream mode — the chat route then falls
+ * back to the `coven run` passthrough path instead of failing.
+ */
+export function copilotStreamSpec(): CopilotStreamSpec | null {
+  const runtime = REGISTRY_RUNTIMES.find((entry) => entry.id === "copilot");
+  if (!runtime || !runtime.capabilities.stream) return null;
+  const manifest = runtime.adapterManifest as {
+    adapters?: Array<{
+      id?: unknown;
+      executable?: unknown;
+      model_flag?: unknown;
+      sandbox?: { full_args?: unknown; read_only_args?: unknown };
+      stream_args?: {
+        prefix_args?: unknown;
+        session_id_flag?: unknown;
+        resume_flag?: unknown;
+      };
+    }>;
+  } | null;
+  const adapter = manifest?.adapters?.find((entry) => entry?.id === "copilot");
+  if (!adapter || typeof adapter.executable !== "string") return null;
+  const prefixArgs = stringArray(adapter.stream_args?.prefix_args);
+  if (!prefixArgs || prefixArgs.length === 0) return null;
+  return {
+    executable: adapter.executable,
+    prefixArgs,
+    sessionIdFlag:
+      typeof adapter.stream_args?.session_id_flag === "string"
+        ? adapter.stream_args.session_id_flag
+        : null,
+    resumeFlag:
+      typeof adapter.stream_args?.resume_flag === "string"
+        ? adapter.stream_args.resume_flag
+        : null,
+    modelFlag: typeof adapter.model_flag === "string" ? adapter.model_flag : null,
+    sandboxFullArgs: stringArray(adapter.sandbox?.full_args) ?? [],
+    sandboxReadOnlyArgs: stringArray(adapter.sandbox?.read_only_args) ?? [],
+  };
+}
+
+/**
+ * Mirror of coven-cli's `FamiliarContext::identity_preamble`. The direct
+ * copilot spawn bypasses `coven run --familiar`, which is what normally
+ * injects this line — without it the familiar answers as the generic CLI.
+ */
+export function copilotIdentityPreamble(
+  familiarId: string,
+  displayName?: string,
+  role?: string,
+): string {
+  const name =
+    displayName?.trim() ||
+    (familiarId ? familiarId.charAt(0).toUpperCase() + familiarId.slice(1) : "");
+  if (!name) return "";
+  const cleanRole = role?.trim();
+  return cleanRole
+    ? `[Identity: You are ${name}, a ${cleanRole}. Respond as ${name}, not as the underlying tool.]`
+    : `[Identity: You are ${name}. Respond as ${name}, not as the underlying tool.]`;
+}
+
+export type CopilotStreamLaunch = {
+  spec: CopilotStreamSpec;
+  prompt: string;
+  /** Resume this copilot-native session id; null starts a fresh session. */
+  resumeSessionId: string | null;
+  /** Pre-assigned id for a fresh session (ignored when resuming). */
+  newSessionId: string | null;
+  /** Cleaned model id; a `provider/` namespace is stripped for copilot. */
+  model: string | null;
+  permissionMode: "full" | "read";
+};
+
+/** Direct-spawn argv for a copilot JSONL stream turn. Options ride ahead of
+ *  the prefix args; the prompt trails the prefix's `-p` flag. */
+export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
+  const { spec } = launch;
+  const args: string[] = [];
+  if (launch.resumeSessionId && spec.resumeFlag) {
+    args.push(spec.resumeFlag, launch.resumeSessionId);
+  } else if (launch.newSessionId && spec.sessionIdFlag) {
+    args.push(spec.sessionIdFlag, launch.newSessionId);
+  }
+  if (launch.model && spec.modelFlag) {
+    // Cave model ids may be namespaced (`openai/gpt-5.5`); copilot expects
+    // the bare id, matching how coven strips the provider prefix.
+    const bare = launch.model.includes("/")
+      ? launch.model.slice(launch.model.lastIndexOf("/") + 1)
+      : launch.model;
+    if (bare) args.push(spec.modelFlag, bare);
+  }
+  // Sandbox mapping from the manifest. Full access maps to the declared
+  // full_args (`--allow-all`) — without it copilot's programmatic mode
+  // auto-denies every tool, which is the tools:0 regression this path fixes.
+  args.push(
+    ...(launch.permissionMode === "read"
+      ? spec.sandboxReadOnlyArgs
+      : spec.sandboxFullArgs),
+  );
+  args.push(...spec.prefixArgs, launch.prompt);
+  return args;
+}
+
+export type CopilotToolRequest = {
+  toolCallId: string;
+  name: string;
+  input?: unknown;
+};
+
+export type CopilotChatEvent =
+  | { kind: "text_delta"; messageId: string; text: string; model?: string }
+  | {
+      kind: "message";
+      messageId: string;
+      content: string;
+      toolRequests: CopilotToolRequest[];
+      model?: string;
+    }
+  | {
+      kind: "tool_start";
+      toolCallId: string;
+      toolName: string;
+      input?: unknown;
+      model?: string;
+    }
+  | {
+      kind: "tool_end";
+      toolCallId: string;
+      output?: string;
+      isError: boolean;
+      model?: string;
+    }
+  | { kind: "result"; sessionId?: string; isError: boolean; durationMs?: number };
+
+function asModel(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+/**
+ * Map one parsed copilot JSONL frame to a chat-relevant event; returns null
+ * for the stream's noise frames (session.*, turn markers, tool-input deltas,
+ * partial tool output) so the route drops them without touching the bubble.
+ */
+export function parseCopilotChatEvent(raw: unknown): CopilotChatEvent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const ev = raw as {
+    type?: unknown;
+    sessionId?: unknown;
+    exitCode?: unknown;
+    usage?: { sessionDurationMs?: unknown };
+    data?: {
+      messageId?: unknown;
+      deltaContent?: unknown;
+      content?: unknown;
+      model?: unknown;
+      toolRequests?: unknown;
+      toolCallId?: unknown;
+      toolName?: unknown;
+      arguments?: unknown;
+      success?: unknown;
+      result?: { content?: unknown };
+    };
+  };
+  if (typeof ev.type !== "string") return null;
+  const data = ev.data;
+  switch (ev.type) {
+    case "assistant.message_delta": {
+      if (typeof data?.messageId !== "string" || typeof data.deltaContent !== "string") {
+        return null;
+      }
+      return {
+        kind: "text_delta",
+        messageId: data.messageId,
+        text: data.deltaContent,
+        model: asModel(data.model),
+      };
+    }
+    case "assistant.message": {
+      if (typeof data?.messageId !== "string") return null;
+      const toolRequests: CopilotToolRequest[] = [];
+      if (Array.isArray(data.toolRequests)) {
+        for (const req of data.toolRequests) {
+          const r = req as { toolCallId?: unknown; name?: unknown; arguments?: unknown };
+          if (typeof r?.toolCallId === "string" && typeof r.name === "string") {
+            toolRequests.push({
+              toolCallId: r.toolCallId,
+              name: r.name,
+              input: r.arguments,
+            });
+          }
+        }
+      }
+      return {
+        kind: "message",
+        messageId: data.messageId,
+        content: typeof data.content === "string" ? data.content : "",
+        toolRequests,
+        model: asModel(data.model),
+      };
+    }
+    case "tool.execution_start": {
+      if (typeof data?.toolCallId !== "string" || typeof data.toolName !== "string") {
+        return null;
+      }
+      return {
+        kind: "tool_start",
+        toolCallId: data.toolCallId,
+        toolName: data.toolName,
+        input: data.arguments,
+        model: asModel(data.model),
+      };
+    }
+    case "tool.execution_complete": {
+      if (typeof data?.toolCallId !== "string") return null;
+      const output =
+        typeof data.result?.content === "string" && data.result.content
+          ? data.result.content
+          : undefined;
+      return {
+        kind: "tool_end",
+        toolCallId: data.toolCallId,
+        output,
+        isError: data.success === false,
+        model: asModel(data.model),
+      };
+    }
+    case "result": {
+      const durationMs =
+        typeof ev.usage?.sessionDurationMs === "number"
+          ? ev.usage.sessionDurationMs
+          : undefined;
+      return {
+        kind: "result",
+        sessionId: typeof ev.sessionId === "string" ? ev.sessionId : undefined,
+        isError: typeof ev.exitCode === "number" && ev.exitCode !== 0,
+        durationMs,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Assembles assistant text from copilot's dual sources without duplication:
+ * `assistant.message_delta` frames stream live text, and the follow-up
+ * `assistant.message` frame repeats the full content (and is the ONLY text
+ * source when the CLI skips deltas, e.g. tool-request-only messages). Both
+ * feed through here; the return value is exactly the new text to append.
+ */
+export class CopilotTextAssembler {
+  private seen = new Map<string, number>();
+
+  delta(messageId: string, text: string): string {
+    this.seen.set(messageId, (this.seen.get(messageId) ?? 0) + text.length);
+    return text;
+  }
+
+  message(messageId: string, content: string): string {
+    const already = this.seen.get(messageId) ?? 0;
+    this.seen.set(messageId, Math.max(already, content.length));
+    return already >= content.length ? "" : content.slice(already);
+  }
+
+  reset(): void {
+    this.seen.clear();
+  }
+}


### PR DESCRIPTION
## Problem (cave-yesg, reported by Val)

Tool calls stopped rendering in chats. Every recent conversation routes through the **copilot** harness, which `coven run copilot --stream-json` launches **one-shot** (`-s -p`) — raw prose stdout, zero tool events. `ToolCallTracker` stays empty, `persistedTools` is never written, and every copilot conv persists `tools: 0` (the last claude-harness conv still has tools).

## Fix

The copilot adapter manifest already declares a JSONL stream mode (`--output-format json --stream on -p`, `--session-id`/`--resume`) — this PR makes Cave consume it:

- **`src/lib/copilot-stream.ts`** (new): stream spec sourced from the synced coven-runtimes registry manifest; direct-spawn argv builder (session pre-assign/resume, model-namespace stripping, manifest sandbox mapping — full access → `--allow-all`, without which copilot's programmatic mode auto-denies every tool, i.e. the actual tools:0 regression); a coven-parity `[Identity: …]` preamble (the direct spawn bypasses `coven run --familiar`); the copilot event parser (`assistant.message_delta` / `assistant.message` / `tool.execution_start` / `tool.execution_complete` / `result`); and a delta-vs-final-message text deduper.
- **chat send route**: local copilot chats spawn the CLI directly with those args and feed its events into `ToolCallTracker`'s envelope lifecycle — live chips, `textOffset` interleaving, and `persistedTools` now work exactly as with claude. **SSH runtimes and every other adapter keep the `coven run` passthrough fallback** (deliberately copilot-only: e.g. coven-code's stream mode is a stdin-frame protocol that would hang under a positional-prompt spawn).
- **Resume migration**: copilot's resume-miss message ("No session, task, or name matched") joins `RESUME_ERR_RE`, so pre-stream conversations (whose `harnessSessionId` exists only in coven's store) transparently retry as a fresh copilot session with replayed history.

## Verification

- Fixture-driven `copilot-stream.test.ts` (sanitized real capture of copilot CLI 1.0.70) + copilot source-shape assertions in `harness-routing.test.ts`; wired into the app suite (`check:tests-wired` green).
- Full app suite: **619 test files pass**; `tsc --noEmit` clean; `pnpm build` green (bundle within budget).
- **Live smoke** against copilot CLI 1.0.70 with the exact built argv: text streams without duplication, the bash tool call tracks running→ok with output, the pre-assigned `--session-id` round-trips on the `result` frame, and the reply answers as the familiar.

Closes bead `cave-yesg`.