### PR TITLE
fix(summoning-circle): allow deselecting the optional template

### DIFF
--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -264,6 +264,13 @@ assert.match(
   /IDENTITY_PRESETS\.map\(\(preset\) => \{[\s\S]*?setRole\(preset\.role\);\s*setDescription\(preset\.description\);/,
   "clicking a preset fills role and description",
 );
+// The template is optional (#3109): clicking the active preset again
+// deselects it, clearing the role + description it filled in.
+assert.match(
+  source,
+  /IDENTITY_PRESETS\.map\(\(preset\) => \{[\s\S]*?if \(active\) \{[\s\S]*?setRole\(""\);\s*setDescription\(""\);\s*return;/,
+  "clicking the active preset again deselects it and clears role + description",
+);
 assert.doesNotMatch(
   source,
   /IDENTITY_PRESETS\.map\(\(preset\) => \{[\s\S]{0,1200}setName\(/,

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -1075,6 +1075,13 @@ function StageName({
                 type="button"
                 aria-pressed={active}
                 onClick={() => {
+                  if (active) {
+                    // Templates are optional — clicking the selected one
+                    // again deselects it and clears what it filled in.
+                    setRole("");
+                    setDescription("");
+                    return;
+                  }
                   // Templates overwrite role + description (that's what
                   // picking a template means); the name stays personal.
                   setRole(preset.role);
@@ -1089,7 +1096,7 @@ function StageName({
           })}
         </div>
         <p className="mt-1 text-[11px] text-[var(--text-muted)]">
-          Fills the role and description below — edit anything after.
+          Fills the role and description below — edit anything after, or click again to deselect.
         </p>
       </div>
       <div>


### PR DESCRIPTION
## Summary

In the Summoning Circle, **Start from a template** is marked optional, but once a template chip was selected there was no way to clear it — clicking again just re-applied the same role/description.

- Clicking the active template chip now **deselects** it, clearing the role and description it filled in (`aria-pressed` toggles accordingly).
- Hint text updated: *"…or click again to deselect."*
- Pin test added asserting the toggle-off branch.

Fixes #3109

## Verification

- `node --experimental-strip-types --no-warnings --test src/components/familiar-summoning-circle.test.ts` — pass
- `pnpm typecheck` — pass