### PR TITLE
fix(windows): keep the startup splash out of webview session history

### DIFF
--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -572,6 +572,11 @@ test("Windows first launch paints progress and supports recovery while the sidec
     "startup must expose retry and cancellation commands",
   );
   assert.match(
+    launcher,
+    /window\.location\.replace\(/,
+    "readiness must replace startup.html in session history so history.back() cannot return to the splash screen",
+  );
+  assert.match(
     startupPage,
     /role="progressbar"[\s\S]*aria-live="polite"/,
     "startup page must expose accessible progress",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1945,8 +1945,17 @@ fn spawn_sidecar_startup(
                         .get_webview_window("main")
                         .ok_or_else(|| "startup window is unavailable".to_string())
                         .and_then(|window| {
+                            // location.replace() swaps startup.html out of the
+                            // webview's session history; window.navigate() pushes
+                            // a new entry instead, so the shell's Back control
+                            // (history.back) could land users on the dead splash
+                            // screen. Fall back to navigate() if eval cannot
+                            // reach the page — a stale history entry beats a
+                            // startup failure.
+                            let escaped = url.to_string().replace('"', "%22");
                             window
-                                .navigate(url)
+                                .eval(format!("window.location.replace(\"{escaped}\");"))
+                                .or_else(|_| window.navigate(url))
                                 .map_err(|error| format!("could not open CovenCave: {error}"))
                         });
                     match navigation {


### PR DESCRIPTION
## What happens

On Windows (v0.1.0), after the "Starting CovenCave" splash hands off to the app, pressing the shell's Back button once lands you back on the dead splash screen — progress bar full, no way out except Forward.

**Repro:** launch after an update → wait for "CovenCave is ready" → app loads → press the Back chevron (top-left) once → "Starting CovenCave" splash.

## Why

The Windows startup path boots the main window on the bundled `startup.html` and, on sidecar readiness, calls `WebviewWindow::navigate(url)` (`spawn_sidecar_startup`, lib.rs). `navigate()` pushes a new session-history entry, so the splash stays underneath in back-history. The shell's history controls drive real browser history (`window.history.back()` in `shell.tsx`), so the first Back press that exhausts the SPA's own entries falls through to the splash. Alt+Left and mouse back buttons reach it the same way.

macOS/Linux are unaffected — they build the window directly at the sidecar URL and never load `startup.html`.

## Fix

Navigate from inside the splash page with `window.location.replace(url)` (via `eval`), which *replaces* the splash's history entry instead of pushing on top of it — no `startup.html` entry survives to go back to. `navigate()` is kept as a fallback if eval can't reach the page (a stale history entry beats a failed startup). This mirrors the existing eval-navigation pattern in `navigate_webview()` (browser.rs).

Also adds a regression assertion to the existing "Windows first launch paints progress…" test in `release-runtime.test.mjs`.

## Verification

- `cargo check --lib` clean on `stable-x86_64-pc-windows-msvc` 1.97.0
- `node --test src-tauri/release-runtime.test.mjs` — 18/18 pass (incl. new assertion)
- Not yet verified against a live packaged build (would need a full release bundle); logic verified against WebView2 semantics: `location.replace` never creates a history entry, and the splash page is demonstrably live at handoff time (it renders the final "CovenCave is ready" status from the same event stream).

---

Note: as a fork PR, the required CodeQL check cannot report on this head SHA (default-setup limitation) — maintainer re-land with Co-authored-by expected, as with previous PRs from this fork.
