### PR TITLE
fix(familiars): surface hub-auth 401 with an actionable message in the notch

### DIFF
--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -47,6 +47,23 @@ export async function GET() {
       .catch(() => new Set<string>()),
   ]);
   if (!res.ok) {
+    // Auth failures (401/403) mean the hub/daemon rejected our access token
+    // — typically a stale or missing token after a hub reconnect. Surface
+    // that distinctly and actionably instead of collapsing every daemon
+    // failure into a bare 503/401 code in the notch ("Failed to load
+    // familiars (401)"), which tells the user nothing about how to recover.
+    if (res.status === 401 || res.status === 403) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            "Not authorized to load familiars — the Coven hub rejected this Cave's access token. Reconnect to the hub (or re-run setup) to refresh it.",
+          reason: "unauthorized",
+          familiars: [],
+        },
+        { status: res.status },
+      );
+    }
     return NextResponse.json(
       { ok: false, error: res.error ?? `daemon http ${res.status}`, familiars: [] },
       { status: 503 },

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -260,7 +260,18 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     void (async () => {
       try {
         const res = await fetch("/api/familiars", { signal: controller.signal });
-        if (!res.ok) throw new Error(`Failed to load familiars (${res.status}).`);
+        if (!res.ok) {
+          // Prefer the route's actionable message (e.g. the hub-auth 401
+          // "reconnect to refresh your token" hint) over a bare status code.
+          let message = `Failed to load familiars (${res.status}).`;
+          try {
+            const body = (await res.clone().json()) as { error?: string };
+            if (body?.error) message = body.error;
+          } catch {
+            // non-JSON body — keep the status-code fallback
+          }
+          throw new Error(message);
+        }
         const json = await res.json();
         if (controller.signal.aborted) return;
         const next = (json?.familiars ?? []) as Familiar[];


### PR DESCRIPTION
## Problem
The top notch showed **`Failed to load familiars (401).`** — a bare status code with no path to recovery.

## Root cause
A 401/403 from `/api/familiars` means the Coven **hub rejected this Cave's access token** (typically stale after a hub reconnect — `callDaemon` attaches `Authorization: Bearer <accessToken>` in hub mode). But the route collapsed **every** daemon failure into a generic `503`, and the notch (`use-quick-chat.ts`) printed only `(${res.status})`. Local-socket mode returns 200 with no auth, so this only bites hub-connected Caves.

## Fix
- **Route** (`src/app/api/familiars/route.ts`): on 401/403 from the daemon/hub, return that status with a clear message — *"the Coven hub rejected this Cave's access token. Reconnect to the hub (or re-run setup) to refresh it."* — plus `reason: "unauthorized"`. Other daemon failures still return 503.
- **Notch** (`src/lib/use-quick-chat.ts`): read the response body's `error` message and display it, falling back to the status code only for non-JSON bodies.

## Verification
- `api-contracts.test.ts` → **170 route contracts pass** (route shape unchanged; the 401/403 branch is internal to GET).
- Local-socket mode unaffected.