### PR TITLE
fix(settings): normalize Windows paths in post-install recheck comparison

### DIFF
--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -52,6 +52,11 @@ assert.doesNotMatch(src, /tool\.installed \? "Up to date" : "Not found"/, "insta
 assert.match(src, /function installResultFromCompletion/, "post-install result reconciliation is centralized");
 assert.match(src, /const refreshed = await load\(\)/, "the UI refreshes status before displaying a completed install result");
 assert.match(src, /Post-install recheck now resolves a different executable/, "a stale status recheck replaces optimistic success with a recovery message");
+assert.match(
+  src,
+  /normalizePath\(rechecked\.path\) === normalizePath\(verification\.path\)/,
+  "recheck path comparison normalizes Windows casing/slashes so a cosmetic difference does not fail verification",
+);
 assert.match(src, /Post-install recheck could not verify npm latest/, "a registry recheck failure is not misdiagnosed as a different executable");
 assert.match(src, /Verified \$\{verification\.current\}/, "green success includes the verified version");
 assert.doesNotMatch(src, /Verified \$\{verification\.current\} at \$\{verification\.path\}/, "green success does not retain a local executable path");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -172,8 +172,17 @@ function installResultFromCompletion(
       detail: "Post-install recheck could not verify npm latest. Check the network or registry, then retry.",
     };
   }
+  // `where` on Windows can report the same executable with different casing
+  // or slash direction than the verification probe; normalize before
+  // comparing so a cosmetic path difference doesn't fail the recheck.
+  const normalizePath = (value: string | null | undefined) => {
+    if (!value) return null;
+    const looksWindows = /[A-Za-z]:\\/.test(value) || value.includes("\\");
+    const normalized = value.replace(/\//g, "\\");
+    return looksWindows ? normalized.toLowerCase() : value;
+  };
   const consistent =
-    rechecked.path === verification.path &&
+    normalizePath(rechecked.path) === normalizePath(verification.path) &&
     rechecked.current === verification.current &&
     rechecked.latest === verification.latest &&
     rechecked.packageVerified &&


### PR DESCRIPTION
Follow-up to #3029 (merged): `installResultFromCompletion` compared `rechecked.path === verification.path` string-identically, so on Windows a cosmetic casing/slash difference from `where` vs the verification probe failed the recheck with a misleading "resolves a different executable" error. Normalize both sides before comparing.

Ports the Copilot-review suggestion applied on #3048 (now closed as superseded by #3029's merge — this was the one piece not covered).

## Validation
- `node --experimental-strip-types src/components/open-coven-tools-update.test.ts` → ok (new guard assertion included)
- `pnpm exec tsc --noEmit` → clean