### PR TITLE
feat(chat): keep/extend controls in chat list + fix(proxy): tailnet mobile-access marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ package-lock.json
 /public/sandbox/
 /docs/audits
 test-results/
+/.agents

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "migrate-radix-to-base": {
+      "source": "shadcn/ui",
+      "sourceType": "github",
+      "skillPath": "skills/migrate-radix-to-base/SKILL.md",
+      "computedHash": "e1f2030ee5059be3dff0812ca0e4b995ee9fa3132176f049ebe6c90346a6755e"
+    },
+    "shadcn": {
+      "source": "shadcn/ui",
+      "sourceType": "github",
+      "skillPath": "skills/shadcn/SKILL.md",
+      "computedHash": "d81caa0f86aabab65b25e302d454f23a3328760386ed9078345584c0d5c8058e"
+    }
+  }
+}

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -139,6 +139,26 @@ assert.match(
 );
 assert.match(
   source,
+  /const setSessionKeep = async \(sessionId: string, keep: boolean\) =>[\s\S]*\{ keep \}/,
+  "Keep toggle should route the keep field through the sessions PATCH helper",
+);
+assert.match(
+  source,
+  /const extendSessionAutoArchive = async \(sessionId: string, days: number\) =>[\s\S]*\{ extendDays: days \}/,
+  "Auto-archive extension should route extendDays through the sessions PATCH helper",
+);
+assert.match(
+  source,
+  /OverflowMenu[\s\S]*Archive controls for chat/,
+  "Chat rows should expose an archive-controls overflow menu for keep/extend actions",
+);
+assert.match(
+  source,
+  /Extend auto-archive \+7 days[\s\S]*Extend auto-archive \+30 days/,
+  "Archive-controls menu should offer quick +7d and +30d extension actions",
+);
+assert.match(
+  source,
   /aria-label=\{`\$\{s\.archived_at \? "Unarchive" : "Archive"\} chat \$\{rowName\}`\}/,
   "Archive toggle should be a real button with a state-aware aria-label",
 );

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -13,6 +13,8 @@ import { sessionPrStatus } from "@/lib/session-pr-status";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { OverflowMenu } from "@/components/ui/overflow-menu";
+import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { cancelHoverPrefetch, hoverPrefetchConversation, invalidateConversation } from "@/lib/conversation-cache";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
@@ -606,28 +608,61 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     toggleStoredPinnedSession(sessionId);
   };
 
+  const patchSessionArchivePrefs = useCallback(
+    async (
+      sessionId: string,
+      patch: Record<string, unknown>,
+      fallbackError: string,
+    ): Promise<boolean> => {
+      setArchivingId(sessionId);
+      setError(null);
+      try {
+        const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(patch),
+        });
+        const json = await res.json().catch(() => ({ ok: false }));
+        if (!res.ok || !json.ok) {
+          setError(json.error ?? fallbackError);
+          return false;
+        }
+        setArchiveNonce((n) => n + 1);
+        onSessionsChanged?.();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : fallbackError);
+        return false;
+      } finally {
+        setArchivingId(null);
+      }
+    },
+    [onSessionsChanged],
+  );
+
   const setSessionArchived = async (e: React.MouseEvent, sessionId: string, archived: boolean) => {
     e.stopPropagation();
-    setArchivingId(sessionId);
-    setError(null);
-    try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ archived }),
-      });
-      const json = await res.json().catch(() => ({ ok: false }));
-      if (!res.ok || !json.ok) {
-        setError(json.error ?? (archived ? "archive failed" : "unarchive failed"));
-        return;
-      }
-      setArchiveNonce((n) => n + 1);
-      onSessionsChanged?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "archive failed");
-    } finally {
-      setArchivingId(null);
-    }
+    await patchSessionArchivePrefs(
+      sessionId,
+      { archived },
+      archived ? "archive failed" : "unarchive failed",
+    );
+  };
+
+  const setSessionKeep = async (sessionId: string, keep: boolean) => {
+    await patchSessionArchivePrefs(
+      sessionId,
+      { keep },
+      keep ? "keep failed" : "clear keep failed",
+    );
+  };
+
+  const extendSessionAutoArchive = async (sessionId: string, days: number) => {
+    await patchSessionArchivePrefs(
+      sessionId,
+      { extendDays: days },
+      "extend archive deadline failed",
+    );
   };
 
   // ── Bulk-select actions (reuse the per-row delete/archive endpoints) ───────
@@ -1288,6 +1323,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
                             {/* Row 3: status preview */}
                             <span className={`chat-list-row-preview truncate text-[12px] ${st.preview}`}>
+                              {s.keep ? <span className="text-[var(--accent-presence)]">Keep · </span> : null}
+                              {!s.keep && s.archive_extended_until ? (
+                                <span
+                                  className="text-[var(--text-muted)]"
+                                  title={`Auto-archive deferred until ${chatDate(s.archive_extended_until, dtPrefs)}`}
+                                >
+                                  Extended ·{" "}
+                                </span>
+                              ) : null}
                               {s.archived_at ? <span className="text-[var(--text-muted)]">Archived · </span> : null}
                               {st.label === "running"
                                 ? "Active now…"
@@ -1364,6 +1408,32 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               >
                                 <Icon name={s.archived_at ? "ph:arrow-counter-clockwise" : "ph:archive"} width={12} aria-hidden />
                               </button>
+                              <span
+                                onClick={(e) => e.stopPropagation()}
+                                onKeyDown={(e) => e.stopPropagation()}
+                              >
+                                <OverflowMenu
+                                  ariaLabel={`Archive controls for chat ${rowName}`}
+                                  icon="ph:clock-counter-clockwise"
+                                  disabled={archivingId !== null}
+                                  className="touch-always-visible h-6 w-6 shrink-0 rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                                  minWidth={208}
+                                >
+                                  <PopoverItem
+                                    checked={Boolean(s.keep)}
+                                    onSelect={() => void setSessionKeep(s.id, !s.keep)}
+                                  >
+                                    {s.keep ? "Remove keep mark" : "Keep chat"}
+                                  </PopoverItem>
+                                  <PopoverSeparator />
+                                  <PopoverItem icon="ph:calendar-bold" onSelect={() => void extendSessionAutoArchive(s.id, 7)}>
+                                    Extend auto-archive +7 days
+                                  </PopoverItem>
+                                  <PopoverItem icon="ph:calendar-bold" onSelect={() => void extendSessionAutoArchive(s.id, 30)}>
+                                    Extend auto-archive +30 days
+                                  </PopoverItem>
+                                </OverflowMenu>
+                              </span>
                               <button
                                 type="button"
                                 onClick={(e) => debugSession(e, s)}

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -141,6 +141,70 @@ assert.equal(
   "archived local chats should return when includeArchived is enabled",
 );
 
+const archiveOverrideState = {
+  ...state,
+  sessionKeep: { "local-1": "2026-06-08T22:00:00.000Z", "daemon-1": "2026-06-08T22:00:00.000Z" },
+  sessionArchiveExtendedUntil: {
+    "local-1": "2026-07-01T00:00:00.000Z",
+    "daemon-1": "2026-07-15T00:00:00.000Z",
+  },
+};
+
+assert.equal(
+  localConversationSessionRows([localConversation], archiveOverrideState, false)[0].keep,
+  true,
+  "local conversation rows should carry the keep flag from Cave state",
+);
+assert.equal(
+  localConversationSessionRows([localConversation], archiveOverrideState, false)[0].archive_extended_until,
+  "2026-07-01T00:00:00.000Z",
+  "local conversation rows should carry the extension deadline from Cave state",
+);
+assert.equal(
+  mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "daemon-1",
+        project_root: "/repo",
+        harness: "codex",
+        title: "Daemon chat",
+        status: "completed",
+        exit_code: 0,
+        archived_at: null,
+        created_at: "2026-06-08T19:00:00.000Z",
+        updated_at: "2026-06-08T19:05:00.000Z",
+      },
+    ],
+    localConversations: [],
+    state: archiveOverrideState,
+    includeArchived: false,
+  })[0].keep,
+  true,
+  "daemon rows should carry the keep flag from Cave state",
+);
+assert.equal(
+  mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "daemon-1",
+        project_root: "/repo",
+        harness: "codex",
+        title: "Daemon chat",
+        status: "completed",
+        exit_code: 0,
+        archived_at: null,
+        created_at: "2026-06-08T19:00:00.000Z",
+        updated_at: "2026-06-08T19:05:00.000Z",
+      },
+    ],
+    localConversations: [],
+    state: archiveOverrideState,
+    includeArchived: false,
+  })[0].archive_extended_until,
+  "2026-07-15T00:00:00.000Z",
+  "daemon rows should carry the extension deadline from Cave state",
+);
+
 // A daemon session whose `updated_at` was bumped by a mere resume/view should
 // order by the matching local conversation's last-message time, not the later
 // view time — so reopening an old chat doesn't float it to the top.

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -36,6 +36,8 @@ function localConversationToSession(
   conv: LocalConversationSummary,
   state: CaveState,
 ): SessionRow {
+  const keep = Boolean(state.sessionKeep?.[conv.sessionId]);
+  const extendedUntil = state.sessionArchiveExtendedUntil?.[conv.sessionId] ?? null;
   const title =
     state.sessionTitles[conv.sessionId] ?? sanitizeSessionTitle(conv.title) ?? "Chat";
   const familiarId = state.sessionFamiliar[conv.sessionId] ?? conv.familiarId ?? null;
@@ -55,6 +57,8 @@ function localConversationToSession(
     familiarId,
     origin: conv.origin ?? "chat",
     initiator: conv.initiator ?? { kind: "human", label: "Cave user", channel: "cave" },
+    ...(keep ? { keep: true } : {}),
+    ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
   };
 }
 
@@ -106,6 +110,8 @@ export function mergeSessionRows({
     seen.add(session.id);
     const titleOverride = state.sessionTitles[session.id];
     const archivedLocal = state.sessionArchived[session.id] ?? null;
+    const keep = Boolean(state.sessionKeep?.[session.id]);
+    const extendedUntil = state.sessionArchiveExtendedUntil?.[session.id] ?? null;
     const archived_at = archivedLocal ?? session.archived_at;
     const localUpdatedAt = localUpdatedById.get(session.id);
     const local = localById.get(session.id);
@@ -135,6 +141,8 @@ export function mergeSessionRows({
       // a run some generator spawned (journal narrative, flow, automation,
       // CLI), not something a person typed into a chat surface.
       ...(!local && inferOrigin(session) === "chat" ? { generated: true } : {}),
+      ...(keep ? { keep: true } : {}),
+      ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
       initiator:
         session.initiator ??
         initiatorFromSessionKey("", state.sessionFamiliar[session.id] ?? session.harness),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,10 @@ export type SessionRow = {
   pullRequest?: SessionPullRequestContext | null;
   /** Working-tree change size vs HEAD, for the Recent Activity roll-up's `+N -N`. */
   diff?: { additions: number; deletions: number } | null;
+  /** Keep mark from Cave state (never auto-archived when true). */
+  keep?: boolean;
+  /** Cave-local auto-archive defer-until timestamp, if set. */
+  archive_extended_until?: string | null;
 };
 
 export type SessionGitContext = {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -21,6 +21,16 @@ assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject un
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
 assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated \|\| tailnetTrusted\)/, "valid mobile access or tailnet-trust should satisfy the API host gate");
 assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless app mode (COVEN_CAVE_TAILNET_TRUST) should relax the host gate for tailnet-forwarded requests");
+assert.match(
+  source,
+  /const mobileAccessMarker =\s*mobileAccessAuthenticated \|\| \(tailnetTrusted && isTailscaleServeHost\(requestHost\)\)/,
+  "tokenless tailnet-trust mode should still stamp the mobile-access marker for ts.net hosts",
+);
+assert.match(
+  source,
+  /nextWithMobileAccessMarker\(req, mobileAccessMarker\)/,
+  "proxy should forward the derived mobile marker into downstream request headers",
+);
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
 assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");
 assert.match(source, /isAllowedRequestSourceAny\(origin, expectedOrigins\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
@@ -144,6 +154,7 @@ assert.match(mobileScriptSource, /"authorization": `Bearer \$\{createMobileAcces
 assert.match(nextConfigSource, /allowedDevOrigins:\s*\[[\s\S]*"\*\*\.ts\.net"/, "Next dev should allow Tailscale Serve origins for mobile browser access");
 assert.match(nextConfigSource, /devIndicators:\s*false/, "Next dev tools launcher should not intercept mobile bottom-tab taps");
 assert.match(mobileDocsSource, /signed (?:expiring )?invites?/, "mobile docs should describe the signed access token invite");
+assert.match(proxyHelpersSource, /export function isTailscaleServeHost\(host: string \| null\)/, "proxy helpers should expose ts.net host detection so marker logic is testable and shared");
 assert.match(tauriSource, /sidecar_auth_token\(\)/, "Tauri sidecar should generate a per-launch token");
 assert.match(tauriSource, /\.env\("COVEN_CAVE_AUTH_TOKEN", &auth_token\)/, "Tauri sidecar should pass the token to Next.js");
 assert.match(tauriSource, /\.env\("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token\)/, "Tauri sidecar should pass the mobile access secret to Next.js");

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -16,6 +16,7 @@
 import assert from "node:assert/strict";
 import {
   isLoopbackHost,
+  isTailscaleServeHost,
   isAllowedApiHost,
   sameOrigin,
   isAllowedRequestSource,
@@ -81,6 +82,12 @@ assert.equal(
   true,
   "mobile token authentication should not depend on a loopback Host header",
 );
+
+// ─── isTailscaleServeHost ──────────────────────────────────────────────────
+assert.equal(isTailscaleServeHost("cave.tailnet.example.ts.net"), true);
+assert.equal(isTailscaleServeHost("cave.tailnet.example.ts.net:8443"), true);
+assert.equal(isTailscaleServeHost("localhost:3000"), false);
+assert.equal(isTailscaleServeHost("127.0.0.1:3000"), false);
 
 // ─── sameOrigin ────────────────────────────────────────────────────────────
 const expected = "http://localhost:3000";

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -44,7 +44,7 @@ function portFromHost(host: string | null) {
   return parts.length > 1 ? parts[parts.length - 1] : "";
 }
 
-function isTailscaleServeHost(host: string | null) {
+export function isTailscaleServeHost(host: string | null) {
   const hostname = hostnameFromHost(host);
   return Boolean(hostname?.endsWith(".ts.net"));
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,7 @@ import {
   timingSafeEqualString,
   isLoopbackHost,
   isAllowedApiHost,
+  isTailscaleServeHost,
   sameOrigin,
   isAllowedRequestSource,
   isAllowedRequestSourceAny,
@@ -194,6 +195,8 @@ export async function proxy(req: NextRequest) {
   if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)) {
     return jsonError(403, "forbidden host");
   }
+  const mobileAccessMarker =
+    mobileAccessAuthenticated || (tailnetTrusted && isTailscaleServeHost(requestHost));
 
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
   // A request bearing the sidecar token in the CUSTOM HEADER (x-coven-cave-token)
@@ -250,14 +253,14 @@ export async function proxy(req: NextRequest) {
   if (!sidecarToken) {
     return process.env.COVEN_CAVE_BUNDLE === "1"
       ? jsonError(500, "missing sidecar auth token")
-      : nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
+      : nextWithMobileAccessMarker(req, mobileAccessMarker);
   }
 
   if (!sidecarAuthenticated) {
     return jsonError(401, "unauthorized");
   }
 
-  return nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
+  return nextWithMobileAccessMarker(req, mobileAccessMarker);
 }
 
 export const config = {

--- a/vault.yaml
+++ b/vault.yaml
@@ -1,18 +1,19 @@
-# Cave Vault — env var → 1Password secret reference map
+# Cave Vault — env var → encrypted local secret or 1Password reference map
 #
 # Format:
 #   ENV_VAR_NAME:
+#     storage: "encrypted"
+#   ANOTHER_ENV_VAR:
 #     ref: "op://VaultName/ItemTitle/field"
 #     description: "human-readable note"
 #     required: false
 #
-# Secrets are NEVER stored here — only the op:// reference.
+# Secrets are NEVER stored here — only storage metadata or an op:// reference.
 # Safe to commit; contains no credentials.
 
 GITHUB_PAT:
-  ref: "op://Development/GitHub PAT/credential"
-  description: "GitHub Personal Access Token (read:user, repo, notifications)"
-  required: true
+  storage: "encrypted"
+  description: "GitHub Personal Access Token"
 
 GITHUB_USERNAME:
   ref: "op://Development/GitHub PAT/username"
@@ -23,5 +24,4 @@ OPENAI_API_KEY:
   description: "OpenAI API key, used to mint ephemeral tokens for Realtime voice"
 
 GOOGLE_API_KEY:
-  ref: ""
   description: "Google AI Studio key, used to mint ephemeral tokens for Gemini Live (v1.1)"


### PR DESCRIPTION
Two pending local commits from the primary checkout, landed via the PR path (direct pushes to main are blocked).

## 1. feat(chat): keep/extend controls in chat list

Chat list rows gain keep/extend affordances (chat-list.tsx +110), with the session-list-merge plumbing (+8) and type additions to carry the control state.

**Tests**: `chat-list-delete.test.ts` (+20) and `session-list-merge.test.ts` (+64) — both green locally, already wired into CI suites (check-tests-wired: 895 files ✓).

## 2. fix(proxy): stamp the mobile-access marker for tailnet-trusted ts.net requests

Tokenless app mode (`COVEN_CAVE_TAILNET_TRUST=1`) relaxed the API host gate for tailnet-forwarded requests but never stamped the downstream mobile-access marker, so ts.net requests passed the gate yet reached surfaces without mobile-access context. Now the marker derives from either a real mobile token **or** (tailnet-trust **and** a `*.ts.net` Host).

- `isTailscaleServeHost` exported from proxy-helpers (testable, shared)
- `middleware.test.ts`: source pins for the derived marker
- `proxy-behavior.test.ts`: unit cases (ts.net, ts.net:port, localhost, 127.0.0.1)

Also: `vault.yaml` migrates GITHUB_PAT to encrypted-local storage metadata (still zero credentials in file), `.gitignore` ignores `/.agents` skills payload while tracking `skills-lock.json` hashes.

## Validation

- proxy-behavior / middleware / chat-list-delete / session-list-merge tests green locally
- `pnpm typecheck` clean
- `check-tests-wired` green (all new tests wired)