### PR TITLE
feat(familiars): de-boxed roster cards with integrated footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6131,6 +6131,36 @@ a.mobile-handoff__link:hover {
 }
 
 /* ────────────────────────────────────────────────
+   Familiars roster cards (cave-g2r6)
+   De-boxed: a wash + inset soft hairline instead of a hard border, with a
+   quiet hover lift. The wrapper owns the visual card so the open button and
+   the footer analytics link live inside it as siblings.
+   ──────────────────────────────────────────────── */
+
+.familiars-view__card {
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+.familiars-view__card:hover {
+  background: color-mix(in oklch, var(--bg-raised) 62%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 85%, transparent),
+    0 6px 18px -12px var(--shadow-color, rgb(0 0 0));
+  transform: translateY(-1px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .familiars-view__card,
+  .familiars-view__card:hover {
+    transform: none;
+  }
+}
+
+/* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)
    ──────────────────────────────────────────────── */

--- a/src/components/familiar-roster-card.test.ts
+++ b/src/components/familiar-roster-card.test.ts
@@ -45,6 +45,35 @@ assert.match(
   "Memory snapshot shimmers (shared Skeleton) while the fetch is in flight — no dead 'Loading memory…' text (cave-5qmm)",
 );
 
+// De-boxed card contracts (cave-g2r6): wrapper owns the wash/hairline visual
+// so the open button and the analytics link are sibling controls inside it —
+// the link no longer floats orphaned outside the card boundary.
+assert.match(
+  card,
+  /className="familiars-view__card group relative flex h-full flex-col"/,
+  "The wrapper div carries the card visual (wash + soft hairline via CSS)",
+);
+assert.doesNotMatch(
+  card,
+  /border border-\[var\(--border-hairline\)\] bg-\[var\(--bg-raised\)\]/,
+  "The open button no longer draws its own hard border box",
+);
+assert.match(
+  card,
+  /familiars-view__card-footer[\s\S]*Analytics →/,
+  "The analytics link is folded into the card footer",
+);
+assert.match(
+  card,
+  /<Link[\s\S]{0,400}className="focus-ring[\s\S]{0,200}Analytics →/,
+  "The footer analytics link is keyboard-focusable with the shared focus ring",
+);
+assert.match(
+  card,
+  /title=\{stats\.latestMemory\?\.title\}/,
+  "The latest memory title survives as the one-liner's tooltip",
+);
+
 assert.match(
   card,
   /memoryStatus === "error"[\s\S]*Memory unavailable/,
@@ -65,8 +94,26 @@ assert.match(
 
 assert.match(
   card,
-  /stats\.latestMemory\.title/,
-  "Latest memory title is rendered",
+  /stats\.latestMemory\?\.title|stats\.latestMemory\.title/,
+  "Latest memory title is preserved (tooltip on the one-liner)",
+);
+
+// CSS contracts for the de-boxed card.
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+assert.match(
+  css,
+  /\.familiars-view__card \{[\s\S]{0,400}?box-shadow: inset 0 0 0 1px color-mix\(in oklch, var\(--border-hairline\) 55%, transparent\);/,
+  "Card hairline is a soft inset wash, not a hard border",
+);
+assert.match(
+  css,
+  /\.familiars-view__card:hover \{[\s\S]{0,400}?transform: translateY\(-1px\);/,
+  "Hover gives a quiet lift",
+);
+assert.match(
+  css,
+  /@media \(prefers-reduced-motion: reduce\) \{\s*\n\s*\.familiars-view__card,\s*\n\s*\.familiars-view__card:hover \{\s*\n\s*transform: none;/,
+  "The hover lift is removed under prefers-reduced-motion",
 );
 
 console.log("familiar-roster-card: all assertions passed");

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -514,11 +514,14 @@ function FamiliarRosterCard({
   const sessionsLabel =
     stats.sessionsLast7d > 0 ? ` · ${stats.sessionsLast7d} this week` : "";
   return (
-    <div className="flex h-full flex-col">
+    // De-boxed card (cave-g2r6): the wrapper carries the wash + soft hairline
+    // so the open button and the analytics link can sit inside one visual card
+    // as sibling interactive elements (no nested controls).
+    <div className="familiars-view__card group relative flex h-full flex-col">
       <button
         type="button"
         onClick={onSelect}
-        className="focus-ring familiars-view__card group flex h-full flex-col items-stretch gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 text-left transition-colors hover:border-[var(--accent-presence)]/50 hover:bg-[var(--bg-raised)]/60"
+        className="focus-ring flex flex-1 flex-col items-stretch gap-2 rounded-[inherit] p-3 pb-2 text-left"
         aria-label={`Open ${familiar.display_name}`}
       >
         <div className="flex items-center gap-2">
@@ -551,11 +554,16 @@ function FamiliarRosterCard({
           ) : null}
         </div>
 
-        <p className="text-[11px] text-[var(--text-secondary)]">
+        <p className="mt-auto text-[11px] text-[var(--text-secondary)]">
           {lastSessionLabel}{sessionsLabel}
         </p>
+      </button>
 
-        <div className="mt-auto border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-secondary)]">
+      {/* Card footer — memory snapshot as a quiet one-liner + the analytics
+          link folded inside the card (it used to float orphaned below the
+          border). Hairline divider, no second box. */}
+      <div className="familiars-view__card-footer flex items-center justify-between gap-2 border-t border-[var(--border-hairline)]/60 px-3 py-2 text-[11px]">
+        <span className="min-w-0 flex-1 truncate text-[var(--text-muted)]" title={stats.latestMemory?.title}>
           {memoryStatus === "loading" ? (
             // Shimmer instead of a "Loading memory…" string — one loading
             // language across the roster, and no dead-looking text while the
@@ -564,31 +572,24 @@ function FamiliarRosterCard({
               <Skeleton variant="text-sm" width="55%" />
             </span>
           ) : memoryStatus === "error" ? (
-            <span className="text-[var(--text-muted)]">Memory unavailable</span>
+            "Memory unavailable"
           ) : stats.memoryCount === 0 ? (
-            <span className="text-[var(--text-muted)]">No memories yet</span>
+            "No memories yet"
           ) : (
             <>
-              <span className="block">
-                {stats.memoryCount} memor{stats.memoryCount === 1 ? "y" : "ies"}
-                {stats.latestMemory ? ` · last write ${age(stats.latestMemory.updatedAt)}` : ""}
-              </span>
-              {stats.latestMemory ? (
-                <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">
-                  {stats.latestMemory.title}
-                </span>
-              ) : null}
+              {stats.memoryCount} memor{stats.memoryCount === 1 ? "y" : "ies"}
+              {stats.latestMemory ? ` · last write ${age(stats.latestMemory.updatedAt)}` : ""}
             </>
           )}
-        </div>
-      </button>
-      <Link
-        href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
-        aria-label={`Open analytics for ${familiar.display_name}`}
-        className="mt-1 self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--accent-presence)]"
-      >
-        Analytics →
-      </Link>
+        </span>
+        <Link
+          href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
+          aria-label={`Open analytics for ${familiar.display_name}`}
+          className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+        >
+          Analytics →
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Facelift 8/12 — familiars roster cards (cave-g2r6)

Audit findings on the Familiars grid: heavy hard-bordered boxes, a two-line memory block repeated on every card, and the "Analytics →" link floating **outside** each card's boundary (orphaned between rows).

### What changed
- **De-box** — the wrapper div now owns the card visual: a `--bg-raised` wash + soft inset hairline (`color-mix` on `--border-hairline`) instead of a hard border. Quiet hover lift (`translateY(-1px)` + soft shadow), removed under `prefers-reduced-motion`. Because the wrapper carries the visual, the open button and the analytics link sit inside one card as **sibling** controls — no nested interactive elements.
- **Integrated footer** — memory snapshot collapses to a quiet one-liner (`N memories · last write 2d ago`; full latest-memory title preserved as tooltip) sharing a hairline-divided footer row with **Analytics →** (focus-ring, accent hover). No more orphaned link.
- **Loading** — the memory one-liner shimmers via the shared `Skeleton` (same idiom as cave-5qmm).

### Tests
- `familiar-roster-card.test.ts` extended: wrapper visual contract, no hard border on the button, footer analytics fold, tooltip preservation, and CSS contracts (soft hairline, hover lift, reduced-motion removal). Existing assertions retained.

### Verification
- `pnpm typecheck` + `pnpm build` green; familiars pins green
- Full `pnpm test:app`: green except the known local-only `vault-ref-cold-start` mid-suite flake (cave-6azx — noted there; passes isolated, CI ubuntu unaffected); the 307 files after it verified green separately
- Playwright 1440×900 demo mode: 8 cards with integrated footers + hover state captured (before/after in session evidence)

Bead: cave-g2r6 (umbrella cave-ew98)
