### PR TITLE
feat(chat): multipane chat — persistence, pane focus, keyboard control, live-IA reachability (cave-e3dj)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12993,6 +12993,19 @@ details[open] > .cave-edit-card__summary::before {
   min-width: 0;
   min-height: 0;
 }
+/* The focused pane (keyboard target): a quiet accent ring drawn as an inset
+   outline — outlines paint above the pane's (opaque, full-bleed) children,
+   where an inset box-shadow would be hidden. The stronger :focus-visible ring
+   is declared after so it wins while the container itself holds real focus
+   (panes get programmatic focus via tabIndex=-1). */
+.chat-split__pane-panel[data-focused="true"] {
+  outline: 1px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  outline-offset: -1px;
+}
+.chat-split__pane-panel:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: calc(-1 * var(--ring-width));
+}
 .chat-split__tile {
   display: flex;
   flex: 1;

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -67,6 +67,10 @@ type Props = {
   onSelect: (selection: ProjectSelection) => void;
   onToggleExpanded: (key: string) => void;
   onOpenSession: (session: SessionRow) => void;
+  /** ⌥↵ on a row: open the conversation in a split pane beside the current
+   *  chat (keyboard twin of drag-to-split). Absent when splits are off
+   *  (compact rail, mobile) — the row falls back to a plain open. */
+  onOpenSessionInSplit?: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
   onOpenProjectsTab?: () => void;
 };
@@ -155,12 +159,14 @@ function ThreadRow({
   active,
   pinned,
   onOpen,
+  onOpenInSplit,
   onTogglePin,
 }: {
   session: SessionRow;
   active: boolean;
   pinned: boolean;
   onOpen: () => void;
+  onOpenInSplit?: () => void;
   onTogglePin: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -187,7 +193,14 @@ function ThreadRow({
         onFocus={() => hoverPrefetchConversation(session.id)}
         onBlur={cancelHoverPrefetch}
         onKeyDown={(e) => {
-          if (e.key === "Enter") onOpen();
+          if (e.key !== "Enter") return;
+          // ⌥↵ opens in a split pane (keyboard twin of drag-to-split).
+          if (e.altKey && onOpenInSplit) {
+            e.preventDefault();
+            onOpenInSplit();
+            return;
+          }
+          onOpen();
         }}
         {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
@@ -275,10 +288,12 @@ function FolderChatRow({
   session,
   active,
   onOpen,
+  onOpenInSplit,
 }: {
   session: SessionRow;
   active: boolean;
   onOpen: () => void;
+  onOpenInSplit?: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
@@ -296,7 +311,14 @@ function FolderChatRow({
         onFocus={() => hoverPrefetchConversation(session.id)}
         onBlur={cancelHoverPrefetch}
         onKeyDown={(e) => {
-          if (e.key === "Enter") onOpen();
+          if (e.key !== "Enter") return;
+          // ⌥↵ opens in a split pane (keyboard twin of drag-to-split).
+          if (e.altKey && onOpenInSplit) {
+            e.preventDefault();
+            onOpenInSplit();
+            return;
+          }
+          onOpen();
         }}
         {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
@@ -344,6 +366,7 @@ export function ChatProjectSidebar({
   onSelect,
   onToggleExpanded,
   onOpenSession,
+  onOpenSessionInSplit,
   onNewChat,
   onOpenProjectsTab,
 }: Props) {
@@ -577,6 +600,9 @@ export function ChatProjectSidebar({
                       active={activeSessionId === session.id}
                       pinned={isSessionPinned(pinnedIds, session.id)}
                       onOpen={() => onOpenSession(session)}
+                      onOpenInSplit={
+                        onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
+                      }
                       onTogglePin={() => togglePin(session.id)}
                     />
                   ))}
@@ -669,6 +695,9 @@ export function ChatProjectSidebar({
                             session={session}
                             active={activeSessionId === session.id}
                             onOpen={() => onOpenSession(session)}
+                            onOpenInSplit={
+                              onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
+                            }
                           />
                         ))}
                       </ul>

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -89,12 +89,19 @@ type Props = {
   compact?: boolean;
   /** Jump from the in-chat project rail to the dedicated Projects tab. */
   onOpenProjectsTab?: () => void;
+  /** Allow split panes (drag/keyboard multi-pane) on this mount. Only the
+   *  full-width main chat surface opts in — the compact companion rail has no
+   *  room, and two mounts must not fight over the persisted layout. */
+  enableSplitPanes?: boolean;
 };
 
 export type ChatRouterHandle = {
   goToList: () => void;
   newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls, initialAttachments?: ChatAttachment[]) => void;
   openSession: (sessionId: string, findQuery?: string) => void;
+  /** Open a conversation in a split pane beside the current chat; falls back
+   *  to a plain open when splits are unavailable (mobile, companion rail). */
+  openSessionInSplit: (sessionId: string) => void;
   currentSessionId: () => string | null;
   clearTranscript: () => void;
   runSlash: (command: string) => void;
@@ -135,6 +142,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     syncUrlHash,
     compact = false,
     onOpenProjectsTab,
+    enableSplitPanes = false,
   },
   ref,
 ) {
@@ -172,10 +180,9 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   const [selection, setSelection] = useState<ProjectSelection>("all");
   const [sidebarHydrated, setSidebarHydrated] = useState(false);
   const isMobile = useIsMobile();
-  // Splits (and their persistence) belong to the full-width desktop chat: the
-  // compact companion rail and mobile have no room, and the Codex surface is
-  // its own world.
-  const enableSplit = !compact && !isMobile && !caveChatoutCodex();
+  // Splits belong to the full-width desktop chat: the opted-in main surface
+  // only (enableSplitPanes), never mobile, never the Codex surface.
+  const enableSplit = enableSplitPanes && !isMobile && !caveChatoutCodex();
   const activeSession = view.kind === "chat" && view.sessionId
     ? sessions.find((s) => s.id === view.sessionId) ?? null
     : null;
@@ -300,25 +307,25 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
 
   // ── Split persistence (cave-e3dj) ──────────────────────────────────────────
   // The split survives reloads: layout + pane sizes hydrate from localStorage
-  // once, then every change writes back. Only the full-width chat surface
-  // participates — the compact companion rail never renders splits and must
-  // not fight the main surface over the same key.
+  // once, then every change writes back. Only the opted-in main chat surface
+  // participates — other mounts (companion rail) must not fight it over the
+  // same key.
   useEffect(() => {
-    if (compact || splitHydratedRef.current || typeof window === "undefined") return;
+    if (!enableSplitPanes || splitHydratedRef.current || typeof window === "undefined") return;
     splitHydratedRef.current = true;
     const restored = parsePersistedChatSplit(window.localStorage.getItem(CHAT_SPLIT_STORAGE_KEY));
     if (!restored || !hasChatSplit(restored.layout)) return;
     setSplit(restored.layout);
     setSplitSizes(restored.sizes);
-  }, [compact]);
+  }, [enableSplitPanes]);
   useEffect(() => {
-    if (compact || !splitHydratedRef.current || typeof window === "undefined") return;
+    if (!enableSplitPanes || !splitHydratedRef.current || typeof window === "undefined") return;
     try {
       window.localStorage.setItem(CHAT_SPLIT_STORAGE_KEY, serializeChatSplit(split, splitSizes));
     } catch {
       /* storage full/blocked — the split just won't survive this reload */
     }
-  }, [compact, split, splitSizes]);
+  }, [enableSplitPanes, split, splitSizes]);
   // Once the session list is authoritative, drop restored panes whose session
   // was deleted while we were away (render already hides them; this stops the
   // dead ids from persisting forever).
@@ -517,11 +524,23 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         const fq = findQuery?.trim();
         if (fq) setPendingFind({ query: fq, nonce: Date.now() });
       },
+      openSessionInSplit: (sessionId: string) => {
+        const session = sessions.find((entry) => entry.id === sessionId);
+        if (!session) return;
+        // Splitting needs an open chat to sit beside; from the list view (or
+        // when splits are unavailable) fall back to a plain open.
+        if (!enableSplit || view.kind !== "chat") {
+          const next = selectFamiliarForChat(session.familiarId ?? null);
+          setView({ kind: "chat", sessionId, familiarId: next?.id ?? session.familiarId ?? null });
+          return;
+        }
+        handleOpenSessionInSplit(session);
+      },
       currentSessionId: () => (view.kind === "chat" ? view.sessionId : null),
       clearTranscript: () => viewHandle.current?.clearTranscript(),
       runSlash: (command: string) => viewHandle.current?.runSlash(command),
     }),
-    [fallbackFamiliar, familiar, familiars, onSetActiveFamiliar, sessions, view],
+    [fallbackFamiliar, familiar, familiars, onSetActiveFamiliar, sessions, view, enableSplit, split],
   );
 
   if (familiars.length === 0 && !familiar) {

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -4,7 +4,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRe
 import { ChatList } from "@/components/chat-list";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import { ChatView } from "@/components/chat-view";
-import { ChatSplitHost, type ChatSplitTile } from "@/components/chat-split-host";
+import { ChatSplitHost, CHAT_SPLIT_PANE_ATTR, type ChatSplitTile } from "@/components/chat-split-host";
 import { NewChatLaunch } from "@/components/new-chat-launch";
 import { FamiliarChatoutCodexSurface } from "@/components/familiar-chatout-codex";
 import { caveChatoutCodex } from "@/lib/feature-flags";
@@ -18,12 +18,23 @@ import { applyProjectOverrides } from "@/lib/chat-project-overrides";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import {
   CHAT_SPLIT_PRIMARY,
+  CHAT_SPLIT_STORAGE_KEY,
+  chatSplitFocusAfterClose,
+  chatSplitFocusTarget,
+  chatSplitKeyboardZone,
   dropSessionIntoChatSplit,
   emptyChatSplitLayout,
+  hasChatSplit,
+  parsePersistedChatSplit,
+  pruneChatSplitPanes,
   removeChatSplitPane,
+  resolveChatSplitFocus,
+  serializeChatSplit,
   type ChatDropZone,
+  type ChatSplitSizes,
 } from "@/lib/chat-split";
 import { sessionRailTitle } from "@/lib/session-rail-title";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
@@ -133,6 +144,15 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   // below it. Pure layout rules live in @/lib/chat-split; panes for deleted
   // sessions are filtered at render (the id simply stops resolving).
   const [split, setSplit] = useState(() => emptyChatSplitLayout());
+  // Persisted pane sizes (RRP flex weights by pane id). Restored alongside
+  // the layout; {} means "even split".
+  const [splitSizes, setSplitSizes] = useState<ChatSplitSizes>({});
+  // The pane holding logical focus — keyboard target + visible affordance.
+  // Reconciled through resolveChatSplitFocus so a closed/promoted pane's
+  // focus falls back to the always-present primary.
+  const [focusedPane, setFocusedPane] = useState<string | null>(null);
+  const splitHydratedRef = useRef(false);
+  const { announce } = useAnnouncer();
   // Set when a conversation-search hit asks the opened chat to jump to a query;
   // handed to ChatView (nonce-keyed) so it opens in-thread find on the match.
   const [pendingFind, setPendingFind] = useState<{ query: string; nonce: number } | null>(null);
@@ -152,6 +172,10 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   const [selection, setSelection] = useState<ProjectSelection>("all");
   const [sidebarHydrated, setSidebarHydrated] = useState(false);
   const isMobile = useIsMobile();
+  // Splits (and their persistence) belong to the full-width desktop chat: the
+  // compact companion rail and mobile have no room, and the Codex surface is
+  // its own world.
+  const enableSplit = !compact && !isMobile && !caveChatoutCodex();
   const activeSession = view.kind === "chat" && view.sessionId
     ? sessions.find((s) => s.id === view.sessionId) ?? null
     : null;
@@ -274,17 +298,132 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     setSplit((prev) => removeChatSplitPane(prev, primarySessionId));
   }, [primarySessionId]);
 
+  // ── Split persistence (cave-e3dj) ──────────────────────────────────────────
+  // The split survives reloads: layout + pane sizes hydrate from localStorage
+  // once, then every change writes back. Only the full-width chat surface
+  // participates — the compact companion rail never renders splits and must
+  // not fight the main surface over the same key.
+  useEffect(() => {
+    if (compact || splitHydratedRef.current || typeof window === "undefined") return;
+    splitHydratedRef.current = true;
+    const restored = parsePersistedChatSplit(window.localStorage.getItem(CHAT_SPLIT_STORAGE_KEY));
+    if (!restored || !hasChatSplit(restored.layout)) return;
+    setSplit(restored.layout);
+    setSplitSizes(restored.sizes);
+  }, [compact]);
+  useEffect(() => {
+    if (compact || !splitHydratedRef.current || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(CHAT_SPLIT_STORAGE_KEY, serializeChatSplit(split, splitSizes));
+    } catch {
+      /* storage full/blocked — the split just won't survive this reload */
+    }
+  }, [compact, split, splitSizes]);
+  // Once the session list is authoritative, drop restored panes whose session
+  // was deleted while we were away (render already hides them; this stops the
+  // dead ids from persisting forever).
+  useEffect(() => {
+    if (sessionsLoaded !== true) return;
+    setSplit((prev) => pruneChatSplitPanes(prev, (id) => sessions.some((entry) => entry.id === id)));
+  }, [sessionsLoaded, sessions]);
+
+  // The pane that actually holds focus, after closes/promotions/deletes.
+  const effectiveFocusedPane = resolveChatSplitFocus(split, focusedPane);
+
+  const paneTitle = useCallback(
+    (paneId: string): string => {
+      if (paneId === CHAT_SPLIT_PRIMARY) return "current chat";
+      const session = sessions.find((entry) => entry.id === paneId);
+      return session ? sessionRailTitle(session) : "chat";
+    },
+    [sessions],
+  );
+
+  // Land real DOM focus on a pane container (double rAF: pane-set changes
+  // remount the RRP group, so the node may not exist until after re-render).
+  const focusPaneElement = useCallback((paneId: string) => {
+    if (typeof document === "undefined") return;
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLElement>(`[${CHAT_SPLIT_PANE_ATTR}="${CSS.escape(paneId)}"]`)
+          ?.focus({ preventScroll: true });
+      }),
+    );
+  }, []);
+
   function handleDropSession(sessionId: string, zone: ChatDropZone) {
     if (sessionId === primarySessionId) return; // already the open chat
     if (!sessions.some((entry) => entry.id === sessionId)) return;
     setSplit((prev) => dropSessionIntoChatSplit(prev, sessionId, zone));
+    setFocusedPane(sessionId);
+    announce(`${paneTitle(sessionId)} opened in a split pane`);
+  }
+
+  // Open a thread-rail conversation in a split pane from the keyboard (⌥↵ on
+  // the row) — the keyboard twin of drag-to-split. Lands at the end of the
+  // strip on the current axis and moves focus into the new pane.
+  function handleOpenSessionInSplit(session: SessionRow) {
+    if (!enableSplit) return;
+    handleDropSession(session.id, chatSplitKeyboardZone(split));
+    focusPaneElement(session.id);
+  }
+
+  function handleClosePane(paneId: string) {
+    const next = removeChatSplitPane(split, paneId);
+    if (next === split) return;
+    setFocusedPane(chatSplitFocusAfterClose(split, paneId));
+    setSplit(next);
+    announce(`${paneTitle(paneId)} split pane closed`);
   }
 
   function handlePromotePane(sessionId: string) {
     const session = sessions.find((entry) => entry.id === sessionId);
     const next = selectFamiliarForChat(session?.familiarId ?? null);
     setView({ kind: "chat", sessionId, familiarId: next?.id ?? session?.familiarId ?? null });
+    setFocusedPane(CHAT_SPLIT_PRIMARY);
+    announce(`${paneTitle(sessionId)} opened as main chat`);
   }
+
+  // ── Split keyboard control (cave-e3dj) ─────────────────────────────────────
+  // ⌥⌘←/↑ and ⌥⌘→/↓ move pane focus along the strip (wrapping), ⌥⌘W closes
+  // the focused secondary pane. Composer-safe: ⌥⌘ combos never type text, so
+  // the handler runs regardless of where focus sits — but not under a modal,
+  // which owns the keyboard while open. Letters match on e.code ("KeyW"):
+  // on macOS ⌥ composes e.key into symbols (⌥W → "∑").
+  useEffect(() => {
+    if (!enableSplit || !hasChatSplit(split)) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || !e.altKey) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (active?.closest?.('[aria-modal="true"]')) return;
+      const delta =
+        e.key === "ArrowLeft" || e.key === "ArrowUp"
+          ? (-1 as const)
+          : e.key === "ArrowRight" || e.key === "ArrowDown"
+            ? (1 as const)
+            : null;
+      if (delta !== null) {
+        const target = chatSplitFocusTarget(split, focusedPane, delta);
+        if (!target) return;
+        e.preventDefault();
+        setFocusedPane(target);
+        focusPaneElement(target);
+        announce(`${paneTitle(target)} pane focused`);
+        return;
+      }
+      if (e.code === "KeyW") {
+        const closing = resolveChatSplitFocus(split, focusedPane);
+        if (closing === CHAT_SPLIT_PRIMARY) return; // primary can't close
+        e.preventDefault();
+        const nextFocus = chatSplitFocusAfterClose(split, closing);
+        handleClosePane(closing);
+        focusPaneElement(nextFocus);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
 
   useEffect(() => {
     const nextFamiliarId = familiar?.id ?? null;
@@ -555,11 +694,10 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     />
   );
 
-  // Split panes only render on the full-width desktop chat: the compact
-  // companion rail and mobile have no room, and the Codex surface is its own
-  // world. Panes whose session vanished (deleted) resolve to nothing here —
-  // the layout state simply stops matching and the strip collapses.
-  const enableSplit = !compact && !isMobile && !caveChatoutCodex();
+  // Split panes only render on the full-width desktop chat (enableSplit,
+  // declared with the split state above). Panes whose session vanished
+  // (deleted) resolve to nothing here — the layout state simply stops
+  // matching and the strip collapses.
   const splitPaneTiles: ChatSplitTile[] = (enableSplit ? split.panes : [CHAT_SPLIT_PRIMARY]).flatMap(
     (paneId): ChatSplitTile[] => {
       if (paneId === CHAT_SPLIT_PRIMARY) {
@@ -610,6 +748,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           const next = selectFamiliarForChat(s.familiarId);
           setView({ kind: "chat", sessionId: s.id, familiarId: next?.id ?? s.familiarId ?? null });
         }}
+        onOpenSessionInSplit={enableSplit ? handleOpenSessionInSplit : undefined}
         onNewChat={(root) => {
           const group = sidebarGroups.find((g) => g.projectRoot === root);
           const nextFamiliarId = group?.defaultFamiliarId ?? fallbackFamiliarId;
@@ -630,8 +769,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           axis={split.axis}
           enableDrop={enableSplit}
           onDropSession={handleDropSession}
-          onClosePane={(paneId) => setSplit((prev) => removeChatSplitPane(prev, paneId))}
+          onClosePane={handleClosePane}
           onPromotePane={handlePromotePane}
+          focusedPaneId={effectiveFocusedPane}
+          onFocusPane={setFocusedPane}
+          sizes={splitSizes}
+          onSizesChange={setSplitSizes}
         />
       </div>
     </div>

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -71,8 +71,8 @@ assert.match(
 );
 assert.match(
   router,
-  /const enableSplit = !compact && !isMobile && !caveChatoutCodex\(\);/,
-  "splits are desktop-only: compact rail, mobile and the Codex surface opt out",
+  /const enableSplit = enableSplitPanes && !isMobile && !caveChatoutCodex\(\);/,
+  "splits are an explicit opt-in: main surface only, never mobile or the Codex surface",
 );
 assert.match(router, /onPromotePane=\{handlePromotePane\}/, "promote opens the pane as the primary chat");
 
@@ -137,7 +137,7 @@ assert.match(host, /setResetNonce\(\(nonce\) => nonce \+ 1\)/, "reset remounts t
 // The router hydrates the split once, persists changes, and prunes dead panes.
 assert.match(router, /parsePersistedChatSplit\(window\.localStorage\.getItem\(CHAT_SPLIT_STORAGE_KEY\)\)/, "layout hydrates from storage");
 assert.match(router, /serializeChatSplit\(split, splitSizes\)/, "layout + sizes persist");
-assert.match(router, /if \(compact \|\| splitHydratedRef\.current/, "only the full-width surface hydrates");
+assert.match(router, /if \(!enableSplitPanes \|\| splitHydratedRef\.current/, "only the opted-in surface hydrates");
 assert.match(router, /pruneChatSplitPanes\(prev, \(id\) => sessions\.some/, "deleted sessions leave the persisted split");
 
 // Keyboard: ⌥⌘arrows move focus, ⌥⌘W closes the focused secondary pane, and
@@ -156,6 +156,38 @@ assert.equal(
   (sidebar.match(/if \(e\.altKey && onOpenInSplit\) \{/g) ?? []).length,
   2,
   "both row flavors handle ⌥↵",
+);
+
+// ── Live IA wiring (the shell nav is the real thread rail) ───────────────────
+// The Workspace mounts ChatSurface with hideThreadRail (the router's own
+// project sidebar is hidden), so splits must reach the chat through the shell:
+// WorkspaceSidebar rows are drag sources + ⌥↵/⌥-click split openers, routed
+// through the pending-chat-action pipeline into the router handle.
+
+const shellNav = await readFile(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const surface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+
+assert.match(shellNav, /emitChatSessionDragStart\(\{ sessionId: session\.id, title \}\)/, "shell nav rows announce drags");
+assert.match(shellNav, /setData\(CHAT_SESSION_DRAG_MIME, session\.id\)/, "shell nav drags carry the session MIME");
+assert.match(shellNav, /if \(e\.key === "Enter" && e\.altKey && onOpenInSplit\) \{/, "shell nav rows handle ⌥↵");
+assert.match(shellNav, /if \(e\.altKey && onOpenInSplit\) \{/, "shell nav rows handle ⌥-click");
+assert.equal(
+  (shellNav.match(/onOpenInSplit=\{\s*onOpenSessionInSplit\s*\?\s*\(\)\s*=>\s*onOpenSessionInSplit\(session\)\s*:\s*undefined\s*\}/g) ?? [])
+    .length >= 1,
+  true,
+  "thread rows receive the split opener",
+);
+
+assert.match(workspace, /kind: "open-split", sessionId: session\.id/, "the workspace files an open-split pending action");
+assert.match(surface, /pendingChatAction\.kind === "open-split"/, "the chat surface routes open-split");
+assert.match(surface, /openSessionInSplit\(pendingChatAction\.sessionId\)/, "open-split reaches the router handle");
+assert.match(surface, /enableSplitPanes\b/, "the main chat surface opts into split panes");
+assert.match(router, /openSessionInSplit: \(sessionId: string\) => \{/, "the router handle exposes openSessionInSplit");
+assert.match(
+  router,
+  /if \(!enableSplit \|\| view\.kind !== "chat"\) \{/,
+  "openSessionInSplit falls back to a plain open when it can't split",
 );
 
 console.log("chat-split-host.test.ts: ok");

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -105,5 +105,57 @@ assert.match(
   /\.chat-split__preview \{ transition: none; \}/,
   "the preview respects prefers-reduced-motion",
 );
+assert.match(
+  css,
+  /\.chat-split__pane-panel\[data-focused="true"\]/,
+  "the focused pane has a visible affordance",
+);
+assert.match(
+  css,
+  /\.chat-split__pane-panel:focus-visible/,
+  "programmatic pane focus shows the standard ring",
+);
+
+// ── Focus + persistence + keyboard (cave-e3dj) ───────────────────────────────
+
+// The host marks panes with the focus attribute and reports focus/pointer
+// entry so the router's logical focus follows real interaction.
+assert.match(host, /CHAT_SPLIT_PANE_ATTR = "data-chat-split-pane"/, "pane DOM marker exists");
+assert.match(host, /data-focused=\{focusedPaneId === tile\.id \? "true" : undefined\}/, "focused pane is marked");
+assert.match(host, /onFocusCapture=\{\(\) => onFocusPane\?\.\(tile\.id\)\}/, "focus entering a pane reports it");
+assert.match(host, /onPointerDownCapture=\{\(\) => onFocusPane\?\.\(tile\.id\)\}/, "pointer down on a pane focuses it");
+assert.match(host, /tabIndex=\{-1\}/, "panes accept programmatic focus");
+
+// Sizes: only user-driven resizes persist, restore only for a matching pane
+// set, and a divider double-click resets to an even split via remount.
+assert.match(host, /if \(!meta\.isUserInteraction \|\| !onSizesChange\) return;/, "mount/programmatic layouts don't persist");
+assert.match(host, /defaultLayout=\{defaultLayout\}/, "restored sizes feed the group");
+assert.match(host, /keys\.length !== ids\.length \|\| !ids\.every\(\(id\) => id in sizes\)/, "stale size maps fall back to even");
+assert.match(host, /onDoubleClick=\{\(\) => \{/, "divider double-click resets");
+assert.match(host, /setResetNonce\(\(nonce\) => nonce \+ 1\)/, "reset remounts the group");
+
+// The router hydrates the split once, persists changes, and prunes dead panes.
+assert.match(router, /parsePersistedChatSplit\(window\.localStorage\.getItem\(CHAT_SPLIT_STORAGE_KEY\)\)/, "layout hydrates from storage");
+assert.match(router, /serializeChatSplit\(split, splitSizes\)/, "layout + sizes persist");
+assert.match(router, /if \(compact \|\| splitHydratedRef\.current/, "only the full-width surface hydrates");
+assert.match(router, /pruneChatSplitPanes\(prev, \(id\) => sessions\.some/, "deleted sessions leave the persisted split");
+
+// Keyboard: ⌥⌘arrows move focus, ⌥⌘W closes the focused secondary pane, and
+// ⌥↵ on a thread-rail row opens it in a split.
+assert.match(router, /chatSplitFocusTarget\(split, focusedPane, delta\)/, "arrow keys move pane focus");
+assert.match(router, /e\.code === "KeyW"/, "close matches on e.code (⌥ composes e.key on macOS)");
+assert.match(router, /closest\?\.\('\[aria-modal="true"\]'\)/, "modals own the keyboard");
+assert.match(router, /chatSplitKeyboardZone\(split\)/, "keyboard split lands on the current axis");
+assert.match(router, /onOpenSessionInSplit=\{enableSplit \? handleOpenSessionInSplit : undefined\}/, "the thread rail gets the split opener only when splits are on");
+assert.match(router, /announce\(/, "split changes are announced to the live region");
+assert.match(router, /focusedPaneId=\{effectiveFocusedPane\}/, "the host renders the reconciled focus");
+
+// The thread rail rows: ⌥↵ opens in a split, plain ↵ still opens.
+assert.match(sidebar, /onOpenSessionInSplit\?: \(session: SessionRow\) => void;/, "sidebar accepts the split opener");
+assert.equal(
+  (sidebar.match(/if \(e\.altKey && onOpenInSplit\) \{/g) ?? []).length,
+  2,
+  "both row flavors handle ⌥↵",
+);
 
 console.log("chat-split-host.test.ts: ok");

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -30,6 +30,7 @@ import {
   type ChatDropZone,
   type ChatSessionDragDetail,
   type ChatSplitAxis,
+  type ChatSplitSizes,
 } from "@/lib/chat-split";
 
 export type ChatSplitTile = {
@@ -51,7 +52,23 @@ export type ChatSplitHostProps = {
   onClosePane: (sessionId: string) => void;
   /** Promote a dropped pane to be the primary chat. */
   onPromotePane?: (sessionId: string) => void;
+  /** The pane holding logical focus (visible affordance + keyboard target). */
+  focusedPaneId?: string | null;
+  /** A pane received pointer/keyboard focus. */
+  onFocusPane?: (paneId: string) => void;
+  /** Persisted pane sizes (RRP flex weights by pane id) to restore at mount.
+   *  Applied only when the map covers exactly the current pane set — a stale
+   *  or partial map falls back to an even layout. */
+  sizes?: ChatSplitSizes;
+  /** A user drag/keyboard resize settled ({} = divider double-click reset). */
+  onSizesChange?: (sizes: ChatSplitSizes) => void;
 };
+
+/** DOM marker carrying the pane id, so keyboard focus moves can land real
+ *  focus on the pane container (`[data-chat-split-pane="<id>"]`). */
+export const CHAT_SPLIT_PANE_ATTR = "data-chat-split-pane";
+
+const PANEL_ID_PREFIX = "chat-split-";
 
 export function ChatSplitHost({
   panes,
@@ -60,8 +77,27 @@ export function ChatSplitHost({
   onDropSession,
   onClosePane,
   onPromotePane,
+  focusedPaneId,
+  onFocusPane,
+  sizes,
+  onSizesChange,
 }: ChatSplitHostProps) {
   const hasSplit = panes.length > 1;
+
+  // Bumped by a divider double-click: remounts the group with no restored
+  // sizes, which is exactly "reset to an even split".
+  const [resetNonce, setResetNonce] = React.useState(0);
+
+  // Restore persisted sizes only when they describe exactly this pane set —
+  // RRP would otherwise honor the stale weights it recognizes and squeeze
+  // the rest, which reads as a corrupted layout.
+  const defaultLayout = React.useMemo(() => {
+    if (!sizes) return undefined;
+    const ids = panes.map((tile) => tile.id);
+    const keys = Object.keys(sizes);
+    if (keys.length !== ids.length || !ids.every((id) => id in sizes)) return undefined;
+    return Object.fromEntries(ids.map((id) => [`${PANEL_ID_PREFIX}${id}`, sizes[id]!]));
+  }, [sizes, panes]);
 
   // ---- Drag-to-split drop zone -------------------------------------------
   const [drag, setDrag] = React.useState<ChatSessionDragDetail | null>(null);
@@ -166,15 +202,36 @@ export function ChatSplitHost({
         <Group
           // Remount on pane-set changes (mirrors DetailSplitHost, cave-hivd):
           // RRP squeezes a panel added to a live group below its min — a fresh
-          // mount re-lays every pane out evenly.
-          key={`${axis}|${panes.map((tile) => tile.id).join("|")}`}
+          // mount re-lays every pane out evenly. The reset nonce rides the same
+          // key: divider double-click remounts into an even layout.
+          key={`${axis}|${panes.map((tile) => tile.id).join("|")}|${resetNonce}`}
           className="chat-split__group"
           orientation={axis === "row" ? "horizontal" : "vertical"}
+          defaultLayout={defaultLayout}
+          onLayoutChanged={(layout, meta) => {
+            // Only user-driven resizes persist — mount/constraint recomputes
+            // would clobber the stored weights with defaults.
+            if (!meta.isUserInteraction || !onSizesChange) return;
+            const next: ChatSplitSizes = {};
+            for (const [panelId, weight] of Object.entries(layout)) {
+              if (panelId.startsWith(PANEL_ID_PREFIX)) {
+                next[panelId.slice(PANEL_ID_PREFIX.length)] = weight;
+              }
+            }
+            onSizesChange(next);
+          }}
         >
           {panes.map((tile, i) => (
             <React.Fragment key={tile.id}>
               {i > 0 ? (
-                <Separator className="shell-separator chat-split__sep">
+                <Separator
+                  className="shell-separator chat-split__sep"
+                  onDoubleClick={() => {
+                    // Reset to an even split: forget stored weights + remount.
+                    onSizesChange?.({});
+                    setResetNonce((nonce) => nonce + 1);
+                  }}
+                >
                   <SeparatorHandle orientation={axis === "row" ? "col" : "row"} />
                 </Separator>
               ) : null}
@@ -184,6 +241,11 @@ export function ChatSplitHost({
                 // Pixel floors so a divider can't crush a conversation into
                 // letter soup; stacked panes need less than side-by-side ones.
                 minSize={axis === "row" ? "280px" : "160px"}
+                {...{ [CHAT_SPLIT_PANE_ATTR]: tile.id }}
+                tabIndex={-1}
+                data-focused={focusedPaneId === tile.id ? "true" : undefined}
+                onFocusCapture={() => onFocusPane?.(tile.id)}
+                onPointerDownCapture={() => onFocusPane?.(tile.id)}
               >
                 {renderTile(tile)}
               </Panel>

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -456,6 +456,12 @@ export function ChatSurface({
       onPendingChatActionHandled();
       return;
     }
+    if (pendingChatAction.kind === "open-split") {
+      setScope("conversation");
+      window.setTimeout(() => routerRef.current?.openSessionInSplit(pendingChatAction.sessionId), 0);
+      onPendingChatActionHandled();
+      return;
+    }
     setScope("conversation");
     window.setTimeout(() => routerRef.current?.goToList(), 0);
     onPendingChatActionHandled();
@@ -633,6 +639,7 @@ export function ChatSurface({
                   onOpenUrl={onOpenUrl}
                   onOpenProjectsTab={() => setScope("projects")}
                   syncUrlHash
+                  enableSplitPanes
                 />
               </div>
             </Panel>

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -27,6 +27,11 @@ import {
 } from "@/lib/chat-session-prefs";
 import { usePinnedSessions } from "@/lib/use-pinned-sessions";
 import { deriveChatRecencyBuckets } from "@/lib/chat-recency";
+import {
+  CHAT_SESSION_DRAG_MIME,
+  emitChatSessionDragEnd,
+  emitChatSessionDragStart,
+} from "@/lib/chat-split";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui/popover";
 import { addChatProject, projectNameForRoot } from "@/lib/chat-add-project";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -43,6 +48,9 @@ type Props = {
   /** Change the familiar scope from the header switcher (`null` = All). */
   onSelectFamiliar: (id: string | null) => void;
   onOpenSession: (session: SessionRow) => void;
+  /** ⌥↵ / ⌥-click / drag on a thread row: open it in a split pane beside the
+   *  current chat (the chat surface falls back to a plain open on mobile). */
+  onOpenSessionInSplit?: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
   onDeleteSession: (session: SessionRow) => Promise<void>;
   /** Badge count for the Scheduled shortcut (from code-sidebar). */
@@ -121,6 +129,8 @@ type ThreadRowProps = {
   /** PR/branch glyph from threadLeadingIcon — shown instead of the status dot when truthy. */
   glyph?: IconName | null;
   onOpen: () => void;
+  /** ⌥↵ / ⌥-click / drag: open beside the current chat in a split pane. */
+  onOpenInSplit?: () => void;
   onTogglePin: () => void;
   onRequestDelete: () => void;
   onCancelDelete: () => void;
@@ -137,6 +147,7 @@ function ThreadRow({
   project = null,
   glyph,
   onOpen,
+  onOpenInSplit,
   onTogglePin,
   onRequestDelete,
   onCancelDelete,
@@ -148,7 +159,35 @@ function ThreadRow({
       <button
         type="button"
         aria-current={active ? "page" : undefined}
-        onClick={onOpen}
+        onClick={(e) => {
+          // ⌥-click opens beside the current chat instead of replacing it.
+          if (e.altKey && onOpenInSplit) {
+            onOpenInSplit();
+            return;
+          }
+          onOpen();
+        }}
+        onKeyDown={(e) => {
+          // ⌥↵ opens in a split pane (keyboard twin of drag-to-split); stop
+          // the native button activation so onClick doesn't also fire.
+          if (e.key === "Enter" && e.altKey && onOpenInSplit) {
+            e.preventDefault();
+            onOpenInSplit();
+          }
+        }}
+        // Dragging the row onto the chat surface snaps it into a split pane
+        // (chat-split-host's drop zone; same protocol as the project rail).
+        draggable={Boolean(onOpenInSplit)}
+        onDragStart={(e) => {
+          if (!onOpenInSplit) return;
+          e.dataTransfer.setData(CHAT_SESSION_DRAG_MIME, session.id);
+          e.dataTransfer.setData("text/plain", title);
+          e.dataTransfer.effectAllowed = "copyMove";
+          emitChatSessionDragStart({ sessionId: session.id, title });
+        }}
+        onDragEnd={() => {
+          if (onOpenInSplit) emitChatSessionDragEnd();
+        }}
         className="cnav__thread-main focus-ring"
       >
         {glyph ? (
@@ -211,6 +250,7 @@ export function WorkspaceSidebar({
   responseNeeded,
   onSelectFamiliar,
   onOpenSession,
+  onOpenSessionInSplit,
   onNewChat,
   onDeleteSession,
   scheduledCount,
@@ -564,6 +604,9 @@ export function WorkspaceSidebar({
                             project={sessionProjectById.get(session.id) ?? null}
                             glyph={threadLeadingIcon(sessionRailTitle(session))}
                             onOpen={() => onOpenSession(session)}
+                            onOpenInSplit={
+                              onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
+                            }
                             onTogglePin={() => togglePin(session.id)}
                             onRequestDelete={() => setConfirmingSessionId(session.id)}
                             onCancelDelete={() => setConfirmingSessionId(null)}
@@ -670,6 +713,11 @@ export function WorkspaceSidebar({
                                   indent="folder"
                                   glyph={glyph}
                                   onOpen={() => onOpenSession(session)}
+                                  onOpenInSplit={
+                                    onOpenSessionInSplit
+                                      ? () => onOpenSessionInSplit(session)
+                                      : undefined
+                                  }
                                   onTogglePin={() => togglePin(session.id)}
                                   onRequestDelete={() => setConfirmingSessionId(session.id)}
                                   onCancelDelete={() => setConfirmingSessionId(null)}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2329,6 +2329,15 @@ export function Workspace() {
         openFamiliarSession(session.id, session.familiarId);
         shellRef.current?.dismissNavMobile();
       }}
+      onOpenSessionInSplit={(session) => {
+        // Open beside the current chat: same pending-action pipeline as a
+        // plain open, but the chat surface routes it into a split pane
+        // (falling back to a normal open when splits are unavailable). The
+        // active familiar is left alone — the pane carries its own.
+        setPendingChatAction({ kind: "open-split", sessionId: session.id, nonce: Date.now() });
+        setMode("chat");
+        shellRef.current?.dismissNavMobile();
+      }}
       onNewChat={(projectRoot) => {
         startFamiliarChat(activeId, projectRoot);
         shellRef.current?.dismissNavMobile();

--- a/src/lib/chat-split.test.ts
+++ b/src/lib/chat-split.test.ts
@@ -6,12 +6,19 @@ import {
   chatDropPreviewRect,
   chatDropZoneLabel,
   chatSplitAxisForZone,
+  chatSplitFocusAfterClose,
+  chatSplitFocusTarget,
+  chatSplitKeyboardZone,
   chatSplitSessionIds,
   dropSessionIntoChatSplit,
   emptyChatSplitLayout,
   hasChatSplit,
+  parsePersistedChatSplit,
+  pruneChatSplitPanes,
   removeChatSplitPane,
   resolveChatDropZone,
+  resolveChatSplitFocus,
+  serializeChatSplit,
 } from "./chat-split.ts";
 
 // ── resolveChatDropZone — closest-edge snap ──────────────────────────────────
@@ -156,4 +163,111 @@ test("chatSplitSessionIds lists dropped panes in layout order", () => {
   let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
   layout = dropSessionIntoChatSplit(layout, "s2", "left");
   assert.deepEqual(chatSplitSessionIds(layout), ["s2", "s1"]);
+});
+
+// ── Pane focus ───────────────────────────────────────────────────────────────
+
+function threePaneLayout() {
+  let layout = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "right");
+  layout = dropSessionIntoChatSplit(layout, "s2", "right");
+  return layout; // [primary, s1, s2]
+}
+
+test("resolveChatSplitFocus keeps a live pane and falls back to primary", () => {
+  const layout = threePaneLayout();
+  assert.equal(resolveChatSplitFocus(layout, "s1"), "s1");
+  assert.equal(resolveChatSplitFocus(layout, "gone"), CHAT_SPLIT_PRIMARY);
+  assert.equal(resolveChatSplitFocus(layout, null), CHAT_SPLIT_PRIMARY);
+});
+
+test("chatSplitFocusTarget steps along the strip and wraps at the edges", () => {
+  const layout = threePaneLayout();
+  assert.equal(chatSplitFocusTarget(layout, CHAT_SPLIT_PRIMARY, 1), "s1");
+  assert.equal(chatSplitFocusTarget(layout, "s1", 1), "s2");
+  assert.equal(chatSplitFocusTarget(layout, "s2", 1), CHAT_SPLIT_PRIMARY); // wrap
+  assert.equal(chatSplitFocusTarget(layout, CHAT_SPLIT_PRIMARY, -1), "s2"); // wrap back
+});
+
+test("chatSplitFocusTarget treats a dead focus id as primary and no-ops solo", () => {
+  const layout = threePaneLayout();
+  assert.equal(chatSplitFocusTarget(layout, "gone", 1), "s1");
+  assert.equal(chatSplitFocusTarget(emptyChatSplitLayout(), CHAT_SPLIT_PRIMARY, 1), null);
+});
+
+test("chatSplitFocusAfterClose lands on the pane that takes the slot", () => {
+  const layout = threePaneLayout(); // [primary, s1, s2]
+  assert.equal(chatSplitFocusAfterClose(layout, "s1"), "s2");
+  assert.equal(chatSplitFocusAfterClose(layout, "s2"), "s1"); // endmost → previous
+  assert.equal(chatSplitFocusAfterClose(layout, CHAT_SPLIT_PRIMARY), CHAT_SPLIT_PRIMARY);
+  assert.equal(chatSplitFocusAfterClose(layout, "gone"), CHAT_SPLIT_PRIMARY);
+});
+
+test("chatSplitKeyboardZone opens at the end of the current axis", () => {
+  assert.equal(chatSplitKeyboardZone(emptyChatSplitLayout()), "right");
+  const column = dropSessionIntoChatSplit(emptyChatSplitLayout(), "s1", "bottom");
+  assert.equal(chatSplitKeyboardZone(column), "bottom");
+});
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+test("serialize → parse round-trips layout and sizes", () => {
+  const layout = threePaneLayout();
+  const sizes = { [CHAT_SPLIT_PRIMARY]: 2, s1: 1, s2: 1 };
+  const restored = parsePersistedChatSplit(serializeChatSplit(layout, sizes));
+  assert.deepEqual(restored, { layout, sizes });
+});
+
+test("parsePersistedChatSplit rejects malformed payloads", () => {
+  assert.equal(parsePersistedChatSplit(null), null);
+  assert.equal(parsePersistedChatSplit(""), null);
+  assert.equal(parsePersistedChatSplit("not json"), null);
+  assert.equal(parsePersistedChatSplit("42"), null);
+  assert.equal(parsePersistedChatSplit(JSON.stringify({ axis: "row" })), null);
+  assert.equal(parsePersistedChatSplit(JSON.stringify({ panes: "nope" })), null);
+});
+
+test("parsePersistedChatSplit repairs what it safely can", () => {
+  // Duplicates dedupe; a missing primary is re-inserted at the front.
+  const repaired = parsePersistedChatSplit(
+    JSON.stringify({ axis: "column", panes: ["s1", "s1", "s2"], sizes: {} }),
+  );
+  assert.deepEqual(repaired?.layout, { axis: "column", panes: [CHAT_SPLIT_PRIMARY, "s1", "s2"] });
+  // Unknown axis values normalize to row; overlong pane lists truncate.
+  const truncated = parsePersistedChatSplit(
+    JSON.stringify({ axis: "diagonal", panes: [CHAT_SPLIT_PRIMARY, "a", "b", "c", "d", "e"] }),
+  );
+  assert.equal(truncated?.layout.axis, "row");
+  assert.equal(truncated?.layout.panes.length, MAX_CHAT_SPLIT_PANES);
+  assert.ok(truncated?.layout.panes.includes(CHAT_SPLIT_PRIMARY));
+});
+
+test("parsePersistedChatSplit drops partial or invalid size maps", () => {
+  const layout = threePaneLayout();
+  // Missing an entry → sizes dropped, layout kept.
+  const partial = parsePersistedChatSplit(
+    serializeChatSplit(layout, { [CHAT_SPLIT_PRIMARY]: 1, s1: 1 } as Record<string, number>),
+  );
+  assert.deepEqual(partial?.sizes, {});
+  // Non-positive / non-finite / unknown-pane entries → sizes dropped.
+  const badMaps: Array<Record<string, number>> = [
+    { [CHAT_SPLIT_PRIMARY]: 0, s1: 1, s2: 1 },
+    { [CHAT_SPLIT_PRIMARY]: Number.NaN, s1: 1, s2: 1 },
+    { [CHAT_SPLIT_PRIMARY]: 1, s1: 1, ghost: 1 },
+  ];
+  for (const bad of badMaps) {
+    const parsed = parsePersistedChatSplit(serializeChatSplit(layout, bad));
+    assert.deepEqual(parsed?.sizes, {});
+    assert.deepEqual(parsed?.layout, layout);
+  }
+});
+
+test("pruneChatSplitPanes drops deleted sessions and keeps the reference stable", () => {
+  const layout = threePaneLayout();
+  const pruned = pruneChatSplitPanes(layout, (id) => id === "s2");
+  assert.deepEqual(pruned.panes, [CHAT_SPLIT_PRIMARY, "s2"]);
+  // Primary survives even though sessionExists says no for it.
+  const solo = pruneChatSplitPanes(layout, () => false);
+  assert.deepEqual(solo.panes, [CHAT_SPLIT_PRIMARY]);
+  // Nothing to prune → same reference (lets setState skip a render).
+  assert.equal(pruneChatSplitPanes(layout, () => true), layout);
 });

--- a/src/lib/chat-split.ts
+++ b/src/lib/chat-split.ts
@@ -177,3 +177,129 @@ export function removeChatSplitPane(layout: ChatSplitLayout, sessionId: string):
   if (panes.length === layout.panes.length) return layout;
   return { axis: layout.axis, panes };
 }
+
+// ── Pane focus ───────────────────────────────────────────────────────────────
+
+/**
+ * The pane that should hold focus, given the id last focused. Falls back to
+ * the primary pane when the focused pane left the layout (closed, promoted,
+ * or its session was deleted) — the primary is always present.
+ */
+export function resolveChatSplitFocus(layout: ChatSplitLayout, focusedId: string | null): string {
+  if (focusedId && layout.panes.includes(focusedId)) return focusedId;
+  return CHAT_SPLIT_PRIMARY;
+}
+
+/**
+ * Move pane focus one step along the strip. `delta` is -1 (toward the
+ * start — left/top) or +1 (toward the end — right/bottom); focus wraps at
+ * the edges so repeated presses cycle every pane. Returns the id to focus,
+ * or null when there is nothing to move to (no split).
+ */
+export function chatSplitFocusTarget(
+  layout: ChatSplitLayout,
+  focusedId: string | null,
+  delta: -1 | 1,
+): string | null {
+  if (!hasChatSplit(layout)) return null;
+  const current = resolveChatSplitFocus(layout, focusedId);
+  const index = layout.panes.indexOf(current);
+  const next = (index + delta + layout.panes.length) % layout.panes.length;
+  return layout.panes[next] ?? null;
+}
+
+/**
+ * Where focus lands after closing `closedId`: the pane that takes its slot
+ * (the next one along the strip), or the last pane when the closed pane was
+ * endmost. Closing a pane that isn't in the layout keeps focus on primary.
+ */
+export function chatSplitFocusAfterClose(layout: ChatSplitLayout, closedId: string): string {
+  const index = layout.panes.indexOf(closedId);
+  if (index === -1 || closedId === CHAT_SPLIT_PRIMARY) {
+    return resolveChatSplitFocus(layout, closedId);
+  }
+  const remaining = layout.panes.filter((id) => id !== closedId);
+  return remaining[Math.min(index, remaining.length - 1)] ?? CHAT_SPLIT_PRIMARY;
+}
+
+/** The drop zone a keyboard-initiated split targets: the end of the strip on
+ *  the current axis, so ⌥↵ reads as "open beside/below what I have". */
+export function chatSplitKeyboardZone(layout: ChatSplitLayout): ChatDropZone {
+  return layout.axis === "column" ? "bottom" : "right";
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+/** localStorage key for the persisted split layout (main chat surface only). */
+export const CHAT_SPLIT_STORAGE_KEY = "cave:chat-split-layout:v1";
+
+/** Pane sizes as RRP flex-grow weights, keyed by pane id (not panel DOM id). */
+export type ChatSplitSizes = Record<string, number>;
+
+export type PersistedChatSplit = {
+  layout: ChatSplitLayout;
+  sizes: ChatSplitSizes;
+};
+
+export function serializeChatSplit(layout: ChatSplitLayout, sizes: ChatSplitSizes): string {
+  return JSON.stringify({ axis: layout.axis, panes: layout.panes, sizes });
+}
+
+/**
+ * Parse a persisted split. Returns null (start from empty) rather than
+ * guessing when the payload is malformed. Repairs what it safely can:
+ * dedupes pane ids, re-inserts a missing primary sentinel at the front, and
+ * truncates beyond MAX_CHAT_SPLIT_PANES. Sizes are kept only when every
+ * entry is a positive finite number for a known pane — a partial size map
+ * would make RRP's layout restore lie.
+ */
+export function parsePersistedChatSplit(raw: string | null): PersistedChatSplit | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as { axis?: unknown; panes?: unknown; sizes?: unknown };
+  const axis: ChatSplitAxis = candidate.axis === "column" ? "column" : "row";
+  if (!Array.isArray(candidate.panes)) return null;
+  const panes: string[] = [];
+  for (const entry of candidate.panes) {
+    if (typeof entry !== "string" || !entry.trim()) continue;
+    if (panes.includes(entry)) continue;
+    panes.push(entry);
+  }
+  if (!panes.includes(CHAT_SPLIT_PRIMARY)) panes.unshift(CHAT_SPLIT_PRIMARY);
+  if (panes.length > MAX_CHAT_SPLIT_PANES) panes.length = MAX_CHAT_SPLIT_PANES;
+  if (!panes.includes(CHAT_SPLIT_PRIMARY)) return null; // primary truncated off — refuse
+  const layout: ChatSplitLayout = { axis, panes };
+
+  let sizes: ChatSplitSizes = {};
+  if (candidate.sizes && typeof candidate.sizes === "object" && !Array.isArray(candidate.sizes)) {
+    const entries = Object.entries(candidate.sizes as Record<string, unknown>);
+    const valid = entries.every(
+      ([id, value]) =>
+        panes.includes(id) && typeof value === "number" && Number.isFinite(value) && value > 0,
+    );
+    if (valid && entries.length === panes.length) {
+      sizes = Object.fromEntries(entries as Array<[string, number]>);
+    }
+  }
+  return { layout, sizes };
+}
+
+/**
+ * Drop panes whose session no longer exists (deleted while we were away).
+ * The primary sentinel always survives. Returns the same reference when
+ * nothing changed so state setters can skip a render.
+ */
+export function pruneChatSplitPanes(
+  layout: ChatSplitLayout,
+  sessionExists: (id: string) => boolean,
+): ChatSplitLayout {
+  const panes = layout.panes.filter((id) => id === CHAT_SPLIT_PRIMARY || sessionExists(id));
+  if (panes.length === layout.panes.length) return layout;
+  return { axis: layout.axis, panes };
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -15,6 +15,8 @@
  *     src/components/home-composer.tsx handleKeyDown
  *   - "/" search focus: each surface's view (familiars-view, projects-view,
  *     marketplace-view, chat-list); "⌘F" sessions search: chat-list.tsx
+ *   - split chat panes (⌥↵ / ⌥⌘arrows / ⌥⌘W): chat-project-sidebar.tsx row
+ *     keydown + the chat-router.tsx split-keyboard effect
  *   - browser pane: src/components/browser-pane.tsx (⌘L / ⌘K / [)
  *   - ⌘S save: familiar-daily-notes.tsx;
  *     artifact refine ⌘↵: chat-artifact-viewer.tsx
@@ -52,6 +54,9 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌥1–⌥9", description: "Select the Nth familiar" },
       { keys: "⌘↑ / ⌘↓", description: "Cycle through familiars" },
       { keys: "⌘N", description: "New chat (on the Chat surface)" },
+      { keys: "⌥↵", description: "Thread rail: open the focused chat in a split pane" },
+      { keys: "⌥⌘← / ⌥⌘→", description: "Move focus between split chat panes (also ⌥⌘↑ / ⌥⌘↓)" },
+      { keys: "⌥⌘W", description: "Close the focused split chat pane" },
       { keys: "/", description: "Focus the search (Familiars, Projects, Capabilities, Sessions)" },
       { keys: "⌘F", description: "Focus the sessions search" },
     ],

--- a/src/lib/pending-chat-action.ts
+++ b/src/lib/pending-chat-action.ts
@@ -15,5 +15,13 @@ export type PendingChatAction =
       nonce: number;
     }
   | { kind: "open"; sessionId: string; familiarId?: string | null; findQuery?: string; nonce: number }
+  | {
+      /** Open the conversation in a split pane beside the current chat
+       *  (thread-rail ⌥↵ / alt-click). Falls back to a plain open when the
+       *  chat surface can't split (mobile). */
+      kind: "open-split";
+      sessionId: string;
+      nonce: number;
+    }
   | { kind: "list"; nonce: number }
   | null;

--- a/tests/chat-split-panes.spec.ts
+++ b/tests/chat-split-panes.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Multipane chat (cave-e3dj): two conversations side by side, driven entirely
+// from the keyboard, surviving a reload.
+//
+//   1. Open one conversation as the primary chat, then ⌥↵ on a thread-rail row
+//      opens a second conversation in a split pane — both transcripts visible
+//      at once, focus lands on the new pane.
+//   2. ⌥⌘← / ⌥⌘→ move the logical pane focus (data-focused affordance).
+//   3. Reload → the split (and the primary, via the #chat- hash) is restored
+//      from localStorage.
+//   4. ⌥⌘W closes the focused secondary pane and the strip collapses to solo.
+//
+// Runs daemon-less: familiars/sessions/conversations come from page.route
+// mocks, per the e2e house rules.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+
+function session(id: string, title: string) {
+  return {
+    id,
+    title,
+    status: "idle",
+    project_root: "/Users/dev/Documents/GitHub/OpenCoven/coven-cave",
+    harness: "claude",
+    familiarId: "nova",
+    model: "openclaw-local",
+    runtime: "local:/Users/dev/Documents/GitHub/OpenCoven/coven-cave",
+    exit_code: null,
+    archived_at: null,
+    created_at: ISO,
+    updated_at: ISO,
+  };
+}
+
+const SESSIONS = [
+  session("s-alpha", "Alpha planning thread"),
+  session("s-beta", "Beta review thread"),
+];
+
+async function setup(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    // Keep the nav expanded so the chat surface keeps its full width.
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3", "1");
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3.two-pane", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [
+          { id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: SESSIONS } }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) => {
+    const url = route.request().url();
+    const which = url.includes("s-alpha") ? "Alpha reply text" : "Beta reply text";
+    return route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: `t-${which}`, role: "assistant", text: which, createdAt: ISO }] },
+      },
+    });
+  });
+}
+
+async function openChatSurface(page: Page) {
+  await page.goto("/");
+  await page.waitForTimeout(500);
+  await page.keyboard.press("Meta+2");
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+}
+
+const pane = (page: Page, id: string) => page.locator(`[data-chat-split-pane="${id}"]`);
+const focusedPane = (page: Page) => page.locator('[data-chat-split-pane][data-focused="true"]');
+
+test("keyboard split: two conversations side by side, focus moves, reload restores, ⌥⌘W closes", async ({ page }) => {
+  await setup(page);
+  await openChatSurface(page);
+
+  // The shell nav lists the chat threads (the live thread rail).
+  const alphaRow = page.getByRole("button", { name: /Alpha planning thread/ }).first();
+  await expect(alphaRow).toBeVisible({ timeout: 30_000 });
+
+  // Open Alpha as the primary chat.
+  await alphaRow.click();
+  await expect(page.getByText("Alpha reply text")).toBeVisible({ timeout: 30_000 });
+
+  // ⌥↵ on the Beta row opens it in a split pane (keyboard twin of drag-to-split).
+  const betaRow = page.getByRole("button", { name: /Beta review thread/ }).first();
+  await betaRow.focus();
+  await page.keyboard.press("Alt+Enter");
+
+  // Both panes exist and both transcripts are visible at the same time.
+  await expect(pane(page, "primary")).toBeVisible({ timeout: 15_000 });
+  await expect(pane(page, "s-beta")).toBeVisible();
+  await expect(page.getByText("Alpha reply text")).toBeVisible();
+  await expect(page.getByText("Beta reply text")).toBeVisible({ timeout: 30_000 });
+
+  // The new pane holds the logical focus; ⌥⌘← moves it back to the primary.
+  await expect(pane(page, "s-beta")).toHaveAttribute("data-focused", "true");
+  await page.keyboard.press("Alt+Meta+ArrowLeft");
+  await expect(pane(page, "primary")).toHaveAttribute("data-focused", "true");
+  await expect(focusedPane(page)).toHaveCount(1);
+
+  // Reload: the split layout comes back from localStorage (and the primary
+  // conversation from the #chat- hash).
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+  await expect(pane(page, "primary")).toBeVisible({ timeout: 30_000 });
+  await expect(pane(page, "s-beta")).toBeVisible();
+  await expect(page.getByText("Beta reply text")).toBeVisible({ timeout: 30_000 });
+
+  // ⌥⌘→ focuses the secondary pane, ⌥⌘W closes it → back to a solo chat
+  // (solo renders without the pane wrapper at all). Composer autofocus may
+  // land logical focus in either pane after a reload — click into the
+  // primary first so the arrow move is deterministic.
+  await page.getByText("Alpha reply text").click();
+  await expect(pane(page, "primary")).toHaveAttribute("data-focused", "true");
+  await page.keyboard.press("Alt+Meta+ArrowRight");
+  await expect(pane(page, "s-beta")).toHaveAttribute("data-focused", "true");
+  await page.keyboard.press("Alt+Meta+KeyW");
+  await expect(page.locator("[data-chat-split-pane]")).toHaveCount(0, { timeout: 15_000 });
+  await expect(page.getByText("Beta reply text")).toBeHidden();
+  await expect(page.getByText("Alpha reply text")).toBeVisible();
+});


### PR DESCRIPTION
Closes the gap between the shipped drag-to-split chat and a real multipane chat interface (bead `cave-e3dj`): panes survive reload, one pane holds visible focus, the whole flow works keyboard-only, changes are announced to AT — and, crucially, the system is now actually reachable from the live IA.

## What was already there
`chat-split.ts` + `ChatSplitHost` + router wiring: drag a conversation onto the chat to snap it left/right/above/below, ≤4 panes, RRP-resizable, dedupe (a thread can't stream twice).

## What this adds
- **Reachability (found during e2e verification):** the Workspace mounts `ChatSurface` with `hideThreadRail` → `compact=true`, which disabled the entire split system in the real app — the only drag source (`ChatProjectSidebar`) never renders there. Splits are now an explicit `enableSplitPanes` opt-in on `ChatRouter` (decoupled from `compact`), and the **shell-nav thread rows** (`WorkspaceSidebar`) are split sources: native drag, **⌥↵**, **⌥-click**, routed via a new `open-split` pending chat action → `routerRef.openSessionInSplit(id)` (plain-open fallback on mobile/list view).
- **Persistence:** layout + pane sizes hydrate from `cave:chat-split-layout:v1` and write back on change; sizes only persist on user-driven resizes (`LayoutChangedMeta.isUserInteraction`); stale/partial size maps fall back to an even layout; divider double-click resets; deleted sessions are pruned once the session list is authoritative.
- **Focus model:** one logical focused pane (reconciled so closes/promotions fall back to the always-present primary), quiet accent outline, pointer/focus-capture keep it honest, panes take programmatic focus (`tabIndex=-1`).
- **Keyboard:** ⌥⌘←/↑ and ⌥⌘→/↓ move pane focus (wrapping), ⌥⌘W closes the focused secondary pane (`e.code` matching — ⌥ composes `e.key` on macOS), combos yield to open modals. Shortcuts sheet documents all bindings.
- **A11y:** split open/close/focus-move/promote announce via the shared live region.

## Verification
- `pnpm typecheck` clean; `pnpm test:app` **698 files green** (new behavioral tests for focus/persistence/prune model + extended wiring pins).
- New **`tests/chat-split-panes.spec.ts`** (daemon-less, route-mocked) proves the DoD in a real browser: keyboard-only split from the shell rail → two conversations visible concurrently → ⌥⌘arrow focus moves → reload restores layout + primary → ⌥⌘W back to solo. Passing locally on the desktop project.
- Single-pane behavior unchanged (solo renders the bare chat view exactly as before; suite pins unchanged elsewhere).

Bead: cave-e3dj
