### PR TITLE
feat(chat): Settings toggle for merged-PR auto-archive

### DIFF
--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -84,6 +84,11 @@ assert.match(
 );
 assert.match(
   sweepModule,
+  /if \(!policy\.enabled \|\| !policy\.archiveOnPrMerge\) return new Map\(\);/,
+  "the merged sweep is gated by the Settings-tab policy (master switch + PR-merge toggle)",
+);
+assert.match(
+  sweepModule,
   /sweepMergedPrAutoArchive[\s\S]*?resolveArchiveNudges\(sessionId\)/,
   "swept chats clear their pending archive nudges",
 );

--- a/src/components/chat-settings-view.test.ts
+++ b/src/components/chat-settings-view.test.ts
@@ -53,13 +53,14 @@ assert.match(
   "settings view persists partial policies through the config PATCH merge",
 );
 
-// Every policy field is editable from the tab — master switch, both event
-// triggers (task completion + the new thread-reflection trigger), and the two
+// Every policy field is editable from the tab — master switch, the event
+// triggers (task completion, thread reflection, PR merge), and the two
 // idle windows.
 for (const field of [
   "enabled",
   "archiveOnTaskCompletion",
   "archiveOnReflection",
+  "archiveOnPrMerge",
   "externalAfterDays",
   "idleAfterDays",
 ]) {
@@ -78,6 +79,11 @@ assert.match(
   settingsView,
   /After thread reflection/,
   "the reflection auto-archive toggle is labeled for what it does",
+);
+assert.match(
+  settingsView,
+  /After PR merge/,
+  "the merged-PR auto-archive toggle is labeled for what it does",
 );
 
 // A failed save must not lie about state: revert the optimistic change.

--- a/src/components/chat-settings-view.tsx
+++ b/src/components/chat-settings-view.tsx
@@ -212,6 +212,18 @@ export function ChatSettingsView() {
                 />
               </PolicyRow>
               <PolicyRow
+                label="After PR merge"
+                description="Archive a chat once the pull request its work produced merges."
+                dimmed={sweepOff}
+              >
+                <PolicySwitch
+                  label="Archive after PR merge"
+                  checked={policy.archiveOnPrMerge}
+                  disabled={sweepOff}
+                  onChange={(archiveOnPrMerge) => update({ archiveOnPrMerge })}
+                />
+              </PolicyRow>
+              <PolicyRow
                 label="External chats idle for"
                 description="Chats created outside the chat surface (cron, flows, generated runs). 0 turns this window off."
                 dimmed={sweepOff}

--- a/src/lib/chat-auto-archive-sweep.ts
+++ b/src/lib/chat-auto-archive-sweep.ts
@@ -58,11 +58,12 @@ export async function sweepAutoArchive(
 /**
  * Sweep `rows` whose pull request has merged and archive them, recording each
  * (session, PR) pair in cave state so the sweep is one-shot — summoning the
- * chat later won't be undone by the next poll. Shares the policy sweep's
- * opt-outs (keep marks, extension windows / summon grace) and env kill-switch
- * (COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1). Returns sessionId → archivedAt for
- * rows archived by this call (empty when nothing was due or the sweep
- * failed).
+ * chat later won't be undone by the next poll. Gated by the configured policy
+ * (master switch + the `archiveOnPrMerge` toggle in the chat Settings tab)
+ * and the env kill-switch (COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1); shares the
+ * policy sweep's opt-outs (keep marks, extension windows / summon grace).
+ * Returns sessionId → archivedAt for rows archived by this call (empty when
+ * nothing was due or the sweep failed).
  */
 export async function sweepMergedPrAutoArchive(
   rows: MergedAutoArchiveRow[],
@@ -71,6 +72,9 @@ export async function sweepMergedPrAutoArchive(
 ): Promise<Map<string, string>> {
   try {
     if (process.env[MERGED_AUTO_ARCHIVE_DISABLE_ENV] === "1") return new Map();
+    const config = await loadConfig();
+    const policy = normalizeChatAutoArchivePolicy(config.chatAutoArchive);
+    if (!policy.enabled || !policy.archiveOnPrMerge) return new Map();
     const decisions = mergedChatAutoArchiveDecisions(
       rows,
       state.mergedPrAutoArchived ?? {},

--- a/src/lib/chat-auto-archive.test.ts
+++ b/src/lib/chat-auto-archive.test.ts
@@ -72,6 +72,21 @@ assert.equal(
   false,
   "non-boolean reflection flags fall back to the default",
 );
+assert.equal(
+  DEFAULT_CHAT_AUTO_ARCHIVE_POLICY.archiveOnPrMerge,
+  true,
+  "merged-PR auto-archive is on by default (preserves shipped behavior)",
+);
+assert.equal(
+  normalizeChatAutoArchivePolicy({ archiveOnPrMerge: false }).archiveOnPrMerge,
+  false,
+  "the Settings-tab toggle can turn merged-PR auto-archive off",
+);
+assert.equal(
+  normalizeChatAutoArchivePolicy({ archiveOnPrMerge: "no" }).archiveOnPrMerge,
+  true,
+  "non-boolean merged-PR flags fall back to the default",
+);
 
 // --- sessionCreatedExternally ------------------------------------------------
 

--- a/src/lib/chat-auto-archive.ts
+++ b/src/lib/chat-auto-archive.ts
@@ -12,6 +12,9 @@ import type { SessionOrigin, SessionRow } from "./types.ts";
  *    (self-report) lands for it — a reflection marks the thread as wrapped up.
  *    Off by default; toggled from the chat page's Settings tab. Periodic
  *    (mid-flight) reports never archive, only `manual`/`auto` reflections.
+ *  - `archiveOnPrMerge`: archive a chat when the pull request its work
+ *    produced merges (see merged-chat-auto-archive.ts). On by default —
+ *    a merged PR is the strongest "this thread is done" signal.
  *  - `externalAfterDays`: chats created outside the chat interface (cron,
  *    heartbeat, journal narratives, board/workflow-invoked runs, generated
  *    daemon sessions) archive after this many days without activity.
@@ -33,6 +36,8 @@ export type ChatAutoArchivePolicy = {
   archiveOnTaskCompletion: boolean;
   /** Archive the chat when a thread reflection (self-report) lands for it. */
   archiveOnReflection: boolean;
+  /** Archive the chat when the PR its work produced merges. */
+  archiveOnPrMerge: boolean;
   /** Days of inactivity before externally-created chats archive. 0 = off. */
   externalAfterDays: number;
   /** Days of inactivity before any chat archives. 0 = off. */
@@ -43,6 +48,7 @@ export const DEFAULT_CHAT_AUTO_ARCHIVE_POLICY: ChatAutoArchivePolicy = {
   enabled: true,
   archiveOnTaskCompletion: false,
   archiveOnReflection: false,
+  archiveOnPrMerge: true,
   externalAfterDays: 7,
   idleAfterDays: 30,
 };
@@ -77,6 +83,10 @@ export function normalizeChatAutoArchivePolicy(
       typeof raw.archiveOnReflection === "boolean"
         ? raw.archiveOnReflection
         : d.archiveOnReflection,
+    archiveOnPrMerge:
+      typeof raw.archiveOnPrMerge === "boolean"
+        ? raw.archiveOnPrMerge
+        : d.archiveOnPrMerge,
     externalAfterDays: clampDays(raw.externalAfterDays, d.externalAfterDays),
     idleAfterDays: clampDays(raw.idleAfterDays, d.idleAfterDays),
   };

--- a/src/lib/merged-chat-auto-archive.ts
+++ b/src/lib/merged-chat-auto-archive.ts
@@ -15,6 +15,8 @@
 //    (`sessionKeep`, "never auto-archive") and chats inside an extension
 //    window (`sessionArchiveExtendedUntil` — explicit extensions and the
 //    summon grace) are never swept.
+//  - Gated by the chat auto-archive policy: the Settings tab's master switch
+//    and `archiveOnPrMerge` toggle both must be on (see the sweep wiring).
 //  - Opt-out via COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1.
 
 import {


### PR DESCRIPTION
## What

Follow-up to #3117. The merged-PR auto-archive could only be disabled via `COVEN_CAVE_NO_MERGED_AUTO_ARCHIVE=1` — invisible to users. This folds it into the chat auto-archive policy that the chat page's **Settings** tab already edits.

## Changes

- **`archiveOnPrMerge`** policy field (default **true** — preserves shipped behavior for existing users; `normalizeChatAutoArchivePolicy` tolerates partial/corrupt stored policies as usual).
- `sweepMergedPrAutoArchive()` loads the configured policy and runs only when **master switch AND PR-merge toggle** are on. Env kill-switch stays as ops-level hard override.
  - Behavior note: this also brings the merged sweep under the master switch — previously `enabled: false` users still had chats archived on merge.
- Settings tab: new **"After PR merge"** switch row (between reflection and the idle windows), dimmed with the rest when the master switch is off; persists through the existing `/api/config` PATCH merge.

## Verification

- `pnpm typecheck` clean
- `pnpm test:app` — 687 files pass (new normalize cases, Settings-tab pins, sweep policy-gate pin)
- `pnpm check:tests-wired` — 929 wired