### PR TITLE
feat(models): add GPT-5.6 Codex models

### DIFF
--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -14,7 +14,7 @@ const STATE_PATH = path.join(homedir(), ".coven", "cave-state.json");
 
 const DEFAULT_CONFIG: CaveConfig = {
   version: 1,
-  defaults: { harness: "codex", model: "openai/gpt-5.5" },
+  defaults: { harness: "codex", model: "openai/gpt-5.6-sol" },
   familiars: {},
   roles: [],
   addons: {

--- a/src/lib/chat-model-state.test.ts
+++ b/src/lib/chat-model-state.test.ts
@@ -90,7 +90,7 @@ assert.deepEqual(
     familiarId: "nova",
     harness: "claude",
     runtime: "local:/tmp/coven-cave",
-    effectiveModel: "openai/gpt-5.5",
+    effectiveModel: "openai/gpt-5.6-sol",
     source: "global-default",
     applicationState: "saved",
     reason: "Inherited from Cave defaults.",

--- a/src/lib/chat-model-state.ts
+++ b/src/lib/chat-model-state.ts
@@ -43,7 +43,7 @@ export type ResolveChatModelStateInput = {
 
 const UNSUPPORTED_REASON =
   "Saved in Cave. Runtime model application is not confirmed by this runtime path yet.";
-const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.5";
+const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.6-sol";
 const SYNTHETIC_LOCAL_MODELS = new Set([
   "codex-local",
   "claude-local",

--- a/src/lib/context-meter.ts
+++ b/src/lib/context-meter.ts
@@ -28,6 +28,9 @@ export const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
  * rather than relying on the fallback.
  */
 export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "openai/gpt-5.6-sol": 1_000_000,
+  "openai/gpt-5.6-terra": 1_000_000,
+  "openai/gpt-5.6-luna": 1_000_000,
   // OpenAI (codex runtime) — estimate; adjust when authoritative. The retired
   // GPT-5.1 ids stay listed so the meter keeps working for older sessions and
   // custom configs that still name them.

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -22,7 +22,7 @@ assert.deepEqual(draft, {
   description: "Finds evidence and summarizes it.",
   glyph: "ph:leaf-fill",
   harness: "openclaw",
-  model: "openai/gpt-5.5",
+  model: "openai/gpt-5.6-sol",
   openclawAgentId: "riley",
   runtime: undefined,
 });
@@ -31,7 +31,7 @@ const toml = buildFamiliarsToml(draft);
 assert.match(toml, /id = "riley-research"/);
 assert.match(toml, /display_name = "Riley Research"/);
 assert.match(toml, /harness = "openclaw"/);
-assert.match(toml, /model = "openai\/gpt-5.5"/);
+assert.match(toml, /model = "openai\/gpt-5.6-sol"/);
 assert.match(toml, /openclaw_agent = "riley"/);
 
 assert.equal(

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -38,6 +38,19 @@ assert.equal(
   "Opus 4.8 must stay first so it remains the claude default",
 );
 assert.ok(catalogForRuntime("codex").models.length > 1, "codex should seed a multi-model menu, not just the default");
+assert.deepEqual(
+  catalogForRuntime("codex").models.map((model) => model.id),
+  [
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
+    "openai/gpt-5.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
+    "openai/gpt-5.3-codex-spark",
+  ],
+  "codex catalog should match the current Codex model order",
+);
 assert.ok(
   catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.4"),
   "codex catalog should seed GPT-5.4",
@@ -56,8 +69,8 @@ assert.ok(
 );
 assert.equal(
   catalogForRuntime("codex").models[0].id,
-  "openai/gpt-5.5",
-  "GPT-5.5 must stay first so it remains the codex default",
+  "openai/gpt-5.6-sol",
+  "GPT-5.6 Sol must stay first so it remains the codex default",
 );
 
 // Copilot serves multiple providers' models through one GitHub subscription.
@@ -103,9 +116,9 @@ const openclaw = catalogForRuntime("openclaw");
 assert.equal(openclaw.provider, null);
 assert.equal(openclaw.models.length, 0, "openclaw renders free-text only");
 assert.equal(openclaw.allowCustom, true, "free-text must stay allowed when there is no menu");
-assert.equal(defaultModelForRuntime("codex"), "openai/gpt-5.5");
+assert.equal(defaultModelForRuntime("codex"), "openai/gpt-5.6-sol");
 assert.equal(defaultModelForRuntime("hermes"), "hermes-local", "Hermes should default to the runtime marker, not a Hermes model");
-assert.equal(defaultModelForRuntime("openclaw"), "openai/gpt-5.5", "OpenClaw should inherit a real global default, not openclaw-local");
+assert.equal(defaultModelForRuntime("openclaw"), "openai/gpt-5.6-sol", "OpenClaw should inherit a real global default, not openclaw-local");
 
 // Unknown runtimes have no catalog.
 assert.equal(catalogForRuntime("nonexistent"), null);

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -3,7 +3,7 @@
 // "Model parity" means every runtime gets the same first-class, working model
 // selection, sourced from the provider tied to that runtime where one exists.
 // Model ids follow Cave's existing namespaced convention (`provider/model`),
-// matching the live default (`openai/gpt-5.5`).
+// matching the live default (`openai/gpt-5.6-sol`).
 //
 // The curated lists below are a seed. They are intentionally a one-line edit as
 // providers ship new models, and `allowCustom` is the safety valve so the menu
@@ -35,6 +35,9 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     runtime: "codex",
     provider: "openai",
     models: [
+      { id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" },
+      { id: "openai/gpt-5.6-terra", label: "GPT-5.6 Terra" },
+      { id: "openai/gpt-5.6-luna", label: "GPT-5.6 Luna" },
       { id: "openai/gpt-5.5", label: "GPT-5.5" },
       { id: "openai/gpt-5.4", label: "GPT-5.4" },
       { id: "openai/gpt-5.4-mini", label: "GPT-5.4 Mini" },
@@ -88,7 +91,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   },
 };
 
-const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.5";
+const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.6-sol";
 
 export function catalogForRuntime(runtime: string): RuntimeModelCatalog | null {
   const curated = RUNTIME_MODEL_CATALOG[runtime];


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to the Codex model picker in live catalog order
- make GPT-5.6 Sol the default and global fallback model
- add 1M-token context metadata and ordered catalog regression coverage

## Why

Codex 0.144.1 now exposes the GPT-5.6 family, while Coven Cave's static model catalog stopped at GPT-5.5. This keeps the UI, defaults, and context meter aligned with the models currently available in Codex.

## Validation

- `node --experimental-strip-types src/lib/runtime-models.test.ts`
- `node --experimental-strip-types src/lib/chat-model-state.test.ts`
- `node --experimental-strip-types src/lib/context-meter.test.ts` (9 tests passed)
- `git diff --check`
- Native Tauri app launched and displayed the updated build

Full `pnpm typecheck` is currently blocked by an unrelated stale generated `.next/types/validator.ts` import for the missing `src/app/api/youtube/route.js` module.