### PR TITLE
fix(chat): line break before bulleted lists — strip the cm-preview shell (cave-855t)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -268,6 +268,7 @@ export const SUITES = {
     "src/components/chat-thread-rail.test.ts",
     "src/components/chat-rail-modern-redesign.test.ts",
     "src/components/message-bubble-markdown.test.ts",
+    "src/lib/markdown-preview-shell.test.ts",
     "src/lib/markdown-table-cells.test.ts",
     "src/components/mermaid-viewer.test.ts",
     "src/components/message-bubble-code-header.test.ts",

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -293,4 +293,25 @@ assert.match(
   "cave-chat.css styles the rendered mermaid diagram card",
 );
 
+// ── Block rhythm: the preview shell must be stripped ─────────────────────────
+// renderAsync wraps documents in <div class="cm-preview">; left in place it
+// makes every block a GRANDCHILD of .cave-md, so the owl spacing rule
+// (.cave-md > * + *) never fires and a bulleted list renders glued to the
+// paragraph introducing it — no line break before bullets.
+assert.match(
+  source,
+  /import \{ unwrapPreviewShell \} from "@\/lib\/markdown-preview-shell"/,
+  "the shell unwrap comes from the pure, unit-tested lib",
+);
+assert.match(
+  source,
+  /sanitizedHtml = unwrapPreviewShell\(sanitizedHtml\);/,
+  "mdToHtml strips the cm-preview shell after sanitize/mermaid so blocks are direct .cave-md children",
+);
+assert.match(
+  css,
+  /\.cave-md > \* \+ \* \{ margin-top: 0\.8em; \}/,
+  "the owl block-rhythm rule the unwrap exists to feed",
+);
+
 console.log("message-bubble-markdown.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -39,6 +39,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SHIKI_LANGS, resolveShikiLang, diffContentLang } from "@/lib/code-lang";
 import { parseFileRef, type FileRef } from "@/lib/file-ref";
 import { toggleCodeBlockCollapse } from "@/lib/code-block-collapse";
+import { unwrapPreviewShell } from "@/lib/markdown-preview-shell";
 import { wireMermaidDiagrams } from "./mermaid-viewer";
 
 // ---------------------------------------------------------------------------
@@ -726,6 +727,11 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
   if (mermaidPlugin?.postProcess) {
     sanitizedHtml = await mermaidPlugin.postProcess(sanitizedHtml);
   }
+  // Strip the renderer's cm-preview shell so blocks land as DIRECT children
+  // of .cave-md — its `> * + *` owl selector is the only block-rhythm rule,
+  // and with the shell in place a list rendered flush against the paragraph
+  // introducing it (no line break before bullets).
+  sanitizedHtml = unwrapPreviewShell(sanitizedHtml);
   // Transient (mid-stream) snapshots are never requested again once the
   // stream advances past them — caching one per throttle tick would churn
   // settled entries out of the LRU for no hit-rate gain.

--- a/src/lib/markdown-preview-shell.test.ts
+++ b/src/lib/markdown-preview-shell.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { unwrapPreviewShell } from "./markdown-preview-shell.ts";
+
+// ── strips the outer shell so blocks are direct children of .cave-md ────────
+{
+  const html = '<div class="cm-preview"><p class="cm-paragraph">Intro:</p>\n<ul class="cm-bullet-list">\n<li>one</li>\n</ul></div>';
+  assert.equal(
+    unwrapPreviewShell(html),
+    '<p class="cm-paragraph">Intro:</p>\n<ul class="cm-bullet-list">\n<li>one</li>\n</ul>',
+  );
+}
+
+// ── inner divs survive — only the single outer shell goes ────────────────────
+{
+  const html = '<div class="cm-preview"><p>a</p><div class="cave-table-scroll"><table></table></div></div>';
+  assert.equal(
+    unwrapPreviewShell(html),
+    '<p>a</p><div class="cave-table-scroll"><table></table></div>',
+  );
+}
+
+// ── tolerates surrounding whitespace from sanitizer round-trips ──────────────
+{
+  assert.equal(unwrapPreviewShell('  <div class="cm-preview"><p>x</p></div>\n'), "<p>x</p>");
+}
+
+// ── non-shell HTML passes through untouched ──────────────────────────────────
+{
+  assert.equal(unwrapPreviewShell("<p>plain</p>"), "<p>plain</p>");
+  assert.equal(unwrapPreviewShell(""), "");
+  const partial = '<div class="cm-preview"><p>unclosed</p>';
+  assert.equal(unwrapPreviewShell(partial), partial, "an unterminated shell is left alone");
+}
+
+// ── the real pipeline shape: parse → renderAsync emits the shell ─────────────
+{
+  // Minimal custom-element shims so @create-markdown/preview loads in node.
+  (globalThis as Record<string, unknown>).HTMLElement = class {};
+  (globalThis as Record<string, unknown>).customElements = { define: () => {}, get: () => undefined };
+  const [{ parse }, { renderAsync }] = await Promise.all([
+    import("@create-markdown/core"),
+    import("@create-markdown/preview"),
+  ]);
+  const html = await renderAsync(parse("Intro:\n- one\n- two"), {});
+  const unwrapped = unwrapPreviewShell(html);
+  assert.match(html, /^<div class="cm-preview">/, "renderAsync emits the shell this module exists to strip");
+  assert.doesNotMatch(unwrapped, /cm-preview/, "the shell is gone");
+  assert.match(unwrapped, /^<p class="cm-paragraph">Intro:<\/p>\n<ul class="cm-bullet-list">/, "paragraph and list become top-level siblings");
+}
+
+console.log("markdown-preview-shell.test.ts passed");

--- a/src/lib/markdown-preview-shell.ts
+++ b/src/lib/markdown-preview-shell.ts
@@ -1,0 +1,16 @@
+/**
+ * @create-markdown/preview's renderAsync wraps every document in
+ * `<div class="cm-preview">…</div>`. Chat inserts that HTML into `.cave-md`,
+ * whose ONLY block-rhythm rule is the owl selector `.cave-md > * + *` — with
+ * the shell in between, paragraphs, lists and headings become grandchildren
+ * and the spacing never applies (a bulleted list renders glued to the
+ * paragraph introducing it). Stripping the shell puts the blocks back where
+ * the stylesheet expects them; the table-cell path (markdown-table-cells.ts)
+ * already does the same unwrap for cell fragments.
+ *
+ * Pure + framework-free so it's unit-testable in node.
+ */
+export function unwrapPreviewShell(html: string): string {
+  const match = /^\s*<div class="cm-preview">([\s\S]*)<\/div>\s*$/.exec(html);
+  return match ? match[1] : html;
+}


### PR DESCRIPTION
## What

Chat messages rendered a bulleted list **glued to the paragraph introducing it** — no line break. Root cause: `@create-markdown/preview`'s `renderAsync` wraps every document in `<div class="cm-preview">`, and chat inserts that into `.cave-md`, whose only block-rhythm rule is the owl selector `.cave-md > * + *`. With the shell in between, every block is a *grandchild* — the spacing never fires (this also deadened paragraph/heading gaps and the `quick-chat-md > .cave-md > :first-child` trims).

**Fix**: new pure `src/lib/markdown-preview-shell.ts` — `unwrapPreviewShell(html)` strips exactly the outer shell (inner divs like `cave-table-scroll` and non-shell fragments pass through) — applied in `mdToHtml` after sanitize + mermaid postProcess. Blocks land as direct `.cave-md` children and the stylesheet's rhythm applies everywhere mdToHtml renders (bubbles, reader, memory, quick chat, table lightbox). The table-cell path (`markdown-table-cells.ts`) already did this exact unwrap for cell fragments; the document path now matches.

## Testing

- `markdown-preview-shell.test.ts`: shell strip, inner-div survival, whitespace tolerance, non-shell/unterminated passthrough, and the **real `parse → renderAsync` output shape** (custom-element shim) proving paragraph + list become top-level siblings. Registered in `run-tests.mjs`.
- `message-bubble-markdown.test.ts`: pins the lib import, the unwrap call after sanitize/mermaid, and the owl rule it feeds.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (703 files).

Bead: cave-855t