### PR TITLE
fix(onboarding): OpenCoven tools setup command

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -51,6 +51,7 @@ export const SUITES = {
     "src-tauri/permissions/desktop-permissions.test.mjs",
     "src-tauri/release-runtime.test.mjs",
     "src/components/open-coven-tools-update.test.ts",
+    "src/lib/opencoven-tools-install.test.ts",
     "src/lib/workflow-run-prompt.test.ts",
     "src/lib/workflow-step-progress.test.ts",
     "src/lib/hfr-trace-export.test.ts",

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -307,6 +307,24 @@ assert.match(
 
 assert.match(
   source,
+  /openCovenToolActionTargets\(tools\)/,
+  "the startup tools step derives one-click targets from the reported tool status",
+);
+
+assert.match(
+  source,
+  /<CommandRow command=\{manualInstallCommand\}/,
+  "the startup tools step shows a manual command matching the needed OpenCoven tools",
+);
+
+assert.match(
+  source,
+  /for \(const target of actionTargets\) onInstall\(target\)/,
+  "the startup tools CTA installs or updates only the OpenCoven tools that need action",
+);
+
+assert.match(
+  source,
   /const covenCodeReady =[\s\S]{0,180}installed[\s\S]{0,80}!.*outdated/,
   "startup should require the latest Coven Code version before treating it as ready",
 );

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -17,6 +17,11 @@ import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry"
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
 import { openExternalUrl } from "@/lib/open-external";
 import { COVEN_CODE_SKIP_KEY } from "@/lib/onboarding-gate";
+import {
+  openCovenToolActionTargets,
+  openCovenToolsInstallCommand,
+  openCovenToolsPrimaryActionLabel,
+} from "@/lib/opencoven-tools-install";
 
 // Guided onboarding: one numbered path from "nothing installed" to "ready to
 // summon". Every step carries its own instructions, a one-click action where
@@ -138,7 +143,6 @@ const NPM_INSTALL_TARGETS = ALL_INSTALL_TARGETS.filter(
 // error instead of an empty runtime grid polling silently forever.
 const HARNESS_RETRY_BUDGET = 15;
 
-const COVEN_CLI_INSTALL_COMMAND = "npm i -g @opencoven/cli@latest";
 const OPENCLAW_AGENT_ROOT = "~/.openclaw/agents";
 const OPENCLAW_WORKSPACE_ROOT = "~/.openclaw/workspace";
 
@@ -192,7 +196,6 @@ const PLATFORM_COPY: Record<
   PlatformId,
   {
     label: string;
-    installCommand: string;
     nodeSetup: string[];
     caveInstall: string[];
     cliInstall: string[];
@@ -202,7 +205,6 @@ const PLATFORM_COPY: Record<
 > = {
   windows: {
     label: "Windows",
-    installCommand: COVEN_CLI_INSTALL_COMMAND,
     warning:
       "The Windows build isn't code-signed yet, so Smart App Control blocks it when enabled. Check Windows Security > App & browser control: if Smart App Control is On, turn it off before downloading. On most PCs it's already Off and nothing is needed.",
     warningLink: {
@@ -221,14 +223,13 @@ const PLATFORM_COPY: Record<
       "Install CovenCave, then open it from Start.",
     ],
     cliInstall: [
-      "Install the coven CLI with npm: npm i -g @opencoven/cli@latest.",
-      "Make sure coven.exe is on PATH after the global npm install.",
-      "Click Re-check after Windows can run coven from a new terminal.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Make sure coven.exe and coven-code are on PATH after the global npm install.",
+      "Click Re-check after Windows can run both tools from a new terminal.",
     ],
   },
   linux: {
     label: "Linux",
-    installCommand: COVEN_CLI_INSTALL_COMMAND,
     nodeSetup: [
       "Install Node.js LTS from https://nodejs.org or your package manager (e.g. sudo apt install nodejs npm).",
       "Open a new terminal so PATH updates apply.",
@@ -240,14 +241,13 @@ const PLATFORM_COPY: Record<
       "Launch the AppImage from your file manager or terminal.",
     ],
     cliInstall: [
-      "Install the coven CLI with npm: npm i -g @opencoven/cli@latest.",
-      "Make sure coven is on PATH after the global npm install.",
-      "If your desktop shell has an older PATH, restart Cave after installing the CLI.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Make sure coven and coven-code are on PATH after the global npm install.",
+      "If your desktop shell has an older PATH, restart Cave after installing the tools.",
     ],
   },
   mac: {
     label: "macOS",
-    installCommand: COVEN_CLI_INSTALL_COMMAND,
     nodeSetup: [
       "Install Node.js LTS from https://nodejs.org, or run brew install node.",
       "Open a new terminal so PATH updates apply.",
@@ -259,14 +259,13 @@ const PLATFORM_COPY: Record<
       "Open CovenCave from Applications.",
     ],
     cliInstall: [
-      "Install the coven CLI with npm: npm i -g @opencoven/cli@latest.",
-      "Make sure a terminal can run coven after the global npm install.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Make sure a terminal can run coven and coven-code after the global npm install.",
       "Click Re-check here after install.",
     ],
   },
   unknown: {
     label: "Your platform",
-    installCommand: COVEN_CLI_INSTALL_COMMAND,
     nodeSetup: [
       "Install Node.js LTS from https://nodejs.org.",
       "Open a new terminal so PATH updates apply.",
@@ -278,8 +277,8 @@ const PLATFORM_COPY: Record<
       "Open CovenCave and continue setup here.",
     ],
     cliInstall: [
-      "Install the coven CLI with npm: npm i -g @opencoven/cli@latest.",
-      "Make sure coven is on PATH.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Make sure coven and coven-code are on PATH.",
       "Click Re-check here after install.",
     ],
   },
@@ -1677,32 +1676,40 @@ function StepCovenCli({
   // client-side now, so per-target busy is enough to coordinate them.
   const covenCodeJob = installJobs["coven-code"];
   const covenCodeJobRunning = covenCodeJob?.status === "running";
+  const actionTargets = openCovenToolActionTargets(tools);
+  const manualInstallCommand = openCovenToolsInstallCommand(tools);
+  const primaryActionLabel = openCovenToolsPrimaryActionLabel(tools);
+  const installBusy = busy || covenCodeJobRunning;
   return (
     <div className="flex flex-col gap-3">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
         Cave needs two OpenCoven tools — the <strong>coven CLI</strong> (powers
-        everything) and <strong>Coven Code</strong> (required). Install both with
-        one click — Cave runs them one after another so they never collide — or
-        copy the command to run it yourself.
+        everything) and <strong>Coven Code</strong> (required). Use the main
+        action to install or update whichever tools need attention — Cave runs
+        npm installs one after another so they never collide — or copy the
+        matching command to run it yourself.
       </p>
       <div className="flex flex-wrap items-center gap-2">
         <Button
           variant="primary"
-          loading={busy || covenCodeJobRunning}
+          loading={installBusy}
           leadingIcon="ph:arrow-down-bold"
           onClick={() => {
-            onInstall("coven-cli");
-            onInstall("coven-code");
+            for (const target of actionTargets) onInstall(target);
           }}
-          disabled={busy || covenCodeJobRunning}
+          disabled={installBusy || actionTargets.length === 0}
         >
-          {busy || covenCodeJobRunning ? "Installing…" : "Install both tools"}
+          {installBusy ? "Installing…" : primaryActionLabel}
         </Button>
-        <span className="text-[11px] text-[var(--text-muted)]">
-          or run it yourself:
-        </span>
+        {actionTargets.length > 0 ? (
+          <span className="text-[11px] text-[var(--text-muted)]">
+            or run it yourself:
+          </span>
+        ) : null}
       </div>
-      <CommandRow command={platformCopy.installCommand} onCopy={onCopy} />
+      {actionTargets.length > 0 ? (
+        <CommandRow command={manualInstallCommand} onCopy={onCopy} />
+      ) : null}
       {busy && job ? <InstallLiveTail tail={job.tail} /> : null}
       <InstallResultNote result={installResults["coven-cli"]} />
       {tools.length > 0 ? (

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -166,8 +166,8 @@ assert.match(
 );
 assert.match(
   source,
-  /<Button[\s\S]{0,140}loading=\{busy \|\| covenCodeJobRunning\}/,
-  "the Install-both CTA uses the primitive's loading state for its spinner",
+  /<Button[\s\S]{0,140}loading=\{installBusy\}/,
+  "the OpenCoven tools CTA uses the primitive's loading state for its spinner",
 );
 assert.doesNotMatch(
   source,

--- a/src/lib/opencoven-tools-install.test.ts
+++ b/src/lib/opencoven-tools-install.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import {
+  openCovenToolActionTargets,
+  openCovenToolsInstallCommand,
+  openCovenToolsPrimaryActionLabel,
+  type OpenCovenToolInstallStatus,
+} from "./opencoven-tools-install.ts";
+
+const cliOutdated: OpenCovenToolInstallStatus = {
+  id: "coven-cli",
+  label: "coven CLI",
+  installed: true,
+  outdated: true,
+};
+
+const codeReady: OpenCovenToolInstallStatus = {
+  id: "coven-code",
+  label: "Coven Code",
+  installed: true,
+  outdated: false,
+};
+
+const codeMissing: OpenCovenToolInstallStatus = {
+  id: "coven-code",
+  label: "Coven Code",
+  installed: false,
+  outdated: false,
+};
+
+assert.deepEqual(
+  openCovenToolActionTargets([]),
+  ["coven-cli", "coven-code"],
+  "fresh setup falls back to installing both OpenCoven tools",
+);
+
+assert.equal(
+  openCovenToolsInstallCommand([]),
+  "npm i -g @opencoven/cli@latest coven-code@latest",
+  "fresh setup manual command installs both required OpenCoven tools",
+);
+
+assert.deepEqual(
+  openCovenToolActionTargets([cliOutdated, codeReady]),
+  ["coven-cli"],
+  "when Coven Code is already current, the primary action only updates the CLI",
+);
+
+assert.equal(
+  openCovenToolsInstallCommand([cliOutdated, codeReady]),
+  "npm i -g @opencoven/cli@latest",
+  "manual command matches the single outdated tool instead of claiming to install both",
+);
+
+assert.equal(
+  openCovenToolsPrimaryActionLabel([cliOutdated, codeReady]),
+  "Update coven CLI",
+  "primary action label reflects a single CLI update",
+);
+
+assert.equal(
+  openCovenToolsPrimaryActionLabel([cliOutdated, codeMissing]),
+  "Update OpenCoven tools",
+  "mixed missing/outdated tools get a neutral update label",
+);
+
+console.log("opencoven-tools-install.test.ts: ok");

--- a/src/lib/opencoven-tools-install.ts
+++ b/src/lib/opencoven-tools-install.ts
@@ -1,0 +1,57 @@
+export type OpenCovenToolInstallTarget = "coven-cli" | "coven-code";
+
+export type OpenCovenToolInstallStatus = {
+  id: OpenCovenToolInstallTarget;
+  label: string;
+  installed: boolean;
+  outdated: boolean;
+};
+
+const OPEN_COVEN_TOOL_ORDER: OpenCovenToolInstallTarget[] = [
+  "coven-cli",
+  "coven-code",
+];
+
+const OPEN_COVEN_TOOL_PACKAGES: Record<OpenCovenToolInstallTarget, string> = {
+  "coven-cli": "@opencoven/cli@latest",
+  "coven-code": "coven-code@latest",
+};
+
+export function openCovenToolActionTargets(
+  tools: readonly OpenCovenToolInstallStatus[],
+): OpenCovenToolInstallTarget[] {
+  if (tools.length === 0) return [...OPEN_COVEN_TOOL_ORDER];
+  const actionable = new Set(
+    tools
+      .filter((tool) => !tool.installed || tool.outdated)
+      .map((tool) => tool.id),
+  );
+  return OPEN_COVEN_TOOL_ORDER.filter((id) => actionable.has(id));
+}
+
+export function openCovenToolsInstallCommand(
+  tools: readonly OpenCovenToolInstallStatus[],
+): string {
+  const targets = openCovenToolActionTargets(tools);
+  const packages = (targets.length > 0 ? targets : OPEN_COVEN_TOOL_ORDER).map(
+    (target) => OPEN_COVEN_TOOL_PACKAGES[target],
+  );
+  return `npm i -g ${packages.join(" ")}`;
+}
+
+export function openCovenToolsPrimaryActionLabel(
+  tools: readonly OpenCovenToolInstallStatus[],
+): string {
+  if (tools.length === 0) return "Install both tools";
+  const actions = tools.filter((tool) =>
+    openCovenToolActionTargets(tools).includes(tool.id),
+  );
+  if (actions.length === 0) return "OpenCoven tools ready";
+  if (actions.length === 1) {
+    const [tool] = actions;
+    return `${tool.outdated ? "Update" : "Install"} ${tool.label}`;
+  }
+  if (actions.every((tool) => !tool.installed)) return "Install both tools";
+  if (actions.every((tool) => tool.outdated)) return "Update OpenCoven tools";
+  return "Update OpenCoven tools";
+}


### PR DESCRIPTION
## Summary

Rescues commit `5a51daa3` that was stranded on the primary checkout's local `main` (direct push correctly rejected by branch protection — GH006). Cherry-picked onto a branch off `origin/main`, original authorship preserved.

Adds `src/lib/opencoven-tools-install.ts` (+66-line test, wired into the CI suite) and reworks the onboarding overlay's tools setup command wiring.

## Test plan

- `tsc --noEmit` and full `pnpm test:app` green on top of latest main (including #3001, which touched the same Tools-output area)
- Cherry-picked commit is SSH-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)