### PR TITLE
feat(vault): add Dashlane (dcli) as a secret backend

### DIFF
--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -19,8 +19,9 @@ import {
 import {
   getVaultStatuses,
   loadVaultMap,
+  refStorage,
   saveVaultMap,
-  validateOpRef,
+  validateRef,
   type VaultEntry,
 } from "@/lib/vault";
 
@@ -71,7 +72,7 @@ export async function POST(req: NextRequest) {
     setLocalEncryptedSecret(key, value);
     entry = { ...baseEntry, storage: "encrypted" };
   } else {
-    const refError = validateOpRef(ref);
+    const refError = validateRef(ref);
     if (refError) return NextResponse.json({ ok: false, error: refError }, { status: 400 });
     deleteLocalEncryptedSecret(key);
     entry = { ...baseEntry, ref };
@@ -86,7 +87,12 @@ export async function POST(req: NextRequest) {
     delete process.env[key];
   }
 
-  return NextResponse.json({ ok: true, key, ref: entry.ref ?? null, storage: entry.storage ?? "1password" });
+  return NextResponse.json({
+    ok: true,
+    key,
+    ref: entry.ref ?? null,
+    storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : "1password"),
+  });
 }
 
 // ── DELETE — remove a mapping ─────────────────────────────────────────────────

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -17,7 +17,7 @@ type VaultStatus = "resolved" | "encrypted" | "env-only" | "unresolved" | "error
 type Mapping = {
   key: string;
   ref: string | null;
-  storage: "1password" | "encrypted" | null;
+  storage: "1password" | "encrypted" | "dashlane" | null;
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -36,8 +36,11 @@ const STATUS_META: Record<VaultStatus, { label: string; color: string; icon: str
   "no-ref":   { label: "no ref",      color: "var(--text-muted)", icon: "ph:minus" },
 };
 
-function StatusBadge({ status }: { status: VaultStatus }) {
+function StatusBadge({ status, storage }: { status: VaultStatus; storage?: Mapping["storage"] }) {
   const meta = STATUS_META[status];
+  // "resolved" means a live ref read succeeded; label it by the backing
+  // provider (1Password op:// vs Dashlane dl://) rather than a fixed string.
+  const label = status === "resolved" && storage === "dashlane" ? "Dashlane" : meta.label;
   return (
     <span
       className="vault-status-badge"
@@ -45,7 +48,7 @@ function StatusBadge({ status }: { status: VaultStatus }) {
       title={status}
     >
       <Icon name={meta.icon as Parameters<typeof Icon>[0]["name"]} width={10} />
-      {meta.label}
+      {label}
     </span>
   );
 }
@@ -63,8 +66,12 @@ function AddMappingForm({
 }) {
   const [key, setKey]         = useState(initial?.key ?? "");
   const [ref, setRef]         = useState(initial?.ref ?? "op://");
-  const [storage, setStorage] = useState<"1password" | "encrypted">(
-    initial?.storage === "encrypted" || initial?.status === "encrypted" ? "encrypted" : "1password",
+  const [storage, setStorage] = useState<"1password" | "encrypted" | "dashlane">(
+    initial?.storage === "encrypted" || initial?.status === "encrypted"
+      ? "encrypted"
+      : initial?.storage === "dashlane" || initial?.ref?.startsWith("dl://")
+        ? "dashlane"
+        : "1password",
   );
   const [secret, setSecret]   = useState("");
   const [desc, setDesc]       = useState(initial?.description ?? "");
@@ -120,9 +127,22 @@ function AddMappingForm({
             <button
               type="button"
               className={`vault-btn${storage === "1password" ? " vault-btn--primary" : ""}`}
-              onClick={() => setStorage("1password")}
+              onClick={() => {
+                setStorage("1password");
+                if (!ref || ref === "dl://") setRef("op://");
+              }}
             >
               1Password
+            </button>
+            <button
+              type="button"
+              className={`vault-btn${storage === "dashlane" ? " vault-btn--primary" : ""}`}
+              onClick={() => {
+                setStorage("dashlane");
+                if (!ref || ref === "op://") setRef("dl://");
+              }}
+            >
+              Dashlane
             </button>
           </div>
         </div>
@@ -141,12 +161,14 @@ function AddMappingForm({
         </label>
       ) : (
         <label className="vault-add-label">
-          1Password reference
+          {storage === "dashlane" ? "Dashlane reference" : "1Password reference"}
           <input
             className="vault-add-input vault-ref-input"
             value={ref}
             onChange={(e) => setRef(e.target.value)}
-            placeholder="op://Personal/GitHub PAT/credential"
+            placeholder={storage === "dashlane"
+              ? "dl://GitHub PAT/username"
+              : "op://Personal/GitHub PAT/credential"}
             required
           />
         </label>
@@ -256,7 +278,7 @@ export function VaultPanel() {
           <Icon name="ph:vault" width={14} />
           Secret Vault
         </div>
-        <span className="vault-header-sub">env vars → encrypted local secrets or 1Password references</span>
+        <span className="vault-header-sub">env vars → encrypted local secrets, 1Password, or Dashlane references</span>
         <button
           type="button"
           className="vault-btn vault-btn--primary"
@@ -339,7 +361,7 @@ export function VaultPanel() {
             <div key={m.key} className={`vault-row${m.status === "error" || m.status === "unresolved" ? " vault-row--warn" : ""}`}>
               <div className="vault-row-main">
                 <code className="vault-row-key">{m.key}</code>
-                <StatusBadge status={m.status} />
+                <StatusBadge status={m.status} storage={m.storage} />
                 {m.required && <span className="vault-required-pill">required</span>}
               </div>
               {m.ref && (

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -245,6 +245,7 @@ function dcliRead(ref: string): string | null {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 8000,
+      env: resolverEnv(),
     }).trim();
     return value || null;
   } catch {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -27,7 +27,7 @@ import { getLocalEncryptedSecret, hasLocalEncryptedSecret } from "./local-encryp
 
 export type VaultEntry = {
   ref?: string;
-  storage?: "1password" | "encrypted";
+  storage?: "1password" | "encrypted" | "dashlane";
   description?: string;
   required?: boolean;
 };
@@ -39,7 +39,7 @@ export type VaultStatus = "resolved" | "configured" | "encrypted" | "env-only" |
 export type VaultMappingStatus = {
   key: string;
   ref: string | null;
-  storage: "1password" | "encrypted" | null;
+  storage: "1password" | "encrypted" | "dashlane" | null;
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -191,6 +191,61 @@ function opRead(ref: string): string | null {
   }
 }
 
+// ── dashlane (dcli) resolver ────────────────────────────────────────────────
+// Dashlane's CLI mirrors 1Password's model: a scheme-prefixed reference read
+// through a local, authenticated CLI. `dcli read dl://<id-or-title>/<field>`.
+// Which backend a mapping uses is carried entirely by the ref scheme, so the
+// resolver/status paths dispatch on the prefix — no extra persisted metadata.
+const DL_REF_PREFIX = "dl://";
+
+export function validateDashlaneRef(ref: unknown): string | null {
+  if (typeof ref !== "string") return "ref must be a string";
+  if (!ref.startsWith(DL_REF_PREFIX)) return "ref must start with dl://";
+  if (ref.length > OP_REF_MAX_LENGTH) return "ref is too long";
+  if (OP_REF_FORBIDDEN_CHARS.test(ref)) return "ref contains invalid characters";
+
+  const path = ref.slice(DL_REF_PREFIX.length).split("?")[0];
+  const segments = path.split("/");
+  if (segments.length < 2 || segments.some((segment) => !segment.trim())) {
+    return "ref must include a secret id/title and a field, e.g. dl://GitHub PAT/username";
+  }
+
+  return null;
+}
+
+/** Call `dcli read` to fetch a Dashlane secret reference. Returns null on failure. */
+function dcliRead(ref: string): string | null {
+  if (validateDashlaneRef(ref)) return null;
+
+  try {
+    const value = execFileSync("dcli", ["read", ref], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 8000,
+    }).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+/** The storage backend a reference resolves through, implied by its scheme. */
+export function refStorage(ref: string): "1password" | "dashlane" {
+  return ref.startsWith(DL_REF_PREFIX) ? "dashlane" : "1password";
+}
+
+/** Validate a secret reference, dispatching by scheme (op:// vs dl://). */
+export function validateRef(ref: unknown): string | null {
+  return typeof ref === "string" && ref.startsWith(DL_REF_PREFIX)
+    ? validateDashlaneRef(ref)
+    : validateOpRef(ref);
+}
+
+/** Resolve a secret reference via the appropriate CLI, dispatching by scheme. */
+function readRef(ref: string): string | null {
+  return ref.startsWith(DL_REF_PREFIX) ? dcliRead(ref) : opRead(ref);
+}
+
 /**
  * Resolve an env var by key.
  * Checks process.env first, then local encrypted vault, then vault.yaml → `op read`.
@@ -222,10 +277,10 @@ export function resolveSecret(key: string): string | undefined {
     return localEncrypted.trim();
   }
 
-  // Try 1Password vault reference
+  // Try a vault reference (1Password op:// or Dashlane dl://)
   if (!entry?.ref) return undefined;
 
-  const value = opRead(entry.ref);
+  const value = readRef(entry.ref);
   if (value) {
     process.env[key] = value; // cache for process lifetime
     return value;
@@ -266,7 +321,7 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
     if (inEnv) {
       return {
         key, ref: entry.ref ?? null, description: entry.description ?? null,
-        storage: entry.storage ?? (entry.ref ? "1password" : null),
+        storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : null),
         required: entry.required ?? false,
         status: "env-only" as VaultStatus, hasValue: true,
       };
@@ -284,7 +339,7 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
     if (entry.ref) {
       return {
         key, ref: entry.ref, description: entry.description ?? null,
-        storage: "1password",
+        storage: refStorage(entry.ref),
         required: entry.required ?? false,
         status: "configured" as VaultStatus, hasValue: false,
       };
@@ -345,7 +400,7 @@ export function getVaultStatuses(): VaultMappingStatus[] {
     if (inEnv) {
       return {
         key, ref: entry.ref ?? null, description: entry.description ?? null,
-        storage: entry.storage ?? (entry.ref ? "1password" : null),
+        storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : null),
         required: entry.required ?? false,
         status: "env-only" as VaultStatus, hasValue: true,
       };
@@ -361,27 +416,29 @@ export function getVaultStatuses(): VaultMappingStatus[] {
     }
 
     try {
-      const value = opRead(entry.ref);
+      const value = readRef(entry.ref);
       if (value) {
         process.env[key] = value; // cache
         return {
           key, ref: entry.ref, description: entry.description ?? null,
-          storage: "1password",
+          storage: refStorage(entry.ref),
           required: entry.required ?? false,
           status: "resolved" as VaultStatus, hasValue: true,
         };
       }
       return {
         key, ref: entry.ref, description: entry.description ?? null,
-        storage: "1password",
+        storage: refStorage(entry.ref),
         required: entry.required ?? false,
         status: "unresolved" as VaultStatus, hasValue: false,
-        error: "op read returned empty — check ref or 1Password auth",
+        error: refStorage(entry.ref) === "dashlane"
+          ? "dcli read returned empty — check ref or Dashlane auth (dcli sync)"
+          : "op read returned empty — check ref or 1Password auth",
       };
     } catch (e) {
       return {
         key, ref: entry.ref, description: entry.description ?? null,
-        storage: "1password",
+        storage: refStorage(entry.ref),
         required: entry.required ?? false,
         status: "error" as VaultStatus, hasValue: false,
         error: e instanceof Error ? e.message : "unknown error",


### PR DESCRIPTION
## Summary

Adds **Dashlane** as a second secret backend for the Secret Vault, alongside 1Password. Env-var references can now be `dl://<title-or-id>/<field>`, resolved through the Dashlane CLI (`dcli read`) — mirroring the existing `op://` / `op read` model.

The backing store is carried entirely by the reference **scheme**, so resolution, status, and validation dispatch on the prefix; no new persisted metadata.

## Changes
- `src/lib/vault.ts` — `validateDashlaneRef` + `dcliRead`, plus scheme dispatchers `readRef` / `validateRef` / `refStorage`. `resolveSecret` and both status reporters pick `op://` vs `dl://` automatically, with provider-aware error text.
- `src/app/api/vault/route.ts` — validate and classify `dl://` references.
- `src/components/vault-panel.tsx` — a **Dashlane** storage toggle, a `dl://…` reference input, a provider-aware status badge, and updated header copy.

## Requirements / notes
- Requires the Dashlane CLI (`dcli`) installed + authenticated (`dcli sync`) — same model as 1Password's `op`.
- `dcli` is **read-only**: secrets are created/edited in the Dashlane app; Cave only reads them.
- Reference format: `dl://<secret title or id>/<field>` (e.g. `dl://github.com/login`).

## Testing
- Typecheck clean.
- End-to-end against a live authenticated vault: POST a `dl://` mapping → `/api/vault` reports `storage: dashlane`, `status: resolved` (the status API never surfaces the value). Malformed refs (`dl://onlyid`) are rejected; an unauthenticated `dcli` fails gracefully → `unresolved` with a Dashlane-specific hint (no hang).

## Known limitation (follow-up)
Like the existing 1Password integration, the resolver invokes the CLI via `PATH`. An app launched from Finder gets a minimal `PATH`, so `dcli`/`op` may not be found in packaged builds. A follow-up PR augments the resolver's `PATH` to fix this for both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)