### PR TITLE
feat(backdrop): ground the home hero + chat landing over scene images

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -555,6 +555,7 @@ export const SUITES = {
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",
     "src/lib/cave-backdrop.test.ts",
+    "src/components/backdrop-scrim.test.ts",
     "src/lib/url-safety.test.ts",
     "src/lib/use-focus-trap.test.ts",
     "src/lib/use-prefers-reduced-motion.test.ts",

--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Facelift cave-8pk2: with a scene backdrop on, the Home hero copy and the
+// chat landing cluster sat straight on the photo — only the layer's global
+// 18→42% gradient behind them. These pin the content-cluster grounds that
+// keep copy legible at any backdrop intensity without dulling the scene.
+const css = readFileSync(new URL("../styles/backdrop.css", import.meta.url), "utf8");
+
+// ── Home hero ground ─────────────────────────────────────────────────────────
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.home-composer-root::before \{[^}]*radial-gradient\(/s,
+  "the Home column gets a radial ground behind the hero + composer",
+);
+assert.match(
+  css,
+  /\.home-composer-root::before \{[^}]*pointer-events: none/s,
+  "the ground never intercepts clicks",
+);
+assert.match(
+  css,
+  /color-mix\(in oklch, var\(--bg-base\) 52%, transparent\)/,
+  "the ground derives from --bg-base (theme-correct in dark and light)",
+);
+
+// ── Chat landing glass ───────────────────────────────────────────────────────
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.cave-chat-empty-shell \{[^}]*backdrop-filter: blur\(var\(--glass-blur\)\)/s,
+  "the chat landing cluster earns the same glass ground as the live transcript",
+);
+
+// ── Quiet-text lift extends to Home ──────────────────────────────────────────
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.home-composer-root \{\n  --text-muted: var\(--text-secondary\);/,
+  "muted text reads at secondary strength over the image on Home too",
+);
+
+// ── Degradation contract ─────────────────────────────────────────────────────
+assert.match(
+  css,
+  /@supports not \(\(backdrop-filter[^)]*\)[^{]*\{[\s\S]*?\.cave-chat-empty-shell \{[^}]*92%/,
+  "no backdrop-filter → the landing glass goes near-opaque",
+);
+assert.match(
+  css,
+  /prefers-reduced-transparency: reduce[\s\S]*\.home-composer-root::before \{\s*display: none/,
+  "reduced transparency hides the image, so the ground goes too",
+);
+assert.match(
+  css,
+  /prefers-reduced-transparency: reduce[\s\S]*\.cave-chat-empty-shell \{[^}]*background: transparent/s,
+  "reduced transparency drops the landing glass with the image",
+);
+
+console.log("backdrop-scrim.test.ts: ok");

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -89,11 +89,53 @@ html[data-backdrop-on] .cave-group-chat-shell {
   --text-muted: var(--text-secondary);
 }
 
+/* ── Hero + empty-state legibility (cave-8pk2) ───────────────────────────────
+   The Home headline/eyebrow and the chat landing cluster sit straight on the
+   photo with only the layer's global gradient behind them — busy imagery
+   (faces, props) fights the copy. Ground the centered content clusters
+   without dulling the scene at its edges. */
+
+/* Home: a radial ground behind the hero + composer column. Sits as the
+   root's first child so all in-flow content paints above it. */
+html[data-backdrop-on] .home-composer-root {
+  position: relative;
+}
+html[data-backdrop-on] .home-composer-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 72% 58% at 50% 42%,
+    color-mix(in oklch, var(--bg-base) 52%, transparent),
+    transparent 78%
+  );
+}
+
+/* Chat landing (no thread yet): the greeting/identity/suggestions cluster
+   gets the same glass ground the live transcript already earns. */
+html[data-backdrop-on] .cave-chat-empty-shell {
+  background: color-mix(in oklch, var(--bg-base) 55%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  border-radius: 14px;
+  padding: clamp(16px, 3vh, 28px) clamp(14px, 2.5vw, 24px);
+}
+
+/* And the same quiet-text contrast lift Home-side. */
+html[data-backdrop-on] .home-composer-root {
+  --text-muted: var(--text-secondary);
+}
+
 /* No backdrop-filter → a see-through fill over a photo is unreadable; go
    near-opaque instead (same rationale as the app-wide glass fallback). */
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   html[data-backdrop-on] .cave-chat-linear .cave-chat-thread,
   html[data-backdrop-on] .cave-group-chat-shell {
+    background: color-mix(in oklch, var(--bg-base) 92%, transparent);
+  }
+
+  html[data-backdrop-on] .cave-chat-empty-shell {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
   }
 }
@@ -114,5 +156,17 @@ html[data-backdrop-on] .cave-group-chat-shell {
 
   html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
     padding-inline: 0;
+  }
+
+  /* Same reasoning for the new grounds: no image → no scrim needed. */
+  html[data-backdrop-on] .home-composer-root::before {
+    display: none;
+  }
+
+  html[data-backdrop-on] .cave-chat-empty-shell {
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    padding: 0;
   }
 }


### PR DESCRIPTION
## Facelift 6/12 — scene backdrop scrim (cave-8pk2)

Custom scene backdrops (familiar images) sat directly behind the home headline and the chat landing shell with only the global wash, so busy imagery fought the text — the weakest legibility spot in the Phase-0 audit.

### What changed (tokens only, CSS only)
- **Home hero ground** — `.home-composer-root::before` gets a soft radial ellipse (`--bg-base` at 52% → transparent 78%) behind the greeting + composer, only when `html[data-backdrop-on]`.
- **Chat landing glass** — `.cave-chat-empty-shell` gets a glass wash (`--bg-base` 55% + `backdrop-filter: blur`, `--radius-*` + padding via clamp) matching the existing glass thread panel language.
- **Muted-text lift** — `--text-muted` raised slightly on backdrop surfaces so secondary copy stays readable over imagery.
- **Degradation contracts** (same patterns as existing backdrop CSS):
  - `@supports not (backdrop-filter…)` → near-opaque 92% fallback
  - `prefers-reduced-transparency` → scrims removed entirely (no fake glass)

### Verification
- `pnpm build` green; `check:tests-wired` green (919 files)
- New pin test `src/components/backdrop-scrim.test.ts` (wired in run-tests.mjs) covering the radial ground, pointer-events, bg-base derivation, glass shell, text lift, and both degradation contracts
- `cave-backdrop.test.ts` + new pin pass; full `pnpm test:app` green except the known `vault-ref-cold-start` flake (cave-6azx — passes isolated)
- Playwright before/after at 1440×900 (demo mode, backdrop on): home headline now reads on a stable ground; chat landing panel is legible over the scene image

Bead: cave-8pk2 (umbrella cave-ew98)
