### PR TITLE
feat(chat): identity hero + wide-canvas grid for the Familiar tab (cave-5p3y)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -508,6 +508,7 @@ export const SUITES = {
     "src/components/inspector-pane-polish.test.ts",
     "src/components/inspector-pane-load-guards.test.ts",
     "src/components/inspector-pane-surface.test.ts",
+    "src/components/familiar-tab-hero.test.ts",
     "src/components/misc-aria-fixes.test.ts",
     "src/components/modal-trap-adoption.test.ts",
     "src/components/mode-toggle.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6173,6 +6173,65 @@ a.mobile-handoff__link:hover {
 }
 
 /* ────────────────────────────────────────────────
+   Chat · Familiar tab (identity hero + capability grid)
+   ──────────────────────────────────────────────── */
+
+/* The tab is a first-class surface, not a 320px sidepanel: the panel measures
+   its own inline size so the capability grid can go two-column when the chat
+   canvas is wide enough, independent of the viewport. */
+.familiar-tab {
+  container-type: inline-size;
+}
+
+.familiar-tab__hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 2px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.familiar-tab__avatar {
+  display: inline-flex;
+  flex-shrink: 0;
+  border-radius: var(--radius-card);
+  /* Soft inset hairline behind transparent avatar corners — same wash idiom
+     as the roster cards, no hard border. */
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
+}
+
+/* Identity moment: the display name is the one serif element on the tab
+   (--font-serif is the display / hero / identity face). */
+.familiar-tab__name {
+  font-family: var(--font-serif, ui-serif, serif);
+  font-size: clamp(22px, 3.2cqi, 30px);
+  font-weight: 500;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.familiar-tab__presence {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* One column by default; two balanced columns once the tab itself is wide
+   enough to earn it (~900px of usable canvas). */
+.familiar-tab__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px 20px;
+}
+
+@container (min-width: 900px) {
+  .familiar-tab__grid {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+/* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)
    ──────────────────────────────────────────────── */

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -223,7 +223,7 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /scope === "familiar" \? \([\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" \/>/,
+  /scope === "familiar" \? \([\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
   "the familiar scope renders the capability panel for the active familiar",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -558,12 +558,12 @@ export function ChatSurface({
         {scope === "projects" ? (
           <ProjectsView sessions={sessions} familiars={familiars} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
         ) : scope === "familiar" ? (
-          // The active familiar's capability panel (identity, role, skills,
-          // tools) — promoted from the retired inspector sidepanel to a
+          // The active familiar's identity + capability surface (hero, role,
+          // skills, tools) — promoted from the retired inspector sidepanel to a
           // first-class chat tab, since it describes who you're chatting with.
           <div className="flex min-h-0 min-w-0 flex-1 justify-center">
-            <div className="h-full w-full max-w-3xl">
-              <InspectorPane familiar={activeFamiliar} tab="familiar" />
+            <div className="h-full w-full max-w-5xl">
+              <InspectorPane familiar={activeFamiliar} tab="familiar" daemonRunning={daemonRunning} />
             </div>
           </div>
         ) : scope === "settings" ? (

--- a/src/components/familiar-tab-hero.test.ts
+++ b/src/components/familiar-tab-hero.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Familiar tab identity hero + wide-canvas layout (cave-5p3y).
+//
+// The chat surface's Familiar tab is a first-class identity surface, not a
+// relocated 320px inspector sidepanel: it must open on WHO the familiar is
+// (avatar, serif display name, role, presence, runtime) before WHAT it can do
+// (the capability grid), and the grid must earn a wide canvas with two columns.
+
+const src = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+test("identity hero leads the Familiar tab and paints before the capability fetches", () => {
+  assert.match(src, /function FamiliarIdentityHero\(/, "hero component declared");
+  // The hero renders in BOTH branches: while loading (skeleton below it) and
+  // with the loaded grid — identity never waits on capability plumbing.
+  const heroMounts = src.match(/<FamiliarIdentityHero familiar=\{familiar\} daemonRunning=\{daemonRunning\} \/>/g) ?? [];
+  assert.ok(heroMounts.length >= 2, `hero mounts in loading AND loaded branches (got ${heroMounts.length})`);
+  assert.match(
+    src,
+    /if \(loading\) \{[\s\S]*?<FamiliarIdentityHero[\s\S]*?<SkeletonRows/,
+    "loading keeps the skeleton below the already-painted hero",
+  );
+});
+
+test("hero identity contract: resolved avatar, serif name, role line, presence", () => {
+  // Avatar resolution rides the same pipeline as every other identity surface
+  // (Cave-local overrides, workspace avatar → upload fallback → glyph).
+  assert.match(src, /useResolvedFamiliars\(heroList, \{ includeArchived: true \}\)/, "hero resolves the familiar");
+  assert.match(src, /<FamiliarAvatar familiar=\{resolved\} size="xl" expandable \/>/, "expandable xl avatar");
+  assert.match(src, /<h2 className="familiar-tab__name">/, "display name is the tab's h2");
+  assert.match(
+    css,
+    /\.familiar-tab__name \{[^}]*font-family: var\(--font-serif/,
+    "name uses the serif identity face",
+  );
+  assert.match(src, /\{daemonRunning \? "online" : "offline"\}/, "presence line from daemon reachability");
+  assert.match(
+    src,
+    /activeSessions > 0 \? \([\s\S]*?bg-\[var\(--accent-presence\)\]\/15/,
+    "active-session chip is the accent moment",
+  );
+});
+
+test("hero bridges: profile card + analytics links (roster idiom, no second identity presentation)", () => {
+  assert.match(
+    src,
+    /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/profile`\}/,
+    "Profile → links to the cave-ujbr profile card route",
+  );
+  assert.match(
+    src,
+    /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/,
+    "Analytics → links to the analytics route",
+  );
+});
+
+test("wide-canvas layout: container-query grid, two columns >=900px, single below", () => {
+  assert.match(css, /\.familiar-tab \{[^}]*container-type: inline-size/, "panel measures its own inline size");
+  assert.match(css, /\.familiar-tab__grid \{[^}]*grid-template-columns: minmax\(0, 1fr\)/, "single column default");
+  assert.match(
+    css,
+    /@container \(min-width: 900px\) \{[\s\S]*?\.familiar-tab__grid \{[\s\S]*?grid-template-columns: minmax\(0, 1\.15fr\) minmax\(0, 1fr\)/,
+    "two-column grid on a wide canvas",
+  );
+  const cols = src.match(/familiar-tab__col/g) ?? [];
+  assert.ok(cols.length >= 2, "capability sections split into two source-ordered columns");
+});
+
+test("the chat surface gives the tab a wide canvas and threads presence", () => {
+  assert.match(
+    chatSurface,
+    /scope === "familiar"[\s\S]*?max-w-5xl[\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
+    "Familiar tab hosts the pane in a max-w-5xl column with daemonRunning threaded",
+  );
+});
+
+test("tokens only — the hero introduces no hex colors or novel palette", () => {
+  const heroBlock = src.slice(
+    src.indexOf("function FamiliarIdentityHero"),
+    src.indexOf("function FamiliarCapabilityPanel"),
+  );
+  assert.ok(heroBlock.length > 0, "hero block located");
+  assert.doesNotMatch(heroBlock, /#[0-9a-fA-F]{3,8}\b/, "no raw hex colors in the hero");
+  assert.doesNotMatch(heroBlock, /(?:^|[^-\w])(?:rgb|hsl)a?\(/, "no raw rgb()/hsl() in the hero");
+});

--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -18,8 +18,8 @@ test("the pane is a controlled section body — memory + familiar only", () => {
   assert.doesNotMatch(src, /FamiliarAnalyticsView|InboxTab|SnoozeMenu/, "no analytics or automations rendering remains");
   assert.match(
     chatSurface,
-    /<InspectorPane familiar=\{activeFamiliar\} tab="familiar" \/>/,
-    "the chat surface's Familiar tab drives the pane's familiar section",
+    /<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
+    "the chat surface's Familiar tab drives the pane's familiar section (presence threaded)",
   );
   assert.doesNotMatch(chatSurface, /INSPECTOR_SECTIONS/, "the promoted right-panel section strip is gone");
 });

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import Link from "next/link";
 import type { Familiar } from "@/lib/types";
 import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { Icon, type IconName } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
@@ -53,6 +56,9 @@ type Props = {
    *  the one section they need, so there is no nested tab strip here.
    *  Defaults to memory for the compact rail variant. */
   tab?: Tab;
+  /** Daemon reachability — drives the identity hero's presence line on the
+   *  chat surface's Familiar tab. Absent for the compact memory rail. */
+  daemonRunning?: boolean;
 };
 
 function InspectorEmpty({
@@ -106,6 +112,7 @@ export function InspectorPane({
   compact = false,
   onOpenFullView,
   tab = "memory",
+  daemonRunning,
 }: Props) {
   const shellClassName = compact
     ? "flex h-full min-h-0 flex-col bg-[var(--bg-base)]"
@@ -121,7 +128,9 @@ export function InspectorPane({
         }`}
       >
         {tab === "memory" ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
-        {tab === "familiar" ? <FamiliarCapabilityPanel familiar={familiar} /> : null}
+        {tab === "familiar" ? (
+          <FamiliarCapabilityPanel familiar={familiar} daemonRunning={daemonRunning} />
+        ) : null}
       </div>
     </aside>
   );
@@ -707,7 +716,101 @@ function CollapsibleSection({
 
 // ── Main panel ───────────────────────────────────────────────────────────────
 
-function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
+/**
+ * Identity hero — answers "who am I chatting with?" before the capability
+ * plumbing below. Needs nothing from the capability fetches (everything here
+ * lives on the Familiar object), so it paints immediately while the grid
+ * below is still loading. Aligned with the roster-card identity idiom
+ * (avatar + name + role + presence) and the profile-card routes from
+ * cave-ujbr rather than inventing a second identity presentation.
+ */
+function FamiliarIdentityHero({
+  familiar,
+  daemonRunning,
+}: {
+  familiar: Familiar;
+  daemonRunning?: boolean;
+}) {
+  // Resolve Cave-local overrides (display name, avatar image, glyph) the same
+  // way every other identity surface does.
+  const heroList = useMemo(() => [familiar], [familiar]);
+  const resolved = useResolvedFamiliars(heroList, { includeArchived: true })[0];
+  const activeSessions = familiar.active_sessions ?? 0;
+  const roleLine = [resolved?.role || familiar.role, familiar.pronouns]
+    .filter(Boolean)
+    .join(" · ");
+  const runtimeLine = [familiar.harness, familiar.model].filter(Boolean).join(" · ");
+
+  return (
+    <header className="familiar-tab__hero">
+      {resolved ? (
+        <span className="familiar-tab__avatar">
+          <FamiliarAvatar familiar={resolved} size="xl" expandable />
+        </span>
+      ) : null}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <h2 className="familiar-tab__name">{resolved?.display_name ?? familiar.display_name}</h2>
+          <span className="familiar-tab__presence text-[11px] text-[var(--text-muted)]">
+            <span
+              aria-hidden="true"
+              className={`inline-flex h-1.5 w-1.5 rounded-full ${
+                daemonRunning ? "bg-[var(--accent-presence)]" : "bg-[var(--text-muted)]"
+              }`}
+            />
+            {daemonRunning ? "online" : "offline"}
+            {activeSessions > 0 ? (
+              <span className="rounded bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[10px] text-[var(--accent-presence)]">
+                {activeSessions} active session{activeSessions === 1 ? "" : "s"}
+              </span>
+            ) : null}
+          </span>
+        </div>
+        {roleLine ? (
+          <p className="mt-0.5 truncate text-[11px] uppercase tracking-widest text-[var(--text-secondary)]">
+            {roleLine}
+          </p>
+        ) : null}
+        {familiar.description ? (
+          <p className="mt-1.5 max-w-[64ch] text-[12px] leading-relaxed text-[var(--text-secondary)]">
+            {familiar.description}
+          </p>
+        ) : null}
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+          {runtimeLine ? (
+            <span className="font-mono text-[10px] text-[var(--text-muted)]" title="Harness · model">
+              {runtimeLine}
+            </span>
+          ) : null}
+          <span className="flex items-center gap-3">
+            <Link
+              href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
+              aria-label={`Open profile card for ${familiar.display_name}`}
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+            >
+              Profile →
+            </Link>
+            <Link
+              href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
+              aria-label={`Open analytics for ${familiar.display_name}`}
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+            >
+              Analytics →
+            </Link>
+          </span>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function FamiliarCapabilityPanel({
+  familiar,
+  daemonRunning,
+}: {
+  familiar: Familiar | null;
+  daemonRunning?: boolean;
+}) {
   const [roles, setRoles] = useState<RoleEntry[]>([]);
   const [localSkills, setLocalSkills] = useState<LocalSkillEntry[]>([]);
   const [harnessCapabilities, setHarnessCapabilities] = useState<HarnessCapabilityManifest[]>([]);
@@ -771,8 +874,15 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
     );
   }
 
+  // The identity hero needs nothing from the capability fetches — paint it
+  // immediately and keep the skeleton for the capability grid alone.
   if (loading) {
-    return <SkeletonRows count={6} className="p-3" />;
+    return (
+      <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
+        <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} />
+        <SkeletonRows count={6} className="p-3" />
+      </div>
+    );
   }
 
   // ── Derive inheritance layers ────────────────────────────────────────────────
@@ -808,7 +918,10 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
   ]);
 
   return (
-    <div className="flex flex-col gap-2 p-3 text-xs">
+    <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
+
+      {/* ── Identity hero ─────────────────────────────────────────────────── */}
+      <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} />
 
       {/* Error banner */}
       {errors.length > 0 ? (
@@ -824,6 +937,10 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
           </div>
         </div>
       ) : null}
+
+      {/* ── Capability grid: two columns on a wide canvas, one below ─────── */}
+      <div className="familiar-tab__grid">
+      <div className="familiar-tab__col flex min-w-0 flex-col gap-2">
 
       {/* ── Section 1: Roles ──────────────────────────────────────────────── */}
       <CapSection title="Roles" scope={`active: ${activeRoles.length}`}>
@@ -1005,6 +1122,9 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
         </div>
       </CapSection>
 
+      </div>{/* end left column */}
+      <div className="familiar-tab__col flex min-w-0 flex-col gap-2">
+
       {/* ── Section 3: Plugins ────────────────────────────────────────────── */}
       <CapSection title="Plugins" scope={`${nonMcpPlugins.length} from runtime`}>
         {nonMcpPlugins.length === 0 ? (
@@ -1118,6 +1238,9 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
           </ul>
         </CapSection>
       ) : null}
+
+      </div>{/* end right column */}
+      </div>{/* end capability grid */}
 
     </div>
   );


### PR DESCRIPTION
## Familiar tab elevation 1/3 (cave-5p3y, umbrella cave-5vvp)

The chat surface's **Familiar** tab answered "what can this familiar do?" before ever answering **"who am I chatting with?"** — it opened straight into inspector-era capability plumbing (a single ~320px-designed column stretched into `max-w-3xl`), with no avatar, name, role, presence, or route to the familiar's profile.

### What changed

- **Identity hero leads the tab** — resolved avatar (xl, expandable via the shared lightbox), serif display name (`--font-serif`, the identity face), role line + pronouns, description, presence dot (daemon reachability) + active-session chip (the view's one accent moment), quiet mono `harness · model`, and **Profile →** / **Analytics →** links. Identity presentation and routes align with the roster cards and the cave-ujbr profile cards (#3111) — no second identity language invented.
- **Hero paints instantly** — it needs nothing from the four capability fetches, so the loading state keeps the skeleton *below* an already-visible identity.
- **Layout earns the width** — the panel measures its own inline size (`container-type: inline-size`); capability sections split into a two-column grid at ≥900px of usable canvas and stay one column below (390px verified). Chat hosts the tab in `max-w-5xl` (was `max-w-3xl`) and threads `daemonRunning`.
- **Data logic untouched** — `FamiliarCapabilityPanel`'s fetches, derivations, and section internals are unchanged (section restyle is PR 2/3: cave-7e1l, bridges PR 3/3: cave-aovo).

### Tests
- New pin `src/components/familiar-tab-hero.test.ts` (hero-first render, identity contract, profile/analytics bridges, container-query grid, tokens-only guard) — wired into `scripts/run-tests.mjs`.
- Updated deliberately: `chat-surface.test.ts` + `inspector-pane-polish.test.ts` mount pins for the new `daemonRunning` prop. No coverage deleted.

### Verification
- `pnpm typecheck` + `pnpm build` green
- Full `pnpm test:app`: **685 files green**
- Playwright before/after at 1440×900 + iPhone 13 across populated / empty / API-failure / no-familiar (gallery archived in session evidence)

| state | before | after |
|---|---|---|
| populated 1440 | single narrow stack, no identity | serif hero + presence + 2-col grid |
| mobile 390 | plumbing-first | hero-first, single column |