### PR TITLE
fix: tolerate legacy familiar records without descriptions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -887,6 +887,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/app/api/familiars/route.test.ts",
   "src/app/api/prompts/route.test.ts",
   "src/app/api/marketplace/pack-prompts-route.test.ts",
   "src/lib/cave-backdrop.test.ts",

--- a/src/app/api/familiars/[id]/route.ts
+++ b/src/app/api/familiars/[id]/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 import { readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 import { loadConfig, saveConfig } from "@/lib/cave-config";
+import { covenHome } from "@/lib/coven-paths";
 import {
   displayNameFromTomlBlock,
   removeFamiliarBlockFromToml,
@@ -17,7 +17,8 @@ export const runtime = "nodejs";
  * Remove ("detach") a familiar — the undo-safe half of the dual-track
  * lifecycle. Archive (client-side, cave-familiar-archive.ts) hides a familiar
  * but leaves it registered; Remove strips its `[[familiar]]` block from
- * ~/.coven/familiars.toml and drops its cave-config.json binding, which is
+ * `$COVEN_HOME/familiars.toml` (defaulting to `~/.coven`) and drops its
+ * cave-config.json binding, which is
  * what a mistaken OpenClaw-agent binding actually needs.
  *
  * Safety model:
@@ -34,7 +35,7 @@ export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string 
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
   }
 
-  const familiarsToml = path.join(homedir(), ".coven", "familiars.toml");
+  const familiarsToml = path.join(covenHome(), "familiars.toml");
   let toml: string | null = null;
   try {
     toml = await readFile(familiarsToml, "utf8");

--- a/src/app/api/familiars/removed/route.ts
+++ b/src/app/api/familiars/removed/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 import { readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 import { saveConfig, type FamiliarBinding } from "@/lib/cave-config";
+import { covenHome } from "@/lib/coven-paths";
 import { buildFamiliarsToml, familiarsTomlContainsId } from "@/lib/onboarding-familiars";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { readTombstones, takeTombstone } from "@/lib/server/familiar-tombstones";
@@ -17,7 +17,8 @@ export const runtime = "nodejs";
  *   POST /api/familiars/removed {id}   → restore the tombstoned familiar
  *
  * Restore re-appends the snapshotted `[[familiar]]` block to
- * ~/.coven/familiars.toml and re-saves the cave-config.json binding, so the
+ * `$COVEN_HOME/familiars.toml` (defaulting to `~/.coven`) and re-saves the
+ * cave-config.json binding, so the
  * familiar comes back exactly as removed (workspace files never moved).
  */
 export async function GET() {
@@ -50,7 +51,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const familiarsToml = path.join(homedir(), ".coven", "familiars.toml");
+  const familiarsToml = path.join(covenHome(), "familiars.toml");
   let existing = "";
   try {
     existing = await readFile(familiarsToml, "utf8");

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -1,6 +1,10 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
@@ -33,6 +37,15 @@ assert.match(
   source,
   /explicitFamiliarIdsFromToml/,
   "Familiars API should distinguish user-authored familiar ids from daemon fallback defaults",
+);
+
+// The executable transport check below asserts the response body. Keep this
+// lightweight guard too, so refactors cannot bypass the shared daemon-error
+// parser and accidentally flatten a structured daemon error.
+assert.match(
+  source,
+  /import\s*\{[^}]*\bextractDaemonError\b[^}]*\}\s*from\s*"@\/lib\/coven-daemon"/,
+  "Familiars API should normalize structured daemon errors",
 );
 
 // ── POST: in-app "create a familiar" write path ──────────────────────────────
@@ -99,5 +112,171 @@ assert.match(
   /try\s*\{\s*contractWrote = await scaffoldFamiliarContractFiles\([\s\S]*?\}\s*catch\s*\{/,
   "contract scaffolding must be best-effort (never fail creation)",
 );
+
+// ── Executable daemon + COVEN_HOME regression ───────────────────────────────
+// Use the actual route and local HTTP transport instead of source-only
+// assertions. This catches both pieces of the failure path: an upstream
+// `{ error: { code, message } }` envelope must survive the Cave proxy, and
+// roster creation must stay inside an explicit COVEN_HOME.
+const originalEnv = Object.fromEntries(
+  [
+    "HOME",
+    "COVEN_HOME",
+    "COVEN_SOCKET",
+    "COVEN_WORKSPACES_ROOT",
+    "COVEN_WORKSPACE_ROOT",
+    "WORKSPACE_ROOT",
+    "NEXT_PUBLIC_WORKSPACE_ROOT",
+  ].map((key) => [key, process.env[key]]),
+);
+const tempRoot = await mkdtemp(path.join(tmpdir(), "coven-familiars-route-"));
+const testHome = path.join(tempRoot, "home");
+const covenHome = path.join(tempRoot, "isolated-coven-home");
+const socket =
+  process.platform === "win32"
+    ? `\\\\.\\pipe\\coven-cave-familiars-${process.pid}-${Date.now()}`
+    : path.join(covenHome, "coven.sock");
+
+process.env.HOME = testHome;
+process.env.COVEN_HOME = covenHome;
+process.env.COVEN_SOCKET = socket;
+for (const key of [
+  "COVEN_WORKSPACES_ROOT",
+  "COVEN_WORKSPACE_ROOT",
+  "WORKSPACE_ROOT",
+  "NEXT_PUBLIC_WORKSPACE_ROOT",
+]) {
+  delete process.env[key];
+}
+
+let server: ReturnType<typeof createServer> | null = null;
+let listening = false;
+try {
+  await mkdir(covenHome, { recursive: true });
+  server = createServer((req, res) => {
+    assert.equal(req.method, "GET");
+    assert.equal(req.url, "/api/v1/familiars");
+    res.writeHead(500, { "content-type": "application/json" });
+    res.end(JSON.stringify({
+      error: {
+        code: "internal_error",
+        message: "The daemon could not process the request.",
+      },
+    }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(socket, () => {
+      server?.off("error", reject);
+      listening = true;
+      resolve();
+    });
+  });
+
+  const { GET, POST } = await import("./route.ts");
+  const { DELETE } = await import("./[id]/route.ts");
+  const { POST: restoreRemoved } = await import("./removed/route.ts");
+  const { POST: onboardingSetup } = await import("../onboarding/setup/route.ts");
+
+  const daemonFailure = await GET();
+  assert.equal(daemonFailure.status, 503, "daemon registry errors map to Cave's roster-unavailable status");
+  assert.deepEqual(await daemonFailure.json(), {
+    ok: false,
+    error: "The daemon could not process the request.",
+    familiars: [],
+  });
+
+  const create = await POST(
+    new Request("http://test/api/familiars", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        familiar: {
+          id: "ash",
+          displayName: "Ash",
+          glyph: "ph:flask-fill",
+          role: "Familiar",
+          harness: "codex",
+          model: "openai/gpt-5.5",
+        },
+      }),
+    }),
+  );
+  assert.equal(create.status, 200, "create accepts a blank-description familiar");
+
+  const toml = await readFile(path.join(covenHome, "familiars.toml"), "utf8");
+  assert.match(toml, /id = "ash"/);
+  assert.match(toml, /description = ""/, "Cave serializes the required empty description field");
+
+  const config = JSON.parse(await readFile(path.join(covenHome, "cave-config.json"), "utf8"));
+  assert.deepEqual(config.familiars.ash, {
+    harness: "codex",
+    model: "openai/gpt-5.5",
+  });
+
+  const remove = await DELETE(new Request("http://test/api/familiars/ash", { method: "DELETE" }), {
+    params: Promise.resolve({ id: "ash" }),
+  });
+  assert.equal(remove.status, 200, "remove reads and writes the COVEN_HOME registry");
+  const tombstones = JSON.parse(
+    await readFile(path.join(covenHome, "cave-removed-familiars.json"), "utf8"),
+  );
+  assert.equal(tombstones.entries[0].id, "ash", "remove stores its undo record under COVEN_HOME");
+
+  const restore = await restoreRemoved(
+    new Request("http://test/api/familiars/removed", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "ash" }),
+    }),
+  );
+  assert.equal(restore.status, 200, "restore writes back to the COVEN_HOME registry");
+  assert.match(
+    await readFile(path.join(covenHome, "familiars.toml"), "utf8"),
+    /id = "ash"[\s\S]*description = ""/,
+    "restore preserves the explicit empty description",
+  );
+
+  const setup = await onboardingSetup(
+    new Request("http://test/api/onboarding/setup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        familiar: {
+          id: "briar",
+          displayName: "Briar",
+          glyph: "ph:code-fill",
+          role: "Familiar",
+          harness: "codex",
+          model: "openai/gpt-5.5",
+        },
+      }),
+    }),
+  );
+  assert.equal(setup.status, 200, "onboarding writes to an explicit COVEN_HOME");
+  assert.equal((await setup.json()).covenDir, covenHome);
+  assert.match(
+    await readFile(path.join(covenHome, "familiars.toml"), "utf8"),
+    /id = "briar"[\s\S]*description = ""/,
+    "onboarding emits the same compatible blank-description registry entry",
+  );
+  await assert.rejects(
+    readFile(path.join(testHome, ".coven", "familiars.toml"), "utf8"),
+    { code: "ENOENT" },
+    "an explicit COVEN_HOME wins over the default home-directory path",
+  );
+} finally {
+  if (listening && server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+  if (process.platform !== "win32") await rm(socket, { force: true }).catch(() => {});
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  await rm(tempRoot, { recursive: true, force: true });
+}
 
 console.log("familiars route.test.ts: ok");

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
-import { callDaemon } from "@/lib/coven-daemon";
+import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
 import { bindingFor, loadConfig, saveConfig } from "@/lib/cave-config";
+import { covenHome } from "@/lib/coven-paths";
 import {
   explicitFamiliarIdsFromToml,
   filterInstallSeedFamiliars,
@@ -34,7 +34,7 @@ export type DaemonFamiliar = {
 };
 
 export async function GET() {
-  const covenDir = path.join(homedir(), ".coven");
+  const covenDir = covenHome();
   const familiarsToml = path.join(covenDir, "familiars.toml");
   const [res, config, removedIds, explicitIds] = await Promise.all([
     callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
@@ -48,7 +48,7 @@ export async function GET() {
   ]);
   if (!res.ok) {
     return NextResponse.json(
-      { ok: false, error: res.error ?? `daemon http ${res.status}`, familiars: [] },
+      { ok: false, error: extractDaemonError(res) ?? `daemon http ${res.status}`, familiars: [] },
       { status: 503 },
     );
   }
@@ -148,7 +148,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const covenDir = path.join(homedir(), ".coven");
+  const covenDir = covenHome();
   const familiarsToml = path.join(covenDir, "familiars.toml");
   const adaptersDir = path.join(covenDir, "adapters");
 

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 import {
   loadConfig,
@@ -18,6 +17,7 @@ import {
   adapterManifestScaffoldForHarness,
   isTrustedOnboardingHarness,
 } from "@/lib/harness-adapters";
+import { covenHome } from "@/lib/coven-paths";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
 
 export const dynamic = "force-dynamic";
@@ -69,8 +69,7 @@ export async function POST(req: Request) {
   const model =
     (draft?.model ?? body.model ?? defaultModelForRuntime(harness)).trim() || defaultModelForRuntime(harness);
 
-  const home = homedir();
-  const covenDir = path.join(home, ".coven");
+  const covenDir = covenHome();
   const familiarsToml = path.join(covenDir, "familiars.toml");
   const configJson = path.join(covenDir, "cave-config.json");
   const conversationsDir = path.join(covenDir, "cave-conversations");

--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -66,6 +66,12 @@ assert.match(
 
 assert.match(
   source,
+  /const p = covenHome\(\)/,
+  "onboarding status checks an explicit COVEN_HOME instead of assuming ~/.coven",
+);
+
+assert.match(
+  source,
   /tool\.outdated[\s\S]{0,240}ok: false[\s\S]{0,240}COVEN_CLI_INSTALL_COMMAND/,
   "startup should require the latest coven CLI version, not just any installed version",
 );

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
 import { covenLaunchCommand, covenSpawnEnv, pickWindowsLauncher } from "@/lib/coven-bin";
+import { covenHome } from "@/lib/coven-paths";
 import {
   openCovenToolStatuses,
   type OpenCovenToolStatus,
@@ -157,14 +158,17 @@ async function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
 }
 
 async function checkCovenHome(): Promise<Step> {
-  const p = path.join(homedir(), ".coven");
+  const p = covenHome();
   try {
     const s = await stat(p);
     if (s.isDirectory()) return { ok: true, detail: p };
   } catch {
     /* missing */
   }
-  return { ok: false, hint: "Cave can create ~/.coven for you." };
+  return {
+    ok: false,
+    hint: process.env.COVEN_HOME ? `Cave can create ${p} for you.` : "Cave can create ~/.coven for you.",
+  };
 }
 
 async function checkDaemon(): Promise<Step> {

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -1,7 +1,7 @@
 import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
-import { homedir } from "node:os";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { covenHome } from "./coven-paths.ts";
 import {
   type ChatAutoArchivePolicy,
   extendUntilIso,
@@ -15,8 +15,13 @@ import {
 } from "@/lib/familiar-runtime";
 import type { UserProfile } from "@/lib/user-profile-shared";
 
-const CONFIG_PATH = path.join(homedir(), ".coven", "cave-config.json");
-const STATE_PATH = path.join(homedir(), ".coven", "cave-state.json");
+function configPath(): string {
+  return path.join(covenHome(), "cave-config.json");
+}
+
+function statePath(): string {
+  return path.join(covenHome(), "cave-state.json");
+}
 
 const DEFAULT_CONFIG: CaveConfig = {
   version: 1,
@@ -228,7 +233,7 @@ export type CaveState = {
 
 export async function loadConfig(): Promise<CaveConfig> {
   try {
-    const raw = await readFile(CONFIG_PATH, "utf8");
+    const raw = await readFile(configPath(), "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveConfig>;
     return {
       version: parsed.version ?? 1,
@@ -444,8 +449,8 @@ export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
           })
         : current.chatAutoArchive,
   };
-  await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeJsonAtomic(CONFIG_PATH, updated);
+  await mkdir(path.dirname(configPath()), { recursive: true });
+  await writeJsonAtomic(configPath(), updated);
   return updated;
   });
 }
@@ -475,8 +480,8 @@ export async function installMarketplacePlugin(
       },
     },
   };
-  await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeJsonAtomic(CONFIG_PATH, updated);
+  await mkdir(path.dirname(configPath()), { recursive: true });
+  await writeJsonAtomic(configPath(), updated);
   return installedAt;
   });
 }
@@ -490,8 +495,8 @@ export async function uninstallMarketplacePlugin(pluginName: string): Promise<vo
     ...cfg,
     marketplace: { installed },
   };
-  await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeJsonAtomic(CONFIG_PATH, updated);
+  await mkdir(path.dirname(configPath()), { recursive: true });
+  await writeJsonAtomic(configPath(), updated);
   });
 }
 
@@ -518,7 +523,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
 
 export async function loadState(): Promise<CaveState> {
   try {
-    const raw = await readFile(STATE_PATH, "utf8");
+    const raw = await readFile(statePath(), "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveState>;
     return {
       sessionFamiliar: parsed.sessionFamiliar ?? {},
@@ -537,8 +542,8 @@ export async function loadState(): Promise<CaveState> {
 }
 
 async function saveState(state: CaveState): Promise<void> {
-  await mkdir(path.dirname(STATE_PATH), { recursive: true });
-  await writeJsonAtomic(STATE_PATH, state);
+  await mkdir(path.dirname(statePath()), { recursive: true });
+  await writeJsonAtomic(statePath(), state);
 }
 
 // In-process serialization of cave-state.json mutations. Without this, two
@@ -840,7 +845,7 @@ export async function upsertRoleConfig(
   } else {
     cfg.roles.push({ id: roleId, familiar, active, activatedAt: active ? now : undefined });
   }
-  await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
-  await writeJsonAtomic(CONFIG_PATH, cfg);
+  await mkdir(path.dirname(configPath()), { recursive: true });
+  await writeJsonAtomic(configPath(), cfg);
   });
 }

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -58,6 +58,39 @@ assert.deepEqual(localDraft, {
   runtime: undefined,
 });
 
+// Legacy Ash/Briar-shaped drafts omitted a description and produced TOML the
+// daemon could not deserialize. A blank description must remain explicit.
+for (const familiar of [
+  {
+    id: "ash",
+    displayName: "Ash",
+    glyph: "ph:flask-fill",
+    role: "Familiar",
+    harness: "codex",
+    model: "openai/gpt-5.5",
+  },
+  {
+    id: "briar",
+    displayName: "Briar",
+    glyph: "ph:code-fill",
+    role: "Familiar",
+    harness: "codex",
+    model: "openai/gpt-5.5",
+  },
+]) {
+  const legacyDraft = normalizeFamiliarDraft(familiar);
+  const legacyToml = buildFamiliarsToml(legacyDraft);
+
+  assert.equal(legacyDraft.description, "", `${familiar.id} defaults its missing description to an empty string`);
+  assert.match(legacyToml, /description = ""/, `${familiar.id} writes an explicit blank description`);
+  assert.match(legacyToml, new RegExp(`id = "${familiar.id}"`));
+  assert.match(legacyToml, new RegExp(`display_name = "${familiar.displayName}"`));
+  assert.match(legacyToml, new RegExp(`emoji = "${familiar.glyph}"`));
+  assert.match(legacyToml, new RegExp(`role = "${familiar.role}"`));
+  assert.match(legacyToml, new RegExp(`harness = "${familiar.harness}"`));
+  assert.match(legacyToml, new RegExp(`model = "${familiar.model}"`));
+}
+
 assert.equal(normalizeFamiliarDraft({ displayName: "Solo" }).harness, "codex");
 
 const hermesDraft = normalizeFamiliarDraft({

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -119,7 +119,9 @@ export function buildFamiliarsToml(draft: OnboardingFamiliarDraft | null): strin
     `role = ${tomlString(draft.role)}`,
   ];
 
-  if (draft.description) lines.push(`description = ${tomlString(draft.description)}`);
+  // Coven's registry schema requires this field. Keep blank user input explicit
+  // so both onboarding and the in-app creator produce daemon-readable TOML.
+  lines.push(`description = ${tomlString(draft.description)}`);
   lines.push(`harness = ${tomlString(draft.harness)}`);
   lines.push(`model = ${tomlString(draft.model)}`);
   if (draft.openclawAgentId) lines.push(`openclaw_agent = ${tomlString(draft.openclawAgentId)}`);

--- a/src/lib/server/familiar-tombstones.ts
+++ b/src/lib/server/familiar-tombstones.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
 import { writeJsonAtomic } from "./atomic-write";
 import {
   normalizeTombstones,
@@ -9,14 +9,15 @@ import {
 } from "@/lib/familiar-removal";
 
 /**
- * ~/.coven/cave-removed-familiars.json — tombstones for removed familiars.
+ * $COVEN_HOME/cave-removed-familiars.json (defaulting to ~/.coven) — tombstones
+ * for removed familiars.
  * DELETE /api/familiars/[id] snapshots an entry here BEFORE mutating
  * familiars.toml / cave-config.json; POST /api/familiars/removed restores
  * from it, and the roster GET hides tombstoned ids until the daemon has
  * re-read familiars.toml.
  */
 function storePath(): string {
-  return path.join(homedir(), ".coven", "cave-removed-familiars.json");
+  return path.join(covenHome(), "cave-removed-familiars.json");
 }
 
 export async function readTombstones(now = Date.now()): Promise<RemovedFamiliarTombstone[]> {


### PR DESCRIPTION
## Summary

Prevent Cave from writing unreadable blank-description familiar records and preserve daemon error context.

## Root Cause

Cave could omit `description`, which older Coven parsed as required. When that happened, Cave discarded structured daemon error details and a `COVEN_HOME` override could split daemon roster state from Cave writes.

## Changes

- Always serialize blank `description = ""`.
- Propagate the structured daemon error message in Cave's stable `503` roster response.
- Route familiar lifecycle, config, and onboarding storage through `COVEN_HOME`.
- Add executable fake-daemon and isolated-home regression coverage.

## Validation

- `pnpm test:api` (`144/144`) in a clean source worktree
- `pnpm exec tsc --noEmit`
- Test wiring check (`834` wired)
- Windows direct route test with the alias loader
- Windows source-level UI loaded Ash and Briar with blank descriptions; human verified.

## Note

The Windows full API suite stops at an unrelated `beads-pr-bridge` path-spawn issue. The full same API suite passed in the clean WSL worktree, and the targeted Windows route test passed.
