### PR TITLE
feat(home): live presence tier — running sessions read from Home (cave-9j6a)

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -101,4 +101,24 @@ assert.match(
   "the once-a-minute digest refresh pauses while the user is typing",
 );
 
+// ── Live presence tier (cave-9j6a): running sessions read from Home ──────────
+assert.match(view, /card\.kind === "live"/, "the carousel renders the live-card branch");
+assert.match(
+  view,
+  /className="home-digest__card home-digest__card--live"/,
+  "live cards wear the presence variant",
+);
+assert.match(view, /home-digest__live-dot/, "live cards carry the breathing status dot");
+assert.match(
+  view,
+  /home-digest__card--live"[\s\S]{0,800}Running now/,
+  "clicking a live card opens the session; AT hears 'Running now'",
+);
+assert.match(css, /\.home-digest__card--live \{/, "live variant styled from presence tokens");
+assert.match(
+  css,
+  /home-digest-live-pulse/,
+  "the dot pulse is a named keyframe (token durations zero it under reduced motion)",
+);
+
 console.log("home-digest-carousel.test.ts passed");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -277,6 +277,25 @@ function DigestCardView({
     );
   }
 
+  if (card.kind === "live") {
+    return (
+      <button
+        type="button"
+        className="home-digest__card home-digest__card--live"
+        tabIndex={tabIndex}
+        onClick={() => onOpenSession?.(card.sessionId, card.familiarId)}
+        title={`Watch “${card.title}” live`}
+      >
+        <span className="home-digest__live-dot" aria-hidden />
+        <span className="home-digest__body">
+          <span className="home-digest__title">{card.title}</span>
+          <span className="home-digest__meta">{card.subtitle}</span>
+        </span>
+        <span className="sr-only">Running now</span>
+      </button>
+    );
+  }
+
   if (card.kind === "summary") {
     return (
       <div className="home-digest__card home-digest__card--summary">

--- a/src/lib/home-digest.test.ts
+++ b/src/lib/home-digest.test.ts
@@ -108,4 +108,55 @@ assert.deepEqual(empty, [], "no activity and no rss → no cards (strip stays hi
 const rssOnly = buildDigestCards({ items: [], sessions: [], rssItems, nowMs: NOW });
 assert.equal(rssOnly[0].kind, "rss", "rss-only digest has no leading summary card");
 
+// ── Live tier: running sessions lead as presence cards (cave-9j6a) ────────────
+{
+  const withLive = buildDigestCards({
+    items,
+    sessions: [
+      ...sessions,
+      { id: "L1", title: "Refactor auth", status: "running", updated_at: hoursAgo(0.05), created_at: hoursAgo(30), familiarId: "f1" },
+      { id: "L2", title: "Long research sweep", status: "running", updated_at: hoursAgo(0.5), created_at: hoursAgo(40), familiarId: null },
+    ],
+    rssItems,
+    familiarNameById,
+    nowMs: NOW,
+  });
+  const kinds2 = withLive.map((c) => c.kind);
+  const live = withLive.filter((c) => c.kind === "live");
+  assert.equal(live.length, 2, "every running session gets a live card");
+  assert.ok(kinds2.indexOf("live") < kinds2.indexOf("summary"), "live tier precedes the summary");
+  assert.equal(live[0].sessionId, "L1", "freshest activity first");
+  assert.ok(live[0].subtitle.includes("Sage"), "live subtitle resolves the familiar");
+  assert.ok(live[0].subtitle.includes("working"), "live subtitle says what's happening");
+  // A running session started before today still surfaces (not day-gated) and
+  // never doubles as a plain session card.
+  assert.ok(
+    !withLive.some((c) => c.kind === "session" && c.sessionId === "L1"),
+    "live sessions are not duplicated into the resumable-session tier",
+  );
+
+  // needs-you still leads overall when present.
+  const withNeeds = buildDigestCards({
+    items,
+    sessions: [{ id: "L1", title: "x", status: "running", updated_at: hoursAgo(1), created_at: hoursAgo(1) }],
+    rssItems: [],
+    needsYou: [{ id: "n1", kind: "response-needed", title: "Reply?", updatedAt: hoursAgo(1), createdAt: hoursAgo(1) }],
+    nowMs: NOW,
+  });
+  const kinds3 = withNeeds.map((c) => c.kind);
+  assert.ok(kinds3.indexOf("needs") < kinds3.indexOf("live"), "attention items outrank ambient presence");
+
+  // maxLive caps the tier.
+  const cappedLive = buildDigestCards({
+    items: [],
+    sessions: Array.from({ length: 6 }, (_, i) => ({
+      id: `L${i}`, title: `run ${i}`, status: "running", updated_at: hoursAgo(i + 1), created_at: hoursAgo(i + 2),
+    })),
+    rssItems: [],
+    nowMs: NOW,
+    maxLive: 2,
+  });
+  assert.equal(cappedLive.filter((c) => c.kind === "live").length, 2, "maxLive caps live cards");
+}
+
 console.log("home-digest.test.ts passed");

--- a/src/lib/home-digest.ts
+++ b/src/lib/home-digest.ts
@@ -44,6 +44,19 @@ export type DigestSessionCard = {
   subtitle: string;
 };
 
+/** A session a familiar is working RIGHT NOW — the agentic-presence tier.
+ *  Leads the chats track (after needs-you) so "what's happening" reads from
+ *  Home without opening a chat (cave-9j6a). */
+export type DigestLiveCard = {
+  kind: "live";
+  id: string;
+  sessionId: string;
+  familiarId: string | null;
+  title: string;
+  /** "Nova · working · 2m" (only the present parts). */
+  subtitle: string;
+};
+
 export type DigestRssCard = {
   kind: "rss";
   id: string;
@@ -87,6 +100,7 @@ export type DigestSuggestionCard = {
 export type DigestCard =
   | DigestNeedsCard
   | DigestNeedsMoreCard
+  | DigestLiveCard
   | DigestSummaryCard
   | DigestSessionCard
   | DigestSuggestionCard
@@ -108,6 +122,8 @@ export type BuildDigestInput = {
   maxSessions?: number;
   maxRss?: number;
   maxNeeds?: number;
+  /** Max live "working now" cards (default 4). */
+  maxLive?: number;
 };
 
 function sameLocalDay(iso: string | null | undefined, now: Date): boolean {
@@ -190,12 +206,33 @@ export function buildDigestCards(input: BuildDigestInput): DigestCard[] {
   const maxSessions = input.maxSessions ?? 6;
   const maxRss = input.maxRss ?? 14;
   const maxNeeds = input.maxNeeds ?? 6;
+  const maxLive = input.maxLive ?? 4;
   const needsYou = input.needsYou ?? [];
   const suggestions = input.suggestions ?? [];
   const now = new Date(nowMs);
 
+  // Sessions a familiar is actively working — the presence tier. Not gated to
+  // "today": a long-running job started yesterday is still happening now.
+  const liveSessions = sessions
+    .filter((s) => !s.archived_at && s.status === "running")
+    .sort((a, b) =>
+      (b.updated_at ?? b.created_at ?? "").localeCompare(a.updated_at ?? a.created_at ?? ""),
+    );
+  const liveIds = new Set(liveSessions.slice(0, maxLive).map((s) => s.id));
+
+  // Summary counts every session touched today (live included) …
+  const todayTouchedCount = sessions.filter(
+    (s) => !s.archived_at && sameLocalDay(s.updated_at ?? s.created_at, now),
+  ).length;
+
+  // … while the resumable-session cards exclude the live tier (no doubles).
   const todaySessions = sessions
-    .filter((s) => !s.archived_at && sameLocalDay(s.updated_at ?? s.created_at, now))
+    .filter(
+      (s) =>
+        !s.archived_at &&
+        !liveIds.has(s.id) &&
+        sameLocalDay(s.updated_at ?? s.created_at, now),
+    )
     .sort((a, b) =>
       (b.updated_at ?? b.created_at ?? "").localeCompare(a.updated_at ?? a.created_at ?? ""),
     );
@@ -233,8 +270,24 @@ export function buildDigestCards(input: BuildDigestInput): DigestCard[] {
     cards.push({ kind: "needs-more", id: "needs-more", count: needsYou.length - maxNeeds });
   }
 
+  // Live tier — what familiars are doing right now, right after what needs
+  // you. Elapsed reads from last activity so the card stays honest while a
+  // long task streams.
+  for (const s of liveSessions.slice(0, maxLive)) {
+    const fam = s.familiarId ? familiarNameById?.get(s.familiarId) ?? null : null;
+    const age = relativeAge(s.updated_at ?? s.created_at ?? null, nowMs);
+    cards.push({
+      kind: "live",
+      id: `live:${s.id}`,
+      sessionId: s.id,
+      familiarId: s.familiarId ?? null,
+      title: s.title?.trim() || "Untitled session",
+      subtitle: [fam, "working", age].filter(Boolean).join(" · "),
+    });
+  }
+
   const summaryLines: string[] = [];
-  if (todaySessions.length) summaryLines.push(plural(todaySessions.length, "session"));
+  if (todayTouchedCount) summaryLines.push(plural(todayTouchedCount, "session"));
   if (remindersFired) summaryLines.push(plural(remindersFired, "reminder"));
   if (responsesWaiting) summaryLines.push(`${responsesWaiting} waiting`);
   if (familiarUpdates) summaryLines.push(plural(familiarUpdates, "familiar update"));

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -1051,6 +1051,31 @@
   background: color-mix(in oklch, var(--color-warning) 12%, var(--bg-raised));
   border-color: color-mix(in oklch, var(--color-warning) 45%, var(--border-hairline));
 }
+/* Live cards — the agentic-presence tier (cave-9j6a): a familiar is working
+   this session RIGHT NOW. Presence tint + a breathing status dot; the pulse
+   collapses to a static dot under prefers-reduced-motion (token durations
+   zero out globally). */
+.home-digest__card--live {
+  opacity: 1;
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+}
+.home-digest__card--live:hover {
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 48%, var(--border-hairline));
+}
+.home-digest__live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  flex-shrink: 0;
+  animation: home-digest-live-pulse 2s var(--ease-standard, ease-out) infinite;
+}
+@keyframes home-digest-live-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent-presence) 45%, transparent); }
+  50% { box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent-presence) 0%, transparent); }
+}
 /* Suggestion cards — quick actions trail the chats track in the presence
    tint so "start this next" reads apart from resumable sessions. */
 .home-digest__card--suggestion {


### PR DESCRIPTION
## Facelift 5 — Home agentic presence

Fifth surface PR of the UI/UX facelift program (`cave-ew98`; this bead `cave-9j6a`). The audit's core "agentic legibility" finding: Home showed what **needs you** (attention cards) and what you could **resume** (session cards), but nothing showed what familiars are doing **right now**.

### After (prod build, sessions API wrapped to mark two sessions running)
- New **live tier** in the digest strip: presence-tinted cards with a breathing status dot — *“Patch the create task button… · Nova · working · just now”*
- Ordered deliberately: **needs-you → live → daily summary → resumable sessions → suggestions** (attention outranks ambient presence)
- Click opens the running session; screen readers hear **“Running now”**
- Dot pulse stills under `prefers-reduced-motion` (global token-duration collapse)

### Changes
- `src/lib/home-digest.ts` — `DigestLiveCard` + build logic: running sessions (**not day-gated** — a long job started yesterday is still happening now), freshest-activity-first, `maxLive` (4) cap; excluded from the resumable-session cards (no doubles) while the daily-summary count still counts every session touched today
- `src/components/home/home-digest-carousel.tsx` — live-card render branch (`onOpenSession`, sr-only "Running now")
- `src/styles/home-composer.css` — `--live` presence variant + `home-digest-live-pulse` keyframe
- Tests — live-tier unit coverage in `home-digest.test.ts` (order vs needs-you/summary, cap, dedupe, familiar resolution, non-day-gating) and carousel/CSS pins in `home-digest-carousel.test.ts`

### Verification
- Full app suite **673 files green** · `pnpm typecheck` clean · `pnpm build` clean
- All existing home pins green (needs-you, composer, feed, carousel)
- Live screenshot evidence captured on the built server with a `page.route` wrap of `/api/sessions/list` (no store writes)

Design rules: presence tokens only (`--accent-presence` washes per the design-language recipe), reduced-motion fallback, keyboard/AT parity, no new dependencies, no new server routes.
