### PR TITLE
feat(chat): bridges + touch ergonomics for the Familiar tab (cave-aovo)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -511,6 +511,7 @@ export const SUITES = {
     "src/components/inspector-pane-surface.test.ts",
     "src/components/familiar-tab-hero.test.ts",
     "src/components/familiar-tab-sections.test.ts",
+    "src/components/familiar-tab-bridges.test.ts",
     "src/components/misc-aria-fixes.test.ts",
     "src/components/modal-trap-adoption.test.ts",
     "src/components/mode-toggle.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6244,6 +6244,22 @@ a.mobile-handoff__link:hover {
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent);
 }
 
+/* Coarse pointers: the hero's quiet links/actions and the group toggles are
+   10-11px targets tuned for a cursor — grow their hit areas on touch without
+   changing the pointer-fine rhythm. */
+@media (pointer: coarse) {
+  .familiar-tab__links a,
+  .familiar-tab__links button {
+    padding-block: 6px;
+  }
+  .familiar-tab__list > button {
+    padding-block: 10px;
+  }
+  .familiar-tab__cta {
+    padding-block: 8px;
+  }
+}
+
 /* ────────────────────────────────────────────────
    Settings · Familiars panel
    (Phase 5, shell-ia-redesign)

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -223,7 +223,7 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /scope === "familiar" \? \([\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
+  /scope === "familiar" \? \([\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} onStartChat=\{startFamiliarHeroChat\} \/>/,
   "the familiar scope renders the capability panel for the active familiar",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -469,6 +469,14 @@ export function ChatSurface({
     window.setTimeout(() => routerRef.current?.newChat(projectRoot), 0);
   }
 
+  // Hero "New chat" bridge: land on the conversation tab with a fresh session
+  // for this familiar (same latch-then-route shape as the handlers above).
+  function startFamiliarHeroChat(familiarId: string) {
+    onSetActiveFamiliar(familiarId);
+    setScope("conversation");
+    window.setTimeout(() => routerRef.current?.newChat(undefined, undefined, familiarId), 0);
+  }
+
   useEffect(() => {
     // Board→Projects handoffs fire the event from a surface where this
     // listener isn't mounted yet — consume the retained latch on mount so the
@@ -563,7 +571,7 @@ export function ChatSurface({
           // first-class chat tab, since it describes who you're chatting with.
           <div className="flex min-h-0 min-w-0 flex-1 justify-center">
             <div className="h-full w-full max-w-5xl">
-              <InspectorPane familiar={activeFamiliar} tab="familiar" daemonRunning={daemonRunning} />
+              <InspectorPane familiar={activeFamiliar} tab="familiar" daemonRunning={daemonRunning} onStartChat={startFamiliarHeroChat} />
             </div>
           </div>
         ) : scope === "settings" ? (

--- a/src/components/familiar-tab-bridges.test.ts
+++ b/src/components/familiar-tab-bridges.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Familiar tab bridges + ergonomics (cave-aovo). The tab must not dead-end:
+// from the hero you can reach the familiar's memory, its Studio editor, its
+// profile card / analytics (pinned in familiar-tab-hero.test.ts), and start a
+// fresh chat. Touch targets grow on coarse pointers, and the pane is a
+// labelled landmark.
+
+const src = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+test("memory bridge: the sibling pane's content is reachable via the Studio memory tab", () => {
+  assert.match(
+    src,
+    /import \{ openFamiliarStudioSettingsTab \} from "@\/lib\/familiar-studio-context"/,
+    "uses the shared Studio redirect helper",
+  );
+  assert.match(
+    src,
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("memory", familiar\.id\)\}[\s\S]{0,300}?Memory →/,
+    "Memory → opens the Studio memory tab for this familiar",
+  );
+});
+
+test("studio bridge: Edit in Studio preselects this familiar's identity tab", () => {
+  assert.match(
+    src,
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("identity", familiar\.id\)\}[\s\S]{0,300}?Edit in Studio →/,
+    "Edit in Studio → opens the Studio identity tab",
+  );
+});
+
+test("new chat is the hero's primary action — the one filled-accent control", () => {
+  assert.match(src, /onStartChat\?: \(familiarId: string\) => void/, "typed callback seam");
+  assert.match(
+    src,
+    /onClick=\{\(\) => onStartChat\(familiar\.id\)\}[\s\S]{0,400}?bg-\[var\(--accent-presence\)\][\s\S]{0,200}?text-\[var\(--accent-presence-foreground\)\]/,
+    "filled accent + readable accent foreground (token pair, not hard-coded white)",
+  );
+  assert.match(src, /\{onStartChat \? \(/, "the button only renders when the host provides the seam");
+  // The chat surface wires the seam: activate the familiar, flip to the
+  // conversation tab, then open a fresh session for it.
+  assert.match(
+    chatSurface,
+    /function startFamiliarHeroChat\(familiarId: string\) \{[\s\S]*?onSetActiveFamiliar\(familiarId\);[\s\S]*?setScope\("conversation"\);[\s\S]*?newChat\(undefined, undefined, familiarId\)/,
+    "chat surface lands the hero action on a fresh conversation",
+  );
+});
+
+test("the pane is a labelled landmark per section", () => {
+  assert.match(
+    src,
+    /aria-label=\{tab === "familiar" \? "Familiar profile" : "Familiar memory"\}/,
+    "the aside names which pane it is",
+  );
+});
+
+test("coarse pointers get honest touch targets without changing pointer-fine rhythm", () => {
+  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,600}?\.familiar-tab__links a,\s*\.familiar-tab__links button \{[^}]*padding-block/, "hero links grow");
+  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,900}?\.familiar-tab__list > button \{[^}]*padding-block/, "group toggles grow");
+  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,1200}?\.familiar-tab__cta \{[^}]*padding-block/, "teach CTAs grow");
+  assert.match(src, /className="familiar-tab__links mt-2/, "hero links row carries the coarse-pointer hook");
+});

--- a/src/components/familiar-tab-hero.test.ts
+++ b/src/components/familiar-tab-hero.test.ts
@@ -18,7 +18,7 @@ test("identity hero leads the Familiar tab and paints before the capability fetc
   assert.match(src, /function FamiliarIdentityHero\(/, "hero component declared");
   // The hero renders in BOTH branches: while loading (skeleton below it) and
   // with the loaded grid — identity never waits on capability plumbing.
-  const heroMounts = src.match(/<FamiliarIdentityHero familiar=\{familiar\} daemonRunning=\{daemonRunning\} \/>/g) ?? [];
+  const heroMounts = src.match(/<FamiliarIdentityHero familiar=\{familiar\} daemonRunning=\{daemonRunning\} onStartChat=\{onStartChat\} \/>/g) ?? [];
   assert.ok(heroMounts.length >= 2, `hero mounts in loading AND loaded branches (got ${heroMounts.length})`);
   assert.match(
     src,
@@ -74,7 +74,7 @@ test("wide-canvas layout: container-query grid, two columns >=900px, single belo
 test("the chat surface gives the tab a wide canvas and threads presence", () => {
   assert.match(
     chatSurface,
-    /scope === "familiar"[\s\S]*?max-w-5xl[\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
+    /scope === "familiar"[\s\S]*?max-w-5xl[\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} onStartChat=\{startFamiliarHeroChat\} \/>/,
     "Familiar tab hosts the pane in a max-w-5xl column with daemonRunning threaded",
   );
 });

--- a/src/components/inspector-pane-polish.test.ts
+++ b/src/components/inspector-pane-polish.test.ts
@@ -18,7 +18,7 @@ test("the pane is a controlled section body — memory + familiar only", () => {
   assert.doesNotMatch(src, /FamiliarAnalyticsView|InboxTab|SnoozeMenu/, "no analytics or automations rendering remains");
   assert.match(
     chatSurface,
-    /<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} \/>/,
+    /<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} onStartChat=\{startFamiliarHeroChat\} \/>/,
     "the chat surface's Familiar tab drives the pane's familiar section (presence threaded)",
   );
   assert.doesNotMatch(chatSurface, /INSPECTOR_SECTIONS/, "the promoted right-panel section strip is gone");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -16,6 +16,7 @@ import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import type { AdapterReport } from "@/lib/harness-adapters";
 import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
 import { openGrimoireDoc } from "@/lib/grimoire-link";
+import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 
 export type Tab = "memory" | "familiar";
@@ -59,6 +60,9 @@ type Props = {
   /** Daemon reachability — drives the identity hero's presence line on the
    *  chat surface's Familiar tab. Absent for the compact memory rail. */
   daemonRunning?: boolean;
+  /** Starts a fresh chat with this familiar (the hero's primary action).
+   *  Provided by the chat surface; absent for the compact memory rail. */
+  onStartChat?: (familiarId: string) => void;
 };
 
 function InspectorEmpty({
@@ -113,6 +117,7 @@ export function InspectorPane({
   onOpenFullView,
   tab = "memory",
   daemonRunning,
+  onStartChat,
 }: Props) {
   const shellClassName = compact
     ? "flex h-full min-h-0 flex-col bg-[var(--bg-base)]"
@@ -121,7 +126,10 @@ export function InspectorPane({
       "flex h-full min-h-0 flex-col";
 
   return (
-    <aside className={shellClassName}>
+    <aside
+      className={shellClassName}
+      aria-label={tab === "familiar" ? "Familiar profile" : "Familiar memory"}
+    >
       <div
         className={`min-h-0 flex-1 ${
           tab === "memory" ? "overflow-hidden" : "overflow-y-auto"
@@ -129,7 +137,7 @@ export function InspectorPane({
       >
         {tab === "memory" ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
         {tab === "familiar" ? (
-          <FamiliarCapabilityPanel familiar={familiar} daemonRunning={daemonRunning} />
+          <FamiliarCapabilityPanel familiar={familiar} daemonRunning={daemonRunning} onStartChat={onStartChat} />
         ) : null}
       </div>
     </aside>
@@ -682,7 +690,7 @@ function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="focus-ring mt-1.5 inline-flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
+      className="familiar-tab__cta focus-ring mt-1.5 inline-flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[11px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
     >
       {label}
     </button>
@@ -782,9 +790,11 @@ function CollapsibleSection({
 function FamiliarIdentityHero({
   familiar,
   daemonRunning,
+  onStartChat,
 }: {
   familiar: Familiar;
   daemonRunning?: boolean;
+  onStartChat?: (familiarId: string) => void;
 }) {
   // Resolve Cave-local overrides (display name, avatar image, glyph) the same
   // way every other identity surface does.
@@ -831,13 +841,13 @@ function FamiliarIdentityHero({
             {familiar.description}
           </p>
         ) : null}
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+        <div className="familiar-tab__links mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
           {runtimeLine ? (
             <span className="font-mono text-[10px] text-[var(--text-muted)]" title="Harness · model">
               {runtimeLine}
             </span>
           ) : null}
-          <span className="flex items-center gap-3">
+          <span className="flex flex-wrap items-center gap-3">
             <Link
               href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
               aria-label={`Open profile card for ${familiar.display_name}`}
@@ -852,9 +862,41 @@ function FamiliarIdentityHero({
             >
               Analytics →
             </Link>
+            {/* The sibling memory pane isn't reachable from this tab — bridge
+                to the Studio's per-familiar Memory tab, its managed home. */}
+            <button
+              type="button"
+              onClick={() => openFamiliarStudioSettingsTab("memory", familiar.id)}
+              aria-label={`Open memory for ${familiar.display_name}`}
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+            >
+              Memory →
+            </button>
+            <button
+              type="button"
+              onClick={() => openFamiliarStudioSettingsTab("identity", familiar.id)}
+              aria-label={`Edit ${familiar.display_name} in the Familiar Studio`}
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+            >
+              Edit in Studio →
+            </button>
           </span>
         </div>
       </div>
+      {onStartChat ? (
+        <div className="shrink-0">
+          {/* The surface's primary action: start a fresh session with this
+              familiar. The one filled-accent control on the tab. */}
+          <button
+            type="button"
+            onClick={() => onStartChat(familiar.id)}
+            className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-2.5 text-[11px] font-medium text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-90"
+          >
+            <Icon name="ph:chat-circle-dots" width={13} aria-hidden />
+            New chat
+          </button>
+        </div>
+      ) : null}
     </header>
   );
 }
@@ -862,9 +904,11 @@ function FamiliarIdentityHero({
 function FamiliarCapabilityPanel({
   familiar,
   daemonRunning,
+  onStartChat,
 }: {
   familiar: Familiar | null;
   daemonRunning?: boolean;
+  onStartChat?: (familiarId: string) => void;
 }) {
   const [roles, setRoles] = useState<RoleEntry[]>([]);
   const [localSkills, setLocalSkills] = useState<LocalSkillEntry[]>([]);
@@ -935,7 +979,7 @@ function FamiliarCapabilityPanel({
   if (loading) {
     return (
       <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
-        <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} />
+        <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} onStartChat={onStartChat} />
         <div className="familiar-tab__grid" aria-hidden>
           <SkeletonRows count={5} className="p-3" />
           <SkeletonRows count={5} className="p-3" />
@@ -980,7 +1024,7 @@ function FamiliarCapabilityPanel({
     <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
 
       {/* ── Identity hero ─────────────────────────────────────────────────── */}
-      <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} />
+      <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} onStartChat={onStartChat} />
 
       {/* Error banner */}
       {errors.length > 0 ? (


### PR DESCRIPTION
## Familiar tab elevation 3/3 (cave-aovo, umbrella cave-5vvp; follows #3116, #3123)

After the hero (#3116) and the de-box (#3123), the tab still **dead-ended**: the familiar's memory — the sibling `InspectorPane` section, unreachable from this tab — had no route, there was no path to the Studio editor, and no way to *start a chat* with the familiar whose profile you were reading.

### Bridges (each verified live with Playwright)
- **Memory →** — bridges to the Studio's per-familiar Memory tab via the shared `openFamiliarStudioSettingsTab("memory", id)` redirect. Probed: lands on `/settings#familiars` with `cave:brain-studio-familiar:v1=<id>` + `tab=memory` latched (the same one-shot handoff every other surface uses).
- **Edit in Studio →** — same helper, identity tab.
- **New chat** — the hero's primary action and the tab's **one filled-accent control** (`--accent-presence` bg + `--accent-presence-foreground` text, per the token-pair rule). The chat surface wires the seam: `onSetActiveFamiliar → setScope("conversation") → routerRef.newChat(…, familiarId)`. Probed: the click lands in a fresh conversation.
- Profile → / Analytics → landed in #3116; with Memory/Studio/New-chat this completes the deliberate bridge set.

### Ergonomics
- The pane announces itself as a labelled landmark (`aria-label`: *Familiar profile* / *Familiar memory*).
- **Coarse pointers** grow the hero links, collapsible toggles, and teach CTAs (`padding-block` under `@media (pointer: coarse)`) — pointer-fine rhythm unchanged. Verified at iPhone 13 emulation (links wrap cleanly at 390px).
- Heading hierarchy already lands h2 (hero name) → h3 (sections) from #3116; collapsibles carry `aria-expanded` + `.focus-ring` from #3123.

### Tests
- New pin `src/components/familiar-tab-bridges.test.ts` (memory/studio bridges, primary action + host wiring, landmark label, coarse-pointer contract) wired into `run-tests.mjs`.
- Mount pins updated deliberately for the `onStartChat` seam (`chat-surface.test.ts`, `inspector-pane-polish.test.ts`, `familiar-tab-hero.test.ts`). No coverage deleted.

### Verification
- `pnpm typecheck` + `pnpm build` green
- Full `pnpm test:app`: 627 green before the known local-only `vault-ref-cold-start` mid-suite flake (cave-6azx) — flake passes isolated, and the 97 remaining files after it pass (100% file coverage green)
- Playwright: bridge probes end-to-end + screenshots at 1440×900 and iPhone 13 (session evidence)
