### PR TITLE
fix(chat): portal the selection Comment pill to <body> — backdrop glass hijacked its fixed positioning (cave-5cwo)

### DIFF
--- a/src/components/artifact-comments.test.ts
+++ b/src/components/artifact-comments.test.ts
@@ -17,6 +17,14 @@ assert.match(
 assert.match(comp, /document\.addEventListener\("mouseup", onMouseUp\)/, "detects selection on mouseup");
 assert.match(comp, /window\.getSelection\(\)/, "reads the live text selection");
 assert.match(comp, /className="cave-artifact-comment-fab"/, "shows a floating Comment affordance on selection");
+// The fab portals to <body>: it is position:fixed with viewport coords, and
+// the backdrop glass (backdrop-filter on .cave-chat-thread) would otherwise
+// become its containing block — landing the pill mid-prose and clipped.
+assert.match(
+  comp,
+  /createPortal\(\s*<button[\s\S]*?cave-artifact-comment-fab[\s\S]*?document\.body,?\s*\)/,
+  "the fab renders through a body portal so ancestor filters can't capture its fixed positioning",
+);
 // The fab's x is clamped so wide selections can't push it off the viewport edge.
 assert.match(
   comp,

--- a/src/components/artifact-comments.tsx
+++ b/src/components/artifact-comments.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import {
   buildCommentsPrompt,
@@ -170,22 +171,31 @@ export function ArtifactComments({
 
   return (
     <>
-      {sel ? (
-        <button
-          type="button"
-          className="cave-artifact-comment-fab"
-          style={{ left: `${sel.x}px`, top: `${Math.max(8, sel.y - 42)}px` }}
-          // Use mouseDown so the click lands before the selection clears.
-          onMouseDown={(e) => {
-            e.preventDefault();
-            addFromSelection();
-          }}
-          aria-label="Comment on selection"
-        >
-          <Icon name="ph:chat-teardrop" width={13} aria-hidden />
-          Comment
-        </button>
-      ) : null}
+      {sel
+        ? // Portal to <body>: the pill is position:fixed with viewport coords,
+          // but it renders inside the chat thread, and the backdrop glass
+          // (html[data-backdrop-on] .cave-chat-thread's backdrop-filter) makes
+          // that ancestor the containing block for fixed descendants — the
+          // pill landed shifted into the prose and clipped at the pane edge.
+          // At body level no ancestor filter/transform can capture it.
+          createPortal(
+            <button
+              type="button"
+              className="cave-artifact-comment-fab"
+              style={{ left: `${sel.x}px`, top: `${Math.max(8, sel.y - 42)}px` }}
+              // Use mouseDown so the click lands before the selection clears.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                addFromSelection();
+              }}
+              aria-label="Comment on selection"
+            >
+              <Icon name="ph:chat-teardrop" width={13} aria-hidden />
+              Comment
+            </button>,
+            document.body,
+          )
+        : null}
 
       {comments.length > 0 ? (
         <div className="cave-artifact-comments" role="group" aria-label="Comments on this document">


### PR DESCRIPTION
With a custom backdrop on, the select-to-comment pill rendered mid-prose and clipped at the pane edge (screenshot report). Root cause: the pill is `position:fixed` with viewport coords but renders inside the chat thread, and the thread's glass column (`html[data-backdrop-on] .cave-chat-thread { backdrop-filter: … }`, extended in #3143's glass pass) creates a **containing block** for fixed descendants — the coords resolved against the thread box, not the viewport.

**Fix:** render the pill through `createPortal(document.body)` (the table-lightbox/modal idiom), immune to ancestor filters/transforms. The scroll/resize reposition logic and `clampFabX` viewport clamping are unchanged and now actually mean what they say.

**Verification:** typecheck clean; `pnpm test:app` 702 files green; portal pinned in `artifact-comments.test.ts`. Audited the other fixed-position chat overlays (table lightbox, mermaid viewer, voice overlay) — already body-appended/portaled.

Bead: cave-5cwo