### PR TITLE
fix(onboarding): coven-code installs only as @opencoven/coven-code, minimum 0.6.0 (cave-gy65)

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -16,7 +16,7 @@ assert.match(
 
 for (const pkg of [
   "@opencoven\\/cli@latest",
-  "coven-code@latest",
+  "@opencoven\\/coven-code@latest",
   "@openai\\/codex",
   "@anthropic-ai\\/claude-code",
   "@github\\/copilot@latest",
@@ -160,8 +160,13 @@ assert.match(
 
 assert.match(
   source,
-  /"coven-code":\s*\{[\s\S]*packageName: "coven-code@latest"[\s\S]*binary: "coven-code"/,
-  "coven-code updates use the public npm package and verify the coven-code binary",
+  /"coven-code":\s*\{[\s\S]*packageName: "@opencoven\/coven-code@latest"[\s\S]*binary: "coven-code"/,
+  "coven-code updates use the SCOPED @opencoven package and verify the coven-code binary",
+);
+assert.doesNotMatch(
+  source,
+  /packageName: "coven-code@/,
+  "bare coven-code is a different, deprecated npm package — installs must never target it",
 );
 
 // ── Background install jobs ─────────────────────────────────────────────────

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -41,7 +41,9 @@ const INSTALL_TARGETS = {
   "coven-code": {
     kind: "npm",
     label: "Coven Code",
-    packageName: "coven-code@latest",
+    // Scoped package only — bare "coven-code" is a different, deprecated
+    // npm package (see opencoven-tools-status.ts).
+    packageName: "@opencoven/coven-code@latest",
     binary: "coven-code",
     timeoutMs: 240_000,
   },

--- a/src/app/api/opencoven-tools/status/route.test.ts
+++ b/src/app/api/opencoven-tools/status/route.test.ts
@@ -34,8 +34,8 @@ assert.match(
 
 assert.match(
   source,
-  /id: "coven-code"[\s\S]*packageName: "coven-code"[\s\S]*binary: "coven-code"/,
-  "the coven-code status checks the public coven-code package and coven-code binary",
+  /id: "coven-code"[\s\S]*packageName: "@opencoven\/coven-code"[\s\S]*binary: "coven-code"/,
+  "the coven-code status checks the SCOPED @opencoven/coven-code package and coven-code binary",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -223,7 +223,7 @@ const PLATFORM_COPY: Record<
       "Install CovenCave, then open it from Start.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
       "Make sure coven.exe and coven-code are on PATH after the global npm install.",
       "Click Re-check after Windows can run both tools from a new terminal.",
     ],
@@ -241,7 +241,7 @@ const PLATFORM_COPY: Record<
       "Launch the AppImage from your file manager or terminal.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
       "Make sure coven and coven-code are on PATH after the global npm install.",
       "If your desktop shell has an older PATH, restart Cave after installing the tools.",
     ],
@@ -259,7 +259,7 @@ const PLATFORM_COPY: Record<
       "Open CovenCave from Applications.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
       "Make sure a terminal can run coven and coven-code after the global npm install.",
       "Click Re-check here after install.",
     ],
@@ -277,7 +277,7 @@ const PLATFORM_COPY: Record<
       "Open CovenCave and continue setup here.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest coven-code@latest.",
+      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
       "Make sure coven and coven-code are on PATH.",
       "Click Re-check here after install.",
     ],

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -75,9 +75,11 @@ assert.match(
   "Primary Settings tool action should have a visible border and elevation",
 );
 assert.match(status, /minimumVersion: "0\.0\.49"/, "Coven CLI compatibility floor is explicit in the status source");
-assert.match(status, /minimumVersion: "0\.0\.22"/, "coven-code compatibility floor is explicit in the status source");
+assert.match(status, /minimumVersion: "0\.6\.0"/, "coven-code compatibility floor is 0.6.0 — older (including the deprecated bare package, stuck at 0.0.22) reads as incompatible");
 assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "Coven CLI exposes the exact update command");
-assert.match(status, /installCommand: "npm i -g coven-code@latest"/, "coven-code exposes the exact update command");
+assert.match(status, /installCommand: "npm i -g @opencoven\/coven-code@latest"/, "coven-code exposes the exact update command, scoped package only");
+assert.match(status, /packageName: "@opencoven\/coven-code"/, "coven-code status probes the SCOPED registry package for latest");
+assert.doesNotMatch(status, /packageName: "coven-code"/, "bare coven-code is a different, deprecated npm package — status must never probe it");
 assert.match(status, /const compatible =[\s\S]*!!installed\?\.version && compareSemver\(installed\.version, tool\.minimumVersion\) >= 0/, "compatibility compares installed version against the Cave minimum");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
 assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");

--- a/src/lib/opencoven-tools-install.test.ts
+++ b/src/lib/opencoven-tools-install.test.ts
@@ -35,8 +35,8 @@ assert.deepEqual(
 
 assert.equal(
   openCovenToolsInstallCommand([]),
-  "npm i -g @opencoven/cli@latest coven-code@latest",
-  "fresh setup manual command installs both required OpenCoven tools",
+  "npm i -g @opencoven/cli@latest @opencoven/coven-code@latest",
+  "fresh setup manual command installs both required OpenCoven tools (scoped packages only)",
 );
 
 assert.deepEqual(

--- a/src/lib/opencoven-tools-install.ts
+++ b/src/lib/opencoven-tools-install.ts
@@ -14,7 +14,9 @@ const OPEN_COVEN_TOOL_ORDER: OpenCovenToolInstallTarget[] = [
 
 const OPEN_COVEN_TOOL_PACKAGES: Record<OpenCovenToolInstallTarget, string> = {
   "coven-cli": "@opencoven/cli@latest",
-  "coven-code": "coven-code@latest",
+  // Scoped package only — bare "coven-code" is a different, deprecated
+  // npm package (see opencoven-tools-status.ts).
+  "coven-code": "@opencoven/coven-code@latest",
 };
 
 export function openCovenToolActionTargets(

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -23,11 +23,16 @@ export const OPEN_COVEN_TOOLS = [
   {
     id: "coven-code",
     label: "Coven Code",
-    packageName: "coven-code",
+    // The SCOPED package only — bare "coven-code" on npm is a different,
+    // deprecated package (stuck at 0.0.22). The scoped package still ships
+    // the `coven-code` binary, so detection below is unchanged, and the
+    // 0.6.0 floor makes a lingering deprecated install read as incompatible
+    // and route users through the update flow.
+    packageName: "@opencoven/coven-code",
     binary: "coven-code",
     versionArgs: ["--version"],
-    minimumVersion: "0.0.22",
-    installCommand: "npm i -g coven-code@latest",
+    minimumVersion: "0.6.0",
+    installCommand: "npm i -g @opencoven/coven-code@latest",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

Bare `coven-code` on npm is a **different, deprecated package** (stuck at 0.0.22) — yet every install path targeted it. All four surfaces now use the scoped `@opencoven/coven-code` exclusively:

- **Actual install execution** — `src/app/api/onboarding/install/route.ts` allowlist entry
- **Status probe** — `opencoven-tools-status.ts` registry check (`npm view`) and spec table
- **Copy-paste command** — `opencoven-tools-install.ts` (`npm i -g @opencoven/cli@latest @opencoven/coven-code@latest`)
- **Onboarding help copy** — four platform-specific instruction strings in `onboarding-overlay.tsx`

`minimumVersion` rises `0.0.22` → **`0.6.0`**: a lingering deprecated install (max 0.0.22) reads as *incompatible*, triggering the existing warning banner + update flow, which reinstalls the scoped package over it — self-healing.

Registry-verified: `@opencoven/coven-code` latest is 0.6.1 and ships the same `coven-code` binary, so binary detection is unchanged.

## Test plan

- Pins updated in 4 test files; **new `doesNotMatch` guards** in the install-route and status tests so the bare package name can never silently return
- Repo-wide sweep for `coven-code@latest` / `packageName: "coven-code"` is clean
- Full `pnpm test:app` + `tsc --noEmit` green; commit SSH-signed

Closes bead `cave-gy65`.