### PR TITLE
chore(release): stamp v0.0.180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.180] - 2026-07-12
+
+> 🔌 **OpenCoven tools clarity: correct coven-code install path, cleaner harness versions, and GPT-5.6 models.** Every coven-code surface now points at the scoped `@opencoven/coven-code` package (min 0.6.0) instead of the deprecated bare squat, harness version probes ignore log noise, the notch centers correctly across monitors, and familiar auth failures explain how to recover.
+
+### Features
+- **Models: GPT-5.6 Codex models** — adds the GPT-5.6 Codex model family (`gpt-5.6-sol`/`-terra`/`-luna`) and moves the default familiar model to `gpt-5.6-sol` (#3007).
+- **Cave: dedicated cave home with startup migration** — a dedicated cave home directory with an automatic startup migration and a one-click migration banner (#3005).
+
+### Fixes
+- **Onboarding: coven-code installs only as `@opencoven/coven-code`** — the bare `coven-code` npm package is a different, deprecated package (stuck at 0.0.22); every install/status/update surface now targets the scoped `@opencoven/coven-code` exclusively, with a 0.6.0 compatibility floor (#3013).
+- **Runtimes: corrected coven-code install hint** — synced the registry so the install hint points at `@opencoven/coven-code` (the old `@opencoven/coven` does not exist on npm) (#3014, #3015).
+- **Harnesses: skip log noise in version probes** — version detection ignores leading timestamp/log-level lines (e.g. OpenCode's `WARN FZF not found`) instead of reporting them as the version (#3006).
+- **Notch: exact-center on the mouse's screen** — the quick-chat notch always centers on the top-bar middle and opens on whatever monitor the cursor is on unless pinned (#3009).
+- **Familiars: actionable hub-auth error** — a 401/403 loading familiars now explains that the hub rejected this Cave's token and to reconnect, instead of a bare status code (#3008).
+- **Onboarding: require descriptions for new familiars** — new familiars must carry a description (#3002).
+- **Onboarding: quiet npm "Unknown env config" warnings** — npm config warnings no longer leak into Tools output (#3001).
+- **Startup: sidecar cache validation** — validates the sidecar cache on startup (#3010).
+
+### Chores
+- **Copy: capitalize "Coven CLI"** — consistent "Coven CLI" casing across prose (#3012).
+
 ## [0.0.179] - 2026-07-12
 
 > 🧹 **Chat housekeeping, familiar lifecycle, and updater polish.** Chats gain an automatic archive policy and a centered quick-chat notch, familiars get a discoverable Remove entry and a cleaner picker, the copilot harness renders tool calls, and the update banner leads with the native installer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.179",
+  "version": "0.0.180",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.179"
+version = "0.0.180"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.179"
+version = "0.0.180"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.179</string>
+	<string>0.0.180</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.179</string>
+	<string>0.0.180</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.179</string>
+	<string>0.0.180</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.179</string>
+	<string>0.0.180</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.179",
+  "version": "0.0.180",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release stamp for **v0.0.180**.

## Included since v0.0.179
- **#3013** coven-code installs only as `@opencoven/coven-code` (min 0.6.0)
- **#3007** GPT-5.6 Codex models
- **#3014 / #3015** registry sync (corrected coven-code install hint)
- **#3012** "Coven CLI" capitalization
- **#3010** startup sidecar cache validation
- **#3009** notch exact-centering on the mouse's screen
- **#3008** actionable hub-auth 401 for familiars
- **#3006** harness version-probe log-noise skip
- **#3002** require familiar descriptions
- **#3001** quiet npm 'Unknown env config' warnings
- **#3005** dedicated cave home + startup migration

## Version bump (six locations + CHANGELOG)
package.json, src-tauri/Cargo.toml, Cargo.lock (app), tauri.conf.json, Info.ios.plist, gen/apple/app_iOS/Info.plist \u2192 all 0.0.180; CHANGELOG entry added.