### PR TITLE
chore(release): stamp v0.0.181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.181] - 2026-07-12
+
+> 🔍 **Trace what your familiars actually did.** Familiar analytics gains a session trace timeline (the daemon event stream finally has a surface), a Recent sessions drill-through list, a clickable 14-day pulse, and live auto-refresh — plus hardened cave-home migration and GitHub chat-launch fixes.
+
+### Features
+- **Analytics: session tracing + live drill-throughs** — a session trace overlay reads the daemon event timeline per session (reachable from the Familiars Sessions tab and the analytics page); familiar analytics adds a Recent sessions section where every row opens its thread or its trace, the hero 14-day pulse becomes a clickable day filter, response-confidence events link back to the conversation that produced them, analytics and growth auto-refresh every 60s, and growth signals carry next-step action links (#3018).
+- **Cave: hardened home migration** — the cave-home startup migration merges directories per-file instead of skipping on collision, and surfaces conflicts instead of silently dropping them (#3019).
+
+### Fixes
+- **GitHub: chat launch payload aligned** — GitHub popover and safe-merge chat launches use `initialPrompt` (the retired `context` field is gone) and safe merge forwards the working `projectRoot`, matching the chat surface contract (#3017).
+- **Tools: Coven CLI freshness floor + Windows shims** — raises the Coven CLI compatibility floor to 0.0.54, fixes Windows npm `.cmd` shim parsing so extensionless package bins resolve correctly, and uses the packaged CovenCave logo on the startup splash (#3011).
+
 ## [0.0.180] - 2026-07-12
 
 > 🔌 **OpenCoven tools clarity: correct coven-code install path, cleaner harness versions, and GPT-5.6 models.** Every coven-code surface now points at the scoped `@opencoven/coven-code` package (min 0.6.0) instead of the deprecated bare squat, harness version probes ignore log noise, the notch centers correctly across monitors, and familiar auth failures explain how to recover.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.180"
+version = "0.0.181"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.180"
+version = "0.0.181"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.180</string>
+	<string>0.0.181</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.180</string>
+	<string>0.0.181</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.180</string>
+	<string>0.0.181</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.180</string>
+	<string>0.0.181</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.181** across all seven version locations (package.json, Cargo.toml, Cargo.lock `app` block, tauri.conf.json, Info.ios.plist ×2, gen/apple Info.plist ×2 — `app-version.test.ts` passes) and adds the changelog entry.

> 🔍 **Trace what your familiars actually did.** Familiar analytics gains a session trace timeline, a Recent sessions drill-through list, a clickable 14-day pulse, and live auto-refresh — plus hardened cave-home migration and GitHub chat-launch fixes.

Rolls up since v0.0.180: #3018, #3019, #3017, #3011.

After merge: signed tag `v0.0.181` on the squash SHA → `release.yml` builds the four platform bundles (~24 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)