### PR TITLE
refactor(quick-chat): serve the notch from /quick-chat?notch=1 — one shared route

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -270,7 +270,11 @@ fn notch_url_from_main(mut url: Url) -> Option<Url> {
     if !trusted_loopback {
         return None;
     }
-    url.set_path("/notch");
+    // The notch shares the /quick-chat route with the tray window; ?notch=1
+    // selects the notch presentation server-side. Appended (not replacing)
+    // because the loopback URL carries the sidecar auth token in its query.
+    url.set_path("/quick-chat");
+    url.query_pairs_mut().append_pair("notch", "1");
     Some(url)
 }
 
@@ -2122,8 +2126,8 @@ mod tests {
         let sidecar = Url::parse("http://127.0.0.1:43123/?token=secret").expect("sidecar URL");
         let notch = notch_url_from_main(sidecar).expect("trusted notch URL");
 
-        assert_eq!(notch.path(), "/notch");
-        assert_eq!(notch.query(), Some("token=secret"));
+        assert_eq!(notch.path(), "/quick-chat");
+        assert_eq!(notch.query(), Some("token=secret&notch=1"));
         assert!(notch_url_from_main(
             Url::parse("https://example.test/").expect("external URL")
         )

--- a/src/app/notch/page.tsx
+++ b/src/app/notch/page.tsx
@@ -1,5 +1,0 @@
-import { NotchQuickChat } from "@/components/notch-quick-chat";
-
-export default function NotchPage() {
-  return <NotchQuickChat />;
-}

--- a/src/app/quick-chat/page.tsx
+++ b/src/app/quick-chat/page.tsx
@@ -1,5 +1,17 @@
+import { NotchQuickChat } from "@/components/notch-quick-chat";
 import { TrayQuickChat } from "@/components/tray-quick-chat";
 
-export default function QuickChatPage() {
-  return <TrayQuickChat />;
+// One route, two presentations: the floating tray window loads /quick-chat
+// plain; the shell's notch window loads /quick-chat?notch=1 (see
+// notch_url_from_main in src-tauri/src/lib.rs). Sharing the route keeps the
+// packaged sidecar runtime closure flat — a dedicated /notch route pushed the
+// traced fileCount over the SIDECAR_RUNTIME_BUDGETS ceiling — and the server
+// switch picks the presentation without a client-side flash.
+export default async function QuickChatPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  return params.notch === "1" ? <NotchQuickChat /> : <TrayQuickChat />;
 }

--- a/src/components/notch-quick-chat.test.ts
+++ b/src/components/notch-quick-chat.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const component = readFileSync(new URL("./notch-quick-chat.tsx", import.meta.url), "utf8");
-const page = readFileSync(new URL("../app/notch/page.tsx", import.meta.url), "utf8");
+const page = readFileSync(new URL("../app/quick-chat/page.tsx", import.meta.url), "utf8");
 const tray = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../styles/notch-quick-chat.css", import.meta.url), "utf8");
 const shell = readFileSync(new URL("../../src-tauri/src/lib.rs", import.meta.url), "utf8");
@@ -11,12 +11,17 @@ const shell = readFileSync(new URL("../../src-tauri/src/lib.rs", import.meta.url
 assert.match(
   page,
   /import \{ NotchQuickChat \} from "@\/components\/notch-quick-chat"/,
-  "the /notch route renders the notch quick chat component",
+  "the shared quick-chat route can render the notch presentation",
+);
+assert.match(
+  page,
+  /params\.notch === "1" \? <NotchQuickChat \/> : <TrayQuickChat \/>/,
+  "?notch=1 selects the notch presentation server-side — no dedicated route, so the sidecar runtime closure stays flat",
 );
 
 // ── The shell owns the notch window ─────────────────────────────────────────
 // A dedicated always-on-top frameless window, top-center of the primary
-// monitor, loading /notch on the trusted loopback origin only.
+// monitor, loading /quick-chat?notch=1 on the trusted loopback origin only.
 assert.match(
   shell,
   /const NOTCH_WINDOW_LABEL: &str = "notch";/,
@@ -24,8 +29,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /url\.set_path\("\/notch"\);/,
-  "notch_url_from_main routes the trusted loopback origin to /notch",
+  /url\.set_path\("\/quick-chat"\);\s*\n\s*url\.query_pairs_mut\(\)\.append_pair\("notch", "1"\);/,
+  "notch_url_from_main routes the trusted loopback origin to /quick-chat?notch=1, keeping the sidecar auth token",
 );
 assert.match(
   shell,

--- a/src/components/notch-quick-chat.tsx
+++ b/src/components/notch-quick-chat.tsx
@@ -14,8 +14,8 @@ import { Icon } from "@/lib/icon";
 import { QuickChatTabPane, type TabReport } from "@/components/tray-quick-chat";
 
 /**
- * The centered-notch presentation of quick chat (the `/notch` route, loaded
- * by show_notch_window in src-tauri/src/lib.rs).
+ * The centered-notch presentation of quick chat (`/quick-chat?notch=1`,
+ * loaded by show_notch_window in src-tauri/src/lib.rs).
  *
  * The Rust shell parks a tiny always-on-top frameless window flush with the
  * top of the screen — the "notch". By default the collapsed pill follows the


### PR DESCRIPTION
## Summary
Re-lands the in-flight follow-up to #2981 that was stranded on the local `feat/notch-quick-chat` worktree.

- A dedicated `/notch` route pushed the traced sidecar runtime closure over the `SIDECAR_RUNTIME_BUDGETS` fileCount ceiling.
- Both presentations now serve from `/quick-chat`: the tray window loads it plain, the shell's notch window loads `/quick-chat?notch=1` (query pair appended — the loopback URL carries the sidecar auth token).
- `notch_url_from_main` in `src-tauri/src/lib.rs` updated accordingly, with test coverage.

## Validation
- `node --experimental-strip-types src/components/notch-quick-chat.test.ts` → OK
- No remaining `/notch` route references outside tests.