### PR TITLE
fix(notifications): bell Open lands on the Inbox view (cave-ipze)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ breaking config changes; patch releases stay additive.
 - **Onboarding: hand-held first run through the first chat** — the setup wizard now shows a three-beat journey strip (Set up Cave → Summon a familiar → First chat) so it never reads as a dead-ended infra checklist; completing setup surfaces an above-the-fold success banner, and the finish CTA keeps its promise by opening the Summoning Circle directly (decided on the wizard's own fresh status, immune to the workspace's slower daemon poll). In the circle, the name stage gains one-click identity templates (Code reviewer, Research assistant, Project planner, Writing partner) that fill the role and required description, and the success stage hands keyboard focus to "Begin the first conversation" so Enter completes the funnel (cave-uvv7).
 
 ### Fixes
+- **Notifications: bell Open lands on the Inbox view** — a notification row's Open now marks the item read, scopes to its familiar, and opens the Inbox (Schedules) surface instead of jumping straight into a chat session; session jumps remain on the chat surface and Home "needs you" paths (cave-ipze).
 - **Familiars: no phantom Summoning Circle on revisit** — a summon request handled by an already-open Familiars surface left the cross-surface latch armed, so the next visit to Familiars popped the circle open uninvited; the event listener now consumes the latch too (cave-ibvl).
 
 ## [0.0.182] - 2026-07-12

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -277,8 +277,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /onOpenInboxItem=\{\(item\) => \{[\s\S]*openFamiliarSession\(item\.sessionId, item\.familiarId\)[\s\S]*setMode\("inbox"\)/,
-  "Workspace should keep notification-bell inbox routing intact for session and non-session items",
+  /onOpenInboxItem=\{\(item\) => \{\s*markInboxItemRead\(item\.id\);\s*if \(item\.familiarId\) setActiveId\(item\.familiarId\);\s*setMode\("inbox"\);/,
+  "Workspace should route notification-bell Open to the Inbox view (cave-ipze), never straight into a session",
 );
 
 // The agents-new-chat bridge forwards an optional initialPrompt so callers

--- a/src/components/daily-summary-notifications.test.ts
+++ b/src/components/daily-summary-notifications.test.ts
@@ -142,4 +142,20 @@ assert.match(
   "Open is a tinted pill, not a solid accent block (accent = presence, not CTA)",
 );
 
+// ── Bell "Open" lands on the Inbox surface (cave-ipze) ──────────────────────
+// The popover is a triage list, not a chat launcher: a row's Open marks the
+// item read, scopes to its familiar, and opens the Inbox (Schedules) view.
+// Session jumps stay on the chat surface and Home needs-you paths, which
+// share openInspectorInboxItem.
+assert.match(
+  workspace,
+  /<TopBar[\s\S]*?onOpenInboxItem=\{\(item\) => \{\s*markInboxItemRead\(item\.id\);\s*if \(item\.familiarId\) setActiveId\(item\.familiarId\);\s*setMode\("inbox"\);\s*\}\}/,
+  "the bell's Open routes to the Inbox view (mark read, scope familiar, mode inbox)",
+);
+assert.doesNotMatch(
+  workspace,
+  /<TopBar[\s\S]*?onOpenInboxItem=\{\(item\) => \{[\s\S]{0,200}?openFamiliarSession/,
+  "the bell's Open never jumps straight into a chat session",
+);
+
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -82,7 +82,6 @@ export type SidebarMinimalProps = {
   responseNeeded?: Set<string>;
   notificationBadgeCount?: number;
   onOpenInbox?: () => void;
-  onOpenInboxItem?: (item: InboxItem) => void;
   onNotificationPrefsChanged?: () => void;
   /** Live counts surfaced as small nav badges (omitted/0 -> no badge). */
   boardOpenCount?: number;

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2313,14 +2313,6 @@ export function Workspace() {
       responseNeeded={responseNeeded}
       notificationBadgeCount={notificationUnreadCount}
       onOpenInbox={() => setMode("inbox")}
-      onOpenInboxItem={(item) => {
-        markInboxItemRead(item.id);
-        if (item.sessionId) {
-          openFamiliarSession(item.sessionId, item.familiarId);
-        } else {
-          setMode("inbox");
-        }
-      }}
       onNotificationPrefsChanged={refreshPrefs}
       boardOpenCount={boardTaskCount}
       scheduleNeedsCount={scheduleNeedsCount}
@@ -2669,10 +2661,14 @@ export function Workspace() {
               familiarSwitcherLabeled={mode === "chat"}
               inboxPrefs={inboxPrefs}
               inboxBadgeCount={notificationUnreadCount}
+              // Bell rows open in the Inbox (Schedules) surface — the popover
+              // is a triage list, not a chat launcher. Session jumps stay on
+              // the chat surface and Home needs-you paths
+              // (openInspectorInboxItem).
               onOpenInboxItem={(item) => {
                 markInboxItemRead(item.id);
-                if (item.sessionId) openFamiliarSession(item.sessionId, item.familiarId);
-                else setMode("inbox");
+                if (item.familiarId) setActiveId(item.familiarId);
+                setMode("inbox");
               }}
               onNotificationPrefsChanged={refreshPrefs}
               onToggleNav={() => shellRef.current?.toggleNav()}


### PR DESCRIPTION
## Why

User request: within a notification, **Open** should open the item in the Inbox view. Previously the bell's per-row Open jumped straight into the chat session whenever the item carried a `sessionId`, and only fell back to the Inbox surface otherwise.

## What

- The TopBar bell's `onOpenInboxItem` now always: mark read → scope to the item's familiar → `setMode("inbox")`. The popover is a triage list, not a chat launcher; session jumps remain available on the chat surface and Home "needs you" paths (`openInspectorInboxItem`, unchanged), and the bell footer's "Open Schedules →" is unchanged.
- Dropped `SidebarMinimal`'s `onOpenInboxItem` prop — declared and fed the same stale session-jump closure but never consumed inside the component (drift bait).
- Guard assertions added in `daily-summary-notifications.test.ts`: the bell's Open routes to the Inbox view and never calls `openFamiliarSession`.

## Verification

- `pnpm typecheck` ✓
- `node --experimental-strip-types src/components/daily-summary-notifications.test.ts` ✓
- `node --experimental-strip-types src/components/workspace-inspector-mount.test.ts` ✓ (chat-surface wiring untouched)

Bead: cave-ipze