### PR TITLE
feat(role-surfaces): Reviewer Review Deck — queue, working-tree diffs, PR context (cave-tqzj)

### DIFF
--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -88,3 +88,7 @@ never fake production data.
   as a plotted course: lane queues, task intake that charts real cards,
   scheduled legs with overdue flags from card dates, real lane moves, and a
   voyage-log drawer of completed and blocked cards.
+- **Review Deck** (`reviewer-review-deck`, role `reviewer`) — a review queue
+  built from sessions carrying PRs, working changes, or branches; real
+  working-tree file lists and capped unified diffs from the changes API;
+  PR/session jumps; saved-checkpoints drawer. Read-only over git state.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -42,6 +42,7 @@ export const SUITES = {
     "src/components/role-surfaces/sentinel-surface.test.ts",
     "src/components/role-surfaces/scribe-surface.test.ts",
     "src/components/role-surfaces/navigator-surface.test.ts",
+    "src/components/role-surfaces/reviewer-surface.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/components/chat-view-transcript-memo.test.ts",
     "src/components/chat-view-chunk-coalescing.test.ts",

--- a/src/components/role-surfaces/ids.ts
+++ b/src/components/role-surfaces/ids.ts
@@ -8,3 +8,4 @@ export const INDEXER_SURFACE_ID = "indexer-archive";
 export const SENTINEL_SURFACE_ID = "sentinel-watchtower";
 export const SCRIBE_SURFACE_ID = "scribe-writing-desk";
 export const NAVIGATOR_SURFACE_ID = "navigator-chart-room";
+export const REVIEWER_SURFACE_ID = "reviewer-review-deck";

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -25,11 +25,13 @@ import { readRoleSurfaceState, writeRoleSurfaceState } from "@/lib/role-surface-
 import { watchtowerStatus } from "./sentinel-watch";
 import { deskSummary, scribeStatus } from "./scribe-craft";
 import { chartRoomStatus } from "./navigator-charts";
+import { reviewDeckStatus } from "./review-deck";
 import {
   INDEXER_SURFACE_ID,
   MESSENGER_SURFACE_ID,
   NAVIGATOR_SURFACE_ID,
   RESEARCHER_SURFACE_ID,
+  REVIEWER_SURFACE_ID,
   SCRIBE_SURFACE_ID,
   SENTINEL_SURFACE_ID,
 } from "./ids";
@@ -64,6 +66,10 @@ const ScribeSurface = dynamic(
 );
 const NavigatorSurface = dynamic(
   () => import("./navigator-surface").then((m) => m.NavigatorSurface),
+  { ssr: false, loading: RoomFallback },
+);
+const ReviewerSurface = dynamic(
+  () => import("./reviewer-surface").then((m) => m.ReviewerSurface),
   { ssr: false, loading: RoomFallback },
 );
 
@@ -338,6 +344,68 @@ registerRoleSurface({
     };
   },
   render: (context) => <NavigatorSurface context={context} />,
+});
+
+registerRoleSurface({
+  id: REVIEWER_SURFACE_ID,
+  role: "reviewer",
+  title: "Review Deck",
+  iconName: "ph:git-diff",
+  description: "Review queue, working-tree diffs, and pull-request context",
+  accentHue: 0,
+  priority: 26,
+  shouldDisplay: () => true,
+  getContributions(context) {
+    const state = readRoleSurfaceState<{ lastCounts?: { queue: number; pullRequests: number } | null }>(
+      context.activeFamiliar.id,
+      REVIEWER_SURFACE_ID,
+    );
+    const counts = state?.lastCounts ?? null;
+    const status = counts ? reviewDeckStatus(counts) : null;
+    return {
+      commands: [
+        {
+          id: "reviewer.toggle-drawer",
+          title: "Toggle checkpoints",
+          hint: "⌘⇧D",
+          run: (ctx) => toggleDrawer(ctx, REVIEWER_SURFACE_ID),
+        },
+      ],
+      toolbarActions: [
+        {
+          id: "reviewer.drawer",
+          title: "Checkpoints",
+          iconName: "ph:list",
+          run: (ctx) => toggleDrawer(ctx, REVIEWER_SURFACE_ID),
+        },
+      ],
+      keyboardShortcuts: [
+        {
+          id: "reviewer.drawer.kbd",
+          combo: "mod+shift+d",
+          description: "Toggle the checkpoints drawer",
+          run: (ctx) => toggleDrawer(ctx, REVIEWER_SURFACE_ID),
+        },
+      ],
+      notifications: daemonNotices(context),
+      statusIndicators: [
+        status == null
+          ? {
+              id: "reviewer.queue",
+              label: "queue unread",
+              tone: "muted" as const,
+              detail: "Queue counts appear after the Review Deck's first pass over the sessions",
+            }
+          : {
+              id: "reviewer.queue",
+              label: status.label,
+              tone: status.tone,
+              detail: "Sessions carrying a PR, working changes, or a branch",
+            },
+      ],
+    };
+  },
+  render: (context) => <ReviewerSurface context={context} />,
 });
 
 registerRoleSurface({

--- a/src/components/role-surfaces/review-deck.ts
+++ b/src/components/role-surfaces/review-deck.ts
@@ -1,0 +1,66 @@
+/**
+ * review-deck — pure review-queue logic for the Reviewer's Review Deck.
+ *
+ * Builds the reviewable queue from the familiar's real sessions (git branch,
+ * pull-request, and diff context) and formats change stats. Kept JSX-free
+ * (type-only imports) so the rules are unit-testable under plain
+ * `node --experimental-strip-types`.
+ */
+
+import type { SessionRow } from "@/lib/types";
+
+export type ReviewItem<T> = {
+  session: T;
+  /** Why this session is on the deck. */
+  reasons: Array<"pull-request" | "working-changes" | "branch">;
+};
+
+/**
+ * Sessions carrying review material — a PR, a nonzero working-tree diff, or a
+ * named branch — newest first. Archived sessions have left the deck.
+ */
+export function reviewQueue<T extends Pick<SessionRow, "archived_at" | "git" | "pullRequest" | "diff" | "updated_at">>(
+  sessions: readonly T[],
+): ReviewItem<T>[] {
+  return sessions
+    .filter((session) => session.archived_at == null)
+    .map((session) => {
+      const reasons: ReviewItem<T>["reasons"] = [];
+      if (session.pullRequest) reasons.push("pull-request");
+      if ((session.diff?.additions ?? 0) > 0 || (session.diff?.deletions ?? 0) > 0) reasons.push("working-changes");
+      if (session.git?.branch) reasons.push("branch");
+      return { session, reasons };
+    })
+    .filter((item) => item.reasons.length > 0)
+    .sort((a, b) => b.session.updated_at.localeCompare(a.session.updated_at));
+}
+
+/** "+12 −3" (thin spaces spared; minus is U+2212 to read as a stat, not a flag). */
+export function diffStatLabel(diff: { additions: number; deletions: number } | null | undefined): string {
+  if (!diff || (diff.additions === 0 && diff.deletions === 0)) return "no changes";
+  return `+${diff.additions} −${diff.deletions}`;
+}
+
+/** "owner/repo#123" for a session's PR, however partially it is known. */
+export function prLabel(pr: { repo: string; number?: number } | null | undefined): string | null {
+  if (!pr) return null;
+  return pr.number != null ? `${pr.repo}#${pr.number}` : pr.repo;
+}
+
+/** The GitHub URL for a session's PR — null until the number is known. */
+export function prUrl(pr: { repo: string; number?: number } | null | undefined): string | null {
+  if (!pr || pr.number == null) return null;
+  return `https://github.com/${pr.repo}/pull/${pr.number}`;
+}
+
+export type ReviewDeckStatus = {
+  label: string;
+  tone: "ok" | "busy";
+};
+
+/** The room's one-line status chip, derived from the latest queue build. */
+export function reviewDeckStatus(counts: { queue: number; pullRequests: number }): ReviewDeckStatus {
+  if (counts.queue === 0) return { label: "deck clear", tone: "ok" };
+  const pr = counts.pullRequests > 0 ? ` · ${counts.pullRequests} PR${counts.pullRequests === 1 ? "" : "s"}` : "";
+  return { label: `${counts.queue} to review${pr}`, tone: "busy" };
+}

--- a/src/components/role-surfaces/reviewer-surface.test.ts
+++ b/src/components/role-surfaces/reviewer-surface.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  diffStatLabel,
+  prLabel,
+  prUrl,
+  reviewDeckStatus,
+  reviewQueue,
+} from "./review-deck.ts";
+
+const surface = readFileSync(new URL("./reviewer-surface.tsx", import.meta.url), "utf8");
+const register = readFileSync(new URL("./register.tsx", import.meta.url), "utf8");
+const docs = readFileSync(new URL("../../../docs/role-surfaces.md", import.meta.url), "utf8");
+
+// ── Queue rules (behavioral, real module) ────────────────────────────────────
+
+function session(overrides = {}) {
+  return {
+    id: "s-0",
+    archived_at: null,
+    git: null,
+    pullRequest: null,
+    diff: null,
+    updated_at: "2026-07-14T10:00:00Z",
+    ...overrides,
+  };
+}
+
+test("reviewQueue keeps only sessions with review material, newest first", () => {
+  const queue = reviewQueue([
+    session({ id: "plain" }),
+    session({ id: "pr", pullRequest: { repo: "o/r", number: 7 }, updated_at: "2026-07-14T09:00:00Z" }),
+    session({ id: "diffed", diff: { additions: 3, deletions: 1 }, updated_at: "2026-07-14T11:00:00Z" }),
+    session({ id: "branched", git: { branch: "feat/x" }, updated_at: "2026-07-14T08:00:00Z" }),
+    session({ id: "archived", pullRequest: { repo: "o/r", number: 9 }, archived_at: "2026-07-13T00:00:00Z" }),
+    session({ id: "zero-diff", diff: { additions: 0, deletions: 0 } }),
+  ]);
+  assert.deepEqual(
+    queue.map((item) => item.session.id),
+    ["diffed", "pr", "branched"],
+  );
+});
+
+test("reviewQueue explains why each session is on the deck", () => {
+  const [item] = reviewQueue([
+    session({
+      id: "everything",
+      pullRequest: { repo: "o/r", number: 1 },
+      diff: { additions: 1, deletions: 0 },
+      git: { branch: "main" },
+    }),
+  ]);
+  assert.deepEqual(item.reasons, ["pull-request", "working-changes", "branch"]);
+});
+
+test("diffStatLabel is honest about empty diffs", () => {
+  assert.equal(diffStatLabel(null), "no changes");
+  assert.equal(diffStatLabel({ additions: 0, deletions: 0 }), "no changes");
+  assert.equal(diffStatLabel({ additions: 12, deletions: 3 }), "+12 −3");
+});
+
+test("PR labels and URLs need a number to link", () => {
+  assert.equal(prLabel(null), null);
+  assert.equal(prLabel({ repo: "o/r" }), "o/r");
+  assert.equal(prLabel({ repo: "o/r", number: 42 }), "o/r#42");
+  assert.equal(prUrl({ repo: "o/r" }), null);
+  assert.equal(prUrl({ repo: "o/r", number: 42 }), "https://github.com/o/r/pull/42");
+});
+
+test("reviewDeckStatus reads ok when clear and busy with a queue", () => {
+  assert.deepEqual(reviewDeckStatus({ queue: 0, pullRequests: 0 }), { label: "deck clear", tone: "ok" });
+  assert.deepEqual(reviewDeckStatus({ queue: 3, pullRequests: 0 }), { label: "3 to review", tone: "busy" });
+  assert.deepEqual(reviewDeckStatus({ queue: 3, pullRequests: 1 }), { label: "3 to review · 1 PR", tone: "busy" });
+});
+
+// ── Surface wiring (source pins) ─────────────────────────────────────────────
+
+test("the deck reads real working trees through the changes API", () => {
+  assert.match(surface, /\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}/);
+  assert.match(surface, /&path=\$\{encodeURIComponent\(relPath\)\}/);
+  assert.match(surface, /&checkpoints=1/);
+  assert.match(surface, /truncated/);
+  assert.match(surface, /Diff truncated server-side/);
+  assert.match(surface, /never edits the working tree/);
+});
+
+test("the queue derives from the familiar's real sessions", () => {
+  assert.match(surface, /reviewQueue\(context\.runtimeState\.sessions\)/);
+  assert.match(surface, /context\.openSession\(selected\.session\.id, familiarId\)/);
+  assert.match(surface, /context\.openUrl\(selectedPrUrl\)/);
+  assert.match(surface, /SurfaceEmpty/);
+  assert.match(surface, /useRoleSurfaceState<ReviewerState>/);
+});
+
+test("the deck exposes errors and expansion state accessibly", () => {
+  assert.match(surface, /role="alert"/);
+  assert.match(surface, /aria-current=\{item\.session\.id === state\.selectedSessionId/);
+  assert.match(surface, /aria-expanded=\{openFile === file\.path\}/);
+});
+
+test("registration names the Review Deck with its own accent and drawer chrome", () => {
+  assert.match(register, /id: REVIEWER_SURFACE_ID/);
+  assert.match(register, /role: "reviewer"/);
+  assert.match(register, /title: "Review Deck"/);
+  assert.match(register, /iconName: "ph:git-diff"/);
+  assert.match(register, /accentHue: 0/);
+  assert.match(register, /combo: "mod\+shift\+d",\s*\n\s*description: "Toggle the checkpoints drawer"/);
+  assert.match(register, /reviewDeckStatus\(/);
+});
+
+test("the Review Deck is documented as an initial room", () => {
+  assert.match(docs, /\*\*Review Deck\*\* \(`reviewer-review-deck`, role `reviewer`\)/);
+});

--- a/src/components/role-surfaces/reviewer-surface.tsx
+++ b/src/components/role-surfaces/reviewer-surface.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+/**
+ * Reviewer Surface — the Review Deck.
+ *
+ * Change review over the familiar's real work. Left rail: the review queue —
+ * this familiar's sessions that carry review material (a pull request, a
+ * nonzero working-tree diff, or a named branch). Center: the selected
+ * session's real working-tree changes (`/api/changes`), with per-file unified
+ * diffs on demand (capped server-side; truncation shown honestly). Right
+ * sidebar: session facts — branch, worktree, PR link, diff stat — and jumps
+ * into the session or the PR. Bottom drawer: the deck's saved checkpoints for
+ * the selected project root.
+ *
+ * Everything rendered is real git state read through the Cave's changes API;
+ * the deck never mutates a working tree. Panels with nothing to show say so.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import type { RoleSurfaceContext } from "@/lib/role-surfaces";
+import { useRoleSurfaceState } from "@/lib/role-surface-state";
+import { relativeTime } from "@/lib/relative-time";
+import { diffStatLabel, prLabel, prUrl, reviewQueue } from "./review-deck";
+import { RailSection, SurfaceCanvas, SurfaceEmpty, SurfaceRail, SurfaceRoom } from "./surface-room";
+import { REVIEWER_SURFACE_ID } from "./ids";
+
+export type ReviewerState = {
+  selectedSessionId: string | null;
+  drawerOpen: boolean;
+  /** Latest queue counts — read by the registration manifest's status chip. */
+  lastCounts: { queue: number; pullRequests: number } | null;
+};
+
+export const REVIEWER_INITIAL_STATE: ReviewerState = {
+  selectedSessionId: null,
+  drawerOpen: false,
+  lastCounts: null,
+};
+
+type ChangedFileWire = {
+  path: string;
+  status: "modified" | "added" | "deleted" | "renamed" | "untracked";
+  renamedFrom?: string;
+  insertions?: number;
+  deletions?: number;
+};
+
+type ChangesWire =
+  | { ok: true; repo: true; repoRoot: string; branch: string | null; worktree: string | null; files: ChangedFileWire[] }
+  | { ok: true; repo: false; error?: string };
+
+type CheckpointWire = { name: string; savedAt: string; bytes: number };
+
+export function ReviewerSurface({ context }: { context: RoleSurfaceContext }) {
+  const familiarId = context.activeFamiliar.id;
+  const [state, patch] = useRoleSurfaceState<ReviewerState>(familiarId, REVIEWER_SURFACE_ID, REVIEWER_INITIAL_STATE);
+
+  // ── The review queue: real sessions with review material ──────────────────
+  const queue = useMemo(() => reviewQueue(context.runtimeState.sessions), [context.runtimeState.sessions]);
+  useEffect(() => {
+    const counts = {
+      queue: queue.length,
+      pullRequests: queue.filter((item) => item.reasons.includes("pull-request")).length,
+    };
+    if (state.lastCounts?.queue === counts.queue && state.lastCounts?.pullRequests === counts.pullRequests) return;
+    patch({ lastCounts: counts });
+  }, [queue, state.lastCounts, patch]);
+
+  const selected = useMemo(
+    () => queue.find((item) => item.session.id === state.selectedSessionId) ?? null,
+    [queue, state.selectedSessionId],
+  );
+  const projectRoot = selected?.session.project_root ?? null;
+
+  // ── Working-tree changes for the selected session's project root ──────────
+  const [changes, setChanges] = useState<ChangesWire | null>(null);
+  const [changesError, setChangesError] = useState<string | null>(null);
+  const loadChanges = useCallback(async () => {
+    setChangesError(null);
+    setChanges(null);
+    if (!projectRoot) return;
+    try {
+      const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`, { cache: "no-store" });
+      const json = res.ok ? ((await res.json()) as ChangesWire) : null;
+      if (!json?.ok) throw new Error("bad response");
+      setChanges(json);
+    } catch {
+      setChangesError("Couldn't read the working tree.");
+      setChanges(null);
+    }
+  }, [projectRoot]);
+  useEffect(() => {
+    void loadChanges();
+  }, [loadChanges]);
+
+  // ── One file's unified diff, on demand ─────────────────────────────────────
+  const [openFile, setOpenFile] = useState<string | null>(null);
+  const [diff, setDiff] = useState<{ text: string; truncated: boolean } | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  useEffect(() => {
+    setOpenFile(null);
+    setDiff(null);
+  }, [projectRoot]);
+  const showDiff = async (relPath: string) => {
+    if (!projectRoot) return;
+    setOpenFile(relPath);
+    setDiff(null);
+    setDiffLoading(true);
+    try {
+      const res = await fetch(
+        `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}&path=${encodeURIComponent(relPath)}`,
+        { cache: "no-store" },
+      );
+      const json = res.ok
+        ? ((await res.json()) as { ok?: boolean; diff?: string; truncated?: boolean })
+        : null;
+      if (!json?.ok || typeof json.diff !== "string") throw new Error("bad response");
+      setDiff({ text: json.diff, truncated: json.truncated === true });
+    } catch {
+      setDiff({ text: "", truncated: false });
+      setChangesError(`Couldn't load the diff for ${relPath}.`);
+    } finally {
+      setDiffLoading(false);
+    }
+  };
+
+  // ── Saved checkpoints for the selected root (drawer) ───────────────────────
+  const [checkpoints, setCheckpoints] = useState<CheckpointWire[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setCheckpoints(null);
+    if (!projectRoot || !state.drawerOpen) return;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}&checkpoints=1`,
+          { cache: "no-store" },
+        );
+        const json = res.ok ? ((await res.json()) as { ok?: boolean; checkpoints?: CheckpointWire[] }) : null;
+        if (!cancelled) setCheckpoints(json?.checkpoints ?? []);
+      } catch {
+        if (!cancelled) setCheckpoints([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectRoot, state.drawerOpen]);
+
+  const selectedPrUrl = prUrl(selected?.session.pullRequest);
+  const repoFiles = changes?.ok && changes.repo ? changes.files : [];
+
+  return (
+    <SurfaceRoom
+      accentHue={0}
+      drawerTitle="Checkpoints"
+      drawerOpen={state.drawerOpen}
+      onToggleDrawer={() => patch({ drawerOpen: !state.drawerOpen })}
+      drawer={
+        <div className="role-surface-drawer-grid">
+          <RailSection title="Saved checkpoints" iconName="ph:bookmark-simple">
+            {!projectRoot ? (
+              <SurfaceEmpty title="Select a session to see its project's checkpoints." />
+            ) : checkpoints == null ? (
+              <SurfaceEmpty title="Loading checkpoints…" />
+            ) : checkpoints.length === 0 ? (
+              <SurfaceEmpty
+                title="No checkpoints saved."
+                hint="Chat's change tools snapshot working trees here before risky edits."
+              />
+            ) : (
+              <ul className="role-surface-list" aria-label="Saved checkpoints">
+                {checkpoints.map((checkpoint) => (
+                  <li key={checkpoint.name} className="role-surface-list-row">
+                    <span className="role-surface-memory-path">{checkpoint.name}</span>
+                    <span className="role-surface-tag">{relativeTime(checkpoint.savedAt)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </RailSection>
+        </div>
+      }
+    >
+      <SurfaceRail side="left" label="Review queue">
+        <RailSection title="Review queue" iconName="ph:git-diff">
+          {queue.length === 0 ? (
+            <SurfaceEmpty
+              title="Deck clear."
+              hint="Sessions with a pull request, working changes, or a branch appear here."
+            />
+          ) : (
+            <ul className="role-surface-list" aria-label="Sessions to review">
+              {queue.slice(0, 30).map((item) => (
+                <li key={item.session.id}>
+                  <button
+                    type="button"
+                    className={`role-surface-row-btn focus-ring-inset${item.session.id === state.selectedSessionId ? " role-surface-row-btn--active" : ""}`}
+                    aria-current={item.session.id === state.selectedSessionId ? "true" : undefined}
+                    onClick={() => patch({ selectedSessionId: item.session.id })}
+                  >
+                    {item.session.title || item.session.id}
+                    {item.reasons.includes("pull-request") && <span className="role-surface-tag">PR</span>}
+                    <span className="role-surface-tag">{diffStatLabel(item.session.diff)}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </RailSection>
+      </SurfaceRail>
+
+      <SurfaceCanvas label="Working-tree changes">
+        <div className="role-surface-canvas-stack">
+          {changesError ? (
+            <div role="alert" className="role-surface-hint">
+              {changesError}{" "}
+              <button type="button" className="role-surface-chip focus-ring" onClick={() => void loadChanges()}>
+                Try again
+              </button>
+            </div>
+          ) : null}
+          {!selected ? (
+            <SurfaceEmpty
+              iconName="ph:git-diff"
+              title="Pick a session from the queue."
+              hint="Its project's real working-tree changes are read on selection."
+            />
+          ) : changes == null && changesError == null ? (
+            <SurfaceEmpty title="Reading the working tree…" />
+          ) : changes?.ok && !changes.repo ? (
+            <SurfaceEmpty title="Not a git repository." hint="This session's project root has no repo to review." />
+          ) : changes?.ok && changes.repo && repoFiles.length === 0 ? (
+            <SurfaceEmpty title="Working tree clean." hint="No uncommitted changes at this project root." />
+          ) : changes?.ok && changes.repo ? (
+            <>
+              <ul className="role-surface-list" aria-label="Changed files">
+                {repoFiles.slice(0, 80).map((file) => (
+                  <li key={file.path}>
+                    <button
+                      type="button"
+                      className={`role-surface-row-btn focus-ring-inset${openFile === file.path ? " role-surface-row-btn--active" : ""}`}
+                      aria-expanded={openFile === file.path}
+                      onClick={() => void showDiff(file.path)}
+                    >
+                      <span className="role-surface-memory-path">{file.path}</span>
+                      <span className="role-surface-tag">{file.status}</span>
+                      {(file.insertions != null || file.deletions != null) && (
+                        <span className="role-surface-tag">
+                          +{file.insertions ?? 0} −{file.deletions ?? 0}
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {openFile != null && (
+                <section aria-label={`Diff for ${openFile}`}>
+                  {diffLoading ? (
+                    <SurfaceEmpty title="Loading diff…" />
+                  ) : diff && diff.text ? (
+                    <>
+                      {diff.truncated && (
+                        <p className="role-surface-hint">Diff truncated server-side — showing the first part only.</p>
+                      )}
+                      <pre className="role-surface-content">{diff.text}</pre>
+                    </>
+                  ) : (
+                    <SurfaceEmpty title="No diff to show." />
+                  )}
+                </section>
+              )}
+            </>
+          ) : null}
+        </div>
+      </SurfaceCanvas>
+
+      <SurfaceRail side="right" label="Session details">
+        {!selected ? (
+          <RailSection title="Details" iconName="ph:note">
+            <SurfaceEmpty title="Select a session to review it." />
+          </RailSection>
+        ) : (
+          <>
+            <RailSection title="Under review" iconName="ph:note">
+              <p className="role-surface-memory-path">{selected.session.title || selected.session.id}</p>
+              <dl className="role-surface-facts">
+                <dt>Branch</dt>
+                <dd>{selected.session.git?.branch ?? (changes?.ok && changes.repo ? changes.branch : null) ?? "—"}</dd>
+                {changes?.ok && changes.repo && changes.worktree && (
+                  <>
+                    <dt>Worktree</dt>
+                    <dd>{changes.worktree}</dd>
+                  </>
+                )}
+                <dt>Working changes</dt>
+                <dd>{diffStatLabel(selected.session.diff)}</dd>
+                <dt>Pull request</dt>
+                <dd>{prLabel(selected.session.pullRequest) ?? "None"}</dd>
+                <dt>Status</dt>
+                <dd>{selected.session.status}</dd>
+                <dt>Updated</dt>
+                <dd>{relativeTime(selected.session.updated_at)}</dd>
+              </dl>
+            </RailSection>
+            <RailSection title="Jump" iconName="ph:arrow-bend-up-right">
+              <div className="role-surface-btn-row">
+                <button
+                  type="button"
+                  className="role-surface-chip role-surface-chip--accent focus-ring"
+                  onClick={() => context.openSession(selected.session.id, familiarId)}
+                >
+                  Open session
+                </button>
+                {selectedPrUrl && (
+                  <button
+                    type="button"
+                    className="role-surface-chip focus-ring"
+                    onClick={() => context.openUrl(selectedPrUrl)}
+                  >
+                    Open pull request
+                    <Icon name="ph:arrow-square-out" width={12} height={12} aria-hidden />
+                  </button>
+                )}
+              </div>
+              <p className="role-surface-hint">The deck reads real git state; it never edits the working tree.</p>
+            </RailSection>
+          </>
+        )}
+      </SurfaceRail>
+    </SurfaceRoom>
+  );
+}


### PR DESCRIPTION
## What

Adds the **Review Deck** — the Role Surface room for the `reviewer` role (`reviewer-review-deck`, accent hue 0, priority 26). Fourth room of the long-running `role-surface-rooms` goal (bead `cave-tqzj`; Watchtower #3130, Writing Desk #3133, Chart Room #3136). Matches familiars summoned with the "Code reviewer" preset via role-token matching (`Code reviewer` → `reviewer`).

## Real data only

- **Review queue** from the familiar's real sessions carrying review material — a pull request, a nonzero working-tree diff, or a named branch — newest first, with reasons and `+N −N` stats.
- **Working-tree reading** through `GET /api/changes?projectRoot=…`: changed-file lists (status + insertions/deletions) and per-file unified diffs on demand (`&path=…`), with the server-side cap surfaced honestly (truncation notice). **Read-only** — the deck never mutates a working tree.
- **Session facts** rail: branch (session context or live repo read), worktree name, PR label, status, updated time; **Open session** and **Open pull request** jumps.
- **Saved-checkpoints drawer** (`&checkpoints=1`) for the selected project root.
- Honest empty states: deck clear, not-a-repo, clean working tree, no checkpoints.

## Chrome contributions

- Status chip from the latest queue pass: `deck clear` (ok) / `N to review · M PRs` (busy), `muted` before first pass.
- ⌘⇧D checkpoints drawer toggle (command + toolbar + shortcut), daemon-offline notice — consistent with the other rooms.
- No shell edits; registration only in `register.tsx`, code-split via `next/dynamic`. No new icons needed (`ph:git-diff` already registered).

## Tests

- `reviewer-surface.test.ts`: behavioral tests over JSX-free `review-deck.ts` (queue membership/order/reasons incl. archived + zero-diff exclusions, stat labels, PR label/URL rules, status tones) + source pins (changes-API wiring incl. truncation honesty, session/PR jumps, a11y, registration, docs). Wired into the app suite; check-tests-wired ✓.
- `pnpm typecheck` ✓; sentinel / scribe / navigator / role-surfaces / shell suites ✓.
