### PR TITLE
chore(release): stamp v0.0.179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.179] - 2026-07-12
+
+> 🧹 **Chat housekeeping, familiar lifecycle, and updater polish.** Chats gain an automatic archive policy and a centered quick-chat notch, familiars get a discoverable Remove entry and a cleaner picker, the copilot harness renders tool calls, and the update banner leads with the native installer.
+
+### Features
+- **Chat: automatic archive policy** — a configurable policy sweeps stale chat sessions into the archive automatically, with session list/detail support and a settings surface (#2995).
+- **Quick-chat: centered notch** — an optional centered notch that expands into quick chat (#2981).
+- **Familiars: discoverable Remove entry** — the familiar detail panel gains a per-familiar overflow menu with Edit in Studio and Remove familiar…, routing to the canonical lifecycle confirm with undo and restore (#2993).
+
+### Fixes
+- **Chat: copilot harness tool calls** — tool calls on the copilot harness render via its JSONL stream instead of staying invisible (#2985).
+- **Updater: native retry before browser fallback** — when the native update check fails, the banner now recommends retrying the signed native installer before falling back to the browser (#2986).
+- **Familiars: cleaner defaults** — internal Coven familiar names no longer appear in the summoning circle's name dice, and the generated first-install roster is filtered from the picker (#2994).
+- **Secrets: one GitHub token** — `GITHUB_PAT` is the single source of truth for the GitHub token; the duplicate `GITHUB_PERSONAL_ACCESS_TOKEN` vault entry is collapsed into it (#2989).
+- **Linux: leaner AppImage** — libmount is stripped from the AppImage bundle (#2987).
+
 ## [0.0.178] - 2026-07-12
 
 > 🪄 **Craft authoring, GitHub event subscriptions, and chat reliability.** Cave can now create local draft Crafts from familiar roles, subscribe to GitHub repository activity, keep pinned chats synchronized across surfaces, and render captured Codex output events reliably on the Windows harness path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.178",
+  "version": "0.0.179",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.178"
+version = "0.0.179"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.178"
+version = "0.0.179"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.178</string>
+	<string>0.0.179</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.178</string>
+	<string>0.0.179</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.178</string>
+	<string>0.0.179</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.178</string>
+	<string>0.0.179</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.178",
+  "version": "0.0.179",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

Rolls up 8 PRs since v0.0.178: automatic chat archive policy (#2995), quick-chat centered notch (#2981), discoverable familiar Remove entry (#2993), copilot harness tool-call rendering (#2985), native-first update banner (#2986), cleaner familiar defaults (#2994), GITHUB_PAT consolidation (#2989), and a leaner Linux AppImage (#2987).

Stamps all seven version locations + the CHANGELOG.

## Test plan

- `src/lib/app-version.test.ts` (seven-location enforcer) passes; full `pnpm test:app` green
- Commit SSH-signed
- After merge: tag the squash commit `v0.0.179` to kick the release build, then install

🤖 Generated with [Claude Code](https://claude.com/claude-code)