### PR TITLE
perf(sessions): stale-while-revalidate cache for /api/sessions/list (cave-5m1c)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -766,6 +766,7 @@ export const SUITES = {
     "src/lib/familiar-identity-scaffold.test.ts",
     "src/lib/session-list-merge.test.ts",
     "src/lib/session-git-enrich.test.ts",
+    "src/lib/swr-cache.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",
     "src/lib/server/operator-profile-context.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -468,13 +468,33 @@ for (const contract of contracts) {
   );
   assert.match(
     sessionsListSource,
-    /let sessionsListCache:[\s\S]*let sessionsListInFlight:/,
-    "/sessions/list: repeated callers should share a short-lived cached response",
+    /const sessionsListCache = createSwrCache<SessionsListResult>\(/,
+    "/sessions/list: repeated callers should share a stale-while-revalidate cached response",
   );
   assert.match(
     sessionsListSource,
-    /const inFlight = sessionsListInFlight\.get\(cacheKey\);[\s\S]*if \(inFlight\) return inFlight;/,
-    "/sessions/list: concurrent callers should await one in-flight session list computation",
+    /canServeStale: \(result\) => result\.payload\.ok/,
+    "/sessions/list: error payloads must never be served stale (no pinned 503s)",
+  );
+  assert.match(
+    sessionsListSource,
+    /SESSIONS_LIST_STALE_SERVE_MS = 30_000/,
+    "/sessions/list: stale serve window covers the poll cadence so polls never block on recompute",
+  );
+
+  const swrCacheSource = readFileSync(
+    path.join(apiRoot, "..", "..", "lib", "swr-cache.ts"),
+    "utf8",
+  );
+  assert.match(
+    swrCacheSource,
+    /const existing = inFlight\.get\(key\);\s*\n\s*if \(existing\) return existing;/,
+    "swr-cache: concurrent callers should await one in-flight computation",
+  );
+  assert.match(
+    swrCacheSource,
+    /revalidate\(key, compute\)\.catch\(\(\) => undefined\);\s*\n\s*return entry\.value;/,
+    "swr-cache: stale reads serve the cached value and revalidate in the background",
   );
 
   const sessionGitEnrichSource = readFileSync(

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -14,6 +14,7 @@ import {
   mergeSessionRows,
 } from "@/lib/session-list-merge";
 import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
+import { createSwrCache } from "@/lib/swr-cache";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { scopeSessionsToFamiliarProjects } from "@/lib/session-project-scope";
@@ -53,14 +54,21 @@ type SessionsListResult = {
   init?: ResponseInit;
 };
 
-type SessionsListCacheEntry = {
-  expiresAt: number;
-  result: SessionsListResult;
-};
-
+// Stale-while-revalidate cache (cave-5m1c). The old plain 2s TTL sat under
+// the workspace's 4s poll, so effectively EVERY poll missed and paid the full
+// daemon + git + archive-sweep recompute on the response path. Now a poll
+// inside the fresh window is a pure cache hit; a poll after it is served the
+// previous payload instantly while one background recompute refreshes it —
+// steady-state pollers never wait on the compute. Error payloads are never
+// served stale (a transient daemon failure must not pin a 503 for the whole
+// stale window), and concurrent callers still share one in-flight compute.
 const SESSIONS_LIST_CACHE_MS = 2000;
-let sessionsListCache: Map<string, SessionsListCacheEntry> = new Map();
-let sessionsListInFlight: Map<string, Promise<SessionsListResult>> = new Map();
+const SESSIONS_LIST_STALE_SERVE_MS = 30_000;
+const sessionsListCache = createSwrCache<SessionsListResult>({
+  ttlMs: SESSIONS_LIST_CACHE_MS,
+  staleServeMs: SESSIONS_LIST_STALE_SERVE_MS,
+  canServeStale: (result) => result.payload.ok,
+});
 
 function isTrueProjectCwd(projectRoot: string): boolean {
   const trimmed = projectRoot.trim();
@@ -221,34 +229,6 @@ async function computeSessionsList(
   };
 }
 
-async function cachedSessionsList(
-  cacheKey: string,
-  includeArchived: boolean,
-  familiarId: string | null,
-): Promise<SessionsListResult> {
-  const now = Date.now();
-  const cached = sessionsListCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) {
-    return cached.result;
-  }
-  const inFlight = sessionsListInFlight.get(cacheKey);
-  if (inFlight) return inFlight;
-
-  const promise = computeSessionsList(includeArchived, familiarId).then((result) => {
-    sessionsListCache.set(cacheKey, {
-      expiresAt: Date.now() + SESSIONS_LIST_CACHE_MS,
-      result,
-    });
-    return result;
-  });
-  sessionsListInFlight.set(cacheKey, promise);
-  try {
-    return await promise;
-  } finally {
-    if (sessionsListInFlight.get(cacheKey) === promise) sessionsListInFlight.delete(cacheKey);
-  }
-}
-
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeArchived = url.searchParams.get("includeArchived") === "1";
@@ -258,6 +238,8 @@ export async function GET(req: Request) {
   }
   // Cache per (archived, familiar) — scoped views differ by grant set.
   const cacheKey = `${includeArchived ? "archived" : "active"}:${familiarId ?? "all"}`;
-  const result = await cachedSessionsList(cacheKey, includeArchived, familiarId);
+  const result = await sessionsListCache.get(cacheKey, () =>
+    computeSessionsList(includeArchived, familiarId),
+  );
   return NextResponse.json(result.payload, result.init);
 }

--- a/src/lib/swr-cache.test.ts
+++ b/src/lib/swr-cache.test.ts
@@ -1,0 +1,154 @@
+// @ts-nocheck
+/**
+ * Tests for src/lib/swr-cache.ts (cave-5m1c): the stale-while-revalidate
+ * cache behind /api/sessions/list.
+ *
+ * Covers, with an injectable fake clock:
+ *  1. cold start awaits the compute
+ *  2. fresh window serves cached without recomputing
+ *  3. stale window serves the OLD value instantly and revalidates in the
+ *     background (next read sees the new value)
+ *  4. beyond the stale window the caller blocks on a fresh compute
+ *  5. concurrent callers share one in-flight compute (dedupe)
+ *  6. canServeStale=false entries (e.g. error payloads) are never served
+ *     stale — the caller re-awaits the compute
+ *  7. background revalidation failure keeps serving the stale value
+ *  8. keys are independent
+ *  9. clear() drops entries
+ */
+
+import assert from "node:assert/strict";
+import { createSwrCache } from "./swr-cache.ts";
+
+function makeClock(start = 0) {
+  let t = start;
+  return { now: () => t, advance: (ms) => { t += ms; } };
+}
+
+/** Deferred compute helper: counts calls, resolves what you tell it to. */
+function makeCompute(values) {
+  let calls = 0;
+  const fn = async () => {
+    const value = values[Math.min(calls, values.length - 1)];
+    calls += 1;
+    if (value instanceof Error) throw value;
+    return value;
+  };
+  return { fn, count: () => calls };
+}
+
+const TTL = 2000;
+const STALE = 30_000;
+
+// ── 1 + 2. cold start computes; fresh window serves without recompute ───────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const compute = makeCompute(["v1", "v2"]);
+  assert.equal(await cache.get("k", compute.fn), "v1");
+  assert.equal(compute.count(), 1);
+  clock.advance(TTL); // age == ttl: still fresh
+  assert.equal(await cache.get("k", compute.fn), "v1");
+  assert.equal(compute.count(), 1, "fresh hit must not recompute");
+}
+
+// ── 3. stale serve + background revalidate ───────────────────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const compute = makeCompute(["v1", "v2"]);
+  await cache.get("k", compute.fn);
+  clock.advance(TTL + 1); // stale but servable
+  assert.equal(await cache.get("k", compute.fn), "v1", "stale read returns the old value instantly");
+  assert.equal(compute.count(), 2, "stale read must kick a background revalidation");
+  await Promise.resolve(); // let the background compute settle
+  await Promise.resolve();
+  assert.equal(await cache.get("k", compute.fn), "v2", "next read sees the revalidated value");
+  assert.equal(compute.count(), 2, "the revalidated entry is fresh again — no extra compute");
+}
+
+// ── 4. beyond the stale window the caller blocks on a fresh value ───────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const compute = makeCompute(["v1", "v2"]);
+  await cache.get("k", compute.fn);
+  clock.advance(STALE + 1);
+  assert.equal(await cache.get("k", compute.fn), "v2", "expired entries are not served");
+  assert.equal(compute.count(), 2);
+}
+
+// ── 5. concurrent callers share one in-flight compute ───────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  let calls = 0;
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const compute = async () => { calls += 1; await gate; return "shared"; };
+  const a = cache.get("k", compute);
+  const b = cache.get("k", compute);
+  release();
+  assert.deepEqual(await Promise.all([a, b]), ["shared", "shared"]);
+  assert.equal(calls, 1, "concurrent cold callers must share one compute");
+}
+
+// ── 6. non-servable entries are never served stale ──────────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({
+    ttlMs: TTL,
+    staleServeMs: STALE,
+    canServeStale: (v) => v.ok,
+    now: clock.now,
+  });
+  const compute = makeCompute([{ ok: false, v: 1 }, { ok: true, v: 2 }]);
+  assert.deepEqual(await cache.get("k", compute.fn), { ok: false, v: 1 });
+  clock.advance(TTL + 1);
+  assert.deepEqual(
+    await cache.get("k", compute.fn),
+    { ok: true, v: 2 },
+    "an error payload must not be pinned for the stale window — recompute instead",
+  );
+  assert.equal(compute.count(), 2);
+}
+
+// ── 7. background revalidation failure keeps the stale value ────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const compute = makeCompute(["v1", new Error("daemon down"), "v3"]);
+  await cache.get("k", compute.fn);
+  clock.advance(TTL + 1);
+  assert.equal(await cache.get("k", compute.fn), "v1"); // kicks failing revalidation
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(
+    await cache.get("k", compute.fn),
+    "v1",
+    "failed revalidation must not clobber the served value",
+  );
+  // The failed revalidation cleared in-flight, so this stale read retries…
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(await cache.get("k", compute.fn), "v3", "…and a later success replaces it");
+}
+
+// ── 8. keys are independent ──────────────────────────────────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  assert.equal(await cache.get("a", async () => "va"), "va");
+  assert.equal(await cache.get("b", async () => "vb"), "vb");
+}
+
+// ── 9. clear() drops entries ─────────────────────────────────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const compute = makeCompute(["v1", "v2"]);
+  await cache.get("k", compute.fn);
+  cache.clear();
+  assert.equal(await cache.get("k", compute.fn), "v2");
+  assert.equal(compute.count(), 2);
+}
+
+console.log("swr-cache.test.ts: all assertions passed");

--- a/src/lib/swr-cache.ts
+++ b/src/lib/swr-cache.ts
@@ -1,0 +1,77 @@
+/**
+ * Small stale-while-revalidate async cache (cave-5m1c).
+ *
+ * Built for /api/sessions/list, whose 2s TTL sat under the workspace's 4s
+ * poll — every poll missed the cache and paid the full daemon + git + sweep
+ * recompute on the response path. With SWR the poll is served instantly from
+ * the last computed payload while one background recompute refreshes it, so
+ * steady-state pollers never wait on the compute and concurrent callers share
+ * a single in-flight computation.
+ *
+ * Semantics:
+ *  - fresh (age <= ttlMs): serve cached, no recompute
+ *  - stale (ttlMs < age <= staleServeMs), entry marked servable: serve cached
+ *    immediately AND kick one background revalidation
+ *  - expired (age > staleServeMs) or never computed: caller awaits the
+ *    compute (deduped with any concurrent caller of the same key)
+ *  - entries the caller marks non-servable (e.g. error payloads) are never
+ *    served stale — callers re-await the compute instead of pinning a
+ *    transient failure for the whole stale window
+ */
+
+export type SwrCache<T> = {
+  get(key: string, compute: () => Promise<T>): Promise<T>;
+  /** Drop every cached entry (state resets in tests / config changes). */
+  clear(): void;
+};
+
+export function createSwrCache<T>(options: {
+  /** Serve without recompute while an entry is younger than this. */
+  ttlMs: number;
+  /** Serve stale + revalidate in background up to this age; beyond it, block. */
+  staleServeMs: number;
+  /** Entries failing this predicate are never served stale. Default: all pass. */
+  canServeStale?: (value: T) => boolean;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}): SwrCache<T> {
+  const { ttlMs, staleServeMs } = options;
+  const canServeStale = options.canServeStale ?? (() => true);
+  const now = options.now ?? Date.now;
+
+  type Entry = { computedAt: number; value: T };
+  const entries = new Map<string, Entry>();
+  const inFlight = new Map<string, Promise<T>>();
+
+  function revalidate(key: string, compute: () => Promise<T>): Promise<T> {
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+    const promise = compute().then((value) => {
+      entries.set(key, { computedAt: now(), value });
+      return value;
+    });
+    inFlight.set(key, promise);
+    void promise.catch(() => undefined).then(() => {
+      if (inFlight.get(key) === promise) inFlight.delete(key);
+    });
+    return promise;
+  }
+
+  return {
+    async get(key, compute) {
+      const entry = entries.get(key);
+      const age = entry ? now() - entry.computedAt : Infinity;
+      if (entry && age <= ttlMs) return entry.value;
+      if (entry && age <= staleServeMs && canServeStale(entry.value)) {
+        // Serve stale, revalidate in the background. Swallow background
+        // failures — the stale value stays until a later compute succeeds.
+        revalidate(key, compute).catch(() => undefined);
+        return entry.value;
+      }
+      return revalidate(key, compute);
+    },
+    clear() {
+      entries.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Problem

`SESSIONS_LIST_CACHE_MS = 2000` sat under the workspace's 4s poll — effectively **every poll missed the cache** and paid the full daemon + git + archive-sweep recompute on the response path (now async after #3044, but still on-path latency).

## Change

New `src/lib/swr-cache.ts` — a small generic stale-while-revalidate async cache (fresh window / stale-serve window / in-flight dedupe / injectable clock) — replacing the route's hand-rolled TTL + in-flight maps:

- **fresh (≤2s)**: pure cache hit
- **stale (≤30s)**: the poll is served the previous payload **instantly** while ONE background recompute refreshes it — steady-state pollers never wait on the compute
- **error payloads are never served stale** (`canServeStale` gates on `payload.ok`, so a transient daemon 503 can't get pinned)
- concurrent callers still share a single in-flight compute

All recurring consumers (workspace 4s poll, recent-activity-rollup 15s) and on-demand consumers (chat-list archived toggle, pickers) now land on the same warm entry — the fetch-dedupe goal achieved server-side with no cross-surface refactor.

## Regression tests

- `src/lib/swr-cache.test.ts` (wired into `test:api`): 9 behavior groups with a fake clock — cold start, fresh hit, **stale-serve + background revalidate**, expiry, **in-flight dedupe**, **no-stale-error-serve**, failed-revalidation resilience, key independence, clear.
- `api-contracts.test.ts` pins the route's SWR usage, the no-pinned-503 gate, and the 30s stale window.

## Validation

- `api-contracts` — 180/180 post-rebase on current main
- `swr-cache.test.ts` — all green
- `pnpm typecheck` — clean
- api+app suites green pre-rebase (789 files)

Closes bead: cave-5m1c