### PR TITLE
feat(onboarding): setup failures carry a hint and an in-banner retry — never a dead end (cave-r6ro)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -548,6 +548,7 @@ export const SUITES = {
     "src/lib/onboarding-familiars.test.ts",
     "src/lib/onboarding-gate.test.ts",
     "src/lib/onboarding-install-queue.test.ts",
+    "src/lib/onboarding-setup-failure.test.ts",
     "src/app/onboarding-install-route.test.ts",
     "src/lib/openclaw-agents.test.ts",
     "src/lib/openclaw-conversation-tools.test.ts",

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -24,6 +24,11 @@ import {
 } from "@/lib/opencoven-tools-status-display";
 import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
+  classifySetupFailure,
+  setupRetryLabel,
+  type SetupFailure,
+} from "@/lib/onboarding-setup-failure";
+import {
   openCovenToolActionTargets,
   openCovenToolsInstallCommand,
   openCovenToolsPrimaryActionLabel,
@@ -350,7 +355,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [platform, setPlatform] = useState<PlatformId>("unknown");
   const [picking, setPicking] = useState<string | null>(null);
   const [startingDaemon, setStartingDaemon] = useState(false);
-  const [setupError, setSetupError] = useState<string | null>(null);
+  // Structured failure for the scaffold / daemon-start / connection actions:
+  // verbatim message + derived hint + the action to retry (never a bare
+  // string, so the banner can always offer the matching retry affordance).
+  const [setupError, setSetupError] = useState<SetupFailure | null>(null);
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
   // Consecutive /api/harnesses failures — the empty-list retry loop gives up
   // once this hits HARNESS_RETRY_BUDGET and StepRuntimes offers a Retry.
@@ -923,7 +931,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         throw new Error(json.error ?? "setup failed");
       await refresh();
     } catch (err) {
-      setSetupError(err instanceof Error ? err.message : "setup failed");
+      setSetupError(classifySetupFailure("scaffold", err));
     } finally {
       setPicking(null);
     }
@@ -955,7 +963,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       }
       await refresh();
     } catch (err) {
-      setSetupError(err instanceof Error ? err.message : "daemon start failed");
+      setSetupError(classifySetupFailure("daemon-start", err));
     } finally {
       setStartingDaemon(false);
     }
@@ -998,10 +1006,23 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       if (!res.ok || json.ok === false) throw new Error(json.error ?? "connection setup failed");
       await refresh();
     } catch (err) {
-      setSetupError(err instanceof Error ? err.message : "connection setup failed");
+      setSetupError(classifySetupFailure("connection-save", err));
     } finally {
       setSavingOnboardingConnection(false);
     }
+  };
+
+  // The banner's retry re-runs exactly the action that failed. Busy-state
+  // mirrors each action's own in-flight flag so a double-click can't stack
+  // requests, and every action clears setupError on entry — a successful
+  // retry removes the banner by construction.
+  const setupRetryBusy =
+    picking !== null || startingDaemon || savingOnboardingConnection;
+  const retrySetupAction = () => {
+    if (!setupError || setupRetryBusy) return;
+    if (setupError.action === "scaffold") void scaffoldOnly();
+    else if (setupError.action === "daemon-start") void startDaemon();
+    else void saveOnboardingConnection();
   };
 
 
@@ -1287,20 +1308,41 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           // Every setup action (scaffold, daemon start, familiar create,
           // connection save) reports through this banner — it must be a live
           // alert or screen-reader users never hear why their click did
-          // nothing, and it must be dismissible so a stale error doesn't
-          // outlive the retry.
+          // nothing. It carries the verbatim failure, one derived hint, and
+          // the matching retry affordance (classifySetupFailure), and stays
+          // dismissible so a stale error doesn't outlive the retry.
           <section
             role="alert"
-            className="mt-5 flex items-start justify-between gap-3 rounded-lg border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] p-4 text-[13px] text-[var(--color-danger)]"
+            className="mt-5 flex flex-wrap items-start justify-between gap-3 rounded-lg border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] p-4 text-[13px] text-[var(--color-danger)]"
           >
-            <div>{setupError}</div>
-            <button
-              type="button"
-              onClick={() => setSetupError(null)}
-              className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] px-2 py-1 font-mono text-[11px] text-[var(--color-danger)] hover:bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)]"
-            >
-              Dismiss
-            </button>
+            <div className="min-w-0 flex-1">
+              <div className="whitespace-pre-wrap break-words font-medium">
+                {setupError.message}
+              </div>
+              {setupError.hint ? (
+                <p className="mt-1 leading-5 text-[var(--text-secondary)]">
+                  {setupError.hint}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={retrySetupAction}
+                disabled={setupRetryBusy}
+                aria-busy={setupRetryBusy}
+                className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] px-2 py-1 font-mono text-[11px] text-[var(--color-danger)] hover:bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)] disabled:opacity-50"
+              >
+                {setupRetryLabel(setupError.action)}
+              </button>
+              <button
+                type="button"
+                onClick={() => setSetupError(null)}
+                className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] px-2 py-1 font-mono text-[11px] text-[var(--color-danger)] hover:bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)]"
+              >
+                Dismiss
+              </button>
+            </div>
           </section>
         ) : null}
 

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -238,4 +238,36 @@ assert.match(
   "the footer CTA only promises a summoning when the roster is actually empty",
 );
 
+// ── cave-r6ro: setup failures carry a hint and a retry, never a dead end ─────
+// scaffold / daemon-start / connection-save previously dumped a raw message
+// into the banner with only a Dismiss — no next step, no way to try again
+// without hunting for the original button.
+for (const action of ["scaffold", "daemon-start", "connection-save"]) {
+  assert.match(
+    source,
+    new RegExp(`classifySetupFailure\\("${action}", err\\)`),
+    `${action} failures are classified into message + derived hint`,
+  );
+}
+assert.match(
+  source,
+  /\{setupError\.hint \? \(/,
+  "the banner renders the derived hint when the failure class is known",
+);
+assert.match(
+  source,
+  /onClick=\{retrySetupAction\}/,
+  "the banner offers a retry that re-runs exactly the failed action",
+);
+assert.match(
+  source,
+  /\{setupRetryLabel\(setupError\.action\)\}/,
+  "the retry affordance names the action it will re-run",
+);
+assert.match(
+  source,
+  /if \(!setupError \|\| setupRetryBusy\) return;/,
+  "retry is a no-op while the action is already in flight (no stacked requests)",
+);
+
 console.log("onboarding-polish.test.ts: ok");

--- a/src/lib/onboarding-setup-failure.test.ts
+++ b/src/lib/onboarding-setup-failure.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import {
+  classifySetupFailure,
+  setupRetryLabel,
+} from "./onboarding-setup-failure.ts";
+
+// ── Message handling ─────────────────────────────────────────────────────────
+assert.equal(
+  classifySetupFailure("scaffold", new Error("EACCES: permission denied, mkdir '/Users/x/.coven'")).message,
+  "EACCES: permission denied, mkdir '/Users/x/.coven'",
+  "the raw message is kept verbatim for diagnostics",
+);
+assert.equal(
+  classifySetupFailure("daemon-start", "").message,
+  "daemon start failed",
+  "an empty message falls back to the action's generic description",
+);
+assert.equal(
+  classifySetupFailure("connection-save", undefined).message,
+  "connection setup failed",
+  "a non-string failure falls back to the action's generic description",
+);
+
+// ── Taxonomy: each covered failure class yields one actionable hint ──────────
+const cliMissing = classifySetupFailure(
+  "daemon-start",
+  "Coven CLI not found on PATH. Open Setup to install it, then try again.",
+);
+assert.match(
+  cliMissing.hint ?? "",
+  /step 1 \(Install the Coven CLI\), then retry/,
+  "a missing coven binary routes the user to the CLI step",
+);
+
+const permission = classifySetupFailure(
+  "scaffold",
+  "EACCES: permission denied, mkdir '/Users/x/.coven'",
+);
+assert.match(
+  permission.hint ?? "",
+  /ownership and permissions of ~\/.coven/,
+  "permission failures explain the ~/.coven ownership fix",
+);
+
+const portHeld = classifySetupFailure("daemon-start", "listen EADDRINUSE: address already in use");
+assert.match(
+  portHeld.hint ?? "",
+  /Another process is holding the daemon's socket or port/,
+  "a held socket/port names the actual blocker",
+);
+
+const diskFull = classifySetupFailure("scaffold", "ENOSPC: no space left on device");
+assert.match(diskFull.hint ?? "", /disk is full/i, "ENOSPC maps to a disk-full hint");
+
+const daemonTimeout = classifySetupFailure("daemon-start", "timeout");
+assert.match(
+  daemonTimeout.hint ?? "",
+  /didn't come up within its start window/,
+  "a daemon start timeout explains warm-up and the retry path",
+);
+
+const transport = classifySetupFailure("scaffold", "Failed to fetch");
+assert.match(
+  transport.hint ?? "",
+  /local server didn't answer/,
+  "a dead sidecar maps to a restart-Cave hint",
+);
+
+const badConnection = classifySetupFailure("connection-save", "hubUrl must be a valid http(s) URL");
+assert.match(
+  badConnection.hint ?? "",
+  /hub URL and executor URLs/,
+  "connection validation failures point at the URL fields",
+);
+
+// Unclassifiable messages keep hint=null — the banner then shows only the raw
+// message plus the retry affordance, never an invented hint.
+assert.equal(
+  classifySetupFailure("scaffold", "something inscrutable").hint,
+  null,
+  "unknown failures never fabricate a hint",
+);
+
+// ── Retry labels ─────────────────────────────────────────────────────────────
+assert.equal(setupRetryLabel("scaffold"), "Retry creating Coven home");
+assert.equal(setupRetryLabel("daemon-start"), "Retry daemon start");
+assert.equal(setupRetryLabel("connection-save"), "Retry saving connection");
+
+console.log("onboarding-setup-failure.test.ts: ok");

--- a/src/lib/onboarding-setup-failure.ts
+++ b/src/lib/onboarding-setup-failure.ts
@@ -1,0 +1,79 @@
+// Failure taxonomy for the wizard's setup actions (Coven home scaffold,
+// daemon start, connection save). The install lane already ships hints from
+// its API route; these three actions surfaced raw error messages with no
+// next step and no retry, which strands exactly the users the wizard exists
+// for. classifySetupFailure keeps the raw message (diagnosable) and derives
+// one plain-language hint (actionable) from its shape.
+
+export type SetupAction = "scaffold" | "daemon-start" | "connection-save";
+
+export type SetupFailure = {
+  action: SetupAction;
+  /** Raw route/exception message — kept verbatim for diagnostics. */
+  message: string;
+  /** One plain-language next step, or null when the message defies classing. */
+  hint: string | null;
+};
+
+const ACTION_FALLBACK_MESSAGE: Record<SetupAction, string> = {
+  scaffold: "setup failed",
+  "daemon-start": "daemon start failed",
+  "connection-save": "connection setup failed",
+};
+
+/** The label the error banner's retry affordance shows for each action. */
+export function setupRetryLabel(action: SetupAction): string {
+  switch (action) {
+    case "scaffold":
+      return "Retry creating Coven home";
+    case "daemon-start":
+      return "Retry daemon start";
+    case "connection-save":
+      return "Retry saving connection";
+  }
+}
+
+function hintFor(action: SetupAction, message: string): string | null {
+  // Order matters: the first matching class wins, and the most specific
+  // shapes (missing binary, permissions, ports) come before generic
+  // transport failures.
+  if (/not found on PATH|ENOENT|spawn .*coven/i.test(message)) {
+    return action === "daemon-start"
+      ? "The daemon is started by the `coven` binary. Finish step 1 (Install the Coven CLI), then retry."
+      : "The Coven CLI wasn't found on PATH. Finish step 1 (Install the Coven CLI), then retry.";
+  }
+  if (/EACCES|EPERM|permission denied|read-only file system|EROFS/i.test(message)) {
+    return "Cave couldn't write to your home folder. Check ownership and permissions of ~/.coven (e.g. `ls -ld ~/.coven`), fix them, then retry.";
+  }
+  if (/EADDRINUSE|address already in use|socket.*in use|port .*in use/i.test(message)) {
+    return "Another process is holding the daemon's socket or port. Stop the other copy (or restart Cave so it can reconnect), then retry.";
+  }
+  if (/ENOSPC|no space left/i.test(message)) {
+    return "The disk is full. Free some space, then retry.";
+  }
+  if (/timeout|timed out|ETIMEDOUT/i.test(message)) {
+    return action === "daemon-start"
+      ? "The daemon didn't come up within its start window. It may still be warming up — wait a moment for the next status re-check, or retry."
+      : "The request timed out. The machine may be busy — retry in a moment.";
+  }
+  if (/failed to fetch|networkerror|fetch failed|ECONNREFUSED|load failed/i.test(message)) {
+    return "Cave's local server didn't answer. Restart Cave, then retry.";
+  }
+  if (/invalid|must be|expected/i.test(message) && action === "connection-save") {
+    return "Check the hub URL and executor URLs — every entry must be a reachable http(s) address.";
+  }
+  return null;
+}
+
+/** Build the structured failure the wizard's error banner renders: verbatim
+ *  message + derived hint. `raw` may be an Error, a string, or anything a
+ *  rejected fetch produced. */
+export function classifySetupFailure(action: SetupAction, raw: unknown): SetupFailure {
+  const message =
+    raw instanceof Error
+      ? raw.message
+      : typeof raw === "string" && raw.trim()
+        ? raw.trim()
+        : ACTION_FALLBACK_MESSAGE[action];
+  return { action, message, hint: hintFor(action, message) };
+}

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -173,4 +173,76 @@ test.describe("onboarding wizard", () => {
     await expect(wizard(page)).toHaveCount(0);
     await expect(page.getByRole("dialog", { name: "Summoning circle" })).toBeVisible({ timeout: 15_000 });
   });
+
+  test("a failed CLI install (npm missing) shows the hint and stays retryable", async ({ page }) => {
+    // The install route's npm-missing shape: the wizard must surface the hint
+    // (NodeSetupNotice + per-tool failure note) and keep the install button
+    // enabled — a machine without Node can never be a dead end.
+    let installCalls = 0;
+    await page.route("**/api/onboarding/install", (r) => {
+      if (r.request().method() !== "POST") return r.fallback();
+      installCalls += 1;
+      return r.fulfill({
+        status: 422,
+        json: {
+          ok: false,
+          npmMissing: true,
+          error: "npm is not available on PATH",
+          hint: "Install Node.js LTS from https://nodejs.org, then try again.",
+        },
+      });
+    });
+    await gotoApp(page, FRESH_STATUS);
+    await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
+
+    const install = wizard(page).getByRole("button", { name: "Install the Coven CLI", exact: true });
+    await install.click();
+    await expect(
+      wizard(page).getByText("Install Node.js LTS from https://nodejs.org, then try again."),
+    ).toBeVisible({ timeout: 10_000 });
+    expect(installCalls).toBeGreaterThanOrEqual(1);
+
+    // Retryable: the primary action is enabled again, and clicking it hits
+    // the route a second time.
+    await expect(install).toBeEnabled();
+    await install.click();
+    await expect.poll(() => installCalls, { timeout: 10_000 }).toBeGreaterThanOrEqual(2);
+  });
+
+  test("a failed daemon start shows message + hint and recovers through the banner's retry", async ({ page }) => {
+    // Structural steps healthy + daemon down: opening the wizard fires its
+    // one automatic daemon start. Fail every start until the flag flips —
+    // deterministic no matter which surface (wizard or workspace) calls
+    // first — then prove the banner's retry clears it on success.
+    let daemonStartShouldFail = true;
+    let startCalls = 0;
+    await page.route("**/api/daemon/start", (r) => {
+      startCalls += 1;
+      return daemonStartShouldFail
+        ? r.fulfill({
+            status: 504,
+            json: { ok: false, error: "timeout", stderr: "daemon did not answer health checks" },
+          })
+        : r.fulfill({ json: { ok: true, exitCode: 0, restart: false, stdout: "", stderr: "" } });
+    });
+    await gotoApp(page, DAEMON_DOWN_VETERAN_STATUS);
+    await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:onboarding-open")));
+    await expect(wizard(page)).toBeVisible({ timeout: 15_000 });
+
+    // The failure banner carries the verbatim error, the derived hint, and a
+    // retry naming the failed action.
+    const banner = wizard(page).getByRole("alert").filter({ hasText: "timeout" });
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+    await expect(banner.getByText(/didn't come up within its start window/)).toBeVisible();
+    const retry = banner.getByRole("button", { name: "Retry daemon start" });
+    await expect(retry).toBeVisible();
+    expect(startCalls).toBeGreaterThanOrEqual(1);
+
+    // Recovery: flip the route to success, retry from the banner, banner
+    // clears — the user never has to hunt for the original button.
+    daemonStartShouldFail = false;
+    await retry.click();
+    await expect(banner).toHaveCount(0, { timeout: 10_000 });
+  });
 });

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -95,6 +95,17 @@ async function gotoApp(page: Page, status: unknown, opts?: { dismissed?: boolean
 
 const wizard = (page: Page) => page.getByRole("dialog", { name: "Onboarding" });
 
+// cave-m3a8: the workspace registers its cave:onboarding-open listener in a
+// mount effect that can land AFTER the searchbox paints — on a cold CI
+// machine a single dispatch fires into the void and the dialog never opens.
+// Re-dispatch until the dialog exists; each attempt is cheap and idempotent.
+async function openWizardManually(page: Page) {
+  await expect(async () => {
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:onboarding-open")));
+    await expect(wizard(page)).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 20_000 });
+}
+
 test.describe("onboarding wizard", () => {
   test("auto-opens on a fresh machine and keeps keyboard focus trapped inside", async ({ page }) => {
     await gotoApp(page, FRESH_STATUS);
@@ -161,8 +172,7 @@ test.describe("onboarding wizard", () => {
     // event every setup entry point dispatches.
     await gotoApp(page, COMPLETE_NO_FAMILIARS_STATUS);
     await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
-    await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:onboarding-open")));
-    await expect(wizard(page)).toBeVisible({ timeout: 15_000 });
+    await openWizardManually(page);
 
     // The banner renders at the top — reachable without scrolling a long page.
     await expect(wizard(page).getByText("Setup complete — Cave is ready.")).toBeVisible();
@@ -227,8 +237,7 @@ test.describe("onboarding wizard", () => {
     });
     await gotoApp(page, DAEMON_DOWN_VETERAN_STATUS);
     await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
-    await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:onboarding-open")));
-    await expect(wizard(page)).toBeVisible({ timeout: 15_000 });
+    await openWizardManually(page);
 
     // The failure banner carries the verbatim error, the derived hint, and a
     // retry naming the failed action.


### PR DESCRIPTION
## What

Brings the wizard's **setup lane** (Coven home scaffold, daemon start, connection save) to error-handling parity with the install lane: every failure now yields (a) the verbatim message, (b) one derived plain-language hint, and (c) an in-banner **retry that re-runs exactly the failed action**.

- **New `src/lib/onboarding-setup-failure.ts`** — pure failure taxonomy. `classifySetupFailure(action, raw)` covers: missing `coven` binary (routes to step 1), `EACCES`/`EPERM` (~/.coven ownership fix), `EADDRINUSE` (who holds the daemon socket), `ENOSPC`, start-window timeouts, dead local sidecar, and connection URL validation. Unknown shapes keep `hint: null` — the banner never invents a hint.
- **Wizard**: `setupError` becomes the structured failure; the `role="alert"` banner renders message + hint + `setupRetryLabel(action)` retry (no-ops while the action is in flight; still dismissible). `copyDiagnostics` captures the structured failure.
- **e2e failure sims** (daemon-less, `page.route` mocks):
  - npm-missing install → hint stays visible, CTA stays enabled, second click re-hits the route
  - failed daemon auto-start → banner shows `timeout` + "didn't come up within its start window" + **Retry daemon start**; flipping the route to success and clicking retry clears the banner

## Why

Phase 3 of the zero-friction onboarding goal: graceful failures — nothing strands the user. The failing actions previously showed a raw message + Dismiss only.

## Testing

- `pnpm typecheck` ✅
- `node scripts/check-tests-wired.mjs` ✅ (new test registered)
- `pnpm test:app` ✅ 686 files
- `COVEN_CAVE_E2E=1 playwright test tests/onboarding-wizard.spec.ts --project=desktop` ✅ 12/12 (incl. both new failure sims)

## Beads

cave-r6ro. Goal chain: cave-u0uu (#3120, merged) → cave-m62w (other session) → **cave-r6ro (this)** → cave-f7d5.
