### PR TITLE
feat(analytics): thread-signals review queue + table UX (cave-13no)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -440,6 +440,7 @@ export const SUITES = {
     "src/lib/server/stuck-created-sweep.test.ts",
     "src/components/thread-signal-card.test.ts",
     "src/components/thread-signals-section.test.ts",
+    "src/lib/thread-signal-dismissals.test.ts",
     "src/components/chat-view.test.ts",
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11249,7 +11249,49 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   overflow-y: auto;
 }
 .fa-thread-review-list li {
+  position: relative;
   min-width: 0;
+}
+/* Dismiss ("acknowledge") — top-right of the item, hover/focus-revealed on
+   fine pointers, always visible on coarse (no hover to reveal it with). */
+.fa-thread-review-dismiss {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.fa-thread-review-list li:hover .fa-thread-review-dismiss,
+.fa-thread-review-list li:focus-within .fa-thread-review-dismiss {
+  opacity: 1;
+}
+@media (pointer: coarse) {
+  .fa-thread-review-dismiss { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fa-thread-review-dismiss { transition: none; }
+}
+/* Kind filter chips + the restore affordance. */
+.fa-thread-review-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.fa-thread-review-chip {
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  color: var(--text-secondary);
+}
+.fa-thread-review-chip b {
+  font-variant-numeric: tabular-nums;
+}
+.fa-thread-review-chip.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline));
+  color: var(--accent-presence);
+}
+.fa-thread-review-chip--restore {
+  margin-left: auto;
+  color: var(--text-muted);
 }
 /* Each review item is a button — selecting it opens a discussion on the topic.
    The shared .ui-btn base sets white-space: nowrap (single-line buttons), which
@@ -11399,6 +11441,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
+}
+/* The header row stays pinned while the wrap scrolls. */
+.fa-thread-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--bg-raised);
+  box-shadow: 0 1px 0 var(--border-hairline);
 }
 .fa-thread-table {
   width: 100%;

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -122,6 +122,39 @@ describe("aggregateThreadSignals", () => {
     assert.ok(review.some((item) => item.kind === "context-pressure" && item.detail.includes("critical")));
   });
 
+  it("orders the queue severity-first — a rank-boosted warning never outranks a critical", () => {
+    // A high-frequency, high-impact blocker in 9 of 20 reports (45% — below
+    // the >50% crit flip) stays a WARNING but accrues rankScore 9×3=27 →
+    // rank 97, which beat critical skill-access items (rank 85) under the
+    // old rank-only ordering.
+    const mixed = [
+      ...Array.from({ length: 9 }, (_, index) =>
+        report({
+          id: `w${index}`,
+          persistentBlockers: [
+            { id: "flaky", title: "Flaky proxy", category: "infra", impact: "high", detail: "drops" },
+          ],
+        })),
+      ...Array.from({ length: 11 }, (_, index) => report({ id: `p${index}` })),
+    ];
+    mixed[9] = report({ id: "p0", skillsNeedingAccess: [{ skillId: "github", reason: "token expired" }] });
+    const review = buildThreadSignalReviewQueue(aggregateThreadSignals(mixed));
+    const flaky = review.find((item) => item.title === "Flaky proxy");
+    const access = review.find((item) => item.title === "github");
+    assert.equal(flaky?.severity, "warning", "the boosted blocker stays a warning");
+    assert.equal(access?.severity, "critical", "the access gap stays critical");
+    assert.ok(
+      review.indexOf(access!) < review.indexOf(flaky!),
+      "the critical access gap sorts before the rank-boosted warning blocker",
+    );
+    const severities = review.map((item) => item.severity);
+    const firstWarning = severities.indexOf("warning");
+    assert.ok(
+      firstWarning === -1 || !severities.slice(firstWarning).includes("critical"),
+      "every critical sorts before every warning",
+    );
+  });
+
   it("renders empty state in source file when no reports", () => {
     assert.match(source, /reports\.length === 0/);
     assert.match(source, /THREAD_SIGNALS_EMPTY_STATE/);
@@ -216,5 +249,74 @@ describe("thread-signals metric ownership", () => {
     assert.doesNotMatch(source, /fa-thread-contexts/, "no duplicate context pills in the signals section");
     assert.doesNotMatch(source, /file locatability/, "the 'locatability' jargon stays out of UI labels");
     assert.match(source, /fa-confidence/, "the section comments point readers at the metrics' new home");
+  });
+});
+
+describe("review queue UX — filters, dismiss with undo, keyboard parity", () => {
+  it("filters the queue by signal kind with pressed-state chips and announcements", () => {
+    assert.match(source, /KIND_CHIP_ORDER\.filter\(\(kind\) => kindCounts\.has\(kind\)\)/, "chips render only for kinds present");
+    assert.match(source, /aria-pressed=\{kindFilter === kind\}/, "chips expose pressed state");
+    assert.match(source, /aria-label="Filter review queue by signal kind"/, "the chip row is a named group");
+    assert.match(source, /announce\(\s*next\s*\?\s*`Filtered to /, "filter changes are announced");
+    assert.match(source, /if \(kindFilter && !kindCounts\.has\(kindFilter\)\) setKindFilter\(null\);/, "a filter never points at an empty kind");
+    assert.match(source, /No signals of this kind — pick another filter\./, "a filtered-empty queue explains itself");
+  });
+
+  it("dismisses (acknowledges) items behind an undo toast, persisted per familiar", () => {
+    assert.match(source, /useUndoDelete<ThreadSignalReviewItem>/, "dismissal rides the shared undo-delete controller");
+    assert.match(source, /<UndoToast/, "a pending dismissal shows the shared undo toast");
+    assert.match(source, /addSignalDismissal\(familiarId, item, safeLocalStorage\(\)\)/, "committing persists via the pure dismissals lib");
+    assert.match(source, /partitionDismissedSignals\(queue, dismissals\)/, "the queue splits visible vs dismissed");
+    assert.match(source, /signalIdentity\(item\) !== pendingIdentity/, "the pending item hides during the undo window");
+    assert.match(source, /Restore \{dismissed\.length\} dismissed/, "acknowledged signals stay restorable — no black hole");
+    assert.match(source, /clearSignalDismissals\(familiarId, safeLocalStorage\(\)\)/, "restore clears the persisted map");
+    assert.match(source, /Every review item is acknowledged — restore them above/, "an all-dismissed queue explains itself");
+    assert.match(source, /aria-label=\{`Dismiss \$\{item\.title\}`\}/, "each dismiss control names its signal");
+  });
+
+  it("gives the queue roving-tabindex keyboard parity with Delete-to-dismiss", () => {
+    assert.match(source, /import \{ useRovingTabIndex \} from "@\/lib\/use-roving-tabindex"/, "uses the shared roving hook");
+    assert.match(source, /itemSelector: "\.fa-thread-review-item"/, "the resolve buttons are the roving items");
+    assert.match(source, /orientation: "vertical"/, "arrows move vertically through the queue");
+    assert.match(source, /event\.key !== "Delete" && event\.key !== "Backspace"/, "Delete/Backspace dismisses the focused item");
+    assert.match(source, /data-signal-identity/, "keyboard dismissal resolves the item by its stable identity");
+    assert.match(source, /aria-describedby=\{`fa-review-keys-\$\{familiarId\}`\}/, "the list points AT users at the key help");
+    assert.match(source, /Press Enter to open a resolution/, "sr-only copy teaches the keys");
+    assert.match(source, /tabIndex=\{-1\}/, "dismiss buttons stay out of the tab order (one tab stop per list)");
+  });
+
+  it("announces queue count changes via an aria-live region", () => {
+    assert.match(source, /<span aria-live="polite">/, "the item count is a live region");
+    assert.match(source, /\$\{shown\.length\} of \$\{queue\.length\} item/, "a filtered count states shown-of-total");
+  });
+
+  it("severity-first ordering is pinned in the lib", () => {
+    const lib = readFileSync(new URL("../lib/thread-self-report.ts", import.meta.url), "utf8");
+    assert.match(lib, /REVIEW_SEVERITY_ORDER\[a\.severity\] - REVIEW_SEVERITY_ORDER\[b\.severity\]/, "queue sorts by severity tier before rank");
+  });
+});
+
+describe("signal table UX — sticky header, coarse-pointer overflow, empty discipline", () => {
+  it("pins the header row while the wrap scrolls", () => {
+    assert.match(
+      globals,
+      /\.fa-thread-table thead th \{[^}]*position: sticky;[^}]*top: 0;[^}]*background: var\(--bg-raised\);/,
+      "thead cells stick to the top of the scrolling wrap on a solid token background",
+    );
+  });
+
+  it("collapses row actions into one overflow menu on coarse pointers", () => {
+    assert.match(source, /const coarsePointer = useIsCoarsePointer\(\);/, "consolidation keys on (pointer: coarse), not viewport");
+    assert.match(source, /coarsePointer \? \(/, "coarse pointers take the consolidated branch");
+    assert.match(source, /<OverflowMenu ariaLabel=\{`Actions for signal \$\{row\.signal\}`\}/, "the ⋯ trigger names its signal");
+    assert.match(source, /Resolve in a thread/, "menu carries the resolve action");
+    assert.match(source, /Add task to board/, "menu carries the task action");
+    assert.match(source, /Task already on board/, "settled rows read as settled inside the menu");
+  });
+
+  it("shows one empty state when the aggregate carries no signals at all", () => {
+    assert.match(source, /if \(allRows\.length === 0\)/, "an all-empty table collapses to a single empty state");
+    assert.match(source, /No signals in these reports\./, "the empty state names the real condition");
+    assert.match(source, /No access gaps\./, "per-category empties survive for partially-filled tables");
   });
 });

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -1,14 +1,30 @@
 "use client";
 
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import { OverflowMenu } from "@/components/ui/overflow-menu";
+import { PopoverItem } from "@/components/ui/popover";
+import { UndoToast } from "@/components/ui/undo-toast";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Icon } from "@/lib/icon";
+import { useIsCoarsePointer } from "@/lib/use-viewport";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
+import { useUndoDelete } from "@/lib/use-undo-delete";
+import {
+  addSignalDismissal,
+  clearSignalDismissals,
+  loadSignalDismissals,
+  partitionDismissedSignals,
+  signalIdentity,
+  type SignalDismissalMap,
+} from "@/lib/thread-signal-dismissals";
 import {
   aggregateThreadSignals,
   buildThreadSignalReviewQueue,
   buildThreadSignalResolutionPrompt,
+  REVIEW_KIND_LABEL,
   THREAD_SIGNALS_EMPTY_STATE,
   type ThreadSignalsAggregate,
   type ThreadSignalReviewItem,
@@ -205,6 +221,7 @@ function ThreadSignalsTable({
   sections: ThreadSignalTableSection[];
 }) {
   const { announce } = useAnnouncer();
+  const coarsePointer = useIsCoarsePointer();
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
@@ -316,37 +333,72 @@ function ThreadSignalsTable({
         <td><span className="fa-thread-table__detail">{row.detail}</span></td>
         <td><span className="board-table-cell-time">{row.count ? `${row.count}x` : "-"}</span></td>
         <td className="fa-thread-table__actions">
-          {row.kind ? (
-            <Button
-              variant="ghost"
-              size="xs"
-              leadingIcon="ph:chat-circle-dots"
-              onClick={() => resolveRow(familiarId, row)}
-              aria-label={`Launch a thread to resolve ${row.signal}`}
-              title="Launch a new thread with this familiar, primed to resolve this signal"
-            >
-              Resolve
-            </Button>
-          ) : null}
-          {isAdded ? (
-            <span className="fa-thread-table__added" title="A task card exists on the board for this signal">
-              <Icon name="ph:check-circle" width={13} aria-hidden /> Task
-            </span>
+          {coarsePointer ? (
+            // Coarse pointers: one ⋯ menu instead of a row of 44px buttons
+            // (chat-list-coarse-actions precedent). Fine pointers keep the
+            // always-visible pair below.
+            <OverflowMenu ariaLabel={`Actions for signal ${row.signal}`} size="sm">
+              {row.kind ? (
+                <PopoverItem icon="ph:chat-circle-dots" onSelect={() => resolveRow(familiarId, row)}>
+                  Resolve in a thread
+                </PopoverItem>
+              ) : null}
+              <PopoverItem
+                icon="ph:plus"
+                disabled={isAdded || isPending}
+                onSelect={() => void createTasks([row])}
+              >
+                {isAdded ? "Task already on board" : "Add task to board"}
+              </PopoverItem>
+            </OverflowMenu>
           ) : (
-            <Button
-              variant="ghost"
-              size="xs"
-              loading={isPending}
-              leadingIcon="ph:plus"
-              onClick={() => void createTasks([row])}
-              aria-label={`Add task for ${row.signal}`}
-              title="Create a task card on the board from this signal"
-            >
-              Task
-            </Button>
+            <>
+              {row.kind ? (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  leadingIcon="ph:chat-circle-dots"
+                  onClick={() => resolveRow(familiarId, row)}
+                  aria-label={`Launch a thread to resolve ${row.signal}`}
+                  title="Launch a new thread with this familiar, primed to resolve this signal"
+                >
+                  Resolve
+                </Button>
+              ) : null}
+              {isAdded ? (
+                <span className="fa-thread-table__added" title="A task card exists on the board for this signal">
+                  <Icon name="ph:check-circle" width={13} aria-hidden /> Task
+                </span>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  loading={isPending}
+                  leadingIcon="ph:plus"
+                  onClick={() => void createTasks([row])}
+                  aria-label={`Add task for ${row.signal}`}
+                  title="Create a task card on the board from this signal"
+                >
+                  Task
+                </Button>
+              )}
+            </>
           )}
         </td>
       </tr>
+    );
+  }
+
+  // Loading is the page's skeleton; a signal-free aggregate is a real state
+  // and says so once, instead of six empty category groups.
+  if (allRows.length === 0) {
+    return (
+      <EmptyState
+        compact
+        icon="ph:waveform-bold"
+        headline="No signals in these reports."
+        subtitle="Blockers, skill gaps, and pressure land here as reflections report them."
+      />
     );
   }
 
@@ -472,23 +524,220 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
 
   return (
     <div className="fa-thread-signals" data-familiar-id={familiarId}>
-      <div className="fa-thread-review">
-        <div className="fa-thread-review-head">
-          <div>
-            <h3>Review queue</h3>
-            <p>{reports.length} reports · Latest report {latestReportDate(reports)}</p>
-          </div>
-          <span>{reviewQueue.length} items</span>
+      <ThreadSignalReviewQueue familiarId={familiarId} reports={reports} queue={reviewQueue} />
+      {/* The metric averages + context-pressure mix live in the "Confidence
+          from thread analysis" panel (fa-confidence) — this section stays
+          focused on the actionable review queue and the signal table. */}
+      <ThreadSignalsTable familiarId={familiarId} sections={sections} />
+    </div>
+  );
+}
+
+/** Short chip labels per review kind (REVIEW_KIND_LABEL carries the long form). */
+const KIND_CHIP_LABEL: Record<ThreadSignalReviewItem["kind"], string> = {
+  blocker: "Blockers",
+  "skill-access": "Skill access",
+  "skill-clarity": "Skill clarity",
+  capability: "Capabilities",
+  "context-pressure": "Context",
+  "low-score": "Low scores",
+};
+
+const KIND_CHIP_ORDER: ThreadSignalReviewItem["kind"][] = [
+  "blocker",
+  "skill-access",
+  "capability",
+  "context-pressure",
+  "skill-clarity",
+  "low-score",
+];
+
+function safeLocalStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The prioritized review queue: severity-first items, kind filter chips,
+ * dismiss/acknowledge behind a 4s undo toast (persisted per familiar via
+ * thread-signal-dismissals), a restore path for acknowledged signals, and
+ * roving-tabindex keyboard parity — arrows move, Enter resolves,
+ * Delete/Backspace dismisses. The item count is an aria-live region so AT
+ * hears queue changes without re-reading the list.
+ */
+function ThreadSignalReviewQueue({
+  familiarId,
+  reports,
+  queue,
+}: {
+  familiarId: string;
+  reports: ThreadSelfReport[];
+  queue: ThreadSignalReviewItem[];
+}) {
+  const { announce } = useAnnouncer();
+  const listRef = useRef<HTMLUListElement>(null);
+  const [kindFilter, setKindFilter] = useState<ThreadSignalReviewItem["kind"] | null>(null);
+  // Dismissals load after mount — localStorage isn't SSR-safe.
+  const [dismissals, setDismissals] = useState<SignalDismissalMap>({});
+  useEffect(() => {
+    setDismissals(loadSignalDismissals(familiarId, safeLocalStorage()));
+  }, [familiarId]);
+
+  const { pending, scheduleDelete, undo, commit } = useUndoDelete<ThreadSignalReviewItem>();
+
+  const { visible, dismissed } = useMemo(
+    () => partitionDismissedSignals(queue, dismissals),
+    [queue, dismissals],
+  );
+  // Hide the item whose dismissal is pending in the undo window.
+  const pendingIdentity = pending ? signalIdentity(pending.item) : null;
+  const actionable = useMemo(
+    () => visible.filter((item) => signalIdentity(item) !== pendingIdentity),
+    [visible, pendingIdentity],
+  );
+  const kindCounts = useMemo(() => {
+    const counts = new Map<ThreadSignalReviewItem["kind"], number>();
+    for (const item of actionable) counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
+    return counts;
+  }, [actionable]);
+  // A filter never points at an empty kind — clear it when its items go away.
+  useEffect(() => {
+    if (kindFilter && !kindCounts.has(kindFilter)) setKindFilter(null);
+  }, [kindFilter, kindCounts]);
+  const shown = kindFilter ? actionable.filter((item) => item.kind === kindFilter) : actionable;
+
+  useRovingTabIndex({
+    containerRef: listRef,
+    itemSelector: ".fa-thread-review-item",
+    orientation: "vertical",
+  });
+
+  const dismissItem = useCallback(
+    (item: ThreadSignalReviewItem) => {
+      scheduleDelete(item, item.title, async () => {
+        setDismissals(addSignalDismissal(familiarId, item, safeLocalStorage()));
+      });
+      announce(`Dismissed ${item.title}.`);
+    },
+    [announce, familiarId, scheduleDelete],
+  );
+
+  const restoreDismissed = useCallback(() => {
+    setDismissals(clearSignalDismissals(familiarId, safeLocalStorage()));
+    announce(
+      dismissed.length === 1
+        ? "Restored 1 dismissed signal."
+        : `Restored ${dismissed.length} dismissed signals.`,
+    );
+  }, [announce, dismissed.length, familiarId]);
+
+  // Keyboard parity: Delete/Backspace dismisses the focused review item.
+  const onListKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLUListElement>) => {
+      if (event.key !== "Delete" && event.key !== "Backspace") return;
+      const target = (event.target as HTMLElement).closest<HTMLElement>(".fa-thread-review-item");
+      const identity = target?.getAttribute("data-signal-identity");
+      if (!identity) return;
+      const item = shown.find((candidate) => signalIdentity(candidate) === identity);
+      if (!item) return;
+      event.preventDefault();
+      dismissItem(item);
+    },
+    [dismissItem, shown],
+  );
+
+  return (
+    <div className="fa-thread-review">
+      <div className="fa-thread-review-head">
+        <div>
+          <h3>Review queue</h3>
+          <p>{reports.length} reports · Latest report {latestReportDate(reports)}</p>
         </div>
-        {reviewQueue.length === 0 ? (
-          <p className="fa-thread-review-empty">No urgent review items in the current summary.</p>
-        ) : (
-          <ul className="fa-thread-review-list">
-            {reviewQueue.map((item, index) => (
-              <li key={`${item.kind}-${item.title}-${index}`} className={`is-${item.severity}`}>
+        {/* Live count — AT hears dismissals/filters without re-reading the list. */}
+        <span aria-live="polite">
+          {shown.length === queue.length
+            ? `${shown.length} item${shown.length === 1 ? "" : "s"}`
+            : `${shown.length} of ${queue.length} item${queue.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+      {actionable.length > 0 || dismissed.length > 0 ? (
+        <div className="fa-thread-review-filters" role="group" aria-label="Filter review queue by signal kind">
+          <Button
+            variant="ghost"
+            size="xs"
+            className={`fa-thread-review-chip${kindFilter === null ? " is-active" : ""}`}
+            aria-pressed={kindFilter === null}
+            onClick={() => {
+              setKindFilter(null);
+              announce("Showing all review signals.");
+            }}
+          >
+            All <b>{actionable.length}</b>
+          </Button>
+          {KIND_CHIP_ORDER.filter((kind) => kindCounts.has(kind)).map((kind) => (
+            <Button
+              key={kind}
+              variant="ghost"
+              size="xs"
+              className={`fa-thread-review-chip${kindFilter === kind ? " is-active" : ""}`}
+              aria-pressed={kindFilter === kind}
+              title={`Show only ${REVIEW_KIND_LABEL[kind]} signals`}
+              onClick={() => {
+                const next = kindFilter === kind ? null : kind;
+                setKindFilter(next);
+                announce(
+                  next
+                    ? `Filtered to ${kindCounts.get(kind)} ${KIND_CHIP_LABEL[kind].toLowerCase()} signal${(kindCounts.get(kind) ?? 0) === 1 ? "" : "s"}.`
+                    : "Showing all review signals.",
+                );
+              }}
+            >
+              {KIND_CHIP_LABEL[kind]} <b>{kindCounts.get(kind)}</b>
+            </Button>
+          ))}
+          {dismissed.length > 0 ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="fa-thread-review-chip fa-thread-review-chip--restore"
+              leadingIcon="ph:arrow-counter-clockwise"
+              title="Bring every acknowledged signal back into the queue"
+              onClick={restoreDismissed}
+            >
+              Restore {dismissed.length} dismissed
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+      {shown.length === 0 ? (
+        <p className="fa-thread-review-empty">
+          {queue.length === 0
+            ? "No urgent review items in the current summary."
+            : dismissed.length > 0 && actionable.length === 0
+              ? "Every review item is acknowledged — restore them above to take another look."
+              : "No signals of this kind — pick another filter."}
+        </p>
+      ) : (
+        <>
+          <p id={`fa-review-keys-${familiarId}`} className="sr-only">
+            Use the arrow keys to move between signals. Press Enter to open a resolution
+            thread, or Delete to dismiss the focused signal.
+          </p>
+          <ul
+            ref={listRef}
+            className="fa-thread-review-list"
+            aria-describedby={`fa-review-keys-${familiarId}`}
+            onKeyDown={onListKeyDown}
+          >
+            {shown.map((item) => (
+              <li key={signalIdentity(item)} className={`is-${item.severity}`}>
                 <Button
                   variant="ghost"
                   className="fa-thread-review-item"
+                  data-signal-identity={signalIdentity(item)}
                   onClick={() => launchResolutionThread(familiarId, item)}
                   title={`Launch a thread to resolve "${item.title}"`}
                   aria-label={`Resolve ${item.title}`}
@@ -500,15 +749,33 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
                     {item.detail}
                   </span>
                 </Button>
+                <IconButton
+                  icon="ph:x"
+                  size="xs"
+                  className="fa-thread-review-dismiss"
+                  aria-label={`Dismiss ${item.title}`}
+                  title="Acknowledge this signal and remove it from the queue"
+                  tabIndex={-1}
+                  onClick={() => dismissItem(item)}
+                />
               </li>
             ))}
           </ul>
-        )}
-      </div>
-      {/* The metric averages + context-pressure mix live in the "Confidence
-          from thread analysis" panel (fa-confidence) — this section stays
-          focused on the actionable review queue and the signal table. */}
-      <ThreadSignalsTable familiarId={familiarId} sections={sections} />
+        </>
+      )}
+      {pending ? (
+        <UndoToast
+          key={pending.id}
+          message={<>Dismissed <strong>{pending.label}</strong></>}
+          icon="ph:x"
+          undoAriaLabel={`Undo dismissing ${pending.label}`}
+          onUndo={() => {
+            announce(`Restored ${pending.label}.`);
+            undo();
+          }}
+          onDismiss={commit}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -228,7 +228,13 @@ export type ThreadSignalReviewItem = {
   detail: string;
 };
 
-const REVIEW_KIND_LABEL: Record<ThreadSignalReviewItem["kind"], string> = {
+export const REVIEW_SEVERITY_ORDER: Record<ThreadSignalReviewItem["severity"], number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+export const REVIEW_KIND_LABEL: Record<ThreadSignalReviewItem["kind"], string> = {
   blocker: "persistent blocker",
   "skill-access": "skill access gap",
   "skill-clarity": "skill clarity gap",
@@ -463,7 +469,15 @@ export function buildThreadSignalReviewQueue(aggregate: ThreadSignalsAggregate):
   }
 
   return items
-    .sort((a, b) => b.rank - a.rank || a.title.localeCompare(b.title))
+    // Severity first — a stack of warnings must never outrank a critical
+    // (rankScore-boosted warning blockers previously could). Rank breaks ties
+    // within a severity tier; title keeps the order stable.
+    .sort(
+      (a, b) =>
+        REVIEW_SEVERITY_ORDER[a.severity] - REVIEW_SEVERITY_ORDER[b.severity] ||
+        b.rank - a.rank ||
+        a.title.localeCompare(b.title),
+    )
     .slice(0, 8)
     .map(({ rank: _rank, ...item }) => item);
 }

--- a/src/lib/thread-signal-dismissals.test.ts
+++ b/src/lib/thread-signal-dismissals.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addSignalDismissal,
+  clearSignalDismissals,
+  loadSignalDismissals,
+  partitionDismissedSignals,
+  pruneSignalDismissals,
+  SIGNAL_DISMISSAL_CAP,
+  signalDismissalKey,
+  signalIdentity,
+  type DismissStorage,
+} from "./thread-signal-dismissals.ts";
+import type { ThreadSignalReviewItem } from "./thread-self-report.ts";
+
+function fakeStorage(): DismissStorage & { data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => void data.set(key, value),
+    removeItem: (key) => void data.delete(key),
+  };
+}
+
+function item(kind: ThreadSignalReviewItem["kind"], title: string): ThreadSignalReviewItem {
+  return { kind, title, severity: "warning", detail: "d" };
+}
+
+const NOW = Date.parse("2026-06-25T12:00:00.000Z");
+
+describe("signal identity + storage round-trip", () => {
+  it("keys dismissals by kind + title (details drift with frequencies)", () => {
+    assert.equal(signalIdentity(item("blocker", "Auth expired")), "blocker:Auth expired");
+  });
+
+  it("persists per familiar and loads back", () => {
+    const storage = fakeStorage();
+    addSignalDismissal("cody", item("blocker", "Auth expired"), storage, NOW);
+    assert.deepEqual(loadSignalDismissals("cody", storage), {
+      "blocker:Auth expired": "2026-06-25T12:00:00.000Z",
+    });
+    assert.deepEqual(loadSignalDismissals("other", storage), {}, "scoped per familiar");
+    assert.ok(storage.data.has(signalDismissalKey("cody")));
+  });
+
+  it("clear removes the key entirely and returns the empty map", () => {
+    const storage = fakeStorage();
+    addSignalDismissal("cody", item("blocker", "Auth expired"), storage, NOW);
+    assert.deepEqual(clearSignalDismissals("cody", storage), {});
+    assert.equal(storage.data.has(signalDismissalKey("cody")), false);
+  });
+
+  it("tolerates missing storage and malformed payloads", () => {
+    assert.deepEqual(loadSignalDismissals("cody", null), {});
+    assert.deepEqual(addSignalDismissal("cody", item("blocker", "x"), undefined, NOW), {
+      "blocker:x": "2026-06-25T12:00:00.000Z",
+    });
+    const storage = fakeStorage();
+    storage.data.set(signalDismissalKey("cody"), "not json");
+    assert.deepEqual(loadSignalDismissals("cody", storage), {});
+    storage.data.set(signalDismissalKey("cody"), JSON.stringify(["array"]));
+    assert.deepEqual(loadSignalDismissals("cody", storage), {});
+    storage.data.set(signalDismissalKey("cody"), JSON.stringify({ ok: "2026-01-01T00:00:00.000Z", bad: 7 }));
+    assert.deepEqual(loadSignalDismissals("cody", storage), { ok: "2026-01-01T00:00:00.000Z" });
+  });
+});
+
+describe("pruning", () => {
+  it("caps the map at the newest entries", () => {
+    const big: Record<string, string> = {};
+    for (let index = 0; index < SIGNAL_DISMISSAL_CAP + 10; index++) {
+      big[`blocker:b${index}`] = new Date(NOW + index * 1000).toISOString();
+    }
+    const pruned = pruneSignalDismissals(big);
+    assert.equal(Object.keys(pruned).length, SIGNAL_DISMISSAL_CAP);
+    assert.equal("blocker:b0" in pruned, false, "oldest dropped");
+    assert.equal(`blocker:b${SIGNAL_DISMISSAL_CAP + 9}` in pruned, true, "newest kept");
+  });
+
+  it("returns the same map when under the cap", () => {
+    const map = { "blocker:x": "2026-01-01T00:00:00.000Z" };
+    assert.equal(pruneSignalDismissals(map), map);
+  });
+});
+
+describe("partitioning a queue", () => {
+  it("splits into visible and dismissed, preserving order", () => {
+    const storage = fakeStorage();
+    const dismissals = addSignalDismissal("cody", item("skill-access", "github"), storage, NOW);
+    const queue = [
+      item("blocker", "Auth expired"),
+      item("skill-access", "github"),
+      item("skill-clarity", "deploy"),
+    ];
+    const { visible, dismissed } = partitionDismissedSignals(queue, dismissals);
+    assert.deepEqual(visible.map((entry) => entry.title), ["Auth expired", "deploy"]);
+    assert.deepEqual(dismissed.map((entry) => entry.title), ["github"]);
+  });
+});

--- a/src/lib/thread-signal-dismissals.ts
+++ b/src/lib/thread-signal-dismissals.ts
@@ -1,0 +1,110 @@
+/**
+ * Thread-signal review-queue dismissals ("acknowledge") — pure helpers only.
+ *
+ * Review-queue items are derived aggregates, not stored rows, so a dismissal
+ * is keyed by the signal's stable identity (kind + title; details drift with
+ * frequencies) and persisted per familiar in localStorage. Storage is
+ * injected (see {@link DismissStorage}, same contract as chat-archive-nudge)
+ * so this module stays trivially testable in node.
+ *
+ * The UI pairs these with use-undo-delete: dismissing schedules the persist
+ * behind a 4s undo toast; committing calls {@link addSignalDismissal}.
+ */
+
+import type { ThreadSignalReviewItem } from "@/lib/thread-self-report";
+
+export type DismissStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/** dismissed identity → ISO time of dismissal. */
+export type SignalDismissalMap = Record<string, string>;
+
+/** Newest-first cap so an old install can't grow the map without bound. */
+export const SIGNAL_DISMISSAL_CAP = 100;
+
+export function signalDismissalKey(familiarId: string): string {
+  return `cave:thread-signals:dismissed:${familiarId}`;
+}
+
+/** Stable identity for a derived review item — kind + title, never detail. */
+export function signalIdentity(item: Pick<ThreadSignalReviewItem, "kind" | "title">): string {
+  return `${item.kind}:${item.title}`;
+}
+
+export function loadSignalDismissals(
+  familiarId: string,
+  storage: DismissStorage | null | undefined,
+): SignalDismissalMap {
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(signalDismissalKey(familiarId));
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    const map: SignalDismissalMap = {};
+    for (const [identity, dismissedAt] of Object.entries(parsed)) {
+      if (typeof dismissedAt === "string") map[identity] = dismissedAt;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+function persist(
+  familiarId: string,
+  storage: DismissStorage | null | undefined,
+  map: SignalDismissalMap,
+): void {
+  if (!storage) return;
+  try {
+    if (Object.keys(map).length === 0) storage.removeItem(signalDismissalKey(familiarId));
+    else storage.setItem(signalDismissalKey(familiarId), JSON.stringify(map));
+  } catch {
+    /* swallow — storage may be unavailable (private mode, quota) */
+  }
+}
+
+/** Cap the map at {@link SIGNAL_DISMISSAL_CAP}, dropping the oldest entries. */
+export function pruneSignalDismissals(map: SignalDismissalMap): SignalDismissalMap {
+  const entries = Object.entries(map);
+  if (entries.length <= SIGNAL_DISMISSAL_CAP) return map;
+  entries.sort((a, b) => new Date(b[1]).getTime() - new Date(a[1]).getTime());
+  return Object.fromEntries(entries.slice(0, SIGNAL_DISMISSAL_CAP));
+}
+
+/** Persist one dismissal; returns the updated map. */
+export function addSignalDismissal(
+  familiarId: string,
+  item: Pick<ThreadSignalReviewItem, "kind" | "title">,
+  storage: DismissStorage | null | undefined,
+  now: number = Date.now(),
+): SignalDismissalMap {
+  const next = pruneSignalDismissals({
+    ...loadSignalDismissals(familiarId, storage),
+    [signalIdentity(item)]: new Date(now).toISOString(),
+  });
+  persist(familiarId, storage, next);
+  return next;
+}
+
+/** Clear every dismissal for a familiar (the "restore" affordance); returns {}. */
+export function clearSignalDismissals(
+  familiarId: string,
+  storage: DismissStorage | null | undefined,
+): SignalDismissalMap {
+  persist(familiarId, storage, {});
+  return {};
+}
+
+/** Split a review queue into visible and dismissed halves. */
+export function partitionDismissedSignals<T extends Pick<ThreadSignalReviewItem, "kind" | "title">>(
+  items: T[],
+  dismissals: SignalDismissalMap,
+): { visible: T[]; dismissed: T[] } {
+  const visible: T[] = [];
+  const dismissed: T[] = [];
+  for (const item of items) {
+    (dismissals[signalIdentity(item)] ? dismissed : visible).push(item);
+  }
+  return { visible, dismissed };
+}


### PR DESCRIPTION
## What

PR 3 of 3 in the familiar-analytics overhaul — **stacked on #3119** (rebases onto main as the stack merges).

Polishes the thread-signals review experience: a filterable, keyboard-first review queue with acknowledge+undo, and a sturdier signal table.

### Review queue
- **Severity-first ordering** in `buildThreadSignalReviewQueue` — a rank-boosted warning (high-frequency, high-impact blocker) can no longer outrank criticals; rank breaks ties within a tier (behavioral test pins the exact regression case).
- **Kind filter chips** with counts + `aria-pressed`, rendered only for kinds present; filter changes are announced; a filter pointing at an emptied kind self-clears; filtered-empty copy explains itself.
- **Dismiss/acknowledge with undo** — shared `use-undo-delete` + `UndoToast` (⌘Z works; closing the toast commits, per board-view precedent). Commits persist per familiar via the new pure `src/lib/thread-signal-dismissals.ts` (injected storage, malformed-payload tolerant, capped map). Acknowledged signals stay restorable via a **Restore N dismissed** chip.
- **Keyboard parity** — roving tabindex (shared `use-roving-tabindex`, vertical) over the resolve buttons; **Delete/Backspace dismisses** the focused item; sr-only key help via `aria-describedby`; dismiss buttons are `tabIndex={-1}` (one tab stop per list) and hover/focus-revealed on fine pointers, always visible on coarse.
- **aria-live queue count** announcing shown-of-total on dismiss/filter/data changes.

### Signal table
- **Sticky header** row inside the scrolling wrap (tokens only: `--bg-raised` + hairline shadow).
- **Coarse pointers collapse row actions** (Resolve / Add task) into one `OverflowMenu` per the chat-list-coarse-actions precedent; fine pointers keep the visible pair.
- **Empty discipline** (cave-5qmm): an aggregate with zero signals renders one compact `EmptyState` instead of six empty category groups; per-category empties survive for partially-filled tables.

## Testing
- New `src/lib/thread-signal-dismissals.test.ts` (7 cases: identity, round-trip, per-familiar scoping, malformed payloads, cap pruning, partitioning) — registered in `scripts/run-tests.mjs`.
- `thread-signals-section.test.ts`: severity-first behavioral case + source pins for chips, undo persistence, roving/Delete keys, aria-live, sticky header, coarse overflow, empty states.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (687 files).

Bead: cave-13no