### PR TITLE
fix(chat): reconcile the policy and merged-PR auto-archive sweeps

### DIFF
--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -1,14 +1,12 @@
 import { NextResponse } from "next/server";
 import fs from "node:fs";
 import { callDaemon } from "@/lib/coven-daemon";
-import { archiveSessionsForMergedPrs, loadState, type CaveState } from "@/lib/cave-config";
+import { loadState, type CaveState } from "@/lib/cave-config";
 import { listConversations } from "@/lib/cave-conversations";
 import {
-  MERGED_AUTO_ARCHIVE_DISABLE_ENV,
-  mergedChatAutoArchiveDecisions,
-} from "@/lib/merged-chat-auto-archive";
-import { resolveArchiveNudges } from "@/lib/task-archive-nudge-emit";
-import { sweepAutoArchive } from "@/lib/chat-auto-archive-sweep";
+  sweepAutoArchive,
+  sweepMergedPrAutoArchive,
+} from "@/lib/chat-auto-archive-sweep";
 import {
   localConversationSessionRows,
   mergeSessionRows,
@@ -85,38 +83,43 @@ function isTrueProjectCwd(projectRoot: string): boolean {
 // blocks the event loop on git subprocesses (cave-n37w).
 
 /**
+ * Rewrite `sessions` to reflect a sweep result: rows archived by the sweep
+ * are dropped from the active view and stamped `archived_at` in the archived
+ * view, so the rows returned by this request already reflect the sweep.
+ */
+function applySweptRows(
+  sessions: SessionRow[],
+  swept: Map<string, string>,
+  includeArchived: boolean,
+): SessionRow[] {
+  if (swept.size === 0) return sessions;
+  const next: SessionRow[] = [];
+  for (const row of sessions) {
+    const archivedAt = swept.get(row.id);
+    if (!archivedAt) next.push(row);
+    else if (includeArchived) next.push({ ...row, archived_at: archivedAt });
+  }
+  return next;
+}
+
+/**
  * Merged-chat auto-archive sweep, piggybacked on the session list read: any
  * unarchived, non-active session whose branch PR is merged gets archived in
- * cave state, and the rows returned by this request already reflect it
- * (dropped from the active view, stamped `archived_at` in the archived view).
- * One-shot per (session, PR) — summoning the chat later sticks. Best-effort:
- * a sweep failure never breaks the listing.
+ * cave state. One-shot per (session, PR) — summoning the chat later sticks —
+ * and the shared opt-outs (keep marks, extension windows) gate it like the
+ * policy sweep. IO wiring lives in @/lib/chat-auto-archive-sweep;
+ * best-effort — a sweep failure never breaks the listing.
  */
 async function applyMergedPrAutoArchive(
   sessions: SessionRow[],
   state: CaveState,
   includeArchived: boolean,
 ): Promise<SessionRow[]> {
-  try {
-    if (process.env[MERGED_AUTO_ARCHIVE_DISABLE_ENV] === "1") return sessions;
-    const decisions = mergedChatAutoArchiveDecisions(
-      sessions,
-      state.mergedPrAutoArchived ?? {},
-    );
-    if (decisions.length === 0) return sessions;
-    const archivedAt = await archiveSessionsForMergedPrs(decisions);
-    // Clear any pending "ready to archive" nudges for the swept chats.
-    await Promise.allSettled(decisions.map((d) => resolveArchiveNudges(d.sessionId)));
-    const archivedIds = new Set(decisions.map((d) => d.sessionId));
-    const next: SessionRow[] = [];
-    for (const row of sessions) {
-      if (!archivedIds.has(row.id)) next.push(row);
-      else if (includeArchived) next.push({ ...row, archived_at: archivedAt });
-    }
-    return next;
-  } catch {
-    return sessions;
-  }
+  return applySweptRows(
+    sessions,
+    await sweepMergedPrAutoArchive(sessions, state),
+    includeArchived,
+  );
 }
 
 /**
@@ -136,29 +139,21 @@ async function scopeForFamiliar(
 }
 
 /**
- * Auto-archive sweep, piggybacked on the session list read. Sessions due per
- * the configured policy are archived in cave state; the rows returned by this
- * request already reflect the sweep (dropped from the active view, stamped
- * `archived_at` in the archived view). Best-effort — sweep failures never
- * break the listing.
+ * Policy auto-archive sweep (idle/external/etc.), piggybacked on the session
+ * list read. Sessions due per the configured policy are archived in cave
+ * state; the returned rows already reflect the sweep. Best-effort — sweep
+ * failures never break the listing.
  */
 async function applyAutoArchiveSweep(
   sessions: SessionRow[],
   state: CaveState,
   includeArchived: boolean,
 ): Promise<SessionRow[]> {
-  const swept = await sweepAutoArchive(sessions, state);
-  if (swept.size === 0) return sessions;
-  const next: SessionRow[] = [];
-  for (const row of sessions) {
-    const archivedAt = swept.get(row.id);
-    if (!archivedAt) {
-      next.push(row);
-    } else if (includeArchived) {
-      next.push({ ...row, archived_at: archivedAt });
-    }
-  }
-  return next;
+  return applySweptRows(
+    sessions,
+    await sweepAutoArchive(sessions, state),
+    includeArchived,
+  );
 }
 
 async function computeSessionsList(

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -73,15 +73,24 @@ assert.match(
   /applyMergedPrAutoArchive\(\s*await enrichSessionsWithGitContext\(scoped\),/,
   "the merged-PR sweep runs over the (async) enriched rows before the payload returns",
 );
+const sweepModule = readFileSync(
+  new URL("../lib/chat-auto-archive-sweep.ts", import.meta.url),
+  "utf8",
+);
 assert.match(
-  listRoute,
+  sweepModule,
   /process\.env\[MERGED_AUTO_ARCHIVE_DISABLE_ENV\] === "1"/,
   "the sweep honors the opt-out env",
 );
 assert.match(
-  listRoute,
-  /resolveArchiveNudges\(d\.sessionId\)/,
+  sweepModule,
+  /sweepMergedPrAutoArchive[\s\S]*?resolveArchiveNudges\(sessionId\)/,
   "swept chats clear their pending archive nudges",
+);
+assert.match(
+  sweepModule,
+  /mergedChatAutoArchiveDecisions\(\s*rows,\s*state\.mergedPrAutoArchived \?\? \{\},\s*\{\s*keep: state\.sessionKeep \?\? \{\},\s*extendedUntil: state\.sessionArchiveExtendedUntil \?\? \{\},/,
+  "the merged sweep honors the shared keep/extension opt-outs from cave state",
 );
 
 // ── One-shot state: summoning an auto-archived chat sticks ───────────────────

--- a/src/lib/chat-auto-archive-sweep.ts
+++ b/src/lib/chat-auto-archive-sweep.ts
@@ -1,4 +1,5 @@
 import {
+  archiveSessionsForMergedPrs,
   autoArchiveSessionsLocal,
   loadConfig,
   type CaveState,
@@ -8,14 +9,21 @@ import {
   normalizeChatAutoArchivePolicy,
   type AutoArchiveSessionInput,
 } from "@/lib/chat-auto-archive";
+import {
+  MERGED_AUTO_ARCHIVE_DISABLE_ENV,
+  mergedChatAutoArchiveDecisions,
+  type MergedAutoArchiveRow,
+} from "@/lib/merged-chat-auto-archive";
 import { resolveArchiveNudges } from "@/lib/task-archive-nudge-emit";
 
 /**
- * Server-side IO wiring for the chat auto-archive sweep. Pure decision logic
- * lives in `chat-auto-archive.ts`; this module reads the configured policy,
- * writes the batched archive timestamps into cave state, and resolves any
- * pending archive nudges for swept sessions. Best-effort throughout: a sweep
- * failure must never break the session list it piggybacks on.
+ * Server-side IO wiring for the chat auto-archive sweeps — the policy sweep
+ * (idle/external/etc.) and the merged-PR sweep. Pure decision logic lives in
+ * `chat-auto-archive.ts` / `merged-chat-auto-archive.ts`; this module reads
+ * the configured policy and cave state, writes the batched archive timestamps
+ * into cave state, and resolves any pending archive nudges for swept
+ * sessions. Best-effort throughout: a sweep failure must never break the
+ * session list it piggybacks on.
  */
 
 /**
@@ -39,6 +47,44 @@ export async function sweepAutoArchive(
     if (decisions.length === 0) return new Map();
     const archived = await autoArchiveSessionsLocal(decisions.map((d) => d.sessionId));
     for (const sessionId of archived.keys()) {
+      await resolveArchiveNudges(sessionId);
+    }
+    return archived;
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Sweep `rows` whose pull request has merged and archive them, recording each
+ * (session, PR) pair in cave state so the sweep is one-shot — summoning the
+ * chat later won't be undone by the next poll. Shares the policy sweep's
+ * opt-outs (keep marks, extension windows / summon grace) and env kill-switch
+ * (COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1). Returns sessionId → archivedAt for
+ * rows archived by this call (empty when nothing was due or the sweep
+ * failed).
+ */
+export async function sweepMergedPrAutoArchive(
+  rows: MergedAutoArchiveRow[],
+  state: CaveState,
+  now: Date = new Date(),
+): Promise<Map<string, string>> {
+  try {
+    if (process.env[MERGED_AUTO_ARCHIVE_DISABLE_ENV] === "1") return new Map();
+    const decisions = mergedChatAutoArchiveDecisions(
+      rows,
+      state.mergedPrAutoArchived ?? {},
+      {
+        keep: state.sessionKeep ?? {},
+        extendedUntil: state.sessionArchiveExtendedUntil ?? {},
+        now,
+      },
+    );
+    if (decisions.length === 0) return new Map();
+    const archivedAt = await archiveSessionsForMergedPrs(decisions);
+    const archived = new Map<string, string>();
+    for (const { sessionId } of decisions) {
+      archived.set(sessionId, archivedAt);
       await resolveArchiveNudges(sessionId);
     }
     return archived;

--- a/src/lib/chat-auto-archive.ts
+++ b/src/lib/chat-auto-archive.ts
@@ -49,8 +49,9 @@ export const DEFAULT_CHAT_AUTO_ARCHIVE_POLICY: ChatAutoArchivePolicy = {
 
 const MAX_DAYS = 365;
 
-/** Grace window applied when a chat is summoned (unarchived) so an idle-based
- *  sweep doesn't immediately re-archive it before the user touches it. */
+/** Grace window applied when a chat is summoned (unarchived) so a sweep
+ *  (idle-based or merged-PR) doesn't immediately re-archive it before the
+ *  user touches it. */
 export const SUMMON_GRACE_DAYS = 7;
 
 function clampDays(value: unknown, fallback: number): number {
@@ -108,10 +109,13 @@ export function sessionCreatedExternally(
   return !USER_FACING_ORIGINS.has(row.origin);
 }
 
-/** Statuses that mean the session may still be doing work — never sweep those. */
-const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
+/** Statuses that mean the session may still be doing work — never sweep
+ *  those. Shared by every auto-archive sweep (policy and merged-PR) so the
+ *  two paths can't drift on what counts as "active". */
+export const ACTIVE_SESSION_STATUSES: ReadonlySet<string> = new Set([
   "running",
   "starting",
+  "working",
   "queued",
   "streaming",
   "waiting",
@@ -133,6 +137,20 @@ export type AutoArchiveContext = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** True while `id` sits inside a still-valid auto-archive extension window
+ *  (explicit "remind me later" extensions and the summon grace both live in
+ *  `sessionArchiveExtendedUntil`). Shared by every auto-archive sweep. */
+export function underExtension(
+  extendedUntil: Record<string, string>,
+  id: string,
+  now: Date,
+): boolean {
+  const raw = extendedUntil[id];
+  if (!raw) return false;
+  const until = Date.parse(raw);
+  return Number.isFinite(until) && until > now.getTime();
+}
 
 function daysIdle(row: AutoArchiveSessionInput, now: Date): number | null {
   const updated = Date.parse(row.updated_at);
@@ -157,12 +175,8 @@ export function autoArchiveDecisions(
   for (const row of rows) {
     if (row.archived_at) continue;
     if (context.keep[row.id]) continue;
-    if (ACTIVE_STATUSES.has((row.status ?? "").toLowerCase())) continue;
-    const extendedUntil = context.extendedUntil[row.id];
-    if (extendedUntil) {
-      const until = Date.parse(extendedUntil);
-      if (Number.isFinite(until) && until > context.now.getTime()) continue;
-    }
+    if (ACTIVE_SESSION_STATUSES.has((row.status ?? "").toLowerCase())) continue;
+    if (underExtension(context.extendedUntil, row.id, context.now)) continue;
     const idle = daysIdle(row, context.now);
     if (idle == null) continue;
 

--- a/src/lib/merged-chat-auto-archive.test.ts
+++ b/src/lib/merged-chat-auto-archive.test.ts
@@ -19,8 +19,15 @@ const row = (over = {}) => ({
   ...over,
 });
 
+const ctx = (over = {}) => ({
+  keep: {},
+  extendedUntil: {},
+  now: new Date("2026-07-14T12:00:00Z"),
+  ...over,
+});
+
 test("merged PR on an idle unarchived chat → archive decision", () => {
-  const decisions = mergedChatAutoArchiveDecisions([row()], {});
+  const decisions = mergedChatAutoArchiveDecisions([row()], {}, ctx());
   assert.deepEqual(decisions, [
     { sessionId: "s1", prKey: "OpenCoven/coven-cave#42" },
   ]);
@@ -31,6 +38,7 @@ test("non-merged states never archive (including task lifecycle words)", () => {
     const decisions = mergedChatAutoArchiveDecisions(
       [row({ pullRequest: { ...row().pullRequest, state } })],
       {},
+      ctx(),
     );
     assert.equal(decisions.length, 0, `state=${state} must not archive`);
   }
@@ -40,6 +48,7 @@ test("MERGED (gh casing) matches", () => {
   const decisions = mergedChatAutoArchiveDecisions(
     [row({ pullRequest: { ...row().pullRequest, state: "MERGED" } })],
     {},
+    ctx(),
   );
   assert.equal(decisions.length, 1);
 });
@@ -47,7 +56,7 @@ test("MERGED (gh casing) matches", () => {
 test("sessions that may still be working are never swept", () => {
   for (const status of ["running", "starting", "working", "queued", "streaming", "waiting"]) {
     assert.equal(
-      mergedChatAutoArchiveDecisions([row({ status })], {}).length,
+      mergedChatAutoArchiveDecisions([row({ status })], {}, ctx()).length,
       0,
       `status=${status} must not archive`,
     );
@@ -56,25 +65,52 @@ test("sessions that may still be working are never swept", () => {
 
 test("already-archived rows are skipped", () => {
   assert.equal(
-    mergedChatAutoArchiveDecisions([row({ archived_at: "2026-07-01T00:00:00Z" })], {}).length,
+    mergedChatAutoArchiveDecisions([row({ archived_at: "2026-07-01T00:00:00Z" })], {}, ctx()).length,
     0,
   );
 });
 
 test("one-shot: a session already auto-archived for this PR is not re-archived", () => {
   const handled = { s1: "OpenCoven/coven-cave#42" };
-  assert.equal(mergedChatAutoArchiveDecisions([row()], handled).length, 0);
+  assert.equal(mergedChatAutoArchiveDecisions([row()], handled, ctx()).length, 0);
 });
 
 test("a NEW merged PR re-arms the sweep for the same session", () => {
   const handled = { s1: "OpenCoven/coven-cave#41" };
-  const decisions = mergedChatAutoArchiveDecisions([row()], handled);
+  const decisions = mergedChatAutoArchiveDecisions([row()], handled, ctx());
   assert.equal(decisions.length, 1);
 });
 
 test("rows without PR context are skipped", () => {
-  assert.equal(mergedChatAutoArchiveDecisions([row({ pullRequest: null })], {}).length, 0);
-  assert.equal(mergedChatAutoArchiveDecisions([row({ pullRequest: undefined })], {}).length, 0);
+  assert.equal(mergedChatAutoArchiveDecisions([row({ pullRequest: null })], {}, ctx()).length, 0);
+  assert.equal(mergedChatAutoArchiveDecisions([row({ pullRequest: undefined })], {}, ctx()).length, 0);
+});
+
+test("keep-marked chats are never merged-swept", () => {
+  const decisions = mergedChatAutoArchiveDecisions(
+    [row()],
+    {},
+    ctx({ keep: { s1: "2026-07-01T00:00:00Z" } }),
+  );
+  assert.equal(decisions.length, 0);
+});
+
+test("chats inside an extension window (incl. summon grace) are not swept", () => {
+  const decisions = mergedChatAutoArchiveDecisions(
+    [row()],
+    {},
+    ctx({ extendedUntil: { s1: "2026-07-21T12:00:00Z" } }),
+  );
+  assert.equal(decisions.length, 0);
+});
+
+test("an expired extension no longer blocks the sweep", () => {
+  const decisions = mergedChatAutoArchiveDecisions(
+    [row()],
+    {},
+    ctx({ extendedUntil: { s1: "2026-07-10T00:00:00Z" } }),
+  );
+  assert.equal(decisions.length, 1);
 });
 
 test("mergedPrKey prefers repo#number, falls back to url, else null", () => {

--- a/src/lib/merged-chat-auto-archive.ts
+++ b/src/lib/merged-chat-auto-archive.ts
@@ -1,7 +1,8 @@
 // Merged-chat auto-archive: when the pull request a chat produced has been
 // merged, the chat's work is done — archive it automatically instead of
 // leaving it in the active list forever. Pure decision logic only; the IO
-// (cave-state writes, nudge resolution) lives in the sessions list route.
+// (cave-state writes, nudge resolution) lives in chat-auto-archive-sweep.ts
+// alongside the policy sweep's wiring.
 //
 // Safety properties:
 //  - Only fires on a real, lowercased "merged" PR state (server-side
@@ -10,8 +11,17 @@
 //  - One-shot per (session, PR): a session the sweep already archived for a
 //    given PR is recorded in cave state (`mergedPrAutoArchived`), so summoning
 //    (unarchiving) it sticks — the sweep won't re-archive it for the same PR.
+//  - Honors the shared auto-archive opt-outs: keep-marked chats
+//    (`sessionKeep`, "never auto-archive") and chats inside an extension
+//    window (`sessionArchiveExtendedUntil` — explicit extensions and the
+//    summon grace) are never swept.
 //  - Opt-out via COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1.
 
+import {
+  ACTIVE_SESSION_STATUSES,
+  underExtension,
+  type AutoArchiveContext,
+} from "./chat-auto-archive.ts";
 import type { SessionPullRequestContext, SessionRow } from "@/lib/types";
 
 export const MERGED_AUTO_ARCHIVE_DISABLE_ENV = "COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE";
@@ -21,21 +31,17 @@ export type MergedAutoArchiveRow = Pick<
   "id" | "status" | "archived_at" | "pullRequest"
 >;
 
+/** Shared per-session opt-out state, same shape the policy sweep consumes. */
+export type MergedAutoArchiveContext = Pick<
+  AutoArchiveContext,
+  "keep" | "extendedUntil" | "now"
+>;
+
 export type MergedAutoArchiveDecision = {
   sessionId: string;
   /** Stable identity of the merged PR — "owner/repo#N", or its URL. */
   prKey: string;
 };
-
-/** Statuses that mean the session may still be doing work — never sweep those. */
-const ACTIVE_STATUSES: ReadonlySet<string> = new Set([
-  "running",
-  "starting",
-  "working",
-  "queued",
-  "streaming",
-  "waiting",
-]);
 
 /** Stable key identifying a PR across polls; null when it can't be identified. */
 export function mergedPrKey(pr: SessionPullRequestContext): string | null {
@@ -46,16 +52,21 @@ export function mergedPrKey(pr: SessionPullRequestContext): string | null {
 /**
  * Which sessions should be archived right now because their PR merged.
  * `handled` is cave state's mergedPrAutoArchived map (session id → PR key of
- * the merge that already auto-archived it once).
+ * the merge that already auto-archived it once). `context` carries the
+ * per-session opt-outs shared with the policy sweep — keep marks and
+ * extension windows gate this sweep too.
  */
 export function mergedChatAutoArchiveDecisions(
   rows: MergedAutoArchiveRow[],
   handled: Record<string, string>,
+  context: MergedAutoArchiveContext,
 ): MergedAutoArchiveDecision[] {
   const decisions: MergedAutoArchiveDecision[] = [];
   for (const row of rows) {
     if (row.archived_at) continue;
-    if (ACTIVE_STATUSES.has((row.status ?? "").toLowerCase())) continue;
+    if (context.keep[row.id]) continue;
+    if (ACTIVE_SESSION_STATUSES.has((row.status ?? "").toLowerCase())) continue;
+    if (underExtension(context.extendedUntil, row.id, context.now)) continue;
     const pr = row.pullRequest;
     if (!pr || (pr.state ?? "").toLowerCase() !== "merged") continue;
     const prKey = mergedPrKey(pr);

--- a/src/lib/task-archive-nudge-wiring.test.ts
+++ b/src/lib/task-archive-nudge-wiring.test.ts
@@ -56,8 +56,8 @@ const sessionsListRoute = readFileSync(
 );
 assert.match(
   sessionsListRoute,
-  /import \{ sweepAutoArchive \} from "@\/lib\/chat-auto-archive-sweep"/,
-  "sessions list imports the auto-archive sweep",
+  /import \{\s*sweepAutoArchive,\s*sweepMergedPrAutoArchive,?\s*\} from "@\/lib\/chat-auto-archive-sweep"/,
+  "sessions list imports both sweeps from the shared sweep module",
 );
 assert.match(
   sessionsListRoute,


### PR DESCRIPTION
## What

The policy auto-archive sweep (#2995, #3050) and the merged-PR auto-archive sweep (#2983) landed in parallel and coexisted in `/api/sessions/list` with divergent guards. This reconciles them onto one contract.

## Defects fixed

- **`sessionKeep` didn't gate the merged-PR sweep** — a chat marked *keep (never auto-archive)* was still auto-archived the moment its PR merged.
- **Extensions/summon grace didn't gate it either** — interplay bug: if the policy sweep archived an idle chat first, the `mergedPrAutoArchived` one-shot pair was never recorded, so *summoning* that chat got it instantly re-archived by the merged sweep on the next poll. "Summon sticks" broken.
- **Drifted ACTIVE_STATUSES sets** — `working` was missing from the policy set.
- **Duplicated route plumbing** — merged-sweep IO inlined in the route; swept-row rewrite duplicated.

## Changes

- `chat-auto-archive.ts`: shared `ACTIVE_SESSION_STATUSES` (+`working`) and `underExtension()` exported; both sweeps consume them.
- `merged-chat-auto-archive.ts`: decisions take the shared `{keep, extendedUntil, now}` context.
- `chat-auto-archive-sweep.ts`: new `sweepMergedPrAutoArchive()` owns the merged sweep's IO (env kill-switch, cave-state write, nudge resolution), mirroring `sweepAutoArchive()`.
- List route: one `applySweptRows()` helper; both apply fns are thin wrappers; call sites unchanged.

## Verification

- `pnpm typecheck` clean
- `pnpm test:app` — 684 files pass (merged-sweep unit test grows keep/extension/expired-extension cases)
- `pnpm test:api` — 168 files pass
- `pnpm check:tests-wired` — 926 wired

## Out of scope

Settings toggle for merged auto-archive (tracked as a listed follow-up path).