### PR TITLE
feat(inbox): manageable, dynamic notifications — read/unread, bulk actions, kind muting (cave-uu2d)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -62,6 +62,7 @@ export const SUITES = {
     "src/lib/familiar-roster-guard.test.ts",
     "src/lib/cave-projects.test.ts",
     "src/lib/cave-inbox-prefs.test.ts",
+    "src/lib/cave-inbox-bulk.test.ts",
     "src/lib/project-permissions.test.ts",
     "src/lib/project-icon-prompt.test.ts",
     "src/lib/project-icon-image-provider.test.ts",
@@ -899,6 +900,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/cave-inbox-bulk.test.ts",
   "src/app/api/prompts/route.test.ts",
   "src/app/api/marketplace/pack-prompts-route.test.ts",
   "src/lib/cave-backdrop.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -96,6 +96,7 @@ const contracts: RouteContract[] = [
   { route: "/inbox/[id]/done", methods: ["POST"], kind: "json", localOriginGuard: true },
   { route: "/inbox/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/inbox/[id]/snooze", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/inbox/bulk", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/inbox/daily-summary", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty", localOriginGuard: true },
   { route: "/inbox/prefs", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/inbox", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },

--- a/src/app/api/inbox/bulk/route.ts
+++ b/src/app/api/inbox/bulk/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { isLocalOrigin } from "@/lib/server/local-origin";
+import { applyBulkAction, type BulkAction } from "@/lib/cave-inbox";
+import {
+  broadcastDeleted,
+  broadcastUpdated,
+  startScheduler,
+} from "@/lib/inbox-scheduler";
+
+export const dynamic = "force-dynamic";
+
+startScheduler();
+
+const ACTIONS: readonly BulkAction[] = ["read", "unread", "dismiss", "done", "delete"];
+
+// `all: true` may only sweep the non-destructive notification stack — done and
+// delete change what exists, so they must name their targets.
+const ALL_ALLOWED: readonly BulkAction[] = ["read", "unread", "dismiss"];
+
+export async function POST(req: Request) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
+  }
+  let body: { action?: string; ids?: unknown; all?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  const action = body.action as BulkAction | undefined;
+  if (!action || !ACTIONS.includes(action)) {
+    return NextResponse.json(
+      { ok: false, error: `action must be one of: ${ACTIONS.join(", ")}` },
+      { status: 400 },
+    );
+  }
+  const ids = Array.isArray(body.ids)
+    ? body.ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+    : null;
+  if (!ids && body.all !== true) {
+    return NextResponse.json(
+      { ok: false, error: "ids array or all:true required" },
+      { status: 400 },
+    );
+  }
+  if (!ids && !ALL_ALLOWED.includes(action)) {
+    return NextResponse.json(
+      { ok: false, error: `all:true is not allowed for ${action} — pass explicit ids` },
+      { status: 400 },
+    );
+  }
+
+  const result = await applyBulkAction(action, ids);
+  // Reuse the existing per-item SSE events — every connected client already
+  // reconciles updated/deleted, so bulk needs no new event type.
+  for (const item of result.updated) broadcastUpdated(item);
+  for (const id of result.deletedIds) broadcastDeleted(id);
+  return NextResponse.json({
+    ok: true,
+    updated: result.updated,
+    deletedIds: result.deletedIds,
+  });
+}

--- a/src/app/api/inbox/prefs/route.ts
+++ b/src/app/api/inbox/prefs/route.ts
@@ -2,8 +2,11 @@ import { NextResponse } from "next/server";
 import { isLocalOrigin } from "@/lib/server/local-origin";
 import {
   loadPrefs,
+  MUTABLE_KINDS,
   patchPrefs,
   toggleMute,
+  toggleMuteKind,
+  type MutableKind,
   type SoundMode,
 } from "@/lib/cave-inbox-prefs";
 
@@ -20,8 +23,10 @@ export async function PATCH(req: Request) {
   }
   let body: {
     mutedFamiliars?: string[];
+    mutedKinds?: MutableKind[];
     sound?: { mode?: SoundMode; name?: string };
     toggleMuteFor?: string;
+    toggleMuteKind?: string;
   };
   try {
     body = await req.json();
@@ -32,12 +37,23 @@ export async function PATCH(req: Request) {
     const prefs = await toggleMute(body.toggleMuteFor);
     return NextResponse.json({ ok: true, prefs });
   }
+  if (body.toggleMuteKind) {
+    if (!(MUTABLE_KINDS as readonly string[]).includes(body.toggleMuteKind)) {
+      return NextResponse.json(
+        { ok: false, error: `kind must be one of: ${MUTABLE_KINDS.join(", ")}` },
+        { status: 400 },
+      );
+    }
+    const prefs = await toggleMuteKind(body.toggleMuteKind as MutableKind);
+    return NextResponse.json({ ok: true, prefs });
+  }
   const sound =
     body.sound && body.sound.mode
       ? { mode: body.sound.mode, name: body.sound.name }
       : undefined;
   const prefs = await patchPrefs({
     mutedFamiliars: body.mutedFamiliars,
+    mutedKinds: body.mutedKinds,
     sound,
   });
   return NextResponse.json({ ok: true, prefs });

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -22,6 +22,13 @@ export type Toast = {
 type Props = {
   toasts: Toast[];
   onDismiss: (id: string) => void;
+  /**
+   * Auto-hide timeout. Distinct from onDismiss (the explicit ✕): expiry means
+   * the user may never have seen the toast, so the caller must NOT resolve or
+   * acknowledge the underlying item — it stays unread in the bell. Falls back
+   * to onDismiss when absent.
+   */
+  onExpire?: (id: string) => void;
   onSnooze: (toast: Toast, untilIso: string) => void;
   onOpen?: (toast: Toast) => void;
 };
@@ -38,7 +45,7 @@ const KIND_ACCENT: Record<NonNullable<Toast["kind"]>, string> = {
   reminder: "var(--color-warning)",
 };
 
-export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) {
+export function InboxToastStack({ toasts, onDismiss, onExpire, onSnooze, onOpen }: Props) {
   // Hover or focus anywhere inside a toast pauses its auto-hide (WCAG 2.2.1) —
   // content stopped vanishing mid-read. Unpausing re-arms the full window,
   // the generous simple option (no per-toast remaining-time bookkeeping).
@@ -54,11 +61,12 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
 
   useEffect(() => {
     if (toasts.length === 0) return;
+    const expire = onExpire ?? onDismiss;
     const timers = toasts
       .filter((t) => !pausedIds.has(t.id))
-      .map((t) => setTimeout(() => onDismiss(t.id), AUTO_DISMISS_MS));
+      .map((t) => setTimeout(() => expire(t.id), AUTO_DISMISS_MS));
     return () => timers.forEach(clearTimeout);
-  }, [toasts, pausedIds, onDismiss]);
+  }, [toasts, pausedIds, onDismiss, onExpire]);
 
   if (toasts.length === 0) return null;
 

--- a/src/components/notification-bell-mutations.test.ts
+++ b/src/components/notification-bell-mutations.test.ts
@@ -2,7 +2,9 @@
 // Notification bell mutations must not silently no-op on network failure
 // (cave-qhz3): every fetch is fire-and-forget with SSE reconcile as the only
 // feedback, so a failed request needs res.ok verification and an assertive
-// announcement — and clear-all must not abandon the fan-out on one rejection.
+// announcement. Bulk actions (clear-all, mark-all-read) go through ONE
+// /api/inbox/bulk POST — a single file write + broadcast server-side — not a
+// per-item fan-out racing its own SSE reconciles (cave-uu2d).
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -23,9 +25,13 @@ assert.match(
 // Each mutation goes through the guard — no bare fire-and-forget fetch remains.
 for (const [name, message] of [
   ["toggleMute", "Mute change failed"],
+  ["toggleKindMute", "Mute change failed"],
   ["setSound", "Sound change failed"],
   ["dismiss", "Dismiss failed"],
   ["snooze", "Snooze failed"],
+  ["markRead", "Mark read failed"],
+  ["markAllRead", "Mark all read failed"],
+  ["dismissAll", "Notifications could not be dismissed"],
 ]) {
   assert.match(
     src,
@@ -41,21 +47,38 @@ assert.match(
   "prefs refresh only fires after the server accepted the change",
 );
 
-// Clear-all: one failed dismiss must not reject the whole fan-out.
+// Bulk actions are single atomic POSTs to /api/inbox/bulk — the old
+// per-item fan-out (N fetches, N file rewrites, N broadcasts) must not return.
 assert.match(
   src,
-  /Promise\.allSettled\(\s*\n\s*dismissableIds\.map/,
-  "clear-all uses allSettled so one failure doesn't abandon the rest",
+  /const dismissAll = useCallback\([\s\S]*?"\/api\/inbox\/bulk"[\s\S]*?action: "dismiss", all: true/,
+  "clear-all is one atomic bulk dismiss",
 );
 assert.match(
   src,
-  /could not be dismissed — check your connection\./,
-  "clear-all reports how many dismissals failed",
+  /const markAllRead = useCallback\([\s\S]*?"\/api\/inbox\/bulk"[\s\S]*?action: "read", all: true/,
+  "mark-all-read is one atomic bulk read",
 );
 assert.doesNotMatch(
   src,
-  /await Promise\.all\(\s*\n\s*dismissableIds/,
-  "the all-or-nothing Promise.all fan-out must not return",
+  /Promise\.allSettled|Promise\.all\(/,
+  "no per-item fan-out remains in the bell",
+);
+
+// Ephemeral response-needed rows (eph:*) are client-synthesized — there is
+// nothing to mark read server-side, so markRead must skip them.
+assert.match(
+  src,
+  /const markRead = useCallback\(\s*\n\s*async \(id: string\) => \{\s*\n\s*if \(id\.startsWith\("eph:"\)\) return;/,
+  "markRead skips ephemeral response-needed rows",
+);
+
+// The badge counts unread from the SAME items the list shows (one shared
+// definition) — never a separately polled count that can disagree.
+assert.match(
+  src,
+  /const derivedBadgeCount = useMemo\(\(\) => unreadInboxCount\(items\), \[items\]\)/,
+  "bell badge derives from unreadInboxCount over the listed items",
 );
 
 console.log("notification-bell-mutations.test.ts: ok");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -4,9 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useDateTimePrefs } from "@/lib/datetime-format";
-import type { InboxItem } from "@/lib/cave-inbox";
+import type { InboxItem, ItemKind } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
-import type { InboxPrefs, SoundMode } from "@/lib/cave-inbox-prefs";
+import { MUTABLE_KINDS, type InboxPrefs, type MutableKind, type SoundMode } from "@/lib/inbox-prefs-shape";
+import { isInboxItemUnread, unreadInboxCount } from "@/lib/inbox-feed";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -19,6 +20,21 @@ type Props = {
   onOpenInbox: () => void;
   onOpenItem?: (item: InboxItem) => void;
   onPrefsChanged: () => void;
+};
+
+type KindFilter = "all" | ItemKind;
+
+const KIND_FILTERS: { kind: ItemKind; label: string }[] = [
+  { kind: "response-needed", label: "Waiting" },
+  { kind: "reminder", label: "Reminders" },
+  { kind: "agent", label: "Familiars" },
+  { kind: "daily-summary", label: "Reports" },
+];
+
+const MUTABLE_KIND_LABELS: Record<MutableKind, string> = {
+  reminder: "Reminders",
+  agent: "Familiar activity",
+  "daily-summary": "Daily reports",
 };
 
 // Live per-row timestamp: ticks each minute so a popover left open doesn't
@@ -45,6 +61,7 @@ export function NotificationBell({
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [open, setOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [kindFilter, setKindFilter] = useState<KindFilter>("all");
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const { announce } = useAnnouncer();
@@ -94,6 +111,22 @@ export function NotificationBell({
     [mutate, onPrefsChanged],
   );
 
+  const toggleKindMute = useCallback(
+    async (kind: MutableKind) => {
+      const ok = await mutate(
+        () =>
+          fetch("/api/inbox/prefs", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ toggleMuteKind: kind }),
+          }),
+        "Mute change failed — check your connection.",
+      );
+      if (ok) onPrefsChanged();
+    },
+    [mutate, onPrefsChanged],
+  );
+
   const setSound = useCallback(
     async (mode: SoundMode, name?: string) => {
       const ok = await mutate(
@@ -111,8 +144,9 @@ export function NotificationBell({
   );
 
   // Items shown in the dropdown: most-recent fired + the loudest pending alerts
-  // (response-needed bridge first). Cap to 10.
-  const recent = useMemo(() => {
+  // (response-needed bridge first), narrowed by the active kind chip. Cap to 30
+  // (the list scrolls; the old cap of 10 hid older notifications entirely).
+  const feed = useMemo(() => {
     const firedSorted = items
       .filter((i) => i.status === "fired")
       .sort((a, b) =>
@@ -121,17 +155,62 @@ export function NotificationBell({
     const ephemeral = items.filter(
       (i) => i.status === "pending" && i.kind === "response-needed",
     );
-    return [...ephemeral, ...firedSorted].slice(0, 10);
+    return [...ephemeral, ...firedSorted];
   }, [items]);
 
-  const derivedBadgeCount = useMemo(() => {
-    return items.filter(
-      (i) =>
-        i.status === "fired" ||
-        (i.status === "pending" && i.kind === "response-needed"),
-    ).length;
-  }, [items]);
+  const recent = useMemo(
+    () =>
+      (kindFilter === "all" ? feed : feed.filter((i) => i.kind === kindFilter)).slice(0, 30),
+    [feed, kindFilter],
+  );
+
+  // Only offer chips for kinds that actually have notifications — an empty
+  // filter is a dead end, not a management tool.
+  const kindChips = useMemo(
+    () => KIND_FILTERS.filter(({ kind }) => feed.some((i) => i.kind === kind)),
+    [feed],
+  );
+
+  // Badge and list share one unread definition (unreadInboxCount) so they can
+  // never disagree the way the old escalations-poll badge did.
+  const derivedBadgeCount = useMemo(() => unreadInboxCount(items), [items]);
   const displayBadgeCount = badgeCount ?? derivedBadgeCount;
+
+  const unreadIds = useMemo(
+    () => items.filter(isInboxItemUnread).map((i) => i.id),
+    [items],
+  );
+
+  // Acknowledge without resolving: reading quiets the badge, the item stays
+  // listed until dismissed/done. Ephemeral response-needed rows (eph:*) are
+  // client-synthesized and have nothing to mark server-side.
+  const markRead = useCallback(
+    async (id: string) => {
+      if (id.startsWith("eph:")) return;
+      await mutate(
+        () =>
+          fetch("/api/inbox/bulk", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ action: "read", ids: [id] }),
+          }),
+        "Mark read failed — check your connection.",
+      );
+    },
+    [mutate],
+  );
+
+  const markAllRead = useCallback(async () => {
+    await mutate(
+      () =>
+        fetch("/api/inbox/bulk", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "read", all: true }),
+        }),
+      "Mark all read failed — check your connection.",
+    );
+  }, [mutate]);
 
   // Close on outside click.
   useEffect(() => {
@@ -153,31 +232,26 @@ export function NotificationBell({
     [mutate],
   );
 
-  // Fired notifications are the dismissible stack the badge counts; response-
-  // needed bridges aren't dismissed here (they need a reply, not a clear).
+  // Fired notifications are the dismissible stack; response-needed bridges
+  // aren't dismissed here (they need a reply, not a clear).
   const dismissableIds = useMemo(
     () => items.filter((i) => i.status === "fired").map((i) => i.id),
     [items],
   );
 
   const dismissAll = useCallback(async () => {
-    // Fan out the existing per-item dismiss; the inbox SSE reconciles the list
-    // and badge (same path the single ✕ uses). allSettled so one failure
-    // doesn't abandon the rest of the stack; report the stragglers once.
-    const results = await Promise.allSettled(
-      dismissableIds.map(async (id) => {
-        const res = await fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
-        if (!res.ok) throw new Error(String(res.status));
-      }),
+    // One atomic bulk dismiss (single file write + broadcast server-side) —
+    // replaces the old N-fetch fan-out that raced its own SSE reconciles.
+    await mutate(
+      () =>
+        fetch("/api/inbox/bulk", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "dismiss", all: true }),
+        }),
+      "Notifications could not be dismissed — check your connection.",
     );
-    const failed = results.filter((r) => r.status === "rejected").length;
-    if (failed > 0) {
-      announce(
-        `${failed} of ${results.length} notifications could not be dismissed — check your connection.`,
-        "assertive",
-      );
-    }
-  }, [dismissableIds, announce]);
+  }, [mutate]);
 
   const snooze = useCallback(
     async (id: string) => {
@@ -241,6 +315,15 @@ export function NotificationBell({
               >
                 <Icon name="ph:gear-six-bold" aria-hidden />
               </button>
+              {unreadIds.length > 0 ? (
+                <button
+                  onClick={() => void markAllRead()}
+                  className="notification-bell__mark-all-read focus-ring rounded text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+                  title={`Mark all ${unreadIds.length} unread notification${unreadIds.length !== 1 ? "s" : ""} as read`}
+                >
+                  Mark read
+                </button>
+              ) : null}
               {dismissableIds.length > 0 ? (
                 <button
                   onClick={() => void dismissAll()}
@@ -301,6 +384,34 @@ export function NotificationBell({
               </div>
 
               <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+                Quiet kinds
+              </div>
+              <div className="mb-3 flex flex-wrap gap-1">
+                {MUTABLE_KINDS.map((kind) => {
+                  const muted = prefs.mutedKinds.includes(kind);
+                  return (
+                    <button
+                      key={kind}
+                      onClick={() => void toggleKindMute(kind)}
+                      aria-pressed={muted}
+                      title={
+                        muted
+                          ? `${MUTABLE_KIND_LABELS[kind]} are quiet — no toast or sound. Click to unmute.`
+                          : `Quiet ${MUTABLE_KIND_LABELS[kind].toLowerCase()} — they still land in the inbox, without toast or sound.`
+                      }
+                      className={`focus-ring rounded border px-2 py-0.5 text-[10px] transition-colors ${
+                        muted
+                          ? "border-[color-mix(in_oklch,var(--color-warning)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_14%,transparent)] text-[var(--color-warning)]"
+                          : "border-[var(--border-strong)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                      }`}
+                    >
+                      {MUTABLE_KIND_LABELS[kind]}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="mb-1.5 text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
                 Muted familiars
               </div>
               <ul className="max-h-32 space-y-0.5 overflow-y-auto">
@@ -330,19 +441,51 @@ export function NotificationBell({
               </ul>
             </div>
           ) : null}
+          {kindChips.length > 1 ? (
+            <div
+              role="group"
+              aria-label="Filter notifications by kind"
+              className="notification-bell__filters flex flex-wrap gap-1 border-b border-[var(--border-hairline)] px-3 py-2"
+            >
+              {[{ kind: "all" as const, label: "All" }, ...kindChips].map(({ kind, label }) => {
+                const active = kindFilter === kind;
+                const count =
+                  kind === "all" ? feed.length : feed.filter((i) => i.kind === kind).length;
+                return (
+                  <button
+                    key={kind}
+                    onClick={() => setKindFilter(kind)}
+                    aria-pressed={active}
+                    className={`focus-ring rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
+                      active
+                        ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] text-[var(--text-primary)]"
+                        : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                    }`}
+                  >
+                    {label} <span aria-hidden className="opacity-60">{count}</span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
           <ul className="notification-bell__list max-h-[420px] overflow-y-auto p-2 text-xs">
             {recent.length === 0 ? (
               <li className="px-2 py-6 text-center text-[11px] text-[var(--text-muted)]">
-                No notifications.
+                {kindFilter === "all" ? "No notifications." : "Nothing in this filter."}
               </li>
             ) : null}
             {recent.map((it) => {
               const fname = it.familiarId ? familiarName(it.familiarId) : null;
               const muted = it.familiarId ? prefs.mutedFamiliars.includes(it.familiarId) : false;
+              const unread = isInboxItemUnread(it);
               return (
                 <li
                   key={it.id}
-                  className="mb-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 p-2.5"
+                  className={`mb-1 rounded-md border p-2.5 ${
+                    unread
+                      ? "border-[color-mix(in_oklch,var(--accent-presence)_30%,var(--border-hairline))] bg-[var(--bg-raised)]/70"
+                      : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/40"
+                  }`}
                 >
                   <div className="flex items-start gap-2.5">
                     <Icon
@@ -360,7 +503,18 @@ export function NotificationBell({
                       height="0.95rem"
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-[12px] font-medium text-[var(--text-primary)]" title={it.title}>{it.title}</div>
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        {unread ? (
+                          <>
+                            <span
+                              aria-hidden
+                              className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--accent-presence)]"
+                            />
+                            <span className="sr-only">Unread:</span>
+                          </>
+                        ) : null}
+                        <div className="truncate text-[12px] font-medium text-[var(--text-primary)]" title={it.title}>{it.title}</div>
+                      </div>
                       {it.body ? (
                         <div className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-[var(--text-muted)]">
                           {it.body}
@@ -392,11 +546,22 @@ export function NotificationBell({
                       <BellBtn
                         primary
                         onClick={() => {
+                          // Opening acknowledges: quiet the badge without
+                          // resolving the item.
+                          if (unread) void markRead(it.id);
                           setOpen(false);
                           onOpenItem(it);
                         }}
                       >
                         Open
+                      </BellBtn>
+                    ) : null}
+                    {unread && it.kind !== "response-needed" ? (
+                      <BellBtn
+                        onClick={() => void markRead(it.id)}
+                        title="Mark as read — keeps the notification, quiets the badge"
+                      >
+                        Read
                       </BellBtn>
                     ) : null}
                     {it.kind !== "response-needed" ? (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { stampFirstOpenOnce } from "@/lib/first-run-stamps";
-import { groupInboxFeed } from "@/lib/inbox-feed";
+import { groupInboxFeed, unreadInboxCount } from "@/lib/inbox-feed";
 import { sameSessionList } from "@/lib/session-list-equal";
 import { invalidateConversation } from "@/lib/conversation-cache";
 import { arrayContentEqual } from "@/lib/array-content-equal";
@@ -447,6 +447,7 @@ export function Workspace() {
   const [inboxPrefs, setInboxPrefs] = useState<InboxPrefs>({
     version: 1,
     mutedFamiliars: [],
+    mutedKinds: [],
     sound: { mode: "default" },
   });
   const [reminderModalOpen, setReminderModalOpen] = useState(false);
@@ -997,9 +998,12 @@ export function Workspace() {
   // macOS system notifications. EventSource auto-reconnects on its own.
   useEffect(() => {
     const es = new EventSource("/api/inbox/stream");
+    // Quiet delivery, not suppression: muted items still land in the inbox and
+    // bell — they just skip the toast/native-notification/sound moment.
     const isMuted = (item: InboxItem) =>
-      !!item.familiarId &&
-      inboxPrefsRef.current.mutedFamiliars.includes(item.familiarId);
+      (!!item.familiarId &&
+        inboxPrefsRef.current.mutedFamiliars.includes(item.familiarId)) ||
+      (inboxPrefsRef.current.mutedKinds as readonly string[]).includes(item.kind);
     const sound = () => {
       const s = inboxPrefsRef.current.sound;
       if (s.mode === "silent") return null;
@@ -1511,13 +1515,32 @@ export function Workspace() {
     openReminderModal();
   }, [openReminderModal]);
 
+  // Acknowledge a real inbox item: stamps readAt so the bell badge quiets, but
+  // the notification stays listed until dismissed/done. No-ops server-side on
+  // already-read items, so callers don't need to check. Skips synthetic ids
+  // (missed-batches, ephemeral response-needed rows, ad-hoc toasts).
+  const markInboxItemRead = useCallback((id: string | null | undefined) => {
+    if (!id || id.startsWith("missed-") || id.startsWith("eph:")) return;
+    void fetch("/api/inbox/bulk", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "read", ids: [id] }),
+    });
+  }, []);
+
+  // Explicit ✕ on a toast = "seen it" — mark read, keep it in the bell. The
+  // old handler POSTed /dismiss, which RESOLVED the item; combined with the
+  // auto-hide timer routing through the same handler, every notification that
+  // fired while you were present silently destroyed itself after 8 seconds.
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
-    // Persist dismissal for real items. Skip synthetic ids (missed-batches,
-    // ephemeral response-needed rows).
-    if (!id.startsWith("missed-") && !id.startsWith("eph:")) {
-      void fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
-    }
+    markInboxItemRead(id);
+  }, [markInboxItemRead]);
+
+  // Auto-hide expiry: the user may never have seen the toast — remove the
+  // visual only, leave the item unread so the bell still carries it.
+  const expireToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
   const snoozeToast = useCallback((toast: Toast, untilIso: string) => {
@@ -1612,6 +1635,7 @@ export function Workspace() {
   }, [nextRouter, openFamiliarSession, openUrlInAppBrowser]);
 
   const openInspectorInboxItem = useCallback((item: InboxItem) => {
+    markInboxItemRead(item.id);
     const sessionId =
       item.sessionId ?? (item.link?.kind === "session" ? item.link.ref : null);
     if (sessionId) {
@@ -1620,7 +1644,7 @@ export function Workspace() {
     }
     if (item.familiarId) setActiveId(item.familiarId);
     setMode("inbox");
-  }, [openFamiliarSession]);
+  }, [openFamiliarSession, markInboxItemRead]);
 
   const startFamiliarChat = useCallback((
     familiarId?: string | null,
@@ -1832,6 +1856,7 @@ export function Workspace() {
 
   const openToastTarget = useCallback((toast: Toast) => {
     setToasts((prev) => prev.filter((t) => t.id !== toast.id));
+    markInboxItemRead(toast.itemId);
     if (toast.link) {
       openReminderLink(toast.link);
     } else if (toast.sessionId) {
@@ -1839,7 +1864,7 @@ export function Workspace() {
     } else {
       setMode("inbox");
     }
-  }, [openFamiliarSession, openReminderLink]);
+  }, [openFamiliarSession, openReminderLink, markInboxItemRead]);
 
   // Open a page in the split beside the current surface (drag-to-split drop).
   const openSplitPage = useCallback(
@@ -2166,6 +2191,15 @@ export function Workspace() {
   // count as needing attention; resolved/dismissed do not.
   const inboxBadgeCount = escalationsUnresolved;
 
+  // The notification bell counts UNREAD notifications from the same items it
+  // lists (one definition, unreadInboxCount) — it used to show the polled
+  // escalations count above a list of inbox items, so badge and list routinely
+  // disagreed. Live via SSE, quieted by Mark read / opening items.
+  const notificationUnreadCount = useMemo(
+    () => unreadInboxCount(inboxItemsWithEphemeral),
+    [inboxItemsWithEphemeral],
+  );
+
   // Role Surfaces: build the shared context from the live session and resolve
   // which registered surfaces the active familiar should see. Entirely
   // registry-driven — the shell never branches on a specific role.
@@ -2276,9 +2310,10 @@ export function Workspace() {
       selectedFamiliarIds={scopeIds}
       onFamiliarScopeChange={selectFamiliarScope}
       responseNeeded={responseNeeded}
-      notificationBadgeCount={inboxBadgeCount}
+      notificationBadgeCount={notificationUnreadCount}
       onOpenInbox={() => setMode("inbox")}
       onOpenInboxItem={(item) => {
+        markInboxItemRead(item.id);
         if (item.sessionId) {
           openFamiliarSession(item.sessionId, item.familiarId);
         } else {
@@ -2632,8 +2667,9 @@ export function Workspace() {
               responseNeeded={responseNeeded}
               familiarSwitcherLabeled={mode === "chat"}
               inboxPrefs={inboxPrefs}
-              inboxBadgeCount={inboxBadgeCount}
+              inboxBadgeCount={notificationUnreadCount}
               onOpenInboxItem={(item) => {
+                markInboxItemRead(item.id);
                 if (item.sessionId) openFamiliarSession(item.sessionId, item.familiarId);
                 else setMode("inbox");
               }}
@@ -2722,6 +2758,7 @@ export function Workspace() {
       <InboxToastStack
         toasts={toasts}
         onDismiss={dismissToast}
+        onExpire={expireToast}
         onSnooze={snoozeToast}
         onOpen={openToastTarget}
       />

--- a/src/lib/cave-inbox-bulk.test.ts
+++ b/src/lib/cave-inbox-bulk.test.ts
@@ -1,0 +1,86 @@
+// @ts-nocheck
+// Behavioral test for the inbox bulk-action helper (cave-uu2d): one locked
+// load→save cycle applies read/unread/dismiss/done/delete to many items —
+// the manageability layer behind /api/inbox/bulk. Runs against a throwaway
+// COVEN_CAVE_HOME so the real ~/.coven/cave/inbox.json is never touched.
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpHome = mkdtempSync(path.join(os.tmpdir(), "cave-inbox-bulk-"));
+process.env.COVEN_CAVE_HOME = tmpHome;
+
+// Import AFTER the env override — INBOX_PATH is computed at module load.
+const { applyBulkAction, createItem, loadInbox } = await import("./cave-inbox.ts");
+
+try {
+  // Agent items with no fireAt land fired immediately — the incoming stack.
+  const a = await createItem({ kind: "agent", title: "a", source: "agent" });
+  const b = await createItem({ kind: "agent", title: "b", source: "agent" });
+  const c = await createItem({ kind: "agent", title: "c", source: "agent" });
+  // A scheduled reminder stays pending — bulk `all` sweeps must not touch it.
+  const pending = await createItem({
+    kind: "reminder",
+    title: "later",
+    fireAt: "2999-01-01T00:00:00.000Z",
+  });
+  assert.equal(a.status, "fired");
+  assert.equal(a.readAt, null, "new items start unread");
+
+  // ── read all: stamps every unread fired item, leaves pending alone ────────
+  let res = await applyBulkAction("read", null);
+  assert.deepEqual(res.updated.map((i) => i.id).sort(), [a.id, b.id, c.id].sort());
+  assert.ok(res.updated.every((i) => typeof i.readAt === "string"));
+  {
+    const file = await loadInbox();
+    const p = file.items.find((i) => i.id === pending.id);
+    assert.equal(p.readAt, null, "pending reminder untouched by read-all");
+  }
+
+  // ── idempotent: a second read-all finds nothing to do ─────────────────────
+  res = await applyBulkAction("read", null);
+  assert.equal(res.updated.length, 0, "already-read items are skipped");
+
+  // ── unread by explicit ids ────────────────────────────────────────────────
+  res = await applyBulkAction("unread", [a.id]);
+  assert.equal(res.updated.length, 1);
+  assert.equal(res.updated[0].readAt, null);
+
+  // ── dismiss all: terminal state implies seen (readAt backfilled) ──────────
+  res = await applyBulkAction("dismiss", null);
+  assert.deepEqual(res.updated.map((i) => i.id).sort(), [a.id, b.id, c.id].sort());
+  assert.ok(
+    res.updated.every((i) => i.status === "dismissed" && typeof i.readAt === "string"),
+    "dismissed items are read",
+  );
+
+  // ── done requires ids; unknown ids are skipped, not errors ────────────────
+  res = await applyBulkAction("done", [b.id, "no-such-id"]);
+  assert.equal(res.updated.length, 1);
+  assert.equal(res.updated[0].status, "done");
+
+  // ── delete by ids removes exactly those items ─────────────────────────────
+  res = await applyBulkAction("delete", [a.id, c.id]);
+  assert.deepEqual(res.deletedIds.sort(), [a.id, c.id].sort());
+  {
+    const file = await loadInbox();
+    assert.deepEqual(
+      file.items.map((i) => i.id).sort(),
+      [b.id, pending.id].sort(),
+      "only the named items were deleted",
+    );
+  }
+
+  // ── the scheduler resets readAt on (re)fire so refires demand attention ───
+  const schedulerSrc = readFileSync(new URL("./inbox-scheduler.ts", import.meta.url), "utf8");
+  assert.match(
+    schedulerSrc,
+    /status: "fired",\s*\n\s*firedAt: nowIso,\s*\n\s*updatedAt: nowIso,[\s\S]{0,200}?readAt: null/,
+    "firing an item clears readAt (a read-then-snoozed reminder comes back unread)",
+  );
+} finally {
+  rmSync(tmpHome, { recursive: true, force: true });
+}
+
+console.log("cave-inbox-bulk.test.ts: ok");

--- a/src/lib/cave-inbox-prefs.test.ts
+++ b/src/lib/cave-inbox-prefs.test.ts
@@ -34,4 +34,38 @@ assert.match(
   "toggleMute takes the lock once and reads+writes atomically via the unlocked patch",
 );
 
+// Kind muting (cave-uu2d) follows the same atomicity contract as familiar muting.
+assert.match(
+  src,
+  /export function toggleMuteKind\([\s\S]*?return withPrefsLock\(async \(\) => \{[\s\S]*?loadPrefs\(\)[\s\S]*?patchPrefsUnlocked\(/,
+  "toggleMuteKind takes the lock once and reads+writes atomically via the unlocked patch",
+);
+
+// mutedKinds is validated on BOTH load and patch — a hand-edited prefs file or
+// a stale client can't persist kinds the delivery gate doesn't know (and
+// response-needed must never be mutable: a reply request clears by replying).
+// The kind list lives in the PURE shape module so the client bell can import
+// the value without dragging fs/promises into the browser bundle.
+const shapeSrc = readFileSync(new URL("./inbox-prefs-shape.ts", import.meta.url), "utf8");
+assert.match(
+  shapeSrc,
+  /MUTABLE_KINDS = \["reminder", "agent", "daily-summary"\] as const/,
+  "response-needed is not a mutable kind",
+);
+assert.doesNotMatch(
+  shapeSrc,
+  /from "node:|require\("node:/,
+  "the prefs shape module must stay free of node: imports (client components import it)",
+);
+assert.match(
+  src,
+  /mutedKinds: Array\.isArray\(parsed\.mutedKinds\)[\s\S]*?MUTABLE_KINDS as readonly string\[\]\)\.includes/,
+  "loadPrefs filters mutedKinds to known kinds",
+);
+assert.match(
+  src,
+  /mutedKinds: patch\.mutedKinds[\s\S]*?MUTABLE_KINDS as readonly string\[\]\)\.includes/,
+  "patchPrefs filters mutedKinds to known kinds",
+);
+
 console.log("cave-inbox-prefs.test.ts: ok");

--- a/src/lib/cave-inbox-prefs.ts
+++ b/src/lib/cave-inbox-prefs.ts
@@ -2,20 +2,25 @@ import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+// Shape definitions live in inbox-prefs-shape.ts (pure, no node: imports) so
+// client components can import MUTABLE_KINDS without pulling fs/promises into
+// the browser bundle. Re-exported here so server consumers keep one import.
+import {
+  MUTABLE_KINDS,
+  type InboxPrefs,
+  type MutableKind,
+  type SoundMode,
+} from "./inbox-prefs-shape.ts";
+
+export { MUTABLE_KINDS };
+export type { InboxPrefs, MutableKind, SoundMode };
 
 const PREFS_PATH = path.join(caveHome(), "inbox-prefs.json");
-
-export type SoundMode = "default" | "silent" | "named";
-
-export type InboxPrefs = {
-  version: number;
-  mutedFamiliars: string[];
-  sound: { mode: SoundMode; name?: string };
-};
 
 const EMPTY: InboxPrefs = {
   version: 1,
   mutedFamiliars: [],
+  mutedKinds: [],
   sound: { mode: "default" },
 };
 
@@ -49,6 +54,11 @@ export async function loadPrefs(): Promise<InboxPrefs> {
       version: parsed.version ?? 1,
       mutedFamiliars: Array.isArray(parsed.mutedFamiliars)
         ? parsed.mutedFamiliars.filter((s): s is string => typeof s === "string")
+        : [],
+      mutedKinds: Array.isArray(parsed.mutedKinds)
+        ? parsed.mutedKinds.filter((k): k is MutableKind =>
+            (MUTABLE_KINDS as readonly string[]).includes(k as string),
+          )
         : [],
       sound:
         parsed.sound && typeof parsed.sound === "object"
@@ -88,6 +98,15 @@ async function patchPrefsUnlocked(
     mutedFamiliars: patch.mutedFamiliars
       ? Array.from(new Set(patch.mutedFamiliars.filter(Boolean)))
       : current.mutedFamiliars,
+    mutedKinds: patch.mutedKinds
+      ? Array.from(
+          new Set(
+            patch.mutedKinds.filter((k) =>
+              (MUTABLE_KINDS as readonly string[]).includes(k as string),
+            ),
+          ),
+        )
+      : current.mutedKinds,
   };
   await savePrefs(next);
   return next;
@@ -110,6 +129,18 @@ export function toggleMute(familiarId: string): Promise<InboxPrefs> {
     if (muted.has(familiarId)) muted.delete(familiarId);
     else muted.add(familiarId);
     return patchPrefsUnlocked({ mutedFamiliars: Array.from(muted) });
+  });
+}
+
+export function toggleMuteKind(kind: MutableKind): Promise<InboxPrefs> {
+  // Same atomicity contract as toggleMute: read the current set and write the
+  // flipped set under one lock acquisition, via the unlocked inner patch.
+  return withPrefsLock(async () => {
+    const current = await loadPrefs();
+    const muted = new Set(current.mutedKinds);
+    if (muted.has(kind)) muted.delete(kind);
+    else muted.add(kind);
+    return patchPrefsUnlocked({ mutedKinds: Array.from(muted) });
   });
 }
 

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -73,6 +73,14 @@ export type InboxItem = {
    * without brittle title matching. See `task-archive-nudge.ts`.
    */
   auto?: string | null;
+  /**
+   * When the user acknowledged this notification (bell "Mark all read",
+   * opening the item). Absent/null = unread — so every pre-upgrade fired item
+   * counts as unread, matching the old badge that counted all of them. The
+   * scheduler clears it on (re)fire so a snoozed reminder demands attention
+   * again.
+   */
+  readAt?: string | null;
 };
 
 type InboxFile = {
@@ -159,6 +167,7 @@ export async function createItem(input: NewItemInput): Promise<InboxItem> {
       link: input.link ?? null,
       media: input.media ?? null,
       auto: input.auto ?? null,
+      readAt: null,
     };
     file.items.push(item);
     await saveInbox(file);
@@ -212,6 +221,78 @@ export async function markDone(id: string): Promise<InboxItem | null> {
 
 export async function dismissItem(id: string): Promise<InboxItem | null> {
   return updateItem(id, { status: "dismissed" });
+}
+
+export type BulkAction = "read" | "unread" | "dismiss" | "done" | "delete";
+
+export type BulkResult = {
+  updated: InboxItem[];
+  deletedIds: string[];
+};
+
+/**
+ * Which items `all: true` targets, per action. Read/unread/dismiss operate on
+ * the fired notification stack (what the bell shows); done and delete are
+ * destructive enough that callers must name ids explicitly — the route
+ * enforces that, this map just documents the eligible set.
+ */
+function eligibleForAll(action: BulkAction, item: InboxItem): boolean {
+  if (action === "read") return item.status === "fired" && !item.readAt;
+  if (action === "unread") return item.status === "fired" && !!item.readAt;
+  if (action === "dismiss") return item.status === "fired";
+  return false;
+}
+
+/**
+ * Apply one action to many items in a single locked load→save cycle. The old
+ * bell "Clear all" fanned out N sequential POSTs — N file rewrites and N SSE
+ * broadcasts racing each other; this is one write. Unknown ids are skipped
+ * (an item deleted elsewhere mid-flight is not an error).
+ */
+export async function applyBulkAction(
+  action: BulkAction,
+  ids: string[] | null,
+): Promise<BulkResult> {
+  return withInboxLock(async () => {
+    const file = await loadInbox();
+    const nowIso = new Date().toISOString();
+    const idSet = ids ? new Set(ids) : null;
+    const targeted = (item: InboxItem) =>
+      idSet ? idSet.has(item.id) : eligibleForAll(action, item);
+
+    const updated: InboxItem[] = [];
+    const deletedIds: string[] = [];
+
+    if (action === "delete") {
+      file.items = file.items.filter((item) => {
+        if (!targeted(item)) return true;
+        deletedIds.push(item.id);
+        return false;
+      });
+    } else {
+      file.items = file.items.map((item) => {
+        if (!targeted(item)) return item;
+        let next: InboxItem;
+        if (action === "read") {
+          if (item.readAt) return item;
+          next = { ...item, readAt: nowIso, updatedAt: nowIso };
+        } else if (action === "unread") {
+          if (!item.readAt) return item;
+          next = { ...item, readAt: null, updatedAt: nowIso };
+        } else {
+          // dismiss | done — terminal states imply the item was seen.
+          const status: ItemStatus = action === "dismiss" ? "dismissed" : "done";
+          if (item.status === status) return item;
+          next = { ...item, status, readAt: item.readAt ?? nowIso, updatedAt: nowIso };
+        }
+        updated.push(next);
+        return next;
+      });
+    }
+
+    if (updated.length > 0 || deletedIds.length > 0) await saveInbox(file);
+    return { updated, deletedIds };
+  });
 }
 
 export { INBOX_PATH };

--- a/src/lib/inbox-feed.test.ts
+++ b/src/lib/inbox-feed.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { groupInboxFeed, inboxActivityTime, inboxKindLabel } from "./inbox-feed.ts";
+import {
+  groupInboxFeed,
+  inboxActivityTime,
+  inboxKindLabel,
+  isInboxItemUnread,
+  unreadInboxCount,
+} from "./inbox-feed.ts";
 
 const item = (over = {}) => ({
   id: over.id ?? Math.random().toString(36).slice(2),
@@ -84,6 +90,41 @@ const item = (over = {}) => ({
   assert.equal(inboxKindLabel("daily-summary"), "Summary");
   assert.equal(inboxKindLabel("response-needed"), "Response");
   assert.equal(inboxKindLabel("agent"), "Agent");
+}
+
+// ── Unread: fired without readAt; reading, resolving, or refiring flips it ──
+{
+  assert.equal(isInboxItemUnread(item({ status: "fired" })), true, "fired + no readAt = unread");
+  assert.equal(
+    isInboxItemUnread(item({ status: "fired", readAt: null })),
+    true,
+    "explicit null readAt = unread (pre-upgrade items)",
+  );
+  assert.equal(
+    isInboxItemUnread(item({ status: "fired", readAt: "2026-06-01T00:00:00Z" })),
+    false,
+    "acknowledged fired item is read",
+  );
+  assert.equal(isInboxItemUnread(item({ status: "pending" })), false, "not fired yet = not unread");
+  assert.equal(
+    isInboxItemUnread(item({ status: "dismissed" })),
+    false,
+    "terminal states never count as unread",
+  );
+}
+
+// ── unreadInboxCount = unread fired + pending response-needed ───────────────
+{
+  const items = [
+    item({ status: "fired" }), // unread
+    item({ status: "fired", readAt: "2026-06-01T00:00:00Z" }), // read
+    item({ kind: "response-needed", status: "pending" }), // waiting on a reply
+    item({ kind: "response-needed", status: "done" }), // replied — quiet
+    item({ status: "pending" }), // not fired yet
+    item({ status: "dismissed" }),
+  ];
+  assert.equal(unreadInboxCount(items), 2, "one unread fired + one pending response-needed");
+  assert.equal(unreadInboxCount([]), 0);
 }
 
 console.log("inbox-feed.test.ts passed");

--- a/src/lib/inbox-feed.ts
+++ b/src/lib/inbox-feed.ts
@@ -50,6 +50,32 @@ export function groupInboxFeed(items: readonly InboxItem[]): InboxFeedGroups {
   return { needsYou, active, resolved };
 }
 
+/**
+ * Unread = a fired notification the user hasn't acknowledged yet (readAt is
+ * stamped by "Mark all read" / opening the item, cleared by the scheduler on
+ * refire). Items that predate readAt count as unread — matching the old badge
+ * that counted every fired item.
+ */
+export function isInboxItemUnread(item: InboxItem): boolean {
+  return item.status === "fired" && !item.readAt;
+}
+
+/**
+ * What the bell badge shows: unread fired notifications plus anything still
+ * waiting on a reply (response-needed clears by replying, not by reading).
+ * ONE definition feeds the badge and the bell list so they can never disagree
+ * — the old badge counted polled escalations while the list showed inbox
+ * items, and the two routinely diverged.
+ */
+export function unreadInboxCount(items: readonly InboxItem[]): number {
+  let count = 0;
+  for (const item of items) {
+    if (isInboxItemUnread(item)) count++;
+    else if (item.kind === "response-needed" && item.status === "pending") count++;
+  }
+  return count;
+}
+
 /** Human label for an inbox item kind (used by the feed's kind badge). */
 export function inboxKindLabel(kind: ItemKind): string {
   switch (kind) {

--- a/src/lib/inbox-prefs-shape.ts
+++ b/src/lib/inbox-prefs-shape.ts
@@ -1,0 +1,21 @@
+// Pure prefs shape — no node: imports — so client components (the bell's
+// settings panel) can reach MUTABLE_KINDS without dragging fs/promises into
+// the browser bundle. Same split as inbox-recurrence.ts vs cave-inbox.ts;
+// the store logic lives in cave-inbox-prefs.ts, which re-exports these.
+
+export type SoundMode = "default" | "silent" | "named";
+
+/**
+ * Kinds whose delivery (toast + native notification + sound) can be quieted.
+ * response-needed is deliberately not mutable — a familiar waiting on a reply
+ * clears by replying, not by silencing it.
+ */
+export const MUTABLE_KINDS = ["reminder", "agent", "daily-summary"] as const;
+export type MutableKind = (typeof MUTABLE_KINDS)[number];
+
+export type InboxPrefs = {
+  version: number;
+  mutedFamiliars: string[];
+  mutedKinds: MutableKind[];
+  sound: { mode: SoundMode; name?: string };
+};

--- a/src/lib/inbox-scheduler.ts
+++ b/src/lib/inbox-scheduler.ts
@@ -89,6 +89,9 @@ async function tick(): Promise<void> {
         status: "fired",
         firedAt: nowIso,
         updatedAt: nowIso,
+        // A (re)fire is a fresh demand for attention — a snoozed reminder the
+        // user read last time must come back unread.
+        readAt: null,
       };
       file.items[i] = updated;
       out.push(updated);
@@ -105,6 +108,7 @@ async function tick(): Promise<void> {
             snoozeUntil: null,
             createdAt: nowIso,
             updatedAt: nowIso,
+            readAt: null,
           };
           file.items.push(sibling);
         }


### PR DESCRIPTION
## Why

Incoming inbox notifications were effectively unmanageable:

- **Badge and list disagreed by design** — the bell badge showed the *polled escalations count* while the popover listed *inbox items* (two unrelated data sources).
- **Nothing quieted the badge** short of destroying items one by one.
- **Toasts destroyed notifications**: the 8s auto-hide routed through the same handler as the explicit ✕, which POSTed `/dismiss` — so any notification that fired while you were present silently resolved itself 8 seconds later. The bell mostly only ever showed items that fired while the app was closed.
- **"Clear all" fanned out N racing POSTs** (N file rewrites + N SSE reconciles).

## What

**Read/unread model** — `InboxItem.readAt`: acknowledged-not-resolved. Absent = unread (pre-upgrade items keep their old badge semantics). The scheduler clears it on (re)fire so a read-then-snoozed reminder returns unread; recurrence siblings start unread.

**Bulk actions** — `POST /api/inbox/bulk {action: read|unread|dismiss|done|delete, ids?|all?}`: one locked load→save cycle, per-item SSE broadcasts (no new event type; existing clients reconcile). `all:true` only sweeps the non-destructive stack; `done`/`delete` require explicit ids. Local-origin guarded.

**Bell**:
- Badge = **live unread count derived from the same items the list shows** (`unreadInboxCount`, one shared definition), streamed over the existing SSE.
- Kind **filter chips with counts** (All / Waiting / Reminders / Familiars / Reports — only kinds that have items).
- **Mark read** header action (atomic bulk), per-row **Read** button + unread accent dots, **Open acknowledges**, Clear all = one bulk dismiss.

**Toasts** — explicit ✕ now *acknowledges* (marks read; the item stays in the bell). Auto-hide expiry is visual-only via a new `onExpire` prop — never a server write.

**Kind muting** — prefs gain `mutedKinds` (reminder / agent / daily-summary) mirroring the per-familiar mute: quiet delivery (no toast/native/sound) while items still land in the inbox and bell. `response-needed` is deliberately not mutable (a reply request clears by replying). Kind list lives in pure `inbox-prefs-shape.ts` so the client bell imports the value without dragging `fs/promises` into the browser bundle.

## Verification

- `node scripts/run-tests.mjs all` — ✓ 855 test files (app 628 · api 148 · mobile 77 · conformance)
- `pnpm typecheck`, `pnpm check:tests-wired`, `pnpm build` (bundle within budget) — all green
- New behavioral test `cave-inbox-bulk.test.ts` runs the bulk helper against a throwaway `COVEN_CAVE_HOME`; unread helpers covered in `inbox-feed.test.ts`; prefs pins for `toggleMuteKind` atomicity + kind validation; bell pins updated to the bulk endpoints; `/inbox/bulk` added to the API contracts.
- Verified in-app (prod server + Playwright, mocked SSE): badge "2 unread", chips `All 3 · Reminders 1 · Familiars 1 · Reports 1`, filter narrows to 1 row, Quiet kinds settings render muted state.

Bead: cave-uu2d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
