### PR TITLE
fix(vault): retry once when a secret CLI read hits the cold-start timeout

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -626,6 +626,7 @@ export const SUITES = {
     "src/lib/workflow-source-bundle.test.ts",
     "src/lib/vault-bundle.test.ts",
     "src/lib/vault-ref-shadowing.test.ts",
+    "src/lib/vault-ref-cold-start.test.ts",
     "src/lib/cave-board-atomic.test.ts",
     "src/lib/server/atomic-write.test.ts",
     "src/lib/server/local-origin.test.ts",

--- a/src/lib/vault-ref-cold-start.test.ts
+++ b/src/lib/vault-ref-cold-start.test.ts
@@ -1,0 +1,86 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+// Regression (cave-ovps): the FIRST `op read` after app launch can exceed the
+// base timeout while the CLI's session daemon spins up, so a healthy ref was
+// reported "unresolved" on the first Vault query and self-healed on refresh.
+// The resolver now retries exactly once — with a longer allowance — when an
+// attempt is killed by the timeout (the killed attempt warms the daemon).
+// Non-timeout failures (bad ref, signed out) must NOT be retried.
+
+const home = mkdtempSync(join(tmpdir(), "cave-vault-cold-home-"));
+const fakeBin = mkdtempSync(join(tmpdir(), "cave-vault-cold-bin-"));
+const vaultYaml = join(home, "vault.yaml");
+const coldCalls = join(home, "cold-calls");
+const coldMarker = join(home, "cold-marker");
+const badCalls = join(home, "bad-calls");
+
+// Fake `op`: the Cold ref sleeps far past every timeout on its first call
+// (cold daemon) and answers instantly afterwards; the Bad ref fails fast.
+// Absolute state paths are baked in so the script needs no env plumbing.
+const opPath = join(fakeBin, "op");
+writeFileSync(opPath, `#!/bin/sh
+ref="$2"
+case "$ref" in
+  *Cold*)
+    echo x >> "${coldCalls}"
+    if [ ! -f "${coldMarker}" ]; then
+      : > "${coldMarker}"
+      sleep 10
+    fi
+    echo cold-secret
+    ;;
+  *)
+    echo x >> "${badCalls}"
+    exit 1
+    ;;
+esac
+`);
+chmodSync(opPath, 0o755);
+
+process.env.COVEN_HOME = home;
+process.env.COVEN_VAULT_FILE = vaultYaml;
+process.env.COVEN_CAVE_ENV_FILE = join(home, ".env.local"); // nonexistent — isolates from the repo's .env.local
+process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ""}`;
+// Tight base timeout so the cold call is killed quickly; generous retry window.
+// The unfixed code ignores these and uses its fixed 8s timeout — the 10s sleep
+// outlasts it, so this test is red without the retry.
+process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS = "300";
+process.env.COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS = "8000";
+delete process.env.COVEN_CAVE_BUNDLE;
+delete process.env.COLD_START_KEY;
+delete process.env.BAD_REF_KEY;
+
+writeFileSync(vaultYaml, [
+  "COLD_START_KEY:",
+  '  ref: "op://Dev/Cold Item/field"',
+  "BAD_REF_KEY:",
+  '  ref: "op://Dev/Bad Item/field"',
+  "",
+].join("\n"));
+
+const { resolveSecret } = await import("./vault.ts");
+
+const countLines = (file) => {
+  try {
+    return readFileSync(file, "utf8").split("\n").filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+};
+
+// 1. A cold-start timeout is retried once and resolves.
+assert.equal(resolveSecret("COLD_START_KEY"), "cold-secret", "first read after launch survives a cold-start timeout via one retry");
+assert.equal(countLines(coldCalls), 2, "cold ref was attempted exactly twice (timed-out attempt + retry)");
+
+// 2. A fast non-timeout failure is not retried.
+assert.equal(resolveSecret("BAD_REF_KEY"), undefined, "genuine failure still resolves to undefined");
+assert.equal(countLines(badCalls), 1, "non-timeout failure is not retried");
+
+rmSync(home, { recursive: true, force: true });
+rmSync(fakeBin, { recursive: true, force: true });
+
+console.log("vault-ref-cold-start.test.ts: ok");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -201,21 +201,54 @@ function resolverEnv(): NodeJS.ProcessEnv {
   return { ...process.env, PATH: merged.join(delimiter) };
 }
 
+/** Base timeout for a `<cli> read` call, and the longer allowance for the
+ *  single retry after a timeout. The first read after app launch can blow past
+ *  the base timeout while the CLI's session daemon spins up (cave-ovps: a cold
+ *  `op read` took >8s and reported a healthy ref as "unresolved"; the killed
+ *  attempt warms the daemon, so the retry completes fast). Genuine failures
+ *  (bad ref, not signed in) exit non-zero quickly and are NOT retried.
+ *  Overridable for tests. */
+function refReadTimeoutMs(): number {
+  const raw = Number(process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 8000;
+}
+
+function refReadRetryTimeoutMs(): number {
+  const raw = Number(process.env.COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 30_000;
+}
+
+function isTimeoutError(e: unknown): boolean {
+  return !!e && typeof e === "object" && (e as NodeJS.ErrnoException).code === "ETIMEDOUT";
+}
+
+/** Run `<cli> read <ref>`, retrying once with a longer timeout if the first
+ *  attempt was killed by the base timeout. Returns null on failure. */
+function cliRead(cli: "op" | "dcli", ref: string): string | null {
+  const run = (timeout: number) =>
+    execFileSync(cli, ["read", ref], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout,
+      env: resolverEnv(),
+    }).trim();
+
+  try {
+    return run(refReadTimeoutMs()) || null;
+  } catch (e) {
+    if (!isTimeoutError(e)) return null;
+    try {
+      return run(refReadRetryTimeoutMs()) || null;
+    } catch {
+      return null;
+    }
+  }
+}
+
 /** Call `op read` to fetch a secret reference. Returns null on failure. */
 function opRead(ref: string): string | null {
   if (validateOpRef(ref)) return null;
-
-  try {
-    const value = execFileSync("op", ["read", ref], {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 8000,
-      env: resolverEnv(),
-    }).trim();
-    return value || null;
-  } catch {
-    return null;
-  }
+  return cliRead("op", ref);
 }
 
 // ── dashlane (dcli) resolver ────────────────────────────────────────────────
@@ -243,18 +276,7 @@ export function validateDashlaneRef(ref: unknown): string | null {
 /** Call `dcli read` to fetch a Dashlane secret reference. Returns null on failure. */
 function dcliRead(ref: string): string | null {
   if (validateDashlaneRef(ref)) return null;
-
-  try {
-    const value = execFileSync("dcli", ["read", ref], {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 8000,
-      env: resolverEnv(),
-    }).trim();
-    return value || null;
-  } catch {
-    return null;
-  }
+  return cliRead("dcli", ref);
 }
 
 /** The storage backend a reference resolves through, implied by its scheme. */


### PR DESCRIPTION
## Problem (cave-ovps)

The first `op read` after app launch can exceed the fixed 8s `execFileSync` timeout while the 1Password CLI's session daemon spins up. The first Vault panel query after launch showed healthy refs as **unresolved — op read returned empty**, then self-healed on refresh. Live evidence on the packaged build: cold `GET /api/vault` took 11.9s with `FIRECRAWL_API_KEY` unresolved; immediate re-query 1.3s, all refs resolved.

## Fix

`opRead`/`dcliRead` now share a `cliRead` helper: an attempt killed by the base timeout (`ETIMEDOUT`) is retried **exactly once** with a longer 30s allowance — the killed attempt warms the daemon, so the retry returns fast. Non-timeout failures (bad ref, signed out) exit non-zero quickly and are **not** retried. Base/retry timeouts are env-overridable (`COVEN_CAVE_REF_READ_TIMEOUT_MS` / `_RETRY_TIMEOUT_MS`) for tests.

## Verification

- New `src/lib/vault-ref-cold-start.test.ts`: invocation-counting fake `op` whose first call sleeps 10s. **Red on old code** (AssertionError at its fixed 8s timeout), **green in 0.76s** with the fix; asserts exactly 2 attempts for the cold ref and exactly 1 (no retry) for a fast genuine failure.
- `vault.test.ts`, `vault-ref-shadowing.test.ts`, `vault-bundle.test.ts` — ok; `check-tests-wired` 904 wired; `pnpm typecheck` clean.

Bead: cave-ovps