### PR TITLE
fix(onboarding): hide unsupported summon runtimes

### DIFF
--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -10,7 +10,7 @@ import { FamiliarGlyph } from "@/components/familiar-glyph";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useFocusTrap } from "@/lib/use-focus-trap";
-import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
+import { COMPATIBILITY_ADAPTERS, isSummonableLocalHarness } from "@/lib/harness-adapters";
 import { slugifyFamiliarId } from "@/lib/onboarding-familiars";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { setFamiliarOverride } from "@/lib/cave-familiar-overrides";
@@ -278,9 +278,9 @@ function SummoningRite({
   const [vessel, setVessel] = useState<VesselKind | null>(draftVessel);
   const [harnesses, setHarnesses] = useState<HarnessReport[] | null>(null);
   const [harness, setHarness] = useState<string | null>(
-    draft?.harness && COMPATIBILITY_ADAPTERS.some((a) => a.id === draft.harness)
+    draft?.harness && isSummonableLocalHarness(draft.harness)
       ? draft.harness
-      : defaultHarness && COMPATIBILITY_ADAPTERS.some((a) => a.id === defaultHarness)
+      : defaultHarness && isSummonableLocalHarness(defaultHarness)
         ? defaultHarness
         : null,
   );
@@ -341,14 +341,14 @@ function SummoningRite({
         const json = (await res.json()) as { ok?: boolean; harnesses?: (HarnessReport & { binary?: string })[] };
         if (cancelled) return;
         if (res.ok && json.ok !== false && (json.harnesses ?? []).length > 0) {
-          setHarnesses(json.harnesses!.filter((h) => h.chatSupported));
+          setHarnesses(json.harnesses!.filter((h) => h.chatSupported && isSummonableLocalHarness(h.id)));
           return;
         }
         throw new Error("empty");
       } catch {
         if (!cancelled)
           setHarnesses(
-            COMPATIBILITY_ADAPTERS.filter((a) => a.chatSupported !== false).map((a) => ({
+            COMPATIBILITY_ADAPTERS.filter((a) => a.chatSupported !== false && isSummonableLocalHarness(a.id)).map((a) => ({
               id: a.id,
               label: a.label,
               chatSupported: true,

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import {
   COMPATIBILITY_ADAPTERS,
+  SUMMONABLE_LOCAL_HARNESS_IDS,
   mergeAdapterReports,
   adapterSetupState,
   runtimeSourceSetupState,
@@ -9,6 +10,7 @@ import {
   covenHelpSupportsAdapterList,
   covenRunSupportsModelFlag,
   covenRunSupportsAddDirFlag,
+  isSummonableLocalHarness,
   isTrustedChatHarness,
   isTrustedOnboardingHarness,
   openClawAdapterReport,
@@ -93,6 +95,19 @@ const curatedIds = ["codex", "claude", "copilot", "hermes", "openclaw"];
     assert.ok(isTrustedOnboardingHarness(adapter.id), `${adapter.id} passes the onboarding trust gate`);
   }
 }
+
+assert.deepEqual(
+  SUMMONABLE_LOCAL_HARNESS_IDS,
+  ["codex", "claude", "copilot", "hermes"],
+  "the summoning circle's local/SSH runtime choices must only include creation-ready local runtimes",
+);
+assert.equal(isSummonableLocalHarness("codex"), true);
+assert.equal(isSummonableLocalHarness("claude"), true);
+assert.equal(isSummonableLocalHarness("copilot"), true);
+assert.equal(isSummonableLocalHarness("hermes"), true);
+assert.equal(isSummonableLocalHarness("openclaw"), false, "OpenClaw is summoned through the dedicated agent vessel");
+assert.equal(isSummonableLocalHarness("coven-code"), false, "Coven Code is an app/tool install, not a familiar runtime choice");
+assert.equal(isSummonableLocalHarness("opencode"), false, "registry runtimes stay hidden until the creation flow has explicit support");
 
 assert.deepEqual(openClawAdapterReport(2), {
   id: "openclaw",

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -123,6 +123,19 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
   ...REGISTRY_ADAPTERS,
 ];
 
+// The familiar creation flow can only complete local/SSH summoning for the
+// runtimes it has explicit setup/copy/model behavior for today. OpenClaw is a
+// separate agent vessel, and registry additions stay hidden here until the
+// circle grows first-class support for their install and binding flow.
+export const SUMMONABLE_LOCAL_HARNESS_IDS = [
+  "codex",
+  "claude",
+  "copilot",
+  "hermes",
+] as const;
+
+const SUMMONABLE_LOCAL_HARNESSES = new Set<string>(SUMMONABLE_LOCAL_HARNESS_IDS);
+
 const TRUSTED_ONBOARDING_HARNESSES = new Set(
   COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
 );
@@ -167,6 +180,10 @@ export function canonicalHarnessId(harness: string): string {
 
 export function isTrustedChatHarness(harness: string): boolean {
   return TRUSTED_CHAT_HARNESSES.has(canonicalHarnessId(harness));
+}
+
+export function isSummonableLocalHarness(harness: string): boolean {
+  return SUMMONABLE_LOCAL_HARNESSES.has(canonicalHarnessId(harness));
 }
 
 // The single display-label authority for runtime/harness ids: curated Cave


### PR DESCRIPTION
## Summary
- Add a dedicated summonable local runtime allowlist for familiar creation.
- Filter Summoning Circle local and SSH runtime choices through that allowlist.
- Keep OpenClaw available through the dedicated agent vessel while hiding unsupported registry/tool entries.

## Test Plan
- pnpm typecheck
- node --experimental-strip-types src/lib/harness-adapters.test.ts
- node --experimental-strip-types src/components/familiar-summoning-circle.test.ts