### PR TITLE
feat(onboarding): auto-install hermes-coven shim after Hermes install

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -692,6 +692,7 @@ export const SUITES = {
     "src/lib/coven-daemon.test.ts",
     "src/lib/coven-bin.test.ts",
     "src/lib/harness-version.test.ts",
+    "src/lib/hermes-shim.test.ts",
     "src/lib/openclaw-bin.test.ts",
     "src/lib/openclaw-bridge.test.ts",
     "src/lib/coven-identity-canon.test.ts",

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -12,6 +12,7 @@ import {
   refreshCovenSpawnEnv,
 } from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
+import { installHermesShim } from "@/lib/hermes-shim";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -579,6 +580,23 @@ export async function POST(req: Request) {
           const installed = await commandPath(target.binary);
           const installedPath = installed.path;
           const ok = code === 0 && !!installedPath && !job.error;
+
+          // Hermes has no positional prompt slot, so the harness's
+          // `-- "<prompt>"` convention needs the `hermes-coven` shim to remap
+          // it onto `-q`. Install the shim next to the freshly-installed
+          // `hermes` binary so chat works out of the box. Best-effort: a shim
+          // failure never fails the Hermes install itself.
+          if (ok && targetName === "hermes" && installedPath) {
+            const shim = await installHermesShim(installedPath);
+            appendOutput(
+              job,
+              shim.ok
+                ? `Installed hermes-coven shim at ${shim.path}\n`
+                : `Note: could not install hermes-coven shim (${shim.error}); ` +
+                    `chat may fail until it is installed manually.\n`,
+            );
+          }
+
           job.status = "done";
           job.finishedAt = Date.now();
           job.ok = ok;

--- a/src/lib/hermes-shim.test.ts
+++ b/src/lib/hermes-shim.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { HERMES_COVEN_SHIM, installHermesShim } from "./hermes-shim.ts";
+
+const execFileAsync = promisify(execFile);
+
+// Run the shim with `hermes` stubbed by a script that just prints its argv,
+// so we can assert the exact command the shim would exec — no real Hermes.
+async function shimArgv(args: string[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "hermes-shim-"));
+  try {
+    // Fake `hermes` on PATH that echoes a stable, parseable argv line.
+    const fakeHermes = join(dir, "hermes");
+    await writeFile(
+      fakeHermes,
+      '#!/usr/bin/env bash\nprintf "ARGV"; for a in "$@"; do printf " [%s]" "$a"; done; printf "\\n"\n',
+      { mode: 0o755 },
+    );
+    const shimPath = join(dir, "hermes-coven");
+    await writeFile(shimPath, HERMES_COVEN_SHIM, { mode: 0o755 });
+    const { stdout } = await execFileAsync("bash", [shimPath, ...args], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+      timeout: 5000,
+    });
+    return stdout.trim();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// Non-interactive: the harness sends `... -- "<prompt>"`; the shim must remap
+// the trailing positional prompt onto `-q`'s inline value.
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "-Q", "--", "hello world"]),
+  "ARGV [chat] [--source] [coven] [-Q] [-q] [hello world]",
+  "trailing positional prompt becomes the inline value of -q",
+);
+
+// A stray bare `-q` in the prefix (older manifest) must not duplicate.
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "-q", "--", "hi"]),
+  "ARGV [chat] [--source] [coven] [-q] [hi]",
+  "a bare -q in the prefix is stripped, not duplicated",
+);
+
+// A VALUED -q in the prefix must drop BOTH the flag and its value — otherwise
+// the value would leak as a stray positional to hermes.
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "-q", "STALE", "-Q", "--", "real"]),
+  "ARGV [chat] [--source] [coven] [-Q] [-q] [real]",
+  "-q <value> in the prefix is fully stripped before the real prompt is added",
+);
+
+// `--query=<value>` inline form is also stripped whole.
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "--query=STALE", "--", "real"]),
+  "ARGV [chat] [--source] [coven] [-q] [real]",
+  "--query=<value> inline form is stripped",
+);
+
+// Interactive: no prompt after `--` → launch the REPL with a query-free prefix
+// (and any valued -q fully removed, so nothing leaks as a positional).
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "-q", "STALE", "--", ""]),
+  "ARGV [chat] [--source] [coven]",
+  "empty prompt launches the REPL with the query flag and its value stripped",
+);
+
+// A prompt that begins with a dash stays intact (it's -q's value, not a flag).
+assert.equal(
+  await shimArgv(["chat", "--source", "coven", "-Q", "--", "--tricky"]),
+  "ARGV [chat] [--source] [coven] [-Q] [-q] [--tricky]",
+  "dash-leading prompt is preserved as -q's value",
+);
+
+// installHermesShim writes an executable shim next to the hermes binary.
+{
+  const dir = await mkdtemp(join(tmpdir(), "hermes-install-"));
+  try {
+    const hermesBin = join(dir, "hermes");
+    await writeFile(hermesBin, "#!/usr/bin/env bash\n", { mode: 0o755 });
+    const result = await installHermesShim(hermesBin);
+    assert.ok(result.ok, "shim install should succeed next to the hermes binary");
+    if (result.ok) {
+      assert.equal(result.path, join(dir, "hermes-coven"), "shim lands beside hermes");
+      const body = await readFile(result.path, "utf8");
+      assert.equal(body, HERMES_COVEN_SHIM, "installed shim matches the pinned source");
+      const st = await stat(result.path);
+      assert.equal(st.mode & 0o111, 0o111, "installed shim is executable");
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("hermes-shim: ok");

--- a/src/lib/hermes-shim.ts
+++ b/src/lib/hermes-shim.ts
@@ -1,0 +1,105 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/**
+ * The `hermes-coven` adapter shim, embedded as a pinned constant so Cave can
+ * install it automatically after Hermes's own installer runs — no dependency
+ * on a repo file at runtime.
+ *
+ * Why it exists: the Coven harness appends the user prompt as a POSITIONAL
+ * argument behind an options terminator, i.e. `hermes chat <prefix…> -- "<p>"`.
+ * But `hermes chat` has no positional prompt slot — the query is only accepted
+ * via `-q/--query <value>` — so the raw invocation fails with:
+ *     hermes chat: error: argument -q/--query: expected one argument
+ * The shim captures the trailing positional prompt and re-emits it as the
+ * inline value of `-q`. Keep this byte-for-byte in sync with
+ * OpenCoven/coven-runtimes:shims/hermes-coven.
+ */
+export const HERMES_COVEN_SHIM = `#!/usr/bin/env bash
+# hermes-coven — adapter shim so the Coven harness can drive \`hermes chat\`.
+# Installed automatically by Cave after Hermes setup. Keep in sync with
+# OpenCoven/coven-runtimes:shims/hermes-coven.
+set -euo pipefail
+
+pre=()
+prompt=""
+seen_term=0
+
+for arg in "$@"; do
+  if [[ "$seen_term" -eq 0 && "$arg" == "--" ]]; then
+    seen_term=1
+    continue
+  fi
+  if [[ "$seen_term" -eq 1 ]]; then
+    if [[ -z "$prompt" ]]; then prompt="$arg"; else prompt="$prompt $arg"; fi
+  else
+    pre+=("$arg")
+  fi
+done
+
+strip_query() {
+  cleaned=()
+  local skip_next=0 a
+  for a in "$@"; do
+    if [[ "$skip_next" -eq 1 ]]; then
+      skip_next=0
+      continue
+    fi
+    case "$a" in
+      -q|--query)
+        skip_next=1
+        continue
+        ;;
+      -q=*|--query=*)
+        continue
+        ;;
+      *)
+        cleaned+=("$a")
+        ;;
+    esac
+  done
+}
+
+strip_query \${pre[@]:+"\${pre[@]}"}
+
+if [[ -n "\${prompt//[[:space:]]/}" ]]; then
+  exec hermes \${cleaned[@]:+"\${cleaned[@]}"} -q "$prompt"
+else
+  exec hermes \${cleaned[@]:+"\${cleaned[@]}"}
+fi
+`;
+
+export type ShimInstallResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string };
+
+/**
+ * Install the `hermes-coven` shim next to the resolved `hermes` binary so it
+ * sits on the same PATH entry Hermes was installed to. POSIX only — the shim
+ * is bash and the Hermes runtime is POSIX-only in the registry.
+ *
+ * @param hermesBinaryPath absolute path to the `hermes` executable (from the
+ *   post-install PATH lookup). The shim is written to its parent directory.
+ */
+export async function installHermesShim(
+  hermesBinaryPath: string,
+): Promise<ShimInstallResult> {
+  if (process.platform === "win32") {
+    return { ok: false, error: "hermes-coven shim is POSIX-only" };
+  }
+  try {
+    const dir = dirname(hermesBinaryPath);
+    await mkdir(dir, { recursive: true });
+    const shimPath = join(dir, "hermes-coven");
+    await writeFile(shimPath, HERMES_COVEN_SHIM, { mode: 0o755 });
+    // writeFile honors mode only on create; enforce it explicitly so an
+    // existing non-executable file is corrected.
+    await chmod(shimPath, 0o755);
+    return { ok: true, path: shimPath };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
Wires the `hermes-coven` shim install into the Cave's Hermes onboarding/install flow so chat works out of the box on **every** machine — no manual shim install.

## Why
`hermes chat` has no positional prompt slot; the harness appends the prompt as `-- "<prompt>"`, so it needs the `hermes-coven` shim to remap that onto `-q/--query`. Until now the shim (shipped in `OpenCoven/coven-runtimes:shims/hermes-coven`, PR #26) had to be installed by hand on each machine.

## What
- **`src/lib/hermes-shim.ts`** — pins the shim body as a constant (kept in sync with coven-runtimes) and `installHermesShim(hermesBinaryPath)` writes it next to the freshly-installed `hermes` binary (chmod 0755). POSIX-only (the shim is bash; Hermes is POSIX-only in the registry).
- **`onboarding/install/route.ts`** — after the Hermes script installer succeeds and `hermes` is found on PATH, drop the shim beside it. **Best-effort**: a shim failure is logged in the install output but never fails the Hermes install itself.
- **Tests** run the generated shim through `bash` and assert the exact remapped argv across every case (bare `-q`, valued `-q <value>`, `--query=<value>`, empty-prompt REPL, dash-leading prompt) plus the install-to-dir + executable-bit behavior. Wired into `run-tests.mjs`.

## Verify
- `hermes-shim.test.ts` ✓ · install route test ✓ · tests-wired ✓ (848) · no type errors in changed files.

Follow-on to #26 (shim source) and #3021 (registry sync). After this, a fresh Cave that installs Hermes via onboarding can chat immediately.