### PR TITLE
Harden About diagnostics path redaction

### DIFF
--- a/src/lib/about-diagnostics.test.ts
+++ b/src/lib/about-diagnostics.test.ts
@@ -15,19 +15,19 @@ const diagnostics = buildSafeToolDiagnostics({
     outdated: true,
     compatible: true,
     minimumVersion: "0.0.54",
-    path: "C:\\Users\\timot\\AppData\\Roaming\\npm\\coven.cmd",
-    executablePath: "C:\\Users\\Timothy Gregg\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\cli\\bin\\coven.js",
-    packagePath: "C:\\Users\\Timothy Gregg\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\cli",
+    path: "C:\\Users\\example-user\\AppData\\Roaming\\npm\\coven.cmd",
+    executablePath: "C:\\Users\\Example Person\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\cli\\bin\\coven.js",
+    packagePath: "C:\\Users\\Example Person\\AppData\\Roaming\\npm\\node_modules\\@opencoven\\cli",
     installCommand: "npm i -g @opencoven/cli@latest",
   }],
   checking: false,
   error: `request failed at https://example.invalid/settings?token=${secret}`,
   lastSuccessfulCheckedAt: "2026-07-12T12:00:00.000Z",
   installJobs: {
-    "coven-cli": { status: "done", elapsedMs: 1024, tail: `raw output ${secret} C:\\Users\\timot\\secret.log` },
+    "coven-cli": { status: "done", elapsedMs: 1024, tail: `raw output ${secret} C:\\Users\\example-user\\secret.log` },
   },
   installResults: {
-    "coven-cli": { ok: false, detail: `failed at /home/timot/.npmrc with token=${secret}` },
+    "coven-cli": { ok: false, detail: `failed at /home/example-user/.npmrc with token=${secret}` },
   },
   href: `http://localhost:3000/settings?access_token=${secret}#about`,
   sidecarTokenPresent: true,
@@ -38,27 +38,85 @@ assert.match(diagnostics, /included/, "diagnostics disclose what is copied");
 assert.match(diagnostics, /excluded/, "diagnostics disclose what is omitted");
 assert.match(diagnostics, /outputCaptured/, "diagnostics identify that output existed without copying it");
 assert.match(diagnostics, /http:\/\/localhost:3000\/settings\/?/, "the route remains useful without its query values");
-assert.doesNotMatch(diagnostics, /ghp_|access_token|C:\\Users\\timot|\/home\/timot|npm i -g|raw output/, "secrets, queries, local paths, commands, and raw output are excluded");
-assert.doesNotMatch(
-  diagnostics,
-  /executablePath|packagePath|Timothy Gregg/,
+assert.equal(
+  /ghp_|access_token|example-user|npm i -g|raw output/.test(diagnostics),
+  false,
+  "secrets, queries, local paths, commands, and raw output are excluded",
+);
+assert.equal(
+  /executablePath|packagePath|Example Person/.test(diagnostics),
+  false,
   "future machine-local tool path fields are excluded by an explicit diagnostics allowlist",
 );
-assert.match(
-  sanitizeAboutDiagnosticText(`https://example.invalid/path?secret=${secret} C:\\Users\\timot\\x`),
-  /\[redacted\]|\[local path omitted\]/,
+assert.equal(
+  /\[redacted\]|\[local path omitted\]/.test(
+    sanitizeAboutDiagnosticText(`https://example.invalid/path?secret=${secret} C:\\Users\\example-user\\x`),
+  ),
+  true,
   "freeform result text is redacted before inclusion",
 );
 
+const pathCases = [
+  String.raw`C:\Users\name\file`,
+  "C:/Users/name/file",
+  String.raw`\\server\share\file`,
+  "file:///C:/Users/name/file",
+  "/root/file",
+  "/opt/app/file",
+];
+
+for (const [index, localPath] of pathCases.entries()) {
+  const sanitized = sanitizeAboutDiagnosticText(`before ${localPath} after`);
+  assert.equal(sanitized.includes(localPath), false, `path form ${index} is not exposed in test failures`);
+  assert.equal(sanitized.startsWith("before [local path omitted]"), true, `path form ${index} is redacted`);
+  assert.equal(sanitized.endsWith(" after"), true, `prose after path form ${index} is preserved`);
+}
+
+const mixed = sanitizeAboutDiagnosticText(
+  `first C:/Users/name/one then ${secret} then /opt/app/two and https://example.com/docs/page?token=${secret}#install done`,
+);
+assert.equal(mixed.includes("[local path omitted]"), true, "mixed diagnostics redact local paths");
+assert.equal(mixed.match(/\[local path omitted\]/g)?.length, 2, "multiple local paths are independently redacted");
+assert.equal(mixed.includes(secret), false, "multiple sensitive values do not expose secrets");
+assert.equal(mixed.includes("https://example.com/docs/page"), true, "safe HTTPS URLs remain useful");
+assert.equal(mixed.includes("?token="), false, "safe HTTPS URL query values are removed");
+assert.equal(mixed.endsWith(" done"), true, "ordinary prose around paths is preserved");
+
+const ambiguousAfterAnotherPath = String.raw`first C:/safe/path then C:\Users\Example Person\secret.log after update`;
+const ambiguousAfterAnotherPathSanitized = sanitizeAboutDiagnosticText(ambiguousAfterAnotherPath);
+assert.equal(
+  ambiguousAfterAnotherPathSanitized.includes("Example Person"),
+  false,
+  "a later space-containing path cannot leak after an earlier path",
+);
+assert.equal(
+  ambiguousAfterAnotherPathSanitized.match(/\[local path omitted\]/g)?.length,
+  2,
+  "paths before a fail-closed path are also redacted",
+);
+
+for (const [index, safeText] of [
+  "plain prose with no filesystem reference",
+  "relative/path/to/file",
+  "version 1/2 is available",
+  "https://example.com/opt/app/file?channel=stable#download",
+  "C: is a drive label",
+  "/ is the root symbol",
+].entries()) {
+  const sanitized = sanitizeAboutDiagnosticText(safeText);
+  const expected = index === 3 ? "https://example.com/opt/app/file" : safeText;
+  assert.equal(sanitized, expected, `non-path form ${index} is preserved`);
+}
+
 for (const text of [
-  "failed at /Users/Timothy Gregg/.npmrc after update",
-  "failed at C:\\Users\\Timothy Gregg\\secret.log after update",
+  "failed at /Users/Example Person/.npmrc after update",
+  "failed at C:\\Users\\Example Person\\secret.log after update",
 ]) {
   const sanitized = sanitizeAboutDiagnosticText(text);
-  assert.match(sanitized, /\[local path omitted\]/, "local paths with spaces are identified");
-  assert.doesNotMatch(
-    sanitized,
-    /Timothy|Gregg|npmrc|secret\.log|after update/,
+  assert.equal(sanitized.includes("[local path omitted]"), true, "local paths with spaces are identified");
+  assert.equal(
+    /Example|Person|npmrc|secret\.log|after update/.test(sanitized),
+    false,
     "diagnostics fail closed at a local path instead of leaking its whitespace-delimited suffix",
   );
 }

--- a/src/lib/about-diagnostics.ts
+++ b/src/lib/about-diagnostics.ts
@@ -25,7 +25,11 @@ type InstallJobDiagnostic = {
 
 type InstallResultDiagnostic = { ok: boolean; detail: string };
 
-const LOCAL_PATH_START = /(^|[\s"'`(<\[])(?:[A-Za-z]:\\|\/(?:Users|home|private|var|tmp)\/)/i;
+const SAFE_WEB_URL = /https?:\/\/[^\s"'<>]+/gi;
+const LOCAL_PATH =
+  /(^|[\s"'`(<\[])(?:file:\/{2,3}(?:[A-Za-z]:[\\/]|\/)[^\s"'`<>\])}]+|\\\\[^\s"'`<>\])}]+[\\/][^\s"'`<>\])}]+|[A-Za-z]:[\\/][^\s"'`<>\])}]+|\/(?!\/)[^\s/"'`<>\])}]+(?:\/[^\s"'`<>\])}]+)*)/i;
+const LOCAL_PATH_START =
+  /(^|[\s"'`(<\[])(?:file:\/{2,3}(?:[A-Za-z]:[\\/]|\/)|\\\\[^\s"'`<>\])}]+[\\/]|[A-Za-z]:[\\/]|\/(?!\/)[^\s/"'`<>\])}]+\/)/i;
 
 function withoutQueryOrFragment(value: string): string {
   try {
@@ -38,14 +42,46 @@ function withoutQueryOrFragment(value: string): string {
   }
 }
 
+function redactLocalPaths(value: string): string {
+  let remaining = value;
+  let redacted = "";
+
+  while (remaining) {
+    const localPath = LOCAL_PATH.exec(remaining);
+    const pathStart = LOCAL_PATH_START.exec(remaining);
+    if (!localPath || !pathStart || localPath.index !== pathStart.index) {
+      return redacted + remaining;
+    }
+
+    const afterStart = remaining.slice(pathStart.index + pathStart[0].length);
+    const firstWhitespace = afterStart.search(/\s/);
+    const nextTokenHasSlash =
+      firstWhitespace >= 0 && /^\s+[^\s]*[\\/][^\s]*/.test(afterStart.slice(firstWhitespace));
+    redacted += remaining.slice(0, localPath.index) + (localPath[1] ?? "") + "[local path omitted]";
+
+    if (nextTokenHasSlash) {
+      // A literal space can be part of a local path, so its end cannot be
+      // inferred from prose. Deliberately sacrifice the rest of this line
+      // rather than risk copying a user or directory name.
+      return redacted;
+    }
+    remaining = remaining.slice(localPath.index + localPath[0].length);
+  }
+
+  return redacted;
+}
+
 /** Remove secrets, URL query values, and machine-local paths from short status text. */
 export function sanitizeAboutDiagnosticText(value: string): string {
-  const querySafe = value.replace(/https?:\/\/[^\s"'<>]+/gi, (url) => withoutQueryOrFragment(url));
-  const localPath = LOCAL_PATH_START.exec(querySafe);
-  const pathSafe = localPath
-    ? `${querySafe.slice(0, localPath.index)}${/\s/.test(localPath[1] ?? "") ? localPath[1] : ""}[local path omitted]`
-    : querySafe;
-  return redactSecretText(pathSafe).slice(0, 280);
+  const webUrls: string[] = [];
+  const querySafe = value.replace(SAFE_WEB_URL, (url) => {
+    webUrls.push(withoutQueryOrFragment(url));
+    return `__ABOUT_WEB_URL_${webUrls.length - 1}__`;
+  });
+
+  const pathSafe = redactLocalPaths(querySafe);
+  const urlSafe = pathSafe.replace(/__ABOUT_WEB_URL_(\d+)__/g, (_placeholder, index: string) => webUrls[Number(index)] ?? "unavailable");
+  return redactSecretText(urlSafe).slice(0, 280);
 }
 
 /**


### PR DESCRIPTION
## What changed

- redact Windows drive paths using either slash style, UNC paths, `file:` URLs, and absolute POSIX paths from About diagnostics
- preserve normalized HTTP(S) URLs and surrounding prose while continuing to remove URL queries, fragments, secrets, and raw installer output
- fail closed when a path containing literal spaces cannot be separated safely from prose
- replace personal test fixtures with generic names and keep sensitive values out of assertion failure output
- add focused coverage for required path forms, multiple values, safe URLs, prose, and false-positive boundaries

## Why

The previous prefix matcher only recognized backslash-based Windows drive paths and a short POSIX allowlist. Forward-slash drive paths, UNC paths, file URLs, and paths such as `/root` or `/opt` could survive sanitization even though copied diagnostics claimed local paths were omitted.

## Impact

Settings → About → OpenCoven tools diagnostics now match their privacy disclosure across supported platforms without changing the diagnostics schema or installer behavior.

## Validation

- `node --experimental-strip-types src/lib/about-diagnostics.test.ts`
- `node --experimental-strip-types src/components/open-coven-tools-update.test.ts`
- `node --experimental-strip-types src/lib/about-status.test.ts`
- `node --experimental-strip-types src/lib/opencoven-tools-install.test.ts`
- `node --experimental-strip-types src/lib/opencoven-tool-verification.test.ts`
- `pnpm check:tests-wired`
- `git diff --check origin/main...HEAD`

The full `pnpm test:app` run reached 80 passing test files, then stopped at an existing Windows-only separator assertion in `scripts/sync-marketplace.test.mjs` that expects `/` while Python emits `\`.

Bead: `cave-9on`
