### PR TITLE
test(vault): deflake vault-ref-cold-start under full-suite load (cave-6azx)

### DIFF
--- a/src/lib/vault-ref-cold-start.test.ts
+++ b/src/lib/vault-ref-cold-start.test.ts
@@ -45,10 +45,15 @@ process.env.COVEN_HOME = home;
 process.env.COVEN_VAULT_FILE = vaultYaml;
 process.env.COVEN_CAVE_ENV_FILE = join(home, ".env.local"); // nonexistent — isolates from the repo's .env.local
 process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ""}`;
-// Tight base timeout so the cold call is killed quickly; generous retry window.
-// The unfixed code ignores these and uses its fixed 8s timeout — the 10s sleep
-// outlasts it, so this test is red without the retry.
-process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS = "300";
+// Tight base timeout so the cold call is killed quickly — but with enough
+// headroom that the fake `op` reliably STARTS (and drops its marker) before
+// the kill, even on a loaded machine. At 300ms the kill raced shell spawn +
+// marker write under full-suite load: the killed first attempt left no
+// marker, so the RETRY became the "cold" call, slept 10s past its own
+// window, and the read resolved undefined (cave-6azx). The unfixed code
+// ignores these and uses its fixed 8s timeout — the 10s sleep outlasts it,
+// so this test is red without the retry.
+process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS = "2000";
 process.env.COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS = "8000";
 delete process.env.COVEN_CAVE_BUNDLE;
 delete process.env.COLD_START_KEY;


### PR DESCRIPTION
## What
Raises the fake `op`'s base read timeout 300ms → 2000ms in `vault-ref-cold-start.test.ts`.

## Why
At 300ms the kill raced shell spawn + marker write under full-suite load: the killed first attempt left no cold-marker, the RETRY became the 'cold' call, slept 10s past its own 8s window → `resolveSecret` returned undefined. Observed 3/3 full-suite failures on a loaded machine and twice on clean `origin/main` worktrees (bead cave-6azx); always passed standalone.

The regression stays red on unfixed code: it ignores the env overrides and uses its fixed 8s timeout, which the 10s sleep still outlasts.

## Testing
- Standalone: pass
- Two **concurrent** full `pnpm test:app` runs (the exact load profile that reproduced the flake): both green (684/685 files)

Closes cave-6azx.