### PR TITLE
perf(polls): hidden-window discipline for client polls + structural guard (cave-e794)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -324,6 +324,7 @@ export const SUITES = {
     "src/lib/github-search.test.ts",
     "src/lib/use-refresh-on-focus.test.ts",
     "src/lib/use-pausable-poll.test.ts",
+    "src/lib/pausable-poll-discipline.test.ts",
     "src/lib/use-autogrow-textarea.test.ts",
     "src/lib/use-composer-draft.test.ts",
     "src/lib/use-composer-history.test.ts",

--- a/src/components/github-advanced.test.ts
+++ b/src/components/github-advanced.test.ts
@@ -119,8 +119,9 @@ assert.match(source, /profileCache\.set\(login, profile\)/, "a fetched profile p
 
 // Checks live-refresh: while the rollup is pending, poll every 30s; the same-PR
 // refresh is silent (no skeleton flash) and a hidden tab spends no rate limit.
-assert.match(source, /if \(rollup !== "pending"\) return;[\s\S]{0,240}setInterval[\s\S]{0,160}30_000/, "a pending rollup schedules a 30s live-refresh");
-assert.match(source, /document\.hidden\) return;[\s\S]{0,60}setTick/, "the live-refresh skips fetching while the tab is hidden");
+// The poll goes through usePausablePoll (cave-e794): hidden pause is built in
+// and returning to the tab ticks immediately instead of waiting out the 30s.
+assert.match(source, /usePausablePoll\(\(\) => setTick\(\(t\) => t \+ 1\), 30_000, \{ enabled: rollup === "pending" \}\)/, "a pending rollup schedules a 30s live-refresh (paused while hidden, instant on return)");
 assert.match(source, /const silent = keyRef\.current === key;[\s\S]{0,120}if \(!silent\) setState\(\{ status: "loading" \}\)/, "a same-PR refresh keeps the list mounted (no loading flash)");
 assert.match(source, /else if \(!silent\) setState\(\{ status: "error" \}\)/, "a failed silent refresh keeps the last good list");
 

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -58,6 +58,7 @@ import {
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { GithubSubscriptionsModal } from "@/components/github-subscriptions-modal";
 import { openExternalUrl } from "@/lib/open-external";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -1698,18 +1699,12 @@ function useGitHubChecks(item: GitHubItem | null, enabled: boolean): ChecksState
   }, [enabled, repo, number, tick]);
 
   // Live-refresh while CI is still running: poll every 30s until the rollup
-  // leaves "pending". Fetches are skipped while the tab is hidden (the interval
-  // itself is a no-op then) so a backgrounded tab doesn't spend rate limit —
-  // mirroring the surface's own activity-poll discipline.
+  // leaves "pending". usePausablePoll (cave-e794) keeps the hidden-tab skip
+  // (a backgrounded tab doesn't spend rate limit) and adds an immediate
+  // refresh on return, so CI status is current the moment the tab comes back
+  // instead of up to 30s later.
   const rollup = state.status === "ready" ? state.data.rollup : null;
-  useEffect(() => {
-    if (rollup !== "pending") return;
-    const id = window.setInterval(() => {
-      if (typeof document !== "undefined" && document.hidden) return;
-      setTick((t) => t + 1);
-    }, 30_000);
-    return () => window.clearInterval(id);
-  }, [rollup]);
+  usePausablePoll(() => setTick((t) => t + 1), 30_000, { enabled: rollup === "pending" });
 
   return state;
 }

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -10,6 +10,7 @@ import {
   type LatestCheckDisplay,
 } from "@/lib/opencoven-tools-status-display";
 import { useShellBanners } from "@/lib/shell-banners";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { buildSafeToolDiagnostics } from "@/lib/about-diagnostics";
 import { relativeTime } from "@/lib/relative-time";
 
@@ -330,12 +331,17 @@ export function OpenCovenToolsUpdate() {
     mounted.current = true;
     void load();
     void refreshNpmLane();
-    const pollLane = setInterval(() => void refreshNpmLane(), 2000);
     return () => {
       mounted.current = false;
-      clearInterval(pollLane);
     };
   }, [load, refreshNpmLane]);
+
+  // Shared npm lane: 2s poll so a concurrently running install started by any
+  // OTHER surface (onboarding, capabilities) shows here too. usePausablePoll
+  // (cave-e794): the raw interval fetched every 2s even in hidden windows —
+  // this surface is always mounted, so that was a permanent background drip.
+  // Now it pauses while hidden and refreshes instantly on return.
+  usePausablePoll(() => void refreshNpmLane(), 2000);
 
   const runningInstallKey = useMemo(
     () =>
@@ -391,7 +397,13 @@ export function OpenCovenToolsUpdate() {
       }
     };
     void tick();
-    const id = setInterval(() => void tick(), 2000);
+    const id = setInterval(() => {
+      // Hidden-window pause (cave-e794): the job completes server-side either
+      // way; polling from a hidden window only spends network. The visible
+      // poll (or the on-return lane refresh) catches the terminal state.
+      if (typeof document !== "undefined" && document.hidden) return;
+      void tick();
+    }, 2000);
     return () => {
       cancelled = true;
       clearInterval(id);

--- a/src/components/remote-theme-controller.tsx
+++ b/src/components/remote-theme-controller.tsx
@@ -172,7 +172,13 @@ export function RemoteThemeController() {
     colorScheme.addEventListener("change", onColorSchemeChange);
     reconcileCanonical();
     void reconcileRemote();
-    const interval = window.setInterval(() => void reconcileRemote(), POLL_MS);
+    const interval = window.setInterval(() => {
+      // Hidden-window pause (cave-e794): remote theme reconciliation is a
+      // visual concern — nothing to reconcile while nothing is visible. The
+      // onVisible listener below refreshes immediately on return.
+      if (document.hidden) return;
+      void reconcileRemote();
+    }, POLL_MS);
     const onVisible = () => {
       if (!document.hidden) void reconcileRemote();
     };

--- a/src/lib/pausable-poll-discipline.test.ts
+++ b/src/lib/pausable-poll-discipline.test.ts
@@ -1,0 +1,132 @@
+// @ts-nocheck
+/**
+ * Client polling discipline (cave-e794).
+ *
+ * usePausablePoll exists because surfaces kept hand-rolling the same
+ * setInterval + document.hidden + visibilitychange trio, and the hand-rolled
+ * copies kept forgetting the hidden-tab pause — a permanently mounted 2s
+ * lane poll (open-coven-tools-update) and a 10s theme reconcile
+ * (remote-theme-controller) fetched from hidden windows for as long as the
+ * app was open.
+ *
+ * This test makes the discipline structural:
+ *
+ *  1. every `setInterval(` in a "use client" file must either sit next to a
+ *     hidden/visibility guard or use the shared hook — OR the file must be on
+ *     the explicit ticker/scoped allowlist below with a reason;
+ *  2. the migrated surfaces stay migrated (pins);
+ *  3. new unguarded client polls fail CI with a pointer to usePausablePoll.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Files allowed to keep raw setInterval WITHOUT a visibility guard.
+ * Every entry needs a reason; "ticker" means a cheap local-state clock with
+ * no network I/O (pausing a call timer or elapsed counter would be wrong or
+ * pointless — they cost no requests).
+ */
+const RAW_INTERVAL_ALLOWLIST = new Map([
+  ["components/ui/thinking-indicator.tsx", "elapsed-time ticker while a turn is pending; no network"],
+  ["components/voice-call-overlay.tsx", "live call-duration ticker; pausing it would misreport the call"],
+  ["components/home/home-feed.tsx", "minute ticker for relative timestamps; no network"],
+  ["components/calendar-view.tsx", "wall-clock minute ticker for the now-line; no network"],
+  ["components/chat-view.tsx", "1s elapsed ticker on the streaming meta line; no network"],
+  ["components/update-available.tsx", "6-hour recheck cadence; a hidden-tab skip would defer updates for days"],
+  ["components/onboarding-overlay.tsx", "modal-scoped 2s install polls; only run while the overlay is open mid-setup"],
+  ["lib/use-pausable-poll.ts", "the shared hook's own interval (it self-guards via document.hidden)"],
+]);
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+const offenders = [];
+const guarded = [];
+for (const file of walk(SRC)) {
+  if (!/\.(ts|tsx)$/.test(file) || /\.test\./.test(file)) continue;
+  const source = readFileSync(file, "utf8");
+  const firstLines = source.slice(0, 200);
+  if (!firstLines.includes('"use client"')) continue;
+
+  const rel = path.relative(SRC, file);
+  let index = 0;
+  let unguardedHere = 0;
+  while ((index = source.indexOf("setInterval(", index)) !== -1) {
+    // The guard usually lives inside the polled callback, which is commonly
+    // declared just above the interval — look far enough back to see it.
+    const context = source.slice(Math.max(0, index - 2000), index + 700);
+    const isGuarded = /document\.hidden|visibilityState/.test(context);
+    if (isGuarded) guarded.push(rel);
+    else unguardedHere += 1;
+    index += "setInterval(".length;
+  }
+  if (unguardedHere > 0 && !RAW_INTERVAL_ALLOWLIST.has(rel)) {
+    offenders.push(`${rel} (${unguardedHere} unguarded setInterval call(s))`);
+  }
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  `Unguarded setInterval in client code. Recurring network polls must use ` +
+    `usePausablePoll (src/lib/use-pausable-poll.ts) — it pauses while hidden ` +
+    `and refreshes on return. Cheap non-network tickers can be added to the ` +
+    `allowlist in this test WITH a reason. Offenders:\n  ${offenders.join("\n  ")}`,
+);
+
+// ── Migrated surfaces stay migrated ─────────────────────────────────────────
+const changesSummary = readFileSync(path.join(SRC, "lib/use-changes-summary.ts"), "utf8");
+assert.match(
+  changesSummary,
+  /usePausablePoll\(\(\) => void load\(\), POLL_MS, \{ enabled: active && Boolean\(projectRoot\) \}\)/,
+  "use-changes-summary polls through the shared hook",
+);
+assert.ok(
+  !changesSummary.includes("setInterval("),
+  "use-changes-summary must not hand-roll its interval again",
+);
+assert.ok(
+  !changesSummary.includes('addEventListener("visibilitychange"'),
+  "use-changes-summary must not hand-roll the visibility listener (the hook owns on-return refresh)",
+);
+assert.match(
+  changesSummary,
+  /generation\.current !== gen\) return;/,
+  "a stale in-flight response for the previous project root must not write into the new root's state",
+);
+
+const githubView = readFileSync(path.join(SRC, "components/github-view.tsx"), "utf8");
+assert.match(
+  githubView,
+  /usePausablePoll\(\(\) => setTick\(\(t\) => t \+ 1\), 30_000, \{ enabled: rollup === "pending" \}\)/,
+  "the CI-rollup live refresh polls through the shared hook (hidden pause + instant on-return tick)",
+);
+
+const toolsUpdate = readFileSync(path.join(SRC, "components/open-coven-tools-update.tsx"), "utf8");
+assert.match(
+  toolsUpdate,
+  /usePausablePoll\(\(\) => void refreshNpmLane\(\), 2000\)/,
+  "the always-mounted npm-lane poll goes through the shared hook — it used to fetch every 2s from hidden windows",
+);
+
+const remoteTheme = readFileSync(path.join(SRC, "components/remote-theme-controller.tsx"), "utf8");
+assert.match(
+  remoteTheme,
+  /if \(document\.hidden\) return;\s*\n\s*void reconcileRemote\(\);/,
+  "the remote-theme reconcile poll skips hidden windows (onVisible refreshes on return)",
+);
+
+console.log(
+  `pausable-poll-discipline.test.ts: ok (${guarded.length} guarded interval(s), ` +
+    `${RAW_INTERVAL_ALLOWLIST.size} allowlisted ticker/scoped file(s))`,
+);

--- a/src/lib/use-changes-summary.test.ts
+++ b/src/lib/use-changes-summary.test.ts
@@ -16,9 +16,20 @@ assert.match(src, /document\.visibilityState !== "visible"/, "skips work while t
 assert.match(src, /inFlight\.current/, "single-flight guard prevents overlapping requests");
 assert.match(src, /`\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}`/, "hits /api/changes for the root");
 assert.doesNotMatch(src, /&path=/, "summary request omits a file path — it only needs the count");
-assert.match(src, /window\.setInterval\(load, POLL_MS\)/, "polls on the interval");
-assert.match(src, /window\.clearInterval\(id\)/, "clears the interval on cleanup");
-assert.match(src, /document\.removeEventListener\("visibilitychange"/, "removes the visibility listener on cleanup");
+// cave-e794: the recurring poll + on-return refresh go through the shared
+// usePausablePoll hook instead of a hand-rolled interval + visibility trio.
+assert.match(
+  src,
+  /usePausablePoll\(\(\) => void load\(\), POLL_MS, \{ enabled: active && Boolean\(projectRoot\) \}\)/,
+  "polls through usePausablePoll (hidden pause + on-return refresh centralized)",
+);
+assert.doesNotMatch(src, /setInterval\(/, "no hand-rolled interval remains");
+assert.doesNotMatch(src, /addEventListener\("visibilitychange"/, "no hand-rolled visibility listener remains");
+assert.match(
+  src,
+  /generation\.current !== gen\) return;/,
+  "a stale in-flight response for a previous root can't write into the new root's state",
+);
 assert.match(src, /Array\.isArray\(json\.files\) \? json\.files\.length : 0/, "count is the changed-file list length");
 
 console.log("use-changes-summary.test.ts: ok");

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 
 /**
  * Lightweight "are there uncommitted edits?" signal for a project root, without
@@ -47,48 +48,49 @@ export function useChangesSummary(
   const [branch, setBranch] = useState<string | null>(null);
   const [worktree, setWorktree] = useState<string | null>(null);
   const inFlight = useRef(false);
+  // Generation guard: bumped whenever (projectRoot, active) changes so a
+  // response still in flight for the PREVIOUS root can't write its summary
+  // into the new root's state.
+  const generation = useRef(0);
 
-  useEffect(() => {
+  const load = useCallback(async () => {
     if (!active || !projectRoot) return;
-
-    let cancelled = false;
-    const load = async () => {
-      if (inFlight.current) return;
-      if (document.visibilityState !== "visible") return;
-      inFlight.current = true;
-      try {
-        const res = await fetch(
-          `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`,
-          { cache: "no-store" },
-        );
-        const json = (await res.json()) as ChangesResponse;
-        if (cancelled) return;
-        if (res.ok && json.ok) {
-          setNotARepo(json.repo === false);
-          setCount(Array.isArray(json.files) ? json.files.length : 0);
-          setBranch(typeof json.branch === "string" ? json.branch : null);
-          setWorktree(typeof json.worktree === "string" ? json.worktree : null);
-        }
-      } catch {
-        /* transient — keep the last known summary */
-      } finally {
-        inFlight.current = false;
-        if (!cancelled) setLoaded(true);
+    if (inFlight.current) return;
+    if (document.visibilityState !== "visible") return;
+    const gen = generation.current;
+    inFlight.current = true;
+    try {
+      const res = await fetch(
+        `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`,
+        { cache: "no-store" },
+      );
+      const json = (await res.json()) as ChangesResponse;
+      if (generation.current !== gen) return;
+      if (res.ok && json.ok) {
+        setNotARepo(json.repo === false);
+        setCount(Array.isArray(json.files) ? json.files.length : 0);
+        setBranch(typeof json.branch === "string" ? json.branch : null);
+        setWorktree(typeof json.worktree === "string" ? json.worktree : null);
       }
-    };
-
-    void load();
-    const onVisible = () => {
-      if (document.visibilityState === "visible") void load();
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    const id = window.setInterval(load, POLL_MS);
-    return () => {
-      cancelled = true;
-      document.removeEventListener("visibilitychange", onVisible);
-      window.clearInterval(id);
-    };
+    } catch {
+      /* transient — keep the last known summary */
+    } finally {
+      inFlight.current = false;
+      if (generation.current === gen) setLoaded(true);
+    }
   }, [projectRoot, active]);
+
+  // Initial load per (root, active) change; the recurring poll + the
+  // on-return refresh are usePausablePoll's job (cave-e794 — this hook used
+  // to hand-roll the interval + visibilitychange trio the shared hook
+  // centralizes).
+  useEffect(() => {
+    generation.current += 1;
+    if (!active || !projectRoot) return;
+    void load();
+  }, [load, projectRoot, active]);
+
+  usePausablePoll(() => void load(), POLL_MS, { enabled: active && Boolean(projectRoot) });
 
   return { count, loaded, notARepo, branch, worktree };
 }


### PR DESCRIPTION
## Problem

`usePausablePoll` exists because surfaces kept hand-rolling the `setInterval` + `document.hidden` + `visibilitychange` trio — and the hand-rolled copies kept forgetting the hidden-tab pause. Two always-on polls fetched from hidden windows indefinitely:

- **open-coven-tools-update**: always-mounted npm-lane poll → `/api/opencoven-tools/status` every **2s, forever**
- **remote-theme-controller**: `/api/theme` reconcile every 10s

## Change

**Fixed leaks**
- tools-update lane poll → `usePausablePoll` (hidden pause + instant on-return refresh); install-job tick keeps its raw interval but now skips hidden windows
- remote-theme reconcile skips hidden windows (existing onVisible refreshes on return)

**Standardized onto the shared hook** (equal or better semantics)
- `use-changes-summary`: hand-rolled trio → `usePausablePoll`; adds a **generation guard** so a stale in-flight response for the previous project root can't write into the new root's state
- `github-view` CI rollup: 30s pending-only refresh → `usePausablePoll`, gaining an instant tick on tab return

**Structural regression net** — `src/lib/pausable-poll-discipline.test.ts` (wired into `test:app`) scans every `"use client"` file: any `setInterval` without a nearby hidden/visibility guard **fails CI** unless allowlisted with a reason (call timers, elapsed tickers, minute clocks, the 6h update recheck, modal-scoped onboarding installs, the hook itself). New unguarded client polls can't land silently.

Already-guarded polls left as-is: session-changes-panel, chat-surface, debug-pane, memory-md-editor, automations-view.

## Validation

- app suite **640/640** (incl. the new discipline test + updated github-advanced / use-changes-summary pins)
- typecheck clean; check-tests-wired green

Closes bead: cave-e794