### PR TITLE
Fix Windows Coven Code version detection

### DIFF
--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -135,6 +135,29 @@ function skip(reason: string): void {
   );
 
   // Host branch — the genuinely per-OS assertion.
+  // Coven Code's npm target is extensionless. It must resolve from its own
+  // shim, never by inferring the Coven CLI's conventional JavaScript path.
+  const codeShimScript = path.join(shimDir, "node_modules", "@opencoven", "coven-code", "bin", "coven-code");
+  mkdirSync(path.dirname(codeShimScript), { recursive: true });
+  writeFileSync(codeShimScript, "console.log('coven-code');\n");
+  const codeShim = path.join(shimDir, "coven-code.cmd");
+  writeFileSync(
+    codeShim,
+    'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\coven-code\\bin\\coven-code" %*\r\n',
+  );
+  assert.deepEqual(
+    covenLaunchCommandForBinary(codeShim, "win32"),
+    { command: process.execPath, fixedArgs: [codeShimScript] },
+    "win32 npm shims resolve extensionless Coven Code targets from their own package",
+  );
+
+  const missingShim = path.join(shimDir, "missing.cmd");
+  assert.deepEqual(
+    covenLaunchCommandForBinary(missingShim, "win32"),
+    { command: missingShim, fixedArgs: [], unresolvedWindowsShim: true },
+    "unreadable Windows shims are explicit unknown targets rather than another package's fallback",
+  );
+
   if (process.platform === "win32") {
     // On a real Windows runner, a .cmd path must resolve to node + script using
     // the host's actual filesystem + path semantics.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -681,6 +681,7 @@ export const SUITES = {
     "src/app/api/marketplace/pack-prompts-route.test.ts",
     "src/app/api/app/latest-release/route.test.ts",
     "src/app/api/opencoven-tools/status/route.test.ts",
+    "src/lib/opencoven-tools-status.test.ts",
     "src/app/api/daemon/status/route.test.ts",
     "src/app/api/daemon/capabilities/route.test.ts",
     "src/app/api/travel/client/route.test.ts",

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -57,6 +57,7 @@ const npmShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-npm-shim-"));
 const npmShimScript = path.join(npmShimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
 await mkdir(path.dirname(npmShimScript), { recursive: true });
 await writeFile(npmShimScript, "console.log('coven');\n");
+await writeFile(path.join(npmShimDir, "node.exe"), "local node runtime probe");
 const npmShim = path.join(npmShimDir, "coven.cmd");
 await writeFile(
   npmShim,
@@ -76,7 +77,7 @@ assert.deepEqual(
 );
 
 const covenCodeShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-code-npm-shim-"));
-const covenCodeShimScript = path.join(covenCodeShimDir, "node_modules", "coven-code", "bin", "coven-code");
+const covenCodeShimScript = path.join(covenCodeShimDir, "node_modules", "@opencoven", "coven-code", "bin", "coven-code");
 await mkdir(path.dirname(covenCodeShimScript), { recursive: true });
 await writeFile(covenCodeShimScript, "console.log('coven-code');\n");
 const covenCodeShim = path.join(covenCodeShimDir, "coven-code.cmd");
@@ -86,7 +87,7 @@ await writeFile(
     "@ECHO off",
     "SETLOCAL",
     "CALL :find_dp0",
-    'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\coven-code\\bin\\coven-code" %*',
+    'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\coven-code\\bin\\coven-code" %*',
     "",
   ].join("\r\n"),
 );
@@ -97,17 +98,43 @@ assert.deepEqual(
   "Windows npm .cmd shims can target extensionless package bin scripts like coven-code",
 );
 
-const fallbackShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-fallback-shim-"));
-const fallbackScript = path.join(fallbackShimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
-await mkdir(path.dirname(fallbackScript), { recursive: true });
-await writeFile(fallbackScript, "console.log('fallback coven');\n");
-const fallbackShim = path.join(fallbackShimDir, "coven.cmd");
-await writeFile(fallbackShim, "@ECHO off\r\nREM unknown shim shape\r\n");
+const covenCodeBat = path.join(covenCodeShimDir, "coven-code.bat");
+await writeFile(
+  covenCodeBat,
+  '"%~dp0\\node_modules\\@opencoven\\coven-code\\bin\\coven-code" %*\r\n',
+);
+assert.deepEqual(
+  covenLaunchCommandForBinary(covenCodeBat, "win32"),
+  { command: process.execPath, fixedArgs: [covenCodeShimScript] },
+  "Windows .bat shims and the %~dp0 batch form resolve the same extensionless target",
+);
 
 assert.deepEqual(
-  covenLaunchCommandForBinary(fallbackShim, "win32"),
-  { command: process.execPath, fixedArgs: [fallbackScript] },
-  "Windows .cmd shims fall back to the standard npm global coven.js location",
+  covenLaunchCommandForBinary("C:\\tools\\coven.exe", "win32"),
+  { command: "C:\\tools\\coven.exe", fixedArgs: [] },
+  "Windows native executables remain direct launch commands",
+);
+
+const unresolvedShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-unresolved-shim-"));
+// A real CLI script alongside an unparseable shim must not become a fallback:
+// doing that is how a coven-code probe used to report Coven CLI's version.
+const wrongPackageScript = path.join(unresolvedShimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
+await mkdir(path.dirname(wrongPackageScript), { recursive: true });
+await writeFile(wrongPackageScript, "console.log('wrong package');\n");
+const unresolvedShim = path.join(unresolvedShimDir, "coven-code.cmd");
+await writeFile(unresolvedShim, "@ECHO off\r\nREM unknown shim shape\r\n");
+
+assert.deepEqual(
+  covenLaunchCommandForBinary(unresolvedShim, "win32"),
+  { command: unresolvedShim, fixedArgs: [], unresolvedWindowsShim: true },
+  "unparseable Windows shims report an unknown target instead of falling back to another package",
+);
+
+const missingShim = path.join(unresolvedShimDir, "missing.cmd");
+assert.deepEqual(
+  covenLaunchCommandForBinary(missingShim, "win32"),
+  { command: missingShim, fixedArgs: [], unresolvedWindowsShim: true },
+  "missing Windows shims retain their path but have an explicit unknown target",
 );
 
 // Windows has no $SHELL, so the login-shell PATH probe always failed there

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -34,6 +34,10 @@ let cachedPath: string | null = null;
 export type CovenLaunchCommand = {
   command: string;
   fixedArgs: string[];
+  // A .cmd/.bat shim was found but its target could not be proven. Callers
+  // that only need a version must report it as unknown instead of asking
+  // Windows to run an ambiguous batch file (or substituting another binary).
+  unresolvedWindowsShim?: true;
 };
 
 const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT", "GITHUB_PERSONAL_ACCESS_TOKEN"] as const;
@@ -260,26 +264,33 @@ function windowsShimTargetFromFile(shimPath: string): string | null {
   const binDir = path.dirname(shimPath);
   try {
     const shim = readFileSync(shimPath, "utf-8");
-    const quotedTargets = shim.matchAll(/"(%(?:~?dp0)%?)[\\/]*([^"]+)"/gi);
-    for (const match of quotedTargets) {
-      const relativeTarget = match[2]?.replace(/[\\/]+/g, path.sep);
-      if (!relativeTarget || relativeTarget.includes("%")) continue;
+    // npm's cmd-shim generator quotes the package entry point relative to
+    // either `%dp0%` (its shim-directory variable) or `%~dp0` (the batch
+    // parameter form). Do not infer a package name: an npm `bin` target may
+    // be JavaScript, extensionless, or any other file Node can execute.
+    for (const line of shim.split(/\r?\n/)) {
+      // Standard npm shims first test and assign a local node.exe. Those are
+      // setup statements, not the package command to invoke. Only accept
+      // quoted `%dp0` paths from a command line; the final one is the entry
+      // point for the older `node <script>` shim form as well.
+      if (/^\s*(?:@?if\s+exist|@?set(?:local)?\b|@?call\b|@?rem\b|::|:)/i.test(line)) {
+        continue;
+      }
+      const targets = Array.from(line.matchAll(/"([^"]+)"/g))
+        .map((match) => match[1]?.trim())
+        .map((target) => target && /^%~?dp0%?[\\/]+(.+)$/i.exec(target)?.[1])
+        .filter((target): target is string => !!target && !target.includes("%"));
+      const relativeTarget = targets.at(-1)?.replace(/[\\/]+/g, path.sep);
+      if (!relativeTarget) continue;
       const candidate = path.resolve(binDir, relativeTarget);
-      if (existsSync(candidate)) return candidate;
+      if (existsSync(candidate)) {
+        return candidate;
+      }
     }
   } catch {
-    /* fall through to the conventional npm global layout */
+    /* unreadable or missing shim: leave it unresolved */
   }
-
-  const conventionalTarget = path.join(
-    binDir,
-    "node_modules",
-    "@opencoven",
-    "cli",
-    "bin",
-    "coven.js",
-  );
-  return existsSync(conventionalTarget) ? conventionalTarget : null;
+  return null;
 }
 
 export function covenLaunchCommandForBinary(
@@ -291,7 +302,9 @@ export function covenLaunchCommandForBinary(
   }
 
   const script = windowsShimTargetFromFile(binary);
-  if (!script) return { command: binary, fixedArgs: [] };
+  if (!script) {
+    return { command: binary, fixedArgs: [], unresolvedWindowsShim: true };
+  }
   return { command: process.execPath, fixedArgs: [script] };
 }
 

--- a/src/lib/opencoven-tools-status.test.ts
+++ b/src/lib/opencoven-tools-status.test.ts
@@ -1,0 +1,94 @@
+// @ts-nocheck
+// Packaged Cave runs the status module directly on Windows. Reproduce npm's
+// global shim layout (including its extensionless PATH shadow) and verify the
+// API reports the launcher that `where` selected and the version that launcher
+// actually executes.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { openCovenToolStatuses } from "./opencoven-tools-status.ts";
+
+if (process.platform !== "win32") {
+  console.log("opencoven-tools-status.test.ts: skipped Windows packaged-server probe (requires win32)");
+} else {
+  const root = await mkdtemp(path.join(os.tmpdir(), "coven-tools-status-"));
+  const npmDir = path.join(root, "npm");
+  const original = {
+    APPDATA: process.env.APPDATA,
+    PATH: process.env.PATH,
+    npm_config_prefix: process.env.npm_config_prefix,
+  };
+
+  try {
+    await mkdir(npmDir, { recursive: true });
+    const cliTarget = path.join(npmDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
+    const codeTarget = path.join(npmDir, "node_modules", "@opencoven", "coven-code", "bin", "coven-code");
+    await mkdir(path.dirname(cliTarget), { recursive: true });
+    await mkdir(path.dirname(codeTarget), { recursive: true });
+    await writeFile(cliTarget, 'console.log("coven 0.0.60");\n');
+    await writeFile(codeTarget, 'console.log("coven-code 0.6.1");\n');
+
+    // npm creates an extensionless launcher as well as the .cmd shim. Its
+    // content deliberately advertises the wrong versions, proving the status
+    // probe does not run the first `where` result merely because it is first.
+    await writeFile(path.join(npmDir, "coven"), 'console.log("coven 9.9.9");\n');
+    await writeFile(path.join(npmDir, "coven-code"), 'console.log("coven-code 9.9.9");\n');
+    await writeFile(
+      path.join(npmDir, "coven.cmd"),
+      'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\cli\\bin\\coven.js" %*\r\n',
+    );
+    await writeFile(
+      path.join(npmDir, "coven-code.cmd"),
+      'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\coven-code\\bin\\coven-code" %*\r\n',
+    );
+
+    // In the packaged-server process `npm` is not directly spawnable on
+    // Windows (it is a .cmd shim), so the latest-version probe fails closed
+    // without a shell. This test only needs the installed-version probe.
+    process.env.APPDATA = root;
+    delete process.env.npm_config_prefix;
+    process.env.PATH = [npmDir, original.PATH].filter(Boolean).join(path.delimiter);
+
+    // `where` sees npm's extensionless shadow and the .cmd launcher. The
+    // status probe must display the latter because it is the spawnable path
+    // that covenLaunchCommandForBinary then resolves without shell mode.
+    for (const [binary, shadow, launcher] of [
+      ["coven", path.join(npmDir, "coven"), path.join(npmDir, "coven.cmd")],
+      ["coven-code", path.join(npmDir, "coven-code"), path.join(npmDir, "coven-code.cmd")],
+    ]) {
+      const matches = execFileSync("where", [binary], { encoding: "utf8", env: process.env })
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((entry) => path.normalize(entry).toLowerCase());
+      assert.ok(matches.includes(shadow.toLowerCase()), `${binary} has its npm extensionless PATH shadow`);
+      assert.ok(matches.includes(launcher.toLowerCase()), `${binary} has its npm .cmd PATH launcher`);
+    }
+
+    const tools = await openCovenToolStatuses();
+    const cli = tools.find((tool) => tool.id === "coven-cli");
+    const code = tools.find((tool) => tool.id === "coven-code");
+
+    assert.deepEqual(
+      { binary: cli?.binary, path: cli?.path, current: cli?.current, installed: cli?.installed },
+      { binary: "coven", path: path.join(npmDir, "coven.cmd"), current: "0.0.60", installed: true },
+      "Coven CLI status displays the .cmd path selected by where and its own JavaScript target version",
+    );
+    assert.deepEqual(
+      { binary: code?.binary, path: code?.path, current: code?.current, installed: code?.installed },
+      { binary: "coven-code", path: path.join(npmDir, "coven-code.cmd"), current: "0.6.1", installed: true },
+      "Coven Code status displays the .cmd path selected by where and its extensionless package target version",
+    );
+  } finally {
+    if (original.APPDATA === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = original.APPDATA;
+    if (original.PATH === undefined) delete process.env.PATH;
+    else process.env.PATH = original.PATH;
+    if (original.npm_config_prefix === undefined) delete process.env.npm_config_prefix;
+    else process.env.npm_config_prefix = original.npm_config_prefix;
+    await rm(root, { recursive: true, force: true });
+  }
+
+  console.log("opencoven-tools-status.test.ts: ok");
+}

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -1,12 +1,12 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { compareSemver } from "@/lib/app-update";
+import { compareSemver } from "./app-update.ts";
 import {
   covenLaunchCommandForBinary,
   covenSpawnEnv,
   pickWindowsLauncher,
   refreshCovenSpawnEnv,
-} from "@/lib/coven-bin";
+} from "./coven-bin.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -99,7 +99,12 @@ async function installedTool(tool: ToolSpec): Promise<InstalledTool | null> {
   // Node refuses to execFile a .cmd directly (EINVAL since the batch-file
   // hardening); convert npm cmd-shims to a direct `node <script>` exec so
   // the version probe works on Windows instead of silently reporting null.
-  const { command, fixedArgs } = covenLaunchCommandForBinary(path);
+  const { command, fixedArgs, unresolvedWindowsShim } = covenLaunchCommandForBinary(path);
+  if (unresolvedWindowsShim) {
+    // The .cmd exists, so retain its displayed path, but a parser failure must
+    // never probe a different launcher or execute the batch file via a shell.
+    return { path, version: null };
+  }
   try {
     const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, ...tool.versionArgs], {
       env: covenSpawnEnv(),


### PR DESCRIPTION
## Summary
- Resolve Windows npm `.cmd` shims from their quoted `%dp0`/`%~dp0` entry point without inferring a package path.
- Report an explicit unknown version when a shim target cannot be proven, rather than probing Coven CLI.
- Add Windows packaged-server coverage for `where` launcher shadows, JavaScript and extensionless targets, `.bat`, `.exe`, and missing shims.

## Root cause
Coven Code's extensionless npm launcher target bypassed the old JavaScript-only parser, which then fell back to `@opencoven/cli/bin/coven.js`. The About page consequently displayed Coven CLI's version for Coven Code.

## Verification
- Targeted Coven launcher, tool-status, and route tests
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:conformance` on Windows
- `pnpm build`

`pnpm test:api` was also run. It is currently blocked by an unrelated Windows-only fixture issue in `scripts/beads-pr-bridge.test.mjs`, which uses `:` instead of the Windows PATH delimiter for its nested process.