### PR TITLE
fix(ui): stop consuming --accent (shadcn surface token) as the brand accent (cave-ilkk)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -392,6 +392,7 @@ export const SUITES = {
     "src/components/familiars-memory-view-sources.test.ts",
     "src/components/familiars-memory-view-scroll-collapse.test.ts",
     "src/app/globals.css.test.ts",
+    "src/app/accent-token-usage.test.ts",
     "src/app/globals-reveal-on-hover.test.ts",
     "src/components/familiar-roster-card.test.ts",
     "src/lib/familiar-growth-signals.test.ts",

--- a/src/app/accent-token-usage.test.ts
+++ b/src/app/accent-token-usage.test.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+// Accent token discipline (cave-ilkk). In this app `--accent` is the
+// shadcn *surface* token — near-black in dark themes, near-white in light —
+// while the BRAND accent is `--accent-presence` (paired with
+// `--accent-presence-foreground` for text/icons on a filled accent).
+//
+// Consuming `var(--accent)` for text, borders, ticks, or focus rings renders
+// them nearly invisible (the familiar-card "Review heal requests" /
+// "Refresh memory" buttons and the "View all →" link shipped that way), and
+// `var(--accent-foreground)` on an `--accent-presence` fill breaks contrast
+// in light mode. This scanner forbids both classes in hand-written CSS:
+//
+//   - `var(--accent)` / `var(--accent,…)` may only appear on the RIGHT side
+//     of a custom-property definition (e.g. the theme blocks' shadcn mapping
+//     `--bg-hover: var(--accent);`) — never consumed directly by a style
+//     property. Use `var(--accent-presence)` (or `--ring-focus` for focus
+//     outlines) instead.
+//   - `var(--accent-foreground…)` is not consumed in CSS at all — on a
+//     presence fill use `var(--accent-presence-foreground)`; shadcn pairings
+//     live in Tailwind utilities, not these sheets.
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function collectCss(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await collectCss(full)));
+    else if (entry.name.endsWith(".css")) out.push(full);
+  }
+  return out;
+}
+
+const stripComments = (text: string) => text.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "));
+
+const offenders: string[] = [];
+for (const file of await collectCss(SRC)) {
+  const rel = path.relative(SRC, file);
+  const lines = stripComments(await readFile(file, "utf8")).split("\n");
+  lines.forEach((line, i) => {
+    const declaration = line.trim();
+    // Defining another token from --accent (shadcn theme mapping) is fine.
+    const definesToken = /^--[\w-]+\s*:/.test(declaration);
+    if (!definesToken && /var\(--accent[,)\s]/.test(line)) {
+      offenders.push(`${rel}:${i + 1} consumes var(--accent) — use var(--accent-presence)`);
+    }
+    if (/var\(--accent-foreground[,)\s]/.test(line)) {
+      offenders.push(`${rel}:${i + 1} consumes var(--accent-foreground) — use var(--accent-presence-foreground)`);
+    }
+  });
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  `--accent is the shadcn surface token, not the brand accent; these render ` +
+    `nearly invisible chrome. Offenders:\n${offenders.join("\n")}`,
+);
+
+console.log("accent-token-usage: ok");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -844,8 +844,10 @@ tr[role="checkbox"]:focus-visible {
   height: 34px;
   padding: 0 8px;
   border-radius: 10px;
-  border: 1px solid color-mix(in oklch, var(--accent) 32%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent) 12%, transparent);
+  /* Brand accent (--accent-presence); var(--accent) is the shadcn surface
+     token and rendered this button's chrome nearly invisible. */
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   color: var(--text-primary);
   font-size: 12px;
   font-weight: 560;
@@ -854,8 +856,8 @@ tr[role="checkbox"]:focus-visible {
     border-color var(--duration-fast) var(--ease-standard);
 }
 .cnav__new:hover {
-  background: color-mix(in oklch, var(--accent) 20%, transparent);
-  border-color: color-mix(in oklch, var(--accent) 48%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 48%, transparent);
 }
 .cnav__new-icon {
   flex-shrink: 0;
@@ -939,8 +941,8 @@ tr[role="checkbox"]:focus-visible {
     box-shadow var(--duration-fast) var(--ease-standard);
 }
 .cnav__search:focus-within {
-  border-color: color-mix(in oklch, var(--accent) 55%, transparent);
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 13%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-presence) 13%, transparent);
 }
 .cnav__search-icon {
   flex-shrink: 0;
@@ -1174,7 +1176,7 @@ tr[role="checkbox"]:focus-visible {
   color: var(--text-primary);
 }
 .cnav__thread.is-active {
-  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   color: var(--text-primary);
 }
 .cnav__thread.is-active::before {
@@ -1185,7 +1187,7 @@ tr[role="checkbox"]:focus-visible {
   bottom: 7px;
   width: 2.5px;
   border-radius: 2px;
-  background: var(--accent);
+  background: var(--accent-presence);
 }
 .cnav__dot {
   width: 6px;
@@ -5495,7 +5497,10 @@ button:active > .edge-rail-chip {
   height: 14px;
   border-radius: 4px;
   border: 1px solid var(--border-strong);
-  color: var(--accent-foreground);
+  /* Checkmark sits on an --accent-presence fill when checked, so it takes the
+     paired on-accent foreground (not shadcn's --accent-foreground, which is
+     near-black in light mode on the dark presence fill). */
+  color: var(--accent-presence-foreground);
   background: transparent;
   opacity: 0;
   transition: background var(--duration-fast) var(--ease-standard),
@@ -12225,7 +12230,7 @@ details[open] > .cave-edit-card__summary::before {
   background: color-mix(in oklch, var(--bg-raised) 40%, var(--bg-base));
 }
 .quick-chat-overlay [aria-haspopup="menu"]:focus-visible {
-  border-color: var(--accent-presence, var(--accent));
+  border-color: var(--accent-presence);
   outline: none;
 }
 
@@ -12277,8 +12282,8 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-bubble--user {
   max-width: 84%;
   color: var(--fg-primary);
-  background: color-mix(in oklch, var(--accent) 20%, var(--bg-base));
-  border: 1px solid color-mix(in oklch, var(--accent) 34%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 20%, var(--bg-base));
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, transparent);
   border-bottom-right-radius: 5px;
 }
 .quick-chat-bubble--familiar {
@@ -12324,7 +12329,7 @@ details[open] > .cave-edit-card__summary::before {
   height: 1em;
   margin-left: 1px;
   vertical-align: text-bottom;
-  background: var(--accent-presence, var(--accent));
+  background: var(--accent-presence);
   animation: quick-chat-caret-blink 1s steps(2, start) infinite;
 }
 @keyframes quick-chat-caret-blink {
@@ -12379,8 +12384,8 @@ details[open] > .cave-edit-card__summary::before {
   width: 40px;
   height: 40px;
   border-radius: 999px;
-  color: var(--accent-presence, var(--accent));
-  background: color-mix(in oklch, var(--accent) 12%, transparent);
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
 .quick-chat-empty__title {
   font-size: 13px;
@@ -12410,8 +12415,8 @@ details[open] > .cave-edit-card__summary::before {
   gap: 8px;
   padding: 6px 8px 6px 10px;
   border-radius: var(--radius-control);
-  border: 1px solid color-mix(in oklch, var(--accent) 30%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent) 6%, var(--bg-raised));
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
 }
 .quick-chat-reco__label {
   display: inline-flex;
@@ -12421,7 +12426,7 @@ details[open] > .cave-edit-card__summary::before {
   font-size: 10.5px;
   font-weight: 600;
   letter-spacing: 0.01em;
-  color: var(--accent-presence, var(--accent));
+  color: var(--accent-presence);
 }
 .quick-chat-reco__text {
   flex: 1 1 auto;
@@ -12544,8 +12549,8 @@ details[open] > .cave-edit-card__summary::before {
     box-shadow var(--duration-fast, 120ms) var(--ease-standard, ease);
 }
 .quick-chat-overlay__input:focus {
-  border-color: var(--accent-presence, var(--accent));
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+  border-color: var(--accent-presence);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-presence) 18%, transparent);
 }
 .quick-chat-overlay__actions {
   display: flex;
@@ -12561,7 +12566,7 @@ details[open] > .cave-edit-card__summary::before {
  * counted enter/leave handlers (shared useAttachmentStaging) keep this veil
  * steady while the drag crosses child elements. */
 .quick-chat-overlay__composer--drop {
-  outline: 1.5px dashed var(--accent-presence, var(--accent));
+  outline: 1.5px dashed var(--accent-presence);
   outline-offset: -4px;
 }
 .quick-chat-dropzone {
@@ -12574,7 +12579,7 @@ details[open] > .cave-edit-card__summary::before {
   gap: 6px;
   font-size: 12px;
   font-weight: 600;
-  color: var(--accent-presence, var(--accent));
+  color: var(--accent-presence);
   background: color-mix(in oklch, var(--bg-base) 78%, transparent);
   border-radius: inherit;
   pointer-events: none;
@@ -12630,8 +12635,8 @@ details[open] > .cave-edit-card__summary::before {
   min-width: 0;
   padding: 2px 4px 2px 8px;
   border-radius: var(--radius-control);
-  border: 1px dashed color-mix(in oklch, var(--accent-presence, var(--accent)) 45%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence, var(--accent)) 6%, transparent);
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 6%, transparent);
   font-size: 11.5px;
   color: var(--text-secondary);
 }
@@ -12841,8 +12846,8 @@ details[open] > .cave-edit-card__summary::before {
   transform: translate(-50%, -50%) scaleY(1);
 }
 .split-host__group[data-resizing] .split-host__grip {
-  background: var(--accent);
-  box-shadow: 0 0 10px color-mix(in oklch, var(--accent) 55%, transparent);
+  background: var(--accent-presence);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 @media (prefers-reduced-motion: reduce) {
   .split-host__grip { transition: opacity var(--duration-fast) var(--ease-standard); }
@@ -12861,17 +12866,17 @@ details[open] > .cave-edit-card__summary::before {
   transition: left 0.04s linear;
 }
 .split-host__guide--snap {
-  background: var(--accent);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent) 40%, transparent),
-    0 0 12px color-mix(in oklch, var(--accent) 55%, transparent);
+  background: var(--accent-presence);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent-presence) 40%, transparent),
+    0 0 12px color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 .split-host__guide--close { background: var(--color-danger, #e5484d); }
 /* Far-edge "Fill" state — promoting the secondary to the whole surface. Uses
    the accent (a positive/constructive action) with a stronger glow than snap. */
 .split-host__guide--collapse {
-  background: var(--accent);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent) 55%, transparent),
-    0 0 16px color-mix(in oklch, var(--accent) 70%, transparent);
+  background: var(--accent-presence);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent-presence) 55%, transparent),
+    0 0 16px color-mix(in oklch, var(--accent-presence) 70%, transparent);
 }
 .split-host__guide-chip {
   position: absolute;
@@ -12883,8 +12888,8 @@ details[open] > .cave-edit-card__summary::before {
   font-size: 11px;
   font-weight: 700;
   line-height: 1.4;
-  color: var(--accent-foreground, #fff);
-  background: var(--accent);
+  color: var(--accent-presence-foreground, #fff);
+  background: var(--accent-presence);
   white-space: nowrap;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
@@ -12908,7 +12913,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   justify-content: center;
   margin: 10px;
-  border: 2px dashed color-mix(in oklch, var(--accent) 40%, transparent);
+  border: 2px dashed color-mix(in oklch, var(--accent-presence) 40%, transparent);
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-base) 55%, transparent);
   backdrop-filter: blur(2px);
@@ -12918,8 +12923,8 @@ details[open] > .cave-edit-card__summary::before {
 .split-dropzone__half--left { margin-right: 5px; }
 .split-dropzone__half--right { margin-left: 5px; }
 .split-dropzone__half.is-hover {
-  background: color-mix(in oklch, var(--accent) 18%, var(--bg-base));
-  border: 2px solid var(--accent);
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-base));
+  border: 2px solid var(--accent-presence);
   color: var(--text-primary);
 }
 .split-dropzone__hint {
@@ -13028,9 +13033,9 @@ details[open] > .cave-edit-card__summary::before {
   display: grid;
   place-items: center;
   padding: 10px;
-  border: 2px solid var(--accent);
+  border: 2px solid var(--accent-presence);
   border-radius: var(--radius-card);
-  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   transition: left 0.12s ease, top 0.12s ease, width 0.12s ease, height 0.12s ease;
   pointer-events: none;
 }
@@ -13090,7 +13095,7 @@ details[open] > .cave-edit-card__summary::before {
   .split-host__mobile-tab[aria-selected="true"] {
     background: var(--bg-raised);
     color: var(--text-primary);
-    border-color: color-mix(in oklch, var(--accent) 45%, var(--border-hairline));
+    border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
   }
 
   .split-host__group {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2944,7 +2944,7 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-model-popover__option[aria-checked="true"] {
   border-color: var(--border-strong);
-  background: color-mix(in oklch, var(--accent) 14%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
 }
 
 .cave-chat-model-popover__option:disabled {
@@ -4550,7 +4550,7 @@ details[open] > .cave-tool-summary::before {
   overflow: hidden;
 }
 .cave-linear-turn-avatar-btn:focus-visible {
-  outline: 2px solid var(--accent, #7c93ff);
+  outline: 2px solid var(--ring-focus, #7c93ff);
   outline-offset: 2px;
 }
 
@@ -4617,9 +4617,24 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-primary, #eee); cursor: pointer;
 }
 .familiar-inline-card__actions button:hover { background: var(--bg-hover, #1c1c1c); }
+.familiar-inline-card__actions button:focus-visible,
+.familiar-inline-card__workload-item:focus-visible,
+.familiar-inline-card__close:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus, #7c93ff);
+  outline-offset: var(--ring-offset, 2px);
+}
 
 .familiar-inline-card__memory-head { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--text-secondary, #aaa); margin-bottom: 4px; }
-.familiar-inline-card__view-all { border: 0; background: transparent; color: var(--accent, #7c93ff); cursor: pointer; font-size: 12px; }
+.familiar-inline-card__view-all {
+  border: 0; background: transparent; cursor: pointer; font-size: 12px;
+  /* Brand accent (--accent-presence), NOT --accent — that's the shadcn
+     surface token (near-black in dark themes), which rendered this link
+     almost invisible. */
+  color: var(--accent-presence, #7c93ff);
+  border-radius: var(--radius-control);
+}
+.familiar-inline-card__view-all:hover { text-decoration: underline; color: var(--text-primary, #fff); }
+.familiar-inline-card__view-all:focus-visible { outline: var(--ring-width, 2px) solid var(--ring-focus, #7c93ff); outline-offset: var(--ring-offset, 2px); }
 .familiar-inline-card__memory-muted { font-size: 12px; color: var(--text-secondary, #888); }
 .familiar-inline-card__memory-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .familiar-inline-card__memory-item { display: flex; flex-direction: column; gap: 1px; }
@@ -4681,8 +4696,13 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__workload-time { font-size: 10px; color: var(--text-secondary, #777); flex-shrink: 0; }
 
 .familiar-inline-card__actions button.familiar-inline-card__action-contextual {
-  color: var(--accent, #7c93ff);
-  border-color: color-mix(in srgb, var(--accent, #7c93ff) 40%, transparent);
+  /* Brand accent, not the --accent surface token (see __view-all note). */
+  color: var(--accent-presence, #7c93ff);
+  border-color: color-mix(in srgb, var(--accent-presence, #7c93ff) 40%, transparent);
+}
+.familiar-inline-card__actions button.familiar-inline-card__action-contextual:hover {
+  background: color-mix(in srgb, var(--accent-presence, #7c93ff) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent-presence, #7c93ff) 60%, transparent);
 }
 
 /* ── New-chat launch surface ───────────────────────────────────────────────

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -140,8 +140,12 @@
 .chat-artifact__refine-foot { display: flex; align-items: center; gap: 8px; }
 .chat-artifact__refine-hint { font-size: 10px; color: var(--text-muted); }
 .chat-artifact__refine-go {
-  flex: none; font-size: var(--text-xs); font-weight: 600; color: #fff;
-  background: var(--accent, #6b8fbf); border: 0; border-radius: 7px; padding: 6px 14px; cursor: pointer;
+  flex: none; font-size: var(--text-xs); font-weight: 600;
+  /* Filled brand-accent CTA: --accent-presence with its paired foreground
+     (var(--accent) is the near-background shadcn surface token — in light
+     mode it left white text on a near-white fill). */
+  color: var(--accent-presence-foreground, #fff);
+  background: var(--accent-presence, #6b8fbf); border: 0; border-radius: 7px; padding: 6px 14px; cursor: pointer;
   transition: filter 0.12s ease;
 }
 .chat-artifact__refine-go:hover:not(:disabled) { filter: brightness(1.08); }

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -444,7 +444,7 @@
 .hc-dest-pill.active {
   background: var(--accent-presence);
   border-color: var(--accent-presence);
-  color: var(--accent-foreground);
+  color: var(--accent-presence-foreground);
   font-weight: 600;
   box-shadow: 0 2px 8px color-mix(in oklch, var(--accent-presence) 38%, transparent);
 }
@@ -452,7 +452,7 @@
 /* Label and icon sit on the solid accent fill, so both take the on-accent
  * foreground colour at full strength for legibility. */
 .hc-dest-pill.active svg {
-  color: var(--accent-foreground);
+  color: var(--accent-presence-foreground);
   opacity: 1;
 }
 

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -479,7 +479,7 @@
 }
 
 .sidebar-section-label:focus-visible {
-  outline: 2px solid var(--accent, currentColor);
+  outline: 2px solid var(--ring-focus, currentColor);
   outline-offset: 1px;
 }
 
@@ -506,7 +506,9 @@
   height: 11px;
   align-self: center;
   border-radius: 999px;
-  background: var(--accent, currentColor);
+  /* Brand accent — var(--accent) is the shadcn surface token and reads as
+     background here, hiding the tick. */
+  background: var(--accent-presence, currentColor);
   opacity: 0.55;
   flex: none;
 }
@@ -1036,7 +1038,7 @@
   cursor: pointer; color: var(--text-secondary); transition: background 0.12s ease, color 0.12s ease; }
 .recent-activity__head:hover { background: var(--bg-raised); color: var(--text-primary); }
 .recent-activity__label { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
-.recent-activity__label::before { content: ""; width: 2px; height: 11px; border-radius: 999px; background: var(--accent, currentColor); opacity: 0.55; flex: none; }
+.recent-activity__label::before { content: ""; width: 2px; height: 11px; border-radius: 999px; background: var(--accent-presence, currentColor); opacity: 0.55; flex: none; }
 .recent-activity__chevron { transition: transform 140ms ease; }
 .recent-activity__chevron--collapsed { transform: rotate(-90deg); }
 .recent-activity__list { display: flex; flex-direction: column; gap: 6px; margin: 0; padding: 0; list-style: none; }


### PR DESCRIPTION
## The bug (screenshot report)

The familiar card's contextual buttons (**Review heal requests** / **Refresh memory**) and its **View all →** link rendered nearly invisible. They styled text/borders with `var(--accent)` — but in this app `--accent` is the **shadcn surface token** (near-black in dark themes, near-white in light). The brand accent is `--accent-presence`, paired with `--accent-presence-foreground` on fills.

## Swept the whole class (not just the reported card)

| Surface | Was | Now |
|---|---|---|
| Familiar card contextual actions + View-all | invisible `--accent` text/borders, no hover/focus states | `--accent-presence` + hover wash + `--ring-focus` focus-visible rings |
| Avatar-btn & sidebar section-label focus rings | `--accent` outline (invisible) | `--ring-focus` |
| Sidebar section / recent-activity ticks | `--accent` (invisible) | `--accent-presence` |
| chat-artifact refine CTA | white text on `--accent` (white-on-near-white in light mode) | presence fill + presence foreground |
| cnav New-chat chrome, search focus, active-thread wash+tick | `--accent` mixes (invisible) | `--accent-presence` mixes |
| quick-chat bubble/reco/empty/input-focus, split-host grips/guides/chips/dropzones/preview/mobile-tab | `--accent` | `--accent-presence` |
| familiar-switcher checkbox, home-composer dest pill | `--accent-foreground` on presence fills (broken in light mode) | `--accent-presence-foreground` |

## Regression guard

`src/app/accent-token-usage.test.ts` scans every CSS file under `src/` and forbids consuming `var(--accent)` / `var(--accent-foreground)` outside custom-property definitions (theme-block shadcn mappings like `--bg-hover: var(--accent)` stay legal). Wired into `test:app`; it flagged each pre-fix site.

## Verification

- App suite **656/656** green (includes new scanner + all pins on touched files)
- Built the app and drove it with Playwright: computed styles resolve to `--accent-presence` exactly; screenshots confirm accent text, tinted borders, hover wash, visible View-all, and visible New-chat chrome
- `check-tests-wired` green

Bead: **cave-ilkk**