### PR TITLE
perf(chat): memoize the transcript subtree out of ChatView's keystroke path (cave-likl)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,6 +35,7 @@ export const SUITES = {
     "src/lib/role-surface-state.test.ts",
     "src/components/role-surface-shell.test.ts",
     "src/components/chat-view-render-cap.test.ts",
+    "src/components/chat-view-transcript-memo.test.ts",
     "src/components/chat-view-scroll-pin.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",

--- a/src/components/chat-reply-wiring.test.ts
+++ b/src/components/chat-reply-wiring.test.ts
@@ -47,8 +47,10 @@ assert.match(view, /Replying to \{replyTarget\.author\}/, "the chip names the qu
 assert.match(view, /aria-label="Cancel reply"/, "the chip has a dismiss control");
 
 // ── both TurnRow call sites pass the Reply action ─────────────────────────
+// (via the transcript's latest-ref so the memoized rows never hold a stale
+// replyFor — see chat-view-transcript-memo.test.ts)
 {
-  const wired = view.match(/onReply=\{replyFor\(t\)\}/g) ?? [];
+  const wired = view.match(/onReply=\{handlers\(\)\.replyFor\(t\)\}/g) ?? [];
   assert.equal(wired.length, 2, "onReply is wired at both TurnRow render sites (linear + voice group)");
 }
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -229,7 +229,7 @@ assert.match(
 
 assert.match(
   source,
-  /onEdit=\{t\.role === "user" && t\.text\.trim\(\) \? \(\) => editTurnInComposer\(t\) : undefined\}/,
+  /onEdit=\{t\.role === "user" && t\.text\.trim\(\) \? \(\) => handlers\(\)\.editTurnInComposer\(t\) : undefined\}/,
   "Only user turns with text get the Edit affordance (CHAT-D6-01)",
 );
 
@@ -247,7 +247,7 @@ assert.match(
 
 assert.match(
   source,
-  /onRegenerate=\{regenerateFor\(t\)\}/,
+  /onRegenerate=\{handlers\(\)\.regenerateFor\(t\)\}/,
   "Assistant turns get the Regenerate affordance via the gated helper (CHAT-D6-02)",
 );
 

--- a/src/components/chat-view-transcript-memo.test.ts
+++ b/src/components/chat-view-transcript-memo.test.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+/**
+ * Source pins for the memoized transcript subtree (cave-likl).
+ *
+ * ChatView holds 60+ pieces of state whose updates have nothing to do with
+ * the transcript (composer input, caret, menus, poll ticks). Before this
+ * optimization, every such update re-ran the transcript row loop inline in
+ * ChatView's JSX: per-row closures, sibling lookups, action-presence
+ * recomputation and the TurnRow memo comparator × up to
+ * TRANSCRIPT_RENDER_CAP rows — per keystroke.
+ *
+ * The loop now lives in `TranscriptRows`, a React.memo component whose props
+ * are all referentially stable across keystroke renders; per-row actions are
+ * routed through a latest-ref so they are read at CALL time (never stale,
+ * never memo-defeating). These pins keep the load-bearing pieces in place.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// ── 1. The transcript subtree is a memo component ───────────────────────────
+assert.match(
+  src,
+  /const TranscriptRows = memo\(function TranscriptRows\(/,
+  "TranscriptRows must be wrapped in React.memo — the whole point is bailing out of keystroke re-renders",
+);
+
+// ── 2. ChatView renders it (the row loop is NOT inline in ChatView JSX) ─────
+assert.match(
+  src,
+  /<TranscriptRows\s[\s\S]*?handlersRef=\{transcriptHandlersRef\}/,
+  "ChatView renders TranscriptRows and hands it the latest-ref for row actions",
+);
+
+// ── 3. Latest-ref pattern: reassigned every render, all six actions ─────────
+assert.match(
+  src,
+  /transcriptHandlersRef\.current = \{\s*siblingsFor,\s*switchBranch,\s*editTurnInComposer,\s*regenerateFor,\s*replyFor,\s*send,\s*\};/,
+  "the handlers ref must be reassigned in the render body so closures never go stale",
+);
+
+// The reassignment must NOT be wrapped in a hook (an effect would lag a
+// render behind and reintroduce the stale-closure hazard the ref exists to
+// prevent).
+const refAssign = src.indexOf("transcriptHandlersRef.current = {");
+const before = src.slice(Math.max(0, refAssign - 250), refAssign);
+assert.ok(
+  !/useEffect\(|useLayoutEffect\(|useMemo\(|useCallback\(/.test(before),
+  "the handlers-ref reassignment must run directly in the render body, not inside a hook",
+);
+
+// ── 4. Handlers are read at call time inside the rows ───────────────────────
+for (const pattern of [
+  /handlers\(\)\.regenerateFor\(t\)/,
+  /handlers\(\)\.replyFor\(t\)/,
+  /handlers\(\)\.editTurnInComposer\(t\)/,
+  /handlers\(\)\.send\(sug\)/,
+  /handlers\(\)\.switchBranch\(t\.id, -1\)/,
+  /handlers\(\)\.siblingsFor\(t\.id\)/,
+]) {
+  assert.match(
+    src,
+    pattern,
+    `row actions must dereference the ref at call time (${pattern}) — capturing handlers at render time would go stale behind the memo`,
+  );
+}
+
+// ── 5. Presence semantics: busy stays a data prop ────────────────────────────
+// regenerateFor hides the Regenerate action while busy. The handler is read
+// through the ref, so the memo would never re-render for the flip unless
+// `busy` itself is a compared prop.
+assert.match(
+  src,
+  /const TranscriptRows = memo\(function TranscriptRows\(\{[\s\S]*?\}: \{[\s\S]*?busy: boolean;[\s\S]*?\}\)/,
+  "busy must be a TranscriptRows prop so action-presence flips re-render the rows",
+);
+assert.match(
+  src,
+  /<TranscriptRows[\s\S]*?busy=\{busy\}/,
+  "ChatView must pass busy through",
+);
+
+// ── 6. The row loop and render cap live inside TranscriptRows ────────────────
+const transcriptRowsStart = src.indexOf("const TranscriptRows = memo(");
+assert.ok(transcriptRowsStart > 0, "TranscriptRows component exists");
+const transcriptRowsBody = src.slice(transcriptRowsStart, transcriptRowsStart + 9000);
+assert.match(
+  transcriptRowsBody,
+  /historyExpanded \|\| groupedTurns\.length <= TRANSCRIPT_RENDER_CAP/,
+  "the render cap decision moved with the loop",
+);
+assert.match(
+  transcriptRowsBody,
+  /return renderGroups\.map\(\(g\) => \{/,
+  "the row loop lives inside the memo component",
+);
+// The pre-extraction inline IIFE form must not come back to ChatView's JSX.
+assert.doesNotMatch(
+  src,
+  /\{\(\(\) => \{[\s\S]{0,400}renderGroups/,
+  "the transcript loop must not be inlined back into ChatView's JSX as an IIFE",
+);
+
+console.log("chat-view-transcript-memo.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3311,9 +3311,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // re-render ChatView but leave `turns` untouched (this was an O(n) rebuild
   // per render).
   const { groupedTurns, turnIndexMap } = useMemo(() => {
-    type VoiceGroup = { kind: "call"; callId: string; turns: Turn[]; durationSec: number };
-    type SingleItem = { kind: "single"; turn: Turn };
-    const grouped: Array<VoiceGroup | SingleItem> = [];
+    const grouped: TranscriptGroup[] = [];
     for (const turn of activePath) {
       if (turn.voiceCallId) {
         const last = grouped[grouped.length - 1];
@@ -4404,6 +4402,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, branchParent !== undefined ? { parentTurnId: branchParent } : undefined);
   };
 
+  // Latest-ref for the memoized transcript's per-row actions (cave-likl).
+  // Reassigned every render so TranscriptRows — which deliberately does NOT
+  // re-render on composer keystrokes — always invokes closures that read the
+  // CURRENT busy/turns/attachments state at call time. See TranscriptHandlers.
+  const transcriptHandlersRef = useRef<TranscriptHandlers>(null as unknown as TranscriptHandlers);
+  transcriptHandlersRef.current = {
+    siblingsFor,
+    switchBranch,
+    editTurnInComposer,
+    regenerateFor,
+    replyFor,
+    send,
+  };
+
   // Auto-send a prompt handed off from the home composer. Deferred one
   // macrotask so it runs after strict-mode's mount-effect replay — sending
   // synchronously here lets the replayed history-load effect (null-session
@@ -5111,115 +5123,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               />
             )
           ) : null}
-          {(() => {
-            // `groupedTurns` + `turnIndexMap` are memoized above (rebuilt only
-            // when `activePath` changes, not on every keystroke). `allTurns`
-            // feeds the per-row prev-turn timestamp-gap lookup and must match
-            // the same sequence used for grouping.
-            const allTurns = activePath;
-            // Render cap (TRANSCRIPT_RENDER_CAP): while pinned to the bottom, only
-            // mount the newest groups. The per-row prev-turn lookup still reads
-            // the full `allTurns`/`turnIndexMap`, so the first visible row's
-            // timestamp gap stays correct. Expands to the whole transcript the
-            // moment the reader scrolls up or opens find (see historyExpanded).
-            const renderGroups =
-              historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
-                ? groupedTurns
-                : groupedTurns.slice(-TRANSCRIPT_RENDER_CAP);
-            return renderGroups.map((g) => {
-              if (g.kind === "single") {
-                const t = g.turn;
-                const i = turnIndexMap.get(t.id) ?? -1;
-                const prev = allTurns[i - 1];
-                const showTimestamp = (() => {
-                  if (!t.createdAt) return false;
-                  if (!prev?.createdAt) return true;
-                  const gap = new Date(t.createdAt).getTime() - new Date(prev.createdAt).getTime();
-                  if (!Number.isFinite(gap)) return true;
-                  if (gap >= 10 * 60 * 1000) return true;
-                  return prev.role !== t.role;
-                })();
-                const singleBranchNav = (() => {
-                  const { siblings, index } = siblingsFor(t.id);
-                  if (siblings.length <= 1) return undefined;
-                  return {
-                    index,
-                    total: siblings.length,
-                    onPrev: () => void switchBranch(t.id, -1),
-                    onNext: () => void switchBranch(t.id, 1),
-                  };
-                })();
-                return (
-                  <TurnRow
-                    key={t.id}
-                    turn={t}
-                    familiar={familiar}
-                    showTimestamp={showTimestamp}
-                    found={foundTurnId === t.id}
-                    onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
-                    onRegenerate={regenerateFor(t)}
-                    onReply={replyFor(t)}
-                    onOpenUrl={onOpenUrl}
-                    onSuggestion={(sug) => void send(sug)}
-                    feedbackContext={feedbackContext}
-                    expanded={expandedAvatarTurnId === t.id}
-                    onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
-                    branchNav={singleBranchNav}
-                  />
-                );
-              }
-              const mm = String(Math.floor(g.durationSec / 60)).padStart(2, "0");
-              const ss = String(g.durationSec % 60).padStart(2, "0");
-              return (
-                <div key={g.callId} className="cave-chat-voice-call-group">
-                  <div className="cave-chat-voice-call-header">
-                    <span aria-hidden>📞</span>
-                    Voice call · {mm}:{ss}
-                  </div>
-                  {g.turns.map((t) => {
-                    const i = turnIndexMap.get(t.id) ?? -1;
-                    const prev = allTurns[i - 1];
-                    const showTimestamp = (() => {
-                      if (!t.createdAt) return false;
-                      if (!prev?.createdAt) return true;
-                      const gap = new Date(t.createdAt).getTime() - new Date(prev.createdAt).getTime();
-                      if (!Number.isFinite(gap)) return true;
-                      if (gap >= 10 * 60 * 1000) return true;
-                      return prev.role !== t.role;
-                    })();
-                    const groupBranchNav = (() => {
-                      const { siblings, index } = siblingsFor(t.id);
-                      if (siblings.length <= 1) return undefined;
-                      return {
-                        index,
-                        total: siblings.length,
-                        onPrev: () => void switchBranch(t.id, -1),
-                        onNext: () => void switchBranch(t.id, 1),
-                      };
-                    })();
-                    return (
-                      <TurnRow
-                        key={t.id}
-                        turn={t}
-                        familiar={familiar}
-                        showTimestamp={showTimestamp}
-                        found={foundTurnId === t.id}
-                        onEdit={t.role === "user" && t.text.trim() ? () => editTurnInComposer(t) : undefined}
-                        onRegenerate={regenerateFor(t)}
-                        onReply={replyFor(t)}
-                        onOpenUrl={onOpenUrl}
-                        onSuggestion={(sug) => void send(sug)}
-                        feedbackContext={feedbackContext}
-                        expanded={expandedAvatarTurnId === t.id}
-                        onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
-                        branchNav={groupBranchNav}
-                      />
-                    );
-                  })}
-                </div>
-              );
-            });
-          })()}
+          {/* Transcript rows: memoized subtree (cave-likl) — the row loop no
+              longer re-runs on composer keystrokes / caret moves / menu
+              toggles. Data props are all referentially stable between
+              transcript changes; per-row actions route through
+              transcriptHandlersRef (read at call time, never stale). */}
+          <TranscriptRows
+            groupedTurns={groupedTurns}
+            turnIndexMap={turnIndexMap}
+            allTurns={activePath}
+            historyExpanded={historyExpanded}
+            familiar={familiar}
+            busy={busy}
+            foundTurnId={foundTurnId}
+            feedbackContext={feedbackContext}
+            expandedAvatarTurnId={expandedAvatarTurnId}
+            setExpandedAvatarTurnId={setExpandedAvatarTurnId}
+            onOpenUrl={onOpenUrl}
+            handlersRef={transcriptHandlersRef}
+          />
           {shouldShowChatArchiveNudge({
             taskLifecycle: linkedContext?.task?.lifecycle ?? null,
             sessionArchived: Boolean(session?.archived_at),
@@ -5860,6 +5782,180 @@ function splitTextForArtifacts(
   if (tail.trim()) out.push({ kind: "text", text: tail });
   return out;
 }
+
+// ── Transcript rows (cave-likl perf) ─────────────────────────────────────────
+// The grouped-turn shapes built by ChatView's `groupedTurns` memo.
+type TranscriptVoiceGroup = { kind: "call"; callId: string; turns: Turn[]; durationSec: number };
+type TranscriptSingleItem = { kind: "single"; turn: Turn };
+type TranscriptGroup = TranscriptVoiceGroup | TranscriptSingleItem;
+
+/**
+ * Per-row actions the transcript needs from ChatView. Routed through a
+ * "latest ref" (`transcriptHandlersRef`, reassigned every ChatView render)
+ * instead of props: the closures read live component state (busy, turns,
+ * attachments, …), so prop-passing them would either defeat the memo (fresh
+ * identity every keystroke) or go stale behind a comparator that skips
+ * function props. Reading `handlersRef.current` at CALL time always hits the
+ * newest closure while keeping every prop of TranscriptRows referentially
+ * stable across keystroke/caret/hover re-renders.
+ */
+type TranscriptHandlers = {
+  siblingsFor: (turnId: string) => { siblings: Turn[]; index: number };
+  switchBranch: (turnId: string, dir: -1 | 1) => Promise<void>;
+  editTurnInComposer: (turn: Turn) => void;
+  regenerateFor: (turn: Turn) => (() => void) | undefined;
+  replyFor: (turn: Turn) => (() => void) | undefined;
+  send: (override?: string) => Promise<void>;
+};
+
+/**
+ * The transcript row loop, extracted from ChatView's JSX and memoized
+ * (cave-likl). ChatView keeps 60+ pieces of state whose updates have nothing
+ * to do with the transcript — every composer keystroke, caret move, menu
+ * toggle and poll tick re-ran this 60-row mapping loop (per-row closures,
+ * sibling lookups, presence recomputation, TurnRow comparator × rows). All
+ * props below are referentially stable across those renders, so React.memo
+ * skips the whole subtree; the rows re-render only when the transcript data
+ * itself changes (activePath/groupedTurns identity), an action's presence
+ * input flips (`busy`), or row-affecting UI state moves (find highlight,
+ * avatar expansion).
+ *
+ * NOTE for presence semantics: `regenerateFor` hides the Regenerate action
+ * while `busy` — `busy` must stay a prop so the flip re-renders the rows even
+ * though the handler itself is read through the ref.
+ */
+const TranscriptRows = memo(function TranscriptRows({
+  groupedTurns,
+  turnIndexMap,
+  allTurns,
+  historyExpanded,
+  familiar,
+  // Presence input for regenerateFor (see doc comment); unused directly.
+  busy: _busy,
+  foundTurnId,
+  feedbackContext,
+  expandedAvatarTurnId,
+  setExpandedAvatarTurnId,
+  onOpenUrl,
+  handlersRef,
+}: {
+  groupedTurns: TranscriptGroup[];
+  turnIndexMap: Map<string, number>;
+  allTurns: Turn[];
+  historyExpanded: boolean;
+  familiar: Familiar;
+  busy: boolean;
+  foundTurnId: string | null;
+  feedbackContext: FeedbackContext;
+  expandedAvatarTurnId: string | null;
+  setExpandedAvatarTurnId: React.Dispatch<React.SetStateAction<string | null>>;
+  onOpenUrl?: (url: string) => void;
+  handlersRef: React.RefObject<TranscriptHandlers>;
+}) {
+  const handlers = () => handlersRef.current;
+  // Render cap (TRANSCRIPT_RENDER_CAP): while pinned to the bottom, only
+  // mount the newest groups. The per-row prev-turn lookup still reads
+  // the full `allTurns`/`turnIndexMap`, so the first visible row's
+  // timestamp gap stays correct. Expands to the whole transcript the
+  // moment the reader scrolls up or opens find (see historyExpanded).
+  const renderGroups =
+    historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
+      ? groupedTurns
+      : groupedTurns.slice(-TRANSCRIPT_RENDER_CAP);
+  return renderGroups.map((g) => {
+    if (g.kind === "single") {
+      const t = g.turn;
+      const i = turnIndexMap.get(t.id) ?? -1;
+      const prev = allTurns[i - 1];
+      const showTimestamp = (() => {
+        if (!t.createdAt) return false;
+        if (!prev?.createdAt) return true;
+        const gap = new Date(t.createdAt).getTime() - new Date(prev.createdAt).getTime();
+        if (!Number.isFinite(gap)) return true;
+        if (gap >= 10 * 60 * 1000) return true;
+        return prev.role !== t.role;
+      })();
+      const singleBranchNav = (() => {
+        const { siblings, index } = handlers().siblingsFor(t.id);
+        if (siblings.length <= 1) return undefined;
+        return {
+          index,
+          total: siblings.length,
+          onPrev: () => void handlers().switchBranch(t.id, -1),
+          onNext: () => void handlers().switchBranch(t.id, 1),
+        };
+      })();
+      return (
+        <TurnRow
+          key={t.id}
+          turn={t}
+          familiar={familiar}
+          showTimestamp={showTimestamp}
+          found={foundTurnId === t.id}
+          onEdit={t.role === "user" && t.text.trim() ? () => handlers().editTurnInComposer(t) : undefined}
+          onRegenerate={handlers().regenerateFor(t)}
+          onReply={handlers().replyFor(t)}
+          onOpenUrl={onOpenUrl}
+          onSuggestion={(sug) => void handlers().send(sug)}
+          feedbackContext={feedbackContext}
+          expanded={expandedAvatarTurnId === t.id}
+          onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
+          branchNav={singleBranchNav}
+        />
+      );
+    }
+    const mm = String(Math.floor(g.durationSec / 60)).padStart(2, "0");
+    const ss = String(g.durationSec % 60).padStart(2, "0");
+    return (
+      <div key={g.callId} className="cave-chat-voice-call-group">
+        <div className="cave-chat-voice-call-header">
+          <span aria-hidden>📞</span>
+          Voice call · {mm}:{ss}
+        </div>
+        {g.turns.map((t) => {
+          const i = turnIndexMap.get(t.id) ?? -1;
+          const prev = allTurns[i - 1];
+          const showTimestamp = (() => {
+            if (!t.createdAt) return false;
+            if (!prev?.createdAt) return true;
+            const gap = new Date(t.createdAt).getTime() - new Date(prev.createdAt).getTime();
+            if (!Number.isFinite(gap)) return true;
+            if (gap >= 10 * 60 * 1000) return true;
+            return prev.role !== t.role;
+          })();
+          const groupBranchNav = (() => {
+            const { siblings, index } = handlers().siblingsFor(t.id);
+            if (siblings.length <= 1) return undefined;
+            return {
+              index,
+              total: siblings.length,
+              onPrev: () => void handlers().switchBranch(t.id, -1),
+              onNext: () => void handlers().switchBranch(t.id, 1),
+            };
+          })();
+          return (
+            <TurnRow
+              key={t.id}
+              turn={t}
+              familiar={familiar}
+              showTimestamp={showTimestamp}
+              found={foundTurnId === t.id}
+              onEdit={t.role === "user" && t.text.trim() ? () => handlers().editTurnInComposer(t) : undefined}
+              onRegenerate={handlers().regenerateFor(t)}
+              onReply={handlers().replyFor(t)}
+              onOpenUrl={onOpenUrl}
+              onSuggestion={(sug) => void handlers().send(sug)}
+              feedbackContext={feedbackContext}
+              expanded={expandedAvatarTurnId === t.id}
+              onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
+              branchNav={groupBranchNav}
+            />
+          );
+        })}
+      </div>
+    );
+  });
+});
 
 // CHAT-D3-07 perf: the implementation is memoized as `TurnRow` below, so a
 // streamed token re-renders only the streaming row rather than every settled


### PR DESCRIPTION
## Problem

ChatView holds ~69 pieces of state; composer keystrokes, caret moves, menu toggles and poll ticks all re-render it. The transcript row loop lived inline in its JSX, so **every keystroke re-ran the whole loop**: per-row closures, sibling lookups, action-presence recomputation and the `TurnRow` memo comparator × up to `TRANSCRIPT_RENDER_CAP` (60) rows.

## Change

Extract the loop into `TranscriptRows`, a `React.memo` component:

- **All data props are referentially stable across keystroke renders** (`groupedTurns`/`turnIndexMap`/`activePath` are memoized on transcript change), so typing no longer touches the transcript subtree at all.
- **Per-row actions route through a latest-ref** (`transcriptHandlersRef`, reassigned every render, dereferenced at *call* time) — the memoized rows never hold stale closures over `busy`/`turns`/`attachments`, and function props can't defeat the memo.
- **`busy` stays a compared prop**: `regenerateFor` presence flips with it and must re-render the rows.
- Render-cap semantics and voice-call grouping unchanged (same pinned expressions, now inside the component).

## Regression tests

- New `chat-view-transcript-memo.test.ts` (wired into `test:app`): pins the memo wrapper, render-body ref reassignment (explicitly **not** inside a hook), call-time dereference at every action site, `busy`-as-prop, and forbids the loop returning to ChatView's JSX as an IIFE.
- Updated pins in `chat-reply-wiring` / `chat-view-lifecycle` to the new call forms.
- Existing `chat-view-render-cap` / `chat-view-render-optimization` / `chat-view-scroll-pin` pass unchanged.

## Validation

- `node scripts/run-tests.mjs app` — 640/640
- `node scripts/run-tests.mjs mobile conformance` — 80/80
- `pnpm typecheck` — clean

Closes bead: cave-likl