### PR TITLE
test(e2e): fix onboarding wizard complete-status mock — verified latestCheck

### DIFF
--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -71,6 +71,9 @@ const COMPLETE_NO_FAMILIARS_STATUS = {
       outdated: false,
       compatible: true,
       minimumVersion: "0.0.50",
+      // effectiveComplete requires hasVerifiedLatestVersion(tool): a verified
+      // latestCheck, not just current === latest.
+      latestCheck: { status: "verified", checkedAt: "2026-07-12T00:00:00.000Z", latest: "0.0.60" },
     },
     {
       id: "coven-code",
@@ -84,6 +87,7 @@ const COMPLETE_NO_FAMILIARS_STATUS = {
       outdated: false,
       compatible: true,
       minimumVersion: "0.0.50",
+      latestCheck: { status: "verified", checkedAt: "2026-07-12T00:00:00.000Z", latest: "0.0.60" },
     },
   ],
 };


### PR DESCRIPTION
## Summary
The required `E2E (Playwright)` gate is red on **every** open PR: `tests/onboarding-wizard.spec.ts › completed setup surfaces an above-the-fold banner…` fails against current main.

Semantic conflict between two merges whose CIs ran before the other landed:
- #3040 added the complete-status banner spec with a mocked `/api/onboarding/status` whose tools have `current === latest` but **no `latestCheck` field**.
- The tools-verification model (#3011/#3034) made `effectiveComplete` require `hasVerifiedLatestVersion(tool)` — i.e. `latestCheck.status === "verified"` — so the wizard treats the mocked machine as incomplete and never shows the banner.

Fix: give both mocked tools a verified `latestCheck`.

## Validation
`COVEN_CAVE_E2E=1 pnpm exec playwright test tests/onboarding-wizard.spec.ts --project desktop` → **10 passed** (was 1 failed).