### PR TITLE
feat(palette): active-row affordances, keycap chips, touch ergonomics, scene contrast floor

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -228,6 +228,7 @@ export const SUITES = {
     "src/components/top-bar.test.ts",
     "src/components/command-palette.test.ts",
     "src/components/command-palette-a11y.test.ts",
+    "src/components/command-palette-polish.test.ts",
     "src/components/command-palette-save-link.test.ts",
     "src/lib/command-palette-search.test.ts",
     "src/lib/command-palette-scope.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2872,6 +2872,13 @@ textarea.required-inputs-control {
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
+/* Contrast floor while a scene backdrop is frontmost: 74% glass over a busy
+   custom image lets the scene bleed through the command surface — raise the
+   fill so results stay legible over any scene (cave-4gg0). */
+html[data-backdrop-on] .glass-overlay {
+  background: color-mix(in oklch, var(--bg-elevated) 88%, transparent);
+}
+
 /* Glass is only legible while the backdrop actually blurs: with no
  * backdrop-filter support, a translucent fill over scrolling content is
  * unreadable soup — restore the opaque theme surfaces. */
@@ -7438,6 +7445,30 @@ a.mobile-handoff__link:hover {
   .touch-always-visible {
     opacity: 1 !important;
   }
+}
+
+/* Complement of .touch-always-visible: desktop keyboard vocabulary (kbd
+   hints, shortcut chips) that means nothing on a touch device. */
+@media (hover: none) and (pointer: coarse) {
+  .touch-hidden {
+    display: none !important;
+  }
+}
+
+/* Mono keycap chip used by the command palette (footer hints + shortcut
+   rows) — one consistent kbd treatment instead of ad-hoc text. */
+.palette-kbd {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  padding: 0 4px;
+  min-height: 15px;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 9.5px;
+  line-height: 1.4;
+  color: var(--text-secondary);
 }
 
 /* ── Calendar agenda (timeline) ──────────────────────────────────────────────

--- a/src/components/command-palette-polish.test.ts
+++ b/src/components/command-palette-polish.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+// Command-palette polish contracts (cave-4gg0): dead scope tabs hidden,
+// affordance labels on the active row only, one mono keycap idiom, touch
+// ergonomics, and a glass contrast floor over scene backdrops.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── Zero-count scope tabs hide (except "all" and the active scope) ──────────
+assert.match(
+  source,
+  /PALETTE_CATEGORIES\.filter\(\s*\n[\s\S]{0,300}?option === "all" \|\| option === category \|\| counts\[option\] > 0,?\s*\n\s*\)\.map/,
+  "Zero-count scope tabs are hidden; 'all' and the active scope always stay",
+);
+
+// ── Right-edge affordance labels render on the active row only ──────────────
+for (const label of ["switch", "card", "memory", "file", "open", "run", "create", "ask"]) {
+  assert.match(
+    source,
+    new RegExp(`\\{active \\? <span className="text-\\[10px\\] text-\\[var\\(--text-muted\\)\\]">${label}</span> : null\\}`),
+    `'${label}' affordance label renders only on the active row (Raycast idiom)`,
+  );
+}
+// Data-bearing right edges (session age, match counts) must NOT be gated.
+assert.match(
+  source,
+  /<span className="shrink-0 text-\[10px\] text-\[var\(--text-muted\)\]">\{sessionAgo \|\| "open"\}<\/span>/,
+  "Session recency stays visible on every row — it's data, not affordance",
+);
+
+// ── One mono keycap idiom ────────────────────────────────────────────────────
+assert.match(
+  source,
+  /<kbd className="palette-kbd touch-hidden">\{platformizeHint\(row\.shortcut, keys\)\}<\/kbd>/,
+  "Shortcut rows use the shared keycap chip (hidden on touch)",
+);
+assert.match(
+  source,
+  /<kbd className="palette-kbd">\{keys\.up\}\{keys\.down\}<\/kbd> navigate/,
+  "Footer nav hints use keycap chips",
+);
+assert.match(
+  source,
+  /<kbd className="palette-kbd">\{keys\.mod\}K<\/kbd>/,
+  "Footer ⌘K hint uses a keycap chip",
+);
+assert.match(
+  css,
+  /\.palette-kbd \{[\s\S]{0,400}?font-family: var\(--font-mono\), ui-monospace, monospace;/,
+  "Keycap chip is mono via the shared token",
+);
+
+// ── Touch ergonomics: desktop keyboard vocabulary hides on coarse pointers ──
+assert.match(
+  source,
+  /<span className="touch-hidden flex items-center gap-1">\s*\n\s*<kbd className="palette-kbd">\{keys\.up\}/,
+  "The footer's keyboard-hint cluster is touch-hidden",
+);
+assert.match(
+  css,
+  /@media \(hover: none\) and \(pointer: coarse\) \{\s*\n\s*\.touch-hidden \{\s*\n\s*display: none !important;/,
+  ".touch-hidden hides under the same coarse-pointer guard as .touch-always-visible",
+);
+
+// ── Glass contrast floor over scenes ─────────────────────────────────────────
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.glass-overlay \{\s*\n\s*background: color-mix\(in oklch, var\(--bg-elevated\) 88%, transparent\);/,
+  "While a scene backdrop is frontmost the palette glass gets an 88% contrast floor",
+);
+
+console.log("command-palette-polish.test.ts: ok");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1012,7 +1012,12 @@ export function CommandPalette({
           aria-label="Filter search results"
           className="flex items-center gap-1 overflow-x-auto border-b border-[var(--border-hairline)] px-3 py-2"
         >
-          {PALETTE_CATEGORIES.map((option) => (
+          {PALETTE_CATEGORIES.filter(
+            // Zero-count scopes are dead tabs — hide them. "All" always shows,
+            // and the active scope stays visible even at 0 so the filter can't
+            // vanish from under the user mid-narrowing (cave-4gg0).
+            (option) => option === "all" || option === category || counts[option] > 0,
+          ).map((option) => (
             <button
               key={option}
               type="button"
@@ -1106,7 +1111,7 @@ export function CommandPalette({
                           {row.familiar.role}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">switch</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">switch</span> : null}
                     </>
                   ) : null}
                   {row.kind === "session" ? (
@@ -1143,11 +1148,10 @@ export function CommandPalette({
                           {row.card.labels.length ? ` · ${row.card.labels.join(", ")}` : ""}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">card</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">card</span> : null}
                     </>
                   ) : null}
-                  {row.kind === "coven-memory" ? (
-                    <>
+                  {row.kind === "coven-memory" ? (                    <>
                       <span className="flex min-w-0 flex-1 flex-col">
                         <span className="truncate text-[var(--text-primary)]">{row.entry.title}</span>
                         <span className="truncate text-[10px] text-[var(--text-muted)]">
@@ -1155,7 +1159,7 @@ export function CommandPalette({
                           {row.entry.excerpt ? ` · ${row.entry.excerpt.slice(0, 70)}` : ""}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">memory</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">memory</span> : null}
                     </>
                   ) : null}
                   {row.kind === "fs-memory" ? (
@@ -1166,7 +1170,7 @@ export function CommandPalette({
                           {row.entry.rootLabel}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">file</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">file</span> : null}
                     </>
                   ) : null}
                   {row.kind === "setting" ? (
@@ -1181,20 +1185,20 @@ export function CommandPalette({
                           {row.entry.familiarTab ? `Familiars · ${row.entry.familiarTab}` : row.entry.keywords}
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">open</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">open</span> : null}
                     </>
                   ) : null}
                   {row.kind === "command" ? (
                     <>
                       <span className="font-mono text-[var(--text-secondary)]">{row.name}</span>
                       <span className="flex-1 text-[var(--text-muted)]">{platformizeHint(row.hint, keys)}</span>
-                      <span className="text-[10px] text-[var(--text-muted)]">run</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">run</span> : null}
                     </>
                   ) : null}
                   {row.kind === "shortcut" ? (
                     <>
                       <span className="flex-1 text-[var(--text-primary)]">{row.label}</span>
-                      <span className="font-mono text-[10px] text-[var(--text-muted)]">{platformizeHint(row.shortcut, keys)}</span>
+                      <kbd className="palette-kbd touch-hidden">{platformizeHint(row.shortcut, keys)}</kbd>
                     </>
                   ) : null}
                   {row.kind === "create-task" ? (
@@ -1206,7 +1210,7 @@ export function CommandPalette({
                           New card on the board, scoped to the active familiar
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">create</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">create</span> : null}
                     </>
                   ) : null}
                   {row.kind === "conversation-hit" ? (
@@ -1234,7 +1238,7 @@ export function CommandPalette({
                           Salem is the docs familiar — answers from the OpenCoven docs
                         </span>
                       </span>
-                      <span className="text-[10px] text-[var(--text-muted)]">ask</span>
+                      {active ? <span className="text-[10px] text-[var(--text-muted)]">ask</span> : null}
                     </>
                   ) : null}
                 </button>
@@ -1243,10 +1247,21 @@ export function CommandPalette({
             );
           })}
         </ul>
-        <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-4 py-2 text-[10px] text-[var(--text-muted)]">
-          <span>{keys.up}{keys.down} navigate · {keys.enter} select · esc close</span>
+        <div className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-2 text-[10px] text-[var(--text-muted)]">
+          {/* Keyboard hints are desktop vocabulary — hidden on coarse-pointer
+              devices where there is no ⌘/esc to press (cave-4gg0). */}
+          <span className="touch-hidden flex items-center gap-1">
+            <kbd className="palette-kbd">{keys.up}{keys.down}</kbd> navigate ·{" "}
+            <kbd className="palette-kbd">{keys.enter}</kbd> select ·{" "}
+            <kbd className="palette-kbd">esc</kbd> close
+          </span>
           <span className="hidden sm:inline">@familiar scopes results</span>
-          <span>{counts[category]} local · {keys.mod}K</span>
+          <span className="flex items-center gap-1">
+            {counts[category]} local
+            <span className="touch-hidden flex items-center gap-1">
+              {" "}· <kbd className="palette-kbd">{keys.mod}K</kbd>
+            </span>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Facelift 9/12 — command palette polish (cave-4gg0)

The ⌘K palette was already near-Raycast structurally; this lands the detail polish the audit called out.

### What changed
- **Dead tabs hidden** — zero-count scope tabs (Tasks 0 / Memory 0 / Settings 0) no longer render. "All" and the *active* scope always stay, so the filter can't vanish from under you mid-narrowing.
- **Active-row affordances** — right-edge labels (`run` / `open` / `switch` / `card` / `memory` / `file` / `create` / `ask`) rendered on **every** row, repeating one word down the whole list. Now they render on the active row only (Raycast idiom). Data-bearing right edges — session recency, match counts — stay on all rows.
- **One keycap idiom** — footer nav hints (↑↓ / ↵ / esc), the ⌘K chip, and shortcut-row combos now use a shared mono keycap chip (`.palette-kbd`: `--font-mono`, `--bg-subtle`, hairline, `--radius-sm`).
- **Touch ergonomics** — new `.touch-hidden` utility (complement of `.touch-always-visible`, same `(hover: none) and (pointer: coarse)` guard) hides desktop keyboard vocabulary on touch: footer hint cluster + shortcut chips.
- **Scene contrast floor** — 74% glass let busy scene backdrops bleed through the command surface. `html[data-backdrop-on] .glass-overlay` floors the fill at 88% `--bg-elevated`.

### Tests
- New pin `src/components/command-palette-polish.test.ts` (wired): tab filtering, per-label active-row gating, session-age ungated, keycap chips, touch-hidden guard, glass floor.

### Verification
- typecheck + build green; palette pins green; **full `pnpm test:app` 677 files green**
- Playwright: desktop 1440×900 (3 tabs only, exactly 1 affordance label visible, keycap footer, palette legible over scene backdrop) · iPhone 13 emulation (palette opens, **0** kbd chips / touch-hidden elements visible)

Bead: cave-4gg0 (umbrella cave-ew98)
