### PR TITLE
fix(vault): resolve secret CLIs via an augmented PATH

### DIFF
--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -17,7 +17,8 @@
 
 import { execFileSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { caveHome } from "./coven-paths.ts";
 import { readEnvLocalAll, readEnvLocalValue } from "./env-file.ts";
@@ -175,6 +176,27 @@ export function validateOpRef(ref: unknown): string | null {
   return null;
 }
 
+// Apps launched from Finder/Spotlight inherit a minimal PATH
+// (/usr/bin:/bin:/usr/sbin:/sbin), so a CLI installed under Homebrew or the
+// user's local bin — where `op` (and other resolver CLIs) typically live — is
+// not found, and every reference silently resolves to "unresolved" in packaged
+// builds even when the CLI is installed and authenticated. Augment PATH with
+// the well-known install locations before spawning, so resolution works the
+// same in a packaged app as it does when launched from a shell.
+function resolverEnv(): NodeJS.ProcessEnv {
+  const home = homedir();
+  const candidates = [
+    "/opt/homebrew/bin",
+    "/opt/homebrew/sbin",
+    "/usr/local/bin",
+    join(home, ".local", "bin"),
+    join(home, "bin"),
+  ];
+  const current = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  const merged = [...current, ...candidates.filter((dir) => !current.includes(dir))];
+  return { ...process.env, PATH: merged.join(delimiter) };
+}
+
 /** Call `op read` to fetch a secret reference. Returns null on failure. */
 function opRead(ref: string): string | null {
   if (validateOpRef(ref)) return null;
@@ -184,6 +206,7 @@ function opRead(ref: string): string | null {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 8000,
+      env: resolverEnv(),
     }).trim();
     return value || null;
   } catch {


### PR DESCRIPTION
## Summary

Secret references are resolved by spawning the backing CLI (`op read <ref>`). An app launched from Finder/Spotlight inherits a **minimal PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`), so a Homebrew- or `~/.local/bin`-installed `op` isn't found — every `op://` reference silently resolves to **unresolved** in packaged builds, even when `op` is installed and authenticated. It works in dev only because the shell's PATH is inherited.

This wraps the resolver spawn with an augmented PATH that includes the well-known install locations (Homebrew, `/usr/local/bin`, `~/.local/bin`, `~/bin`), so a packaged app resolves references the same as a shell-launched run.

## Change
- `src/lib/vault.ts` — a `resolverEnv()` helper; `opRead` now spawns with it.

## Note
Companion to #3076 (Dashlane `dcli` backend): its `dcliRead` should spawn with the same `resolverEnv()` for the identical reason. If both land, that's a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)