### PR TITLE
feat(runtimes): first-class OpenCode — deliberate glyph + sign-in failure detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ breaking config changes; patch releases stay additive.
 ## [Unreleased]
 
 ### Features
+- **Runtimes: OpenCode enabled comprehensively** — the registry-accepted OpenCode runtime now gets first-class treatment across Cave: a deliberate runtime glyph in the composer chip and adapter surfaces (instead of the generic fallback), and sign-in failure detection that offers the copyable `opencode auth login` fix. Everything else (onboarding detection, chat trust, adapter-manifest scaffolding, model selection, raw-stdout chat passthrough) already flows from the synced runtime registry.
 - **Chat: consolidated Settings tab + auto-archive on thread reflections** — the chat page gains a Settings tab (beside Sessions and Projects) consolidating device-wide chat behavior: the full auto-archive policy (master switch, archive on task completion, idle windows for external and any chats) is now editable in the app instead of config-file only. It also introduces a new trigger — archive on thread reflection: when enabled, a thread archives itself the moment its reflection (self-report) lands, for manual and auto reflections alike; periodic reports and keep-marked chats never auto-archive, and the reflect flow refreshes the session list so the row moves immediately.
 - **Onboarding: hand-held first run through the first chat** — the setup wizard now shows a three-beat journey strip (Set up Cave → Summon a familiar → First chat) so it never reads as a dead-ended infra checklist; completing setup surfaces an above-the-fold success banner, and the finish CTA keeps its promise by opening the Summoning Circle directly (decided on the wizard's own fresh status, immune to the workspace's slower daemon poll). In the circle, the name stage gains one-click identity templates (Code reviewer, Research assistant, Project planner, Writing partner) that fill the role and required description, and the success stage hands keyboard focus to "Begin the first conversation" so Enter completes the funnel (cave-uvv7).
 
@@ -96,7 +97,6 @@ Patch release on top of v0.0.177.
 
 ### Docs
 - **Settings: attribution note** — the preference-persistence changelog credit now names the original author correctly (#2977).
-
 
 ## [0.0.177] - 2026-07-12
 

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -102,6 +102,7 @@ assert.match(
 // ── Brand marks: real logos for provider runtimes, glyphs for the rest ──────
 assert.match(logo, /codex: OPENAI_PATH,\s*\n\s*claude: ANTHROPIC_PATH,/, "codex and claude carry their providers' brand marks");
 assert.match(logo, /hermes: "ph:plug-bold",\s*\n\s*openclaw: "ph:paw-print-bold",/, "brand-less runtimes reuse the glyph language skill-card established");
+assert.match(logo, /opencode: "ph:code-bold",/, "opencode carries a deliberate glyph (skill-card's /code/ rule) instead of the generic robot fallback");
 assert.match(logo, /fill="currentColor"[\s\S]{0,80}?aria-hidden/, "brand SVGs inherit currentColor and stay decorative (the trigger carries the name)");
 
 // ── Tokens only; the mark reads as presence ──────────────────────────────────

--- a/src/components/runtime-logo.tsx
+++ b/src/components/runtime-logo.tsx
@@ -30,6 +30,9 @@ const BRAND_PATHS: Record<string, string> = {
 const GLYPH_FALLBACKS: Record<string, IconName> = {
   hermes: "ph:plug-bold",
   openclaw: "ph:paw-print-bold",
+  // Registry runtime — same glyph skill-card's /code/ rule resolves, so the
+  // runtime chip and skill cards speak one visual language for OpenCode.
+  opencode: "ph:code-bold",
 };
 
 export function runtimeDisplayName(runtime: string): string {

--- a/src/lib/harness-failure.test.ts
+++ b/src/lib/harness-failure.test.ts
@@ -117,6 +117,17 @@ import {
   assert.ok(codex);
   assert.equal(codex.loginCommand, "codex login");
 
+  // OpenCode (registry runtime): its sign-in flow is `opencode auth login`,
+  // and the package alias must canonicalize before the command lookup.
+  const opencode = parseHarnessAuthFailure("Error: no credentials found. Run `opencode auth login` first.", "opencode");
+  assert.ok(opencode, "opencode sign-in failure detected");
+  assert.equal(opencode.harness, "opencode");
+  assert.equal(opencode.loginCommand, "opencode auth login", "opencode login command offered");
+  const opencodeAlias = parseHarnessAuthFailure("authentication required", "opencode-ai");
+  assert.ok(opencodeAlias);
+  assert.equal(opencodeAlias.harness, "opencode", "npm package alias canonicalizes");
+  assert.equal(opencodeAlias.loginCommand, "opencode auth login");
+
   const unknownRuntime = parseHarnessAuthFailure("authentication required", "mystery-harness");
   assert.ok(unknownRuntime, "auth failure still detected without a known runtime");
   assert.equal(unknownRuntime.harness, null, "unknown runtime ids don't map");

--- a/src/lib/harness-failure.ts
+++ b/src/lib/harness-failure.ts
@@ -155,7 +155,7 @@ export type HarnessAuthFailure = {
 const AUTH_FAILURE_PATTERNS: RegExp[] = [
   /\bnot (?:signed|logged) in\b/i,
   /\bplease (?:run )?[`'"]?\/?login\b/i,
-  /\brun [`'"]?(?:codex login|claude \/login|copilot \/login|gh auth login)[`'"]?/i,
+  /\brun [`'"]?(?:codex login|claude \/login|copilot \/login|gh auth login|opencode auth login)[`'"]?/i,
   /\binvalid api key\b/i,
   /\bapi key (?:not set|missing|not found|expired)\b/i,
   /\bauthentication (?:error|failed|required)\b/i,
@@ -168,6 +168,7 @@ const LOGIN_COMMANDS: Record<string, string> = {
   claude: "claude /login",
   codex: "codex login",
   copilot: "copilot /login",
+  opencode: "opencode auth login",
 };
 
 /**


### PR DESCRIPTION
Re-lands the stranded WIP from the local `feat/opencode-enable` worktree, rebased onto current main.

- **Runtime glyph**: `opencode` maps to `ph:code-bold` in `runtime-logo.tsx` (the same glyph skill-card's `/code/` rule resolves) instead of the generic robot fallback.
- **Sign-in failure detection**: `harness-failure.ts` recognizes `opencode auth login` in failure output and offers it as the copyable login command; the `opencode-ai` npm package alias canonicalizes first.
- CHANGELOG entry under Unreleased.

Everything else for OpenCode (onboarding detection, chat trust, adapter-manifest scaffolding, model selection, raw-stdout passthrough) already flows from the synced runtime registry.

## Validation
- `node --experimental-strip-types src/components/composer-runtime-chip.test.ts` → ok
- `node --experimental-strip-types src/lib/harness-failure.test.ts` → ok