### PR TITLE
perf(sessions): make /api/sessions/list git enrichment async (cave-n37w)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -752,6 +752,7 @@ export const SUITES = {
     "src/lib/conversation-cache.test.ts",
     "src/lib/familiar-identity-scaffold.test.ts",
     "src/lib/session-list-merge.test.ts",
+    "src/lib/session-git-enrich.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",
     "src/lib/server/operator-profile-context.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -449,23 +449,18 @@ for (const contract of contracts) {
   );
   assert.match(
     sessionsListSource,
-    /execFileSync\("git"/,
-    "/sessions/list: sessions should be enriched from local git context",
+    /import \{ enrichSessionsWithGitContext \} from "@\/lib\/session-git-enrich"/,
+    "/sessions/list: sessions should be enriched from local git context (async lib)",
+  );
+  assert.doesNotMatch(
+    sessionsListSource,
+    /execFileSync|execSync|spawnSync/,
+    "/sessions/list: the polled list route must never run sync subprocesses on the event loop (cave-n37w)",
   );
   assert.match(
     sessionsListSource,
-    /"branch", "--show-current"[\s\S]*"rev-parse", "--short", "HEAD"/,
-    "/sessions/list: git context should expose branch or detached head",
-  );
-  assert.match(
-    sessionsListSource,
-    /"rev-parse", "--show-toplevel"[\s\S]*"rev-parse", "--git-common-dir"/,
-    "/sessions/list: git context should detect worktree-backed roots",
-  );
-  assert.match(
-    sessionsListSource,
-    /"rev-parse", "--is-inside-work-tree"/,
-    "/sessions/list: git context should skip non-worktree roots before slower git probes",
+    /await enrichSessionsWithGitContext\(/,
+    "/sessions/list: git enrichment should be awaited (async), not run synchronously",
   );
   assert.match(
     sessionsListSource,
@@ -476,6 +471,36 @@ for (const contract of contracts) {
     sessionsListSource,
     /const inFlight = sessionsListInFlight\.get\(cacheKey\);[\s\S]*if \(inFlight\) return inFlight;/,
     "/sessions/list: concurrent callers should await one in-flight session list computation",
+  );
+
+  const sessionGitEnrichSource = readFileSync(
+    path.join(apiRoot, "..", "..", "lib", "session-git-enrich.ts"),
+    "utf8",
+  );
+  assert.match(
+    sessionGitEnrichSource,
+    /promisify\(execFile\)/,
+    "session-git-enrich: git must run through async execFile (no event-loop block)",
+  );
+  assert.doesNotMatch(
+    sessionGitEnrichSource,
+    /execFileSync|execSync|spawnSync/,
+    "session-git-enrich: no sync subprocess fallbacks",
+  );
+  assert.match(
+    sessionGitEnrichSource,
+    /"branch", "--show-current"[\s\S]*"rev-parse", "--short", "HEAD"/,
+    "session-git-enrich: git context should expose branch or detached head",
+  );
+  assert.match(
+    sessionGitEnrichSource,
+    /"rev-parse", "--show-toplevel"[\s\S]*"rev-parse", "--git-common-dir"/,
+    "session-git-enrich: git context should detect worktree-backed roots",
+  );
+  assert.match(
+    sessionGitEnrichSource,
+    /"rev-parse", "--is-inside-work-tree"/,
+    "session-git-enrich: git context should skip non-worktree roots before slower git probes",
   );
 }
 

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from "next/server";
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 import { callDaemon } from "@/lib/coven-daemon";
 import { archiveSessionsForMergedPrs, loadState, type CaveState } from "@/lib/cave-config";
 import { listConversations } from "@/lib/cave-conversations";
-import { branchPrCache } from "@/lib/branch-pr-context";
 import {
   MERGED_AUTO_ARCHIVE_DISABLE_ENV,
   mergedChatAutoArchiveDecisions,
@@ -16,11 +13,12 @@ import {
   localConversationSessionRows,
   mergeSessionRows,
 } from "@/lib/session-list-merge";
+import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { scopeSessionsToFamiliarProjects } from "@/lib/session-project-scope";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
-import type { SessionGitContext, SessionInitiator, SessionRow } from "@/lib/types";
+import type { SessionInitiator, SessionRow } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -74,126 +72,9 @@ function isTrueProjectCwd(projectRoot: string): boolean {
   }
 }
 
-function git(projectRoot: string, args: string[]): string | null {
-  try {
-    const output = execFileSync("git", args, {
-      cwd: projectRoot,
-      encoding: "utf8",
-      timeout: 1000,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    const value = output.trim();
-    return value || null;
-  } catch {
-    return null;
-  }
-}
-
-function isGitWorkTree(projectRoot: string): boolean {
-  return git(projectRoot, ["rev-parse", "--is-inside-work-tree"]) === "true";
-}
-
-function resolveGitPath(projectRoot: string, value: string | null): string | null {
-  if (!value) return null;
-  return path.resolve(path.isAbsolute(value) ? value : path.join(projectRoot, value));
-}
-
-function readGitContext(projectRoot: string): SessionGitContext | null {
-  const trimmed = projectRoot.trim();
-  if (!isTrueProjectCwd(trimmed)) return null;
-  if (!isGitWorkTree(trimmed)) return null;
-
-  const branch =
-    git(trimmed, ["branch", "--show-current"]) ??
-    git(trimmed, ["rev-parse", "--short", "HEAD"]);
-  const worktreeRoot = git(trimmed, ["rev-parse", "--show-toplevel"]);
-  const gitDir = resolveGitPath(trimmed, git(trimmed, ["rev-parse", "--git-dir"]));
-  const commonDir = resolveGitPath(trimmed, git(trimmed, ["rev-parse", "--git-common-dir"]));
-  const isWorktree = Boolean(gitDir && commonDir && gitDir !== commonDir);
-
-  if (!branch && !worktreeRoot && !isWorktree) return null;
-  return { branch, worktreeRoot, isWorktree };
-}
-
-type DiffStat = { additions: number; deletions: number };
-
-function parseShortstat(out: string | null): DiffStat | null {
-  if (out == null) return null;
-  const add = /(\d+) insertion/.exec(out);
-  const del = /(\d+) deletion/.exec(out);
-  return { additions: add ? Number(add[1]) : 0, deletions: del ? Number(del[1]) : 0 };
-}
-
-/**
- * The repo's default base ref (e.g. `origin/main`) to diff a session branch
- * against. Prefers `origin/HEAD`, then common fallbacks.
- */
-function defaultBaseRef(root: string): string | null {
-  const originHead = git(root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-  if (originHead) return originHead;
-  for (const ref of ["origin/main", "origin/master", "main", "master"]) {
-    if (git(root, ["rev-parse", "--verify", "--quiet", ref]) != null) return ref;
-  }
-  return null;
-}
-
-// Bound the per-request git work; sessions arrive most-recent-first, so the
-// roll-up's visible rows are covered well within this cap.
-const MAX_DIFF_CALLS = 32;
-
-function enrichSessionsWithGitContext(sessions: SessionRow[]): SessionRow[] {
-  const gitContextByRoot = new Map<string, SessionGitContext | null>();
-  const baseByRoot = new Map<string, string | null>();
-  const diffByKey = new Map<string, DiffStat | null>();
-  let diffCalls = 0;
-
-  return sessions.map((session) => {
-    const root = session.project_root?.trim();
-    if (!root) return session;
-    if (!gitContextByRoot.has(root)) {
-      gitContextByRoot.set(root, readGitContext(root));
-    }
-    const gitContext = gitContextByRoot.get(root) ?? null;
-
-    // Per-session diff = the session's own branch vs the repo base (committed
-    // changes since it diverged), cached per (root, branch) so sessions on the
-    // same branch share the figure but different branches read distinctly.
-    let diff: DiffStat | null = null;
-    const branch = gitContext?.branch;
-    if (branch) {
-      const key = `${root}\u0000${branch}`;
-      if (diffByKey.has(key)) {
-        diff = diffByKey.get(key) ?? null;
-      } else if (diffCalls < MAX_DIFF_CALLS) {
-        if (!baseByRoot.has(root)) baseByRoot.set(root, defaultBaseRef(root));
-        const base = baseByRoot.get(root) ?? null;
-        let computed: DiffStat | null = null;
-        if (base) {
-          diffCalls += 1;
-          computed = parseShortstat(git(root, ["diff", `${base}...${branch}`, "--shortstat"])) ?? {
-            additions: 0,
-            deletions: 0,
-          };
-        }
-        diffByKey.set(key, computed);
-        diff = computed;
-      }
-    }
-
-    const enriched: SessionRow = { ...session };
-    if (gitContext) enriched.git = gitContext;
-    if (diff) enriched.diff = diff;
-    // PR context for the thread's branch — synchronous read from the
-    // stale-while-revalidate cache (never blocks the poll; see
-    // branch-pr-context.ts). Powers the chat list's PR-status signal and the
-    // merged-chat auto-archive sweep.
-    if (branch) {
-      const pr = branchPrCache.get(root, branch);
-      if (pr) enriched.pullRequest = pr;
-    }
-    return enriched;
-  });
-}
+// Git enrichment (branch/worktree context, diffstat vs base, PR context) lives
+// in @/lib/session-git-enrich — fully async so the polled list request never
+// blocks the event loop on git subprocesses (cave-n37w).
 
 /**
  * Merged-chat auto-archive sweep, piggybacked on the session list read: any
@@ -295,7 +176,7 @@ async function computeSessionsList(
           degraded: true,
           error: res.error ?? `daemon http ${res.status}`,
           sessions: await applyMergedPrAutoArchive(
-            enrichSessionsWithGitContext(
+            await enrichSessionsWithGitContext(
               await scopeForFamiliar(localSessions, projects, familiarId),
             ),
             state,
@@ -332,7 +213,7 @@ async function computeSessionsList(
     payload: {
       ok: true,
       sessions: await applyMergedPrAutoArchive(
-        enrichSessionsWithGitContext(scoped),
+        await enrichSessionsWithGitContext(scoped),
         state,
         includeArchived,
       ),

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -59,15 +59,19 @@ for (const state of ["merged", "closed", "draft"]) {
 }
 
 // ── Sessions list: branch PR enrichment never blocks the poll ────────────────
+const gitEnrichLib = readFileSync(
+  new URL("../lib/session-git-enrich.ts", import.meta.url),
+  "utf8",
+);
 assert.match(
-  listRoute,
+  gitEnrichLib,
   /branchPrCache\.get\(root, branch\)/,
-  "the list route reads PR context from the stale-while-revalidate cache",
+  "session enrichment reads PR context from the stale-while-revalidate cache",
 );
 assert.match(
   listRoute,
-  /applyMergedPrAutoArchive\(\s*enrichSessionsWithGitContext\(scoped\),/,
-  "the merged-PR sweep runs over the enriched rows before the payload returns",
+  /applyMergedPrAutoArchive\(\s*await enrichSessionsWithGitContext\(scoped\),/,
+  "the merged-PR sweep runs over the (async) enriched rows before the payload returns",
 );
 assert.match(
   listRoute,

--- a/src/lib/session-git-enrich.test.ts
+++ b/src/lib/session-git-enrich.test.ts
@@ -1,0 +1,246 @@
+// @ts-nocheck
+/**
+ * Tests for src/lib/session-git-enrich.ts (cave-n37w): the async replacement
+ * for /api/sessions/list's execFileSync git enrichment.
+ *
+ * Covers, with a fake injectable git runner:
+ *  1. branch + worktree context enrichment (semantics parity with the old
+ *     sync version)
+ *  2. detached-HEAD fallback (rev-parse --short HEAD)
+ *  3. the is-inside-work-tree gate short-circuits non-repo dirs
+ *  4. missing directories never spawn git at all
+ *  5. per-root dedup — many sessions on one root probe git once
+ *  6. diffstat vs base ref + parseShortstat parsing
+ *  7. MAX_DIFF_CALLS global cap
+ *  8. failed base-ref resolution yields no diff and does not consume the cap
+ *  9. root-level concurrency stays within ROOT_CONCURRENCY
+ * 10. rows without a root pass through untouched
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  enrichSessionsWithGitContext,
+  parseShortstat,
+  MAX_DIFF_CALLS,
+  ROOT_CONCURRENCY,
+} from "./session-git-enrich.ts";
+
+// Real directories: the lib stat-gates roots before probing git.
+const scratch = mkdtempSync(path.join(tmpdir(), "session-git-enrich-"));
+process.on("exit", () => rmSync(scratch, { recursive: true, force: true }));
+function makeRoot(name) {
+  const dir = path.join(scratch, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function session(id, root) {
+  return { id, project_root: root, harness: "codex", title: id, status: "completed" };
+}
+
+/**
+ * Fake git runner scripted per argv key. Records every call. `script` maps a
+ * space-joined argv prefix to a value (string | null) or function(root).
+ */
+function fakeGit(script) {
+  const calls = [];
+  const runner = async (root, args) => {
+    calls.push({ root, args });
+    const key = args.join(" ");
+    for (const [prefix, value] of Object.entries(script)) {
+      if (key.startsWith(prefix)) {
+        return typeof value === "function" ? value(root, args) : value;
+      }
+    }
+    return null;
+  };
+  return { runner, calls };
+}
+
+const REPO_SCRIPT = {
+  "rev-parse --is-inside-work-tree": "true",
+  "branch --show-current": "feat/thing",
+  "rev-parse --show-toplevel": (root) => root,
+  "rev-parse --git-dir": ".git",
+  "rev-parse --git-common-dir": ".git",
+  "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+  "diff origin/main...feat/thing --shortstat": " 3 files changed, 10 insertions(+), 2 deletions(-)",
+};
+
+// ── 1. branch + diff enrichment, semantics parity ───────────────────────────
+{
+  const rootA = makeRoot("repo-a");
+  const { runner } = fakeGit(REPO_SCRIPT);
+  const rows = await enrichSessionsWithGitContext([session("s1", rootA)], runner);
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0].git, {
+    branch: "feat/thing",
+    worktreeRoot: rootA,
+    isWorktree: false,
+  });
+  assert.deepEqual(rows[0].diff, { additions: 10, deletions: 2 });
+}
+
+// ── 2. detached HEAD falls back to the short hash ───────────────────────────
+{
+  const root = makeRoot("repo-detached");
+  const { runner, calls } = fakeGit({
+    "rev-parse --is-inside-work-tree": "true",
+    "branch --show-current": null,
+    "rev-parse --short HEAD": "abc1234",
+    "rev-parse --show-toplevel": (r) => r,
+    "rev-parse --git-dir": ".git",
+    "rev-parse --git-common-dir": ".git",
+    "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+    "diff origin/main...abc1234 --shortstat": " 1 file changed, 1 insertion(+)",
+  });
+  const rows = await enrichSessionsWithGitContext([session("s1", root)], runner);
+  assert.equal(rows[0].git.branch, "abc1234");
+  assert.deepEqual(rows[0].diff, { additions: 1, deletions: 0 });
+  assert.ok(calls.some((c) => c.args.join(" ") === "rev-parse --short HEAD"));
+}
+
+// ── 3. non-repo dirs stop at the is-inside-work-tree gate ──────────────────
+{
+  const root = makeRoot("not-a-repo");
+  const { runner, calls } = fakeGit({ "rev-parse --is-inside-work-tree": null });
+  const rows = await enrichSessionsWithGitContext([session("s1", root)], runner);
+  assert.equal(rows[0].git, undefined);
+  assert.equal(rows[0].diff, undefined);
+  assert.equal(calls.length, 1, "only the gate probe may run for non-repo dirs");
+}
+
+// ── 4. missing directories never spawn git ──────────────────────────────────
+{
+  const { runner, calls } = fakeGit(REPO_SCRIPT);
+  const rows = await enrichSessionsWithGitContext(
+    [session("s1", path.join(scratch, "does-not-exist"))],
+    runner,
+  );
+  assert.equal(rows[0].git, undefined);
+  assert.equal(calls.length, 0, "stat gate must precede any git call");
+}
+
+// ── 5. sessions sharing a root share one probe set ──────────────────────────
+{
+  const root = makeRoot("repo-shared");
+  const { runner, calls } = fakeGit(REPO_SCRIPT);
+  const rows = await enrichSessionsWithGitContext(
+    [session("s1", root), session("s2", root), session("s3", root)],
+    runner,
+  );
+  assert.equal(rows.length, 3);
+  for (const row of rows) {
+    assert.equal(row.git.branch, "feat/thing");
+    assert.deepEqual(row.diff, { additions: 10, deletions: 2 });
+  }
+  const diffCalls = calls.filter((c) => c.args[0] === "diff");
+  assert.equal(diffCalls.length, 1, "one diff per root, not per session");
+  const gateCalls = calls.filter((c) => c.args.join(" ") === "rev-parse --is-inside-work-tree");
+  assert.equal(gateCalls.length, 1, "one context probe set per root");
+}
+
+// ── 6. parseShortstat parsing ────────────────────────────────────────────────
+{
+  assert.deepEqual(parseShortstat(" 3 files changed, 10 insertions(+), 2 deletions(-)"), {
+    additions: 10,
+    deletions: 2,
+  });
+  assert.deepEqual(parseShortstat(" 1 file changed, 1 insertion(+)"), {
+    additions: 1,
+    deletions: 0,
+  });
+  assert.deepEqual(parseShortstat(""), { additions: 0, deletions: 0 });
+  assert.equal(parseShortstat(null), null);
+}
+
+// ── 7. the global diff cap holds across many roots ──────────────────────────
+{
+  const roots = Array.from({ length: MAX_DIFF_CALLS + 8 }, (_, i) => makeRoot(`repo-cap-${i}`));
+  const { runner, calls } = fakeGit(REPO_SCRIPT);
+  const rows = await enrichSessionsWithGitContext(
+    roots.map((root, i) => session(`s${i}`, root)),
+    runner,
+  );
+  const diffCalls = calls.filter((c) => c.args[0] === "diff");
+  assert.equal(diffCalls.length, MAX_DIFF_CALLS, "diff calls must stop at MAX_DIFF_CALLS");
+  // Every root still gets branch context even past the diff cap.
+  for (const row of rows) assert.equal(row.git.branch, "feat/thing");
+  assert.equal(
+    rows.filter((r) => r.diff).length,
+    MAX_DIFF_CALLS,
+    "rows beyond the cap carry no diff",
+  );
+}
+
+// ── 8. missing base ref: no diff, and the cap is not consumed ───────────────
+{
+  const noBase = makeRoot("repo-no-base");
+  const withBase = makeRoot("repo-with-base");
+  const { runner, calls } = fakeGit({
+    ...REPO_SCRIPT,
+    "symbolic-ref --short refs/remotes/origin/HEAD": (root) =>
+      root === noBase ? null : "origin/main",
+    "rev-parse --verify --quiet": null,
+  });
+  const rows = await enrichSessionsWithGitContext(
+    [session("s1", noBase), session("s2", withBase)],
+    runner,
+  );
+  assert.equal(rows[0].diff, undefined, "no base ref -> no diff");
+  assert.deepEqual(rows[1].diff, { additions: 10, deletions: 2 });
+  const diffCalls = calls.filter((c) => c.args[0] === "diff");
+  assert.equal(diffCalls.length, 1, "the failed-base root must not consume a diff slot");
+}
+
+// ── 9. root-level concurrency stays bounded ─────────────────────────────────
+{
+  const roots = Array.from({ length: 12 }, (_, i) => makeRoot(`repo-conc-${i}`));
+  let inFlight = 0;
+  let peak = 0;
+  const perRootActive = new Set();
+  const runner = async (root, args) => {
+    // Count distinct roots being probed at once (the unit of parallelism).
+    if (!perRootActive.has(root)) {
+      perRootActive.add(root);
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+    }
+    await new Promise((r) => setTimeout(r, 2));
+    const key = args.join(" ");
+    if (key === "rev-parse --is-inside-work-tree") return "true";
+    if (key === "branch --show-current") return "main";
+    if (key === "rev-parse --show-toplevel") return root;
+    if (key.startsWith("diff")) {
+      // Last probe for the root — release its concurrency slot.
+      perRootActive.delete(root);
+      inFlight -= 1;
+      return " 1 file changed, 1 insertion(+)";
+    }
+    if (key.startsWith("symbolic-ref")) return "origin/main";
+    return ".git";
+  };
+  await enrichSessionsWithGitContext(
+    roots.map((root, i) => session(`s${i}`, root)),
+    runner,
+  );
+  assert.ok(
+    peak <= ROOT_CONCURRENCY,
+    `peak concurrent roots ${peak} must stay <= ROOT_CONCURRENCY (${ROOT_CONCURRENCY})`,
+  );
+  assert.ok(peak >= 2, "roots must actually be probed in parallel");
+}
+
+// ── 10. rootless rows pass through untouched ────────────────────────────────
+{
+  const { runner, calls } = fakeGit(REPO_SCRIPT);
+  const bare = { id: "s1", project_root: "", harness: "codex", title: "s1", status: "completed" };
+  const rows = await enrichSessionsWithGitContext([bare], runner);
+  assert.equal(rows[0], bare, "rootless rows keep their identity");
+  assert.equal(calls.length, 0);
+}
+
+console.log("session-git-enrich.test.ts: all assertions passed");

--- a/src/lib/session-git-enrich.ts
+++ b/src/lib/session-git-enrich.ts
@@ -1,0 +1,219 @@
+/**
+ * Async git enrichment for /api/sessions/list rows (cave-n37w).
+ *
+ * The route previously shelled out synchronously — ~5 sequential git
+ * probes per unique project root plus up to MAX_DIFF_CALLS `git diff`
+ * invocations, each blocking the event loop for up to its 1s timeout. The
+ * sessions list is polled every few seconds by the workspace, and the same
+ * Node process serves SSE chat streaming and the PTY bridge, so those stalls
+ * surfaced as token stutter and terminal lag.
+ *
+ * This module keeps the exact enrichment semantics (branch, worktree
+ * detection, per-branch diffstat vs the repo base ref, PR-context lookup)
+ * but runs every git call through async execFile, parallelised per project
+ * root under a small concurrency cap so a machine with many roots neither
+ * serialises the whole sweep nor forks an unbounded process herd.
+ *
+ * Security posture matches /api/changes: every invocation is execFile with an
+ * argument array (no shell), a timeout, and stdout capped by maxBuffer.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+import { branchPrCache } from "./branch-pr-context.ts";
+import type { SessionGitContext, SessionRow } from "./types.ts";
+
+const execFileAsync = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 1000;
+const MAX_GIT_BUFFER = 1024 * 1024;
+
+/**
+ * Bound the per-request git work; sessions arrive most-recent-first, so the
+ * roll-up's visible rows are covered well within this cap.
+ */
+export const MAX_DIFF_CALLS = 32;
+
+/** How many project roots are enriched concurrently. */
+export const ROOT_CONCURRENCY = 4;
+
+/**
+ * Injectable git runner: resolves trimmed stdout, or null on any failure
+ * (missing binary, non-zero exit, timeout). Tests substitute a fake.
+ */
+export type GitRunner = (projectRoot: string, args: string[]) => Promise<string | null>;
+
+export const defaultGitRunner: GitRunner = async (projectRoot, args) => {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: projectRoot,
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: MAX_GIT_BUFFER,
+    });
+    const value = stdout.trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+};
+
+function isTrueProjectCwd(projectRoot: string): boolean {
+  const trimmed = projectRoot.trim();
+  if (!trimmed) return false;
+  try {
+    return fs.statSync(trimmed).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resolveGitPath(projectRoot: string, value: string | null): string | null {
+  if (!value) return null;
+  return path.resolve(path.isAbsolute(value) ? value : path.join(projectRoot, value));
+}
+
+async function readGitContext(git: GitRunner, projectRoot: string): Promise<SessionGitContext | null> {
+  const trimmed = projectRoot.trim();
+  if (!isTrueProjectCwd(trimmed)) return null;
+  // Cheap gate first: skip non-worktree roots before the slower probes.
+  if ((await git(trimmed, ["rev-parse", "--is-inside-work-tree"])) !== "true") return null;
+
+  // Independent probes — run together instead of serially.
+  const [currentBranch, worktreeRoot, gitDirRaw, commonDirRaw] = await Promise.all([
+    git(trimmed, ["branch", "--show-current"]),
+    git(trimmed, ["rev-parse", "--show-toplevel"]),
+    git(trimmed, ["rev-parse", "--git-dir"]),
+    git(trimmed, ["rev-parse", "--git-common-dir"]),
+  ]);
+  const branch = currentBranch ?? (await git(trimmed, ["rev-parse", "--short", "HEAD"]));
+  const gitDir = resolveGitPath(trimmed, gitDirRaw);
+  const commonDir = resolveGitPath(trimmed, commonDirRaw);
+  const isWorktree = Boolean(gitDir && commonDir && gitDir !== commonDir);
+
+  if (!branch && !worktreeRoot && !isWorktree) return null;
+  return { branch, worktreeRoot, isWorktree };
+}
+
+export type DiffStat = { additions: number; deletions: number };
+
+export function parseShortstat(out: string | null): DiffStat | null {
+  if (out == null) return null;
+  const add = /(\d+) insertion/.exec(out);
+  const del = /(\d+) deletion/.exec(out);
+  return { additions: add ? Number(add[1]) : 0, deletions: del ? Number(del[1]) : 0 };
+}
+
+/**
+ * The repo's default base ref (e.g. `origin/main`) to diff a session branch
+ * against. Prefers `origin/HEAD`, then common fallbacks.
+ */
+async function defaultBaseRef(git: GitRunner, root: string): Promise<string | null> {
+  const originHead = await git(root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+  if (originHead) return originHead;
+  for (const ref of ["origin/main", "origin/master", "main", "master"]) {
+    if ((await git(root, ["rev-parse", "--verify", "--quiet", ref])) != null) return ref;
+  }
+  return null;
+}
+
+/** Run `tasks` with at most `limit` in flight at once; preserves result order. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await task(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+type RootEnrichment = {
+  gitContext: SessionGitContext | null;
+  base: string | null;
+  /** branch -> diffstat (or null when the diff was skipped/failed). */
+  diffByBranch: Map<string, DiffStat | null>;
+};
+
+/**
+ * Enrich session rows with git context (branch/worktree), a committed-diff
+ * stat vs the repo base ref, and cached PR context. All git work is async and
+ * grouped per unique project root; roots are processed under a concurrency
+ * cap and the total number of `git diff` calls stays bounded by
+ * MAX_DIFF_CALLS across the whole request (matching the sync version).
+ */
+export async function enrichSessionsWithGitContext(
+  sessions: SessionRow[],
+  git: GitRunner = defaultGitRunner,
+): Promise<SessionRow[]> {
+  // Collect unique roots and, per root, the branches sessions sit on — the
+  // per-root git work happens once regardless of how many sessions share it.
+  const roots: string[] = [];
+  const seenRoots = new Set<string>();
+  for (const session of sessions) {
+    const root = session.project_root?.trim();
+    if (root && !seenRoots.has(root)) {
+      seenRoots.add(root);
+      roots.push(root);
+    }
+  }
+
+  // Global diff budget shared across roots. Reserving a slot synchronously
+  // before each await keeps the cap exact even with concurrent workers.
+  let diffCalls = 0;
+  const enrichmentByRoot = new Map<string, RootEnrichment>();
+
+  await mapWithConcurrency(roots, ROOT_CONCURRENCY, async (root) => {
+    const entry: RootEnrichment = { gitContext: null, base: null, diffByBranch: new Map() };
+    enrichmentByRoot.set(root, entry);
+    entry.gitContext = await readGitContext(git, root);
+    const branch = entry.gitContext?.branch;
+    if (!branch) return;
+    if (diffCalls >= MAX_DIFF_CALLS) return;
+    entry.base = await defaultBaseRef(git, root);
+    if (!entry.base) {
+      entry.diffByBranch.set(branch, null);
+      return;
+    }
+    // Re-check and reserve synchronously (no await between check and
+    // increment) so the cap stays exact under concurrent root workers.
+    if (diffCalls >= MAX_DIFF_CALLS) return;
+    diffCalls += 1;
+    const diff = parseShortstat(
+      await git(root, ["diff", `${entry.base}...${branch}`, "--shortstat"]),
+    ) ?? { additions: 0, deletions: 0 };
+    entry.diffByBranch.set(branch, diff);
+  });
+
+  return sessions.map((session) => {
+    const root = session.project_root?.trim();
+    if (!root) return session;
+    const entry = enrichmentByRoot.get(root);
+    if (!entry) return session;
+
+    const enriched: SessionRow = { ...session };
+    if (entry.gitContext) enriched.git = entry.gitContext;
+    const branch = entry.gitContext?.branch;
+    const diff = branch ? entry.diffByBranch.get(branch) ?? null : null;
+    if (diff) enriched.diff = diff;
+    // PR context for the thread's branch — synchronous read from the
+    // stale-while-revalidate cache (never blocks the poll; see
+    // branch-pr-context.ts). Powers the chat list's PR-status signal and the
+    // merged-chat auto-archive sweep.
+    if (branch) {
+      const pr = branchPrCache.get(root, branch);
+      if (pr) enriched.pullRequest = pr;
+    }
+    return enriched;
+  });
+}


### PR DESCRIPTION
## Problem

`/api/sessions/list` — polled every 4s by the workspace — ran **synchronous** git subprocesses on the Node event loop per cache miss (2s TTL, so nearly every poll):

- ~5 sequential `execFileSync` git probes per unique project root
- up to `MAX_DIFF_CALLS=32` sync `git diff --shortstat` calls
- each call can block up to its 1s timeout

The same Node process serves SSE chat streaming and the PTY bridge, so these stalls surfaced as **token stutter and terminal lag**.

## Change

- New `src/lib/session-git-enrich.ts`: all git calls via async `execFile` (argv array, timeout, maxBuffer — same security posture as `/api/changes`), per-root probes parallelised, roots processed under a 4-wide concurrency cap, exact preservation of the 32-diff global budget.
- Route now imports and `await`s the lib; sync-exec code deleted.
- Semantics parity: branch / detached-HEAD fallback, worktree detection, per-root diffstat vs base ref, `branchPrCache` PR context.

## Regression tests

- `src/lib/session-git-enrich.test.ts` (wired into `test:api`): 10 behavior groups with an injectable fake git runner — enrichment parity, detached HEAD, non-repo gate ordering, stat gate (no spawn for missing dirs), per-root dedup, shortstat parsing, **diff cap enforcement**, failed-base cap accounting, **bounded concurrency**, rootless passthrough.
- `api-contracts.test.ts`: now **forbids** `execFileSync|execSync|spawnSync` in the route, pins the async-lib import + `await` call sites, and moves the git-argv contract pins to the lib.

## Validation

- `node scripts/run-tests.mjs api` — 154/154 pass
- `pnpm typecheck` — clean
- `node scripts/check-tests-wired.mjs` — all wired

Closes bead: cave-n37w