### PR TITLE
fix: require descriptions for new familiars

### DIFF
--- a/src/app/api/familiars/removed/route.ts
+++ b/src/app/api/familiars/removed/route.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { saveConfig, type FamiliarBinding } from "@/lib/cave-config";
 import { buildFamiliarsToml, familiarsTomlContainsId } from "@/lib/onboarding-familiars";
+import { hasNonemptyDescriptionFromTomlBlock } from "@/lib/familiar-removal";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { readTombstones, takeTombstone } from "@/lib/server/familiar-tombstones";
 
@@ -47,6 +48,16 @@ export async function POST(req: Request) {
     return NextResponse.json(
       { ok: false, error: `Nothing to restore for "${id}".` },
       { status: 404 },
+    );
+  }
+
+  // Older tombstones can contain the same description-less block that broke
+  // the daemon roster. Keep the tombstone so the user can recreate it with a
+  // description; never restore a registry record Coven cannot parse.
+  if (entry.tomlBlock && !hasNonemptyDescriptionFromTomlBlock(entry.tomlBlock)) {
+    return NextResponse.json(
+      { ok: false, error: `"${id}" needs a description before it can be restored.` },
+      { status: 409 },
     );
   }
 

--- a/src/components/familiar-studio-lifecycle-tab.test.ts
+++ b/src/components/familiar-studio-lifecycle-tab.test.ts
@@ -114,6 +114,13 @@ assert.match(source, /onRosterChanged\?\.\(\)/);
   // Restore refuses to clobber a re-created id (duplicate [[familiar]] blocks —
   // the daemon only reads the first) and keeps the tombstone for later.
   assert.match(removedRoute, /familiarsTomlContainsId/);
+  assert.match(removedRoute, /hasNonemptyDescriptionFromTomlBlock/);
+  const descriptionValidationAt = removedRoute.lastIndexOf("hasNonemptyDescriptionFromTomlBlock");
+  assert.ok(descriptionValidationAt > 0, "restore validates its tombstone description");
+  assert.ok(
+    descriptionValidationAt < removedRoute.indexOf("await takeTombstone(id)"),
+    "restore validates a tombstone description before consuming it",
+  );
   assert.match(removedRoute, /status: 409/);
 }
 

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -76,8 +76,28 @@ assert.match(
 assert.match(source, /idTaken/, "the circle computes whether the derived id is taken");
 assert.match(
   source,
-  /disabled=\{!vesselComplete \|\| !nameComplete \|\| idTaken \|\| submitting\}/,
-  "Summon must be disabled when the id is taken or a rite is incomplete",
+  /const descriptionComplete = description\.trim\(\)\.length > 0/,
+  "the circle requires a non-empty familiar description",
+);
+assert.match(
+  source,
+  /const identityComplete = nameComplete && descriptionComplete/,
+  "the identity stage requires both name and description",
+);
+assert.match(
+  source,
+  /disabled=\{!vesselComplete \|\| !identityComplete \|\| idTaken \|\| submitting\}/,
+  "Summon must be disabled when the id is taken or a required description is missing",
+);
+assert.match(
+  source,
+  /description: description\.trim\(\)/,
+  "the circle always sends the required description to the creation route",
+);
+assert.match(
+  source,
+  /htmlFor="summon-description">What it does \*</,
+  "the description input is visibly required",
 );
 assert.match(source, /NAME_POOL/, "the name stage offers suggested names");
 {

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -438,9 +438,11 @@ function SummoningRite({
           ? agentId !== null
           : false;
   const nameComplete = name.trim().length > 0 && derivedId.length > 0 && !idTaken;
+  const descriptionComplete = description.trim().length > 0;
+  const identityComplete = nameComplete && descriptionComplete;
   const stageComplete: boolean[] = [
     vesselComplete,
-    nameComplete,
+    identityComplete,
     // The form always has a valid default; it counts once the user has seen it.
     maxVisited >= 2,
     summoned !== null,
@@ -458,7 +460,7 @@ function SummoningRite({
   );
 
   const canContinue =
-    stage === 0 ? vesselComplete : stage === 1 ? nameComplete : stage === 2;
+    stage === 0 ? vesselComplete : stage === 1 ? identityComplete : stage === 2;
 
   const suggestName = useCallback(() => {
     const pool = filterInternalCovenNameSuggestions(NAME_POOL).filter(
@@ -474,7 +476,7 @@ function SummoningRite({
       : model.trim() || (harness ? defaultModelForRuntime(harness) : "runtime default");
 
   async function handleSummon() {
-    if (!vesselComplete || !nameComplete || submitting) return;
+    if (!vesselComplete || !identityComplete || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -486,12 +488,8 @@ function SummoningRite({
             id: derivedId,
             displayName: name.trim(),
             glyph,
+            description: description.trim(),
             ...(role.trim() ? { role: role.trim() } : {}),
-            ...(description.trim()
-              ? { description: description.trim() }
-              : vessel === "ssh"
-                ? { description: `Remote familiar over SSH (${sshHost.trim()}).` }
-                : {}),
             ...(vessel === "openclaw" && selectedAgent
               ? { openclawAgentId: selectedAgent.id }
               : { harness }),
@@ -741,7 +739,7 @@ function SummoningRite({
                       variant="primary"
                       leadingIcon="ph:magic-wand-fill"
                       onClick={() => void handleSummon()}
-                      disabled={!vesselComplete || !nameComplete || idTaken || submitting}
+                      disabled={!vesselComplete || !identityComplete || idTaken || submitting}
                       loading={submitting}
                     >
                       {submitting ? "Summoning…" : "Summon"}
@@ -1040,12 +1038,14 @@ function StageName({
         />
       </div>
       <div>
-        <label className={labelClass} htmlFor="summon-description">What it does</label>
+        <label className={labelClass} htmlFor="summon-description">What it does *</label>
         <textarea
           id="summon-description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder="A short description of this familiar’s focus."
+          required
+          aria-required="true"
           rows={3}
           className={`${inputClass} h-auto resize-y py-2`}
         />

--- a/src/lib/familiar-removal.test.ts
+++ b/src/lib/familiar-removal.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 const {
   removeFamiliarBlockFromToml,
   displayNameFromTomlBlock,
+  hasNonemptyDescriptionFromTomlBlock,
   pruneTombstones,
   normalizeTombstones,
   TOMBSTONE_MAX_ENTRIES,
@@ -11,7 +12,7 @@ const {
 
 const HEADER = "# User familiars for this Coven.\n";
 const block = (id, name) =>
-  `[[familiar]]\nid = "${id}"\ndisplay_name = "${name}"\nrole = "Familiar"\nharness = "codex"\nmodel = "gpt-5.2-codex"\n`;
+  `[[familiar]]\nid = "${id}"\ndisplay_name = "${name}"\nrole = "Familiar"\ndescription = "Helps with familiar work."\nharness = "codex"\nmodel = "gpt-5.2-codex"\n`;
 const THREE = `${HEADER}\n${block("ada", "Ada")}\n${block("bel", "Bel")}\n${block("cyra", "Cyra")}`;
 
 // Remove the middle block: neighbors and the header survive byte-for-byte order.
@@ -87,6 +88,29 @@ const THREE = `${HEADER}\n${block("ada", "Ada")}\n${block("bel", "Bel")}\n${bloc
     'The "Best"',
   );
   assert.equal(displayNameFromTomlBlock('[[familiar]]\nid = "x"\n'), null);
+}
+
+// Restores must never reintroduce a registry record that the daemon cannot
+// parse because its required description is missing or blank.
+{
+  assert.equal(hasNonemptyDescriptionFromTomlBlock(block("ada", "Ada")), true);
+  assert.equal(
+    hasNonemptyDescriptionFromTomlBlock('[[familiar]]\nid = "x"\ndescription = "   "\n'),
+    false,
+  );
+  assert.equal(
+    hasNonemptyDescriptionFromTomlBlock('[[familiar]]\nid = "x"\ndescription = "\\n"\n'),
+    false,
+  );
+  assert.equal(
+    hasNonemptyDescriptionFromTomlBlock('[[familiar]]\nid = "x"\ndescription = "\\u0020"\n'),
+    false,
+  );
+  assert.equal(hasNonemptyDescriptionFromTomlBlock('[[familiar]]\nid = "x"\n'), false);
+  assert.equal(
+    hasNonemptyDescriptionFromTomlBlock("[[familiar]]\nid = 'x'\ndescription = 'Restores safely.'\n"),
+    true,
+  );
 }
 
 // Tombstone pruning: age out past the window, cap the list, newest first.

--- a/src/lib/familiar-removal.ts
+++ b/src/lib/familiar-removal.ts
@@ -76,6 +76,59 @@ export function displayNameFromTomlBlock(block: string): string | null {
   return unescaped || null;
 }
 
+function unescapeTomlBasicString(value: string): string | null {
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character !== "\\") {
+      output += character;
+      continue;
+    }
+
+    const escape = value[index + 1];
+    if (!escape) return null;
+    index += 1;
+    const simple: Record<string, string> = {
+      b: "\b",
+      t: "\t",
+      n: "\n",
+      f: "\f",
+      r: "\r",
+      '"': '"',
+      "\\": "\\",
+    };
+    if (escape in simple) {
+      output += simple[escape];
+      continue;
+    }
+
+    const digits = escape === "u" ? 4 : escape === "U" ? 8 : 0;
+    if (!digits) return null;
+    const hex = value.slice(index + 1, index + 1 + digits);
+    if (!new RegExp(`^[0-9a-fA-F]{${digits}}$`).test(hex)) return null;
+    const codePoint = Number.parseInt(hex, 16);
+    if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) return null;
+    output += String.fromCodePoint(codePoint);
+    index += digits;
+  }
+  return output;
+}
+
+/** True when a tombstoned block can be restored without violating the roster schema. */
+export function hasNonemptyDescriptionFromTomlBlock(block: string): boolean {
+  const multilineBasic = /^\s*description\s*=\s*"""([\s\S]*?)"""\s*(?:#.*)?$/m.exec(block);
+  if (multilineBasic) return (unescapeTomlBasicString(multilineBasic[1]) ?? "").trim().length > 0;
+
+  const multilineLiteral = /^\s*description\s*=\s*'''([\s\S]*?)'''\s*(?:#.*)?$/m.exec(block);
+  if (multilineLiteral) return multilineLiteral[1].trim().length > 0;
+
+  const basic = /^\s*description\s*=\s*"((?:[^"\\]|\\.)*)"\s*(?:#.*)?$/m.exec(block);
+  if (basic) return (unescapeTomlBasicString(basic[1]) ?? "").trim().length > 0;
+
+  const literal = /^\s*description\s*=\s*'([^']*)'\s*(?:#.*)?$/m.exec(block);
+  return literal ? literal[1].trim().length > 0 : false;
+}
+
 /** Age out tombstones past the restore window and cap the list, newest first. */
 export function pruneTombstones(
   entries: RemovedFamiliarTombstone[],

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -30,18 +30,31 @@ assert.deepEqual(draft, {
 const toml = buildFamiliarsToml(draft);
 assert.match(toml, /id = "riley-research"/);
 assert.match(toml, /display_name = "Riley Research"/);
+assert.match(toml, /description = "Finds evidence and summarizes it\."/);
 assert.match(toml, /harness = "openclaw"/);
 assert.match(toml, /model = "openai\/gpt-5.5"/);
 assert.match(toml, /openclaw_agent = "riley"/);
 
 assert.equal(
-  normalizeFamiliarDraft({ displayName: "Cody", openclawAgentId: "cody" }).id,
+  normalizeFamiliarDraft({
+    displayName: "Cody",
+    description: "Handles code tasks.",
+    openclawAgentId: "cody",
+  }).id,
   "cody",
 );
+
+for (const description of [undefined, "", "   \t\n"]) {
+  assert.throws(
+    () => normalizeFamiliarDraft({ displayName: "Descriptionless", description }),
+    /Familiar description is required\./,
+  );
+}
 
 const localDraft = normalizeFamiliarDraft({
   displayName: "Codex Local",
   role: "Code",
+  description: "Writes and reviews code.",
   harness: "codex",
   model: "local-codex",
 });
@@ -50,7 +63,7 @@ assert.deepEqual(localDraft, {
   id: "codex-local",
   displayName: "Codex Local",
   role: "Code",
-  description: "",
+  description: "Writes and reviews code.",
   glyph: "ph:sparkle-fill",
   harness: "codex",
   model: "local-codex",
@@ -58,11 +71,15 @@ assert.deepEqual(localDraft, {
   runtime: undefined,
 });
 
-assert.equal(normalizeFamiliarDraft({ displayName: "Solo" }).harness, "codex");
+assert.equal(
+  normalizeFamiliarDraft({ displayName: "Solo", description: "Works independently." }).harness,
+  "codex",
+);
 
 const hermesDraft = normalizeFamiliarDraft({
   displayName: "Hermes Local",
   role: "Planning",
+  description: "Plans and coordinates work.",
   harness: "hermes",
   model: "hermes-local",
 });
@@ -71,7 +88,7 @@ assert.deepEqual(hermesDraft, {
   id: "hermes-local",
   displayName: "Hermes Local",
   role: "Planning",
-  description: "",
+  description: "Plans and coordinates work.",
   glyph: "ph:sparkle-fill",
   harness: "hermes",
   model: "hermes-local",
@@ -79,6 +96,7 @@ assert.deepEqual(hermesDraft, {
   runtime: undefined,
 });
 
+assert.match(buildFamiliarsToml(hermesDraft), /description = "Plans and coordinates work\."/);
 assert.match(buildFamiliarsToml(hermesDraft), /harness = "hermes"/);
 
 
@@ -86,6 +104,7 @@ assert.throws(
   () =>
     normalizeFamiliarDraft({
       displayName: "Evil",
+      description: "Attempts an unsupported adapter.",
       harness: "attacker-adapter",
       model: "evil-local",
     }),
@@ -96,6 +115,7 @@ assert.throws(
 
 const sshDraft = normalizeFamiliarDraft({
   displayName: "Remote Codex",
+  description: "Runs code work on a remote host.",
   harness: "codex",
   model: "codex-remote",
   runtime: { kind: "ssh", host: "build-box", cwd: "/srv/work", command: "" },
@@ -115,6 +135,7 @@ assert.throws(
   () =>
     normalizeFamiliarDraft({
       displayName: "Half Remote",
+      description: "Has incomplete remote settings.",
       runtime: { kind: "ssh", host: "build-box", cwd: "" },
     }),
   /SSH runtime needs a host/,
@@ -125,6 +146,7 @@ assert.throws(
   () =>
     normalizeFamiliarDraft({
       displayName: "Bad Host",
+      description: "Uses an invalid remote host.",
       runtime: { kind: "ssh", host: "host name!", cwd: "/srv" },
     }),
   /SSH runtime needs a host/,
@@ -134,6 +156,7 @@ assert.throws(
 assert.equal(
   normalizeFamiliarDraft({
     displayName: "Local",
+    description: "Stays on this machine.",
     runtime: { kind: "local" },
   }).runtime,
   undefined,
@@ -144,7 +167,10 @@ assert.equal(
 {
   const manyDashes = "-".repeat(100_000);
   const start = Date.now();
-  normalizeFamiliarDraft({ displayName: manyDashes + "x" });
+  normalizeFamiliarDraft({
+    displayName: manyDashes + "x",
+    description: "Exercises the slugifier guard.",
+  });
   const elapsed = Date.now() - start;
   assert.ok(elapsed < 500, `slugify ReDoS guard: took ${elapsed}ms on long dash string (expected <500ms)`);
 }

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -99,6 +99,23 @@ assert.deepEqual(hermesDraft, {
 assert.match(buildFamiliarsToml(hermesDraft), /description = "Plans and coordinates work\."/);
 assert.match(buildFamiliarsToml(hermesDraft), /harness = "hermes"/);
 
+const escapedDescriptionToml = buildFamiliarsToml(
+  normalizeFamiliarDraft({
+    displayName: "Escaped",
+    description: 'First line\nSecond line\twith a quote " and a slash \\.',
+  }),
+);
+assert.match(
+  escapedDescriptionToml,
+  /description = "First line\\nSecond line\\twith a quote \\" and a slash \\\\."/,
+  "control characters and quotes are escaped into a valid TOML basic string",
+);
+assert.doesNotMatch(
+  escapedDescriptionToml,
+  /description = "First line\nSecond line/,
+  "a multiline description never creates a multiline TOML basic string",
+);
+
 
 assert.throws(
   () =>

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -66,6 +66,9 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
   const id = slugifyFamiliarId(cleanText(input.id) || displayName);
   if (!id) throw new Error("Familiar id is required.");
 
+  const description = cleanText(input.description);
+  if (!description) throw new Error("Familiar description is required.");
+
   const openclawAgentId = slugifyFamiliarId(cleanText(input.openclawAgentId));
   const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "codex");
   if (!isTrustedOnboardingHarness(harness)) {
@@ -96,7 +99,7 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
     id,
     displayName,
     role: cleanText(input.role) || "Familiar",
-    description: cleanText(input.description),
+    description,
     glyph: cleanText(input.glyph) || "ph:sparkle-fill",
     harness,
     model,
@@ -117,9 +120,9 @@ export function buildFamiliarsToml(draft: OnboardingFamiliarDraft | null): strin
     `display_name = ${tomlString(draft.displayName)}`,
     `emoji = ${tomlString(draft.glyph)}`,
     `role = ${tomlString(draft.role)}`,
+    `description = ${tomlString(draft.description)}`,
   ];
 
-  if (draft.description) lines.push(`description = ${tomlString(draft.description)}`);
   lines.push(`harness = ${tomlString(draft.harness)}`);
   lines.push(`model = ${tomlString(draft.model)}`);
   if (draft.openclawAgentId) lines.push(`openclaw_agent = ${tomlString(draft.openclawAgentId)}`);

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -56,7 +56,26 @@ export function slugifyFamiliarId(value: string): string {
 }
 
 function tomlString(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return `"${value.replace(/[\\"\b\t\n\f\r\u0000-\u001f\u007f]/g, (character) => {
+    switch (character) {
+      case "\\":
+        return "\\\\";
+      case '"':
+        return '\\"';
+      case "\b":
+        return "\\b";
+      case "\t":
+        return "\\t";
+      case "\n":
+        return "\\n";
+      case "\f":
+        return "\\f";
+      case "\r":
+        return "\\r";
+      default:
+        return `\\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`;
+    }
+  })}"`;
 }
 
 export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): OnboardingFamiliarDraft {


### PR DESCRIPTION
## Summary

Require every familiar Cave creates or restores to have a non-empty description.

## Root Cause

Coven requires `description` in `familiars.toml`, but Cave allowed a blank draft field to be omitted. That could create an unreadable registry and make Cave show its familiar-roster retry state.

## Changes

- Reject missing, empty, and whitespace-only descriptions in the shared draft validator.
- Serialize descriptions unconditionally with TOML-safe escaping for textarea content.
- Require `What it does` in the Summoning Circle before users can continue or summon.
- Refuse to restore a legacy tombstone whose familiar block lacks a valid description, without consuming the tombstone.

## Validation

- `pnpm test:api` - 144 test files passed.
- `pnpm exec tsc --noEmit`.
- Focused writer, removal, lifecycle, and Summoning Circle tests.
- Windows-native focused tests and TypeScript check.
- Human verification of the required-description UI flow completed before publication.

## Scope

This intentionally does not modify Coven's existing strict schema. Cave now prevents invalid records at its creation and restoration write boundaries while preserving valid existing familiar data.
