### PR TITLE
feat(chat-list): consolidate touch row actions into one overflow menu (cave-kcah)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -554,6 +554,7 @@ export const SUITES = {
     "src/app/globals-background.test.ts",
     "src/components/board-chat-link.test.ts",
     "src/components/chat-list-panel.test.ts",
+    "src/components/chat-list-coarse-actions.test.ts",
     "src/components/chat-surface.test.ts",
     "src/components/chat-settings-view.test.ts",
     "src/components/chat-switching.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8148,6 +8148,14 @@ a.mobile-handoff__link:hover {
     min-width: 0;
   }
 
+  /* Coarse pointers consolidate the row actions into one ⋯ menu — a single
+     trigger doesn't earn its own grid row, so it sits inline top-right and
+     the row tightens by a full band. */
+  .chat-list-row:has(.chat-list-row-actions--compact) {
+    grid-template-columns: 24px 14px minmax(0, 1fr) auto;
+    grid-template-areas: "handle dot content actions";
+  }
+
   .chat-list-row-actions > button {
     display: grid;
     width: var(--touch-target);

--- a/src/components/chat-list-coarse-actions.test.ts
+++ b/src/components/chat-list-coarse-actions.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Facelift cave-kcah: on touch devices the five per-row controls (pin,
+// archive, archive-controls, debug, delete) rendered permanently at 44px
+// each — most of every session row was buttons. On coarse pointers they
+// consolidate into one ⋯ menu; fine pointers keep the hover-revealed row.
+const src = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+
+// ── Branch on the pointer, not the viewport ──────────────────────────────────
+assert.match(
+  src,
+  /const coarsePointer = useIsCoarsePointer\(\);/,
+  "the consolidation keys on (pointer: coarse) — hover-reveal is what touch lacks",
+);
+assert.match(
+  src,
+  /\) : coarsePointer \? \(/,
+  "coarse pointers take the consolidated branch; fine pointers keep row buttons",
+);
+
+// ── One menu, every action ───────────────────────────────────────────────────
+assert.match(
+  src,
+  /ariaLabel=\{`Actions for chat \$\{rowName\}`\}/,
+  "the ⋯ trigger names its chat",
+);
+for (const item of [
+  "Pin chat",
+  "Archive chat",
+  "Keep chat",
+  "Extend auto-archive \\+7 days",
+  "Extend auto-archive \\+30 days",
+  "Debug chat",
+  "Delete chat…",
+]) {
+  assert.match(src, new RegExp(item), `menu carries: ${item}`);
+}
+assert.match(
+  src,
+  /danger onSelect=\{\(\) => setConfirmDeleteId\(s\.id\)\}/,
+  "menu Delete routes through the same two-step inline confirm",
+);
+
+// ── Handlers tolerate menu invocation (no event to stop) ─────────────────────
+assert.match(src, /const togglePin = \(e: React\.MouseEvent \| null/, "togglePin accepts null event");
+assert.match(src, /const setSessionArchived = async \(e: React\.MouseEvent \| null/, "setSessionArchived accepts null event");
+assert.match(src, /const debugSession = \(e: React\.MouseEvent \| null/, "debugSession accepts null event");
+
+console.log("chat-list-coarse-actions.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -6,7 +6,7 @@ import { stripLeadingTrailingEmoji, disambiguateSessionTitles } from "@/lib/cave
 import { Icon } from "@/lib/icon";
 import { modelIcon, modelLabel } from "@/lib/model-label";
 import { useKeySymbols } from "@/lib/platform-keys";
-import { useIsMobile } from "@/lib/use-viewport";
+import { useIsMobile, useIsCoarsePointer } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { sessionPrStatus } from "@/lib/session-pr-status";
@@ -301,6 +301,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const searchRef = useRef<HTMLInputElement>(null);
   const keys = useKeySymbols();
   const isMobile = useIsMobile();
+  // Touch devices can't hover-reveal the per-row controls, and rendering all
+  // five permanently (the old .touch-always-visible behaviour) ate most of
+  // each row — one ⋯ menu carries them instead.
+  const coarsePointer = useIsCoarsePointer();
   const allFamiliars = familiar ? [familiar] : familiars;
   const resolvedFamiliars = useResolvedFamiliars(allFamiliars, { includeArchived: true });
   const resolvedFamiliar = familiar ? resolvedFamiliars[0] : null;
@@ -568,8 +572,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   }
   // ── Row actions ──────────────────────────────────────────────────────────
 
-  const debugSession = (e: React.MouseEvent, session: SessionRow) => {
-    e.stopPropagation();
+  const debugSession = (e: React.MouseEvent | null, session: SessionRow) => {
+    e?.stopPropagation();
     setActiveId(session.id);
     onOpen(session.id, session.familiarId);
     window.requestAnimationFrame(() => {
@@ -603,8 +607,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   // ── Pin (Cave-local) + archive (sessions PATCH) ──────────────────────────
 
-  const togglePin = (e: React.MouseEvent, sessionId: string) => {
-    e.stopPropagation();
+  const togglePin = (e: React.MouseEvent | null, sessionId: string) => {
+    e?.stopPropagation();
     toggleStoredPinnedSession(sessionId);
   };
 
@@ -640,8 +644,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     [onSessionsChanged],
   );
 
-  const setSessionArchived = async (e: React.MouseEvent, sessionId: string, archived: boolean) => {
-    e.stopPropagation();
+  const setSessionArchived = async (e: React.MouseEvent | null, sessionId: string, archived: boolean) => {
+    e?.stopPropagation();
     await patchSessionArchivePrefs(
       sessionId,
       { archived },
@@ -1374,6 +1378,54 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                                 <Icon name="ph:trash" width={10} aria-hidden />
                                 {deletingId === s.id ? "…" : "Delete"}
                               </button>
+                            </span>
+                          ) : coarsePointer ? (
+                            /* Touch: one ⋯ menu carries every row action —
+                               five permanent buttons per row ate the list. */
+                            <span
+                              className="chat-list-row-actions chat-list-row-actions--compact flex shrink-0 items-center self-center"
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => e.stopPropagation()}
+                            >
+                              <OverflowMenu
+                                ariaLabel={`Actions for chat ${rowName}`}
+                                disabled={archivingId !== null}
+                                className="h-9 w-9 shrink-0 rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)]"
+                                minWidth={224}
+                              >
+                                <PopoverItem
+                                  icon={pinned ? "ph:bookmark-simple-fill" : "ph:bookmark-simple"}
+                                  onSelect={() => togglePin(null, s.id)}
+                                >
+                                  {pinned ? "Unpin chat" : "Pin chat"}
+                                </PopoverItem>
+                                <PopoverItem
+                                  icon={s.archived_at ? "ph:arrow-counter-clockwise" : "ph:archive"}
+                                  onSelect={() => void setSessionArchived(null, s.id, !s.archived_at)}
+                                >
+                                  {s.archived_at ? "Unarchive chat" : "Archive chat"}
+                                </PopoverItem>
+                                <PopoverSeparator />
+                                <PopoverItem
+                                  checked={Boolean(s.keep)}
+                                  onSelect={() => void setSessionKeep(s.id, !s.keep)}
+                                >
+                                  {s.keep ? "Remove keep mark" : "Keep chat"}
+                                </PopoverItem>
+                                <PopoverItem icon="ph:calendar-bold" onSelect={() => void extendSessionAutoArchive(s.id, 7)}>
+                                  Extend auto-archive +7 days
+                                </PopoverItem>
+                                <PopoverItem icon="ph:calendar-bold" onSelect={() => void extendSessionAutoArchive(s.id, 30)}>
+                                  Extend auto-archive +30 days
+                                </PopoverItem>
+                                <PopoverSeparator />
+                                <PopoverItem icon="ph:bug-bold" onSelect={() => debugSession(null, s)}>
+                                  Debug chat
+                                </PopoverItem>
+                                <PopoverItem icon="ph:trash" danger onSelect={() => setConfirmDeleteId(s.id)}>
+                                  Delete chat…
+                                </PopoverItem>
+                              </OverflowMenu>
                             </span>
                           ) : (
                             /* Row actions — pin (Cave-local), archive (PATCH), debug, delete.


### PR DESCRIPTION
## Facelift 3 — mobile chat list density

Third surface PR of the UI/UX facelift program (`cave-ew98`; this bead `cave-kcah`). The Phase-0 audit's mobile pass showed each session row rendering **five permanent 44px action buttons** (pin, archive, archive-controls, debug, delete) — the buttons consumed more space than the content, leaving ~3.5 rows per screen.

### After (iPhone emulation, prod build, real data)
- One quiet **⋯ menu** per row, inline top-right — **row height roughly halved**, no dead actions band
- Menu carries every action: Pin/Unpin · Archive/Unarchive · Keep · Extend auto-archive +7/+30 · Debug · **Delete…** (danger, routes through the existing two-step inline confirm)
- Desktop/fine-pointer behavior **unchanged** (hover-revealed row buttons)

### Changes
- `src/components/chat-list.tsx` — branch on `useIsCoarsePointer()` (the consolidation keys on *pointer*, not viewport: hover-reveal is what touch lacks). One `OverflowMenu` with `PopoverItem`s replaces the five buttons; `togglePin`/`setSessionArchived`/`debugSession` accept a null event for menu invocation.
- `src/app/globals.css` — `.chat-list-row:has(.chat-list-row-actions--compact)` folds the dedicated mobile actions grid row into a fourth column so the single trigger sits inline (`:has()` precedented in this sheet).
- `src/components/chat-list-coarse-actions.test.ts` — source pin for the coarse-pointer contract (branch, menu inventory, null-event handlers, confirm routing); wired in `run-tests.mjs`.

### Verification
- Full app suite: **663 test files green** (includes all existing chat-list pins: collapse, delete, mobile-command-center, mobile-rail-port, panel, pr-badge)
- `pnpm typecheck` clean · `pnpm build` clean · `check:tests-wired` green
- Live iPhone-13-emulated screenshots (before from audit set, after from this build) captured against real store data; menu open state verified (all seven items reachable)

Design rules: existing primitives only (`OverflowMenu`/`Popover` — Escape, outside-click, focus-return for free), tokens only, keyboard/AT parity (menu semantics, named trigger per chat), no new dependencies.
