### PR TITLE
fix(familiars): consume the summon latch in the already-mounted path (cave-ibvl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ breaking config changes; patch releases stay additive.
 ### Features
 - **Onboarding: hand-held first run through the first chat** — the setup wizard now shows a three-beat journey strip (Set up Cave → Summon a familiar → First chat) so it never reads as a dead-ended infra checklist; completing setup surfaces an above-the-fold success banner, and the finish CTA keeps its promise by opening the Summoning Circle directly (decided on the wizard's own fresh status, immune to the workspace's slower daemon poll). In the circle, the name stage gains one-click identity templates (Code reviewer, Research assistant, Project planner, Writing partner) that fill the role and required description, and the success stage hands keyboard focus to "Begin the first conversation" so Enter completes the funnel (cave-uvv7).
 
+### Fixes
+- **Familiars: no phantom Summoning Circle on revisit** — a summon request handled by an already-open Familiars surface left the cross-surface latch armed, so the next visit to Familiars popped the circle open uninvited; the event listener now consumes the latch too (cave-ibvl).
+
 ## [0.0.182] - 2026-07-12
 
 > 🧼 **The open-issue sweep, plus Hermes chat out of the box.** Every open UI issue from the queue lands fixed — the drifting comment pill, overflowing Salem answers, the stranded post-summon error screen, and the silent Enhance button — alongside working Hermes-familiar chat on fresh machines and a chat-tab home for the inspector.

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -318,3 +318,19 @@ assert.match(
   /\{traceTarget \? \(\s*<SessionTraceOverlay target=\{traceTarget\} onClose=\{\(\) => setTraceTarget\(null\)\} \/>\s*\) : null\}/,
   "the overlay renders from panel state and closes cleanly",
 );
+
+// ── cave-ibvl: the summon-event listener consumes the latch ──────────────────
+// requestSummonFamiliar() arms the module latch unconditionally; a mounted
+// view that only reacted to the event left the latch armed, so the NEXT
+// FamiliarsView mount popped the circle open uninvited. Both intake paths
+// must consume it: the mount check and the live event listener.
+assert.match(
+  source,
+  /if \(consumeSummonPending\(\)\) setCreateOpen\(true\);/,
+  "a fresh mount consumes the summon latch",
+);
+assert.match(
+  source,
+  /const open = \(\) => \{\s*consumeSummonPending\(\);\s*setCreateOpen\(true\);\s*\};/,
+  "the already-mounted event listener also consumes the latch (cave-ibvl)",
+);

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -95,10 +95,17 @@ export function FamiliarsView({
   const [createOpen, setCreateOpen] = useState(false);
   // Other surfaces request the Summoning Circle through summon-events: the
   // retained latch covers the fresh-mount race (mode flip → this view mounts
-  // after the event fired); the event covers the already-mounted case.
+  // after the event fired); the event covers the already-mounted case. The
+  // listener consumes the latch too — requestSummonFamiliar arms it
+  // unconditionally, so an already-mounted view that only reacted to the
+  // event left it armed and the NEXT mount popped the circle open uninvited
+  // (cave-ibvl).
   useEffect(() => {
     if (consumeSummonPending()) setCreateOpen(true);
-    const open = () => setCreateOpen(true);
+    const open = () => {
+      consumeSummonPending();
+      setCreateOpen(true);
+    };
     window.addEventListener(SUMMON_FAMILIAR_EVENT, open);
     return () => window.removeEventListener(SUMMON_FAMILIAR_EVENT, open);
   }, []);


### PR DESCRIPTION
## Why

Follow-up from the code review of #3040 (commit `4e59af57`): `requestSummonFamiliar()` arms a module latch **and** dispatches `SUMMON_FAMILIAR_EVENT`. When FamiliarsView is already mounted (summon from the familiar switcher on the agents surface, or the onboarding finish CTA when the wizard was opened from Familiars), the event listener opened the circle but nothing consumed the latch — so the **next** mount of the surface popped the Summoning Circle open uninvited.

## Fix

The event listener now consumes the latch too. `requestSummonFamiliar()` sets the latch synchronously before dispatching, so a mounted listener clears it immediately; an unmounted view still finds it on mount. Both intake paths pinned by new guard assertions in `familiars-view.test.ts`.

## Verification

- `pnpm typecheck` ✓
- `node --experimental-strip-types src/components/familiars-view.test.ts` ✓ (incl. two new assertions)
- `node --experimental-strip-types src/components/familiar-summoning-circle.test.ts` ✓

Bead: cave-ibvl