### PR TITLE
feat(inbox): group-by control + select-by-group/search collective actions (cave-fcy8)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -170,6 +170,7 @@ assert.match(
   "an active search relabels select-all as 'all N matches'",
 );
 assert.match(source, /fetch\("\/api\/inbox\/bulk"/, "collective actions post once to the bulk endpoint");
+assert.match(source, /\.filter\(\(id\) => !id\.startsWith\("eph:"\)\)/, "ephemeral client-only items never reach the bulk endpoint");
 assert.match(source, /inboxBulkAct\("read", "Marked read"\)/, "bulk read is offered");
 assert.match(source, /inboxBulkAct\("done", "Marked done"\)/, "bulk done is offered");
 assert.match(source, /inboxBulkAct\("dismiss", "Dismissed"\)/, "bulk dismiss is offered");

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -148,11 +148,36 @@ assert.doesNotMatch(
   "detail panel actions should use radius tokens instead of hard-coded radii",
 );
 
-// The active Rituals surface is Inbox + Calendar + Crons; reminder bulk
-// selection belongs to the older unified Automations surface.
+// The active Rituals surface is Inbox + Calendar + Crons. Bulk selection now
+// belongs to the INBOX feed (group-by + select-by-group/search, cave-fcy8);
+// the older per-reminder bulk machinery is gone for good.
 assert.match(source, /type AutomationTab = "inbox" \| "calendar" \| "crons"/, "Rituals exposes Inbox, Calendar and Crons tabs");
-assert.doesNotMatch(source, /<SelectionToolbar/, "Rituals no longer renders reminder bulk-select chrome");
+assert.doesNotMatch(source, /bulkPatchReminders|bulkDeleteReminders|ReminderTaskList|reminderSelect/, "the orphaned reminder bulk-select machinery stays deleted");
 assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : initialTab === "crons" \? "crons" : "inbox"/, "Inbox is the default landing tab; calendar/crons deep links still win");
+
+// ── Inbox grouping + collective actions (cave-fcy8) ─────────────────────────
+// Group-by control re-shapes the feed; selection acts on the visible
+// (search-filtered) universe; whole groups toggle from their headers; bulk
+// actions ride ONE POST /api/inbox/bulk; delete keeps the undo window.
+assert.match(source, /buildInboxGroups\(inboxVisible, inboxGroupBy, familiarLabel\)/, "groups derive from the pure lib over the filtered feed");
+assert.match(source, /INBOX_GROUP_BY_OPTIONS/, "the group-by control offers the lib's dimensions");
+assert.match(source, /cave:inbox:group-by/, "the group-by choice persists per install");
+assert.match(source, /const inboxSelect = useMultiSelect\(inboxVisible, \(it\) => it\.id\)/, "selection universe = the visible matches");
+assert.match(source, /<SelectionToolbar/, "inbox select mode uses the shared bulk toolbar");
+assert.match(
+  source,
+  /`Select all \$\{inboxVisible\.length\} match\$\{inboxVisible\.length === 1 \? "" : "es"\}`/,
+  "an active search relabels select-all as 'all N matches'",
+);
+assert.match(source, /fetch\("\/api\/inbox\/bulk"/, "collective actions post once to the bulk endpoint");
+assert.match(source, /inboxBulkAct\("read", "Marked read"\)/, "bulk read is offered");
+assert.match(source, /inboxBulkAct\("done", "Marked done"\)/, "bulk done is offered");
+assert.match(source, /inboxBulkAct\("dismiss", "Dismissed"\)/, "bulk dismiss is offered");
+assert.match(source, /scheduleDelete\(ids, `\$\{ids\.length\} inbox item/, "bulk delete rides the undo toast");
+assert.match(source, /groupChecked=\{groupSelected\(group\)\}/, "each group header reflects its selection state");
+assert.match(source, /aria-label=\{`Select every item in \$\{group\.title\}`\}/, "the group checkbox names its group");
+assert.match(source, /role=\{selectMode \? "checkbox" : undefined\}/, "rows become checkboxes in select mode");
+assert.match(source, /inboxSelect\.exit\(\); \/\/ selection is an inbox-tab mode, never carried across/, "switching tabs drops the selection");
 
 // ── Polling pauses while hidden + async fetch guards ────────────────────────
 // The 15s list poll + 2.5s in-flight run poll otherwise keep firing in a
@@ -176,18 +201,16 @@ assert.match(source, /if \(!live\(\)\) return;/, "a superseded load() drops its 
 // ── Per-row quick actions (run-now + pause/resume), always visible ──
 assert.match(source, /const ScheduleActionsContext = createContext/, "row actions are provided via context (no prop threading)");
 assert.match(source, /<ScheduleActionsContext\.Provider/, "AutomationsView provides the row actions");
-assert.match(source, /runReminder: runNow/, "reminder run-now is wired");
-assert.match(source, /togglePauseReminder: togglePaused/, "reminder pause/resume is wired");
 assert.match(source, /runAutomation: runCodexNow/, "automation run-now is wired");
 assert.match(source, /togglePauseAutomation: toggleCodex/, "automation pause/resume is wired");
 // Actions are labeled, always-visible siblings of the row button (never a
 // hover-revealed overlay, and never nested inside the row's own button).
 assert.doesNotMatch(source, /group-hover\/srow/, "row actions are always visible — no hover reveal remains");
-assert.match(source, /text=\{paused \? "Resume" : "Pause"\}/, "the reminder row's pause action is a labeled button");
 assert.match(source, /text=\{isActive \? "Pause" : "Resume"\}/, "the cron row's pause action is a labeled button");
 assert.match(source, /actions\.runAutomation\(auto\)/, "the automation row exposes run-now");
-assert.match(source, /actions\.togglePauseReminder\(item\)/, "the reminder row exposes pause/resume");
-assert.match(source, /item\.kind !== "daily-summary"/, "daily-summary rows get no run/pause actions");
+// Inbox feed rows expose done/snooze/dismiss instead (run/pause live in the
+// reminder detail panel) — and never while picking rows in select mode.
+assert.match(source, /\{!selectMode && !resolved && \(onDone \|\| onSnooze \|\| onDismiss\)/, "inbox row actions hide in select mode");
 assert.match(
   source,
   /entry\.name[\s\S]*?label=\{`Run \$\{entry\.name\} now`\}/,

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -9,7 +9,14 @@ import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useAnnouncer } from "@/components/ui/live-region";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
 import type { Recurrence } from "@/lib/inbox-recurrence";
-import { groupInboxFeed, inboxKindLabel } from "@/lib/inbox-feed";
+import {
+  buildInboxGroups,
+  groupInboxFeed,
+  INBOX_GROUP_BY_OPTIONS,
+  inboxKindLabel,
+  type InboxFeedGroup,
+  type InboxGroupBy,
+} from "@/lib/inbox-feed";
 import type {
   AutomationStatus,
   CodexAutomation,
@@ -110,22 +117,6 @@ function scheduleTime(hour: number, minute: number): string {
 
 const humanSchedule = (rec: Recurrence | undefined | null): string =>
   humanRecurrence(rec, scheduleTime);
-
-function isScheduleInboxItem(item: InboxItem): boolean {
-  return item.kind === "reminder" || item.kind === "daily-summary";
-}
-
-// A one-shot reminder still pending after its fire time never fired (e.g. the
-// daemon was offline) — worth surfacing instead of a quiet "3h ago".
-function isReminderOverdue(item: InboxItem): boolean {
-  return (
-    item.kind !== "daily-summary" &&
-    (item.recurrence?.type ?? "none") === "none" &&
-    item.status === "pending" &&
-    !!item.fireAt &&
-    new Date(item.fireAt).getTime() < Date.now()
-  );
-}
 
 function relTime(iso: string | undefined | null): string {
   if (!iso) return "—";
@@ -444,8 +435,6 @@ function DetailPanel({
 // row instead of buried in the detail panel. Avoids threading callbacks through
 // the list/section components.
 type ScheduleActions = {
-  runReminder: (id: string) => void;
-  togglePauseReminder: (item: InboxItem) => void;
   runAutomation: (auto: CodexAutomation) => void;
   togglePauseAutomation: (auto: CodexAutomation) => void;
 };
@@ -475,201 +464,6 @@ function RowActionButton({ icon, label, text, onClick, disabled }: { icon: IconN
 
 function RowActions({ children }: { children: ReactNode }) {
   return <span className="flex shrink-0 items-center gap-0.5 pl-1">{children}</span>;
-}
-
-function ReminderTaskRow({
-  item,
-  selected,
-  selectMode,
-  checked,
-  familiarLabel,
-  onSelect,
-  onToggle,
-}: {
-  item: InboxItem;
-  selected: boolean;
-  selectMode: boolean;
-  checked: boolean;
-  familiarLabel: (fid?: string | null) => string | null;
-  onSelect: (item: InboxItem) => void;
-  onToggle: (id: string) => void;
-}) {
-  const workspace = familiarLabel(item.familiarId);
-  const isOverdue = isReminderOverdue(item);
-  const schedule = item.kind === "daily-summary"
-    ? "Daily summary"
-    : item.recurrence?.type !== "none"
-    ? humanSchedule(item.recurrence)
-    : isOverdue
-    ? "Overdue"
-    : item.fireAt
-    ? relTime(item.fireAt)
-    : "Paused";
-
-  // In select mode the row IS a checkbox (click/Enter/Space toggle); otherwise
-  // it opens the detail panel. The active-row highlight tracks `checked` while
-  // selecting, and the detail-panel `selected` highlight otherwise.
-  const active = selectMode ? checked : selected;
-  const activate = () => (selectMode ? onToggle(item.id) : onSelect(item));
-  const actions = useContext(ScheduleActionsContext);
-  const paused = item.status === "dismissed";
-  // Run-now / pause make sense for actual reminders, not daily summaries, and
-  // never while picking rows in select mode.
-  const showActions = !selectMode && item.kind !== "daily-summary" && !!actions;
-
-  return (
-    <li className="flex items-center">
-      <button
-        type="button"
-        role={selectMode ? "checkbox" : undefined}
-        aria-checked={selectMode ? checked : undefined}
-        onClick={activate}
-        className="focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
-        style={{
-          background: active ? "rgba(255,255,255,0.05)" : "transparent",
-        }}
-        onMouseEnter={(e) => {
-          if (!active) (e.currentTarget as HTMLButtonElement).style.background = "rgba(255,255,255,0.03)";
-        }}
-        onMouseLeave={(e) => {
-          if (!active) (e.currentTarget as HTMLButtonElement).style.background = "transparent";
-        }}
-      >
-        {selectMode ? (
-          <span
-            aria-hidden
-            className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border transition-colors"
-            style={{
-              borderColor: checked ? "var(--accent-presence)" : "var(--border-strong)",
-              background: checked ? "var(--accent-presence)" : "transparent",
-            }}
-          >
-            {checked && <Icon name="ph:check-bold" width={12} className="text-[var(--accent-presence-foreground)]" />}
-          </span>
-        ) : (
-          <StatusIcon item={item} />
-        )}
-        <span className="flex-1 min-w-0 flex items-baseline gap-2">
-          <span className="text-[13px] truncate" style={{ color: "var(--text-primary)" }}>
-            {item.title}
-          </span>
-          {workspace && (
-            <span className="shrink-0 text-[11px]" style={{ color: "var(--text-muted)" }}>
-              {workspace}
-            </span>
-          )}
-        </span>
-        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: isOverdue ? "var(--color-warning)" : "var(--text-muted)" }}>
-          {schedule}
-        </span>
-      </button>
-      {showActions && actions && (
-        <RowActions>
-          {!paused && (
-            <RowActionButton icon="ph:play" label={`Run ${item.title} now`} text="Run" onClick={() => actions.runReminder(item.id)} />
-          )}
-          <RowActionButton
-            icon={paused ? "ph:play" : "ph:pause"}
-            label={`${paused ? "Resume" : "Pause"} ${item.title}`}
-            text={paused ? "Resume" : "Pause"}
-            onClick={() => actions.togglePauseReminder(item)}
-          />
-        </RowActions>
-      )}
-    </li>
-  );
-}
-
-function ReminderTaskSection({
-  title,
-  items,
-  selectedId,
-  selectMode,
-  isSelected,
-  familiarLabel,
-  onSelect,
-  onToggle,
-}: {
-  title: string;
-  items: InboxItem[];
-  selectedId: string | null;
-  selectMode: boolean;
-  isSelected: (id: string) => boolean;
-  familiarLabel: (fid?: string | null) => string | null;
-  onSelect: (item: InboxItem) => void;
-  onToggle: (id: string) => void;
-}) {
-  if (items.length === 0) return null;
-  const overdueCount = items.filter(isReminderOverdue).length;
-  const headingId = `reminder-section-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
-  return (
-    <section aria-labelledby={headingId} className="mb-6">
-      <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
-        style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
-        <h3 id={headingId} className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
-          {title}
-        </h3>
-        {overdueCount > 0 && (
-          <span
-            className="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
-            style={{ background: "color-mix(in oklch, var(--color-warning) 18%, transparent)", color: "var(--color-warning)" }}
-          >
-            {overdueCount} overdue
-          </span>
-        )}
-      </div>
-      <ul>
-        {items.map((item) => (
-          <ReminderTaskRow
-            key={item.id}
-            item={item}
-            selected={selectedId === item.id}
-            selectMode={selectMode}
-            checked={isSelected(item.id)}
-            familiarLabel={familiarLabel}
-            onSelect={onSelect}
-            onToggle={onToggle}
-          />
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-function ReminderTaskList({
-  current,
-  paused,
-  oneShots,
-  history,
-  selectedId,
-  selectMode,
-  isSelected,
-  familiarLabel,
-  onSelect,
-  onToggle,
-}: {
-  current: InboxItem[];
-  paused: InboxItem[];
-  oneShots: InboxItem[];
-  history: InboxItem[];
-  selectedId: string | null;
-  selectMode: boolean;
-  isSelected: (id: string) => boolean;
-  familiarLabel: (fid?: string | null) => string | null;
-  onSelect: (item: InboxItem) => void;
-  onToggle: (id: string) => void;
-}) {
-  const shared = { selectedId, selectMode, isSelected, familiarLabel, onSelect, onToggle };
-  return (
-    <>
-      <ReminderTaskSection title="Repeating" items={current} {...shared} />
-      <ReminderTaskSection title="Paused" items={paused} {...shared} />
-      <ReminderTaskSection title="One-time" items={oneShots} {...shared} />
-      {history.length > 0 && (
-        <ReminderTaskSection title="History" items={history} {...shared} />
-      )}
-    </>
-  );
 }
 
 // ── Codex automation detail panel ────────────────────────────────────────────
@@ -1386,16 +1180,22 @@ function InboxKindBadge({ kind }: { kind: InboxItem["kind"] }) {
 function InboxFeedRow({
   item,
   selected,
+  selectMode,
+  checked,
   familiarLabel,
   onSelect,
+  onToggle,
   onDone,
   onSnooze,
   onDismiss,
 }: {
   item: InboxItem;
   selected: boolean;
+  selectMode: boolean;
+  checked: boolean;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
+  onToggle: (id: string) => void;
   onDone?: (item: InboxItem) => void;
   onSnooze?: (item: InboxItem) => void;
   onDismiss?: (item: InboxItem) => void;
@@ -1409,16 +1209,35 @@ function InboxFeedRow({
   // Done/snooze/dismiss only make sense while the item is still live; snooze
   // additionally only for something that already fired (re-surface later).
   const resolved = item.status === "done" || item.status === "dismissed";
+  // In select mode the row IS a checkbox (click/Enter/Space toggle); otherwise
+  // it opens the detail panel — the shared list select-mode pattern.
+  const active = selectMode ? checked : selected;
+  const activate = () => (selectMode ? onToggle(item.id) : onSelect(item));
 
   return (
     <li className="flex items-center">
       <button
         type="button"
-        onClick={() => onSelect(item)}
-        aria-current={selected ? "true" : undefined}
-        className={`focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${selected ? "bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]" : "hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"}`}
+        role={selectMode ? "checkbox" : undefined}
+        aria-checked={selectMode ? checked : undefined}
+        onClick={activate}
+        aria-current={!selectMode && selected ? "true" : undefined}
+        className={`focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${active ? "bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]" : "hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"}`}
       >
-        <StatusIcon item={item} />
+        {selectMode ? (
+          <span
+            aria-hidden
+            className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border transition-colors"
+            style={{
+              borderColor: checked ? "var(--accent-presence)" : "var(--border-strong)",
+              background: checked ? "var(--accent-presence)" : "transparent",
+            }}
+          >
+            {checked && <Icon name="ph:check-bold" width={12} className="text-[var(--accent-presence-foreground)]" />}
+          </span>
+        ) : (
+          <StatusIcon item={item} />
+        )}
         <span className="flex-1 min-w-0 flex items-center gap-2">
           <span className="text-[13px] truncate" style={{ color: "var(--text-primary)" }}>
             {item.title}
@@ -1434,7 +1253,7 @@ function InboxFeedRow({
           {when}
         </span>
       </button>
-      {!resolved && (onDone || onSnooze || onDismiss) && (
+      {!selectMode && !resolved && (onDone || onSnooze || onDismiss) && (
         <RowActions>
           {onDone && (
             <RowActionButton icon="ph:check-bold" label={`Mark ${item.title} done`} text="Done" onClick={() => onDone(item)} />
@@ -1452,20 +1271,26 @@ function InboxFeedRow({
 }
 
 function InboxFeedSection({
-  title,
-  accent,
-  items,
+  group,
   selectedId,
+  selectMode,
+  groupChecked,
+  onToggleGroup,
+  isSelected,
+  onToggle,
   familiarLabel,
   onSelect,
   onDone,
   onSnooze,
   onDismiss,
 }: {
-  title: string;
-  accent?: boolean;
-  items: InboxItem[];
+  group: InboxFeedGroup;
   selectedId: string | null;
+  selectMode: boolean;
+  groupChecked: boolean;
+  onToggleGroup: (group: InboxFeedGroup) => void;
+  isSelected: (id: string) => boolean;
+  onToggle: (id: string) => void;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
   onDone?: (item: InboxItem) => void;
@@ -1473,33 +1298,55 @@ function InboxFeedSection({
   onDismiss?: (item: InboxItem) => void;
 }) {
   const headingId = useId();
-  if (items.length === 0) return null;
+  if (group.items.length === 0) return null;
   return (
     <section className="mb-6" aria-labelledby={headingId}>
       <div className="flex items-center gap-3 mb-1 rounded-md px-3 py-1.5"
         style={{ background: "color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%)", borderBottom: "1px solid var(--border-hairline)" }}>
+        {/* Select a whole group at once — the header grows a checkbox in
+            select mode so a tier/kind/familiar bucket is one click to act on. */}
+        {selectMode ? (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={groupChecked}
+            aria-label={`Select every item in ${group.title}`}
+            title={`Select all ${group.items.length} in ${group.title}`}
+            onClick={() => onToggleGroup(group)}
+            className="focus-ring flex h-[16px] w-[16px] shrink-0 items-center justify-center rounded-[4px] border transition-colors"
+            style={{
+              borderColor: groupChecked ? "var(--accent-presence)" : "var(--border-strong)",
+              background: groupChecked ? "var(--accent-presence)" : "transparent",
+            }}
+          >
+            {groupChecked && <Icon name="ph:check-bold" width={11} className="text-[var(--accent-presence-foreground)]" aria-hidden />}
+          </button>
+        ) : null}
         <h3 id={headingId} className="text-[12px] font-bold" style={{ color: "var(--text-primary)" }}>
-          {title}
+          {group.title}
         </h3>
         <span
           className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
           style={
-            accent
+            group.accent
               ? { background: "color-mix(in oklch, var(--color-warning) 18%, transparent)", color: "var(--color-warning)" }
               : { background: "var(--bg-raised)", color: "var(--text-muted)" }
           }
         >
-          {items.length}
+          {group.items.length}
         </span>
       </div>
       <ul aria-labelledby={headingId}>
-        {items.map((item) => (
+        {group.items.map((item) => (
           <InboxFeedRow
             key={item.id}
             item={item}
             selected={selectedId === item.id}
+            selectMode={selectMode}
+            checked={isSelected(item.id)}
             familiarLabel={familiarLabel}
             onSelect={onSelect}
+            onToggle={onToggle}
             onDone={onDone}
             onSnooze={onSnooze}
             onDismiss={onDismiss}
@@ -1511,35 +1358,51 @@ function InboxFeedSection({
 }
 
 function InboxFeedList({
-  needsYou,
-  active,
-  resolved,
+  groups,
   selectedId,
+  selectMode,
+  isSelected,
+  groupSelected,
+  onToggleGroup,
+  onToggle,
   familiarLabel,
   onSelect,
   onDone,
   onSnooze,
   onDismiss,
 }: {
-  needsYou: InboxItem[];
-  active: InboxItem[];
-  resolved: InboxItem[];
+  groups: InboxFeedGroup[];
   selectedId: string | null;
+  selectMode: boolean;
+  isSelected: (id: string) => boolean;
+  groupSelected: (group: InboxFeedGroup) => boolean;
+  onToggleGroup: (group: InboxFeedGroup) => void;
+  onToggle: (id: string) => void;
   familiarLabel: (fid?: string | null) => string | null;
   onSelect: (item: InboxItem) => void;
   onDone?: (item: InboxItem) => void;
   onSnooze?: (item: InboxItem) => void;
   onDismiss?: (item: InboxItem) => void;
 }) {
-  const rowActions = { onDone, onSnooze, onDismiss };
   return (
     <>
-      <InboxFeedSection title="Needs you" accent items={needsYou} selectedId={selectedId}
-        familiarLabel={familiarLabel} onSelect={onSelect} {...rowActions} />
-      <InboxFeedSection title="Active" items={active} selectedId={selectedId}
-        familiarLabel={familiarLabel} onSelect={onSelect} {...rowActions} />
-      <InboxFeedSection title="Resolved" items={resolved} selectedId={selectedId}
-        familiarLabel={familiarLabel} onSelect={onSelect} />
+      {groups.map((group) => (
+        <InboxFeedSection
+          key={group.id}
+          group={group}
+          selectedId={selectedId}
+          selectMode={selectMode}
+          groupChecked={groupSelected(group)}
+          onToggleGroup={onToggleGroup}
+          isSelected={isSelected}
+          onToggle={onToggle}
+          familiarLabel={familiarLabel}
+          onSelect={onSelect}
+          onDone={onDone}
+          onSnooze={onSnooze}
+          onDismiss={onDismiss}
+        />
+      ))}
     </>
   );
 }
@@ -2318,90 +2181,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // Normalized text filter applied to whichever tab is active (title/name).
   const q = query.trim().toLowerCase();
 
-  // ── Sections ──────────────────────────────────────────────────────────────
-  const reminderItems = useMemo(() =>
-    items.filter((it) => isScheduleInboxItem(it) && !hiddenIds.has(it.id) && (!q || (it.title ?? "").toLowerCase().includes(q))),
-    [items, hiddenIds, q]);
-
-  const current = useMemo(() =>
-    reminderItems.filter((it) =>
-      (it.status === "pending" || it.status === "fired") &&
-      it.recurrence && it.recurrence.type !== "none"
-    ).sort((a, b) => (a.fireAt ?? "").localeCompare(b.fireAt ?? "")),
-    [reminderItems]);
-
-  const paused = useMemo(() =>
-    reminderItems.filter((it) =>
-      it.status === "dismissed" && it.recurrence && it.recurrence.type !== "none"
-    ).sort((a, b) => (a.title).localeCompare(b.title)),
-    [reminderItems]);
-
-  const oneShots = useMemo(() =>
-    reminderItems.filter((it) =>
-      (!it.recurrence || it.recurrence.type === "none") &&
-      (it.status === "pending" || it.status === "snoozed")
-    ).sort((a, b) => (a.fireAt ?? "").localeCompare(b.fireAt ?? "")),
-    [reminderItems]);
-
-  const history = useMemo(() =>
-    reminderItems.filter((it) =>
-      it.status === "fired" || it.status === "done" ||
-      (it.status === "dismissed" && (!it.recurrence || it.recurrence.type === "none"))
-    ).sort((a, b) => (b.firedAt ?? b.updatedAt).localeCompare(a.firedAt ?? a.updatedAt))
-      .slice(0, 20),
-    [reminderItems]);
-
-  // Multi-select over exactly the reminders rendered across the four sections,
-  // so "Select all" and the count match what's on screen.
-  const reminderVisible = useMemo(
-    () => [...current, ...paused, ...oneShots, ...history],
-    [current, paused, oneShots, history],
-  );
-  const reminderSelect = useMultiSelect(reminderVisible, (it) => it.id);
-  const [bulkBusy, setBulkBusy] = useState(false);
-  const selectedRealIds = () =>
-    reminderSelect
-      .selectedFrom(reminderVisible)
-      .map((it) => it.id)
-      .filter((id) => !id.startsWith("eph:"));
-
-  const bulkPatchReminders = async (body: object) => {
-    const ids = selectedRealIds();
-    if (ids.length === 0) { reminderSelect.exit(); return; }
-    setBulkBusy(true);
-    try {
-      await Promise.all(ids.map((id) =>
-        fetch(`/api/inbox/${id}`, {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(body),
-        }).then((r) => { if (!r.ok) throw new Error(`http ${r.status}`); })));
-      await load();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "bulk action failed");
-    } finally {
-      setBulkBusy(false);
-      reminderSelect.exit();
-    }
-  };
-
-  const bulkDeleteReminders = () => {
-    const ids = selectedRealIds();
-    if (ids.length === 0) { reminderSelect.exit(); return; }
-    reminderSelect.exit();
-    scheduleDelete(ids, `${ids.length} reminder${ids.length === 1 ? "" : "s"}`, async () => {
-      const idSet = new Set(ids);
-      setItems((prev) => prev.filter((i) => !idSet.has(i.id)));
-      try {
-        await Promise.all(ids.map((id) =>
-          fetch(`/api/inbox/${id}`, { method: "DELETE" })
-            .then((r) => { if (!r.ok) throw new Error(`http ${r.status}`); })));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "bulk delete failed");
-      } finally { await load(); }
-    });
-  };
-
   const resolvedFamiliars = useResolvedFamiliars(familiars);
   const familiarsById = useMemo(
     () => new Map(resolvedFamiliars.map((f) => [f.id, f])),
@@ -2437,9 +2216,80 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     [codexAutos, familiarFilter, hiddenIds, q],
   );
 
-  // Inbox tab: the FULL feed (every kind), grouped by attention tier.
-  const inboxFeed = useMemo(() => groupInboxFeed(items.filter((it) => !hiddenIds.has(it.id) && (!q || (it.title ?? "").toLowerCase().includes(q)))), [items, hiddenIds, q]);
-  const remindersEmpty = current.length + paused.length + oneShots.length + history.length === 0;
+  // Inbox tab: the FULL feed (every kind). `inboxVisible` is the search-filtered
+  // flat list — the selection universe, so "select all" always means "all
+  // matches" while a filter is active. Groups re-shape per the group-by control.
+  const inboxVisible = useMemo(
+    () => items.filter((it) => !hiddenIds.has(it.id) && (!q || (it.title ?? "").toLowerCase().includes(q))),
+    [items, hiddenIds, q],
+  );
+  const inboxFeed = useMemo(() => groupInboxFeed(inboxVisible), [inboxVisible]);
+  const [inboxGroupBy, setInboxGroupBy] = useState<InboxGroupBy>(() => {
+    if (typeof window === "undefined") return "attention";
+    const raw = window.localStorage.getItem("cave:inbox:group-by");
+    return raw === "kind" || raw === "familiar" ? raw : "attention";
+  });
+  const updateInboxGroupBy = useCallback((next: InboxGroupBy) => {
+    setInboxGroupBy(next);
+    try {
+      window.localStorage.setItem("cave:inbox:group-by", next);
+    } catch {
+      /* ignore storage errors */
+    }
+  }, []);
+  const inboxGroups = useMemo(
+    () => buildInboxGroups(inboxVisible, inboxGroupBy, familiarLabel),
+    [inboxVisible, inboxGroupBy, familiarLabel],
+  );
+
+  // Multi-select over exactly the visible (search-filtered) feed, so "Select
+  // all" and per-group selection act on what's on screen — a live search term
+  // makes the selection universe "every match".
+  const inboxSelect = useMultiSelect(inboxVisible, (it) => it.id);
+  const [inboxBulkBusy, setInboxBulkBusy] = useState(false);
+
+  /** One-write collective action over the current selection (POST /api/inbox/bulk). */
+  const inboxBulkAct = async (action: "read" | "done" | "dismiss", pastTense: string) => {
+    const ids = inboxSelect.selectedFrom(inboxVisible).map((it) => it.id);
+    if (ids.length === 0) { inboxSelect.exit(); return; }
+    setInboxBulkBusy(true);
+    try {
+      const res = await fetch("/api/inbox/bulk", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action, ids }),
+      });
+      if (!res.ok) throw new Error(`http ${res.status}`);
+      announce(`${pastTense} ${ids.length} item${ids.length === 1 ? "" : "s"}.`);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "bulk action failed");
+    } finally {
+      setInboxBulkBusy(false);
+      inboxSelect.exit();
+    }
+  };
+
+  /** Collective delete rides the shared undo toast, then ONE bulk request. */
+  const inboxBulkDelete = () => {
+    const ids = inboxSelect.selectedFrom(inboxVisible).map((it) => it.id);
+    if (ids.length === 0) { inboxSelect.exit(); return; }
+    inboxSelect.exit();
+    scheduleDelete(ids, `${ids.length} inbox item${ids.length === 1 ? "" : "s"}`, async () => {
+      const idSet = new Set(ids);
+      setItems((prev) => prev.filter((i) => !idSet.has(i.id)));
+      try {
+        const res = await fetch("/api/inbox/bulk", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "delete", ids }),
+        });
+        if (!res.ok) throw new Error(`http ${res.status}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "bulk delete failed");
+      } finally { await load(); }
+    });
+  };
   const automationsEmpty = codexAutos.length === 0;
   const inboxEmpty = items.length === 0;
   const selectedReminderId = selectedItem?.id ?? null;
@@ -2466,6 +2316,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const selectTab = (tab: AutomationTab) => {
     setActiveTab(tab);
     setQuery(""); // the filter is scoped to one tab at a time
+    inboxSelect.exit(); // selection is an inbox-tab mode, never carried across
     // Clear any open detail on switch — the new tab may not host that type.
     setSelectedItem(null);
     setSelectedCodex(null);
@@ -2474,8 +2325,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   return (
     <ScheduleActionsContext.Provider
       value={{
-        runReminder: runNow,
-        togglePauseReminder: togglePaused,
         runAutomation: runCodexNow,
         togglePauseAutomation: toggleCodex,
       }}
@@ -2529,8 +2378,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
           <div className="surface-compact-actions">
             {/* Text filter, scoped per tab. Gated on the UNfiltered presence
                 of rows so filtering to zero never hides the box (you can still
-                clear). */}
-            {activeTab !== "calendar" && initialLoadDone && !reminderSelect.selectMode &&
+                clear) — and it stays up in inbox select mode, so "search →
+                select all matches → act" is one flow. */}
+            {activeTab !== "calendar" && initialLoadDone &&
               (activeTab === "inbox" ? items.length > 0 : codexAutos.length > 0) ? (
               <div className="surface-compact-search">
                 <SearchInput
@@ -2541,6 +2391,27 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   aria-label={activeTab === "inbox" ? "Filter inbox" : "Filter crons"}
                 />
               </div>
+            ) : null}
+            {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 ? (
+              <StandardSelect
+                label="Group inbox by"
+                title="Group the inbox feed by attention, kind, or familiar"
+                value={inboxGroupBy}
+                onChange={updateInboxGroupBy}
+                options={INBOX_GROUP_BY_OPTIONS}
+                renderValue={(selected) => <>Group: {selected?.label ?? "Attention"}</>}
+              />
+            ) : null}
+            {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 && !inboxSelect.selectMode ? (
+              <Button
+                size="sm"
+                variant="secondary"
+                leadingIcon="ph:check-square"
+                onClick={() => inboxSelect.setSelectMode(true)}
+                title="Pick inbox items (or whole groups) for a collective action"
+              >
+                Select
+              </Button>
             ) : null}
             {activeTab === "inbox" && onNewReminder ? (
               <Button size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={onNewReminder}>
@@ -2609,17 +2480,52 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 />
               )
             ) : (
-              <InboxFeedList
-                needsYou={inboxFeed.needsYou}
-                active={inboxFeed.active}
-                resolved={inboxFeed.resolved}
-                selectedId={selectedItem?.id ?? null}
-                familiarLabel={familiarLabel}
-                onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
-                onDone={(item) => void completeInboxItem(item)}
-                onSnooze={(item) => void snoozeInboxItem(item)}
-                onDismiss={(item) => void dismissInboxItem(item)}
-              />
+              <>
+                {inboxSelect.selectMode ? (
+                  <SelectionToolbar
+                    allSelected={inboxSelect.allSelected(inboxVisible)}
+                    count={inboxSelect.selectedCount}
+                    onToggleSelectAll={() => inboxSelect.toggleSelectAll(inboxVisible)}
+                    onCancel={() => inboxSelect.exit()}
+                    selectAllLabel={
+                      q
+                        ? `Select all ${inboxVisible.length} match${inboxVisible.length === 1 ? "" : "es"}`
+                        : "Select all"
+                    }
+                  >
+                    <Button size="xs" variant="ghost" disabled={inboxBulkBusy || inboxSelect.selectedCount === 0}
+                      onClick={() => void inboxBulkAct("read", "Marked read")} title="Stamp the selected items as read">
+                      Read
+                    </Button>
+                    <Button size="xs" variant="ghost" disabled={inboxBulkBusy || inboxSelect.selectedCount === 0}
+                      onClick={() => void inboxBulkAct("done", "Marked done")} title="Mark the selected items done">
+                      Done
+                    </Button>
+                    <Button size="xs" variant="ghost" disabled={inboxBulkBusy || inboxSelect.selectedCount === 0}
+                      onClick={() => void inboxBulkAct("dismiss", "Dismissed")} title="Dismiss the selected items">
+                      Dismiss
+                    </Button>
+                    <Button size="xs" variant="danger" disabled={inboxBulkBusy || inboxSelect.selectedCount === 0}
+                      onClick={inboxBulkDelete} title="Delete the selected items (undo window applies)">
+                      Delete
+                    </Button>
+                  </SelectionToolbar>
+                ) : null}
+                <InboxFeedList
+                  groups={inboxGroups}
+                  selectedId={selectedItem?.id ?? null}
+                  selectMode={inboxSelect.selectMode}
+                  isSelected={inboxSelect.isSelected}
+                  groupSelected={(group) => inboxSelect.allSelected(group.items)}
+                  onToggleGroup={(group) => inboxSelect.toggleSelectAll(group.items)}
+                  onToggle={inboxSelect.toggle}
+                  familiarLabel={familiarLabel}
+                  onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
+                  onDone={(item) => void completeInboxItem(item)}
+                  onSnooze={(item) => void snoozeInboxItem(item)}
+                  onDismiss={(item) => void dismissInboxItem(item)}
+                />
+              </>
             )
           ) : q && codexActive.length + codexPaused.length === 0 ? (
             <EmptyState

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2247,10 +2247,17 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // makes the selection universe "every match".
   const inboxSelect = useMultiSelect(inboxVisible, (it) => it.id);
   const [inboxBulkBusy, setInboxBulkBusy] = useState(false);
+  // Ephemeral (client-synthesized "eph:*") items have no server row — the
+  // single-item PATCH/DELETE paths skip them, and bulk must too.
+  const selectedInboxIds = () =>
+    inboxSelect
+      .selectedFrom(inboxVisible)
+      .map((it) => it.id)
+      .filter((id) => !id.startsWith("eph:"));
 
   /** One-write collective action over the current selection (POST /api/inbox/bulk). */
   const inboxBulkAct = async (action: "read" | "done" | "dismiss", pastTense: string) => {
-    const ids = inboxSelect.selectedFrom(inboxVisible).map((it) => it.id);
+    const ids = selectedInboxIds();
     if (ids.length === 0) { inboxSelect.exit(); return; }
     setInboxBulkBusy(true);
     try {
@@ -2272,7 +2279,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   /** Collective delete rides the shared undo toast, then ONE bulk request. */
   const inboxBulkDelete = () => {
-    const ids = inboxSelect.selectedFrom(inboxVisible).map((it) => it.id);
+    const ids = selectedInboxIds();
     if (ids.length === 0) { inboxSelect.exit(); return; }
     inboxSelect.exit();
     scheduleDelete(ids, `${ids.length} inbox item${ids.length === 1 ? "" : "s"}`, async () => {

--- a/src/components/daily-summary-notifications.test.ts
+++ b/src/components/daily-summary-notifications.test.ts
@@ -61,15 +61,19 @@ assert.match(
   "Notification bell should render daily summaries with the same distinct icon",
 );
 
+// The old Schedules reminders list (and its isScheduleInboxItem gate) is gone —
+// daily summaries now ride the FULL inbox feed alongside every other kind,
+// grouped via the pure buildInboxGroups (attention/kind/familiar) and badged
+// by inboxKindLabel, so they stay visible after their popup dismisses.
 assert.match(
   automations,
-  /function isScheduleInboxItem\(item: InboxItem\)/,
-  "Schedules should centralize which inbox kinds appear in the reminders list",
+  /buildInboxGroups\(inboxVisible/,
+  "the inbox feed groups every item kind — daily summaries included",
 );
 assert.match(
   automations,
-  /item\.kind === "reminder" \|\| item\.kind === "daily-summary"/,
-  "Schedules should retain daily summary notifications after their popup dismisses",
+  /<InboxKindBadge kind=\{item\.kind\} \/>/,
+  "feed rows badge their kind so summaries stay distinguishable",
 );
 
 assert.match(

--- a/src/components/delete-undo-surfaces.test.ts
+++ b/src/components/delete-undo-surfaces.test.ts
@@ -26,13 +26,13 @@ for (const rel of [
   assert.match(src, /deletePending\.item\.key/, "vault hides the pending secret row during the undo window");
 }
 
-// Automations: reminders + automations both hide by pending id; reminder, codex,
-// and bulk deletes all route through the deferred helper.
+// Automations: inbox rows + automations both hide by pending id; the inbox
+// bulk delete routes through the deferred helper (no async confirm).
 {
   const src = read("./automations-view.tsx");
-  assert.match(src, /hiddenIds\.has\(it\.id\)/, "automations hides pending reminders/inbox rows");
+  assert.match(src, /hiddenIds\.has\(it\.id\)/, "automations hides pending inbox rows");
   assert.match(src, /hiddenIds\.has\(a\.id\)/, "automations hides pending codex automations");
-  assert.match(src, /const bulkDeleteReminders = \(\) =>/, "bulk reminder delete is deferred (no async confirm)");
+  assert.match(src, /const inboxBulkDelete = \(\) =>/, "bulk inbox delete is deferred (no async confirm)");
 }
 
 // Journal: a pending date makes the day read as empty without mutating `day`.

--- a/src/components/ui/selection-toolbar.tsx
+++ b/src/components/ui/selection-toolbar.tsx
@@ -11,12 +11,15 @@ export function SelectionToolbar({
   count,
   onToggleSelectAll,
   onCancel,
+  selectAllLabel = "Select all",
   children,
 }: {
   allSelected: boolean;
   count: number;
   onToggleSelectAll: () => void;
   onCancel: () => void;
+  /** Custom select-all copy (e.g. "Select all 12 matches" under a search). */
+  selectAllLabel?: string;
   /** Bulk-action buttons (e.g. Pause, Resume, Delete) shown before Cancel. */
   children?: ReactNode;
 }) {
@@ -32,9 +35,9 @@ export function SelectionToolbar({
           onClick={onToggleSelectAll}
           className="focus-ring rounded px-1.5 py-0.5 text-[11px] font-medium text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
         >
-          {allSelected ? "Clear" : "Select all"}
+          {allSelected ? "Clear" : selectAllLabel}
         </button>
-        <span className="text-[11px] text-[var(--text-muted)]">{count} selected</span>
+        <span aria-live="polite" className="text-[11px] text-[var(--text-muted)]">{count} selected</span>
       </div>
       <div className="flex items-center gap-1">
         {children}

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -15,8 +15,9 @@ assert.match(vault, /No secrets match/, "vault shows a no-matches message");
 const auto = read("./automations-view.tsx");
 assert.match(auto, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "automations imports SearchInput");
 assert.match(auto, /<SearchInput[\s\S]*?aria-label=\{activeTab === "inbox" \? "Filter inbox" : "Filter crons"\}/, "automations renders a tab-scoped filter (inbox/crons)");
-// The text filter applies to all three tabs' source derivations.
-assert.match(auto, /isScheduleInboxItem\(it\) && !hiddenIds\.has\(it\.id\) && \(!q \|\| \(it\.title \?\? ""\)\.toLowerCase\(\)\.includes\(q\)\)/, "reminders honor the text filter");
+// The text filter applies to both tabs' source derivations (the inbox feed is
+// the selection universe, so a live search term = "every match").
+assert.match(auto, /items\.filter\(\(it\) => !hiddenIds\.has\(it\.id\) && \(!q \|\| \(it\.title \?\? ""\)\.toLowerCase\(\)\.includes\(q\)\)\)/, "the inbox feed honors the text filter");
 assert.match(auto, /a\.name\.toLowerCase\(\)\.includes\(q\)/, "automations honor the text filter");
 assert.match(auto, /No matches for/, "automations show a no-matches message");
 // The filter is scoped to the active tab — switching tabs clears it.

--- a/src/lib/inbox-feed.test.ts
+++ b/src/lib/inbox-feed.test.ts
@@ -1,7 +1,9 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import {
+  buildInboxGroups,
   groupInboxFeed,
+  INBOX_GROUP_BY_OPTIONS,
   inboxActivityTime,
   inboxKindLabel,
   isInboxItemUnread,
@@ -125,6 +127,80 @@ const item = (over = {}) => ({
   ];
   assert.equal(unreadInboxCount(items), 2, "one unread fired + one pending response-needed");
   assert.equal(unreadInboxCount([]), 0);
+}
+
+// ── buildInboxGroups: attention mode mirrors the tiers, empty tiers dropped ──
+{
+  const groups = buildInboxGroups(
+    [
+      item({ id: "fired", status: "fired" }),
+      item({ id: "pending", status: "pending" }),
+    ],
+    "attention",
+  );
+  assert.deepEqual(groups.map((g) => g.id), ["attention:needs-you", "attention:active"], "resolved tier absent when empty");
+  assert.equal(groups[0].title, "Needs you");
+  assert.equal(groups[0].accent, true, "needs-you keeps the warning badge");
+  assert.deepEqual(groups[0].items.map((i) => i.id), ["fired"]);
+}
+
+// ── buildInboxGroups: kind mode orders demanding kinds first, recent first ──
+{
+  const groups = buildInboxGroups(
+    [
+      item({ id: "sum", kind: "daily-summary", updatedAt: "2026-06-03T00:00:00Z" }),
+      item({ id: "rem-old", kind: "reminder", updatedAt: "2026-06-01T00:00:00Z" }),
+      item({ id: "rem-new", kind: "reminder", updatedAt: "2026-06-02T00:00:00Z" }),
+      item({ id: "resp", kind: "response-needed" }),
+    ],
+    "kind",
+  );
+  assert.deepEqual(groups.map((g) => g.id), ["kind:response-needed", "kind:reminder", "kind:daily-summary"]);
+  assert.equal(groups[0].title, "Response", "titles reuse inboxKindLabel");
+  assert.deepEqual(groups[1].items.map((i) => i.id), ["rem-new", "rem-old"], "kind groups sort by recency");
+}
+
+// ── buildInboxGroups: familiar mode labels via callback, unassigned last ────
+{
+  const groups = buildInboxGroups(
+    [
+      item({ id: "z1", familiarId: "zelda" }),
+      item({ id: "a1", familiarId: "arch" }),
+      item({ id: "loose" }),
+    ],
+    "familiar",
+    (fid) => (fid === "arch" ? "Archivist" : fid === "zelda" ? "Zelda" : null),
+  );
+  assert.deepEqual(groups.map((g) => g.id), ["familiar:arch", "familiar:zelda", "familiar:none"], "alphabetical by label, unassigned trailing");
+  assert.equal(groups[0].title, "Archivist");
+  assert.equal(groups[2].title, "No familiar");
+  assert.deepEqual(groups[2].items.map((i) => i.id), ["loose"]);
+}
+
+// ── buildInboxGroups: falls back to the raw familiar id without a label ─────
+{
+  const groups = buildInboxGroups([item({ id: "x", familiarId: "ghost" })], "familiar");
+  assert.equal(groups[0].title, "ghost");
+}
+
+// ── every mode partitions: no item duplicated or dropped ────────────────────
+{
+  const items = [
+    item({ id: "a", kind: "agent", status: "fired", familiarId: "f1" }),
+    item({ id: "b", kind: "reminder", status: "done" }),
+    item({ id: "c", kind: "response-needed", status: "pending", familiarId: "f2" }),
+  ];
+  for (const mode of ["attention", "kind", "familiar"]) {
+    const groups = buildInboxGroups(items, mode);
+    const ids = groups.flatMap((g) => g.items.map((i) => i.id)).sort();
+    assert.deepEqual(ids, ["a", "b", "c"], `${mode} mode keeps every item exactly once`);
+  }
+  assert.deepEqual(buildInboxGroups([], "attention"), [], "empty feed → no groups");
+}
+
+// ── the group-by options cover every mode exactly once ──────────────────────
+{
+  assert.deepEqual(INBOX_GROUP_BY_OPTIONS.map((o) => o.value), ["attention", "kind", "familiar"]);
 }
 
 console.log("inbox-feed.test.ts passed");

--- a/src/lib/inbox-feed.ts
+++ b/src/lib/inbox-feed.ts
@@ -91,3 +91,89 @@ export function inboxKindLabel(kind: ItemKind): string {
       return kind;
   }
 }
+
+// ── Generalized feed grouping (group-by control + bulk selection) ────────────
+
+export type InboxGroupBy = "attention" | "kind" | "familiar";
+
+export type InboxFeedGroup = {
+  /** Stable key for React lists and select-group targeting. */
+  id: string;
+  title: string;
+  /** Warning-tinted count badge (the "Needs you" tier). */
+  accent?: boolean;
+  items: InboxItem[];
+};
+
+export const INBOX_GROUP_BY_OPTIONS: { value: InboxGroupBy; label: string }[] = [
+  { value: "attention", label: "Attention" },
+  { value: "kind", label: "Kind" },
+  { value: "familiar", label: "Familiar" },
+];
+
+/** Kind-group order: what demands a reply first, ambient noise last. */
+const KIND_ORDER: ItemKind[] = ["response-needed", "reminder", "agent", "daily-summary"];
+
+/**
+ * Group the (already search-filtered) feed for rendering, per the active
+ * group-by dimension. Every mode returns the same shape so the section list,
+ * per-group selection, and bulk actions are dimension-agnostic:
+ *   • attention — the classic three tiers (groupInboxFeed), empty tiers kept out.
+ *   • kind      — one group per item kind present, most-demanding kind first.
+ *   • familiar  — one group per familiar present (label via `familiarLabel`),
+ *                 items without a familiar land in a trailing "No familiar".
+ * Non-attention groups sort by most-recent activity, matching the tiers.
+ */
+export function buildInboxGroups(
+  items: readonly InboxItem[],
+  groupBy: InboxGroupBy,
+  familiarLabel?: (familiarId?: string | null) => string | null,
+): InboxFeedGroup[] {
+  if (groupBy === "attention") {
+    const tiers = groupInboxFeed(items);
+    return [
+      { id: "attention:needs-you", title: "Needs you", accent: true, items: tiers.needsYou },
+      { id: "attention:active", title: "Active", items: tiers.active },
+      { id: "attention:resolved", title: "Resolved", items: tiers.resolved },
+    ].filter((group) => group.items.length > 0);
+  }
+
+  const byRecent = (a: InboxItem, b: InboxItem) => inboxActivityTime(b) - inboxActivityTime(a);
+
+  if (groupBy === "kind") {
+    const byKind = new Map<ItemKind, InboxItem[]>();
+    for (const item of items) {
+      const bucket = byKind.get(item.kind);
+      if (bucket) bucket.push(item);
+      else byKind.set(item.kind, [item]);
+    }
+    return KIND_ORDER.filter((kind) => byKind.has(kind)).map((kind) => ({
+      id: `kind:${kind}`,
+      title: inboxKindLabel(kind),
+      items: byKind.get(kind)!.sort(byRecent),
+    }));
+  }
+
+  const byFamiliar = new Map<string, InboxItem[]>();
+  const unassigned: InboxItem[] = [];
+  for (const item of items) {
+    if (item.familiarId) {
+      const bucket = byFamiliar.get(item.familiarId);
+      if (bucket) bucket.push(item);
+      else byFamiliar.set(item.familiarId, [item]);
+    } else {
+      unassigned.push(item);
+    }
+  }
+  const groups: InboxFeedGroup[] = [...byFamiliar.entries()]
+    .map(([familiarId, bucket]) => ({
+      id: `familiar:${familiarId}`,
+      title: familiarLabel?.(familiarId) ?? familiarId,
+      items: bucket.sort(byRecent),
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
+  if (unassigned.length > 0) {
+    groups.push({ id: "familiar:none", title: "No familiar", items: unassigned.sort(byRecent) });
+  }
+  return groups;
+}


### PR DESCRIPTION
## What

The Rituals **Inbox** feed gains grouping and bulk selection: group the feed by a chosen dimension, select whole groups (or every search match) in one click, and run a collective action on the selection.

- **Group-by control** — Attention (classic tiers) / **Kind** / **Familiar**, via a generalized pure `buildInboxGroups` in `inbox-feed.ts`. Kind mode orders demanding kinds first (response → reminder → agent → summary); familiar mode sorts by label with a trailing "No familiar"; every mode partitions (behavioral test: no item duplicated or dropped). Choice persists (`cave:inbox:group-by`).
- **Select mode** — rows flip to checkboxes (shared list pattern), each group header grows a **select-group checkbox** ("Select every item in <group>"), and the shared `SelectionToolbar` drives the actions. With a live search term the select-all affordance reads **"Select all N matches"** — search → select matches → act is one flow (the filter stays visible in select mode).
- **Collective actions** — one `POST /api/inbox/bulk` (read / done / dismiss); **delete** rides the shared UndoToast deferred window before a single bulk request. Results announced; selection drops on tab switch.
- `SelectionToolbar`: additive `selectAllLabel` prop (default unchanged) + aria-live count.
- **Coupled cleanup** — the orphaned reminder bulk-select machinery (ReminderTaskList/Row/Section, `reminderSelect`, `bulkPatchReminders`, `bulkDeleteReminders`, `isScheduleInboxItem`, `isReminderOverdue`, the reminder half of `ScheduleActionsContext`) was dead code from the retired Reminders tab; deleted now that the inbox owns selection. Stale pins in `daily-summary-notifications`, `delete-undo-surfaces`, and `vault-automations-filter` tests rewritten deliberately for the current surface.

## Testing

- `inbox-feed.test.ts`: buildInboxGroups behavioral cases (attention/kind/familiar ordering, labels, empty-tier drop, partition invariant, options).
- `automations-view.test.ts`: pins for the group-by wiring, selection universe (= visible matches), toolbar, bulk endpoints, undo-deferred delete, group checkboxes, select-mode row semantics, tab-switch reset.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (697 files).

Bead: cave-fcy8