### PR TITLE
fix: harden knowledge packs after code review (#3042 follow-up)

### DIFF
--- a/src/components/grimoire-helpers.ts
+++ b/src/components/grimoire-helpers.ts
@@ -58,7 +58,10 @@ export function rawToKnowledgePayload(id: string | null, raw: string, collection
     enabled: enabled !== false,
     body: doc.body.trim(),
   };
-  if (Object.keys(extra).length > 0) payload.extra = extra;
+  // Always send extra — omitting it means "client is extra-unaware" to the
+  // route, which then resurrects stored keys; an explicit `{}` clears them, so
+  // deleting the last entity field in the raw editor actually sticks.
+  payload.extra = extra;
   return payload;
 }
 
@@ -101,10 +104,13 @@ export function groupKnowledgeByCollection(
     root,
     collections: ids.map((id) => {
       const collection = metaById.get(id) ?? { id, meta: null, count: byCollection.get(id)?.length ?? 0 };
+      // Meta values come from hand-edited YAML; tolerate non-string types.
+      const name = collection.meta?.name;
+      const storyQuestion = collection.meta?.storyQuestion;
       return {
         ...collection,
-        label: collection.meta?.name?.trim() || id,
-        storyQuestion: collection.meta?.storyQuestion?.trim() || undefined,
+        label: (typeof name === "string" && name.trim()) || id,
+        storyQuestion: (typeof storyQuestion === "string" && storyQuestion.trim()) || undefined,
         entries: byCollection.get(id) ?? [],
       };
     }),

--- a/src/components/grimoire-stub-links.test.ts
+++ b/src/components/grimoire-stub-links.test.ts
@@ -36,6 +36,15 @@ assert.deepEqual(
   "raw knowledge payload keeps collection and non-reserved extra keys",
 );
 
+// Deleting the last extra key in the raw editor must clear stored extras: an
+// explicit `extra: {}` tells the route "extra-aware client, nothing left",
+// while an omitted field would resurrect the stored keys.
+assert.deepEqual(
+  rawToKnowledgePayload("mara", '---\ntitle: "Mara"\nscope: "global"\nenabled: true\n---\n\nBio\n').extra,
+  {},
+  "payload always carries extra so clearing the last key sticks",
+);
+
 assert.deepEqual(
   buildStubPayload("Lost Queen", {
     id: "characters",

--- a/src/lib/server/knowledge-packs.test.ts
+++ b/src/lib/server/knowledge-packs.test.ts
@@ -61,7 +61,12 @@ try {
   const firstVault = await packs.seedKnowledgePack({ packId: "worldbuilding", target: "vault" });
   assert.equal(firstVault.ok, true);
   assert.deepEqual(firstVault.collections, ["characters", "locations"]);
-  assert.deepEqual(firstVault.created.sort(), ["characters/character", "locations/location"]);
+  assert.deepEqual(firstVault.created.sort(), [
+    "characters/character",
+    "characters/collection.yml",
+    "locations/collection.yml",
+    "locations/location",
+  ]);
   const character = await vault.readKnowledgeEntry("character", "characters");
   assert.equal(character?.enabled, false, "seeded vault stubs are disabled by default");
   assert.deepEqual(character?.extra, { type: "character", status: "draft" }, "seeded stubs preserve entity/template frontmatter in extra");
@@ -76,7 +81,28 @@ try {
 
   const secondVault = await packs.seedKnowledgePack({ packId: "worldbuilding", target: "vault" });
   assert.deepEqual(secondVault.created, []);
-  assert.deepEqual(secondVault.skipped.sort(), ["characters/character", "locations/location"]);
+  assert.deepEqual(secondVault.skipped.sort(), [
+    "characters/character",
+    "characters/collection.yml",
+    "locations/collection.yml",
+    "locations/location",
+  ]);
+
+  // Same-pack provenance must not license clobbering user customizations:
+  // `summary` reaches every harness prompt, so a re-seed reverting it would be
+  // silent data loss (docs promise seeding never overwrites existing files).
+  await vault.writeCollectionMeta("characters", {
+    name: "Characters",
+    pack: { id: "worldbuilding", version: "0.1.0" },
+    summary: "my customized summary",
+  });
+  const samePackReseed = await packs.seedKnowledgePack({ packId: "worldbuilding", target: "vault" });
+  assert.ok(samePackReseed.skipped.includes("characters/collection.yml"));
+  assert.equal(
+    (await vault.readCollectionMeta("characters"))?.summary,
+    "my customized summary",
+    "re-seeding never overwrites an existing collection.yml, even from the same pack",
+  );
 
   await vault.writeCollectionMeta("characters", { name: "Other", pack: { id: "other-pack", version: "1" } });
   const protectedMeta = await packs.seedKnowledgePack({ packId: "worldbuilding", target: "vault" });

--- a/src/lib/server/knowledge-packs.ts
+++ b/src/lib/server/knowledge-packs.ts
@@ -157,9 +157,15 @@ async function seedVault(pack: KnowledgePackManifest): Promise<KnowledgePackSeed
     const meta = folderMeta(pack, folder);
     result.collections?.push(folder.id);
     const hasMetaFile = await collectionMetaExists(folder.id);
-    const currentMeta = await readCollectionMeta(folder.id);
-    if (!hasMetaFile || currentMeta?.pack?.id === pack.id) await writeCollectionMeta(folder.id, meta);
-    else result.skipped.push(`${folder.id}/collection.yml`);
+    // Never overwrite an existing collection.yml — users customize it (esp.
+    // `summary`, which reaches every harness prompt) and the docs promise
+    // seeding never clobbers existing files. Report the touch either way.
+    if (!hasMetaFile) {
+      await writeCollectionMeta(folder.id, meta);
+      result.created.push(`${folder.id}/collection.yml`);
+    } else {
+      result.skipped.push(`${folder.id}/collection.yml`);
+    }
 
     const [template] = templatesByFolder(pack, folder);
     if (!template) continue;

--- a/src/lib/server/knowledge-vault-collections.test.ts
+++ b/src/lib/server/knowledge-vault-collections.test.ts
@@ -111,6 +111,43 @@ try {
   );
   assert.match(prompt, /root body/);
   assert.doesNotMatch(prompt, /seed body/, "disabled seeded entries stay out of the prompt block");
+
+  // collection.yml is hand-editable: non-string optional fields must degrade
+  // to "absent" at the readCollectionMeta chokepoint instead of crashing the
+  // prompt builder (`summary: 2026` parses as a YAML number) on every send.
+  await mkdir(path.join(scratchRoot, "typo"), { recursive: true });
+  await writeFile(
+    path.join(scratchRoot, "typo", "collection.yml"),
+    "name: Typo\nsummary: 2026\nstoryQuestion: true\ndescription: [not, a, string]\nfields: nope\npack: broken\n",
+    "utf8",
+  );
+  const typoMeta = await readCollectionMeta("typo");
+  assert.deepEqual(typoMeta, { name: "Typo" }, "non-string optional meta fields are dropped, not passed through");
+  assert.doesNotThrow(
+    () =>
+      buildPromptWithKnowledgeVault("User prompt", [], [
+        { id: "typo", meta: { name: "C", summary: 2026 }, count: 0 },
+      ]),
+    "the pure prompt builder tolerates raw unsanitized metas from direct callers",
+  );
+
+  // Multi-line extra values keep their blank lines through a full
+  // serialize→parse round-trip (paragraph breaks were being stripped).
+  await writeKnowledgeEntry({
+    id: "notes",
+    collection: "characters",
+    title: "Notes",
+    tags: [],
+    scope: "global",
+    enabled: true,
+    body: "body",
+    extra: { notes: "para one\n\npara two" },
+  });
+  assert.deepEqual(
+    (await readKnowledgeEntry("notes", "characters"))?.extra,
+    { notes: "para one\n\npara two" },
+    "blank lines inside multi-line extra values survive the round-trip",
+  );
 } finally {
   if (prev === undefined) delete process.env.COVEN_KNOWLEDGE_DIR;
   else process.env.COVEN_KNOWLEDGE_DIR = prev;

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -120,7 +120,11 @@ export function normalizeScope(value: unknown): KnowledgeScope {
 function extraFrontmatterLines(entry: KnowledgeEntry): string[] {
   const extra = sanitizeKnowledgeExtra(entry.extra);
   if (Object.keys(extra).length === 0) return [];
-  return stringifyYaml(extra).trimEnd().split("\n").filter(Boolean);
+  // Keep empty lines: block scalars use blank lines for paragraph breaks, and
+  // dropping them would silently corrupt multi-line values on every save. The
+  // frontmatter fence stays unambiguous — block content is always indented, so
+  // no emitted line can match the column-0 `---` terminator.
+  return stringifyYaml(extra).trimEnd().split("\n");
 }
 
 const RESERVED_FRONTMATTER_KEYS = new Set(["title", "tags", "scope", "enabled", "pins"]);
@@ -221,12 +225,17 @@ export function buildPromptWithKnowledgeVault(
 ): string {
   const text = prompt.trim();
   const usable = entries.filter((e) => e.enabled && e.body.trim());
+  // collection.yml is hand-edited YAML; readCollectionMeta coerces types, but
+  // this is a pure function other callers can feed raw metas — a non-string
+  // summary must be skipped, never crash the chat-send path. Whitespace and
+  // newlines are collapsed so a multi-line summary can't break the one-line
+  // list format or balloon prompt tokens.
+  const summaryOf = (meta: KnowledgeCollectionMeta | null): string =>
+    meta && typeof meta.summary === "string" ? meta.summary.replace(/\s+/g, " ").trim() : "";
   const collectionIndex = collections
-    .filter((collection) => collection.meta?.summary?.trim())
+    .filter((collection) => summaryOf(collection.meta))
     .slice(0, 20)
-    // Collapse whitespace/newlines so a multi-line summary can't break the
-    // one-line list format or balloon prompt tokens.
-    .map((collection) => `- ${collection.id}: ${(collection.meta?.summary ?? "").replace(/\s+/g, " ").trim()}`);
+    .map((collection) => `- ${collection.id}: ${summaryOf(collection.meta)}`);
   if (usable.length === 0 && collectionIndex.length === 0) return text;
 
   const blocks = usable.map((entry) => {
@@ -390,9 +399,33 @@ export async function readCollectionMeta(collection: string): Promise<KnowledgeC
     const raw = await readFile(collectionMetaPath(collection), "utf8");
     const parsed = parseYaml(raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    const meta = parsed as Partial<KnowledgeCollectionMeta>;
+    const meta = parsed as Record<string, unknown>;
     if (typeof meta.name !== "string" || !meta.name.trim()) return null;
-    return meta as KnowledgeCollectionMeta;
+    // collection.yml is hand-editable YAML, so every optional field is coerced
+    // at this single chokepoint: a stray `summary: 2026` (YAML number) must
+    // degrade to "field absent", not throw `.trim is not a function` in the
+    // prompt builder on every chat send.
+    const str = (v: unknown): string | undefined =>
+      typeof v === "string" && v.trim() ? v : undefined;
+    const fields = Array.isArray(meta.fields)
+      ? meta.fields.filter(
+          (f): f is { key: string; label: string } =>
+            isPlainRecord(f) && typeof f.key === "string" && typeof f.label === "string",
+        )
+      : undefined;
+    const pack =
+      isPlainRecord(meta.pack) && typeof meta.pack.id === "string" && typeof meta.pack.version === "string"
+        ? { id: meta.pack.id, version: meta.pack.version }
+        : undefined;
+    return {
+      name: meta.name,
+      ...(str(meta.description) ? { description: str(meta.description) } : {}),
+      ...(str(meta.entityType) ? { entityType: str(meta.entityType) } : {}),
+      ...(str(meta.storyQuestion) ? { storyQuestion: str(meta.storyQuestion) } : {}),
+      ...(fields ? { fields } : {}),
+      ...(pack ? { pack } : {}),
+      ...(str(meta.summary) ? { summary: str(meta.summary) } : {}),
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
Post-merge `/review` of #3042 surfaced four verified issues (each reproduced before fixing):

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | High | Hand-edited `collection.yml` with a non-string field (`summary: 2026` parses as a YAML number) threw `TypeError: .trim is not a function` inside `buildPromptWithKnowledgeVault` — **500 on every `/api/chat/send`** — and crashed the Grimoire grouping render. | `readCollectionMeta` coerces all optional fields at the chokepoint; both `.trim()` call sites (server prompt builder, client grouping) type-guard raw metas. |
| 2 | Medium | `extraFrontmatterLines`'s `.filter(Boolean)` stripped blank lines from YAML block scalars — paragraph breaks in multi-line `extra` values silently corrupted on every save, defeating the "preserved verbatim" contract. | Keep empty lines (block content is always indented, so the `---` fence stays unambiguous). |
| 3 | Medium | `seedVault` rewrote `collection.yml` when its `pack.id` matched — "Seed again" silently reverted user-customized summaries (which reach every harness prompt), unreported in `created`/`skipped`, contradicting the documented never-overwrite idempotence. | Never overwrite an existing `collection.yml`; report meta writes in `created` and skips in `skipped`. |
| 4 | Medium | `rawToKnowledgePayload` omitted empty `extra`, which the route reads as "extra-unaware client" and resurrects stored keys — deleting the last entity frontmatter key in the Grimoire raw editor never stuck. | Always send `extra` (an explicit `{}` clears). |

Regression tests added for all four (typo-meta coercion + pure-function tolerance, blank-line round-trip, same-pack reseed protection + reporting, explicit-`{}` clear). `tsc`, affected suites green locally.