### PR TITLE
fix(ui): Skeleton renders a <span> — valid inside <p> hosts

### DIFF
--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -134,4 +134,19 @@ assert.match(
   /historyState === "loading" \? \(\s*<ChatHistorySkeleton \/>/,
   "The blanked transcript renders ChatHistorySkeleton while history loads",
 );
+// The shared Skeleton is phrasing content: it stands in for text runs inside
+// <p>/<span> hosts (e.g. the marketplace count line), where a <div> is invalid
+// HTML and trips React hydration (cave-m97f). `.ui-skeleton` supplies
+// display:block, so a <span> renders identically everywhere.
+const skeleton = read("./ui/skeleton.tsx");
+assert.match(
+  skeleton,
+  /<span\s*\n?\s*className=\{classes\}\s*\n?\s*aria-hidden/,
+  "Skeleton renders a <span> so it stays valid inside <p> hosts",
+);
+assert.doesNotMatch(
+  skeleton,
+  /<div\s*\n?\s*className=\{classes\}/,
+  "Skeleton must not regress to a <div> (hydration error inside <p>)",
+);
 console.log("surface-loading-states.test.ts: ok");

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -25,7 +25,10 @@ const variantClass: Record<Variant, string> = {
 export function Skeleton({ variant = "text", width, height, className, style }: SkeletonProps) {
   const classes = ["ui-skeleton", variantClass[variant], className ?? ""].filter(Boolean).join(" ");
   return (
-    <div
+    // A <span>, not a <div>: skeletons stand in for text runs inside <p>/<span>
+    // hosts too, where a div is invalid HTML and trips React hydration
+    // (cave-m97f). `.ui-skeleton` sets display:block, so rendering is identical.
+    <span
       className={classes}
       aria-hidden
       style={{


### PR DESCRIPTION
## Problem

Console/hydration error on the Marketplace surface:

> In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.

`marketplace-view.tsx` renders `<Skeleton>` inside the browse-summary `<p>` while loading (cave-5qmm's one-loading-language pattern), and `Skeleton` rendered a `<div>`.

## Fix

`Skeleton` now renders a **`<span>`**. `.ui-skeleton` already sets `display: block` in globals.css, so rendering is pixel-identical everywhere — but as phrasing content it's valid inside `<p>`/`<span>` hosts, fixing this entire class of hydration bugs (not just the marketplace call site). No test pins the element name; new pins prevent regressing to a div.

## Verification
- `pnpm typecheck` clean
- `surface-loading-states` + `loading-discipline` pass; full `pnpm test:app` **703 files pass**

Bead: cave-m97f