### PR TITLE
feat(familiars): discoverable Remove entry in the detail panel menu (cave-ioac)

### DIFF
--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -274,3 +274,23 @@ assert.match(source, /role="tabpanel"[\s\S]{0,120}?aria-labelledby=\{`familiar-d
 assert.doesNotMatch(source, /aria-current=\{tab === id \? "page"/, "old aria-current=page tab pattern is gone");
 
 console.log("familiars-view: all assertions passed");
+
+// The detail panel header carries a per-familiar overflow menu — the
+// discoverable entry points for Edit-in-Studio and Remove. Remove must ROUTE
+// to the Studio lifecycle tab (the canonical confirm + undo + tombstone flow),
+// never confirm or DELETE from this surface.
+assert.match(
+  source,
+  /aria-label=\{`\$\{familiar\.display_name\} options`\}[\s\S]{0,600}openFamiliarStudio\(familiar\.id, "identity"\)/,
+  "Detail panel overflow menu opens the familiar's Studio (Edit in Studio)",
+);
+assert.match(
+  source,
+  /danger[\s\S]{0,200}openFamiliarStudio\(familiar\.id, "lifecycle"\)[\s\S]{0,120}Remove familiar/,
+  "Remove familiar routes to the Studio lifecycle tab where the canonical confirm lives",
+);
+assert.doesNotMatch(
+  source,
+  /fetch\([^)]*\/api\/familiars\/[^)]*\{\s*method:\s*"DELETE"/,
+  "FamiliarsView never performs the destructive DELETE itself — that stays in the lifecycle tab",
+);

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/familiars-view-stats";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { SUMMON_FAMILIAR_EVENT, consumeSummonPending } from "@/lib/summon-events";
+import { useFamiliarStudio } from "@/lib/familiar-studio-context";
+import { Popover, PopoverBody, PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 
 type CovenMemoryResponse =
   | { ok: true; entries: CovenMemoryEntry[] }
@@ -715,6 +717,64 @@ type AgentDetailPanelProps = {
   onOpenUrl: (url: string) => void;
 };
 
+// Per-familiar overflow menu on the detail panel header. Remove routes to the
+// Studio lifecycle tab rather than confirming here — the destructive flow
+// (confirm copy, undo toast, tombstone coupling) lives only in
+// familiar-studio-lifecycle-tab.tsx, and this menu is the discoverable
+// entry point the Familiars surface lacked.
+function FamiliarPanelMenu({ familiar }: { familiar: ResolvedFamiliar }) {
+  const { openFamiliarStudio } = useFamiliarStudio();
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+        aria-label={`${familiar.display_name} options`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Familiar options"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Icon name="ph:dots-three-vertical" width={14} aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={triggerRef}
+        placement="bottom-end"
+        minWidth={200}
+        ariaLabel="Familiar options"
+      >
+        <PopoverBody>
+          <PopoverItem
+            icon="ph:pencil-simple"
+            onSelect={() => {
+              setOpen(false);
+              openFamiliarStudio(familiar.id, "identity");
+            }}
+          >
+            Edit in Studio
+          </PopoverItem>
+          <PopoverSeparator />
+          <PopoverItem
+            icon="ph:trash"
+            danger
+            onSelect={() => {
+              setOpen(false);
+              openFamiliarStudio(familiar.id, "lifecycle");
+            }}
+          >
+            Remove familiar…
+          </PopoverItem>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
 function FamiliarDetailPanel({
   familiar,
   familiars,
@@ -788,6 +848,7 @@ function FamiliarDetailPanel({
             <Icon name="ph:magic-wand-fill" width={12} />
             Enhance
           </button>
+          <FamiliarPanelMenu familiar={familiar} />
           <button
             type="button"
             onClick={onClose}


### PR DESCRIPTION
## Summary

Removing a familiar has been possible since #2873 — but only via Settings → Familiars → Lifecycle tab, four levels deep with no entry point on the Familiars surface itself. The familiar detail panel header now carries a per-familiar overflow menu (the canonical `Popover`/`PopoverItem` kebab idiom) with:

- **Edit in Studio** → `openFamiliarStudio(id, "identity")`
- **Remove familiar…** (danger) → `openFamiliarStudio(id, "lifecycle")`

Remove deliberately *routes* to the Studio lifecycle tab instead of confirming in place — the destructive flow (confirm copy, undo toast, tombstone couplings from #2873) stays single-homed there, and this menu is just the discoverable doorway. Under the workspace provider that navigation lands on `/settings#familiars` with the familiar pre-selected.

## Test plan

- Source pins in `familiars-view.test.ts`: menu wiring to both studio tabs + a `doesNotMatch` guard that FamiliarsView never issues the familiar DELETE itself
- Full `pnpm test:app` + `tsc --noEmit` green
- **Live-verified** (Playwright, mocked roster): kebab renders in the detail header → menu opens → Remove familiar… navigates to `/settings#familiars` with the Lifecycle tab visible; screenshot-checked placement
- Commit SSH-signed

Closes bead `cave-ioac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)