### PR TITLE
feat(covenwiki): plan-semantics status/regenerate commands, S1-S4 (cave-007q)

### DIFF
--- a/scripts/covenwiki-regen-cli.test.mjs
+++ b/scripts/covenwiki-regen-cli.test.mjs
@@ -1,0 +1,180 @@
+// End-to-end coverage for the plan-semantics wiki commands (S1–S4) of
+// scripts/covenwiki-regen.ts: status freshness reporting, regenerate no-op on
+// fresh, the fail-closed validate-then-swap, and the non-local refusal.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dir = mkdtempSync(path.join(tmpdir(), "covenwiki-regen-cli-"));
+const repoDir = path.join(dir, "repo");
+const wikisDir = path.join(dir, "wikis");
+const wikiDir = path.join(wikisDir, "testrepo");
+const genScript = path.join(dir, "gen.mjs");
+
+function writeRepo() {
+  mkdirSync(path.join(repoDir, "src"), { recursive: true });
+  writeFileSync(path.join(repoDir, "README.md"), "# testrepo\n");
+  writeFileSync(path.join(repoDir, "src", "main.ts"), "export const x = 1;\n");
+}
+
+function manifestFor(slug, fingerprint, marker) {
+  return {
+    schemaVersion: "1.0",
+    slug,
+    title: `Wiki ${marker}`,
+    source: { kind: "local", repoRoot: repoDir, revision: null, fingerprint, fileCount: 2 },
+    generation: { generatedAt: "2026-07-03T12:09:52Z", backend: "stub", status: "stub" },
+    navigation: [{ title: "Overview", slug: "overview", children: [] }],
+    pages: [
+      {
+        slug: "overview",
+        title: "Overview",
+        path: "pages/overview.md",
+        meta: "pages/overview.meta.json",
+        priority: "required",
+      },
+    ],
+    counts: { pages: 1 },
+  };
+}
+
+function writeWiki(target, { fingerprint, marker, kind = "local" }) {
+  rmSync(target, { recursive: true, force: true });
+  mkdirSync(path.join(target, "pages"), { recursive: true });
+  const manifest = manifestFor(path.basename(target), fingerprint, marker);
+  manifest.source.kind = kind;
+  writeFileSync(path.join(target, "manifest.json"), JSON.stringify(manifest, null, 2));
+  writeFileSync(path.join(target, "pages", "overview.md"), `# Overview (${marker})\n`);
+  writeFileSync(
+    path.join(target, "pages", "overview.meta.json"),
+    JSON.stringify({ slug: "overview", title: "Overview", citations: [], coverageNotes: [], relatedPages: [] }),
+  );
+}
+
+// Generator fixture: mode comes from GEN_MODE (ok | invalid | fail).
+writeFileSync(
+  genScript,
+  `import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+const [out, slug] = process.argv.slice(2);
+const mode = process.env.GEN_MODE ?? "ok";
+if (mode === "fail") process.exit(3);
+mkdirSync(path.join(out, "pages"), { recursive: true });
+const manifest = ${JSON.stringify(manifestFor("SLUG", "ffffffffffffffff", "regenerated"))};
+manifest.slug = slug;
+manifest.source.repoRoot = ${JSON.stringify(repoDir)};
+if (mode === "invalid") delete manifest.pages;
+writeFileSync(path.join(out, "manifest.json"), JSON.stringify(manifest, null, 2));
+if (mode !== "missing-page") {
+  writeFileSync(path.join(out, "pages", "overview.md"), "# Overview (regenerated)\\n");
+  writeFileSync(path.join(out, "pages", "overview.meta.json"), "{}");
+}
+`,
+);
+
+const GENERATOR = `node "${genScript}" "{out}" {slug}`;
+
+function run(args, env = {}) {
+  return spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", "scripts/covenwiki-regen.ts", ...args, "--wikis-dir", wikisDir],
+    { cwd: new URL("..", import.meta.url), encoding: "utf8", env: { ...process.env, ...env } },
+  );
+}
+
+function statusJson() {
+  const result = run(["status", "testrepo", "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+try {
+  writeRepo();
+
+  // status: wrong fingerprint => stale, and both fingerprints are reported.
+  writeWiki(wikiDir, { fingerprint: "0000000000000000", marker: "v1" });
+  let status = statusJson();
+  assert.equal(status.freshness, "stale");
+  assert.equal(status.fingerprint.manifest, "0000000000000000");
+  assert.match(status.fingerprint.live, /^[0-9a-f]{16}$/);
+  assert.equal(status.fileCount.live, 2);
+  const liveFingerprint = status.fingerprint.live;
+
+  // status: matching fingerprint => fresh.
+  writeWiki(wikiDir, { fingerprint: liveFingerprint, marker: "v1" });
+  status = statusJson();
+  assert.equal(status.freshness, "fresh");
+
+  // status: missing fingerprint => unknown.
+  writeWiki(wikiDir, { fingerprint: null, marker: "v1" });
+  assert.equal(statusJson().freshness, "unknown");
+
+  // regenerate: fresh wiki is a no-op with exit 0.
+  writeWiki(wikiDir, { fingerprint: liveFingerprint, marker: "v1" });
+  let result = run(["regenerate", "testrepo", "--json", "--generator", GENERATOR]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).action, "none");
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /v1/);
+
+  // regenerate: stale wiki runs the generator and swaps atomically.
+  writeFileSync(path.join(repoDir, "src", "main.ts"), "export const x = 2;\n");
+  result = run(["regenerate", "testrepo", "--json", "--generator", GENERATOR]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).action, "regenerated");
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /regenerated/);
+  assert.ok(!existsSync(`${wikiDir}.tmp`), "tmp dir should be gone after the swap");
+
+  // regenerate --force works even when fresh.
+  writeWiki(wikiDir, { fingerprint: statusJson().fingerprint.live, marker: "v2" });
+  result = run(["regenerate", "testrepo", "--force", "--json", "--generator", GENERATOR]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).action, "regenerated");
+
+  // fail-closed: generator emitting an invalid manifest leaves the live wiki untouched.
+  writeWiki(wikiDir, { fingerprint: "0000000000000000", marker: "v3" });
+  result = run(["regenerate", "testrepo", "--generator", GENERATOR], { GEN_MODE: "invalid" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /validation/);
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /v3/);
+
+  // fail-closed: generator omitting a listed page file is rejected too.
+  result = run(["regenerate", "testrepo", "--generator", GENERATOR], { GEN_MODE: "missing-page" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /missing pages\/overview/);
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /v3/);
+
+  // fail-closed: generator exiting nonzero keeps the live wiki and forwards failure.
+  result = run(["regenerate", "testrepo", "--generator", GENERATOR], { GEN_MODE: "fail" });
+  assert.equal(result.status, 3);
+  assert.match(result.stderr, /live wiki untouched/);
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /v3/);
+
+  // dry run: reports the command without touching anything.
+  result = run(["regenerate", "testrepo", "--dry-run", "--json", "--generator", GENERATOR]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).action, "would-regenerate");
+  assert.match(readFileSync(path.join(wikiDir, "pages", "overview.md"), "utf8"), /v3/);
+
+  // non-local sources are unknown and never auto-regenerate.
+  writeWiki(wikiDir, { fingerprint: "0000000000000000", marker: "gh", kind: "github" });
+  assert.equal(statusJson().freshness, "unknown");
+  result = run(["regenerate", "testrepo", "--generator", GENERATOR]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /refusing to regenerate/);
+  result = run(["regenerate", "testrepo", "--force", "--generator", GENERATOR]);
+  assert.equal(result.status, 1, "github kind must refuse even with --force");
+
+  // guardrails: unknown wiki and path-shaped slugs error cleanly.
+  result = run(["status", "missing-wiki"]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /wiki not found/);
+  result = run(["status", "../escape"]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /invalid slug/);
+
+  console.log("covenwiki-regen CLI: all assertions passed");
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/scripts/covenwiki-regen.ts
+++ b/scripts/covenwiki-regen.ts
@@ -1,36 +1,68 @@
 #!/usr/bin/env node --experimental-strip-types
-// CovenWiki v0 Phase 3 — regeneration hook CLI (Route B stages S1–S4).
+// CovenWiki v0 Phase 3 — regeneration hook CLI (Route B).
 //
-// Thin I/O wrapper over src/lib/covenwiki-regen.ts. Stage semantics:
-//   scan  (S1) hash every file under the source roots -> manifest JSON
-//   diff  (S2) compare a fresh scan against the saved state; --check for hooks
-//   plan  (S3) print the regeneration actions the diff implies
-//   run   (S4) execute the plan (optional --generator), then persist new state
+// Thin I/O wrapper over src/lib/covenwiki-regen.ts.
 //
-// The Phase 1/2 wiki generator plugs in via --generator: the plan is piped to
-// its stdin as JSON. Without --generator, `run` is report-then-persist, which
-// is enough to seed state and wire the hook before the generator lands.
+// Plan-semantics commands (phase3 regen-hook step plan, S1–S4):
+//   status <slug>       (S1+S2) pure read: fresh|stale|unknown + fingerprints;
+//                       zero side effects, cheap enough for the daemon/UI to poll
+//   regenerate <slug>   (S3+S4) if stale (or --force) re-run the generator into
+//                       <wiki>.tmp, validate fail-closed, atomically swap over
+//                       the live wiki dir. Fresh => no-op, exit 0.
+//
+// Incremental stages (S6 groundwork; content-hash based):
+//   scan   hash every file under the source roots -> manifest JSON
+//   diff   compare a fresh scan against the saved state; --check for hooks
+//   plan   print the regeneration actions the diff implies
+//   run    execute the plan (optional --generator), then persist new state
+//
+// Wikis resolve as <wikis-dir>/<slug>/manifest.json (default ~/.coven/wikis),
+// per the CovenWiki manifest contract. The regenerate generator command is a
+// template: {repo}, {out}, {slug} are substituted before shell execution.
 import { createHash } from "node:crypto";
-import { readdirSync, readFileSync, statSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import {
   buildManifest,
+  buildWikiStatus,
+  computeSourceFingerprint,
   diffManifests,
+  formatWikiStatus,
   nextState,
   parseState,
+  parseWikiManifest,
   planRegeneration,
   serializeState,
   summarizePlan,
+  validateWikiManifest,
   type Manifest,
   type SourceEntry,
+  type StatEntry,
+  type WikiManifest,
 } from "../src/lib/covenwiki-regen.ts";
 
 const STAGES = ["scan", "diff", "plan", "run"] as const;
+const WIKI_COMMANDS = ["status", "regenerate"] as const;
 type Stage = (typeof STAGES)[number];
+type WikiCommand = (typeof WIKI_COMMANDS)[number];
+type Command = Stage | WikiCommand;
 
 type Options = {
-  stage: Stage;
+  command: Command;
+  slug: string | null;
+  wikisDir: string;
+  force: boolean;
   sources: string[];
   state: string;
   fullRebuild: string[];
@@ -41,24 +73,35 @@ type Options = {
 };
 
 const SKIP_DIRS = new Set([".git", "node_modules", ".worktrees", ".next", "target"]);
+const DEFAULT_WIKIS_DIR = path.join(homedir(), ".coven", "wikis");
+const DEFAULT_GENERATOR = "covenwiki generate --repo {repo} --out {out}";
 
 function printHelp() {
-  console.log(`Usage: node --experimental-strip-types scripts/covenwiki-regen.ts <stage> [options]
+  console.log(`Usage: node --experimental-strip-types scripts/covenwiki-regen.ts <command> [options]
 
-Stages (CovenWiki Route B Phase 3, S1-S4):
-  scan   S1: hash all wiki sources and print the manifest
-  diff   S2: compare a fresh scan with the saved state
-  plan   S3: show the regeneration actions the current diff implies
-  run    S4: execute the plan and persist the new state
+Wiki commands (plan S1-S4; wikis resolve as <wikis-dir>/<slug>/manifest.json):
+  status <slug>      S1+S2: report fresh|stale|unknown vs manifest.source.fingerprint (pure read)
+  regenerate <slug>  S3+S4: if stale (or --force) re-run the generator into <wiki>.tmp,
+                     validate fail-closed, then atomically swap over the live wiki
+
+Incremental stages (S6 groundwork, content-hash based):
+  scan   hash all wiki sources and print the manifest
+  diff   compare a fresh scan with the saved state
+  plan   show the regeneration actions the current diff implies
+  run    execute the plan and persist the new state
 
 Options:
-  --source <path>        source root to scan (repeatable; default: docs)
-  --state <file>         state file (default: .covenwiki/state.json)
-  --full-rebuild <path>  path or dir/ prefix that forces a full rebuild (repeatable)
-  --generator <cmd>      shell command for 'run'; receives the plan JSON on stdin
+  --wikis-dir <dir>      wiki store root (default: ~/.coven/wikis)
+  --force                (regenerate) regenerate even when fresh
+  --generator <cmd>      regenerate: command template, {repo}/{out}/{slug} substituted
+                           (default: "${DEFAULT_GENERATOR}")
+                         run: shell command; receives the plan JSON on stdin
+  --source <path>        (stages) source root to scan (repeatable; default: docs)
+  --state <file>         (stages) state file (default: .covenwiki/state.json)
+  --full-rebuild <path>  (stages) path or dir/ prefix that forces a full rebuild (repeatable)
   --json                 emit machine-readable JSON instead of text
   --check                (diff/plan) exit 1 when regeneration is needed
-  --dry-run              (run) skip the generator and state write
+  --dry-run              (regenerate/run) report without running the generator or writing
   -h, --help             show this help`);
 }
 
@@ -68,10 +111,14 @@ function parseArgs(argv: string[]): Options {
     printHelp();
     process.exit(first ? 0 : 1);
   }
-  if (!STAGES.includes(first as Stage)) throw new Error(`unknown stage: ${first} (expected ${STAGES.join("|")})`);
-  const stage = first as Stage;
+  const known = [...STAGES, ...WIKI_COMMANDS] as string[];
+  if (!known.includes(first)) throw new Error(`unknown command: ${first} (expected ${known.join("|")})`);
+  const command = first as Command;
   const opts: Options = {
-    stage,
+    command,
+    slug: null,
+    wikisDir: DEFAULT_WIKIS_DIR,
+    force: false,
     sources: [],
     state: ".covenwiki/state.json",
     fullRebuild: [],
@@ -83,6 +130,12 @@ function parseArgs(argv: string[]): Options {
   for (let i = 1; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
+      case "--wikis-dir":
+        opts.wikisDir = requireValue(argv, ++i, arg);
+        break;
+      case "--force":
+        opts.force = true;
+        break;
       case "--source":
         opts.sources.push(requireValue(argv, ++i, arg));
         break;
@@ -109,11 +162,20 @@ function parseArgs(argv: string[]): Options {
         printHelp();
         process.exit(0);
       default:
+        if (!arg.startsWith("-") && opts.slug === null && isWikiCommand(command)) {
+          opts.slug = arg;
+          break;
+        }
         throw new Error(`unsupported argument: ${arg}`);
     }
   }
+  if (isWikiCommand(command) && !opts.slug) throw new Error(`${command} requires a wiki <slug>`);
   if (opts.sources.length === 0) opts.sources.push("docs");
   return opts;
+}
+
+function isWikiCommand(command: Command): command is WikiCommand {
+  return (WIKI_COMMANDS as readonly string[]).includes(command);
 }
 
 function requireValue(argv: string[], index: number, flag: string): string {
@@ -132,7 +194,7 @@ function walk(root: string, out: string[]) {
   }
 }
 
-/** S1: scan the source roots into a manifest. */
+/** scan: hash the source roots into a content manifest. */
 function scan(opts: Options): Manifest {
   const files: string[] = [];
   for (const source of opts.sources) {
@@ -152,11 +214,176 @@ function loadPreviousManifest(stateFile: string): Manifest | null {
   return parseState(readFileSync(stateFile, "utf8")).manifest;
 }
 
+// ─── Wiki commands (plan S1–S4) ─────────────────────────────────────────────
+
+/** Stat-only inventory of a repo root, mirroring the fingerprint contract. */
+function statInventory(repoRoot: string): StatEntry[] {
+  const files: string[] = [];
+  walk(repoRoot, files);
+  return files.map((file) => {
+    const st = statSync(file);
+    return {
+      path: path.relative(repoRoot, file).split(path.sep).join("/"),
+      size: st.size,
+      mtimeMs: st.mtimeMs,
+    };
+  });
+}
+
+type LiveSource = { fingerprint: string | null; fileCount: number | null };
+
+function computeLiveSource(manifest: WikiManifest): LiveSource {
+  const repoRoot = manifest.source.repoRoot;
+  if (manifest.source.kind !== "local" || !repoRoot) return { fingerprint: null, fileCount: null };
+  if (!existsSync(repoRoot) || !statSync(repoRoot).isDirectory()) return { fingerprint: null, fileCount: null };
+  const inventory = statInventory(repoRoot);
+  return { fingerprint: computeSourceFingerprint(inventory), fileCount: inventory.length };
+}
+
+function resolveWiki(opts: Options): { wikiDir: string; manifest: WikiManifest } {
+  const slug = opts.slug!;
+  if (slug.includes("/") || slug.includes("\\") || slug === "." || slug === "..") {
+    throw new Error(`invalid slug: ${slug}`);
+  }
+  const wikiDir = path.join(opts.wikisDir, slug);
+  const manifestPath = path.join(wikiDir, "manifest.json");
+  if (!existsSync(manifestPath)) throw new Error(`wiki not found: ${manifestPath}`);
+  const manifest = parseWikiManifest(readFileSync(manifestPath, "utf8"));
+  if (manifest.slug !== slug) {
+    throw new Error(`manifest slug "${manifest.slug}" does not match wiki directory "${slug}"`);
+  }
+  return { wikiDir, manifest };
+}
+
+/** S2 — status <slug>: pure read, exit 0 whenever a report was produced. */
+function runStatus(opts: Options) {
+  const { manifest } = resolveWiki(opts);
+  const live = computeLiveSource(manifest);
+  const status = buildWikiStatus(manifest, live.fingerprint, live.fileCount);
+  if (opts.json) console.log(JSON.stringify(status, null, 2));
+  else for (const line of formatWikiStatus(status)) console.log(line);
+}
+
+/**
+ * S4 — fail-closed validation of a freshly generated wiki dir: the manifest
+ * must parse clean, keep the slug, and every page/meta file it lists must
+ * exist. Any error leaves the live wiki untouched.
+ */
+function validateGeneratedWiki(tmpDir: string, slug: string): string[] {
+  const manifestPath = path.join(tmpDir, "manifest.json");
+  if (!existsSync(manifestPath)) return [`generated wiki has no manifest.json (${manifestPath})`];
+  let data: unknown;
+  try {
+    data = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch {
+    return ["generated manifest.json is not valid JSON"];
+  }
+  const errors = validateWikiManifest(data);
+  if (errors.length > 0) return errors;
+  const manifest = data as WikiManifest;
+  if (manifest.slug !== slug) errors.push(`generated manifest slug "${manifest.slug}" does not match wiki "${slug}"`);
+  for (const page of manifest.pages) {
+    for (const rel of [page.path, page.meta]) {
+      if (!existsSync(path.join(tmpDir, rel))) errors.push(`generated wiki is missing ${rel}`);
+    }
+  }
+  return errors;
+}
+
+/** S3+S4 — regenerate <slug>: re-run the pipeline when stale, swap atomically. */
+function runRegenerate(opts: Options) {
+  const slug = opts.slug!;
+  const { wikiDir, manifest } = resolveWiki(opts);
+  const live = computeLiveSource(manifest);
+  const status = buildWikiStatus(manifest, live.fingerprint, live.fileCount);
+  const report = (extra: Record<string, unknown>) => {
+    if (opts.json) console.log(JSON.stringify({ ...status, ...extra }, null, 2));
+    else for (const line of formatWikiStatus(status)) console.log(line);
+  };
+
+  if (status.freshness === "fresh" && !opts.force) {
+    report({ action: "none" });
+    if (!opts.json) console.log("fresh — nothing to regenerate (use --force to override)");
+    return;
+  }
+  if (status.freshness === "unknown") {
+    // "unknown" never auto-regenerates; --force only helps when a local repo
+    // root actually exists to regenerate from.
+    const repoRoot = manifest.source.repoRoot;
+    const forceable = opts.force && manifest.source.kind === "local" && repoRoot && existsSync(repoRoot);
+    if (!forceable) {
+      report({ action: "refused" });
+      console.error(`refusing to regenerate: ${status.reason}`);
+      process.exit(1);
+    }
+  }
+
+  const repoRoot = manifest.source.repoRoot!;
+  const tmpDir = `${wikiDir}.tmp`;
+  const template = opts.generator ?? DEFAULT_GENERATOR;
+  const command = template
+    .replaceAll("{repo}", repoRoot)
+    .replaceAll("{out}", tmpDir)
+    .replaceAll("{slug}", slug);
+
+  if (opts.dryRun) {
+    report({ action: "would-regenerate", command });
+    if (!opts.json) console.log(`dry run — would execute: ${command}`);
+    return;
+  }
+
+  rmSync(tmpDir, { recursive: true, force: true });
+  const result = spawnSync(command, { shell: true, stdio: ["ignore", "inherit", "inherit"] });
+  if (result.status !== 0) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    console.error(`generator failed (exit ${result.status ?? "signal"}); live wiki untouched`);
+    process.exit(result.status ?? 1);
+  }
+
+  const errors = validateGeneratedWiki(tmpDir, slug);
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`validation: ${error}`);
+    console.error(`regenerated wiki failed validation; live wiki untouched (inspect ${tmpDir})`);
+    process.exit(1);
+  }
+
+  // Swap: retire the live dir, promote the validated tmp dir, drop the backup.
+  const backupDir = `${wikiDir}.old-${process.pid}`;
+  rmSync(backupDir, { recursive: true, force: true });
+  renameSync(wikiDir, backupDir);
+  try {
+    renameSync(tmpDir, wikiDir);
+  } catch (error) {
+    renameSync(backupDir, wikiDir);
+    throw error;
+  }
+  rmSync(backupDir, { recursive: true, force: true });
+
+  const refreshed = parseWikiManifest(readFileSync(path.join(wikiDir, "manifest.json"), "utf8"));
+  const after = computeLiveSource(refreshed);
+  const final = buildWikiStatus(refreshed, after.fingerprint, after.fileCount);
+  if (opts.json) console.log(JSON.stringify({ ...final, action: "regenerated", command }, null, 2));
+  else {
+    for (const line of formatWikiStatus(final)) console.log(line);
+    console.log(`regenerated ${slug} → ${wikiDir}`);
+  }
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.command === "status") {
+    runStatus(opts);
+    return;
+  }
+  if (opts.command === "regenerate") {
+    runRegenerate(opts);
+    return;
+  }
+
   const manifest = scan(opts);
 
-  if (opts.stage === "scan") {
+  if (opts.command === "scan") {
     if (opts.json) console.log(JSON.stringify(manifest, null, 2));
     else {
       console.log(`scanned ${Object.keys(manifest.entries).length} source file(s) under: ${opts.sources.join(", ")}`);
@@ -169,18 +396,18 @@ function main() {
   const diff = diffManifests(previous, manifest);
   const plan = planRegeneration(diff, { sourceRoots: opts.sources, fullRebuildPaths: opts.fullRebuild });
 
-  if (opts.stage === "diff" || opts.stage === "plan") {
+  if (opts.command === "diff" || opts.command === "plan") {
     if (opts.json) {
-      console.log(JSON.stringify(opts.stage === "diff" ? { diff } : { diff, plan }, null, 2));
+      console.log(JSON.stringify(opts.command === "diff" ? { diff } : { diff, plan }, null, 2));
     } else {
-      const lines = opts.stage === "diff" ? summarizePlan(diff, { dirty: diff.dirty, actions: [] }) : summarizePlan(diff, plan);
+      const lines = opts.command === "diff" ? summarizePlan(diff, { dirty: diff.dirty, actions: [] }) : summarizePlan(diff, plan);
       for (const line of lines) console.log(line);
     }
     if (opts.check && diff.dirty) process.exit(1);
     return;
   }
 
-  // run (S4)
+  // run
   for (const line of summarizePlan(diff, plan)) console.log(line);
   if (!diff.dirty) return;
   if (opts.dryRun) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -80,6 +80,7 @@ export const SUITES = {
     "src/lib/hfr-trace-export.test.ts",
     "scripts/coven-hfr-export.test.mjs",
     "src/lib/covenwiki-regen.test.ts",
+    "scripts/covenwiki-regen-cli.test.mjs",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/familiar-roster-guard.test.ts",

--- a/src/lib/covenwiki-regen.test.ts
+++ b/src/lib/covenwiki-regen.test.ts
@@ -3,13 +3,19 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   buildManifest,
+  buildWikiStatus,
+  computeSourceFingerprint,
   diffManifests,
+  formatWikiStatus,
+  isStale,
   nextState,
   pageIdForSource,
   parseState,
+  parseWikiManifest,
   planRegeneration,
   serializeState,
   summarizePlan,
+  validateWikiManifest,
 } from "./covenwiki-regen.ts";
 
 const ROOTS = ["docs"];
@@ -185,4 +191,138 @@ test("summarizePlan reports a clean tree", () => {
   const diff = { added: [], changed: [], removed: [], unchangedCount: 5, dirty: false };
   const lines = summarizePlan(diff, { dirty: false, actions: [] });
   assert.deepEqual(lines, ["sources: +0 ~0 -0 =5", "wiki up to date — no regeneration needed"]);
+});
+
+// ─── plan-semantics layer (S1–S4) ───
+
+function wikiManifest(overrides = {}) {
+  return {
+    schemaVersion: "1.0",
+    slug: "testrepo",
+    title: "Test Repo",
+    source: { kind: "local", repoRoot: "/tmp/testrepo", fingerprint: "30bbd660aaaaaaaa", fileCount: 2 },
+    generation: { generatedAt: "2026-07-03T12:09:52Z", backend: "stub", status: "stub" },
+    navigation: [{ title: "Overview", slug: "overview", children: [] }],
+    pages: [
+      {
+        slug: "overview",
+        title: "Overview",
+        path: "pages/overview.md",
+        meta: "pages/overview.meta.json",
+        priority: "required",
+      },
+    ],
+    counts: { pages: 1 },
+    ...overrides,
+  };
+}
+
+// fingerprint
+
+test("computeSourceFingerprint emits 16 hex chars, independent of entry order", () => {
+  const a = { path: "src/a.ts", size: 10, mtimeMs: 1000 };
+  const b = { path: "src/b.ts", size: 20, mtimeMs: 2000 };
+  const fp = computeSourceFingerprint([a, b]);
+  assert.match(fp, /^[0-9a-f]{16}$/);
+  assert.equal(computeSourceFingerprint([b, a]), fp);
+});
+
+test("computeSourceFingerprint flips on path, size, or mtime changes", () => {
+  const base = [{ path: "a.md", size: 5, mtimeMs: 100 }];
+  const fp = computeSourceFingerprint(base);
+  assert.notEqual(computeSourceFingerprint([{ ...base[0], path: "b.md" }]), fp);
+  assert.notEqual(computeSourceFingerprint([{ ...base[0], size: 6 }]), fp);
+  assert.notEqual(computeSourceFingerprint([{ ...base[0], mtimeMs: 101 }]), fp);
+  assert.equal(computeSourceFingerprint([{ ...base[0] }]), fp);
+});
+
+test("computeSourceFingerprint floors fractional mtimes", () => {
+  const fp = computeSourceFingerprint([{ path: "a.md", size: 5, mtimeMs: 100.4 }]);
+  assert.equal(computeSourceFingerprint([{ path: "a.md", size: 5, mtimeMs: 100.9 }]), fp);
+});
+
+// S1 — isStale
+
+test("isStale is fresh when fingerprints match", () => {
+  const m = wikiManifest();
+  assert.equal(isStale(m, "30bbd660aaaaaaaa").freshness, "fresh");
+});
+
+test("isStale is stale when fingerprints differ", () => {
+  const m = wikiManifest();
+  assert.equal(isStale(m, "5914649ebbbbbbbb").freshness, "stale");
+});
+
+test("isStale is unknown for non-local sources (github is Phase 5)", () => {
+  const m = wikiManifest({ source: { kind: "github", fingerprint: "30bbd660aaaaaaaa" } });
+  const result = isStale(m, "30bbd660aaaaaaaa");
+  assert.equal(result.freshness, "unknown");
+  assert.match(result.reason, /github|local/);
+});
+
+test("isStale is unknown when the manifest or live fingerprint is missing", () => {
+  assert.equal(isStale(wikiManifest({ source: { kind: "local", fingerprint: null } }), "abc").freshness, "unknown");
+  assert.equal(isStale(wikiManifest(), null).freshness, "unknown");
+});
+
+// S2 — status report
+
+test("buildWikiStatus reports both fingerprints and generation metadata", () => {
+  const status = buildWikiStatus(wikiManifest(), "5914649ebbbbbbbb", 3);
+  assert.equal(status.slug, "testrepo");
+  assert.equal(status.freshness, "stale");
+  assert.deepEqual(status.fingerprint, { manifest: "30bbd660aaaaaaaa", live: "5914649ebbbbbbbb" });
+  assert.deepEqual(status.fileCount, { manifest: 2, live: 3 });
+  assert.equal(status.generatedAt, "2026-07-03T12:09:52Z");
+  assert.equal(status.backend, "stub");
+  assert.equal(status.pages, 1);
+});
+
+test("formatWikiStatus renders freshness, fingerprints, and generatedAt", () => {
+  const lines = formatWikiStatus(buildWikiStatus(wikiManifest(), "30bbd660aaaaaaaa", 2));
+  assert.match(lines[0], /^testrepo: fresh/);
+  assert.match(lines[1], /manifest=30bbd660aaaaaaaa live=30bbd660aaaaaaaa/);
+  assert.match(lines[2], /generatedAt: 2026-07-03T12:09:52Z/);
+});
+
+// S4 — manifest validator
+
+test("validateWikiManifest accepts a contract-shaped manifest", () => {
+  assert.deepEqual(validateWikiManifest(wikiManifest()), []);
+});
+
+test("validateWikiManifest accepts null-slug folder nav nodes", () => {
+  const m = wikiManifest({
+    navigation: [{ title: "Guides", slug: null, children: [{ title: "Setup", slug: "setup", children: [] }] }],
+  });
+  assert.deepEqual(validateWikiManifest(m), []);
+});
+
+test("validateWikiManifest lists every missing required field", () => {
+  const errors = validateWikiManifest({});
+  for (const field of ["schemaVersion", "slug", "title", "source", "generation", "navigation", "pages", "counts"]) {
+    assert.ok(errors.some((e) => e.includes(field)), `expected an error mentioning ${field}`);
+  }
+});
+
+test("validateWikiManifest rejects malformed nav and page entries", () => {
+  const badNav = wikiManifest({ navigation: [{ title: "", slug: 3, children: "nope" }] });
+  const navErrors = validateWikiManifest(badNav);
+  assert.ok(navErrors.some((e) => e.includes("navigation[0].title")));
+  assert.ok(navErrors.some((e) => e.includes("navigation[0].slug")));
+  assert.ok(navErrors.some((e) => e.includes("navigation[0].children")));
+
+  const badPage = wikiManifest({ pages: [{ slug: "x", title: "X", path: "", meta: "m", priority: "urgent" }] });
+  const pageErrors = validateWikiManifest(badPage);
+  assert.ok(pageErrors.some((e) => e.includes("pages[0].path")));
+  assert.ok(pageErrors.some((e) => e.includes("pages[0].priority")));
+
+  assert.deepEqual(validateWikiManifest("nope"), ["manifest must be a JSON object"]);
+});
+
+test("parseWikiManifest round-trips valid JSON and throws otherwise", () => {
+  const m = wikiManifest();
+  assert.deepEqual(parseWikiManifest(JSON.stringify(m)), m);
+  assert.throws(() => parseWikiManifest("not json"), /not valid JSON/);
+  assert.throws(() => parseWikiManifest(JSON.stringify({ slug: "x" })), /invalid/);
 });

--- a/src/lib/covenwiki-regen.ts
+++ b/src/lib/covenwiki-regen.ts
@@ -1,13 +1,22 @@
-// CovenWiki v0 Phase 3 — regeneration hook core (Route B, stages S1–S4).
+// CovenWiki v0 Phase 3 — regeneration hook core (Route B).
 //
 // Pure logic only: nothing in this module touches the filesystem or spawns
 // processes. The CLI wrapper (scripts/covenwiki-regen.ts) owns I/O so every
-// stage here is unit-testable with plain data.
+// piece here is unit-testable with plain data.
 //
-//   S1 scan — buildManifest: content hashes for every wiki source file
-//   S2 diff — diffManifests: compare a scan against the last persisted state
-//   S3 plan — planRegeneration: turn a diff into concrete regeneration actions
-//   S4 run  — nextState/summarizePlan: state handoff + report for the executor
+// Plan-semantics layer (phase3 regen-hook step plan, S1–S4):
+//   S1 isStale                  — fresh|stale|unknown vs manifest.source.fingerprint
+//   S2 buildWikiStatus          — the `status <slug>` report the daemon/UI polls
+//   S3/S4 validateWikiManifest  — fail-closed validator run before the atomic swap
+//   computeSourceFingerprint    — 16-hex stat digest (path+size+mtime, sorted)
+//
+// Incremental layer (S6 groundwork; predates the step plan):
+//   scan — buildManifest: content hashes for every wiki source file
+//   diff — diffManifests: compare a scan against the last persisted state
+//   plan — planRegeneration: turn a diff into concrete regeneration actions
+//   run  — nextState/summarizePlan: state handoff + report for the executor
+
+import { createHash } from "node:crypto";
 
 export type SourceEntry = {
   /** Repo-relative path, POSIX separators. */
@@ -56,7 +65,7 @@ const STATE_VERSION = 1 as const;
 /** Wiki page sources; anything else under a source root only affects the index. */
 const PAGE_EXTENSIONS = [".md", ".mdx"];
 
-/** S1: assemble a manifest from hashed source entries (sorted, duplicate-safe). */
+/** scan: assemble a manifest from hashed source entries (sorted, duplicate-safe). */
 export function buildManifest(entries: SourceEntry[], generatedAt: string): Manifest {
   const map: Record<string, string> = {};
   for (const entry of entries) {
@@ -69,7 +78,7 @@ export function buildManifest(entries: SourceEntry[], generatedAt: string): Mani
   return { generatedAt, entries: sorted };
 }
 
-/** S2: diff a fresh scan against the previous manifest (null = first run). */
+/** diff: compare a fresh scan against the previous manifest (null = first run). */
 export function diffManifests(previous: Manifest | null, next: Manifest): ManifestDiff {
   const prev = previous?.entries ?? {};
   const added: string[] = [];
@@ -129,7 +138,7 @@ function matchesFullRebuild(path: string, patterns: string[]): boolean {
   return patterns.some((p) => (p.endsWith("/") ? path.startsWith(p) : path === p));
 }
 
-/** S3: turn a diff into an ordered, deduplicated list of regeneration actions. */
+/** plan: turn a diff into an ordered, deduplicated list of regeneration actions. */
 export function planRegeneration(diff: ManifestDiff, opts: PlanOptions): RegenPlan {
   if (!diff.dirty) return { dirty: false, actions: [] };
 
@@ -211,7 +220,7 @@ export function planRegeneration(diff: ManifestDiff, opts: PlanOptions): RegenPl
   return { dirty: true, actions };
 }
 
-/** S4: the state to persist after a successful regeneration run. */
+/** run: the state to persist after a successful regeneration run. */
 export function nextState(manifest: Manifest): RegenState {
   return { version: STATE_VERSION, manifest };
 }
@@ -249,4 +258,229 @@ export function summarizePlan(diff: ManifestDiff, plan: RegenPlan): string[] {
     lines.push(`${action.kind}${target} — ${action.reason}${via}`);
   }
   return lines;
+}
+
+// ─── Plan-semantics layer (phase3 regen-hook step plan S1–S4) ───────────────
+
+export type WikiFreshness = "fresh" | "stale" | "unknown";
+
+/** One stat record per source file; the inventory behind the fingerprint. */
+export type StatEntry = {
+  /** Repo-relative path, POSIX separators. */
+  path: string;
+  size: number;
+  /** Modification time in integer milliseconds. */
+  mtimeMs: number;
+};
+
+export type WikiNavNode = {
+  title: string;
+  /** null => folder/group header, not a link. */
+  slug: string | null;
+  children: WikiNavNode[];
+};
+
+export type WikiPageEntry = {
+  slug: string;
+  title: string;
+  path: string;
+  meta: string;
+  priority: "required" | "recommended" | "optional";
+  sourcePaths?: string[];
+  wordCount?: number;
+};
+
+/** The subset of the CovenWiki manifest.json contract the regen hook reads. */
+export type WikiManifest = {
+  schemaVersion: string;
+  slug: string;
+  title: string;
+  source: {
+    kind: string;
+    repoRoot?: string | null;
+    revision?: string | null;
+    fingerprint?: string | null;
+    fileCount?: number | null;
+  };
+  generation: {
+    generatedAt: string;
+    backend: string;
+    status: string;
+  };
+  navigation: WikiNavNode[];
+  pages: WikiPageEntry[];
+  counts: Record<string, number>;
+  index?: string;
+};
+
+/**
+ * The 16-hex stat digest that is the Phase 3 staleness key: sha256 over the
+ * sorted source inventory (path + size + mtime), truncated to 16 hex chars.
+ *
+ * Contract: manifest handoff doc (2026-07-03), `source.fingerprint`. The
+ * reference implementation lives in the covenwiki-generate CLI; byte-parity
+ * with it must be verified before the daemon wires `status` polling — any
+ * inventory or format drift shows up as a permanent false "stale".
+ */
+export function computeSourceFingerprint(entries: StatEntry[]): string {
+  const lines = entries
+    .map((e) => `${e.path}\u0000${e.size}\u0000${Math.floor(e.mtimeMs)}`)
+    .sort();
+  return createHash("sha256").update(lines.join("\n")).digest("hex").slice(0, 16);
+}
+
+export type FreshnessResult = {
+  freshness: WikiFreshness;
+  reason: string;
+};
+
+/**
+ * S1 — the shared staleness compare every other path uses. Pure and stat-only:
+ * compares the stored `manifest.source.fingerprint` with a live fingerprint
+ * computed by the caller. Non-local sources (github is Phase 5) are `unknown`
+ * and must never auto-regenerate.
+ */
+export function isStale(
+  manifest: Pick<WikiManifest, "source">,
+  liveFingerprint: string | null,
+): FreshnessResult {
+  const source = manifest.source;
+  if (source.kind !== "local") {
+    return { freshness: "unknown", reason: `source.kind is "${source.kind}" — only local sources support staleness checks (github is Phase 5)` };
+  }
+  if (!source.fingerprint) {
+    return { freshness: "unknown", reason: "manifest has no source.fingerprint" };
+  }
+  if (!liveFingerprint) {
+    return { freshness: "unknown", reason: "live fingerprint unavailable (source root missing or unreadable)" };
+  }
+  if (source.fingerprint === liveFingerprint) {
+    return { freshness: "fresh", reason: "live fingerprint matches manifest" };
+  }
+  return { freshness: "stale", reason: "live fingerprint differs from manifest" };
+}
+
+export type WikiStatus = {
+  slug: string;
+  freshness: WikiFreshness;
+  reason: string;
+  fingerprint: { manifest: string | null; live: string | null };
+  fileCount: { manifest: number | null; live: number | null };
+  generatedAt: string;
+  backend: string;
+  generationStatus: string;
+  pages: number;
+};
+
+/** S2 — the pollable status report behind `covenwiki-regen status <slug>`. */
+export function buildWikiStatus(
+  manifest: WikiManifest,
+  liveFingerprint: string | null,
+  liveFileCount: number | null,
+): WikiStatus {
+  const { freshness, reason } = isStale(manifest, liveFingerprint);
+  return {
+    slug: manifest.slug,
+    freshness,
+    reason,
+    fingerprint: { manifest: manifest.source.fingerprint ?? null, live: liveFingerprint },
+    fileCount: { manifest: manifest.source.fileCount ?? null, live: liveFileCount },
+    generatedAt: manifest.generation.generatedAt,
+    backend: manifest.generation.backend,
+    generationStatus: manifest.generation.status,
+    pages: manifest.pages.length,
+  };
+}
+
+export function formatWikiStatus(status: WikiStatus): string[] {
+  return [
+    `${status.slug}: ${status.freshness} — ${status.reason}`,
+    `fingerprint: manifest=${status.fingerprint.manifest ?? "∅"} live=${status.fingerprint.live ?? "∅"}`,
+    `generatedAt: ${status.generatedAt} (backend=${status.backend}, status=${status.generationStatus}, pages=${status.pages})`,
+  ];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateNav(nodes: unknown, at: string, errors: string[]): void {
+  if (!Array.isArray(nodes)) {
+    errors.push(`${at} must be an array`);
+    return;
+  }
+  nodes.forEach((node, i) => {
+    const here = `${at}[${i}]`;
+    if (!isRecord(node)) {
+      errors.push(`${here} must be an object`);
+      return;
+    }
+    if (typeof node.title !== "string" || node.title === "") errors.push(`${here}.title must be a non-empty string`);
+    if (node.slug !== null && typeof node.slug !== "string") errors.push(`${here}.slug must be a string or null`);
+    validateNav(node.children, `${here}.children`, errors);
+  });
+}
+
+const PAGE_PRIORITIES = new Set(["required", "recommended", "optional"]);
+
+/**
+ * S4 — the fail-closed structural validator run against a freshly regenerated
+ * wiki before it may be swapped over the live directory. Returns a list of
+ * errors; only an empty list allows the swap. Structure-only: file-existence
+ * checks (page/meta paths) are the CLI's job because they need I/O.
+ */
+export function validateWikiManifest(data: unknown): string[] {
+  const errors: string[] = [];
+  if (!isRecord(data)) return ["manifest must be a JSON object"];
+
+  if (typeof data.schemaVersion !== "string" || data.schemaVersion === "") errors.push("schemaVersion must be a non-empty string");
+  if (typeof data.slug !== "string" || data.slug === "") errors.push("slug must be a non-empty string");
+  if (typeof data.title !== "string" || data.title === "") errors.push("title must be a non-empty string");
+
+  if (!isRecord(data.source)) errors.push("source must be an object");
+  else if (typeof data.source.kind !== "string" || data.source.kind === "") errors.push("source.kind must be a non-empty string");
+
+  if (!isRecord(data.generation)) errors.push("generation must be an object");
+  else {
+    if (typeof data.generation.generatedAt !== "string" || data.generation.generatedAt === "") errors.push("generation.generatedAt must be a non-empty string");
+    if (typeof data.generation.backend !== "string") errors.push("generation.backend must be a string");
+    if (typeof data.generation.status !== "string") errors.push("generation.status must be a string");
+  }
+
+  validateNav(data.navigation, "navigation", errors);
+
+  if (!Array.isArray(data.pages)) errors.push("pages must be an array");
+  else {
+    data.pages.forEach((page, i) => {
+      const here = `pages[${i}]`;
+      if (!isRecord(page)) {
+        errors.push(`${here} must be an object`);
+        return;
+      }
+      if (typeof page.slug !== "string" || page.slug === "") errors.push(`${here}.slug must be a non-empty string`);
+      if (typeof page.title !== "string" || page.title === "") errors.push(`${here}.title must be a non-empty string`);
+      if (typeof page.path !== "string" || page.path === "") errors.push(`${here}.path must be a non-empty string`);
+      if (typeof page.meta !== "string" || page.meta === "") errors.push(`${here}.meta must be a non-empty string`);
+      if (typeof page.priority !== "string" || !PAGE_PRIORITIES.has(page.priority)) errors.push(`${here}.priority must be one of required|recommended|optional`);
+    });
+  }
+
+  if (!isRecord(data.counts)) errors.push("counts must be an object");
+
+  return errors;
+}
+
+/** Parse + validate a manifest.json payload; throws with every error listed. */
+export function parseWikiManifest(raw: string): WikiManifest {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error("manifest.json is not valid JSON");
+  }
+  const errors = validateWikiManifest(data);
+  if (errors.length > 0) {
+    throw new Error(`manifest.json is invalid: ${errors.join("; ")}`);
+  }
+  return data as WikiManifest;
 }


### PR DESCRIPTION
Reworks the Phase 3 regeneration hook (landed as scan/diff/plan/run in #3064) to the committed step-plan semantics (sage workspace: `research/synthesis/covenwiki-phase3-regen-hook-plan-2026-07-03.md`). Bead: `cave-007q` (scope item 3, slug-oriented entry point).

## What
- **S1** `isStale(manifest, live)` → `fresh|stale|unknown`, keyed on the 16-hex stat fingerprint (path+size+mtime, sorted) per the manifest contract; `source.kind != "local"` → `unknown`, never auto-regenerated (github is Phase 5)
- **S2** `status <slug> [--json]` — pure pollable read (the S5 daemon/UI surface): freshness + manifest/live fingerprints + `generatedAt`, resolving `<wikis-dir>/<slug>/manifest.json` (default `~/.coven/wikis`)
- **S3** `regenerate <slug> [--force] [--json]` — fresh ⇒ no-op exit 0; stale/--force ⇒ re-run the generator (`{repo}`/`{out}`/`{slug}` template, default `covenwiki generate --repo {repo} --out {out}`)
- **S4** fail-closed atomic swap — generator writes `<wiki>.tmp` → manifest re-validated (structure, slug match, page/meta files exist) → only then renamed over the live dir; a broken regen never clobbers a good wiki and exits nonzero

The content-hash `scan|diff|plan|run` stages remain as **S6** (incremental) groundwork; their invented S1–S4 labels are dropped.

## Verification
- 32 lib unit tests (18 existing + 14 new) pass
- New `scripts/covenwiki-regen-cli.test.mjs` e2e: fresh no-op, stale swap, `--force`, all three fail-closed paths (invalid manifest / missing page file / generator exit), github refusal, missing-wiki + path-slug guards — wired into `run-tests.mjs`
- `pnpm typecheck` clean, `pnpm check:tests-wired` clean (943 wired)

## Caveat
Byte-parity of `computeSourceFingerprint` with the reference `covenwiki-generate` CLI (`~/.coven/skills/`, outside this session's granted roots) is **unverified**; the digest is isolated in one function and `status` surfaces both fingerprints so drift is immediately visible. Verify parity before wiring S5 daemon polling.