### PR TITLE
fix(workspace): remove cave:continue-on-phone listener in bridge-effect cleanup (cave-z9z8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ breaking config changes; patch releases stay additive.
 
 ### Fixed
 - **Analytics: Resolve actually launches the thread** — thread-signal Resolve buttons on the familiar analytics pages dispatched `cave:agents-new-chat` into the void: those pages are standalone routes where no workspace listener is mounted, so the click was a silent no-op. Resolve now hands the primed resolution prompt off through sessionStorage and navigates to the workspace, which consumes it at boot into an auto-sent familiar chat — same handoff shape the in-app browser uses (cave-hbpb).
+- **Workspace: chat-bridge effect no longer leaks the continue-on-phone listener** — the effect that bridges `cave:agents-new-chat` also registers `cave:continue-on-phone`, but its cleanup removed only the former; re-runs or remounts stacked handlers and could open the phone-pairing modal multiple times (cave-z9z8).
 - **Tools: Update can now clear stale PATH launchers** — when `npm install -g` succeeds but an older copy of the same package still shadows the fresh install on PATH (orphaned nvm trees, old Homebrew-node prefixes), the Update/Repair flow no longer fails forever with "a stale executable is still first on PATH": it removes the stale same-package launcher under strict identity gates (the fresh npm-prefix copy must verify first; unrelated binaries and directories are never touched) and re-verifies — and when removal isn't safe or permitted, the error now carries the exact manual command instead of a dead end (cave-kii6).
 
 

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -255,3 +255,11 @@ assert.match(
   /const pending = consumePendingAgentsNewChat\(\);[\s\S]{0,200}startFamiliarChat\(\s*pending\.familiarId \?\? null,\s*pending\.projectRoot \?\? null,\s*pending\.initialPrompt \?\? null,\s*pending\.initialControls \?\? null,?\s*\)/,
   "Workspace boot should turn a pending cross-page request into a primed familiar chat",
 );
+// The bridge effect registers BOTH cave:agents-new-chat and
+// cave:continue-on-phone; its cleanup must remove both or re-runs/remounts
+// leak continue-on-phone handlers (duplicate pairing-modal opens).
+assert.match(
+  workspace,
+  /return \(\) => \{\s*window\.removeEventListener\("cave:agents-new-chat", onAgentsNewChat\);\s*window\.removeEventListener\("cave:continue-on-phone", onContinueOnPhone as EventListener\);\s*\};/,
+  "Workspace bridge cleanup should remove every listener the effect adds",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1708,7 +1708,10 @@ export function Workspace() {
       setMobileHandoffOpen(true);
     };
     window.addEventListener("cave:continue-on-phone", onContinueOnPhone as EventListener);
-    return () => window.removeEventListener("cave:agents-new-chat", onAgentsNewChat);
+    return () => {
+      window.removeEventListener("cave:agents-new-chat", onAgentsNewChat);
+      window.removeEventListener("cave:continue-on-phone", onContinueOnPhone as EventListener);
+    };
   }, [startFamiliarChat]);
 
   // Consume a cross-page "new chat" handoff (cave-hbpb): standalone routes like


### PR DESCRIPTION
## What

**Scope changed after a race:** this PR originally fixed the dead thread-signal Resolve launch from the standalone analytics routes — but #3153 (cave-hbpb) landed an equivalent sessionStorage-handoff fix on `main` while it was in review. What remains here is the review finding that #3153 does **not** cover:

The workspace effect that bridges `cave:agents-new-chat` also registers `cave:continue-on-phone`, but its cleanup removed only the former. Effect re-runs or Workspace remounts stack continue-on-phone handlers, so one "Continue on phone" event can open the pairing modal multiple times. (Flagged by copilot-pull-request-reviewer on the original diff; confirmed still present on main.)

## How

- `workspace.tsx` — cleanup now removes both listeners.
- `workspace-chat-handoff.test.ts` — regression pin: the bridge cleanup must remove every listener the effect adds.
- CHANGELOG entry (cave-z9z8).

## Verification

- `pnpm typecheck` clean; workspace-chat-handoff + chat-surface tests green.
- Also live-verified main's landed Resolve flow with this patch applied (prod build + Playwright): analytics Resolve click → `/` → primed resolution prompt auto-sent in a Cody thread (send intercepted; stash cleared) — i.e. #3153's fix works and this change doesn't disturb it.

Bead: cave-z9z8
