### PR TITLE
feat(loading): one loading language + self-remedying offline notice

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -286,6 +286,7 @@ export const SUITES = {
     "src/components/surface-error-states.test.ts",
     "src/components/glass-overlay-chrome.test.ts",
     "src/components/surface-loading-states.test.ts",
+    "src/components/loading-discipline.test.ts",
     "src/components/chat-header-row.test.ts",
     "src/components/chat-usage-plan-ui.test.ts",
     "src/components/sidebar-minimal.test.ts",

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2514,7 +2514,8 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               {Array.from({ length: 5 }).map((_, index) => (
                 <div
                   key={index}
-                  className="h-14 animate-pulse rounded-lg bg-[var(--bg-raised)]"
+                  className="ui-skeleton ui-skeleton--row"
+                  style={{ height: 56 }}
                 />
               ))}
             </div>

--- a/src/components/capability-card.tsx
+++ b/src/components/capability-card.tsx
@@ -114,12 +114,12 @@ function GridSkeleton() {
           key={i}
           className="flex min-w-0 items-center gap-3 rounded-xl border border-border bg-card px-4 py-3"
         >
-          <span className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-muted" />
+          <span className="ui-skeleton h-10 w-10 shrink-0" />
           <span className="flex-1 space-y-1.5">
-            <span className="block h-3 w-1/2 animate-pulse rounded bg-muted" />
-            <span className="block h-2.5 w-3/4 animate-pulse rounded bg-muted" />
+            <span className="ui-skeleton block h-3 w-1/2" />
+            <span className="ui-skeleton block h-2.5 w-3/4" />
           </span>
-          <span className="h-5 w-5 animate-pulse rounded-full bg-muted" />
+          <span className="ui-skeleton ui-skeleton--avatar shrink-0" style={{ height: 20, width: 20 }} />
         </div>
       ))}
     </div>

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -241,8 +241,8 @@ assert.match(
 );
 assert.match(
   source,
-  /contentLoading && contentMatches\.length === 0 \?[\s\S]{0,200}?animate-pulse/,
-  "Content search shows the shimmer idiom while the first fetch is in flight",
+  /contentLoading && contentMatches\.length === 0 \?[\s\S]{0,300}?ui-skeleton/,
+  "Content search shows the shared shimmer skeleton while the first fetch is in flight",
 );
 assert.match(
   source,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -981,12 +981,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         {!sessionsLoaded && !hasAny ? (
           <div aria-hidden className="space-y-px px-4 py-3">
             {[0, 1, 2, 3].map((i) => (
-              <div key={i} className="animate-pulse flex gap-3 px-0 py-3.5">
-                <span className="mt-1 block h-2 w-2 rounded-full bg-[var(--bg-hover)]" />
+              <div key={i} className="flex gap-3 px-0 py-3.5">
+                <span className="ui-skeleton ui-skeleton--avatar mt-1" style={{ height: 8, width: 8 }} />
                 <span className="flex min-w-0 flex-1 flex-col gap-1.5">
-                  <span className="h-2.5 w-1/4 rounded bg-[var(--bg-hover)] opacity-70" />
-                  <span className="h-3 w-1/2 rounded bg-[var(--bg-hover)]" />
-                  <span className="h-2.5 w-1/3 rounded bg-[var(--bg-hover)] opacity-50" />
+                  <span className="ui-skeleton h-2.5 w-1/4" />
+                  <span className="ui-skeleton h-3 w-1/2" />
+                  <span className="ui-skeleton h-2.5 w-1/3 opacity-60" />
                 </span>
               </div>
             ))}
@@ -1536,9 +1536,9 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               {contentLoading && contentMatches.length === 0 ? (
                 <div aria-hidden className="space-y-px px-4 py-2">
                   {[0, 1].map((i) => (
-                    <div key={i} className="animate-pulse flex flex-col gap-1.5 py-2.5">
-                      <span className="h-3 w-1/2 rounded bg-[var(--bg-hover)]" />
-                      <span className="h-2.5 w-3/4 rounded bg-[var(--bg-hover)] opacity-60" />
+                    <div key={i} className="flex flex-col gap-1.5 py-2.5">
+                      <span className="ui-skeleton h-3 w-1/2" />
+                      <span className="ui-skeleton h-2.5 w-3/4 opacity-60" />
                     </div>
                   ))}
                 </div>

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1474,9 +1474,10 @@ function metaLineSegments(args: {
   // reads as a folder.
   const runtime = formatRuntime(args.runtime) ?? formatRuntime(args.projectRoot ? `local:${args.projectRoot}` : null);
   if (args.state === "offline") {
-    // "check Coven" named nothing findable — the banner's Start-daemon action
-    // is the actual remedy (cave-7jzq).
-    segs.push("daemon offline · start it from the banner above");
+    // The remedy renders inline: MetaLine appends its own Start-daemon action
+    // after the segments, so the notice never points at chrome that may not be
+    // visible (the banner can be dismissed or scrolled away) (cave-5qmm).
+    segs.push("daemon offline");
   } else if (args.state === "failed") {
     if (args.model) segs.push(shortModelLabel(args.model));
     if (runtime) segs.push({ dir: runtime });
@@ -1646,6 +1647,35 @@ function ChatFindBar({
  *  the role="status" live region, so the per-second rewrite is excluded from
  *  the accessibility tree and never announced (the rewrites-per-second
  *  problem from CHAT-D12-04). */
+/** Inline remedy for the offline meta line: the old copy said "start it from
+ *  the banner above", but the banner can be dismissed or off-screen — a broken
+ *  reference. The action lives in the notice itself, self-contained like the
+ *  settings/onboarding start buttons; the workspace's 5s status poll picks up
+ *  the flip and clears the offline state (cave-5qmm). */
+function MetaLineStartDaemon() {
+  const [starting, setStarting] = useState(false);
+  return (
+    <button
+      type="button"
+      className="cave-chat-meta-line__action focus-ring"
+      disabled={starting}
+      onClick={async () => {
+        setStarting(true);
+        try {
+          await fetch("/api/daemon/start", { method: "POST" });
+        } catch {
+          // The meta line keeps reading "daemon offline" and the button
+          // re-arms — the workspace banner surfaces start errors in detail.
+        } finally {
+          setStarting(false);
+        }
+      }}
+    >
+      {starting ? "starting…" : "Start daemon"}
+    </button>
+  );
+}
+
 function MetaLineElapsed({ since }: { since: string }) {
   const [elapsed, setElapsed] = useState(0);
   useEffect(() => {
@@ -1813,6 +1843,7 @@ function MetaLine({
         </span>
         {state === "streaming" && pendingSince ? <MetaLineElapsed since={pendingSince} /> : null}
         {state === "streaming" ? " · esc to cancel" : null}
+        {state === "offline" ? <MetaLineStartDaemon /> : null}
       </span>
       {children}
     </div>

--- a/src/components/familiar-roster-card.test.ts
+++ b/src/components/familiar-roster-card.test.ts
@@ -41,8 +41,8 @@ assert.match(card, /this week/, "Activity line shows sessionsLast7d label");
 
 assert.match(
   card,
-  /memoryStatus === "loading"[\s\S]*Loading memory/,
-  "Memory snapshot shows 'Loading memory…' while the fetch is in flight",
+  /memoryStatus === "loading"[\s\S]*<Skeleton variant="text-sm"/,
+  "Memory snapshot shimmers (shared Skeleton) while the fetch is in flight — no dead 'Loading memory…' text (cave-5qmm)",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -20,6 +20,7 @@ import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
 import { HomeFeed } from "@/components/home/home-feed";
 import { Modal } from "@/components/ui/modal";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { FamiliarSummoningCircle } from "@/components/familiar-summoning-circle";
 import {
@@ -556,7 +557,12 @@ function FamiliarRosterCard({
 
         <div className="mt-auto border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-secondary)]">
           {memoryStatus === "loading" ? (
-            <span className="text-[var(--text-muted)]">Loading memory…</span>
+            // Shimmer instead of a "Loading memory…" string — one loading
+            // language across the roster, and no dead-looking text while the
+            // first fetch is cold (cave-5qmm).
+            <span aria-hidden className="block py-0.5">
+              <Skeleton variant="text-sm" width="55%" />
+            </span>
           ) : memoryStatus === "error" ? (
             <span className="text-[var(--text-muted)]">Memory unavailable</span>
           ) : stats.memoryCount === 0 ? (

--- a/src/components/loading-discipline.test.ts
+++ b/src/components/loading-discipline.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck
+// Loading/empty/error discipline (cave-5qmm): one loading language per
+// surface (the shared shimmer skeleton), and offline/error notices that carry
+// their own remedy instead of pointing at chrome that may not be visible.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (rel) => readFileSync(new URL(rel, import.meta.url), "utf8");
+
+// ── Chat meta line: the offline notice is self-remedying ────────────────────
+const chatView = read("./chat-view.tsx");
+assert.doesNotMatch(
+  chatView,
+  /start it from the banner above/,
+  "The offline meta line no longer references the (dismissable) banner",
+);
+assert.match(
+  chatView,
+  /function MetaLineStartDaemon\(\)/,
+  "The offline meta line owns an inline Start-daemon action",
+);
+assert.match(
+  chatView,
+  /MetaLineStartDaemon[\s\S]{0,400}fetch\("\/api\/daemon\/start", \{ method: "POST" \}\)/,
+  "The inline action posts /api/daemon/start like the settings/onboarding start buttons",
+);
+assert.match(
+  chatView,
+  /\{state === "offline" \? <MetaLineStartDaemon \/> : null\}/,
+  "The action renders only in the offline state",
+);
+assert.match(
+  chatView,
+  /className="cave-chat-meta-line__action focus-ring"/,
+  "The inline action is keyboard-focusable with the shared focus ring",
+);
+
+const chatCss = read("../styles/cave-chat.css");
+assert.match(
+  chatCss,
+  /\.cave-chat-meta-line__action:hover \{\s*color: var\(--accent-presence\);/,
+  "Hover feedback uses the accent token",
+);
+assert.match(
+  chatCss,
+  /\.cave-chat-meta-line__action:disabled \{[\s\S]{0,120}cursor: default;/,
+  "The disabled (starting…) state drops the affordance",
+);
+
+// ── Marketplace: one loading language (skeleton), no mixed text cue ─────────
+const marketplace = read("./marketplace-view.tsx");
+assert.doesNotMatch(
+  marketplace,
+  /Loading the catalog/,
+  "Marketplace no longer mixes a 'Loading the catalog…' string with skeleton rows",
+);
+assert.match(
+  marketplace,
+  /\{!loaded \? \([\s\S]{0,300}?<Skeleton variant="text-sm"/,
+  "The browse result-count line shimmers while the catalog loads",
+);
+
+// ── Roster memory snapshot: shimmer, not dead text ──────────────────────────
+const familiars = read("./familiars-view.tsx");
+assert.doesNotMatch(
+  familiars,
+  />Loading memory…</,
+  "Roster cards no longer show a bare 'Loading memory…' line",
+);
+assert.match(
+  familiars,
+  /memoryStatus === "loading" \? \([\s\S]{0,400}?<Skeleton variant="text-sm"/,
+  "Roster memory snapshot renders the shared Skeleton while loading",
+);
+
+// ── Ad-hoc animate-pulse placeholders converted to the shared shimmer ───────
+// animate-pulse stays legitimate for live-status dots and streaming carets —
+// but data-loading PLACEHOLDERS must use .ui-skeleton so they shimmer and
+// degrade to static under prefers-reduced-motion via one contract.
+for (const [file, label] of [
+  ["./chat-list.tsx", "Chat list boot + content-search placeholders"],
+  ["./capability-card.tsx", "Capability card placeholder"],
+  ["./automations-view.tsx", "Schedules first-load placeholder"],
+]) {
+  const src = read(file);
+  assert.match(src, /ui-skeleton/, `${label} uses the shared shimmer skeleton`);
+}
+assert.doesNotMatch(
+  read("./capability-card.tsx"),
+  /animate-pulse/,
+  "Capability placeholder no longer uses the static animate-pulse idiom",
+);
+assert.doesNotMatch(
+  read("./automations-view.tsx"),
+  /animate-pulse rounded-lg/,
+  "Schedules placeholder no longer uses the static animate-pulse idiom",
+);
+
+// ── The shared skeleton's degradation contract stays pinned ─────────────────
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(
+  globals,
+  /animation: ui-skeleton-shimmer 1\.4s ease-in-out infinite;/,
+  "ui-skeleton shimmers (perceived progress on cold routes)",
+);
+assert.match(
+  globals,
+  /@media \(prefers-reduced-motion: reduce\) \{\s*\n\s*\.ui-skeleton \{ animation: none; opacity: 0\.65; \}/,
+  "ui-skeleton degrades to a static wash under prefers-reduced-motion",
+);
+
+console.log("loading-discipline.test.ts: ok");

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -15,7 +15,7 @@ import { Icon, type IconName } from "@/lib/icon";
 import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
-import { SkeletonRows } from "@/components/ui/skeleton";
+import { Skeleton, SkeletonRows } from "@/components/ui/skeleton";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { StandardSelect } from "@/components/ui/select";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -679,7 +679,10 @@ export function MarketplaceViewSurface({
             <div className="marketplace-browse-summary mb-4">
               <p className="min-w-0 self-center truncate text-[12px] text-[var(--text-muted)]">
                 {!loaded ? (
-                  "Loading the catalog…"
+                  // One loading language per surface: the grid below already
+                  // shows skeleton rows, so the count line shimmers too instead
+                  // of mixing in a "Loading…" string (cave-5qmm).
+                  <Skeleton variant="text-sm" width={132} className="self-center" />
                 ) : (
                   <>
                     {scopeLabel ? (

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -16,8 +16,8 @@ assert.match(
   inbox,
   // The Calendar tab branch may precede this (calendarSlot is rendered first),
   // so the skeleton ternary need not be the very first child of the list box.
-  /!initialLoadDone \? \([\s\S]*?animate-pulse[\s\S]*?\) : activeTab === "crons" && automationsEmpty \? \(/,
-  "Schedules shows a skeleton before first load, ahead of the Crons empty state",
+  /!initialLoadDone \? \([\s\S]*?ui-skeleton[\s\S]*?\) : activeTab === "crons" && automationsEmpty \? \(/,
+  "Schedules shows a shimmer skeleton before first load, ahead of the Crons empty state",
 );
 
 const chatList = read("./chat-list.tsx");
@@ -28,8 +28,8 @@ assert.match(
 );
 assert.match(
   chatList,
-  /\{!sessionsLoaded && !hasAny \? \([\s\S]*?animate-pulse[\s\S]*?\) : !hasAny \? \(/,
-  "ChatList shows skeleton rows instead of flashing the no-chats empty state on boot",
+  /\{!sessionsLoaded && !hasAny \? \([\s\S]*?ui-skeleton[\s\S]*?\) : !hasAny \? \(/,
+  "ChatList shows shimmer skeleton rows instead of flashing the no-chats empty state on boot",
 );
 
 const workspace = read("./workspace.tsx");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2832,6 +2832,28 @@ details[open] > .cave-tool-summary::before {
   color: var(--color-danger);
 }
 
+/* Inline remedy inside the offline meta line — a real button (keyboard
+   focusable) styled as a quiet text action so the notice stays one line. */
+.cave-chat-meta-line__action {
+  margin-left: 6px;
+  border-radius: var(--radius-sm);
+  padding: 0 4px;
+  color: var(--text-primary);
+  font-size: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.cave-chat-meta-line__action:hover {
+  color: var(--accent-presence);
+}
+.cave-chat-meta-line__action:disabled {
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: default;
+}
+
 .cave-chat-model-wrap {
   position: relative;
   min-width: 0;


### PR DESCRIPTION
## Facelift 7/12 — loading/empty/error discipline (cave-5qmm)

The Phase-0 audit flagged mixed loading languages and notices that reference invisible chrome. This PR standardizes on the shared shimmer skeleton and makes the offline notice self-remedying.

### What changed
- **Chat meta line** — "daemon offline · start it from the banner above" pointed at a banner that can be dismissed/off-screen (broken reference). The notice now carries its own inline **Start daemon** action: keyboard-focusable (`focus-ring`), accent hover, disabled "starting…" state; posts `/api/daemon/start` exactly like the settings/onboarding start buttons. The workspace's 5s status poll clears the offline state.
- **Marketplace** — the browse summary mixed a `Loading the catalog…` string with skeleton rows below it. The count line now shimmers (`Skeleton variant="text-sm"`) — one loading language per surface.
- **Familiars roster** — per-card `Loading memory…` text (repeated 8×) becomes a quiet shimmer bar; no dead-looking text while routes are cold.
- **Chat list / capability cards / Schedules** — ad-hoc static `animate-pulse` placeholders converted to the shared `.ui-skeleton` shimmer, inheriting its single degradation contract (static wash under `prefers-reduced-motion`). Status dots/streaming carets keep `animate-pulse` — those are live indicators, not placeholders.

### Tests
- New pin: `src/components/loading-discipline.test.ts` (wired in run-tests.mjs) — offline notice owns its remedy (+ no banner reference), marketplace/roster shimmer, converted placeholders, and the ui-skeleton reduced-motion contract.
- Updated pins deliberately (coverage retained, tightened to the shimmer idiom): `surface-loading-states`, `chat-list-delete`, `familiar-roster-card`.

### Verification
- `pnpm build` + `pnpm typecheck` green; `check:tests-wired` green (920 files)
- Full `pnpm test:app` green except the known `vault-ref-cold-start` flake (cave-6azx — passes isolated; the 307 files after it verified green separately)
- Playwright evidence at 1440×900: offline meta line renders `daemon offline · Start daemon` inline (with the banner dismissed), marketplace loading shows 6 shimmer rows and zero "Loading the catalog" text

Bead: cave-5qmm (umbrella cave-ew98)
