### PR TITLE
feat(quick-chat): readable measure, meta chips, visible disabled Send, define --bg-subtle

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -653,6 +653,7 @@ export const SUITES = {
     "src/components/familiar-menu-bar.test.ts",
     "src/components/menu-bar-icon-size.test.ts",
     "src/components/tray-quick-chat.test.ts",
+    "src/components/quick-chat-polish.test.ts",
     "src/components/notch-quick-chat.test.ts",
     "src/components/quick-chat-controls.test.ts",
     "src/components/familiar-quick-switch.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,6 +76,11 @@
   --code-surface: oklch(0.12 0.012 280 / 92%);
   --bg-panel: oklch(0.10 0.020 293);        /* deepest — app shell / sidebar floor */
   --bg-raised: var(--card);
+  /* Subtle inline fill (chips, keycaps, recent-search pills). Derived from
+     the raised surface so it tracks every theme — this token was referenced
+     by several components while undefined, which computed to transparent
+     (cave-fdt5). */
+  --bg-subtle: color-mix(in oklch, var(--bg-raised) 72%, transparent);
   --bg-elevated: oklch(0.20 0.028 293);     /* dropdowns / popovers */
   --bg-hover: oklch(0.24 0.030 293);        /* hover state */
   --border-hairline: var(--border);
@@ -12385,6 +12390,41 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-overlay__actions button:not(:disabled):hover {
   filter: brightness(1.06);
+}
+
+/* Composer meta chips (cave-fdt5): thinking/speed/model as quiet pills
+   instead of a plain-text run-on sentence. */
+.quick-chat-meta-chips {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+}
+.quick-chat-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  background: var(--bg-subtle);
+  padding: 1px 7px;
+  font-size: 10px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.quick-chat-meta-chip:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* A disabled Send at 50% opacity over the dark composer was near-invisible —
+   keep the control legible as "present but not ready" (cave-fdt5). */
+.quick-chat-overlay__actions .ui-btn--primary:disabled {
+  opacity: 1;
+  border-color: var(--border-hairline);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
 }
 
 /* Drag-and-drop attachments — the composer footer is the drop target; the

--- a/src/components/quick-chat-polish.test.ts
+++ b/src/components/quick-chat-polish.test.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+// Quick-chat window polish (cave-fdt5): readable measure on wide windows,
+// meta chips instead of a status sentence, and a legible disabled Send.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const glass = readFileSync(new URL("../styles/quick-chat-glass.css", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const tray = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
+
+// ── Readable measure ─────────────────────────────────────────────────────────
+assert.match(
+  glass,
+  /\.tray-quick-chat__pane \{[\s\S]{0,700}?max-width: 920px;\s*\n\s*margin-inline: auto;/,
+  "The pane column caps at a readable measure and centers on wide windows",
+);
+
+// ── Meta chips ───────────────────────────────────────────────────────────────
+assert.match(
+  globals,
+  /\.quick-chat-meta-chip \{[\s\S]{0,400}?border-radius: 999px;[\s\S]{0,200}?background: var\(--bg-subtle\);/,
+  "Meta chips are quiet token pills",
+);
+assert.doesNotMatch(
+  tray,
+  /Thinking: \$\{thinkingEffort\}/,
+  "The status run-on sentence is gone from the composer hint area",
+);
+assert.match(
+  tray,
+  /className="quick-chat-meta-chip" title="Thinking effort"/,
+  "Thinking chip labels itself via tooltip",
+);
+assert.match(
+  tray,
+  /className="quick-chat-meta-chip" title="Model"/,
+  "Model chip labels itself via tooltip",
+);
+
+// ── Disabled Send stays visible ──────────────────────────────────────────────
+assert.match(
+  globals,
+  /\.quick-chat-overlay__actions \.ui-btn--primary:disabled \{\s*\n\s*opacity: 1;\s*\n\s*border-color: var\(--border-hairline\);\s*\n\s*background: var\(--bg-subtle\);\s*\n\s*color: var\(--text-muted\);/,
+  "Disabled Send renders as a visible 'present but not ready' control, not a 50% ghost",
+);
+
+// ── The composer input keeps its visible focus treatment ────────────────────
+assert.match(
+  globals,
+  /\.quick-chat-overlay__input:focus \{\s*\n\s*border-color: var\(--accent-presence\);/,
+  "Composer input keeps the accent focus treatment",
+);
+
+// ── The --bg-subtle token is actually defined ────────────────────────────────
+// Chips, keycaps, and recent-search pills referenced --bg-subtle while no
+// theme defined it — every one rendered transparent. It now derives from
+// --bg-raised so it tracks all themes through one definition.
+assert.match(
+  globals,
+  /--bg-subtle: color-mix\(in oklch, var\(--bg-raised\) 72%, transparent\);/,
+  "--bg-subtle is defined (derived from --bg-raised)",
+);
+
+console.log("quick-chat-polish.test.ts: ok");

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -164,8 +164,13 @@ assert.match(
 );
 assert.match(
   component,
-  /const hintText = selectedFamiliar\s*\?\s*`Thinking: \$\{thinkingEffort\} · Speed: \$\{responseSpeed\} · Model: \$\{modelOverride \?\? "Runtime managed"\}`\s*:\s*"@id switches familiars · ⌘N new chat";/,
-  "once a familiar is chosen, the composer hint area shows thinking/speed/model instead of the @id switch hint",
+  /selectedFamiliar \? \([\s\S]{0,700}?quick-chat-meta-chips[\s\S]{0,900}?\) : \(\s*\n\s*<p className="min-w-0 truncate text-xs text-\[var\(--fg-muted\)\]">\s*\n\s*@id switches familiars · ⌘N new chat/,
+  "once a familiar is chosen, the composer hint area shows thinking/speed/model as quiet meta chips (cave-fdt5); the @id switch hint remains for the unpicked state",
+);
+assert.match(
+  component,
+  /aria-label=\{`Thinking \$\{thinkingEffort\}, speed \$\{responseSpeed\}, model \$\{modelLabel\}`\}/,
+  "the chips group carries one full accessible reading; individual chips stay aria-hidden with sighted tooltips",
 );
 assert.match(component, /<QuickChatComposer/, "tray renders the shared composer");
 assert.match(

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -300,9 +300,7 @@ export function QuickChatTabPane({
       window.location.href = `/#chat-${encodeURIComponent(sessionId)}`;
     }
   }, [selectedFamiliarId, sessionId]);
-  const hintText = selectedFamiliar
-    ? `Thinking: ${thinkingEffort} · Speed: ${responseSpeed} · Model: ${modelOverride ?? "Runtime managed"}`
-    : "@id switches familiars · ⌘N new chat";
+  const modelLabel = modelOverride ?? "auto";
 
   return (
     <section
@@ -370,9 +368,30 @@ export function QuickChatTabPane({
               disabled={!sessionId}
               onClick={() => void openFullSession()}
             />
-            <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
-              {hintText}
-            </p>
+            {selectedFamiliar ? (
+              // Quiet meta chips instead of a "Thinking: high · Speed: fast ·
+              // Model: …" run-on sentence (cave-fdt5). The group carries the
+              // full reading for screen readers; chips get sighted tooltips.
+              <span
+                className="quick-chat-meta-chips"
+                role="group"
+                aria-label={`Thinking ${thinkingEffort}, speed ${responseSpeed}, model ${modelLabel}`}
+              >
+                <span aria-hidden className="quick-chat-meta-chip" title="Thinking effort">
+                  {thinkingEffort}
+                </span>
+                <span aria-hidden className="quick-chat-meta-chip" title="Response speed">
+                  {responseSpeed}
+                </span>
+                <span aria-hidden className="quick-chat-meta-chip" title="Model">
+                  {modelLabel}
+                </span>
+              </span>
+            ) : (
+              <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
+                @id switches familiars · ⌘N new chat
+              </p>
+            )}
           </div>
         }
       />

--- a/src/styles/quick-chat-glass.css
+++ b/src/styles/quick-chat-glass.css
@@ -139,6 +139,13 @@ html[data-glass] .quick-tab--active {
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  /* Readable measure (cave-fdt5): the /quick-chat route can be a full-screen
+     window — cap the working column and center it so the controls row stops
+     reading as a second full-width header and the thread keeps a prose-friendly
+     width. Inert in the ~390px tray and the notch panel. */
+  width: 100%;
+  max-width: 920px;
+  margin-inline: auto;
 }
 
 /* The thread fills whatever height the window has — globals' 46vh cap


### PR DESCRIPTION
## Facelift 10/12 — quick-chat window (cave-fdt5)

At full window size, /quick-chat read poorly: the project/controls row stretched into a second full-width header, the empty state floated in a huge void, the composer status line was a plain-text run-on, and a disabled Send at 50% opacity was near-invisible.

### What changed
- **Readable measure** — `.tray-quick-chat__pane` caps at 920px and centers on wide windows (inert in the ~390px tray and the notch panel). Controls, thread, and composer share one column; the "second header" impression dissolves.
- **Meta chips** — `Thinking: high · Speed: fast · Model: Runtime managed` becomes three quiet token pills (`high` / `fast` / `auto`) with sighted tooltips and a single accessible group reading. The `@id switches familiars` hint stays for the unpicked state.
- **Visible disabled Send** — scoped override: opacity 1 + hairline + `--bg-subtle` fill + `--text-muted` — reads "present but not ready" instead of a ghost.
- **Token fix: `--bg-subtle` was never defined** — 5 call sites referenced it (palette keycaps, recent-search pills, @scope chip, the new meta chips, disabled Send) and all computed **transparent**. Now defined once in `:root`, derived from `--bg-raised` (`color-mix 72%`), so it tracks all 38 theme blocks via var() resolution. This also gives #3104's keycap chips their intended fill.

### Tests
- New pin `src/components/quick-chat-polish.test.ts` (wired): measure cap, chip pills, run-on removal, disabled-Send contract, input focus treatment, token definition.
- `tray-quick-chat.test.ts` hint pin updated to the chips contract (coverage retained).

### Verification
- typecheck + build green; **full `pnpm test:app` 677 green**; rebased over #3104 (palette pins green post-rebase)
- Playwright 2000×1250: pane centered (x=540, w=920), 3 chips render as pills, disabled Send computes opacity 1 with a resolved background (before the token fix it computed `rgba(0,0,0,0)`)

Bead: cave-fdt5 (umbrella cave-ew98)
