### PR TITLE
fix(updater): recommend native retry before browser fallback in update banner

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -101,7 +101,7 @@ assert.match(src, /Retry native update/, "settings row makes retrying native upd
 // failure (often a transient mid-release latest.json gap) first offers a
 // native retry; only after a user-initiated retry also fails does the banner
 // escalate to the canonical release page in the Browser surface.
-assert.match(src, /recommendNativeRetry/, "banner recommends retrying the native updater before any browser handoff");
+// (Avoid asserting on internal helper variable names; CTA/copy assertions below pin the banner behavior.)
 assert.match(src, /Native updater still unavailable/, "banner escalates copy only after a failed native retry");
 assert.match(
   src,

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -97,6 +97,23 @@ assert.match(src, /Open installer in Browser/, "fallback keeps installer recover
 assert.match(src, /Native updater unavailable/, "settings row distinguishes native updater failure from a normal installer fallback");
 assert.match(src, /Retry native update/, "settings row makes retrying native update the primary recovery action");
 
+// Banner: the native updater is the recommended install path. A native check
+// failure (often a transient mid-release latest.json gap) first offers a
+// native retry; only after a user-initiated retry also fails does the banner
+// escalate to the canonical release page in the Browser surface.
+assert.match(src, /recommendNativeRetry/, "banner recommends retrying the native updater before any browser handoff");
+assert.match(src, /Native updater still unavailable/, "banner escalates copy only after a failed native retry");
+assert.match(
+  src,
+  /recommendNativeRetry[\s\S]{0,400}?"Retry native update"[\s\S]{0,200}?"Open release page in Browser"/,
+  "banner CTA orders native retry ahead of the browser release page",
+);
+assert.match(
+  src,
+  /r\.kind === "native-unavailable"\) \{\s*if \(recommendNativeRetry\) \{\s*nativeRetryFailed\.add\(r\.version\);/,
+  "clicking retry records the attempt so a second failure offers browser recovery",
+);
+
 // A failed native install must not bypass the signed updater by resolving a
 // direct installer asset from release metadata. It captures the reason, keeps
 // recovery inside Cave, and sends users to the canonical release page instead.

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -171,6 +171,12 @@ export function UpdateBannerTrigger() {
     let busy = false;
     let activeCancellation: CancellationSignal | null = null;
     let preparedUpdate: NativeUpdateHandle | null = null;
+    // Versions whose user-initiated native retry already failed. The native
+    // updater is the recommended install path — a check failure is usually
+    // transient (e.g. latest.json not yet published mid-release), so the
+    // banner offers a native retry first and only escalates to the browser
+    // release page after a retry also fails.
+    const nativeRetryFailed = new Set<string>();
 
     const runCheck = () => {
       if (busy) return;
@@ -191,15 +197,26 @@ export function UpdateBannerTrigger() {
           return;
         }
 
+        const recommendNativeRetry =
+          r.kind === "native-unavailable" && !nativeRetryFailed.has(r.version);
         pushBanner({
           id: BANNER_ID,
           severity: r.kind === "native-unavailable" ? "warning" : "info",
           title:
             r.kind === "native-unavailable"
-              ? `Native updater unavailable — v${r.version}`
+              ? recommendNativeRetry
+                ? `Native updater unavailable — v${r.version}`
+                : `Native updater still unavailable — v${r.version}`
               : `Update available — v${r.version}`,
           cta: {
-            label: r.kind === "native" ? "Download update" : "Open installer in Browser",
+            label:
+              r.kind === "native"
+                ? "Download update"
+                : r.kind === "native-unavailable"
+                  ? recommendNativeRetry
+                    ? "Retry native update"
+                    : "Open release page in Browser"
+                  : "Open installer in Browser",
             onClick: () => {
               if (r.kind === "native") {
                 if (busy) return;
@@ -315,7 +332,13 @@ export function UpdateBannerTrigger() {
                   });
                 });
               } else if (r.kind === "native-unavailable") {
-                openReleasePageInBrowser();
+                if (recommendNativeRetry) {
+                  nativeRetryFailed.add(r.version);
+                  dismissBanner(BANNER_ID);
+                  runCheck();
+                } else {
+                  openReleasePageInBrowser();
+                }
               } else {
                 openInAppBrowserUrl(r.url);
               }

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -171,11 +171,10 @@ export function UpdateBannerTrigger() {
     let busy = false;
     let activeCancellation: CancellationSignal | null = null;
     let preparedUpdate: NativeUpdateHandle | null = null;
-    // Versions whose user-initiated native retry already failed. The native
-    // updater is the recommended install path — a check failure is usually
-    // transient (e.g. latest.json not yet published mid-release), so the
-    // banner offers a native retry first and only escalates to the browser
-    // release page after a retry also fails.
+    // Versions for which the user already clicked "Retry native update" in this session. Native
+    // updater check failures are usually transient (e.g. latest.json not yet published mid-release),
+    // so the banner offers a native retry first and only escalates to the browser release page if
+    // the subsequent check is still `native-unavailable`.
     const nativeRetryFailed = new Set<string>();
 
     const runCheck = () => {

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -196,6 +196,8 @@ export function UpdateBannerTrigger() {
           return;
         }
 
+        if (r.kind !== "native-unavailable") nativeRetryFailed.delete(r.version);
+
         const recommendNativeRetry =
           r.kind === "native-unavailable" && !nativeRetryFailed.has(r.version);
         pushBanner({


### PR DESCRIPTION
## What

When the native updater check fails, the shell banner sent users straight to **Open installer in Browser**. The native signed updater is the recommended install path, so the banner now:

1. Offers **Retry native update** as the primary CTA on a native check failure (title: `Native updater unavailable — vX`).
2. Escalates to **Open release page in Browser** only after a user-initiated retry also fails (title: `Native updater still unavailable — vX`).

This mirrors the Settings ▸ About row, which already leads with a native retry.

## Why

The most common cause of this banner is transient: the `updater-manifest` job publishes `latest.json` *after* the platform build legs, so mid-release the endpoint 404s (observed live during the v0.0.178 rollout — banner showed while the release run was still in progress). Routing users to a browser install during that window bypasses the signed native path for no reason.

## Verification

- `node --test src/components/update-available.test.ts` — pass (new source assertions pin retry-first ordering and escalation).
- `pnpm exec tsc --noEmit` — clean.