### PR TITLE
fix(familiars): surface remote familiar state; keep internal coven names out of suggestions

### DIFF
--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -31,8 +31,31 @@ assert.match(
 );
 assert.match(
   source,
-  /explicitFamiliarIdsFromToml/,
-  "Familiars API should distinguish user-authored familiar ids from daemon fallback defaults",
+  /parseFamiliarsToml/,
+  "Familiars API should read the locally-declared familiars so they can be merged and exempted",
+);
+
+// ── GET: the list must reflect the coven's real state (cave-7cv4) ────────────
+// Hub rosters are real registered familiars — the install-seed guard judges
+// entries against the LOCAL familiars.toml, which knows nothing about a
+// remote coven, so it must not run in hub mode.
+assert.match(
+  source,
+  /daemonTargetForConfig\(config\)\.mode === "hub"\s*\?\s*\(res\.data \?\? \[\]\)\s*:\s*filterInstallSeedFamiliars\(/,
+  "hub rosters bypass the local-toml install-seed guard",
+);
+// Familiars declared in the local familiars.toml but missing from the daemon
+// roster (not re-read yet / hub unaware) merge into the response — everything
+// the POST duplicate check can 409 on must be visible in the list.
+assert.match(
+  source,
+  /const declaredOnly[^=]*= declaredEntries\s*\.filter\(\(entry\) => !rosterIds\.has\(entry\.id\.toLowerCase\(\)\) && !removedIds\.has\(entry\.id\)\)/,
+  "locally-declared familiars missing from the daemon roster are merged in (minus tombstones)",
+);
+assert.match(
+  source,
+  /\[\.\.\.visibleRoster, \.\.\.declaredOnly\]\.map\(/,
+  "daemon roster and declared-only familiars flow through the same enrichment",
 );
 
 // ── POST: in-app "create a familiar" write path ──────────────────────────────
@@ -62,6 +85,17 @@ assert.match(
   "POST should detect an existing id before appending",
 );
 assert.match(source, /status:\s*409/, "POST should return 409 on a duplicate id");
+
+// The local familiars.toml is only half the truth — in hub mode (or before
+// the local daemon re-reads the file) the roster can hold ids this machine
+// has never declared. POST checks the live roster best-effort (daemon failure
+// must not block creation) so it never shadows an existing remote familiar;
+// tombstoned ids are exempt so Remove → re-create keeps working (cave-7cv4).
+assert.match(
+  source,
+  /liveRoster\.ok &&\s*!removed\.has\(draft\.id\) &&\s*\(liveRoster\.data \?\? \[\]\)\.some\(\(f\) => f\.id\.toLowerCase\(\) === draft\.id\.toLowerCase\(\)\)/,
+  "POST rejects ids that already exist in the live roster (best-effort, tombstone-exempt)",
+);
 
 // CRITICAL: creating an additional familiar must NOT rewrite the global
 // defaults (that's onboarding's job for the first familiar). The route only

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -2,17 +2,15 @@ import { NextResponse } from "next/server";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { callDaemon } from "@/lib/coven-daemon";
+import { callDaemon, daemonTargetForConfig } from "@/lib/coven-daemon";
 import { bindingFor, loadConfig, saveConfig } from "@/lib/cave-config";
-import {
-  explicitFamiliarIdsFromToml,
-  filterInstallSeedFamiliars,
-} from "@/lib/familiar-roster-guard";
+import { filterInstallSeedFamiliars } from "@/lib/familiar-roster-guard";
 import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
 import {
   buildFamiliarsToml,
   familiarsTomlContainsId,
   normalizeFamiliarDraft,
+  parseFamiliarsToml,
   type OnboardingFamiliarInput,
 } from "@/lib/onboarding-familiars";
 import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
@@ -36,16 +34,19 @@ export type DaemonFamiliar = {
 export async function GET() {
   const covenDir = path.join(homedir(), ".coven");
   const familiarsToml = path.join(covenDir, "familiars.toml");
-  const [res, config, removedIds, explicitIds] = await Promise.all([
+  const [res, config, removedIds, declaredEntries] = await Promise.all([
     callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
       path: "/api/v1/familiars",
     }),
     loadConfig(),
     removedFamiliarIds().catch(() => new Set<string>()),
     readFile(familiarsToml, "utf8")
-      .then(explicitFamiliarIdsFromToml)
-      .catch(() => new Set<string>()),
+      .then(parseFamiliarsToml)
+      .catch(() => []),
   ]);
+  // Ids the user has explicitly declared in the local familiars.toml —
+  // exempt from the install-seed heuristics below.
+  const explicitIds = new Set(declaredEntries.map((entry) => entry.id.toLowerCase()));
   if (!res.ok) {
     // Auth failures (401/403) mean the hub/daemon rejected our access token
     // — typically a stale or missing token after a hub reconnect. Surface
@@ -81,10 +82,37 @@ export async function GET() {
   // A removed familiar (DELETE /api/familiars/[id]) can linger in the daemon's
   // in-memory roster until it re-reads familiars.toml — hide tombstoned ids so
   // Remove takes effect immediately in every client.
+  //
+  // Roster shaping is mode-aware (the list must reflect the coven's REAL
+  // state, not just this machine's — cave-7cv4):
+  //  - hub mode: the roster comes from the remote hub, where every entry is a
+  //    real registered familiar. The install-seed guard judges entries against
+  //    the LOCAL familiars.toml, which says nothing about a remote coven — a
+  //    hub familiar genuinely named Sage or Salem must not be hidden here.
+  //  - local mode: filter the daemon's seeded first-install suggestions as
+  //    before (entries with live activity state are never hidden).
+  //  - either mode: familiars declared in the local familiars.toml but missing
+  //    from the daemon roster (daemon hasn't re-read the file yet, or the hub
+  //    doesn't know this machine's file) are merged in, so every id the POST
+  //    duplicate check can 409 on is VISIBLE in the list instead of looking
+  //    summonable again.
+  const daemonRoster =
+    daemonTargetForConfig(config).mode === "hub"
+      ? (res.data ?? [])
+      : filterInstallSeedFamiliars(res.data ?? [], explicitIds);
+  const visibleRoster = daemonRoster.filter((f) => !removedIds.has(f.id));
+  const rosterIds = new Set(visibleRoster.map((f) => f.id.toLowerCase()));
+  const declaredOnly: (DaemonFamiliar & { emoji?: string; icon?: string })[] = declaredEntries
+    .filter((entry) => !rosterIds.has(entry.id.toLowerCase()) && !removedIds.has(entry.id))
+    .map((entry) => ({
+      id: entry.id,
+      display_name: entry.displayName ?? entry.id,
+      role: entry.role ?? "Familiar",
+      ...(entry.description ? { description: entry.description } : {}),
+      ...(entry.emoji ? { emoji: entry.emoji } : {}),
+    }));
   const familiars = await Promise.all(
-    filterInstallSeedFamiliars(res.data ?? [], explicitIds)
-      .filter((f) => !removedIds.has(f.id))
-      .map(async (f) => {
+    [...visibleRoster, ...declaredOnly].map(async (f) => {
       const configEntry = config.familiars[f.id] ?? {};
       const binding = bindingFor(config, f.id);
       const avatar = await resolveFamiliarAvatar(f.id);
@@ -170,6 +198,28 @@ export async function POST(req: Request) {
   const adaptersDir = path.join(covenDir, "adapters");
 
   await mkdir(covenDir, { recursive: true });
+
+  // The local familiars.toml is only half the truth: in hub mode (or before
+  // the local daemon re-reads the file) the roster can hold ids this file has
+  // never seen — e.g. a familiar summoned from another machine on the same
+  // hub. Check the live roster best-effort so we don't shadow an existing
+  // familiar with a second declaration; a daemon failure must not block
+  // creation. Tombstoned ids are exempt — a lingering roster entry for a
+  // removed familiar must not veto re-creating it.
+  const [liveRoster, removed] = await Promise.all([
+    callDaemon<DaemonFamiliar[]>({ path: "/api/v1/familiars" }),
+    removedFamiliarIds().catch(() => new Set<string>()),
+  ]);
+  if (
+    liveRoster.ok &&
+    !removed.has(draft.id) &&
+    (liveRoster.data ?? []).some((f) => f.id.toLowerCase() === draft.id.toLowerCase())
+  ) {
+    return NextResponse.json(
+      { ok: false, error: `A familiar with id "${draft.id}" already exists in this coven.` },
+      { status: 409 },
+    );
+  }
 
   // Reject duplicates rather than appending a second [[familiar]] block with
   // the same id (the daemon would only ever see the first).

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -104,7 +104,7 @@ assert.match(source, /NAME_POOL/, "the name stage offers suggested names");
   const poolMatch = source.match(/const NAME_POOL = \[([\s\S]*?)\] as const;/);
   assert.ok(poolMatch, "NAME_POOL should stay a literal array so reserved-name filtering is reviewable");
   const poolSource = poolMatch[1] ?? "";
-  for (const reserved of ["Nova", "Kitty", "Cody", "Sage", "Astra", "Echo", "Salem"]) {
+  for (const reserved of ["Nova", "Kitty", "Cody", "Charm", "Sage", "Astra", "Echo", "Salem"]) {
     assert.doesNotMatch(
       poolSource,
       new RegExp(`"${reserved}"`),

--- a/src/components/ui/avatar-lightbox.tsx
+++ b/src/components/ui/avatar-lightbox.tsx
@@ -11,7 +11,7 @@ type AvatarLightboxProps = {
   /** Full-resolution image src shown enlarged inside the lightbox. */
   src: string;
   /** Subject name — drives the trigger aria-label, breadcrumb, and alt text
-   *  (e.g. "Nova", a project name, or the operator's display name). */
+   *  (e.g. "Wren", a project name, or the operator's display name). */
   label: string;
   /** Breadcrumb tail and alt qualifier. Defaults to "Avatar". */
   category?: string;

--- a/src/lib/familiar-roster-guard.test.ts
+++ b/src/lib/familiar-roster-guard.test.ts
@@ -4,6 +4,7 @@ import {
   explicitFamiliarIdsFromToml,
   filterInstallSeedFamiliars,
   filterInternalCovenNameSuggestions,
+  hasLiveFamiliarState,
   isInternalCovenFamiliarName,
 } from "./familiar-roster-guard.ts";
 
@@ -13,6 +14,7 @@ assert.deepEqual(
     "Wren",
     "Kitty",
     "Cody",
+    "Charm",
     "Sage",
     "Astra",
     "Echo",
@@ -63,6 +65,39 @@ id = "wren"
   ).map((f) => f.id),
   ["sage", "wren"],
   "an intentionally user-authored reserved id is preserved outside the generated default trio",
+);
+
+// ── cave-7cv4: live familiars are never hidden by the name heuristics ────────
+// A coven can genuinely contain familiars named Sage/Nova/Salem — especially
+// on a remote host or hub, where the LOCAL familiars.toml says nothing about
+// them. Seeded suggestions carry only id/name/role; anything with activity
+// state is real and must stay visible even with zero explicit ids.
+assert.equal(hasLiveFamiliarState({ id: "sage" }), false);
+assert.equal(hasLiveFamiliarState({ id: "sage", last_seen: "2026-07-14T00:00:00Z" }), true);
+assert.equal(hasLiveFamiliarState({ id: "sage", active_sessions: 2 }), true);
+assert.equal(hasLiveFamiliarState({ id: "sage", active_sessions: 0 }), false);
+assert.equal(hasLiveFamiliarState({ id: "sage", memory_freshness: "fresh" }), true);
+
+assert.deepEqual(
+  filterInstallSeedFamiliars(
+    [
+      { id: "sage", display_name: "Sage", role: "Guide", last_seen: "2026-07-14T00:00:00Z" },
+      { id: "salem", display_name: "Salem", role: "Archivist", active_sessions: 2 },
+      { id: "nova", display_name: "Nova", role: "Research", memory_freshness: "fresh" },
+    ],
+    new Set(),
+  ).map((f) => f.id),
+  ["sage", "salem", "nova"],
+  "familiars with live activity state survive the reserved-name filter without local toml entries",
+);
+
+assert.deepEqual(
+  filterInstallSeedFamiliars(
+    [{ id: "sage", display_name: "Sage", role: "Guide", active_sessions: 1 }],
+    new Set(),
+  ).map((f) => f.id),
+  ["sage"],
+  "a lone install-default-shaped familiar with live state is real, not a generated roster",
 );
 
 console.log("familiar-roster-guard.test.ts: ok");

--- a/src/lib/familiar-roster-guard.ts
+++ b/src/lib/familiar-roster-guard.ts
@@ -2,6 +2,7 @@ export const INTERNAL_COVEN_FAMILIAR_IDS = new Set([
   "nova",
   "kitty",
   "cody",
+  "charm",
   "sage",
   "astra",
   "echo",
@@ -20,6 +21,9 @@ type FamiliarRosterEntry = {
   id: string;
   display_name?: string | null;
   role?: string | null;
+  last_seen?: string | null;
+  active_sessions?: number | null;
+  memory_freshness?: string | null;
 };
 
 function normalizeId(value: string): string {
@@ -67,6 +71,21 @@ function isInstallDefaultFamiliar(familiar: FamiliarRosterEntry): boolean {
   );
 }
 
+/**
+ * Evidence that a roster entry is a real, living familiar rather than a
+ * daemon-seeded suggestion: seeded defaults carry only id/name/role, while a
+ * familiar that has actually run has activity fields. A coven can genuinely
+ * contain a familiar named Sage or Salem (on this machine or a remote host),
+ * so live entries are exempt from every name-based hide heuristic below.
+ */
+export function hasLiveFamiliarState(familiar: FamiliarRosterEntry): boolean {
+  return Boolean(
+    (familiar.last_seen ?? "").trim() ||
+      (familiar.memory_freshness ?? "").trim() ||
+      (typeof familiar.active_sessions === "number" && familiar.active_sessions > 0),
+  );
+}
+
 export function filterInstallSeedFamiliars<T extends FamiliarRosterEntry>(
   familiars: readonly T[],
   explicitIdsInput: ReadonlySet<string> | readonly string[],
@@ -76,9 +95,12 @@ export function filterInstallSeedFamiliars<T extends FamiliarRosterEntry>(
     ? new Set(explicitIdsInput.map(normalizeId))
     : new Set(Array.from(explicitIdsInput, normalizeId));
 
-  if (familiars.every(isInstallDefaultFamiliar)) return [];
+  if (familiars.every((familiar) => isInstallDefaultFamiliar(familiar) && !hasLiveFamiliarState(familiar))) {
+    return [];
+  }
 
   return familiars.filter((familiar) => {
+    if (hasLiveFamiliarState(familiar)) return true;
     const id = normalizeId(familiar.id);
     const explicit = explicitIds.has(id);
     if (isInstallDefaultFamiliar(familiar) && !explicit) return false;

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -337,7 +337,7 @@ assert.ok(!prodNames.has("openclaw-skills"), "bundled OpenClaw Skills umbrella s
 for (const name of ["ocr", "higgsfield-generate", "prompt-vault"]) {
   assert.ok(prodNames.has(name), `individual OpenClaw skill "${name}" should be a Cave marketplace card`);
 }
-for (const familiarSkill of ["coven-nova", "coven-kitty", "coven-cody", "coven-charm", "coven-sage", "coven-astra", "coven-echo"]) {
+for (const familiarSkill of ["coven-nova", "coven-kitty", "coven-cody", "coven-charm", "coven-sage", "coven-astra", "coven-echo", "coven-salem"]) {
   assert.ok(!prodNames.has(familiarSkill), `${familiarSkill} should not be exposed as a hardcoded familiar skill`);
 }
 	assert.ok(!prodNames.has("rollcall"), "rollcall should not be exposed as a hardcoded familiar skill");
@@ -346,7 +346,7 @@ for (const plugin of sanitizedProductionPlugins) {
   assert.deepEqual(plugin.roleAffinity ?? [], [], `${plugin.name} should not expose hardcoded familiar role affinity`);
 }
 for (const plugin of sanitizedProductionCards) {
-  assert.doesNotMatch(JSON.stringify(plugin).toLowerCase(), /\b(nova|kitty|cody|charm|sage|astra|echo)\b/, `${plugin.id} should not mention named familiars`);
+  assert.doesNotMatch(JSON.stringify(plugin).toLowerCase(), /\b(nova|kitty|cody|charm|sage|astra|echo|salem)\b/, `${plugin.id} should not mention named familiars`);
 }
 for (const [label, source] of [
   ["/api/marketplace", marketplaceRoute],

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IconName } from "@/lib/icon";
+import { INTERNAL_COVEN_FAMILIAR_IDS } from "./familiar-roster-guard.ts";
 
 export type RoleAffinity = { familiar: string; roles: string[] };
 
@@ -218,12 +219,15 @@ function authorName(author: PluginManifest["author"]): string {
   return "OpenCoven";
 }
 
-const FAMILIAR_MARKETPLACE_NAMES = new Set(["nova", "kitty", "cody", "charm", "sage", "astra", "echo"]);
-const FAMILIAR_PLUGIN_RE = /^coven-(nova|kitty|cody|charm|sage|astra|echo)$/i;
-const FAMILIAR_NAME_RE = /\b(nova|kitty|cody|charm|sage|astra|echo)\b/i;
+// One source of truth for the internal coven familiar names that must never
+// leak into the shared catalog: the roster guard's list (ids are plain
+// lowercase alphanumerics, so joining them into a regex needs no escaping).
+const FAMILIAR_NAME_ALTERNATION = [...INTERNAL_COVEN_FAMILIAR_IDS].join("|");
+const FAMILIAR_PLUGIN_RE = new RegExp(`^coven-(${FAMILIAR_NAME_ALTERNATION})$`, "i");
+const FAMILIAR_NAME_RE = new RegExp(`\\b(${FAMILIAR_NAME_ALTERNATION})\\b`, "i");
 
 function hasHardcodedFamiliarName(value: string): boolean {
-  return FAMILIAR_MARKETPLACE_NAMES.has(value.trim().toLowerCase());
+  return INTERNAL_COVEN_FAMILIAR_IDS.has(value.trim().toLowerCase());
 }
 
 export function sanitizeMarketplacePlugins(

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildFamiliarsToml,
   normalizeFamiliarDraft,
+  parseFamiliarsToml,
 } from "./onboarding-familiars.ts";
 
 assert.equal(buildFamiliarsToml(null), "# User familiars for this Coven.\n");
@@ -191,5 +192,58 @@ assert.equal(
   const elapsed = Date.now() - start;
   assert.ok(elapsed < 500, `slugify ReDoS guard: took ${elapsed}ms on long dash string (expected <500ms)`);
 }
+
+// ── parseFamiliarsToml (cave-7cv4) ───────────────────────────────────────────
+// The familiars route merges locally-declared familiars into the roster while
+// the daemon hasn't re-read the file (or a hub doesn't know it), so the parser
+// must round-trip exactly what buildFamiliarsToml writes — escapes included.
+{
+  const written = buildFamiliarsToml({
+    id: "sage-remote",
+    displayName: 'Sage "The Wise"',
+    role: "Guide",
+    description: "Line one.\nLine two.",
+    glyph: "ph:cat-fill",
+    harness: "codex",
+    model: "gpt-5",
+  });
+  const twoBlocks = `${written}
+[[familiar]]
+id = "salem"
+display_name = "Salem"
+role = "Archivist"
+description = "Keeps the archives."
+
+[other-table]
+id = "not-a-familiar"
+`;
+  assert.deepEqual(parseFamiliarsToml(twoBlocks), [
+    {
+      id: "sage-remote",
+      displayName: 'Sage "The Wise"',
+      role: "Guide",
+      description: "Line one.\nLine two.",
+      emoji: "ph:cat-fill",
+    },
+    {
+      id: "salem",
+      displayName: "Salem",
+      role: "Archivist",
+      description: "Keeps the archives.",
+      emoji: undefined,
+    },
+  ]);
+}
+assert.deepEqual(parseFamiliarsToml(""), [], "empty file parses to no familiars");
+assert.deepEqual(
+  parseFamiliarsToml("# User familiars for this Coven.\n"),
+  [],
+  "the header-only file parses to no familiars",
+);
+assert.deepEqual(
+  parseFamiliarsToml('[[familiar]]\ndisplay_name = "No Id"\n'),
+  [],
+  "a block without an id is skipped",
+);
 
 console.log("onboarding-familiars ssh runtime: ok");

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -153,3 +153,82 @@ export function familiarsTomlContainsId(toml: string, id: string): boolean {
   const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`^\\s*id\\s*=\\s*"${escaped}"\\s*$`, "m").test(toml);
 }
+
+export type FamiliarsTomlEntry = {
+  id: string;
+  displayName?: string;
+  role?: string;
+  description?: string;
+  emoji?: string;
+};
+
+/** Reverse of `tomlString` for the escapes it writes. */
+function unescapeTomlString(value: string): string {
+  return value.replace(/\\(u[0-9A-Fa-f]{4}|.)/g, (_, esc: string) => {
+    if (esc[0] === "u" && esc.length === 5) {
+      return String.fromCodePoint(Number.parseInt(esc.slice(1), 16));
+    }
+    switch (esc) {
+      case "\\":
+        return "\\";
+      case '"':
+        return '"';
+      case "b":
+        return "\b";
+      case "t":
+        return "\t";
+      case "n":
+        return "\n";
+      case "f":
+        return "\f";
+      case "r":
+        return "\r";
+      default:
+        return esc;
+    }
+  });
+}
+
+/**
+ * Minimal parser for the `[[familiar]]` blocks `buildFamiliarsToml` writes
+ * (basic-string values only — the exact shape this module produces). Used to
+ * surface familiars the user has declared locally even while the daemon's
+ * in-memory roster hasn't re-read the file (or, in hub mode, doesn't know
+ * this machine's file at all), so the visible list always covers every id the
+ * duplicate check can reject.
+ */
+export function parseFamiliarsToml(toml: string): FamiliarsTomlEntry[] {
+  const entries: FamiliarsTomlEntry[] = [];
+  let current: Record<string, string> | null = null;
+  const flush = () => {
+    const id = (current?.id ?? "").trim();
+    if (current && id) {
+      entries.push({
+        id,
+        displayName: current.display_name,
+        role: current.role,
+        description: current.description,
+        emoji: current.emoji,
+      });
+    }
+    current = null;
+  };
+  for (const rawLine of toml.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "[[familiar]]") {
+      flush();
+      current = {};
+      continue;
+    }
+    if (line.startsWith("[")) {
+      // Some other table — stop collecting so its keys don't bleed in.
+      flush();
+      continue;
+    }
+    if (!current) continue;
+    const match = line.match(/^([A-Za-z0-9_]+)\s*=\s*"((?:[^"\\]|\\.)*)"\s*$/);
+    if (match) current[match[1]!] = unescapeTomlString(match[2] ?? "");
+  }
+  flush();
+  return entries;
+}


### PR DESCRIPTION
## Problem

Remote familiar state was not showing up in Coven Cave. A familiar could already exist on the remote host, but the UI read local state only — the familiar looked missing, the Summoning Circle offered to summon it again, and the second attempt failed with **"already exists"** for a familiar the list never showed.

Root causes:

1. `filterInstallSeedFamiliars` judges roster entries against the **local** `familiars.toml` and hides anything named nova/kitty/cody/sage/astra/echo/salem that the local file doesn't declare. In hub mode the roster comes from the remote coven — whose real familiars carry exactly those names — so they were hidden.
2. GET `/api/familiars` showed only the daemon's in-memory roster, while POST's duplicate check reads `familiars.toml` — ids in the file but not yet re-read by the daemon were invisible yet 409'd.

## Changes

- **roster guard** — `hasLiveFamiliarState` (last_seen / active_sessions / memory_freshness) exempts real familiars from every reserved-name hide heuristic; seeded suggestions (id/name/role only) are still filtered.
- **GET /api/familiars** — hub-mode rosters bypass the local-toml install-seed guard; familiars declared in the local `familiars.toml` but missing from the daemon roster merge into the response (`parseFamiliarsToml`, tombstone-aware). Everything the duplicate check can 409 on is now visible, and the Circle's `existingIds` warns at the name stage instead of failing at submit.
- **POST /api/familiars** — best-effort live-roster duplicate check (daemon failure never blocks creation; tombstoned ids exempt so Remove → re-create still works) so an existing remote familiar is never shadowed by a second local declaration.
- **names** — the marketplace sanitizers now derive from the roster guard's `INTERNAL_COVEN_FAMILIAR_IDS` (single source of truth; gains `charm`+`salem`), so the user's coven names — sage, nova, salem, … — never appear in name suggestions or leak into the shared catalog.

## Verification

- `pnpm typecheck` — clean
- Targeted: roster-guard, onboarding-familiars, familiars route, marketplace-catalog, summoning-circle tests — pass
- Full `pnpm test:api` (168 files) and `pnpm test:app` (684 files) — pass

Bead: cave-7cv4