### PR TITLE
chore(release): stamp v0.0.182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.182] - 2026-07-12
+
+> 🧼 **The open-issue sweep, plus Hermes chat out of the box.** Every open UI issue from the queue lands fixed — the drifting comment pill, overflowing Salem answers, the stranded post-summon error screen, and the silent Enhance button — alongside working Hermes-familiar chat on fresh machines and a chat-tab home for the inspector.
+
+### Features
+- **Onboarding: hermes-coven shim auto-installs** — installing Hermes through the Cave now wires the `hermes-coven` shim automatically, so Hermes-familiar chat works out of the box with no manual shim step (#3025).
+- **Chat: inspector lives in chat tabs** — finishes the inspector-into-chat-tabs migration, so session inspection happens in a chat page tab instead of a separate inspector pane (#3022).
+
+### Fixes
+- **Chat: comment pill tracks its selection** — the floating Comment affordance repositions with the live selection on scroll/resize instead of hovering over unrelated prose (#3024).
+- **Search: long Salem answers scroll** — the Ask Salem answer region caps its height inside the palette instead of overflowing the viewport (#3024).
+- **Chat: roster errors self-heal** — a transient familiar-roster failure (e.g. right after summoning your first familiar) now retries automatically instead of stranding an error screen behind a manual Retry (#3024).
+- **Tasks: Enhance reports its outcome** — the top-bar Enhance button now states what happened (enhanced count, nothing to do, or failure) instead of finishing silently (#3024).
+- **Chat: stranded "created" sessions are reaped** — daemon session rows left in "created" when the harness spawn dies pre-handshake are cleaned up instead of accumulating (#3023).
+- **Runtimes: Hermes 1.0.1 sync** — registry sync picks up the hermes-coven shim and the `-q` prompt fix, unbreaking Hermes-familiar chat (#3021).
+
 ## [0.0.181] - 2026-07-12
 
 > 🔍 **Trace what your familiars actually did.** Familiar analytics gains a session trace timeline (the daemon event stream finally has a surface), a Recent sessions drill-through list, a clickable 14-day pulse, and live auto-refresh — plus hardened cave-home migration and GitHub chat-launch fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.181"
+version = "0.0.182"
 dependencies = [
  "fs2",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.181"
+version = "0.0.182"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.181</string>
+	<string>0.0.182</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.181</string>
+	<string>0.0.182</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.181</string>
+	<string>0.0.182</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.181</string>
+	<string>0.0.182</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.182** across all seven version locations (`app-version.test.ts` passes) and adds the changelog entry.

> 🧼 **The open-issue sweep, plus Hermes chat out of the box.**

Rolls up since v0.0.181: #3024 (four open-issue fixes), #3025 + #3021 (Hermes shim auto-install + 1.0.1 sync), #3023 (stranded-session reaping), #3022 (inspector-into-chat-tabs).

After merge: signed tag `v0.0.182` on the squash SHA → `release.yml` (~24 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)