### PR TITLE
feat(chat): Familiar tab voice identity + capability-fetch lifecycle guards (cave-zpfq)

### DIFF
--- a/src/components/chat-familiar-view.tsx
+++ b/src/components/chat-familiar-view.tsx
@@ -95,6 +95,16 @@ function navigateMode(mode: "roles" | "capabilities" | "marketplace"): void {
   window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
 }
 
+/** Human names for the voice providers the Studio's Brain tab can bind. */
+const VOICE_PROVIDER_LABELS: Record<string, string> = {
+  openai: "OpenAI Realtime",
+  gemini: "Gemini Live",
+};
+
+function voiceProviderLabel(provider: string): string {
+  return VOICE_PROVIDER_LABELS[provider] ?? provider;
+}
+
 /** Teach-state CTA — every empty state gets a real affordance, not a
  *  dead-end sentence naming a page. */
 function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
@@ -218,6 +228,13 @@ function FamiliarIdentityHero({
     .filter(Boolean)
     .join(" · ");
   const runtimeLine = [familiar.harness, familiar.model].filter(Boolean).join(" · ");
+  // The familiar's speaking voice (bound in the Studio's Brain tab). Silent
+  // familiars add no noise — the line only renders when a provider is set.
+  const voiceLine = familiar.voiceProvider
+    ? [voiceProviderLabel(familiar.voiceProvider), familiar.voiceName || familiar.voiceModel]
+        .filter(Boolean)
+        .join(" · ")
+    : "";
   // "offline · last seen 2h ago" — the honest half of presence: reachability
   // comes from the daemon, recency from the familiar's own activity record.
   const lastSeen = daemonRunning ? "" : relativeTime(familiar.last_seen);
@@ -268,6 +285,18 @@ function FamiliarIdentityHero({
             <span className="font-mono text-[11px] text-[var(--text-muted)]" title="Harness · model">
               {runtimeLine}
             </span>
+          ) : null}
+          {voiceLine ? (
+            <button
+              type="button"
+              onClick={() => openFamiliarStudioSettingsTab("brain", familiar.id)}
+              aria-label={`Voice settings for ${familiar.display_name} — ${voiceLine}`}
+              title="Speaking voice — manage in the Studio's Brain tab"
+              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-sm)] font-mono text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+            >
+              <Icon name="ph:waveform-bold" width={11} aria-hidden />
+              {voiceLine}
+            </button>
           ) : null}
           <span className="flex flex-wrap items-center gap-3">
             <Link
@@ -352,6 +381,10 @@ function FamiliarCapabilityPanel({
   const harnessId = familiar.harness ?? "codex";
 
   useEffect(() => {
+    // Guard against stale / post-unmount responses: switching familiars
+    // remounts the panel (keyed host), but a slow response from THIS mount
+    // must still not apply after cleanup.
+    let cancelled = false;
     setLoading(true);
     setErrors([]);
 
@@ -371,6 +404,7 @@ function FamiliarCapabilityPanel({
         .then((r) => r.json() as Promise<{ ok: boolean; harnesses?: AdapterReport[]; error?: string }>)
         .catch(() => ({ ok: false as const, error: "harnesses fetch failed" })),
     ]).then(([rolesRes, skillsRes, capsRes, harnessesRes]) => {
+      if (cancelled) return;
       if (rolesRes.ok) setRoles(rolesRes.roles ?? []);
       else errs.push(rolesRes.error ?? "roles unavailable");
 
@@ -386,6 +420,7 @@ function FamiliarCapabilityPanel({
       setErrors(errs);
       setLoading(false);
     });
+    return () => { cancelled = true; };
   }, [familiar.id, harnessId]);
 
   // The identity hero needs nothing from the capability fetches — paint it

--- a/src/components/chat-familiar-view.tsx
+++ b/src/components/chat-familiar-view.tsx
@@ -24,6 +24,7 @@ import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import type { AdapterReport } from "@/lib/harness-adapters";
 import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
+import { getVoiceProvider } from "@/lib/voice/registry";
 import { relativeTime } from "@/lib/relative-time";
 
 // ── Building blocks ──────────────────────────────────────────────────────────
@@ -93,16 +94,6 @@ function KindBadge({ kind }: { kind: string }) {
 function navigateMode(mode: "roles" | "capabilities" | "marketplace"): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
-}
-
-/** Human names for the voice providers the Studio's Brain tab can bind. */
-const VOICE_PROVIDER_LABELS: Record<string, string> = {
-  openai: "OpenAI Realtime",
-  gemini: "Gemini Live",
-};
-
-function voiceProviderLabel(provider: string): string {
-  return VOICE_PROVIDER_LABELS[provider] ?? provider;
 }
 
 /** Teach-state CTA — every empty state gets a real affordance, not a
@@ -228,10 +219,14 @@ function FamiliarIdentityHero({
     .filter(Boolean)
     .join(" · ");
   const runtimeLine = [familiar.harness, familiar.model].filter(Boolean).join(" · ");
-  // The familiar's speaking voice (bound in the Studio's Brain tab). Silent
-  // familiars add no noise — the line only renders when a provider is set.
+  // The familiar's speaking voice (bound in the Studio's Brain tab), labelled
+  // by the canonical voice-provider registry. Silent familiars add no noise —
+  // the line only renders when a provider is set.
   const voiceLine = familiar.voiceProvider
-    ? [voiceProviderLabel(familiar.voiceProvider), familiar.voiceName || familiar.voiceModel]
+    ? [
+        getVoiceProvider(familiar.voiceProvider)?.label ?? familiar.voiceProvider,
+        familiar.voiceName || familiar.voiceModel,
+      ]
         .filter(Boolean)
         .join(" · ")
     : "";
@@ -290,7 +285,7 @@ function FamiliarIdentityHero({
             <button
               type="button"
               onClick={() => openFamiliarStudioSettingsTab("brain", familiar.id)}
-              aria-label={`Voice settings for ${familiar.display_name} — ${voiceLine}`}
+              aria-label={`Voice settings for ${resolved?.display_name ?? familiar.display_name} — ${voiceLine}`}
               title="Speaking voice — manage in the Studio's Brain tab"
               className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-sm)] font-mono text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
             >

--- a/src/components/familiar-tab-bridges.test.ts
+++ b/src/components/familiar-tab-bridges.test.ts
@@ -62,7 +62,11 @@ test("the tab and the memory rail are separately labelled landmarks", () => {
 });
 
 test("voice bridge: a configured speaking voice is shown and opens the Studio Brain tab", () => {
-  assert.match(src, /const VOICE_PROVIDER_LABELS: Record<string, string> = \{/, "provider ids get human labels");
+  assert.match(
+    src,
+    /getVoiceProvider\(familiar\.voiceProvider\)\?\.label \?\? familiar\.voiceProvider/,
+    "provider labels come from the canonical voice registry (no second mapping)",
+  );
   assert.match(
     src,
     /const voiceLine = familiar\.voiceProvider\s*\?/,
@@ -70,8 +74,13 @@ test("voice bridge: a configured speaking voice is shown and opens the Studio Br
   );
   assert.match(
     src,
-    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("brain", familiar\.id\)\}[\s\S]{0,400}?\{voiceLine\}/,
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("brain", familiar\.id\)\}[\s\S]{0,500}?\{voiceLine\}/,
     "the voice line bridges to the Studio Brain tab, voice's managed home",
+  );
+  assert.match(
+    src,
+    /aria-label=\{`Voice settings for \$\{resolved\?\.display_name \?\? familiar\.display_name\}/,
+    "the voice bridge announces the same resolved name the heading shows",
   );
 });
 

--- a/src/components/familiar-tab-bridges.test.ts
+++ b/src/components/familiar-tab-bridges.test.ts
@@ -61,6 +61,20 @@ test("the tab and the memory rail are separately labelled landmarks", () => {
   assert.match(pane, /aria-label="Familiar memory"/, "the memory rail keeps its own label");
 });
 
+test("voice bridge: a configured speaking voice is shown and opens the Studio Brain tab", () => {
+  assert.match(src, /const VOICE_PROVIDER_LABELS: Record<string, string> = \{/, "provider ids get human labels");
+  assert.match(
+    src,
+    /const voiceLine = familiar\.voiceProvider\s*\?/,
+    "silent familiars add no voice noise — the line renders only when a provider is bound",
+  );
+  assert.match(
+    src,
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("brain", familiar\.id\)\}[\s\S]{0,400}?\{voiceLine\}/,
+    "the voice line bridges to the Studio Brain tab, voice's managed home",
+  );
+});
+
 test("coarse pointers get honest touch targets without changing pointer-fine rhythm", () => {
   assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,600}?\.familiar-tab__links a,\s*\.familiar-tab__links button \{[^}]*padding-block/, "hero links grow");
   assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,900}?\.familiar-tab__list > button \{[^}]*padding-block/, "group toggles grow");

--- a/src/components/inspector-pane-load-guards.test.ts
+++ b/src/components/inspector-pane-load-guards.test.ts
@@ -40,4 +40,16 @@ assert.match(
   "the open-file loader drops a stale response when the selection changes",
 );
 
+// The Familiar tab's capability panel (extracted to chat-familiar-view.tsx)
+// awaits four fetches with one Promise.all — same rule: a slow response must
+// not setState after cleanup, even though the keyed host remounts per familiar.
+const familiarView = readFileSync(new URL("./chat-familiar-view.tsx", import.meta.url), "utf8");
+assert.match(familiarView, /let cancelled = false;/, "the capability loader declares a cancelled guard");
+assert.match(
+  familiarView,
+  /\.then\(\(\[rolesRes, skillsRes, capsRes, harnessesRes\]\) => \{\s*if \(cancelled\) return;/,
+  "the capability loader drops stale/post-unmount responses before any setState",
+);
+assert.match(familiarView, /return \(\) => \{ cancelled = true; \};/, "the capability loader cleans up by cancelling in-flight work");
+
 console.log("inspector-pane-load-guards.test.ts: ok");


### PR DESCRIPTION
Slice 2 of the chat-familiar-tab-rebuild goal (bead cave-zpfq), following #3149's extraction.

## What changed

- **Voice identity in the hero** — a familiar with a bound speaking voice now shows it ("OpenAI Realtime · marin"; provider ids get human labels) as a quiet mono line beside the harness · model line. It bridges to the Studio **Brain** tab (voice's managed home) via the existing `openFamiliarStudioSettingsTab` idiom. Silent familiars render nothing — no empty-state noise.
- **Capability-fetch lifecycle guards** — the panel's four-fetch `Promise.all` loader now declares a `cancelled` flag, drops stale/post-unmount responses before any `setState`, and cleans up on unmount — the same load-guard idiom the memory loaders are pinned to in `inspector-pane-load-guards.test.ts`.

## Pins

- `familiar-tab-bridges.test.ts`: voice line renders only when a provider is bound + bridges to the Studio Brain tab.
- `inspector-pane-load-guards.test.ts`: the capability loader joins the guarded-loader contract.

## Verification

- Targeted: 26 tests across the tab/pane pin files pass
- `pnpm typecheck` clean
- `pnpm test:app`: 704 files pass

Bead: cave-zpfq
