### PR TITLE
refactor(inbox): drop the bell's redundant mark-read on Open (cave-uu2d follow-up)

### DIFF
--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -546,9 +546,10 @@ export function NotificationBell({
                       <BellBtn
                         primary
                         onClick={() => {
-                          // Opening acknowledges: quiet the badge without
-                          // resolving the item.
-                          if (unread) void markRead(it.id);
+                          // Opening acknowledges the item, but the parent's
+                          // onOpenItem handler already marks it read (every
+                          // open-path funnels through markInboxItemRead) — so
+                          // the bell must not POST a second, redundant read.
                           setOpen(false);
                           onOpenItem(it);
                         }}


### PR DESCRIPTION
## Why

Follow-up to #3035. Opening an unread notification from the bell fired **two identical `POST /api/inbox/bulk {action:"read"}` requests**:

1. the bell's own `Open` handler (`if (unread) void markRead(it.id)`), and
2. the parent's `onOpenItem` handler → `markInboxItemRead(item.id)`.

Every open-path — bell, sidebar, inspector, and toast — already funnels through the workspace's `markInboxItemRead`, so that parent handler is the single choke point for "opening acknowledges the item." The bell's own call was a pure duplicate.

## What

Remove the bell's Open-handler `markRead` call. The per-row **Read** button remains its only `markRead` consumer, so nothing goes dead. The op is idempotent server-side, so behavior is unchanged — opening an unread item now sends one `read` POST instead of two.

## Verification

- `pnpm typecheck` — clean
- `notification-bell-mutations.test.ts` — ok (its `markRead`-routes-through-the-guard pin still holds via the Read button; no test pinned the Open path)
- `node scripts/run-tests.mjs app` — ✓ 630 test files

Surfaced by a manual pass after the xhigh code-review workflow's verify stage was cut short by an API rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)