### PR TITLE
fix(ui): guard fire-and-forget fetches so a dead daemon can't crash the app (cave-nwm5)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -264,6 +264,7 @@ export const SUITES = {
     "src/components/chat-view-canvas-artifact.test.ts",
     "src/components/chat-response-metadata.test.ts",
     "src/components/daily-summary-notifications.test.ts",
+    "src/components/fire-and-forget-fetch.test.ts",
     "src/components/notification-bell-mutations.test.ts",
     "src/components/surface-error-states.test.ts",
     "src/components/glass-overlay-chrome.test.ts",

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -128,7 +128,7 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved, onRosterChan
       method: "PATCH",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ familiars: { [familiar.id]: null } }),
-    });
+    }).catch(() => undefined);
     setConfirmReset(false);
   }
 

--- a/src/components/fire-and-forget-fetch.test.ts
+++ b/src/components/fire-and-forget-fetch.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+// Fire-and-forget fetches must never crash the app (cave: toast dismiss threw
+// an unhandled "Failed to fetch" TypeError from markInboxItemRead when the
+// daemon was unreachable — a background best-effort POST became a Runtime
+// Error overlay). Rule: every `void fetch(...)` statement carries a `.catch`
+// somewhere in its chain. `void` explicitly discards the promise, so nothing
+// downstream can ever attach the handler — the statement itself must.
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function collect(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await collect(full)));
+    else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Extract the full `void fetch(...)` statement starting at `start`: walk the
+ * expression tracking bracket depth and skipping strings, template literals,
+ * and comments, ending at the first top-level `;`.
+ */
+function statementAt(text: string, start: number): string {
+  let depth = 0;
+  let i = start;
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (ch === "/" && next === "/") {
+      i = text.indexOf("\n", i);
+      if (i === -1) break;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i = text.indexOf("*/", i + 2);
+      if (i === -1) break;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      i += 1;
+      while (i < text.length && text[i] !== ch) {
+        if (text[i] === "\\") i += 1;
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === "(" || ch === "{" || ch === "[") depth += 1;
+    else if (ch === ")" || ch === "}" || ch === "]") depth -= 1;
+    else if (ch === ";" && depth === 0) return text.slice(start, i + 1);
+    i += 1;
+  }
+  return text.slice(start, i);
+}
+
+const offenders: string[] = [];
+for (const file of await collect(SRC)) {
+  const text = await readFile(file, "utf8");
+  let from = 0;
+  for (;;) {
+    const at = text.indexOf("void fetch(", from);
+    if (at === -1) break;
+    const statement = statementAt(text, at);
+    if (!statement.includes(".catch(")) {
+      const line = text.slice(0, at).split("\n").length;
+      offenders.push(`${path.relative(SRC, file)}:${line}`);
+    }
+    from = at + 1;
+  }
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  `every void fetch(...) must chain a .catch — a rejected best-effort request ` +
+    `(daemon down, network drop) otherwise surfaces as an unhandled runtime ` +
+    `TypeError. Unguarded: ${offenders.join(", ")}`,
+);
+
+console.log("fire-and-forget-fetch-guard: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1521,11 +1521,12 @@ export function Workspace() {
   // (missed-batches, ephemeral response-needed rows, ad-hoc toasts).
   const markInboxItemRead = useCallback((id: string | null | undefined) => {
     if (!id || id.startsWith("missed-") || id.startsWith("eph:")) return;
+    // Best-effort: a dead daemon must not turn a toast timer into a crash.
     void fetch("/api/inbox/bulk", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action: "read", ids: [id] }),
-    });
+    }).catch(() => undefined);
   }, []);
 
   // Explicit ✕ on a toast = "seen it" — mark read, keep it in the bell. The
@@ -1549,7 +1550,7 @@ export function Workspace() {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ untilIso }),
-      });
+      }).catch(() => undefined);
     }
     setToasts((prev) => prev.filter((t) => t.id !== toast.id));
   }, []);
@@ -1927,7 +1928,7 @@ export function Workspace() {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ mode: "attach", sessionId: intent.sessionId }),
-      });
+      }).catch(() => undefined);
       return;
     }
     if (intent.kind === "open-board") {
@@ -2103,7 +2104,7 @@ export function Workspace() {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ mode: "attach", sessionId: sid }),
-          });
+          }).catch(() => undefined);
         }
         return true;
       }


### PR DESCRIPTION
## Crash

Reported from the dev server:

```
Runtime TypeError: Failed to fetch
  at Workspace.useCallback[dismissToast]
  at InboxToastStack.useEffect.timers
```

A toast's auto-dismiss timer routed into `dismissToast` → `markInboxItemRead` → `void fetch('/api/inbox/bulk', …)` with **no rejection handler**. When the daemon/API is unreachable the fetch rejects, and because `void` discards the promise, nothing downstream can catch it — it surfaces as an unhandled Runtime Error overlay.

## Fix

- Chain `.catch(() => undefined)` (the repo's established best-effort convention — see `src/lib/cave-inbox.ts:128`, `src/lib/github-watcher.ts:156`, etc.) on the **five** unguarded fire-and-forget sites:
  - `workspace.tsx` — inbox read-ack (`markInboxItemRead`, the reported crash), inbox snooze, and both `/api/launch` TUI attaches
  - `familiar-studio-lifecycle-tab.tsx` — config reset PATCH
- **Regression guard:** `src/components/fire-and-forget-fetch.test.ts` — a paren-balanced scanner (string/comment-aware) asserting every `void fetch(` statement under `src/` carries a `.catch` in its chain. Wired into `test:app`.

## Verification

- Scanner proven against pre-fix code: flags exactly the five sites; passes post-fix
- Targeted pins green: `daily-summary-notifications`, `notification-bell-mutations`, new guard
- `node scripts/check-tests-wired.mjs` → all 885 wired
- `tsc --noEmit` clean

Bead: **cave-nwm5**