### PR TITLE
fix(tools): Update button resolves stale PATH launchers instead of erroring forever (cave-kii6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ breaking config changes; patch releases stay additive.
 ### Changed
 - **Shared assist runner** — the stitch sew's bounded `codex exec` lane (read-only sandbox pinned inside the module, stdin prompt, `--output-last-message` parse) is extracted to `src/lib/server/assist-runner.ts` for every authoring assist to reuse (cave-c40b).
 
+### Fixed
+- **Tools: Update can now clear stale PATH launchers** — when `npm install -g` succeeds but an older copy of the same package still shadows the fresh install on PATH (orphaned nvm trees, old Homebrew-node prefixes), the Update/Repair flow no longer fails forever with "a stale executable is still first on PATH": it removes the stale same-package launcher under strict identity gates (the fresh npm-prefix copy must verify first; unrelated binaries and directories are never touched) and re-verifies — and when removal isn't safe or permitted, the error now carries the exact manual command instead of a dead end (cave-kii6).
+
 
 ## [0.1.0] - 2026-07-12
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -69,6 +69,7 @@ export const SUITES = {
     "src/lib/opencoven-install-job-observer.test.ts",
     "src/lib/opencoven-tools-install.test.ts",
     "src/lib/opencoven-tool-verification.test.ts",
+    "src/lib/opencoven-tools-resolve.test.ts",
     "src/components/cave-home-migration-banner.test.ts",
     "src/lib/workflow-run-prompt.test.ts",
     "src/lib/workflow-step-progress.test.ts",

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -24,6 +24,7 @@ import {
   type OpenCovenToolVerification,
 } from "@/lib/opencoven-tools-status";
 import { isVerifiedOpenCovenInstallSuccess } from "@/lib/opencoven-tool-verification";
+import { resolveStaleOpenCovenLaunchers } from "@/lib/opencoven-tools-resolve";
 import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
 import { startLocalDaemon } from "@/lib/daemon-start";
 import { redactSecretText } from "@/lib/secret-redaction";
@@ -613,9 +614,31 @@ async function finishInstallJob(
       try {
         verification = await verifyOpenCovenToolInstall(targetName);
         installed = { path: verification.path };
+        let resolutionHint: string | null = null;
         if (!isVerifiedOpenCovenInstallSuccess(code, verification)) {
-          verificationError = verification.error ??
-            `Could not verify ${target.binary} after install.`;
+          // npm succeeded but PATH still resolves something that fails
+          // verification — usually a stale launcher shadowing the fresh
+          // npm-prefix copy. Try the identity-gated cleanup so the Update
+          // button can actually resolve that state instead of reporting it
+          // forever; when cleanup is unsafe, surface its manual hint.
+          const resolution = await resolveStaleOpenCovenLaunchers(
+            targetName,
+            verification.latest,
+          );
+          for (const line of resolution.log) appendOutput(job, `${line}\n`);
+          resolutionHint = resolution.hint;
+          if (resolution.verification) {
+            verification = resolution.verification;
+            installed = { path: verification.path };
+          }
+        }
+        if (!isVerifiedOpenCovenInstallSuccess(code, verification)) {
+          verificationError = [
+            verification.error ?? `Could not verify ${target.binary} after install.`,
+            resolutionHint,
+          ]
+            .filter(Boolean)
+            .join(" ");
         }
       } catch {
         installed = { path: null };

--- a/src/lib/opencoven-tools-resolve.test.ts
+++ b/src/lib/opencoven-tools-resolve.test.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  removeLauncherFile,
+  resolveStaleOpenCovenLaunchers,
+  type StaleLauncherDependencies,
+} from "./opencoven-tools-resolve.ts";
+import type { OpenCovenToolProbe } from "./opencoven-tool-verification.ts";
+
+const LATEST = "0.1.1";
+const GOOD_PATH = "/home/user/.local/bin/coven";
+const GOOD_PKG = "/home/user/.local/lib/node_modules/@opencoven/cli";
+
+function probe(overrides: Partial<OpenCovenToolProbe>): OpenCovenToolProbe {
+  return {
+    path: GOOD_PATH,
+    executablePath: `${GOOD_PKG}/bin/coven.js`,
+    executableVerified: true,
+    version: LATEST,
+    packageName: "@opencoven/cli",
+    packagePath: GOOD_PKG,
+    ...overrides,
+  };
+}
+
+function staleProbe(binPath: string, version: string): OpenCovenToolProbe {
+  const pkg = `${path.dirname(path.dirname(binPath))}/lib/node_modules/@opencoven/cli`;
+  return probe({
+    path: binPath,
+    executablePath: `${pkg}/bin/coven.js`,
+    packagePath: pkg,
+    version,
+  });
+}
+
+function makeDeps({
+  discoverQueue,
+  goodProbe = probe({}),
+  existing = new Set([GOOD_PATH]),
+  removeError,
+}: {
+  discoverQueue: OpenCovenToolProbe[];
+  goodProbe?: OpenCovenToolProbe;
+  existing?: Set<string>;
+  removeError?: Error;
+}): { deps: StaleLauncherDependencies; removed: string[] } {
+  const removed: string[] = [];
+  const deps: StaleLauncherDependencies = {
+    platform: "linux",
+    refreshEnv: () => ({ NODE_ENV: "test" }),
+    npmGlobalPrefix: async () => "/home/user/.local",
+    discover: async () => {
+      const next = discoverQueue.shift();
+      assert.ok(next, "discover called more times than the scripted queue expected");
+      return next;
+    },
+    probeAt: async (_tool, binaryPath) => {
+      assert.equal(binaryPath, GOOD_PATH, "the fresh copy is probed at npm's global bin");
+      return goodProbe;
+    },
+    fileExists: async (file) => existing.has(file),
+    removeFile: async (file) => {
+      if (removeError) throw removeError;
+      removed.push(file);
+      existing.delete(file);
+    },
+  };
+  return { deps, removed };
+}
+
+test("removes an orphaned same-package stale launcher, then verifies the fresh copy", async () => {
+  const stale = staleProbe("/home/user/.nvm/versions/node/v24.13.0/bin/coven", "0.0.54");
+  const { deps, removed } = makeDeps({
+    discoverQueue: [stale, probe({})],
+    existing: new Set([GOOD_PATH, stale.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, [stale.path]);
+  assert.deepEqual(resolution.removed, [stale.path]);
+  assert.equal(resolution.hint, null);
+  assert.ok(resolution.verification?.ok, "final verification succeeds after removal");
+  assert.equal(resolution.verification?.current, LATEST);
+  assert.match(resolution.log[0]!, /Removed stale coven launcher .* \(0\.0\.54\)/);
+  assert.match(resolution.log[1]!, /now resolves at .*\.local\/bin\/coven \(0\.1\.1\)/);
+});
+
+test("clears multiple stacked stale launchers in one pass", async () => {
+  const nvm = staleProbe("/home/user/.nvm/versions/node/v24.13.0/bin/coven", "0.0.54");
+  const brew = staleProbe("/opt/homebrew/bin/coven", "0.0.31");
+  const { deps, removed } = makeDeps({
+    discoverQueue: [nvm, brew, probe({})],
+    existing: new Set([GOOD_PATH, nvm.path!, brew.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, [nvm.path, brew.path]);
+  assert.ok(resolution.verification?.ok);
+});
+
+test("refuses to remove a launcher owned by a different package and hints instead", async () => {
+  const foreign = probe({
+    path: "/home/user/.cargo/bin/coven",
+    executablePath: "/home/user/.cargo/bin/coven",
+    executableVerified: false,
+    version: "0.0.30",
+    packageName: null,
+    packagePath: null,
+  });
+  const { deps, removed } = makeDeps({ discoverQueue: [foreign] });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.equal(resolution.verification?.ok, false);
+  assert.match(resolution.hint!, /\.cargo\/bin\/coven belongs to an unrecognized launcher/);
+  assert.match(resolution.hint!, /Move npm's global bin/);
+});
+
+test("refuses to remove a same-package copy that is not behind the fresh install", async () => {
+  const equalVersion = probe({
+    path: "/opt/other/bin/coven",
+    executableVerified: false,
+    packagePath: "/opt/other/lib/node_modules/@opencoven/cli",
+    executablePath: "/opt/other/lib/node_modules/@opencoven/cli/bin/coven.js",
+  });
+  const { deps, removed } = makeDeps({
+    discoverQueue: [equalVersion],
+    existing: new Set([GOOD_PATH, equalVersion.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.ok(resolution.hint, "a non-removable copy still yields manual guidance");
+});
+
+test("never acts when the fresh npm-prefix copy is missing or unverified", async () => {
+  const stale = staleProbe("/home/user/.nvm/versions/node/v24.13.0/bin/coven", "0.0.54");
+  const missing = makeDeps({
+    discoverQueue: [stale],
+    existing: new Set([stale.path!]),
+  });
+  const missingResolution = await resolveStaleOpenCovenLaunchers(
+    "coven-cli",
+    LATEST,
+    missing.deps,
+  );
+  assert.deepEqual(missing.removed, []);
+  assert.match(missingResolution.log[0]!, /no coven launcher found under npm's global prefix/);
+
+  const unverified = makeDeps({
+    discoverQueue: [stale, stale],
+    goodProbe: probe({ version: "0.0.54" }),
+    existing: new Set([GOOD_PATH, stale.path!]),
+  });
+  const unverifiedResolution = await resolveStaleOpenCovenLaunchers(
+    "coven-cli",
+    LATEST,
+    unverified.deps,
+  );
+  assert.deepEqual(unverified.removed, []);
+  assert.match(
+    unverifiedResolution.log[0]!,
+    /did not verify as the freshly installed @opencoven\/cli/,
+  );
+});
+
+test("a permission failure surfaces an exact manual removal command", async () => {
+  const stale = staleProbe("/usr/local/bin/coven", "0.0.54");
+  const { deps, removed } = makeDeps({
+    discoverQueue: [stale, stale],
+    existing: new Set([GOOD_PATH, stale.path!]),
+    removeError: new Error("EACCES: permission denied"),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.match(resolution.log[0]!, /Could not remove stale coven launcher .*EACCES/);
+  assert.match(resolution.hint!, /rm '\/usr\/local\/bin\/coven'/);
+  assert.equal(resolution.verification?.ok, false);
+});
+
+test("stops without removal when PATH already resolves the fresh copy", async () => {
+  const failingGood = probe({ executableVerified: false });
+  const { deps, removed } = makeDeps({ discoverQueue: [failingGood] });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.equal(resolution.hint, null);
+  assert.equal(resolution.verification?.ok, false);
+});
+
+test("Windows removal covers the launcher's sibling shims", async () => {
+  const goodPath = "C:\\npm\\coven.cmd";
+  const goodProbe = probe({
+    path: goodPath,
+    executablePath: "C:\\npm\\node_modules\\@opencoven\\cli\\bin\\coven.js",
+    packagePath: "C:\\npm\\node_modules\\@opencoven\\cli",
+  });
+  const stale = probe({
+    path: "C:\\old\\coven.cmd",
+    executablePath: "C:\\old\\node_modules\\@opencoven\\cli\\bin\\coven.js",
+    packagePath: "C:\\old\\node_modules\\@opencoven\\cli",
+    version: "0.0.54",
+  });
+  const existing = new Set([goodPath, "C:\\old\\coven", "C:\\old\\coven.cmd", "C:\\old\\coven.ps1"]);
+  const removed: string[] = [];
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, {
+    platform: "win32",
+    refreshEnv: () => ({ NODE_ENV: "test" }),
+    npmGlobalPrefix: async () => "C:\\npm",
+    discover: (() => {
+      const queue = [stale, goodProbe];
+      return async () => queue.shift()!;
+    })(),
+    probeAt: async () => goodProbe,
+    fileExists: async (file) => existing.has(file),
+    removeFile: async (file) => {
+      removed.push(file);
+      existing.delete(file);
+    },
+  });
+
+  assert.deepEqual(removed, ["C:\\old\\coven", "C:\\old\\coven.cmd", "C:\\old\\coven.ps1"]);
+  assert.ok(resolution.verification?.ok);
+});
+
+test("removeLauncherFile deletes files but refuses directories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "coven-resolve-"));
+  const file = path.join(dir, "coven");
+  await writeFile(file, "#!/bin/sh\n");
+
+  await removeLauncherFile(file);
+  await assert.rejects(() => removeLauncherFile(dir), /is not a launcher file/);
+});
+
+test("end-to-end on a real filesystem: stale launcher removed, fresh copy verifies", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX launcher layout (symlink + shebang) does not exist on win32");
+    return;
+  }
+  const root = await mkdtemp(path.join(os.tmpdir(), "coven-resolve-e2e-"));
+  const makeInstall = async (prefix: string, version: string) => {
+    const pkg = path.join(prefix, "lib", "node_modules", "@opencoven", "cli");
+    const bin = path.join(prefix, "bin");
+    await mkdir(path.join(pkg, "bin"), { recursive: true });
+    await mkdir(bin, { recursive: true });
+    await writeFile(
+      path.join(pkg, "package.json"),
+      JSON.stringify({ name: "@opencoven/cli", version, bin: { coven: "bin/coven.js" } }),
+    );
+    await writeFile(
+      path.join(pkg, "bin", "coven.js"),
+      `#!/usr/bin/env node\nconsole.log("coven v${version}");\n`,
+      { mode: 0o755 },
+    );
+    await symlink(
+      path.relative(bin, path.join(pkg, "bin", "coven.js")),
+      path.join(bin, "coven"),
+    );
+    return { launcher: path.join(bin, "coven") };
+  };
+
+  const stale = await makeInstall(path.join(root, "stale"), "0.0.54");
+  const good = await makeInstall(path.join(root, "good"), LATEST);
+  const covenPath = [
+    path.join(root, "stale", "bin"),
+    path.join(root, "good", "bin"),
+    path.dirname(process.execPath),
+    // `which` and realpath live in the system dirs on every CI platform.
+    "/usr/bin",
+    "/bin",
+  ].join(path.delimiter);
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, {
+    refreshEnv: () => ({ ...process.env, PATH: covenPath }),
+    npmGlobalPrefix: async () => path.join(root, "good"),
+  });
+
+  assert.deepEqual(resolution.removed, [stale.launcher]);
+  assert.ok(resolution.verification?.ok, "fresh copy verifies after real removal");
+  assert.equal(resolution.verification?.current, LATEST);
+  assert.equal(resolution.verification?.path, good.launcher);
+  await rm(root, { recursive: true, force: true });
+});
+
+console.log("opencoven-tools-resolve.test.ts: ok");

--- a/src/lib/opencoven-tools-resolve.ts
+++ b/src/lib/opencoven-tools-resolve.ts
@@ -1,0 +1,300 @@
+import { execFile } from "node:child_process";
+import { lstat, rm } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { compareSemver } from "./app-update.ts";
+import { pickWindowsLauncher, refreshCovenSpawnEnv } from "./coven-bin.ts";
+import {
+  discoverOpenCovenTool,
+  probeOpenCovenBinaryAt,
+  OPEN_COVEN_TOOLS,
+  type OpenCovenToolId,
+  type OpenCovenToolSpec,
+} from "./opencoven-tools-status.ts";
+import {
+  evaluateOpenCovenToolVerification,
+  type OpenCovenToolProbe,
+  type OpenCovenToolVerification,
+} from "./opencoven-tool-verification.ts";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Stale-launcher remediation for the OpenCoven tool Update/Repair flow.
+ *
+ * `npm install -g` always writes to npm's global prefix, so when an older
+ * copy of the same package sits earlier on PATH (an orphaned nvm tree, an
+ * old Homebrew-node prefix, ...), the post-install verification correctly
+ * fails with "a stale executable is still first on PATH" — and clicking
+ * Update can never succeed. This module makes the flow able to fix that
+ * state instead of only reporting it, under strict identity gates:
+ *
+ *   - The freshly installed copy at npm's global bin must itself verify
+ *     (same npm package, version >= the tool minimum and >= npm latest when
+ *     known) BEFORE anything is touched. Never delete the only working copy.
+ *   - Only launcher FILES whose resolved target belongs to the same npm
+ *     package are removed — never directories, never binaries owned by other
+ *     packages or by non-npm builds, never the fresh copy itself.
+ *   - When removal is not safe or not permitted, the caller gets an exact,
+ *     copyable manual command instead of a silent failure.
+ */
+export type StaleLauncherResolution = {
+  /** True when remediation ran (a failed verification was re-examined). */
+  attempted: boolean;
+  /** Launcher files removed, in removal order. */
+  removed: string[];
+  /** Human-readable progress lines for the install job tail. */
+  log: string[];
+  /** Manual remediation command/path guidance when blocked, else null. */
+  hint: string | null;
+  /** Final verification after remediation; null when nothing was attempted. */
+  verification: OpenCovenToolVerification<OpenCovenToolId> | null;
+};
+
+export type StaleLauncherDependencies = {
+  platform?: NodeJS.Platform;
+  refreshEnv?: () => NodeJS.ProcessEnv;
+  /** Resolve npm's global prefix (`npm prefix -g`). */
+  npmGlobalPrefix?: (env: NodeJS.ProcessEnv) => Promise<string | null>;
+  discover?: (
+    tool: OpenCovenToolSpec,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<OpenCovenToolProbe>;
+  probeAt?: (
+    tool: OpenCovenToolSpec,
+    binaryPath: string,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<OpenCovenToolProbe>;
+  fileExists?: (file: string) => Promise<boolean>;
+  removeFile?: (file: string) => Promise<void>;
+};
+
+const MAX_REMOVALS = 4;
+
+/** Path semantics must follow the (injectable, testable) target platform,
+ *  not the host: launcher paths on win32 are `C:\...` even when the logic
+ *  is exercised from a POSIX test host. */
+function pathApiFor(platform: NodeJS.Platform): path.PlatformPath {
+  return platform === "win32" ? path.win32 : path.posix;
+}
+
+function samePath(left: string, right: string, platform: NodeJS.Platform): boolean {
+  const api = pathApiFor(platform);
+  const normalize = (value: string) =>
+    platform === "win32" ? api.normalize(value).toLowerCase() : api.normalize(value);
+  return normalize(left) === normalize(right);
+}
+
+async function defaultNpmGlobalPrefix(env: NodeJS.ProcessEnv): Promise<string | null> {
+  const finder = process.platform === "win32" ? "where" : "which";
+  try {
+    const { stdout: npmOut } = await execFileAsync(finder, ["npm"], { env, timeout: 1500 });
+    const npm =
+      process.platform === "win32"
+        ? pickWindowsLauncher(npmOut.split(/\r?\n/))
+        : npmOut.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
+    if (!npm) return null;
+    const { stdout } = await execFileAsync(npm, ["prefix", "-g"], { env, timeout: 5000 });
+    const prefix = stdout.trim();
+    return prefix || null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultFileExists(file: string): Promise<boolean> {
+  try {
+    const stats = await lstat(file);
+    return stats.isFile() || stats.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/** Launcher-file removal only: refuses directories so a surprising probe
+ *  result can never turn into a recursive delete. */
+export async function removeLauncherFile(file: string): Promise<void> {
+  const stats = await lstat(file);
+  if (!stats.isFile() && !stats.isSymbolicLink()) {
+    throw new Error(`${file} is not a launcher file`);
+  }
+  await rm(file, { force: false });
+}
+
+/** npm's global bin location: `<prefix>/bin/<binary>` on POSIX; the shims sit
+ *  directly in the prefix on Windows. */
+function npmGlobalLauncherCandidates(
+  prefix: string,
+  binary: string,
+  platform: NodeJS.Platform,
+): string[] {
+  const api = pathApiFor(platform);
+  if (platform === "win32") {
+    return [
+      api.join(prefix, `${binary}.cmd`),
+      api.join(prefix, `${binary}.ps1`),
+      api.join(prefix, binary),
+    ];
+  }
+  return [api.join(prefix, "bin", binary)];
+}
+
+/** Sibling Windows shims (`coven`, `coven.cmd`, `coven.ps1`) installed next to
+ *  the launcher npm resolved; removing one while its siblings keep shadowing
+ *  would leave the tool broken in other shells. */
+function launcherSiblings(launcher: string, platform: NodeJS.Platform): string[] {
+  if (platform !== "win32") return [launcher];
+  const api = pathApiFor(platform);
+  const dir = api.dirname(launcher);
+  const stem = api.basename(launcher, api.extname(launcher));
+  return [api.join(dir, stem), api.join(dir, `${stem}.cmd`), api.join(dir, `${stem}.ps1`)];
+}
+
+function manualRemovalHint(paths: string[], platform: NodeJS.Platform): string {
+  const command =
+    platform === "win32"
+      ? paths.map((path) => `del "${path}"`).join(" & ")
+      : `rm ${paths.map((path) => `'${path}'`).join(" ")}`;
+  return `Remove it manually (${command}), then re-check.`;
+}
+
+function staleProbeIsRemovableSamePackage(
+  tool: OpenCovenToolSpec,
+  probe: OpenCovenToolProbe,
+  goodVersion: string,
+): boolean {
+  if (!probe.path || probe.packageName !== tool.packageName) return false;
+  // Only remove copies that are strictly behind the verified fresh install;
+  // an equal-or-newer copy failing verification is a different problem that
+  // deletion would not fix.
+  if (probe.version && compareSemver(probe.version, goodVersion) >= 0) return false;
+  return true;
+}
+
+/**
+ * After a failed post-install verification, remove stale same-package
+ * launchers that shadow the npm global bin on PATH, then re-verify. Returns
+ * the final verification so the install flow can report a genuine success
+ * (or a genuinely actionable failure) instead of an eternal stale-PATH error.
+ */
+export async function resolveStaleOpenCovenLaunchers(
+  id: OpenCovenToolId,
+  latest: string | null,
+  dependencies: StaleLauncherDependencies = {},
+): Promise<StaleLauncherResolution> {
+  const tool = OPEN_COVEN_TOOLS.find((candidate) => candidate.id === id);
+  if (!tool) throw new Error("unknown OpenCoven tool");
+
+  const platform = dependencies.platform ?? process.platform;
+  const refreshEnv = dependencies.refreshEnv ?? refreshCovenSpawnEnv;
+  const npmGlobalPrefix = dependencies.npmGlobalPrefix ?? defaultNpmGlobalPrefix;
+  const discover =
+    dependencies.discover ??
+    ((spec: OpenCovenToolSpec, env: NodeJS.ProcessEnv) =>
+      discoverOpenCovenTool(spec, { env }));
+  const probeAt = dependencies.probeAt ?? probeOpenCovenBinaryAt;
+  const fileExists = dependencies.fileExists ?? defaultFileExists;
+  const removeFile = dependencies.removeFile ?? removeLauncherFile;
+
+  const resolution: StaleLauncherResolution = {
+    attempted: true,
+    removed: [],
+    log: [],
+    hint: null,
+    verification: null,
+  };
+  const finish = async (env: NodeJS.ProcessEnv): Promise<StaleLauncherResolution> => {
+    const probe = await discover(tool, env);
+    resolution.verification = evaluateOpenCovenToolVerification(tool, probe, latest);
+    return resolution;
+  };
+
+  let env = refreshEnv();
+
+  // Gate 0: locate and verify the freshly installed copy at npm's global bin.
+  const prefix = await npmGlobalPrefix(env);
+  if (!prefix) {
+    resolution.log.push(
+      "Stale-launcher cleanup skipped: npm's global prefix could not be determined.",
+    );
+    return finish(env);
+  }
+  let goodPath: string | null = null;
+  for (const candidate of npmGlobalLauncherCandidates(prefix, tool.binary, platform)) {
+    if (await fileExists(candidate)) {
+      goodPath = candidate;
+      break;
+    }
+  }
+  if (!goodPath) {
+    resolution.log.push(
+      `Stale-launcher cleanup skipped: no ${tool.binary} launcher found under npm's global prefix (${prefix}).`,
+    );
+    return finish(env);
+  }
+  const goodProbe = await probeAt(tool, goodPath, env);
+  const goodVerification = evaluateOpenCovenToolVerification(tool, goodProbe, latest);
+  const goodVersion = goodProbe.version;
+  if (
+    goodProbe.packageName !== tool.packageName ||
+    !goodProbe.executableVerified ||
+    !goodVersion ||
+    (latest ? compareSemver(goodVersion, latest) < 0 : !goodVerification.compatible)
+  ) {
+    resolution.log.push(
+      `Stale-launcher cleanup skipped: the copy at ${goodPath} did not verify as the freshly installed ${tool.packageName}.`,
+    );
+    return finish(env);
+  }
+
+  for (let pass = 0; pass < MAX_REMOVALS; pass += 1) {
+    const probe = await discover(tool, env);
+    const verification = evaluateOpenCovenToolVerification(tool, probe, latest);
+    resolution.verification = verification;
+    if (verification.ok) {
+      if (resolution.removed.length > 0) {
+        resolution.log.push(
+          `${tool.binary} now resolves at ${probe.path} (${probe.version}).`,
+        );
+      }
+      return resolution;
+    }
+    if (!probe.path || samePath(probe.path, goodPath, platform)) {
+      // PATH already reaches the fresh copy (or nothing) and it still fails
+      // verification — removal has nothing left to fix.
+      return resolution;
+    }
+    if (!staleProbeIsRemovableSamePackage(tool, probe, goodVersion)) {
+      const owner = probe.packageName ?? "an unrecognized launcher";
+      resolution.hint =
+        `${tool.binary} at ${probe.path} belongs to ${owner}, so Cave will not remove it. ` +
+        `Move npm's global bin (${pathApiFor(platform).dirname(goodPath)}) ahead of it on PATH, or remove it yourself and re-check.`;
+      return resolution;
+    }
+
+    const targets: string[] = [];
+    for (const sibling of launcherSiblings(probe.path, platform)) {
+      if (samePath(sibling, goodPath, platform)) continue;
+      if (await fileExists(sibling)) targets.push(sibling);
+    }
+    try {
+      for (const target of targets) {
+        await removeFile(target);
+        resolution.removed.push(target);
+      }
+      resolution.log.push(
+        `Removed stale ${tool.binary} launcher at ${probe.path} (${probe.version ?? "version unreadable"}); it shadowed ${goodPath}.`,
+      );
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      resolution.log.push(`Could not remove stale ${tool.binary} launcher at ${probe.path}: ${detail}`);
+      resolution.hint = manualRemovalHint(
+        targets.length > 0 ? targets : [probe.path],
+        platform,
+      );
+      return finish(env);
+    }
+    env = refreshEnv();
+  }
+  return finish(env);
+}

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -241,15 +241,26 @@ export async function discoverOpenCovenTool(
       packagePath: null,
     };
   }
+  return probeOpenCovenBinaryAt(tool, located.path, env);
+}
 
-  const executablePath = await resolvedExecutablePath(located.path);
+/** Probe one explicit launcher path (no PATH lookup): resolve its executable
+ *  target, attribute it to an npm package, and read its version. Shared by
+ *  PATH discovery above and by stale-launcher remediation, which must verify
+ *  a fresh npm-prefix copy at a known location before touching anything. */
+export async function probeOpenCovenBinaryAt(
+  tool: Pick<OpenCovenToolSpec, "binary" | "versionArgs">,
+  binaryPath: string,
+  env: NodeJS.ProcessEnv = refreshCovenSpawnEnv(),
+): Promise<OpenCovenToolProbe> {
+  const executablePath = await resolvedExecutablePath(binaryPath);
   const identity = executablePath
     ? await packageIdentityForExecutable(executablePath, tool.binary)
     : null;
-  const launch = covenLaunchCommandForBinary(located.path);
+  const launch = covenLaunchCommandForBinary(binaryPath);
   if (launch.unresolvedWindowsShim) {
     return {
-      path: located.path,
+      path: binaryPath,
       executablePath: null,
       executableVerified: false,
       version: null,
@@ -266,7 +277,7 @@ export async function discoverOpenCovenTool(
     );
     const version = firstSemver(`${stdout}\n${stderr}`);
     return {
-      path: located.path,
+      path: binaryPath,
       executablePath,
       executableVerified: identity?.binaryVerified ?? false,
       version,
@@ -276,7 +287,7 @@ export async function discoverOpenCovenTool(
     };
   } catch {
     return {
-      path: located.path,
+      path: binaryPath,
       executablePath,
       executableVerified: identity?.binaryVerified ?? false,
       version: null,


### PR DESCRIPTION
## Problem

The OpenCoven Tools **Update** button runs `npm i -g` then fail-closed verification — but when a stale copy of the same package shadows npm's global bin on PATH (orphaned nvm tree, old Homebrew-node prefix), verification fails with *'A stale executable is still first on PATH'* **every time**. The button reports the state forever and can never fix it. (Exactly the state this Mac was in earlier today: `~/.nvm/.../v24.13.0/bin/coven` @ 0.0.54 shadowing `~/.local/bin/coven` @ 0.1.1.)

## Fix

New `src/lib/opencoven-tools-resolve.ts`, invoked by the install route after a failed post-install verification:

1. **Gate first, act second** — the freshly installed copy at npm's global bin (`npm prefix -g`) must itself verify (same npm package via package.json identity walk, `executableVerified`, version ≥ minimum and ≥ npm latest when known). Never deletes the only working copy.
2. **Remove only stale same-package launcher files** — never directories (`removeLauncherFile` refuses them), never foreign binaries (e.g. a cargo dev build named `coven` → refusal + precise hint), never equal-or-newer copies, never the fresh copy. Windows removes the `coven`/`.cmd`/`.ps1` shim trio. Up to 4 stacked shadows cleared (nvm + homebrew case).
3. **Re-verify and report** — job tail gets progress lines; success flips the flow green; refusals/EACCES append an exact manual command (`rm '/path'` / `del "path"`) to the error instead of a dead end.

`probeOpenCovenBinaryAt` extracted from `discoverOpenCovenTool` (behavior unchanged) so the fresh copy can be probed at an explicit path.

## Validation

- 10 new tests in `src/lib/opencoven-tools-resolve.test.ts` (wired into run-tests app suite), including a **real-filesystem end-to-end**: synthetic stale+good npm prefixes, real `which`/probe/removal path, verifies removal + final ok.
- Existing suites green: onboarding/install route, opencoven-tools-status, latest-check, verification, opencoven-tools status route.
- `pnpm typecheck` clean; `check-tests-wired` passes (917 files).

Bead: cave-kii6