### PR TITLE
feat(chat): de-box + one-accent the Familiar tab capability sections (cave-7e1l)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -509,6 +509,7 @@ export const SUITES = {
     "src/components/inspector-pane-load-guards.test.ts",
     "src/components/inspector-pane-surface.test.ts",
     "src/components/familiar-tab-hero.test.ts",
+    "src/components/familiar-tab-sections.test.ts",
     "src/components/misc-aria-fixes.test.ts",
     "src/components/modal-trap-adoption.test.ts",
     "src/components/mode-toggle.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6231,6 +6231,19 @@ a.mobile-handoff__link:hover {
   }
 }
 
+/* De-boxed capability lists (facelift language): one wash + soft inset
+   hairline per group, hairline dividers between rows — no per-row boxes, no
+   accent tints on metadata. Accent stays reserved for presence. */
+.familiar-tab__list {
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
+}
+
+.familiar-tab__rows > li + li {
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent);
+}
+
 /* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)

--- a/src/components/familiar-tab-sections.test.ts
+++ b/src/components/familiar-tab-sections.test.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Familiar tab capability sections — de-box / one-accent / teach states
+// (cave-7e1l). The inspector-era section styling put an accent tint, border,
+// or colored chip on nearly every row; empty states named pages with no
+// affordance; raw filesystem paths ran as body copy. This pins the facelift
+// language: washes + hairlines, accent reserved for presence, CTAs on empty
+// states, paths demoted to tooltips.
+
+const src = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+test("KindBadge is neutral — the per-kind color map is gone", () => {
+  assert.doesNotMatch(src, /const colorMap/, "no per-kind color map");
+  const badge = src.slice(src.indexOf("function KindBadge"), src.indexOf("function navigateMode"));
+  assert.match(badge, /bg-\[var\(--bg-raised\)\][^"]*text-\[var\(--text-muted\)\]/, "one quiet style for every kind");
+  assert.doesNotMatch(badge, /accent-presence|color-success|color-warning/, "no status colors on kind metadata");
+});
+
+test("capability rows are de-boxed: shared list wash + hairline dividers, no accent tints", () => {
+  assert.match(css, /\.familiar-tab__list \{[^}]*color-mix\(in oklch, var\(--bg-raised\) 40%, transparent\)/, "group wash");
+  assert.match(css, /\.familiar-tab__list \{[^}]*inset 0 0 0 1px color-mix\(in oklch, var\(--border-hairline\)/, "soft inset hairline, no hard border");
+  assert.match(css, /\.familiar-tab__rows > li \+ li \{[^}]*border-top: 1px solid color-mix\(in oklch, var\(--border-hairline\)/, "hairline row dividers");
+  // The old boxed/tinted row classes must not survive anywhere in the panel.
+  assert.doesNotMatch(src, /border-\[color-mix\(in_oklch,var\(--accent-presence\)_20%,transparent\)\]/, "no accent-bordered role boxes");
+  assert.doesNotMatch(src, /bg-\[color-mix\(in_oklch,var\(--accent-presence\)_10%,transparent\)\] px-2 py-1/, "no accent-tinted skill rows");
+  assert.doesNotMatch(src, /bg-\[color-mix\(in_oklch,var\(--color-success\)_10%,transparent\)\]/, "no success-tinted skill rows");
+  assert.doesNotMatch(src, /border-\[color-mix\(in_oklch,var\(--color-warning\)_20%,transparent\)\]/, "no warning-bordered MCP boxes");
+  assert.doesNotMatch(src, /accentClass/, "collapsible groups lost their colored left-border seam");
+});
+
+test("skills render through one shared SkillItem row with the path demoted to a tooltip", () => {
+  assert.match(src, /function SkillItem\(/, "shared row component");
+  const items = src.match(/<SkillItem\b/g) ?? [];
+  assert.ok(items.length >= 3, `all three provenance groups use SkillItem (got ${items.length})`);
+  assert.match(src, /<li className="px-2 py-1\.5" title=\{sourcePath\}>/, "source path is a tooltip, not body copy");
+  // Raw workspace paths no longer run as visible copy.
+  assert.doesNotMatch(src, /No skills in ~\/\.openclaw/, "empty copy no longer recites raw paths");
+  assert.doesNotMatch(src, /inherited from: roles\//, "role provenance path is not body copy");
+  assert.match(src, /title=\{`Inherited from roles\/\$\{role\.id\}\/ROLE\.md`\}/, "role provenance lives in the row tooltip");
+});
+
+test("every teach state has a real CTA riding cave:navigate-mode", () => {
+  assert.match(src, /function navigateMode\(mode: "roles" \| "capabilities" \| "marketplace"\)/, "navigate helper");
+  assert.match(src, /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode \} \}\)/, "workspace bridge event");
+  assert.match(src, /No roles active for this familiar\.[\s\S]{0,200}?CapCta label="Open Roles →" onClick=\{\(\) => navigateMode\("roles"\)\}/, "roles empty → Open Roles");
+  assert.match(src, /No plugins in the latest runtime capability scan\.[\s\S]{0,200}?CapCta label="Open Capabilities →" onClick=\{\(\) => navigateMode\("capabilities"\)\}/, "plugins empty → Open Capabilities");
+  assert.match(src, /No skills installed for this familiar yet\.[\s\S]{0,200}?CapCta label="Browse Marketplace →" onClick=\{\(\) => navigateMode\("marketplace"\)\}/, "familiar skills empty → Browse Marketplace");
+  assert.match(src, /function CapCta\([\s\S]*?focus-ring/, "CTA buttons carry the shared focus ring");
+});
+
+test("chip diet: enabled is silent, only disabled earns a marker (and a dimmed row)", () => {
+  assert.doesNotMatch(src, /\{p\.enabled \? "enabled" : "disabled"\}/, "no enabled/disabled twin chips");
+  const disabledMarkers = src.match(/\{p\.enabled \? null : \(/g) ?? [];
+  assert.ok(disabledMarkers.length >= 2, "plugins + MCP rows only mark the disabled exception");
+  const dimmedRows = src.match(/p\.enabled \? "" : "opacity-60"/g) ?? [];
+  assert.ok(dimmedRows.length >= 2, "disabled rows dim instead of chipping");
+});
+
+test("collapsible groups are keyboard-honest: aria-expanded + focus ring", () => {
+  const section = src.slice(src.indexOf("function CollapsibleSection"), src.indexOf("// ── Main panel"));
+  assert.match(section, /aria-expanded=\{open\}/, "toggle announces its state");
+  assert.match(section, /focus-ring/, "toggle has the shared focus ring");
+});
+
+test("runtime section drops the duplicate runtime row; loading shimmer is grid-shaped", () => {
+  assert.doesNotMatch(src, /<CapRow label="runtime"/, "the header scope already names the runtime");
+  assert.match(
+    src,
+    /if \(loading\) \{[\s\S]*?<div className="familiar-tab__grid" aria-hidden>[\s\S]*?<SkeletonRows[\s\S]*?<SkeletonRows/,
+    "loading shimmer mirrors the two-column grid it resolves into",
+  );
+});

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -657,20 +657,76 @@ function CapRow({ label, value, mono }: { label: string; value: string; mono?: b
   );
 }
 
+/** Neutral kind marker — the kind is metadata, not a status: one quiet style
+ *  for every kind (the old per-kind color map was accent soup on every row). */
 function KindBadge({ kind }: { kind: string }) {
-  const colorMap: Record<string, string> = {
-    agent: "bg-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] text-[var(--accent-presence)]",
-    harness: "bg-[color-mix(in_oklch,var(--accent-presence-soft)_20%,transparent)] text-[var(--accent-presence-soft)]",
-    hybrid: "bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)] text-[var(--color-success)]",
-    mcp: "bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] text-[var(--color-warning)]",
-    builtin: "bg-[var(--bg-raised)] text-[var(--text-muted)]",
-  };
-  const k = (kind ?? "").toLowerCase();
-  const cls = colorMap[k] ?? "bg-[var(--bg-raised)] text-[var(--text-muted)]";
   return (
-    <span className={`rounded px-1 text-[10px] uppercase tracking-wider ${cls}`}>
+    <span className="rounded bg-[var(--bg-raised)] px-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
       {kind || "—"}
     </span>
+  );
+}
+
+/** Navigate the workspace to a management surface (Roles / Capabilities /
+ *  Marketplace hub) through the same `cave:navigate-mode` bridge every other
+ *  cross-surface link uses. */
+function navigateMode(mode: "roles" | "capabilities" | "marketplace"): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
+}
+
+/** Teach-state CTA — every empty state gets a real affordance, not a
+ *  dead-end sentence naming a page. */
+function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="focus-ring mt-1.5 inline-flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
+    >
+      {label}
+    </button>
+  );
+}
+
+/** One de-boxed skill row, shared by all three provenance groups: quiet name
+ *  + kind, one-line description, neutral tag chips — and the source path
+ *  demoted from body copy to a hover/focus tooltip. */
+function SkillItem({
+  name,
+  kind,
+  description,
+  tags,
+  sourcePath,
+}: {
+  name: string;
+  kind: string;
+  description?: string;
+  tags?: string[];
+  sourcePath?: string;
+}) {
+  return (
+    <li className="px-2 py-1.5" title={sourcePath}>
+      <div className="flex items-center gap-1.5">
+        <span className="font-medium text-[var(--text-primary)]">{name}</span>
+        <KindBadge kind={kind} />
+      </div>
+      {description ? (
+        <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">{description}</p>
+      ) : null}
+      {tags && tags.length > 0 ? (
+        <div className="mt-0.5 flex flex-wrap gap-1">
+          {tags.map((t) => (
+            <span
+              key={t}
+              className="rounded bg-[var(--bg-raised)] px-1 text-[10px] text-[var(--text-muted)]"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </li>
   );
 }
 
@@ -679,21 +735,20 @@ function CollapsibleSection({
   badge,
   open,
   onToggle,
-  accentClass,
   children,
 }: {
   title: string;
   badge?: string;
   open: boolean;
   onToggle: () => void;
-  accentClass?: string;
   children: React.ReactNode;
 }) {
   return (
-    <div className={`rounded border border-[var(--border-hairline)] ${accentClass ?? ""}`}>
+    <div className="familiar-tab__list">
       <button
         onClick={onToggle}
-        className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]/40"
+        aria-expanded={open}
+        className="focus-ring flex w-full items-center gap-1.5 rounded-[inherit] px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]/40"
       >
         <Icon
           name={open ? "ph:caret-down" : "ph:caret-right"}
@@ -875,12 +930,16 @@ function FamiliarCapabilityPanel({
   }
 
   // The identity hero needs nothing from the capability fetches — paint it
-  // immediately and keep the skeleton for the capability grid alone.
+  // immediately and keep the shimmer for the capability grid alone, shaped
+  // like the grid it resolves into.
   if (loading) {
     return (
       <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
         <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} />
-        <SkeletonRows count={6} className="p-3" />
+        <div className="familiar-tab__grid" aria-hidden>
+          <SkeletonRows count={5} className="p-3" />
+          <SkeletonRows count={5} className="p-3" />
+        </div>
       </div>
     );
   }
@@ -945,39 +1004,40 @@ function FamiliarCapabilityPanel({
       {/* ── Section 1: Roles ──────────────────────────────────────────────── */}
       <CapSection title="Roles" scope={`active: ${activeRoles.length}`}>
         {activeRoles.length === 0 ? (
-          <p className="rounded border border-dashed border-[var(--border-hairline)] px-2 py-2 text-[var(--text-muted)]">
-            No roles active — activate one in the Roles page.
-          </p>
+          <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
+            <p>No roles active for this familiar.</p>
+            <CapCta label="Open Roles →" onClick={() => navigateMode("roles")} />
+          </div>
         ) : (
-          <ul className="space-y-1.5">
-            {activeRoles.map((role) => (
-              <li
-                key={`${role.familiar}:${role.id}`}
-                className="rounded border border-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)] px-2 py-1.5"
-              >
-                <div className="flex items-center gap-1.5">
-                  <Icon name="ph:sparkle" width={13} className="shrink-0 text-[var(--accent-presence)]" />
-                  <span className="font-medium text-[var(--text-primary)]">{role.name}</span>
-                  <span className="ml-auto rounded bg-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] px-1 text-[10px] text-[var(--accent-presence)]">
-                    {role.familiar}
-                  </span>
-                  {role.skills.length > 0 ? (
-                    <span className="rounded bg-[var(--bg-raised)] px-1 text-[10px] text-[var(--text-muted)]">
-                      {role.skills.length} skill{role.skills.length === 1 ? "" : "s"}
+          <div className="familiar-tab__list">
+            <ul className="familiar-tab__rows">
+              {activeRoles.map((role) => (
+                <li
+                  key={`${role.familiar}:${role.id}`}
+                  className="px-3 py-2"
+                  title={`Inherited from roles/${role.id}/ROLE.md`}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <Icon name="ph:sparkle" width={13} className="shrink-0 text-[var(--text-secondary)]" aria-hidden />
+                    <span className="font-medium text-[var(--text-primary)]">{role.name}</span>
+                    <span className="ml-auto text-[10px] text-[var(--text-muted)]">
+                      {role.familiar}
                     </span>
+                    {role.skills.length > 0 ? (
+                      <span className="rounded bg-[var(--bg-raised)] px-1 text-[10px] text-[var(--text-muted)]">
+                        {role.skills.length} skill{role.skills.length === 1 ? "" : "s"}
+                      </span>
+                    ) : null}
+                  </div>
+                  {role.description ? (
+                    <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">
+                      {role.description}
+                    </p>
                   ) : null}
-                </div>
-                {role.description ? (
-                  <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">
-                    {role.description}
-                  </p>
-                ) : null}
-                <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">
-                  inherited from: roles/{role.id}/ROLE.md
-                </p>
-              </li>
-            ))}
-          </ul>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </CapSection>
 
@@ -992,37 +1052,19 @@ function FamiliarCapabilityPanel({
               badge={`${roleGrantedSkillIds.size} via active roles`}
               open={skillsRoleOpen}
               onToggle={() => setSkillsRoleOpen((v) => !v)}
-              accentClass="border-l-2 border-l-[var(--accent-presence)]"
             >
-              <ul className="space-y-1 pt-1">
+              <ul className="familiar-tab__rows pt-1">
                 {Array.from(roleGrantedSkillIds).map((sid) => {
                   const skill = localSkills.find((s) => s.id === sid);
                   return (
-                    <li key={sid} className="rounded bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)] px-2 py-1">
-                      <div className="flex items-center gap-1.5">
-                        <span className="font-medium text-[var(--text-primary)]">
-                          {skill?.name ?? sid}
-                        </span>
-                        <KindBadge kind={skill?.kind ?? "agent"} />
-                      </div>
-                      {skill?.description ? (
-                        <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">
-                          {skill.description}
-                        </p>
-                      ) : null}
-                      {skill?.tags && skill.tags.length > 0 ? (
-                        <div className="mt-0.5 flex flex-wrap gap-1">
-                          {skill.tags.map((t) => (
-                            <span
-                              key={t}
-                              className="rounded bg-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] px-1 text-[10px] text-[var(--accent-presence)]"
-                            >
-                              {t}
-                            </span>
-                          ))}
-                        </div>
-                      ) : null}
-                    </li>
+                    <SkillItem
+                      key={sid}
+                      name={skill?.name ?? sid}
+                      kind={skill?.kind ?? "agent"}
+                      description={skill?.description}
+                      tags={skill?.tags}
+                      sourcePath="Granted by an active role"
+                    />
                   );
                 })}
               </ul>
@@ -1035,41 +1077,23 @@ function FamiliarCapabilityPanel({
             badge={String(familiarSkills.length)}
             open={skillsFamiliarOpen}
             onToggle={() => setSkillsFamiliarOpen((v) => !v)}
-            accentClass="border-l-2 border-l-[var(--color-success)]"
           >
             {familiarSkills.length === 0 ? (
-              <p className="pt-1 text-[10px] text-[var(--text-muted)]">
-                No skills in ~/.openclaw/workspace/{familiar.id}/skills/
-              </p>
+              <div className="px-1 pb-1 pt-1 text-[10px] text-[var(--text-muted)]">
+                <p>No skills installed for this familiar yet.</p>
+                <CapCta label="Browse Marketplace →" onClick={() => navigateMode("marketplace")} />
+              </div>
             ) : (
-              <ul className="space-y-1 pt-1">
+              <ul className="familiar-tab__rows pt-1">
                 {familiarSkills.map((s) => (
-                  <li key={s.path} className="rounded bg-[color-mix(in_oklch,var(--color-success)_10%,transparent)] px-2 py-1">
-                    <div className="flex items-center gap-1.5">
-                      <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
-                      <KindBadge kind={s.kind ?? "agent"} />
-                    </div>
-                    {s.description ? (
-                      <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">
-                        {s.description}
-                      </p>
-                    ) : null}
-                    {s.tags && s.tags.length > 0 ? (
-                      <div className="mt-0.5 flex flex-wrap gap-1">
-                        {s.tags.map((t) => (
-                          <span
-                            key={t}
-                            className="rounded bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)] px-1 text-[10px] text-[var(--color-success)]"
-                          >
-                            {t}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-                    <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">
-                      ~/.openclaw/workspace/{familiar.id}/skills/
-                    </p>
-                  </li>
+                  <SkillItem
+                    key={s.path}
+                    name={s.name}
+                    kind={s.kind ?? "agent"}
+                    description={s.description}
+                    tags={s.tags}
+                    sourcePath={s.path}
+                  />
                 ))}
               </ul>
             )}
@@ -1083,38 +1107,20 @@ function FamiliarCapabilityPanel({
             onToggle={() => setSkillsGlobalOpen((v) => !v)}
           >
             {globalSkills.length === 0 ? (
-              <p className="pt-1 text-[10px] text-[var(--text-muted)]">
-                No skills in ~/.openclaw/workspace/skills/
+              <p className="px-1 pb-1 pt-1 text-[10px] text-[var(--text-muted)]">
+                No global workspace skills.
               </p>
             ) : (
-              <ul className="space-y-1 pt-1">
+              <ul className="familiar-tab__rows pt-1">
                 {globalSkills.map((s) => (
-                  <li key={s.path} className="rounded bg-[var(--bg-raised)]/60 px-2 py-1">
-                    <div className="flex items-center gap-1.5">
-                      <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
-                      <KindBadge kind={s.kind ?? "agent"} />
-                    </div>
-                    {s.description ? (
-                      <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">
-                        {s.description}
-                      </p>
-                    ) : null}
-                    {s.tags && s.tags.length > 0 ? (
-                      <div className="mt-0.5 flex flex-wrap gap-1">
-                        {s.tags.map((t) => (
-                          <span
-                            key={t}
-                            className="rounded bg-[var(--bg-raised)] px-1 text-[10px] text-[var(--text-secondary)]"
-                          >
-                            {t}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-                    <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">
-                      ~/.openclaw/workspace/skills/
-                    </p>
-                  </li>
+                  <SkillItem
+                    key={s.path}
+                    name={s.name}
+                    kind={s.kind ?? "agent"}
+                    description={s.description}
+                    tags={s.tags}
+                    sourcePath={s.path}
+                  />
                 ))}
               </ul>
             )}
@@ -1128,35 +1134,33 @@ function FamiliarCapabilityPanel({
       {/* ── Section 3: Plugins ────────────────────────────────────────────── */}
       <CapSection title="Plugins" scope={`${nonMcpPlugins.length} from runtime`}>
         {nonMcpPlugins.length === 0 ? (
-          <p className="rounded border border-dashed border-[var(--border-hairline)] px-2 py-2 text-[var(--text-muted)]">
-            No plugins in runtime capability scan. Run /refresh in the Capabilities page.
-          </p>
+          <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
+            <p>No plugins in the latest runtime capability scan.</p>
+            <CapCta label="Open Capabilities →" onClick={() => navigateMode("capabilities")} />
+          </div>
         ) : (
-          <ul className="space-y-1.5">
-            {nonMcpPlugins.map((p) => (
-              <li
-                key={p.id}
-                className="rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1.5"
-              >
-                <div className="flex items-center gap-1.5">
-                  <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
-                  <KindBadge kind={p.kind} />
-                  <span
-                    className={`rounded px-1 text-[10px] uppercase tracking-wider ${
-                      p.enabled
-                        ? "bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)] text-[var(--color-success)]"
-                        : "bg-[var(--bg-raised)] text-[var(--text-muted)]"
-                    }`}
-                  >
-                    {p.enabled ? "enabled" : "disabled"}
-                  </span>
-                </div>
-                {p.command ? (
-                  <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">{p.command}</p>
-                ) : null}
-              </li>
-            ))}
-          </ul>
+          <div className="familiar-tab__list">
+            <ul className="familiar-tab__rows">
+              {nonMcpPlugins.map((p) => (
+                <li key={p.id} className={`px-3 py-2 ${p.enabled ? "" : "opacity-60"}`}>
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
+                    <KindBadge kind={p.kind} />
+                    {/* Chip diet: enabled is the expected state — only the
+                        exception (disabled) earns a marker. */}
+                    {p.enabled ? null : (
+                      <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  {p.command ? (
+                    <p className="mt-0.5 truncate font-mono text-[10px] text-[var(--text-muted)]">{p.command}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </CapSection>
 
@@ -1170,7 +1174,6 @@ function FamiliarCapabilityPanel({
         }
       >
         <ul className="space-y-1">
-          <CapRow label="runtime" value={harnessId} />
           <CapRow label="binary" value={harnessReport?.binary ?? "—"} />
           <CapRow label="path" value={harnessReport?.path ?? "—"} mono />
           <CapRow label="version" value={harnessReport?.version ?? "—"} />
@@ -1184,38 +1187,32 @@ function FamiliarCapabilityPanel({
       {/* ── Section 5: MCP Servers ───────────────────────────────────────── */}
       <CapSection title="MCP Servers" scope={`${mcpPlugins.length} discovered`}>
         {mcpPlugins.length === 0 ? (
-          <p className="rounded border border-dashed border-[var(--border-hairline)] px-2 py-2 text-[var(--text-muted)]">
-            No MCP servers in capability scan.
+          <p className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
+            No MCP servers in the capability scan.
           </p>
         ) : (
-          <ul className="space-y-1.5">
-            {mcpPlugins.map((p) => (
-              <li
-                key={p.id}
-                className="rounded border border-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_5%,transparent)] px-2 py-1.5"
-              >
-                <div className="flex items-center gap-1.5">
-                  <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
-                  <KindBadge kind="mcp" />
-                  <span
-                    className={`rounded px-1 text-[10px] uppercase tracking-wider ${
-                      p.enabled
-                        ? "bg-[color-mix(in_oklch,var(--color-success)_20%,transparent)] text-[var(--color-success)]"
-                        : "bg-[var(--bg-raised)] text-[var(--text-muted)]"
-                    }`}
-                  >
-                    {p.enabled ? "enabled" : "disabled"}
-                  </span>
-                </div>
-                {p.command ? (
-                  <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">{p.command}</p>
-                ) : null}
-                {p.args && p.args.length > 0 ? (
-                  <p className="mt-0.5 font-mono text-[10px] text-[var(--text-muted)]">{p.args.join(" ")}</p>
-                ) : null}
-              </li>
-            ))}
-          </ul>
+          <div className="familiar-tab__list">
+            <ul className="familiar-tab__rows">
+              {mcpPlugins.map((p) => (
+                <li key={p.id} className={`px-3 py-2 ${p.enabled ? "" : "opacity-60"}`}>
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
+                    <KindBadge kind="mcp" />
+                    {p.enabled ? null : (
+                      <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  {p.command ? (
+                    <p className="mt-0.5 truncate font-mono text-[10px] text-[var(--text-muted)]" title={[p.command, ...(p.args ?? [])].join(" ")}>
+                      {[p.command, ...(p.args ?? [])].join(" ")}
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </CapSection>
 


### PR DESCRIPTION
## Familiar tab elevation 2/3 (cave-7e1l, umbrella cave-5vvp; follows #3116)

The inspector-era capability sections put an **accent tint, border, or colored chip on nearly every row** — a 5-color `KindBadge`, accent-boxed role rows, color-coded skill sub-groups (accent/success left borders + matching tag chips), warning-tinted MCP boxes, and twin enabled/disabled chips. Empty states named pages with no affordance ("activate one in the Roles page"), and raw filesystem paths (`inherited from: roles/<id>/ROLE.md`, `~/.openclaw/workspace/<id>/skills/`) ran as body copy.

### What changed
- **De-box** — one `.familiar-tab__list` wash + soft inset hairline per group, hairline dividers between rows (the merged facelift idiom from #3095/#3103). No per-row boxes, no accent tints on metadata; accent stays reserved for presence (the hero's active-session chip).
- **Neutral `KindBadge`** — kind is metadata, not a status; the per-kind color map is gone.
- **Chip diet** (per the #3095 precedent) — *enabled* is the expected state and stays silent; only *disabled* earns a quiet marker + dimmed row.
- **Paths → tooltips** — one shared `SkillItem` row for all three provenance groups; role provenance and workspace paths live in `title` tooltips, not body copy.
- **Teach states with real CTAs** riding `cave:navigate-mode`: Roles → **Open Roles →**, Plugins → **Open Capabilities →**, familiar skills → **Browse Marketplace →**. Functionally probed: the click lands on the Roles hub.
- **A11y** — collapsible toggles announce `aria-expanded` and carry `.focus-ring`.
- **Polish** — Runtime section drops its duplicate `runtime` row; the loading shimmer is shaped like the grid it resolves into.

### Tests
- New pin `src/components/familiar-tab-sections.test.ts` (neutral badge, de-box contract incl. CSS, SkillItem/tooltip demotion, CTA contract, chip diet, aria-expanded, runtime dedup + grid shimmer) — wired into `run-tests.mjs`.
- All existing inspector-pane + familiar-tab-hero pins pass unchanged. No coverage deleted.

### Verification
- `pnpm typecheck` + `pnpm build` green
- Full `pnpm test:app`: **686 files green**
- Playwright 1440×900 + iPhone 13 (populated / empty / API-failure); CTA navigation verified end-to-end (gallery in session evidence)
