### PR TITLE
fix(onboarding): quiet npm 'Unknown env config' warnings in Tools output

### DIFF
--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -206,4 +206,10 @@ assert.match(
   "covenSpawnEnv wires the adapter dirs into every coven child process",
 );
 
+assert.match(
+  source,
+  /env\.NPM_CONFIG_LOGLEVEL = "error"/,
+  "covenSpawnEnv quiets npm warn-level 'Unknown env config' noise in spawned installs",
+);
+
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -354,6 +354,16 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
     process.env.COVEN_HARNESS_ADAPTER_DIRS,
     process.env.COVEN_HOME,
   );
+  // npm emits `npm warn Unknown env config <key>` to stderr for any config
+  // key it no longer recognizes (e.g. a stale `_jsr-registry`,
+  // `minimum-release-age`, or `manage-package-manager-versions` left in the
+  // user's ~/.npmrc or environment). We surface interleaved stdout+stderr in
+  // the Tools panel, so those benign warnings pollute the installer output.
+  // Quiet npm to error-level only — real failures still come through, the
+  // config-parse noise does not. Non-npm children ignore this variable.
+  if (env.NPM_CONFIG_LOGLEVEL === undefined && env.npm_config_loglevel === undefined) {
+    env.NPM_CONFIG_LOGLEVEL = "error";
+  }
   for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
     delete env[key];
   }


### PR DESCRIPTION
## Problem
The Tools panel surfaces `npm warn Unknown env config _jsr-registry` / `minimum-release-age` / `manage-package-manager-versions` lines in installer output — benign noise that reads like an error.

## Root cause
The onboarding install/status routes (`src/app/api/onboarding/{install,status}/route.ts`) spawn npm (`install -g`, `prefix -g`, version checks) and **merge stdout+stderr verbatim** into the surfaced output (`child.stderr.on("data", …)`). When the user's `~/.npmrc` or environment carries config keys npm no longer recognizes, npm emits `npm warn Unknown env config <key>` to stderr → it lands in the panel.

## Fix
Set `NPM_CONFIG_LOGLEVEL=error` in `covenSpawnEnv()` (only when the user hasn't already set a loglevel). npm then suppresses **warn-level** config-parse noise while **real errors still surface**. Non-npm children ignore the variable, so this is safe for the shared spawn env.

## Verification
- `src/lib/coven-bin.test.ts` — added an assertion that the suppression is wired; **test passes** (`coven-bin.test.ts: ok`).
- Change is a 2-line, well-typed env addition; no behavior change beyond log verbosity.