### PR TITLE
fix(harnesses): skip log noise when probing harness versions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -684,6 +684,7 @@ export const SUITES = {
     "src/app/api/coven/exec/route.test.ts",
     "src/lib/coven-daemon.test.ts",
     "src/lib/coven-bin.test.ts",
+    "src/lib/harness-version.test.ts",
     "src/lib/openclaw-bin.test.ts",
     "src/lib/openclaw-bridge.test.ts",
     "src/lib/coven-identity-canon.test.ts",

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { pickVersionLine } from "@/lib/harness-version";
 import {
   COMPATIBILITY_ADAPTERS,
   covenHelpSupportsAdapterList,
@@ -73,7 +74,7 @@ function probeVersion(binary: string, args: string[]): Promise<string | null> {
     }, 2500);
     child.on("close", () => {
       clearTimeout(t);
-      resolve(out.split(/\r?\n/)[0]?.trim() || null);
+      resolve(pickVersionLine(out));
     });
     child.on("error", () => {
       clearTimeout(t);

--- a/src/lib/harness-version.test.ts
+++ b/src/lib/harness-version.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { pickVersionLine } from "./harness-version.ts";
+
+// OpenCode prints an FZF warning to stderr before its version — the warning
+// must not be captured as the "version".
+assert.equal(
+  pickVersionLine(
+    "2026/07/12 11:01:30 WARN FZF not found in $PATH. Some features might be limited or slower.\nopencode 0.4.2",
+  ),
+  "opencode 0.4.2",
+  "skips a timestamped WARN log line and returns the real version",
+);
+
+// Bracketed level tokens are also noise.
+assert.equal(
+  pickVersionLine("[warn] slow start\nsome-tool v1.2.3"),
+  "some-tool v1.2.3",
+  "skips a [warn] bracketed log line",
+);
+
+// Level-prefixed lines (no timestamp) are noise too.
+assert.equal(
+  pickVersionLine("INFO booting\nERROR transient\ncli 2.0.0"),
+  "cli 2.0.0",
+  "skips INFO/ERROR prefixed lines and returns the first version-like line",
+);
+
+// Normal single-line version output is unchanged.
+assert.equal(
+  pickVersionLine("codex-cli 0.143.0-alpha.28"),
+  "codex-cli 0.143.0-alpha.28",
+  "returns a normal single-line version verbatim",
+);
+
+// Leading/trailing blank lines are trimmed away.
+assert.equal(
+  pickVersionLine("\n\n  claude 2.1.185  \n"),
+  "claude 2.1.185",
+  "trims surrounding whitespace/blank lines",
+);
+
+// If nothing looks like a version, fall back to the first non-noise line
+// rather than returning noise or null.
+assert.equal(
+  pickVersionLine("WARN something\nunknown build"),
+  "unknown build",
+  "falls back to the first non-noise line when no digit-bearing line exists",
+);
+
+// Empty output stays null.
+assert.equal(pickVersionLine("   \n  \n"), null, "empty output returns null");
+
+console.log("harness-version.test.ts (pickVersionLine): ok");

--- a/src/lib/harness-version.ts
+++ b/src/lib/harness-version.ts
@@ -1,0 +1,27 @@
+// Extract the first line of a version-probe's output that actually looks like
+// a version, skipping leading log/warning noise.
+//
+// Some harnesses print log lines (e.g. OpenCode's
+// `2026/07/12 11:01:30 WARN FZF not found in $PATH...`) to stdout/stderr
+// *before* their version string. Naively taking the first output line would
+// surface that noise as the "version". This skips obvious log lines and
+// returns the first line that looks like a version (contains a digit), falling
+// back to the first non-noise line so we never regress to null when a tool
+// reports an unusual-but-valid version format.
+export function pickVersionLine(raw: string): string | null {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length === 0) return null;
+  // A leading log line typically starts with a timestamp and/or a level token
+  // like WARN/INFO/ERROR/DEBUG/TRACE, or is bracketed like [warn].
+  const isLogNoise = (l: string): boolean =>
+    /^\d{4}[/-]\d{2}[/-]\d{2}[ tT]/.test(l) ||
+    /^\[?(warn|warning|info|error|debug|trace|notice)\b/i.test(l);
+  const looksLikeVersion = (l: string): boolean => /\d/.test(l);
+  const firstSignal = lines.find((l) => !isLogNoise(l) && looksLikeVersion(l));
+  if (firstSignal) return firstSignal;
+  const firstNonNoise = lines.find((l) => !isLogNoise(l));
+  return firstNonNoise ?? lines[0] ?? null;
+}


### PR DESCRIPTION
## Problem
The Tools panel showed OpenCode's "version" as:
```
2026/07/12 11:01:30 WARN FZF not found in $PATH. Some features might be limited or slower.
```
That's a **log warning**, not a version. Harness version probes (`probeVersion` in `src/app/api/harnesses/route.ts`) captured the **first line** of `--version` output, but some tools print log/warning lines to stdout/stderr *before* the version string.

## Fix
Extract `pickVersionLine()` into `src/lib/harness-version.ts`:
- Skip lines that look like logs — leading timestamp (`2026/07/12 ...`) or level tokens (`WARN/INFO/ERROR/DEBUG/TRACE/NOTICE`, incl. bracketed `[warn]`).
- Return the first line that looks like a version (contains a digit).
- Fall back to the first non-noise line, then the raw first line — so unusual-but-valid version formats never regress to `null`.

Route change is minimal: one import + `resolve(pickVersionLine(out))`.

## Verification
- `src/lib/harness-version.test.ts` — 7 cases (OpenCode WARN, bracketed `[warn]`, INFO/ERROR-prefixed, normal single-line, whitespace trim, non-version fallback, empty→null). **All pass.**
- Extracted to a plain helper module (no `next` import) so it's unit-testable in isolation.