### PR TITLE
feat(onboarding): demote Coven Code to an optional runtime — the Coven CLI alone completes setup (cave-u0uu)

### DIFF
--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -294,7 +294,7 @@ assert.match(
 assert.match(
   source,
   /type InstallTarget =[\s\S]*"coven-cli"[\s\S]*"coven-code"/,
-  "startup one-click installs include coven-code as an OpenCoven tool target",
+  "startup one-click installs keep coven-code as an install target (optional runtime)",
 );
 
 assert.match(
@@ -305,8 +305,8 @@ assert.match(
 
 assert.match(
   source,
-  /tools=\{status\?\.tools \?\? \[\]\}/,
-  "the startup CLI step receives OpenCoven tool status from onboarding status",
+  /tools=\{\(status\?\.tools \?\? \[\]\)\.filter\(\s*\(tool\) => tool\.id === "coven-cli",?\s*\)\}/,
+  "the startup CLI step receives only the Coven CLI status — Coven Code never gates the tools step",
 );
 
 assert.match(
@@ -339,16 +339,31 @@ assert.match(
   "the startup tools CTA installs or updates only the OpenCoven tools that need action",
 );
 
-assert.match(
+// Coven Code is an optional runtime adapter, not a setup requirement: the
+// wizard must not AND any client-side tool check into server `complete`
+// (cave-219's divergence class), and the runtime grid offers it one-click.
+assert.doesNotMatch(
   source,
-  /const covenCodeReady =[\s\S]{0,180}installed[\s\S]{0,80}!.*outdated/,
-  "startup should require the latest Coven Code version before treating it as ready",
+  /covenCodeSatisfied|covenCodeSkipped|COVEN_CODE_SKIP_KEY/,
+  "no client-side Coven Code requirement machinery remains in the wizard",
 );
 
 assert.match(
   source,
-  /OpenCoven tools/,
-  "the startup CLI step renders both OpenCoven tool statuses",
+  /const setupComplete = status\?\.complete \?\? false/,
+  "server complete is the wizard's single source of truth for setup",
+);
+
+assert.match(
+  source,
+  /"coven-code": \{\s*target: "coven-code"/,
+  "the runtime grid offers Coven Code as a one-click optional install",
+);
+
+assert.match(
+  source,
+  /Coven CLI/,
+  "the startup CLI step renders the Coven CLI status",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -22,7 +22,6 @@ import {
   toolStatusText,
   type LatestCheckDisplay,
 } from "@/lib/opencoven-tools-status-display";
-import { COVEN_CODE_SKIP_KEY } from "@/lib/onboarding-gate";
 import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
   openCovenToolActionTargets,
@@ -154,9 +153,6 @@ function isInstallTargetValue(value: string): value is InstallTarget {
   return ALL_INSTALL_TARGETS.includes(value as InstallTarget);
 }
 
-// The "skip Coven Code" choice persists under COVEN_CODE_SKIP_KEY (shared
-// with the workspace auto-open gate via @/lib/onboarding-gate — cave-219) so
-// a failing install can't permanently strand onboarding.
 // ~30s of 2s ticks: long enough to ride out a slow sidecar start, short
 // enough that a genuinely broken /api/harnesses surfaces as a retryable
 // error instead of an empty runtime grid polling silently forever.
@@ -201,6 +197,12 @@ const HARNESS_ONE_CLICK: Partial<
     afterInstall:
       `then summon a familiar from an agent in ${OPENCLAW_AGENT_ROOT} once you're inside Cave (Familiars → Summon familiar)`,
   },
+  "coven-code": {
+    target: "coven-code",
+    command: "npm i -g @opencoven/coven-code@latest",
+    afterInstall:
+      "then run `coven-code` in a terminal once to connect a provider",
+  },
   hermes: {
     target: "hermes",
     command:
@@ -242,9 +244,9 @@ const PLATFORM_COPY: Record<
       "Install CovenCave, then open it from Start.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
-      "Make sure coven.exe and coven-code are on PATH after the global npm install.",
-      "Click Re-check after Windows can run both tools from a new terminal.",
+      "Install the Coven CLI with npm: npm i -g @opencoven/cli@latest.",
+      "Make sure coven.exe is on PATH after the global npm install.",
+      "Click Re-check after Windows can run coven from a new terminal.",
     ],
   },
   linux: {
@@ -260,8 +262,8 @@ const PLATFORM_COPY: Record<
       "Launch the AppImage from your file manager or terminal.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
-      "Make sure coven and coven-code are on PATH after the global npm install.",
+      "Install the Coven CLI with npm: npm i -g @opencoven/cli@latest.",
+      "Make sure coven is on PATH after the global npm install.",
       "If your desktop shell has an older PATH, restart Cave after installing the tools.",
     ],
   },
@@ -278,8 +280,8 @@ const PLATFORM_COPY: Record<
       "Open CovenCave from Applications.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
-      "Make sure a terminal can run coven and coven-code after the global npm install.",
+      "Install the Coven CLI with npm: npm i -g @opencoven/cli@latest.",
+      "Make sure a terminal can run coven after the global npm install.",
       "Click Re-check here after install.",
     ],
   },
@@ -296,8 +298,8 @@ const PLATFORM_COPY: Record<
       "Open CovenCave and continue setup here.",
     ],
     cliInstall: [
-      "Install the OpenCoven tools with npm: npm i -g @opencoven/cli@latest @opencoven/coven-code@latest.",
-      "Make sure coven and coven-code are on PATH.",
+      "Install the Coven CLI with npm: npm i -g @opencoven/cli@latest.",
+      "Make sure coven is on PATH.",
       "Click Re-check here after install.",
     ],
   },
@@ -378,9 +380,6 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // concurrent one), so a user who clicks "install both" otherwise gets a
   // failure on the second. Queue npm targets here and drain them one at a time.
   const [installQueue, setInstallQueue] = useState<InstallTarget[]>([]);
-  // "Required + skippable": Coven Code is required to finish setup, but a
-  // user can skip it so a failing install never permanently strands onboarding.
-  const [covenCodeSkipped, setCovenCodeSkipped] = useState(false);
   const [nodeHint, setNodeHint] = useState<string | null>(null);
   const [onboardingMultiHostMode, setOnboardingMultiHostMode] =
     useState<MultiHostMode>("local");
@@ -1006,53 +1005,21 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   };
 
 
-  // Restore a prior "skip Coven Code" choice so a failing install can't trap
-  // the user on this step across reloads.
-  useEffect(() => {
-    try {
-      if (localStorage.getItem(COVEN_CODE_SKIP_KEY) === "1") setCovenCodeSkipped(true);
-    } catch {
-      /* private mode */
-    }
-  }, []);
-
-  const skipCovenCode = () => {
-    setCovenCodeSkipped(true);
-    try {
-      localStorage.setItem(COVEN_CODE_SKIP_KEY, "1");
-    } catch {
-      /* private mode */
-    }
-  };
-
-  // Coven Code is a required OpenCoven tool, but skippable so a failed install
-  // can never permanently strand onboarding (see covenCodeSkipped).
-  const covenCodeTool = status?.tools?.find((t) => t.id === "coven-code");
-  const covenCodeInstalled = !!covenCodeTool?.installed;
-  const covenCodeReady =
-    !!covenCodeTool?.installed &&
-    hasVerifiedLatestVersion(covenCodeTool) &&
-    !covenCodeTool.outdated &&
-    covenCodeTool.compatible;
-  const covenCodeSatisfied = covenCodeReady || covenCodeSkipped;
-  // Server `complete` already requires every other step; AND-in the Coven Code
-  // requirement so the finish CTA only appears once both tools are handled.
-  const effectiveComplete = (status?.complete ?? false) && covenCodeSatisfied;
+  // Server `complete` is the single source of truth for setup — the Coven CLI
+  // is the only required OpenCoven tool. Coven Code is an ordinary optional
+  // runtime adapter offered in the runtime step (cave-219 history: it used to
+  // be "required + skippable" via a client-side AND that could diverge from
+  // the workspace auto-open gate).
+  const setupComplete = status?.complete ?? false;
 
   const steps = useMemo<GuidedStep[]>(() => {
     const s = status?.steps;
     return [
       {
         key: "covenCli",
-        title: "Install the OpenCoven tools",
-        // Require both Coven CLI (server step) and Coven Code (required, but
-        // skippable) before this step counts as done.
-        ok: !!s?.covenCli.ok && covenCodeSatisfied,
-        detail: !s?.covenCli.ok
-          ? (s?.covenCli.detail ?? s?.covenCli.hint ?? "checking…")
-          : covenCodeSatisfied
-            ? (s?.covenCli.detail ?? "Installed")
-            : "Coven CLI ready — Coven Code still needs installing.",
+        title: "Install the Coven CLI",
+        ok: !!s?.covenCli.ok,
+        detail: s?.covenCli.detail ?? s?.covenCli.hint ?? "checking…",
         icon: "ph:gear-six",
       },
       {
@@ -1089,7 +1056,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         icon: "ph:git-branch-bold",
       },
     ];
-  }, [status, covenCodeSatisfied]);
+  }, [status]);
 
   // The step the guide spotlights: the first required step that isn't done.
   const activeStepKey = useMemo(() => {
@@ -1222,11 +1189,11 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
             Without it the page reads as a dead-ended infra checklist — users
             can't see that a 30-second summoning and a first chat follow. */}
         <JourneyStrip
-          setupDone={effectiveComplete}
+          setupDone={setupComplete}
           familiarDone={hasFamiliars}
         />
 
-        {effectiveComplete ? (
+        {setupComplete ? (
           // The finish CTA lives in the footer of a long scrolling page; when
           // the last step ticks, the counter reads 4/4 but the next action is
           // below the fold. Surface it above the fold the moment setup
@@ -1419,15 +1386,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             platformCopy={platformCopy}
                             installJobs={installJobs}
                             installResults={installResults}
-                            tools={status?.tools ?? []}
+                            tools={(status?.tools ?? []).filter(
+                              (tool) => tool.id === "coven-cli",
+                            )}
                             nodeHint={nodeHint}
                             npmBusy={
                               npmLane !== null || anyNpmInstallRunning(installJobs)
                             }
                             npmBusyLabel={npmLane?.label ?? "another npm update"}
-                            covenCodeInstalled={covenCodeInstalled}
-                            covenCodeSkipped={covenCodeSkipped}
-                            onSkipCovenCode={skipCovenCode}
                             onInstall={(target) => void runInstall(target)}
                             onCopy={copyText}
                           />
@@ -1618,7 +1584,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           >
             Skip for now
           </button>
-          {effectiveComplete ? (
+          {setupComplete ? (
             <button
               onClick={finishOnboarding}
               className="focus-ring inline-flex items-center gap-2 rounded-md bg-[color-mix(in_oklch,var(--color-success)_92%,#000)] px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-[color-mix(in_oklch,var(--color-success)_30%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-success)_82%,#000)]"
@@ -1842,9 +1808,6 @@ function StepCovenCli({
   nodeHint,
   npmBusy,
   npmBusyLabel,
-  covenCodeInstalled,
-  covenCodeSkipped,
-  onSkipCovenCode,
   onInstall,
   onCopy,
 }: {
@@ -1855,32 +1818,23 @@ function StepCovenCli({
   nodeHint: string | null;
   npmBusy: boolean;
   npmBusyLabel: string;
-  covenCodeInstalled: boolean;
-  covenCodeSkipped: boolean;
-  onSkipCovenCode: () => void;
   onInstall: (target: "coven-cli" | "coven-code") => void;
   onCopy: (text: string) => Promise<boolean>;
 }) {
   const job = installJobs["coven-cli"];
   const busy = job?.status === "running";
-  // Per-target busy — track coven-code's running state separately so the
-  // "Install both" button reflects either job. npm installs are queued
-  // client-side now, so per-target busy is enough to coordinate them.
-  const covenCodeJob = installJobs["coven-code"];
-  const covenCodeJobRunning = covenCodeJob?.status === "running";
   const actionTargets = openCovenToolActionTargets(tools);
   const manualInstallCommand = openCovenToolsInstallCommand(tools);
   const primaryActionLabel = openCovenToolsPrimaryActionLabel(tools);
-  const ownInstallBusy = busy || covenCodeJobRunning;
+  const ownInstallBusy = busy;
   const installBusy = ownInstallBusy || npmBusy;
   return (
     <div className="flex flex-col gap-3">
       <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
-        Cave needs two OpenCoven tools — the <strong>Coven CLI</strong> (powers
-        everything) and <strong>Coven Code</strong> (required). Use the main
-        action to install or update whichever tools need attention — Cave runs
-        npm installs one after another so they never collide — or copy the
-        matching command to run it yourself.
+        Cave needs one tool — the <strong>Coven CLI</strong> powers everything.
+        Use the main action to install or update it — Cave runs npm installs
+        one after another so they never collide — or copy the matching command
+        to run it yourself.
       </p>
       {npmBusy && !ownInstallBusy ? (
         <p role="status" className="text-[11px] text-[var(--text-muted)]">
@@ -1917,7 +1871,7 @@ function StepCovenCli({
       {tools.length > 0 ? (
         <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-3">
           <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-            OpenCoven tools
+            Coven CLI
           </div>
           <div className="grid gap-2">
             {tools.map((tool) => {
@@ -1931,8 +1885,6 @@ function StepCovenCli({
                 !tool.outdated &&
                 tool.compatible;
               const result = installResults[tool.id];
-              const isCovenCode = tool.id === "coven-code";
-              const showSkip = isCovenCode && !tool.installed && !covenCodeSkipped;
               return (
                 <div
                   key={tool.id}
@@ -1942,11 +1894,6 @@ function StepCovenCli({
                     <div className="min-w-0">
                       <div className="flex items-center gap-1.5 truncate text-[12px] font-medium text-[var(--text-primary)]">
                         {tool.label}
-                        {isCovenCode ? (
-                          <span className="rounded-full border border-[var(--border-hairline)] px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-[var(--text-muted)]">
-                            {covenCodeInstalled ? "Required" : covenCodeSkipped ? "Skipped" : "Required"}
-                          </span>
-                        ) : null}
                       </div>
                       <div className="mt-0.5 truncate font-mono text-[11px] text-[var(--text-muted)]">
                         {openCovenToolVersionText(tool)}
@@ -1990,16 +1937,6 @@ function StepCovenCli({
                             : tool.outdated || !tool.compatible
                               ? "Update"
                               : "Install"}
-                        </button>
-                      ) : null}
-                      {showSkip ? (
-                        <button
-                          type="button"
-                          onClick={onSkipCovenCode}
-                          className="focus-ring rounded-md px-2 py-1.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:underline"
-                          title="Continue setup without Coven Code — you can install it later from Settings."
-                        >
-                          Skip for now
                         </button>
                       ) : null}
                     </div>

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -144,7 +144,7 @@ assert.match(
 
 // ── cave-4op: the wizard's primary CTAs use the shared Button primitive ──────
 // The four accent-background call-to-action buttons (Create Coven home, Start
-// local daemon, Install both tools, Install <adapter>) render through
+// local daemon, Install the Coven CLI, Install <adapter>) render through
 // <Button variant="primary">, so their radius / height / focus ring /
 // disabled + busy treatment come from one place. The two install CTAs use the
 // primitive's `loading` prop for their spinner. Bordered secondary actions,
@@ -220,8 +220,8 @@ for (const beat of ["Set up Cave", "Summon a familiar", "First chat"]) {
 }
 assert.match(
   source,
-  /<JourneyStrip\s+setupDone=\{effectiveComplete\}\s+familiarDone=\{hasFamiliars\}/,
-  "the strip's beats derive from live status (effectiveComplete / familiars step)",
+  /<JourneyStrip\s+setupDone=\{setupComplete\}\s+familiarDone=\{hasFamiliars\}/,
+  "the strip's beats derive from live status (server complete / familiars step)",
 );
 
 // ── cave-uvv7: completion surfaces above the fold ────────────────────────────
@@ -229,7 +229,7 @@ assert.match(
 // the user must see the next action without scrolling.
 assert.match(
   source,
-  /\{effectiveComplete \? \([\s\S]{0,1200}?Setup complete — Cave is ready\./,
+  /\{setupComplete \? \([\s\S]{0,1200}?Setup complete — Cave is ready\./,
   "a completion banner renders at the top of the wizard once setup is done",
 );
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -19,7 +19,6 @@ import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
 import {
-  COVEN_CODE_SKIP_KEY,
   shouldAutoOpenOnboarding,
   type OnboardingStatusPayload,
 } from "@/lib/onboarding-gate";
@@ -1207,10 +1206,9 @@ export function Workspace() {
   // First-run: auto-open onboarding if setup is missing and the user hasn't
   // explicitly skipped or finished it. The decision lives in the shared
   // shouldAutoOpenOnboarding gate so it can't diverge from the wizard's
-  // finish-state again (cave-219): server `complete` ignores Coven Code
-  // (client-side tools[] check + skip choice), so bare `complete` must not
-  // short-circuit the gate. See onboarding-gate.ts for the structural-steps
-  // vs daemon-down rationale.
+  // finish-state (cave-219): both read bare server `complete` now that Coven
+  // Code is an optional runtime rather than a requirement. See
+  // onboarding-gate.ts for the structural-steps vs daemon-down rationale.
   useEffect(() => {
     let cancelled = false;
     const skipped =
@@ -1221,8 +1219,7 @@ export function Workspace() {
         const res = await fetch("/api/onboarding/status", { cache: "no-store" });
         if (!res.ok || cancelled) return;
         const json = (await res.json()) as OnboardingStatusPayload;
-        const covenCodeSkipped = window.localStorage.getItem(COVEN_CODE_SKIP_KEY) === "1";
-        if (shouldAutoOpenOnboarding(json, covenCodeSkipped)) setOnboardingOpen(true);
+        if (shouldAutoOpenOnboarding(json)) setOnboardingOpen(true);
       } catch {
         /* ignore — the daemon-offline banner surfaces transport issues */
       }

--- a/src/lib/onboarding-gate.test.ts
+++ b/src/lib/onboarding-gate.test.ts
@@ -1,12 +1,12 @@
-// cave-219: the workspace auto-open gate must agree with the wizard's
-// finish-state (`effectiveComplete = complete && covenCodeSatisfied`). Before
-// the shared gate, the gatekeeper returned early on bare server `complete`,
-// so a user missing only Coven Code never saw onboarding auto-open even
-// though the wizard (opened manually) showed step 1 unfinished.
+// cave-219 (updated): the workspace auto-open gate and the wizard's finish
+// state must never diverge. Historically the wizard ANDed a client-side
+// "Coven Code satisfied" check into server `complete`, and the gate had to
+// mirror it or a user missing only Coven Code saw contradictory states.
+// Coven Code is an ordinary optional runtime now: both sides read bare
+// server `complete`, so divergence is impossible by construction. These
+// pins keep that contract — tool state must NEVER re-enter this decision.
 import assert from "node:assert/strict";
 import {
-  COVEN_CODE_SKIP_KEY,
-  isCovenCodeSatisfied,
   shouldAutoOpenOnboarding,
   type OnboardingStatusPayload,
 } from "./onboarding-gate.ts";
@@ -20,60 +20,33 @@ const allStepsOk = {
   familiars: { ok: true },
 };
 
-const covenCodeReady = { id: "coven-code", installed: true, outdated: false, compatible: true };
-const covenCodeMissing = { id: "coven-code", installed: false, outdated: false, compatible: false };
-const covenCodeOutdated = { id: "coven-code", installed: true, outdated: true, compatible: true };
-const covenCodeBelowFloor = { id: "coven-code", installed: true, outdated: false, compatible: false };
-
 function payload(overrides: Partial<OnboardingStatusPayload>): OnboardingStatusPayload {
-  return { complete: true, steps: allStepsOk, tools: [covenCodeReady], ...overrides };
+  return { complete: true, steps: allStepsOk, ...overrides };
 }
 
 // ── Fully set up: never auto-open ────────────────────────────────────────────
 assert.equal(
-  shouldAutoOpenOnboarding(payload({}), false),
+  shouldAutoOpenOnboarding(payload({})),
   false,
-  "complete + Coven Code ready → no auto-open",
+  "server complete → no auto-open",
 );
 
-// ── The cave-219 divergence: complete=true but Coven Code unhandled ──────────
+// ── Coven Code is not a setup requirement (the cave-219 AND-gate is gone) ────
+// A payload may still carry a tools[] array (the status route reports every
+// OpenCoven tool for the Settings panel); the gate must ignore it entirely.
 assert.equal(
-  shouldAutoOpenOnboarding(payload({ tools: [covenCodeMissing] }), false),
-  true,
-  "server complete but Coven Code missing → auto-open (wizard shows step 1 unfinished)",
-);
-assert.equal(
-  shouldAutoOpenOnboarding(payload({ tools: [covenCodeOutdated] }), false),
-  true,
-  "server complete but Coven Code outdated → auto-open",
-);
-assert.equal(
-  shouldAutoOpenOnboarding(payload({ tools: [covenCodeBelowFloor] }), false),
-  true,
-  "server complete but Coven Code below the Cave floor → auto-open",
-);
-assert.equal(
-  shouldAutoOpenOnboarding(payload({ tools: [] }), false),
-  true,
-  "server complete but Coven Code not reported → auto-open (matches wizard's unsatisfied state)",
-);
-
-// ── An explicit skip satisfies Coven Code, exactly like the wizard ───────────
-assert.equal(
-  shouldAutoOpenOnboarding(payload({ tools: [covenCodeMissing] }), true),
+  shouldAutoOpenOnboarding({
+    ...payload({}),
+    tools: [{ id: "coven-code", installed: false, outdated: false, compatible: false }],
+  } as OnboardingStatusPayload),
   false,
-  "complete + Coven Code skipped → no auto-open",
+  "complete with Coven Code missing → no auto-open; it is an optional runtime, not a requirement",
 );
-assert.equal(isCovenCodeSatisfied(payload({ tools: [covenCodeMissing] }), true), true);
-assert.equal(isCovenCodeSatisfied(payload({}), false), true);
-assert.equal(isCovenCodeSatisfied(payload({ tools: [covenCodeOutdated] }), false), false);
-assert.equal(isCovenCodeSatisfied(payload({ tools: [covenCodeBelowFloor] }), false), false);
 
-// ── Incomplete payloads keep the pre-existing structural/daemon rules ────────
+// ── Incomplete payloads keep the structural/daemon rules ─────────────────────
 assert.equal(
   shouldAutoOpenOnboarding(
     payload({ complete: false, steps: { ...allStepsOk, covenCli: { ok: false }, daemon: { ok: false } } }),
-    false,
   ),
   true,
   "structural step missing → auto-open even with the daemon down",
@@ -84,7 +57,6 @@ assert.equal(
       complete: false,
       steps: { ...allStepsOk, daemon: { ok: false }, binding: { ok: false }, familiars: { ok: false } },
     }),
-    false,
   ),
   false,
   "set-up machine with the daemon stopped → offline banner territory, no wizard relaunch",
@@ -92,7 +64,6 @@ assert.equal(
 assert.equal(
   shouldAutoOpenOnboarding(
     payload({ complete: false, steps: { ...allStepsOk, adapters: { ok: false } } }),
-    false,
   ),
   true,
   "daemon up with genuine setup work left (runtime missing) → auto-open",
@@ -105,18 +76,14 @@ assert.equal(
 assert.equal(
   shouldAutoOpenOnboarding(
     payload({ steps: { ...allStepsOk, binding: { ok: false }, familiars: { ok: false } } }),
-    false,
   ),
   false,
   "infra complete + no familiars → no wizard; the summoning circle owns creation",
 );
 assert.equal(
-  shouldAutoOpenOnboarding({ complete: false }, false),
+  shouldAutoOpenOnboarding({ complete: false }),
   true,
   "missing steps map counts as structural-missing → auto-open",
 );
-
-// ── Skip key stays the wizard's key ──────────────────────────────────────────
-assert.equal(COVEN_CODE_SKIP_KEY, "cave:onboarding:skip-coven-code");
 
 console.log("onboarding-gate.test.ts: ok");

--- a/src/lib/onboarding-gate.ts
+++ b/src/lib/onboarding-gate.ts
@@ -1,32 +1,17 @@
 // Onboarding auto-open gate — the single decision for whether the workspace
 // should launch the first-run wizard from a /api/onboarding/status payload.
 //
-// The server's `complete` covers every step EXCEPT Coven Code: that tool only
-// exists in the payload's `tools[]`, and the user's "skip Coven Code" choice
-// lives client-side (localStorage). The wizard's finish CTA already ANDs the
-// two (`effectiveComplete = complete && covenCodeSatisfied`); this gate must
-// apply the same rule or the two diverge — a user missing only Coven Code had
-// server `complete: true`, so onboarding never auto-opened, yet the wizard
-// showed step 1 unfinished when opened manually (cave-219).
-
-/** localStorage key recording an explicit "skip Coven Code" choice. */
-export const COVEN_CODE_SKIP_KEY = "cave:onboarding:skip-coven-code";
+// Server `complete` is the single source of truth for setup. Coven Code is an
+// ordinary optional runtime adapter — never a setup requirement. History
+// (cave-219): it used to be "required + skippable", with the skip stored
+// client-side and ANDed into the wizard's finish state; the gate had to
+// mirror that AND or the two diverged. Demoting Coven Code removed the
+// client-side AND entirely, so the gate and wizard now agree by construction.
 
 export type OnboardingStatusPayload = {
   complete?: boolean;
   steps?: Record<string, { ok?: boolean }>;
-  tools?: Array<{ id?: string; installed?: boolean; outdated?: boolean; compatible?: boolean }>;
 };
-
-/** Mirrors the wizard's rule: an explicit skip, or installed and current. */
-export function isCovenCodeSatisfied(
-  payload: OnboardingStatusPayload,
-  covenCodeSkipped: boolean,
-): boolean {
-  if (covenCodeSkipped) return true;
-  const tool = payload.tools?.find((t) => t.id === "coven-code");
-  return !!tool?.installed && !tool.outdated && tool.compatible !== false;
-}
 
 /**
  * First-run: auto-open onboarding if setup is missing. Keyed on the STRUCTURAL
@@ -35,16 +20,13 @@ export function isCovenCodeSatisfied(
  * not-ok while it's down), and that would relaunch the full wizard for an
  * already-set-up machine on every visit. Daemon-down on a set-up machine
  * belongs to the offline banner, not the first-run flow. When the daemon IS
- * reachable, any remaining incompleteness (a missing tool or runtime, Coven
- * Code unhandled) is genuine setup work, so the wizard opens. A machine with
- * no familiars is NOT unfinished — the status route reports familiars/binding
- * as advisory since creation moved to the in-app Summoning Circle.
+ * reachable, any remaining incompleteness (a missing tool or runtime) is
+ * genuine setup work, so the wizard opens. A machine with no familiars is NOT
+ * unfinished — the status route reports familiars/binding as advisory since
+ * creation moved to the in-app Summoning Circle.
  */
-export function shouldAutoOpenOnboarding(
-  payload: OnboardingStatusPayload,
-  covenCodeSkipped: boolean,
-): boolean {
-  if (payload.complete && isCovenCodeSatisfied(payload, covenCodeSkipped)) return false;
+export function shouldAutoOpenOnboarding(payload: OnboardingStatusPayload): boolean {
+  if (payload.complete) return false;
   const step = (key: string) => payload.steps?.[key]?.ok === true;
   const structuralMissing =
     !step("covenCli") || !step("covenHome") || !step("adapters");

--- a/src/lib/opencoven-tools-install.test.ts
+++ b/src/lib/opencoven-tools-install.test.ts
@@ -13,12 +13,28 @@ const cliOutdated: OpenCovenToolInstallStatus = {
   outdated: true,
 };
 
-const codeReady: OpenCovenToolInstallStatus = {
-  id: "coven-code",
-  label: "Coven Code",
+const cliReady: OpenCovenToolInstallStatus = {
+  id: "coven-cli",
+  label: "Coven CLI",
   installed: true,
   outdated: false,
   compatible: true,
+};
+
+const cliMissing: OpenCovenToolInstallStatus = {
+  id: "coven-cli",
+  label: "Coven CLI",
+  installed: false,
+  outdated: false,
+  compatible: false,
+};
+
+const cliBelowFloor: OpenCovenToolInstallStatus = {
+  id: "coven-cli",
+  label: "Coven CLI",
+  installed: true,
+  outdated: false,
+  compatible: false,
 };
 
 const codeMissing: OpenCovenToolInstallStatus = {
@@ -29,60 +45,82 @@ const codeMissing: OpenCovenToolInstallStatus = {
   compatible: false,
 };
 
-const cliBelowFloor: OpenCovenToolInstallStatus = {
-  id: "coven-cli",
-  label: "coven CLI",
-  installed: true,
-  outdated: false,
-  compatible: false,
-};
-
+// The Coven CLI is the only required OpenCoven tool — a fresh setup (status
+// not loaded yet) must not claim Coven Code is needed.
 assert.deepEqual(
   openCovenToolActionTargets([]),
-  ["coven-cli", "coven-code"],
-  "fresh setup falls back to installing both OpenCoven tools",
+  ["coven-cli"],
+  "fresh setup falls back to installing the Coven CLI only",
 );
 
 assert.equal(
   openCovenToolsInstallCommand([]),
-  "npm i -g @opencoven/cli@latest @opencoven/coven-code@latest",
-  "fresh setup manual command installs both required OpenCoven tools (scoped packages only)",
+  "npm i -g @opencoven/cli@latest",
+  "fresh setup manual command installs the Coven CLI only (scoped package)",
+);
+
+assert.equal(
+  openCovenToolsPrimaryActionLabel([]),
+  "Install the Coven CLI",
+  "fresh setup primary action names the single required tool",
 );
 
 assert.deepEqual(
-  openCovenToolActionTargets([cliOutdated, codeReady]),
+  openCovenToolActionTargets([cliMissing]),
   ["coven-cli"],
-  "when Coven Code is already current, the primary action only updates the CLI",
+  "missing CLI is actionable",
 );
 
 assert.deepEqual(
-  openCovenToolActionTargets([cliBelowFloor, codeReady]),
+  openCovenToolActionTargets([cliOutdated]),
+  ["coven-cli"],
+  "outdated CLI is actionable",
+);
+
+assert.deepEqual(
+  openCovenToolActionTargets([cliBelowFloor]),
   ["coven-cli"],
   "a tool below Cave's compatibility floor is actionable even when latest metadata is unavailable",
 );
 
-assert.equal(
-  openCovenToolsInstallCommand([cliOutdated, codeReady]),
-  "npm i -g @opencoven/cli@latest",
-  "manual command matches the single outdated tool instead of claiming to install both",
+assert.deepEqual(
+  openCovenToolActionTargets([cliReady]),
+  [],
+  "a current, verified CLI needs no action",
 );
 
 assert.equal(
-  openCovenToolsPrimaryActionLabel([cliOutdated, codeReady]),
+  openCovenToolsInstallCommand([cliOutdated]),
+  "npm i -g @opencoven/cli@latest",
+  "manual command targets the CLI",
+);
+
+assert.equal(
+  openCovenToolsPrimaryActionLabel([cliOutdated]),
   "Update Coven CLI",
   "primary action label reflects a single CLI update",
 );
 
 assert.equal(
-  openCovenToolsPrimaryActionLabel([cliBelowFloor, codeReady]),
-  "Update coven CLI",
-  "primary action label treats below-floor tools as updates",
+  openCovenToolsPrimaryActionLabel([cliMissing]),
+  "Install Coven CLI",
+  "primary action label reflects a fresh CLI install",
 );
 
 assert.equal(
-  openCovenToolsPrimaryActionLabel([cliOutdated, codeMissing]),
-  "Update OpenCoven tools",
-  "mixed missing/outdated tools get a neutral update label",
+  openCovenToolsPrimaryActionLabel([cliReady]),
+  "Coven CLI ready",
+  "a satisfied CLI reads as ready",
+);
+
+// The helper stays generic: Coven Code remains a valid OPTIONAL install
+// target (runtime grid, Settings tools panel), so a caller that passes it
+// still gets a correct command — the wizard's required step simply never
+// passes it anymore.
+assert.equal(
+  openCovenToolsInstallCommand([cliOutdated, codeMissing]),
+  "npm i -g @opencoven/cli@latest @opencoven/coven-code@latest",
+  "optional Coven Code is still installable when a caller passes it explicitly",
 );
 
 console.log("opencoven-tools-install.test.ts: ok");

--- a/src/lib/opencoven-tools-install.ts
+++ b/src/lib/opencoven-tools-install.ts
@@ -20,10 +20,16 @@ const OPEN_COVEN_TOOL_PACKAGES: Record<OpenCovenToolInstallTarget, string> = {
   "coven-code": "@opencoven/coven-code@latest",
 };
 
+// The Coven CLI is the only REQUIRED OpenCoven tool: the wizard's tools step
+// passes just the coven-cli status. Coven Code stays a valid target because
+// it is still installable — as an optional runtime from the wizard's runtime
+// grid and from the Settings tools panel.
+const REQUIRED_TOOL: OpenCovenToolInstallTarget = "coven-cli";
+
 export function openCovenToolActionTargets(
   tools: readonly OpenCovenToolInstallStatus[],
 ): OpenCovenToolInstallTarget[] {
-  if (tools.length === 0) return [...OPEN_COVEN_TOOL_ORDER];
+  if (tools.length === 0) return [REQUIRED_TOOL];
   const actionable = new Set(
     tools
       .filter((tool) => !tool.installed || tool.outdated || tool.compatible === false)
@@ -36,7 +42,7 @@ export function openCovenToolsInstallCommand(
   tools: readonly OpenCovenToolInstallStatus[],
 ): string {
   const targets = openCovenToolActionTargets(tools);
-  const packages = (targets.length > 0 ? targets : OPEN_COVEN_TOOL_ORDER).map(
+  const packages = (targets.length > 0 ? targets : [REQUIRED_TOOL]).map(
     (target) => OPEN_COVEN_TOOL_PACKAGES[target],
   );
   return `npm i -g ${packages.join(" ")}`;
@@ -45,16 +51,15 @@ export function openCovenToolsInstallCommand(
 export function openCovenToolsPrimaryActionLabel(
   tools: readonly OpenCovenToolInstallStatus[],
 ): string {
-  if (tools.length === 0) return "Install both tools";
+  if (tools.length === 0) return "Install the Coven CLI";
   const actions = tools.filter((tool) =>
     openCovenToolActionTargets(tools).includes(tool.id),
   );
-  if (actions.length === 0) return "OpenCoven tools ready";
+  if (actions.length === 0) return "Coven CLI ready";
   if (actions.length === 1) {
     const [tool] = actions;
     return `${tool.installed ? "Update" : "Install"} ${tool.label}`;
   }
-  if (actions.every((tool) => !tool.installed)) return "Install both tools";
-  if (actions.every((tool) => tool.installed)) return "Update OpenCoven tools";
+  if (actions.every((tool) => !tool.installed)) return "Install OpenCoven tools";
   return "Update OpenCoven tools";
 }

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -44,8 +44,9 @@ const DAEMON_DOWN_VETERAN_STATUS = {
 };
 
 // Every step healthy but the roster empty — the state the finish CTA's
-// "summon your familiar" promise is about. Coven Code must be present and
-// current in tools[]: the wizard ANDs it into effectiveComplete.
+// "summon your familiar" promise is about. Server `complete` alone drives the
+// wizard's finish state: Coven Code is an optional runtime adapter, so it is
+// deliberately ABSENT from tools[] here — the banner must still appear.
 const COMPLETE_NO_FAMILIARS_STATUS = {
   ok: true,
   complete: true,
@@ -71,22 +72,8 @@ const COMPLETE_NO_FAMILIARS_STATUS = {
       outdated: false,
       compatible: true,
       minimumVersion: "0.0.50",
-      // effectiveComplete requires hasVerifiedLatestVersion(tool): a verified
-      // latestCheck, not just current === latest.
-      latestCheck: { status: "verified", checkedAt: "2026-07-12T00:00:00.000Z", latest: "0.0.60" },
-    },
-    {
-      id: "coven-code",
-      label: "Coven Code",
-      packageName: "@opencoven/coven-code",
-      binary: "coven-code",
-      installed: true,
-      path: "/usr/local/bin/coven-code",
-      current: "0.0.60",
-      latest: "0.0.60",
-      outdated: false,
-      compatible: true,
-      minimumVersion: "0.0.50",
+      // Display-only now: the tools card shows verified freshness, but
+      // completion is the server's `complete` — no client-side tool AND.
       latestCheck: { status: "verified", checkedAt: "2026-07-12T00:00:00.000Z", latest: "0.0.60" },
     },
   ],
@@ -131,7 +118,7 @@ test.describe("onboarding wizard", () => {
     await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
     const current = wizard(page).locator('li[aria-current="step"]');
     await expect(current).toHaveCount(1);
-    await expect(current.first()).toContainText("Install the OpenCoven tools");
+    await expect(current.first()).toContainText("Install the Coven CLI");
   });
 
   test("Escape closes for the session without permanently skipping", async ({ page }) => {


### PR DESCRIPTION
## What

Removes the Coven Code requirement from first-run onboarding. The Coven CLI is now the only required OpenCoven tool; **server `complete` is the single source of truth** for the wizard's finish state.

- **Gate** (`onboarding-gate.ts`): deletes the client-side skip machinery (`COVEN_CODE_SKIP_KEY`, `isCovenCodeSatisfied`, the `covenCodeSkipped` parameter) rather than defaulting it on. cave-219 regression pins are **updated, not deleted** — they now assert tool state can never re-enter the auto-open decision.
- **Wizard** (`onboarding-overlay.tsx`): tools step retitled **Install the Coven CLI**, receives only the coven-cli status; the `effectiveComplete` AND-gate is gone (`setupComplete = status?.complete ?? false`); the skip button, Required badge, and per-tool coven-code job tracking are removed.
- **Runtime grid**: Coven Code gains a one-click install (`HARNESS_ONE_CLICK`) beside Codex/Claude/Copilot/OpenClaw/Hermes — it was already a registry runtime adapter in the grid, it just lacked the button.
- **Platform copy** (mac/windows/linux/unknown): CLI-only install commands.
- **Helpers** (`opencoven-tools-install.ts`): CLI-only defaults; still generic, so Coven Code remains a valid optional install target (runtime grid + Settings tools panel keep managing/updating it).
- **e2e**: the completed-setup spec now proves the finish banner appears with coven-code **absent** from `tools[]`.

## Why

'Required + skippable' forced a second global npm install on every fresh machine and created the cave-219 divergence class (client-side AND vs server complete). The CLI alone is sufficient to run Cave; Coven Code is one runtime among six.

## Testing

- `pnpm typecheck` ✅
- Targeted: onboarding-gate, opencoven-tools-install, onboarding-guided-steps, onboarding-polish ✅
- `pnpm test:app`: 684 files — only pre-existing flake `vault-ref-cold-start.test.ts` (cave-6azx, reproduced on clean origin/main today, unrelated to this diff; deflake follow-up queued)

## Beads

Phase 1 of the zero-friction onboarding goal: cave-u0uu (this) -> cave-m62w (one-confirmation pipeline, other session) -> cave-r6ro (error hardening) -> cave-f7d5 (platform/docs sweep).
