### PR TITLE
fix(ux): resolve four open UI issues — comment fab drift, Salem overflow, roster self-heal, enhance feedback

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -348,6 +348,7 @@ export const SUITES = {
     "src/components/evals-removal.test.ts",
     "src/components/debug-pane.test.ts",
     "src/components/workspace-mode-fade.test.ts",
+    "src/components/workspace-feedback.test.ts",
     "src/components/session-changes-inner.test.ts",
     "src/components/code-editor.test.ts",
     "src/components/code-view.test.ts",

--- a/src/components/artifact-comments.test.ts
+++ b/src/components/artifact-comments.test.ts
@@ -58,3 +58,33 @@ assert.match(css, /\.cave-artifact-comments \{/, "the comments panel is styled")
 assert.match(css, /\.cave-artifact-comments__send \{/, "the request-revision button is styled");
 
 console.log("artifact-comments.test.ts: ok");
+
+// ── fab tracks its selection through scroll (issue #2997) ───────────────────
+// position:fixed coords captured at mouseup go stale the moment the chat
+// scrolls — the pill then floats over unrelated prose. The reposition effect
+// re-derives the coords from the live selection range on scroll/resize.
+assert.match(
+  comp,
+  /window\.addEventListener\("scroll", reposition, true\)/,
+  "fab repositions on scroll (capture — the chat scrolls in an inner container)",
+);
+assert.match(
+  comp,
+  /window\.addEventListener\("resize", reposition\)/,
+  "fab repositions on resize",
+);
+assert.match(
+  comp,
+  /raf = requestAnimationFrame\(\(\) => \{\s*raf = 0;/,
+  "reposition is rAF-coalesced and nulls its handle on fire (wedge trap)",
+);
+assert.match(
+  comp,
+  /if \(raf\) \{\s*cancelAnimationFrame\(raf\);\s*raf = 0;/,
+  "cleanup cancels AND nulls the pending frame",
+);
+assert.match(
+  comp,
+  /clampFabX\(rect\.left \+ rect\.width \/ 2, window\.innerWidth\), y: rect\.top \} : prev/,
+  "repositioning reuses the same clamp as the initial placement",
+);

--- a/src/components/artifact-comments.tsx
+++ b/src/components/artifact-comments.tsx
@@ -93,6 +93,47 @@ export function ArtifactComments({
     };
   }, [turnId]);
 
+  // Keep the pill anchored to the TEXT, not the viewport: the fab is
+  // position:fixed at coords captured on mouseup, so scrolling the chat left
+  // it hovering over unrelated prose mid-response (issue #2997). While the
+  // pill is up, recompute its position from the live selection range on any
+  // scroll (capture phase — the chat scrolls in an inner container) or
+  // resize; it now travels with — and off-screen with — its selection.
+  const fabVisible = sel !== null;
+  useEffect(() => {
+    if (!fabVisible) return;
+    let raf = 0;
+    const reposition = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const selection = window.getSelection();
+        if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+          setSel(null);
+          return;
+        }
+        const rect = selection.getRangeAt(0).getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) {
+          setSel(null);
+          return;
+        }
+        setSel((prev) =>
+          prev ? { ...prev, x: clampFabX(rect.left + rect.width / 2, window.innerWidth), y: rect.top } : prev,
+        );
+      });
+    };
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+      if (raf) {
+        cancelAnimationFrame(raf);
+        raf = 0;
+      }
+    };
+  }, [fabVisible]);
+
   // Focus the note field of a freshly added comment.
   useEffect(() => {
     if (!focusIdRef.current) return;

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -404,3 +404,12 @@ assert.match(
 );
 
 console.log("chat-router-switching.test.ts: ok");
+
+// ── roster-error state is self-healing (issue #2990) ─────────────────────────
+// Workspace auto-retries loadFamiliars while the error shows; the copy must
+// not tell the user to retry manually as if nothing else will happen.
+assert.match(
+  source,
+  /retrying automatically/,
+  "the roster-error copy states that retries happen automatically",
+);

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -411,7 +411,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             <p className="mt-1 text-[12px]">
               {daemonRunning === false
                 ? "The daemon is offline, so the roster can't be read. Your familiars are safe."
-                : "The roster didn't load. Your familiars are safe — retry in a moment."}
+                : "The roster didn't load. Your familiars are safe — retrying automatically."}
             </p>
           </div>
           {onRetryFamiliars ? (

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -212,3 +212,12 @@ assert.match(
 );
 
 console.log("command-palette.test.ts OK");
+
+// ── Salem answer stays inside the palette (issue #2988) ──────────────────────
+// Long answers previously grew the region unboundedly and overflowed the
+// viewport; it now caps and scrolls like the listbox below it.
+assert.match(
+  source,
+  /max-h-\[45vh\] overflow-y-auto border-b/,
+  "the Salem answer region caps its height and scrolls internally",
+);

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -833,7 +833,9 @@ export function CommandPalette({
           <div
             role={salemLoading ? "status" : salemError ? "alert" : "region"}
             aria-label="Salem AI response"
-            className="border-b border-[var(--border-hairline)] bg-[var(--bg-subtle)] px-4 py-3 text-xs text-[var(--text-secondary)]"
+            // Long answers scroll inside the palette instead of growing it past
+            // the viewport (issue #2988) — mirrors the listbox's own cap below.
+            className="max-h-[45vh] overflow-y-auto border-b border-[var(--border-hairline)] bg-[var(--bg-subtle)] px-4 py-3 text-xs text-[var(--text-secondary)]"
           >
             {salemLoading ? (
               <span>Asking Salem through salem.opencoven.ai...</span>

--- a/src/components/workspace-feedback.test.ts
+++ b/src/components/workspace-feedback.test.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// ── Enhance-tasks button closes its loop (issue #2991) ───────────────────────
+// The top-bar sparkle ran a whole enrichment pass and then said nothing —
+// success, no-op, and failure all looked identical ("loading, then back to the
+// start"). Every outcome now lands a toast.
+assert.match(
+  source,
+  /pushToast\(\s*total === 0\s*\? "No open tasks to enhance right now\."/,
+  "a run that found no tasks says so",
+);
+assert.match(
+  source,
+  /Open tasks already have steps — nothing to enhance\./,
+  "a run that skipped everything says so",
+);
+assert.match(
+  source,
+  /Enhanced \$\{enhanced\} task\$\{enhanced === 1 \? "" : "s"\} — open Tasks to review\./,
+  "a successful run states the count and where to look",
+);
+assert.match(
+  source,
+  /pushToast\("Enhance tasks failed — check the daemon banner and try again\."\)/,
+  "failures surface instead of being swallowed",
+);
+// pushToast must be declared BEFORE handleEnrichTasks — the deps array reads
+// it at render time, and a later `const` would throw a TDZ ReferenceError.
+assert.ok(
+  source.indexOf("const pushToast = useCallback") < source.indexOf("const handleEnrichTasks = useCallback"),
+  "pushToast is declared above handleEnrichTasks, which closes over it",
+);
+
+// ── Roster error self-heals (issue #2990) ────────────────────────────────────
+// The daemonRunning effect only fires on TRANSITIONS; a one-off fetch flake
+// with the daemon already running (first-familiar summon) stranded the error
+// screen until a manual Retry. A quiet poll now retries while the error shows.
+assert.match(
+  source,
+  /usePausablePoll\(\(\) => void loadFamiliars\(\), 4_000, \{\s*enabled: familiarsError !== null,\s*\}\)/,
+  "loadFamiliars auto-retries every 4s while familiarsError is set",
+);
+
+console.log("workspace-feedback.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -822,6 +822,13 @@ export function Workspace() {
   useEffect(() => {
     if (daemonRunning) void loadFamiliars();
   }, [daemonRunning, loadFamiliars]);
+  // …and while an error IS showing, keep retrying quietly. The effect above
+  // only fires on daemonRunning TRANSITIONS, so a one-off fetch flake with the
+  // daemon already "running" (e.g. it restarts right after the first familiar
+  // is summoned) stranded the error screen until a manual Retry (issue #2990).
+  usePausablePoll(() => void loadFamiliars(), 4_000, {
+    enabled: familiarsError !== null,
+  });
 
   // Scope the view to a familiar. `null` clears to "All". With `opts.multi`
   // (⌘/Ctrl-click) the id is toggled in/out of the multiselect set; a plain
@@ -1419,10 +1426,22 @@ export function Workspace() {
     pauseWhileInputActive: true,
   });
 
+  // Declared above handleEnrichTasks, which closes over it.
+  const pushToast = useCallback((title: string) => {
+    const id = `eph:adhoc-${Date.now()}`;
+    setToasts((prev) => [...prev, { id, title }]);
+  }, []);
+
   const handleEnrichTasks = useCallback(async () => {
     if (!activeId || enrichingTasks) return;
     setEnrichingTasks(true);
     setEnrichProgress(null);
+    // The trigger is a small top-bar button with no surface of its own — count
+    // the outcome so it can say what happened when the run ends (issue #2991:
+    // "clicking it results in loading and then returns to the start, no
+    // feedback").
+    let total = 0;
+    let enhanced = 0;
     try {
       const res = await fetch("/api/board/enrich-steps", {
         method: "POST",
@@ -1449,8 +1468,10 @@ export function Workspace() {
           try {
             const msg = JSON.parse(trimmed) as Record<string, unknown>;
             if (msg.kind === "start") {
-              setEnrichProgress({ done: 0, total: (msg.total as number) ?? 0 });
+              total = (msg.total as number) ?? 0;
+              setEnrichProgress({ done: 0, total });
             } else if (msg.kind === "done" || msg.kind === "skip") {
+              if (msg.kind === "done") enhanced += 1;
               setEnrichProgress((prev) => prev ? { ...prev, done: prev.done + 1 } : prev);
             } else if (msg.kind === "complete") {
               window.dispatchEvent(new CustomEvent("cave:board:reload"));
@@ -1461,12 +1482,22 @@ export function Workspace() {
           }
         }
       }
+      // Close the loop: the live label disappears when the run ends, so state
+      // the outcome — especially the two "nothing happened" shapes that read
+      // as a silent failure.
+      pushToast(
+        total === 0
+          ? "No open tasks to enhance right now."
+          : enhanced === 0
+            ? "Open tasks already have steps — nothing to enhance."
+            : `Enhanced ${enhanced} task${enhanced === 1 ? "" : "s"} — open Tasks to review.`,
+      );
     } catch {
-      /* keep the top-bar action quiet; progress resets below */
+      pushToast("Enhance tasks failed — check the daemon banner and try again.");
     } finally {
       setEnrichingTasks(false);
     }
-  }, [activeId, enrichingTasks, refreshOpenTaskCards]);
+  }, [activeId, enrichingTasks, pushToast, refreshOpenTaskCards]);
 
   const openReminderModal = useCallback((title = "", whenText = "", fireAt = "") => {
     setReminderModalDefaults({ fireAt, title, whenText });
@@ -1477,11 +1508,6 @@ export function Workspace() {
     setActiveId(familiarId);
     openReminderModal();
   }, [openReminderModal]);
-
-  const pushToast = useCallback((title: string) => {
-    const id = `eph:adhoc-${Date.now()}`;
-    setToasts((prev) => [...prev, { id, title }]);
-  }, []);
 
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));


### PR DESCRIPTION
Sweep of the open issue queue — four of the five open issues, each root-caused and fixed:

| Issue | Root cause | Fix |
|---|---|---|
| #2997 comment button floating mid-response | Fab is `position:fixed` at coords captured on mouseup; scrolling moves the text but not the pill | Reposition from the live selection range on scroll (capture) / resize, rAF-coalesced; pill now travels with — and off-screen with — its selection |
| #2988 Ask Salem long answer overflows | Answer region had no height cap (only the listbox below caps) | `max-h-[45vh] overflow-y-auto` on the answer region |
| #2990 empty screen after first familiar | Roster self-heal only fires on `daemonRunning` *transitions*; a one-off fetch flake with the daemon already running strands the error screen until manual Retry | Quiet 4s `usePausablePoll` retry while `familiarsError` is set + honest "retrying automatically" copy |
| #2991 mystery sparkle button, no feedback | `handleEnrichTasks` swallowed errors and reported nothing on success/no-op | Outcome toast for every shape: enhanced count / no open tasks / already have steps / failed |

**#2992 (Grimoire browser below content) is intentionally not in this PR** — it does not reproduce on the web build at the reported window size (browser opens full-screen overtop, verified with Playwright); it appears Tauri-native/platform-specific on v0.0.178. Verifying natively against v0.0.181 next; findings will land on the issue.

## Verification
- Live against the production build: Salem region scrolls internally and fits the viewport; roster error shows on a mocked double-flake, then self-heals in one poll cycle with zero clicks.
- Full app suite: **628 test files green**; `tsc` clean; `check:tests-wired` clean.
- New pins: fab scroll-anchoring (incl. rAF null-on-cancel), Salem cap, auto-retry poll, all four toast outcomes, and the pushToast-above-handler TDZ ordering.

Fixes #2997
Fixes #2988
Fixes #2990
Fixes #2991

🤖 Generated with [Claude Code](https://claude.com/claude-code)