### PR TITLE
fix(ios): consume the .search deep link so a stale marker can't tear down the tab tree

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -8,9 +8,12 @@ struct RootView: View {
     var body: some View {
         @Bindable var app = app
         Group {
-            if app.deepLink == .search && app.connectionState != .connected {
+            if app.deepLink == .search && !app.hasLoadedSurfaces && app.connectionState != .connected {
                 // Search deep link before a connection exists: land on the
-                // local-index SearchView rather than the Connect screen.
+                // local-index SearchView rather than the Connect screen. The
+                // hasLoadedSurfaces guard limits this to the genuine
+                // pre-connection case — once the tab tree has data, a stale
+                // .search marker must never tear it down on a connection blip.
                 SearchView()
             } else {
                 switch app.connectionState {

--- a/apps/ios/CovenCave/CovenCave/Views/SearchView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SearchView.swift
@@ -72,6 +72,13 @@ struct SearchView: View {
                 async let reminders: Void = app.loadReminders()
                 _ = await (sessions, tasks, reminders)
             }
+            // The .search deep link is consumed once the connected tab tree
+            // hosts this view; only the pre-connection standalone SearchView
+            // keeps the marker (it gates that presentation in RootView).
+            .onAppear { consumeSearchDeepLinkIfConnected() }
+            .onChange(of: app.connectionState) { _, state in
+                if state == .connected { consumeSearchDeepLinkIfConnected() }
+            }
             .refreshable {
                 async let familiars: Void = app.loadFamiliars()
                 async let sessions: Void = app.loadSessions()
@@ -143,7 +150,18 @@ struct SearchView: View {
         .themedListBackground()
     }
 
+    private func consumeSearchDeepLinkIfConnected() {
+        if app.deepLink == .search && app.connectionState == .connected {
+            app.selectedTab = .search
+            app.deepLink = nil
+        }
+    }
+
     private func open(_ item: CaveSearchItem) {
+        // Routing into the tab tree consumes the search deep link — a stale
+        // .search marker would otherwise re-hijack RootView on the next
+        // connection blip and leave these taps pointing at an unmounted tree.
+        if app.deepLink == .search { app.deepLink = nil }
         switch item.destination {
         case .familiar(let id):
             if let familiar = app.familiar(id) { app.requestOpenFamiliar(familiar) }

--- a/scripts/ios-global-search.test.mjs
+++ b/scripts/ios-global-search.test.mjs
@@ -10,7 +10,7 @@ const chats = await readFile(new URL("../apps/ios/CovenCave/CovenCave/Views/Chat
 assert.match(root, /Tab\(value: \.search, role: \.search\)/, "Search is a system-pinned search-role tab");
 assert.match(root, /SearchView\(\)/, "the search tab renders the native search destination");
 assert.match(root, /\.search/, "hardware-keyboard tab order includes search");
-assert.match(root, /app\.deepLink == \.search && app\.connectionState != \.connected/, "deep-linked Search remains available while the desktop is offline");
+assert.match(root, /app\.deepLink == \.search && !app\.hasLoadedSurfaces && app\.connectionState != \.connected/, "deep-linked Search remains available while the desktop is offline, but only before the tab tree has surfaces — a stale marker must not tear down a mounted session");
 
 assert.match(model, /enum CaveSearchScope:[\s\S]*case all, chats, tasks, reminders/, "search exposes four explicit scopes");
 assert.match(model, /case familiar\(String\)/, "search results can open familiar thread lists");
@@ -23,6 +23,8 @@ assert.match(view, /\.searchable\(text: \$query/, "native search owns a system s
 assert.match(view, /Picker\("Search scope"/, "native search provides an explicit scope picker");
 assert.match(view, /ContentUnavailableView\.search\(text: query\)/, "no matches use the native unavailable state");
 assert.match(view, /app\.deepLink = nil/, "offline Search provides a return to connection setup");
+assert.match(view, /func consumeSearchDeepLinkIfConnected\(\)[\s\S]*app\.deepLink = nil/, "the search deep link is consumed once the connected tab tree hosts Search");
+assert.match(view, /if app\.deepLink == \.search \{ app\.deepLink = nil \}/, "routing a result into the tab tree consumes the search deep link");
 assert.match(view, /app\.requestOpenFamiliar/, "familiar results route through AppModel");
 assert.match(view, /app\.requestOpenTask/, "task results route through AppModel");
 assert.match(view, /offlineThreadId = id/, "local chat results stay navigable while Search is offline");


### PR DESCRIPTION
## What

Post-merge review of #3070 (cross-platform find-anything) surfaced a high-severity iOS lifecycle bug: `AppModel.deepLink = .search` was set by `handleDeepLink` but never cleared when the search surface successfully consumed it — only the standalone view's manual **Connection** back-button cleared it, and `.reminders` overwrote it.

**Consequences of the stale marker:**
1. **Whole-app teardown on routine connection blips.** After launching via `covencave://search` and connecting, any later `checking`/`unreachable`/`needsAuth` transition re-matched RootView's pre-connection branch and replaced the mounted `MainTabView` with the standalone `SearchView` — destroying navigation stacks and composer drafts mid-chat. This is precisely the teardown the `hasLoadedSurfaces` guards (kept in #3070's conflict resolution) exist to prevent; the new branch sat above them unguarded. It also masked the pairing screen on `needsAuth`.
2. **Dead result taps while disconnected with cached surfaces:** standalone-SearchView taps for familiar/serverSession/task set tab-tree intents on a tree RootView wasn't rendering.

## Fix
- **RootView:** standalone SearchView branch now also requires `!app.hasLoadedSurfaces` — it covers only the genuine pre-connection launch case.
- **SearchView:** the marker is consumed when the connected tab tree hosts the view (`onAppear` + `connectionState` `onChange` → selects the search tab, clears `deepLink`) and whenever a result routes into the tab tree.
- **Pins:** `scripts/ios-global-search.test.mjs` locks in the guard and both consumption paths (iOS sources aren't compiled in CI, so the pins are the regression net).

## Validation
- `node scripts/ios-global-search.test.mjs` ✓, `node scripts/ios-no-canvas-tab.test.mjs` ✓
- `xcrun swiftc -parse` on both edited files: no syntax errors
- Preserved intent: `covencave://search` before any connection still lands on the local-index SearchView (pin retained)