### PR TITLE
fix(settings): verified OpenCoven tool updates — post-install verification

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -49,6 +49,7 @@ export const SUITES = {
     "src/lib/browser-navigation-queue.test.ts",
     "src/lib/open-external.test.ts",
     "src/lib/coven-version.test.ts",
+    "src/lib/opencoven-tool-verification.test.ts",
     "src/lib/opencoven-tools-status-display.test.ts",
     "src/components/update-available.test.ts",
     "src-tauri/permissions/desktop-permissions.test.mjs",

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -178,8 +178,26 @@ assert.match(
 
 assert.match(
   source,
-  /targetName === "coven-cli" \? \{ refresh: true \}/,
-  "CLI success refreshes the executable environment before resolving the installed binary",
+  /isOpenCovenToolInstallTarget\(targetName\) \? \{ refresh: true \}/,
+  "OpenCoven tool success refreshes the executable environment before resolving the installed binary",
+);
+
+assert.match(
+  source,
+  /verifyOpenCovenToolInstall/,
+  "OpenCoven tool updates perform package, entry-point, and latest-version verification after npm exits",
+);
+
+assert.match(
+  source,
+  /isVerifiedOpenCovenInstallSuccess\(code, verification\)/,
+  "a zero npm exit is not enough to mark OpenCoven tool updates successful",
+);
+
+assert.match(
+  source,
+  /verification: job\.verification/,
+  "polled jobs expose post-install verification so the UI can report verified recovery states",
 );
 
 assert.match(

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -610,7 +610,7 @@ async function finishInstallJob(
       launchError ? installStartErrorMessage(launchError) : job.error,
     );
     const verificationError =
-      verification && !isVerifiedOpenCovenInstallSuccess(code, verification)
+      verification && code === 0 && !verification.ok
         ? verification.error ?? "post-install verification failed"
         : null;
     const installOk = verification

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -29,6 +29,11 @@ import {
   type DaemonUpdateDependencies,
   type DaemonUpdateLifecycle,
 } from "@/lib/daemon-update-lifecycle";
+import { verifyOpenCovenToolInstall, type OpenCovenToolId } from "@/lib/opencoven-tools-status";
+import {
+  isVerifiedOpenCovenInstallSuccess,
+  type OpenCovenToolVerification,
+} from "@/lib/opencoven-tool-verification";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -152,6 +157,10 @@ async function commandPath(
 
 function isInstallTarget(value: unknown): value is InstallTarget {
   return typeof value === "string" && value in INSTALL_TARGETS;
+}
+
+function isOpenCovenToolInstallTarget(value: InstallTarget): value is OpenCovenToolId {
+  return value === "coven-cli" || value === "coven-code";
 }
 
 /** Walk up from `start` to the nearest directory that actually exists. The
@@ -285,6 +294,8 @@ type InstallJob = {
   error?: string;
   /** Present only for a Coven CLI update, never for other tool installers. */
   daemon?: DaemonUpdateLifecycle;
+  /** Present only for OpenCoven npm tools after installer completion. */
+  verification?: OpenCovenToolVerification<OpenCovenToolId>;
   /** Cancels preparation or the spawned process; never exposed to clients. */
   cancel?: () => void;
   cancelRequested?: boolean;
@@ -510,6 +521,7 @@ function jobView(job: InstallJob) {
     ok: job.ok ?? false,
     code: job.code ?? null,
     binaryPath: job.binaryPath ?? null,
+    ...(job.verification ? { verification: job.verification } : {}),
     ...(job.daemon ? { daemon: job.daemon } : {}),
     ...(job.error ? { error: job.error } : {}),
   };
@@ -582,8 +594,12 @@ async function finishInstallJob(
     // launch for daemon recovery.
     const installed = await commandPath(
       target.binary,
-      targetName === "coven-cli" ? { refresh: true } : undefined,
+      isOpenCovenToolInstallTarget(targetName) ? { refresh: true } : undefined,
     );
+    const verification = isOpenCovenToolInstallTarget(targetName)
+      ? await verifyOpenCovenToolInstall(targetName)
+      : null;
+    if (verification) job.verification = verification;
     const installError = installerOutcomeError(
       targetName,
       target,
@@ -593,7 +609,13 @@ async function finishInstallJob(
       job.output,
       launchError ? installStartErrorMessage(launchError) : job.error,
     );
-    const installOk = !installError && code === 0 && !!installed.path;
+    const verificationError =
+      verification && !isVerifiedOpenCovenInstallSuccess(code, verification)
+        ? verification.error ?? "post-install verification failed"
+        : null;
+    const installOk = verification
+      ? !installError && isVerifiedOpenCovenInstallSuccess(code, verification)
+      : !installError && code === 0 && !!installed.path;
 
     // Hermes has no positional prompt slot, so the harness's `-- "<prompt>"`
     // convention needs the hermes-coven shim to remap it onto -q. This remains
@@ -626,9 +648,9 @@ async function finishInstallJob(
     job.finishedAt = Date.now();
     job.ok = installOk && recovered;
     job.code = code;
-    job.binaryPath = installed.path;
+    job.binaryPath = verification?.path ?? installed.path;
     if (!job.ok) {
-      job.error = [installError, recoveryError].filter(Boolean).join(" ");
+      job.error = [installError, verificationError, recoveryError].filter(Boolean).join(" ");
     } else {
       delete job.error;
     }

--- a/src/app/api/opencoven-tools/status/route.test.ts
+++ b/src/app/api/opencoven-tools/status/route.test.ts
@@ -64,7 +64,7 @@ assert.match(
 
 assert.match(
   source,
-  /compareSemver\(latest, installed\.version\) > 0/,
+  /compareSemver\(latest, version\) > 0/,
   "outdated status uses the shared semver comparison",
 );
 

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -65,6 +65,10 @@ assert.match(src, /Updating CLI; local daemon will restart afterward/, "About pa
 assert.match(src, /Local daemon restarted and healthy/, "About panel surfaces final verified daemon health");
 assert.match(src, /local daemon remained stopped/, "an intentionally stopped daemon is not presented as a failed restart");
 assert.match(src, /Daemon: \{daemonLifecycleText\(daemon\)\}/, "About panel renders lifecycle health beside the update result");
+assert.match(src, /type InstallVerification = \{/, "the About updater understands post-install verification payloads");
+assert.match(src, /verification\?: InstallVerification/, "installer polling keeps verification attached to completed jobs");
+assert.match(src, /Post-install recheck now resolves a different executable/, "the UI refuses to show success when the follow-up status check disagrees with verification");
+assert.match(src, /Verified \$\{verification\.current\} at \$\{verification\.path\}/, "successful update copy is based on the verified executable, not npm exit alone");
 assert.match(src, /lastSuccessfulCheckedAt/, "tool checks retain a visible successful-check timestamp");
 assert.match(src, /Stale data from/, "failed rechecks explicitly mark retained tool rows as stale");
 assert.match(src, /Last known/, "each retained tool row identifies last-known data");
@@ -105,7 +109,7 @@ assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "Coven
 assert.match(status, /installCommand: "npm i -g @opencoven\/coven-code@latest"/, "coven-code exposes the exact update command, scoped package only");
 assert.match(status, /packageName: "@opencoven\/coven-code"/, "coven-code status probes the SCOPED registry package for latest");
 assert.doesNotMatch(status, /packageName: "coven-code"/, "bare coven-code is a different, deprecated npm package — status must never probe it");
-assert.match(status, /const compatible =[\s\S]*!!installed\?\.version && compareSemver\(installed\.version, tool\.minimumVersion\) >= 0/, "compatibility compares installed version against the Cave minimum");
+assert.match(status, /const compatible =[\s\S]*packageVerified && !!version && compareSemver\(version, tool\.minimumVersion\) >= 0/, "compatibility compares the verified package version against the Cave minimum");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
 assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");
 assert.match(runner, /src\/components\/open-coven-tools-update\.test\.ts/, "OpenCoven tools update test is wired into the test:app suite (scripts/run-tests.mjs)");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -22,14 +22,30 @@ type ToolStatus = {
   binary: string;
   installed: boolean;
   path: string | null;
+  executablePath: string | null;
   current: string | null;
   latest: string | null;
   latestCheck: LatestCheckDisplay;
   outdated: boolean;
   compatible: boolean;
+  packageVerified: boolean;
+  executableVerified: boolean;
+  packagePath: string | null;
+  discoveryError: "version-probe-failed" | "launcher-unreadable" | null;
   minimumVersion: string;
   installCommand: string;
   checkedAt: string;
+};
+
+type InstallVerification = {
+  path: string | null;
+  current: string | null;
+  latest: string | null;
+  packageVerified: boolean;
+  compatible: boolean;
+  latestSatisfied: boolean | null;
+  ok: boolean;
+  error?: string;
 };
 
 type InstallJobView = {
@@ -37,6 +53,8 @@ type InstallJobView = {
   elapsedMs: number;
   tail: string;
   ok?: boolean;
+  binaryPath?: string | null;
+  verification?: InstallVerification;
   error?: string;
   daemon?: {
     wasRunning: boolean;
@@ -115,6 +133,43 @@ function successfulInstallDetail(
   if (job.daemon.phase === "healthy") return `${location}; local daemon restarted and healthy`;
   if (job.daemon.phase === "not-running") return `${location}; local daemon remained stopped`;
   return `${location}; daemon health: ${job.daemon.health}`;
+}
+
+function installResultFromCompletion(
+  target: InstallTarget,
+  job: InstallJobView,
+  rechecked: ToolStatus | undefined,
+): InstallResult {
+  if (!job.ok) return { ok: false, detail: job.error ?? "update failed" };
+  const verification = job.verification;
+  if (!verification) return { ok: true, detail: successfulInstallDetail(target, job) };
+  if (!verification.ok) {
+    return { ok: false, detail: verification.error ?? "post-install verification failed" };
+  }
+  const consistent =
+    rechecked &&
+    rechecked.path === verification.path &&
+    rechecked.current === verification.current &&
+    rechecked.latest === verification.latest &&
+    rechecked.packageVerified &&
+    rechecked.compatible &&
+    !rechecked.outdated;
+  if (!consistent) {
+    const current = rechecked?.current ? ` (${rechecked.current})` : "";
+    const path = rechecked?.path ? ` at ${rechecked.path}` : "";
+    return {
+      ok: false,
+      detail: `Post-install recheck now resolves a different executable${current}${path}. Retry after fixing PATH precedence.`,
+    };
+  }
+  const daemonDetail =
+    target === "coven-cli" && job.daemon
+      ? `; ${successfulInstallDetail(target, job)}`
+      : "";
+  return {
+    ok: true,
+    detail: `Verified ${verification.current} at ${verification.path}${daemonDetail}`,
+  };
 }
 
 function isInstallTarget(id: string): id is InstallTarget {
@@ -288,7 +343,7 @@ export function OpenCovenToolsUpdate() {
     }
   }, []);
 
-  const load = useCallback(async (): Promise<boolean> => {
+  const load = useCallback(async (): Promise<ToolStatus[] | null> => {
     setChecking(true);
     setError(null);
     try {
@@ -311,7 +366,7 @@ export function OpenCovenToolsUpdate() {
           dismissBanner(TOOL_UPDATE_BANNER_ID);
         }
       }
-      return true;
+      return (json.tools ?? []).filter((tool) => isInstallTarget(tool.id));
     } catch (err) {
       if (mounted.current) {
         const message = err instanceof Error ? err.message : "tool check failed";
@@ -320,7 +375,7 @@ export function OpenCovenToolsUpdate() {
         // A failed refresh cannot leave prior rows looking fresh.
         setStale(true);
       }
-      return false;
+      return null;
     } finally {
       if (mounted.current) setChecking(false);
     }
@@ -371,17 +426,17 @@ export function OpenCovenToolsUpdate() {
           }
           setInstallJobs((prev) => ({ ...prev, [target]: json }));
           if (json.status === "done") {
+            const refreshed = await load();
+            const result = installResultFromCompletion(
+              target,
+              json,
+              refreshed?.find((tool) => tool.id === target),
+            );
             setInstallResults((prev) => ({
               ...prev,
-              [target]: json.ok
-                ? {
-                    ok: true,
-                    detail: successfulInstallDetail(target, json),
-                  }
-                : { ok: false, detail: json.error ?? "update failed" },
+              [target]: result,
             }));
-            const refreshed = await load();
-            if (json.ok && refreshed) {
+            if (result.ok && refreshed) {
               window.dispatchEvent(new Event(TOOL_UPDATE_RECHECK_EVENT));
             }
           }

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -146,11 +146,17 @@ function installResultFromCompletion(
   if (!verification.ok) {
     return { ok: false, detail: verification.error ?? "post-install verification failed" };
   }
+  const normalizePath = (value: string | null | undefined) => {
+    if (!value) return null;
+    const looksWindows = /[A-Za-z]:\\/.test(value) || value.includes("\\");
+    const normalized = value.replace(/\//g, "\\");
+    return looksWindows ? normalized.toLowerCase() : normalized;
+  };
   const consistent =
     rechecked &&
-    rechecked.path === verification.path &&
+    normalizePath(rechecked.path) === normalizePath(verification.path) &&
     rechecked.current === verification.current &&
-    rechecked.latest === verification.latest &&
+    (rechecked.latest ? rechecked.latest === verification.latest : true) &&
     rechecked.packageVerified &&
     rechecked.compatible &&
     !rechecked.outdated;

--- a/src/lib/opencoven-tool-verification.test.ts
+++ b/src/lib/opencoven-tool-verification.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import {
+  evaluateOpenCovenToolVerification,
+  isVerifiedOpenCovenInstallSuccess,
+  type OpenCovenToolProbe,
+} from "./opencoven-tool-verification.ts";
+
+const covenCode = {
+  id: "coven-code",
+  binary: "coven-code",
+  packageName: "@opencoven/coven-code",
+  minimumVersion: "0.6.0",
+} as const;
+
+const verifiedProbe: OpenCovenToolProbe = {
+  path: "C:\\Users\\witch\\AppData\\Roaming\\npm\\coven-code.cmd",
+  executablePath:
+    "C:\\Users\\witch\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\coven-code\\bin\\coven-code.js",
+  executableVerified: true,
+  version: "0.7.2",
+  packageName: "@opencoven/coven-code",
+  packagePath: "C:\\Users\\witch\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\coven-code",
+};
+
+const success = evaluateOpenCovenToolVerification(covenCode, verifiedProbe, "0.7.2");
+assert.equal(success.ok, true, "a matching npm shim, package entry point, and latest version succeeds");
+assert.equal(success.compatible, true);
+assert.equal(success.packageVerified, true);
+assert.equal(isVerifiedOpenCovenInstallSuccess(0, success), true, "a zero npm exit plus verified tool reports success");
+assert.equal(isVerifiedOpenCovenInstallSuccess(1, success), false, "a nonzero npm exit never reports success even if an older valid executable remains on PATH");
+
+const staleShadow = evaluateOpenCovenToolVerification(
+  covenCode,
+  {
+    ...verifiedProbe,
+    path: "C:\\stale-bin\\coven-code.cmd",
+    executablePath: "C:\\stale-bin\\node_modules\\@opencoven\\coven-code\\bin\\coven-code.js",
+    version: "0.6.0",
+  },
+  "0.7.2",
+);
+assert.equal(staleShadow.ok, false, "a stale PATH shadow must not report success after npm exits zero");
+assert.match(staleShadow.error ?? "", /C:\\stale-bin\\coven-code\.cmd/);
+assert.match(staleShadow.error ?? "", /npm latest is 0\.7\.2/);
+
+const wrongPackage = evaluateOpenCovenToolVerification(
+  covenCode,
+  {
+    ...verifiedProbe,
+    path: "C:\\legacy\\coven-code.cmd",
+    packageName: "coven-code",
+    packagePath: "C:\\legacy\\node_modules\\coven-code",
+    executablePath: "C:\\legacy\\node_modules\\coven-code\\bin\\coven-code.js",
+  },
+  "0.7.2",
+);
+assert.equal(wrongPackage.ok, false, "a launcher from the deprecated bare package is rejected");
+assert.match(wrongPackage.error ?? "", /coven-code, not @opencoven\/coven-code/);
+
+const wrongLauncher = evaluateOpenCovenToolVerification(
+  covenCode,
+  { ...verifiedProbe, executableVerified: false },
+  "0.7.2",
+);
+assert.equal(wrongLauncher.ok, false, "a launcher targeting the wrong file inside a package is rejected");
+assert.match(wrongLauncher.error ?? "", /does not point to the coven-code entry point/);
+
+const unreadableVersion = evaluateOpenCovenToolVerification(
+  covenCode,
+  { ...verifiedProbe, version: null, error: "version-probe-failed" },
+  "0.7.2",
+);
+assert.equal(unreadableVersion.ok, false, "an unreadable version probe is a recovery state, not success");
+assert.match(unreadableVersion.error ?? "", /version probe/);
+
+const belowFloor = evaluateOpenCovenToolVerification(
+  covenCode,
+  { ...verifiedProbe, version: "0.5.9" },
+  "0.7.2",
+);
+assert.equal(belowFloor.ok, false, "a successful install that remains below Cave's floor is rejected");
+assert.match(belowFloor.error ?? "", /below the required 0\.6\.0/);
+assert.equal(isVerifiedOpenCovenInstallSuccess(0, belowFloor), false, "a zero npm exit cannot override a below-floor post-install result");
+
+const latestUnavailable = evaluateOpenCovenToolVerification(covenCode, verifiedProbe, null);
+assert.equal(latestUnavailable.ok, false, "latest-tag verification must complete before the UI can report success");
+assert.match(latestUnavailable.error ?? "", /could not read npm's latest version/);
+
+console.log("opencoven-tool-verification.test.ts: ok");

--- a/src/lib/opencoven-tool-verification.ts
+++ b/src/lib/opencoven-tool-verification.ts
@@ -1,0 +1,112 @@
+import { compareSemver } from "./app-update.ts";
+
+export type OpenCovenToolVerificationSpec<TId extends string = string> = {
+  id: TId;
+  binary: string;
+  packageName: string;
+  minimumVersion: string;
+};
+
+export type OpenCovenToolProbe = {
+  path: string | null;
+  executablePath: string | null;
+  executableVerified: boolean;
+  version: string | null;
+  packageName: string | null;
+  packagePath: string | null;
+  error?: "version-probe-failed" | "launcher-unreadable";
+};
+
+export type OpenCovenToolVerification<TId extends string = string> = {
+  id: TId;
+  path: string | null;
+  executablePath: string | null;
+  current: string | null;
+  latest: string | null;
+  expectedPackageName: string;
+  discoveredPackageName: string | null;
+  packagePath: string | null;
+  packageVerified: boolean;
+  executableVerified: boolean;
+  compatible: boolean;
+  latestSatisfied: boolean | null;
+  ok: boolean;
+  error?: string;
+};
+
+function verificationError<TId extends string>(
+  tool: OpenCovenToolVerificationSpec<TId>,
+  probe: OpenCovenToolProbe,
+  latest: string | null,
+): string | undefined {
+  if (!probe.path) {
+    return `${tool.binary} was not found on PATH after install. Restart Cave or move the npm global bin directory ahead of stale launchers, then retry.`;
+  }
+  const pathDetail = ` at ${probe.path}`;
+  if (!probe.executablePath) {
+    return `Cave found ${tool.binary}${pathDetail}, but its launcher target could not be read. Remove or repair that stale launcher, then retry.`;
+  }
+  if (probe.packageName !== tool.packageName) {
+    const actual = probe.packageName ?? "an unrecognized package";
+    return `Cave resolves ${tool.binary}${pathDetail} to ${actual}, not ${tool.packageName}. A stale PATH entry is shadowing the requested package.`;
+  }
+  if (!probe.executableVerified) {
+    return `Cave found ${tool.binary}${pathDetail}, but it does not point to the ${tool.binary} entry point from ${tool.packageName}. Repair the launcher or move the intended npm bin directory ahead of it.`;
+  }
+  if (!probe.version) {
+    return `Cave found ${tool.binary}${pathDetail}, but its version probe could not verify the expected executable. Repair the launcher or retry after restarting Cave.`;
+  }
+  if (compareSemver(probe.version, tool.minimumVersion) < 0) {
+    return `Cave resolves ${tool.binary}${pathDetail} as ${probe.version}, below the required ${tool.minimumVersion}. A stale executable is still first on PATH.`;
+  }
+  if (!latest) {
+    return `Cave verified ${tool.binary}${pathDetail} as ${probe.version}, but could not read npm's latest version. Check the network or registry and retry before treating the update as complete.`;
+  }
+  if (compareSemver(probe.version, latest) < 0) {
+    return `Cave resolves ${tool.binary}${pathDetail} as ${probe.version}, but npm latest is ${latest}. A stale executable is still first on PATH.`;
+  }
+  return undefined;
+}
+
+export function evaluateOpenCovenToolVerification<TId extends string>(
+  tool: OpenCovenToolVerificationSpec<TId>,
+  probe: OpenCovenToolProbe,
+  latest: string | null,
+): OpenCovenToolVerification<TId> {
+  const packageVerified =
+    probe.packageName === tool.packageName &&
+    Boolean(probe.packagePath) &&
+    Boolean(probe.executablePath) &&
+    probe.executableVerified;
+  const compatible =
+    packageVerified &&
+    !!probe.version &&
+    compareSemver(probe.version, tool.minimumVersion) >= 0;
+  const latestSatisfied = latest
+    ? !!probe.version && compareSemver(probe.version, latest) >= 0
+    : null;
+  const error = verificationError(tool, probe, latest);
+  return {
+    id: tool.id,
+    path: probe.path,
+    executablePath: probe.executablePath,
+    current: probe.version,
+    latest,
+    expectedPackageName: tool.packageName,
+    discoveredPackageName: probe.packageName,
+    packagePath: probe.packagePath,
+    packageVerified,
+    executableVerified: probe.executableVerified,
+    compatible,
+    latestSatisfied,
+    ok: !error,
+    ...(error ? { error } : {}),
+  };
+}
+
+export function isVerifiedOpenCovenInstallSuccess(
+  exitCode: number | null,
+  verification: OpenCovenToolVerification,
+): boolean {
+  return exitCode === 0 && verification.ok;
+}

--- a/src/lib/opencoven-tools-status.test.ts
+++ b/src/lib/opencoven-tools-status.test.ts
@@ -5,10 +5,33 @@
 // actually executes.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { openCovenToolStatuses } from "./opencoven-tools-status.ts";
+
+const source = await readFile(new URL("./opencoven-tools-status.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /executablePath: string \| null/,
+  "OpenCoven tool status exposes the resolved package entry point for local recovery decisions",
+);
+assert.match(
+  source,
+  /packagePath: string \| null/,
+  "OpenCoven tool status exposes package identity for stale PATH shadow detection",
+);
+assert.match(
+  source,
+  /if \(launch\.unresolvedWindowsShim\)/,
+  "unresolved Windows shims remain explicit instead of being executed or guessed",
+);
+assert.match(
+  source,
+  /export async function verifyOpenCovenToolInstall/,
+  "status module provides the authoritative post-install verification entry point",
+);
 
 if (process.platform !== "win32") {
   console.log("opencoven-tools-status.test.ts: skipped Windows packaged-server probe (requires win32)");

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { compareSemver } from "./app-update.ts";
@@ -9,6 +10,16 @@ import {
   pickWindowsLauncher,
   refreshCovenSpawnEnv,
 } from "./coven-bin.ts";
+import {
+  evaluateOpenCovenToolVerification,
+  type OpenCovenToolProbe,
+  type OpenCovenToolVerification,
+} from "./opencoven-tool-verification.ts";
+
+export type {
+  OpenCovenToolProbe,
+  OpenCovenToolVerification,
+} from "./opencoven-tool-verification.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -90,28 +101,173 @@ export type OpenCovenToolStatus = {
   binary: string;
   installed: boolean;
   path: string | null;
+  executablePath: string | null;
   current: string | null;
   latest: string | null;
   latestCheck: NpmLatestCheck;
   outdated: boolean;
   compatible: boolean;
+  packageVerified: boolean;
+  executableVerified: boolean;
+  packagePath: string | null;
+  discoveryError: OpenCovenToolProbe["error"] | null;
   minimumVersion: string;
   installCommand: string;
   checkedAt: string;
 };
 
-async function commandPath(binary: string): Promise<string | null> {
+function firstSemver(text: string): string | null {
+  const match = /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(text);
+  return match?.[1] ?? null;
+}
+
+async function resolvedExecutablePath(binaryPath: string): Promise<string | null> {
+  const launch = covenLaunchCommandForBinary(binaryPath);
+  if (launch.unresolvedWindowsShim) return null;
+  if (launch.command === process.execPath && launch.fixedArgs[0]) {
+    try {
+      return await realpath(launch.fixedArgs[0]);
+    } catch {
+      return launch.fixedArgs[0];
+    }
+  }
+  try {
+    return await realpath(binaryPath);
+  } catch {
+    return null;
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  const normalize = (value: string) =>
+    process.platform === "win32" ? value.toLowerCase() : value;
+  return normalize(path.resolve(left)) === normalize(path.resolve(right));
+}
+
+type PackageIdentity = {
+  name: string;
+  path: string;
+  binaryVerified: boolean;
+};
+
+async function packageIdentityForExecutable(
+  executablePath: string,
+  binary: string,
+): Promise<PackageIdentity | null> {
+  let directory = path.dirname(executablePath);
+  for (let depth = 0; depth < 16; depth += 1) {
+    try {
+      const manifest = JSON.parse(await readFile(path.join(directory, "package.json"), "utf8")) as {
+        name?: unknown;
+        bin?: unknown;
+      };
+      if (typeof manifest.name === "string") {
+        const binPath =
+          typeof manifest.bin === "string"
+            ? manifest.bin
+            : manifest.bin &&
+                typeof manifest.bin === "object" &&
+                !Array.isArray(manifest.bin) &&
+                typeof (manifest.bin as Record<string, unknown>)[binary] === "string"
+              ? (manifest.bin as Record<string, string>)[binary]
+              : null;
+        let binaryVerified = false;
+        if (binPath) {
+          const expectedPath = path.resolve(directory, binPath);
+          try {
+            binaryVerified = samePath(await realpath(expectedPath), executablePath);
+          } catch {
+            binaryVerified = samePath(expectedPath, executablePath);
+          }
+        }
+        return { name: manifest.name, path: directory, binaryVerified };
+      }
+    } catch {
+      /* Keep walking toward the package root. */
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+export async function discoverOpenCovenTool(
+  tool: ToolSpec,
+  options: { refresh?: boolean } = {},
+): Promise<OpenCovenToolProbe> {
+  const env = options.refresh ? refreshCovenSpawnEnv() : covenSpawnEnv();
+  const located = await commandPathWithEnv(tool.binary, env, options.refresh);
+  if (!located) {
+    return {
+      path: null,
+      executablePath: null,
+      executableVerified: false,
+      version: null,
+      packageName: null,
+      packagePath: null,
+    };
+  }
+
+  const launch = covenLaunchCommandForBinary(located);
+  if (launch.unresolvedWindowsShim) {
+    return {
+      path: located,
+      executablePath: null,
+      executableVerified: false,
+      version: null,
+      packageName: null,
+      packagePath: null,
+      error: "launcher-unreadable",
+    };
+  }
+
+  const executablePath = await resolvedExecutablePath(located);
+  const identity = executablePath
+    ? await packageIdentityForExecutable(executablePath, tool.binary)
+    : null;
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      launch.command,
+      [...launch.fixedArgs, ...tool.versionArgs],
+      { env, timeout: 2500 },
+    );
+    const version = firstSemver(`${stdout}\n${stderr}`);
+    return {
+      path: located,
+      executablePath,
+      executableVerified: identity?.binaryVerified ?? false,
+      version,
+      packageName: identity?.name ?? null,
+      packagePath: identity?.path ?? null,
+      ...(version ? {} : { error: "version-probe-failed" as const }),
+    };
+  } catch {
+    return {
+      path: located,
+      executablePath,
+      executableVerified: identity?.binaryVerified ?? false,
+      version: null,
+      packageName: identity?.name ?? null,
+      packagePath: identity?.path ?? null,
+      error: executablePath ? "version-probe-failed" : "launcher-unreadable",
+    };
+  }
+}
+
+async function commandPathWithEnv(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+  refresh: boolean | undefined,
+): Promise<string | null> {
   const finder = process.platform === "win32" ? "where" : "which";
-  const find = async (env: NodeJS.ProcessEnv): Promise<string | null> => {
+  const find = async (lookupEnv: NodeJS.ProcessEnv): Promise<string | null> => {
     try {
       const { stdout } = await execFileAsync(finder, [binary], {
-        env,
+        env: lookupEnv,
         timeout: 1500,
       });
       const lines = stdout.split(/\r?\n/);
-      // `where` lists npm's unspawnable extensionless launcher first; the
-      // .cmd/.exe sibling is the one execFile can actually run (versions
-      // below, and callers that spawn the returned path).
       return process.platform === "win32"
         ? pickWindowsLauncher(lines)
         : lines.map((l) => l.trim()).find(Boolean) ?? null;
@@ -119,41 +275,9 @@ async function commandPath(binary: string): Promise<string | null> {
       return null;
     }
   };
-  // covenSpawnEnv() caches PATH for the server's lifetime. A cave launched from
-  // Finder/Spotlight starts with a minimal PATH (no nvm/fnm), so a tool the
-  // user actually has goes undetected and shows as "Not installed". Re-probe
-  // once with a freshly rebuilt PATH before concluding the binary is missing.
-  const found = await find(covenSpawnEnv());
-  if (found) return found;
+  const found = await find(env);
+  if (found || refresh) return found;
   return find(refreshCovenSpawnEnv());
-}
-
-function firstSemver(text: string): string | null {
-  const match = /\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/.exec(text);
-  return match?.[1] ?? null;
-}
-
-async function installedTool(tool: ToolSpec): Promise<InstalledTool | null> {
-  const path = await commandPath(tool.binary);
-  if (!path) return null;
-  // Node refuses to execFile a .cmd directly (EINVAL since the batch-file
-  // hardening); convert npm cmd-shims to a direct `node <script>` exec so
-  // the version probe works on Windows instead of silently reporting null.
-  const { command, fixedArgs, unresolvedWindowsShim } = covenLaunchCommandForBinary(path);
-  if (unresolvedWindowsShim) {
-    // The .cmd exists, so retain its displayed path, but a parser failure must
-    // never probe a different launcher or execute the batch file via a shell.
-    return { path, version: null };
-  }
-  try {
-    const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, ...tool.versionArgs], {
-      env: covenSpawnEnv(),
-      timeout: 2500,
-    });
-    return { path, version: firstSemver(`${stdout}\n${stderr}`) };
-  } catch {
-    return { path, version: null };
-  }
 }
 
 async function execLatestVersion(
@@ -280,27 +404,43 @@ export async function checkNpmLatestVersion(
 
 export function composeOpenCovenToolStatus(
   tool: ToolSpec,
-  installed: InstalledTool | null,
+  installed: InstalledTool | null | OpenCovenToolProbe,
   latestCheck: NpmLatestCheck,
 ): OpenCovenToolStatus {
   const latest = latestCheck.status === "verified" ? latestCheck.latest : null;
+  const probe = installed && "executableVerified" in installed ? installed : null;
+  const version = installed?.version ?? null;
+  const installedPath = installed?.path ?? null;
+  const executableVerified = probe ? probe.executableVerified : Boolean(installed);
+  const packageVerified =
+    probe
+      ? probe.packageName === tool.packageName &&
+        Boolean(probe.packagePath) &&
+        Boolean(probe.executablePath) &&
+        Boolean(probe.executableVerified)
+      : Boolean(installed);
   const outdated =
-    !!installed?.version && !!latest && compareSemver(latest, installed.version) > 0;
+    packageVerified && !!version && !!latest && compareSemver(latest, version) > 0;
   const compatible =
-    !!installed?.version && compareSemver(installed.version, tool.minimumVersion) >= 0;
+    packageVerified && !!version && compareSemver(version, tool.minimumVersion) >= 0;
 
   return {
     id: tool.id,
     label: tool.label,
     packageName: tool.packageName,
     binary: tool.binary,
-    installed: !!installed,
-    path: installed?.path ?? null,
-    current: installed?.version ?? null,
+    installed: !!installedPath,
+    path: installedPath,
+    executablePath: probe ? probe.executablePath : installedPath,
+    current: version,
     latest,
     latestCheck,
     outdated,
     compatible,
+    packageVerified,
+    executableVerified,
+    packagePath: probe ? probe.packagePath : null,
+    discoveryError: probe ? probe.error ?? null : null,
     minimumVersion: tool.minimumVersion,
     installCommand: tool.installCommand,
     checkedAt: latestCheck.checkedAt,
@@ -308,13 +448,27 @@ export function composeOpenCovenToolStatus(
 }
 
 async function toolStatus(tool: ToolSpec): Promise<OpenCovenToolStatus> {
-  const [installed, latestCheck] = await Promise.all([
-    installedTool(tool),
+  const [probe, latestCheck] = await Promise.all([
+    discoverOpenCovenTool(tool),
     checkNpmLatestVersion(tool),
   ]);
-  return composeOpenCovenToolStatus(tool, installed, latestCheck);
+  return composeOpenCovenToolStatus(tool, probe, latestCheck);
 }
 
 export async function openCovenToolStatuses(): Promise<OpenCovenToolStatus[]> {
   return Promise.all(OPEN_COVEN_TOOLS.map(toolStatus));
+}
+
+export async function verifyOpenCovenToolInstall(
+  id: OpenCovenToolId,
+): Promise<OpenCovenToolVerification<OpenCovenToolId>> {
+  const tool = OPEN_COVEN_TOOLS.find((candidate) => candidate.id === id);
+  if (!tool) throw new Error("unknown OpenCoven tool");
+
+  const [probe, latestCheck] = await Promise.all([
+    discoverOpenCovenTool(tool, { refresh: true }),
+    checkNpmLatestVersion(tool, { env: refreshCovenSpawnEnv, refreshEnv: refreshCovenSpawnEnv }),
+  ]);
+  const latest = latestCheck.status === "verified" ? latestCheck.latest : null;
+  return evaluateOpenCovenToolVerification(tool, probe, latest);
 }


### PR DESCRIPTION
Re-lands #3029 ("Fix OpenCoven tool update verification" by @romgenie) reconciled onto current main, addressing the CHANGES_REQUESTED integration blockers:

1. **#3026 preserved** — main's stricter Windows `.cmd`/`.bat` shim parser and explicit unresolved-shim signal in `coven-bin.ts` are untouched.
2. **#3028 preserved** — the atomic global npm lane and cancellation-safe finalizers stay; post-install verification layers on top.
3. **Machine-local paths** — the new `executablePath`/`packagePath` status fields are omitted from copied About diagnostics (the omission landed with #3030 and is regression-covered).

New: `src/lib/opencoven-tool-verification.ts` — package/entry-point/latest-version verification gating update success — wired into tools status, the settings update flow, and the onboarding install route.

Supersedes #3029.

## Validation
- `pnpm exec tsc --noEmit`
- Targeted `node --experimental-strip-types` runs on all touched test files
- `node scripts/check-tests-wired.mjs`