### PR TITLE
feat(chat): widen the Familiar tab + deep-blur glass over backdrops (cave-w3us)

### DIFF
--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -32,6 +32,18 @@ assert.match(
   "the chat landing cluster earns the same glass ground as the live transcript",
 );
 
+// ── Familiar tab glass ───────────────────────────────────────────────────────
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.familiar-tab \{[^}]*backdrop-filter: blur\(50px\)/s,
+  "the Familiar tab earns a deep-blur glass column over the image",
+);
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.familiar-tab \{[^}]*--text-muted: var\(--text-secondary\)/s,
+  "muted text reads at secondary strength on the Familiar tab over the image",
+);
+
 // ── Quiet-text lift extends to Home ──────────────────────────────────────────
 assert.match(
   css,
@@ -42,8 +54,8 @@ assert.match(
 // ── Degradation contract ─────────────────────────────────────────────────────
 assert.match(
   css,
-  /@supports not \(\(backdrop-filter[^)]*\)[^{]*\{[\s\S]*?\.cave-chat-empty-shell \{[^}]*92%/,
-  "no backdrop-filter → the landing glass goes near-opaque",
+  /@supports not \(\(backdrop-filter[^)]*\)[^{]*\{[\s\S]*?\.cave-chat-empty-shell,\s*html\[data-backdrop-on\] \.familiar-tab \{[^}]*92%/,
+  "no backdrop-filter → the landing and Familiar-tab glass go near-opaque",
 );
 assert.match(
   css,
@@ -54,6 +66,11 @@ assert.match(
   css,
   /prefers-reduced-transparency: reduce[\s\S]*\.cave-chat-empty-shell \{[^}]*background: transparent/s,
   "reduced transparency drops the landing glass with the image",
+);
+assert.match(
+  css,
+  /prefers-reduced-transparency: reduce[\s\S]*\.familiar-tab \{[^}]*background: transparent/s,
+  "reduced transparency drops the Familiar-tab glass with the image",
 );
 
 console.log("backdrop-scrim.test.ts: ok");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -586,7 +586,7 @@ export function ChatSurface({
           // skills, tools) — promoted from the retired inspector sidepanel to a
           // first-class chat tab, since it describes who you're chatting with.
           <div className="flex min-h-0 min-w-0 flex-1 justify-center">
-            <div className="h-full w-full max-w-5xl">
+            <div className="h-full w-full max-w-7xl">
               <InspectorPane familiar={activeFamiliar} tab="familiar" daemonRunning={daemonRunning} onStartChat={startFamiliarHeroChat} />
             </div>
           </div>

--- a/src/components/familiar-tab-hero.test.ts
+++ b/src/components/familiar-tab-hero.test.ts
@@ -74,8 +74,8 @@ test("wide-canvas layout: container-query grid, two columns >=900px, single belo
 test("the chat surface gives the tab a wide canvas and threads presence", () => {
   assert.match(
     chatSurface,
-    /scope === "familiar"[\s\S]*?max-w-5xl[\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} onStartChat=\{startFamiliarHeroChat\} \/>/,
-    "Familiar tab hosts the pane in a max-w-5xl column with daemonRunning threaded",
+    /scope === "familiar"[\s\S]*?max-w-7xl[\s\S]*?<InspectorPane familiar=\{activeFamiliar\} tab="familiar" daemonRunning=\{daemonRunning\} onStartChat=\{startFamiliarHeroChat\} \/>/,
+    "Familiar tab hosts the pane in a max-w-7xl column with daemonRunning threaded",
   );
 });
 

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -653,7 +653,7 @@ function CapSection({
 function CapRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <li className="flex items-baseline justify-between gap-2">
-      <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+      <span className="text-[11px] uppercase tracking-wider text-[var(--text-muted)]">
         {label}
       </span>
       <span
@@ -720,7 +720,7 @@ function SkillItem({
         <KindBadge kind={kind} />
       </div>
       {description ? (
-        <p className="mt-0.5 line-clamp-1 text-[10px] text-[var(--text-muted)]">{description}</p>
+        <p className="mt-0.5 line-clamp-1 text-[11px] text-[var(--text-muted)]">{description}</p>
       ) : null}
       {tags && tags.length > 0 ? (
         <div className="mt-0.5 flex flex-wrap gap-1">
@@ -763,7 +763,7 @@ function CollapsibleSection({
           width={10}
           className="shrink-0 text-[var(--text-muted)]"
         />
-        <span className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+        <span className="text-[11px] uppercase tracking-widest text-[var(--text-secondary)]">
           {title}
         </span>
         {badge ? (
@@ -837,13 +837,13 @@ function FamiliarIdentityHero({
           </p>
         ) : null}
         {familiar.description ? (
-          <p className="mt-1.5 max-w-[64ch] text-[12px] leading-relaxed text-[var(--text-secondary)]">
+          <p className="mt-1.5 max-w-[64ch] text-[13px] leading-relaxed text-[var(--text-secondary)]">
             {familiar.description}
           </p>
         ) : null}
         <div className="familiar-tab__links mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
           {runtimeLine ? (
-            <span className="font-mono text-[10px] text-[var(--text-muted)]" title="Harness · model">
+            <span className="font-mono text-[11px] text-[var(--text-muted)]" title="Harness · model">
               {runtimeLine}
             </span>
           ) : null}
@@ -851,14 +851,14 @@ function FamiliarIdentityHero({
             <Link
               href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
               aria-label={`Open profile card for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
             >
               Profile →
             </Link>
             <Link
               href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
               aria-label={`Open analytics for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
             >
               Analytics →
             </Link>
@@ -868,7 +868,7 @@ function FamiliarIdentityHero({
               type="button"
               onClick={() => openFamiliarStudioSettingsTab("memory", familiar.id)}
               aria-label={`Open memory for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
             >
               Memory →
             </button>
@@ -876,7 +876,7 @@ function FamiliarIdentityHero({
               type="button"
               onClick={() => openFamiliarStudioSettingsTab("identity", familiar.id)}
               aria-label={`Edit ${familiar.display_name} in the Familiar Studio`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
             >
               Edit in Studio →
             </button>

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -122,6 +122,19 @@ html[data-backdrop-on] .cave-chat-empty-shell {
   padding: clamp(16px, 3vh, 28px) clamp(14px, 2.5vw, 24px);
 }
 
+/* Familiar tab over the image: the identity hero and the dense capability
+   rows have no bubbles at all, so their small type sits straight on the
+   photo. Give the tab the transcript's glass-column idiom with a much deeper
+   blur — 50px flattens faces/props into a soft wash that 10–13px metadata
+   stays legible against at any intensity. */
+html[data-backdrop-on] .familiar-tab {
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+  backdrop-filter: blur(50px) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(50px) saturate(var(--glass-saturate));
+  border-radius: 14px;
+  --text-muted: var(--text-secondary);
+}
+
 /* And the same quiet-text contrast lift Home-side. */
 html[data-backdrop-on] .home-composer-root {
   --text-muted: var(--text-secondary);
@@ -135,7 +148,8 @@ html[data-backdrop-on] .home-composer-root {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
   }
 
-  html[data-backdrop-on] .cave-chat-empty-shell {
+  html[data-backdrop-on] .cave-chat-empty-shell,
+  html[data-backdrop-on] .familiar-tab {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
   }
 }
@@ -168,5 +182,12 @@ html[data-backdrop-on] .home-composer-root {
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
     padding: 0;
+  }
+
+  /* No image layer → the familiar tab sits on the base surface again. */
+  html[data-backdrop-on] .familiar-tab {
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }


### PR DESCRIPTION
## What

The chat page's **Familiar tab**: a wider canvas and real text legibility over scene backdrops (bead `cave-w3us`).

## Why

With a backdrop image enabled (the `cave:backdrop` scene layer), the Familiar tab's identity hero and dense capability rows sat **straight on the photo** — no bubbles, no glass, 10–13px type fighting faces and props (screenshot-verified before/after below). The tab's column also capped at `max-w-5xl`, wasting wide screens.

## How

- **Wider max**: the hosted column grows `max-w-5xl` → `max-w-7xl` (1024 → 1280px measured).
- **Deep-blur glass** (`styles/backdrop.css`, extending the cave-5oeu transcript idiom): under `html[data-backdrop-on]`, `.familiar-tab` gets a 62% `--bg-base` wash + **`blur(50px)`** + saturate, 14px radius, and the muted-text lift — the image flattens to a soft wash the small type stays legible against at any intensity.
- **Degradation intact**: near-opaque fill when `backdrop-filter` is unsupported; glass drops with the image under `prefers-reduced-transparency` — both mirrored from the existing blocks and pinned.
- **Type bumps** (`inspector-pane.tsx`): capability descriptions, section titles, cap-row labels, and the hero's quiet links 10→11px; familiar description 12→13px (verified computed 13px).

## Verification

- Playwright before/after over a vivid image: before = raw text on photo at 1024px; after = washed/blurred panel at 1280px, description 13px. Also verified against this machine's real enabled backdrop prefs.
- `backdrop-scrim.test.ts` (+3 pins: familiar-tab glass, degradation, reduced-transparency), `familiar-tab-hero.test.ts` (width pin), `familiar-tab-sections/bridges` all green; `pnpm typecheck` ✓.
- (`cave-backdrop.test.ts` fails standalone on clean main too — `@/lib` alias needs the suite runner; unrelated.)
