### PR TITLE
feat(ios): modern-Apple polish — six optimization vectors for chat + shared chrome (cave-v6eq)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Haptics.swift
+++ b/apps/ios/CovenCave/CovenCave/Haptics.swift
@@ -1,16 +1,36 @@
 import UIKit
 
 /// Lightweight haptic feedback for chat interactions (send, copy, retry).
+///
+/// Generators are cached and re-`prepare()`d after every fire so the Taptic
+/// Engine stays primed — Apple's recommended pattern. The old approach
+/// (allocating a fresh `UIImpactFeedbackGenerator` per tap) both added
+/// first-tap latency while the engine spun up and churned an allocation on
+/// every send/copy/toggle.
+@MainActor
 enum Haptics {
+    private static var impacts: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
+    private static let notifier = UINotificationFeedbackGenerator()
+
     static func tap(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
-        UIImpactFeedbackGenerator(style: style).impactOccurred()
+        let generator: UIImpactFeedbackGenerator
+        if let cached = impacts[style] {
+            generator = cached
+        } else {
+            generator = UIImpactFeedbackGenerator(style: style)
+            impacts[style] = generator
+        }
+        generator.impactOccurred()
+        generator.prepare()
     }
 
     static func success() {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        notifier.notificationOccurred(.success)
+        notifier.prepare()
     }
 
     static func error() {
-        UINotificationFeedbackGenerator().notificationOccurred(.error)
+        notifier.notificationOccurred(.error)
+        notifier.prepare()
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift
@@ -23,6 +23,30 @@ enum ChatChrome {
     static let iconWell: CGFloat = 34
 }
 
+// MARK: - GlassPressStyle
+
+/// The app's standard pressed state: a quick springy dip plus a slight dim, so
+/// every glass control answers the finger the way native Apple controls do
+/// (`.plain` gives no feedback at all on custom-backgrounded buttons). Under
+/// Reduce Motion the scale is dropped and only the dim remains.
+struct GlassPressStyle: ButtonStyle {
+    var scale: CGFloat = 0.96
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(reduceMotion ? 1 : (configuration.isPressed ? scale : 1))
+            .opacity(configuration.isPressed ? 0.85 : 1)
+            .animation(reduceMotion ? nil : .spring(response: 0.28, dampingFraction: 0.75),
+                       value: configuration.isPressed)
+    }
+}
+
+extension ButtonStyle where Self == GlassPressStyle {
+    /// Springy scale-on-press for glass chrome controls.
+    static var glassPress: GlassPressStyle { GlassPressStyle() }
+}
+
 // MARK: - CircularIconButton
 
 /// A round glass icon button — the app's standard tap target for icon-only
@@ -44,7 +68,7 @@ struct CircularIconButton: View {
                 .glass(.control, in: Circle())
                 .accentGlow(active: active)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.glassPress)
         .accessibilityLabel(label)
     }
 }
@@ -89,7 +113,7 @@ struct PillSelector<Leading: View>: View {
             .glass(.control, in: Capsule())
             .accentGlow(active: active)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.glassPress)
         .accessibilityLabel(label)
         .accessibilityHint(accessibilityHint ?? "")
     }
@@ -134,7 +158,7 @@ struct FloatingActionMenu: View {
                     .padding(.vertical, 7)
                     .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(GlassPressStyle(scale: 0.98))
                 .accessibilityLabel(item.label)
             }
         }
@@ -183,7 +207,7 @@ struct DrawerRow: View {
                     .fill(active ? Color.accentColor.opacity(0.12) : .clear)
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(GlassPressStyle(scale: 0.98))
         .accessibilityLabel(label)
         .accessibilityAddTraits(active ? [.isSelected] : [])
     }
@@ -218,7 +242,7 @@ struct EmptyChatSuggestionRow: View {
             .glass(.raised, in: RoundedRectangle(cornerRadius: ChatChrome.menuRadius, style: .continuous))
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(GlassPressStyle(scale: 0.98))
         .accessibilityLabel(label)
         .accessibilityHint("Fills the message field")
     }

--- a/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/Theme.swift
@@ -48,6 +48,44 @@ extension ChromePalette {
         if let c = Color(hex: t["--accent-presence"]) { accent = c; accentHex = t["--accent-presence"] }
         colorScheme = snapshot.mode.lowercased() == "light" ? .light : .dark
     }
+
+    /// Readable text/icon colour on an accent-filled surface — the iOS mirror
+    /// of the desktop's `--accent-presence-foreground` token. Light accents
+    /// (a pale lavender, a lemon) get near-black text; everything else keeps
+    /// white. Falls back to white when the accent can't be resolved, which is
+    /// exactly the pre-theme behaviour.
+    var accentForeground: Color {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard UIColor(accent).getRed(&r, green: &g, blue: &b, alpha: &a) else { return .white }
+        // Perceived brightness (YIQ): light accents need dark text.
+        let brightness = 0.299 * r + 0.587 * g + 0.114 * b
+        return brightness > 0.62 ? Color(white: 0.08) : .white
+    }
+
+    /// A soft vertical wash of the accent for filled "presence" surfaces (the
+    /// user's chat bubble): slightly brighter at the top, the pure accent at
+    /// the bottom — the same treatment the system Messages bubble uses instead
+    /// of a flat fill.
+    var accentGradient: LinearGradient {
+        LinearGradient(colors: [accent.toned(lighter: 0.10), accent],
+                       startPoint: .top, endPoint: .bottom)
+    }
+}
+
+extension Color {
+    /// Blend a colour toward white by `lighter` (0–1). Returns self unchanged
+    /// when the colour can't be resolved to RGBA (e.g. some dynamic colours),
+    /// so callers degrade to the flat original rather than misrendering.
+    func toned(lighter amount: Double) -> Color {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        guard UIColor(self).getRed(&r, green: &g, blue: &b, alpha: &a) else { return self }
+        let t = CGFloat(max(0, min(1, amount)))
+        return Color(.sRGB,
+                     red: Double(r + (1 - r) * t),
+                     green: Double(g + (1 - g) * t),
+                     blue: Double(b + (1 - b) * t),
+                     opacity: Double(a))
+    }
 }
 
 /// Reach the desktop palette from any view (`@Environment(\.chrome)`); defaults

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -279,13 +279,25 @@ struct ChatView: View {
                                       operatorName: app.operatorDisplayName,
                                       operatorAvatarURL: app.operatorAvatarURL)
                         .id(message.id)
+                        // New bubbles settle in with a soft rise-and-fade
+                        // (native Messages behaviour) instead of popping;
+                        // deletions fade out. Driven by the count-keyed
+                        // animation below; Reduce Motion turns it off.
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)),
+                            removal: .opacity))
                     }
                     Color.clear.frame(height: 1).id("bottom")
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 14)
+                .animation(reduceMotion ? nil : .spring(duration: 0.3), value: thread.messages.count)
             }
             .scrollDismissesKeyboard(.interactively)
+            // Open at the latest message without the post-layout jump a
+            // proxy.scrollTo onAppear causes (the onAppear call stays as a
+            // backstop for restored offsets).
+            .defaultScrollAnchor(.bottom, for: .initialOffset)
             // Pull to re-sync a direct chat that may have advanced on another
             // device (no-op for groups / unsent threads, see ChatThread.reload).
             .refreshable {
@@ -324,6 +336,7 @@ struct ChatView: View {
                             .overlay(Circle().strokeBorder(Color(.separator).opacity(0.4), lineWidth: 1))
                             .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
                     }
+                    .buttonStyle(.glassPress)
                     .padding(.trailing, 14)
                     .padding(.bottom, 10)
                     .transition(.scale.combined(with: .opacity))
@@ -331,11 +344,24 @@ struct ChatView: View {
                 }
             }
             .animation(.snappy(duration: 0.2), value: atBottom)
+            // Follow the stream only while the reader is parked at the bottom.
+            // Scrolling up to reread must never be yanked back down by each
+            // arriving token — the native Messages contract; returning to the
+            // bottom re-engages following via `atBottom`.
             .onChange(of: thread.messages.last?.text) { _, _ in
-                withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo("bottom", anchor: .bottom) }
+                guard atBottom else { return }
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
             }
+            // A new message reveals itself when it's the user's own send (you
+            // always watch your message leave) or when already at the bottom —
+            // otherwise the unread stays put behind the jump-to-latest button.
             .onChange(of: thread.messages.count) { _, _ in
-                withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+                guard atBottom || thread.messages.last?.role == .user else { return }
+                withAnimation(reduceMotion ? nil : .snappy(duration: 0.25)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
             }
             .onAppear { proxy.scrollTo("bottom", anchor: .bottom) }
         }
@@ -608,7 +634,11 @@ struct ChatView: View {
                     }
                 }
             }
+            .glassFill(.control, in: Capsule())
             .overlay(Capsule().strokeBorder(dictation.isRecording ? Color.red.opacity(0.5) : borderColor, lineWidth: 1))
+            // The focused field earns the accent halo — the design language's
+            // one "active" cue — matching the drawer's search treatment.
+            .accentGlow(active: composerFocused || dictation.isRecording)
             .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: canSend)
             .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: isCommand)
             .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: dictation.isRecording)

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -337,7 +337,7 @@ struct MessageBubble: View {
         } else {
             Text(parsed.visible.isEmpty ? " " : parsed.visible)
                 .textSelection(.enabled)
-                .foregroundStyle(isUser ? Color.white : Color.primary)
+                .foregroundStyle(isUser ? chrome.accentForeground : Color.primary)
                 .padding(.horizontal, 14).padding(.vertical, 9)
                 .background(bubbleBackground, in: bubbleShape)
                 .overlay(alignment: .bottomTrailing) {
@@ -352,36 +352,64 @@ struct MessageBubble: View {
         RoundedRectangle(cornerRadius: isUser ? 22 : 26, style: .continuous)
     }
 
-    private var bubbleBackground: Color {
-        if message.isError { return Color.red.opacity(0.85) }
-        if isUser { return Color.accentColor }
-        return Color(.secondarySystemBackground)
+    /// Bubble fills: errors stay red; the user's bubble is a soft vertical
+    /// accent gradient (readable text comes from `chrome.accentForeground`);
+    /// the assistant's bubble sits on the theme's raised surface so it tracks
+    /// the desktop palette — the fallback palette resolves to the same
+    /// `secondarySystemBackground` as before.
+    private var bubbleBackground: AnyShapeStyle {
+        if message.isError { return AnyShapeStyle(Color.red.opacity(0.85)) }
+        if isUser { return AnyShapeStyle(chrome.accentGradient) }
+        return AnyShapeStyle(chrome.bgRaised)
     }
 }
 
+/// Three staggered dots while a familiar is thinking — a real wave driven by
+/// `PhaseAnimator` (each phase lifts one dot), not a repeat-forever hack.
+/// Reduce Motion swaps the wave for calm static dots.
 struct TypingIndicator: View {
-    @State private var phase = 0.0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
+        if reduceMotion {
+            dots { _ in (opacity: 0.55, scale: 1) }
+        } else {
+            PhaseAnimator([0, 1, 2]) { phase in
+                dots { i in (opacity: phase == i ? 1 : 0.3, scale: phase == i ? 1.2 : 1) }
+            } animation: { _ in .easeInOut(duration: 0.28) }
+        }
+    }
+
+    private func dots(_ style: @escaping (Int) -> (opacity: Double, scale: Double)) -> some View {
         HStack(spacing: 4) {
             ForEach(0..<3) { i in
                 Circle().frame(width: 6, height: 6)
                     .foregroundStyle(.secondary)
-                    .opacity(phase == Double(i) ? 1 : 0.3)
+                    .opacity(style(i).opacity)
+                    .scaleEffect(style(i).scale)
             }
         }
-        .onAppear {
-            withAnimation(.easeInOut(duration: 0.5).repeatForever()) { phase = 2 }
-        }
+        .accessibilityLabel("Thinking")
     }
 }
 
+/// The pulsing "still streaming" dot in a reply's corner. `PhaseAnimator`
+/// breathes it between dim and bright; Reduce Motion holds it steady.
 struct StreamingDot: View {
-    @State private var on = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
-        Circle().frame(width: 6, height: 6)
-            .foregroundStyle(.secondary)
-            .opacity(on ? 1 : 0.2)
-            .onAppear { withAnimation(.easeInOut(duration: 0.6).repeatForever()) { on = true } }
+        if reduceMotion {
+            dot.opacity(0.6)
+        } else {
+            PhaseAnimator([0.2, 1.0]) { phase in
+                dot.opacity(phase)
+            } animation: { _ in .easeInOut(duration: 0.6) }
+        }
+    }
+
+    private var dot: some View {
+        Circle().frame(width: 6, height: 6).foregroundStyle(.secondary)
     }
 }
 
@@ -423,7 +451,7 @@ struct SuggestionPills: View {
                         )
                     )
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(GlassPressStyle(scale: 0.98))
             }
         }
         .frame(maxWidth: .infinity)

--- a/scripts/ios-modern-polish.test.mjs
+++ b/scripts/ios-modern-polish.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Modern-Apple polish pass (cave-v6eq): six optimization vectors across the
+// chat interface and the shared chrome every surface reuses.
+//   1. Haptics — cached, prepare()d generators (no per-tap allocation/latency)
+//   2. Streaming scroll — never yank a reader who scrolled up; flash-free open
+//   3. Composer — glassmorphic capsule field with a focus accent halo
+//   4. Bubbles — accent-gradient user bubble w/ luminance-aware foreground,
+//      theme-tracking assistant bubble
+//   5. Indicators — PhaseAnimator waves that respect Reduce Motion
+//   6. Press states — GlassPressStyle on the shared glass controls
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const haptics = await read("apps/ios/CovenCave/CovenCave/Haptics.swift");
+const chatView = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
+const theme = await read("apps/ios/CovenCave/CovenCave/Theme/Theme.swift");
+const chrome = await read("apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift");
+
+// ── 1. Haptics: cached generators, kept prepared ─────────────────────────────
+assert.match(
+  haptics,
+  /private static var impacts: \[UIImpactFeedbackGenerator\.FeedbackStyle: UIImpactFeedbackGenerator\]/,
+  "impact generators should be cached per style, not allocated per tap",
+);
+assert.match(
+  haptics,
+  /generator\.impactOccurred\(\)\s*\n\s*generator\.prepare\(\)/,
+  "the impact generator should be re-prepared after firing so the Taptic Engine stays primed",
+);
+assert.match(
+  haptics,
+  /notifier\.notificationOccurred\(\.success\)\s*\n\s*notifier\.prepare\(\)/,
+  "the notification generator should be shared and re-prepared",
+);
+assert.doesNotMatch(
+  haptics,
+  /static func tap[\s\S]{0,120}?UIImpactFeedbackGenerator\(style: style\)\.impactOccurred/,
+  "tap() must not allocate a throwaway generator per call",
+);
+
+// ── 2. Streaming scroll: reader position is sacred ───────────────────────────
+assert.match(
+  chatView,
+  /onChange\(of: thread\.messages\.last\?\.text\) \{ _, _ in\s*\n\s*guard atBottom else \{ return \}/,
+  "token streaming must only auto-scroll while the reader is parked at the bottom",
+);
+assert.match(
+  chatView,
+  /onChange\(of: thread\.messages\.count\) \{ _, _ in\s*\n\s*guard atBottom \|\| thread\.messages\.last\?\.role == \.user else \{ return \}/,
+  "a new message auto-reveals only at the bottom, or when it's the user's own send",
+);
+assert.match(
+  chatView,
+  /\.defaultScrollAnchor\(\.bottom, for: \.initialOffset\)/,
+  "the transcript should open anchored at the latest message (no post-layout jump)",
+);
+
+// ── 3. Composer: glass capsule + focus halo ──────────────────────────────────
+assert.match(
+  chatView,
+  /\.glassFill\(\.control, in: Capsule\(\)\)\s*\n\s*\.overlay\(Capsule\(\)\.strokeBorder/,
+  "the composer field should be a frosted .control capsule, not a bare hairline",
+);
+assert.match(
+  chatView,
+  /\.accentGlow\(active: composerFocused \|\| dictation\.isRecording\)/,
+  "the focused composer earns the accent halo (the design language's active cue)",
+);
+
+// ── 4. Bubbles: gradient + luminance-aware contrast + themed assistant ───────
+assert.match(
+  theme,
+  /var accentForeground: Color \{[\s\S]{0,400}?0\.299 \* r \+ 0\.587 \* g \+ 0\.114 \* b/,
+  "ChromePalette.accentForeground should pick black/white text from accent brightness",
+);
+assert.match(
+  theme,
+  /var accentGradient: LinearGradient/,
+  "ChromePalette should expose the soft vertical accent gradient for filled surfaces",
+);
+assert.match(
+  bubble,
+  /if isUser \{ return AnyShapeStyle\(chrome\.accentGradient\) \}/,
+  "the user bubble should use the accent gradient wash",
+);
+assert.match(
+  bubble,
+  /return AnyShapeStyle\(chrome\.bgRaised\)/,
+  "the assistant bubble should sit on the theme's raised surface",
+);
+assert.match(
+  bubble,
+  /foregroundStyle\(isUser \? chrome\.accentForeground : Color\.primary\)/,
+  "user-bubble text must use the luminance-aware accent foreground, not hard-coded white",
+);
+assert.match(
+  chatView,
+  /\.transition\(\.asymmetric\([\s\S]{0,160}?insertion: \.opacity\.combined\(with: \.scale\(scale: 0\.9\d, anchor: \.bottom\)\)/,
+  "new bubbles should rise-and-fade in rather than popping",
+);
+assert.match(
+  chatView,
+  /\.animation\(reduceMotion \? nil : \.spring\(duration: 0\.3\), value: thread\.messages\.count\)/,
+  "bubble insertion animates on count changes and honours Reduce Motion",
+);
+
+// ── 5. Indicators: PhaseAnimator waves, Reduce Motion fallback ───────────────
+assert.match(
+  bubble,
+  /struct TypingIndicator: View \{[\s\S]{0,700}?PhaseAnimator\(\[0, 1, 2\]\)/,
+  "the typing indicator should be a PhaseAnimator stagger wave",
+);
+assert.match(
+  bubble,
+  /struct StreamingDot: View \{[\s\S]{0,500}?PhaseAnimator\(\[0\.2, 1\.0\]\)/,
+  "the streaming dot should breathe via PhaseAnimator",
+);
+const indicatorGuards = bubble.match(
+  /accessibilityReduceMotion\) private var reduceMotion/g,
+);
+assert.ok(
+  (indicatorGuards?.length ?? 0) >= 2,
+  "both indicators must read Reduce Motion and fall back to static dots",
+);
+assert.doesNotMatch(
+  bubble,
+  /repeatForever/,
+  "no unguarded repeat-forever animations in the transcript",
+);
+
+// ── 6. Press states: shared GlassPressStyle across the chrome ────────────────
+assert.match(chrome, /struct GlassPressStyle: ButtonStyle/, "the pressed-state style is shared chrome");
+assert.match(
+  chrome,
+  /scaleEffect\(reduceMotion \? 1 : \(configuration\.isPressed \? scale : 1\)\)/,
+  "the press dip collapses to a dim under Reduce Motion",
+);
+for (const [component, pattern] of [
+  ["CircularIconButton", /struct CircularIconButton: View[\s\S]{0,900}?\.buttonStyle\(\.glassPress\)/],
+  ["PillSelector", /struct PillSelector<Leading: View>: View[\s\S]{0,1400}?\.buttonStyle\(\.glassPress\)/],
+  ["FloatingActionMenu", /struct FloatingActionMenu: View[\s\S]{0,1600}?\.buttonStyle\(GlassPressStyle\(scale: 0\.98\)\)/],
+  ["DrawerRow", /struct DrawerRow: View[\s\S]{0,1600}?\.buttonStyle\(GlassPressStyle\(scale: 0\.98\)\)/],
+  ["EmptyChatSuggestionRow", /struct EmptyChatSuggestionRow: View[\s\S]{0,1300}?\.buttonStyle\(GlassPressStyle\(scale: 0\.98\)\)/],
+]) {
+  assert.match(chrome, pattern, `${component} should answer touches with the press style`);
+}
+assert.match(
+  bubble,
+  /struct SuggestionPills: View[\s\S]*?\.buttonStyle\(GlassPressStyle\(scale: 0\.98\)\)/,
+  "suggestion pills should answer touches with the press style",
+);
+
+console.log("ios-modern-polish: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -808,6 +808,7 @@ export const SUITES = {
     "src/lib/mobile-token-refresh.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-restyle.test.mjs",
+    "scripts/ios-modern-polish.test.mjs",
     "scripts/ios-hide-generated-sessions.test.mjs",
     "scripts/ios-code-browser-files.test.mjs",
     "scripts/ios-code-viewer.test.mjs",


### PR DESCRIPTION
## Objective

Identify 4–6 ways to optimize the chat interface and the iOS app's components for a sleek, modern, glassmorphic native-Apple experience — then implement them.

## The six vectors

| # | Vector | What changed | Why it's more native |
|---|--------|--------------|---------------------|
| 1 | **Zero-latency haptics** | `Haptics.swift` now caches one generator per impact style + a shared notification generator, and re-`prepare()`s after every fire | Apple's documented Taptic pattern: no first-tap engine spin-up latency, no per-tap allocation churn (40+ call sites app-wide) |
| 2 | **Streaming-scroll contract** | Token streaming only auto-scrolls while the reader is parked at the bottom; new messages reveal only at bottom **or** for your own send; `defaultScrollAnchor(.bottom, for: .initialOffset)` opens flash-free at the latest message | Messages never yanks you down while you're re-reading; returning to the bottom re-engages following via the existing `atBottom` tracking |
| 3 | **Glassmorphic composer** | The field becomes a frosted `.control` glass capsule (same treatment as the drawer's search field) with the accent halo while focused/recording | The composer was the one hairline-only control on the glass bar; now it follows the app's own design language |
| 4 | **Modern bubbles** | User bubbles: iMessage-style vertical accent gradient + luminance-aware `ChromePalette.accentForeground` (iOS mirror of `--accent-presence-foreground`). Assistant bubbles track `chrome.bgRaised`. New bubbles rise-and-fade in | **Fixes a real contrast bug** — white text was hard-coded on the accent, unreadable with light theme accents; assistant bubbles now follow the desktop theme instead of fixed `secondarySystemBackground` (fallback palette is identical, so no visual change untthemed) |
| 5 | **PhaseAnimator indicators** | `TypingIndicator` becomes a real staggered dot wave; `StreamingDot` breathes via `PhaseAnimator` | **Fixes an a11y violation** — the old `repeatForever` hacks ignored Reduce Motion (now: calm static dots) and the typing 'stagger' never actually staggered |
| 6 | **Pressed-state micro-interactions** | Shared `GlassPressStyle` (springy dip + dim; Reduce Motion collapses to dim) on `CircularIconButton`, `PillSelector`, `FloatingActionMenu` rows, `DrawerRow`, `EmptyChatSuggestionRow`, `SuggestionPills`, jump-to-latest | `.plain` gave zero touch feedback on custom-backgrounded buttons; these shared controls power Chats home, the drawer, chat, and the empty states — every touch now answers |

## Verification

- `xcodebuild -scheme CovenCave -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED** (Xcode 26.6, arm64 + x86_64)
- `node scripts/run-tests.mjs mobile` → **78/78 test files pass** (includes the new pin)
- `node scripts/check-tests-wired.mjs` → all 851 test files wired
- New regression pin: `scripts/ios-modern-polish.test.mjs` locks all six vectors (wired into `test:mobile`)
- Existing pins untouched and green: `ios-chat-restyle`, `ios-reply-feedback`, `ios-swipe-reply`, `ios-chat-draft-lag`

Bead: **cave-v6eq**