### PR TITLE
fix(analytics): Resolve actually launches the thread from the standalone analytics pages (cave-hbpb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ breaking config changes; patch releases stay additive.
 - **Shared assist runner** — the stitch sew's bounded `codex exec` lane (read-only sandbox pinned inside the module, stdin prompt, `--output-last-message` parse) is extracted to `src/lib/server/assist-runner.ts` for every authoring assist to reuse (cave-c40b).
 
 ### Fixed
+- **Analytics: Resolve actually launches the thread** — thread-signal Resolve buttons on the familiar analytics pages dispatched `cave:agents-new-chat` into the void: those pages are standalone routes where no workspace listener is mounted, so the click was a silent no-op. Resolve now hands the primed resolution prompt off through sessionStorage and navigates to the workspace, which consumes it at boot into an auto-sent familiar chat — same handoff shape the in-app browser uses (cave-hbpb).
 - **Tools: Update can now clear stale PATH launchers** — when `npm install -g` succeeds but an older copy of the same package still shadows the fresh install on PATH (orphaned nvm trees, old Homebrew-node prefixes), the Update/Repair flow no longer fails forever with "a stale executable is still first on PATH": it removes the stale same-package launcher under strict identity gates (the fresh npm-prefix copy must verify first; unrelated binaries and directories are never touched) and re-verifies — and when removal isn't safe or permitted, the error now carries the exact manual command instead of a dead end (cave-kii6).
 
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -62,6 +62,7 @@ export const SUITES = {
     "src/lib/about-diagnostics.test.ts",
     "src/lib/browser-navigation-queue.test.ts",
     "src/lib/open-external.test.ts",
+    "src/lib/agents-new-chat.test.ts",
     "src/lib/coven-version.test.ts",
     "src/lib/opencoven-tools-status-display.test.ts",
     "src/components/update-available.test.ts",

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -220,7 +220,12 @@ describe("aggregateThreadSignals", () => {
 
   it("launches a resolution thread from a review item, primed with an auto-sent fix prompt", () => {
     assert.match(source, /buildThreadSignalResolutionPrompt/, "seeds the thread with a resolution-directive prompt");
-    assert.match(source, /new CustomEvent\("cave:agents-new-chat"/, "opens a new chat thread with the familiar");
+    assert.match(source, /requestAgentsNewChat\(\{/, "opens a new chat thread via the cross-page launcher");
+    assert.doesNotMatch(
+      source,
+      /new CustomEvent\("cave:agents-new-chat"/,
+      "no raw dispatch — this section renders on standalone routes where no listener is mounted (cave-hbpb)",
+    );
     assert.match(source, /Analytics source: \$\{analyticsPath\}/, "ties the thread back to the familiar analytics page");
     assert.match(source, /origin: "chat"/, "thread signal resolutions stay regular chat threads");
     assert.doesNotMatch(source, /origin: "eval"/, "thread signal resolutions are not routed through Evals");

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -20,6 +20,7 @@ import {
   signalIdentity,
   type SignalDismissalMap,
 } from "@/lib/thread-signal-dismissals";
+import { requestAgentsNewChat } from "@/lib/agents-new-chat";
 import {
   aggregateThreadSignals,
   buildThreadSignalReviewQueue,
@@ -154,18 +155,17 @@ function tableSections(aggregate: ThreadSignalsAggregate): ThreadSignalTableSect
   ];
 }
 
-/** Launch a new working thread with this familiar, primed with an auto-sent prompt to resolve the signal. */
+/** Launch a new working thread with this familiar, primed with an auto-sent prompt to resolve the signal.
+ *  Uses the cross-page launcher: this section renders on the standalone analytics
+ *  routes, where no `cave:agents-new-chat` listener is mounted — a raw dispatch
+ *  there would be a silent no-op (cave-hbpb). */
 function launchResolutionThread(familiarId: string, item: ThreadSignalReviewItem) {
   const analyticsPath = `/dashboard/familiars/${encodeURIComponent(familiarId)}/analytics`;
-  window.dispatchEvent(
-    new CustomEvent("cave:agents-new-chat", {
-      detail: {
-        familiarId,
-        initialPrompt: `${buildThreadSignalResolutionPrompt(item)}\n\nAnalytics source: ${analyticsPath}`,
-        origin: "chat" as const,
-      },
-    }),
-  );
+  requestAgentsNewChat({
+    familiarId,
+    initialPrompt: `${buildThreadSignalResolutionPrompt(item)}\n\nAnalytics source: ${analyticsPath}`,
+    origin: "chat" as const,
+  });
 }
 
 /** Shape a table row into a review item so it can launch the same resolution thread. */

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -230,3 +230,28 @@ assert.match(
   /focusPath\?: string \| null[\s\S]*focusNonce\?: number[\s\S]*useEffect\(\(\) => \{[\s\S]*setSelectedPath\([\s\S]*focusPath/,
   "RailFilesPanel should update its selected file from an external focus target",
 );
+
+// Cross-page handoff (cave-hbpb): standalone routes (familiar analytics) have no
+// cave:agents-new-chat listener — they persist the request and navigate to /,
+// where Workspace must consume it at boot into a primed chat.
+const agentsNewChatLib = await readFile(new URL("../lib/agents-new-chat.ts", import.meta.url), "utf8");
+assert.match(
+  agentsNewChatLib,
+  /window\.location\.pathname === "\/"[\s\S]*dispatchEvent\(new CustomEvent\(AGENTS_NEW_CHAT_EVENT/,
+  "same-page callers keep dispatching the live event",
+);
+assert.match(
+  agentsNewChatLib,
+  /sessionStorage\.setItem\(PENDING_AGENTS_NEW_CHAT_KEY[\s\S]*window\.location\.assign\("\/"\)/,
+  "off-page callers persist the request and navigate to the workspace",
+);
+assert.match(
+  workspace,
+  /import \{ consumePendingAgentsNewChat \} from "@\/lib\/agents-new-chat"/,
+  "Workspace should import the cross-page chat handoff consumer",
+);
+assert.match(
+  workspace,
+  /const pending = consumePendingAgentsNewChat\(\);[\s\S]{0,200}startFamiliarChat\(\s*pending\.familiarId \?\? null,\s*pending\.projectRoot \?\? null,\s*pending\.initialPrompt \?\? null,\s*pending\.initialControls \?\? null,?\s*\)/,
+  "Workspace boot should turn a pending cross-page request into a primed familiar chat",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -103,6 +103,7 @@ import { useShellBanners } from "@/lib/shell-banners";
 import { TopBar } from "@/components/top-bar";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import { consumePendingAgentsNewChat } from "@/lib/agents-new-chat";
 import type { PendingCodeRailOpen } from "@/lib/pending-code-rail-open";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import {
@@ -1708,6 +1709,20 @@ export function Workspace() {
     };
     window.addEventListener("cave:continue-on-phone", onContinueOnPhone as EventListener);
     return () => window.removeEventListener("cave:agents-new-chat", onAgentsNewChat);
+  }, [startFamiliarChat]);
+
+  // Consume a cross-page "new chat" handoff (cave-hbpb): standalone routes like
+  // the familiar analytics pages have no workspace listeners, so their Resolve
+  // actions persist the request to sessionStorage and navigate here.
+  useEffect(() => {
+    const pending = consumePendingAgentsNewChat();
+    if (!pending) return;
+    startFamiliarChat(
+      pending.familiarId ?? null,
+      pending.projectRoot ?? null,
+      pending.initialPrompt ?? null,
+      pending.initialControls ?? null,
+    );
   }, [startFamiliarChat]);
 
   useEffect(() => {

--- a/src/lib/agents-new-chat.test.ts
+++ b/src/lib/agents-new-chat.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  AGENTS_NEW_CHAT_EVENT,
+  PENDING_AGENTS_NEW_CHAT_KEY,
+  consumePendingAgentsNewChat,
+  requestAgentsNewChat,
+} from "./agents-new-chat.ts";
+
+type FakeWindow = {
+  location: { pathname: string; assign: (url: string) => void };
+  sessionStorage: {
+    getItem: (k: string) => string | null;
+    setItem: (k: string, v: string) => void;
+    removeItem: (k: string) => void;
+  };
+  dispatchEvent: (e: Event) => boolean;
+};
+
+function makeWindow(pathname: string) {
+  const store = new Map<string, string>();
+  const dispatched: Array<{ type: string; detail: unknown }> = [];
+  const assigned: string[] = [];
+  const win: FakeWindow = {
+    location: { pathname, assign: (url) => assigned.push(url) },
+    sessionStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k, v) => void store.set(k, v),
+      removeItem: (k) => void store.delete(k),
+    },
+    dispatchEvent: (e) => {
+      dispatched.push({ type: e.type, detail: (e as CustomEvent).detail });
+      return true;
+    },
+  };
+  return { win, store, dispatched, assigned };
+}
+
+function withWindow<T>(win: FakeWindow, fn: () => T): T {
+  const g = globalThis as { window?: unknown };
+  const had = "window" in g;
+  const prev = g.window;
+  g.window = win;
+  try {
+    return fn();
+  } finally {
+    if (had) g.window = prev;
+    else delete g.window;
+  }
+}
+
+describe("requestAgentsNewChat", () => {
+  it("dispatches the live event on the main workspace page", () => {
+    const { win, store, dispatched, assigned } = makeWindow("/");
+    withWindow(win, () => requestAgentsNewChat({ familiarId: "cody", initialPrompt: "fix it" }));
+    assert.equal(dispatched.length, 1, "one event dispatched");
+    assert.equal(dispatched[0].type, AGENTS_NEW_CHAT_EVENT);
+    assert.deepEqual(dispatched[0].detail, { familiarId: "cody", initialPrompt: "fix it" });
+    assert.equal(assigned.length, 0, "no navigation on the main page");
+    assert.equal(store.size, 0, "nothing persisted on the main page");
+  });
+
+  it("persists the request and navigates home from a standalone route", () => {
+    const { win, store, dispatched, assigned } = makeWindow("/familiars/cody/analytics");
+    withWindow(win, () =>
+      requestAgentsNewChat({ familiarId: "cody", initialPrompt: "resolve the blocker", origin: "chat" }),
+    );
+    assert.equal(dispatched.length, 0, "no dead-end dispatch off the main page");
+    assert.deepEqual(assigned, ["/"], "navigates to the workspace");
+    assert.deepEqual(JSON.parse(store.get(PENDING_AGENTS_NEW_CHAT_KEY)!), {
+      familiarId: "cody",
+      initialPrompt: "resolve the blocker",
+      origin: "chat",
+    });
+  });
+
+  it("still navigates when sessionStorage writes throw", () => {
+    const { win, assigned } = makeWindow("/dashboard/familiars/cody/analytics");
+    win.sessionStorage.setItem = () => {
+      throw new Error("quota");
+    };
+    withWindow(win, () => requestAgentsNewChat({ familiarId: "cody" }));
+    assert.deepEqual(assigned, ["/"], "chat opens unprimed rather than not at all");
+  });
+});
+
+describe("consumePendingAgentsNewChat", () => {
+  it("returns and clears a pending request", () => {
+    const { win, store } = makeWindow("/");
+    store.set(PENDING_AGENTS_NEW_CHAT_KEY, JSON.stringify({ familiarId: "cody", initialPrompt: "go" }));
+    const got = withWindow(win, () => consumePendingAgentsNewChat());
+    assert.deepEqual(got, { familiarId: "cody", initialPrompt: "go" });
+    assert.equal(store.has(PENDING_AGENTS_NEW_CHAT_KEY), false, "consumed exactly once");
+  });
+
+  it("returns null when nothing is pending", () => {
+    const { win } = makeWindow("/");
+    assert.equal(withWindow(win, () => consumePendingAgentsNewChat()), null);
+  });
+
+  it("clears and ignores malformed payloads", () => {
+    const { win, store } = makeWindow("/");
+    store.set(PENDING_AGENTS_NEW_CHAT_KEY, "{not json");
+    assert.equal(withWindow(win, () => consumePendingAgentsNewChat()), null);
+    assert.equal(store.has(PENDING_AGENTS_NEW_CHAT_KEY), false, "bad payloads do not wedge future boots");
+  });
+});

--- a/src/lib/agents-new-chat.ts
+++ b/src/lib/agents-new-chat.ts
@@ -1,0 +1,58 @@
+import type { InitialCommandControls } from "@/lib/command-controls";
+import type { SessionOrigin } from "@/lib/types";
+
+export const AGENTS_NEW_CHAT_EVENT = "cave:agents-new-chat";
+export const PENDING_AGENTS_NEW_CHAT_KEY = "cave:pending-agents-new-chat";
+
+export type AgentsNewChatRequest = {
+  familiarId?: string | null;
+  projectRoot?: string | null;
+  /** Auto-sent by the chat surface once the new thread mounts. */
+  initialPrompt?: string | null;
+  initialControls?: InitialCommandControls | null;
+  origin?: SessionOrigin;
+};
+
+/**
+ * Launch a new familiar chat from anywhere in the app.
+ *
+ * On the main workspace page (`/`) this dispatches `cave:agents-new-chat`,
+ * which Workspace/ChatSurface already handle. On standalone routes (e.g. the
+ * familiar analytics pages under /familiars and /dashboard) no workspace
+ * listeners are mounted, so a plain dispatch is a silent no-op — instead the
+ * request is persisted to sessionStorage and the browser navigates to `/`,
+ * where Workspace consumes it at boot (same handoff shape as open-external.ts).
+ */
+export function requestAgentsNewChat(detail: AgentsNewChatRequest): void {
+  if (typeof window === "undefined") return;
+  if (window.location.pathname === "/") {
+    window.dispatchEvent(new CustomEvent(AGENTS_NEW_CHAT_EVENT, { detail }));
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(PENDING_AGENTS_NEW_CHAT_KEY, JSON.stringify(detail));
+  } catch {
+    // Storage denied/full — still navigate; the chat opens unprimed.
+  }
+  window.location.assign("/");
+}
+
+/** Read-and-clear the pending cross-page request. Called by Workspace on boot. */
+export function consumePendingAgentsNewChat(): AgentsNewChatRequest | null {
+  if (typeof window === "undefined") return null;
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(PENDING_AGENTS_NEW_CHAT_KEY);
+    if (raw !== null) window.sessionStorage.removeItem(PENDING_AGENTS_NEW_CHAT_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as AgentsNewChatRequest;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

Clicking **Resolve** on a familiar's analytics page did nothing. The thread-signals section dispatches `cave:agents-new-chat`, but the analytics surface only mounts on standalone routes (`/familiars/[id]/analytics`, `/dashboard/familiars/[id]/analytics`) — outside the main `/` workspace where the only listeners (workspace.tsx, chat-surface.tsx) live. The event dispatched into the void.

**Repro (live, real cody self-reports, prod build):** click Resolve → event fires with the correct resolution prompt → URL unchanged, no chat, no feedback.

## Fix

- **`src/lib/agents-new-chat.ts`** (new): `requestAgentsNewChat(detail)` — on `/` dispatches the live event exactly as before; on any other route persists the request to sessionStorage (`cave:pending-agents-new-chat`) and navigates to `/`. Same handoff shape as `open-external.ts`.
- **`workspace.tsx`**: boot effect consumes the pending request into `startFamiliarChat(...)` — the resolution prompt auto-sends through the normal streaming path.
- **`thread-signals-section.tsx`**: `launchResolutionThread` uses the launcher.

## Verification

- Live post-fix (Playwright, prod build, real data): Resolve on `/familiars/cody/analytics` → navigates to `/`, pending key consumed, chat opens with cody, resolution prompt auto-sent, thread starts.
- `pnpm typecheck` clean · `pnpm test:app` 705/705 · `check:tests-wired` 947 wired.
- New functional tests: dispatch-on-`/`, persist+navigate off-`/`, storage-throw fallback, consume/clear, malformed payload. Pins updated: no raw dispatch in the section; workspace boot consumption.

Bead: cave-hbpb