### PR TITLE
feat(covenwiki): Phase 3 regeneration hook CLI (scan/diff/plan/run)

### DIFF
--- a/scripts/covenwiki-regen.ts
+++ b/scripts/covenwiki-regen.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env node --experimental-strip-types
+// CovenWiki v0 Phase 3 — regeneration hook CLI (Route B stages S1–S4).
+//
+// Thin I/O wrapper over src/lib/covenwiki-regen.ts. Stage semantics:
+//   scan  (S1) hash every file under the source roots -> manifest JSON
+//   diff  (S2) compare a fresh scan against the saved state; --check for hooks
+//   plan  (S3) print the regeneration actions the diff implies
+//   run   (S4) execute the plan (optional --generator), then persist new state
+//
+// The Phase 1/2 wiki generator plugs in via --generator: the plan is piped to
+// its stdin as JSON. Without --generator, `run` is report-then-persist, which
+// is enough to seed state and wire the hook before the generator lands.
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  buildManifest,
+  diffManifests,
+  nextState,
+  parseState,
+  planRegeneration,
+  serializeState,
+  summarizePlan,
+  type Manifest,
+  type SourceEntry,
+} from "../src/lib/covenwiki-regen.ts";
+
+const STAGES = ["scan", "diff", "plan", "run"] as const;
+type Stage = (typeof STAGES)[number];
+
+type Options = {
+  stage: Stage;
+  sources: string[];
+  state: string;
+  fullRebuild: string[];
+  generator: string | null;
+  json: boolean;
+  check: boolean;
+  dryRun: boolean;
+};
+
+const SKIP_DIRS = new Set([".git", "node_modules", ".worktrees", ".next", "target"]);
+
+function printHelp() {
+  console.log(`Usage: node --experimental-strip-types scripts/covenwiki-regen.ts <stage> [options]
+
+Stages (CovenWiki Route B Phase 3, S1-S4):
+  scan   S1: hash all wiki sources and print the manifest
+  diff   S2: compare a fresh scan with the saved state
+  plan   S3: show the regeneration actions the current diff implies
+  run    S4: execute the plan and persist the new state
+
+Options:
+  --source <path>        source root to scan (repeatable; default: docs)
+  --state <file>         state file (default: .covenwiki/state.json)
+  --full-rebuild <path>  path or dir/ prefix that forces a full rebuild (repeatable)
+  --generator <cmd>      shell command for 'run'; receives the plan JSON on stdin
+  --json                 emit machine-readable JSON instead of text
+  --check                (diff/plan) exit 1 when regeneration is needed
+  --dry-run              (run) skip the generator and state write
+  -h, --help             show this help`);
+}
+
+function parseArgs(argv: string[]): Options {
+  const first = argv[0];
+  if (!first || first === "-h" || first === "--help") {
+    printHelp();
+    process.exit(first ? 0 : 1);
+  }
+  if (!STAGES.includes(first as Stage)) throw new Error(`unknown stage: ${first} (expected ${STAGES.join("|")})`);
+  const stage = first as Stage;
+  const opts: Options = {
+    stage,
+    sources: [],
+    state: ".covenwiki/state.json",
+    fullRebuild: [],
+    generator: null,
+    json: false,
+    check: false,
+    dryRun: false,
+  };
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--source":
+        opts.sources.push(requireValue(argv, ++i, arg));
+        break;
+      case "--state":
+        opts.state = requireValue(argv, ++i, arg);
+        break;
+      case "--full-rebuild":
+        opts.fullRebuild.push(requireValue(argv, ++i, arg));
+        break;
+      case "--generator":
+        opts.generator = requireValue(argv, ++i, arg);
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "--check":
+        opts.check = true;
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`unsupported argument: ${arg}`);
+    }
+  }
+  if (opts.sources.length === 0) opts.sources.push("docs");
+  return opts;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value === undefined) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function walk(root: string, out: string[]) {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") && entry.isDirectory()) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.isFile()) out.push(full);
+  }
+}
+
+/** S1: scan the source roots into a manifest. */
+function scan(opts: Options): Manifest {
+  const files: string[] = [];
+  for (const source of opts.sources) {
+    if (!existsSync(source)) throw new Error(`source root not found: ${source}`);
+    if (statSync(source).isFile()) files.push(source);
+    else walk(source, files);
+  }
+  const entries: SourceEntry[] = files.map((file) => ({
+    path: file.split(path.sep).join("/"),
+    hash: createHash("sha256").update(readFileSync(file)).digest("hex"),
+  }));
+  return buildManifest(entries, new Date().toISOString());
+}
+
+function loadPreviousManifest(stateFile: string): Manifest | null {
+  if (!existsSync(stateFile)) return null;
+  return parseState(readFileSync(stateFile, "utf8")).manifest;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const manifest = scan(opts);
+
+  if (opts.stage === "scan") {
+    if (opts.json) console.log(JSON.stringify(manifest, null, 2));
+    else {
+      console.log(`scanned ${Object.keys(manifest.entries).length} source file(s) under: ${opts.sources.join(", ")}`);
+      for (const file of Object.keys(manifest.entries)) console.log(`  ${file}`);
+    }
+    return;
+  }
+
+  const previous = loadPreviousManifest(opts.state);
+  const diff = diffManifests(previous, manifest);
+  const plan = planRegeneration(diff, { sourceRoots: opts.sources, fullRebuildPaths: opts.fullRebuild });
+
+  if (opts.stage === "diff" || opts.stage === "plan") {
+    if (opts.json) {
+      console.log(JSON.stringify(opts.stage === "diff" ? { diff } : { diff, plan }, null, 2));
+    } else {
+      const lines = opts.stage === "diff" ? summarizePlan(diff, { dirty: diff.dirty, actions: [] }) : summarizePlan(diff, plan);
+      for (const line of lines) console.log(line);
+    }
+    if (opts.check && diff.dirty) process.exit(1);
+    return;
+  }
+
+  // run (S4)
+  for (const line of summarizePlan(diff, plan)) console.log(line);
+  if (!diff.dirty) return;
+  if (opts.dryRun) {
+    console.log("dry run — generator and state write skipped");
+    return;
+  }
+  if (opts.generator) {
+    const result = spawnSync(opts.generator, {
+      shell: true,
+      input: JSON.stringify({ diff, plan }, null, 2),
+      stdio: ["pipe", "inherit", "inherit"],
+    });
+    if (result.status !== 0) {
+      console.error(`generator failed (exit ${result.status ?? "signal"}); state not updated`);
+      process.exit(result.status ?? 1);
+    }
+  } else {
+    console.log("no --generator configured — recording state only");
+  }
+  mkdirSync(path.dirname(opts.state), { recursive: true });
+  writeFileSync(opts.state, serializeState(nextState(manifest)));
+  console.log(`state updated: ${opts.state}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`covenwiki-regen: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -71,6 +71,7 @@ export const SUITES = {
     "src/lib/workflow-step-progress.test.ts",
     "src/lib/hfr-trace-export.test.ts",
     "scripts/coven-hfr-export.test.mjs",
+    "src/lib/covenwiki-regen.test.ts",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/familiar-roster-guard.test.ts",

--- a/src/lib/covenwiki-regen.test.ts
+++ b/src/lib/covenwiki-regen.test.ts
@@ -1,0 +1,188 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildManifest,
+  diffManifests,
+  nextState,
+  pageIdForSource,
+  parseState,
+  planRegeneration,
+  serializeState,
+  summarizePlan,
+} from "./covenwiki-regen.ts";
+
+const ROOTS = ["docs"];
+
+function manifest(entries, generatedAt = "2026-07-12T00:00:00.000Z") {
+  return buildManifest(
+    Object.entries(entries).map(([path, hash]) => ({ path, hash })),
+    generatedAt,
+  );
+}
+
+// S1 — scan/manifest
+
+test("buildManifest sorts entries by path", () => {
+  const m = manifest({ "docs/z.md": "1", "docs/a.md": "2" });
+  assert.deepEqual(Object.keys(m.entries), ["docs/a.md", "docs/z.md"]);
+});
+
+test("buildManifest rejects duplicate and empty paths", () => {
+  assert.throws(
+    () =>
+      buildManifest(
+        [
+          { path: "docs/a.md", hash: "1" },
+          { path: "docs/a.md", hash: "2" },
+        ],
+        "t",
+      ),
+    /duplicate/,
+  );
+  assert.throws(() => buildManifest([{ path: "", hash: "1" }], "t"), /empty path/);
+});
+
+// S2 — diff
+
+test("diffManifests against null previous marks everything added", () => {
+  const diff = diffManifests(null, manifest({ "docs/a.md": "1", "docs/b.md": "2" }));
+  assert.deepEqual(diff.added, ["docs/a.md", "docs/b.md"]);
+  assert.deepEqual(diff.removed, []);
+  assert.deepEqual(diff.changed, []);
+  assert.equal(diff.dirty, true);
+});
+
+test("diffManifests detects added, removed, changed, unchanged", () => {
+  const prev = manifest({ "docs/keep.md": "1", "docs/edit.md": "1", "docs/gone.md": "1" });
+  const next = manifest({ "docs/keep.md": "1", "docs/edit.md": "2", "docs/new.md": "1" });
+  const diff = diffManifests(prev, next);
+  assert.deepEqual(diff.added, ["docs/new.md"]);
+  assert.deepEqual(diff.changed, ["docs/edit.md"]);
+  assert.deepEqual(diff.removed, ["docs/gone.md"]);
+  assert.equal(diff.unchangedCount, 1);
+  assert.equal(diff.dirty, true);
+});
+
+test("diffManifests reports clean when nothing moved", () => {
+  const m = manifest({ "docs/a.md": "1" });
+  const diff = diffManifests(m, manifest({ "docs/a.md": "1" }, "2026-07-12T01:00:00.000Z"));
+  assert.equal(diff.dirty, false);
+  assert.equal(diff.unchangedCount, 1);
+});
+
+// page id mapping
+
+test("pageIdForSource strips source root and markdown extension", () => {
+  assert.equal(pageIdForSource("docs/guides/setup.md", ROOTS), "guides/setup");
+  assert.equal(pageIdForSource("docs/index.mdx", ROOTS), "index");
+});
+
+test("pageIdForSource prefers the longest matching root", () => {
+  assert.equal(pageIdForSource("docs/wiki/a.md", ["docs", "docs/wiki"]), "a");
+});
+
+test("pageIdForSource returns null for non-markdown sources", () => {
+  assert.equal(pageIdForSource("docs/assets/logo.png", ROOTS), null);
+});
+
+test("pageIdForSource handles a source root that is itself a file", () => {
+  assert.equal(pageIdForSource("README.md", ["README.md"]), "README");
+});
+
+// S3 — plan
+
+test("planRegeneration is empty when the diff is clean", () => {
+  const plan = planRegeneration(
+    { added: [], removed: [], changed: [], unchangedCount: 3, dirty: false },
+    { sourceRoots: ROOTS },
+  );
+  assert.deepEqual(plan, { dirty: false, actions: [] });
+});
+
+test("planRegeneration maps added/changed/removed sources to page actions plus index", () => {
+  const plan = planRegeneration(
+    {
+      added: ["docs/new.md"],
+      changed: ["docs/edit.md"],
+      removed: ["docs/gone.md"],
+      unchangedCount: 0,
+      dirty: true,
+    },
+    { sourceRoots: ROOTS },
+  );
+  assert.deepEqual(
+    plan.actions.map((a) => [a.kind, a.page]),
+    [
+      ["regenerate-page", "edit"],
+      ["regenerate-page", "new"],
+      ["remove-page", "gone"],
+      ["rebuild-index", null],
+    ],
+  );
+});
+
+test("planRegeneration treats a removed source of a still-live page as regen, not removal", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["docs/page.md"], removed: ["docs/page.mdx"], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS },
+  );
+  const kinds = plan.actions.map((a) => a.kind);
+  assert.ok(!kinds.includes("remove-page"));
+  assert.deepEqual(plan.actions[0].sources, ["docs/page.md", "docs/page.mdx"]);
+});
+
+test("planRegeneration collapses to full-rebuild when a shared path changes", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["templates/wiki.hbs", "docs/a.md"], removed: [], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS, fullRebuildPaths: ["templates/"] },
+  );
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0].kind, "full-rebuild");
+  assert.deepEqual(plan.actions[0].sources, ["templates/wiki.hbs"]);
+});
+
+test("planRegeneration routes non-page sources to the index rebuild", () => {
+  const plan = planRegeneration(
+    { added: ["docs/assets/logo.png"], changed: [], removed: [], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS },
+  );
+  assert.deepEqual(
+    plan.actions.map((a) => a.kind),
+    ["rebuild-index"],
+  );
+});
+
+// S4 — state + report
+
+test("state round-trips through serialize/parse", () => {
+  const state = nextState(manifest({ "docs/a.md": "1" }));
+  const restored = parseState(serializeState(state));
+  assert.deepEqual(restored, state);
+});
+
+test("parseState rejects garbage and wrong versions", () => {
+  assert.throws(() => parseState("not json"), /not valid JSON/);
+  assert.throws(() => parseState(JSON.stringify({ version: 2, manifest: { entries: {} } })), /unsupported/);
+  assert.throws(() => parseState(JSON.stringify({ version: 1 })), /unsupported/);
+});
+
+test("summarizePlan reports counts and actions", () => {
+  const diff = {
+    added: ["docs/new.md"],
+    changed: [],
+    removed: [],
+    unchangedCount: 2,
+    dirty: true,
+  };
+  const plan = planRegeneration(diff, { sourceRoots: ROOTS });
+  const lines = summarizePlan(diff, plan);
+  assert.equal(lines[0], "sources: +1 ~0 -0 =2");
+  assert.ok(lines.some((l) => l.startsWith("regenerate-page new")));
+});
+
+test("summarizePlan reports a clean tree", () => {
+  const diff = { added: [], changed: [], removed: [], unchangedCount: 5, dirty: false };
+  const lines = summarizePlan(diff, { dirty: false, actions: [] });
+  assert.deepEqual(lines, ["sources: +0 ~0 -0 =5", "wiki up to date — no regeneration needed"]);
+});

--- a/src/lib/covenwiki-regen.ts
+++ b/src/lib/covenwiki-regen.ts
@@ -1,0 +1,252 @@
+// CovenWiki v0 Phase 3 — regeneration hook core (Route B, stages S1–S4).
+//
+// Pure logic only: nothing in this module touches the filesystem or spawns
+// processes. The CLI wrapper (scripts/covenwiki-regen.ts) owns I/O so every
+// stage here is unit-testable with plain data.
+//
+//   S1 scan — buildManifest: content hashes for every wiki source file
+//   S2 diff — diffManifests: compare a scan against the last persisted state
+//   S3 plan — planRegeneration: turn a diff into concrete regeneration actions
+//   S4 run  — nextState/summarizePlan: state handoff + report for the executor
+
+export type SourceEntry = {
+  /** Repo-relative path, POSIX separators. */
+  path: string;
+  /** Content hash (the CLI uses sha256, but the core only compares equality). */
+  hash: string;
+};
+
+export type Manifest = {
+  generatedAt: string;
+  /** path -> hash, keys sorted for stable serialization. */
+  entries: Record<string, string>;
+};
+
+export type ManifestDiff = {
+  added: string[];
+  removed: string[];
+  changed: string[];
+  unchangedCount: number;
+  dirty: boolean;
+};
+
+export type RegenActionKind = "regenerate-page" | "remove-page" | "rebuild-index" | "full-rebuild";
+
+export type RegenAction = {
+  kind: RegenActionKind;
+  /** Wiki page id for page-scoped actions; null for index/full rebuilds. */
+  page: string | null;
+  /** Source paths that triggered this action. */
+  sources: string[];
+  reason: string;
+};
+
+export type RegenPlan = {
+  dirty: boolean;
+  actions: RegenAction[];
+};
+
+export type RegenState = {
+  version: 1;
+  manifest: Manifest;
+};
+
+const STATE_VERSION = 1 as const;
+
+/** Wiki page sources; anything else under a source root only affects the index. */
+const PAGE_EXTENSIONS = [".md", ".mdx"];
+
+/** S1: assemble a manifest from hashed source entries (sorted, duplicate-safe). */
+export function buildManifest(entries: SourceEntry[], generatedAt: string): Manifest {
+  const map: Record<string, string> = {};
+  for (const entry of entries) {
+    if (!entry.path) throw new Error("manifest entry has an empty path");
+    if (entry.path in map) throw new Error(`duplicate manifest path: ${entry.path}`);
+    map[entry.path] = entry.hash;
+  }
+  const sorted: Record<string, string> = {};
+  for (const key of Object.keys(map).sort()) sorted[key] = map[key];
+  return { generatedAt, entries: sorted };
+}
+
+/** S2: diff a fresh scan against the previous manifest (null = first run). */
+export function diffManifests(previous: Manifest | null, next: Manifest): ManifestDiff {
+  const prev = previous?.entries ?? {};
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+  let unchangedCount = 0;
+  for (const [path, hash] of Object.entries(next.entries)) {
+    if (!(path in prev)) added.push(path);
+    else if (prev[path] !== hash) changed.push(path);
+    else unchangedCount += 1;
+  }
+  for (const path of Object.keys(prev)) {
+    if (!(path in next.entries)) removed.push(path);
+  }
+  return {
+    added,
+    removed,
+    changed,
+    unchangedCount,
+    dirty: added.length > 0 || removed.length > 0 || changed.length > 0,
+  };
+}
+
+/**
+ * Map a source path to a wiki page id: strip the matching source root and the
+ * markdown extension. Non-markdown sources return null (index-only impact).
+ */
+export function pageIdForSource(path: string, sourceRoots: string[]): string | null {
+  const ext = PAGE_EXTENSIONS.find((e) => path.toLowerCase().endsWith(e));
+  if (!ext) return null;
+  let rel = path;
+  for (const root of [...sourceRoots].sort((a, b) => b.length - a.length)) {
+    const prefix = root.endsWith("/") ? root : `${root}/`;
+    if (path === root) {
+      rel = path.slice(path.lastIndexOf("/") + 1);
+      break;
+    }
+    if (path.startsWith(prefix)) {
+      rel = path.slice(prefix.length);
+      break;
+    }
+  }
+  const id = rel.slice(0, rel.length - ext.length);
+  return id || null;
+}
+
+export type PlanOptions = {
+  sourceRoots: string[];
+  /**
+   * Paths (exact, or directory prefixes ending in "/") whose changes force a
+   * full rebuild — e.g. templates or wiki config shared by every page.
+   */
+  fullRebuildPaths?: string[];
+};
+
+function matchesFullRebuild(path: string, patterns: string[]): boolean {
+  return patterns.some((p) => (p.endsWith("/") ? path.startsWith(p) : path === p));
+}
+
+/** S3: turn a diff into an ordered, deduplicated list of regeneration actions. */
+export function planRegeneration(diff: ManifestDiff, opts: PlanOptions): RegenPlan {
+  if (!diff.dirty) return { dirty: false, actions: [] };
+
+  const fullPatterns = opts.fullRebuildPaths ?? [];
+  const fullTriggers = [...diff.added, ...diff.changed, ...diff.removed].filter((p) =>
+    matchesFullRebuild(p, fullPatterns),
+  );
+  if (fullTriggers.length > 0) {
+    return {
+      dirty: true,
+      actions: [
+        {
+          kind: "full-rebuild",
+          page: null,
+          sources: [...fullTriggers].sort(),
+          reason: "shared source changed",
+        },
+      ],
+    };
+  }
+
+  const actions: RegenAction[] = [];
+  const pages = new Map<string, { sources: string[]; reasons: Set<string> }>();
+  const record = (path: string, reason: string) => {
+    const page = pageIdForSource(path, opts.sourceRoots);
+    if (!page) return false;
+    const slot = pages.get(page) ?? { sources: [], reasons: new Set<string>() };
+    slot.sources.push(path);
+    slot.reasons.add(reason);
+    pages.set(page, slot);
+    return true;
+  };
+
+  let indexOnly = 0;
+  for (const path of diff.added) if (!record(path, "added")) indexOnly += 1;
+  for (const path of diff.changed) if (!record(path, "changed")) indexOnly += 1;
+
+  const removedPages = new Map<string, string[]>();
+  for (const path of diff.removed) {
+    const page = pageIdForSource(path, opts.sourceRoots);
+    if (!page) {
+      indexOnly += 1;
+      continue;
+    }
+    // A page that still has live sources is a regen, not a removal.
+    if (pages.has(page)) {
+      pages.get(page)!.sources.push(path);
+      pages.get(page)!.reasons.add("source removed");
+      continue;
+    }
+    removedPages.set(page, [...(removedPages.get(page) ?? []), path]);
+  }
+
+  for (const page of [...pages.keys()].sort()) {
+    const slot = pages.get(page)!;
+    actions.push({
+      kind: "regenerate-page",
+      page,
+      sources: [...slot.sources].sort(),
+      reason: [...slot.reasons].sort().join(", "),
+    });
+  }
+  for (const page of [...removedPages.keys()].sort()) {
+    actions.push({
+      kind: "remove-page",
+      page,
+      sources: [...removedPages.get(page)!].sort(),
+      reason: "removed",
+    });
+  }
+
+  actions.push({
+    kind: "rebuild-index",
+    page: null,
+    sources: [],
+    reason: indexOnly > 0 ? "page set or shared assets changed" : "page set changed",
+  });
+
+  return { dirty: true, actions };
+}
+
+/** S4: the state to persist after a successful regeneration run. */
+export function nextState(manifest: Manifest): RegenState {
+  return { version: STATE_VERSION, manifest };
+}
+
+export function parseState(raw: string): RegenState {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error("state file is not valid JSON");
+  }
+  const state = data as Partial<RegenState>;
+  if (state?.version !== STATE_VERSION || typeof state.manifest?.entries !== "object" || state.manifest.entries === null) {
+    throw new Error(`unsupported covenwiki state (expected version ${STATE_VERSION})`);
+  }
+  return { version: STATE_VERSION, manifest: state.manifest as Manifest };
+}
+
+export function serializeState(state: RegenState): string {
+  return `${JSON.stringify(state, null, 2)}\n`;
+}
+
+/** Human-readable one-line-per-item report used by every CLI stage. */
+export function summarizePlan(diff: ManifestDiff, plan: RegenPlan): string[] {
+  const lines = [
+    `sources: +${diff.added.length} ~${diff.changed.length} -${diff.removed.length} =${diff.unchangedCount}`,
+  ];
+  if (!plan.dirty) {
+    lines.push("wiki up to date — no regeneration needed");
+    return lines;
+  }
+  for (const action of plan.actions) {
+    const target = action.page ? ` ${action.page}` : "";
+    const via = action.sources.length > 0 ? ` (${action.sources.join(", ")})` : "";
+    lines.push(`${action.kind}${target} — ${action.reason}${via}`);
+  }
+  return lines;
+}


### PR DESCRIPTION
Re-lands the stranded WIP from the local `covenwiki-phase3-cli-core` worktree, rebased onto current main.

CovenWiki v0 Route B Phase 3, stages S1–S4:
- `src/lib/covenwiki-regen.ts` — pure library: manifest building/hashing, diffing, state (de)serialization, regeneration planning.
- `scripts/covenwiki-regen.ts` — thin I/O CLI: `scan` → manifest JSON, `diff` (`--check` for hooks), `plan`, `run` (pipes the plan to an optional `--generator`, then persists state; report-then-persist without one, so state can seed before the Phase 1/2 generator lands).
- Test wired into the api suite in `scripts/run-tests.mjs`.

## Validation
- `node --experimental-strip-types src/lib/covenwiki-regen.test.ts` → 18 pass / 0 fail
- `node scripts/check-tests-wired.mjs` → all wired
- `pnpm exec tsc --noEmit` → clean
- CLI smoke: `covenwiki-regen.ts scan --help` prints stage usage