### PR TITLE
fix(images): render API-served avatars through an authenticated blob URL (cave-wgc2)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -51,6 +51,7 @@ export const SUITES = {
     "src/lib/user-profile.test.ts",
     "src/lib/legacy-svg-avatar-hint.test.ts",
     "src/lib/familiar-avatar-src.test.ts",
+    "src/lib/authed-image.test.ts",
     "src/lib/app-update.test.ts",
     "src/lib/about-status.test.ts",
     "src/lib/about-diagnostics.test.ts",

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type CSSProperties } from "react";
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
+import { AuthedImage } from "@/components/ui/authed-image";
 import type { DashboardModel } from "@/lib/dashboard-model";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -791,7 +792,7 @@ function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; l
         <a key={r.id} className="cockpit-fam__row" role="row" href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}>
           <span className="cockpit-fam__who" role="cell">
             <span className="cockpit-fam__avatar" style={{ background: r.color }}>
-              {r.avatarUrl ? <img src={r.avatarUrl} alt="" /> : (r.emoji || r.name.slice(0, 1).toUpperCase())}
+              <AuthedImage src={r.avatarUrl} alt="" fallback={r.emoji || r.name.slice(0, 1).toUpperCase()} />
               {r.active ? <span className="cockpit-fam__on" title="Active session" /> : null}
             </span>
             <span className="cockpit-fam__id">

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/familiar-analytics-data";
 import type { FeedbackSliceStat, MessageFeedbackRollup } from "@/lib/message-feedback-rollup";
 import { Button } from "@/components/ui/button";
+import { AuthedImage } from "@/components/ui/authed-image";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PulseBars } from "@/components/ui/pulse-bars";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -877,11 +878,12 @@ export function FamiliarAnalyticsContent({
 
       <header className="fa-header">
         <div className="fa-header__identity">
-          {model.familiar?.avatarUrl ? (
-            <img className="fa-avatar" src={model.familiar.avatarUrl} alt={familiarName} />
-          ) : (
-            <span className="fa-avatar" aria-hidden>{familiarName.slice(0, 1).toUpperCase()}</span>
-          )}
+          <AuthedImage
+            className="fa-avatar"
+            src={model.familiar?.avatarUrl}
+            alt={familiarName}
+            fallback={<span className="fa-avatar" aria-hidden>{familiarName.slice(0, 1).toUpperCase()}</span>}
+          />
           <div>
             <p className="retro-eyebrow">
               <Icon name="ph:chart-bar-bold" aria-hidden />

--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -20,7 +20,9 @@ assert.match(source, /rounded-\[var\(--radius-control\)\]/, "default avatar radi
 // avatar → Cave-local upload) and only renders the glyph once all sources fail.
 assert.match(source, /avatarImageFallback/, "must consume the fallback image source");
 assert.match(source, /onError=\{\(\) => setSrcIdx\(\(i\) => i \+ 1\)\}/, "img must advance to the next source on load error");
-assert.match(source, /const hasImage = Boolean\(currentSrc\)/, "render must gate the img on a resolvable current source");
+assert.match(source, /const hasImage = Boolean\(resolvedSrc\)/, "render must gate the img on a resolved authed source");
+assert.match(source, /useAuthedImageState\(rawSrc\)/, "current source must resolve through the authed image state");
+assert.match(source, /if \(status === "error"\) setSrcIdx\(\(i\) => i \+ 1\);/, "a failed authed fetch must advance to the next source");
 assert.match(source, /useEffect\(\s*\(\) => \{\s*setSrcIdx\(0\);\s*\}, \[familiar\.avatarImage, familiar\.avatarImageFallback\]\)/, "source index must reset when either avatar src changes");
 
 // The enlarged preview can carry footer actions (e.g. the inline card's

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
 import { AvatarLightbox } from "./ui/avatar-lightbox";
+import { useAuthedImageState } from "@/lib/authed-image";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type Size = "sm" | "md" | "lg" | "xl";
@@ -42,12 +43,25 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
     setSrcIdx(0);
   }, [familiar.avatarImage, familiar.avatarImageFallback]);
 
-  const currentSrc = sources[srcIdx];
-  const hasImage = Boolean(currentSrc);
+  // The workspace avatar source is `/api/familiars/<id>/avatar`, which the
+  // packaged sidecar gates behind an auth token that a native <img> can't
+  // carry — it would 401 into the broken-image glyph. Resolve the current
+  // source through the authed fetch (→ a blob: URL); data-URL uploads and
+  // http(s) sources pass through untouched. A genuine fetch failure advances
+  // the fallback chain exactly like a native decode error would.
+  const rawSrc = sources[srcIdx];
+  const { url: resolvedSrc, status } = useAuthedImageState(rawSrc);
+  useEffect(() => {
+    if (status === "error") setSrcIdx((i) => i + 1);
+  }, [status, rawSrc]);
+
+  // Render the image once resolved (`ready`); while an authed fetch is still in
+  // flight, hold on the glyph placeholder rather than flashing a broken image.
+  const hasImage = Boolean(resolvedSrc);
 
   const imgEl = hasImage ? (
     <img
-      src={currentSrc}
+      src={resolvedSrc ?? undefined}
       alt={familiar.display_name}
       width={px}
       height={px}
@@ -64,9 +78,9 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
     />
   );
 
-  if (expandable && hasImage) {
+  if (expandable && hasImage && resolvedSrc) {
     return (
-      <AvatarLightbox src={currentSrc} label={familiar.display_name} footerActions={expandFooterActions}>
+      <AvatarLightbox src={resolvedSrc} label={familiar.display_name} footerActions={expandFooterActions}>
         {imgEl}
       </AvatarLightbox>
     );

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { PulseBars } from "@/components/ui/pulse-bars";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { AuthedImage } from "@/components/ui/authed-image";
 import {
   buildFamiliarCardStats,
   type CovenMemoryEntry,
@@ -301,13 +302,16 @@ export function FamiliarGrowthView({
                       aria-pressed={selectedItem}
                       onClick={() => setSelectedFamiliarId(familiar.id)}
                     >
-                      {familiar.avatarUrl ? (
-                        <img className="retro-avatar growth-familiar__avatar" src={familiar.avatarUrl} alt="" />
-                      ) : (
-                        <span className="retro-avatar growth-familiar__avatar">
-                          {familiar.display_name.slice(0, 1).toUpperCase()}
-                        </span>
-                      )}
+                      <AuthedImage
+                        className="retro-avatar growth-familiar__avatar"
+                        src={familiar.avatarUrl}
+                        alt=""
+                        fallback={
+                          <span className="retro-avatar growth-familiar__avatar">
+                            {familiar.display_name.slice(0, 1).toUpperCase()}
+                          </span>
+                        }
+                      />
                       <span className="growth-familiar__copy">
                         <b>{familiar.display_name}</b>
                         <small>{familiar.role || familiar.harness || "familiar"}</small>

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -172,8 +172,8 @@ assert.match(
 
 assert.match(
   source,
-  /familiar\.avatarImage \?[\s\S]*className="h-full w-full object-cover"/,
-  "Avatar preview enlarges uploaded avatar images",
+  /<AuthedImage[\s\S]*src=\{familiar\.avatarImage\}[\s\S]*className="h-full w-full object-cover"[\s\S]*fallback=/,
+  "Avatar preview enlarges uploaded avatar images via the authenticated image renderer",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -13,6 +13,7 @@ import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { AuthedImage } from "@/components/ui/authed-image";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
 import type { FileMemoryEntry, MemoryFeed } from "@/components/familiars-memory-view";
 import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
@@ -1003,15 +1004,12 @@ function FamiliarAvatarPreviewOverlay({ familiar, onClose }: FamiliarAvatarPrevi
     >
       <div className="flex flex-col items-center gap-3 text-center">
         <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
-          {familiar.avatarImage ? (
-            <img
-              src={familiar.avatarImage}
-              alt={`${familiar.display_name} avatar`}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <FamiliarAvatar familiar={familiar} size="xl" />
-          )}
+          <AuthedImage
+            src={familiar.avatarImage}
+            alt={`${familiar.display_name} avatar`}
+            className="h-full w-full object-cover"
+            fallback={<FamiliarAvatar familiar={familiar} size="xl" />}
+          />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[14px] font-semibold text-[var(--text-primary)]">

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/command-controls";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { Icon, type IconName } from "@/lib/icon";
+import { AuthedImage } from "@/components/ui/authed-image";
 import type { Familiar } from "@/lib/types";
 import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
@@ -70,12 +71,17 @@ function initials(familiar: Familiar): string {
 
 export function FamiliarMark({ familiar, size = "sm" }: { familiar: Familiar; size?: "sm" | "md" }) {
   const sizeClass = size === "md" ? "h-6 w-6 text-[10px]" : "h-5 w-5 text-[9px]";
-  return familiar.avatarUrl ? (
-    <img src={familiar.avatarUrl} alt="" className={`${sizeClass} rounded-[var(--radius-control)] object-cover`} />
-  ) : (
-    <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
-      {initials(familiar)}
-    </span>
+  return (
+    <AuthedImage
+      src={familiar.avatarUrl}
+      alt=""
+      className={`${sizeClass} rounded-[var(--radius-control)] object-cover`}
+      fallback={
+        <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
+          {initials(familiar)}
+        </span>
+      }
+    />
   );
 }
 

--- a/src/components/ui/authed-image.tsx
+++ b/src/components/ui/authed-image.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ImgHTMLAttributes, ReactNode } from "react";
+import { useAuthedImageState } from "@/lib/authed-image";
+
+type Props = Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> & {
+  /**
+   * Image source. A same-origin `/api/...` URL is fetched through the patched
+   * `window.fetch` (which carries the sidecar auth token) and rendered as a
+   * `blob:` URL, so it survives the packaged app's fail-closed `/api/` gate.
+   * `data:` / `blob:` / cross-origin sources render directly. See
+   * {@link file://src/lib/authed-image.ts} for the why.
+   */
+  src: string | null | undefined;
+  /** Rendered while the authenticated fetch is in flight or after it fails. */
+  fallback?: ReactNode;
+};
+
+/**
+ * Drop-in `<img>` replacement that never paints WebKit's broken-image glyph for
+ * an authenticated `/api/...` source in the packaged app. Prefer this over a raw
+ * `<img src="/api/...">` anywhere an API-served image is displayed.
+ */
+export function AuthedImage({ src, fallback = null, alt = "", ...rest }: Props) {
+  const { url } = useAuthedImageState(src);
+  if (!url) return <>{fallback}</>;
+  return <img src={url} alt={alt} {...rest} />;
+}

--- a/src/lib/authed-image.test.ts
+++ b/src/lib/authed-image.test.ts
@@ -32,13 +32,14 @@ import { needsAuthedImageFetch } from "./authed-image.ts";
   );
 }
 
-// No window (SSR/node): a bare `/api/...` path can't be resolved, so we must not
-// claim it needs an authed fetch — the effect re-runs client-side anyway.
+// No window (SSR/node): still treat a relative `/api/...` path as needing an
+// authed fetch so server-rendered HTML never emits a raw <img src="/api/...">
+// that will 401 before hydration.
 {
   assert.equal(
     needsAuthedImageFetch("/api/familiars/x/avatar"),
-    false,
-    "no window → false (SSR defers to the client effect)",
+    true,
+    "no window + relative /api/* → true (avoid SSR broken-image fetch)",
   );
 }
 

--- a/src/lib/authed-image.test.ts
+++ b/src/lib/authed-image.test.ts
@@ -1,0 +1,142 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { needsAuthedImageFetch } from "./authed-image.ts";
+
+// --- needsAuthedImageFetch --------------------------------------------------
+// This predicate decides which sources must go through the authenticated fetch
+// (→ blob URL) to survive the packaged app's `/api/` auth gate. It MUST agree
+// with the sidecar auth bridge's own "is this an /api request" condition:
+// same-origin + pathname starts with `/api/`. Everything else renders directly.
+
+// Empty inputs never need a fetch.
+{
+  assert.equal(needsAuthedImageFetch(null), false, "null → false");
+  assert.equal(needsAuthedImageFetch(undefined), false, "undefined → false");
+  assert.equal(needsAuthedImageFetch(""), false, "empty string → false");
+}
+
+// data:/blob: payloads carry their own bytes and are checked before window, so
+// they classify correctly even under SSR (no window).
+{
+  assert.equal(
+    needsAuthedImageFetch("data:image/png;base64,AAAA"),
+    false,
+    "data: URL → false (self-contained)",
+  );
+  assert.equal(
+    needsAuthedImageFetch("blob:https://app.local/abc"),
+    false,
+    "blob: URL → false (already an object URL)",
+  );
+}
+
+// No window (SSR/node): a bare `/api/...` path can't be resolved, so we must not
+// claim it needs an authed fetch — the effect re-runs client-side anyway.
+{
+  assert.equal(
+    needsAuthedImageFetch("/api/familiars/x/avatar"),
+    false,
+    "no window → false (SSR defers to the client effect)",
+  );
+}
+
+// In a browser window the same-origin /api rule kicks in.
+{
+  const had = "window" in globalThis;
+  const prev = globalThis.window;
+  try {
+    globalThis.window = { location: { href: "https://app.local/home", origin: "https://app.local" } };
+
+    assert.equal(
+      needsAuthedImageFetch("/api/familiars/cody/avatar?v=1&format=png"),
+      true,
+      "same-origin relative /api/* → true",
+    );
+    assert.equal(
+      needsAuthedImageFetch("https://app.local/api/profile/avatar"),
+      true,
+      "same-origin absolute /api/* → true",
+    );
+    assert.equal(
+      needsAuthedImageFetch("/_next/static/media/x.png"),
+      false,
+      "same-origin non-/api asset → false",
+    );
+    assert.equal(
+      needsAuthedImageFetch("https://avatars.githubusercontent.com/u/1"),
+      false,
+      "cross-origin (GitHub avatar) → false",
+    );
+  } finally {
+    if (had) globalThis.window = prev;
+    else delete globalThis.window;
+  }
+}
+
+// --- source invariants ------------------------------------------------------
+// The stateful hook + cache are awkward to exercise without a DOM, so pin their
+// load-bearing behaviors against the source the way user-profile.test.ts does.
+const source = readFileSync(
+  fileURLToPath(new URL("./authed-image.ts", import.meta.url)),
+  "utf8",
+);
+
+// The whole point: fetch bytes (through the patched window.fetch) and hand back
+// a blob object URL, never the raw /api URL.
+assert.match(source, /await fetch\(src\)/, "fetches the source via window.fetch");
+assert.match(source, /URL\.createObjectURL\(blob\)/, "creates a blob object URL");
+
+// A failed fetch must surface as an "error" status so fallback chains advance,
+// and must not poison the cache (so a later mount can retry).
+assert.match(source, /status: "error"/, "reports an error status on failure");
+assert.match(source, /cache\.delete\(src\)/, "drops the failed entry for retry");
+
+// The shared cache is bounded and revokes object URLs on eviction (no leaks) and
+// must NOT revoke on unmount (that races other live consumers of the blob).
+assert.match(source, /URL\.revokeObjectURL/, "revokes object URLs on eviction");
+assert.match(source, /MAX_CACHE_ENTRIES/, "bounds the cache with an LRU cap");
+assert.doesNotMatch(
+  source,
+  /revokeObjectURL[\s\S]{0,120}unmount/i,
+  "does not revoke on unmount",
+);
+
+// --- call-site wiring -------------------------------------------------------
+// The central familiar avatar and every direct render site must route their
+// /api-backed source through the primitive, not a raw <img src="/api/...">.
+function read(rel) {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}
+
+const familiarAvatar = read("../components/familiar-avatar.tsx");
+assert.match(familiarAvatar, /useAuthedImageState/, "FamiliarAvatar uses the authed hook");
+assert.match(
+  familiarAvatar,
+  /status === "error"/,
+  "FamiliarAvatar advances its fallback chain on a fetch error",
+);
+assert.doesNotMatch(
+  familiarAvatar,
+  /src=\{currentSrc\}/,
+  "FamiliarAvatar no longer renders the raw source directly",
+);
+
+for (const rel of [
+  "../components/quick-chat-controls.tsx",
+  "../components/familiar-growth-view.tsx",
+  "../components/familiar-analytics-view.tsx",
+  "../components/familiars-view.tsx",
+  "../components/dashboard/dashboard-cockpit.tsx",
+]) {
+  const src = read(rel);
+  assert.match(src, /AuthedImage/, `${rel} renders avatars via <AuthedImage>`);
+  assert.doesNotMatch(
+    src,
+    /<img[^>]*src=\{[^}]*avatarUrl\}/,
+    `${rel} has no raw <img src={...avatarUrl}>`,
+  );
+}
+
+console.log("authed-image.test.ts: ok");

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -104,6 +104,7 @@ function loadAuthedObjectUrl(src: string): Promise<string | null> {
         evictOldestIfNeeded();
       }
       return objectUrl;
+    } catch {
       // Drop the failed entry so a later mount can retry (e.g. daemon came
       // back online); callers render their initial/glyph fallback meanwhile.
       cache.delete(src);

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * # Authenticated image loading for the packaged sidecar
+ *
+ * In the packaged app the Next.js server runs as a sidecar that requires the
+ * `x-coven-cave-token` header on every `/api/*` request (see
+ * `src/components/security/sidecar-auth-bridge.tsx` and the fail-closed gate in
+ * `src/proxy.ts`). The bridge patches `window.fetch` / `window.EventSource` to
+ * inject that token — but NATIVE image loads (`<img src="/api/...">`, CSS
+ * `background-image: url(/api/...)`, `new Image()`, SVG `<image href>`) go
+ * straight to the network without it, so the sidecar answers 401 and WebKit
+ * paints its broken-image glyph. That is the single root cause behind the
+ * recurring "avatars/images won't render" bugs (profile avatar cave-g8t8,
+ * quick-chat detach cave-pzyy, and every familiar/project/skill image surface).
+ *
+ * The fix is uniform: fetch the bytes through the patched `window.fetch` (which
+ * DOES carry the token) and hand renderers a same-origin `blob:` object URL.
+ * `useAuthedImageUrl` / `<AuthedImage>` (in `src/components/ui/authed-image.tsx`)
+ * are the shared primitives so no surface has to reinvent this — mirroring the
+ * bespoke store-level solution already living in `src/lib/user-profile.ts`.
+ *
+ * Sources that are already self-contained (`data:`, `blob:`) or cross-origin
+ * (e.g. GitHub `avatars.githubusercontent.com`) don't need — and must not get —
+ * the token, so they pass through untouched with no fetch and no flash.
+ */
+
+/**
+ * True when `src` is a same-origin `/api/...` URL that the sidecar gates behind
+ * the auth token. This deliberately mirrors the exact condition the auth bridge
+ * uses to decide which `fetch` calls to stamp, so the two never disagree about
+ * what "an authenticated request" is.
+ */
+export function needsAuthedImageFetch(src: string | null | undefined): boolean {
+  if (!src) return false;
+  // Already-inline payloads carry their own bytes — never same-origin API.
+  if (src.startsWith("data:") || src.startsWith("blob:")) return false;
+  if (typeof window === "undefined") return false;
+  try {
+    const url = new URL(src, window.location.href);
+    return url.origin === window.location.origin && url.pathname.startsWith("/api/");
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared object-URL cache
+//
+// Familiar lists, chat headers, and the composer render the SAME cache-busted
+// avatar URL many times over. Fetching per-mount would hammer the sidecar and
+// churn object URLs, so identical URLs share one in-flight fetch and one blob.
+// URLs are cache-busted by mtime (`?v=<mtimeMs>`), so a superseded avatar is
+// simply never requested again — we bound growth with a small LRU and revoke on
+// eviction. We intentionally do NOT revoke on unmount (that races other live
+// consumers of the same shared blob and reintroduces the broken-image glyph).
+// ---------------------------------------------------------------------------
+
+type CacheEntry = { objectUrl: string | null; promise: Promise<string | null> };
+
+const MAX_CACHE_ENTRIES = 64;
+const cache = new Map<string, CacheEntry>();
+
+function evictOldestIfNeeded(): void {
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value as string | undefined;
+    if (oldestKey === undefined) break;
+    const evicted = cache.get(oldestKey);
+    cache.delete(oldestKey);
+    if (evicted?.objectUrl) URL.revokeObjectURL(evicted.objectUrl);
+  }
+}
+
+function loadAuthedObjectUrl(src: string): Promise<string | null> {
+  const existing = cache.get(src);
+  if (existing) {
+    // Refresh LRU recency on hit.
+    cache.delete(src);
+    cache.set(src, existing);
+    return existing.promise;
+  }
+
+  const promise = (async (): Promise<string | null> => {
+    try {
+      // Bare `fetch` on purpose: the sidecar auth bridge has patched
+      // `window.fetch` to stamp the token onto same-origin `/api/` requests.
+      const res = await fetch(src);
+      if (!res.ok) throw new Error(`image fetch ${res.status}`);
+      const blob = await res.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const entry = cache.get(src);
+      if (entry) entry.objectUrl = objectUrl;
+      return objectUrl;
+    } catch {
+      // Drop the failed entry so a later mount can retry (e.g. daemon came
+      // back online); callers render their initial/glyph fallback meanwhile.
+      cache.delete(src);
+      return null;
+    }
+  })();
+
+  cache.set(src, { objectUrl: null, promise });
+  evictOldestIfNeeded();
+  return promise;
+}
+
+export type AuthedImageStatus = "idle" | "loading" | "ready" | "error";
+
+export type AuthedImageState = {
+  /** The URL to hand a native renderer, or `null` while loading / on failure. */
+  url: string | null;
+  status: AuthedImageStatus;
+};
+
+/**
+ * Resolve an image `src` to something a native renderer can actually display in
+ * the packaged app, reporting the load status so callers with a fallback chain
+ * (e.g. `FamiliarAvatar`) can advance to the next source on a genuine failure.
+ *
+ * - `null`/empty → `{ url: null, status: "idle" }`.
+ * - `data:` / `blob:` / cross-origin → `{ url: src, status: "ready" }`
+ *   synchronously — no fetch, no flash (native `<img onError>` still catches a
+ *   later decode failure).
+ * - same-origin `/api/...` → `status: "loading"` (url `null`) until the
+ *   authenticated fetch resolves to a `blob:` URL (`"ready"`) or fails
+ *   (`"error"`, url `null`).
+ */
+export function useAuthedImageState(src: string | null | undefined): AuthedImageState {
+  const passthrough = src && !needsAuthedImageFetch(src) ? src : null;
+  const [state, setState] = useState<AuthedImageState>(() => {
+    // Seed synchronously from cache so re-renders of an already-loaded avatar
+    // don't flash the fallback.
+    if (src && needsAuthedImageFetch(src)) {
+      const cached = cache.get(src)?.objectUrl ?? null;
+      return cached ? { url: cached, status: "ready" } : { url: null, status: "loading" };
+    }
+    return { url: null, status: "idle" };
+  });
+
+  useEffect(() => {
+    if (!src || !needsAuthedImageFetch(src)) {
+      setState({ url: null, status: "idle" });
+      return;
+    }
+    let active = true;
+    const cached = cache.get(src)?.objectUrl;
+    if (cached) {
+      setState({ url: cached, status: "ready" });
+      return;
+    }
+    setState({ url: null, status: "loading" });
+    void loadAuthedObjectUrl(src).then((resolved) => {
+      if (!active) return;
+      setState(resolved ? { url: resolved, status: "ready" } : { url: null, status: "error" });
+    });
+    return () => {
+      active = false;
+    };
+  }, [src]);
+
+  if (passthrough) return { url: passthrough, status: "ready" };
+  return state;
+}
+
+/**
+ * Convenience wrapper returning just the resolved URL (or `null`). Use this for
+ * simple sites; reach for {@link useAuthedImageState} when you need to react to
+ * a load failure (e.g. advancing a fallback chain).
+ */
+export function useAuthedImageUrl(src: string | null | undefined): string | null {
+  return useAuthedImageState(src).url;
+}
+
+/** Test-only: clear the shared cache (and revoke its object URLs). */
+export function __resetAuthedImageCacheForTests(): void {
+  for (const entry of cache.values()) {
+    if (entry.objectUrl) URL.revokeObjectURL(entry.objectUrl);
+  }
+  cache.clear();
+}

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -96,9 +96,11 @@ function loadAuthedObjectUrl(src: string): Promise<string | null> {
       const blob = await res.blob();
       const objectUrl = URL.createObjectURL(blob);
       const entry = cache.get(src);
-      if (entry) entry.objectUrl = objectUrl;
+      if (entry) {
+        entry.objectUrl = objectUrl;
+        evictOldestIfNeeded();
+      }
       return objectUrl;
-    } catch {
       // Drop the failed entry so a later mount can retry (e.g. daemon came
       // back online); callers render their initial/glyph fallback meanwhile.
       cache.delete(src);

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -69,12 +69,15 @@ const MAX_CACHE_ENTRIES = 64;
 const cache = new Map<string, CacheEntry>();
 
 function evictOldestIfNeeded(): void {
-  while (cache.size > MAX_CACHE_ENTRIES) {
-    const oldestKey = cache.keys().next().value as string | undefined;
-    if (oldestKey === undefined) break;
-    const evicted = cache.get(oldestKey);
-    cache.delete(oldestKey);
-    if (evicted?.objectUrl) URL.revokeObjectURL(evicted.objectUrl);
+  if (cache.size <= MAX_CACHE_ENTRIES) return;
+
+  // Only evict entries that have an object URL. Evicting an in-flight entry
+  // would lose the reference needed to revoke its eventual object URL.
+  for (const [key, entry] of cache) {
+    if (cache.size <= MAX_CACHE_ENTRIES) break;
+    if (!entry.objectUrl) continue;
+    cache.delete(key);
+    URL.revokeObjectURL(entry.objectUrl);
   }
 }
 

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -37,6 +37,11 @@ export function needsAuthedImageFetch(src: string | null | undefined): boolean {
   if (!src) return false;
   // Already-inline payloads carry their own bytes — never same-origin API.
   if (src.startsWith("data:") || src.startsWith("blob:")) return false;
+
+  // Relative /api URLs are always same-origin (and this prevents SSR from
+  // emitting a raw <img src="/api/..."> that will 401 before hydration).
+  if (src.startsWith("/api/")) return true;
+
   if (typeof window === "undefined") return false;
   try {
     const url = new URL(src, window.location.href);


### PR DESCRIPTION
## Root cause — why so many avatar/image bugs

Every "avatars/images won't render" bug shares **one systemic cause**. In the packaged app the Next.js server runs as a sidecar that gates **every `/api/*` request** behind the `x-coven-cave-token` header (`src/proxy.ts`, fail-closed). Only the patched `window.fetch` / `EventSource` in `sidecar-auth-bridge.tsx` carries that token — a **native `<img src="/api/...">` request has no token, so it 401s into WebKit's broken-image glyph**.

Because the token is invisible to native image loads, this bit every surface that renders an `/api/*` image, and it was being fixed **one surface at a time** (profile avatar `cave-g8t8`, quick-chat detach `cave-pzyy`) rather than at the root — classic whack-a-mole.

## Comprehensive fix

A single shared primitive that fetches bytes through the **patched** `fetch` (which carries the token) and hands renderers a same-origin `blob:` URL, passing `data:` / `blob:` / cross-origin sources through untouched:

- **`src/lib/authed-image.ts`** — `useAuthedImageUrl` / `useAuthedImageState` hooks + `needsAuthedImageFetch` classifier (mirrors the bridge's own "is this an `/api` request" rule). Shared **LRU object-URL cache** (revoke on eviction, never on unmount → no leaks, no races), and an `error` status so fallback chains advance on a real 404.
- **`src/components/ui/authed-image.tsx`** — `<AuthedImage>`, a drop-in `<img>` with a `fallback`.

Routed every `/api`-backed render through it:

| Surface | Was |
|---|---|
| `FamiliarAvatar` (central — all 20 `<FamiliarAvatar>` call sites: chat, boards, switcher, …) | `<img src={avatarImage}>` (= `/api/familiars/[id]/avatar`) |
| `familiars-view` (lightbox preview) | `<img src={familiar.avatarImage}>` |
| `familiar-analytics-view` | `<img src={model.familiar.avatarUrl}>` |
| `familiar-growth-view` | `<img src={familiar.avatarUrl}>` |
| `quick-chat-controls` (`FamiliarMark`) | `<img src={familiar.avatarUrl}>` |
| `dashboard-cockpit` | `<img src={r.avatarUrl}>` |

**Left untouched (correctly safe):** GitHub avatars (cross-origin), data-URL uploads, blob-preview sources, and profile avatars (already on the equivalent blob path).

## Verification

- `pnpm typecheck` ✅
- `pnpm build` (the **Frontend build** required check; runs ESLint) ✅ — bundle-budget within budget
- New `src/lib/authed-image.test.ts` ✅ (classifier + source invariants + call-site wiring), wired into `SUITES.app`
- `pnpm check:tests-wired` ✅

Closes bead cave-wgc2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)