### PR TITLE
fix startup sidecar cache validation

### DIFF
--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -198,6 +198,13 @@ fn runtime_has_required_files(root: &Path) -> bool {
 }
 
 fn cache_is_ready(destination: &Path, manifest: &SidecarArchiveManifest) -> bool {
+    // The marker is written only after extraction has passed a full tree hash
+    // and is moved into this content-addressed destination atomically. Trust
+    // that durable commit record on later launches: re-hashing the runtime here
+    // makes every Windows startup read thousands of files before the sidecar can
+    // start (and is especially expensive under real-time antivirus scanning).
+    // Required entrypoints are still checked so common partial-cache damage is
+    // repaired automatically.
     if !runtime_has_required_files(destination) {
         return false;
     }
@@ -205,18 +212,14 @@ fn cache_is_ready(destination: &Path, manifest: &SidecarArchiveManifest) -> bool
         Ok(contents) => contents,
         Err(_) => return false,
     };
-    let marker_matches = match serde_json::from_str::<CompletionMarker>(&marker) {
+    match serde_json::from_str::<CompletionMarker>(&marker) {
         Ok(marker) => {
             marker.schema_version == MANIFEST_SCHEMA_VERSION
                 && marker.payload_sha256 == manifest.payload_sha256
                 && marker.tree_sha256 == manifest.tree_sha256
         }
         Err(_) => false,
-    };
-    if !marker_matches {
-        return false;
     }
-    tree_metrics(destination).is_ok_and(|(_, _, _, digest)| digest == manifest.tree_sha256)
 }
 
 fn lock_is_contended(error: &io::Error) -> bool {
@@ -1091,21 +1094,24 @@ mod tests {
     }
 
     #[test]
-    fn recovers_same_size_corruption_outside_required_paths() {
-        let root = test_root("content-corruption");
+    fn cache_hit_trusts_verified_marker_without_rehashing_runtime_tree() {
+        let root = test_root("constant-time-cache-hit");
         let (archive, manifest_path, _) = write_fixture(&root);
         let cache = root.join("cache");
         let runtime = prepare_runtime_from_files(&archive, &manifest_path, &cache)
             .expect("prepare initial runtime");
         let helper = runtime.join("node_modules/@swc/helpers/_/index");
         fs::write(&helper, b"corrupt").expect("corrupt non-sentinel file with same byte length");
+        fs::remove_file(&archive).expect("remove archive to require a cache hit");
 
-        let recovered = prepare_runtime_from_files(&archive, &manifest_path, &cache)
-            .expect("recover arbitrary cached-file corruption");
+        let reused = prepare_runtime_from_files(&archive, &manifest_path, &cache)
+            .expect("reuse runtime from its verified completion marker");
+        assert_eq!(reused, runtime);
         assert_eq!(
-            fs::read(recovered.join("node_modules/@swc/helpers/_/index"))
-                .expect("read recovered helper"),
-            b"fixture"
+            fs::read(reused.join("node_modules/@swc/helpers/_/index"))
+                .expect("read untouched helper"),
+            b"corrupt",
+            "cache hits must not traverse and re-hash unrelated runtime files"
         );
         fs::remove_dir_all(root).expect("remove test root");
     }


### PR DESCRIPTION
## Summary

- make Windows sidecar cache hits trust the atomically committed completion marker
- retain required-entrypoint checks so partial caches are still repaired
- replace the full-tree rehash regression with coverage for the constant-time cache-hit contract

## Root cause

Every Windows launch recursively scanned and SHA-256 hashed the extracted sidecar runtime before starting the server. On the reported installation that meant reading 4,942 files (about 102 MB) under real-time antivirus scanning. Runtime telemetry measured the cache lookup at 253.85 seconds, so the native window appeared not to load.

Fresh extraction remains fully verified against the archive manifest before `.complete.json` is written and the staging directory is atomically renamed into its content-addressed cache location. Subsequent launches now validate that marker and the required runtime entrypoints without walking the full runtime tree.

## Impact

The real installed 4,942-file cache hit completed in 2.426 ms with this patch, down from the previously recorded 253.85 seconds. The sidecar can begin starting immediately instead of blocking the UI for more than four minutes.

## Verification

- `rustfmt --check src-tauri/src/sidecar_archive.rs`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 66 passed
- local installed-runtime performance probe against `C:\Users\timot\AppData\Local\ai.opencoven.cave\sidecar-runtime` — 2.426 ms
- `git diff --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings` — changed module clean; command remains blocked by seven pre-existing findings in `lib.rs`, `browser.rs`, and `pty.rs`

## Tracking

Beads context could not be updated because the `bd` executable is not installed in the current environment.
