### PR TITLE
style(copy): capitalize "Coven CLI" everywhere in prose (cave-btj4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Patch release on top of v0.0.177.
 
 ### Fixes
 - **Folder picker is summoned to the foreground** — the native "choose a folder" dialog no longer opens hidden behind the window. On Windows the `FolderBrowserDialog` now gets a `TopMost` owner form so it comes forward focused; macOS activates System Events before `choose folder`; Linux runs zenity modal (#2614, #2944).
-- **A failed chat send keeps you in the conversation** — when the coven CLI can't be resolved from the app's environment, the send failure now surfaces as an inline error strip with your message preserved for one-click Retry and a soft "Open Setup" link (wizard overlay, not a hard navigation) instead of eating the message and bouncing to Setup (#2618, #2944).
+- **A failed chat send keeps you in the conversation** — when the Coven CLI can't be resolved from the app's environment, the send failure now surfaces as an inline error strip with your message preserved for one-click Retry and a soft "Open Setup" link (wizard overlay, not a hard navigation) instead of eating the message and bouncing to Setup (#2618, #2944).
 - **Board: table never mounts with the selected card hidden** — switching to the table view with a card selected in the collapsed-by-default "done" group used to leave no row for the anchor scroll to find; the collapse initializer is now selection-aware and the still-selected card is revealed after a view-mode switch (cave-iote) (#2940, #2943).
 - **Board: detail-panel action popover no longer clips** — the popover anchors left so it isn't cut off at the panel edge (#2936).
 - **Projects: deduped by normalized root at load** — projects registered under differently-normalized paths no longer show as duplicates (#2932).
@@ -1852,7 +1852,7 @@ Patch release: respect persisted home navigation state after the v0.0.102 chat-w
 ### Fixed
 - **Shell** — reverted the forced home-screen nav reopen so fresh desktop launches still default open, but a deliberate collapsed nav stays collapsed across reloads and app launches (#920).
 - **Windows OpenClaw bridge** — Cave now resolves and launches npm `openclaw.cmd` shims safely, so OpenClaw-backed familiars such as TARS do not require a hand-built `openclaw.exe`.
-- **OpenCoven tools update** — updating the coven CLI from Cave now best-effort stops the running daemon first and surfaces clearer guidance if Windows still has `coven.exe` locked.
+- **OpenCoven tools update** — updating the Coven CLI from Cave now best-effort stops the running daemon first and surfaces clearer guidance if Windows still has `coven.exe` locked.
 
 ## [0.0.102] - 2026-06-18
 
@@ -1901,7 +1901,7 @@ Patch release: Salem perch proximity polish, companion rail alignment fixes, nex
 Patch release: Windows first-run daemon startup fix and a Salem typecheck guard after 0.0.98.
 
 ### Fixed
-- **Windows setup** — Cave now resolves npm-installed `coven.cmd` shims from `%APPDATA%\npm` / `npm_config_prefix`, preserves Windows PATH delimiters, and starts the daemon through shell mode for the fixed `coven daemon start` command. This fixes the welcome screen reporting `covenCli.ok: true` while the daemon button still surfaced "coven CLI not found on PATH."
+- **Windows setup** — Cave now resolves npm-installed `coven.cmd` shims from `%APPDATA%\npm` / `npm_config_prefix`, preserves Windows PATH delimiters, and starts the daemon through shell mode for the fixed `coven daemon start` command. This fixes the welcome screen reporting `covenCli.ok: true` while the daemon button still surfaced "Coven CLI not found on PATH."
 - **Salem** — restored the floating Salem perch `retreat` prop and right-edge retreat behavior so the workspace typecheck stays green.
 
 ## [0.0.98] - 2026-06-16
@@ -2263,7 +2263,7 @@ Chats that persist and a workflow canvas you can rearrange by hand.
 - **Chat conversations no longer fork on resumed turns** — continued turns now resume in the conversation's original working directory (harness session stores are cwd-scoped) and keep a stable cave-owned conversation id while the harness's per-resume session id is tracked internally. Previously each continued turn could lose project context and spawn a new sidebar session.
 - **Workflow canvas edges render** — step nodes gained explicit connection handles (React Flow error #008), with a toggleable themed minimap.
 - **Machines without Node or Git are covered** — Node ships inside the app bundle (the release now refuses to build without it); Git became an advisory setup check with platform-aware install hints, missing-git API errors are actionable, and the README gains a dependency table.
-- **Friendly error when the coven CLI is missing**, and mobile-access token checks no longer trust spoofable `Host` headers.
+- **Friendly error when the Coven CLI is missing**, and mobile-access token checks no longer trust spoofable `Host` headers.
 
 ### Changed
 - **Workflow studio polish** — role attach rows align as fixed columns with right-pinned familiar tags; all studio scroll regions use thin dark scrollbars.

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -213,7 +213,7 @@ async function resolveFamiliarWorkspace(
   }
 }
 
-// Run coven CLI and collect full stdout output as a string.
+// Run Coven CLI and collect full stdout output as a string.
 function runCoven(
   args: string[],
   signal: AbortSignal,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1930,7 +1930,7 @@ export async function POST(req: Request) {
                     ? "ssh CLI not found on PATH. Install OpenSSH or run this familiar locally."
                     : copilotStream
                       ? "copilot CLI not found on PATH. Install it with `npm install -g @github/copilot`, then try again."
-                      : "coven CLI not found on PATH. Open Setup to install it, then try again.",
+                      : "Coven CLI not found on PATH. Open Setup to install it, then try again.",
               });
             } else {
               push({ kind: "error", message: err.message });

--- a/src/app/api/coven/exec/route.test.ts
+++ b/src/app/api/coven/exec/route.test.ts
@@ -19,7 +19,7 @@ assert.match(
 assert.match(
   source,
   /isMissingExecutableError\(e\)[\s\S]*covenCliMissingError\(\)/,
-  "missing coven CLI spawn errors should return the stable install/setup payload",
+  "missing Coven CLI spawn errors should return the stable install/setup payload",
 );
 
 console.log("coven exec route.test.ts: ok");

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -33,7 +33,7 @@ const execFileAsync = promisify(execFile);
 const INSTALL_TARGETS = {
   "coven-cli": {
     kind: "npm",
-    label: "coven CLI",
+    label: "Coven CLI",
     packageName: "@opencoven/cli@latest",
     binary: "coven",
     timeoutMs: 240_000,
@@ -328,7 +328,7 @@ async function prepareForInstall(
   job: InstallJob,
 ) {
   if (targetName !== "coven-cli") return;
-  appendOutput(job, "Preparing coven CLI update: checking daemon lock state...\n");
+  appendOutput(job, "Preparing Coven CLI update: checking daemon lock state...\n");
   const health = await callDaemon<{ ok?: boolean; daemon?: { pid?: number } }>({
     path: "/api/v1/health",
     timeoutMs: 800,

--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -61,19 +61,19 @@ assert.match(
 assert.match(
   source,
   /checkCovenCli\(tool: OpenCovenToolStatus \| undefined\)/,
-  "coven CLI status is derived from the shared coven-cli tool result",
+  "Coven CLI status is derived from the shared coven-cli tool result",
 );
 
 assert.match(
   source,
   /tool\.outdated[\s\S]{0,240}ok: false[\s\S]{0,240}COVEN_CLI_INSTALL_COMMAND/,
-  "startup should require the latest coven CLI version, not just any installed version",
+  "startup should require the latest Coven CLI version, not just any installed version",
 );
 
 assert.match(
   source,
   /openCovenTools\.find\(\(tool\) => tool\.id === "coven-cli"\)/,
-  "startup identifies the coven CLI by the shared tool id",
+  "startup identifies the Coven CLI by the shared tool id",
 );
 
 assert.match(
@@ -84,7 +84,7 @@ assert.match(
 
 assert.doesNotMatch(
   source,
-  /Install the coven CLI from OpenCoven\/coven/,
+  /Install the Coven CLI from OpenCoven\/coven/,
   "onboarding status should not return stale repo-source CLI install guidance",
 );
 

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -57,7 +57,7 @@ function checkCovenCli(tool: OpenCovenToolStatus | undefined): Step {
   if (!tool?.installed) {
     return {
       ok: false,
-      hint: `Install the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, make sure it is on PATH, then re-check.`,
+      hint: `Install the Coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, make sure it is on PATH, then re-check.`,
     };
   }
   if (tool.outdated) {
@@ -68,7 +68,7 @@ function checkCovenCli(tool: OpenCovenToolStatus | undefined): Step {
     return {
       ok: false,
       detail,
-      hint: `Update the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, then re-check.`,
+      hint: `Update the Coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, then re-check.`,
     };
   }
   const location = tool.path ?? tool.binary;

--- a/src/app/api/opencoven-tools/status/route.test.ts
+++ b/src/app/api/opencoven-tools/status/route.test.ts
@@ -29,7 +29,7 @@ assert.match(
 assert.match(
   source,
   /id: "coven-cli"[\s\S]*packageName: "@opencoven\/cli"[\s\S]*binary: "coven"/,
-  "the coven CLI status checks the npm-published @opencoven/cli package and coven binary",
+  "the Coven CLI status checks the npm-published @opencoven/cli package and coven binary",
 );
 
 assert.match(

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -192,7 +192,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const covenMissing = useMemo\(\s*\(\) => \/coven CLI not found on PATH\/i\.test\(message\) \|\| code === "ENOENT"/,
+  /const covenMissing = useMemo\(\s*\(\) => \/Coven CLI not found on PATH\/i\.test\(message\) \|\| code === "ENOENT"/,
   "the error strip detects the coven-CLI-missing failure class",
 );
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -641,12 +641,12 @@ function ChatErrorStrip({
     () => parseHarnessAuthFailure(detailText, harnessId),
     [detailText, harnessId],
   );
-  // The coven CLI couldn't be resolved from the app's spawn environment
+  // The Coven CLI couldn't be resolved from the app's spawn environment
   // (the #2610 class of failure). Rather than a bare error + generic Retry,
   // offer a soft "Open Setup" link (overlay, not a hard nav) — the message
   // stays in the composer for retry (#2618).
   const covenMissing = useMemo(
-    () => /coven CLI not found on PATH/i.test(message) || code === "ENOENT",
+    () => /Coven CLI not found on PATH/i.test(message) || code === "ENOENT",
     [message, code],
   );
 
@@ -730,7 +730,7 @@ function ChatErrorStrip({
       {!harnessFailure && !authFailure && covenMissing ? (
         <div className="flex flex-wrap items-center gap-2 px-5 pb-2 text-[11px]">
           <span className="min-w-0">
-            The coven CLI isn&apos;t resolvable from this app&apos;s environment. Open Setup to install
+            The Coven CLI isn&apos;t resolvable from this app&apos;s environment. Open Setup to install
             or repair it, then retry — your message is kept.
           </span>
           <button type="button" onClick={onOpenSetup} className={btn}>

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -968,14 +968,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       {
         key: "covenCli",
         title: "Install the OpenCoven tools",
-        // Require both coven CLI (server step) and Coven Code (required, but
+        // Require both Coven CLI (server step) and Coven Code (required, but
         // skippable) before this step counts as done.
         ok: !!s?.covenCli.ok && covenCodeSatisfied,
         detail: !s?.covenCli.ok
           ? (s?.covenCli.detail ?? s?.covenCli.hint ?? "checking…")
           : covenCodeSatisfied
             ? (s?.covenCli.detail ?? "Installed")
-            : "coven CLI ready — Coven Code still needs installing.",
+            : "Coven CLI ready — Coven Code still needs installing.",
         icon: "ph:gear-six",
       },
       {
@@ -1178,7 +1178,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             <div>
               <div className="font-semibold">Setup status is unreachable.</div>
               <p className="mt-1 leading-6 text-[var(--text-secondary)]">
-                Cave couldn&rsquo;t reach <code className="font-mono">/api/onboarding/status</code> in {statusFailures} attempts. The coven CLI may not be installed, or the local sidecar may be blocked. Steps will stay on &ldquo;checking…&rdquo; until this clears — step 1 below still works and is the usual fix.
+                Cave couldn&rsquo;t reach <code className="font-mono">/api/onboarding/status</code> in {statusFailures} attempts. The Coven CLI may not be installed, or the local sidecar may be blocked. Steps will stay on &ldquo;checking…&rdquo; until this clears — step 1 below still works and is the usual fix.
               </p>
             </div>
             <button
@@ -1424,7 +1424,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                 }
                                 title={
                                   !status?.steps.covenCli.ok
-                                    ? "Install coven CLI first (step 1)"
+                                    ? "Install Coven CLI first (step 1)"
                                     : "Start local daemon (coven daemon start)"
                                 }
                               >
@@ -1433,7 +1433,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                               {!status?.steps.covenCli.ok ? (
                                 <span className="text-[11px] text-[var(--text-muted)]">
                                   Needs step 1 first — the daemon ships with the
-                                  coven CLI.
+                                  Coven CLI.
                                 </span>
                               ) : null}
                             </div>
@@ -1683,7 +1683,7 @@ function StepCovenCli({
   return (
     <div className="flex flex-col gap-3">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
-        Cave needs two OpenCoven tools — the <strong>coven CLI</strong> (powers
+        Cave needs two OpenCoven tools — the <strong>Coven CLI</strong> (powers
         everything) and <strong>Coven Code</strong> (required). Use the main
         action to install or update whichever tools need attention — Cave runs
         npm installs one after another so they never collide — or copy the

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -74,9 +74,9 @@ assert.match(
   /\.settings-tool-action--primary\s*\{[\s\S]*?border:[\s\S]*?box-shadow:/,
   "Primary Settings tool action should have a visible border and elevation",
 );
-assert.match(status, /minimumVersion: "0\.0\.49"/, "coven CLI compatibility floor is explicit in the status source");
+assert.match(status, /minimumVersion: "0\.0\.49"/, "Coven CLI compatibility floor is explicit in the status source");
 assert.match(status, /minimumVersion: "0\.0\.22"/, "coven-code compatibility floor is explicit in the status source");
-assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "coven CLI exposes the exact update command");
+assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "Coven CLI exposes the exact update command");
 assert.match(status, /installCommand: "npm i -g coven-code@latest"/, "coven-code exposes the exact update command");
 assert.match(status, /const compatible =[\s\S]*!!installed\?\.version && compareSemver\(installed\.version, tool\.minimumVersion\) >= 0/, "compatibility compares installed version against the Cave minimum");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -175,7 +175,7 @@ assert.match(
   "covenBin falls back to `where` + launcher picking before the literal name on Windows",
 );
 
-// Released coven CLIs only auto-trust recipe-installed manifests inside
+// Released Coven CLIs only auto-trust recipe-installed manifests inside
 // COVEN_HOME/adapters (hermes); Cave-scaffolded copilot/opencode manifests
 // there are ignored unless COVEN_HARNESS_ADAPTER_DIRS names the directory.
 // Every coven spawn must therefore carry the env var.

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -303,7 +303,7 @@ export function covenLaunchCommand(): CovenLaunchCommand {
  * Value for COVEN_HARNESS_ADAPTER_DIRS in coven child processes: the user's
  * own value (if any) with COVEN_HOME/adapters appended.
  *
- * Released coven CLIs (≤0.0.53) only auto-trust manifests in
+ * Released Coven CLIs (≤0.0.53) only auto-trust manifests in
  * COVEN_HOME/adapters whose id matches a built-in install recipe (hermes
  * today). The manifests Cave scaffolds there for other runtimes (copilot,
  * opencode, …) are silently ignored, so `coven run copilot` failed with

--- a/src/lib/coven-spawn-error.test.ts
+++ b/src/lib/coven-spawn-error.test.ts
@@ -16,7 +16,7 @@ assert.equal(isMissingExecutableError(new Error("spawn coven ENOENT")), false);
 assert.deepEqual(covenCliMissingError(), {
   ok: false,
   code: "ENOENT",
-  error: "coven CLI not found on PATH. Open Setup to install it, then try again.",
+  error: "Coven CLI not found on PATH. Open Setup to install it, then try again.",
 });
 
 console.log("coven-spawn-error.test.ts: ok");

--- a/src/lib/coven-spawn-error.ts
+++ b/src/lib/coven-spawn-error.ts
@@ -11,6 +11,6 @@ export function covenCliMissingError() {
   return {
     ok: false,
     code: "ENOENT",
-    error: "coven CLI not found on PATH. Open Setup to install it, then try again.",
+    error: "Coven CLI not found on PATH. Open Setup to install it, then try again.",
   };
 }

--- a/src/lib/coven-version.test.ts
+++ b/src/lib/coven-version.test.ts
@@ -16,13 +16,13 @@ assert.equal(
 assert.equal(
   displayCovenVersion({ daemonVersion: "0.0.0", installedVersion: "0.0.39" }),
   "0.0.39",
-  "daemon health placeholder should fall back to the installed coven CLI version",
+  "daemon health placeholder should fall back to the installed Coven CLI version",
 );
 
 assert.equal(
   displayCovenVersion({ daemonVersion: undefined, installedVersion: "0.0.39" }),
   "0.0.39",
-  "missing daemon health version should fall back to the installed coven CLI version",
+  "missing daemon health version should fall back to the installed Coven CLI version",
 );
 
 assert.equal(

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -4,7 +4,7 @@
  * A *coven* is a saved set of familiars you talk to together. Sending a prompt
  * fans it out to every participant in parallel (one `/api/chat/send` stream per
  * familiar — the same client-side broadcast model the iOS app uses, since the
- * daemon/coven CLI has no server-side "group session" concept). Each familiar
+ * daemon/Coven CLI has no server-side "group session" concept). Each familiar
  * keeps its own resumable session; the group just remembers which session id
  * belongs to which familiar so every thread persists across reloads.
  *

--- a/src/lib/opencoven-tools-install.test.ts
+++ b/src/lib/opencoven-tools-install.test.ts
@@ -8,7 +8,7 @@ import {
 
 const cliOutdated: OpenCovenToolInstallStatus = {
   id: "coven-cli",
-  label: "coven CLI",
+  label: "Coven CLI",
   installed: true,
   outdated: true,
 };
@@ -53,7 +53,7 @@ assert.equal(
 
 assert.equal(
   openCovenToolsPrimaryActionLabel([cliOutdated, codeReady]),
-  "Update coven CLI",
+  "Update Coven CLI",
   "primary action label reflects a single CLI update",
 );
 

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -13,7 +13,7 @@ const execFileAsync = promisify(execFile);
 export const OPEN_COVEN_TOOLS = [
   {
     id: "coven-cli",
-    label: "coven CLI",
+    label: "Coven CLI",
     packageName: "@opencoven/cli",
     binary: "coven",
     versionArgs: ["--version"],


### PR DESCRIPTION
## What

User style rule: the product name is **"Coven CLI"**, capital C — never "coven CLI". Repo-wide prose sweep: 34 occurrences across 20 files (UI strings, error messages, setup hints, code comments, test descriptions, CHANGELOG prose), 38 lines changed.

## What's untouched

- Identifiers and commands: `coven-cli` tool id, `covenCli.*` fields, the `coven` binary and its commands (`coven daemon start`), `coven.exe`/`coven.cmd`.
- `.beads/interactions.jsonl` (generated export).

## Runtime safety

The only code that matches these strings is chat-view's missing-CLI detector, which is a **case-insensitive** regex — capitalizing the emitted error can't break detection (including old-client/new-server skew). The detector's exact-source test pin (`chat-view.test.ts`) is updated in the same sweep, as are all string-pinning test assertions.

## Validation

- `pnpm typecheck` clean
- `pnpm test:app` — 624/624 test files pass
- Post-sweep grep: zero lowercase "coven CLI" outside the generated beads export

🤖 Generated with [Claude Code](https://claude.com/claude-code)