### PR TITLE
fix(a11y): restore tablist semantics on chat right-panel section tabs (cave-t7uz)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -476,6 +476,7 @@ export const SUITES = {
     "src/components/mode-toggle.test.ts",
     "src/components/onboarding-polish.test.ts",
     "src/components/right-sidebar-fit.test.ts",
+    "src/components/right-panel-tablist-a11y.test.ts",
     "src/components/salem/salem.test.ts",
     "src/components/settings-shell-polish.test.ts",
     "src/components/settings-action-buttons.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3516,6 +3516,17 @@ textarea.required-inputs-control {
   padding: 0 4px;
 }
 
+/* The section tabs live in a real tablist (WAI-ARIA tabs pattern, cave-t7uz);
+   debug/close remain plain sibling controls outside it. Shrinkable so the
+   tabs keep truncating inside narrow sidebar widths. */
+.right-panel-tablist {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  height: 100%;
+  min-width: 0;
+}
+
 .right-panel-tab {
   display: inline-flex;
   align-items: center;

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -226,8 +226,8 @@ assert.match(
 
 assert.match(
   chatSurface,
-  /<div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">\s*\{primaryPanel === "inspector" &&/,
-  "ChatSurface right side panel should put tab content in a min-height-zero scroll boundary",
+  /className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto"\s*>\s*\{primaryPanel === "inspector" &&/,
+  "ChatSurface right side panel should put tab content in a min-height-zero scroll boundary (the div also carries the cave-t7uz tabpanel wiring)",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -16,6 +16,7 @@ import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
@@ -150,6 +151,22 @@ function RightPanel({
     ? inboxItems.filter((i) => i.familiarId === activeFamiliar.id && i.status === "fired").length
     : 0;
 
+  // cave-t7uz: the promoted section strip is a real WAI-ARIA tablist again —
+  // tab roles, aria-selected, and arrow-key roving focus (same contract the
+  // shared Tabs component provides). Debug/close stay outside the tablist:
+  // they're controls beside the tabs, not co-equal sections.
+  const tablistRef = useRef<HTMLDivElement>(null);
+  const { setActiveIndex } = useRovingTabIndex({
+    containerRef: tablistRef,
+    itemSelector: '[role="tab"]',
+    orientation: "horizontal",
+    loop: false,
+  });
+  useEffect(() => {
+    const idx = INSPECTOR_SECTIONS.findIndex((sec) => sec.id === section);
+    if (idx >= 0) setActiveIndex(idx);
+  }, [section, setActiveIndex]);
+
   return (
     // CHAT-D13-05: this panel renders inside the shell's <main>, where a
     // complementary landmark is invalid (axe landmark-complementary-is-top-level)
@@ -159,27 +176,36 @@ function RightPanel({
       <Group className="right-panel-split" orientation="vertical">
         <Panel id="right-panel-primary" className="right-panel-pane min-h-0" defaultSize="50%" minSize="25%">
           <div className="right-panel-tabs">
-            {INSPECTOR_SECTIONS.map((sec) => (
-              <button
-                key={sec.id}
-                type="button"
-                className={`right-panel-tab${primaryPanel === "inspector" && section === sec.id ? " right-panel-tab--active" : ""}`}
-                onClick={() => {
-                  onSetSection(sec.id);
-                  onSetPanel("inspector");
-                }}
-              >
-                {sec.label}
-                {sec.id === "inbox" && inboxBadge > 0 ? (
-                  <span
-                    className="ml-1 inline-flex min-w-[14px] items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-warning)_28%,transparent)] px-1 text-[9px] font-semibold text-[var(--color-warning)]"
-                    aria-label={`${inboxBadge} fired reminder${inboxBadge === 1 ? "" : "s"}`}
+            <div ref={tablistRef} role="tablist" aria-label="Inspector sections" className="right-panel-tablist">
+              {INSPECTOR_SECTIONS.map((sec) => {
+                const active = primaryPanel === "inspector" && section === sec.id;
+                return (
+                  <button
+                    key={sec.id}
+                    type="button"
+                    role="tab"
+                    id={`right-panel-tab-${sec.id}`}
+                    aria-selected={active}
+                    aria-controls="right-panel-section-panel"
+                    className={`right-panel-tab${active ? " right-panel-tab--active" : ""}`}
+                    onClick={() => {
+                      onSetSection(sec.id);
+                      onSetPanel("inspector");
+                    }}
                   >
-                    {inboxBadge}
-                  </span>
-                ) : null}
-              </button>
-            ))}
+                    {sec.label}
+                    {sec.id === "inbox" && inboxBadge > 0 ? (
+                      <span
+                        className="ml-1 inline-flex min-w-[14px] items-center justify-center rounded-full bg-[color-mix(in_oklch,var(--color-warning)_28%,transparent)] px-1 text-[9px] font-semibold text-[var(--color-warning)]"
+                        aria-label={`${inboxBadge} fired reminder${inboxBadge === 1 ? "" : "s"}`}
+                      >
+                        {inboxBadge}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
             {/* Debug is diagnostics, not a co-equal section — a quiet icon
                 toggle beside the close control (same demotion vocabulary as
                 the Group icon in the scope-tab strip). */}
@@ -197,7 +223,12 @@ function RightPanel({
               <Icon name="ph:x-bold" width={11} />
             </button>
           </div>
-          <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+          <div
+            id="right-panel-section-panel"
+            role={primaryPanel === "inspector" ? "tabpanel" : undefined}
+            aria-labelledby={primaryPanel === "inspector" ? `right-panel-tab-${section}` : undefined}
+            className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto"
+          >
             {primaryPanel === "inspector" && (
               <InspectorPane
                 familiar={activeFamiliar}

--- a/src/components/chat-task-create-button-wiring.test.ts
+++ b/src/components/chat-task-create-button-wiring.test.ts
@@ -43,6 +43,11 @@ assert.match(
 );
 assert.match(
   chatView,
+  /createSmartTaskFromChat\(\{ sessionId, context: handoff \}\)[\s\S]{0,1500}catch \(err\) \{[\s\S]{0,400}err instanceof Error && err\.message[\s\S]{0,160}check your connection/,
+  "creation failure surfaces the server's specific reason (err.message), with the connection hint only as fallback",
+);
+assert.match(
+  chatView,
   /announce\(\s*`Task "\$\{result\.card\.title\}" created from this chat/,
   "success is announced to screen readers, naming what was auto-filled",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1952,8 +1952,12 @@ function LinkedContextRow({
       announce(
         `Task "${result.card.title}" created from this chat${filled.length ? ` with ${filled.join(", ")}` : ""}.`,
       );
-    } catch {
-      announce("Couldn't create a task from this chat — check your connection.", "assertive");
+    } catch (err) {
+      // Surface the server's specific reason (validation message, HTTP status)
+      // instead of always blaming the connection (cave-t7uz).
+      const reason =
+        err instanceof Error && err.message ? err.message.replace(/\.$/, "") : "check your connection";
+      announce(`Couldn't create a task from this chat — ${reason}.`, "assertive");
     } finally {
       setCreatingTask(false);
     }

--- a/src/components/right-panel-tablist-a11y.test.ts
+++ b/src/components/right-panel-tablist-a11y.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// cave-t7uz: PR #2970 promoted the Inspector sections to the chat right
+// panel's top strip as plain <button>s, dropping the WAI-ARIA tabs contract
+// the shared Tabs component used to provide. These pins hold the restored
+// semantics: tablist/tab roles, aria-selected, roving arrow-key focus, and
+// tabpanel labelling on the pane body.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chatSurface = readFileSync(resolve(here, "./chat-surface.tsx"), "utf8");
+const globals = readFileSync(resolve(here, "../app/globals.css"), "utf8");
+
+test("right-panel section strip is a labelled tablist", () => {
+  assert.match(
+    chatSurface,
+    /<div[^>]*role="tablist"[^>]*aria-label="Inspector sections"[^>]*className="right-panel-tablist"/,
+    "section buttons are grouped in a labelled tablist container",
+  );
+  // Debug/close are controls beside the tabs, not co-equal sections — they
+  // must stay OUTSIDE the tablist (the icon toggle keeps aria-pressed).
+  assert.match(
+    chatSurface,
+    /right-panel-tab--icon[\s\S]{0,200}aria-pressed=\{primaryPanel === "debug"\}/,
+    "debug stays an aria-pressed toggle, not a tab",
+  );
+});
+
+test("each section button carries the tab role + selection wiring", () => {
+  assert.match(
+    chatSurface,
+    /role="tab"\s+id=\{`right-panel-tab-\$\{sec\.id\}`\}\s+aria-selected=\{active\}\s+aria-controls="right-panel-section-panel"/,
+    "tab role, stable id, aria-selected, and aria-controls are wired per section",
+  );
+  // Selection tracks the inspector being the visible primary panel, so all
+  // tabs read unselected while the debug toggle is active.
+  assert.match(
+    chatSurface,
+    /const active = primaryPanel === "inspector" && section === sec\.id;/,
+    "aria-selected is false for every tab when debug owns the panel",
+  );
+});
+
+test("tablist has arrow-key roving focus (WAI-ARIA APG)", () => {
+  assert.match(
+    chatSurface,
+    /useRovingTabIndex\(\{\s*containerRef: tablistRef,\s*itemSelector: '\[role="tab"\]',\s*orientation: "horizontal"/,
+    "roving tabindex is installed on the tablist",
+  );
+  assert.match(
+    chatSurface,
+    /INSPECTOR_SECTIONS\.findIndex\(\(sec\) => sec\.id === section\);\s*if \(idx >= 0\) setActiveIndex\(idx\)/,
+    "the tab stop follows the controlled section",
+  );
+});
+
+test("pane body is the labelled tabpanel while the inspector is shown", () => {
+  assert.match(
+    chatSurface,
+    /id="right-panel-section-panel"\s+role=\{primaryPanel === "inspector" \? "tabpanel" : undefined\}\s+aria-labelledby=\{primaryPanel === "inspector" \? `right-panel-tab-\$\{section\}` : undefined\}/,
+    "tabpanel role + aria-labelledby point at the active section tab (and drop for the debug pane)",
+  );
+});
+
+test("tablist wrapper keeps the strip shrinkable in narrow sidebars", () => {
+  assert.match(
+    globals,
+    /\.right-panel-tablist\s*\{[^}]*min-width:\s*0[^}]*\}/,
+    ".right-panel-tablist allows shrinking so tabs still truncate",
+  );
+  assert.match(
+    globals,
+    /\.right-panel-tablist\s*\{[^}]*height:\s*100%[^}]*\}/,
+    ".right-panel-tablist preserves the full-height tab hit area",
+  );
+});

--- a/src/lib/chat-task-autofill.test.ts
+++ b/src/lib/chat-task-autofill.test.ts
@@ -80,7 +80,9 @@ assert.equal(
 );
 
 // ── due date inference ───────────────────────────────────────────────────────
-const wed = new Date("2026-07-15T14:30:00.000Z"); // a Wednesday
+// Local-time literal (not a Z-instant): "today" means the requester's local
+// calendar date, so the fixture must be the same Wednesday in every runner TZ.
+const wed = new Date(2026, 6, 15, 14, 30); // Wed 2026-07-15, local
 assert.equal(
   inferDueDateFromTurns([t("u1", "user", "ship it, due 2026-08-01")], wed),
   "2026-08-01",
@@ -116,6 +118,32 @@ assert.equal(
   null,
   "no deadline → null endDate",
 );
+
+// cave-t7uz regression: UTC getters made "by today" resolve to tomorrow for
+// evening users west of UTC. Pin the local-calendar-date contract with a UTC
+// instant that falls on the previous local evening in western zones (e.g.
+// 21:30 CDT), computing expectations from local getters so the assertion
+// holds in any runner TZ.
+{
+  const lateEvening = new Date("2026-07-13T02:30:00.000Z");
+  const pad = (n) => String(n).padStart(2, "0");
+  const localDate = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  assert.equal(
+    inferDueDateFromTurns([t("u1", "user", "need this done by today")], lateEvening),
+    localDate(lateEvening),
+    "'by today' → the requester's local calendar date, not the UTC date",
+  );
+  const localTomorrow = new Date(
+    lateEvening.getFullYear(),
+    lateEvening.getMonth(),
+    lateEvening.getDate() + 1,
+  );
+  assert.equal(
+    inferDueDateFromTurns([t("u1", "user", "due tomorrow")], lateEvening),
+    localDate(localTomorrow),
+    "'tomorrow' → local today + 1",
+  );
+}
 
 // ── subtask extraction ───────────────────────────────────────────────────────
 {

--- a/src/lib/chat-task-autofill.ts
+++ b/src/lib/chat-task-autofill.ts
@@ -114,7 +114,11 @@ export function inferDueDateFromTurns(turns: HandoffTurn[], now: Date = new Date
     ...usable.filter((turn) => turn.role === "user"),
     ...usable.filter((turn) => turn.role !== "user"),
   ];
-  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  // The requester's LOCAL calendar date, pinned at UTC midnight so the day
+  // math below (setUTCDate / getUTCDay / toISOString) stays DST-proof. Built
+  // from local getters: UTC getters made "by today" resolve to tomorrow for
+  // evening users west of UTC (cave-t7uz).
+  const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
   for (const turn of ranked) {
     const text = turn.text.toLowerCase();
 


### PR DESCRIPTION
Lands orphaned-but-complete session work (branch was committed, pushed, and verified but its session ended before opening a PR — bead `cave-t7uz`).

PR #2970 promoted the Inspector sections (Familiar/Analytics/Automations) to the chat right panel's top strip as plain buttons, dropping the WAI-ARIA tabs contract. This restores it in place:

- labelled `role=tablist` wrapping the three section buttons: `role=tab`, `aria-selected`, `aria-controls`, arrow-key roving focus via `useRovingTabIndex`; debug (`aria-pressed`) and close stay outside as sibling controls
- `role=tabpanel` + labelling restored on the pane body
- riders from the same review: `inferDueDateFromTurns` now uses local-date getters pinned to UTC midnight ("by today" no longer resolves to tomorrow for evening users west of UTC); `createTaskFromConversation` surfaces the server's specific error instead of always announcing "check your connection"
- new `right-panel-tablist-a11y.test.ts` (wired), `inspector-pane-polish.test.ts` un-pins the accessible strip's absence

Verified locally CI-style (`nodeArgsFor`): all five touched test files pass; `tsc --noEmit` clean; `check:tests-wired` green.