### PR TITLE
fix(images): make the authed-image cache safe for long sessions (cave-fea6, cave-x63e, cave-wnhh)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -52,6 +52,7 @@ export const SUITES = {
     "src/lib/legacy-svg-avatar-hint.test.ts",
     "src/lib/familiar-avatar-src.test.ts",
     "src/lib/authed-image.test.ts",
+    "src/lib/authed-image-cache.test.ts",
     "src/lib/app-update.test.ts",
     "src/lib/about-status.test.ts",
     "src/lib/about-diagnostics.test.ts",

--- a/src/lib/authed-image-cache.test.ts
+++ b/src/lib/authed-image-cache.test.ts
@@ -177,6 +177,36 @@ test("a retained (mounted) entry is never evicted-and-revoked; releasing makes i
   assert.ok(revoked.includes(first), "released entry becomes evictable again");
 });
 
+test("releasing the last consumer shrinks an over-cap cache without waiting for a future load", async (t) => {
+  const { revoked, madeBy } = stubEnv(t);
+
+  // A big view mounts: every entry is retained, so the cache legitimately
+  // grows past the cap (eviction must not revoke in-use URLs).
+  const releases = [];
+  for (let i = 1; i <= MAX_CACHE_ENTRIES + 3; i++) {
+    await loadAuthedObjectUrl(`/api/avatar/big-view-${i}`);
+    releases.push(retainAuthedImage(`/api/avatar/big-view-${i}`));
+  }
+  assert.deepEqual(revoked, [], "nothing revoked while every entry is in use");
+
+  // The view unmounts the three oldest images. The cache must shrink back to
+  // the cap right then — not linger over-cap until some future load happens.
+  releases[0]();
+  releases[1]();
+  releases[2]();
+
+  assert.deepEqual(
+    revoked,
+    [madeBy.get("/api/avatar/big-view-1"), madeBy.get("/api/avatar/big-view-2"), madeBy.get("/api/avatar/big-view-3")],
+    "released entries are evicted-and-revoked immediately, oldest first",
+  );
+  assert.equal(
+    readCachedAuthedImageUrl("/api/avatar/big-view-4"),
+    madeBy.get("/api/avatar/big-view-4"),
+    "still-retained entries survive",
+  );
+});
+
 // --- cave-fea6: success-path eviction must not kill the URL it hands out -------
 
 test("an entry resolving while the cache is over-cap with in-flight loads is not its own eviction victim", async (t) => {

--- a/src/lib/authed-image-cache.test.ts
+++ b/src/lib/authed-image-cache.test.ts
@@ -1,0 +1,236 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_CACHE_ENTRIES,
+  __resetAuthedImageCacheForTests,
+  loadAuthedObjectUrl,
+  readCachedAuthedImageUrl,
+  retainAuthedImage,
+  seedAuthedImageState,
+} from "./authed-image.ts";
+
+// Behavioral coverage for the shared object-URL cache (cave-wnhh): the loader
+// and cache are pure JS with injectable `fetch` / `URL` statics, so exercise
+// them for real — eviction, recency, refcounts, dedupe, retry — instead of
+// pinning source regexes. (Hook↔React wiring stays source-pinned in
+// authed-image.test.ts; there is no DOM harness in this suite.)
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Stub `fetch` + the object-URL statics for one test.
+ * - `failFor`: srcs that respond 404.
+ * - `gates`: src → deferred; the fetch for that src stalls until resolved.
+ * Restores everything (and resets the shared cache) when the test ends.
+ */
+function stubEnv(t, { failFor = new Set(), gates = new Map() } = {}) {
+  const fetchCalls = [];
+  const revoked = [];
+  let counter = 0;
+  const madeBy = new Map(); // src → object URL it resolved to
+
+  const origFetch = globalThis.fetch;
+  const origCreate = URL.createObjectURL;
+  const origRevoke = URL.revokeObjectURL;
+
+  globalThis.fetch = async (src) => {
+    fetchCalls.push(src);
+    const gate = gates.get(src);
+    if (gate) await gate.promise;
+    if (failFor.has(src)) return { ok: false, status: 404 };
+    return { ok: true, blob: async () => ({ src }) };
+  };
+  URL.createObjectURL = (blob) => {
+    const url = `blob:mock-${++counter}`;
+    if (blob && blob.src) madeBy.set(blob.src, url);
+    return url;
+  };
+  URL.revokeObjectURL = (url) => {
+    revoked.push(url);
+  };
+
+  __resetAuthedImageCacheForTests();
+  t.after(() => {
+    __resetAuthedImageCacheForTests(); // revokes via stubs, then restore
+    globalThis.fetch = origFetch;
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+  });
+
+  return { fetchCalls, revoked, madeBy };
+}
+
+// --- request dedupe ----------------------------------------------------------
+
+test("identical srcs share one in-flight fetch and resolve to one object URL", async (t) => {
+  const { fetchCalls } = stubEnv(t);
+
+  const [a, b] = await Promise.all([
+    loadAuthedObjectUrl("/api/familiars/x/avatar"),
+    loadAuthedObjectUrl("/api/familiars/x/avatar"),
+  ]);
+  const c = await loadAuthedObjectUrl("/api/familiars/x/avatar");
+
+  assert.equal(fetchCalls.length, 1, "N concurrent + repeat loads = 1 fetch");
+  assert.ok(a && a.startsWith("blob:"), "resolves to an object URL");
+  assert.equal(a, b, "concurrent loads share the blob URL");
+  assert.equal(a, c, "later loads reuse the cached blob URL");
+});
+
+// --- error path enables retry --------------------------------------------------
+
+test("a failed fetch resolves null, is not cached, and a later load retries", async (t) => {
+  const failFor = new Set(["/api/familiars/x/avatar"]);
+  const { fetchCalls } = stubEnv(t, { failFor });
+
+  assert.equal(await loadAuthedObjectUrl("/api/familiars/x/avatar"), null, "404 → null");
+  assert.equal(
+    readCachedAuthedImageUrl("/api/familiars/x/avatar"),
+    null,
+    "failure is not cached",
+  );
+
+  failFor.clear(); // daemon came back
+  const url = await loadAuthedObjectUrl("/api/familiars/x/avatar");
+  assert.equal(fetchCalls.length, 2, "second load re-fetches");
+  assert.ok(url && url.startsWith("blob:"), "retry succeeds");
+});
+
+// --- eviction revokes exactly the evicted URL ---------------------------------
+
+test("filling past the cap evicts and revokes exactly the oldest resolved entry", async (t) => {
+  const { revoked, madeBy } = stubEnv(t);
+
+  const first = await loadAuthedObjectUrl("/api/avatar/first");
+  for (let i = 1; i <= MAX_CACHE_ENTRIES; i++) {
+    await loadAuthedObjectUrl(`/api/avatar/filler-${i}`);
+  }
+
+  assert.deepEqual(revoked, [first], "exactly the oldest URL is revoked, nothing else");
+  assert.equal(readCachedAuthedImageUrl("/api/avatar/first"), null, "evicted entry is gone");
+  assert.equal(
+    readCachedAuthedImageUrl(`/api/avatar/filler-${MAX_CACHE_ENTRIES}`),
+    madeBy.get(`/api/avatar/filler-${MAX_CACHE_ENTRIES}`),
+    "surviving entries stay readable",
+  );
+});
+
+// --- cave-fea6: reads refresh LRU recency --------------------------------------
+
+test("a hook-style cache read refreshes recency so the still-rendered image is not the eviction victim", async (t) => {
+  const { revoked, madeBy } = stubEnv(t);
+
+  const first = await loadAuthedObjectUrl("/api/avatar/first");
+  for (let i = 1; i < MAX_CACHE_ENTRIES; i++) {
+    await loadAuthedObjectUrl(`/api/avatar/filler-${i}`);
+  }
+  // Cache is exactly at the cap. A component re-render reads `first` (the exact
+  // read both hook paths perform) — that must make it the most recent entry.
+  assert.equal(readCachedAuthedImageUrl("/api/avatar/first"), first, "read hits");
+
+  await loadAuthedObjectUrl("/api/avatar/one-more");
+
+  assert.equal(
+    readCachedAuthedImageUrl("/api/avatar/first"),
+    first,
+    "recently-read entry survives eviction",
+  );
+  assert.deepEqual(
+    revoked,
+    [madeBy.get("/api/avatar/filler-1")],
+    "the true least-recently-used entry is evicted instead",
+  );
+});
+
+// --- cave-fea6: live consumers are refcounted ----------------------------------
+
+test("a retained (mounted) entry is never evicted-and-revoked; releasing makes it evictable", async (t) => {
+  const { revoked, madeBy } = stubEnv(t);
+
+  const first = await loadAuthedObjectUrl("/api/avatar/first");
+  const release = retainAuthedImage("/api/avatar/first");
+
+  // Push far past the cap without ever touching `first` again — a mounted
+  // component that never re-renders must still keep its URL alive.
+  for (let i = 1; i <= MAX_CACHE_ENTRIES; i++) {
+    await loadAuthedObjectUrl(`/api/avatar/filler-${i}`);
+  }
+  assert.ok(!revoked.includes(first), "in-use URL is never revoked");
+  assert.equal(revoked[0], madeBy.get("/api/avatar/filler-1"), "eviction skips to unretained entries");
+  assert.equal(readCachedAuthedImageUrl("/api/avatar/first"), first, "in-use entry stays cached");
+
+  release();
+  release(); // double-release must not double-decrement
+
+  // Once released (and not re-read), it ages out like anything else.
+  for (let i = 1; i <= MAX_CACHE_ENTRIES; i++) {
+    await loadAuthedObjectUrl(`/api/avatar/late-${i}`);
+  }
+  assert.ok(revoked.includes(first), "released entry becomes evictable again");
+});
+
+// --- cave-fea6: success-path eviction must not kill the URL it hands out -------
+
+test("an entry resolving while the cache is over-cap with in-flight loads is not its own eviction victim", async (t) => {
+  const gates = new Map();
+  gates.set("/api/avatar/first", deferred());
+  for (let i = 1; i <= MAX_CACHE_ENTRIES; i++) gates.set(`/api/avatar/inflight-${i}`, deferred());
+  const { revoked } = stubEnv(t, { gates });
+
+  // `first` starts, then the cache floods past the cap with in-flight entries
+  // (in-flight entries are exempt from eviction, so the map exceeds the cap).
+  const firstPromise = loadAuthedObjectUrl("/api/avatar/first");
+  const rest = [];
+  for (let i = 1; i <= MAX_CACHE_ENTRIES; i++) {
+    rest.push(loadAuthedObjectUrl(`/api/avatar/inflight-${i}`));
+  }
+
+  // `first` resolves while it is the ONLY entry holding an object URL. The
+  // success-path eviction pass must not revoke the URL it is about to return.
+  gates.get("/api/avatar/first").resolve();
+  const first = await firstPromise;
+
+  assert.ok(first && first.startsWith("blob:"), "resolves to an object URL");
+  assert.deepEqual(revoked, [], "the just-resolved URL is not revoked");
+  assert.equal(
+    readCachedAuthedImageUrl("/api/avatar/first"),
+    first,
+    "the just-resolved entry is still cached",
+  );
+
+  for (const [, gate] of gates) gate.resolve();
+  await Promise.all(rest);
+});
+
+// --- cave-x63e: state seeding for a (possibly new) src --------------------------
+
+test("seedAuthedImageState reports loading/ready/idle for the src it was asked about", async (t) => {
+  stubEnv(t);
+
+  assert.deepEqual(seedAuthedImageState(null), { url: null, status: "idle" }, "null → idle");
+  assert.deepEqual(
+    seedAuthedImageState("data:image/png;base64,AAAA"),
+    { url: null, status: "idle" },
+    "passthrough src → idle (the hook returns it synchronously as ready)",
+  );
+  assert.deepEqual(
+    seedAuthedImageState("/api/familiars/x/avatar"),
+    { url: null, status: "loading" },
+    "un-cached authed src → loading, never a stale error/ready from a previous src",
+  );
+
+  const url = await loadAuthedObjectUrl("/api/familiars/x/avatar");
+  assert.deepEqual(
+    seedAuthedImageState("/api/familiars/x/avatar"),
+    { url, status: "ready" },
+    "cached authed src → ready synchronously (no fallback flash)",
+  );
+});

--- a/src/lib/authed-image.test.ts
+++ b/src/lib/authed-image.test.ts
@@ -91,8 +91,45 @@ assert.match(source, /URL\.createObjectURL\(blob\)/, "creates a blob object URL"
 
 // A failed fetch must surface as an "error" status so fallback chains advance,
 // and must not poison the cache (so a later mount can retry).
-assert.match(source, /status: "error"/, "reports an error status on failure");
+assert.match(
+  source,
+  /commit\(resolved, resolved \? "ready" : "error"\)/,
+  "reports an error status on failure",
+);
 assert.match(source, /cache\.delete\(src\)/, "drops the failed entry for retry");
+
+// The state a consumer observes must always describe the CURRENT src: the hook
+// resets synchronously on a src change (render-phase derived-state pattern), so
+// a fallback-chain consumer can never misread the previous src's "error" and
+// double-advance past a loadable source (cave-x63e).
+assert.match(source, /if \(prevSrc !== src\) \{/, "state is keyed to its src");
+assert.match(
+  source,
+  /setPrevSrc\(src\);\s*\n\s*setState\(seedAuthedImageState\(src\)\)/,
+  "src change reseeds state synchronously during render",
+);
+
+// Mounted consumers hold a ref on their entry so eviction never revokes an
+// object URL something is still displaying, and render-time cache reads refresh
+// LRU recency so live images don't age to the front of the eviction queue
+// (cave-fea6).
+assert.match(source, /const release = retainAuthedImage\(src\)/, "hook retains its entry while mounted");
+assert.match(source, /release\(\);/, "hook releases its entry on cleanup");
+assert.match(
+  source,
+  /entry\.refs > 0 \|\| entry === protect/,
+  "eviction skips in-use and just-resolved entries",
+);
+assert.match(
+  source,
+  /const cached = readCachedAuthedImageUrl\(src\)/,
+  "effect cache reads refresh recency",
+);
+assert.match(
+  source,
+  /const cached = readCachedAuthedImageUrl\(src\);\s*\n\s*return cached \? \{ url: cached, status: "ready" \}/,
+  "seed cache reads refresh recency",
+);
 
 // The shared cache is bounded and revokes object URLs on eviction (no leaks) and
 // must NOT revoke on unmount (that races other live consumers of the blob).

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -63,30 +63,80 @@ export function needsAuthedImageFetch(src: string | null | undefined): boolean {
 // consumers of the same shared blob and reintroduces the broken-image glyph).
 // ---------------------------------------------------------------------------
 
-type CacheEntry = { objectUrl: string | null; promise: Promise<string | null> };
+type CacheEntry = {
+  objectUrl: string | null;
+  promise: Promise<string | null>;
+  /** Mounted consumers of this entry; eviction never revokes while refs > 0. */
+  refs: number;
+};
 
-const MAX_CACHE_ENTRIES = 64;
+/** Exported for tests. */
+export const MAX_CACHE_ENTRIES = 64;
 const cache = new Map<string, CacheEntry>();
 
-function evictOldestIfNeeded(): void {
+/** Move `entry` to the most-recently-used position. */
+function touch(src: string, entry: CacheEntry): void {
+  cache.delete(src);
+  cache.set(src, entry);
+}
+
+function evictOldestIfNeeded(protect?: CacheEntry): void {
   if (cache.size <= MAX_CACHE_ENTRIES) return;
 
-  // Only evict entries that have an object URL. Evicting an in-flight entry
-  // would lose the reference needed to revoke its eventual object URL.
+  // Never evict: in-flight entries (no URL to revoke yet — losing the entry
+  // would leak the eventual object URL), in-use entries (revoking would break
+  // the next element to render the URL, e.g. the avatar lightbox — cave-fea6),
+  // or the entry a resolving fetch is about to hand to its consumer. The cache
+  // may transiently exceed the cap; it shrinks back as consumers unmount.
   for (const [key, entry] of cache) {
     if (cache.size <= MAX_CACHE_ENTRIES) break;
-    if (!entry.objectUrl) continue;
+    if (!entry.objectUrl || entry.refs > 0 || entry === protect) continue;
     cache.delete(key);
     URL.revokeObjectURL(entry.objectUrl);
   }
 }
 
-function loadAuthedObjectUrl(src: string): Promise<string | null> {
+/**
+ * Read the cached object URL for `src` (or `null`), marking the entry
+ * most-recently-used. Every render-time cache read MUST go through this so
+ * still-rendered images don't age to the front of the eviction queue
+ * (cave-fea6: reads that skip the recency refresh turn the LRU into a FIFO).
+ */
+export function readCachedAuthedImageUrl(src: string): string | null {
+  const entry = cache.get(src);
+  if (!entry) return null;
+  touch(src, entry);
+  return entry.objectUrl;
+}
+
+/**
+ * Mark `src` in-use by a mounted consumer so eviction never revokes an object
+ * URL something is still displaying. Returns an idempotent release function —
+ * releasing does NOT revoke (see the cache header), it only makes the entry
+ * evictable again once no consumers remain.
+ */
+export function retainAuthedImage(src: string): () => void {
+  const entry = cache.get(src);
+  if (!entry) return () => {};
+  entry.refs += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    entry.refs = Math.max(0, entry.refs - 1);
+  };
+}
+
+/**
+ * Fetch `src` through the (auth-bridge-patched) `fetch` and resolve to a shared
+ * `blob:` object URL, or `null` on failure. Concurrent and repeat calls for the
+ * same `src` share one fetch and one blob. Exported for tests and non-hook
+ * call sites; components should reach for the hooks below.
+ */
+export function loadAuthedObjectUrl(src: string): Promise<string | null> {
   const existing = cache.get(src);
   if (existing) {
-    // Refresh LRU recency on hit.
-    cache.delete(src);
-    cache.set(src, existing);
+    touch(src, existing);
     return existing.promise;
   }
 
@@ -101,7 +151,11 @@ function loadAuthedObjectUrl(src: string): Promise<string | null> {
       const entry = cache.get(src);
       if (entry) {
         entry.objectUrl = objectUrl;
-        evictOldestIfNeeded();
+        // Just resolved = just used: make it MRU and shield it from the
+        // eviction pass below, which could otherwise revoke the very URL we
+        // are about to return (cache over-cap during a burst of loads).
+        touch(src, entry);
+        evictOldestIfNeeded(entry);
       }
       return objectUrl;
     } catch {
@@ -112,7 +166,7 @@ function loadAuthedObjectUrl(src: string): Promise<string | null> {
     }
   })();
 
-  cache.set(src, { objectUrl: null, promise });
+  cache.set(src, { objectUrl: null, promise, refs: 0 });
   evictOldestIfNeeded();
   return promise;
 }
@@ -126,6 +180,20 @@ export type AuthedImageState = {
 };
 
 /**
+ * The state {@link useAuthedImageState} starts from for a given `src` — `idle`
+ * for empty/passthrough sources, and for authed sources `ready` synchronously
+ * when the blob is already cached (no fallback flash) or `loading` otherwise.
+ * Exported for tests.
+ */
+export function seedAuthedImageState(src: string | null | undefined): AuthedImageState {
+  if (src && needsAuthedImageFetch(src)) {
+    const cached = readCachedAuthedImageUrl(src);
+    return cached ? { url: cached, status: "ready" } : { url: null, status: "loading" };
+  }
+  return { url: null, status: "idle" };
+}
+
+/**
  * Resolve an image `src` to something a native renderer can actually display in
  * the packaged app, reporting the load status so callers with a fallback chain
  * (e.g. `FamiliarAvatar`) can advance to the next source on a genuine failure.
@@ -137,37 +205,52 @@ export type AuthedImageState = {
  * - same-origin `/api/...` → `status: "loading"` (url `null`) until the
  *   authenticated fetch resolves to a `blob:` URL (`"ready"`) or fails
  *   (`"error"`, url `null`).
+ *
+ * The returned state always describes the CURRENT `src` — never a stale
+ * status/url left over from a previous one.
  */
 export function useAuthedImageState(src: string | null | undefined): AuthedImageState {
   const passthrough = src && !needsAuthedImageFetch(src) ? src : null;
-  const [state, setState] = useState<AuthedImageState>(() => {
-    // Seed synchronously from cache so re-renders of an already-loaded avatar
-    // don't flash the fallback.
-    if (src && needsAuthedImageFetch(src)) {
-      const cached = cache.get(src)?.objectUrl ?? null;
-      return cached ? { url: cached, status: "ready" } : { url: null, status: "loading" };
-    }
-    return { url: null, status: "idle" };
-  });
+  const [state, setState] = useState<AuthedImageState>(() => seedAuthedImageState(src));
+
+  // Key the state to the src it describes (cave-x63e). Without this, the first
+  // render after a src change still returns the PREVIOUS src's state — e.g. a
+  // lingering `"error"` that a fallback-chain consumer (FamiliarAvatar) would
+  // misread as the NEW source having failed, double-advancing past a loadable
+  // source. Render-phase reset (React's derived-state-from-props pattern)
+  // guarantees no consumer ever observes state for a src it didn't ask about.
+  const [prevSrc, setPrevSrc] = useState(src);
+  if (prevSrc !== src) {
+    setPrevSrc(src);
+    setState(seedAuthedImageState(src));
+  }
 
   useEffect(() => {
     if (!src || !needsAuthedImageFetch(src)) {
-      setState({ url: null, status: "idle" });
+      setState((prev) => (prev.status === "idle" ? prev : { url: null, status: "idle" }));
       return;
     }
     let active = true;
-    const cached = cache.get(src)?.objectUrl;
+    const commit = (url: string | null, status: AuthedImageStatus) =>
+      setState((prev) => (prev.url === url && prev.status === status ? prev : { url, status }));
+
+    const cached = readCachedAuthedImageUrl(src);
     if (cached) {
-      setState({ url: cached, status: "ready" });
-      return;
+      commit(cached, "ready");
+    } else {
+      commit(null, "loading");
+      void loadAuthedObjectUrl(src).then((resolved) => {
+        if (!active) return;
+        commit(resolved, resolved ? "ready" : "error");
+      });
     }
-    setState({ url: null, status: "loading" });
-    void loadAuthedObjectUrl(src).then((resolved) => {
-      if (!active) return;
-      setState(resolved ? { url: resolved, status: "ready" } : { url: null, status: "error" });
-    });
+    // Hold the entry (cached or just-created in-flight) for this component's
+    // lifetime so eviction never revokes an object URL a mounted element is
+    // displaying (cave-fea6).
+    const release = retainAuthedImage(src);
     return () => {
       active = false;
+      release();
     };
   }, [src]);
 

--- a/src/lib/authed-image.ts
+++ b/src/lib/authed-image.ts
@@ -124,6 +124,9 @@ export function retainAuthedImage(src: string): () => void {
     if (released) return;
     released = true;
     entry.refs = Math.max(0, entry.refs - 1);
+    // If retained entries pushed the cache over the cap, shrink it back now —
+    // don't leave released blobs alive waiting for some future load's pass.
+    if (entry.refs === 0) evictOldestIfNeeded();
   };
 }
 


### PR DESCRIPTION
Follow-ups from the post-merge review of #3081 (authenticated blob-URL avatar rendering). Both bugs were latent — unreachable with today's producers — but each would silently reintroduce the exact "image won't render" symptom that PR exists to kill.

## cave-fea6 — LRU was effectively FIFO; eviction could revoke in-use blob URLs

The recency refresh lived only in `loadAuthedObjectUrl`, but both hook read paths (`useState` seed + effect cached-hit) read the map directly — a completed entry's recency was never refreshed no matter how many components rendered it. Past `MAX_CACHE_ENTRIES` (64) distinct images in one session (large roster + `?v=` churn from avatar edits), eviction revoked the first-fetched — plausibly most-visible — URL while mounted components still held it in `ready` state; the next element to render it (e.g. `AvatarLightbox`, which has no `onError`) painted the broken-image glyph with no recovery.

**Fix, three layers:**
- `readCachedAuthedImageUrl` — every render-time read refreshes recency (true LRU).
- Mounted consumers `retainAuthedImage`/release around the effect lifetime; eviction skips `refs > 0` entries, so an in-use URL can never be revoked, even for a component that never re-renders.
- A resolving fetch makes its entry MRU and shields it from its own eviction pass (previously it could revoke the URL it was about to return when the cache was over-cap with in-flight loads).

## cave-x63e — hook returned the previous src's state for one render after a src change

State wasn't keyed to the src it described: with two consecutive authed sources S0 → S1, S0's `error` was still the returned state on the first render after advancing to S1, so `FamiliarAvatar`'s advance effect (deps include the changed src) double-advanced and skipped S1 entirely. Fixed with the React derived-state pattern: `prevSrc` tracked in state, synchronous `seedAuthedImageState(src)` reset during render — no consumer can ever observe state for a src it didn't ask about. Also removes the one-frame stale-image render when switching between two authed srcs.

## cave-wnhh — behavioral tests where the risk lives

New `src/lib/authed-image-cache.test.ts` exercises the real module through stubbed `fetch`/`URL` statics (no DOM needed): shared-promise dedupe (N mounts = 1 fetch), error-path retry (failures aren't cached), eviction revokes exactly the evicted URL, recency after hook-style reads, refcount retain/release (idempotent release), over-cap resolution safety, and `seedAuthedImageState` semantics. Hook↔React wiring stays source-pinned in `authed-image.test.ts` per suite convention (no DOM harness).

## Testing
- `pnpm typecheck` clean
- `pnpm test:app` — 673/673 files pass locally (new file registered in `scripts/run-tests.mjs`)
- New tests were written first and verified failing against the old implementation