### PR TITLE
fix(vault): stop stale encrypted orphans shadowing op:// ref mappings

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -624,6 +624,7 @@ export const SUITES = {
     "src/components/ui/relative-time.test.ts",
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",
+    "src/lib/vault-ref-shadowing.test.ts",
     "src/lib/cave-board-atomic.test.ts",
     "src/lib/server/atomic-write.test.ts",
     "src/lib/server/local-origin.test.ts",

--- a/src/lib/vault-ref-shadowing.test.ts
+++ b/src/lib/vault-ref-shadowing.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+// Regression (cave-6iee): the vault map's declared backend must win. A stale
+// orphaned entry in the local encrypted store used to shadow a newer op://
+// reference for the same key — resolveSecret() and the status reporters
+// checked hasLocalEncryptedSecret() before entry.ref, so the ref was never
+// consulted and the UI kept showing "encrypted" for a mapping the user had
+// switched to 1Password.
+
+const home = mkdtempSync(join(tmpdir(), "cave-vault-shadow-home-"));
+const fakeBin = mkdtempSync(join(tmpdir(), "cave-vault-shadow-bin-"));
+const vaultYaml = join(home, "vault.yaml");
+
+// Fake `op` binary so ref resolution is deterministic and never invokes a
+// real (possibly interactive) 1Password CLI.
+const opPath = join(fakeBin, "op");
+writeFileSync(opPath, "#!/bin/sh\necho from-op\n");
+chmodSync(opPath, 0o755);
+
+process.env.COVEN_HOME = home;
+process.env.COVEN_VAULT_FILE = vaultYaml;
+process.env.COVEN_CAVE_ENV_FILE = join(home, ".env.local"); // nonexistent — isolates from the repo's .env.local
+process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ""}`;
+delete process.env.COVEN_CAVE_BUNDLE;
+const KEYS = ["SHADOWED_REF_KEY", "SHADOWED_STATUS_KEY", "DECLARED_ENC_KEY", "UNMAPPED_ENC_KEY"];
+for (const key of KEYS) delete process.env[key];
+
+writeFileSync(vaultYaml, [
+  "SHADOWED_REF_KEY:",
+  '  ref: "op://Dev/Item/field"',
+  "SHADOWED_STATUS_KEY:",
+  '  ref: "op://Dev/Item/field"',
+  "DECLARED_ENC_KEY:",
+  '  storage: "encrypted"',
+  "",
+].join("\n"));
+
+const { setLocalEncryptedSecret } = await import("./local-encrypted-vault.ts");
+const { getVaultMetadataStatuses, getVaultStatuses, resolveSecret } = await import("./vault.ts");
+
+// Seed stale/orphaned encrypted values for the ref-mapped keys, a legitimate
+// declared-encrypted value, and an unmapped orphan that must keep resolving.
+setLocalEncryptedSecret("SHADOWED_REF_KEY", "stale-encrypted");
+setLocalEncryptedSecret("SHADOWED_STATUS_KEY", "stale-encrypted");
+setLocalEncryptedSecret("DECLARED_ENC_KEY", "declared-encrypted");
+setLocalEncryptedSecret("UNMAPPED_ENC_KEY", "unmapped-encrypted");
+
+// 1. The ref wins over the orphaned encrypted value.
+assert.equal(resolveSecret("SHADOWED_REF_KEY"), "from-op", "ref mapping resolves via op, not the stale encrypted orphan");
+
+// 2. Metadata status (no secret reads) reports the ref backend, not "encrypted".
+const meta = getVaultMetadataStatuses().find((s) => s.key === "SHADOWED_STATUS_KEY");
+assert.equal(meta?.status, "configured", "metadata status for a ref mapping is configured, not encrypted");
+assert.equal(meta?.storage, "1password");
+
+// 3. Live status resolves the ref and labels it by its ref backend.
+const statuses = getVaultStatuses();
+const shadowed = statuses.find((s) => s.key === "SHADOWED_STATUS_KEY");
+assert.equal(shadowed?.status, "resolved", "live status for a ref mapping resolves the ref");
+assert.equal(shadowed?.storage, "1password");
+
+// 4. A mapping declared encrypted still resolves from the local store.
+const declared = statuses.find((s) => s.key === "DECLARED_ENC_KEY");
+assert.equal(declared?.status, "encrypted");
+assert.equal(resolveSecret("DECLARED_ENC_KEY"), "declared-encrypted");
+
+// 5. An encrypted secret with no vault.yaml mapping at all still resolves.
+assert.equal(resolveSecret("UNMAPPED_ENC_KEY"), "unmapped-encrypted");
+
+rmSync(home, { recursive: true, force: true });
+rmSync(fakeBin, { recursive: true, force: true });
+
+console.log("vault-ref-shadowing.test.ts: ok");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -10,6 +10,10 @@
  *   4. vault.yaml has a ref for this key → resolve via `op read`
  *   5. undefined
  *
+ * The vault.yaml mapping declares which backend a key uses: when it carries a
+ * ref (and is not declared `storage: "encrypted"`), the ref wins — a stale or
+ * orphaned entry left behind in the local encrypted store must never shadow it.
+ *
  * Resolved values are cached in process.env for the lifetime of the process
  * so subsequent calls are instant. The raw secret value is NEVER written to
  * any file — it lives only in process memory.
@@ -293,9 +297,12 @@ export function resolveSecret(key: string): string | undefined {
   const map = loadVaultMap();
   const entry = map[key];
 
-  const localEncrypted = entry?.storage === "encrypted" || hasLocalEncryptedSecret(key)
-    ? getLocalEncryptedSecret(key)
-    : null;
+  // The map's declared backend wins: a ref mapping is never shadowed by a
+  // stale/orphaned entry in the local encrypted store. Unmapped encrypted
+  // secrets (no entry at all) still resolve.
+  const preferEncrypted =
+    entry?.storage === "encrypted" || (!entry?.ref && hasLocalEncryptedSecret(key));
+  const localEncrypted = preferEncrypted ? getLocalEncryptedSecret(key) : null;
   if (localEncrypted?.trim()) {
     process.env[key] = localEncrypted.trim();
     return localEncrypted.trim();
@@ -340,7 +347,9 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
   const envLocal = readEnvLocalAll(); // read once for all entries
   return Object.entries(map).map(([key, entry]) => {
     const inEnv = !!(process.env[key]?.trim()) || key in envLocal;
-    const hasEncrypted = entry.storage === "encrypted" || hasLocalEncryptedSecret(key);
+    // A ref mapping reports its ref backend even if an orphaned encrypted
+    // entry lingers in the local store (cave-6iee).
+    const hasEncrypted = entry.storage === "encrypted" || (!entry.ref && hasLocalEncryptedSecret(key));
 
     if (inEnv) {
       return {
@@ -383,7 +392,9 @@ export function getVaultStatuses(): VaultMappingStatus[] {
   return Object.entries(map).map(([key, entry]) => {
     const inEnv = !!(process.env[key]?.trim());
 
-    if (entry.storage === "encrypted" || hasLocalEncryptedSecret(key)) {
+    // Same backend-priority rule as resolveSecret: an orphaned encrypted
+    // entry must not make a ref mapping report (or resolve) as "encrypted".
+    if (entry.storage === "encrypted" || (!entry.ref && hasLocalEncryptedSecret(key))) {
       try {
         const value = getLocalEncryptedSecret(key);
         if (value) {


### PR DESCRIPTION
## Problem (cave-6iee)

`resolveSecret()`, `getVaultStatuses()`, and `getVaultMetadataStatuses()` checked `hasLocalEncryptedSecret(key)` **before** `entry.ref`, so a stale/orphaned entry in `local-vault.enc.json` silently shadowed a newer `op://` (or `dl://`) reference for the same key. The vault UI kept showing **encrypted** and the ref was never consulted. Live repro: `GITHUB_PAT` mapped to `op://Development/GitHub PAT/credential` in `~/.coven/cave/vault.yaml` still resolved from a Jul 12 encrypted orphan.

Orphans arise from hand-edited vault.yaml or older builds; `POST /api/vault` already deletes the encrypted copy when saving a ref, but resolution must not trust the store over the map.

## Fix

The vault.yaml mapping declares the backend. When an entry has a ref and is not `storage: "encrypted"`, the ref wins. Unchanged behavior for: declared-encrypted mappings, unmapped encrypted secrets (no vault.yaml entry), env/.env.local precedence.

## Verification

- New behavioral regression test `src/lib/vault-ref-shadowing.test.ts` (fake `op` on PATH, temp COVEN_HOME): **fails on old code** (`AssertionError: ref mapping resolves via op, not the stale encrypted orphan`), passes with the fix. Wired into the `app` suite.
- `node src/lib/vault.test.ts`, `vault-bundle.test.ts`, `local-encrypted-vault.test.ts` — ok
- `pnpm typecheck` — clean; `check-tests-wired` — 902 files wired

Bead: cave-6iee