### PR TITLE
feat(chat): archive-free siderail + branch switcher and worktree creation in the composer git chip

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -275,6 +275,7 @@ export const SUITES = {
     "src/components/chat-view-polish.test.ts",
     "src/components/composer-runtime-chip.test.ts",
     "src/components/composer-git-chip.test.ts",
+    "src/components/chat-siderail-hide-archived.test.ts",
     "src/components/chat-empty-state.test.ts",
     "src/components/user-chat-avatar.test.ts",
     "src/components/user-profile-invariants.test.ts",

--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -51,4 +51,74 @@ assert.match(
   "branchPr validates the PR URL shape before returning it",
 );
 
+// ── Branch menu (?branches=1, switch-branch, create-worktree) ────────────────
+
+// Every user-supplied branch name is gated by the shared strict allow-list
+// BEFORE it can reach a git argv — both actions, plus the client mirrors it.
+assert.match(
+  source,
+  /if \(action === "switch-branch"\) \{[\s\S]*?if \(!isSafeBranchName\(branch\)\) \{/,
+  "switch-branch validates the branch name with the shared strict rule",
+);
+assert.match(
+  source,
+  /if \(action === "create-worktree"\) \{[\s\S]*?if \(!isSafeBranchName\(branch\)\) \{/,
+  "create-worktree validates the branch name with the shared strict rule",
+);
+
+// switch-branch requires the ref to already exist (local or origin) and uses
+// `git switch` — carrying edits when safe, surfacing git's refusal otherwise —
+// never a forced checkout.
+assert.match(
+  source,
+  /refExists\(root\.repoRoot, `refs\/heads\/\$\{branch\}`\)/,
+  "switch-branch checks for the local ref before switching",
+);
+assert.match(
+  source,
+  /refExists\(root\.repoRoot, `refs\/remotes\/origin\/\$\{branch\}`\)/,
+  "switch-branch accepts an origin-only branch (git switch dwims the tracking branch)",
+);
+assert.match(
+  source,
+  /await git\(root\.repoRoot, \["switch", branch\]\);/,
+  "the switch is a plain `git switch` via the argv helper (no shell, no -f)",
+);
+assert.doesNotMatch(
+  source,
+  /"switch", "-f"|"switch", "--force"|"checkout", "-f"/,
+  "branch switching must never force-discard local state",
+);
+
+// create-worktree delegates to the shared provisioning lib (containment under
+// .worktrees/, idempotent reuse, origin/main base) rather than reimplementing.
+assert.match(
+  source,
+  /provisionBranchWorktree\(\s*root\.repoRoot,\s*branch,/,
+  "create-worktree provisions through the shared issue-worktree-provision lib",
+);
+
+// The branch listing marks the current branch and which worktree holds each
+// checked-out branch, so the menu can disable non-switchable rows.
+assert.match(
+  source,
+  /\["for-each-ref", "refs\/heads", "--sort=-committerdate", "--format=%\(refname:short\)"\]/,
+  "listBranches reads local branches newest-first via for-each-ref",
+);
+assert.match(
+  source,
+  /\["worktree", "list", "--porcelain"\]/,
+  "listBranches maps branches to their checkouts from the porcelain worktree list",
+);
+assert.match(
+  source,
+  /if \(wantBranches !== null\) return await listBranches\(root\.repoRoot\);/,
+  "the GET handler routes ?branches=1 to the branch listing",
+);
+assert.match(
+  source,
+  /if \(\/\^__\.\*__\$\/\.test\(name\)\) continue;/,
+  "tool-internal dunder refs (beads' __dolt_remote_info__) stay out of the menu",
+);
+
 console.log("changes route.test.ts: ok");

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 import { daemonSessionRoots, resolveWithinSessionRoots } from "@/lib/server/session-project-roots";
 import { isCheckpointName, parseNumstatZ, parsePorcelainZ, planRevert } from "@/lib/git-changes";
+import { isSafeBranchName } from "@/lib/issue-worktree";
+import { provisionBranchWorktree } from "@/lib/server/issue-worktree-provision";
 
 export const dynamic = "force-dynamic";
 
@@ -20,10 +22,13 @@ const DEV_NULL = os.devNull;
  * GET  ?projectRoot=<abs>&path=<rel>       → unified diff for one file (capped)
  * GET  ?projectRoot=<abs>&checkpoints=1    → list saved checkpoints
  * GET  ?projectRoot=<abs>&checkpoint=<name>→ one checkpoint's patch text (capped)
+ * GET  ?projectRoot=<abs>&branches=1       → local branches (current/worktree marked)
  * POST { projectRoot, path, confirmUntracked? } → revert ONE file (auto-checkpoints first)
  * POST { projectRoot, action: "checkpoint" } → save a patch snapshot
  * POST { projectRoot, action: "restore-checkpoint", checkpoint } → git apply a snapshot
  * POST { projectRoot, action: "delete-checkpoint", checkpoint } → remove a snapshot
+ * POST { projectRoot, action: "switch-branch", branch } → git switch (chat's branch menu)
+ * POST { projectRoot, action: "create-worktree", branch, baseRef? } → .worktrees/<branch>
  *
  * Security posture: every git invocation goes through execFile with an
  * argument array — no shell, so paths are never string-interpolated into a
@@ -107,6 +112,63 @@ async function defaultBranch(repoRoot: string): Promise<string> {
     } catch { /* not present */ }
   }
   return "main";
+}
+
+/** True when `ref` resolves to a commit in this repo. */
+async function refExists(repoRoot: string, ref: string): Promise<boolean> {
+  try {
+    await git(repoRoot, ["rev-parse", "--verify", "--quiet", ref]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type BranchRow = {
+  name: string;
+  /** This checkout's current branch. */
+  current: boolean;
+  /** Checkout dir basename when some worktree has the branch checked out. */
+  worktree: string | null;
+};
+
+/** Branch-menu payload cap: enough for real repos, bounded for pathological ones. */
+const MAX_BRANCH_ROWS = 40;
+
+/** Local branches (newest commit first, current branch pinned to the top)
+ *  plus which worktree, if any, has each one checked out — powers the chat
+ *  composer's branch menu. */
+async function listBranches(repoRoot: string) {
+  const [{ stdout: refsOut }, { stdout: wtOut }, current] = await Promise.all([
+    git(repoRoot, ["for-each-ref", "refs/heads", "--sort=-committerdate", "--format=%(refname:short)"]),
+    git(repoRoot, ["worktree", "list", "--porcelain"]),
+    currentBranch(repoRoot),
+  ]);
+  const checkedOut = new Map<string, string>();
+  let dir: string | null = null;
+  for (const line of wtOut.split("\n")) {
+    if (line.startsWith("worktree ")) dir = line.slice("worktree ".length).trim();
+    else if (line.startsWith("branch refs/heads/") && dir) {
+      checkedOut.set(line.slice("branch refs/heads/".length).trim(), path.basename(dir));
+    }
+  }
+  const branches: BranchRow[] = [];
+  for (const raw of refsOut.split("\n")) {
+    const name = raw.trim();
+    if (!name) continue;
+    // Tool-internal refs (e.g. beads' __dolt_remote_info__) aren't human
+    // switch targets — keep them out of the menu.
+    if (/^__.*__$/.test(name)) continue;
+    branches.push({
+      name,
+      current: name === current,
+      worktree: checkedOut.get(name) ?? null,
+    });
+    if (branches.length >= MAX_BRANCH_ROWS) break;
+  }
+  // Stable sort: current branch first, recency order preserved within the rest.
+  branches.sort((a, b) => Number(b.current) - Number(a.current));
+  return NextResponse.json({ ok: true, branches });
 }
 
 /** Server-generated, shell-safe feature branch name derived from the commit
@@ -345,6 +407,7 @@ export async function GET(req: NextRequest) {
   const wantCheckpoints = req.nextUrl.searchParams.get("checkpoints");
   const checkpointName = req.nextUrl.searchParams.get("checkpoint");
   const wantPr = req.nextUrl.searchParams.get("pr");
+  const wantBranches = req.nextUrl.searchParams.get("branches");
   if (!projectRoot) {
     return NextResponse.json({ ok: false, error: "missing projectRoot param" }, { status: 400 });
   }
@@ -379,6 +442,7 @@ export async function GET(req: NextRequest) {
       });
     }
     if (wantPr !== null) return await branchPr(root.repoRoot);
+    if (wantBranches !== null) return await listBranches(root.repoRoot);
     if (filePath === null) return await listChanges(root.repoRoot);
     const abs = resolveContainedFile(root.repoRoot, filePath);
     if (!abs) return pathNotAllowed();
@@ -491,11 +555,13 @@ export async function POST(req: NextRequest) {
     projectRoot?: string;
     path?: string;
     confirmUntracked?: boolean;
-    action?: "revert" | "checkpoint" | "restore-checkpoint" | "delete-checkpoint" | "commit" | "create-pr";
+    action?: "revert" | "checkpoint" | "restore-checkpoint" | "delete-checkpoint" | "commit" | "create-pr" | "switch-branch" | "create-worktree";
     checkpoint?: string;
     message?: string;
     title?: string;
     prBody?: string;
+    branch?: string;
+    baseRef?: string;
   };
   try {
     body = await req.json();
@@ -617,6 +683,51 @@ export async function POST(req: NextRequest) {
     } catch (err) {
       return NextResponse.json({ ok: false, error: stderrOf(err) }, { status: 500 });
     }
+  }
+  // Switch the checkout's branch — the chat composer's branch menu. `git
+  // switch` carries clean local edits along and refuses (with a precise
+  // stderr) when they'd be clobbered or the branch is checked out in another
+  // worktree; that refusal is surfaced verbatim rather than forced with -f.
+  if (action === "switch-branch") {
+    const branch = typeof body.branch === "string" ? body.branch.trim() : "";
+    if (!isSafeBranchName(branch)) {
+      return NextResponse.json({ ok: false, error: "invalid branch name" }, { status: 400 });
+    }
+    const isLocal = await refExists(root.repoRoot, `refs/heads/${branch}`);
+    if (!isLocal && !(await refExists(root.repoRoot, `refs/remotes/origin/${branch}`))) {
+      return NextResponse.json({ ok: false, error: "branch not found" }, { status: 404 });
+    }
+    try {
+      await git(root.repoRoot, ["switch", branch]);
+      return NextResponse.json({ ok: true, branch: await currentBranch(root.repoRoot) });
+    } catch (err) {
+      return NextResponse.json({ ok: false, error: stderrOf(err) }, { status: 409 });
+    }
+  }
+  // Provision a `.worktrees/<branch>` checkout for a user-named branch (the
+  // chat composer's "New worktree…" flow) — idempotent; new branches start
+  // from origin/main when available. Naming + validation live in
+  // @/lib/issue-worktree; the git work in @/lib/server/issue-worktree-provision.
+  if (action === "create-worktree") {
+    const branch = typeof body.branch === "string" ? body.branch.trim() : "";
+    if (!isSafeBranchName(branch)) {
+      return NextResponse.json({ ok: false, error: "invalid branch name" }, { status: 400 });
+    }
+    const result = await provisionBranchWorktree(
+      root.repoRoot,
+      branch,
+      typeof body.baseRef === "string" ? body.baseRef : null,
+    );
+    if (!result.ok) {
+      return NextResponse.json({ ok: false, error: result.error }, { status: result.status });
+    }
+    return NextResponse.json({
+      ok: true,
+      worktree: result.worktree,
+      branch: result.branch,
+      created: result.created,
+      baseRef: result.baseRef,
+    });
   }
   if (action === "restore-checkpoint" || action === "delete-checkpoint") {
     if (typeof body.checkpoint !== "string") {

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -333,8 +333,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     // server; restored if the user hits Undo).
     const hidden = new Set((deletePending?.item ?? []).map((s) => s.id));
     if (hidden.size) rows = rows.filter((s) => !hidden.has(s.id));
-    return filterVisibleChatSessions(rows, familiar?.id ?? null);
+    return filterVisibleChatSessions(rows, familiar?.id ?? null, { includeArchived: showArchived });
   }, [sessions, showArchived, archivedRows, familiar?.id, deletePending]);
+
+  // The siderail never shows archived chats: even while the list's "Show
+  // archived" toggle is on, rail groups build from an archive-free view.
+  const railSessions = useMemo(() => mine.filter((s) => !s.archived_at), [mine]);
 
   const filtered = useMemo(() => {
     let rows = mine;
@@ -363,7 +367,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   // every render: stale projects degrade to "all" silently. Below lg the
   // sidebar is hidden, so a persisted project selection must not scope the
   // list there — no affordance would exist to unscope it.
-  const sidebarGroups = useMemo(() => deriveChatProjectGroups(applyProjectOverrides(mine, projectOverrides), projects), [mine, projects, projectOverrides]);
+  const sidebarGroups = useMemo(() => deriveChatProjectGroups(applyProjectOverrides(railSessions, projectOverrides), projects), [railSessions, projects, projectOverrides]);
   const effectiveSelection = useMemo(
     () => normalizeSelection(isMobile ? "all" : selection, sidebarGroups),
     [isMobile, selection, sidebarGroups],

--- a/src/components/chat-siderail-hide-archived.test.ts
+++ b/src/components/chat-siderail-hide-archived.test.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+//
+// Guard: archived chats never render in the siderail.
+//
+// Two layers keep an archived chat out of every rail:
+//  1. `filterVisibleChatSessions` (the shared visibility filter every rail —
+//     ChatProjectSidebar via chat-list/chat-router, WorkspaceSidebar — builds
+//     from) drops `archived_at` rows by DEFAULT; only an explicit
+//     `{ includeArchived: true }` opts back in.
+//  2. chat-list's own "Show archived" toggle opts the MAIN list in, but its
+//     sidebar groups are built from an archive-free `railSessions` view, so
+//     toggling archived chats visible in the list can't leak them into the
+//     rail.
+//
+// Source-string pins, same convention as chat-thread-rail.test.ts. The
+// behavioral half (default drop / opt-in keep) lives in
+// src/lib/chat-projects.test.ts.
+//
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const chatProjects = readFileSync(new URL("../lib/chat-projects.ts", import.meta.url), "utf8");
+const chatList = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+const chatRouter = readFileSync(new URL("./chat-router.tsx", import.meta.url), "utf8");
+const workspaceSidebar = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+
+// 1. The shared filter is archive-free by default, with an explicit opt-in.
+assert.match(
+  chatProjects,
+  /const includeArchived = opts\?\.includeArchived \?\? false;/,
+  "filterVisibleChatSessions must default to excluding archived chats",
+);
+assert.match(
+  chatProjects,
+  /\.filter\(\(session\) => includeArchived \|\| !session\.archived_at\)/,
+  "the filter must drop archived_at rows unless the caller opts in",
+);
+
+// 2. chat-list: the list's toggle opts in explicitly…
+assert.match(
+  chatList,
+  /filterVisibleChatSessions\(rows, familiar\?\.id \?\? null, \{ includeArchived: showArchived \}\)/,
+  "the main chat list passes its Show-archived toggle through the opt-in",
+);
+
+// …but the rail builds from an archive-free view of the same rows.
+assert.match(
+  chatList,
+  /const railSessions = useMemo\(\(\) => mine\.filter\(\(s\) => !s\.archived_at\), \[mine\]\);/,
+  "the siderail's session source strips archived rows even while the toggle is on",
+);
+assert.match(
+  chatList,
+  /const sidebarGroups = useMemo\(\(\) => deriveChatProjectGroups\(applyProjectOverrides\(railSessions, projectOverrides\), projects\)/,
+  "sidebar groups must derive from the archive-free railSessions view",
+);
+
+// 3. The other rails build from the shared filter WITHOUT the archived opt-in,
+//    so they inherit the archive-free default.
+assert.match(
+  chatRouter,
+  /filterVisibleChatSessions\(sessions, familiar\?\.id \?\? null\)/,
+  "chat-router's rail source uses the default (archive-free) filter",
+);
+assert.doesNotMatch(
+  chatRouter,
+  /includeArchived: true/,
+  "chat-router never opts rails into archived rows",
+);
+assert.match(
+  workspaceSidebar,
+  /filterVisibleChatSessions\(sessions, activeFamiliarId \?\? null\)/,
+  "the workspace siderail uses the default (archive-free) filter",
+);
+assert.doesNotMatch(
+  workspaceSidebar,
+  /includeArchived/,
+  "the workspace siderail never opts into archived rows",
+);
+
+console.log("chat-siderail-hide-archived.test.ts: ok");

--- a/src/components/code-surface-familiar-scope.test.ts
+++ b/src/components/code-surface-familiar-scope.test.ts
@@ -45,7 +45,7 @@ assert.match(
 //    even a directly-mounted list can't show another familiar's threads.
 assert.match(
   chatList,
-  /return filterVisibleChatSessions\(rows, familiar\?\.id \?\? null\);/,
+  /return filterVisibleChatSessions\(rows, familiar\?\.id \?\? null, \{ includeArchived: showArchived \}\);/,
   "ChatList must filter its visible rows by the familiar",
 );
 

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -74,4 +74,51 @@ assert.match(
   "branch/worktree labels truncate with an ellipsis",
 );
 
+// ── The branch segment is a menu: switch branches / create a worktree ───────
+assert.match(
+  chip,
+  /aria-haspopup="menu"[\s\S]*?aria-expanded=\{menuOpen\}/,
+  "the branch segment is a real menu trigger with ARIA state",
+);
+assert.match(
+  chip,
+  /\/api\/changes\?projectRoot=\$\{encodeURIComponent\(root\)\}&branches=1/,
+  "opening the menu lists local branches via the changes route's ?branches=1 query",
+);
+assert.match(
+  chip,
+  /action: "switch-branch", branch: name/,
+  "picking a branch posts the switch-branch action",
+);
+assert.match(
+  chip,
+  /closeMenu\(\);\s*\n\s*reload\(\);/,
+  "a successful switch refreshes the summary immediately instead of waiting out the poll",
+);
+assert.match(
+  chip,
+  /disabled=\{menuBusy \|\| row\.current \|\| row\.worktree !== null\}/,
+  "branches checked out in another worktree (and the current one) are not switch targets",
+);
+assert.match(
+  chip,
+  /isSafeBranchName\(name\)/,
+  "the worktree form validates the branch name client-side with the shared rule",
+);
+assert.match(
+  chip,
+  /action: "create-worktree", branch: name/,
+  "creating a worktree posts the create-worktree action",
+);
+assert.match(
+  chip,
+  /new CustomEvent\("cave:agents-new-chat", \{\s*\n\s*detail: \{ projectRoot: json\.worktree \}/,
+  "a created worktree opens as a fresh chat rooted in it (safe-merge hand-off pattern)",
+);
+assert.match(
+  chip,
+  /onClick=\{\(event\) => \{\s*\n\s*event\.stopPropagation\(\);\s*\n\s*setMenuOpen/,
+  "the branch trigger stops propagation so it never fires the chip's open-changes click",
+);
+
 console.log("composer-git-chip.test.ts: ok");

--- a/src/components/composer-git-chip.tsx
+++ b/src/components/composer-git-chip.tsx
@@ -10,10 +10,29 @@
 // is network-bound (`gh pr view`), so it's fetched once per (root, branch)
 // through the separate `?pr=1` query instead of riding the poll. Chats whose
 // root isn't a repo (or have no project root at all) render nothing.
+//
+// The branch segment is also a menu: it lists the repo's local branches
+// (?branches=1), switches the checkout with POST action=switch-branch, and can
+// provision a `.worktrees/<branch>` checkout (action=create-worktree) that
+// opens as a fresh chat rooted in the new worktree — the same
+// `cave:agents-new-chat` hand-off the GitHub safe-merge flow uses.
 
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { Icon } from "@/lib/icon";
 import { useChangesSummary } from "@/lib/use-changes-summary";
+import { isSafeBranchName } from "@/lib/issue-worktree";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+  PopoverSeparator,
+} from "@/components/ui/popover";
 import "@/styles/composer-git-chip.css";
 
 type BranchPr = {
@@ -25,6 +44,13 @@ type BranchPr = {
 };
 
 type PrResponse = { ok?: boolean; pr?: BranchPr | null };
+
+type BranchRow = {
+  name: string;
+  current: boolean;
+  /** Checkout dir basename when some worktree has the branch checked out. */
+  worktree: string | null;
+};
 
 /** The branch's PR, fetched once per (projectRoot, branch) — null when the
  *  branch has no PR (or gh is unavailable), undefined while unresolved. */
@@ -77,8 +103,116 @@ export function ComposerGitChip({
   onOpenUrl?: (url: string) => void;
 }) {
   const root = projectRoot?.trim() ? projectRoot : undefined;
-  const { loaded, notARepo, branch, count, worktree } = useChangesSummary(root, Boolean(root));
+  const { loaded, notARepo, branch, count, worktree, reload } = useChangesSummary(root, Boolean(root));
   const pr = useBranchPr(root, branch);
+
+  // ── Branch menu state ──────────────────────────────────────────────────────
+  const branchButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [rows, setRows] = useState<BranchRow[] | null>(null);
+  const [menuBusy, setMenuBusy] = useState(false);
+  const [menuError, setMenuError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newBranch, setNewBranch] = useState("");
+
+  // One branch-list fetch per menu open — the list is only as fresh as the
+  // moment the menu opened, which is exactly when it's read.
+  useEffect(() => {
+    if (!menuOpen || !root) return;
+    let cancelled = false;
+    setRows(null);
+    setMenuError(null);
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(root)}&branches=1`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as { ok?: boolean; error?: string; branches?: BranchRow[] };
+        if (cancelled) return;
+        if (!res.ok || !json.ok || !Array.isArray(json.branches)) {
+          throw new Error(json.error ?? `branches HTTP ${res.status}`);
+        }
+        setRows(json.branches);
+      } catch (err) {
+        if (!cancelled) {
+          setRows([]);
+          setMenuError(err instanceof Error ? err.message : "couldn't list branches");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [menuOpen, root]);
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setCreating(false);
+    setNewBranch("");
+    setMenuError(null);
+  };
+
+  const switchBranch = async (name: string) => {
+    if (!root || menuBusy) return;
+    setMenuBusy(true);
+    setMenuError(null);
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectRoot: root, action: "switch-branch", branch: name }),
+      });
+      const json = (await res.json()) as { ok?: boolean; error?: string; branch?: string };
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `switch HTTP ${res.status}`);
+      closeMenu();
+      reload();
+    } catch (err) {
+      setMenuError(err instanceof Error ? err.message : "branch switch failed");
+    } finally {
+      setMenuBusy(false);
+    }
+  };
+
+  const createWorktree = async () => {
+    if (!root || menuBusy) return;
+    const name = newBranch.trim();
+    if (!isSafeBranchName(name)) {
+      setMenuError("Branch names use letters, digits and . _ / - (no leading dash).");
+      return;
+    }
+    setMenuBusy(true);
+    setMenuError(null);
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectRoot: root, action: "create-worktree", branch: name }),
+      });
+      const json = (await res.json()) as {
+        ok?: boolean;
+        error?: string;
+        worktree?: string;
+        branch?: string;
+        created?: boolean;
+      };
+      if (!res.ok || !json.ok || !json.worktree) {
+        throw new Error(json.error ?? `worktree HTTP ${res.status}`);
+      }
+      closeMenu();
+      // Hand off to a fresh chat rooted in the worktree — the same event the
+      // GitHub safe-merge flow uses, so routing/familiar defaults match.
+      window.dispatchEvent(
+        new CustomEvent("cave:agents-new-chat", {
+          detail: { projectRoot: json.worktree },
+        }),
+      );
+    } catch (err) {
+      setMenuError(err instanceof Error ? err.message : "worktree creation failed");
+    } finally {
+      setMenuBusy(false);
+    }
+  };
 
   // Git-less chats (no project, or a non-repo root) show nothing — the chip
   // only appears once the repo status has actually loaded.
@@ -116,9 +250,23 @@ export function ComposerGitChip({
     >
       <span className="cave-composer-git-chip__branch">
         <Icon name="ph:git-branch" width={12} aria-hidden />
-        <span className="cave-composer-git-chip__label" aria-label={`Branch: ${branch}`}>
-          {branch}
-        </span>
+        <button
+          type="button"
+          ref={branchButtonRef}
+          className="cave-composer-git-chip__branch-button focus-ring"
+          aria-label={`Branch: ${branch} — switch branch or create a worktree`}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          title={`Branch: ${branch} · Switch branch / new worktree`}
+          onClick={(event) => {
+            event.stopPropagation();
+            setMenuOpen((open) => !open);
+          }}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          <span className="cave-composer-git-chip__label">{branch}</span>
+          <Icon name="ph:caret-down" width={9} aria-hidden />
+        </button>
         {count > 0 ? (
           <span className="cave-composer-git-chip__dirty" aria-label={dirtyLabel}>
             +{count}
@@ -148,6 +296,91 @@ export function ComposerGitChip({
           <span>#{pr.number}</span>
         </button>
       ) : null}
+      <Popover
+        open={menuOpen}
+        onOpenChange={(next) => {
+          if (!next) closeMenu();
+          else setMenuOpen(true);
+        }}
+        anchorRef={branchButtonRef}
+        placement="top-start"
+        minWidth={240}
+        ariaLabel="Switch branch"
+      >
+        <PopoverBody role="menu" ariaLabel="Branches">
+          <PopoverLabel>Switch branch</PopoverLabel>
+          {rows === null ? (
+            <div className="cave-composer-git-chip__menu-note">Loading branches…</div>
+          ) : (
+            <>
+              {rows.map((row) => (
+                <PopoverItem
+                  key={row.name}
+                  icon="ph:git-branch"
+                  checked={row.current}
+                  disabled={menuBusy || row.current || row.worktree !== null}
+                  title={
+                    row.worktree && !row.current
+                      ? `Checked out in worktree ${row.worktree}`
+                      : row.current
+                        ? "Current branch"
+                        : `Switch to ${row.name}`
+                  }
+                  onSelect={() => void switchBranch(row.name)}
+                >
+                  {row.name}
+                  {row.worktree && !row.current ? ` · ${row.worktree}` : ""}
+                </PopoverItem>
+              ))}
+              {rows.length === 0 && !menuError ? (
+                <div className="cave-composer-git-chip__menu-note">No local branches</div>
+              ) : null}
+            </>
+          )}
+          <PopoverSeparator />
+          {creating ? (
+            <form
+              className="cave-composer-git-chip__worktree-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void createWorktree();
+              }}
+            >
+              <input
+                type="text"
+                className="cave-composer-git-chip__worktree-input focus-ring"
+                placeholder="feat/my-branch"
+                aria-label="New worktree branch name"
+                value={newBranch}
+                onChange={(event) => setNewBranch(event.target.value)}
+                disabled={menuBusy}
+                autoFocus
+              />
+              <button
+                type="submit"
+                className="cave-composer-git-chip__worktree-create focus-ring"
+                disabled={menuBusy || !newBranch.trim()}
+              >
+                {menuBusy ? "Creating…" : "Create"}
+              </button>
+            </form>
+          ) : (
+            <PopoverItem
+              icon="ph:tree-structure"
+              disabled={menuBusy}
+              title="Create a .worktrees/<branch> checkout and open a chat rooted in it"
+              onSelect={() => setCreating(true)}
+            >
+              New worktree…
+            </PopoverItem>
+          )}
+          {menuError ? (
+            <div className="cave-composer-git-chip__menu-error" role="alert">
+              {menuError}
+            </div>
+          ) : null}
+        </PopoverBody>
+      </Popover>
     </div>
   );
 }

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -55,6 +55,29 @@ assert.deepEqual(
   "specific familiar scope should still show only that familiar's chats",
 );
 
+// Cave-archived chats (archived_at stamped, status still e.g. "completed")
+// are excluded by default so no rail/picker caller can surface them; the chat
+// list's "Show archived" toggle opts back in explicitly.
+{
+  const archivedRow = { ...session("stashed", "/work/alpha", "2026-06-06T00:00:00.000Z", "cody"), archived_at: "2026-06-06T01:00:00.000Z" };
+  const withArchived = [...sessions, archivedRow];
+  assert.deepEqual(
+    filterVisibleChatSessions(withArchived, null).map((s) => s.id),
+    ["scratch", "new-alpha", "beta", "old-alpha"],
+    "archived_at rows are hidden by default",
+  );
+  assert.deepEqual(
+    filterVisibleChatSessions(withArchived, null, { includeArchived: true }).map((s) => s.id),
+    ["stashed", "scratch", "new-alpha", "beta", "old-alpha"],
+    "includeArchived keeps archived_at rows for the explicit toggle",
+  );
+  assert.deepEqual(
+    filterVisibleChatSessions(withArchived, "cody", { includeArchived: true }).map((s) => s.id),
+    ["stashed", "new-alpha"],
+    "includeArchived still applies the familiar scope",
+  );
+}
+
 // Externally-generated sessions stay out of the chat lists: daemon-only runs
 // flagged `generated` (journal narratives, flows, automations, CLI) and
 // generator origins (canvas refines, cron/heartbeat automations). They remain

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -150,9 +150,17 @@ export function isGeneratedChatSession(session: SessionRow): boolean {
 export function filterVisibleChatSessions(
   sessions: SessionRow[],
   familiarId: string | null,
+  opts?: {
+    /** Keep Cave-archived rows (`archived_at` set) — the chat list's explicit
+     *  "Show archived" toggle. Rails and pickers never opt in, so an archived
+     *  chat can't resurface in the siderail through any caller's data path. */
+    includeArchived?: boolean;
+  },
 ): SessionRow[] {
+  const includeArchived = opts?.includeArchived ?? false;
   return sessions
     .filter((session) => !DEAD_CHAT_STATUSES.has(session.status))
+    .filter((session) => includeArchived || !session.archived_at)
     .filter((session) => !isGeneratedChatSession(session))
     .filter((session) => familiarId === null || session.familiarId === familiarId)
     .sort((a, b) => (sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1));

--- a/src/lib/issue-worktree.test.ts
+++ b/src/lib/issue-worktree.test.ts
@@ -6,6 +6,8 @@ import {
   issueWorktreeDir,
   issueWorktreeBranch,
   shouldIsolateInWorktree,
+  isSafeBranchName,
+  branchWorktreeDir,
   issueContentionKey,
 } from "./issue-worktree.ts";
 
@@ -85,5 +87,30 @@ assert.equal(
 assert.equal(issueContentionKey("OpenCoven/Coven-Cave", 267), "opencoven/coven-cave#267");
 assert.equal(issueContentionKey("a/b"), "a/b#0", "missing number → #0");
 assert.equal(issueContentionKey("a/b", 9.9), "a/b#9", "number is truncated");
+
+// ── user-named branch worktrees (chat composer) ──────────────────────────────
+assert.equal(isSafeBranchName("feat/chat-git-ergonomics"), true, "conventional feature branch is safe");
+assert.equal(isSafeBranchName("release-1.2.3"), true, "dots and dashes are fine mid-name");
+assert.equal(isSafeBranchName("a"), true, "single alphanumeric char is allowed");
+assert.equal(isSafeBranchName(""), false, "empty name rejected");
+assert.equal(isSafeBranchName("-rf"), false, "leading dash (option injection) rejected");
+assert.equal(isSafeBranchName("feat/../escape"), false, "dotdot rejected");
+assert.equal(isSafeBranchName("feat//x"), false, "double slash rejected");
+assert.equal(isSafeBranchName("feat/"), false, "trailing slash rejected");
+assert.equal(isSafeBranchName("feat."), false, "trailing dot rejected");
+assert.equal(isSafeBranchName("feat.lock"), false, "trailing .lock rejected");
+assert.equal(isSafeBranchName("feat/.hidden"), false, "dot-led segment rejected");
+assert.equal(isSafeBranchName("feat/x.lock/y"), false, ".lock-tailed segment rejected");
+assert.equal(isSafeBranchName("has space"), false, "spaces rejected");
+assert.equal(isSafeBranchName("semi;rm"), false, "shell metacharacters rejected");
+assert.equal(isSafeBranchName("x".repeat(121)), false, "over-long names rejected");
+assert.equal(isSafeBranchName("x".repeat(120)), true, "120 chars is the inclusive cap");
+
+assert.equal(
+  branchWorktreeDir("feat/chat-git-ergonomics"),
+  ".worktrees/feat-chat-git-ergonomics",
+  "slashes flatten to dashes so the checkout is one level under .worktrees/",
+);
+assert.equal(branchWorktreeDir("fix"), ".worktrees/fix", "plain names pass through");
 
 console.log("issue-worktree.test.ts OK");

--- a/src/lib/issue-worktree.ts
+++ b/src/lib/issue-worktree.ts
@@ -96,3 +96,33 @@ export function issueContentionKey(repo: string, number?: number | null): string
   const n = Number.isFinite(number) && number ? Math.trunc(number as number) : 0;
   return `${repo.trim().toLowerCase()}#${n}`;
 }
+
+// ── User-named branch worktrees (chat composer's "New worktree…") ────────────
+
+/**
+ * Strict allow-list for a user-typed branch name that will reach a git argv.
+ * Deliberately tighter than git-check-ref-format: alphanumeric head, then
+ * `[A-Za-z0-9._/-]`, no `..`, no `//`, no `.lock`/`/`/`.` endings, no dot-led
+ * or `.lock`-tailed path segments. Rejecting a leading `-` is what makes the
+ * name safe to pass as a positional git argument (never parsed as an option).
+ */
+export function isSafeBranchName(name: string): boolean {
+  if (!name || name.length > 120) return false;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(name)) return false;
+  if (name.includes("..") || name.includes("//")) return false;
+  if (name.endsWith("/") || name.endsWith(".") || name.endsWith(".lock")) return false;
+  const segments = name.split("/");
+  return segments.every(
+    (seg) => seg !== "" && !seg.startsWith(".") && !seg.endsWith(".lock"),
+  );
+}
+
+/**
+ * Repo-relative worktree directory for a user-named branch, mirroring the
+ * repository convention (`feat/chat-x` → `.worktrees/feat-chat-x`). Callers
+ * must validate with `isSafeBranchName` first; the slash flattening keeps the
+ * checkout a single directory level under `.worktrees/`.
+ */
+export function branchWorktreeDir(branch: string): string {
+  return `.worktrees/${branch.replace(/\//g, "-")}`;
+}

--- a/src/lib/server/issue-worktree-provision.ts
+++ b/src/lib/server/issue-worktree-provision.ts
@@ -21,6 +21,8 @@ import path from "node:path";
 import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
 import { daemonSessionRoots, resolveWithinSessionRoots } from "@/lib/server/session-project-roots";
 import {
+  branchWorktreeDir,
+  isSafeBranchName,
   issueWorktreeBranch,
   issueWorktreeDir,
   type IssueWorktreeRef,
@@ -145,6 +147,41 @@ export async function provisionIssueWorktree(
   const relDir = issueWorktreeDir(ref);
   const branch = issueWorktreeBranch(ref);
   const absPath = resolveWorktreePath(repoRoot, relDir);
+  if (!absPath) return { ok: false, status: 400, error: "invalid worktree path" };
+
+  if (await worktreeExists(repoRoot, absPath)) {
+    return { ok: true, worktree: absPath, branch, created: false, baseRef: null };
+  }
+
+  const baseRef = await pickBaseRef(repoRoot, baseRefRequest ?? null);
+  try {
+    const args = (await branchExists(repoRoot, branch))
+      ? ["worktree", "add", absPath, branch]
+      : ["worktree", "add", "-b", branch, absPath, baseRef];
+    await git(repoRoot, args);
+    return { ok: true, worktree: absPath, branch, created: true, baseRef };
+  } catch (err) {
+    return { ok: false, status: 500, error: err instanceof Error ? err.message : "git worktree add failed" };
+  }
+}
+
+/**
+ * Idempotently provision a worktree for a user-named branch (the chat
+ * composer's "New worktree…" flow) under `.worktrees/<flattened-branch>`.
+ * Reuses the existing worktree when present; otherwise creates the branch off
+ * the best base ref (origin/main preferred) — or checks out the existing local
+ * branch — and adds the worktree. A branch already checked out in another
+ * worktree fails with git's own "already checked out" error, surfaced verbatim.
+ */
+export async function provisionBranchWorktree(
+  repoRoot: string,
+  branch: string,
+  baseRefRequest?: string | null,
+): Promise<ProvisionResult> {
+  if (!isSafeBranchName(branch)) {
+    return { ok: false, status: 400, error: "invalid branch name" };
+  }
+  const absPath = resolveWorktreePath(repoRoot, branchWorktreeDir(branch));
   if (!absPath) return { ok: false, status: 400, error: "invalid worktree path" };
 
   if (await worktreeExists(repoRoot, absPath)) {

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -28,6 +28,9 @@ type ChangesSummary = {
   branch: string | null;
   /** Linked-worktree name (checkout dir basename) — null in the primary checkout. */
   worktree: string | null;
+  /** Immediate refetch — for callers that just mutated git state (e.g. the
+   *  composer's branch switch) and shouldn't wait out the 5s poll. */
+  reload: () => void;
 };
 
 type ChangesResponse = {
@@ -92,5 +95,9 @@ export function useChangesSummary(
 
   usePausablePoll(() => void load(), POLL_MS, { enabled: active && Boolean(projectRoot) });
 
-  return { count, loaded, notARepo, branch, worktree };
+  const reload = useCallback(() => {
+    void load();
+  }, [load]);
+
+  return { count, loaded, notARepo, branch, worktree, reload };
 }

--- a/src/styles/composer-git-chip.css
+++ b/src/styles/composer-git-chip.css
@@ -35,6 +35,79 @@
   gap: 4px;
 }
 
+/* The branch segment is a real button — it opens the switch-branch menu
+   without triggering the chip's open-changes click. */
+.cave-composer-git-chip__branch-button {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 3px;
+  margin: 0;
+  padding: 2px 4px;
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+}
+.cave-composer-git-chip__branch-button:hover {
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.cave-composer-git-chip__branch-button svg:last-child {
+  color: var(--text-muted);
+}
+
+.cave-composer-git-chip__menu-note,
+.cave-composer-git-chip__menu-error {
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.cave-composer-git-chip__menu-error {
+  color: var(--color-danger, oklch(0.65 0.2 25));
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-width: 280px;
+}
+
+.cave-composer-git-chip__worktree-form {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 6px;
+}
+.cave-composer-git-chip__worktree-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-family: inherit;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+.cave-composer-git-chip__worktree-create {
+  flex: 0 0 auto;
+  height: 26px;
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+}
+.cave-composer-git-chip__worktree-create:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .cave-composer-git-chip svg {
   flex-shrink: 0;
   color: var(--composer-pill-gold, oklch(0.81 0.105 83));


### PR DESCRIPTION
## What

Three chat git-ergonomics features (bead **cave-46gg**, long-running goal `chat-git-ergonomics`):

### 1. Archived chats never show in the siderail
- `filterVisibleChatSessions` drops `archived_at` rows **by default**; explicit `{ includeArchived }` opt-in.
- The chat list's *Show archived* toggle still works for the main list, but its sidebar groups now build from an archive-free `railSessions` view — toggling archived rows visible can't leak them into the rail.
- `chat-router` and `workspace-sidebar` rails inherit the safe default.

### 2. Change branch from the chat composer
- The git chip's branch segment is now a menu trigger (`aria-haspopup`, Popover).
- `GET /api/changes?branches=1` lists local branches — current pinned first, branches checked out in other worktrees marked + disabled, tool-internal dunder refs (beads' `__dolt_remote_info__`) filtered.
- `POST action=switch-branch`: strict shared branch-name allow-list, ref existence verified (local or origin), plain `git switch` — git's refusal (dirty conflict / checked out elsewhere) surfaced verbatim, never `-f`.
- `useChangesSummary` gains `reload()` so the chip updates immediately instead of waiting out the 5s poll.

### 3. Create worktrees from chat
- "New worktree…" in the same menu: inline branch-name form → `POST action=create-worktree` → new `provisionBranchWorktree` (shared containment under `.worktrees/`, idempotent reuse, branches off `origin/main`) → opens a fresh chat rooted in the worktree via the `cave:agents-new-chat` hand-off (same pattern as the GitHub safe-merge flow).

## Security posture
- Every user-supplied branch name passes `isSafeBranchName` (alnum head, no leading dash, no `..`/`//`/`.lock`, segment rules) **before** reaching a git argv; all git calls remain execFile argv arrays (no shell).
- Worktree paths re-checked for containment under `repoRoot/.worktrees`.

## Verification
- `pnpm typecheck` ✓
- `pnpm test:app` 694 files ✓ · `pnpm test:api` 168 files ✓ · `pnpm check:tests-wired` ✓ (new test registered)
- `pnpm build` ✓ (bundle within budget)
- `listBranches` porcelain parsing smoke-tested against this repo's real worktree layout.

## Tests
- `src/lib/chat-projects.test.ts` — archived default-drop / opt-in behavioral cases.
- `src/lib/issue-worktree.test.ts` — `isSafeBranchName` + `branchWorktreeDir` cases.
- `src/components/chat-siderail-hide-archived.test.ts` (new) — rail archive-free pins.
- `src/components/composer-git-chip.test.ts` — branch-menu pins (existing pins untouched).
- `src/app/api/changes/route.test.ts` — switch-branch/create-worktree/?branches=1 pins.