### PR TITLE
polish(rituals): honest copy and link labels for the rebranded surface

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -29,6 +29,7 @@ import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
 import { formatTimestamp, formatClock, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { relativeTimeSigned } from "@/lib/relative-time";
+import { parseGitHubItemUrl } from "@/lib/github-item-url";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { StandardSelect } from "@/components/ui/select";
@@ -83,7 +84,13 @@ type Props = {
 };
 
 function linkLabel(link: LinkRef): string {
-  if (link.kind === "url") return link.ref;
+  if (link.kind === "url") {
+    // GitHub items open natively (cave-qcsv) — say where the button goes
+    // instead of printing the raw URL.
+    const gh = parseGitHubItemUrl(link.ref);
+    if (gh) return `Open in GitHub · ${gh.repo} #${gh.number}`;
+    return link.ref;
+  }
   if (link.kind === "card") return "Card";
   if (link.kind === "session") return "Session";
   return "Memory";

--- a/src/components/github-subscribe-ux.test.ts
+++ b/src/components/github-subscribe-ux.test.ts
@@ -89,4 +89,13 @@ assert.match(
   "a failed subscriptions refresh must not derive an empty repos list (it would PATCH the watch list away)",
 );
 
+// ── Polish (cave-e4oz): honest labels ────────────────────────────────────────
+// The DetailPanel's Link button names its native destination for GitHub items
+// instead of printing a raw URL.
+assert.match(
+  automations,
+  /const gh = parseGitHubItemUrl\(link\.ref\);\s*if \(gh\) return `Open in GitHub · \$\{gh\.repo\} #\$\{gh\.number\}`;/,
+  "GitHub item links label as 'Open in GitHub · owner/repo #N'",
+);
+
 console.log("github-subscribe-ux.test.ts: ok");

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -513,7 +513,7 @@ export function MarketplaceViewSurface({
     // on a wide screen (same pattern as chat's chatlist/composer containers).
     <section className="marketplace-view @container/marketplace flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       {/* Compact header — one slim topmost band (shared .surface-compact
-          chrome with Schedules and the GitHub surface): small title, size-sm
+          chrome with Rituals and the GitHub surface): small title, size-sm
           segment section tabs (live counts, subtitle as tooltip), scoped
           search on the right. The shared Tabs primitive supplies
           role=tablist/tab, roving tabindex, and the marketplace-tab / panel

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -119,7 +119,7 @@ const FOLDER_MODES: Array<{
   // Group Chat ("coven") is no longer a standalone destination — it lives as the
   // Group tab inside Chat. The `groupchat` mode still exists as a redirect target.
   { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
-  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and scheduled jobs in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
+  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Inbox, calendar, and scheduled jobs in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
   // Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
   // ⌘-numbered daily destinations (Home · Chat · Tasks · Schedules — Schedules
   // also carries the needs-you badge). Memories joins the quiet cluster: same


### PR DESCRIPTION
## Checkpoint 5 (final) of the Rituals rebrand

Small honesty pass to close the goal:

- **Sidebar tooltip** — "Inbox, calendar, and scheduled jobs in one place" (the Inbox tab is the surface's default landing tab since C2).
- **Link labels** — the Rituals DetailPanel Link button now reads **Open in GitHub · owner/repo #N** for GitHub items (they open the native surface per C3) instead of a raw URL.
- **Comment accuracy** — marketplace-view chrome comment says Rituals.

Verified as already conforming (no code needed): nav badge ↔ Inbox tab count share `groupInboxFeed`; empty/no-match states (C2); row actions always visible → touch-safe; a11y announcements on every feed mutation; docs have no stale "Schedules" references.

## Verification
`pnpm typecheck` clean · targeted pin suites pass · full `pnpm test:app` **702 files pass**

Bead: cave-e4oz · closes the five-checkpoint goal (C1 #3128 · C2 #3132 · C3 #3135 · C4 #3140).