### PR TITLE
fix(agents): force-add the stitch-sewer + skill-builder companion skills swallowed by .gitignore

### DIFF
--- a/.agents/skills/skill-builder/SKILL.md
+++ b/.agents/skills/skill-builder/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: skill-builder
+description: Use when asked to build, author, draft, or save a Coven Cave skill (a SKILL.md familiars load), or when a chat brief carries the skills build API contract. Trigger on "build a skill", "write a SKILL.md", "author a skill for", "turn this procedure into a skill", or a brief naming POST /api/skills/build.
+---
+
+# Skill Builder
+
+A Cave skill is a `SKILL.md` — YAML frontmatter (`name`, `description`,
+optional `tags`) plus terse markdown instructions — that familiars load while
+they work. The frontmatter `description` is the **trigger**: an agent reading
+only the name + description must know exactly when to load the skill. Your job
+in a build chat: draft the skill **with** the operator, then save it through
+the local Cave API.
+
+## The build loop
+
+All endpoints are loopback HTTP on the machine running Cave (no auth). Use
+`curl` against the running app (ports 3000–3010 in dev; the desktop app serves
+the same routes).
+
+1. **Check what exists**
+
+   ```bash
+   curl -s http://127.0.0.1:3000/api/skills/local
+   ```
+
+   → installed skills across the local roots. Don't duplicate a slug, and
+   don't author a trigger that collides with one that already fires.
+
+2. **Draft with the operator** — name (a few words), the one-line trigger
+   `description` (name the situations and cue phrases), 0–6 lowercase tags,
+   and imperative instructions with `## ` sections (When to use / Steps /
+   Verification). Iterate until they approve.
+
+3. **Save it**
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:3000/api/skills/build \
+     -H 'content-type: application/json' \
+     -d '{"name":"…","description":"…","instructions":"…","root":"coven","tags":["…"]}'
+   ```
+
+   → `{ ok, slug, path }`. The file lands at `<root>/<slug>/SKILL.md` and is
+   immediately visible in the Skills tab.
+
+4. **Prove it fires (optional but recommended)**
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:3000/api/skills/dry-run \
+     -H 'content-type: application/json' \
+     -d '{"mode":"trigger","name":"…","description":"…","scenario":"…"}'
+   ```
+
+   → `{ ok, fires, reason }`. A `no` verdict means the description needs
+   sharper cue phrases — fix it with the operator before calling it done.
+
+5. **Report back** — the written path, the slug, and the trigger description
+   you settled on.
+
+## Contract notes
+
+- **Creation-only:** a duplicate slug is refused with `code: "exists"` (409)
+  — pick a new name rather than overwriting.
+- The slug is derived server-side from the name (lowercase kebab); you don't
+  pick ids.
+- Roots: `coven` → `~/.coven/skills` (every familiar), `claude` →
+  `~/.claude/skills`, `codex` → `~/.codex/skills`, `agents` →
+  `~/.agents/skills`. Default to `coven` unless the operator says otherwise.
+- Caps: name 80 chars, description 500 chars, instructions 64 KB, tags 12.
+- Only save what the operator approved.

--- a/.agents/skills/stitch-sewer/SKILL.md
+++ b/.agents/skills/stitch-sewer/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: stitch-sewer
+description: Use when asked to sew, finish, or draft a Grimoire stitch — distilling a thread of pinned sources into one durable Knowledge Vault entry — or when a chat brief carries the stitches sew API contract. Trigger on "sew this stitch", "finish the stitch", "sew a Grimoire stitch", or a pinned-sources digest asking for one durable reference entry.
+---
+
+# Stitch Sewer
+
+A stitch is one durable Knowledge Vault entry distilled from a **thread** of
+pinned sources (web pages, pasted text, files, chat sessions, GitHub content,
+memory sections). The operator gathers pins in the Grimoire's stitch intake;
+sewing turns them into reference material. Your job in a sew chat: draft the
+entry **with** the operator, then save it through the local Cave API so
+provenance lands and the thread completes — never leave the finished draft in
+scrollback.
+
+## The sew loop
+
+All endpoints are loopback HTTP on the machine running Cave (no auth). Use
+`curl` against the running app (ports 3000–3010 in dev; the desktop app serves
+the same routes).
+
+1. **Draft from the pins** — the chat brief carries the pin digest (titles,
+   sources, excerpts). Write reference material: factual, self-contained,
+   deduplicated across sources, no meta-commentary. Prefer the sources' own
+   terminology. **Ask before assuming anything the pins don't cover.** If the
+   brief names a shape (section headings), structure the body with exactly
+   those `## ` sections, in order.
+
+2. **Agree on the draft** — title (one line), 2–6 lowercase tags, markdown
+   body. Iterate with the operator until they approve.
+
+3. **Save it**
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:3000/api/stitches/sew \
+     -H 'content-type: application/json' \
+     -d '{"threadId":"<id>","mode":"manual","draft":{"title":"…","tags":["…"],"body":"…"}}'
+   ```
+
+   → `{ ok, entry }`. The entry lands in the vault with the thread's pin
+   provenance in its frontmatter, and the thread is marked sewn — the intake
+   tab the operator left open picks the entry up on its next focus.
+
+4. **File into a collection (optional)** — add `"collection": "<id>"` to the
+   body to sew into an existing collection:
+
+   ```bash
+   curl -s http://127.0.0.1:3000/api/knowledge/collections
+   ```
+
+   → `{ ok, collections: [{ id, meta, count }] }`. Unknown collections are a
+   `404` — never invent collection ids, and never invent thread ids either
+   (the brief provides the real one; `GET /api/stitches` lists threads).
+
+## Contract notes
+
+- `draft.title` caps at 200 chars; `draft.tags` at 8 (lowercased); an empty
+  title or body is a `400 invalid draft`.
+- The entry id is slugified from the title server-side (collisions get
+  `-2`, `-3`, …) — you don't pick ids.
+- A thread that was already sewn keeps working: a second sew writes a second
+  entry rather than clobbering (the operator may want a revision — confirm
+  first).
+- The vault entry is direct-write and stays editable in the Grimoire; there
+  is no review gate on this path, so only save what the operator approved.
+
+## Related endpoints
+
+- `GET /api/stitches` → `{ ok, threads }` — every thread (pin contents
+  stripped), including `sewnEntryId` once sewn.
+- `POST /api/stitches/sew` with `{ "threadId": "<id>", "mode": "agentic" }`
+  — the one-shot headless distillation (no draft), when the operator asks
+  for it instead of a collaborative draft.

--- a/src/components/marketplace/skill-builder.test.ts
+++ b/src/components/marketplace/skill-builder.test.ts
@@ -3,6 +3,7 @@
 // preview/writer formatter, and the CTA reroute away from the old
 // Capabilities dead-end.
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 
 const view = await readFile(new URL("../marketplace-view.tsx", import.meta.url), "utf8");
@@ -60,6 +61,13 @@ assert.match(builder, /usePromptEnhance\(\{/, "instructions enhance rides the sh
 assert.match(builder, /enhancer\.state\.phase === "suggested"/, "a raced enhance surfaces as an apply/dismiss suggestion");
 assert.match(builder, /buildSkillAgentPrompt\(\{ description: goal, root \}\)/, "Build in chat carries the full build-API brief");
 assert.match(builder, /new CustomEvent\("cave:agents-new-chat"/, "the brief dispatches the shared chat event");
+// .agents/ is gitignored with tracked exceptions — the companion skill must
+// stay force-added, or the chat brief references a ghost (cave-yz8n).
+assert.equal(
+  existsSync(new URL("../../../.agents/skills/skill-builder/SKILL.md", import.meta.url)),
+  true,
+  "the skill-builder agent skill documents the same build loop for harness sessions",
+);
 
 // ── Dry-run (cave-cyfc) ─────────────────────────────────────────────────────
 // The success panel proves the saved skill fires (and is followable) before

--- a/src/components/stitch-intake.test.ts
+++ b/src/components/stitch-intake.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 
@@ -38,6 +39,13 @@ describe("stitch intake panel", () => {
     assert.match(intake, /new CustomEvent\("cave:agents-new-chat"/, "sew-in-chat dispatches a primed chat");
     assert.match(intake, /buildSewChatPrompt/, "the chat is seeded with a pin digest");
     assert.match(intake, /disabled=\{pins\.length === 0 \|\| busy\}/, "sewing needs at least one pin");
+    // .agents/ is gitignored with tracked exceptions — the companion skill
+    // must stay force-added, or the chat brief references a ghost (cave-x1za).
+    assert.equal(
+      existsSync(new URL("../../.agents/skills/stitch-sewer/SKILL.md", import.meta.url)),
+      true,
+      "the stitch-sewer agent skill documents the sew contract for harness sessions",
+    );
   });
 
   it("aims the sew at a shape and a destination (cave-kwx4)", () => {


### PR DESCRIPTION
Follow-up to #3082 / #3085. `/.agents` is gitignored with force-added exceptions; the two new companion skills were authored but silently skipped by plain `git add`, so the sew/build chat briefs referenced ghosts.

- Re-adds `.agents/skills/stitch-sewer/SKILL.md` and `.agents/skills/skill-builder/SKILL.md` (`git add -f`, same as craft-builder).
- Pins their existence in `stitch-intake.test.ts` and `skill-builder.test.ts` via the `existsSync` pattern `crafts-marketplace.test.ts` already uses — a future swallow fails CI.

Verification: both extended test files green locally.