### PR TITLE
fix(voice): surface provider error detail through the call overlay (cave-8c9c)

### DIFF
--- a/src/components/voice-call-overlay-state.test.ts
+++ b/src/components/voice-call-overlay-state.test.ts
@@ -90,6 +90,33 @@ test("live → error on PROVIDER_ERROR", () => {
   assert.equal(next.errorCode, "connect_failed");
 });
 
+test("PROVIDER_ERROR carries provider hint into error state", () => {
+  let s = reduce(initialState, { type: "START" });
+  s = reduce(s, { type: "MIC_READY" });
+  s = reduce(s, { type: "SESSION_GRANTED", callId: "c1" });
+  const next = reduce(s, {
+    type: "PROVIDER_ERROR",
+    errorCode: "sdp_exchange_failed_400",
+    hint: 'Model "mock-model" is not supported in realtime mode.',
+  });
+  assert.equal(next.state, "error");
+  assert.equal(next.errorCode, "sdp_exchange_failed_400");
+  assert.equal(next.hint, 'Model "mock-model" is not supported in realtime mode.');
+});
+
+test("PROVIDER_ERROR without hint clears any stale hint", () => {
+  let s = reduce(initialState, { type: "START" });
+  s = reduce(s, { type: "MIC_READY" });
+  s = reduce(s, {
+    type: "SESSION_FAILED",
+    errorCode: "vault_key_unresolved",
+    hint: "stale detail from an earlier failure",
+  });
+  const next = reduce(s, { type: "PROVIDER_ERROR", errorCode: "connect_failed" });
+  assert.equal(next.state, "error");
+  assert.equal(next.hint, undefined);
+});
+
 test("error → requesting-mic on RETRY (clears errorCode)", () => {
   const errored = reduce(reduce(initialState, { type: "START" }), { type: "MIC_DENIED" });
   const next = reduce(errored, { type: "RETRY" });

--- a/src/components/voice-call-overlay-state.ts
+++ b/src/components/voice-call-overlay-state.ts
@@ -28,7 +28,7 @@ export type CallEvent =
   | { type: "SESSION_FAILED"; errorCode: string; missingKey?: string; hint?: string }
   | { type: "CONNECTED"; startedAt: number }
   | { type: "DISCONNECTED" }
-  | { type: "PROVIDER_ERROR"; errorCode: string }
+  | { type: "PROVIDER_ERROR"; errorCode: string; hint?: string }
   | { type: "CLOSE_REQUEST" }
   | { type: "MUTE_TOGGLE" }
   | { type: "RETRY" };
@@ -58,7 +58,7 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
       if (s.state !== "connecting") return s;
       return { ...s, state: "live", startedAt: ev.startedAt };
     case "PROVIDER_ERROR":
-      return { ...s, state: "error", errorCode: ev.errorCode };
+      return { ...s, state: "error", errorCode: ev.errorCode, hint: ev.hint };
     case "CLOSE_REQUEST":
       if (s.state === "live") return { ...s, state: "ending" };
       return { ...s, state: "closed" };

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -98,4 +98,34 @@ assert.doesNotMatch(
   "the raw error code is no longer rendered as the headline",
 );
 
+// ── Provider error detail is threaded to the error UI, not swallowed ─────────
+// Was: clientAdapter.connect threw bare `sdp_exchange_failed_<status>` and the
+// PROVIDER_ERROR dispatches dropped everything but the code, so a stale
+// voiceModel surfaced only as "The call ran into a problem." (cave-8c9c)
+assert.match(
+  component,
+  /import\s+\{[^}]*voiceErrorHint[^}]*\}\s+from\s+["']@\/lib\/voice\/types["']/,
+  "overlay imports the shared voiceErrorHint extractor",
+);
+assert.match(
+  component,
+  /onError:\s*\(err\)\s*=>\s*dispatch\(\{\s*type:\s*"PROVIDER_ERROR",\s*errorCode:\s*err\.message,\s*hint:\s*voiceErrorHint\(err\)\s*\}\)/,
+  "live provider errors thread their hint into PROVIDER_ERROR",
+);
+assert.match(
+  component,
+  /type:\s*"PROVIDER_ERROR",[\s\S]{0,120}errorCode:\s*err instanceof Error \? err\.message : "connect_failed",[\s\S]{0,120}hint:\s*voiceErrorHint\(err\)/,
+  "connect failures thread their hint into PROVIDER_ERROR",
+);
+assert.match(
+  component,
+  /startsWith\("sdp_exchange_failed_"\)/,
+  "SDP-exchange failures get their own human headline",
+);
+assert.match(
+  component,
+  /\{state\.hint && <div className="voice-call-overlay__hint">\{state\.hint\}<\/div>\}/,
+  "the provider hint renders under the headline when present",
+);
+
 console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -7,6 +7,7 @@ import type { Familiar } from "@/lib/types";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { getVoiceProvider } from "@/lib/voice/registry";
 import type { LiveSession, VoiceSessionGrant } from "@/lib/voice/types";
+import { voiceErrorHint } from "@/lib/voice/types";
 import { reduce, initialState, type CallState } from "./voice-call-overlay-state";
 
 type Props = {
@@ -74,7 +75,7 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
             onUserTranscriptFinal: (text) => postTranscript(sessionId, callId, "user", text),
             onAssistantTranscriptFinal: (text) => postTranscript(sessionId, callId, "assistant", text),
             onPartialTranscript: () => { /* live caption surface, not persisted */ },
-            onError: (err) => dispatch({ type: "PROVIDER_ERROR", errorCode: err.message }),
+            onError: (err) => dispatch({ type: "PROVIDER_ERROR", errorCode: err.message, hint: voiceErrorHint(err) }),
             onDisconnect: () => dispatch({ type: "DISCONNECTED" }),
           });
           if (cancelled) { await live.close(); return; }
@@ -85,6 +86,7 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           dispatch({
             type: "PROVIDER_ERROR",
             errorCode: err instanceof Error ? err.message : "connect_failed",
+            hint: voiceErrorHint(err),
           });
         }
       } else if (state.state === "ending") {
@@ -212,6 +214,11 @@ function labelFor(s: CallState): string {
 // Turn the machine-readable error code into something a person can act on. The
 // raw code (and any provider detail) still surfaces via the `hint` line below.
 function errorMessage(code: string | undefined): string {
+  // Connection-phase rejections (e.g. an invalid voiceModel only surfaces at
+  // the SDP exchange); the provider's own detail renders as the hint below.
+  if (code?.startsWith("sdp_exchange_failed_")) {
+    return "The voice provider rejected the call setup.";
+  }
   switch (code) {
     case "microphone_denied":
       return "Microphone access was denied. Allow it in your browser settings to start a call.";

--- a/src/lib/voice/openai-realtime.test.ts
+++ b/src/lib/voice/openai-realtime.test.ts
@@ -10,7 +10,43 @@ let nextResponse: Response = new Response("{}", { status: 200 });
   return nextResponse;
 };
 
+// Minimal WebRTC stubs so clientAdapter.connect runs under node.
+let lastDataChannel: { onmessage: ((ev: { data: unknown }) => void) | null; close: () => void } | null = null;
+(globalThis as any).RTCPeerConnection = class {
+  ontrack: unknown = null;
+  onconnectionstatechange: unknown = null;
+  addTrack() {}
+  createDataChannel() {
+    lastDataChannel = { onmessage: null, close() {} };
+    return lastDataChannel;
+  }
+  async createOffer() { return { type: "offer", sdp: "v=0\r\n" }; }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  close() {}
+};
+(globalThis as any).MediaStream = class {
+  addTrack() {}
+  getAudioTracks() { return []; }
+};
+
+const fakeMic = { getAudioTracks: () => [] } as any;
+const noopCallbacks = {
+  onUserTranscriptFinal() {},
+  onAssistantTranscriptFinal() {},
+  onPartialTranscript() {},
+  onError() {},
+  onDisconnect() {},
+};
+const sdpGrant = {
+  provider: "openai",
+  clientSecret: "ek_test",
+  expiresAt: new Date().toISOString(),
+  connection: { kind: "openai-realtime", url: "https://api.openai.com/v1/realtime/calls" },
+} as any;
+
 const { openaiRealtimeProvider } = await import("./openai-realtime.ts");
+const { VoiceConnectError } = await import("./types.ts");
 
 test("mintSession POSTs to /v1/realtime/client_secrets with bearer auth", async () => {
   captured = [];
@@ -83,4 +119,51 @@ test("mintSession surfaces provider error message verbatim on non-2xx", async ()
     }),
     /model not enabled for this account/,
   );
+});
+
+test("connect: failed SDP exchange throws VoiceConnectError with provider detail as hint", async () => {
+  captured = [];
+  nextResponse = new Response(
+    JSON.stringify({ error: { message: 'Model "mock-model" is not supported in realtime mode.', code: "invalid_model" } }),
+    { status: 400 },
+  );
+  await assert.rejects(
+    () => openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, noopCallbacks),
+    (err: unknown) => {
+      assert.ok(err instanceof VoiceConnectError, "throws VoiceConnectError");
+      assert.equal(err.message, "sdp_exchange_failed_400");
+      assert.match(err.hint ?? "", /mock-model.*not supported in realtime mode/);
+      return true;
+    },
+  );
+});
+
+test("connect: failed SDP exchange with non-JSON body still throws coded error, no hint", async () => {
+  captured = [];
+  nextResponse = new Response("<html>bad gateway</html>", { status: 502 });
+  await assert.rejects(
+    () => openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, noopCallbacks),
+    (err: unknown) => {
+      assert.ok(err instanceof VoiceConnectError);
+      assert.equal(err.message, "sdp_exchange_failed_502");
+      assert.equal(err.hint, undefined);
+      return true;
+    },
+  );
+});
+
+test("data-channel error events surface provider message as hint under a stable code", async () => {
+  captured = [];
+  nextResponse = new Response("v=0\r\n", { status: 201 });
+  let seen: unknown = null;
+  await openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, {
+    ...noopCallbacks,
+    onError(err: unknown) { seen = err; },
+  });
+  lastDataChannel?.onmessage?.({
+    data: JSON.stringify({ type: "error", error: { message: "session expired" } }),
+  });
+  assert.ok(seen instanceof VoiceConnectError, "onError receives VoiceConnectError");
+  assert.equal((seen as any).message, "provider_error");
+  assert.equal((seen as any).hint, "session expired");
 });

--- a/src/lib/voice/openai-realtime.ts
+++ b/src/lib/voice/openai-realtime.ts
@@ -1,4 +1,5 @@
-import type { VoiceProvider, VoiceClientAdapter, LiveSession, VoiceCallbacks, VoiceSessionGrant } from "./types";
+import type { VoiceProvider, VoiceClientAdapter, LiveSession, VoiceCallbacks, VoiceSessionGrant } from "./types.ts";
+import { VoiceConnectError } from "./types.ts";
 
 const CLIENT_SECRETS_URL = "https://api.openai.com/v1/realtime/client_secrets";
 const REALTIME_BASE = "https://api.openai.com/v1/realtime";
@@ -88,7 +89,14 @@ const clientAdapter: VoiceClientAdapter = {
         body: offer.sdp,
       });
       if (!res.ok) {
-        throw new Error(`sdp_exchange_failed_${res.status}`);
+        // The mint endpoint accepts unknown models, so a bad voiceModel only
+        // surfaces here — keep the provider's explanation. (cave-8c9c)
+        let hint: string | undefined;
+        try {
+          const body = JSON.parse(await res.text()) as { error?: { message?: string } };
+          if (typeof body.error?.message === "string") hint = body.error.message;
+        } catch { /* non-JSON body: code alone */ }
+        throw new VoiceConnectError(`sdp_exchange_failed_${res.status}`, hint);
       }
       const answer = await res.text();
       await pc.setRemoteDescription({ type: "answer", sdp: answer });
@@ -127,7 +135,8 @@ function handleEvent(raw: unknown, callbacks: VoiceCallbacks) {
   } else if (type === "conversation.item.input_audio_transcription.delta") {
     if (typeof ev.delta === "string") callbacks.onPartialTranscript("user", ev.delta);
   } else if (type === "error") {
-    callbacks.onError(new Error(ev.error?.message ?? "provider_error"));
+    const detail = typeof ev.error?.message === "string" ? ev.error.message : undefined;
+    callbacks.onError(new VoiceConnectError("provider_error", detail));
   }
 }
 

--- a/src/lib/voice/types.ts
+++ b/src/lib/voice/types.ts
@@ -46,3 +46,22 @@ export interface LiveSession {
   setMuted(muted: boolean): void;
   close(): Promise<void>;
 }
+
+/**
+ * Connection-phase error: `message` stays a stable machine code (e.g.
+ * `sdp_exchange_failed_400`) while `hint` carries the human-readable detail
+ * the provider returned, so the overlay can show both. (cave-8c9c)
+ */
+export class VoiceConnectError extends Error {
+  hint?: string;
+  constructor(code: string, hint?: string) {
+    super(code);
+    this.name = "VoiceConnectError";
+    this.hint = hint;
+  }
+}
+
+/** Extract the provider detail from an unknown error, if it carries one. */
+export function voiceErrorHint(err: unknown): string | undefined {
+  return err instanceof VoiceConnectError ? err.hint : undefined;
+}


### PR DESCRIPTION
## Problem

OpenAI's `client_secrets` mint endpoint accepts unknown models, so a stale `voiceModel` (e.g. `mock-model` left in `~/.coven/cave/config.json` from mock testing) mints fine and only fails at the browser SDP exchange with HTTP 400 `invalid_model`. The client adapter threw bare `sdp_exchange_failed_400`, discarding OpenAI's explanation, and `PROVIDER_ERROR` carried no hint — the overlay showed only *“The call ran into a problem.”* (Debugged live: reproduced the mint-200 → SDP-400 sequence, and verified `gpt-realtime` handshakes HTTP 201 end-to-end.)

## Fix

- **`VoiceConnectError`** (`src/lib/voice/types.ts`): stable machine code in `message`, human provider detail in `hint`, plus a `voiceErrorHint()` extractor.
- **Adapter** (`openai-realtime.ts`): parses the SDP-exchange error body into the hint; data-channel `error` events now use stable code `provider_error` with the provider message as hint.
- **State** (`voice-call-overlay-state.ts`): `PROVIDER_ERROR` threads `hint` into the error state and clears stale hints.
- **Overlay** (`voice-call-overlay.tsx`): `sdp_exchange_failed_*` gets a human headline (“The voice provider rejected the call setup.”); the provider detail renders as the existing hint line.

## Testing

- TDD: new behavioral tests for the adapter (SDP failure → coded error + hint; non-JSON body → code only; data-channel error → `provider_error` + hint) and reducer (hint threaded, stale hint cleared), plus source pins for the JSX wiring — all watched fail first.
- `node --experimental-strip-types --no-warnings --test` across all 5 voice test files + overlay pins: **41/41 pass**.
- `pnpm typecheck` clean.

Closes bead `cave-8c9c`.