### PR TITLE
fix(tools): harden stale-launcher remediation per #3099 review (cave-5320)

### DIFF
--- a/src/lib/opencoven-tools-resolve.test.ts
+++ b/src/lib/opencoven-tools-resolve.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import {
+  isNodeModulesPackagePath,
+  npmGlobalPrefixFromNpmPath,
   removeLauncherFile,
   resolveStaleOpenCovenLaunchers,
   type StaleLauncherDependencies,
@@ -122,10 +124,9 @@ test("refuses to remove a launcher owned by a different package and hints instea
   assert.match(resolution.hint!, /Move npm's global bin/);
 });
 
-test("refuses to remove a same-package copy that is not behind the fresh install", async () => {
+test("an equal-version verified copy first on PATH simply verifies — no removal", async () => {
   const equalVersion = probe({
     path: "/opt/other/bin/coven",
-    executableVerified: false,
     packagePath: "/opt/other/lib/node_modules/@opencoven/cli",
     executablePath: "/opt/other/lib/node_modules/@opencoven/cli/bin/coven.js",
   });
@@ -135,6 +136,24 @@ test("refuses to remove a same-package copy that is not behind the fresh install
   });
 
   const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.equal(resolution.hint, null);
+  assert.ok(resolution.verification?.ok, "another equally-new verified install is not stale");
+});
+
+test("refuses removal when the shadow is not strictly behind the fresh copy (latest unknown)", async () => {
+  const equalVersion = probe({
+    path: "/opt/other/bin/coven",
+    packagePath: "/opt/other/lib/node_modules/@opencoven/cli",
+    executablePath: "/opt/other/lib/node_modules/@opencoven/cli/bin/coven.js",
+  });
+  const { deps, removed } = makeDeps({
+    discoverQueue: [equalVersion],
+    existing: new Set([GOOD_PATH, equalVersion.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", null, deps);
 
   assert.deepEqual(removed, []);
   assert.ok(resolution.hint, "a non-removable copy still yields manual guidance");
@@ -231,6 +250,93 @@ test("Windows removal covers the launcher's sibling shims", async () => {
 
   assert.deepEqual(removed, ["C:\\old\\coven", "C:\\old\\coven.cmd", "C:\\old\\coven.ps1"]);
   assert.ok(resolution.verification?.ok);
+});
+
+test("refuses to remove a same-package SOURCE CHECKOUT on PATH (name match is not provenance)", async () => {
+  // A developer working on @opencoven/cli with their git checkout's bin on
+  // PATH: the checkout root package.json carries the same name and an older
+  // version, but it is NOT an npm-managed install — deleting from it would
+  // destroy tracked working-tree files.
+  const checkout = probe({
+    path: "/home/user/src/cli/bin/coven",
+    executablePath: "/home/user/src/cli/bin/coven.js",
+    packagePath: "/home/user/src/cli",
+    version: "0.0.54",
+  });
+  const { deps, removed } = makeDeps({
+    discoverQueue: [checkout],
+    existing: new Set([GOOD_PATH, checkout.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.match(resolution.hint!, /src\/cli\/bin\/coven belongs to @opencoven\/cli, so Cave will not remove it/);
+});
+
+test("refuses to remove a same-package copy whose bin entry does not verify", async () => {
+  const unverifiable = probe({
+    path: "/opt/weird/bin/coven",
+    executablePath: "/opt/weird/lib/node_modules/@opencoven/cli/bin/coven.js",
+    packagePath: "/opt/weird/lib/node_modules/@opencoven/cli",
+    executableVerified: false,
+    version: "0.0.54",
+  });
+  const { deps, removed } = makeDeps({
+    discoverQueue: [unverifiable],
+    existing: new Set([GOOD_PATH, unverifiable.path!]),
+  });
+
+  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, deps);
+
+  assert.deepEqual(removed, []);
+  assert.ok(resolution.hint, "unproven provenance yields manual guidance, never deletion");
+});
+
+test("isNodeModulesPackagePath demands a node_modules/<package> tail", () => {
+  assert.ok(
+    isNodeModulesPackagePath(
+      "/home/u/.nvm/versions/node/v24.13.0/lib/node_modules/@opencoven/cli",
+      "@opencoven/cli",
+      "linux",
+    ),
+  );
+  assert.ok(
+    isNodeModulesPackagePath(
+      "C:\\npm\\node_modules\\@OpenCoven\\cli",
+      "@opencoven/cli",
+      "win32",
+    ),
+    "win32 comparison is case-insensitive",
+  );
+  assert.ok(!isNodeModulesPackagePath("/home/u/src/cli", "@opencoven/cli", "linux"));
+  assert.ok(
+    !isNodeModulesPackagePath("/home/u/node_modules/cli", "@opencoven/cli", "linux"),
+    "scope segment must match too",
+  );
+  assert.ok(
+    !isNodeModulesPackagePath("/home/u/not_node_modules/@opencoven/cli", "@opencoven/cli", "linux"),
+  );
+});
+
+test("npmGlobalPrefixFromNpmPath routes Windows npm.cmd through node npm-cli.js", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "coven-npm-prefix-"));
+  const npmCli = path.join(dir, "node_modules", "npm", "bin", "npm-cli.js");
+  const npmCmd = path.join(dir, "npm.cmd");
+  await mkdir(path.dirname(npmCli), { recursive: true });
+  await writeFile(npmCli, "process.stdout.write('C:\\\\Users\\\\dev\\\\npm-global\\n');\n");
+  await writeFile(npmCmd, "@ECHO off\r\nREM npm shim\r\n");
+
+  // The .cmd shim itself is never exec'd (Node >= 21.7 rejects it without a
+  // shell); the launch remap runs npm-cli.js with Cave's own Node, so this
+  // works — and is asserted — even from a POSIX test host.
+  const prefix = await npmGlobalPrefixFromNpmPath(
+    npmCmd,
+    { ...process.env },
+    "win32",
+  );
+  assert.equal(prefix, "C:\\Users\\dev\\npm-global");
+  await rm(dir, { recursive: true, force: true });
 });
 
 test("removeLauncherFile deletes files but refuses directories", async () => {

--- a/src/lib/opencoven-tools-resolve.ts
+++ b/src/lib/opencoven-tools-resolve.ts
@@ -6,6 +6,7 @@ import { compareSemver } from "./app-update.ts";
 import { pickWindowsLauncher, refreshCovenSpawnEnv } from "./coven-bin.ts";
 import {
   discoverOpenCovenTool,
+  npmViewLaunchCommandForPath,
   probeOpenCovenBinaryAt,
   OPEN_COVEN_TOOLS,
   type OpenCovenToolId,
@@ -33,8 +34,10 @@ const execFileAsync = promisify(execFile);
  *     (same npm package, version >= the tool minimum and >= npm latest when
  *     known) BEFORE anything is touched. Never delete the only working copy.
  *   - Only launcher FILES whose resolved target belongs to the same npm
- *     package are removed — never directories, never binaries owned by other
- *     packages or by non-npm builds, never the fresh copy itself.
+ *     package — proven by a verifying package.json bin entry inside a
+ *     node_modules tree — are removed. Never directories, never binaries
+ *     owned by other packages, never same-named source checkouts or
+ *     non-npm builds, never the fresh copy itself.
  *   - When removal is not safe or not permitted, the caller gets an exact,
  *     copyable manual command instead of a silent failure.
  */
@@ -85,6 +88,30 @@ function samePath(left: string, right: string, platform: NodeJS.Platform): boole
   return normalize(left) === normalize(right);
 }
 
+/** Read npm's global prefix from an already-located npm launcher. Routed
+ *  through npmViewLaunchCommandForPath because npm on Windows is a .cmd shim
+ *  that Node (>= 21.7 / CVE-2024-27980) refuses to execFile without a shell —
+ *  the shim is remapped onto `node npm-cli.js`, keeping the query argv-only. */
+export async function npmGlobalPrefixFromNpmPath(
+  npmPath: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string | null> {
+  const launch = npmViewLaunchCommandForPath(npmPath, platform);
+  if (!launch) return null;
+  try {
+    const { stdout } = await execFileAsync(
+      launch.command,
+      [...launch.fixedArgs, "prefix", "-g"],
+      { env, timeout: 5000 },
+    );
+    const prefix = stdout.trim();
+    return prefix || null;
+  } catch {
+    return null;
+  }
+}
+
 async function defaultNpmGlobalPrefix(env: NodeJS.ProcessEnv): Promise<string | null> {
   const finder = process.platform === "win32" ? "where" : "which";
   try {
@@ -94,9 +121,7 @@ async function defaultNpmGlobalPrefix(env: NodeJS.ProcessEnv): Promise<string | 
         ? pickWindowsLauncher(npmOut.split(/\r?\n/))
         : npmOut.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? null;
     if (!npm) return null;
-    const { stdout } = await execFileAsync(npm, ["prefix", "-g"], { env, timeout: 5000 });
-    const prefix = stdout.trim();
-    return prefix || null;
+    return await npmGlobalPrefixFromNpmPath(npm, env);
   } catch {
     return null;
   }
@@ -158,12 +183,40 @@ function manualRemovalHint(paths: string[], platform: NodeJS.Platform): string {
   return `Remove it manually (${command}), then re-check.`;
 }
 
+/** True when `packagePath` is a `node_modules/<packageName>` directory —
+ *  the layout every npm-managed global install uses. A source checkout whose
+ *  root package.json carries the same name fails this test, which is the
+ *  point: deletion demands npm-launcher provenance, not just a name match. */
+export function isNodeModulesPackagePath(
+  packagePath: string,
+  packageName: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const api = pathApiFor(platform);
+  const segments = api.normalize(packagePath).split(api.sep).filter(Boolean);
+  const expected = ["node_modules", ...packageName.split("/")];
+  if (segments.length < expected.length) return false;
+  const tail = segments.slice(-expected.length);
+  const matches = (left: string, right: string) =>
+    platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
+  return expected.every((segment, index) => matches(tail[index]!, segment));
+}
+
 function staleProbeIsRemovableSamePackage(
   tool: OpenCovenToolSpec,
   probe: OpenCovenToolProbe,
   goodVersion: string,
+  platform: NodeJS.Platform,
 ): boolean {
   if (!probe.path || probe.packageName !== tool.packageName) return false;
+  // Deletion demands proven npm-launcher provenance, not just an ancestor
+  // package.json with the right name: the manifest's bin entry must resolve
+  // to this executable, and the package must live in a node_modules tree.
+  // A same-named source checkout or non-npm build on PATH is never removed.
+  if (!probe.executableVerified) return false;
+  if (!probe.packagePath || !isNodeModulesPackagePath(probe.packagePath, tool.packageName, platform)) {
+    return false;
+  }
   // Only remove copies that are strictly behind the verified fresh install;
   // an equal-or-newer copy failing verification is a different problem that
   // deletion would not fix.
@@ -264,7 +317,7 @@ export async function resolveStaleOpenCovenLaunchers(
       // verification — removal has nothing left to fix.
       return resolution;
     }
-    if (!staleProbeIsRemovableSamePackage(tool, probe, goodVersion)) {
+    if (!staleProbeIsRemovableSamePackage(tool, probe, goodVersion, platform)) {
       const owner = probe.packageName ?? "an unrecognized launcher";
       resolution.hint =
         `${tool.binary} at ${probe.path} belongs to ${owner}, so Cave will not remove it. ` +


### PR DESCRIPTION
Follow-up to #3099 from its code review — two high-confidence findings, both fixed:

## 1. Windows remediation was silently inert (High)

`defaultNpmGlobalPrefix` exec'd `npm.cmd` without the `.cmd` workaround; Node ≥ 21.7 (CVE-2024-27980) throws EINVAL, the catch returned null, and Gate 0 always skipped with a misleading log. The prefix query now routes through `npmViewLaunchCommandForPath` (`node npm-cli.js prefix -g`), exactly like the existing `npm view` probe. New test exercises the win32 remap from any host (the shim is never exec'd).

## 2. Name match ≠ provenance (Medium)

`staleProbeIsRemovableSamePackage` accepted any launcher whose ancestor `package.json` name matched — which could delete a launcher out of a same-named **source checkout** (tracked working-tree files!) or a pnpm/bun-managed tree. Removal now also requires:
- `probe.executableVerified` — the manifest's `bin` entry realpath-resolves to the executable, and
- `isNodeModulesPackagePath` — `packagePath` ends in `node_modules/<package>` (scope-aware, case-insensitive on win32).

Same-named checkouts now get the manual hint instead of an `rm`. Behavior change ripple: a fully-verified equal-version copy first on PATH now simply verifies (no removal needed) — tests split to cover both latest-known and latest-unknown paths.

## Validation

- 15 tests pass (5 new: source-checkout refusal, unverified-bin refusal, `isNodeModulesPackagePath` cases, win32 `npm.cmd` prefix remap, equal-version verify-not-remove)
- `pnpm typecheck` clean; onboarding/install route + status + latest-check suites green

Bead: cave-5320 (review follow-up to cave-kii6)