### PR TITLE
feat(research-desk): legibility polish — visible ledger errors, human schedules, relative times, clamped bounds (cave-655d)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15442,6 +15442,8 @@ details[open] > .cave-edit-card__summary::before {
 .research-mission-row__top { display: flex; align-items: flex-start; gap: 7px; }
 .research-mission-row__top strong { font-size: 11.5px; font-weight: 600; line-height: 1.35; }
 .research-mission-row__meta { display: flex; gap: 7px; padding-left: 13px; font-size: 9.5px; text-transform: capitalize; color: var(--text-muted); }
+.research-mission-row__meta time { margin-left: auto; text-transform: none; }
+.research-mission-detail__eyebrow time { text-transform: none; letter-spacing: 0.02em; }
 
 .research-status-dot {
   flex: 0 0 auto;

--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -11,6 +11,7 @@ import type {
   ResearchMissionActionInput,
   ResearchSourceRef,
 } from "@/lib/research-missions";
+import { relativeTime } from "@/lib/relative-time";
 
 type Props = {
   mission: ResearchMission;
@@ -85,6 +86,7 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
           { id: "sources", label: "Sources", count: mission.sources.length },
         ]}
       />
+      {error ? <p className="research-mission-error" role="alert">{error}</p> : null}
       <section
         id="research-output-panel-artifacts"
         role="tabpanel"
@@ -100,7 +102,10 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
               <li key={artifact.key} className="research-artifact-card">
                 <span className="research-artifact-card__kind">{artifact.kind}</span>
                 <strong>{artifact.title}</strong>
-                <span>{artifact.state} · iteration {artifact.iteration}</span>
+                <span>
+                  {artifact.state} · iteration {artifact.iteration} ·{" "}
+                  <time dateTime={artifact.updatedAt}>{relativeTime(artifact.updatedAt) || "just now"}</time>
+                </span>
                 {artifact.rejectionReason ? <p>{artifact.rejectionReason}</p> : null}
                 {artifact.knowledgeId ? (
                   <button
@@ -199,7 +204,6 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
             ))}
           </ul>
         )}
-        {error ? <p className="research-mission-error" role="alert">{error}</p> : null}
       </section>
     </aside>
   );

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -8,6 +8,7 @@ import {
   inferResearchMissionMode,
 } from "@/lib/research-mission-routing";
 import {
+  RESEARCH_BOUND_LIMITS,
   RESEARCH_MISSION_MODES,
   type CreateResearchMissionInput,
   type ResearchBounds,
@@ -32,9 +33,10 @@ const MODE_LABELS: Record<ResearchMissionMode, string> = {
   autoresearch: "Autoresearch",
 };
 
-function boundNumber(value: string, fallback: number): number {
+function boundNumber(value: string, fallback: number, max: number): number {
   const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(Math.trunc(parsed), max);
 }
 
 export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: Props) {
@@ -146,9 +148,9 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
             <input
               type="number"
               min={1}
-              max={1440}
+              max={RESEARCH_BOUND_LIMITS.wallClockMinutes}
               value={bounds.wallClockMinutes}
-              onChange={(event) => updateBound("wallClockMinutes", boundNumber(event.target.value, 1))}
+              onChange={(event) => updateBound("wallClockMinutes", boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.wallClockMinutes))}
             />
           </label>
           <label>
@@ -156,10 +158,10 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
             <input
               type="number"
               min={1}
-              max={100}
+              max={RESEARCH_BOUND_LIMITS.maxIterations}
               value={bounds.maxIterations}
               onChange={(event) => {
-                const maxIterations = boundNumber(event.target.value, 1);
+                const maxIterations = boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.maxIterations);
                 setBounds((current) => ({
                   ...current,
                   maxIterations,
@@ -173,9 +175,9 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
             <input
               type="number"
               min={1}
-              max={500}
+              max={RESEARCH_BOUND_LIMITS.sourceTarget}
               value={bounds.sourceTarget}
-              onChange={(event) => updateBound("sourceTarget", boundNumber(event.target.value, 1))}
+              onChange={(event) => updateBound("sourceTarget", boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.sourceTarget))}
             />
           </label>
           <label>
@@ -185,7 +187,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
               min={1}
               max={bounds.maxIterations}
               value={bounds.checkpointEvery}
-              onChange={(event) => updateBound("checkpointEvery", boundNumber(event.target.value, 1))}
+              onChange={(event) => updateBound("checkpointEvery", boundNumber(event.target.value, 1, bounds.maxIterations))}
             />
           </label>
         </div>

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -6,10 +6,12 @@ import { useAnnouncer } from "@/components/ui/live-region";
 import { Icon } from "@/lib/icon";
 import {
   allowedResearchActions,
+  describeResearchSchedule,
   type ResearchMission,
   type ResearchMissionAction,
   type ResearchMissionActionInput,
 } from "@/lib/research-missions";
+import { relativeTime } from "@/lib/relative-time";
 import { ResearchEvidenceLedger } from "./research-evidence-ledger";
 
 type Props = {
@@ -146,6 +148,8 @@ export function ResearchMissionDetail({
         <div>
           <span className="research-mission-detail__eyebrow">
             {mission.mode} · {mission.status}
+            {" · "}
+            <time dateTime={mission.updatedAt}>updated {relativeTime(mission.updatedAt) || "just now"}</time>
           </span>
           <h2 id="research-mission-title">{mission.title}</h2>
           <p>{mission.intent}</p>
@@ -207,7 +211,11 @@ export function ResearchMissionDetail({
               <div className="research-automation__summary">
                 <div>
                   <span>Codex Automation</span>
-                  <strong>{mission.automation ? mission.automation.rrule : "Daily at 09:00 · paused on creation"}</strong>
+                  <strong>
+                    {mission.automation
+                      ? describeResearchSchedule(mission.automation.rrule)
+                      : "Daily at 09:00 · paused on creation"}
+                  </strong>
                 </div>
                 <span className={`research-automation__status research-automation__status--${mission.automation?.status.toLowerCase() ?? "draft"}`}>
                   {mission.automation?.status ?? "not scheduled"}
@@ -234,7 +242,17 @@ export function ResearchMissionDetail({
                     </Button>
                   </div>
                   {mission.automation.lastRunStatus ? (
-                    <p>Last run: {mission.automation.lastRunStatus}{mission.automation.lastRunAt ? ` · ${mission.automation.lastRunAt}` : ""}</p>
+                    <p>
+                      Last run: {mission.automation.lastRunStatus}
+                      {mission.automation.lastRunAt ? (
+                        <>
+                          {" · "}
+                          <time dateTime={mission.automation.lastRunAt}>
+                            {relativeTime(mission.automation.lastRunAt) || "just now"}
+                          </time>
+                        </>
+                      ) : null}
+                    </p>
                   ) : null}
                   {mission.automation.stopReason ? <p className="research-automation__stop">Stopped: {mission.automation.stopReason}</p> : null}
                 </>

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from "@/lib/icon";
 import type { ResearchMission } from "@/lib/research-missions";
+import { relativeTime } from "@/lib/relative-time";
 
 type Props = {
   missions: ResearchMission[];
@@ -55,6 +56,7 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
                     <span>{mission.mode}</span>
                     <span>{mission.status}</span>
                     {iteration ? <span>i{iteration.number}/{mission.bounds.maxIterations}</span> : null}
+                    <time dateTime={mission.updatedAt}>{relativeTime(mission.updatedAt) || "just now"}</time>
                   </span>
                 </button>
               </li>

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -24,6 +24,9 @@ test("composer makes Auto routing and finite bounds reviewable", () => {
   assert.match(composer, /inferResearchMissionMode/);
   assert.match(composer, /Auto/);
   assert.match(composer, /maxIterations/);
+  // Bound inputs clamp to the same limits the server enforces.
+  assert.match(composer, /RESEARCH_BOUND_LIMITS/);
+  assert.doesNotMatch(composer, /max=\{1440\}/);
 });
 
 test("mission list and evidence trajectory expose semantic state", () => {
@@ -31,6 +34,26 @@ test("mission list and evidence trajectory expose semantic state", () => {
   assert.match(detail, /aria-label="Research progress"/);
   assert.match(detail, /Open session/);
   assert.match(ledger, /Open in Grimoire/);
+});
+
+test("timestamps are relative and schedules read as prose, not raw data", () => {
+  assert.match(list, /relativeTime\(mission\.updatedAt\)/);
+  assert.match(detail, /relativeTime\(mission\.updatedAt\)/);
+  assert.match(detail, /describeResearchSchedule\(mission\.automation\.rrule\)/);
+  assert.match(detail, /relativeTime\(mission\.automation\.lastRunAt\)/);
+  assert.match(ledger, /relativeTime\(artifact\.updatedAt\)/);
+  // Uppercase/capitalize chrome must not distort the relative-time text.
+  assert.match(css, /\.research-mission-row__meta time \{[^}]*text-transform: none/);
+  assert.match(css, /\.research-mission-detail__eyebrow time \{[^}]*text-transform: none/);
+});
+
+test("ledger errors stay visible regardless of the active output tab", () => {
+  // The error paragraph renders between the tab strip and the first tab panel,
+  // not inside a panel that may be hidden.
+  assert.match(
+    ledger,
+    /\{error \? <p className="research-mission-error" role="alert">\{error\}<\/p> : null\}\s*<section\s+id="research-output-panel-artifacts"/,
+  );
 });
 
 test("checkpoint lifecycle controls are explicit and server-backed", () => {

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -6,7 +6,9 @@ import {
 } from "./research-mission-routing.ts";
 import {
   allowedResearchActions,
+  describeResearchSchedule,
   normalizeResearchBounds,
+  RESEARCH_BOUND_LIMITS,
   validateCreateResearchMissionInput,
 } from "./research-missions.ts";
 
@@ -120,4 +122,41 @@ test("mission creation validates familiar, intent, mode, and bounded input", () 
     }).ok,
     false,
   );
+});
+
+test("composer clamp limits match what the server accepts", () => {
+  assert.equal(
+    normalizeResearchBounds({
+      wallClockMinutes: RESEARCH_BOUND_LIMITS.wallClockMinutes,
+      maxIterations: RESEARCH_BOUND_LIMITS.maxIterations,
+      sourceTarget: RESEARCH_BOUND_LIMITS.sourceTarget,
+      checkpointEvery: RESEARCH_BOUND_LIMITS.checkpointEvery,
+      stopWhenCostUnavailable: false,
+    }).ok,
+    true,
+  );
+  assert.equal(
+    normalizeResearchBounds({
+      wallClockMinutes: RESEARCH_BOUND_LIMITS.wallClockMinutes + 1,
+      maxIterations: 1,
+      sourceTarget: 1,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+    }).ok,
+    false,
+  );
+});
+
+test("automation schedules are described in human terms, not raw RRULE", () => {
+  assert.equal(describeResearchSchedule("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"), "Daily at 09:00");
+  assert.equal(
+    describeResearchSchedule("RRULE:FREQ=WEEKLY;BYHOUR=8;BYMINUTE=30;BYDAY=MO,WE,FR"),
+    "Weekly on Mon, Wed, Fri at 08:30",
+  );
+  assert.equal(describeResearchSchedule("RRULE:FREQ=WEEKLY;BYHOUR=7;BYMINUTE=15"), "Weekly at 07:15");
+  // Unknown shapes fall back to honest rule text instead of a wrong guess.
+  assert.equal(describeResearchSchedule("RRULE:FREQ=HOURLY;INTERVAL=2"), "FREQ=HOURLY;INTERVAL=2");
+  assert.equal(describeResearchSchedule(""), "Not scheduled");
+  assert.equal(describeResearchSchedule(null), "Not scheduled");
+  assert.equal(describeResearchSchedule(undefined), "Not scheduled");
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -1,3 +1,5 @@
+import { parseCodexRrule, RRULE_DAY_LABEL } from "./codex-automation-form.ts";
+
 export const RESEARCH_MISSION_MODES = [
   "brief",
   "sweep",
@@ -249,13 +251,16 @@ export type ResearchBoundsResult =
   | { ok: true; value: ResearchBounds }
   | { ok: false; reason: string };
 
-const BOUND_LIMITS = {
+/** Server-enforced upper limits for research bounds; the composer clamps to these. */
+export const RESEARCH_BOUND_LIMITS = {
   wallClockMinutes: 24 * 60,
   maxIterations: 100,
   sourceTarget: 500,
   checkpointEvery: 100,
   maxSpendUsd: 100_000,
 } as const;
+
+const BOUND_LIMITS = RESEARCH_BOUND_LIMITS;
 
 function positiveInteger(
   value: unknown,
@@ -321,4 +326,22 @@ export function allowedResearchActions(
     return ["continue", "archive"];
   }
   return [];
+}
+
+/**
+ * Human-readable schedule for an autoresearch Automation link. Understands the
+ * daily/weekly RRULEs the desk itself creates; anything else falls back to the
+ * rule text without the RRULE: prefix rather than pretending to parse it.
+ */
+export function describeResearchSchedule(rrule: string | null | undefined): string {
+  const raw = rrule?.trim();
+  if (!raw) return "Not scheduled";
+  const parsed = parseCodexRrule(raw);
+  if (parsed.mode === "daily") return `Daily at ${parsed.time}`;
+  if (parsed.mode === "weekly") {
+    if (!/BYDAY=/.test(raw)) return `Weekly at ${parsed.time}`;
+    const days = parsed.days.map((day) => RRULE_DAY_LABEL[day] ?? day).join(", ");
+    return `Weekly on ${days} at ${parsed.time}`;
+  }
+  return raw.replace(/^RRULE:/, "");
 }


### PR DESCRIPTION
First slice of the research-desk-polish goal (.copilot/goals.md): make the Research Desk more legible and trustworthy.

## What changed

- **Bug fix — invisible action errors:** the evidence ledger's error `<p role="alert">` rendered inside the Sources tabpanel, so a failed *reject artifact* action from the Artifacts tab showed nothing (the panel is `hidden`). The alert now renders between the tab strip and the panels, visible from either tab.
- **Human-readable schedules:** `describeResearchSchedule` (new, in `research-missions.ts`, built on `parseCodexRrule`) renders "Daily at 09:00" / "Weekly on Mon, Wed, Fri at 08:30" instead of the raw `RRULE:FREQ=…` string; unknown rule shapes fall back to the rule text rather than a wrong guess.
- **Relative timestamps:** mission list rows, the detail eyebrow, automation last-run, and artifact cards now show canonical `relativeTime` in semantic `<time>` elements (raw ISO string removed from the automation panel). CSS exempts `<time>` from the uppercase/capitalize chrome.
- **Clamped bounds:** composer bound inputs clamp to the server-enforced limits, now exported as `RESEARCH_BOUND_LIMITS`, so typing 2000 minutes can no longer round-trip into a server rejection.

## Verification

- `node --experimental-strip-types --test` on all research suites: 35 + 33 pass
- `pnpm typecheck` clean
- `pnpm test:app`: 688 files pass

Bead: cave-655d
