### PR TITLE
feat(chat): consolidated Settings tab + auto-archive on thread reflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ breaking config changes; patch releases stay additive.
 ## [Unreleased]
 
 ### Features
+- **Chat: consolidated Settings tab + auto-archive on thread reflections** — the chat page gains a Settings tab (beside Sessions and Projects) consolidating device-wide chat behavior: the full auto-archive policy (master switch, archive on task completion, idle windows for external and any chats) is now editable in the app instead of config-file only. It also introduces a new trigger — archive on thread reflection: when enabled, a thread archives itself the moment its reflection (self-report) lands, for manual and auto reflections alike; periodic reports and keep-marked chats never auto-archive, and the reflect flow refreshes the session list so the row moves immediately.
 - **Onboarding: hand-held first run through the first chat** — the setup wizard now shows a three-beat journey strip (Set up Cave → Summon a familiar → First chat) so it never reads as a dead-ended infra checklist; completing setup surfaces an above-the-fold success banner, and the finish CTA keeps its promise by opening the Summoning Circle directly (decided on the wizard's own fresh status, immune to the workspace's slower daemon poll). In the circle, the name stage gains one-click identity templates (Code reviewer, Research assistant, Project planner, Writing partner) that fill the role and required description, and the success stage hands keyboard focus to "Begin the first conversation" so Enter completes the funnel (cave-uvv7).
 
 ## [0.0.182] - 2026-07-12

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -533,6 +533,7 @@ export const SUITES = {
     "src/components/board-chat-link.test.ts",
     "src/components/chat-list-panel.test.ts",
     "src/components/chat-surface.test.ts",
+    "src/components/chat-settings-view.test.ts",
     "src/components/chat-switching.test.ts",
     "src/components/chat-view-first-class.test.ts",
     "src/components/labels-and-live-regions.test.ts",

--- a/src/app/api/familiar-self-report-route.test.ts
+++ b/src/app/api/familiar-self-report-route.test.ts
@@ -12,6 +12,44 @@ const routeSource = readFileSync(
   "utf8",
 );
 
+describe("reflection auto-archive wiring", () => {
+  it("archives the reflected thread through the shared policy helper", () => {
+    assert.match(
+      routeSource,
+      /shouldAutoArchiveOnReflection\(sessionId, trigger, policy, \{/,
+      "route must delegate the archive decision to the pure policy helper",
+    );
+    assert.match(
+      routeSource,
+      /normalizeChatAutoArchivePolicy\(config\.chatAutoArchive\)/,
+      "route must read the policy from cave config, tolerating partial storage",
+    );
+    assert.match(
+      routeSource,
+      /autoArchiveSessionsLocal\(\[sessionId\]\)/,
+      "route must archive through the shared batch helper (skips sacrificed/archived)",
+    );
+    assert.match(
+      routeSource,
+      /await resolveArchiveNudges\(sessionId\)/,
+      "archiving on reflection must resolve any pending archive nudges",
+    );
+  });
+
+  it("keeps the archive best-effort and reports archivedAt to the client", () => {
+    assert.match(
+      routeSource,
+      /async function maybeAutoArchiveReflectedThread[\s\S]*?catch \{\s*return null;\s*\}/,
+      "an archive failure must never fail the self-report that triggered it",
+    );
+    assert.match(
+      routeSource,
+      /\{ ok: true, report, \.\.\.\(archivedAt \? \{ archivedAt \} : \{\}\) \}/,
+      "POST response must carry archivedAt so the chat can refresh its list",
+    );
+  });
+});
+
 describe("self-report route JSON parsing", () => {
   it("parses fenced JSON without using an ambiguous closing-fence regex in the route", () => {
     assert.doesNotMatch(

--- a/src/app/api/familiars/[id]/self-report/route.ts
+++ b/src/app/api/familiars/[id]/self-report/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server";
 import { redactSecretsDeep, redactSecretText } from "@/lib/secret-redaction";
 import {
+  autoArchiveSessionsLocal,
+  loadConfig,
+  loadState,
+} from "@/lib/cave-config";
+import {
+  normalizeChatAutoArchivePolicy,
+  shouldAutoArchiveOnReflection,
+  type ReflectionTrigger,
+} from "@/lib/chat-auto-archive";
+import { resolveArchiveNudges } from "@/lib/task-archive-nudge-emit";
+import {
   appendSelfReport,
   listSelfReports,
   SELF_REPORT_SESSION_ID_RE,
@@ -66,6 +77,34 @@ function enumValue<T extends string>(value: unknown, allowed: Set<T>, field: str
 
 function objectArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+/**
+ * Auto-archive the reflected thread when the chat auto-archive policy opts in
+ * (`archiveOnReflection`, edited from the chat page's Settings tab). A landed
+ * reflection marks the thread as wrapped up. Best-effort: an archive failure
+ * must never fail the self-report that triggered it. Returns the archive
+ * timestamp when the session was archived by this call, else null.
+ */
+async function maybeAutoArchiveReflectedThread(
+  sessionId: string,
+  trigger: ReflectionTrigger,
+): Promise<string | null> {
+  try {
+    const [config, state] = await Promise.all([loadConfig(), loadState()]);
+    const policy = normalizeChatAutoArchivePolicy(config.chatAutoArchive);
+    const due = shouldAutoArchiveOnReflection(sessionId, trigger, policy, {
+      keep: state.sessionKeep,
+      archivedSessionIds: Object.keys(state.sessionArchived),
+    });
+    if (!due) return null;
+    const archived = await autoArchiveSessionsLocal([sessionId]);
+    const archivedAt = archived.get(sessionId) ?? null;
+    if (archivedAt) await resolveArchiveNudges(sessionId);
+    return archivedAt;
+  } catch {
+    return null;
+  }
 }
 
 function normalizePayload(payload: Record<string, unknown>, meta: {
@@ -161,7 +200,11 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       threadTitle: optionalText(body.threadTitle),
     }));
     await appendSelfReport(id, report);
-    return NextResponse.json({ ok: true, report });
+    const archivedAt = await maybeAutoArchiveReflectedThread(
+      sessionId,
+      body.trigger as ReflectionTrigger,
+    );
+    return NextResponse.json({ ok: true, report, ...(archivedAt ? { archivedAt } : {}) });
   } catch (err) {
     const message = err instanceof Error ? err.message : "self-report failed";
     return NextResponse.json({ ok: false, error: redactSecretText(message) });

--- a/src/components/chat-settings-view.test.ts
+++ b/src/components/chat-settings-view.test.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Consolidated chat settings (the chat page's Settings tab) + auto-archive on
+// thread reflections. Source-contract tests in the repo's house style: the tab
+// must exist on the chat surface, the settings view must round-trip the
+// `chatAutoArchive` policy through /api/config, and the reflect flows must
+// refresh the session list when a reflection auto-archived the thread.
+
+const settingsView = readFileSync(new URL("./chat-settings-view.tsx", import.meta.url), "utf8");
+const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// --- chat-surface: Settings is a first-class chat scope tab -------------------
+
+assert.match(
+  surface,
+  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "settings"/,
+  "chat surface must know the settings scope",
+);
+assert.match(
+  surface,
+  /\{\s*id:\s*"settings",\s*label:\s*"Settings"\s*\}/,
+  "chat exposes Settings as a dedicated tab beside Sessions/Projects",
+);
+assert.match(
+  surface,
+  /scope === "settings" \? \([\s\S]*?<ChatSettingsView \/>/,
+  "the settings scope renders the consolidated ChatSettingsView",
+);
+assert.match(
+  surface,
+  /import \{ ChatSettingsView \} from "@\/components\/chat-settings-view"/,
+  "chat-surface imports ChatSettingsView",
+);
+
+// --- chat-settings-view: reads and writes the policy through /api/config ------
+
+assert.match(
+  settingsView,
+  /normalizeChatAutoArchivePolicy\(json\.config\?\.chatAutoArchive\)/,
+  "settings view must normalize the stored policy (tolerates partial/corrupt config)",
+);
+assert.match(
+  settingsView,
+  /fetch\("\/api\/config", \{ cache: "no-store"/,
+  "settings view loads the live config, never a cached copy",
+);
+assert.match(
+  settingsView,
+  /method: "PATCH",[\s\S]*?JSON\.stringify\(\{ chatAutoArchive: patch \}\)/,
+  "settings view persists partial policies through the config PATCH merge",
+);
+
+// Every policy field is editable from the tab — master switch, both event
+// triggers (task completion + the new thread-reflection trigger), and the two
+// idle windows.
+for (const field of [
+  "enabled",
+  "archiveOnTaskCompletion",
+  "archiveOnReflection",
+  "externalAfterDays",
+  "idleAfterDays",
+]) {
+  assert.match(
+    settingsView,
+    new RegExp(`update\\(\\{ ${field} \\}\\)`),
+    `settings view edits ${field}`,
+  );
+}
+assert.match(
+  settingsView,
+  /role="switch"[\s\S]*?aria-checked=\{checked\}/,
+  "policy toggles are accessible switches, matching the settings shell idiom",
+);
+assert.match(
+  settingsView,
+  /After thread reflection/,
+  "the reflection auto-archive toggle is labeled for what it does",
+);
+
+// A failed save must not lie about state: revert the optimistic change.
+assert.match(
+  settingsView,
+  /\.catch\(\(\) => \{\s*setPolicy\(previous\);/,
+  "failed PATCHes revert the optimistic policy update",
+);
+
+// --- chat-view: reflect flows react to a reflection-triggered archive ---------
+
+assert.match(
+  chatView,
+  /report: ThreadSelfReport; archivedAt\?: string/,
+  "reflect responses carry the optional archive timestamp",
+);
+const refreshOnArchive = chatView.match(/if \(json\.archivedAt\) onSessionsChanged\?\.\(\);/g) ?? [];
+assert.equal(
+  refreshOnArchive.length,
+  2,
+  "both manual reflect and auto self-report refresh the session list when the thread archived",
+);
+
+console.log("chat-settings-view.test.ts ok");

--- a/src/components/chat-settings-view.tsx
+++ b/src/components/chat-settings-view.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { SettingsGroup } from "@/components/ui/settings-group";
+import {
+  normalizeChatAutoArchivePolicy,
+  type ChatAutoArchivePolicy,
+} from "@/lib/chat-auto-archive";
+
+/**
+ * Consolidated chat settings — the chat page's Settings tab. One place for the
+ * behavior knobs that apply to every chat on this device, starting with the
+ * auto-archive policy (previously config-file only): the master sweep switch,
+ * event-driven archiving (task completion, thread reflections), and the idle
+ * windows. Reads/writes the `chatAutoArchive` key through `/api/config`, whose
+ * PATCH merges partial policies over the stored one.
+ */
+
+type SaveState = "idle" | "saving" | "error";
+
+function PolicyRow({
+  label,
+  description,
+  dimmed,
+  children,
+}: {
+  label: string;
+  description?: string;
+  dimmed?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`flex items-center justify-between gap-4 px-4 py-3 ${dimmed ? "opacity-50" : ""}`}>
+      <div className="min-w-0">
+        <p className="text-[13px] text-[var(--text-primary)]">{label}</p>
+        {description && <p className="text-[11px] text-[var(--text-muted)]">{description}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function PolicySwitch({
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`settings-switch focus-ring${checked ? " is-on" : ""}`}
+    >
+      <span className="settings-switch__knob" aria-hidden />
+    </button>
+  );
+}
+
+/** Days input that commits on blur/Enter so each keystroke doesn't PATCH. */
+function PolicyDays({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  disabled?: boolean;
+  onCommit: (days: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => setDraft(String(value)), [value]);
+  const commit = () => {
+    const parsed = Number.parseInt(draft, 10);
+    const days = Number.isFinite(parsed) ? Math.min(Math.max(parsed, 0), 365) : value;
+    setDraft(String(days));
+    if (days !== value) onCommit(days);
+  };
+  return (
+    <label className="flex shrink-0 items-center gap-1.5 text-[12px] text-[var(--text-secondary)]">
+      <input
+        type="number"
+        min={0}
+        max={365}
+        value={draft}
+        disabled={disabled}
+        aria-label={label}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        className="w-16 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-right text-[12px] text-[var(--text-primary)] focus-ring"
+      />
+      days
+    </label>
+  );
+}
+
+export function ChatSettingsView() {
+  const [policy, setPolicy] = useState<ChatAutoArchivePolicy | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const policyRef = useRef<ChatAutoArchivePolicy | null>(null);
+  policyRef.current = policy;
+
+  useEffect(() => {
+    const ctl = new AbortController();
+    fetch("/api/config", { cache: "no-store", signal: ctl.signal })
+      .then((r) => r.json())
+      .then((json: { ok?: boolean; config?: { chatAutoArchive?: Partial<ChatAutoArchivePolicy> }; error?: string }) => {
+        if (ctl.signal.aborted) return;
+        if (!json.ok) throw new Error(json.error ?? "failed to load config");
+        setPolicy(normalizeChatAutoArchivePolicy(json.config?.chatAutoArchive));
+      })
+      .catch((err) => {
+        if (ctl.signal.aborted) return;
+        setLoadError(err instanceof Error ? err.message : "failed to load config");
+      });
+    return () => ctl.abort();
+  }, []);
+
+  // Optimistic patch: apply locally, persist the changed fields, revert on failure.
+  const update = useCallback((patch: Partial<ChatAutoArchivePolicy>) => {
+    const previous = policyRef.current;
+    if (!previous) return;
+    setPolicy({ ...previous, ...patch });
+    setSaveState("saving");
+    fetch("/api/config", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatAutoArchive: patch }),
+    })
+      .then((r) => r.json())
+      .then((json: { ok?: boolean; error?: string }) => {
+        if (!json.ok) throw new Error(json.error ?? "failed to save");
+        setSaveState("idle");
+      })
+      .catch(() => {
+        setPolicy(previous);
+        setSaveState("error");
+      });
+  }, []);
+
+  const sweepOff = policy ? !policy.enabled : false;
+
+  return (
+    <div className="chat-settings-view min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-8">
+        <header>
+          <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">Chat settings</h2>
+          <p className="mt-1 text-[12px] text-[var(--text-muted)]">
+            Applies to every chat on this device. Per-familiar behavior (like auto
+            self-report) lives with each familiar under Familiars → Brain.
+          </p>
+        </header>
+
+        {loadError ? (
+          <p role="alert" className="text-[12px] text-[var(--accent-danger,#e5484d)]">
+            {loadError}
+          </p>
+        ) : !policy ? (
+          <p className="text-[12px] text-[var(--text-muted)]">Loading…</p>
+        ) : (
+          <>
+            <SettingsGroup
+              label="Auto-archive"
+              description="Move finished chats out of the list automatically. Chats marked keep are never auto-archived."
+            >
+              <PolicyRow
+                label="Auto-archive"
+                description="Master switch for event- and time-based archiving."
+              >
+                <PolicySwitch
+                  label="Auto-archive"
+                  checked={policy.enabled}
+                  onChange={(enabled) => update({ enabled })}
+                />
+              </PolicyRow>
+              <PolicyRow
+                label="After task completion"
+                description="Archive a chat when its linked task completes, instead of only nudging."
+                dimmed={sweepOff}
+              >
+                <PolicySwitch
+                  label="Archive after task completion"
+                  checked={policy.archiveOnTaskCompletion}
+                  disabled={sweepOff}
+                  onChange={(archiveOnTaskCompletion) => update({ archiveOnTaskCompletion })}
+                />
+              </PolicyRow>
+              <PolicyRow
+                label="After thread reflection"
+                description="Archive a thread as soon as its reflection lands — a reflection marks it wrapped up."
+                dimmed={sweepOff}
+              >
+                <PolicySwitch
+                  label="Archive after thread reflection"
+                  checked={policy.archiveOnReflection}
+                  disabled={sweepOff}
+                  onChange={(archiveOnReflection) => update({ archiveOnReflection })}
+                />
+              </PolicyRow>
+              <PolicyRow
+                label="External chats idle for"
+                description="Chats created outside the chat surface (cron, flows, generated runs). 0 turns this window off."
+                dimmed={sweepOff}
+              >
+                <PolicyDays
+                  label="Archive external chats after days idle"
+                  value={policy.externalAfterDays}
+                  disabled={sweepOff}
+                  onCommit={(externalAfterDays) => update({ externalAfterDays })}
+                />
+              </PolicyRow>
+              <PolicyRow
+                label="Any chat idle for"
+                description="Every chat, regardless of origin. 0 turns this window off."
+                dimmed={sweepOff}
+              >
+                <PolicyDays
+                  label="Archive any chat after days idle"
+                  value={policy.idleAfterDays}
+                  disabled={sweepOff}
+                  onCommit={(idleAfterDays) => update({ idleAfterDays })}
+                />
+              </PolicyRow>
+            </SettingsGroup>
+            <p aria-live="polite" className="text-[11px] text-[var(--text-muted)]">
+              {saveState === "error"
+                ? "Saving failed — change reverted. Try again."
+                : saveState === "saving"
+                  ? "Saving…"
+                  : "Changes save automatically."}
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -5,6 +5,7 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { killPtyBridge } from "@/lib/pty-ws-bridge";
 import { ProjectsView } from "@/components/projects-view";
+import { ChatSettingsView } from "@/components/chat-settings-view";
 import { GroupChatView } from "@/components/group-chat-view";
 import { InspectorPane, type Tab as InspectorSection } from "@/components/inspector-pane";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending, consumeProjectsTabPending } from "@/lib/chat-tab-events";
@@ -57,7 +58,8 @@ const chatStorage = {
 
 // Memory is deliberately absent: familiar memory lives in the Familiars
 // surface and the Grimoire editor, not as a chat scope (cave-liut).
-type FamiliarsScope = "conversation" | "projects" | "coven";
+// "settings" is the consolidated chat-settings tab (auto-archive policy et al).
+type FamiliarsScope = "conversation" | "projects" | "coven" | "settings";
 
 export type RightPanelKind = "inspector" | "changes" | "debug";
 
@@ -685,6 +687,7 @@ export function ChatSurface({
             items={[
               { id: "conversation", label: "Sessions" },
               { id: "projects", label: "Projects" },
+              { id: "settings", label: "Settings" },
             ]}
           />
           <div className="flex items-center gap-1.5">
@@ -732,6 +735,13 @@ export function ChatSurface({
 
         {scope === "projects" ? (
           <ProjectsView sessions={sessions} familiars={familiars} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
+        ) : scope === "settings" ? (
+          // Consolidated chat settings (cave-wide auto-archive policy, incl.
+          // archive-on-reflection) as a first-class chat tab — the knobs govern
+          // chat behavior, so they live where chats live.
+          <div className="flex min-h-0 min-w-0 flex-1">
+            <ChatSettingsView />
+          </div>
         ) : scope === "coven" ? (
           // Group Chat ("coven") lives here as a first-class chat tab instead of
           // a standalone surface. It broadcasts one prompt to several familiars,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2295,15 +2295,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           payload: text,
         }),
       });
-      const json = await res.json() as { ok: true; report: ThreadSelfReport } | { ok: false; error?: string };
+      const json = await res.json() as
+        | { ok: true; report: ThreadSelfReport; archivedAt?: string }
+        | { ok: false; error?: string };
       if (!json.ok) throw new Error(json.error ?? "reflection failed");
       setThreadSignalReport(json.report);
+      // Chat settings can auto-archive a thread once its reflection lands
+      // (archiveOnReflection); refresh the list so the row moves immediately.
+      if (json.archivedAt) onSessionsChanged?.();
     } catch (err) {
       setReflectError(err instanceof Error ? err.message : "reflection failed");
     } finally {
       setReflecting(false);
     }
-  }, [familiar.display_name, familiar.id, reflecting, session?.title, sessionId, turns]);
+  }, [familiar.display_name, familiar.id, onSessionsChanged, reflecting, session?.title, sessionId, turns]);
 
   const autoReflectOnThread = useCallback(async (targetSessionId: string) => {
     if (!familiar.autoSelfReport) return;
@@ -2322,14 +2327,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         }),
       });
       const json = await res.json().catch(() => null) as
-        | { ok: true; report: ThreadSelfReport }
+        | { ok: true; report: ThreadSelfReport; archivedAt?: string }
         | { ok: false; error?: string }
         | null;
-      if (json?.ok) setThreadSignalReport(json.report);
+      if (json?.ok) {
+        setThreadSignalReport(json.report);
+        if (json.archivedAt) onSessionsChanged?.();
+      }
     } catch {
       /* Auto self-report is best-effort and intentionally silent. */
     }
-  }, [familiar.autoSelfReport, familiar.display_name, familiar.id, session?.title, turns]);
+  }, [familiar.autoSelfReport, familiar.display_name, familiar.id, onSessionsChanged, session?.title, turns]);
 
   useEffect(() => {
     const status = session?.status?.toLowerCase();

--- a/src/lib/chat-auto-archive.test.ts
+++ b/src/lib/chat-auto-archive.test.ts
@@ -7,6 +7,7 @@ import {
   extendUntilIso,
   normalizeChatAutoArchivePolicy,
   sessionCreatedExternally,
+  shouldAutoArchiveOnReflection,
   shouldAutoArchiveOnTaskCompletion,
   SUMMON_GRACE_DAYS,
 } from "./chat-auto-archive.ts";
@@ -56,6 +57,20 @@ assert.equal(
 assert.equal(
   normalizeChatAutoArchivePolicy({ archiveOnTaskCompletion: true }).archiveOnTaskCompletion,
   true,
+);
+assert.equal(
+  normalizeChatAutoArchivePolicy({ archiveOnReflection: true }).archiveOnReflection,
+  true,
+);
+assert.equal(
+  DEFAULT_CHAT_AUTO_ARCHIVE_POLICY.archiveOnReflection,
+  false,
+  "reflection auto-archive is opt-in via the chat Settings tab",
+);
+assert.equal(
+  normalizeChatAutoArchivePolicy({ archiveOnReflection: "yes" }).archiveOnReflection,
+  false,
+  "non-boolean reflection flags fall back to the default",
 );
 
 // --- sessionCreatedExternally ------------------------------------------------
@@ -212,6 +227,61 @@ assert.equal(
 );
 assert.equal(
   shouldAutoArchiveOnTaskCompletion("s-1", completionPolicy, {
+    keep: {},
+    archivedSessionIds: ["s-1"],
+  }),
+  false,
+);
+
+// --- shouldAutoArchiveOnReflection --------------------------------------------
+
+const reflectionPolicy = { ...policy, archiveOnReflection: true };
+
+// 13. A landed reflection archives only when opted in, with a session, not
+//     kept, not already archived — and never for periodic (mid-flight) reports.
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "manual", reflectionPolicy, { keep: {}, archivedSessionIds: [] }),
+  true,
+);
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "auto", reflectionPolicy, { keep: {}, archivedSessionIds: [] }),
+  true,
+  "auto self-reports archive too — the thread already reached a closed state",
+);
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "periodic", reflectionPolicy, { keep: {}, archivedSessionIds: [] }),
+  false,
+  "periodic reports are mid-flight health checks, never an archive trigger",
+);
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "manual", policy, { keep: {}, archivedSessionIds: [] }),
+  false,
+  "default policy leaves reflected threads alone",
+);
+assert.equal(
+  shouldAutoArchiveOnReflection(null, "manual", reflectionPolicy, { keep: {}, archivedSessionIds: [] }),
+  false,
+);
+assert.equal(
+  shouldAutoArchiveOnReflection(
+    "s-1",
+    "manual",
+    { ...reflectionPolicy, enabled: false },
+    { keep: {}, archivedSessionIds: [] },
+  ),
+  false,
+  "the master switch also gates reflection archiving",
+);
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "manual", reflectionPolicy, {
+    keep: { "s-1": daysAgo(1) },
+    archivedSessionIds: [],
+  }),
+  false,
+  "keep-marked chats are never auto-archived on reflection",
+);
+assert.equal(
+  shouldAutoArchiveOnReflection("s-1", "manual", reflectionPolicy, {
     keep: {},
     archivedSessionIds: ["s-1"],
   }),

--- a/src/lib/chat-auto-archive.ts
+++ b/src/lib/chat-auto-archive.ts
@@ -8,6 +8,10 @@ import type { SessionOrigin, SessionRow } from "./types.ts";
  *    reaches the end of its execution lifecycle (card → `completed`). Off by
  *    default — the inline/inbox nudge (see task-archive-nudge*) remains the
  *    default behavior; enabling this flips the nudge into an automatic archive.
+ *  - `archiveOnReflection`: archive a chat as soon as a thread reflection
+ *    (self-report) lands for it — a reflection marks the thread as wrapped up.
+ *    Off by default; toggled from the chat page's Settings tab. Periodic
+ *    (mid-flight) reports never archive, only `manual`/`auto` reflections.
  *  - `externalAfterDays`: chats created outside the chat interface (cron,
  *    heartbeat, journal narratives, board/workflow-invoked runs, generated
  *    daemon sessions) archive after this many days without activity.
@@ -27,6 +31,8 @@ export type ChatAutoArchivePolicy = {
   enabled: boolean;
   /** Archive the linked chat when its task completes (instead of only nudging). */
   archiveOnTaskCompletion: boolean;
+  /** Archive the chat when a thread reflection (self-report) lands for it. */
+  archiveOnReflection: boolean;
   /** Days of inactivity before externally-created chats archive. 0 = off. */
   externalAfterDays: number;
   /** Days of inactivity before any chat archives. 0 = off. */
@@ -36,6 +42,7 @@ export type ChatAutoArchivePolicy = {
 export const DEFAULT_CHAT_AUTO_ARCHIVE_POLICY: ChatAutoArchivePolicy = {
   enabled: true,
   archiveOnTaskCompletion: false,
+  archiveOnReflection: false,
   externalAfterDays: 7,
   idleAfterDays: 30,
 };
@@ -65,6 +72,10 @@ export function normalizeChatAutoArchivePolicy(
       typeof raw.archiveOnTaskCompletion === "boolean"
         ? raw.archiveOnTaskCompletion
         : d.archiveOnTaskCompletion,
+    archiveOnReflection:
+      typeof raw.archiveOnReflection === "boolean"
+        ? raw.archiveOnReflection
+        : d.archiveOnReflection,
     externalAfterDays: clampDays(raw.externalAfterDays, d.externalAfterDays),
     idleAfterDays: clampDays(raw.idleAfterDays, d.idleAfterDays),
   };
@@ -184,6 +195,31 @@ export function shouldAutoArchiveOnTaskCompletion(
 ): boolean {
   if (!sessionId) return false;
   if (!policy.enabled || !policy.archiveOnTaskCompletion) return false;
+  if (context.keep[sessionId]) return false;
+  return !context.archivedSessionIds.includes(sessionId);
+}
+
+/** How a thread reflection (self-report) was triggered. Mirrors the triggers
+ *  the self-report route accepts. */
+export type ReflectionTrigger = "auto" | "manual" | "periodic";
+
+/**
+ * Whether a thread whose reflection just landed should be archived
+ * automatically. `periodic` reports are mid-flight health checks — they never
+ * archive. Keep-marked and already-archived sessions are left alone, same as
+ * the task-completion path.
+ */
+export function shouldAutoArchiveOnReflection(
+  sessionId: string | null | undefined,
+  trigger: ReflectionTrigger,
+  policy: ChatAutoArchivePolicy,
+  context: Pick<AutoArchiveContext, "keep"> & {
+    archivedSessionIds: readonly string[];
+  },
+): boolean {
+  if (!sessionId) return false;
+  if (trigger === "periodic") return false;
+  if (!policy.enabled || !policy.archiveOnReflection) return false;
   if (context.keep[sessionId]) return false;
   return !context.archivedSessionIds.includes(sessionId);
 }


### PR DESCRIPTION
## What

The chat page gains a **Settings** tab (beside Sessions / Projects) with consolidated device-wide chat settings, and the auto-archive policy learns a new event trigger: **archive on thread reflection**.

### Settings tab
- New `ChatSettingsView` rendered as a first-class chat scope tab, editing the full `chatAutoArchive` policy in-app (previously config-file only): master switch, archive-after-task-completion, the new archive-after-thread-reflection, and both idle windows (external / any chat, 0 = off).
- Reads `GET /api/config` (no-store) and persists partial policies through the existing `PATCH /api/config` merge; optimistic updates revert on failure with an inline notice. Switches reuse the settings-shell `role=switch` idiom; day inputs commit on blur/Enter.

### Auto-archive on reflection
- `ChatAutoArchivePolicy.archiveOnReflection` (default **off**) plus a pure `shouldAutoArchiveOnReflection` helper: `manual` and `auto` reflections qualify; `periodic` (mid-flight) reports, keep-marked, and already-archived chats never do. The master switch gates it like every other trigger.
- The self-report POST route archives the reflected thread server-side (best-effort — an archive failure never fails the report), resolves pending archive nudges, and returns `archivedAt`; both reflect flows in `ChatView` refresh the session list so the row moves immediately.

## Verification
- `node --experimental-strip-types` on `chat-auto-archive.test.ts`, `chat-settings-view.test.ts` (new), `familiar-self-report-route.test.ts` — pass
- Neighboring tests (chat-surface, chat-surface-projects-tab, chat-view, merged-chat-auto-archive, cave-config, task-archive-nudge-wiring, chat-projects) — pass
- `pnpm typecheck` — clean
- `node scripts/check-tests-wired.mjs` — 871 files wired
- `pnpm test:app` — **640 test files passed**