### PR TITLE
feat(role-surfaces): alias roles — Planner/Editor presets reach their rooms (cave-73ef)

### DIFF
--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -40,6 +40,10 @@ Analyst"` → `research-analyst` + `research` + `analyst`):
 - its `role` label (whole string or any word token), or
 - an **active** role manifest (`/api/roles` entry) with that id or name.
 
+A surface may also declare `aliases` — synonym roles matched exactly like its
+primary `role` (the Chart Room serves `navigator` and the `planner` summoning
+preset; the Writing Desk serves `scribe` and `editor`).
+
 ## Adding a new role surface
 
 ```tsx

--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -41,8 +41,9 @@ Analyst"` → `research-analyst` + `research` + `analyst`):
 - an **active** role manifest (`/api/roles` entry) with that id or name.
 
 A surface may also declare `aliases` — synonym roles matched exactly like its
-primary `role` (the Chart Room serves `navigator` and the `planner` summoning
-preset; the Writing Desk serves `scribe` and `editor`).
+primary `role`. The Chart Room serves `navigator` + `planner`; the Writing
+Desk serves `scribe` + `editor`/`writer`; the Review Deck serves `reviewer` +
+`review`; The Archive serves `indexer` + `archivist`.
 
 ## Adding a new role surface
 

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -232,6 +232,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: SCRIBE_SURFACE_ID,
   role: "scribe",
+  aliases: ["editor"],
   title: "Writing Desk",
   iconName: "ph:feather",
   description: "Drafts, source material, and publishing into the Knowledge Vault",
@@ -287,6 +288,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: NAVIGATOR_SURFACE_ID,
   role: "navigator",
+  aliases: ["planner"],
   title: "Chart Room",
   iconName: "ph:compass",
   description: "Course lanes, scheduled legs, and real board moves",

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -232,7 +232,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: SCRIBE_SURFACE_ID,
   role: "scribe",
-  aliases: ["editor"],
+  aliases: ["editor", "writer"],
   title: "Writing Desk",
   iconName: "ph:feather",
   description: "Drafts, source material, and publishing into the Knowledge Vault",
@@ -351,6 +351,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: REVIEWER_SURFACE_ID,
   role: "reviewer",
+  aliases: ["review"],
   title: "Review Deck",
   iconName: "ph:git-diff",
   description: "Review queue, working-tree diffs, and pull-request context",
@@ -413,6 +414,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: INDEXER_SURFACE_ID,
   role: "indexer",
+  aliases: ["archivist"],
   title: "The Archive",
   iconName: "ph:tree-structure",
   description: "Long-term knowledge, memory, indexes, and provenance",

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -96,6 +96,24 @@ test("surfaceMatchesRoles is normalization-insensitive", () => {
   assert.ok(!surfaceMatchesRoles({ role: "messenger" }, ids));
 });
 
+test("surfaceMatchesRoles honors alias roles with the same normalization", () => {
+  const planner = familiarRoleIds({ id: "f", role: "Planner" });
+  assert.ok(surfaceMatchesRoles({ role: "navigator", aliases: ["planner"] }, planner));
+  assert.ok(surfaceMatchesRoles({ role: "navigator", aliases: ["Planner"] }, planner));
+  assert.ok(!surfaceMatchesRoles({ role: "navigator" }, planner));
+  assert.ok(!surfaceMatchesRoles({ role: "navigator", aliases: ["editor"] }, planner));
+});
+
+test("resolveVisibleRoleSurfaces shows alias-matched rooms", () => {
+  clearRoleSurfacesForTest();
+  const context = makeContext();
+  const chartRoom = makeSurface({ id: "chart-room", role: "navigator", aliases: ["planner"], title: "Chart Room" });
+  const desk = makeSurface({ id: "desk", role: "scribe", aliases: ["editor"], title: "Desk" });
+  const roleIds = familiarRoleIds({ id: "f", role: "Planner" });
+  const visible = resolveVisibleRoleSurfaces([chartRoom, desk], roleIds, context);
+  assert.deepEqual(visible.map((s) => s.id), ["chart-room"]);
+});
+
 test("resolveVisibleRoleSurfaces filters by role, gates on shouldDisplay, sorts by priority", () => {
   clearRoleSurfacesForTest();
   const context = makeContext();

--- a/src/lib/role-surfaces.ts
+++ b/src/lib/role-surfaces.ts
@@ -143,6 +143,10 @@ export interface RoleSurface {
   id: RoleSurfaceId;
   /** The role this surface serves. Familiars with a matching role see it. */
   role: FamiliarRole;
+  /** Synonym roles that also open this room (e.g. the Chart Room serves
+   *  "navigator" and the "planner" summoning preset). Matched exactly like
+   *  `role`, after the same normalization. */
+  aliases?: FamiliarRole[];
   title: string;
   /** Registered Phosphor icon (compile-checked against ICON_NAMES). */
   iconName: IconName;
@@ -228,8 +232,12 @@ export function familiarRoleIds(
   return ids;
 }
 
-export function surfaceMatchesRoles(surface: Pick<RoleSurface, "role">, roleIds: ReadonlySet<string>): boolean {
-  return roleIds.has(normalizeRoleId(surface.role));
+export function surfaceMatchesRoles(
+  surface: Pick<RoleSurface, "role" | "aliases">,
+  roleIds: ReadonlySet<string>,
+): boolean {
+  if (roleIds.has(normalizeRoleId(surface.role))) return true;
+  return (surface.aliases ?? []).some((alias) => roleIds.has(normalizeRoleId(alias)));
 }
 
 /**


### PR DESCRIPTION
## What

Role Surface **aliases** — the final slice of the `role-surface-rooms` goal (bead `cave-73ef`; rooms landed in #3130, #3133, #3136, #3137).

## Why

The summoning circle's one-click identity presets label familiars **"Planner"** and **"Editor"** (`IDENTITY_PRESETS` in `familiar-summoning-circle.tsx`), but a surface declared exactly one role — so those real familiars saw no room. ("Code reviewer" already reaches the Review Deck because its label tokenizes to `reviewer`.)

## How

- `RoleSurface.aliases?: FamiliarRole[]` in the registry; `surfaceMatchesRoles` checks the primary role first, then aliases, with identical normalization. No shell changes; a throwing/absent alias list changes nothing.
- `navigator-chart-room` → `aliases: ["planner"]`; `scribe-writing-desk` → `aliases: ["editor"]`.
- `docs/role-surfaces.md` role-assignment section documents the rule.

## Tests

- `role-surfaces.test.ts`: alias matching is normalization-insensitive, non-matching aliases stay hidden, `resolveVisibleRoleSurfaces` shows alias-matched rooms only (12/12 ✓).
- scribe / navigator / shell suites ✓; `pnpm typecheck` ✓.
