### PR TITLE
feat(rituals): first-class Inbox tab — default landing tab

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -148,11 +148,11 @@ assert.doesNotMatch(
   "detail panel actions should use radius tokens instead of hard-coded radii",
 );
 
-// The active Schedules surface is narrowed to Calendar + Crons; reminder bulk
+// The active Rituals surface is Inbox + Calendar + Crons; reminder bulk
 // selection belongs to the older unified Automations surface.
-assert.match(source, /type AutomationTab = "calendar" \| "crons"/, "Schedules exposes only Calendar and Crons tabs");
-assert.doesNotMatch(source, /<SelectionToolbar/, "Schedules no longer renders reminder bulk-select chrome");
-assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : calendarSlot \? "calendar" : "crons"/, "non-calendar deep links land on Crons");
+assert.match(source, /type AutomationTab = "inbox" \| "calendar" \| "crons"/, "Rituals exposes Inbox, Calendar and Crons tabs");
+assert.doesNotMatch(source, /<SelectionToolbar/, "Rituals no longer renders reminder bulk-select chrome");
+assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : initialTab === "crons" \? "crons" : "inbox"/, "Inbox is the default landing tab; calendar/crons deep links still win");
 
 // ── Polling pauses while hidden + async fetch guards ────────────────────────
 // The 15s list poll + 2.5s in-flight run poll otherwise keep firing in a

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -80,9 +80,10 @@ function linkLabel(link: LinkRef): string {
   return "Memory";
 }
 
-// The active Schedules surface is intentionally narrow: Calendar plus Crons.
-// The broader Automations/Flow experience lives on feature/automations-flow.
-type AutomationTab = "calendar" | "crons";
+// The active Rituals surface: Inbox (the full feed, mostly reminders) plus
+// Calendar and Crons. The broader Automations/Flow experience lives on
+// feature/automations-flow.
+type AutomationTab = "inbox" | "calendar" | "crons";
 
 // Fire a cross-surface navigation so "Open" on a flow jumps to its
 // dedicated editor surface (the Workspace owns setMode; see cave:navigate-mode).
@@ -1387,11 +1388,17 @@ function InboxFeedRow({
   selected,
   familiarLabel,
   onSelect,
+  onDone,
+  onSnooze,
+  onDismiss,
 }: {
   item: InboxItem;
   selected: boolean;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
+  onDone?: (item: InboxItem) => void;
+  onSnooze?: (item: InboxItem) => void;
+  onDismiss?: (item: InboxItem) => void;
 }) {
   const workspace = familiarLabel(item.familiarId);
   const when = item.firedAt
@@ -1399,14 +1406,17 @@ function InboxFeedRow({
     : item.fireAt
     ? relTime(item.fireAt)
     : relTime(item.updatedAt);
+  // Done/snooze/dismiss only make sense while the item is still live; snooze
+  // additionally only for something that already fired (re-surface later).
+  const resolved = item.status === "done" || item.status === "dismissed";
 
   return (
-    <li>
+    <li className="flex items-center">
       <button
         type="button"
         onClick={() => onSelect(item)}
         aria-current={selected ? "true" : undefined}
-        className={`focus-ring-inset automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${selected ? "bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]" : "hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"}`}
+        className={`focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${selected ? "bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]" : "hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"}`}
       >
         <StatusIcon item={item} />
         <span className="flex-1 min-w-0 flex items-center gap-2">
@@ -1424,6 +1434,19 @@ function InboxFeedRow({
           {when}
         </span>
       </button>
+      {!resolved && (onDone || onSnooze || onDismiss) && (
+        <RowActions>
+          {onDone && (
+            <RowActionButton icon="ph:check-bold" label={`Mark ${item.title} done`} text="Done" onClick={() => onDone(item)} />
+          )}
+          {onSnooze && item.status === "fired" && (
+            <RowActionButton icon="ph:clock-countdown" label={`Snooze ${item.title} for 1 hour`} text="Snooze 1h" onClick={() => onSnooze(item)} />
+          )}
+          {onDismiss && (
+            <RowActionButton icon="ph:x" label={`Dismiss ${item.title}`} text="Dismiss" onClick={() => onDismiss(item)} />
+          )}
+        </RowActions>
+      )}
     </li>
   );
 }
@@ -1435,6 +1458,9 @@ function InboxFeedSection({
   selectedId,
   familiarLabel,
   onSelect,
+  onDone,
+  onSnooze,
+  onDismiss,
 }: {
   title: string;
   accent?: boolean;
@@ -1442,6 +1468,9 @@ function InboxFeedSection({
   selectedId: string | null;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
+  onDone?: (item: InboxItem) => void;
+  onSnooze?: (item: InboxItem) => void;
+  onDismiss?: (item: InboxItem) => void;
 }) {
   const headingId = useId();
   if (items.length === 0) return null;
@@ -1471,6 +1500,9 @@ function InboxFeedSection({
             selected={selectedId === item.id}
             familiarLabel={familiarLabel}
             onSelect={onSelect}
+            onDone={onDone}
+            onSnooze={onSnooze}
+            onDismiss={onDismiss}
           />
         ))}
       </ul>
@@ -1485,6 +1517,9 @@ function InboxFeedList({
   selectedId,
   familiarLabel,
   onSelect,
+  onDone,
+  onSnooze,
+  onDismiss,
 }: {
   needsYou: InboxItem[];
   active: InboxItem[];
@@ -1492,13 +1527,17 @@ function InboxFeedList({
   selectedId: string | null;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
+  onDone?: (item: InboxItem) => void;
+  onSnooze?: (item: InboxItem) => void;
+  onDismiss?: (item: InboxItem) => void;
 }) {
+  const rowActions = { onDone, onSnooze, onDismiss };
   return (
     <>
       <InboxFeedSection title="Needs you" accent items={needsYou} selectedId={selectedId}
-        familiarLabel={familiarLabel} onSelect={onSelect} />
+        familiarLabel={familiarLabel} onSelect={onSelect} {...rowActions} />
       <InboxFeedSection title="Active" items={active} selectedId={selectedId}
-        familiarLabel={familiarLabel} onSelect={onSelect} />
+        familiarLabel={familiarLabel} onSelect={onSelect} {...rowActions} />
       <InboxFeedSection title="Resolved" items={resolved} selectedId={selectedId}
         familiarLabel={familiarLabel} onSelect={onSelect} />
     </>
@@ -1870,7 +1909,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // otherwise it falls to <body> and keyboard users lose their place.
   const newBtnRef = useRef<HTMLButtonElement | null>(null);
   const [activeTab, setActiveTab] = useState<AutomationTab>(
-    initialTab === "calendar" && calendarSlot ? "calendar" : calendarSlot ? "calendar" : "crons",
+    initialTab === "calendar" && calendarSlot ? "calendar" : initialTab === "crons" ? "crons" : "inbox",
   );
   const [newMenuOpen, setNewMenuOpen] = useState(false);
   // Selected item is either an InboxItem or a CodexAutomation — track by kind
@@ -2128,6 +2167,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   const stopRecurrence = (id: string) =>
     patchItem(id, { recurrence: { type: "none" } });
+
+  // ── Inbox feed row actions (Done / Snooze / Dismiss) ──────────────────────
+  const completeInboxItem = (item: InboxItem) => {
+    announce(`Marked '${item.title}' done.`);
+    return actItem(item.id, "done");
+  };
+  const snoozeInboxItem = (item: InboxItem) => {
+    announce(`Snoozed '${item.title}' for 1 hour.`);
+    return actItem(item.id, "snooze", { minutes: 60 });
+  };
+  const dismissInboxItem = (item: InboxItem) => {
+    announce(`Dismissed '${item.title}'.`);
+    return actItem(item.id, "dismiss");
+  };
 
   // ── Codex toggle ──────────────────────────────────────────────────────────
   const toggleCodex = useCallback(async (auto: CodexAutomation) => {
@@ -2445,11 +2498,12 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             value={activeTab}
             onChange={selectTab}
             items={[
+              { id: "inbox" as const, label: "Inbox", count: inboxFeed.needsYou.length },
               ...(calendarSlot ? [{ id: "calendar" as const, label: "Calendar" }] : []),
               { id: "crons", label: "Crons", count: codexAutos.length },
             ] satisfies TabItem<AutomationTab>[]}
           />
-          {activeTab !== "calendar" && initialLoadDone && summary.active + summary.paused > 0 && (
+          {activeTab === "crons" && initialLoadDone && summary.active + summary.paused > 0 && (
             <p className="surface-compact-summary">
               <span className="inline-flex items-center gap-1.5">
                 <span aria-hidden className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--accent-presence)" }} />
@@ -2461,20 +2515,37 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               )}
             </p>
           )}
+          {activeTab === "inbox" && initialLoadDone && inboxFeed.needsYou.length + inboxFeed.active.length > 0 && (
+            <p className="surface-compact-summary">
+              {inboxFeed.needsYou.length > 0 && (
+                <span className="inline-flex items-center gap-1.5">
+                  <span aria-hidden className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--color-warning)" }} />
+                  {inboxFeed.needsYou.length} need{inboxFeed.needsYou.length === 1 ? "s" : ""} you
+                </span>
+              )}
+              {inboxFeed.active.length > 0 && <span>{inboxFeed.needsYou.length > 0 ? "· " : ""}{inboxFeed.active.length} active</span>}
+            </p>
+          )}
           <div className="surface-compact-actions">
-            {/* Text filter for the crons tab. Gated on the UNfiltered presence
+            {/* Text filter, scoped per tab. Gated on the UNfiltered presence
                 of rows so filtering to zero never hides the box (you can still
                 clear). */}
-            {activeTab !== "calendar" && initialLoadDone && !reminderSelect.selectMode && codexAutos.length > 0 ? (
+            {activeTab !== "calendar" && initialLoadDone && !reminderSelect.selectMode &&
+              (activeTab === "inbox" ? items.length > 0 : codexAutos.length > 0) ? (
               <div className="surface-compact-search">
                 <SearchInput
                   value={query}
                   onValueChange={setQuery}
                   onClear={() => setQuery("")}
-                  placeholder="Filter crons…"
-                  aria-label="Filter crons"
+                  placeholder={activeTab === "inbox" ? "Filter inbox…" : "Filter crons…"}
+                  aria-label={activeTab === "inbox" ? "Filter inbox" : "Filter crons"}
                 />
               </div>
+            ) : null}
+            {activeTab === "inbox" && onNewReminder ? (
+              <Button size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={onNewReminder}>
+                New reminder
+              </Button>
             ) : null}
             {activeTab === "crons" ? (
               <Button ref={newBtnRef} size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={() => setCreateOpen(true)}>
@@ -2519,6 +2590,37 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 />
               ))}
             </div>
+          ) : activeTab === "inbox" ? (
+            inboxFeed.needsYou.length + inboxFeed.active.length + inboxFeed.resolved.length === 0 ? (
+              q ? (
+                <EmptyState
+                  className="mt-12"
+                  icon="ph:magnifying-glass"
+                  headline={`No matches for “${query.trim()}”`}
+                  subtitle="Try a different search term."
+                />
+              ) : (
+                <EmptyState
+                  className="mt-12"
+                  icon="ph:tray"
+                  headline="Inbox zero"
+                  subtitle="Reminders and notifications land here as they fire — enjoy the quiet."
+                  actions={onNewReminder ? <Button leadingIcon="ph:plus" onClick={onNewReminder}>New reminder</Button> : undefined}
+                />
+              )
+            ) : (
+              <InboxFeedList
+                needsYou={inboxFeed.needsYou}
+                active={inboxFeed.active}
+                resolved={inboxFeed.resolved}
+                selectedId={selectedItem?.id ?? null}
+                familiarLabel={familiarLabel}
+                onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
+                onDone={(item) => void completeInboxItem(item)}
+                onSnooze={(item) => void snoozeInboxItem(item)}
+                onDismiss={(item) => void dismissInboxItem(item)}
+              />
+            )
           ) : q && codexActive.length + codexPaused.length === 0 ? (
             <EmptyState
               className="mt-12"

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -18,7 +18,7 @@ type Props = {
   /** Calendar surface rendered as the leading tab (merged schedule page). */
   calendarSlot?: ReactNode;
   /** Tab to open on mount — "calendar" deep-links the Calendar nav button. */
-  initialTab?: "calendar" | "crons";
+  initialTab?: "inbox" | "calendar" | "crons";
 };
 
 export function InboxEscalationsView({

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -67,20 +67,21 @@ assert.match(
 // ── Slim typed tab model ────────────────────────────────────────────────────
 assert.match(
   automations,
-  /type AutomationTab = "calendar" \| "crons"/,
-  "Surface exposes only Calendar and Crons tabs",
+  /type AutomationTab = "inbox" \| "calendar" \| "crons"/,
+  "Surface exposes Inbox, Calendar, and Crons tabs",
 );
 assert.match(
   automations,
-  // Defaults to Calendar when present; otherwise Crons remains usable alone.
-  // may override on mount.
-  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*calendarSlot \? "calendar" : "crons",?\s*\)/,
-  "Surface defaults to Calendar when it has a calendar slot",
+  // Inbox is the default landing tab; explicit deep links (Calendar nav,
+  // legacy crons links) may override on mount.
+  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*initialTab === "crons" \? "crons" : "inbox",?\s*\)/,
+  "Surface defaults to the Inbox tab unless a deep link asks otherwise",
 );
 assert.match(automations, /<h1[\s\S]*?>\s*Rituals\s*<\/h1>/, "Surface header reads Rituals");
 assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Tabs use the shared segment Tabs");
 
-// Tabs present, in order.
+// Tabs present, in order: Inbox first (the landing tab), then Calendar, Crons.
+assert.match(automations, /\{ id: "inbox" as const, label: "Inbox", count: inboxFeed\.needsYou\.length \}/, "Inbox tab with the needs-you count");
 assert.match(automations, /\{ id: "calendar" as const, label: "Calendar" \}/, "Calendar tab");
 assert.match(automations, /\{ id: "crons", label: "Crons", count: codexAutos\.length \}/, "Crons tab");
 assert.doesNotMatch(automations, /\{ id: "all", label: "All"/, "All tab moved out with Automations");
@@ -90,8 +91,25 @@ assert.doesNotMatch(automations, /\{ id: "activity", label: "Activity"/, "Activi
 assert.doesNotMatch(automations, /\{ id: "templates", label: "Templates"/, "Templates tab moved out with Automations");
 assert.match(
   automations,
-  /id: "calendar"[\s\S]*id: "crons"/,
-  "tabs ordered Calendar, Crons",
+  /id: "inbox"[\s\S]*id: "calendar"[\s\S]*id: "crons"/,
+  "tabs ordered Inbox, Calendar, Crons",
+);
+// The Inbox tab renders the full grouped feed and lands there by default from
+// the workspace (Calendar deep links still open Calendar).
+assert.match(
+  automations,
+  /activeTab === "inbox" \?[\s\S]*?<InboxFeedList/,
+  "the Inbox tab renders the grouped inbox feed",
+);
+assert.match(
+  automations,
+  /<InboxFeedList[\s\S]*?onDone=\{\(item\) => void completeInboxItem\(item\)\}[\s\S]*?onSnooze=\{\(item\) => void snoozeInboxItem\(item\)\}[\s\S]*?onDismiss=\{\(item\) => void dismissInboxItem\(item\)\}/,
+  "feed rows wire Done / Snooze / Dismiss to the inbox action endpoints",
+);
+assert.match(
+  workspace,
+  /initialTab=\{mode === "calendar" \? "calendar" : "inbox"\}/,
+  "Workspace lands the surface on Inbox unless the Calendar deep link asked for Calendar",
 );
 assert.doesNotMatch(sidebar, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");
 

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -14,7 +14,7 @@ assert.match(vault, /No secrets match/, "vault shows a no-matches message");
 
 const auto = read("./automations-view.tsx");
 assert.match(auto, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "automations imports SearchInput");
-assert.match(auto, /<SearchInput[\s\S]*?aria-label="Filter crons"/, "automations renders a crons filter");
+assert.match(auto, /<SearchInput[\s\S]*?aria-label=\{activeTab === "inbox" \? "Filter inbox" : "Filter crons"\}/, "automations renders a tab-scoped filter (inbox/crons)");
 // The text filter applies to all three tabs' source derivations.
 assert.match(auto, /isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\) && \(!q \|\| \(it\.title \?\? ""\)\.toLowerCase\(\)\.includes\(q\)\)/, "reminders honor the text filter");
 assert.match(auto, /a\.name\.toLowerCase\(\)\.includes\(q\)/, "automations honor the text filter");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2442,7 +2442,7 @@ export function Workspace() {
       // remounts so the deep link lands on it.
       <InboxEscalationsView
         key={mode}
-        initialTab={mode === "calendar" ? "calendar" : "crons"}
+        initialTab={mode === "calendar" ? "calendar" : "inbox"}
         onOpenSource={(item) => {
           if (item.sourceSessionKey) {
             openFamiliarSession(item.sourceSessionKey);


### PR DESCRIPTION
## Checkpoint 2 of the Rituals rebrand

The Rituals surface becomes **Inbox · Calendar · Crons**, with **Inbox as the default landing tab** showing the full inbox feed (mostly reminders).

- **Inbox tab (default)** — renders `groupInboxFeed(items)` → *Needs you / Active / Resolved* via the previously-unused `InboxFeedList`; tab badge = needs-you count (same slice as the nav badge).
- **Row actions** — hover/focus **Done · Snooze 1h** (fired items) **· Dismiss** → `/api/inbox/[id]/{done,snooze,dismiss}`, with `useAnnouncer` announcements; row click opens the existing `DetailPanel` (edit via `new-reminder-modal` path, run/pause, link).
- **Header** — inbox summary line ('N need you · M active'), tab-scoped filter (`Filter inbox…`/`Filter crons…`), **New reminder** action on Inbox; cron chrome stays on Crons.
- **Empty states** — 'Inbox zero' + New reminder CTA; filter no-matches state.
- **Routing** — workspace `mode 'inbox'` lands on Inbox; Calendar nav deep-link still opens Calendar; `initialTab='crons'` still honored. `inbox-escalations-view` prop widened.

Pins updated deliberately: `rituals-tabs`, `automations-view`, `vault-automations-filter` tests.

## Verification
- `pnpm typecheck` — clean
- targeted suites — pass
- full `pnpm test:app` — **691 files pass**

Bead: cave-sz7k · C3 (GitHub-event deep links) follows.