### PR TITLE
feat(inbox): group-by as segmented tabs, not a dropdown (cave-u9ew)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -161,6 +161,10 @@ assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : 
 // actions ride ONE POST /api/inbox/bulk; delete keeps the undo window.
 assert.match(source, /buildInboxGroups\(inboxVisible, inboxGroupBy, familiarLabel\)/, "groups derive from the pure lib over the filtered feed");
 assert.match(source, /INBOX_GROUP_BY_OPTIONS/, "the group-by control offers the lib's dimensions");
+// The group-by is three visible segmented tabs (marketplace kind-filter
+// precedent), never a dropdown — the active dimension reads at a glance.
+assert.match(source, /ariaLabel="Group inbox by"[\s\S]{0,220}INBOX_GROUP_BY_OPTIONS\.map\(\(option\) => \(\{ id: option\.value, label: option\.label \}\)\)/, "group-by renders as a named segmented Tabs control");
+assert.doesNotMatch(source, /<StandardSelect[\s\S]{0,120}label="Group inbox by"/, "the group-by dropdown is gone");
 assert.match(source, /cave:inbox:group-by/, "the group-by choice persists per install");
 assert.match(source, /const inboxSelect = useMultiSelect\(inboxVisible, \(it\) => it\.id\)/, "selection universe = the visible matches");
 assert.match(source, /<SelectionToolbar/, "inbox select mode uses the shared bulk toolbar");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2400,13 +2400,17 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               </div>
             ) : null}
             {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 ? (
-              <StandardSelect
-                label="Group inbox by"
-                title="Group the inbox feed by attention, kind, or familiar"
+              // Group-by reads as three visible choices (marketplace kind-filter
+              // precedent), not a dropdown — one glance shows the active dimension.
+              <Tabs
+                variant="segment"
+                size="sm"
+                bordered={false}
+                ariaLabel="Group inbox by"
+                idPrefix="inbox-group-by"
                 value={inboxGroupBy}
                 onChange={updateInboxGroupBy}
-                options={INBOX_GROUP_BY_OPTIONS}
-                renderValue={(selected) => <>Group: {selected?.label ?? "Attention"}</>}
+                items={INBOX_GROUP_BY_OPTIONS.map((option) => ({ id: option.value, label: option.label }))}
               />
             ) : null}
             {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 && !inboxSelect.selectMode ? (

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2407,7 +2407,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 size="sm"
                 bordered={false}
                 ariaLabel="Group inbox by"
-                idPrefix="inbox-group-by"
                 value={inboxGroupBy}
                 onChange={updateInboxGroupBy}
                 items={INBOX_GROUP_BY_OPTIONS.map((option) => ({ id: option.value, label: option.label }))}


### PR DESCRIPTION
## What

Follow-up to #3139: the Rituals Inbox **group-by** control is now three visible segmented tabs — **Attention / Kind / Familiar** — instead of a `StandardSelect` dropdown, so the active grouping dimension reads at a glance and switching is one click.

- Shared `Tabs` `variant="segment" size="sm" bordered={false}` with `ariaLabel="Group inbox by"` — the marketplace kind-filter precedent for segment-Tabs-as-filter.
- Options still derive from `INBOX_GROUP_BY_OPTIONS`; persistence (`cave:inbox:group-by`) and `buildInboxGroups` wiring unchanged.
- Pins updated deliberately: segmented control asserted, the dropdown pinned out.

## Testing

`pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (700 files).

Bead: cave-u9ew