### PR TITLE
feat(chat): reposition split panes by dragging their header (cave-xw0v)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13033,6 +13033,21 @@ details[open] > .cave-edit-card__summary::before {
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
 }
+/* The header doubles as the pane's drag handle (reposition via the snap
+   overlay); the grip glyph + grab cursor carry the affordance. */
+.chat-split__pane-head[draggable="true"] {
+  cursor: grab;
+}
+.chat-split__pane-head[draggable="true"]:active {
+  cursor: grabbing;
+}
+.chat-split__pane-grip {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+.chat-split__pane-head[draggable="true"]:hover .chat-split__pane-grip {
+  color: var(--text-secondary);
+}
 .chat-split__pane-title {
   display: inline-flex;
   align-items: center;

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -366,8 +366,16 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     if (!sessions.some((entry) => entry.id === sessionId)) return;
     // A session already open in a pane is MOVED to the drop edge (the pure
     // layout dedupes) — header drags land here, so announce them honestly.
+    // Dropping a pane back onto its current edge changes nothing: bail before
+    // any state churn or a misleading "moved" announcement.
     const repositioning = split.panes.includes(sessionId);
-    setSplit((prev) => dropSessionIntoChatSplit(prev, sessionId, zone));
+    const next = dropSessionIntoChatSplit(split, sessionId, zone);
+    const unchanged =
+      next.axis === split.axis &&
+      next.panes.length === split.panes.length &&
+      next.panes.every((id, index) => id === split.panes[index]);
+    if (unchanged) return;
+    setSplit(next);
     setFocusedPane(sessionId);
     announce(`${paneTitle(sessionId)} ${repositioning ? `pane moved ${chatDropZoneLabel(zone)}` : "opened in a split pane"}`);
   }

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -19,12 +19,14 @@ import type { ChatAttachment } from "@/lib/chat-attachments";
 import {
   CHAT_SPLIT_PRIMARY,
   CHAT_SPLIT_STORAGE_KEY,
+  chatDropZoneLabel,
   chatSplitFocusAfterClose,
   chatSplitFocusTarget,
   chatSplitKeyboardZone,
   dropSessionIntoChatSplit,
   emptyChatSplitLayout,
   hasChatSplit,
+  moveChatSplitPane,
   parsePersistedChatSplit,
   pruneChatSplitPanes,
   removeChatSplitPane,
@@ -362,9 +364,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   function handleDropSession(sessionId: string, zone: ChatDropZone) {
     if (sessionId === primarySessionId) return; // already the open chat
     if (!sessions.some((entry) => entry.id === sessionId)) return;
+    // A session already open in a pane is MOVED to the drop edge (the pure
+    // layout dedupes) — header drags land here, so announce them honestly.
+    const repositioning = split.panes.includes(sessionId);
     setSplit((prev) => dropSessionIntoChatSplit(prev, sessionId, zone));
     setFocusedPane(sessionId);
-    announce(`${paneTitle(sessionId)} opened in a split pane`);
+    announce(`${paneTitle(sessionId)} ${repositioning ? `pane moved ${chatDropZoneLabel(zone)}` : "opened in a split pane"}`);
   }
 
   // Open a thread-rail conversation in a split pane from the keyboard (⌥↵ on
@@ -410,6 +415,19 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           : e.key === "ArrowRight" || e.key === "ArrowDown"
             ? (1 as const)
             : null;
+      if (delta !== null && e.shiftKey) {
+        // ⌥⌘⇧←/→ (or ↑/↓): move the focused pane one step along the strip —
+        // keyboard parity for dragging a pane by its header.
+        const moving = resolveChatSplitFocus(split, focusedPane);
+        const next = moveChatSplitPane(split, moving, delta);
+        if (next === split) return; // edge — clamped, nothing to announce
+        e.preventDefault();
+        setSplit(next);
+        setFocusedPane(moving);
+        focusPaneElement(moving);
+        announce(`${paneTitle(moving)} pane moved ${delta === -1 ? "back" : "forward"}`);
+        return;
+      }
       if (delta !== null) {
         const target = chatSplitFocusTarget(split, focusedPane, delta);
         if (!target) return;

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -89,6 +89,8 @@ assert.match(
 );
 assert.match(host, /onDragEnd=\{\(\) => emitChatSessionDragEnd\(\)\}/, "drag end always clears the overlay");
 assert.match(host, /Drag to reposition this pane/, "the handle says what it does");
+assert.match(host, /aria-describedby=\{enableDrop \? `chat-split-hint-\$\{tile\.id\}` : undefined\}/, "the reposition hint is a real accessible description, not a title tooltip");
+assert.match(host, /or press Control or Command with Alt, Shift and an/, "the sr-only hint teaches the keyboard path too");
 assert.match(host, /chat-split__pane-grip/, "a grip glyph carries the drag affordance");
 assert.match(
   css,
@@ -191,6 +193,11 @@ assert.match(router, /if \(next === split\) return; \/\/ edge/, "clamped edge mo
 assert.match(router, /pane moved \$\{delta === -1 \? "back" : "forward"\}/, "keyboard moves are announced");
 assert.match(router, /pane moved \$\{chatDropZoneLabel\(zone\)\}/, "a header-drag reposition announces as a move, not an open");
 assert.match(router, /const repositioning = split\.panes\.includes\(sessionId\);/, "drops distinguish repositioning from opening");
+assert.match(
+  router,
+  /next\.panes\.every\(\(id, index\) => id === split\.panes\[index\]\);\s*if \(unchanged\) return;/,
+  "dropping a pane back onto its current edge changes nothing — no state churn, no false announcement",
+);
 assert.match(router, /e\.code === "KeyW"/, "close matches on e.code (⌥ composes e.key on macOS)");
 assert.match(router, /closest\?\.\('\[aria-modal="true"\]'\)/, "modals own the keyboard");
 assert.match(router, /chatSplitKeyboardZone\(split\)/, "keyboard split lands on the current axis");

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -101,7 +101,7 @@ assert.match(
 // ── Layout owner (chat-router) ───────────────────────────────────────────────
 
 assert.match(router, /<ChatSplitHost/, "the chat view area renders through the split host");
-assert.match(router, /dropSessionIntoChatSplit\(prev, sessionId, zone\)/, "drops feed the pure layout");
+assert.match(router, /const next = dropSessionIntoChatSplit\(split, sessionId, zone\);/, "drops feed the pure layout");
 assert.match(
   router,
   /if \(sessionId === primarySessionId\) return;/,

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -77,6 +77,25 @@ assert.match(
   "the primary pane renders without extra chrome",
 );
 
+// ── Reposition by header drag ────────────────────────────────────────────────
+// The header is the pane's drag handle: it re-enters the same session-drag
+// protocol the thread rail uses, so the snap overlay lights up and the drop
+// MOVES the pane (dropSessionIntoChatSplit dedupes an open session).
+assert.match(host, /draggable=\{enableDrop\}/, "the header is draggable exactly when the drop overlay can catch it");
+assert.match(
+  host,
+  /onDragStart=\{\(e\) => \{[\s\S]{0,220}setData\(CHAT_SESSION_DRAG_MIME, tile\.id\);[\s\S]{0,220}emitChatSessionDragStart\(\{ sessionId: tile\.id, title: tile\.title \}\)/,
+  "header drags speak the shared session-drag protocol",
+);
+assert.match(host, /onDragEnd=\{\(\) => emitChatSessionDragEnd\(\)\}/, "drag end always clears the overlay");
+assert.match(host, /Drag to reposition this pane/, "the handle says what it does");
+assert.match(host, /chat-split__pane-grip/, "a grip glyph carries the drag affordance");
+assert.match(
+  css,
+  /\.chat-split__pane-head\[draggable="true"\] \{\s*cursor: grab;/,
+  "draggable headers show the grab cursor",
+);
+
 // ── Layout owner (chat-router) ───────────────────────────────────────────────
 
 assert.match(router, /<ChatSplitHost/, "the chat view area renders through the split host");
@@ -162,9 +181,16 @@ assert.match(router, /serializeChatSplit\(split, splitSizes\)/, "layout + sizes 
 assert.match(router, /if \(!enableSplitPanes \|\| splitHydratedRef\.current/, "only the opted-in surface hydrates");
 assert.match(router, /pruneChatSplitPanes\(prev, \(id\) => sessions\.some/, "deleted sessions leave the persisted split");
 
-// Keyboard: ⌥⌘arrows move focus, ⌥⌘W closes the focused secondary pane, and
-// ⌥↵ on a thread-rail row opens it in a split.
+// Keyboard: ⌥⌘arrows move focus, ⌥⌘⇧arrows move the focused PANE (parity with
+// the header drag), ⌥⌘W closes the focused secondary pane, and ⌥↵ on a
+// thread-rail row opens it in a split.
 assert.match(router, /chatSplitFocusTarget\(split, focusedPane, delta\)/, "arrow keys move pane focus");
+assert.match(router, /delta !== null && e\.shiftKey/, "shifted arrows take the move-pane branch");
+assert.match(router, /moveChatSplitPane\(split, moving, delta\)/, "pane moves go through the pure swap");
+assert.match(router, /if \(next === split\) return; \/\/ edge/, "clamped edge moves stay silent (same-reference no-op)");
+assert.match(router, /pane moved \$\{delta === -1 \? "back" : "forward"\}/, "keyboard moves are announced");
+assert.match(router, /pane moved \$\{chatDropZoneLabel\(zone\)\}/, "a header-drag reposition announces as a move, not an open");
+assert.match(router, /const repositioning = split\.panes\.includes\(sessionId\);/, "drops distinguish repositioning from opening");
 assert.match(router, /e\.code === "KeyW"/, "close matches on e.code (⌥ composes e.key on macOS)");
 assert.match(router, /closest\?\.\('\[aria-modal="true"\]'\)/, "modals own the keyboard");
 assert.match(router, /chatSplitKeyboardZone\(split\)/, "keyboard split lands on the current axis");

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -160,7 +160,19 @@ export function ChatSplitHost({
       return <div className="chat-split__pane-body">{tile.content}</div>;
     }
     return (
-      <section className="chat-split__tile" aria-label={`${tile.title} (split pane)`}>
+      <section
+        className="chat-split__tile"
+        aria-label={`${tile.title} (split pane)`}
+        aria-describedby={enableDrop ? `chat-split-hint-${tile.id}` : undefined}
+      >
+        {/* title tooltips aren't reliably announced — the reposition hint
+            (drag OR the keyboard shortcut) rides an sr-only description. */}
+        {enableDrop ? (
+          <span className="sr-only" id={`chat-split-hint-${tile.id}`}>
+            Drag this pane&apos;s header, or press Control or Command with Alt, Shift and an
+            arrow key while the pane is focused, to reposition it.
+          </span>
+        ) : null}
         {/* The header is the pane's drag handle: dragging it re-enters the
             same session-drag protocol the thread rail uses, so the snap
             overlay lights up and dropping MOVES the pane (the layout's

--- a/src/components/chat-split-host.tsx
+++ b/src/components/chat-split-host.tsx
@@ -27,6 +27,8 @@ import {
   chatDropPreviewRect,
   chatDropZoneLabel,
   chatSplitQuadRows,
+  emitChatSessionDragEnd,
+  emitChatSessionDragStart,
   resolveChatDropZone,
   type ChatDropZone,
   type ChatSessionDragDetail,
@@ -159,9 +161,34 @@ export function ChatSplitHost({
     }
     return (
       <section className="chat-split__tile" aria-label={`${tile.title} (split pane)`}>
-        <header className="chat-split__pane-head">
+        {/* The header is the pane's drag handle: dragging it re-enters the
+            same session-drag protocol the thread rail uses, so the snap
+            overlay lights up and dropping MOVES the pane (the layout's
+            dedupe re-inserts an open session at the drop edge). Buttons
+            inside stay clickable — a drag only starts past the threshold. */}
+        <header
+          className="chat-split__pane-head"
+          draggable={enableDrop}
+          title={enableDrop ? "Drag to reposition this pane" : undefined}
+          onDragStart={(e) => {
+            e.dataTransfer.setData(CHAT_SESSION_DRAG_MIME, tile.id);
+            e.dataTransfer.effectAllowed = "move";
+            emitChatSessionDragStart({ sessionId: tile.id, title: tile.title });
+          }}
+          onDragEnd={() => emitChatSessionDragEnd()}
+        >
           <span className="chat-split__pane-title" title={tile.title}>
-            <Icon name="ph:chats-circle" width={13} height={13} aria-hidden />
+            {enableDrop ? (
+              <Icon
+                name="ph:dots-six-vertical"
+                className="chat-split__pane-grip"
+                width={13}
+                height={13}
+                aria-hidden
+              />
+            ) : (
+              <Icon name="ph:chats-circle" width={13} height={13} aria-hidden />
+            )}
             <span className="chat-split__pane-title-text">{tile.title}</span>
           </span>
           <span className="chat-split__pane-actions">

--- a/src/lib/chat-split.test.ts
+++ b/src/lib/chat-split.test.ts
@@ -14,6 +14,7 @@ import {
   dropSessionIntoChatSplit,
   emptyChatSplitLayout,
   hasChatSplit,
+  moveChatSplitPane,
   parsePersistedChatSplit,
   pruneChatSplitPanes,
   removeChatSplitPane,
@@ -286,4 +287,20 @@ test("chatSplitQuadRows deals a full split into 2×2 reading-order rows", () => 
   assert.equal(chatSplitQuadRows([CHAT_SPLIT_PRIMARY, "s1"]), null);
   assert.equal(chatSplitQuadRows([CHAT_SPLIT_PRIMARY, "s1", "s2"]), null);
   assert.equal(chatSplitQuadRows([]), null);
+});
+
+test("moveChatSplitPane swaps a pane with its neighbor, clamped at the edges", () => {
+  const layout = { axis: "row" as const, panes: [CHAT_SPLIT_PRIMARY, "s1", "s2"] };
+  // Forward: s1 swaps past s2.
+  assert.deepEqual(moveChatSplitPane(layout, "s1", 1).panes, [CHAT_SPLIT_PRIMARY, "s2", "s1"]);
+  // Back: s1 swaps ahead of the primary — strip order is presentation, not
+  // hierarchy, so the primary moves like any pane.
+  assert.deepEqual(moveChatSplitPane(layout, "s1", -1).panes, ["s1", CHAT_SPLIT_PRIMARY, "s2"]);
+  assert.deepEqual(moveChatSplitPane(layout, CHAT_SPLIT_PRIMARY, 1).panes, ["s1", CHAT_SPLIT_PRIMARY, "s2"]);
+  // Clamped no-ops return the SAME reference (state setters skip a render).
+  assert.equal(moveChatSplitPane(layout, CHAT_SPLIT_PRIMARY, -1), layout);
+  assert.equal(moveChatSplitPane(layout, "s2", 1), layout);
+  assert.equal(moveChatSplitPane(layout, "ghost", 1), layout, "unknown pane is a no-op");
+  // The axis rides along untouched.
+  assert.equal(moveChatSplitPane(layout, "s1", 1).axis, "row");
 });

--- a/src/lib/chat-split.ts
+++ b/src/lib/chat-split.ts
@@ -228,6 +228,27 @@ export function chatSplitKeyboardZone(layout: ChatSplitLayout): ChatDropZone {
   return layout.axis === "column" ? "bottom" : "right";
 }
 
+/**
+ * Move a pane one step along the strip (keyboard parity for the header
+ * drag): swaps it with its neighbor toward `delta`. Any pane — the primary
+ * included — can move; strip order is presentation, not hierarchy. Clamped
+ * at the edges (no wrap: "move left" at the far left is a no-op), and
+ * returns the SAME reference for every no-op so state setters skip renders.
+ */
+export function moveChatSplitPane(
+  layout: ChatSplitLayout,
+  paneId: string,
+  delta: -1 | 1,
+): ChatSplitLayout {
+  const index = layout.panes.indexOf(paneId);
+  if (index === -1) return layout;
+  const target = index + delta;
+  if (target < 0 || target >= layout.panes.length) return layout;
+  const panes = [...layout.panes];
+  [panes[index], panes[target]] = [panes[target]!, panes[index]!];
+  return { axis: layout.axis, panes };
+}
+
 // ── Persistence ──────────────────────────────────────────────────────────────
 
 /** localStorage key for the persisted split layout (main chat surface only). */


### PR DESCRIPTION
## What

Chat split panes can now be **repositioned by dragging their header** (and by keyboard).

- **Header = drag handle** — dragging a secondary pane's header re-enters the same session-drag protocol the thread rail uses (`CHAT_SESSION_DRAG_MIME` + start/end window events), so the existing snap overlay lights up with the edge previews and dropping **moves** the pane — `dropSessionIntoChatSplit` already dedupes an open session to the drop edge, so no new layout logic. Works in both the strip and the 2×2 quad grid.
- **Affordance** — grip glyph (`ph:dots-six-vertical`), `grab`/`grabbing` cursors, and a "Drag to reposition this pane" hint; headers are draggable exactly when the drop overlay is enabled. Promote/close buttons stay clickable (drags only start past the pointer threshold).
- **Keyboard parity** — ⌥⌘⇧←/→ (or ↑/↓) moves the **focused** pane one step along the strip via new pure `moveChatSplitPane` (neighbor swap; the primary moves like any pane — strip order is presentation, not hierarchy; clamped edges return the same reference so no-ops skip renders and announcements). Focus follows the moved pane.
- **Honest announcements** — a drop that repositions an open pane announces `pane moved <zone>` instead of `opened in a split pane`.

## Testing

- `chat-split.test.ts`: `moveChatSplitPane` behavioral cases — swap both directions, primary movement, clamped edges (same-reference no-op), unknown pane, axis untouched.
- `chat-split-host.test.ts`: pins for the drag protocol wiring (setData + emit start/end), enableDrop gating, grip + hint + grab cursor CSS, the shifted-arrow move branch, pure-swap usage, silent clamped edges, and the moved-vs-opened announcement split.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` green (704 files).

Bead: cave-xw0v