### PR TITLE
feat(cave): harden home migration — per-file dir merge + conflict surfacing (cave-lzx3)

### DIFF
--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -23,8 +23,33 @@ assert.match(
 );
 assert.match(
   src,
-  /pending\.length === 0 \|\| dismissedMigrationBanner\(pending\)/,
-  "only machines with pending legacy files qualify for the banner",
+  /if \(pending\.length > 0\)/,
+  "fixable pending files take precedence over conflict surfacing",
+);
+assert.match(
+  src,
+  /dismissedMigrationBanner\(pending\)/,
+  "pending banner respects per-set dismissal",
+);
+assert.match(
+  src,
+  /conflicts\.length > 0 && !dismissedConflictsBanner\(conflicts\)/,
+  "unfixable conflicts surface as a review banner instead of staying invisible (cave-lzx3)",
+);
+assert.match(
+  src,
+  /coven-cave:cave-home-migration:conflicts-dismissed:/,
+  "conflict dismissal persists per conflict set so new conflicts re-surface",
+);
+assert.match(
+  src,
+  /the ~\/\.coven\/cave versions win\. Review and remove the legacy/,
+  "conflicts banner states the outcome and the next step",
+);
+assert.match(
+  src,
+  /left for manual review/,
+  "a run that finishes with collisions hands off to the review path, not a clean success",
 );
 assert.match(src, /severity: "warning"/, "pending legacy files warrant a warning banner");
 assert.match(src, /Migrate now/, "banner exposes a one-click migrate button");

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -11,7 +11,11 @@ type MigrationStatus = {
 
 type StatusPayload = { ok?: boolean; status?: MigrationStatus };
 type RunPayload = StatusPayload & {
-  result?: { moved?: string[]; errors?: Array<{ legacy: string; error: string }> };
+  result?: {
+    moved?: string[];
+    merged?: Array<{ legacy: string; files?: number; collisions?: number }>;
+    errors?: Array<{ legacy: string; error: string }>;
+  };
 };
 
 const MIGRATION_BANNER_ID = "cave-home-migration";
@@ -38,9 +42,36 @@ function dismissMigrationBanner(pending: string[]): void {
   }
 }
 
+/** Conflict dismissal is namespaced apart from pending, keyed by the exact set. */
+const MIGRATION_CONFLICTS_DISMISS_KEY = (conflicts: string[]) =>
+  `coven-cave:cave-home-migration:conflicts-dismissed:${[...conflicts].sort().join("|")}`;
+
+function dismissedConflictsBanner(conflicts: string[]): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(MIGRATION_CONFLICTS_DISMISS_KEY(conflicts)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function dismissConflictsBanner(conflicts: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MIGRATION_CONFLICTS_DISMISS_KEY(conflicts), "1");
+  } catch {
+    /* private mode */
+  }
+}
+
 function pendingBannerTitle(pending: string[]): string {
   const count = pending.length;
   return `${count} legacy Cave file${count === 1 ? "" : "s"} in ~/.coven still need${count === 1 ? "s" : ""} to move into ~/.coven/cave.`;
+}
+
+function conflictsBannerTitle(conflicts: string[]): string {
+  const count = conflicts.length;
+  return `${count} legacy Cave file${count === 1 ? "" : "s"} in ~/.coven conflict${count === 1 ? "s" : ""} with migrated copies — the ~/.coven/cave versions win. Review and remove the legacy cop${count === 1 ? "y" : "ies"}.`;
 }
 
 /**
@@ -51,6 +82,10 @@ function pendingBannerTitle(pending: string[]): string {
  * Everyone else — fresh installs and machines the boot migration already
  * cleaned — never sees it. The CTA runs the same idempotent migration on
  * demand, reports the outcome in place, and clears once nothing is pending.
+ *
+ * Unfixable conflicts (legacy and migrated copies both real — cave-lzx3) get
+ * a CTA-less review banner instead of staying invisible forever; dismissal is
+ * keyed per conflict set so new conflicts re-surface.
  */
 export function CaveHomeMigrationBannerTrigger() {
   const { pushBanner, dismissBanner } = useShellBanners();
@@ -73,6 +108,17 @@ export function CaveHomeMigrationBannerTrigger() {
       });
     };
 
+    // No button — nothing safe to run. Destination wins by design (cave-lzx3);
+    // the user resolves conflicts by reviewing and deleting the legacy copies.
+    const showConflictsBanner = (conflicts: string[]) => {
+      pushBanner({
+        id: MIGRATION_BANNER_ID,
+        severity: "warning",
+        title: conflictsBannerTitle(conflicts),
+        onDismiss: () => dismissConflictsBanner(conflicts),
+      });
+    };
+
     const runMigration = async () => {
       try {
         const res = await fetch("/api/cave-home-migration", { method: "POST" });
@@ -82,12 +128,25 @@ export function CaveHomeMigrationBannerTrigger() {
         const errors = json.result?.errors ?? [];
         if (remaining.length === 0 && errors.length === 0) {
           const moved = json.result?.moved?.length ?? 0;
+          const mergedFiles = (json.result?.merged ?? []).reduce((n, m) => n + (m.files ?? 0), 0);
+          const conflictsAfter = json.status?.conflicts ?? [];
+          if (conflictsAfter.length > 0) {
+            // The run finished but same-name collisions remain — hand off to
+            // the review path instead of claiming a clean finish.
+            pushBanner({
+              id: MIGRATION_BANNER_ID,
+              severity: "warning",
+              title: `Cave files migrated — moved ${moved} file${moved === 1 ? "" : "s"}${mergedFiles > 0 ? ` and merged ${mergedFiles} more` : ""}; ${conflictsAfter.length} conflict${conflictsAfter.length === 1 ? "" : "s"} left for manual review in ~/.coven.`,
+              onDismiss: () => dismissConflictsBanner(conflictsAfter),
+            });
+            return;
+          }
           pushBanner({
             id: MIGRATION_BANNER_ID,
             severity: "info",
             title:
-              moved > 0
-                ? `Cave files migrated — moved ${moved} file${moved === 1 ? "" : "s"} into ~/.coven/cave.`
+              moved > 0 || mergedFiles > 0
+                ? `Cave files migrated — moved ${moved} file${moved === 1 ? "" : "s"}${mergedFiles > 0 ? ` and merged ${mergedFiles} more` : ""} into ~/.coven/cave.`
                 : "Cave files are already in ~/.coven/cave — nothing left to migrate.",
           });
           return;
@@ -114,8 +173,15 @@ export function CaveHomeMigrationBannerTrigger() {
       .then((json) => {
         if (cancelled || !json?.ok || !json.status) return;
         const pending = json.status.pending ?? [];
-        if (pending.length === 0 || dismissedMigrationBanner(pending)) return;
-        showPendingBanner(pending);
+        const conflicts = json.status.conflicts ?? [];
+        if (pending.length > 0) {
+          // Fixable files take precedence — one banner at a time.
+          if (!dismissedMigrationBanner(pending)) showPendingBanner(pending);
+          return;
+        }
+        if (conflicts.length > 0 && !dismissedConflictsBanner(conflicts)) {
+          showConflictsBanner(conflicts);
+        }
       })
       .catch(() => {
         /* Status checks are best-effort. */

--- a/src/lib/server/cave-home-migration-status.test.ts
+++ b/src/lib/server/cave-home-migration-status.test.ts
@@ -63,6 +63,29 @@ try {
     assert.equal(status.migrated, false, "conflicts still count as unmigrated");
   }
 
+  // Directory pairs mirror the migrator's per-file merge (cave-lzx3): a legacy
+  // dir whose children all fit the destination drains in one run — that's
+  // PENDING, so the banner button can fix it. A same-name child (ignoring
+  // Finder junk) makes it a CONFLICT.
+  await mkdir(path.join(covenDir, "cave-conversations"));
+  await mkdir(path.join(caveDir, "conversations"));
+  await writeFile(path.join(covenDir, "cave-conversations", "sess-a.json"), "{}", "utf8");
+  await writeFile(path.join(covenDir, "cave-conversations", ".DS_Store"), "junk", "utf8");
+
+  {
+    const status = await caveHomeMigrationStatus();
+    assert.ok(status.pending.includes("cave-conversations"), "drainable dir pair is pending");
+    assert.ok(!status.conflicts.includes("cave-conversations"), "drainable dir pair is not a conflict");
+  }
+
+  await writeFile(path.join(caveDir, "conversations", "sess-a.json"), "{}", "utf8");
+
+  {
+    const status = await caveHomeMigrationStatus();
+    assert.ok(status.conflicts.includes("cave-conversations"), "same-name child makes the dir a conflict");
+    assert.ok(!status.pending.includes("cave-conversations"), "colliding dir is no longer pending");
+  }
+
   console.log("cave-home-migration-status.test.ts: ok");
 } finally {
   await rm(tmpHome, { recursive: true, force: true });

--- a/src/lib/server/cave-home-migration-status.ts
+++ b/src/lib/server/cave-home-migration-status.ts
@@ -1,21 +1,24 @@
-import { lstat } from "node:fs/promises";
+import { lstat, readdir } from "node:fs/promises";
 import path from "node:path";
 import { caveHome, covenHome } from "@/lib/coven-paths";
 import { CAVE_HOME_MIGRATIONS } from "@/lib/server/cave-home-migration";
 
 /**
- * Qualification check for the manual "Migrate now" shell banner.
+ * Qualification check for the cave home migration shell banner.
  *
  * The boot-time cave home migration (instrumentation.ts) normally clears every
  * legacy `~/.coven/cave-*` entry, so a machine only *qualifies* for the banner
  * when that run errored or was interrupted and real legacy files remain:
  *
- *  - `pending`   — legacy entry is a real file/dir and its destination under
- *                  `~/.coven/cave/` is free: one `migrateCaveHome()` run moves
- *                  it. These are what the banner button fixes.
- *  - `conflicts` — legacy entry AND destination both exist. Destination wins
- *                  by design; the legacy copy is left for manual review and
- *                  never blocks the banner from clearing.
+ *  - `pending`   — one `migrateCaveHome()` run clears it: a real legacy entry
+ *                  whose destination under `~/.coven/cave/` is free, or a
+ *                  legacy DIRECTORY whose children all fit the destination
+ *                  (the migrator drains those per-file — cave-lzx3). These are
+ *                  what the banner's "Migrate now" button fixes.
+ *  - `conflicts` — legacy entry and destination both exist and can't be
+ *                  auto-merged (same-name children, or a file pair).
+ *                  Destination wins by design; the legacy copy is left for
+ *                  manual review and surfaced as a review banner.
  *
  * Symlinked legacy paths are already-migrated compat bridges, not candidates.
  */
@@ -26,23 +29,47 @@ export type CaveHomeMigrationStatus = {
   migrated: boolean;
 };
 
-async function pathState(target: string): Promise<"missing" | "symlink" | "present"> {
+async function pathState(target: string): Promise<"missing" | "symlink" | "file" | "dir"> {
   try {
     const st = await lstat(target);
-    return st.isSymbolicLink() ? "symlink" : "present";
+    return st.isSymbolicLink() ? "symlink" : st.isDirectory() ? "dir" : "file";
   } catch {
     return "missing";
   }
+}
+
+/** Mirrors mergeDirEntry: `.DS_Store` never blocks a drain. */
+async function dirHasCollisions(legacyDir: string, nextDir: string): Promise<boolean> {
+  for (const name of await readdir(legacyDir)) {
+    if (name === ".DS_Store") continue;
+    if ((await pathState(path.join(nextDir, name))) !== "missing") return true;
+  }
+  return false;
 }
 
 export async function caveHomeMigrationStatus(): Promise<CaveHomeMigrationStatus> {
   const pending: string[] = [];
   const conflicts: string[] = [];
   for (const entry of CAVE_HOME_MIGRATIONS) {
-    const legacyState = await pathState(path.join(covenHome(), entry.legacy));
-    if (legacyState !== "present") continue;
-    const nextState = await pathState(path.join(caveHome(), entry.next));
-    (nextState === "missing" ? pending : conflicts).push(entry.legacy);
+    const legacyPath = path.join(covenHome(), entry.legacy);
+    const legacyState = await pathState(legacyPath);
+    if (legacyState === "missing" || legacyState === "symlink") continue;
+    const nextPath = path.join(caveHome(), entry.next);
+    const nextState = await pathState(nextPath);
+    if (nextState === "missing") {
+      pending.push(entry.legacy);
+      continue;
+    }
+    if (legacyState === "dir" && nextState === "dir") {
+      // A drainable dir pair is fixable by one run — pending, not a conflict.
+      try {
+        (await dirHasCollisions(legacyPath, nextPath)) ? conflicts.push(entry.legacy) : pending.push(entry.legacy);
+      } catch {
+        conflicts.push(entry.legacy); // unreadable dir: don't promise the button fixes it
+      }
+      continue;
+    }
+    conflicts.push(entry.legacy);
   }
   return {
     pending,

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -104,6 +104,63 @@ try {
     );
   }
 
+  // Directory conflict → per-file merge (cave-lzx3): legacy-only children move
+  // losslessly, same-name children keep the destination copy and hold the
+  // legacy dir open for review. Finder junk never blocks the drain.
+  {
+    await rm(path.join(covenDir, "cave-conversations"), { recursive: true, force: true });
+    await mkdir(path.join(covenDir, "cave-conversations"));
+    await writeFile(path.join(covenDir, "cave-conversations", "sess-legacy.json"), '{"side":"legacy"}', "utf8");
+    await writeFile(path.join(covenDir, "cave-conversations", "sess-both.json"), '{"side":"legacy"}', "utf8");
+    await writeFile(path.join(covenDir, "cave-conversations", ".DS_Store"), "junk", "utf8");
+    await writeFile(path.join(caveDir, "conversations", "sess-both.json"), '{"side":"cave"}', "utf8");
+
+    const result = await migrateCaveHome();
+    assert.deepEqual(
+      result.merged,
+      [{ legacy: "cave-conversations", files: 1, collisions: 1 }],
+      "dir merge reports moved children and collisions",
+    );
+    assert.equal(
+      await readFile(path.join(caveDir, "conversations", "sess-legacy.json"), "utf8"),
+      '{"side":"legacy"}',
+      "legacy-only conversation is recovered into the destination",
+    );
+    assert.equal(
+      await readFile(path.join(caveDir, "conversations", "sess-both.json"), "utf8"),
+      '{"side":"cave"}',
+      "destination wins per colliding child",
+    );
+    assert.equal(
+      await pathKind(path.join(covenDir, "cave-conversations")),
+      "dir",
+      "collision holds the legacy dir open for review",
+    );
+    assert.ok(result.skipped.includes("cave-conversations"), "colliding dir stays skipped");
+    assert.equal(
+      await pathKind(path.join(covenDir, "cave-conversations", ".DS_Store")),
+      "missing",
+      "Finder junk is dropped, never migrated",
+    );
+  }
+
+  // Once collisions are resolved the next run drains the dir and bridges it.
+  {
+    await rm(path.join(covenDir, "cave-conversations", "sess-both.json"));
+    const result = await migrateCaveHome();
+    assert.ok(result.moved.includes("cave-conversations"), "drained dir counts as moved");
+    assert.equal(
+      await pathKind(path.join(covenDir, "cave-conversations")),
+      "symlink",
+      "drained legacy dir is replaced by the compat bridge",
+    );
+    assert.equal(
+      await readFile(path.join(covenDir, "cave-conversations", "sess-legacy.json"), "utf8"),
+      '{"side":"legacy"}',
+      "legacy path resolves through the bridge",
+    );
+  }
+
   // The manifest never claims daemon-owned ledgers.
   for (const entry of CAVE_HOME_MIGRATIONS) {
     assert.ok(

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, rename, symlink } from "node:fs/promises";
+import { lstat, mkdir, readdir, rename, rm, rmdir, symlink } from "node:fs/promises";
 import path from "node:path";
 import { caveHome, covenHome } from "@/lib/coven-paths";
 
@@ -20,6 +20,13 @@ import { caveHome, covenHome } from "@/lib/coven-paths";
  * Semantics per entry (idempotent, crash-safe):
  *  - legacy path missing            → nothing to do
  *  - legacy path is a symlink       → already migrated (or user-bridged); skip
+ *  - legacy AND destination are both real directories
+ *                                   → per-file merge: children that only exist
+ *                                     on the legacy side move over (lossless —
+ *                                     each conversation is its own file);
+ *                                     same-name children keep the destination
+ *                                     copy. A fully drained legacy dir is
+ *                                     replaced by the compat symlink.
  *  - destination already exists     → destination wins; legacy left untouched
  *  - otherwise                      → rename(legacy → cave/<name>), then
  *                                     best-effort compat symlink at legacy
@@ -58,19 +65,93 @@ export const CAVE_HOME_MIGRATIONS: readonly CaveHomeMigrationEntry[] = [
   { legacy: "cave-conversations", next: "conversations" },
 ];
 
+export type CaveHomeMigrationDirMerge = {
+  /** Legacy dir name under `covenHome()`. */
+  legacy: string;
+  /** Children moved out of the legacy dir into its destination. */
+  files: number;
+  /** Same-name children left behind (destination copy wins per file). */
+  collisions: number;
+};
+
 export type CaveHomeMigrationResult = {
   moved: string[];
   linked: string[];
   skipped: string[];
+  merged: CaveHomeMigrationDirMerge[];
   errors: Array<{ legacy: string; error: string }>;
 };
 
-async function pathState(target: string): Promise<"missing" | "symlink" | "present"> {
+async function pathState(target: string): Promise<"missing" | "symlink" | "file" | "dir"> {
   try {
     const st = await lstat(target);
-    return st.isSymbolicLink() ? "symlink" : "present";
+    return st.isSymbolicLink() ? "symlink" : st.isDirectory() ? "dir" : "file";
   } catch {
     return "missing";
+  }
+}
+
+// Compat bridge for external readers. Relative target so the link survives a
+// moved home dir. Best-effort: symlink creation can fail on Windows without
+// elevation — the migration itself already succeeded.
+async function bridgeLegacyPath(
+  entry: CaveHomeMigrationEntry,
+  legacyPath: string,
+  nextPath: string,
+  kind: "file" | "dir",
+  result: CaveHomeMigrationResult,
+): Promise<void> {
+  try {
+    const relativeTarget = path.relative(path.dirname(legacyPath), nextPath);
+    await symlink(relativeTarget, legacyPath, kind === "dir" ? "junction" : "file");
+    result.linked.push(entry.legacy);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Both sides of a directory entry exist — e.g. an old build recreated
+ * `cave-conversations/` after migration (cave-lzx3). Children are independent
+ * files keyed by name, so legacy-only ones move over losslessly; same-name
+ * children keep the destination copy (the same destination-wins rule applied
+ * per file) and hold the legacy dir open for review.
+ */
+async function mergeDirEntry(
+  entry: CaveHomeMigrationEntry,
+  legacyPath: string,
+  nextPath: string,
+  result: CaveHomeMigrationResult,
+): Promise<void> {
+  const merge: CaveHomeMigrationDirMerge = { legacy: entry.legacy, files: 0, collisions: 0 };
+  try {
+    for (const name of await readdir(legacyPath)) {
+      // Finder metadata must never hold the compat bridge hostage.
+      if (name === ".DS_Store") {
+        await rm(path.join(legacyPath, name), { force: true });
+        continue;
+      }
+      if ((await pathState(path.join(nextPath, name))) === "missing") {
+        try {
+          await rename(path.join(legacyPath, name), path.join(nextPath, name));
+          merge.files += 1;
+        } catch (error) {
+          result.errors.push({ legacy: `${entry.legacy}/${name}`, error: String(error) });
+        }
+      } else {
+        merge.collisions += 1;
+      }
+    }
+    result.merged.push(merge);
+    if ((await readdir(legacyPath)).length === 0) {
+      await rmdir(legacyPath);
+      result.moved.push(entry.legacy);
+      await bridgeLegacyPath(entry, legacyPath, nextPath, "dir", result);
+    } else {
+      result.skipped.push(entry.legacy);
+    }
+  } catch (error) {
+    result.errors.push({ legacy: entry.legacy, error: String(error) });
   }
 }
 
@@ -82,11 +163,17 @@ async function migrateEntry(
   const nextPath = path.join(caveHome(), entry.next);
 
   const legacyState = await pathState(legacyPath);
-  if (legacyState !== "present") {
+  if (legacyState === "missing" || legacyState === "symlink") {
     result.skipped.push(entry.legacy);
     return;
   }
-  if ((await pathState(nextPath)) !== "missing") {
+  const nextState = await pathState(nextPath);
+
+  if (nextState !== "missing") {
+    if (legacyState === "dir" && nextState === "dir") {
+      await mergeDirEntry(entry, legacyPath, nextPath, result);
+      return;
+    }
     // Destination wins — a newer build already wrote there. Leave the legacy
     // file for the user to inspect rather than clobbering either side.
     result.skipped.push(entry.legacy);
@@ -101,21 +188,12 @@ async function migrateEntry(
     return;
   }
 
-  // Compat bridge for external readers. Relative target so the link survives
-  // a moved home dir. Best-effort: symlink creation can fail on Windows
-  // without elevation — the migration itself already succeeded.
-  try {
-    const relativeTarget = path.relative(path.dirname(legacyPath), nextPath);
-    await symlink(relativeTarget, legacyPath, entry.next === "conversations" ? "junction" : "file");
-    result.linked.push(entry.legacy);
-  } catch {
-    /* best-effort */
-  }
+  await bridgeLegacyPath(entry, legacyPath, nextPath, legacyState, result);
 }
 
 /** Run the full migration once. Safe to call repeatedly (idempotent). */
 export async function migrateCaveHome(): Promise<CaveHomeMigrationResult> {
-  const result: CaveHomeMigrationResult = { moved: [], linked: [], skipped: [], errors: [] };
+  const result: CaveHomeMigrationResult = { moved: [], linked: [], skipped: [], merged: [], errors: [] };
   try {
     await mkdir(caveHome(), { recursive: true });
   } catch (error) {
@@ -129,6 +207,14 @@ export async function migrateCaveHome(): Promise<CaveHomeMigrationResult> {
     console.log(
       `[cave-home-migration] moved ${result.moved.length} legacy file(s) into ${caveHome()}: ${result.moved.join(", ")}`,
     );
+  }
+  for (const merge of result.merged) {
+    if (merge.files > 0 || merge.collisions > 0) {
+      console.log(
+        `[cave-home-migration] merged ${merge.files} file(s) from ${merge.legacy} into ${caveHome()}` +
+          (merge.collisions > 0 ? ` (${merge.collisions} name collision(s) left for review)` : ""),
+      );
+    }
   }
   for (const failure of result.errors) {
     console.warn(`[cave-home-migration] ${failure.legacy}: ${failure.error}`);


### PR DESCRIPTION
## Why

Old builds resurrect legacy `~/.coven/cave-*` paths after migration — their atomic writes (temp + rename) replace the compat symlink with a real file — and both sides then diverge. Under the previous semantics the whole entry was skipped as a conflict (destination wins), and the banner only surfaced *pending* files, so conflicts stayed **invisible forever** and the legacy-side data was silently orphaned. Observed live on this machine 2026-07-12: 5 chats stranded in a resurrected `cave-conversations/`. Full forensics in bead `cave-lzx3`.

## What

**Migrator (`cave-home-migration.ts`)**
- Directory conflicts now merge **per file**: legacy-only children move over losslessly (each conversation is its own `<sessionId>.json`); same-name children keep the destination copy. A fully drained dir is replaced by the compat symlink; collisions hold it open for review.
- `.DS_Store` is dropped, never migrated — Finder junk can't block the drain.
- New `merged: {legacy, files, collisions}[]` on the result, logged at boot.
- Dir bridges use symlink type `junction` for every directory entry (previously only `conversations`; `preferences.json.locks` got `"file"` — Windows nit).

**Status (`cave-home-migration-status.ts`)**
- A drainable dir pair now classifies as **pending** — the banner's Migrate-now button fixes it in one run. Only same-name children (or file pairs) remain conflicts.

**Banner (`cave-home-migration-banner.tsx`)**
- Conflicts surface as a CTA-less review banner with a distinct per-set dismissal namespace ("the ~/.coven/cave versions win. Review and remove the legacy copies."). Pending takes precedence; a run ending with collisions hands off to the review path instead of claiming clean success; success copy counts merged files.

## Verification

- 852-file app suite green in the worktree; `tsc --noEmit` clean
- New unit coverage: dir merge (move/collision/junk), drain→bridge on the follow-up run, dir-pair status classification (pending vs conflict), banner source pins for the conflict path

Bead: cave-lzx3

🤖 Generated with [Claude Code](https://claude.com/claude-code)