### PR TITLE
fix(stitches): prime the GitHub pin field with the github.com prefix

### DIFF
--- a/src/components/stitch-intake.test.ts
+++ b/src/components/stitch-intake.test.ts
@@ -23,6 +23,13 @@ describe("stitch intake panel", () => {
     assert.match(intake, /\/api\/sessions\/list/, "chat pins pick from real sessions");
   });
 
+  it("autofills GitHub refs with the GitHub URL prefix", () => {
+    assert.match(intake, /const GITHUB_SOURCE_PREFIX = "https:\/\/github\.com\/";/, "the prefix is a named constant");
+    assert.match(intake, /setRef\(defaultRefForKind\(k\)\)/, "choosing GitHub primes the source field");
+    assert.match(intake, /setRef\(defaultRefForKind\(kind\)\)/, "adding another GitHub pin restores the prefix");
+    assert.match(intake, /kind === "github" && sourceRef === GITHUB_SOURCE_PREFIX/, "the prefix alone is not submitted");
+  });
+
   it("sews agentically, in chat, and manually", () => {
     assert.match(intake, /fetch\("\/api\/stitches\/sew"/, "agentic + manual sew post to the sew route");
     assert.match(intake, /mode, title/, "the sew carries the latest working title");

--- a/src/components/stitch-intake.tsx
+++ b/src/components/stitch-intake.tsx
@@ -46,6 +46,12 @@ const KIND_PLACEHOLDER: Record<PinKind, string> = {
   memory: "/path/to/memory.md#optional-heading",
 };
 
+const GITHUB_SOURCE_PREFIX = "https://github.com/";
+
+function defaultRefForKind(kind: PinKind): string {
+  return kind === "github" ? GITHUB_SOURCE_PREFIX : "";
+}
+
 type SessionOption = { id: string; title: string };
 
 export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) {
@@ -128,6 +134,10 @@ export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) 
       setError(kind === "chat" ? "Pick a chat session to pin." : "Enter a source to pin.");
       return;
     }
+    if (kind === "github" && sourceRef === GITHUB_SOURCE_PREFIX) {
+      setError("Enter a GitHub source to pin.");
+      return;
+    }
     if (kind === "paste" && !paste.trim()) {
       setError("Paste some text to pin.");
       return;
@@ -152,7 +162,7 @@ export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) 
         return;
       }
       setThread(json.thread as StitchThread);
-      setRef("");
+      setRef(defaultRefForKind(kind));
       setPaste("");
       announce(`Pinned ${pinKindLabel(kind)}.`);
     } catch {
@@ -252,6 +262,7 @@ export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) 
             aria-pressed={kind === k}
             onClick={() => {
               setKind(k);
+              setRef(defaultRefForKind(k));
               setError(null);
             }}
             className={`focus-ring inline-flex h-[26px] items-center gap-1 rounded-md border px-2 text-[11px] transition-colors ${


### PR DESCRIPTION
Re-lands the stranded WIP from the local `cody/stitches-github-prefix` worktree, rebased onto current main.

- Choosing the **GitHub** pin kind primes the source field with `https://github.com/` (named constant), so users type/paste just the repo path.
- Submitting the bare prefix is rejected with "Enter a GitHub source to pin."
- After a successful pin, the field resets to the prefix for the next GitHub pin (and to empty for other kinds).

## Validation
`node --experimental-strip-types --test src/components/stitch-intake.test.ts` → 10 pass / 0 fail (includes new guard test).