### PR TITLE
fix(profile): operator avatar preview 401s in the packaged app — serve it through an authenticated blob URL (cave-g8t8)

### DIFF
--- a/src/lib/user-profile.test.ts
+++ b/src/lib/user-profile.test.ts
@@ -22,6 +22,18 @@ describe("user-profile client store", () => {
   it("exposes avatar URL with an updatedAt cache-buster", () => {
     assert.match(source, /\/api\/profile\/avatar\?v=/);
   });
+  it("serves the avatar as a blob object URL fetched with the authenticated fetch", () => {
+    // Native <img src="/api/..."> requests can't carry the packaged app's
+    // sidecar token (only the patched window.fetch does) and 401 into the
+    // WebKit broken-image glyph — so components must get a blob: URL.
+    assert.match(source, /URL\.createObjectURL/);
+    assert.match(source, /return snapshot\.avatar\.objectUrl \?\? null/);
+    assert.doesNotMatch(source, /return `\/api\/profile\/avatar/);
+  });
+  it("revokes stale object URLs on replacement and removal", () => {
+    assert.match(source, /URL\.revokeObjectURL/);
+    assert.match(source, /clearAvatarObjectUrl\(\)/);
+  });
   it("reports avatar removal failures instead of silently succeeding", () => {
     assert.match(source, /export async function removeUserProfileAvatar\(\): Promise<SaveResult>/);
     assert.match(source, /return \{ ok: false, reason:/);

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -14,7 +14,7 @@ export type { UserProfile } from "@/lib/user-profile-shared";
 
 export type UserProfileSnapshot = {
   profile: UserProfile;
-  avatar: { present: boolean; updatedAt?: string };
+  avatar: { present: boolean; updatedAt?: string; objectUrl?: string };
 };
 
 const CHANNEL_NAME = "cave:user-profile";
@@ -44,6 +44,48 @@ function broadcast(): void {
   channel?.postMessage("changed");
 }
 
+/**
+ * The packaged app's sidecar requires an auth token on every /api/* request.
+ * Only the patched window.fetch (sidecar-auth-bridge) carries it — a native
+ * <img src="/api/profile/avatar"> request has no token and 401s, rendering the
+ * WebKit broken-image glyph. So the store fetches the bytes itself and hands
+ * components a same-origin blob: URL instead. While loading (or on failure)
+ * `objectUrl` stays unset and renderers fall back to the initial/icon.
+ */
+let avatarObjectUrl: string | null = null;
+let avatarLoadedFor: string | null = null;
+let avatarFetchSeq = 0;
+
+function avatarWithObjectUrl(avatar: { present: boolean; updatedAt?: string }): UserProfileSnapshot["avatar"] {
+  return avatar.present && avatarObjectUrl ? { ...avatar, objectUrl: avatarObjectUrl } : { ...avatar };
+}
+
+async function refreshAvatarObjectUrl(updatedAt: string): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (avatarLoadedFor === updatedAt && avatarObjectUrl) return;
+  const seq = ++avatarFetchSeq;
+  try {
+    const res = await fetch(`/api/profile/avatar?v=${encodeURIComponent(updatedAt)}`);
+    if (!res.ok) return;
+    const blob = await res.blob();
+    if (seq !== avatarFetchSeq) return; // superseded by a newer upload/removal
+    if (avatarObjectUrl) URL.revokeObjectURL(avatarObjectUrl);
+    avatarObjectUrl = URL.createObjectURL(blob);
+    avatarLoadedFor = updatedAt;
+    if (cached?.avatar.present) {
+      cached = { ...cached, avatar: { ...cached.avatar, objectUrl: avatarObjectUrl } };
+      notify();
+    }
+  } catch { /* keep the fallback rendering; next hydrate retries */ }
+}
+
+function clearAvatarObjectUrl(): void {
+  avatarFetchSeq++;
+  if (avatarObjectUrl) URL.revokeObjectURL(avatarObjectUrl);
+  avatarObjectUrl = null;
+  avatarLoadedFor = null;
+}
+
 async function hydrate(): Promise<void> {
   if (typeof window === "undefined") return;
   ensureChannel();
@@ -51,8 +93,11 @@ async function hydrate(): Promise<void> {
     const res = await fetch("/api/profile");
     const json = (await res.json()) as { ok?: boolean; profile?: UserProfile; avatar?: UserProfileSnapshot["avatar"] };
     if (res.ok && json?.ok) {
-      cached = { profile: json.profile ?? {}, avatar: json.avatar ?? { present: false } };
+      const avatar = json.avatar ?? { present: false };
+      if (!avatar.present) clearAvatarObjectUrl();
+      cached = { profile: json.profile ?? {}, avatar: avatarWithObjectUrl(avatar) };
       notify();
+      if (avatar.present) void refreshAvatarObjectUrl(avatar.updatedAt ?? "0");
     }
   } catch { /* daemon offline — keep previous snapshot (or null → "You") */ }
 }
@@ -92,12 +137,14 @@ export async function uploadUserProfileAvatar(image: { dataUrl: string; mime: st
   if (!res || !res.ok || !json?.ok) {
     return { ok: false, reason: json?.error ?? "Could not upload image." };
   }
+  const updatedAt = json.updatedAt ?? new Date().toISOString();
   cached = {
     profile: cached?.profile ?? {},
-    avatar: { present: true, updatedAt: json.updatedAt ?? new Date().toISOString() },
+    avatar: avatarWithObjectUrl({ present: true, updatedAt }),
   };
   notify();
   broadcast();
+  void refreshAvatarObjectUrl(updatedAt);
   return { ok: true };
 }
 
@@ -105,6 +152,7 @@ export async function removeUserProfileAvatar(): Promise<SaveResult> {
   const res = await fetch("/api/profile/avatar", { method: "DELETE" }).catch(() => null);
   const json = res ? ((await res.json().catch(() => null)) as { error?: string } | null) : null;
   if (!res?.ok) return { ok: false, reason: json?.error ?? "Could not remove image." };
+  clearAvatarObjectUrl();
   cached = { profile: cached?.profile ?? {}, avatar: { present: false } };
   notify();
   broadcast();
@@ -126,10 +174,13 @@ export function readUserProfileSnapshot(): UserProfileSnapshot | null {
   return cached;
 }
 
-/** `/api/profile/avatar?v=<updatedAt>` when present, else null. */
+/** Same-origin blob: URL for the stored avatar, fetched with the authenticated
+ *  fetch (the packaged app's sidecar token never reaches native <img> requests).
+ *  Null while absent, still loading, or when the fetch failed — callers render
+ *  their initial/icon fallback instead of a broken image. */
 export function userAvatarUrl(snapshot: UserProfileSnapshot | null): string | null {
   if (!snapshot?.avatar.present) return null;
-  return `/api/profile/avatar?v=${encodeURIComponent(snapshot.avatar.updatedAt ?? "0")}`;
+  return snapshot.avatar.objectUrl ?? null;
 }
 
 /** Resolves once the profile has been fetched (used by the avatar migration). */


### PR DESCRIPTION
## Problem

In the packaged `CovenCave.app`, uploading a profile image in **Settings → Profile** succeeds, but the preview immediately shows WebKit's broken-image glyph (and the chat avatar breaks the same way).

## Root cause

- The packaged sidecar requires the auth token on **every** `/api/*` request (`src/proxy.ts`).
- The sidecar-auth-bridge patches `window.fetch` to attach `x-coven-cave-token` — but a native `<img src="/api/profile/avatar?v=…">` request carries no token (the bridge also strips the token from the page URL, so the Referer fallback is empty).
- Result: `401 {"ok":false,"error":"unauthorized"}` → broken-image glyph. Verified live against the installed app's sidecar (401) vs the tokenless dev server (200); the uploaded file itself is a valid PNG under `~/.coven/`.

## Fix

`src/lib/user-profile.ts` (fixes both render sites — Settings preview and `UserChatAvatar`):

- The store fetches the avatar bytes itself via the **authenticated** `fetch` and exposes a same-origin `blob:` object URL on the snapshot; `userAvatarUrl()` now returns that.
- Stale object URLs are revoked on replace/remove; a sequence counter guards refresh races (upload/remove superseding an in-flight fetch).
- While loading or on any failure, `userAvatarUrl()` returns `null` → renderers fall back to the initial/icon. A broken-image glyph can no longer render.

## Verification

- `pnpm typecheck` — clean
- `pnpm test:app` — 661 test files pass
- New source-pinned assertions in `src/lib/user-profile.test.ts` (blob URL, revocation, no raw API URL returned)
- Behavioral smoke against the real store module with mocked `fetch`/`URL`: hydrate → blob URL; upload → new blob + old revoked; remove → null + revoked; **401 byte-fetch degrades to fallback**, never a broken URL

Bead: `cave-g8t8`