### PR TITLE
feat(dashboard): teach-empty KPI tiles, one-accent trends, quiet insight note

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -194,6 +194,7 @@ export const SUITES = {
     "src/lib/dashboard-analytics.test.ts",
     "src/lib/coven-analytics.test.ts",
     "src/app/dashboard-page.test.ts",
+    "src/components/dashboard/dashboard-cockpit-polish.test.ts",
     "src/app/prod-hardening.test.ts",
     "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",

--- a/src/components/dashboard/dashboard-cockpit-polish.test.ts
+++ b/src/components/dashboard/dashboard-cockpit-polish.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+// Dashboard cockpit polish (cave-m4oq): empty KPI tiles teach instead of
+// shrugging, no fake flatlines under missing data, one-accent trend waves,
+// and a quiet insight note instead of a heavy banner.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const cockpit = readFileSync(new URL("./dashboard-cockpit.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../../styles/dashboard.css", import.meta.url), "utf8");
+
+// ── Empty tiles teach the action that fills them ─────────────────────────────
+assert.match(cockpit, /fills in after the first retro run/, "Retro tile teaches when empty");
+assert.match(cockpit, /fills in once familiars have contracts/, "Contract tile teaches when empty");
+assert.match(cockpit, /fills in after growth reviews/, "Confidence tile teaches when empty");
+for (const shrug of ["no retro runs", "no contracts", "no scores yet"]) {
+  assert.doesNotMatch(cockpit, new RegExp(`"${shrug}"`), `dead-end sub "${shrug}" is gone`);
+}
+
+// ── No fake flatline under a metric with no data ─────────────────────────────
+assert.match(
+  cockpit,
+  /\{value == null \? null : \(\s*\n\s*<Sparkline points=\{series\} color="var\(--accent-presence\)" height=\{22\} \/>/,
+  "KPI tiles skip the sparkline while the metric has no data, and use the shared accent",
+);
+
+// ── One accent for every trend wave ──────────────────────────────────────────
+assert.match(
+  cockpit,
+  /<Sparkline points=\{r\.trend\} color="var\(--accent-presence\)" height=\{22\} \/>/,
+  "Familiar-insight rows draw one-accent sparklines (identity color stays on the avatar)",
+);
+assert.match(
+  cockpit,
+  /<Sparkline points=\{p\.trend\} color="var\(--accent-presence\)" height=\{20\} \/>/,
+  "Agent-panel trends draw one-accent sparklines",
+);
+assert.doesNotMatch(
+  cockpit,
+  /<Sparkline[^>]*color=\{r\.color\}/,
+  "No per-row rainbow sparkline remains",
+);
+
+// ── Insight banner reads as a quiet note ─────────────────────────────────────
+assert.match(
+  css,
+  /\.coven-insight \{[\s\S]{0,400}?padding: 9px 13px; border-radius: 10px; font-size: 12\.5px;/,
+  "Insight note is compact",
+);
+assert.match(
+  css,
+  /\.coven-insight--good \{ border-color: color-mix\(in oklch, var\(--color-success\) 18%, var\(--border-hairline\)\); background: color-mix\(in oklch, var\(--color-success\) 4%, var\(--bg-raised\)\); \}/,
+  "Good-tone note is a wash over hairline, not a heavy green banner",
+);
+
+console.log("dashboard-cockpit-polish.test.ts: ok");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -346,10 +346,10 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   //    colored by meaning, and drills into the surface that owns the number. ──
   const contractPct = vitals.contractTotal ? Math.round((vitals.contractPass / vitals.contractTotal) * 100) : null;
   const acceptPct = vitals.retroAcceptRate != null ? Math.round(vitals.retroAcceptRate * 100) : null;
-  const scoredCoverageSub = coverageSub(vitals.confidenceTier ?? "no scores yet", contractFetchedCount, data.familiars.length, "scored");
+  const scoredCoverageSub = coverageSub(vitals.confidenceTier ?? "fills in after growth reviews", contractFetchedCount, data.familiars.length, "scored");
   const contractCoverageSub = coverageSub(contractSub(vitals), contractFetchedCount, data.familiars.length, "checked");
   const kpis: KpiSpec[] = [
-    { icon: "ph:seal-check", value: vitals.avgConfidence, label: "Coven confidence", sub: contractFetchPartial ? scoredCoverageSub : vitals.confidenceTier ?? "no scores yet", accent: "teal", metric: "confidence", good: "up", href: "/dashboard/familiars/growth" },
+    { icon: "ph:seal-check", value: vitals.avgConfidence, label: "Coven confidence", sub: contractFetchPartial ? scoredCoverageSub : vitals.confidenceTier ?? "fills in after growth reviews", accent: "teal", metric: "confidence", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:sparkle", value: vitals.activeFamiliars, label: "Active familiars", sub: `${vitals.familiarCount} in coven`, accent: "green", metric: "active", good: "up", src: "familiars", href: "/?mode=agents" },
     { icon: "ph:heartbeat", value: vitals.sessions7d, label: "Sessions · 7d", sub: wowSub(vitals.sessionsWowDelta), accent: "lavender", metric: "sessions", good: "up", src: "sessions", href: "/?mode=agents" },
     { icon: "ph:flag-checkered", value: acceptPct, suffix: "%", label: "Retro accept rate", sub: retroSub(vitals), accent: "blue", metric: "accept", good: "up", href: "/dashboard/familiars/growth" },
@@ -699,7 +699,12 @@ function KpiTile({ icon, value, suffix, label, sub, accent, good, href, loading,
       <span className="cockpit-kpi__value">{display}</span>
       <span className="cockpit-kpi__label">{label}</span>
       {sub ? <span className="cockpit-kpi__sub">{sub}</span> : null}
-      <Sparkline points={series} color={color} height={22} />
+      {/* No wave without data — loading or empty, a flatline under "—" reads
+          as a dead metric (cave-m4oq). One accent for every trend: the wave is
+          texture, the tile icon carries the semantic tint. */}
+      {value == null ? null : (
+        <Sparkline points={series} color="var(--accent-presence)" height={22} />
+      )}
     </>
   );
   return href ? <a className="cockpit-kpi" href={href}>{inner}</a> : <div className="cockpit-kpi">{inner}</div>;
@@ -712,11 +717,12 @@ function wowSub(delta: number): string {
 }
 function retroSub(v: CovenVitals): string {
   const runs = v.retroAccepted + v.retroReverted;
-  if (runs === 0) return "no retro runs";
+  // Teach, don't shrug: name the action that fills the tile (cave-m4oq).
+  if (runs === 0) return "fills in after the first retro run";
   return `${v.retroAccepted}/${runs} accepted`;
 }
 function contractSub(v: CovenVitals): string {
-  if (v.contractTotal === 0) return "no contracts";
+  if (v.contractTotal === 0) return "fills in once familiars have contracts";
   return `${v.contractPass}/${v.contractTotal} passing`;
 }
 function coverageSub(base: string, fetched: number, total: number, verb: "scored" | "checked"): string {
@@ -813,7 +819,7 @@ function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; l
             <span className="cockpit-fam__sessions">{r.sessions7d}<i>/7d</i></span>
           </span>
           <span className="cockpit-fam__trend cockpit-fam__trendcol" role="cell">
-            {r.trend.length ? <Sparkline points={r.trend} color={r.color} height={22} /> : <span className="cockpit-fam__dash">—</span>}
+            {r.trend.length ? <Sparkline points={r.trend} color="var(--accent-presence)" height={22} /> : <span className="cockpit-fam__dash">—</span>}
           </span>
           <span className="cockpit-fam__contract cockpit-fam__contractcol" role="cell">
             {r.contractTotal > 0 ? (
@@ -932,7 +938,7 @@ function AgentsPanel({ familiars, sessions, loaded }: { familiars: Familiar[]; s
                 <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
               </span>
               {p ? <span className="cockpit-agent__count">{p.sessionsLast7d}/7d</span> : null}
-              {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color={f.color || "var(--accent-presence)"} height={20} /></span> : null}
+              {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color="var(--accent-presence)" height={20} /></span> : null}
               {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
             </a>
           </li>

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -679,15 +679,17 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
 
 /* ── Coven insight banner — the plain-language "what you should know" read ── */
 .coven-insight {
-  display: flex; align-items: flex-start; gap: 10px;
-  padding: 12px 15px; border-radius: 12px; font-size: 13px; line-height: 1.5;
+  display: flex; align-items: flex-start; gap: 9px;
+  /* Quiet note, not a hero banner — the headline h1 above already says the
+     same thing; this row adds the numbers (cave-m4oq). */
+  padding: 9px 13px; border-radius: 10px; font-size: 12.5px; line-height: 1.5;
   color: var(--text-secondary);
   border: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
+  background: color-mix(in oklch, var(--accent-presence) 4%, var(--bg-raised));
 }
-.coven-insight__icon { flex: 0 0 auto; margin-top: 2px; width: 18px; height: 18px; color: var(--accent-presence); }
+.coven-insight__icon { flex: 0 0 auto; margin-top: 2px; width: 15px; height: 15px; color: var(--accent-presence); }
 .coven-insight__text b { color: var(--text-primary); font-weight: 680; }
-.coven-insight--good { border-color: color-mix(in oklch, var(--color-success) 30%, transparent); background: color-mix(in oklch, var(--color-success) 7%, var(--bg-raised)); }
+.coven-insight--good { border-color: color-mix(in oklch, var(--color-success) 18%, var(--border-hairline)); background: color-mix(in oklch, var(--color-success) 4%, var(--bg-raised)); }
 .coven-insight--good .coven-insight__icon { color: var(--color-success); }
 .coven-insight--warn { border-color: color-mix(in oklch, var(--color-warning) 32%, transparent); background: color-mix(in oklch, var(--color-warning) 8%, var(--bg-raised)); }
 .coven-insight--warn .coven-insight__icon { color: var(--color-warning); }


### PR DESCRIPTION
## Facelift 12/12 — dashboard cockpit (cave-m4oq)

Audit: 3 of 6 KPI tiles permanently "—" with shrug subs over fake flatline sparklines; rainbow per-row sparklines in the insights table; heavy green all-good banner; a floating red "1 Issue" pill.

### What changed
- **Teach-empty tiles** — subs name the action that fills the metric: `fills in after the first retro run` / `fills in once familiars have contracts` / `fills in after growth reviews`. A tile with no data draws **no sparkline** — no fake flatline under a dash.
- **One-accent trends** — KPI tiles, insight-table rows, and agent-panel trends all draw `--accent-presence` waves. The familiar's identity color stays on its avatar; tile icons keep their semantic tint.
- **Quiet insight note** — compact padding/type, hairline-mixed border, 4% wash (was a 7% fill + 30% border green slab), 15px icon. The `<h1>` above already carries the verdict; the note adds the numbers.
- **The "1 Issue" pill is not product UI** — it's Next's dev-only error badge surfacing a *real hydration mismatch* on /dashboard. Filed separately with repro + fix direction (bead `cave-…` "Dashboard hydration mismatch"); `devIndicators: false` already hides route indicators, and prod builds never render the badge.

### Tests
- New pin `src/components/dashboard/dashboard-cockpit-polish.test.ts` (wired): teach strings + no-shrug guard, sparkline data-gating + shared accent, no per-row rainbow, banner compactness contracts.

### Verification
- typecheck 0 errors · build green · **full `pnpm test:app` 679 green**
- Playwright live probe: row spark strokes = `["var(--accent-presence)"]` (was 4+ colors); with real data, the one dead tile (retro) has `spark:false` while filled tiles keep waves; before/after screenshots in session evidence

Bead: cave-m4oq (umbrella cave-ew98) — **last of the 12 ranked audit beads**
