### PR TITLE
chore(runtimes): sync hermes 1.0.1 (hermes-coven shim, -q prompt fix)

### DIFF
--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -281,9 +281,9 @@ assert.equal(hermesManifest?.filename, "hermes.json");
   const parsed = JSON.parse(hermesManifest?.contents ?? "{}");
   const adapter = parsed.adapters?.[0];
   assert.equal(adapter?.id, "hermes");
-  assert.equal(adapter?.executable, "hermes");
-  assert.deepEqual(adapter?.interactive_prompt_prefix_args, ["chat", "--source", "coven", "-q"], "hermes keeps the coven-source chat entry");
-  assert.deepEqual(adapter?.non_interactive_prompt_prefix_args, ["chat", "--source", "coven", "-Q", "-q"]);
+  assert.equal(adapter?.executable, "hermes-coven", "hermes launches via the hermes-coven shim (hermes chat has no positional prompt slot)");
+  assert.deepEqual(adapter?.interactive_prompt_prefix_args, ["chat", "--source", "coven"], "hermes keeps the coven-source chat entry; the shim maps the prompt to -q");
+  assert.deepEqual(adapter?.non_interactive_prompt_prefix_args, ["chat", "--source", "coven", "-Q"]);
   assert.ok(typeof adapter?.install_hint === "string" && adapter.install_hint.length > 0);
 }
 assert.equal(adapterManifestScaffoldForHarness("codex"), null, "curated runtimes without a registry manifest scaffold nothing");

--- a/src/lib/runtime-registry.gen.ts
+++ b/src/lib/runtime-registry.gen.ts
@@ -3,7 +3,7 @@
 //
 // Source: OpenCoven/coven-runtimes canonical registry index
 //   ref:      main
-//   blob sha: 1379e72f7d310a40a79daa2d40eddcb5c7300922
+//   blob sha: 051805ae24056d3efee0b93b73fee75e0d737b52
 //
 // Every entry passed coven-runtimes acceptance (conformance + review), so
 // Cave treats these as trusted runtimes (see harness-adapters.ts). New
@@ -35,7 +35,7 @@ export type RegistryRuntime = {
 export const REGISTRY_SOURCE = {
   repo: "OpenCoven/coven-runtimes",
   ref: "main",
-  blobSha: "1379e72f7d310a40a79daa2d40eddcb5c7300922",
+  blobSha: "051805ae24056d3efee0b93b73fee75e0d737b52",
 } as const;
 
 export const REGISTRY_RUNTIMES: RegistryRuntime[] = [
@@ -164,10 +164,10 @@ export const REGISTRY_RUNTIMES: RegistryRuntime[] = [
   {
     "id": "hermes",
     "label": "Hermes Agent",
-    "binary": "hermes",
-    "installHint": "Install Hermes Agent, add it to PATH, and complete Hermes setup before using this adapter.",
-    "version": "1.0.0",
-    "description": "Reference adapter — mirrors coven's built-in Hermes recipe. A plain one-shot runtime with baseline capabilities.",
+    "binary": "hermes-coven",
+    "installHint": "Install Hermes Agent, add it to PATH, install the hermes-coven shim, and complete Hermes setup before using this adapter.",
+    "version": "1.0.1",
+    "description": "Reference adapter — mirrors coven's built-in Hermes recipe. A plain one-shot runtime with baseline capabilities. Uses the hermes-coven shim so the harness's trailing positional prompt is remapped to hermes chat's -q/--query flag (hermes has no positional prompt slot).",
     "modelFlag": null,
     "capabilities": {
       "stream": false,
@@ -180,29 +180,27 @@ export const REGISTRY_RUNTIMES: RegistryRuntime[] = [
         {
           "id": "hermes",
           "label": "Hermes Agent",
-          "executable": "hermes",
+          "executable": "hermes-coven",
           "interactive_prompt_prefix_args": [
             "chat",
             "--source",
-            "coven",
-            "-q"
+            "coven"
           ],
           "non_interactive_prompt_prefix_args": [
             "chat",
             "--source",
             "coven",
-            "-Q",
-            "-q"
+            "-Q"
           ],
-          "install_hint": "Install Hermes Agent, add it to PATH, and complete Hermes setup before using this adapter.",
+          "install_hint": "Install Hermes Agent, add it to PATH, install the hermes-coven shim, and complete Hermes setup before using this adapter.",
           "capabilities": {
             "stream": false,
             "preassigned_session_id": false,
             "think": false,
             "speed": false
           },
-          "version": "1.0.0",
-          "description": "Reference adapter — mirrors coven's built-in Hermes recipe. A plain one-shot runtime with baseline capabilities."
+          "version": "1.0.1",
+          "description": "Reference adapter — mirrors coven's built-in Hermes recipe. A plain one-shot runtime with baseline capabilities. Uses the hermes-coven shim so the harness's trailing positional prompt is remapped to hermes chat's -q/--query flag (hermes has no positional prompt slot)."
         }
       ]
     }


### PR DESCRIPTION
Regenerates `src/lib/runtime-registry.gen.ts` via `pnpm sync:runtimes` after **OpenCoven/coven-runtimes#26**.

Fixes Hermes-familiar chat, which failed immediately with:
```
hermes chat: error: argument -q/--query: expected one argument
```

Hermes now launches via the `hermes-coven` shim, which remaps the harness's trailing positional prompt (`-- "<prompt>"`) to `hermes chat`'s `-q/--query` flag (hermes has no positional prompt slot). Manifest bumped 1.0.0 → 1.0.1.

Pure generated-output sync — no hand edits.