### PR TITLE
fix(settings): standardize action buttons

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -472,6 +472,7 @@ export const SUITES = {
     "src/components/right-sidebar-fit.test.ts",
     "src/components/salem/salem.test.ts",
     "src/components/settings-shell-polish.test.ts",
+    "src/components/settings-action-buttons.test.ts",
     "src/components/settings-section-tabs.test.ts",
     "src/components/settings-overview.test.ts",
     "src/components/theme-script.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6369,7 +6369,7 @@ a.mobile-handoff__link:hover {
 @media (max-width: 767px) {
   .settings-back-button {
     min-height: var(--touch-target);
-    border-radius: 10px;
+    border-radius: var(--radius-control);
     padding-inline: 12px;
     -webkit-tap-highlight-color: transparent;
   }
@@ -6728,29 +6728,6 @@ a.mobile-handoff__link:hover {
   border-top: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
 }
-.familiar-studio-picker__summon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  min-height: 36px;
-  gap: 7px;
-  border: 1px dashed color-mix(in oklch, var(--accent-presence) 48%, var(--border-hairline));
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: var(--text-sm);
-}
-.familiar-studio-picker__summon:hover {
-  border-color: color-mix(in oklch, var(--accent-presence) 70%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
-  color: var(--text-primary);
-}
-.familiar-studio-picker__summon:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 1px;
-}
 .familiar-studio-inline__detail {
   display: grid;
   grid-template-rows: auto 1fr auto;
@@ -6808,46 +6785,27 @@ a.mobile-handoff__link:hover {
   transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
 }
 .familiar-studio-identity__input:focus { outline: none; border-color: var(--accent-presence); box-shadow: 0 0 0 3px var(--ring-focus-soft); }
-.familiar-studio-identity__reset {
-  display: grid;
-  place-items: center;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--text-muted);
-  border: 1px solid var(--border-hairline);
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
-}
-.familiar-studio-identity__reset:not(:disabled):hover { color: var(--text-primary); background: var(--bg-raised); }
-.familiar-studio-identity__reset:disabled { opacity: 0.3; cursor: not-allowed; }
 
 .familiar-studio-look { display: flex; flex-direction: column; gap: 18px; }
 .familiar-studio-look__section { display: flex; flex-direction: column; gap: 8px; }
 .familiar-studio-look__heading { font-size: 11px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; margin: 0; }
-.familiar-studio-look__scope { display: inline-flex; width: fit-content; overflow: hidden; border: 1px solid var(--border-hairline); border-radius: 6px; background: color-mix(in oklch, var(--bg-raised) 35%, transparent); }
+.familiar-studio-look__scope { display: inline-flex; width: fit-content; overflow: hidden; border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: color-mix(in oklch, var(--bg-raised) 35%, transparent); }
 .familiar-studio-look__scope-btn { display: inline-flex; height: 26px; align-items: center; gap: 6px; border: 0; border-right: 1px solid var(--border-hairline); background: transparent; color: var(--text-secondary); cursor: pointer; font-size: 11px; padding: 0 9px; }
 .familiar-studio-look__scope-btn:last-child { border-right: 0; }
 .familiar-studio-look__scope-btn--active { background: color-mix(in oklch, var(--accent-presence) 16%, transparent); color: var(--text-primary); }
-.familiar-studio-look__scope-btn span { border-radius: 999px; background: color-mix(in oklch, var(--accent-presence) 18%, transparent); color: var(--accent-presence); font-size: 10px; line-height: 1; padding: 2px 5px; }
+.familiar-studio-look__scope-btn span { border-radius: var(--radius-pill); background: color-mix(in oklch, var(--accent-presence) 18%, transparent); color: var(--accent-presence); font-size: 10px; line-height: 1; padding: 2px 5px; }
 .familiar-studio-look__swatches { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
-.familiar-studio-look__swatch { width: 22px; height: 22px; border-radius: 6px; border: 2px solid transparent; cursor: pointer; padding: 0; }
+.familiar-studio-look__swatch { width: 22px; height: 22px; border-radius: var(--radius-control); border: 2px solid transparent; cursor: pointer; padding: 0; }
 .familiar-studio-look__swatch--active { border-color: var(--text-primary); }
 .familiar-studio-look__custom { width: 28px; height: 28px; border: none; background: transparent; cursor: pointer; padding: 0; }
-.familiar-studio-look__reset { font-size: 11px; color: var(--text-secondary); background: transparent; border: 1px solid var(--border-hairline); border-radius: 4px; padding: 4px 8px; cursor: pointer; }
-.familiar-studio-look__reset:disabled { opacity: 0.3; cursor: not-allowed; }
 .familiar-studio-look__palette-actions { display: flex; flex-wrap: wrap; gap: 6px; }
-.familiar-studio-look__palette-actions button { border: 1px solid var(--border-hairline); border-radius: 5px; background: color-mix(in oklch, var(--bg-raised) 30%, transparent); color: var(--text-secondary); cursor: pointer; font-size: 11px; padding: 5px 8px; }
-.familiar-studio-look__palette-actions button:hover,
 .familiar-studio-look__scope-btn:hover { background: color-mix(in oklch, var(--accent-presence) 12%, transparent); color: var(--text-primary); }
 .familiar-studio-look__note { color: var(--text-muted); font-size: 11px; line-height: 1.4; margin: 0; }
-.familiar-studio-look__dropzone { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 16px; border: 1px dashed var(--border-hairline); border-radius: 8px; }
+.familiar-studio-look__dropzone { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 16px; border: 1px dashed var(--border-hairline); border-radius: var(--radius-card); }
 .familiar-studio-look__hint { font-size: 12px; color: var(--text-muted); }
-.familiar-studio-look__avatar-zoom { display: inline-flex; padding: 0; border: 0; background: transparent; cursor: zoom-in; border-radius: 6px; line-height: 0; transition: transform 0.12s ease; }
+.familiar-studio-look__avatar-zoom { display: inline-flex; padding: 0; border: 0; background: transparent; cursor: zoom-in; border-radius: var(--radius-control); line-height: 0; transition: transform 0.12s ease; }
 .familiar-studio-look__avatar-zoom:hover { transform: scale(1.04); }
 .familiar-studio-look__upload { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-primary); cursor: pointer; }
-.familiar-studio-look__remove { font-size: 11px; color: var(--text-secondary); background: transparent; border: 1px solid var(--border-hairline); border-radius: 4px; padding: 4px 8px; cursor: pointer; }
 .familiar-studio-look__toast { font-size: 11px; color: var(--color-warning); margin: 0; }
 
 .familiar-studio-brain { min-width: 0; }
@@ -7005,34 +6963,14 @@ a.mobile-handoff__link:hover {
 .familiar-studio-lifecycle__section { display: flex; flex-direction: column; gap: 6px; }
 .familiar-studio-lifecycle__heading { font-size: 11px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; margin: 0; }
 .familiar-studio-lifecycle__hint { margin: 4px 0 8px; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
-.familiar-studio-lifecycle__hint-link {
-  display: inline;
-  padding: 0;
-  border: 0;
-  background: none;
-  color: var(--text-secondary);
-  font-size: inherit;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  cursor: pointer;
-}
-.familiar-studio-lifecycle__hint-link:hover { color: var(--text-primary); }
 .familiar-studio-lifecycle__hint { font-size: 12px; color: var(--text-muted); line-height: 1.4; margin: 0; }
-.familiar-studio-lifecycle__btn { display: inline-flex; align-items: center; gap: 6px; align-self: flex-start; background: var(--bg-raised); border: 1px solid var(--border-hairline); border-radius: 6px; padding: 6px 10px; color: var(--text-primary); font-size: 12px; cursor: pointer; }
-.familiar-studio-lifecycle__btn:hover { background: color-mix(in oklch, var(--text-primary) 8%, var(--bg-raised)); }
-.familiar-studio-lifecycle__btn--danger { color: var(--color-danger); }
-.familiar-studio-lifecycle__btn--confirm { background: var(--color-danger); color: var(--bg-base); border-color: transparent; }
-.familiar-studio-lifecycle__row { display: flex; align-items: center; gap: 4px; padding: 4px; border-radius: 6px; }
+.familiar-studio-lifecycle__row { display: flex; align-items: center; gap: 4px; padding: 4px; border-radius: var(--radius-control); }
 .familiar-studio-lifecycle__row:hover { background: var(--bg-raised); }
 .familiar-studio-lifecycle__row[data-dragging] { background: var(--bg-raised); box-shadow: var(--shadow-popover); opacity: 0.95; position: relative; z-index: 1; }
 .familiar-studio-lifecycle__grip { display: grid; place-items: center; width: 20px; height: 24px; flex-shrink: 0; background: transparent; border: none; color: var(--text-faint); cursor: grab; touch-action: none; }
 .familiar-studio-lifecycle__grip:hover { color: var(--text-secondary); }
 .familiar-studio-lifecycle__row[data-dragging] .familiar-studio-lifecycle__grip { cursor: grabbing; }
 .familiar-studio-lifecycle__row-main { display: flex; gap: 8px; align-items: center; flex: 1; background: transparent; border: none; padding: 4px 6px; cursor: pointer; color: var(--text-primary); font-size: 13px; }
-.familiar-studio-lifecycle__row-action { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 4px; background: transparent; border: none; color: var(--text-secondary); cursor: pointer; }
-.familiar-studio-lifecycle__row-action:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-base); }
-.familiar-studio-lifecycle__row-action:disabled { opacity: 0.25; cursor: not-allowed; }
-.familiar-studio-lifecycle__row-action--danger:hover:not(:disabled) { color: var(--color-danger); background: color-mix(in oklch, var(--color-danger) 12%, transparent); }
 
 /* Remove-confirm strip: detach semantics spelled out inline before scheduling
    the undo-safe delete (danger tint recipe: solid text / 6% fill / 35% border). */
@@ -7053,13 +6991,6 @@ a.mobile-handoff__link:hover {
 .familiar-studio-contract__intro { display: flex; align-items: flex-start; gap: 10px; justify-content: space-between; }
 .familiar-studio-contract__lede { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-secondary); flex: 1; }
 .familiar-studio-contract__link { color: var(--accent-presence); text-decoration: underline; }
-.familiar-studio-contract__rerun {
-  display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0;
-  background: var(--bg-raised); border: 1px solid var(--border-hairline); border-radius: var(--radius-control);
-  padding: 6px 10px; color: var(--text-primary); font-size: 12px; cursor: pointer;
-}
-.familiar-studio-contract__rerun:hover:not(:disabled) { background: color-mix(in oklch, var(--text-primary) 8%, var(--bg-raised)); }
-.familiar-studio-contract__rerun:disabled { opacity: 0.5; cursor: progress; }
 .familiar-studio-contract__status { margin: 0; font-size: 12px; color: var(--text-muted); }
 .familiar-studio-contract__status--error { color: var(--color-warning); }
 .familiar-studio-contract__verdict {
@@ -7071,13 +7002,6 @@ a.mobile-handoff__link:hover {
 .familiar-studio-contract__verdict-text { display: flex; flex-direction: column; gap: 1px; }
 .familiar-studio-contract__verdict-text strong { font-size: 14px; }
 .familiar-studio-contract__verdict-text span { font-size: 11px; color: var(--text-muted); }
-.familiar-studio-contract__rehab {
-  display: inline-flex; align-items: center; gap: 6px; align-self: flex-start;
-  background: var(--accent); color: var(--bg-base);
-  border: 1px solid transparent; border-radius: var(--radius-control);
-  padding: 7px 12px; font-size: 12px; font-weight: 500; cursor: pointer;
-}
-.familiar-studio-contract__rehab:hover { background: color-mix(in oklch, var(--accent) 88%, black); }
 .familiar-studio-contract__section { display: flex; flex-direction: column; gap: 8px; }
 .familiar-studio-contract__heading { margin: 0; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-secondary); }
 .familiar-studio-contract__properties { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
@@ -7108,19 +7032,14 @@ a.mobile-handoff__link:hover {
    Keyboard Tab landed invisibly across the modal before this. */
 .familiar-studio__close:focus-visible,
 .familiar-studio__name:focus-visible,
-.familiar-studio-identity__reset:focus-visible,
 .familiar-studio-look__scope-btn:focus-visible,
 .familiar-studio-look__swatch:focus-visible,
 .familiar-studio-look__custom:focus-visible,
-.familiar-studio-look__reset:focus-visible,
-.familiar-studio-look__palette-actions button:focus-visible,
-.familiar-studio-look__remove:focus-visible,
 .familiar-studio-look__avatar-zoom:focus-visible,
 .familiar-studio-look__upload:focus-visible,
 .familiar-studio-brain__capabilities-summary:focus-visible,
-.familiar-studio-lifecycle__btn:focus-visible,
 .familiar-studio-lifecycle__row-main:focus-visible,
-.familiar-studio-lifecycle__row-action:focus-visible {
+.familiar-studio-lifecycle__grip:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: 1px;
 }

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -345,7 +345,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                     // default is false), keeping the file free of no-op entries.
                     void save({ autoSelfReport: next ? true : null });
                   }}
-                  className={`familiar-studio-brain__switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+                  className={`familiar-studio-brain__switch rounded-[var(--radius-pill)] border px-3 py-1.5 text-[12px] transition-colors ${
                     draftAutoSelfReport
                       ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
                       : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"

--- a/src/components/familiar-studio-contract-tab.test.ts
+++ b/src/components/familiar-studio-contract-tab.test.ts
@@ -67,6 +67,10 @@ assert.match(
   /initialPrompt:\s*buildRehabilitationBrief\(/,
   "Rehab chat is seeded with the rehabilitation brief as its initial prompt",
 );
-assert.match(source, /familiar-studio-contract__rehab/, "Rehab button has its own BEM class");
+assert.match(
+  source,
+  /<Button[\s\S]*variant="primary"[\s\S]*Work with \{familiar\.display_name\} to fix this[\s\S]*<\/Button>/,
+  "Rehab action uses the shared primary Button",
+);
 
 console.log("familiar-studio-contract-tab.test.ts: ok");

--- a/src/components/familiar-studio-contract-tab.tsx
+++ b/src/components/familiar-studio-contract-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { ContractReport, ContractFile } from "@/lib/familiar-contract";
 import { buildRehabilitationBrief } from "@/lib/familiar-rehabilitation";
@@ -74,15 +75,16 @@ export function FamiliarStudioContractTab({ familiar }: Props) {
           </a>{" "}
           — the five-property identity spec a familiar must honor.
         </p>
-        <button
-          type="button"
-          className="familiar-studio-contract__rerun"
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={() => void runCheck()}
+          loading={state === "loading"}
           disabled={state === "loading"}
+          leadingIcon="ph:arrows-clockwise"
         >
-          <Icon name="ph:arrows-clockwise" width={13} />
           {state === "loading" ? "Checking…" : "Re-run check"}
-        </button>
+        </Button>
       </div>
 
       {state === "loading" && !report ? (
@@ -125,9 +127,10 @@ export function FamiliarStudioContractTab({ familiar }: Props) {
               agent. This opens a chat seeded with a brief that instructs it to
               work with its human to close the gaps and cross to familiar. */}
           {!report.pass ? (
-            <button
-              type="button"
-              className="familiar-studio-contract__rehab"
+            <Button
+              variant="primary"
+              size="sm"
+              className="self-start"
               onClick={() =>
                 window.dispatchEvent(
                   new CustomEvent("cave:agents-new-chat", {
@@ -138,10 +141,10 @@ export function FamiliarStudioContractTab({ familiar }: Props) {
                   }),
                 )
               }
+              leadingIcon="ph:sparkle"
             >
-              <Icon name="ph:sparkle" width={14} aria-hidden />
               Work with {familiar.display_name} to fix this
-            </button>
+            </Button>
           ) : null}
 
           {/* Five-property coverage */}

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { IconButton } from "@/components/ui/icon-button";
 import {
   setFamiliarOverride,
   clearFamiliarOverrideField,
@@ -101,8 +101,9 @@ function IdentityField({
         ) : (
           <input type="text" {...(sharedProps as any)} />
         )}
-        <button
-          type="button"
+        <IconButton
+          icon="ph:arrow-counter-clockwise"
+          size="lg"
           aria-label={`Reset ${label} to daemon value`}
           title="Reset to daemon value"
           disabled={!hasOverride}
@@ -110,10 +111,7 @@ function IdentityField({
             onReset();
             setDraft("");
           }}
-          className="familiar-studio-identity__reset"
-        >
-          <Icon name="ph:arrow-counter-clockwise" width={12} />
-        </button>
+        />
       </div>
     </label>
   );

--- a/src/components/familiar-studio-lifecycle-tab.test.ts
+++ b/src/components/familiar-studio-lifecycle-tab.test.ts
@@ -33,7 +33,7 @@ assert.match(source, /arrayMove\(ids, oldIndex, newIndex\)/, "drag reorder moves
 
 // The roster order here is distinct from the avatar-strip pin order in
 // Appearance — the hint cross-links so users find both (2026-07-06).
-assert.match(source, /avatar strip's pinned order/, "lifecycle hint disambiguates roster order from pin order");
+assert.match(source, /avatar strip(?:'|&apos;)s pinned order/, "lifecycle hint disambiguates roster order from pin order");
 assert.match(source, /window\.location\.hash = "appearance"/, "lifecycle hint links to Appearance");
 
 // ── Dual-track lifecycle (cave-ykwk): Remove = undo-safe detach ─────────────

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -20,6 +20,8 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useAnnouncer } from "@/components/ui/live-region";
 import {
@@ -222,19 +224,19 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved, onRosterChan
       <section>
         <h3 className="familiar-studio-lifecycle__heading">Active</h3>
         <p className="familiar-studio-lifecycle__hint">
-          Sets the roster order across the app. The avatar strip's pinned order
-          is separate —{" "}
-          <button
-            type="button"
-            className="familiar-studio-lifecycle__hint-link focus-ring"
-            onClick={() => {
-              window.location.hash = "appearance";
-            }}
-          >
-            set it in Appearance
-          </button>
-          .
+          Sets the roster order across the app. The avatar strip&apos;s pinned order is separate.
         </p>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="self-start"
+          leadingIcon="ph:paint-brush"
+          onClick={() => {
+            window.location.hash = "appearance";
+          }}
+        >
+          Open Appearance
+        </Button>
         <DndContext
           id="familiar-lifecycle-order"
           sensors={sensors}
@@ -312,15 +314,16 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved, onRosterChan
               <span className="familiar-studio-lifecycle__removed-when">
                 removed {relativeTime(entry.removedAt)}
               </span>
-              <button
-                type="button"
+              <Button
+                variant="secondary"
+                size="xs"
                 onClick={() => void restoreRemoved(entry)}
                 disabled={restoringId !== null}
-                className="familiar-studio-lifecycle__btn"
+                loading={restoringId === entry.id}
+                leadingIcon="ph:arrow-counter-clockwise"
               >
-                <Icon name="ph:arrow-counter-clockwise" width={12} />
                 {restoringId === entry.id ? "Restoring…" : "Restore"}
-              </button>
+              </Button>
             </div>
           ))}
         </section>
@@ -333,13 +336,15 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved, onRosterChan
             Clears {familiar.display_name}&apos;s identity / look / brain customizations and
             reverts it to its daemon defaults.
           </p>
-          <button
+          <Button
+            variant="danger"
+            size="sm"
+            className="self-start"
             onClick={resetAll}
-            className={`familiar-studio-lifecycle__btn familiar-studio-lifecycle__btn--danger${confirmReset ? " familiar-studio-lifecycle__btn--confirm" : ""}`}
+            leadingIcon="ph:trash"
           >
-            <Icon name="ph:trash" width={14} />
             {confirmReset ? "Click again to confirm" : "Reset all overrides"}
-          </button>
+          </Button>
         </section>
       ) : null}
 
@@ -388,17 +393,17 @@ function RemoveConfirm({
         </p>
       ) : null}
       <div className="familiar-studio-lifecycle__confirm-actions">
-        <button
-          type="button"
+        <Button
+          variant="danger"
+          size="sm"
           onClick={onConfirm}
-          className="familiar-studio-lifecycle__btn familiar-studio-lifecycle__btn--danger familiar-studio-lifecycle__btn--confirm"
+          leadingIcon="ph:trash"
         >
-          <Icon name="ph:trash" width={14} />
           Remove familiar
-        </button>
-        <button type="button" onClick={onCancel} className="familiar-studio-lifecycle__btn">
+        </Button>
+        <Button variant="secondary" size="sm" onClick={onCancel}>
           Cancel
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -490,51 +495,47 @@ function FamiliarRow({
       </button>
       {!isArchived ? (
         <>
-          <button
+          <IconButton
+            icon="ph:arrow-up-bold"
+            size="xs"
             onClick={onMoveUp}
             disabled={!canMoveUp}
             aria-label={`Move ${familiar.display_name} up`}
-            className="familiar-studio-lifecycle__row-action"
-          >
-            <Icon name="ph:arrow-up-bold" width={12} />
-          </button>
-          <button
+          />
+          <IconButton
+            icon="ph:arrow-down-bold"
+            size="xs"
             onClick={onMoveDown}
             disabled={!canMoveDown}
             aria-label={`Move ${familiar.display_name} down`}
-            className="familiar-studio-lifecycle__row-action"
-          >
-            <Icon name="ph:arrow-down-bold" width={12} />
-          </button>
+          />
         </>
       ) : null}
       {isArchived ? (
-        <button
+        <IconButton
+          icon="ph:arrow-counter-clockwise"
+          size="xs"
           onClick={onUnarchive}
           aria-label={`Unarchive ${familiar.display_name}`}
           title="Unarchive — return to the active roster"
-          className="familiar-studio-lifecycle__row-action"
-        >
-          <Icon name="ph:arrow-counter-clockwise" width={12} />
-        </button>
+        />
       ) : (
-        <button
+        <IconButton
+          icon="ph:archive"
+          size="xs"
           onClick={onArchive}
           aria-label={`Archive ${familiar.display_name}`}
           title="Archive — hide from switchers; stays bound, unarchive anytime"
-          className="familiar-studio-lifecycle__row-action"
-        >
-          <Icon name="ph:archive" width={12} />
-        </button>
+        />
       )}
-      <button
+      <IconButton
+        icon="ph:trash"
+        size="xs"
+        danger
         onClick={onRemove}
         aria-label={`Remove ${familiar.display_name}`}
         title="Remove — detach from your Cave (undo-safe); chats and memory stay on disk"
-        className="familiar-studio-lifecycle__row-action familiar-studio-lifecycle__row-action--danger"
-      >
-        <Icon name="ph:trash" width={12} />
-      </button>
+      />
     </div>
   );
 }

--- a/src/components/familiar-studio-look-tab.tsx
+++ b/src/components/familiar-studio-look-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
 import { Modal } from "./ui/modal";
 import { FamiliarGlyphPickerPanel } from "./familiar-glyph-picker-panel";
 import { useFamiliarImages } from "@/lib/cave-familiar-images";
@@ -151,13 +152,13 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
                   className="rounded-md object-cover"
                 />
               </button>
-              <button
-                type="button"
+              <Button
+                variant="danger-ghost"
+                size="xs"
                 onClick={() => removeImageConfirm.trigger(clear)}
-                className="familiar-studio-look__remove"
               >
                 {removeImageConfirm.armed ? "Really remove?" : "Remove image"}
-              </button>
+              </Button>
             </>
           ) : (
             <span className="familiar-studio-look__hint">
@@ -230,22 +231,22 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
             aria-label="Custom accent color"
             className="familiar-studio-look__custom"
           />
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
             onClick={() => pickColor(null)}
             disabled={!currentColor}
-            className="familiar-studio-look__reset"
           >
             Reset
-          </button>
+          </Button>
         </div>
         <div className="familiar-studio-look__palette-actions">
-          <button type="button" onClick={applyPaletteByFamiliar}>
+          <Button variant="secondary" size="xs" onClick={applyPaletteByFamiliar}>
             Palette by familiar
-          </button>
-          <button type="button" onClick={applyPaletteByHarness}>
+          </Button>
+          <Button variant="secondary" size="xs" onClick={applyPaletteByHarness}>
             Palette by runtime
-          </button>
+          </Button>
         </div>
         <p className="familiar-studio-look__note">
           Pastels follow the current theme accent. Use same-runtime scope for a

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react
 
 import { Icon, type IconName } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { SettingsGroup } from "@/components/ui/settings-group";
@@ -287,14 +288,12 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
                   className="w-full bg-transparent text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
                 />
                 {projectQuery ? (
-                  <button
-                    type="button"
+                  <IconButton
+                    icon="ph:x-bold"
+                    size="xs"
                     aria-label="Clear project filter"
                     onClick={() => setProjectQuery("")}
-                    className="focus-ring shrink-0 rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-                  >
-                    <Icon name="ph:x-bold" width={10} aria-hidden />
-                  </button>
+                  />
                 ) : null}
               </label>
             </div>
@@ -348,12 +347,12 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
                   aria-label={`${on ? "Revoke" : "Grant"} ${project.name} for ${familiar.display_name}`}
                   disabled={busy}
                   onClick={() => toggle(project.id, !on)}
-                  className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
+                  className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-[var(--radius-pill)] transition-colors duration-150 ${
                     on ? "bg-[var(--accent-presence)]" : "bg-[var(--bg-elevated)]"
                   } ${busy ? "opacity-60" : ""}`}
                 >
                   <span
-                    className={`pointer-events-none mt-0.5 inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
+                    className={`pointer-events-none mt-0.5 inline-block h-4 w-4 rounded-[var(--radius-pill)] bg-white shadow transition-transform duration-150 ${
                       on ? "translate-x-4" : "translate-x-0.5"
                     }`}
                   />
@@ -451,14 +450,18 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
             );
           })}
           {famAudit.length > AUDIT_PREVIEW ? (
-            <button
-              type="button"
-              onClick={() => setShowAllAudit((v) => !v)}
-              aria-expanded={showAllAudit}
-              className="focus-ring w-full border-t border-[var(--border-hairline)] px-4 py-2 text-left text-[11px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            >
-              {showAllAudit ? "Show recent only" : `Show all ${famAudit.length} decisions`}
-            </button>
+            <div className="border-t border-[var(--border-hairline)] px-2 py-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                fullWidth
+                className="justify-start"
+                onClick={() => setShowAllAudit((v) => !v)}
+                aria-expanded={showAllAudit}
+              >
+                {showAllAudit ? "Show recent only" : `Show all ${famAudit.length} decisions`}
+              </Button>
+            </div>
           ) : null}
         </SettingsGroup>
       )}

--- a/src/components/settings-action-buttons.test.ts
+++ b/src/components/settings-action-buttons.test.ts
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const picker = readFileSync(new URL("./settings-familiar-picker.tsx", import.meta.url), "utf8");
+const controls = readFileSync(new URL("./ui/settings-controls.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const studioSources = [
+  "familiar-studio-brain-tab.tsx",
+  "familiar-studio-contract-tab.tsx",
+  "familiar-studio-identity-tab.tsx",
+  "familiar-studio-lifecycle-tab.tsx",
+  "familiar-studio-look-tab.tsx",
+  "familiar-studio-projects-tab.tsx",
+].map((fileName) => [fileName, readFileSync(new URL(`./${fileName}`, import.meta.url), "utf8")] as const);
+
+function rawButtons(fileName: string, source: string): Array<{ block: string; opening: string }> {
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const buttons: Array<{ block: string; opening: string }> = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxElement(node) && node.openingElement.tagName.getText(sourceFile) === "button") {
+      buttons.push({ block: node.getText(sourceFile), opening: node.openingElement.getText(sourceFile) });
+    } else if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(sourceFile) === "button") {
+      const text = node.getText(sourceFile);
+      buttons.push({ block: text, opening: text });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return buttons;
+}
+
+function jsxElementBlocks(fileName: string, source: string, tagName: string): string[] {
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const blocks: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxElement(node) && node.openingElement.tagName.getText(sourceFile) === tagName) {
+      blocks.push(node.getText(sourceFile));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return blocks;
+}
+
+const reviewedSemanticControl = (button: string): boolean =>
+  /goToSetting\(e\)|settings-nav__item|role="switch"|aria-pressed=|aria-label=\{`Pick \$\{label\} color`\}|aria-haspopup="dialog"|role="option"|setEnlarged\(true\)|Drag to reorder|familiar-studio-lifecycle__row-main/.test(
+    button,
+  );
+
+for (const [name, source] of [
+  ["settings shell", shell],
+  ["settings familiar picker", picker],
+  ["settings segmented control", controls],
+  ...studioSources,
+] as const) {
+  const buttons = rawButtons(`${name}.tsx`, source);
+  const unreviewed = buttons.map(({ block }) => block).filter((button) => !reviewedSemanticControl(button));
+  assert.deepEqual(
+    unreviewed,
+    [],
+    `${name} ordinary actions must render through the shared Button or IconButton primitive`,
+  );
+
+  for (const { opening } of buttons) {
+    assert.doesNotMatch(
+      opening,
+      /\brounded-(?:md|lg|xl|full|\[5px\])(?=["`\s])|\brounded(?=["`\s])/,
+      `${name} specialized controls must not hard-code a button radius`,
+    );
+  }
+}
+
+const saveConnectionButtons = jsxElementBlocks("settings-shell.tsx", shell, "Button").filter((block) =>
+  block.includes("Save connection"),
+);
+assert.equal(saveConnectionButtons.length, 1, "Save connection renders through exactly one shared Button");
+assert.match(
+  saveConnectionButtons[0],
+  /onClick=\{\(\) => void saveConnection\(\)\}/,
+  "the Save connection Button invokes the connection save action",
+);
+assert.match(
+  css,
+  /\.ui-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-control\)/,
+  "shared buttons follow the selected design's control radius",
+);
+assert.match(
+  css,
+  /\.ui-icon-btn--xs\s*\{[^}]*border-radius:\s*var\(--radius-control\)/,
+  "shared icon buttons follow the selected design's control radius",
+);
+for (const selector of [
+  ".familiar-studio-picker__trigger",
+  ".familiar-studio-picker__option",
+  ".familiar-studio-lifecycle__row",
+]) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  assert.match(
+    css,
+    new RegExp(`${escaped}\\s*\\{[^}]*border-radius:\\s*var\\(--radius-control\\)`),
+    `${selector} follows the selected design's control radius`,
+  );
+}
+assert.equal(
+  (controls.match(/rounded-\[var\(--radius-control\)\]/g) ?? []).length,
+  2,
+  "the segmented track and each option follow the selected design's control radius",
+);
+
+console.log("settings-action-buttons.test.ts OK");

--- a/src/components/settings-familiar-picker.tsx
+++ b/src/components/settings-familiar-picker.tsx
@@ -9,6 +9,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { Button } from "@/components/ui/button";
 import { Popover } from "@/components/ui/popover";
 import { Icon } from "@/lib/icon";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -258,17 +259,19 @@ export function SettingsFamiliarPicker({ familiars, value, onChange, onSummon }:
 
           {onSummon ? (
             <div className="familiar-studio-picker__footer">
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="lg"
+                fullWidth
                 className="familiar-studio-picker__summon"
                 onClick={() => {
                   resetAndClose();
                   onSummon();
                 }}
+                leadingIcon="ph:magic-wand-fill"
               >
-                <Icon name="ph:magic-wand-fill" width={14} aria-hidden />
                 Summon familiar
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -162,8 +162,13 @@ assert.match(
 // theme is unrecoverable once cleared).
 assert.match(
   source,
-  /aria-label=\{resetCustomArmed \? `Really discard \$\{customData\.name\}\? Click again to confirm` : `Discard \$\{customData\.name\}`\}/,
-  "the custom-theme discard button names the theme and confirms via a second click",
+  /resetCustomArmed \? \([\s\S]*?aria-label=\{`Really discard \$\{customData\.name\}\? Click again to confirm`\}/,
+  "the armed custom-theme discard button names the theme and confirms via a second click",
+);
+assert.match(
+  source,
+  /<IconButton[\s\S]*?aria-label=\{`Discard \$\{customData\.name\}`\}/,
+  "the idle custom-theme discard icon button names the theme",
 );
 assert.match(source, /setResetCustomArmed\(false\), 4000\)/, "arming auto-disarms after a beat");
 
@@ -338,8 +343,13 @@ assert.match(
 );
 assert.match(
   dashboardCss,
-  /\.settings-switch \{[\s\S]{0,400}?border-radius: 999px/,
-  "the minimal switch is a pill track",
+  /\.settings-switch \{[\s\S]{0,400}?border-radius: var\(--radius-pill\)/,
+  "the minimal switch track follows the selected pill radius",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-switch__knob \{[\s\S]{0,220}?border-radius: var\(--radius-pill\)/,
+  "the minimal switch knob follows the selected pill radius",
 );
 assert.match(
   dashboardCss,

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -7,6 +7,7 @@ import { relativeTime } from "@/lib/relative-time";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { SettingsGroup, settingsGroupId } from "@/components/ui/settings-group";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { SettingControlRow, Segmented } from "@/components/ui/settings-controls";
 import { SearchInput } from "@/components/ui/search-input";
@@ -243,17 +244,18 @@ export function SettingsShell() {
         // Back button and other controls opt out automatically as clickables.
         data-tauri-drag-region="deep"
       >
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => {
             if (isMobile && !pickerView) backToPicker();
             else router.back();
           }}
-          className="settings-back-button focus-ring flex h-[26px] items-center gap-1.5 rounded-md px-2 text-[12px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          className="settings-back-button"
+          leadingIcon="ph:arrow-left"
         >
-          <Icon name="ph:arrow-left" width={13} />
           {isMobile && !pickerView ? "Settings" : "Back"}
-        </button>
+        </Button>
         <div className="min-w-0">
           <span className="surface-compact-title block truncate">
             {isMobile && !pickerView ? (activeSection?.label ?? "CovenCave control room") : "CovenCave control room"}
@@ -292,7 +294,7 @@ export function SettingsShell() {
                   <button
                     type="button"
                     onClick={() => goToSetting(e)}
-                    className="focus-ring flex w-full flex-col items-start rounded-[5px] px-2.5 py-[5px] text-left text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+                    className="focus-ring flex w-full flex-col items-start rounded-[var(--radius-control)] px-2.5 py-[5px] text-left text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
                   >
                     <span className="text-[12px] font-medium">{e.group ?? settingsSectionLabel(e.section)}</span>
                     <span className="text-[10px] text-[var(--text-muted)]">{settingsSectionLabel(e.section)}</span>
@@ -308,7 +310,7 @@ export function SettingsShell() {
                 type="button"
                 onClick={() => openSection(s.id)}
                 aria-current={section === s.id && !showPicker ? "page" : undefined}
-                className={`settings-nav__item focus-ring flex w-full items-center rounded-[5px] px-2.5 text-left transition-colors ${
+                className={`settings-nav__item focus-ring flex w-full items-center rounded-[var(--radius-control)] px-2.5 text-left transition-colors ${
                   showPicker
                     ? "min-h-[var(--touch-target)] gap-3 py-3 text-[14px]"
                     : "gap-2 py-[6px] text-[12px]"
@@ -732,15 +734,16 @@ function DaemonSection() {
                 <span className="rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
                   {status.travel.mode}
                 </span>
-                <button
-                  type="button"
+                <Button
+                  variant="secondary"
+                  size="xs"
                   onClick={() => void setManualOffline(!status.travel?.manualOffline)}
                   disabled={savingTravel}
-                  className="focus-ring ml-auto inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-60"
+                  className="ml-auto"
+                  leadingIcon={status.travel.manualOffline ? "ph:plug-bold" : "ph:plug"}
                 >
-                  <Icon name={status.travel.manualOffline ? "ph:plug-bold" : "ph:plug"} width={12} />
                   {status.travel.manualOffline ? "Return online" : "Manual offline"}
-                </button>
+                </Button>
               </div>
               <div className="grid gap-2 text-[11px] text-[var(--text-muted)] sm:grid-cols-3">
                 <span>Reason: <strong className="font-medium text-[var(--text-primary)]">{status.travel.reason}</strong></span>
@@ -1205,7 +1208,7 @@ function ThemePresetCard({
       type="button"
       onClick={() => onSelect(preset.id)}
       aria-pressed={active}
-      className={`focus-ring relative flex flex-col gap-3 rounded-xl border p-4 text-left transition-all ${
+      className={`focus-ring relative flex flex-col gap-3 rounded-[var(--radius-card)] border p-4 text-left transition-all ${
         active
           ? "border-[var(--accent-presence)] bg-[var(--bg-raised)] ring-1 ring-[var(--accent-presence)]"
           : "border-[var(--border-hairline)] bg-[var(--bg-base)] hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)]"
@@ -1397,7 +1400,7 @@ function TokenColorRow({
         aria-label={`Pick ${label} color`}
         title={`Pick ${label} color`}
         onClick={() => setOpen((o) => !o)}
-        className="focus-ring h-6 w-6 shrink-0 cursor-pointer rounded-md border border-[var(--border-strong)] transition-transform hover:scale-110"
+        className="focus-ring h-6 w-6 shrink-0 cursor-pointer rounded-[var(--radius-control)] border border-[var(--border-strong)] transition-transform hover:scale-110"
         style={{ background: value }}
       />
       <span className="flex-1 text-[12px] text-[var(--text-primary)]">{label}</span>
@@ -1748,18 +1751,25 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
             <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--accent-presence)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] px-3 py-0.5 text-[11px] font-medium text-[var(--text-primary)]">
               <Icon name="ph:sparkle" width={11} className="text-[var(--accent-presence)]" />
               Custom: {customData.name}
-              <button
-                type="button"
-                onClick={handleResetCustom}
-                className={`focus-ring ml-1 inline-flex items-center justify-center rounded-full ${
-                  resetCustomArmed
-                    ? "h-auto w-auto px-1.5 text-[10px] font-semibold text-[var(--color-danger)]"
-                    : "h-3.5 w-3.5 opacity-70 hover:opacity-100"
-                }`}
-                aria-label={resetCustomArmed ? `Really discard ${customData.name}? Click again to confirm` : `Discard ${customData.name}`}
-              >
-                {resetCustomArmed ? "Discard?" : <Icon name="ph:x-bold" width={9} />}
-              </button>
+              {resetCustomArmed ? (
+                <Button
+                  variant="danger-ghost"
+                  size="xs"
+                  className="ml-1"
+                  onClick={handleResetCustom}
+                  aria-label={`Really discard ${customData.name}? Click again to confirm`}
+                >
+                  Discard?
+                </Button>
+              ) : (
+                <IconButton
+                  icon="ph:x-bold"
+                  size="xs"
+                  className="ml-1"
+                  onClick={handleResetCustom}
+                  aria-label={`Discard ${customData.name}`}
+                />
+              )}
             </span>
             <span className="text-[11px] text-[var(--text-muted)]">
               {resetCustomArmed
@@ -1821,16 +1831,7 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
       <SettingsGroup label="Import from tweakcn">
         <div className="flex flex-col gap-2 px-4 py-3">
           <p className="text-[12px] text-[var(--text-muted)]">
-            Browse{" "}
-            <button
-              type="button"
-              className="focus-ring rounded underline decoration-dotted underline-offset-2 text-[var(--accent-presence)] hover:text-[var(--text-primary)] transition-colors"
-              onClick={() => openExternalUrl("https://tweakcn.com/editor/theme")}
-              title="Open tweakcn in the in-app browser"
-            >
-              tweakcn.com
-            </button>{" "}
-            in the in-app browser, then paste a theme URL to apply it. Supports{" "}
+            Use Browse to open tweakcn.com in the in-app browser, then paste a theme URL to apply it. Supports{" "}
             <code className="rounded bg-[var(--bg-raised)] px-1 py-0.5 font-mono text-[11px]">
               /themes/&#123;id&#125;
             </code>
@@ -2216,14 +2217,15 @@ function MobileSection() {
       <SettingsGroup label="Get the app">
         <SettingsRow label="Build it with Xcode" description="apps/ios/CovenCave — open in Xcode and run on your device, or install the TestFlight build." />
         <div className="flex flex-wrap gap-2 px-4 py-3">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
+            className="settings-touch-action"
             onClick={() => openExternalUrl("https://github.com/OpenCoven/coven-cave/blob/main/docs/ios-native-rebuild.md")}
-            className="settings-touch-action gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            leadingIcon="ph:file-text"
           >
-            <Icon name="ph:file-text" width={12} />
             Setup guide
-          </button>
+          </Button>
         </div>
       </SettingsGroup>
     </SettingsPage>
@@ -2262,15 +2264,16 @@ function AboutSection() {
             { label: "Grimoire", href: "https://mind.opencoven.ai",               icon: "ph:book-open" as const },
             { label: "Podcast",  href: "https://pod.opencoven.ai",                icon: "ph:waveform-bold" as const },
           ].map((l) => (
-            <button
+            <Button
               key={l.href}
-              type="button"
+              variant="secondary"
+              size="sm"
+              className="settings-touch-action"
               onClick={() => openExternalUrl(l.href)}
-              className="settings-touch-action gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              leadingIcon={l.icon}
             >
-              <Icon name={l.icon} width={12} />
               {l.label}
-            </button>
+            </Button>
           ))}
         </div>
       </SettingsGroup>

--- a/src/components/ui/settings-controls.tsx
+++ b/src/components/ui/settings-controls.tsx
@@ -57,7 +57,7 @@ export function Segmented<T extends string>({
     <div
       role="group"
       aria-label={ariaLabel}
-      className="flex w-fit shrink-0 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
+      className="flex w-fit shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5"
     >
       {options.map((option) => {
         const active = value === option;
@@ -68,7 +68,7 @@ export function Segmented<T extends string>({
             aria-pressed={active}
             aria-label={`${ariaLabel}: ${getLabel(option)}`}
             onClick={() => onChange(option)}
-            className={`focus-ring rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
+            className={`focus-ring rounded-[var(--radius-control)] px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
               equalWidth ? "min-w-12 text-center" : ""
             } ${
               active

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -365,7 +365,7 @@
   height: 20px;
   padding: 0;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-base);
   cursor: pointer;
   transition: background 140ms ease, border-color 140ms ease;
@@ -380,7 +380,7 @@
   left: 2px;
   width: 14px;
   height: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-muted);
   transition: transform 140ms var(--ease-standard, ease), background 140ms ease;
 }


### PR DESCRIPTION
## Summary

Standardize ordinary action buttons across Settings and direct Familiar Studio surfaces on the shared `Button`/`IconButton` primitives, including **Save connection**, while keeping semantic controls on the selected design's radius tokens.

## Why

Settings had accumulated bespoke raw buttons and fixed radii, so controls could diverge visually and fail to follow the Sharp/Default/Round appearance choice. Bead: `cave-qapp`.

## Changes

- migrate ordinary Settings and direct Familiar Studio actions to shared button primitives
- move specialized navigation, switch, picker, segmented, card, and lifecycle-row shapes to semantic radius tokens
- explicitly guard the Save connection button and its save handler with an AST-local conformance assertion
- add Settings/Familiar Studio button conformance coverage and wire it into the app suite

## Verification

- `pnpm typecheck`
- `pnpm check:tests-wired` — 855 test files wired, 1 allowlisted
- `pnpm test:app` — 631 test files passed
- `pnpm build` — 447 KB shell within the 650 KB budget
- focused Settings/Familiar Studio regression suite
- rendered production verification: Save connection Round 12px / Sharp 2px; News switch Round 999px / Sharp 4px; Summon and Familiar Studio actions use `ui-btn` at the selected radius
- independent code review: no Critical or Important findings

## Risk + rollout notes

Low-risk UI consistency change. Specialized semantic controls remain specialized; the new conformance test enumerates reviewed exceptions and prevents ordinary actions or fixed-radius controls from drifting back. No migration or release-note entry required.