### PR TITLE
perf(chat): coalesce SSE assistant_chunk frames into one commit per flush window (cave-w50e)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -41,6 +41,8 @@ export const SUITES = {
     "src/components/role-surfaces/research-evidence-ledger.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/components/chat-view-transcript-memo.test.ts",
+    "src/components/chat-view-chunk-coalescing.test.ts",
+    "src/lib/chunk-coalescer.test.ts",
     "src/components/chat-view-scroll-pin.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",

--- a/src/components/chat-view-chunk-coalescing.test.ts
+++ b/src/components/chat-view-chunk-coalescing.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+/**
+ * Source pins for SSE chunk coalescing in the chat stream loop (cave-w50e).
+ *
+ * SSE delivers ~one assistant_chunk frame per token; before this change each
+ * frame triggered a full turns map + registry advance + React commit —
+ * 50-100 commits/second on fast models. The stream loop now buffers chunk
+ * text in a coalescer and flushes it at most every CHUNK_FLUSH_MS, while
+ * non-chunk events and stream end/error force an immediate flush so ordering
+ * between text and progress/attachment/done records — and the final text —
+ * are exactly what they were before.
+ *
+ * Behavior of the buffer itself is covered in src/lib/chunk-coalescer.test.ts;
+ * these pins keep the chat-view wiring honest.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// ── 1. The stream loop routes chunks through the coalescer ──────────────────
+assert.match(
+  src,
+  /if \(ev\.kind === "assistant_chunk"\) \{[\s\S]{0,200}?chunkCoalescer\.push\(ev\.text\);/,
+  "assistant_chunk frames must be buffered, not committed per frame",
+);
+
+// ── 2. Non-chunk events flush buffered text FIRST (ordering) ────────────────
+assert.match(
+  src,
+  /\} else \{[\s\S]{0,300}?chunkCoalescer\.flush\(\);\s*\n\s*handleEvent\(ev, assistantId, request, liveGeneration\);/,
+  "any non-chunk event must flush buffered text before it is handled — text vs progress/attachment ordering is load-bearing",
+);
+
+// ── 3. Stream end flushes ────────────────────────────────────────────────────
+assert.match(
+  src,
+  /\n\s*\}\s*\n\s*chunkCoalescer\.flush\(\);\s*\n\s*\} catch \(err\) \{/,
+  "normal stream end must flush the tail of the buffer",
+);
+
+// ── 4. The error/abort path flushes before reading t.text ───────────────────
+assert.match(
+  src,
+  /\} catch \(err\) \{[\s\S]{0,300}?chunkCoalescer\.flush\(\);[\s\S]{0,300}?AbortError/,
+  "abort/error handling must flush first — the cancelled fallback reads t.text and must see all streamed text",
+);
+
+// ── 5. The coalescer is declared outside the try so the catch can flush ─────
+assert.match(
+  src,
+  /const chunkCoalescer = createChunkCoalescer\(\{\s*\n\s*flushMs: CHUNK_FLUSH_MS,\s*\n\s*apply: \(text\) => applyAssistantChunk\(text, assistantId, liveGeneration\),/,
+  "the coalescer applies through applyAssistantChunk with the send's own liveGeneration",
+);
+
+// ── 6. One application path: the extracted applyAssistantChunk ───────────────
+assert.match(
+  src,
+  /const applyAssistantChunk = \(\s*\n\s*text: string,/,
+  "the chunk application is extracted so coalesced and direct paths share one implementation",
+);
+assert.match(
+  src,
+  /case "assistant_chunk": \{[\s\S]{0,400}?applyAssistantChunk\(ev\.text, assistantId, liveGeneration\);/,
+  "handleEvent's assistant_chunk case must delegate to the shared implementation (never drop a chunk)",
+);
+// The heavy inline per-chunk map must not return to the switch case.
+const chunkCase = src.slice(src.indexOf('case "assistant_chunk"'), src.indexOf('case "assistant_chunk"') + 600);
+assert.ok(
+  !chunkCase.includes("appendCollapsingNewlines"),
+  "the per-frame switch case must stay a thin delegate — the text append lives in applyAssistantChunk",
+);
+
+// ── 7. The flush window is short enough to be imperceptible ─────────────────
+const flushMs = src.match(/const CHUNK_FLUSH_MS = (\d+);/);
+assert.ok(flushMs, "CHUNK_FLUSH_MS constant exists");
+const ms = Number(flushMs[1]);
+assert.ok(ms >= 15 && ms <= 100, `CHUNK_FLUSH_MS (${ms}) must batch meaningfully (>=15ms) but stay imperceptible (<=100ms)`);
+
+// ── 8. Timer-based, not rAF — chunks keep landing after unmount/hide ────────
+const coalescerLib = readFileSync(new URL("../lib/chunk-coalescer.ts", import.meta.url), "utf8");
+assert.ok(
+  !coalescerLib.includes("requestAnimationFrame("),
+  "the coalescer must use timers — rAF stalls in hidden windows and the registry accumulates post-unmount",
+);
+
+console.log("chat-view-chunk-coalescing.test.ts: ok");

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -93,8 +93,14 @@ assert.match(
 
 assert.match(
   source,
-  /case "assistant_chunk":[\s\S]*setAssistantLifecycle\(assistantId, "streaming", liveGeneration\.sessionId\)/,
+  /const applyAssistantChunk = \([\s\S]*?setAssistantLifecycle\(assistantId, "streaming", liveGeneration\.sessionId\)/,
   "Assistant chunks should move the turn into a streaming lifecycle",
+);
+
+assert.match(
+  source,
+  /case "assistant_chunk": \{[\s\S]{0,400}?applyAssistantChunk\(ev\.text, assistantId, liveGeneration\)/,
+  "The assistant_chunk event delegates to the shared streaming-lifecycle application",
 );
 
 assert.match(
@@ -423,10 +429,12 @@ assert.doesNotMatch(
 // (b) The synthetic "Receiving response" progress row settles at the first
 // assistant chunk instead of staying "running" for the whole stream — the
 // streamed text itself is the live signal, and the auto-open ProgressGroup
-// quiets down to real connect/tool events.
+// quiets down to real connect/tool events. (The chunk application lives in
+// applyAssistantChunk; both the coalesced stream-loop path and handleEvent's
+// assistant_chunk case delegate to it — see chat-view-chunk-coalescing.)
 assert.match(
   source,
-  /case "assistant_chunk":[\s\S]*?id: "stream",\s*\n\s*label: "Receiving response",\s*\n\s*status: "done",/,
+  /const applyAssistantChunk = \([\s\S]*?id: "stream",\s*\n\s*label: "Receiving response",\s*\n\s*status: "done",/,
   "The synthetic Receiving-response row settles (done) at first chunk (CHAT-D12-01)",
 );
 

--- a/src/components/chat-view-render-optimization.test.ts
+++ b/src/components/chat-view-render-optimization.test.ts
@@ -142,7 +142,7 @@ assert.match(
 // ── 2026-07-03 chat perf/a11y batch ──────────────────────────────────────────
 assert.match(chatViewSource, /const siblingIndex = useMemo\(\(\) => buildSiblingIndex\(turns\), \[turns\]\)/, "branch-nav siblings are precomputed once per turns change, not scanned per row");
 assert.doesNotMatch(chatViewSource, /siblingsOf\(turns/, "no per-row siblingsOf(turns) scans remain in render");
-assert.match(chatViewSource, /text: appendCollapsingNewlines\(t\.text, ev\.text\)/, "streaming append collapses newlines incrementally, not by re-scanning the whole buffer");
+assert.match(chatViewSource, /text: appendCollapsingNewlines\(t\.text, text\)/, "streaming append collapses newlines incrementally, not by re-scanning the whole buffer");
 assert.match(chatViewSource, /role="log"[\s\S]{0,80}aria-busy=\{busy \|\| undefined\}/, "the transcript log is aria-busy while streaming so AT doesn't re-announce the growing message");
 assert.match(chatViewSource, /aria-controls=\{panelId\}/, "RunActivityStrip's disclosure references its panel");
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -138,6 +138,7 @@ import { ComposerRuntimeChip } from "@/components/composer-runtime-chip";
 import { ComposerGitChip } from "@/components/composer-git-chip";
 import { resolveActivePath, buildSiblingIndex, childLeaf } from "@/lib/conversation-tree";
 import { appendCollapsingNewlines } from "@/lib/stream-text";
+import { createChunkCoalescer } from "@/lib/chunk-coalescer";
 import { stripStepMarkers } from "@/lib/workflow-step-progress";
 import {
   buildReflectTranscript,
@@ -404,6 +405,12 @@ const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
 // the find effect — the full transcript renders, so seeking, find, and deep
 // scroll are never limited by the cap.
 const TRANSCRIPT_RENDER_CAP = 60;
+// Streaming text flush window (cave-w50e): assistant_chunk frames arrive
+// ~one per token; buffering them for this long collapses dozens of React
+// commits (each a full turns map + registry advance) into one, while staying
+// well under perception threshold (~2-3 frames). Non-chunk events and stream
+// end flush immediately, so ordering and final text are exact.
+const CHUNK_FLUSH_MS = 40;
 const THINKING_OPTIONS = COMMAND_THINKING_OPTIONS;
 const SPEED_OPTIONS = COMMAND_RESPONSE_SPEED_OPTIONS;
 const CHAT_ATTACHMENT_ACCEPT = [
@@ -3975,6 +3982,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // background generation (user switched threads mid-stream) can tell it no
     // longer owns the displayed view and must not adopt its late session id.
     const liveGeneration = { sessionId: initialLiveSessionId, originSessionId: initialLiveSessionId, controller };
+    // Coalesce assistant_chunk frames (~one per token → one React commit per
+    // token) into one applyAssistantChunk per CHUNK_FLUSH_MS window. Declared
+    // outside the try so the catch (abort/error) can flush buffered text
+    // before it derives labels from t.text (cave-w50e).
+    const chunkCoalescer = createChunkCoalescer({
+      flushMs: CHUNK_FLUSH_MS,
+      apply: (text) => applyAssistantChunk(text, assistantId, liveGeneration),
+    });
     const runId = crypto.randomUUID();
     abortRef.current = controller;
     stopKeysRef.current = { runId, sessionId: initialLiveSessionId ?? null };
@@ -4116,13 +4131,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           if (!payload) continue;
           try {
             const ev = JSON.parse(payload) as StreamEvent;
-            handleEvent(ev, assistantId, request, liveGeneration);
+            if (ev.kind === "assistant_chunk") {
+              // Hot path: buffer instead of committing per token.
+              chunkCoalescer.push(ev.text);
+            } else {
+              // Ordering: buffered text must land before any progress /
+              // attachment / done record derived from later frames.
+              chunkCoalescer.flush();
+              handleEvent(ev, assistantId, request, liveGeneration);
+            }
           } catch {
             /* skip malformed */
           }
         }
       }
+      chunkCoalescer.flush();
     } catch (err) {
+      // Apply any buffered streamed text FIRST — the handlers below read
+      // t.text (e.g. the cancelled fallback label) and must see all of it.
+      chunkCoalescer.flush();
       if ((err as Error)?.name === "AbortError") {
         updateLiveTurns((prev) =>
           prev.map((t) =>
@@ -4499,6 +4526,46 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
+  /**
+   * Apply streamed assistant text to the live turn in ONE state update.
+   * Extracted from handleEvent's assistant_chunk case (cave-w50e) so the
+   * stream loop's coalescer can flush a whole buffered window — dozens of
+   * tokens — as a single turns map + registry advance instead of one per
+   * SSE frame. appendCollapsingNewlines is chunking-invariant (see
+   * stream-text.test.ts), so buffering never changes the final text.
+   */
+  const applyAssistantChunk = (
+    text: string,
+    assistantId: string,
+    liveGeneration: { sessionId: string | null },
+  ) => {
+    setAssistantLifecycle(assistantId, "streaming", liveGeneration.sessionId);
+    updateLiveTurns((prev) =>
+      prev.map((t) =>
+        t.id === assistantId
+          ? {
+              ...t,
+              text: appendCollapsingNewlines(t.text, text),
+              pending: true,
+              lifecycle: "streaming",
+              // CHAT-D12-01: settle the synthetic row the moment text is
+              // flowing — the streamed text IS the live signal from here
+              // on. Leaving it "running" kept the auto-open ProgressGroup
+              // pulsing for the entire stream.
+              progress: upsertProgressEvent(t.progress, {
+                id: "stream",
+                label: "Receiving response",
+                status: "done",
+              }),
+            }
+          : t,
+      ),
+      assistantId,
+      undefined,
+      liveGeneration.sessionId,
+    );
+  };
+
   const handleEvent = (
     ev: StreamEvent,
     assistantId: string,
@@ -4535,31 +4602,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
       case "assistant_chunk": {
-        setAssistantLifecycle(assistantId, "streaming", liveGeneration.sessionId);
-        updateLiveTurns((prev) =>
-          prev.map((t) =>
-            t.id === assistantId
-              ? {
-                  ...t,
-                  text: appendCollapsingNewlines(t.text, ev.text),
-                  pending: true,
-                  lifecycle: "streaming",
-                  // CHAT-D12-01: settle the synthetic row the moment text is
-                  // flowing — the streamed text IS the live signal from here
-                  // on. Leaving it "running" kept the auto-open ProgressGroup
-                  // pulsing for the entire stream.
-                  progress: upsertProgressEvent(t.progress, {
-                    id: "stream",
-                    label: "Receiving response",
-                    status: "done",
-                  }),
-                }
-              : t,
-          ),
-          assistantId,
-          undefined,
-          liveGeneration.sessionId,
-        );
+        // Direct (non-coalesced) path — the stream loop routes chunks through
+        // chunkCoalescer and never reaches this case; it stays for any other
+        // handleEvent caller so a chunk is never silently dropped.
+        applyAssistantChunk(ev.text, assistantId, liveGeneration);
         return;
       }
       case "attachment": {

--- a/src/lib/chunk-coalescer.test.ts
+++ b/src/lib/chunk-coalescer.test.ts
@@ -1,0 +1,137 @@
+// @ts-nocheck
+/**
+ * Tests for src/lib/chunk-coalescer.ts (cave-w50e): the buffer that collapses
+ * per-token SSE frames into one state update per flush window.
+ *
+ * Covers, with injectable timers:
+ *  1. pushes accumulate; the scheduled flush applies ONE concatenated string
+ *  2. only one timer is scheduled per window (no timer-per-token)
+ *  3. explicit flush() applies immediately and cancels the pending timer
+ *  4. flush() with an empty buffer never calls apply
+ *  5. empty-string pushes are no-ops (no timer, no apply)
+ *  6. the coalescer keeps working after a flush (next window schedules again)
+ *  7. real-timer smoke: a scheduled flush actually fires
+ */
+
+import assert from "node:assert/strict";
+import { createChunkCoalescer } from "./chunk-coalescer.ts";
+
+function makeTimers() {
+  let nextId = 1;
+  const scheduled = new Map();
+  return {
+    schedule: (fn, ms) => {
+      const id = nextId++;
+      scheduled.set(id, { fn, ms });
+      return id;
+    },
+    cancel: (id) => {
+      scheduled.delete(id);
+    },
+    fire: () => {
+      const entries = [...scheduled.entries()];
+      scheduled.clear();
+      for (const [, { fn }] of entries) fn();
+    },
+    count: () => scheduled.size,
+  };
+}
+
+// ── 1 + 2. accumulate, single timer, one concatenated apply ─────────────────
+{
+  const timers = makeTimers();
+  const applied = [];
+  const c = createChunkCoalescer({
+    flushMs: 40,
+    apply: (text) => applied.push(text),
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  c.push("Hel");
+  c.push("lo ");
+  c.push("world");
+  assert.equal(timers.count(), 1, "one timer per flush window, not per token");
+  assert.deepEqual(applied, [], "nothing applies before the flush");
+  assert.equal(c.pending(), "Hello world".length);
+  timers.fire();
+  assert.deepEqual(applied, ["Hello world"], "the flush applies one concatenated string");
+  assert.equal(c.pending(), 0);
+}
+
+// ── 3. explicit flush applies now and cancels the timer ─────────────────────
+{
+  const timers = makeTimers();
+  const applied = [];
+  const c = createChunkCoalescer({
+    flushMs: 40,
+    apply: (t) => applied.push(t),
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  c.push("abc");
+  c.flush();
+  assert.deepEqual(applied, ["abc"]);
+  assert.equal(timers.count(), 0, "explicit flush cancels the scheduled timer");
+  timers.fire(); // nothing scheduled — must not double-apply
+  assert.deepEqual(applied, ["abc"]);
+}
+
+// ── 4. empty flush never calls apply ─────────────────────────────────────────
+{
+  const timers = makeTimers();
+  let calls = 0;
+  const c = createChunkCoalescer({
+    flushMs: 40,
+    apply: () => { calls += 1; },
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  c.flush();
+  assert.equal(calls, 0, "flushing an empty buffer is a no-op");
+}
+
+// ── 5. empty-string pushes are no-ops ────────────────────────────────────────
+{
+  const timers = makeTimers();
+  let calls = 0;
+  const c = createChunkCoalescer({
+    flushMs: 40,
+    apply: () => { calls += 1; },
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  c.push("");
+  assert.equal(timers.count(), 0, "an empty chunk must not schedule a flush");
+  timers.fire();
+  assert.equal(calls, 0);
+}
+
+// ── 6. subsequent windows schedule again ─────────────────────────────────────
+{
+  const timers = makeTimers();
+  const applied = [];
+  const c = createChunkCoalescer({
+    flushMs: 40,
+    apply: (t) => applied.push(t),
+    schedule: timers.schedule,
+    cancel: timers.cancel,
+  });
+  c.push("one");
+  timers.fire();
+  c.push("two");
+  assert.equal(timers.count(), 1, "a new window schedules a fresh timer");
+  timers.fire();
+  assert.deepEqual(applied, ["one", "two"]);
+}
+
+// ── 7. real-timer smoke ──────────────────────────────────────────────────────
+{
+  const applied = [];
+  const c = createChunkCoalescer({ flushMs: 5, apply: (t) => applied.push(t) });
+  c.push("re");
+  c.push("al");
+  await new Promise((r) => setTimeout(r, 25));
+  assert.deepEqual(applied, ["real"], "default timers flush on their own");
+}
+
+console.log("chunk-coalescer.test.ts: all assertions passed");

--- a/src/lib/chunk-coalescer.ts
+++ b/src/lib/chunk-coalescer.ts
@@ -1,0 +1,69 @@
+/**
+ * Token-stream chunk coalescer (cave-w50e).
+ *
+ * SSE delivers roughly one `assistant_chunk` frame per network packet, i.e.
+ * one React commit per token at 50–100 tokens/s. Each commit mapped the whole
+ * turns array, advanced the live-chat registry and re-rendered the streaming
+ * subtree. Coalescing buffers chunk text and flushes it on a short timer so
+ * dozens of tokens collapse into one state update, while every non-chunk
+ * event (progress, attachments, done) forces a flush first — ordering between
+ * text and tool/progress records is preserved exactly.
+ *
+ * Timer-based (not requestAnimationFrame) on purpose: chunks keep landing
+ * after the view unmounts or the window is hidden (the live-chat registry
+ * accumulates at module scope), and rAF stalls in hidden windows would leave
+ * an unbounded buffer.
+ */
+
+export type ChunkCoalescer = {
+  /** Buffer a chunk; schedules a flush if one isn't already pending. */
+  push(text: string): void;
+  /**
+   * Apply everything buffered NOW (cancels the pending timer). Call before
+   * handling any non-chunk event and at stream end/error/abort so ordering
+   * and final text are exact.
+   */
+  flush(): void;
+  /** Buffered-but-unapplied text length (introspection/tests). */
+  pending(): number;
+};
+
+export function createChunkCoalescer(options: {
+  /** How long buffered chunks may wait before a scheduled flush applies them. */
+  flushMs: number;
+  /** Applies the coalesced text — exactly once per flush with a non-empty buffer. */
+  apply: (text: string) => void;
+  /** Injectable timer hooks for tests. Default: global setTimeout/clearTimeout. */
+  schedule?: (fn: () => void, ms: number) => unknown;
+  cancel?: (handle: unknown) => void;
+}): ChunkCoalescer {
+  const { flushMs, apply } = options;
+  const schedule = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+  const cancel = options.cancel ?? ((handle) => clearTimeout(handle as Parameters<typeof clearTimeout>[0]));
+
+  let buffer = "";
+  let timer: unknown = null;
+
+  const flush = () => {
+    if (timer != null) {
+      cancel(timer);
+      timer = null;
+    }
+    if (!buffer) return;
+    const text = buffer;
+    buffer = "";
+    apply(text);
+  };
+
+  return {
+    push(text) {
+      if (!text) return;
+      buffer += text;
+      if (timer == null) {
+        timer = schedule(flush, flushMs);
+      }
+    },
+    flush,
+    pending: () => buffer.length,
+  };
+}


### PR DESCRIPTION
## Problem

SSE delivers ~one `assistant_chunk` frame per network packet — **one React commit per token** at 50–100 tokens/s, each mapping the whole turns array and advancing the live-chat registry.

## Change

New `src/lib/chunk-coalescer.ts` (generic, injectable timers) wired into the chat stream loop:

- chunks buffer and flush at most every `CHUNK_FLUSH_MS` (40ms ≈ 2–3 frames — imperceptible; **10–50× fewer commits** at fast token rates)
- any **non-chunk** event (progress/attachment/done) flushes buffered text first → text vs progress ordering exactly as before
- stream end flushes the tail; the catch flushes **before** abort/error handlers read `t.text`
- timer-based (not rAF): chunks keep landing after unmount/hidden-window via the module-scope registry; rAF stalls when hidden
- application extracted to `applyAssistantChunk`; `handleEvent`'s case delegates to it (no path can drop a chunk)
- `appendCollapsingNewlines` is chunking-invariant (randomized proof in stream-text.test.ts) → buffering never changes final text

## Regression tests

- `chunk-coalescer.test.ts`: 7 behavior groups w/ fake timers (accumulation, single-timer-per-window, explicit flush+cancel, empty no-ops, window restart, real-timer smoke)
- `chat-view-chunk-coalescing.test.ts`: source pins (buffer-not-commit, flush-before-non-chunk, flush-at-end, flush-before-error-reads, shared implementation, 15–100ms bound, no-rAF)
- lifecycle/render-optimization pins updated to the extracted site

## Validation

- app suite 642/642, api+mobile+conformance 238/238, typecheck clean (pre-rebase); rebased onto current main cleanly

Closes bead: cave-w50e