### PR TITLE
feat(calendar): cap event lanes, roll concurrent bursts into +N pills (cave-pmeh)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -320,6 +320,7 @@ export const SUITES = {
     "src/components/calendar-view-polish.test.ts",
     "src/components/calendar-agenda-redesign.test.ts",
     "src/lib/calendar-layout.test.ts",
+    "src/components/calendar-overflow-pill.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-artifacts.test.ts",
     "src/lib/refine-suggestions.test.ts",

--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -33,11 +33,11 @@ assert.match(
 assert.match(view, /\.filter\(\(it\) => it\.status !== "dismissed"\)/, "Dismissed items must be filtered out of the calendar");
 
 // ───────── Overlap-aware time grid ─────────
-assert.match(view, /import \{ itemDate, packEventColumns \} from "@\/lib\/calendar-layout"/, "TimeGrid uses the extracted lane packer");
+assert.match(view, /import \{ itemDate, packEventColumnsWithOverflow, WEEK_MAX_LANES, DAY_MAX_LANES, type PlacedOverflow \} from "@\/lib\/calendar-layout"/, "TimeGrid uses the extracted lane packer");
 // Lane packing is memoised per columns change (a drag re-renders the grid
 // continuously) and rendered from the cached result, not recomputed inline.
-assert.match(view, /const packedColumns = useMemo\(\(\) => columns\.map\(\(c\) => packEventColumns\(c\.items\)\), \[columns\]\)/, "Time-grid lane packing is memoised on columns");
-assert.match(view, /packedColumns\[ci\]\.map/, "Time-grid events render from the packed lanes");
+assert.match(view, /const packedColumns = useMemo\(\n?\s*\(\) => columns\.map\(\(c\) => packEventColumnsWithOverflow\(c\.items, maxLanes\)\),\n?\s*\[columns, maxLanes\],?\n?\s*\)/, "Time-grid lane packing is memoised on columns");
+assert.match(view, /packedColumns\[ci\]\.events\.map/, "Time-grid events render from the packed lanes");
 assert.match(view, /data-calendar-event="true"/, "Events keep the roving-tabindex hook attribute");
 assert.doesNotMatch(view, /minHeight: 20/, "Old fixed 20px event height must be gone");
 

--- a/src/components/calendar-overflow-pill.test.ts
+++ b/src/components/calendar-overflow-pill.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Facelift cave-pmeh: the week grid used to give every concurrent event its
+// own lane, so a cron fan-out (a dozen co-timed runs) rendered as unreadable
+// sliver chips. These pin the capped-lane + "+N" rollup contract in TimeGrid.
+const src = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
+
+// ── Capped packing ───────────────────────────────────────────────────────────
+assert.match(
+  src,
+  /packEventColumnsWithOverflow\(c\.items, maxLanes\)/,
+  "TimeGrid packs with a lane cap (concurrent events beyond it roll up)",
+);
+assert.match(
+  src,
+  /maxLanes = WEEK_MAX_LANES/,
+  "week view defaults to the week lane budget",
+);
+assert.match(
+  src,
+  /maxLanes=\{DAY_MAX_LANES\}/,
+  "the wider single-day column passes the larger day budget",
+);
+
+// ── The "+N" pill ────────────────────────────────────────────────────────────
+assert.match(
+  src,
+  /packedColumns\[ci\]\.overflows\.map/,
+  "each cluster's rolled-up events render as a pill",
+);
+assert.match(src, /\+\{ov\.items\.length\}/, "pill shows how many events it holds");
+assert.match(
+  src,
+  /aria-haspopup="menu"/,
+  "pill is a disclosure button (menu semantics), not a dead label",
+);
+assert.match(
+  src,
+  /\$\{ov\.items\.length\} more events from/,
+  "pill carries an accessible name with count and start time",
+);
+assert.match(
+  src,
+  /data-calendar-event="true"[\s\S]{0,40}aria-haspopup/,
+  "pill participates in the grid's roving tabindex like event chips",
+);
+
+// ── The rollup popover ───────────────────────────────────────────────────────
+assert.match(src, /<PopoverBody role="menu" ariaLabel="More events">/, "popover lists the hidden events as a menu");
+assert.match(
+  src,
+  /onOpenItem\?\.\(item\);/,
+  "selecting a listed event opens it like a regular chip click",
+);
+
+console.log("calendar-overflow-pill.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -14,7 +14,8 @@ import { useAnnouncer } from "@/components/ui/live-region";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import { SnoozeMenu } from "@/components/snooze-menu";
-import { itemDate, packEventColumns } from "@/lib/calendar-layout";
+import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
+import { itemDate, packEventColumnsWithOverflow, WEEK_MAX_LANES, DAY_MAX_LANES, type PlacedOverflow } from "@/lib/calendar-layout";
 import { familiarInScope } from "@/lib/familiar-multiselect";
 import { useIsMobile } from "@/lib/use-viewport";
 
@@ -719,11 +720,14 @@ function TimeGrid({
   onOpenItem,
   onAddEntry,
   onReschedule,
+  maxLanes = WEEK_MAX_LANES,
 }: {
   columns: { label: string; date: Date; items: InboxItem[] }[];
   onOpenItem?: (item: InboxItem) => void;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onReschedule?: (id: string, fireAtIso: string) => void;
+  /** Lane cap before concurrent events roll up into a "+N" pill. */
+  maxLanes?: number;
 }) {
   // Read the per-familiar accent fn once (events render in a loop, so we can't
   // call the hook per item).
@@ -758,7 +762,15 @@ function TimeGrid({
 
   // Lane-pack each column once per columns change rather than on every render
   // (a drag re-renders the grid continuously).
-  const packedColumns = useMemo(() => columns.map((c) => packEventColumns(c.items)), [columns]);
+  const packedColumns = useMemo(
+    () => columns.map((c) => packEventColumnsWithOverflow(c.items, maxLanes)),
+    [columns, maxLanes],
+  );
+
+  // One popover serves every "+N" pill: clicking a pill anchors the popover to
+  // that pill and lists its rolled-up events.
+  const [overflowOpen, setOverflowOpen] = useState<{ colIdx: number; overflow: PlacedOverflow } | null>(null);
+  const overflowAnchorRef = useRef<HTMLElement | null>(null);
 
   const totalHeight = 24 * HOUR_HEIGHT;
   const nowTop = now ? ((now.getHours() * 60 + now.getMinutes()) / 60) * HOUR_HEIGHT : 0;
@@ -861,7 +873,7 @@ function TimeGrid({
             )}
 
             {/* Items — lane-packed so overlaps sit side by side */}
-            {packedColumns[ci].map((ev) => {
+            {packedColumns[ci].events.map((ev) => {
               const widthPct = 100 / ev.lanes;
               const leftPct = ev.lane * widthPct;
               const height = Math.max(18, ((ev.end - ev.start) / 60) * HOUR_HEIGHT - 2);
@@ -927,11 +939,81 @@ function TimeGrid({
                 </button>
               );
             })}
+
+            {/* "+N" rollup pills — concurrent events beyond the lane cap */}
+            {packedColumns[ci].overflows.map((ov, oi) => {
+              const widthPct = 100 / ov.lanes;
+              const leftPct = ov.lane * widthPct;
+              const height = Math.max(18, ((ov.end - ov.start) / 60) * HOUR_HEIGHT - 2);
+              const open = overflowOpen?.colIdx === ci && overflowOpen.overflow === ov;
+              return (
+                <button
+                  key={`ov-${oi}`}
+                  type="button"
+                  data-calendar-event="true"
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  aria-label={`${ov.items.length} more events from ${fmtTime(minutesToIso(col.date, ov.start))}`}
+                  title={`${ov.items.length} more events — click to list`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    overflowAnchorRef.current = e.currentTarget;
+                    setOverflowOpen(open ? null : { colIdx: ci, overflow: ov });
+                  }}
+                  className="focus-ring-inset absolute flex items-center justify-center rounded border border-[var(--border-strong)] bg-[var(--bg-elevated)] px-1 text-[10px] font-semibold tabular-nums text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                  style={{
+                    top: (ov.start / 60) * HOUR_HEIGHT + 1,
+                    height,
+                    left: `calc(${leftPct}% + 1px)`,
+                    width: `calc(${widthPct}% - 2px)`,
+                  }}
+                >
+                  +{ov.items.length}
+                </button>
+              );
+            })}
           </div>
         ))}
       </div>
+
+      {/* One shared popover lists whichever "+N" pill is open */}
+      <Popover
+        open={overflowOpen !== null}
+        onOpenChange={(next) => { if (!next) setOverflowOpen(null); }}
+        anchorRef={overflowAnchorRef}
+        placement="bottom-start"
+        minWidth={220}
+        ariaLabel="More events"
+      >
+        <PopoverBody role="menu" ariaLabel="More events">
+          {(overflowOpen?.overflow.items ?? []).map((item) => {
+            const iso = item.fireAt ?? item.firedAt;
+            return (
+              <PopoverItem
+                key={item.id}
+                onSelect={() => {
+                  setOverflowOpen(null);
+                  onOpenItem?.(item);
+                }}
+                title={item.title}
+              >
+                <span className="tabular-nums text-[var(--text-muted)]">{iso ? fmtTime(iso) : ""}</span>
+                {" "}
+                {item.title}
+              </PopoverItem>
+            );
+          })}
+        </PopoverBody>
+      </Popover>
     </div>
   );
+}
+
+/** ISO timestamp for a minutes-from-midnight offset on a given day. */
+function minutesToIso(day: Date, minutes: number): string {
+  const d = new Date(day);
+  d.setHours(0, minutes, 0, 0);
+  return d.toISOString();
 }
 
 // ─── Day view ─────────────────────────────────────────────────────────────────
@@ -1018,7 +1100,7 @@ function DayView({
       )}
       {/* Time grid — always rendered for visual parity with Week */}
       <div className="relative flex flex-1 overflow-hidden">
-        <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} onReschedule={onReschedule} />
+        <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} onReschedule={onReschedule} maxLanes={DAY_MAX_LANES} />
       </div>
     </div>
   );

--- a/src/lib/calendar-layout.test.ts
+++ b/src/lib/calendar-layout.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { packEventColumns, DEFAULT_EVENT_MIN } from "./calendar-layout.ts";
+import {
+  packEventColumns,
+  packEventColumnsWithOverflow,
+  DEFAULT_EVENT_MIN,
+  WEEK_MAX_LANES,
+  DAY_MAX_LANES,
+} from "./calendar-layout.ts";
 
 // Build an InboxItem-ish object at HH:MM on a fixed date.
 function at(id: string, h: number, m = 0) {
@@ -52,6 +58,61 @@ function at(id: string, h: number, m = 0) {
 {
   const noDate = { id: "x", kind: "reminder", title: "x", status: "pending", createdAt: "", updatedAt: "", fireAt: null, firedAt: null, recurrence: { type: "none" }, source: "user" };
   assert.equal(packEventColumns([noDate]).length, 0);
+}
+
+// ── Capped packing (week/day lane budgets) ───────────────────────────────────
+
+// Under the cap, capped packing matches uncapped exactly (no reserved lane).
+{
+  const items = [at("a", 9, 0), at("b", 9, 5), at("c", 9, 10)];
+  const { events, overflows } = packEventColumnsWithOverflow(items, WEEK_MAX_LANES);
+  assert.equal(overflows.length, 0, "3 concurrent events fit 3 lanes — no pill");
+  assert.deepEqual(
+    events.map((e) => [e.item.id, e.lane, e.lanes]).sort(),
+    packEventColumns(items).map((e) => [e.item.id, e.lane, e.lanes]).sort(),
+  );
+}
+
+// Over the cap: visible events re-pack into maxLanes-1 lanes, the rest roll
+// into one overflow pill in the reserved last lane.
+{
+  const items = [at("a", 9, 0), at("b", 9, 2), at("c", 9, 4), at("d", 9, 6), at("e", 9, 8)];
+  const { events, overflows } = packEventColumnsWithOverflow(items, WEEK_MAX_LANES);
+  assert.equal(events.length, 2, "two visible chips in lanes 0..1");
+  assert.ok(events.every((e) => e.lanes === WEEK_MAX_LANES));
+  assert.ok(events.every((e) => e.lane < WEEK_MAX_LANES - 1), "visible events never sit in the pill lane");
+  assert.equal(overflows.length, 1);
+  const [ov] = overflows;
+  assert.equal(ov.items.length, 3, "the three that no longer fit roll up");
+  assert.equal(ov.lane, WEEK_MAX_LANES - 1, "pill occupies the reserved last lane");
+  assert.equal(ov.lanes, WEEK_MAX_LANES);
+  assert.equal(ov.start, 9 * 60 + 4, "pill spans from the first rolled-up start");
+  assert.equal(ov.end, 9 * 60 + 8 + DEFAULT_EVENT_MIN, "…to the last rolled-up end");
+}
+
+// Sequential events never overflow regardless of cap (lanes are reused).
+{
+  const { events, overflows } = packEventColumnsWithOverflow(
+    [at("a", 9, 0), at("b", 9, 30), at("c", 10, 0), at("d", 10, 30), at("e", 11, 0)],
+    WEEK_MAX_LANES,
+  );
+  assert.equal(overflows.length, 0);
+  assert.ok(events.every((e) => e.lane === 0 && e.lanes === 1));
+}
+
+// The wider day column affords more lanes before rolling up.
+{
+  const five = [at("a", 9, 0), at("b", 9, 2), at("c", 9, 4), at("d", 9, 6), at("e", 9, 8)];
+  const { events, overflows } = packEventColumnsWithOverflow(five, DAY_MAX_LANES);
+  assert.equal(overflows.length, 0, "5 concurrent events fit the day cap");
+  assert.equal(events.length, 5);
+}
+
+// Distinct overlapping clusters each get their own pill.
+{
+  const burst = (h) => [at(`${h}-a`, h, 0), at(`${h}-b`, h, 2), at(`${h}-c`, h, 4), at(`${h}-d`, h, 6)];
+  const { overflows } = packEventColumnsWithOverflow([...burst(9), ...burst(14)], WEEK_MAX_LANES);
+  assert.equal(overflows.length, 2, "one pill per overflowing cluster");
 }
 
 console.log("calendar-layout.test.ts: all assertions passed");

--- a/src/lib/calendar-layout.ts
+++ b/src/lib/calendar-layout.ts
@@ -11,6 +11,15 @@ export function itemDate(item: InboxItem): Date | null {
 /** InboxItems carry no end time, so each occupies a nominal slot. */
 export const DEFAULT_EVENT_MIN = 30;
 
+/** Side-by-side lanes a week column fits before extra concurrent events roll
+ *  up into a "+N" pill. Three lanes keep chips ≳33% of an ~80-180px column —
+ *  the floor where titles still read as words instead of single glyphs. */
+export const WEEK_MAX_LANES = 3;
+
+/** The single-day column is several times wider, so it affords more lanes
+ *  before legibility collapses. */
+export const DAY_MAX_LANES = 5;
+
 export type PlacedEvent = {
   item: InboxItem;
   /** minutes from midnight */
@@ -22,14 +31,39 @@ export type PlacedEvent = {
   lanes: number;
 };
 
+/** Concurrent events beyond the lane cap, rolled up into one "+N" pill that
+ *  spans the overflowed range in the cluster's reserved last lane. */
+export type PlacedOverflow = {
+  items: InboxItem[];
+  /** minutes from midnight — pill spans min(start)..max(end) of its items */
+  start: number;
+  end: number;
+  lane: number;
+  lanes: number;
+};
+
+export type PackedColumn = {
+  events: PlacedEvent[];
+  overflows: PlacedOverflow[];
+};
+
 /**
  * Pack a column's events into side-by-side lanes so overlapping events are
  * readable instead of stacked on top of each other. Events are grouped into
  * overlap clusters; within a cluster each event takes the first free lane and
- * every member is widened to 1/maxLanes of the column. Pure + JSX-free so the
- * geometry can be unit-tested.
+ * every member is widened to 1/maxLanes of the column.
+ *
+ * When a cluster needs more than `maxLanes` lanes, its visible events re-pack
+ * into `maxLanes - 1` lanes and the rest roll up into a PlacedOverflow pill
+ * occupying the reserved last lane — a burst of co-timed events (e.g. a cron
+ * fan-out) becomes one legible "+N" instead of sliver chips.
+ *
+ * Pure + JSX-free so the geometry can be unit-tested.
  */
-export function packEventColumns(items: InboxItem[]): PlacedEvent[] {
+export function packEventColumnsWithOverflow(
+  items: InboxItem[],
+  maxLanes: number = Infinity,
+): PackedColumn {
   const evs = items
     .map((item) => {
       const d = itemDate(item);
@@ -39,20 +73,54 @@ export function packEventColumns(items: InboxItem[]): PlacedEvent[] {
     .map((e) => ({ ...e, end: e.start + DEFAULT_EVENT_MIN }))
     .sort((a, b) => a.start - b.start || a.end - b.end);
 
-  const placed: PlacedEvent[] = [];
+  const events: PlacedEvent[] = [];
+  const overflows: PlacedOverflow[] = [];
   let cluster: { item: InboxItem; start: number; end: number; lane: number }[] = [];
   let clusterEnd = -1;
 
-  const flush = () => {
+  const assignLanes = (
+    members: typeof cluster,
+    laneCap: number,
+  ): { fit: typeof cluster; spill: typeof cluster; laneCount: number } => {
     const laneEnds: number[] = [];
-    for (const e of cluster) {
+    const fit: typeof cluster = [];
+    const spill: typeof cluster = [];
+    for (const e of members) {
       let lane = laneEnds.findIndex((end) => end <= e.start);
-      if (lane === -1) { lane = laneEnds.length; laneEnds.push(e.end); }
-      else laneEnds[lane] = e.end;
-      e.lane = lane;
+      if (lane === -1) {
+        if (laneEnds.length >= laneCap) {
+          spill.push(e);
+          continue;
+        }
+        lane = laneEnds.length;
+        laneEnds.push(e.end);
+      } else {
+        laneEnds[lane] = e.end;
+      }
+      fit.push({ ...e, lane });
     }
-    const lanes = Math.max(1, laneEnds.length);
-    for (const e of cluster) placed.push({ ...e, lanes });
+    return { fit, spill, laneCount: Math.max(1, laneEnds.length) };
+  };
+
+  const flush = () => {
+    if (cluster.length === 0) return;
+    // First try the full budget; only reserve the pill lane when it overflows.
+    const full = assignLanes(cluster, maxLanes);
+    if (full.spill.length === 0) {
+      for (const e of full.fit) events.push({ ...e, lanes: full.laneCount });
+    } else {
+      const capped = assignLanes(cluster, Math.max(1, maxLanes - 1));
+      const lanes = Math.max(2, maxLanes);
+      for (const e of capped.fit) events.push({ ...e, lanes });
+      const spill = capped.spill;
+      overflows.push({
+        items: spill.map((e) => e.item),
+        start: Math.min(...spill.map((e) => e.start)),
+        end: Math.max(...spill.map((e) => e.end)),
+        lane: lanes - 1,
+        lanes,
+      });
+    }
     cluster = [];
     clusterEnd = -1;
   };
@@ -63,5 +131,10 @@ export function packEventColumns(items: InboxItem[]): PlacedEvent[] {
     clusterEnd = Math.max(clusterEnd, e.end);
   }
   flush();
-  return placed;
+  return { events, overflows };
+}
+
+/** Uncapped packing — every overlapping event gets its own lane. */
+export function packEventColumns(items: InboxItem[]): PlacedEvent[] {
+  return packEventColumnsWithOverflow(items).events;
 }


### PR DESCRIPTION
## Facelift 2 — calendar week/day event clustering

Second surface PR of the UI/UX facelift program (`cave-ew98`; this bead `cave-pmeh`). In the Phase-0 audit, the Schedules week view was the least legible surface in the app: bursts of co-timed events (cron/CI fan-outs) each took their own lane, rendering as overlapping sliver chips one character wide.

### Before
`desktop--inbox-data.png` (audit set): Tue 01–05h and Sun 08–11h are walls of unlabeled micro-chips — dozens of 14-px buttons showing “C”/“P” fragments.

### After (this branch, prod build, same real data)
- Each burst renders **two readable chips + one `+N` pill** (`+5`, `+9`, `+49`…) per overlap cluster
- Clicking a pill opens a **menu popover** listing every rolled-up event (time + full title); selecting one opens it exactly like a chip click
- Single-day view keeps more side-by-side lanes (wider column) before rolling up

### Changes
- `src/lib/calendar-layout.ts` — `packEventColumnsWithOverflow(items, maxLanes)`: overflowing clusters re-pack into `maxLanes−1` lanes; the remainder becomes a `PlacedOverflow` pill spanning its items’ time range in the reserved last lane. `WEEK_MAX_LANES = 3`, `DAY_MAX_LANES = 5`. `packEventColumns` delegates with `Infinity` (geometry unchanged under the cap).
- `src/components/calendar-view.tsx` — TimeGrid takes `maxLanes`; pills are disclosure buttons (`aria-haspopup="menu"`, accessible count+time name, roving-tabindex participants); one shared `Popover`/`PopoverBody role="menu"` lists hidden events.
- Tests — new capped-packing unit cases (cap parity, spill, lane reuse, per-cluster pills, day budget); new `calendar-overflow-pill.test.ts` source pin; `calendar-actions.test.ts` pins updated deliberately for the new packer signature; wired in `run-tests.mjs`.

### Verification
- `calendar-layout.test.ts`, `calendar-overflow-pill.test.ts`, `calendar-actions.test.ts`, `calendar-view-polish.test.ts`, `calendar-keyboard.test.ts`, `calendar-agenda-redesign.test.ts` — all green
- `pnpm typecheck` clean, `pnpm build` clean (bundle budget ok), `check:tests-wired` green
- Live before/after screenshots captured on the built server against real store data

Design rules: tokens only (`--bg-elevated`/`--border-strong`/`--text-secondary` pill, existing chip accents), keyboard parity (pills in roving tabindex; popover has Escape/outside-click/focus-return), no new dependencies.
