### PR TITLE
feat(chat): four split panes render as a 2×2 grid (cave-36eb)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12989,6 +12989,15 @@ details[open] > .cave-edit-card__summary::before {
   min-height: 0;
   min-width: 0;
 }
+/* Quad (2×2) grid: each outer row hosts a nested horizontal group. */
+.chat-split__quad-row {
+  min-width: 0;
+  min-height: 0;
+}
+.chat-split__group--inner {
+  flex: 1 1 auto;
+  width: 100%;
+}
 .chat-split__pane-panel {
   min-width: 0;
   min-height: 0;

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -60,6 +60,11 @@ assert.match(
   /if \(!sizes \|\| quadRows\) return undefined;/,
   "quad mounts even — the flat per-pane size map can't describe three nested groups",
 );
+assert.match(
+  host,
+  /if \(!quadRows\) onSizesChange\?\.\(\{\}\);/,
+  "a quad divider reset only remounts — it never wipes the persisted strip weights",
+);
 assert.match(host, /chat-split__group--inner/, "nested row groups carry their own layout class");
 
 // Secondary panes get chrome: close + open-as-main; the primary keeps its own

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -39,11 +39,28 @@ assert.match(
 );
 assert.match(
   host,
-  /minSize=\{axis === "row" \? "280px" : "160px"\}/,
-  "panes keep a pixel floor so a divider can't crush a conversation",
+  /renderPanePanel\(tile, axis === "row" \? "280px" : "160px"\)/,
+  "strip panes keep a pixel floor so a divider can't crush a conversation",
 );
 // RRP re-layout bug guard (cave-hivd idiom): remount the group per pane set.
 assert.match(host, /key=\{`\$\{axis\}\|\$\{panes\.map/, "the group remounts on pane-set changes");
+
+// ── Quad (2×2) grid — four panes render as nested groups, not a 4-up strip ──
+assert.match(host, /chatSplitQuadRows,/, "the quad shape comes from the pure lib helper");
+assert.match(host, /const quadRows = chatSplitQuadRows\(panes\);/, "the host derives the 2×2 rows from the pane strip");
+assert.match(
+  host,
+  /quadRows \? \([\s\S]{0,700}orientation="vertical"[\s\S]{0,900}orientation="horizontal"/,
+  "quad renders an outer vertical group with nested horizontal rows — every divider stays draggable",
+);
+assert.match(host, /key=\{`quad\|\$\{panes\.map\(\(tile\) => tile\.id\)\.join\("\|"\)\}\|\$\{resetNonce\}`\}/, "the quad group remounts per pane set and on divider reset");
+assert.match(host, /renderPanePanel\(tile, "280px"\)/, "quad panes keep the side-by-side pixel floor");
+assert.match(
+  host,
+  /if \(!sizes \|\| quadRows\) return undefined;/,
+  "quad mounts even — the flat per-pane size map can't describe three nested groups",
+);
+assert.match(host, /chat-split__group--inner/, "nested row groups carry their own layout class");
 
 // Secondary panes get chrome: close + open-as-main; the primary keeps its own
 // header (no double chrome).

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -26,6 +26,7 @@ import {
   CHAT_SPLIT_PRIMARY,
   chatDropPreviewRect,
   chatDropZoneLabel,
+  chatSplitQuadRows,
   resolveChatDropZone,
   type ChatDropZone,
   type ChatSessionDragDetail,
@@ -83,6 +84,9 @@ export function ChatSplitHost({
   onSizesChange,
 }: ChatSplitHostProps) {
   const hasSplit = panes.length > 1;
+  // A full split renders as a 2×2 grid (nested groups) instead of a four-up
+  // strip; rows are dealt in reading order so focus/eviction order holds.
+  const quadRows = chatSplitQuadRows(panes);
 
   // Bumped by a divider double-click: remounts the group with no restored
   // sizes, which is exactly "reset to an even split".
@@ -90,14 +94,16 @@ export function ChatSplitHost({
 
   // Restore persisted sizes only when they describe exactly this pane set —
   // RRP would otherwise honor the stale weights it recognizes and squeeze
-  // the rest, which reads as a corrupted layout.
+  // the rest, which reads as a corrupted layout. The quad grid always mounts
+  // even: its weights live in three nested groups, which the flat per-pane
+  // map can't describe honestly.
   const defaultLayout = React.useMemo(() => {
-    if (!sizes) return undefined;
+    if (!sizes || quadRows) return undefined;
     const ids = panes.map((tile) => tile.id);
     const keys = Object.keys(sizes);
     if (keys.length !== ids.length || !ids.every((id) => id in sizes)) return undefined;
     return Object.fromEntries(ids.map((id) => [`${PANEL_ID_PREFIX}${id}`, sizes[id]!]));
-  }, [sizes, panes]);
+  }, [sizes, panes, quadRows]);
 
   // ---- Drag-to-split drop zone -------------------------------------------
   const [drag, setDrag] = React.useState<ChatSessionDragDetail | null>(null);
@@ -196,62 +202,99 @@ export function ChatSplitHost({
     );
   };
 
+  const renderPanePanel = (tile: ChatSplitTile, minSize: string) => (
+    <Panel
+      id={`chat-split-${tile.id}`}
+      className="chat-split__pane-panel flex min-h-0 min-w-0"
+      // Pixel floors so a divider can't crush a conversation into
+      // letter soup; stacked panes need less than side-by-side ones.
+      minSize={minSize}
+      {...{ [CHAT_SPLIT_PANE_ATTR]: tile.id }}
+      tabIndex={-1}
+      data-focused={focusedPaneId === tile.id ? "true" : undefined}
+      onFocusCapture={() => onFocusPane?.(tile.id)}
+      onPointerDownCapture={() => onFocusPane?.(tile.id)}
+    >
+      {renderTile(tile)}
+    </Panel>
+  );
+
+  const resetSeparator = (orientation: "row" | "col") => (
+    <Separator
+      className="shell-separator chat-split__sep"
+      onDoubleClick={() => {
+        // Reset to an even split: forget stored weights + remount.
+        onSizesChange?.({});
+        setResetNonce((nonce) => nonce + 1);
+      }}
+    >
+      <SeparatorHandle orientation={orientation} />
+    </Separator>
+  );
+
   return (
     <>
       {hasSplit ? (
-        <Group
-          // Remount on pane-set changes (mirrors DetailSplitHost, cave-hivd):
-          // RRP squeezes a panel added to a live group below its min — a fresh
-          // mount re-lays every pane out evenly. The reset nonce rides the same
-          // key: divider double-click remounts into an even layout.
-          key={`${axis}|${panes.map((tile) => tile.id).join("|")}|${resetNonce}`}
-          className="chat-split__group"
-          orientation={axis === "row" ? "horizontal" : "vertical"}
-          defaultLayout={defaultLayout}
-          onLayoutChanged={(layout, meta) => {
-            // Only user-driven resizes persist — mount/constraint recomputes
-            // would clobber the stored weights with defaults.
-            if (!meta.isUserInteraction || !onSizesChange) return;
-            const next: ChatSplitSizes = {};
-            for (const [panelId, weight] of Object.entries(layout)) {
-              if (panelId.startsWith(PANEL_ID_PREFIX)) {
-                next[panelId.slice(PANEL_ID_PREFIX.length)] = weight;
-              }
-            }
-            onSizesChange(next);
-          }}
-        >
-          {panes.map((tile, i) => (
-            <React.Fragment key={tile.id}>
-              {i > 0 ? (
-                <Separator
-                  className="shell-separator chat-split__sep"
-                  onDoubleClick={() => {
-                    // Reset to an even split: forget stored weights + remount.
-                    onSizesChange?.({});
-                    setResetNonce((nonce) => nonce + 1);
-                  }}
+        quadRows ? (
+          // Four panes: a 2×2 grid — nested groups keep every divider
+          // draggable (the outer row divider + each row's column divider)
+          // where a four-up strip would crush panes below readability.
+          <Group
+            key={`quad|${panes.map((tile) => tile.id).join("|")}|${resetNonce}`}
+            className="chat-split__group"
+            orientation="vertical"
+          >
+            {quadRows.map((row, rowIndex) => (
+              <React.Fragment key={row.map((tile) => tile.id).join("|")}>
+                {rowIndex > 0 ? resetSeparator("row") : null}
+                <Panel
+                  id={`chat-split-quad-row-${rowIndex}`}
+                  className="chat-split__quad-row flex min-h-0 min-w-0"
+                  minSize="160px"
                 >
-                  <SeparatorHandle orientation={axis === "row" ? "col" : "row"} />
-                </Separator>
-              ) : null}
-              <Panel
-                id={`chat-split-${tile.id}`}
-                className="chat-split__pane-panel flex min-h-0 min-w-0"
-                // Pixel floors so a divider can't crush a conversation into
-                // letter soup; stacked panes need less than side-by-side ones.
-                minSize={axis === "row" ? "280px" : "160px"}
-                {...{ [CHAT_SPLIT_PANE_ATTR]: tile.id }}
-                tabIndex={-1}
-                data-focused={focusedPaneId === tile.id ? "true" : undefined}
-                onFocusCapture={() => onFocusPane?.(tile.id)}
-                onPointerDownCapture={() => onFocusPane?.(tile.id)}
-              >
-                {renderTile(tile)}
-              </Panel>
-            </React.Fragment>
-          ))}
-        </Group>
+                  <Group className="chat-split__group chat-split__group--inner" orientation="horizontal">
+                    {row.map((tile, colIndex) => (
+                      <React.Fragment key={tile.id}>
+                        {colIndex > 0 ? resetSeparator("col") : null}
+                        {renderPanePanel(tile, "280px")}
+                      </React.Fragment>
+                    ))}
+                  </Group>
+                </Panel>
+              </React.Fragment>
+            ))}
+          </Group>
+        ) : (
+          <Group
+            // Remount on pane-set changes (mirrors DetailSplitHost, cave-hivd):
+            // RRP squeezes a panel added to a live group below its min — a fresh
+            // mount re-lays every pane out evenly. The reset nonce rides the same
+            // key: divider double-click remounts into an even layout.
+            key={`${axis}|${panes.map((tile) => tile.id).join("|")}|${resetNonce}`}
+            className="chat-split__group"
+            orientation={axis === "row" ? "horizontal" : "vertical"}
+            defaultLayout={defaultLayout}
+            onLayoutChanged={(layout, meta) => {
+              // Only user-driven resizes persist — mount/constraint recomputes
+              // would clobber the stored weights with defaults.
+              if (!meta.isUserInteraction || !onSizesChange) return;
+              const next: ChatSplitSizes = {};
+              for (const [panelId, weight] of Object.entries(layout)) {
+                if (panelId.startsWith(PANEL_ID_PREFIX)) {
+                  next[panelId.slice(PANEL_ID_PREFIX.length)] = weight;
+                }
+              }
+              onSizesChange(next);
+            }}
+          >
+            {panes.map((tile, i) => (
+              <React.Fragment key={tile.id}>
+                {i > 0 ? resetSeparator(axis === "row" ? "col" : "row") : null}
+                {renderPanePanel(tile, axis === "row" ? "280px" : "160px")}
+              </React.Fragment>
+            ))}
+          </Group>
+        )
       ) : (
         panes[0]?.content ?? null
       )}

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -223,8 +223,10 @@ export function ChatSplitHost({
     <Separator
       className="shell-separator chat-split__sep"
       onDoubleClick={() => {
-        // Reset to an even split: forget stored weights + remount.
-        onSizesChange?.({});
+        // Reset to an even split: remount. Only the strip persists weights —
+        // clearing them from quad would wipe the saved ≤3-pane layout for a
+        // grid that never reads the map in the first place.
+        if (!quadRows) onSizesChange?.({});
         setResetNonce((nonce) => nonce + 1);
       }}
     >

--- a/src/lib/chat-split.test.ts
+++ b/src/lib/chat-split.test.ts
@@ -9,6 +9,7 @@ import {
   chatSplitFocusAfterClose,
   chatSplitFocusTarget,
   chatSplitKeyboardZone,
+  chatSplitQuadRows,
   chatSplitSessionIds,
   dropSessionIntoChatSplit,
   emptyChatSplitLayout,
@@ -270,4 +271,19 @@ test("pruneChatSplitPanes drops deleted sessions and keeps the reference stable"
   assert.deepEqual(solo.panes, [CHAT_SPLIT_PRIMARY]);
   // Nothing to prune → same reference (lets setState skip a render).
   assert.equal(pruneChatSplitPanes(layout, () => true), layout);
+});
+
+test("chatSplitQuadRows deals a full split into 2×2 reading-order rows", () => {
+  // Exactly MAX panes → [[a,b],[c,d]] — strip order preserved, so keyboard
+  // focus cycling and drop/eviction semantics are unchanged by the grid.
+  assert.deepEqual(chatSplitQuadRows([CHAT_SPLIT_PRIMARY, "s1", "s2", "s3"]), [
+    [CHAT_SPLIT_PRIMARY, "s1"],
+    ["s2", "s3"],
+  ]);
+  assert.equal(MAX_CHAT_SPLIT_PANES, 4, "the quad shape assumes the four-pane cap");
+  // Any other count keeps the single-axis strip.
+  assert.equal(chatSplitQuadRows([CHAT_SPLIT_PRIMARY]), null);
+  assert.equal(chatSplitQuadRows([CHAT_SPLIT_PRIMARY, "s1"]), null);
+  assert.equal(chatSplitQuadRows([CHAT_SPLIT_PRIMARY, "s1", "s2"]), null);
+  assert.equal(chatSplitQuadRows([]), null);
 });

--- a/src/lib/chat-split.ts
+++ b/src/lib/chat-split.ts
@@ -303,3 +303,21 @@ export function pruneChatSplitPanes(
   if (panes.length === layout.panes.length) return layout;
   return { axis: layout.axis, panes };
 }
+
+// ── Quad grid (2×2) ─────────────────────────────────────────────────────────
+
+/**
+ * A full split (exactly MAX_CHAT_SPLIT_PANES panes) renders as a 2×2 grid
+ * instead of a four-up single-axis strip — four side-by-side conversations
+ * crush into letter soup, while quadrants stay readable. Rows are dealt in
+ * reading order ([a,b] over [c,d]), matching the strip order so keyboard
+ * focus cycling and drop/eviction semantics are unchanged. Returns null for
+ * any other pane count (the strip keeps those).
+ */
+export function chatSplitQuadRows<T>(panes: readonly T[]): [[T, T], [T, T]] | null {
+  if (panes.length !== MAX_CHAT_SPLIT_PANES) return null;
+  return [
+    [panes[0]!, panes[1]!],
+    [panes[2]!, panes[3]!],
+  ];
+}


### PR DESCRIPTION
## What

A full chat split (4 panes) rendered as a **four-up single-axis strip** — side-by-side conversations crushed into letter soup. Exactly four panes now render as a **2×2 grid**.

- **Pure `chatSplitQuadRows`** (chat-split.ts) deals the pane strip into reading-order rows (`[a,b]` over `[c,d]`) — strip order preserved, so keyboard focus cycling (⌥⌘←/→), drop placement, and at-cap eviction semantics are unchanged. Any other pane count returns `null` and keeps the existing strip.
- **`ChatSplitHost`** renders quad as **nested react-resizable-panels groups** (outer vertical rows, two inner horizontal pairs) so every divider stays draggable — the outer row divider plus each row's column divider. Pane `Panel`s keep their focus attributes, secondary chrome, and pixel floors (280px columns / 160px rows). Shared `renderPanePanel`/`resetSeparator` helpers keep strip and grid rendering identical.
- **Sizes**: quad mounts even and skips the flat per-pane weight persistence (three nested groups can't be honestly described by the `paneId → weight` map); divider double-click reset still remounts. Closing back to ≤3 panes returns to the persisted strip behavior.

## Testing

- `chat-split.test.ts`: `chatSplitQuadRows` behavioral cases (reading order ties to the 4-pane cap, non-quad counts → null).
- `chat-split-host.test.ts`: quad-branch pins — nested vertical/horizontal orientations, quad remount key, the `!sizes || quadRows` persistence guard, pixel floors, inner-group class.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (704 files). The chat-split e2e spec exercises the 2-pane path — unaffected.

Bead: cave-36eb