### PR TITLE
Fix global npm update concurrency

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -666,6 +666,7 @@ export const SUITES = {
     "src/lib/coven-paths.test.ts",
     "src/lib/server/cave-home-migration.test.ts",
     "src/lib/server/cave-home-migration-status.test.ts",
+    "src/lib/server/global-npm-install-lane.test.ts",
     "src/app/api/cave-home-migration/route.test.ts",
     "src/lib/server/agent-attachments.test.ts",
     "src/app/api/api-contracts.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -123,7 +123,7 @@ const contracts: RouteContract[] = [
   { route: "/memory/purge", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/memory/restore", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/memory", methods: ["GET"], kind: "json" },
-  { route: "/onboarding/install", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/onboarding/install", methods: ["GET", "DELETE", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/onboarding/setup", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/onboarding/codex-port-preflight", methods: ["POST"], kind: "json" },
   { route: "/onboarding/ssh-check", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -198,8 +198,50 @@ assert.match(
 
 assert.match(
   source,
-  /other\.kind === "npm"/,
-  "npm-kind installs are mutually exclusive (global npm tree races)",
+  /reserveGlobalNpmInstall\(targetName\)/,
+  "npm installs reserve one global npm lease across every allowlisted target",
+);
+
+assert.match(
+  source,
+  /const plan = await spawnPlanFor\(target\);[\s\S]*?reserveGlobalNpmInstall\(targetName\)/,
+  "the atomic global reservation happens after asynchronous plan preparation",
+);
+
+assert.match(
+  source,
+  /retryable: true,[\s\S]*?code: "npm_install_in_progress"[\s\S]*?"Retry-After": "2"/,
+  "a competing npm request gets a specific, retryable conflict response",
+);
+
+assert.match(
+  source,
+  /npmBusyTarget: InstallTarget \| null/,
+  "GET exposes the global npm owner so every client surface can reflect it",
+);
+
+assert.match(
+  source,
+  /export async function DELETE[\s\S]*?job\.cancel\?\.\(\)/,
+  "a running install can be cancelled through the route",
+);
+
+assert.match(
+  source,
+  /function finishInstallJobError\([\s\S]*?npmLease\?\.release\(\)/,
+  "terminal job error paths release the global npm lease",
+);
+
+assert.match(
+  source,
+  /forceFinishTimer = setTimeout\([\s\S]*?fail\(new Error\(job\.error \?\? reason\)\)/,
+  "the timeout watchdog settles a child that never emits close",
+);
+
+assert.match(
+  source,
+  /@\/lib\/server\/global-npm-install-lane/,
+  "the HMR-safe global npm lease is owned by a dedicated server module",
 );
 
 assert.match(

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -6,6 +6,12 @@ import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { stripAnsi } from "@/lib/ansi";
 import {
+  globalNpmInstallOwner,
+  releaseGlobalNpmInstall,
+  reserveGlobalNpmInstall,
+  type NpmInstallLease,
+} from "@/lib/server/global-npm-install-lane";
+import {
   covenBin,
   covenSpawnEnv,
   pickWindowsLauncher,
@@ -267,6 +273,9 @@ type InstallJob = {
   code?: number | null;
   binaryPath?: string | null;
   error?: string;
+  /** Cancels preparation or the spawned process; never exposed to clients. */
+  cancel?: () => void;
+  cancelRequested?: boolean;
 };
 
 /** Last ~8 KB of installer output is plenty for a progress tail and keeps
@@ -281,6 +290,57 @@ const globalScope = globalThis as unknown as {
 };
 const jobs: Map<InstallTarget, InstallJob> = (globalScope.__covenInstallJobs ??=
   new Map());
+
+type NpmLaneView = {
+  npmBusy: boolean;
+  npmBusyTarget: InstallTarget | null;
+  npmBusyLabel: string | null;
+  npmJob?: ReturnType<typeof jobView>;
+};
+
+/**
+ * The lease intentionally lives outside the jobs map. A request can spend time
+ * on target-specific preparation before it reserves the npm tree, and the
+ * final reservation has to be atomic across every npm target.
+ */
+function activeNpmInstallTarget(): InstallTarget | null {
+  const owner = globalNpmInstallOwner();
+  if (!owner || !isInstallTarget(owner)) return null;
+  const job = jobs.get(owner);
+  if (job?.status === "running" && job.kind === "npm") return owner;
+  // Recovery after HMR/reload: a completed or orphaned job must never leave
+  // the process-wide lease stuck. This only clears the same owner, so it
+  // cannot release a newer reservation.
+  releaseGlobalNpmInstall(owner);
+  return null;
+}
+
+function npmLaneView(): NpmLaneView {
+  const target = activeNpmInstallTarget();
+  if (!target) {
+    return { npmBusy: false, npmBusyTarget: null, npmBusyLabel: null };
+  }
+  const job = jobs.get(target);
+  return {
+    npmBusy: true,
+    npmBusyTarget: target,
+    npmBusyLabel: INSTALL_TARGETS[target].label,
+    ...(job ? { npmJob: jobView(job) } : {}),
+  };
+}
+
+function npmBusyResponse(owner: InstallTarget) {
+  return NextResponse.json(
+    {
+      ok: false,
+      retryable: true,
+      code: "npm_install_in_progress",
+      error: `${INSTALL_TARGETS[owner].label} is updating the shared global npm directory. Wait for it to finish, then retry.`,
+      ...npmLaneView(),
+    },
+    { status: 409, headers: { "Retry-After": "2" } },
+  );
+}
 
 function appendOutput(job: InstallJob, chunk: string) {
   job.output = (job.output + chunk).slice(-OUTPUT_CAP);
@@ -425,14 +485,201 @@ function installStartErrorMessage(err: unknown): string {
   return message || "install failed to start";
 }
 
-function finishInstallJobError(job: InstallJob, err: unknown) {
+function finishInstallJobError(
+  job: InstallJob,
+  err: unknown,
+  npmLease?: NpmInstallLease,
+) {
+  if (job.status !== "running") return;
   job.status = "done";
   job.finishedAt = Date.now();
   job.ok = false;
   job.error = installStartErrorMessage(err);
+  job.cancel = undefined;
+  npmLease?.release();
+}
+
+function finishInstallJob(
+  job: InstallJob,
+  result: {
+    ok: boolean;
+    code: number | null;
+    binaryPath: string | null;
+    error?: string;
+  },
+  npmLease?: NpmInstallLease,
+) {
+  if (job.status !== "running") return;
+  job.status = "done";
+  job.finishedAt = Date.now();
+  job.ok = result.ok;
+  job.code = result.code;
+  job.binaryPath = result.binaryPath;
+  if (result.error) job.error = result.error;
+  job.cancel = undefined;
+  npmLease?.release();
+}
+
+/**
+ * Run one already-reserved install job. The lease is released from every
+ * terminal path (spawn error, normal close, cancellation, and the timeout
+ * watchdog), rather than from client polling.
+ */
+async function runInstallJob(
+  targetName: InstallTarget,
+  target: (typeof INSTALL_TARGETS)[InstallTarget],
+  plan: SpawnPlan,
+  job: InstallJob,
+  npmLease?: NpmInstallLease,
+) {
+  let child: ReturnType<typeof spawn> | undefined;
+  let timer: NodeJS.Timeout | undefined;
+  let killTimer: NodeJS.Timeout | undefined;
+  let forceFinishTimer: NodeJS.Timeout | undefined;
+  let terminationRequested = false;
+
+  const clearTimers = () => {
+    if (timer) clearTimeout(timer);
+    if (killTimer) clearTimeout(killTimer);
+    if (forceFinishTimer) clearTimeout(forceFinishTimer);
+  };
+  const fail = (err: unknown) => {
+    clearTimers();
+    finishInstallJobError(job, err, npmLease);
+  };
+  const requestTermination = (reason: string) => {
+    if (!child || terminationRequested) return;
+    terminationRequested = true;
+    if (timer) clearTimeout(timer);
+    appendOutput(job, `${reason}\n`);
+    child.kill("SIGTERM");
+    killTimer = setTimeout(() => child?.kill("SIGKILL"), 10_000);
+    // A misbehaving child must not keep the UI or the npm lane stuck forever.
+    // SIGKILL/TerminateProcess has already been requested at this point; this
+    // watchdog only settles the in-memory job if Node never emits `close`.
+    forceFinishTimer = setTimeout(
+      () => fail(new Error(job.error ?? reason)),
+      11_000,
+    );
+  };
+
+  job.cancel = () => {
+    if (job.status !== "running" || job.cancelRequested) return;
+    job.cancelRequested = true;
+    job.error = "install cancelled";
+    if (!child) {
+      appendOutput(job, "Cancellation requested during preparation.\n");
+      return;
+    }
+    requestTermination("Cancellation requested; stopping installer...");
+  };
+
+  try {
+    try {
+      await prepareForInstall(targetName, target, job);
+    } catch (err) {
+      appendOutput(
+        job,
+        `Preparation warning: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+
+    if (job.cancelRequested) {
+      fail(new Error("install cancelled"));
+      return;
+    }
+
+    child = spawn(plan.command, plan.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: covenSpawnEnv(),
+      shell: plan.shell,
+    });
+    child.stdout?.on("data", (d) => appendOutput(job, stripAnsi(d.toString())));
+    child.stderr?.on("data", (d) => appendOutput(job, stripAnsi(d.toString())));
+    timer = setTimeout(() => {
+      job.error = `install timed out after ${target.timeoutMs / 1000}s`;
+      requestTermination(`${job.error}; stopping installer...`);
+    }, target.timeoutMs);
+    child.on("error", (err) => fail(err));
+    child.on("close", (code, signal) => {
+      if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      void (async () => {
+        if (job.status !== "running") return;
+        if (job.cancelRequested) {
+          fail(new Error("install cancelled"));
+          return;
+        }
+        const installed = await commandPath(target.binary);
+        const installedPath = installed.path;
+        const ok = code === 0 && !!installedPath && !job.error;
+
+        // Hermes has no positional prompt slot, so Cave installs its adapter
+        // shim beside a successful Hermes binary. This is best-effort: a shim
+        // write failure must not turn a completed installer into a failed job.
+        if (ok && targetName === "hermes" && installedPath) {
+          try {
+            const shim = await installHermesShim(installedPath);
+            appendOutput(
+              job,
+              shim.ok
+                ? `Installed hermes-coven shim at ${shim.path}\n`
+                : `Note: could not install hermes-coven shim (${shim.error}); ` +
+                  "chat may fail until it is installed manually.\n",
+            );
+          } catch (err) {
+            appendOutput(
+              job,
+              `Note: could not install hermes-coven shim (${err instanceof Error ? err.message : String(err)}); chat may fail until it is installed manually.\n`,
+            );
+          }
+        }
+        clearTimers();
+        finishInstallJob(
+          job,
+          {
+            ok,
+            code,
+            binaryPath: installedPath,
+            ...(!ok && !job.error
+              ? {
+                  error: installed.error
+                    ? `Could not verify ${target.binary} on PATH after install: ${installed.error}`
+                    : installFailureHint(targetName, job.output) ??
+                      (code === 0
+                        ? `${target.binary} still is not on PATH after install — open a new terminal or restart Cave, then re-check.`
+                        : `installer exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}`),
+                }
+              : {}),
+          },
+          npmLease,
+        );
+      })().catch((err) => fail(err));
+    });
+  } catch (err) {
+    fail(err);
+  }
 }
 
 export async function GET(req: Request) {
+  const target = new URL(req.url).searchParams.get("target");
+  // Client surfaces poll this lightweight lane view so a job started from a
+  // different surface/window disables its own npm actions immediately.
+  if (target === null) {
+    return NextResponse.json({ status: "idle", ...npmLaneView() });
+  }
+  if (!isInstallTarget(target)) {
+    return NextResponse.json(
+      { ok: false, error: "unknown install target" },
+      { status: 400 },
+    );
+  }
+  const job = jobs.get(target);
+  if (!job) return NextResponse.json({ status: "idle", ...npmLaneView() });
+  return NextResponse.json({ ...jobView(job), ...npmLaneView() });
+}
+
+export async function DELETE(req: Request) {
   const target = new URL(req.url).searchParams.get("target");
   if (!isInstallTarget(target)) {
     return NextResponse.json(
@@ -441,8 +688,19 @@ export async function GET(req: Request) {
     );
   }
   const job = jobs.get(target);
-  if (!job) return NextResponse.json({ status: "idle" });
-  return NextResponse.json(jobView(job));
+  if (!job || job.status !== "running") {
+    return NextResponse.json(
+      { ok: false, error: "no running install for this target", ...npmLaneView() },
+      { status: 409 },
+    );
+  }
+  job.cancel?.();
+  return NextResponse.json({
+    ok: true,
+    cancelling: true,
+    ...jobView(job),
+    ...npmLaneView(),
+  });
 }
 
 export async function POST(req: Request) {
@@ -471,20 +729,12 @@ export async function POST(req: Request) {
     return NextResponse.json(jobView(existing));
   }
 
-  // Concurrent `npm install -g` calls race the global tree; script installers
-  // (Hermes) are independent and may run alongside anything.
+  // This early check keeps the ordinary busy path quick. The authoritative,
+  // atomic reservation comes *after* spawnPlanFor below, because that function
+  // awaits target preparation and two requests can pass this check together.
   if (target.kind === "npm") {
-    for (const [otherName, other] of jobs) {
-      if (other.status === "running" && other.kind === "npm") {
-        return NextResponse.json(
-          {
-            ok: false,
-            error: `wait for ${INSTALL_TARGETS[otherName].label} to finish`,
-          },
-          { status: 409 },
-        );
-      }
-    }
+    const activeTarget = activeNpmInstallTarget();
+    if (activeTarget) return npmBusyResponse(activeTarget);
   }
 
   const plan = await spawnPlanFor(target);
@@ -535,6 +785,20 @@ export async function POST(req: Request) {
     return NextResponse.json(jobView(recheck));
   }
 
+  // This is the atomic boundary. It comes after every asynchronous plan
+  // lookup/preparation step and covers every npm allowlist target, rather than
+  // only the requested target. Script installers intentionally do not reserve
+  // it and may continue under the existing independent-installer policy.
+  const reservation =
+    target.kind === "npm" ? reserveGlobalNpmInstall(targetName) : null;
+  if (reservation && !reservation.ok) {
+    const owner = isInstallTarget(reservation.owner)
+      ? reservation.owner
+      : targetName;
+    return npmBusyResponse(owner);
+  }
+  const npmLease = reservation?.ok ? reservation.lease : undefined;
+
   const job: InstallJob = {
     status: "running",
     kind: target.kind,
@@ -543,82 +807,10 @@ export async function POST(req: Request) {
   };
   jobs.set(targetName, job);
 
-  void (async () => {
-    try {
-      try {
-        await prepareForInstall(targetName, target, job);
-      } catch (err) {
-        appendOutput(
-          job,
-          `Preparation warning: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-      }
-
-      const child = spawn(plan.command, plan.args, {
-        stdio: ["ignore", "pipe", "pipe"],
-        env: covenSpawnEnv(),
-        shell: plan.shell,
-      });
-      child.stdout.on("data", (d) => appendOutput(job, stripAnsi(d.toString())));
-      child.stderr.on("data", (d) => appendOutput(job, stripAnsi(d.toString())));
-      let killTimer: NodeJS.Timeout | undefined;
-      const timer = setTimeout(() => {
-        // curl|bash bootstraps can ignore SIGTERM; escalate so the job can't stay running forever
-        job.error = `install timed out after ${target.timeoutMs / 1000}s`;
-        child.kill("SIGTERM");
-        killTimer = setTimeout(() => child.kill("SIGKILL"), 10_000);
-      }, target.timeoutMs);
-      child.on("error", (e) => {
-        clearTimeout(timer);
-        if (killTimer) clearTimeout(killTimer);
-        finishInstallJobError(job, e);
-      });
-      child.on("close", (code, signal) => {
-        clearTimeout(timer);
-        if (killTimer) clearTimeout(killTimer);
-        void (async () => {
-          const installed = await commandPath(target.binary);
-          const installedPath = installed.path;
-          const ok = code === 0 && !!installedPath && !job.error;
-
-          // Hermes has no positional prompt slot, so the harness's
-          // `-- "<prompt>"` convention needs the `hermes-coven` shim to remap
-          // it onto `-q`. Install the shim next to the freshly-installed
-          // `hermes` binary so chat works out of the box. Best-effort: a shim
-          // failure never fails the Hermes install itself.
-          if (ok && targetName === "hermes" && installedPath) {
-            const shim = await installHermesShim(installedPath);
-            appendOutput(
-              job,
-              shim.ok
-                ? `Installed hermes-coven shim at ${shim.path}\n`
-                : `Note: could not install hermes-coven shim (${shim.error}); ` +
-                    `chat may fail until it is installed manually.\n`,
-            );
-          }
-
-          job.status = "done";
-          job.finishedAt = Date.now();
-          job.ok = ok;
-          job.code = code;
-          job.binaryPath = installedPath;
-          if (!ok && !job.error) {
-            job.error = installed.error
-              ? `Could not verify ${target.binary} on PATH after install: ${installed.error}`
-              : installFailureHint(targetName, job.output) ??
-                (code === 0
-                  ? `${target.binary} still is not on PATH after install — open a new terminal or restart Cave, then re-check.`
-                  : `installer exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}`);
-          }
-        })();
-      });
-    } catch (err) {
-      finishInstallJobError(job, err);
-    }
-  })();
+  void runInstallJob(targetName, target, plan, job, npmLease);
 
   return NextResponse.json(
-    { started: true, target: targetName },
+    { started: true, target: targetName, ...npmLaneView() },
     { status: 202 },
   );
 }

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -21,8 +21,14 @@ assert.match(
 
 assert.match(
   route,
-  /void \(async \(\) => \{\s*try \{[\s\S]*?const child = spawn\(plan\.command, plan\.args,[\s\S]*?\} catch \(err\) \{\s*finishInstallJobError\(job, err\);/,
-  "fire-and-forget installer task should catch synchronous spawn failures",
+  /void runInstallJob\(targetName, target, plan, job, npmLease\);/,
+  "POST should hand the background installer to the shared lifecycle runner",
+);
+
+assert.match(
+  route,
+  /async function runInstallJob\([\s\S]*?child = spawn\(plan\.command, plan\.args,[\s\S]*?\} catch \(err\) \{\s*fail\(err\);/,
+  "the background lifecycle runner should catch synchronous spawn failures",
 );
 
 assert.doesNotMatch(

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -380,7 +380,25 @@ assert.match(
 assert.match(
   source,
   /disabled=\{busy \|\|/,
-  "the disable rule is per-target (own busy state), not a global lock",
+  "runtime controls stay disabled for their own in-progress install",
+);
+
+assert.match(
+  source,
+  /const refreshNpmLane = useCallback/,
+  "onboarding polls the server-owned global npm lane across client surfaces",
+);
+
+assert.match(
+  source,
+  /Other npm updates are disabled until it finishes/,
+  "onboarding clearly explains the shared npm lock",
+);
+
+assert.match(
+  source,
+  /disabled=\{toolBusy \|\| toolBlockedByNpm\}/,
+  "onboarding disables other OpenCoven npm actions while a global update runs",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -98,6 +98,11 @@ type InstallResult = {
   detail: string;
 };
 
+type NpmLaneState = {
+  target: InstallTarget;
+  label: string;
+};
+
 /** Result of the codex OAuth port preflight (POST /api/onboarding/codex-port-preflight).
  *  The four outcomes mirror the route handler's response shape. UI consumes
  *  `ok` for color/icon and `detail` for the user-facing message. */
@@ -136,6 +141,10 @@ const ALL_INSTALL_TARGETS = Object.keys(INSTALL_TARGET_KIND) as InstallTarget[];
 const NPM_INSTALL_TARGETS = ALL_INSTALL_TARGETS.filter(
   (target) => INSTALL_TARGET_KIND[target] === "npm",
 );
+
+function isInstallTargetValue(value: string): value is InstallTarget {
+  return ALL_INSTALL_TARGETS.includes(value as InstallTarget);
+}
 
 // The "skip Coven Code" choice persists under COVEN_CODE_SKIP_KEY (shared
 // with the workspace auto-open gate via @/lib/onboarding-gate — cave-219) so
@@ -348,6 +357,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [installResults, setInstallResults] = useState<
     Partial<Record<InstallTarget, InstallResult>>
   >({});
+  const [npmLane, setNpmLane] = useState<NpmLaneState | null>(null);
   // Codex's `codex login` opens an OAuth callback server on port 1455 that
   // sometimes leaks as a stale process when the auth flow is killed mid-way.
   // The preflight POST identifies and clears the orphan; we display the
@@ -408,6 +418,30 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   }, []);
 
+  const refreshNpmLane = useCallback(async () => {
+    try {
+      const res = await fetch("/api/onboarding/install", { cache: "no-store" });
+      if (!res.ok) return;
+      const json = (await res.json()) as {
+        npmBusy?: boolean;
+        npmBusyTarget?: string | null;
+        npmBusyLabel?: string | null;
+        npmJob?: InstallJobView;
+      };
+      const target = json.npmBusyTarget;
+      if (!json.npmBusy || !target || !isInstallTargetValue(target)) {
+        setNpmLane(null);
+        return;
+      }
+      setNpmLane({ target, label: json.npmBusyLabel ?? target });
+      if (json.npmJob?.status === "running") {
+        setInstallJobs((prev) => ({ ...prev, [target]: json.npmJob! }));
+      }
+    } catch {
+      /* Retain the last observed lane state until the next successful poll. */
+    }
+  }, []);
+
   useEffect(() => setPlatform(detectPlatform()), []);
 
   useEffect(() => {
@@ -448,12 +482,16 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     if (!open) return;
     void refresh();
     void loadHarnesses();
-    pollRef.current = setInterval(refresh, 2000);
+    void refreshNpmLane();
+    pollRef.current = setInterval(() => {
+      void refresh();
+      void refreshNpmLane();
+    }, 2000);
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       pollRef.current = null;
     };
-  }, [open, refresh, loadHarnesses]);
+  }, [open, refresh, loadHarnesses, refreshNpmLane]);
 
   // The harness probe races first paint: it loads once at open, so a slow or
   // failed first fetch left the runtime step's grid empty until a manual
@@ -572,7 +610,20 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         npmMissing?: boolean;
         hint?: string;
         error?: string;
+        npmBusy?: boolean;
+        npmBusyTarget?: string | null;
+        npmBusyLabel?: string | null;
       };
+      if (
+        json.npmBusy &&
+        json.npmBusyTarget &&
+        isInstallTargetValue(json.npmBusyTarget)
+      ) {
+        setNpmLane({
+          target: json.npmBusyTarget,
+          label: json.npmBusyLabel ?? json.npmBusyTarget,
+        });
+      }
       if (json.npmMissing) {
         setNodeHint(
           json.hint ??
@@ -640,7 +691,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     if (
       shouldQueueInstall({
         kind: INSTALL_TARGET_KIND[target],
-        npmBusy: anyNpmInstallRunning(installJobs),
+        npmBusy: npmLane !== null || anyNpmInstallRunning(installJobs),
         inFlight: installInFlightRef.current,
         queuedCount: installQueue.length,
       })
@@ -698,13 +749,13 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // Drain the npm queue one at a time as the lane frees up.
   useEffect(() => {
     const next = nextDrainTarget(installQueue, {
-      npmBusy: anyNpmInstallRunning(installJobs),
+      npmBusy: npmLane !== null || anyNpmInstallRunning(installJobs),
       inFlight: installInFlightRef.current,
     });
     if (next == null) return;
     setInstallQueue((q) => q.slice(1));
     void postInstall(next);
-  }, [installQueue, installJobs, postInstall]);
+  }, [installQueue, installJobs, npmLane, postInstall]);
 
   // Poll cadence is keyed on WHICH targets are running, not on the job map
   // itself — every poll stores a fresh view object, and keying on the map
@@ -1299,6 +1350,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             installResults={installResults}
                             tools={status?.tools ?? []}
                             nodeHint={nodeHint}
+                            npmBusy={
+                              npmLane !== null || anyNpmInstallRunning(installJobs)
+                            }
+                            npmBusyLabel={npmLane?.label ?? "another npm update"}
                             covenCodeInstalled={covenCodeInstalled}
                             covenCodeSkipped={covenCodeSkipped}
                             onSkipCovenCode={skipCovenCode}
@@ -1333,6 +1388,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             installJobs={installJobs}
                             installResults={installResults}
                             nodeHint={nodeHint}
+                            npmBusy={
+                              npmLane !== null || anyNpmInstallRunning(installJobs)
+                            }
+                            npmBusyLabel={npmLane?.label ?? "another npm update"}
                             harnessesStuck={
                               harnesses.length === 0 &&
                               harnessFailures >= HARNESS_RETRY_BUDGET
@@ -1656,6 +1715,8 @@ function StepCovenCli({
   installResults,
   tools,
   nodeHint,
+  npmBusy,
+  npmBusyLabel,
   covenCodeInstalled,
   covenCodeSkipped,
   onSkipCovenCode,
@@ -1667,6 +1728,8 @@ function StepCovenCli({
   installResults: Partial<Record<InstallTarget, InstallResult>>;
   tools: OpenCovenToolStatus[];
   nodeHint: string | null;
+  npmBusy: boolean;
+  npmBusyLabel: string;
   covenCodeInstalled: boolean;
   covenCodeSkipped: boolean;
   onSkipCovenCode: () => void;
@@ -1683,7 +1746,8 @@ function StepCovenCli({
   const actionTargets = openCovenToolActionTargets(tools);
   const manualInstallCommand = openCovenToolsInstallCommand(tools);
   const primaryActionLabel = openCovenToolsPrimaryActionLabel(tools);
-  const installBusy = busy || covenCodeJobRunning;
+  const ownInstallBusy = busy || covenCodeJobRunning;
+  const installBusy = ownInstallBusy || npmBusy;
   return (
     <div className="flex flex-col gap-3">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
@@ -1693,6 +1757,11 @@ function StepCovenCli({
         npm installs one after another so they never collide — or copy the
         matching command to run it yourself.
       </p>
+      {npmBusy && !ownInstallBusy ? (
+        <p role="status" className="text-[11px] text-[var(--text-muted)]">
+          {npmBusyLabel} is updating the shared global npm directory. Other npm updates are disabled until it finishes.
+        </p>
+      ) : null}
       <div className="flex flex-wrap items-center gap-2">
         <Button
           variant="primary"
@@ -1703,7 +1772,11 @@ function StepCovenCli({
           }}
           disabled={installBusy || actionTargets.length === 0}
         >
-          {installBusy ? "Installing…" : primaryActionLabel}
+          {ownInstallBusy
+            ? "Installing…"
+            : npmBusy
+              ? `Waiting for ${npmBusyLabel}`
+              : primaryActionLabel}
         </Button>
         {actionTargets.length > 0 ? (
           <span className="text-[11px] text-[var(--text-muted)]">
@@ -1725,6 +1798,7 @@ function StepCovenCli({
             {tools.map((tool) => {
               const toolJob = installJobs[tool.id];
               const toolBusy = toolJob?.status === "running";
+              const toolBlockedByNpm = npmBusy && !toolBusy;
               const needsAction = !tool.installed || tool.outdated || !tool.compatible;
               const result = installResults[tool.id];
               const isCovenCode = tool.id === "coven-code";
@@ -1767,8 +1841,8 @@ function StepCovenCli({
                         <button
                           type="button"
                           onClick={() => onInstall(tool.id)}
-                          disabled={toolBusy}
-                          aria-busy={toolBusy}
+                          disabled={toolBusy || toolBlockedByNpm}
+                          aria-busy={toolBusy || toolBlockedByNpm}
                           className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 py-1.5 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] disabled:opacity-50"
                         >
                           {toolBusy ? (
@@ -1778,6 +1852,8 @@ function StepCovenCli({
                           )}
                           {toolBusy && toolJob
                             ? `Installing… ${formatElapsed(toolJob.elapsedMs)}`
+                            : toolBlockedByNpm
+                              ? `Waiting for ${npmBusyLabel}`
                             : tool.outdated || !tool.compatible
                               ? "Update"
                               : "Install"}
@@ -1824,6 +1900,8 @@ function StepRuntimes({
   installJobs,
   installResults,
   nodeHint,
+  npmBusy,
+  npmBusyLabel,
   harnessesStuck,
   onInstall,
   onCopy,
@@ -1837,6 +1915,8 @@ function StepRuntimes({
   installJobs: Partial<Record<InstallTarget, InstallJobView>>;
   installResults: Partial<Record<InstallTarget, InstallResult>>;
   nodeHint: string | null;
+  npmBusy: boolean;
+  npmBusyLabel: string;
   harnessesStuck: boolean;
   onInstall: (target: InstallTarget) => void;
   onCopy: (text: string) => Promise<boolean>;
@@ -1845,9 +1925,14 @@ function StepRuntimes({
   codexPortPreflightBusy: boolean;
   onCodexPortPreflight: () => void;
 }) {
-  const npmJobRunning = anyNpmInstallRunning(installJobs);
+  const npmJobRunning = npmBusy || anyNpmInstallRunning(installJobs);
   return (
     <div className="flex flex-col gap-3">
+      {npmBusy ? (
+        <p role="status" className="text-[11px] text-[var(--text-muted)]">
+          {npmBusyLabel} is updating the shared global npm directory. Other npm updates are disabled until it finishes.
+        </p>
+      ) : null}
       {harnessesStuck ? (
         <div
           role="alert"

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -18,12 +18,17 @@ assert.doesNotMatch(
 );
 assert.match(src, /\/api\/opencoven-tools\/status/, "component fetches OpenCoven tool version status");
 assert.match(src, /\/api\/onboarding\/install/, "component reuses the allowlisted background installer");
+assert.match(src, /const refreshNpmLane = useCallback/, "About polls the server-owned global npm lane");
+assert.match(src, /\/api\/onboarding\/install", \{ cache: "no-store" \}/, "About queries the global installer lane without a target");
+assert.match(src, /Other npm updates are disabled until it finishes/, "About explains the shared npm lock before a second update can start");
+assert.match(src, /disabled=\{blockedByGlobalNpm\}/, "About disables a different tool's update button while npm is busy");
+assert.match(src, /Updating in another Cave window/, "About distinguishes a job reattached from another client surface");
 assert.match(src, /tool\.outdated/, "update buttons are gated to outdated tools");
 assert.match(src, /tool\.compatible/, "tool rows distinguish update availability from Cave compatibility");
 assert.match(src, /tool\.minimumVersion/, "tool rows expose the minimum compatible version");
 assert.match(src, /tool\.installCommand/, "tool rows expose a copyable install/update command");
 assert.match(src, /Copy command/, "tool rows can copy the exact update command");
-assert.match(src, /Update \{tool\.label\}/, "outdated tools expose a clear update button");
+assert.match(src, /`Update \$\{tool\.label\}`/, "outdated tools expose a clear update button");
 assert.match(src, /function toolVersionText\(tool: ToolStatus\): string/, "tool version text is centralized");
 assert.match(src, /if \(!tool\.current\) return "Installed, version unknown"/, "installed tools with unknown versions should say the version is unknown");
 assert.match(src, /function toolStatusText\(tool: ToolStatus\): string/, "tool status text is centralized");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -36,6 +36,11 @@ type InstallResult = {
   detail: string;
 };
 
+type NpmLaneState = {
+  target: string;
+  label: string;
+};
+
 const SIDECAR_TOKEN_STORAGE_KEY = "coven-cave:sidecar-auth-token";
 const TOOL_UPDATE_BANNER_ID = "opencoven-tools-update";
 const TOOL_DISMISS_KEY = (tools: ToolStatus[]) =>
@@ -196,7 +201,31 @@ export function OpenCovenToolsUpdate() {
   const [installResults, setInstallResults] = useState<
     Partial<Record<InstallTarget, InstallResult>>
   >({});
+  const [npmLane, setNpmLane] = useState<NpmLaneState | null>(null);
   const mounted = useRef(true);
+
+  const refreshNpmLane = useCallback(async () => {
+    try {
+      const res = await fetch("/api/onboarding/install", { cache: "no-store" });
+      if (!res.ok) return;
+      const json = (await res.json()) as {
+        npmBusy?: boolean;
+        npmBusyTarget?: string | null;
+        npmBusyLabel?: string | null;
+      };
+      if (!mounted.current) return;
+      setNpmLane(
+        json.npmBusy && json.npmBusyTarget
+          ? {
+              target: json.npmBusyTarget,
+              label: json.npmBusyLabel ?? json.npmBusyTarget,
+            }
+          : null,
+      );
+    } catch {
+      /* A later poll will reconcile the shared lane. */
+    }
+  }, []);
 
   const load = useCallback(async () => {
     setChecking(true);
@@ -226,10 +255,13 @@ export function OpenCovenToolsUpdate() {
   useEffect(() => {
     mounted.current = true;
     void load();
+    void refreshNpmLane();
+    const pollLane = setInterval(() => void refreshNpmLane(), 2000);
     return () => {
       mounted.current = false;
+      clearInterval(pollLane);
     };
-  }, [load]);
+  }, [load, refreshNpmLane]);
 
   const runningInstallKey = useMemo(
     () =>
@@ -311,7 +343,16 @@ export function OpenCovenToolsUpdate() {
         npmMissing?: boolean;
         hint?: string;
         error?: string;
+        npmBusy?: boolean;
+        npmBusyTarget?: string | null;
+        npmBusyLabel?: string | null;
       };
+      if (json.npmBusy && json.npmBusyTarget) {
+        setNpmLane({
+          target: json.npmBusyTarget,
+          label: json.npmBusyLabel ?? json.npmBusyTarget,
+        });
+      }
       if (!res.ok || json.npmMissing) {
         setInstallResults((prev) => ({
           ...prev,
@@ -399,9 +440,19 @@ export function OpenCovenToolsUpdate() {
 
   return (
     <>
+      {npmLane ? (
+        <p
+          role="status"
+          className="px-4 pt-3 text-[11px] text-[var(--text-secondary)]"
+        >
+          {npmLane.label} is updating the shared global npm directory. Other npm updates are disabled until it finishes.
+        </p>
+      ) : null}
       {tools.map((tool) => {
         const job = installJobs[tool.id];
         const busy = job?.status === "running";
+        const updatingElsewhere = !busy && npmLane?.target === tool.id;
+        const blockedByGlobalNpm = Boolean(npmLane && npmLane.target !== tool.id);
         const result = installResults[tool.id];
         return (
           <div key={tool.id} className="flex items-center justify-between gap-4 px-4 py-3">
@@ -436,22 +487,33 @@ export function OpenCovenToolsUpdate() {
                   <Icon name="ph:circle-notch-bold" className="animate-spin" width={12} />
                   Updating... {formatElapsed(job.elapsedMs)}
                 </span>
+              ) : updatingElsewhere ? (
+                <span className="inline-flex items-center gap-1.5 text-[12px] text-[var(--text-muted)]">
+                  <Icon name="ph:circle-notch-bold" className="animate-spin" width={12} />
+                  Updating in another Cave window
+                </span>
               ) : tool.outdated || toolNeedsCompatibilityUpdate(tool) ? (
                 <Button
                   variant="primary"
                   size="xs"
                   onClick={() => void updateTool(tool.id)}
+                  disabled={blockedByGlobalNpm}
+                  title={
+                    blockedByGlobalNpm
+                      ? `Wait for ${npmLane?.label} to finish updating npm.`
+                      : undefined
+                  }
                   className={accentBtn}
                   leadingIcon="ph:arrow-down-bold"
                 >
-                  Update {tool.label}
+                  {blockedByGlobalNpm ? `Waiting for ${npmLane?.label}` : `Update ${tool.label}`}
                 </Button>
               ) : (
                 <span className="text-[12px] text-[var(--text-muted)]">
                   {toolStatusText(tool)}
                 </span>
               )}
-              {!busy ? (
+              {!busy && !updatingElsewhere ? (
                 <Button
                   variant="secondary"
                   size="xs"

--- a/src/lib/server/global-npm-install-lane.test.ts
+++ b/src/lib/server/global-npm-install-lane.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  globalNpmInstallOwner,
+  resetGlobalNpmInstallLaneForTest,
+  reserveGlobalNpmInstall,
+} from "./global-npm-install-lane.ts";
+
+test("parallel Coven CLI and Coven Code requests start exactly one global npm child", async () => {
+  resetGlobalNpmInstallLaneForTest();
+  let childStarts = 0;
+  let releaseChild!: () => void;
+  const childFinished = new Promise<void>((resolve) => {
+    releaseChild = resolve;
+  });
+
+  const attemptStart = async (target: "coven-cli" | "coven-code") => {
+    // Matching the route's post-preparation point: both requests arrive here
+    // together, so the reservation itself must be the atomic boundary.
+    await Promise.resolve();
+    const reservation = reserveGlobalNpmInstall(target);
+    if (!reservation.ok) return reservation;
+    childStarts += 1;
+    await childFinished;
+    reservation.lease.release();
+    return reservation;
+  };
+
+  const first = attemptStart("coven-cli");
+  const second = attemptStart("coven-code");
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(childStarts, 1, "only one npm child starts for simultaneous targets");
+  assert.ok(globalNpmInstallOwner(), "the winning child owns the global lane");
+  releaseChild();
+  const results = await Promise.all([first, second]);
+  assert.equal(results.filter((result) => result.ok).length, 1);
+  assert.equal(globalNpmInstallOwner(), null, "completion releases the lane");
+});
+
+test("failure, timeout, and cancellation release the lease so a retry can start", () => {
+  resetGlobalNpmInstallLaneForTest();
+  for (const terminalState of ["failure", "timeout", "cancellation"] as const) {
+    const first = reserveGlobalNpmInstall("coven-cli");
+    assert.equal(first.ok, true, `${terminalState} test reserves the lane`);
+    if (!first.ok) continue;
+    first.lease.release();
+    assert.equal(globalNpmInstallOwner(), null, `${terminalState} releases the lane`);
+
+    const retry = reserveGlobalNpmInstall("coven-code");
+    assert.equal(retry.ok, true, `retry starts after ${terminalState}`);
+    if (retry.ok) retry.lease.release();
+  }
+});
+
+test("the global lease survives module reload and its original cleanup still releases it", async () => {
+  resetGlobalNpmInstallLaneForTest();
+  const first = reserveGlobalNpmInstall("coven-cli");
+  assert.equal(first.ok, true);
+  if (!first.ok) return;
+
+  const reloaded = await import(
+    `${new URL("./global-npm-install-lane.ts", import.meta.url).href}?hmr=${Date.now()}`
+  );
+  assert.equal(
+    reloaded.globalNpmInstallOwner(),
+    "coven-cli",
+    "a re-evaluated module sees the active lease",
+  );
+  first.lease.release();
+  assert.equal(reloaded.globalNpmInstallOwner(), null, "the old child cleanup releases it");
+});
+
+console.log("global-npm-install-lane.test.ts: ok");

--- a/src/lib/server/global-npm-install-lane.ts
+++ b/src/lib/server/global-npm-install-lane.ts
@@ -1,0 +1,66 @@
+/**
+ * Process-wide lease for global npm mutations.
+ *
+ * npm stores global packages, shims, and cache metadata under one prefix, so
+ * two unrelated `npm install -g` invocations can corrupt or lock the same
+ * tree. Keep this state on globalThis: Next's dev HMR can re-evaluate a module
+ * while a child process is active, but it must not forget the active lease.
+ */
+
+type GlobalNpmInstallLane = {
+  target: string | null;
+};
+
+type GlobalScope = typeof globalThis & {
+  __covenGlobalNpmInstallLane?: GlobalNpmInstallLane;
+};
+
+function lane(): GlobalNpmInstallLane {
+  const scope = globalThis as GlobalScope;
+  return (scope.__covenGlobalNpmInstallLane ??= { target: null });
+}
+
+export type NpmInstallLease = {
+  target: string;
+  release: () => void;
+};
+
+export type NpmInstallReservation =
+  | { ok: true; lease: NpmInstallLease }
+  | { ok: false; owner: string };
+
+/** Atomically reserve the one global npm lane, or identify its current owner. */
+export function reserveGlobalNpmInstall(target: string): NpmInstallReservation {
+  const current = lane();
+  if (current.target) return { ok: false, owner: current.target };
+  current.target = target;
+
+  let released = false;
+  return {
+    ok: true,
+    lease: {
+      target,
+      // A late child `error` after `close` must not clear a newer lease.
+      release: () => {
+        if (released) return;
+        released = true;
+        if (current.target === target) current.target = null;
+      },
+    },
+  };
+}
+
+export function globalNpmInstallOwner(): string | null {
+  return lane().target;
+}
+
+/** Clear a completed/stale owner without touching a newer lease. */
+export function releaseGlobalNpmInstall(target: string): void {
+  const current = lane();
+  if (current.target === target) current.target = null;
+}
+
+/** Test-only recovery for a process that has no active child to clean up. */
+export function resetGlobalNpmInstallLaneForTest(): void {
+  lane().target = null;
+}


### PR DESCRIPTION
## What changed

- Reserve a process-wide global npm lane after asynchronous installer preparation, so only one `npm install -g` can start across all allowlisted npm targets.
- Return a retryable, specific `409` response for a competing request; script installers remain independent.
- Expose the global lane through the install API and make onboarding and Settings disable/describe other npm updates while it is busy.
- Add cancellation and lifecycle cleanup so errors, timeouts, polling, and HMR/module reloads cannot strand the lane.

## Why

The pre-check occurred before `spawnPlanFor`, while the post-await check only covered the same target. Concurrent Coven CLI and Coven Code requests could therefore both spawn npm against the same global prefix.

## Validation

- `pnpm typecheck`
- Global npm lane concurrency/lifecycle tests, installer-route tests, and onboarding/Settings UI behavior tests
- `pnpm check:tests-wired`
- `pnpm exec next build`
- `pnpm build:server`
- `pnpm test:bundle`

Full suites were attempted. `pnpm test:api` is blocked by the host's missing WSL `/bin/bash`; `pnpm test:app` is blocked by a missing `python3` executable in this Windows environment.