### PR TITLE
fix(familiars): hide internal default suggestions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -57,6 +57,7 @@ export const SUITES = {
     "scripts/coven-hfr-export.test.mjs",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
+    "src/lib/familiar-roster-guard.test.ts",
     "src/lib/cave-projects.test.ts",
     "src/lib/cave-inbox-prefs.test.ts",
     "src/lib/project-permissions.test.ts",

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -24,6 +24,16 @@ assert.match(
   /autoSelfReport: configEntry\.autoSelfReport \?\? false/,
   "Familiars API should expose per-familiar auto self-report config with a false default",
 );
+assert.match(
+  source,
+  /filterInstallSeedFamiliars\(/,
+  "Familiars API should hide the known first-install default roster before the picker sees it",
+);
+assert.match(
+  source,
+  /explicitFamiliarIdsFromToml/,
+  "Familiars API should distinguish user-authored familiar ids from daemon fallback defaults",
+);
 
 // ── POST: in-app "create a familiar" write path ──────────────────────────────
 // Source-text guards (same pattern as src/app/api/onboarding/setup/route.test.ts).

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -4,6 +4,10 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { callDaemon } from "@/lib/coven-daemon";
 import { bindingFor, loadConfig, saveConfig } from "@/lib/cave-config";
+import {
+  explicitFamiliarIdsFromToml,
+  filterInstallSeedFamiliars,
+} from "@/lib/familiar-roster-guard";
 import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
 import {
   buildFamiliarsToml,
@@ -30,12 +34,17 @@ export type DaemonFamiliar = {
 };
 
 export async function GET() {
-  const [res, config, removedIds] = await Promise.all([
+  const covenDir = path.join(homedir(), ".coven");
+  const familiarsToml = path.join(covenDir, "familiars.toml");
+  const [res, config, removedIds, explicitIds] = await Promise.all([
     callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
       path: "/api/v1/familiars",
     }),
     loadConfig(),
     removedFamiliarIds().catch(() => new Set<string>()),
+    readFile(familiarsToml, "utf8")
+      .then(explicitFamiliarIdsFromToml)
+      .catch(() => new Set<string>()),
   ]);
   if (!res.ok) {
     return NextResponse.json(
@@ -56,7 +65,7 @@ export async function GET() {
   // in-memory roster until it re-reads familiars.toml — hide tombstoned ids so
   // Remove takes effect immediately in every client.
   const familiars = await Promise.all(
-    (res.data ?? [])
+    filterInstallSeedFamiliars(res.data ?? [], explicitIds)
       .filter((f) => !removedIds.has(f.id))
       .map(async (f) => {
       const configEntry = config.familiars[f.id] ?? {};

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -80,6 +80,28 @@ assert.match(
   "Summon must be disabled when the id is taken or a rite is incomplete",
 );
 assert.match(source, /NAME_POOL/, "the name stage offers suggested names");
+{
+  const poolMatch = source.match(/const NAME_POOL = \[([\s\S]*?)\] as const;/);
+  assert.ok(poolMatch, "NAME_POOL should stay a literal array so reserved-name filtering is reviewable");
+  const poolSource = poolMatch[1] ?? "";
+  for (const reserved of ["Nova", "Kitty", "Cody", "Sage", "Astra", "Echo", "Salem"]) {
+    assert.doesNotMatch(
+      poolSource,
+      new RegExp(`"${reserved}"`),
+      `name dice must not suggest internal Coven familiar name ${reserved}`,
+    );
+  }
+}
+assert.doesNotMatch(
+  source,
+  /placeholder="e\.g\. Nova"/,
+  "the default name example must not show an internal Coven familiar name",
+);
+assert.doesNotMatch(
+  source,
+  /Math\.random\(\) \* pool\.length\)\] \?\? "Nova"/,
+  "empty suggestion fallback must not use an internal Coven familiar name",
+);
 
 // ── Form: shared glyph component, best-effort adornments ────────────────────
 assert.match(

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -16,6 +16,7 @@ import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { setFamiliarOverride } from "@/lib/cave-familiar-overrides";
 import { clearSummoningDraft, readSummoningDraft, saveSummoningDraft } from "@/lib/summoning-draft";
 import { setGlyphOverride } from "@/lib/cave-glyph-overrides";
+import { filterInternalCovenNameSuggestions } from "@/lib/familiar-roster-guard";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 /**
@@ -96,9 +97,9 @@ const AURA_PRESETS: { label: string; color: string }[] = [
 
 // The name dice. Short, familiar-shaped names; the user can always type their own.
 const NAME_POOL = [
-  "Nova", "Wren", "Salem", "Ember", "Onyx", "Sage", "Luna", "Rook",
+  "Wren", "Ember", "Onyx", "Luna", "Rook",
   "Hazel", "Fenn", "Moss", "Thistle", "Juniper", "Ivy", "Basil", "Clove",
-  "Nyx", "Ash", "Briar", "Echo", "Pip", "Marlow", "Quill", "Vesper",
+  "Nyx", "Ash", "Briar", "Pip", "Marlow", "Quill", "Vesper",
 ] as const;
 
 const STAGES = [
@@ -460,10 +461,10 @@ function SummoningRite({
     stage === 0 ? vesselComplete : stage === 1 ? nameComplete : stage === 2;
 
   const suggestName = useCallback(() => {
-    const pool = NAME_POOL.filter(
+    const pool = filterInternalCovenNameSuggestions(NAME_POOL).filter(
       (n) => n !== name && !existing.has(slugifyFamiliarId(n)),
     );
-    const pick = pool[Math.floor(Math.random() * pool.length)] ?? "Nova";
+    const pick = pool[Math.floor(Math.random() * pool.length)] ?? "Wren";
     setName(pick);
   }, [name, existing]);
 
@@ -999,7 +1000,7 @@ function StageName({
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. Nova"
+            placeholder="e.g. Wren"
             className={inputClass}
           />
           <Button

--- a/src/lib/familiar-roster-guard.test.ts
+++ b/src/lib/familiar-roster-guard.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  explicitFamiliarIdsFromToml,
+  filterInstallSeedFamiliars,
+  filterInternalCovenNameSuggestions,
+  isInternalCovenFamiliarName,
+} from "./familiar-roster-guard.ts";
+
+assert.deepEqual(
+  filterInternalCovenNameSuggestions([
+    "Nova",
+    "Wren",
+    "Kitty",
+    "Cody",
+    "Sage",
+    "Astra",
+    "Echo",
+    "Salem",
+    "Quill",
+  ]),
+  ["Wren", "Quill"],
+);
+assert.equal(isInternalCovenFamiliarName("Nova"), true);
+assert.equal(isInternalCovenFamiliarName("nova prime"), false);
+
+const installDefaults = [
+  { id: "sage", display_name: "Sage", role: "Guide" },
+  { id: "forge", display_name: "Forge", role: "Builder" },
+  { id: "opencode-local", display_name: "OpenCode", role: "Code Familiar" },
+];
+
+assert.deepEqual(
+  filterInstallSeedFamiliars(installDefaults, new Set()),
+  [],
+  "the known generated first-install roster should not reach the picker",
+);
+
+assert.deepEqual(
+  filterInstallSeedFamiliars(
+    [
+      ...installDefaults,
+      { id: "wren", display_name: "Wren", role: "Research" },
+    ],
+    new Set(["wren"]),
+  ).map((f) => f.id),
+  ["wren"],
+  "implicit install defaults are hidden while explicit user familiars remain",
+);
+
+assert.deepEqual(
+  filterInstallSeedFamiliars(
+    [
+      { id: "sage", display_name: "Sage", role: "Guide" },
+      { id: "wren", display_name: "Wren", role: "Research" },
+    ],
+    explicitFamiliarIdsFromToml(`[[familiar]]
+id = "sage"
+
+[[familiar]]
+id = "wren"
+`),
+  ).map((f) => f.id),
+  ["sage", "wren"],
+  "an intentionally user-authored reserved id is preserved outside the generated default trio",
+);
+
+console.log("familiar-roster-guard.test.ts: ok");

--- a/src/lib/familiar-roster-guard.ts
+++ b/src/lib/familiar-roster-guard.ts
@@ -1,0 +1,89 @@
+export const INTERNAL_COVEN_FAMILIAR_IDS = new Set([
+  "nova",
+  "kitty",
+  "cody",
+  "sage",
+  "astra",
+  "echo",
+  "salem",
+]);
+
+const INSTALL_DEFAULT_FAMILIARS: ReadonlyMap<string, { displayName: string; role: string }> = new Map(
+  [
+    ["sage", { displayName: "Sage", role: "Guide" }],
+    ["forge", { displayName: "Forge", role: "Builder" }],
+    ["opencode-local", { displayName: "OpenCode", role: "Code Familiar" }],
+  ] as const,
+);
+
+type FamiliarRosterEntry = {
+  id: string;
+  display_name?: string | null;
+  role?: string | null;
+};
+
+function normalizeId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeName(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function slugName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function isInternalCovenFamiliarName(value: string): boolean {
+  return INTERNAL_COVEN_FAMILIAR_IDS.has(slugName(value));
+}
+
+export function filterInternalCovenNameSuggestions<T extends string>(names: readonly T[]): T[] {
+  return names.filter((name) => !isInternalCovenFamiliarName(name));
+}
+
+export function explicitFamiliarIdsFromToml(toml: string): Set<string> {
+  const ids = new Set<string>();
+  for (const line of toml.split(/\r?\n/)) {
+    const match = line.match(/^\s*id\s*=\s*"([^"]+)"\s*$/);
+    if (match) ids.add(normalizeId(match[1] ?? ""));
+  }
+  ids.delete("");
+  return ids;
+}
+
+function isInstallDefaultFamiliar(familiar: FamiliarRosterEntry): boolean {
+  const signature = INSTALL_DEFAULT_FAMILIARS.get(normalizeId(familiar.id));
+  if (!signature) return false;
+  const displayName = normalizeName(familiar.display_name);
+  const role = normalizeName(familiar.role);
+  return (
+    (!displayName || displayName === normalizeName(signature.displayName)) &&
+    (!role || role === normalizeName(signature.role))
+  );
+}
+
+export function filterInstallSeedFamiliars<T extends FamiliarRosterEntry>(
+  familiars: readonly T[],
+  explicitIdsInput: ReadonlySet<string> | readonly string[],
+): T[] {
+  if (familiars.length === 0) return [];
+  const explicitIds = Array.isArray(explicitIdsInput)
+    ? new Set(explicitIdsInput.map(normalizeId))
+    : new Set(Array.from(explicitIdsInput, normalizeId));
+
+  if (familiars.every(isInstallDefaultFamiliar)) return [];
+
+  return familiars.filter((familiar) => {
+    const id = normalizeId(familiar.id);
+    const explicit = explicitIds.has(id);
+    if (isInstallDefaultFamiliar(familiar) && !explicit) return false;
+    if (INTERNAL_COVEN_FAMILIAR_IDS.has(id) && !explicit) return false;
+    if (isInternalCovenFamiliarName(familiar.display_name ?? "") && !explicit) return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- remove internal Coven familiar names from the summoning circle name dice and default placeholder
- filter the known generated first-install roster (Sage / Forge / OpenCode) from /api/familiars before it reaches the picker
- add a shared roster guard with source and behavior coverage

## Verification
- pnpm check:tests-wired
- pnpm exec tsc --noEmit
- node src/lib/familiar-roster-guard.test.ts && node src/components/familiar-summoning-circle.test.ts && node src/app/api/familiars/route.test.ts && git diff --check HEAD~1..HEAD
- node scripts/run-tests.mjs app