### PR TITLE
fix(knowledge): address #3042 review follow-ups

### DIFF
--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -596,6 +596,13 @@ def package_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) 
                 source = marketplace_dir / Path(*PurePosixPath(skill["sourcePath"]).parts)
                 source_root = source.parent
                 for source_file in source_root.rglob("*"):
+                    # Reject symlinks before is_file()/read_bytes() follow them:
+                    # a link inside the pack source tree could otherwise ship
+                    # bytes from anywhere on disk.
+                    if source_file.is_symlink():
+                        raise SystemExit(
+                            f"knowledge-pack skill source contains a symlink: {source_file}"
+                        )
                     if not source_file.is_file():
                         continue
                     relative = source_file.relative_to(source_root)

--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -570,6 +570,10 @@ def package_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) 
                 source = marketplace_dir / Path(*PurePosixPath(skill["sourcePath"]).parts)
                 source_root = source.parent
                 for source_file in source_root.rglob("*"):
+                    # Reject symlinks during traversal so packaging never reads
+                    # through links to bytes outside the source tree.
+                    if source_file.is_symlink():
+                        raise SystemExit(f"craft skill source contains a symlink: {source_file}")
                     if not source_file.is_file():
                         continue
                     relative = source_file.relative_to(source_root)
@@ -596,9 +600,8 @@ def package_files(catalog: dict[str, Any], marketplace_dir: Path = MARKETPLACE) 
                 source = marketplace_dir / Path(*PurePosixPath(skill["sourcePath"]).parts)
                 source_root = source.parent
                 for source_file in source_root.rglob("*"):
-                    # Reject symlinks before is_file()/read_bytes() follow them:
-                    # a link inside the pack source tree could otherwise ship
-                    # bytes from anywhere on disk.
+                    # Reject symlinks during traversal so packaging never reads
+                    # through links to bytes outside the source tree.
                     if source_file.is_symlink():
                         raise SystemExit(
                             f"knowledge-pack skill source contains a symlink: {source_file}"

--- a/scripts/sync-marketplace.test.mjs
+++ b/scripts/sync-marketplace.test.mjs
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -271,6 +272,19 @@ expectRejected(fixtureCatalog(duplicate), /duplicate Craft resource id "brainsto
 const unsafe = validCraft();
 unsafe.craft.bundled.skills[0].sourcePath = "../outside/SKILL.md";
 expectRejected(fixtureCatalog(unsafe), /unsafe Craft source path/i, false);
+
+const craftSymlinkFixture = writeFixture(fixtureCatalog());
+try {
+  const target = path.join(craftSymlinkFixture.marketplace, "outside-secret.md");
+  writeFileSync(target, "outside\n");
+  const skillRoot = path.join(craftSymlinkFixture.marketplace, "craft-sources", "seekers-lens", "brainstorming-research-ideas");
+  symlinkSync(target, path.join(skillRoot, "leak.md"));
+  const result = runSync(craftSymlinkFixture);
+  assert.notEqual(result.status, 0, "craft symlink source should be rejected");
+  assert.match(result.stderr, /craft skill source contains a symlink/i);
+} finally {
+  rmSync(craftSymlinkFixture.dir, { recursive: true, force: true });
+}
 
 const unsupported = validCraft();
 unsupported.craft.provenance.license = "GPL-3.0";

--- a/src/lib/server/knowledge-vault-collections.test.ts
+++ b/src/lib/server/knowledge-vault-collections.test.ts
@@ -96,6 +96,19 @@ try {
   const prompt = buildPromptWithKnowledgeVault("User prompt", await listKnowledgeEntries(), collections);
   assert.match(prompt, /Collections index/);
   assert.match(prompt, /- characters: Characters — People in the story/);
+
+  const messyPrompt = buildPromptWithKnowledgeVault("User prompt", [], [
+    {
+      id: "places",
+      meta: { name: "Places", summary: "  Multi-line\n\n   summary\ttext  " },
+      count: 1,
+    },
+  ]);
+  assert.match(
+    messyPrompt,
+    /- places: Multi-line summary text/,
+    "multi-line/whitespace-heavy summaries collapse to one line in the index",
+  );
   assert.match(prompt, /root body/);
   assert.doesNotMatch(prompt, /seed body/, "disabled seeded entries stay out of the prompt block");
 } finally {

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -417,15 +417,18 @@ export async function writeCollectionMeta(collection: string, meta: KnowledgeCol
 /** Count valid `*.md` entry files in a collection directory without reading
  *  (or parsing) their contents — listCollections runs on every chat send. */
 async function countCollectionEntries(collection: string): Promise<number> {
-  let names: string[];
+  let dirents: import("node:fs").Dirent[];
   try {
-    names = await readdir(collectionPath(collection));
+    dirents = await readdir(collectionPath(collection), { withFileTypes: true });
   } catch {
     return 0;
   }
-  return names.filter(
-    (name) => name !== "collection.yml" && name.endsWith(".md") && isValidKnowledgeId(name.slice(0, -3)),
-  ).length;
+  return dirents.filter((dirent) => {
+    const name = dirent.name;
+    if (name === "collection.yml" || !name.endsWith(".md")) return false;
+    if (!dirent.isFile()) return false;
+    return isValidKnowledgeId(name.slice(0, -3));
+  }).length;
 }
 
 export async function listCollections(): Promise<{ id: string; meta: KnowledgeCollectionMeta | null; count: number }[]> {

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -224,7 +224,9 @@ export function buildPromptWithKnowledgeVault(
   const collectionIndex = collections
     .filter((collection) => collection.meta?.summary?.trim())
     .slice(0, 20)
-    .map((collection) => `- ${collection.id}: ${collection.meta?.summary?.trim()}`);
+    // Collapse whitespace/newlines so a multi-line summary can't break the
+    // one-line list format or balloon prompt tokens.
+    .map((collection) => `- ${collection.id}: ${(collection.meta?.summary ?? "").replace(/\s+/g, " ").trim()}`);
   if (usable.length === 0 && collectionIndex.length === 0) return text;
 
   const blocks = usable.map((entry) => {
@@ -412,6 +414,20 @@ export async function writeCollectionMeta(collection: string, meta: KnowledgeCol
   await writeFile(collectionMetaPath(collection), stringifyYaml(meta), "utf8");
 }
 
+/** Count valid `*.md` entry files in a collection directory without reading
+ *  (or parsing) their contents — listCollections runs on every chat send. */
+async function countCollectionEntries(collection: string): Promise<number> {
+  let names: string[];
+  try {
+    names = await readdir(collectionPath(collection));
+  } catch {
+    return 0;
+  }
+  return names.filter(
+    (name) => name !== "collection.yml" && name.endsWith(".md") && isValidKnowledgeId(name.slice(0, -3)),
+  ).length;
+}
+
 export async function listCollections(): Promise<{ id: string; meta: KnowledgeCollectionMeta | null; count: number }[]> {
   const root = covenKnowledgeRoot();
   let names: string[];
@@ -430,7 +446,7 @@ export async function listCollections(): Promise<{ id: string; meta: KnowledgeCo
       collections.push({
         id: name,
         meta: await readCollectionMeta(name),
-        count: (await listKnowledgeEntries(name)).length,
+        count: await countCollectionEntries(name),
       });
     } catch {
       // Skip unreadable collection directories.


### PR DESCRIPTION
Follow-up to #3042, addressing the three unresolved copilot-review threads:

1. **Summary normalization** — `buildPromptWithKnowledgeVault` collapses whitespace/newlines in `collection.meta.summary` before interpolation, so a multi-line summary can't break the one-line collections-index format.
2. **Cheap collection counts** — `listCollections()` now counts valid `*.md` entry files via `readdir` instead of reading + parsing every entry through `listKnowledgeEntries()` (it runs on every chat send).
3. **Symlink guard in packaging** — `sync-marketplace.py` rejects symlinks inside knowledge-pack skill sources before `read_bytes()` could follow them outside the pack source tree.

## Validation
- `node --experimental-strip-types src/lib/server/knowledge-vault-collections.test.ts` → ok (includes new multi-line-summary assertion)
- `node --experimental-strip-types src/lib/server/knowledge-vault.test.ts` → ok
- `python3 scripts/sync-marketplace.py --check` → `marketplace_ok files=572 plugins=127`
- `node scripts/sync-marketplace.test.mjs` → ok