### PR TITLE
fix(settings): compact About links to match page action buttons (cave-svy1)

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2354,8 +2354,8 @@ function AboutSection() {
             <Button
               key={l.href}
               variant="secondary"
-              size="sm"
-              className="settings-touch-action"
+              size="xs"
+              className="settings-touch-action settings-tool-action gap-1.5 px-2.5 text-[11px]"
               onClick={() => openExternalUrl(l.href)}
               leadingIcon={l.icon}
             >

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -320,7 +320,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: var(--touch-target);
   line-height: 1.2;
   text-decoration: none;
   white-space: nowrap;
@@ -330,6 +329,15 @@
   height: 28px;
   min-height: 28px;
   line-height: 1;
+}
+
+/* Touch widths keep the WCAG floor; on desktop the shared action stays as
+   compact as the neighboring xs/tool-action buttons. Placed after
+   .settings-tool-action so the floor wins when both classes are present. */
+@media (max-width: 767px) {
+  .settings-touch-action {
+    min-height: var(--touch-target);
+  }
 }
 
 .settings-tool-action--primary {


### PR DESCRIPTION
## What

The **Links** row in Settings → About rendered as ~44px-tall buttons while every other action on the page (update row, daemon Retry, OpenCoven tools) is 22–28px. This streamlines the links to match.

## How

- `.settings-touch-action`'s `min-height: var(--touch-target)` (44px) is now scoped to `@media (max-width: 767px)` — the WCAG touch floor stays on mobile, desktop gets the natural compact size. Placed after `.settings-tool-action` so the floor still wins when both classes are present.
- About links switch to `size="xs"` + `settings-tool-action` (28px, `--radius-control`), the exact treatment of the OpenCoven tools buttons directly above them.
- Mobile → "Setup guide" button benefits from the same desktop compaction automatically.

## Verification

- `pnpm test:app` — 673 test files pass (incl. `settings-shell-polish.test.ts`, `open-coven-tools-update.test.ts` guards)
- `pnpm typecheck` — clean

Bead: cave-svy1