### PR TITLE
feat(schedules): track the human phrase into the actual plan — wider grammar, custom recurrences, verifiable plan echo (cave-rdfc)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -187,6 +187,8 @@ export const SUITES = {
     "src/lib/artifact-comments.test.ts",
     "src/components/artifact-comments.test.ts",
     "src/lib/reminder-draft.test.ts",
+    "src/lib/parse-when.test.ts",
+    "src/lib/schedule-plan.test.ts",
     "src/lib/daily-report.test.ts",
     "src/lib/daily-note.test.ts",
     "src/components/familiar-daily-notes.test.ts",

--- a/src/app/api/inbox/[id]/route.ts
+++ b/src/app/api/inbox/[id]/route.ts
@@ -19,7 +19,7 @@ startScheduler();
 // page rewrite kind/source/firedAt/machine-discriminator fields and persist
 // shapes the scheduler can't handle.
 const PATCHABLE_FIELDS = [
-  "title", "body", "status", "fireAt", "snoozeUntil", "recurrence", "familiarId", "link",
+  "title", "body", "status", "fireAt", "snoozeUntil", "recurrence", "whenText", "familiarId", "link",
 ] as const;
 
 export async function PATCH(

--- a/src/app/api/inbox/[id]/route.ts
+++ b/src/app/api/inbox/[id]/route.ts
@@ -38,7 +38,13 @@ export async function PATCH(
   }
   const body: Partial<Omit<InboxItem, "id" | "createdAt">> = {};
   for (const key of PATCHABLE_FIELDS) {
-    if (key in raw) (body as Record<string, unknown>)[key] = raw[key];
+    if (!(key in raw)) continue;
+    // whenText is free text persisted verbatim — reject non-string shapes so
+    // a malformed client can't store an object/number on the item.
+    if (key === "whenText" && raw.whenText !== null && typeof raw.whenText !== "string") {
+      return NextResponse.json({ ok: false, error: "whenText must be a string or null" }, { status: 400 });
+    }
+    (body as Record<string, unknown>)[key] = raw[key];
   }
   const item = await updateItem(id, body);
   if (!item) {

--- a/src/app/api/inbox/route.ts
+++ b/src/app/api/inbox/route.ts
@@ -36,6 +36,7 @@ export async function POST(req: Request) {
     body?: string;
     fireAt?: string | null;
     recurrence?: Recurrence;
+    whenText?: string | null;
     source?: "user" | "agent" | "system";
     familiarId?: string | null;
     sessionId?: string | null;
@@ -63,6 +64,7 @@ export async function POST(req: Request) {
     body: body.body,
     fireAt: body.fireAt,
     recurrence: body.recurrence,
+    whenText: typeof body.whenText === "string" ? body.whenText : null,
     source: body.source ?? (kind === "agent" ? "agent" : "user"),
     familiarId: body.familiarId,
     sessionId: body.sessionId,

--- a/src/components/new-reminder-modal.test.ts
+++ b/src/components/new-reminder-modal.test.ts
@@ -26,6 +26,22 @@ assert.match(modal, /function presetForRecurrence/, "should map a stored recurre
 assert.match(modal, /setRecurPreset\(preset\)/, "edit prefill should restore the recurrence preset");
 assert.match(modal, /setLink\(editing\.link \?\? null\)/, "edit prefill should restore the link");
 
+// ── Phrase → plan tracking (cave-rdfc) ───────────────────────────────────────
+// A parsed schedule that no named preset represents must survive as the
+// "custom" preset carrying the exact recurrence — never silently downgrade to
+// a one-shot (the old mon,wed,fri bug).
+assert.match(modal, /return \{ preset: "custom", customRec: rec \};/, "unrepresentable recurrences map to the custom preset");
+assert.match(modal, /if \(preset === "custom"\) return customRec \?\? \{ type: "none" \};/, "submit honors the custom recurrence verbatim");
+assert.match(modal, /whenText: whenText\.trim\(\) \|\| null,/, "the human phrase is persisted with the draft");
+assert.match(modal, /const \[whenDirty, setWhenDirty\] = useState\(false\);/, "edit mode tracks phrase dirtiness");
+assert.match(modal, /if \(isEditing && !whenDirty\) return;/, "retyping the phrase in edit mode retakes the picker");
+
+// The plan echo shows the cadence sentence and upcoming fires, announced to AT.
+assert.match(modal, /describeRecurrence\(planRecurrence, \{ hour12 \}\)/, "plan echo describes the cadence in words");
+assert.match(modal, /nextOccurrences\(planRecurrence, Date\.now\(\), 3\)/, "plan echo lists the next 3 concrete fires");
+assert.match(modal, /aria-live="polite"/, "plan echo is announced politely to AT");
+assert.match(modal, /\{planCadence \? "Repeats" : "Once"\}/, "plan echo distinguishes one-shots from repeats");
+
 // ── Both paths carry link ────────────────────────────────────────────────────
 assert.match(modal, /link,/, "draft submitted to create/update should include the link");
 

--- a/src/components/new-reminder-modal.tsx
+++ b/src/components/new-reminder-modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
 import { parseWhen } from "@/lib/parse-when";
+import { describeRecurrence, nextOccurrences } from "@/lib/schedule-plan";
 import { draftReminderFromText } from "@/lib/reminder-draft";
 import { parseCron } from "@/lib/cron";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -22,6 +23,8 @@ export type NewReminderDraft = {
   familiarId: string | null;
   recurrence?: Recurrence;
   link?: LinkRef | null;
+  /** The human phrase the plan came from — persisted so edits round-trip it. */
+  whenText?: string | null;
 };
 
 type RecurPreset =
@@ -31,6 +34,7 @@ type RecurPreset =
   | "every-day"
   | "every-weekday"
   | "every-weekend"
+  | "custom"
   | "cron";
 
 const RECUR_PRESETS: { value: RecurPreset; label: string }[] = [
@@ -47,11 +51,15 @@ function recurrenceFor(
   preset: RecurPreset,
   fireAt: string,
   cronExpr: string,
+  customRec: Recurrence | null,
 ): Recurrence {
   if (preset === "none") return { type: "none" };
   if (preset === "every-30m") return { type: "interval", everyMs: 30 * 60_000 };
   if (preset === "every-1h") return { type: "interval", everyMs: 60 * 60_000 };
   if (preset === "cron") return { type: "cron", expr: cronExpr.trim() };
+  // The phrase (or the reminder being edited) described a schedule no preset
+  // represents — keep the exact plan instead of silently downgrading it.
+  if (preset === "custom") return customRec ?? { type: "none" };
   const d = new Date(fireAt);
   const hour = d.getHours();
   const minute = d.getMinutes();
@@ -85,22 +93,26 @@ type Props = {
 };
 
 // Mirror of the parsed-recurrence → preset effect, used to map an existing
-// reminder's stored recurrence back onto the picker when editing.
+// reminder's stored recurrence back onto the picker when editing. Anything a
+// named preset can't represent maps to "custom" carrying the exact recurrence,
+// so editing never silently rewrites the stored plan.
 function presetForRecurrence(rec: Recurrence | undefined): {
   preset: RecurPreset;
   cronExpr?: string;
+  customRec?: Recurrence;
 } {
   if (!rec || rec.type === "none") return { preset: "none" };
   if (rec.type === "interval" && rec.everyMs === 30 * 60_000)
     return { preset: "every-30m" };
   if (rec.type === "interval" && rec.everyMs === 60 * 60_000)
     return { preset: "every-1h" };
+  if (rec.type === "interval") return { preset: "custom", customRec: rec };
   if (rec.type === "daily") return { preset: "every-day" };
   if (rec.type === "weekly") {
     const days = rec.days.slice().sort().join(",");
     if (days === "1,2,3,4,5") return { preset: "every-weekday" };
     if (days === "0,6") return { preset: "every-weekend" };
-    return { preset: "none" };
+    return { preset: "custom", customRec: rec };
   }
   if (rec.type === "cron") return { preset: "cron", cronExpr: rec.expr };
   return { preset: "none" };
@@ -132,6 +144,12 @@ export function NewReminderModal({
   const [familiarId, setFamiliarId] = useState<string | null>(defaultFamiliarId);
   const [recurPreset, setRecurPreset] = useState<RecurPreset>("none");
   const [cronExpr, setCronExpr] = useState<string>("*/15 * * * *");
+  // The exact recurrence behind the "custom" preset (from the phrase or the
+  // reminder being edited) — held verbatim so the saved plan matches it.
+  const [customRec, setCustomRec] = useState<Recurrence | null>(null);
+  // In edit mode the picker starts from the STORED recurrence; only once the
+  // user retypes the phrase does the parse retake the picker (whenDirty).
+  const [whenDirty, setWhenDirty] = useState(false);
   const [link, setLink] = useState<LinkRef | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -146,10 +164,12 @@ export function NewReminderModal({
       setWhenText(editing.whenText ?? "");
       setManualFireAt(editing.whenText ? "" : toLocalInput(editing.fireAt));
       setFamiliarId(defaultFamiliarId);
-      const { preset, cronExpr: cron } = presetForRecurrence(editing.recurrence);
+      const { preset, cronExpr: cron, customRec: custom } = presetForRecurrence(editing.recurrence);
       setRecurPreset(preset);
       setCronExpr(cron ?? "*/15 * * * *");
+      setCustomRec(custom ?? null);
       setLink(editing.link ?? null);
+      setWhenDirty(false);
       setError(null);
       return;
     }
@@ -159,7 +179,9 @@ export function NewReminderModal({
     setFamiliarId(defaultFamiliarId);
     setRecurPreset("none");
     setCronExpr("*/15 * * * *");
+    setCustomRec(null);
     setLink(null);
+    setWhenDirty(false);
     setError(null);
   }, [open, defaultFamiliarId, defaultFireAt, defaultWhenText, defaultTitle, editing]);
 
@@ -175,28 +197,18 @@ export function NewReminderModal({
   }, [whenText]);
 
   // If the natural-language phrase implies a recurrence, reflect it in the
-  // picker — user sees what was inferred and can override.
+  // picker — user sees what was inferred and can override. Schedules with no
+  // named preset (e.g. "every tuesday 4pm") become the "custom" preset holding
+  // the exact parsed recurrence instead of silently saving a one-shot. In edit
+  // mode this only kicks in after the user actually retypes the phrase.
   useEffect(() => {
-    if (isEditing) return;
+    if (isEditing && !whenDirty) return;
     if (!parsed) return;
-    const r = parsed.recurrence;
-    if (r.type === "none") {
-      setRecurPreset("none");
-    } else if (r.type === "interval" && r.everyMs === 30 * 60_000) {
-      setRecurPreset("every-30m");
-    } else if (r.type === "interval" && r.everyMs === 60 * 60_000) {
-      setRecurPreset("every-1h");
-    } else if (r.type === "daily") {
-      setRecurPreset("every-day");
-    } else if (r.type === "weekly") {
-      const days = r.days.slice().sort().join(",");
-      if (days === "1,2,3,4,5") setRecurPreset("every-weekday");
-      else if (days === "0,6") setRecurPreset("every-weekend");
-    } else if (r.type === "cron") {
-      setRecurPreset("cron");
-      setCronExpr(r.expr);
-    }
-  }, [parsed, isEditing]);
+    const { preset, cronExpr: cron, customRec: custom } = presetForRecurrence(parsed.recurrence);
+    setRecurPreset(preset);
+    if (cron) setCronExpr(cron);
+    setCustomRec(custom ?? null);
+  }, [parsed, isEditing, whenDirty]);
 
   const cronFields = useMemo(() => {
     if (recurPreset !== "cron") return null;
@@ -237,8 +249,11 @@ export function NewReminderModal({
         title: title.trim(),
         fireAt: resolvedFireAt,
         familiarId,
-        recurrence: recurrenceFor(recurPreset, resolvedFireAt, cronExpr),
+        recurrence: recurrenceFor(recurPreset, resolvedFireAt, cronExpr, customRec),
         link,
+        // Persist the phrase that produced the plan so editing round-trips
+        // the human input, not just the machine schedule.
+        whenText: whenText.trim() || null,
       };
       if (editing && onUpdate) {
         await onUpdate(editing.id, draft);
@@ -253,6 +268,7 @@ export function NewReminderModal({
     }
   };
 
+  const hour12 = readDateTimePrefs().clock !== "24h";
   const previewLabel = resolvedFireAt
     ? new Date(resolvedFireAt).toLocaleString(undefined, {
         weekday: "short",
@@ -261,9 +277,22 @@ export function NewReminderModal({
         hour: "numeric",
         minute: "2-digit",
         // Honor the user's 12h/24h clock preference for the fire-time preview.
-        hour12: readDateTimePrefs().clock !== "24h",
+        hour12,
       })
     : null;
+
+  // The plan the dialog will actually save, echoed back for verification:
+  // cadence sentence for recurring plans + the next few concrete fires.
+  const planRecurrence = resolvedFireAt
+    ? recurrenceFor(recurPreset, resolvedFireAt, cronExpr, customRec)
+    : null;
+  const planCadence = planRecurrence ? describeRecurrence(planRecurrence, { hour12 }) : null;
+  // Cheap (≤3 next-occurrence steps) — computed per render; no hook after the
+  // early `if (!open) return null` above.
+  const planUpcoming: string[] =
+    planRecurrence && planRecurrence.type !== "none"
+      ? nextOccurrences(planRecurrence, Date.now(), 3)
+      : [];
 
   return (
     <div
@@ -286,7 +315,7 @@ export function NewReminderModal({
               {isEditing ? "Edit reminder" : "New reminder"}
             </h2>
             <p className="text-[12px] text-[var(--text-muted)]">
-              Type a natural phrase like “in 30m” or pick a date.
+              Type a natural phrase like “in 30m” or “every tuesday 4pm” — the plan below shows exactly what will fire.
             </p>
           </div>
           <IconButton
@@ -312,23 +341,53 @@ export function NewReminderModal({
             value={whenText}
             onChange={(e) => {
               setWhenText(e.target.value);
+              setWhenDirty(true);
               if (e.target.value.trim()) setManualFireAt("");
             }}
-            placeholder="in 30m · in 2h · today 17:30 · tomorrow 9am"
+            placeholder="in 30m · tomorrow at 9am · every tuesday 4pm · jul 20"
             className={`w-full rounded-[var(--radius-control)] border bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] ${
               whenText && !parsed
                 ? "border-[color-mix(in_oklch,var(--color-warning)_60%,transparent)]"
                 : "border-[var(--border-hairline)] focus:border-[var(--accent-presence)]"
             }`}
           />
-          <div className="mt-1 flex items-center justify-between text-[10px] text-[var(--text-muted)]">
-            <span>
-              {whenText && !parsed
-                ? "Couldn't parse — try “in 30m”, “today 9pm”, or use the picker below."
-                : parsed
-                ? `Parsed → ${previewLabel}`
-                : "Or pick exactly:"}
-            </span>
+          <div
+            aria-live="polite"
+            className="mt-1.5 text-[10px] text-[var(--text-muted)]"
+          >
+            {whenText && !parsed ? (
+              <span>Couldn't parse — try “in 30m”, “tomorrow at 9am”, “every tuesday 4pm”, or use the picker below.</span>
+            ) : resolvedFireAt ? (
+              <div className="rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2.5 py-1.5">
+                <div className="flex items-baseline gap-1.5">
+                  <span className="font-semibold uppercase tracking-widest text-[var(--accent-presence)]">
+                    {planCadence ? "Repeats" : "Once"}
+                  </span>
+                  <span className="text-[11px] text-[var(--text-primary)]">
+                    {planCadence ?? previewLabel}
+                  </span>
+                </div>
+                {planUpcoming.length > 0 ? (
+                  <div className="mt-0.5">
+                    Next:{" "}
+                    {planUpcoming
+                      .map((isoDate) =>
+                        new Date(isoDate).toLocaleString(undefined, {
+                          weekday: "short",
+                          month: "short",
+                          day: "numeric",
+                          hour: "numeric",
+                          minute: "2-digit",
+                          hour12,
+                        }),
+                      )
+                      .join(" · ")}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <span>Or pick exactly:</span>
+            )}
           </div>
         </Field>
 
@@ -350,7 +409,19 @@ export function NewReminderModal({
             <Select
               value={recurPreset}
               onChange={(v) => setRecurPreset(v as RecurPreset)}
-              options={RECUR_PRESETS}
+              options={
+                // "Custom" only exists while a phrase/edit holds an exact
+                // schedule no named preset represents — never hand-pickable.
+                recurPreset === "custom"
+                  ? [
+                      {
+                        value: "custom",
+                        label: `Custom — ${describeRecurrence(customRec ?? { type: "none" }, { hour12 }) ?? "from phrase"}`,
+                      },
+                      ...RECUR_PRESETS,
+                    ]
+                  : RECUR_PRESETS
+              }
             />
           </Field>
           <Field label="Familiar">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2706,6 +2706,7 @@ export function Workspace() {
             ? {
                 id: editingReminder.id,
                 title: editingReminder.title,
+                whenText: editingReminder.whenText ?? undefined,
                 fireAt: editingReminder.fireAt ?? new Date().toISOString(),
                 recurrence: editingReminder.recurrence,
                 link: editingReminder.link ?? null,
@@ -2720,6 +2721,7 @@ export function Workspace() {
               title: draft.title,
               fireAt: draft.fireAt,
               recurrence: draft.recurrence ?? { type: "none" },
+              whenText: draft.whenText ?? null,
               link: draft.link ?? null,
             }),
           });
@@ -2736,6 +2738,7 @@ export function Workspace() {
               fireAt: draft.fireAt,
               familiarId: draft.familiarId,
               recurrence: draft.recurrence ?? { type: "none" },
+              whenText: draft.whenText ?? null,
               link: draft.link ?? null,
               source: "user",
             }),

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -62,6 +62,12 @@ export type InboxItem = {
   firedAt?: string | null;
   snoozeUntil?: string | null;
   recurrence: Recurrence;
+  /**
+   * The human phrase the schedule was created from ("every tuesday 4pm").
+   * Provenance only — fireAt/recurrence stay the machine truth; editing
+   * surfaces show the phrase so the plan round-trips in the user's words.
+   */
+  whenText?: string | null;
   source: "user" | "agent" | "system";
   familiarId?: string | null;
   sessionId?: string | null;
@@ -135,6 +141,7 @@ export type NewItemInput = {
   body?: string;
   fireAt?: string | null;
   recurrence?: Recurrence;
+  whenText?: string | null;
   source?: "user" | "agent" | "system";
   familiarId?: string | null;
   sessionId?: string | null;
@@ -161,6 +168,7 @@ export async function createItem(input: NewItemInput): Promise<InboxItem> {
       firedAt: status === "fired" ? now : null,
       snoozeUntil: null,
       recurrence: input.recurrence ?? { type: "none" },
+      whenText: input.whenText ?? null,
       source: input.source ?? "user",
       familiarId: input.familiarId ?? null,
       sessionId: input.sessionId ?? null,

--- a/src/lib/parse-when.test.ts
+++ b/src/lib/parse-when.test.ts
@@ -1,0 +1,125 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { parseWhen, splitWhenAndText } from "./parse-when.ts";
+
+// Fixed clock: Tuesday 2026-07-14 10:00 local. Every expectation below is
+// computed in local time (the semantics the user types in).
+const NOW = new Date(2026, 6, 14, 10, 0, 0, 0);
+assert.equal(NOW.getDay(), 2, "fixture sanity: Jul 14 2026 is a Tuesday");
+
+const iso = (y, mo, d, h, mi) => new Date(y, mo, d, h, mi, 0, 0).toISOString();
+
+function fireAt(input) {
+  const p = parseWhen(input, NOW);
+  assert.ok(p, `should parse: "${input}"`);
+  return p;
+}
+
+// ── Offsets ("in …") ─────────────────────────────────────────────────────────
+{
+  assert.equal(fireAt("in 30m").fireAt, new Date(NOW.getTime() + 30 * 60_000).toISOString());
+  assert.equal(fireAt("in 2h").fireAt, new Date(NOW.getTime() + 2 * 3_600_000).toISOString());
+  assert.equal(fireAt("in 2 hours").fireAt, new Date(NOW.getTime() + 2 * 3_600_000).toISOString());
+  assert.equal(fireAt("in 90 minutes").fireAt, new Date(NOW.getTime() + 90 * 60_000).toISOString());
+  assert.equal(fireAt("in an hour").fireAt, new Date(NOW.getTime() + 3_600_000).toISOString());
+  assert.equal(fireAt("in a minute").fireAt, new Date(NOW.getTime() + 60_000).toISOString());
+  assert.equal(fireAt("in half an hour").fireAt, new Date(NOW.getTime() + 30 * 60_000).toISOString());
+  assert.equal(fireAt("in 1h30m").fireAt, new Date(NOW.getTime() + 90 * 60_000).toISOString());
+  assert.equal(fireAt("in 1 week").fireAt, new Date(NOW.getTime() + 7 * 86_400_000).toISOString());
+  assert.equal(fireAt("in 30m").recurrence.type, "none");
+  assert.equal(parseWhen("in 0m", NOW), null, "zero offset fails closed");
+}
+
+// ── Same/next day ────────────────────────────────────────────────────────────
+{
+  assert.equal(fireAt("today 5pm").fireAt, iso(2026, 6, 14, 17, 0));
+  assert.equal(fireAt("today at 17:30").fireAt, iso(2026, 6, 14, 17, 30));
+  assert.equal(parseWhen("today 9am", NOW), null, "past time today fails closed");
+  assert.equal(fireAt("tonight").fireAt, iso(2026, 6, 14, 20, 0));
+  assert.equal(fireAt("tomorrow 9am").fireAt, iso(2026, 6, 15, 9, 0));
+  assert.equal(fireAt("tomorrow at 9am").fireAt, iso(2026, 6, 15, 9, 0));
+  assert.equal(fireAt("tomorrow noon").fireAt, iso(2026, 6, 15, 12, 0));
+  assert.equal(fireAt("at 9am").fireAt, iso(2026, 6, 15, 9, 0), "past 'at' rolls to tomorrow");
+  assert.equal(fireAt("at 5pm").fireAt, iso(2026, 6, 14, 17, 0));
+  assert.equal(fireAt("at midnight").fireAt, iso(2026, 6, 15, 0, 0));
+}
+
+// ── Weekdays (one-shot) ──────────────────────────────────────────────────────
+{
+  assert.equal(fireAt("friday 4pm").fireAt, iso(2026, 6, 17, 16, 0));
+  assert.equal(fireAt("wednesday 9am").fireAt, iso(2026, 6, 15, 9, 0), "full day names parse");
+  assert.equal(fireAt("saturday 10am").fireAt, iso(2026, 6, 18, 10, 0));
+  assert.equal(fireAt("next wednesday at 4pm").fireAt, iso(2026, 6, 15, 16, 0));
+  assert.equal(fireAt("thurs 17:30").fireAt, iso(2026, 6, 16, 17, 30));
+  assert.equal(fireAt("tuesday 9am").fireAt, iso(2026, 6, 21, 9, 0), "past today's time → next week");
+  assert.equal(fireAt("friday 4pm").recurrence.type, "none", "bare day is one-shot, not weekly");
+}
+
+// ── Calendar dates ───────────────────────────────────────────────────────────
+{
+  assert.equal(fireAt("jul 20 9am").fireAt, iso(2026, 6, 20, 9, 0));
+  assert.equal(fireAt("july 20th at 5pm").fireAt, iso(2026, 6, 20, 17, 0));
+  assert.equal(fireAt("on jul 20").fireAt, iso(2026, 6, 20, 9, 0), "date without time defaults 9:00");
+  assert.equal(fireAt("7/20 17:00").fireAt, iso(2026, 6, 20, 17, 0));
+  assert.equal(fireAt("jan 5").fireAt, iso(2027, 0, 5, 9, 0), "past date rolls to next year");
+  assert.equal(parseWhen("feb 30", NOW), null, "impossible dates fail closed");
+}
+
+// ── Recurrences ──────────────────────────────────────────────────────────────
+{
+  const int = fireAt("every 30m");
+  assert.deepEqual(int.recurrence, { type: "interval", everyMs: 30 * 60_000 });
+  assert.deepEqual(fireAt("every 2 hours").recurrence, { type: "interval", everyMs: 2 * 3_600_000 });
+  assert.deepEqual(fireAt("every hour").recurrence, { type: "interval", everyMs: 3_600_000 });
+
+  const daily = fireAt("every day 9am");
+  assert.deepEqual(daily.recurrence, { type: "daily", hour: 9, minute: 0 });
+  assert.equal(daily.fireAt, iso(2026, 6, 15, 9, 0), "fireAt = next occurrence");
+  assert.deepEqual(fireAt("daily at noon").recurrence, { type: "daily", hour: 12, minute: 0 });
+
+  assert.deepEqual(fireAt("every weekday 9am").recurrence, { type: "weekly", days: [1, 2, 3, 4, 5], hour: 9, minute: 0 });
+  assert.deepEqual(fireAt("weekdays at 9am").recurrence, { type: "weekly", days: [1, 2, 3, 4, 5], hour: 9, minute: 0 });
+  assert.deepEqual(fireAt("every weekend 10am").recurrence, { type: "weekly", days: [0, 6], hour: 10, minute: 0 });
+
+  assert.deepEqual(fireAt("every tuesday 4pm").recurrence, { type: "weekly", days: [2], hour: 16, minute: 0 });
+  assert.deepEqual(fireAt("mon,wed,fri 8:30").recurrence, { type: "weekly", days: [1, 3, 5], hour: 8, minute: 30 });
+  assert.deepEqual(fireAt("every mon and wed at 8am").recurrence, { type: "weekly", days: [1, 3], hour: 8, minute: 0 });
+  assert.deepEqual(fireAt("every tue, thu 9:15").recurrence, { type: "weekly", days: [2, 4], hour: 9, minute: 15 });
+}
+
+// ── Time-first reorder ───────────────────────────────────────────────────────
+{
+  assert.deepEqual(fireAt("9am every weekday").recurrence, { type: "weekly", days: [1, 2, 3, 4, 5], hour: 9, minute: 0 });
+  assert.deepEqual(fireAt("noon every day").recurrence, { type: "daily", hour: 12, minute: 0 });
+}
+
+// ── Fail-closed ──────────────────────────────────────────────────────────────
+{
+  assert.equal(parseWhen("", NOW), null);
+  assert.equal(parseWhen("whenever", NOW), null);
+  assert.equal(parseWhen("today 25:00", NOW), null, "invalid hour");
+  assert.equal(parseWhen("today 9:75", NOW), null, "invalid minute");
+  assert.equal(parseWhen("every blursday 9am", NOW), null);
+  assert.equal(parseWhen("13pm", NOW), null);
+}
+
+// ── splitWhenAndText ─────────────────────────────────────────────────────────
+{
+  const s1 = splitWhenAndText("in 30m check the build", NOW);
+  assert.equal(s1.text, "check the build");
+  assert.ok(s1.when);
+
+  const s2 = splitWhenAndText("tomorrow at 9am review PRs", NOW);
+  assert.equal(s2.text, "review PRs");
+  assert.equal(s2.when?.fireAt, iso(2026, 6, 15, 9, 0));
+
+  const s3 = splitWhenAndText("every mon and wed at 8am standup notes", NOW);
+  assert.equal(s3.text, "standup notes");
+  assert.deepEqual(s3.when?.recurrence, { type: "weekly", days: [1, 3], hour: 8, minute: 0 });
+
+  const s4 = splitWhenAndText("review the queue", NOW);
+  assert.equal(s4.when, null);
+  assert.equal(s4.text, "review the queue");
+}
+
+console.log("parse-when.test.ts: ok");

--- a/src/lib/parse-when.ts
+++ b/src/lib/parse-when.ts
@@ -5,38 +5,97 @@ export type ParsedWhen = {
   recurrence: Recurrence;
 };
 
-// Anchored on both ends so splitWhenAndText can reliably probe prefixes.
-const RE_IN = /^in\s+(\d+)\s*(s|sec|secs|m|min|mins|h|hr|hrs|d|day|days)\s*$/i;
-const RE_TODAY = /^today\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_TOMORROW = /^tomorrow\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_AT = /^at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-
-// Phase 2 grammar
-const RE_EVERY_INTERVAL =
-  /^every\s+(\d+)\s*(s|sec|secs|m|min|mins|h|hr|hrs)\s*$/i;
-const RE_EVERY_DAY =
-  /^every\s+day\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_EVERY_WEEKDAY =
-  /^every\s+weekday\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_EVERY_WEEKEND =
-  /^every\s+weekend\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_EVERY_DAYS =
-  /^((?:mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)(?:\s*,\s*(?:mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun))*)\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
-const RE_DOW_ONE =
-  /^(mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)(?:day)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*$/i;
+// ── Shared vocabulary ────────────────────────────────────────────────────────
 
 const DOW_INDEX: Record<string, number> = {
-  sun: 0,
-  mon: 1,
-  tue: 2,
-  tues: 2,
-  wed: 3,
-  thu: 4,
-  thur: 4,
-  thurs: 4,
-  fri: 5,
-  sat: 6,
+  sun: 0, sunday: 0, sundays: 0,
+  mon: 1, monday: 1, mondays: 1,
+  tue: 2, tues: 2, tuesday: 2, tuesdays: 2,
+  wed: 3, weds: 3, wednesday: 3, wednesdays: 3,
+  thu: 4, thur: 4, thurs: 4, thursday: 4, thursdays: 4,
+  fri: 5, friday: 5, fridays: 5,
+  sat: 6, saturday: 6, saturdays: 6,
 };
+
+const MONTH_INDEX: Record<string, number> = {
+  jan: 0, january: 0,
+  feb: 1, february: 1,
+  mar: 2, march: 2,
+  apr: 3, april: 3,
+  may: 4,
+  jun: 5, june: 5,
+  jul: 6, july: 6,
+  aug: 7, august: 7,
+  sep: 8, sept: 8, september: 8,
+  oct: 9, october: 9,
+  nov: 10, november: 10,
+  dec: 11, december: 11,
+};
+
+const DAY_WORDS = Object.keys(DOW_INDEX).join("|");
+const MONTH_WORDS = Object.keys(MONTH_INDEX).join("|");
+
+// "9", "9am", "9:30pm", "17:30", "noon", "midnight" — with an optional
+// leading "at"/"@". Named times carry their own clock position.
+const TIME_PART = String.raw`(?:(?:at|@)\s+)?(?:(\d{1,2})(?::(\d{2}))?\s*(am|pm)?|(noon|midday|midnight))`;
+// A time the caller REQUIRES to be present (day/date forms with meridiem or
+// minutes or a named word — plainly a time, not a bare number).
+
+const SPELLED_COUNT: Record<string, number> = {
+  a: 1, an: 1, one: 1, two: 2, three: 3, four: 4, five: 5,
+  six: 6, seven: 7, eight: 8, nine: 9, ten: 10, fifteen: 15,
+  twenty: 20, thirty: 30, "forty-five": 45, sixty: 60,
+};
+const COUNT_WORDS = Object.keys(SPELLED_COUNT).join("|");
+
+const UNIT_PART = String.raw`(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?|d|days?|w|wks?|weeks?)`;
+
+// ── Regexes (anchored on both ends so splitWhenAndText can probe prefixes) ──
+
+// in 30m | in 2 hours | in one hour | in half an hour | in 1h30m | in 1 week
+const RE_IN = new RegExp(
+  String.raw`^in\s+(?:(half)\s+(?:an?\s+)?hour|((?:\d+)|(?:${COUNT_WORDS}))\s*${UNIT_PART}(?:\s*(?:and\s+)?(\d+)\s*(m|mins?|minutes?))?)\s*$`,
+  "i",
+);
+// today 9am | today at 17:30 | tonight | tomorrow noon | tomorrow at 9
+const RE_TODAY = new RegExp(String.raw`^today\s+${TIME_PART}\s*$`, "i");
+const RE_TONIGHT = /^tonight\s*$/i;
+const RE_TOMORROW = new RegExp(String.raw`^tomorrow\s+${TIME_PART}\s*$`, "i");
+const RE_AT = new RegExp(String.raw`^(?:at|@)\s+(?:(\d{1,2})(?::(\d{2}))?\s*(am|pm)?|(noon|midday|midnight))\s*$`, "i");
+// friday 4pm | next wednesday at 9 | thurs 17:30
+const RE_DOW_ONE = new RegExp(String.raw`^(?:next\s+)?(${DAY_WORDS})\s+${TIME_PART}\s*$`, "i");
+// jul 20 | july 20th 9am | on jul 20 at 5pm | 7/20 17:00
+const RE_DATE_MONTH = new RegExp(
+  String.raw`^(?:on\s+)?(${MONTH_WORDS})\.?\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+${TIME_PART})?\s*$`,
+  "i",
+);
+const RE_DATE_SLASH = new RegExp(
+  String.raw`^(?:on\s+)?(\d{1,2})\/(\d{1,2})(?:\s+${TIME_PART})?\s*$`,
+  "i",
+);
+
+// every 30m | every 2 hours
+const RE_EVERY_INTERVAL = new RegExp(
+  String.raw`^every\s+((?:\d+)|(?:${COUNT_WORDS}))?\s*(s|secs?|seconds?|m|mins?|minutes?|h|hrs?|hours?)\s*$`,
+  "i",
+);
+// every day 9am | daily at noon | every day at 17:30
+const RE_EVERY_DAY = new RegExp(String.raw`^(?:every\s+day|daily|each\s+day)\s+${TIME_PART}\s*$`, "i");
+// every weekday 9am | weekdays at 9
+const RE_EVERY_WEEKDAY = new RegExp(String.raw`^(?:every\s+)?week\s?days?\s+${TIME_PART}\s*$`, "i");
+// every weekend 10am | weekends at 10
+const RE_EVERY_WEEKEND = new RegExp(String.raw`^(?:every\s+)?weekends?\s+${TIME_PART}\s*$`, "i");
+// every tuesday 4pm | every mon and wed at 8 | mon,wed,fri 8:30 | every tue, thu 9:15
+const DAY_LIST = String.raw`(${DAY_WORDS})((?:\s*(?:,|and|&)\s*(?:${DAY_WORDS}))*)`;
+const RE_EVERY_DAYS = new RegExp(String.raw`^(?:every\s+)?${DAY_LIST}\s+${TIME_PART}\s*$`, "i");
+
+// Time-first reorder: "9am every weekday" → "every weekday 9am".
+const RE_TIME_FIRST = new RegExp(
+  String.raw`^((?:at\s+|@\s*)?(?:\d{1,2}(?::\d{2})?\s*(?:am|pm)?|noon|midday|midnight))\s+(every\s+.+|daily.*|weekdays?.*|weekends?.*)$`,
+  "i",
+);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 function unitMs(unit: string): number {
   const u = unit.toLowerCase();
@@ -44,81 +103,139 @@ function unitMs(unit: string): number {
   if (u.startsWith("m")) return 60_000;
   if (u.startsWith("h")) return 3_600_000;
   if (u.startsWith("d")) return 86_400_000;
+  if (u.startsWith("w")) return 7 * 86_400_000;
   return 0;
 }
 
-function normalizeHour(h: number, ampm: string | undefined): number {
-  if (!ampm) return h;
-  const lower = ampm.toLowerCase();
-  if (lower === "am") return h === 12 ? 0 : h;
-  return h === 12 ? 12 : h + 12;
-}
-
-function parseDayList(spec: string): number[] {
-  const out: number[] = [];
-  for (const raw of spec.split(",")) {
-    const k = raw.trim().toLowerCase();
-    const idx = DOW_INDEX[k];
-    if (idx === undefined) return [];
-    if (!out.includes(idx)) out.push(idx);
-  }
-  return out;
+function countOf(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const t = raw.toLowerCase();
+  if (/^\d+$/.test(t)) return Number(t);
+  return SPELLED_COUNT[t] ?? null;
 }
 
 /**
- * Recognized:
- *   in 5s | in 5m | in 2h | in 1d
- *   today 9am | today 17:30
- *   tomorrow 9am | tomorrow 17:30
- *   at 9am | at 17:30           (today if still future, else tomorrow)
- *   friday 9am | thu 17:30      (next-future weekday)
- *   every 30m | every 2h        (interval recurrence; fireAt = first hit)
- *   every day 9am               (daily recurrence)
- *   every weekday 9am           (weekly, mon-fri)
- *   every weekend 10am          (weekly, sat+sun)
- *   mon,wed,fri 8:30            (weekly, specific days)
- *
- * Returns null on no match — caller should fall back to explicit inputs.
+ * Resolve the TIME_PART capture groups (hour, minute, meridiem, named) into
+ * {hour, minute}, or null when the time is absent/invalid. A bare hour > 23
+ * or minute > 59 fails closed. `named` handles noon/midday/midnight.
+ */
+function timeOf(
+  hour: string | undefined,
+  minute: string | undefined,
+  meridiem: string | undefined,
+  named: string | undefined,
+): { hour: number; minute: number } | null {
+  if (named) {
+    const n = named.toLowerCase();
+    return { hour: n === "midnight" ? 0 : 12, minute: 0 };
+  }
+  if (hour === undefined) return null;
+  let h = Number(hour);
+  const mi = minute === undefined ? 0 : Number(minute);
+  if (!Number.isInteger(h) || !Number.isInteger(mi) || mi > 59) return null;
+  const mer = meridiem?.toLowerCase();
+  if (mer === "am" || mer === "pm") {
+    if (h < 1 || h > 12) return null;
+    if (mer === "pm" && h !== 12) h += 12;
+    if (mer === "am" && h === 12) h = 0;
+  } else if (h > 23) {
+    return null;
+  }
+  return { hour: h, minute: mi };
+}
+
+function parseDayList(first: string, rest: string): number[] {
+  const out: number[] = [];
+  const push = (word: string) => {
+    const idx = DOW_INDEX[word.trim().toLowerCase()];
+    if (idx !== undefined && !out.includes(idx)) out.push(idx);
+  };
+  push(first);
+  for (const m of rest.matchAll(new RegExp(`(${DAY_WORDS})`, "gi"))) push(m[1]);
+  return out;
+}
+
+function weeklyFrom(days: number[], hour: number, minute: number, now: Date): ParsedWhen | null {
+  if (days.length === 0) return null;
+  const rec: Recurrence = { type: "weekly", days: days.slice().sort((a, b) => a - b), hour, minute };
+  const next = computeNextOccurrence(rec, now.getTime());
+  if (!next) return null;
+  return { fireAt: next, recurrence: rec };
+}
+
+/**
+ * Recognized (all local time; fail-closed — unrecognized input returns null):
+ *   in 5s | in 30m | in 2 hours | in an hour | in half an hour | in 1h30m | in 1 week
+ *   today 9am | today at 17:30 | tonight | tomorrow 9am | tomorrow at noon
+ *   at 9am | at 17:30 | at midnight        (today if still future, else tomorrow)
+ *   friday 9am | next wednesday at 4pm     (next-future weekday, one-shot)
+ *   jul 20 | july 20th 9am | 7/20 17:00    (next-future date; 9:00 default)
+ *   every 30m | every 2 hours              (interval; fireAt = first hit)
+ *   every day 9am | daily at noon          (daily)
+ *   every weekday 9am | weekdays at 9      (weekly, mon-fri)
+ *   every weekend 10am | weekends at 10    (weekly, sat+sun)
+ *   every tuesday 4pm | every mon and wed at 8 | mon,wed,fri 8:30  (weekly)
+ *   9am every weekday                      (time-first reorder of the above)
  */
 export function parseWhen(input: string, now: Date = new Date()): ParsedWhen | null {
-  const text = input.trim().toLowerCase();
+  const text = input.trim().toLowerCase().replace(/\s+/g, " ");
   if (!text) return null;
+
+  // Time-first recurrences reorder into canonical "<cadence> <time>" form.
+  const reorder = text.match(RE_TIME_FIRST);
+  if (reorder) return parseWhen(`${reorder[2]} ${reorder[1]}`, now);
 
   let m = text.match(RE_IN);
   if (m) {
-    const n = Number(m[1]);
-    const ms = unitMs(m[2]);
-    if (!Number.isFinite(n) || ms === 0) return null;
-    const fireAt = new Date(now.getTime() + n * ms).toISOString();
-    return { fireAt, recurrence: { type: "none" } };
+    if (m[1]) {
+      // "in half an hour"
+      return { fireAt: new Date(now.getTime() + 30 * 60_000).toISOString(), recurrence: { type: "none" } };
+    }
+    const n = countOf(m[2]);
+    const ms = unitMs(m[3]);
+    if (n === null || !Number.isFinite(n) || n <= 0 || ms === 0) return null;
+    let total = n * ms;
+    // Compound tail: "in 1h30m" / "in 1 hour and 30 minutes".
+    if (m[4]) {
+      if (unitMs(m[3]) !== 3_600_000) return null; // tail minutes only follow hours
+      total += Number(m[4]) * 60_000;
+    }
+    return { fireAt: new Date(now.getTime() + total).toISOString(), recurrence: { type: "none" } };
+  }
+
+  if (RE_TONIGHT.test(text)) {
+    const d = new Date(now);
+    d.setHours(20, 0, 0, 0);
+    if (d.getTime() <= now.getTime()) return null;
+    return { fireAt: d.toISOString(), recurrence: { type: "none" } };
   }
 
   m = text.match(RE_TODAY);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
     const d = new Date(now);
-    d.setHours(h, mi, 0, 0);
+    d.setHours(t.hour, t.minute, 0, 0);
     if (d.getTime() <= now.getTime()) return null;
     return { fireAt: d.toISOString(), recurrence: { type: "none" } };
   }
 
   m = text.match(RE_TOMORROW);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
     const d = new Date(now);
     d.setDate(d.getDate() + 1);
-    d.setHours(h, mi, 0, 0);
+    d.setHours(t.hour, t.minute, 0, 0);
     return { fireAt: d.toISOString(), recurrence: { type: "none" } };
   }
 
   m = text.match(RE_AT);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
     const d = new Date(now);
-    d.setHours(h, mi, 0, 0);
+    d.setHours(t.hour, t.minute, 0, 0);
     if (d.getTime() <= now.getTime()) d.setDate(d.getDate() + 1);
     return { fireAt: d.toISOString(), recurrence: { type: "none" } };
   }
@@ -126,9 +243,9 @@ export function parseWhen(input: string, now: Date = new Date()): ParsedWhen | n
   // every Nm/Nh — interval recurrence. fireAt = first hit (now + interval).
   m = text.match(RE_EVERY_INTERVAL);
   if (m) {
-    const n = Number(m[1]);
+    const n = m[1] ? countOf(m[1]) : 1; // "every hour" → 1
     const ms = unitMs(m[2]);
-    if (!Number.isFinite(n) || ms === 0) return null;
+    if (n === null || !Number.isFinite(n) || n <= 0 || ms === 0) return null;
     const everyMs = n * ms;
     return {
       fireAt: new Date(now.getTime() + everyMs).toISOString(),
@@ -136,81 +253,98 @@ export function parseWhen(input: string, now: Date = new Date()): ParsedWhen | n
     };
   }
 
-  // every day HH:MM
   m = text.match(RE_EVERY_DAY);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
-    const rec: Recurrence = { type: "daily", hour: h, minute: mi };
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
+    const rec: Recurrence = { type: "daily", hour: t.hour, minute: t.minute };
     const next = computeNextOccurrence(rec, now.getTime());
     if (!next) return null;
     return { fireAt: next, recurrence: rec };
   }
 
-  // every weekday HH:MM  (mon-fri)
   m = text.match(RE_EVERY_WEEKDAY);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
-    const rec: Recurrence = {
-      type: "weekly",
-      days: [1, 2, 3, 4, 5],
-      hour: h,
-      minute: mi,
-    };
-    const next = computeNextOccurrence(rec, now.getTime());
-    if (!next) return null;
-    return { fireAt: next, recurrence: rec };
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
+    return weeklyFrom([1, 2, 3, 4, 5], t.hour, t.minute, now);
   }
 
-  // every weekend HH:MM  (sat+sun)
   m = text.match(RE_EVERY_WEEKEND);
   if (m) {
-    const h = normalizeHour(Number(m[1]), m[3]);
-    const mi = Number(m[2] ?? 0);
-    const rec: Recurrence = {
-      type: "weekly",
-      days: [0, 6],
-      hour: h,
-      minute: mi,
-    };
-    const next = computeNextOccurrence(rec, now.getTime());
-    if (!next) return null;
-    return { fireAt: next, recurrence: rec };
+    const t = timeOf(m[1], m[2], m[3], m[4]);
+    if (!t) return null;
+    return weeklyFrom([0, 6], t.hour, t.minute, now);
   }
 
-  // friday 9am  → next-future Friday, one-shot. Checked BEFORE RE_EVERY_DAYS
-  // so a single day name doesn't get treated as a 1-day weekly recurrence.
-  m = text.match(RE_DOW_ONE);
-  if (m) {
-    const idx = DOW_INDEX[m[1]];
-    if (idx === undefined) return null;
-    const h = normalizeHour(Number(m[2]), m[4]);
-    const mi = Number(m[3] ?? 0);
-    const d = new Date(now);
-    d.setHours(h, mi, 0, 0);
-    for (let i = 0; i < 8; i++) {
-      if (d.getDay() === idx && d.getTime() > now.getTime()) {
-        return { fireAt: d.toISOString(), recurrence: { type: "none" } };
+  // "friday 9am" / "next wednesday at 4pm" → next-future weekday, ONE-SHOT.
+  // Checked BEFORE RE_EVERY_DAYS so a bare day name isn't a 1-day recurrence;
+  // an explicit "every …" prefix falls through to the recurrence branch.
+  if (!text.startsWith("every ")) {
+    m = text.match(RE_DOW_ONE);
+    if (m) {
+      const idx = DOW_INDEX[m[1]];
+      const t = timeOf(m[2], m[3], m[4], m[5]);
+      if (idx === undefined || !t) return null;
+      const d = new Date(now);
+      d.setHours(t.hour, t.minute, 0, 0);
+      for (let i = 0; i < 8; i++) {
+        if (d.getDay() === idx && d.getTime() > now.getTime()) {
+          return { fireAt: d.toISOString(), recurrence: { type: "none" } };
+        }
+        d.setDate(d.getDate() + 1);
       }
-      d.setDate(d.getDate() + 1);
+      return null;
     }
-    return null;
   }
 
-  // mon,wed,fri 8:30  → weekly recurrence on the listed days.
+  // "every tuesday 4pm" | "mon,wed,fri 8:30" | "every mon and wed at 8".
   m = text.match(RE_EVERY_DAYS);
   if (m) {
-    const days = parseDayList(m[1]);
-    if (days.length === 0) return null;
-    const h = normalizeHour(Number(m[2]), m[4]);
-    const mi = Number(m[3] ?? 0);
-    const rec: Recurrence = { type: "weekly", days, hour: h, minute: mi };
-    const next = computeNextOccurrence(rec, now.getTime());
-    if (!next) return null;
-    return { fireAt: next, recurrence: rec };
+    const days = parseDayList(m[1], m[2] ?? "");
+    const t = timeOf(m[3], m[4], m[5], m[6]);
+    if (days.length === 0 || !t) return null;
+    return weeklyFrom(days, t.hour, t.minute, now);
   }
 
+  // "jul 20 9am" | "july 20th" | "on jul 20 at 5pm" — next future occurrence.
+  m = text.match(RE_DATE_MONTH);
+  if (m) {
+    const month = MONTH_INDEX[m[1]];
+    const day = Number(m[2]);
+    if (month === undefined || day < 1 || day > 31) return null;
+    const t = timeOf(m[3], m[4], m[5], m[6]) ?? { hour: 9, minute: 0 };
+    return dateOneShot(month, day, t, now);
+  }
+
+  // "7/20 17:00" — month/day (US order, matching the app's prose locale).
+  m = text.match(RE_DATE_SLASH);
+  if (m) {
+    const month = Number(m[1]) - 1;
+    const day = Number(m[2]);
+    if (month < 0 || month > 11 || day < 1 || day > 31) return null;
+    const t = timeOf(m[3], m[4], m[5], m[6]) ?? { hour: 9, minute: 0 };
+    return dateOneShot(month, day, t, now);
+  }
+
+  return null;
+}
+
+/** Next future <month day, time> (this year, else next). Rejects overflowing
+ *  days (e.g. feb 30 → rolls the month) instead of silently rolling. */
+function dateOneShot(
+  month: number,
+  day: number,
+  t: { hour: number; minute: number },
+  now: Date,
+): ParsedWhen | null {
+  for (const year of [now.getFullYear(), now.getFullYear() + 1]) {
+    const d = new Date(year, month, day, t.hour, t.minute, 0, 0);
+    if (d.getMonth() !== month || d.getDate() !== day) return null; // overflowed
+    if (d.getTime() > now.getTime()) {
+      return { fireAt: d.toISOString(), recurrence: { type: "none" } };
+    }
+  }
   return null;
 }
 
@@ -226,8 +360,8 @@ export function splitWhenAndText(
   const trimmed = body.trim();
   if (!trimmed) return { when: null, text: "" };
   const tokens = trimmed.split(/\s+/);
-  // Phase 2 grammar can use up to 4 leading tokens ("every weekend 9am check…").
-  for (let i = Math.min(tokens.length, 5); i >= 1; i--) {
+  // The widest form is 7 leading tokens ("every mon and wed at 8 am check…").
+  for (let i = Math.min(tokens.length, 7); i >= 1; i--) {
     const candidate = tokens.slice(0, i).join(" ");
     const when = parseWhen(candidate, now);
     if (when) {

--- a/src/lib/reminder-draft.test.ts
+++ b/src/lib/reminder-draft.test.ts
@@ -54,4 +54,24 @@ const nextLocalISO = (hour) => {
   assert.equal(draft.title, "review the queue");
 }
 
+// Extended grammar (cave-rdfc): "at"-joined phrases and phrase-carried
+// recurrences split cleanly into when + title.
+{
+  const draft = draftReminderFromText("tomorrow at 9am review PRs", now);
+
+  assert.equal(draft.ok, true);
+  assert.equal(draft.title, "review PRs");
+  assert.equal(draft.whenText, "tomorrow at 9am");
+}
+
+{
+  const draft = draftReminderFromText("every tuesday 4pm triage the inbox", now);
+
+  assert.equal(draft.ok, true);
+  assert.equal(draft.title, "triage the inbox");
+  assert.equal(draft.whenText, "every tuesday 4pm");
+  assert.equal(draft.recurrence.type, "weekly");
+  assert.deepEqual(draft.recurrence.days, [2]);
+}
+
 console.log("reminder-draft.test.ts: reminder draft parsing passed");

--- a/src/lib/schedule-plan.test.ts
+++ b/src/lib/schedule-plan.test.ts
@@ -9,6 +9,8 @@ import { describeRecurrence, nextOccurrences } from "./schedule-plan.ts";
   assert.equal(describeRecurrence({ type: "interval", everyMs: 3_600_000 }), "every hour");
   assert.equal(describeRecurrence({ type: "interval", everyMs: 2 * 3_600_000 }), "every 2 hours");
   assert.equal(describeRecurrence({ type: "interval", everyMs: 90 * 60_000 }), "every 90 min");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 30_000 }), "every 30s", "sub-minute intervals keep seconds");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 90_000 }), "every 1m 30s", "non-minute-aligned intervals keep the remainder");
   assert.equal(describeRecurrence({ type: "daily", hour: 9, minute: 0 }), "every day at 9 AM");
   assert.equal(describeRecurrence({ type: "daily", hour: 9, minute: 0 }, { hour12: false }), "every day at 09:00");
   assert.equal(

--- a/src/lib/schedule-plan.test.ts
+++ b/src/lib/schedule-plan.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { describeRecurrence, nextOccurrences } from "./schedule-plan.ts";
+
+// ── describeRecurrence ───────────────────────────────────────────────────────
+{
+  assert.equal(describeRecurrence({ type: "none" }), null, "one-shots have no cadence sentence");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 30 * 60_000 }), "every 30 min");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 3_600_000 }), "every hour");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 2 * 3_600_000 }), "every 2 hours");
+  assert.equal(describeRecurrence({ type: "interval", everyMs: 90 * 60_000 }), "every 90 min");
+  assert.equal(describeRecurrence({ type: "daily", hour: 9, minute: 0 }), "every day at 9 AM");
+  assert.equal(describeRecurrence({ type: "daily", hour: 9, minute: 0 }, { hour12: false }), "every day at 09:00");
+  assert.equal(
+    describeRecurrence({ type: "weekly", days: [1, 2, 3, 4, 5], hour: 9, minute: 0 }),
+    "weekdays at 9 AM",
+  );
+  assert.equal(
+    describeRecurrence({ type: "weekly", days: [0, 6], hour: 10, minute: 0 }),
+    "weekends at 10 AM",
+  );
+  assert.equal(
+    describeRecurrence({ type: "weekly", days: [5, 1, 3], hour: 8, minute: 30 }),
+    "Mon, Wed, Fri at 8:30 AM",
+    "days render sorted regardless of stored order",
+  );
+  assert.equal(describeRecurrence({ type: "cron", expr: "*/15 * * * *" }), "cron */15 * * * *");
+}
+
+// ── nextOccurrences ──────────────────────────────────────────────────────────
+{
+  // Tuesday 2026-07-14 10:00 local.
+  const NOW = new Date(2026, 6, 14, 10, 0, 0, 0).getTime();
+  const iso = (y, mo, d, h, mi) => new Date(y, mo, d, h, mi, 0, 0).toISOString();
+
+  assert.deepEqual(nextOccurrences({ type: "none" }, NOW, 3), [], "one-shots produce no sequence");
+
+  const interval = nextOccurrences({ type: "interval", everyMs: 3_600_000 }, NOW, 3);
+  assert.equal(interval.length, 3);
+  assert.equal(new Date(interval[1]).getTime() - new Date(interval[0]).getTime(), 3_600_000, "steps chain without drift");
+
+  assert.deepEqual(
+    nextOccurrences({ type: "daily", hour: 9, minute: 0 }, NOW, 3),
+    [iso(2026, 6, 15, 9, 0), iso(2026, 6, 16, 9, 0), iso(2026, 6, 17, 9, 0)],
+  );
+
+  assert.deepEqual(
+    nextOccurrences({ type: "weekly", days: [1, 3, 5], hour: 8, minute: 30 }, NOW, 3),
+    [iso(2026, 6, 15, 8, 30), iso(2026, 6, 17, 8, 30), iso(2026, 6, 20, 8, 30)],
+    "weekly walks its day set across the week boundary",
+  );
+
+  assert.deepEqual(nextOccurrences({ type: "weekly", days: [], hour: 9, minute: 0 }, NOW, 3), [], "empty day set can't fire");
+  assert.deepEqual(nextOccurrences({ type: "cron", expr: "not a cron" }, NOW, 3), [], "invalid cron fails closed");
+  assert.equal(nextOccurrences({ type: "cron", expr: "*/15 * * * *" }, NOW, 4).length, 4, "valid cron produces the full window");
+}
+
+console.log("schedule-plan.test.ts: ok");

--- a/src/lib/schedule-plan.ts
+++ b/src/lib/schedule-plan.ts
@@ -17,7 +17,10 @@ function formatClock(hour: number, minute: number, hour12: boolean): string {
 }
 
 function formatInterval(everyMs: number): string {
-  const minutes = Math.round(everyMs / 60_000);
+  const seconds = Math.round(everyMs / 1000);
+  if (seconds < 60) return `every ${seconds}s`;
+  if (seconds % 60 !== 0) return `every ${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  const minutes = seconds / 60;
   if (minutes < 60) return `every ${minutes} min`;
   const hours = minutes / 60;
   if (Number.isInteger(hours)) return hours === 1 ? "every hour" : `every ${hours} hours`;

--- a/src/lib/schedule-plan.ts
+++ b/src/lib/schedule-plan.ts
@@ -1,0 +1,76 @@
+// Pure helpers that turn a schedule (Recurrence + first fire) into the
+// human-verifiable plan the UI echoes back: a cadence sentence and the next
+// few concrete occurrences. Client-safe (no node imports) so the reminder
+// modal — and any future scheduling surface — can render the plan live while
+// the user types. The inverse of parse-when.ts: phrase → plan → phrase-shaped
+// confirmation.
+
+import { computeNextOccurrence, type Recurrence } from "./inbox-recurrence.ts";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function formatClock(hour: number, minute: number, hour12: boolean): string {
+  if (!hour12) return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+  const mer = hour < 12 ? "AM" : "PM";
+  const h = hour % 12 === 0 ? 12 : hour % 12;
+  return minute === 0 ? `${h} ${mer}` : `${h}:${String(minute).padStart(2, "0")} ${mer}`;
+}
+
+function formatInterval(everyMs: number): string {
+  const minutes = Math.round(everyMs / 60_000);
+  if (minutes < 60) return `every ${minutes} min`;
+  const hours = minutes / 60;
+  if (Number.isInteger(hours)) return hours === 1 ? "every hour" : `every ${hours} hours`;
+  return `every ${minutes} min`;
+}
+
+/**
+ * One human-readable sentence for a recurrence — the cadence half of the plan
+ * echo ("every day at 9 AM", "weekly on Mon, Wed, Fri at 8:30 AM").
+ * Returns null for one-shots (the fire time alone describes those).
+ */
+export function describeRecurrence(
+  rec: Recurrence,
+  opts: { hour12?: boolean } = {},
+): string | null {
+  const hour12 = opts.hour12 ?? true;
+  if (rec.type === "none") return null;
+  if (rec.type === "interval") return formatInterval(rec.everyMs);
+  if (rec.type === "daily") return `every day at ${formatClock(rec.hour, rec.minute, hour12)}`;
+  if (rec.type === "weekly") {
+    const days = rec.days.slice().sort((a, b) => a - b);
+    const key = days.join(",");
+    const label =
+      key === "1,2,3,4,5" ? "weekdays" :
+      key === "0,6" ? "weekends" :
+      key === "0,1,2,3,4,5,6" ? "every day" :
+      days.map((d) => DAY_LABELS[d] ?? "?").join(", ");
+    return `${label} at ${formatClock(rec.hour, rec.minute, hour12)}`;
+  }
+  if (rec.type === "cron") return `cron ${rec.expr}`;
+  return null;
+}
+
+/**
+ * The next `count` concrete fires for a recurrence, each step seeded from the
+ * previous one (so interval schedules don't drift and weekly schedules walk
+ * their day set). Returns fewer than `count` when the schedule can't produce
+ * more (invalid cron, empty weekly days).
+ */
+export function nextOccurrences(
+  rec: Recurrence,
+  fromMs: number,
+  count: number,
+): string[] {
+  const out: string[] = [];
+  let cursor = fromMs;
+  for (let i = 0; i < count; i++) {
+    const next = computeNextOccurrence(rec, cursor);
+    if (!next) break;
+    out.push(next);
+    const t = new Date(next).getTime();
+    if (!Number.isFinite(t) || t <= cursor) break; // safety: never loop
+    cursor = t;
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem

The scheduling mechanism accepted a natural phrase but tracked it into the saved plan poorly:

1. **Silent plan loss (bug).** The modal derived the saved recurrence from a lossy preset picker: `parseWhen("mon,wed,fri 8:30")` returns a correct weekly recurrence, but no preset matches, so it **saved as a one-shot** without telling the user.
2. **Grammar gaps.** "wednesday 4pm" (full day names), "tomorrow at 9am" (the word *at*), "every tuesday 4pm", "in 2 hours" (spelled units), calendar dates, "next friday", "tonight" — all failed.
3. **No plan verification.** One tiny "Parsed → date" line; recurring phrases showed no cadence and no upcoming fires.
4. **Lost provenance.** The typed phrase was never persisted; the edit dialog's `whenText` prefill was wired but always empty.

## Change

- **`parse-when.ts` grammar (backward compatible, fail-closed, local-time):** full/abbrev day names, optional `at`/`@`/`next`, `tonight`/`noon`/`midnight`, spelled offsets ("in 2 hours", "in half an hour", "in 1h30m", "in 1 week"), calendar dates ("jul 20 9am", "july 20th", "7/20 17:00" — date-only defaults 9:00, made visible in the echo), single/multi-day recurrences ("every tuesday 4pm", "every mon and wed at 8am", "every tue, thu 9:15"), `daily`/`weekdays`/`weekends` aliases, and time-first reorder ("9am every weekday").
- **`schedule-plan.ts` (new):** `describeRecurrence` (cadence sentence honoring the 12h/24h pref) + `nextOccurrences` (chained, drift-free) — the verifiable half of the plan.
- **Modal:** parsed recurrence is now the source of truth — schedules no preset represents survive via a **Custom** preset carrying the exact recurrence (fixes the silent one-shot bug). The echo is a **plan card** (aria-live polite): *Once/Repeats* + cadence sentence + next 3 concrete fires. Retyping the phrase in edit mode retakes the picker (`whenDirty`).
- **Provenance:** `InboxItem.whenText` (additive/optional) persists the phrase through POST + PATCH allowlist and both workspace submit paths, so editing round-trips the human input.

## Verification

- New fixed-clock suites: `parse-when.test.ts` (all grammar families + fail-closed), `schedule-plan.test.ts`
- Extended: `new-reminder-modal.test.ts` (custom preset, plan card, whenText, whenDirty pins), `reminder-draft.test.ts` ("tomorrow at 9am …", "every tuesday 4pm …" splits)
- `node scripts/run-tests.mjs app` → **679 test files passed**; `check:tests-wired` green; `pnpm typecheck` clean
- No new dependencies; deterministic parsing per house stance (no LLM round-trip)

Bead: cave-rdfc