### PR TITLE
feat(covenwiki): Phase 1 outline+page skills + covenwiki-generate CLI (cave-whji)

### DIFF
--- a/.agents/skills/covenwiki-outline/SKILL.md
+++ b/.agents/skills/covenwiki-outline/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: covenwiki-outline
+description: Design the information architecture for a CovenWiki — a source-grounded wiki generated from one local repository. Takes a repo file inventory and README evidence as JSON; returns a strict JSON outline (pages, navigation, concepts, coverage notes). Used by the covenwiki-generate orchestrator (CovenWiki Route B Phase 1); not a general-purpose summarizer.
+---
+
+# CovenWiki Outline Generator
+
+You are the outline generator for CovenWiki, a source-cited documentation
+generator. You receive a repository's file inventory and README evidence as a
+JSON payload. You return **one JSON object** — the wiki outline — and nothing
+else. No prose before or after the JSON.
+
+A validator rejects your output mechanically. Every rule below marked *hard*
+is enforced in code; violating it fails the run.
+
+## Output contract (hard)
+
+Return exactly this shape:
+
+```json
+{
+  "title": "Human project title",
+  "summary": "One-to-three sentence source-grounded description of the project.",
+  "navigation": [
+    { "title": "Overview", "slug": "overview", "children": [] },
+    {
+      "title": "Core Concepts",
+      "slug": null,
+      "children": [
+        { "title": "Session Model", "slug": "session-model", "children": [] },
+        { "title": "Authority Boundary", "slug": "authority-boundary", "children": [] }
+      ]
+    }
+  ],
+  "pages": [
+    {
+      "slug": "overview",
+      "title": "Overview",
+      "purpose": "What this page answers for the reader.",
+      "priority": "required",
+      "sourcePaths": ["README.md", "package.json"]
+    }
+  ],
+  "concepts": ["session", "authority boundary"],
+  "coverageNotes": ["Anything under-evidenced or contradictory, stated plainly."]
+}
+```
+
+- `navigation` is a tree. **Group nodes have `slug: null` and at least 2
+  children** (hard — a folder-of-one is a lie about hierarchy). Leaf nodes
+  have a string `slug` and empty `children`.
+- **Every string navigation slug must be a page slug, and every page must be
+  reachable from navigation** (hard).
+- **Page slugs: stable, lowercase, URL-friendly** `a-z0-9` dash-separated
+  (hard). Never invent duplicate slugs (hard).
+- **Every `sourcePaths` entry must appear verbatim in `inventoryPaths`**
+  (hard). Never invent paths. Repository-relative only.
+- Each page's `priority` is `required`, `recommended`, or `optional` (hard).
+
+## Information architecture (the actual craft)
+
+1. **A documentation tree is a human plan, not a file listing.** The shape of
+   `src/` is a clue, not a spec. Never let repository structure force the
+   docs structure.
+2. **Prefer first-party docs shape when present.** If the inventory has
+   `docs/`, its section shape is the strongest IA signal. Preserve it; split
+   broad pages into focused leaves; do not collapse it.
+3. **Source paths are evidence for claims, not the outline itself.**
+   Structure comes from reader tasks.
+4. **A page explains a system, workflow, or API surface.** Not a folder. Not
+   a file. A page is a unit of understanding.
+5. **Ignore internal planning/status docs** when selecting pages: nothing
+   from `docs/active/`, `docs/completed/`, feedback notes, gap analyses,
+   implementation plans, audit reports. Use source code, README, package
+   metadata, and reader-facing docs.
+6. **Always include a root Overview page, slug `overview`, priority
+   `required`** (hard). Overview is a table of contents in prose — if a topic
+   deserves depth, give it its own page, don't compress it into Overview.
+7. **No one-page-per-folder.** A folder maps to a page only when it is itself
+   a system boundary (`agent/subagents/` yes; `components/` no).
+8. **No one-page-per-example / per-test / per-config-file.** Group into
+   conceptual pages (Examples and Usage Patterns, Testing Infrastructure,
+   Build Configuration).
+
+## Size discipline (hard ceiling; use `pageBudget` from the input)
+
+| Scale in input | Pages | Shape |
+|---|---|---|
+| `compact` (<25 files) | 3–4 | Overview, API Surface, Runtime Behavior and Edge Cases, Testing and Release Signals |
+| `small` (<50) | 3–5 | Overview + a few focused subsystem pages |
+| `medium` (few hundred) | 6–10 | Major subsystems, each an independent reader task |
+| `large` (framework/monorepo) | 16–48 | Major subsystems across package/app/crate/doc/test/build boundaries |
+
+- Compact packages must not fragment. Hard minimum 3 pages when the
+  inventory has source plus metadata/tests/docs.
+- Use the high end only when each page maps to an independently useful
+  reader task. No filler pages.
+- For docs-rich agent frameworks, do not compress documented primitives into
+  one generic "Architecture" page — give focused leaves (instructions, tools,
+  skills, channels, sandbox, schedules, sessions, CLI…) grouped under section
+  nodes: Start Here → Core Concepts → Runtime Capabilities → Reference.
+
+## Evidence honesty
+
+- Say when evidence is thin — in `coverageNotes`, per topic. Do not paper
+  over gaps with confident prose.
+- Contradictions in evidence go in `coverageNotes`, not silently resolved.
+- The `summary` must be defensible from the README excerpt and inventory
+  alone. No marketing language the evidence doesn't support.
+
+## Input
+
+You receive (after this skill text) a `## Repository input` JSON block:
+`repoName`, `repoRoot`, `scale`, `pageBudget` `[min, max]`, `wordTarget`,
+`fileCount`, `inventoryPaths` (repo-relative, possibly truncated — see
+`inventoryTruncated`), `readmeExcerpt`. Choose `sourcePaths` per page that
+the page skill will hydrate as evidence: pick the 2–8 most load-bearing
+files per page.

--- a/.agents/skills/covenwiki-page/SKILL.md
+++ b/.agents/skills/covenwiki-page/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: covenwiki-page
+description: Write one source-cited CovenWiki page from an outline entry plus hydrated source evidence. Takes page spec, outline context, and source excerpts as JSON; returns strict JSON (markdown, citations, coverageNotes, relatedPages). Used by the covenwiki-generate orchestrator (CovenWiki Route B Phase 1); every claim must cite hydrated evidence.
+---
+
+# CovenWiki Page Generator
+
+You write **one wiki page** from an outline entry and hydrated source
+evidence. You return **one JSON object** and nothing else. No prose before or
+after the JSON.
+
+A validator rejects your output mechanically. Rules marked *hard* are
+enforced in code.
+
+## Output contract (hard)
+
+```json
+{
+  "slug": "session-model",
+  "title": "Session Model",
+  "markdown": "# Session Model\n\nIntro paragraph…\n\n## Relevant source files\n\n- `src/session.rs`\n…",
+  "citations": [
+    { "path": "src/session.rs", "startLine": 12, "endLine": 48 },
+    { "path": "README.md", "startLine": null, "endLine": null }
+  ],
+  "coverageNotes": ["Evidence gaps or contradictions, stated plainly."],
+  "relatedPages": ["overview", "authority-boundary"]
+}
+```
+
+- `slug` must equal the requested page's slug (hard).
+- `markdown` must start with `# Title` (hard), followed by a short
+  source-grounded introduction, then a `## Relevant source files` section
+  listing the most important paths for this page.
+- **Every citation `path` must appear verbatim in the hydrated evidence /
+  file inventory** (hard). Repository-relative paths only — no absolute
+  paths, no URLs (hard). At least one citation per page (hard).
+- **Cite line ranges when you can point at the exact lines in the provided
+  excerpt; otherwise set `startLine`/`endLine` to `null`. Never guess line
+  numbers** (hard: integers must be ≥ 1 or null).
+- `relatedPages` may only reference slugs from the provided outline, never
+  the page itself (hard).
+
+## Writing the page
+
+1. **Every concrete claim needs support in the provided evidence.** You have
+   already been given all the evidence you get — the excerpts in the input.
+   Do not invent behavior, options, or APIs the excerpts don't show.
+2. **Use sections that match the page's purpose:** Purpose and Scope ·
+   System-to-Code Mapping · Core Concepts · Execution Flow · API Components ·
+   Implementation Details · Testing Signals · Summary. Include only sections
+   the evidence supports.
+3. **Reference-like pages must state concrete source-level contracts:**
+   exported names, options, commands, config fields, route patterns, runtime
+   phases — all from evidence.
+4. **Prose means paragraphs.** Hit the `wordTarget` with 60–120-word
+   paragraphs that survive removing every table, code fence, path list, and
+   `Sources:` line. Tables are welcome for scanability (concept-to-path
+   mappings, config summaries) but never substitute for prose.
+5. **No line-by-line code commentary.** A wiki is not a code annotation.
+6. **No raw file lists** outside the `## Relevant source files` section.
+   Grouping is the whole job.
+7. **Thin evidence ⇒ shorter page + explicit `coverageNotes`.** Do not pad
+   with filler to hit the word target; expand only with source-backed
+   content (workflow steps, config explanations, system-to-code mapping).
+8. **Contradictions in evidence go in `coverageNotes`**, not silently
+   resolved.
+9. **Do not call tools.** All hydration already happened; work only from the
+   input payload.
+
+## Input
+
+You receive (after this skill text) a `## Page input` JSON block: `page`
+(slug, title, purpose, priority), `wordTarget` `[lo, hi]` (prose words),
+`outline` (title, summary, all page slugs/titles/purposes — for
+`relatedPages` and to avoid duplicating sibling pages' scope), and
+`evidence` (array of `{ path, totalLines, excerpt }`; excerpts may be
+truncated).

--- a/docs/covenwiki-manifest.schema.json
+++ b/docs/covenwiki-manifest.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CovenWiki manifest.json",
+  "description": "Render contract for a generated CovenWiki (Route B). A wiki resolves as <wikis-dir>/<slug>/manifest.json (default ~/.coven/wikis); manifest.slug must equal the wiki directory name. The Phase 2 coven-cave route reads only this file for the shell (title, summary, nav tree, page list, badges) and loads pages/<slug>.md + pages/<slug>.meta.json lazily per page. The Phase 3 regen hook (scripts/covenwiki-regen.ts) compares source.fingerprint against a live stat digest. Emitted by scripts/covenwiki-generate.ts; changes must stay additive or bump schemaVersion.",
+  "type": "object",
+  "required": ["schemaVersion", "slug", "title", "source", "generation", "navigation", "pages", "counts"],
+  "properties": {
+    "schemaVersion": { "type": "string", "const": "1.0" },
+    "generator": { "type": "string" },
+    "generatorVersion": { "type": "string" },
+    "slug": { "type": "string", "description": "== [repo] route segment == wiki dir name" },
+    "title": { "type": "string" },
+    "summary": { "type": "string" },
+    "index": { "type": "string", "description": "relative path to human index, e.g. index.md" },
+    "source": {
+      "type": "object",
+      "required": ["kind", "fingerprint"],
+      "properties": {
+        "kind": { "enum": ["local", "github"], "description": "github is Phase 5" },
+        "repoRoot": { "type": ["string", "null"] },
+        "revision": { "type": ["string", "null"], "description": "git sha when known; null in v0 local" },
+        "fingerprint": {
+          "type": ["string", "null"],
+          "description": "16-hex stat digest over the sorted source inventory (path+size+mtime); Phase 3 staleness key. Reference implementation: computeSourceFingerprint in src/lib/covenwiki-regen.ts over statInventory in scripts/covenwiki-fs.ts — shared by generator and regen hook."
+        },
+        "fileCount": { "type": ["integer", "null"] }
+      }
+    },
+    "generation": {
+      "type": "object",
+      "required": ["generatedAt", "backend", "status"],
+      "properties": {
+        "generatedAt": { "type": "string", "description": "ISO-8601 UTC, e.g. 2026-07-03T12:09:52Z" },
+        "backend": { "enum": ["stub", "cli"] },
+        "scale": { "type": ["string", "null"], "enum": ["compact", "small", "medium", "large", null] },
+        "status": { "enum": ["stub", "complete", "partial"], "description": "stub => draft/placeholder prose" },
+        "models": {
+          "type": "object",
+          "properties": { "outline": { "type": "string" }, "page": { "type": "string" } }
+        },
+        "wordTarget": {
+          "type": ["array", "null"],
+          "items": { "type": "integer" },
+          "description": "[lo, hi] prose target for this scale; use to badge under-target pages"
+        }
+      }
+    },
+    "navigation": { "$ref": "#/definitions/navNodeList" },
+    "concepts": { "type": "array" },
+    "pages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slug", "title", "path", "meta", "priority"],
+        "properties": {
+          "slug": { "type": "string" },
+          "title": { "type": "string" },
+          "purpose": { "type": "string" },
+          "priority": { "enum": ["required", "recommended", "optional"] },
+          "path": { "type": "string", "description": "relative, e.g. pages/overview.md" },
+          "meta": { "type": "string", "description": "relative, e.g. pages/overview.meta.json; holds citations/coverageNotes/relatedPages so page loads stay lazy" },
+          "sourcePaths": { "type": "array", "items": { "type": "string" } },
+          "wordCount": { "type": "integer", "description": "prose-only words; compare to generation.wordTarget" }
+        }
+      }
+    },
+    "counts": {
+      "type": "object",
+      "properties": {
+        "pages": { "type": "integer" },
+        "required": { "type": "integer" },
+        "recommended": { "type": "integer" },
+        "optional": { "type": "integer" }
+      }
+    }
+  },
+  "definitions": {
+    "navNodeList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "slug", "children"],
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": ["string", "null"], "description": "null => folder/group header (non-navigable), needs >= 2 children; string => leaf page link" },
+          "children": { "$ref": "#/definitions/navNodeList" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/covenwiki-fs.ts
+++ b/scripts/covenwiki-fs.ts
@@ -1,0 +1,44 @@
+// CovenWiki shared filesystem helpers (Phase 1, cave-whji).
+//
+// Extracted from scripts/covenwiki-regen.ts so both sides of the Phase 3
+// staleness contract share ONE walk and ONE stat inventory: the
+// `source.fingerprint` a generator writes into manifest.json and the live
+// fingerprint `covenwiki-regen status` computes must be built from an
+// identical inventory, or every wiki reads as permanently "stale". Sharing
+// the implementation makes the parity structural instead of aspirational
+// (see the computeSourceFingerprint contract note in src/lib/covenwiki-regen.ts).
+
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import type { StatEntry } from "../src/lib/covenwiki-regen.ts";
+
+/** Directories never counted as wiki source (build output, deps, VCS). */
+export const SKIP_DIRS = new Set([".git", "node_modules", ".worktrees", ".next", "target"]);
+
+/** Recursively collect file paths under root, skipping hidden dirs + SKIP_DIRS. */
+export function walk(root: string, out: string[]): void {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") && entry.isDirectory()) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.isFile()) out.push(full);
+  }
+}
+
+/**
+ * Stat-only inventory of a repo root — the exact input of the Phase 3
+ * fingerprint contract (repo-relative POSIX paths + size + mtimeMs).
+ */
+export function statInventory(repoRoot: string): StatEntry[] {
+  const files: string[] = [];
+  walk(repoRoot, files);
+  return files.map((file) => {
+    const st = statSync(file);
+    return {
+      path: path.relative(repoRoot, file).split(path.sep).join("/"),
+      size: st.size,
+      mtimeMs: st.mtimeMs,
+    };
+  });
+}

--- a/scripts/covenwiki-generate-cli.test.mjs
+++ b/scripts/covenwiki-generate-cli.test.mjs
@@ -1,0 +1,227 @@
+// End-to-end coverage for the CovenWiki Phase 1 generator CLI
+// (scripts/covenwiki-generate.ts): stub generation produces the full wiki
+// contract, the emitted fingerprint reads as "fresh" through the Phase 3
+// regen hook (the parity gate), the regen regenerate round-trip works with
+// this generator, the cli backend drives the two skills through a fake model
+// command, and rule-violating model output fails closed with no wiki written.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dir = mkdtempSync(path.join(tmpdir(), "covenwiki-generate-cli-"));
+const repoDir = path.join(dir, "repo");
+const wikisDir = path.join(dir, "wikis");
+const wikiDir = path.join(wikisDir, "testrepo");
+const fakeModelScript = path.join(dir, "fake-model.mjs");
+const repoRootUrl = new URL("..", import.meta.url);
+
+function writeRepo() {
+  mkdirSync(path.join(repoDir, "src"), { recursive: true });
+  mkdirSync(path.join(repoDir, "tests"), { recursive: true });
+  mkdirSync(path.join(repoDir, "docs"), { recursive: true });
+  writeFileSync(path.join(repoDir, "README.md"), "# testrepo\n\nA fixture repository for covenwiki tests.\n");
+  writeFileSync(path.join(repoDir, "package.json"), '{ "name": "testrepo", "version": "1.0.0" }\n');
+  writeFileSync(path.join(repoDir, "src", "main.ts"), "export const main = () => 1;\n");
+  writeFileSync(path.join(repoDir, "src", "util.ts"), "export const util = () => 2;\n");
+  writeFileSync(path.join(repoDir, "tests", "main.test.ts"), "// test fixture\n");
+  writeFileSync(path.join(repoDir, "docs", "guide.md"), "# Guide\n");
+}
+
+// Fake model: reads the composed skill prompt on stdin, parses the input
+// payload out of the trailing ```json block, and answers the outline or page
+// contract. FAKE_MODEL_MODE=bad-outline emits a folder-of-one + invented path.
+writeFileSync(
+  fakeModelScript,
+  `const chunks = [];
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", () => {
+  const prompt = Buffer.concat(chunks).toString("utf8");
+  const fences = [...prompt.matchAll(/\\u0060\\u0060\\u0060json\\n([\\s\\S]*?)\\n\\u0060\\u0060\\u0060/g)];
+  const payload = JSON.parse(fences[fences.length - 1][1]);
+  const mode = process.env.FAKE_MODEL_MODE ?? "ok";
+  if (prompt.includes("## Repository input")) {
+    if (mode === "bad-outline") {
+      console.log(JSON.stringify({
+        title: payload.repoName,
+        summary: "Bad outline.",
+        navigation: [
+          { title: "Overview", slug: "overview", children: [] },
+          { title: "Lonely Group", slug: null, children: [{ title: "Only", slug: "only-child", children: [] }] },
+        ],
+        pages: [
+          { slug: "overview", title: "Overview", purpose: "Entry.", priority: "required", sourcePaths: ["README.md"] },
+          { slug: "only-child", title: "Only", purpose: "x.", priority: "optional", sourcePaths: ["invented/path.ts"] },
+        ],
+        concepts: [],
+        coverageNotes: [],
+      }));
+      return;
+    }
+    const src = payload.inventoryPaths.filter((p) => p.startsWith("src/"));
+    console.log("Sure — here is the outline:\\n\\u0060\\u0060\\u0060json\\n" + JSON.stringify({
+      title: payload.repoName,
+      summary: "A fixture repository documented by the fake model.",
+      navigation: [
+        { title: "Overview", slug: "overview", children: [] },
+        { title: "Source Layout", slug: "source-layout", children: [] },
+        { title: "Documentation Guide", slug: "documentation-guide", children: [] },
+      ],
+      pages: [
+        { slug: "overview", title: "Overview", purpose: "Entry point.", priority: "required", sourcePaths: ["README.md", "package.json"] },
+        { slug: "source-layout", title: "Source Layout", purpose: "Source map.", priority: "recommended", sourcePaths: src },
+        { slug: "documentation-guide", title: "Documentation Guide", purpose: "Docs tour.", priority: "optional", sourcePaths: ["docs/guide.md"] },
+      ],
+      concepts: ["fixture"],
+      coverageNotes: [],
+    }) + "\\n\\u0060\\u0060\\u0060\\nDone!");
+    return;
+  }
+  const evidence = payload.evidence.map((e) => e.path);
+  const others = payload.outline.pages.map((p) => p.slug).filter((s) => s !== payload.page.slug);
+  console.log(JSON.stringify({
+    slug: payload.page.slug,
+    title: payload.page.title,
+    markdown: "# " + payload.page.title + "\\n\\nFake-model prose grounded in the provided excerpts.\\n\\n## Relevant source files\\n\\n" + evidence.map((p) => "- \\u0060" + p + "\\u0060").join("\\n") + "\\n",
+    citations: evidence.map((p) => ({ path: p, startLine: 1, endLine: 1 })),
+    coverageNotes: [],
+    relatedPages: others.slice(0, 2),
+  }));
+});
+`,
+);
+
+function runGenerate(args, env = {}) {
+  return spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", "scripts/covenwiki-generate.ts", "generate", ...args],
+    { cwd: repoRootUrl, encoding: "utf8", env: { ...process.env, ...env } },
+  );
+}
+
+function runRegen(args) {
+  return spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", "scripts/covenwiki-regen.ts", ...args, "--wikis-dir", wikisDir],
+    { cwd: repoRootUrl, encoding: "utf8" },
+  );
+}
+
+function readJson(...segments) {
+  return JSON.parse(readFileSync(path.join(...segments), "utf8"));
+}
+
+/** Parse the last top-level JSON object in mixed stdout (regen inherits the generator's stdout). */
+function tailJson(text) {
+  const idx = text.lastIndexOf("\n{");
+  return JSON.parse(text.slice(idx === -1 ? 0 : idx + 1));
+}
+
+try {
+  writeRepo();
+
+  // ── stub generation writes the full wiki contract ──
+  let result = runGenerate(["--repo", repoDir, "--out", wikiDir, "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.slug, "testrepo");
+  assert.equal(summary.backend, "stub");
+  assert.equal(summary.status, "stub");
+  assert.match(summary.fingerprint, /^[0-9a-f]{16}$/);
+
+  const manifest = readJson(wikiDir, "manifest.json");
+  assert.equal(manifest.schemaVersion, "1.0");
+  assert.equal(manifest.slug, "testrepo");
+  assert.equal(manifest.source.kind, "local");
+  assert.equal(manifest.source.fingerprint, summary.fingerprint);
+  assert.equal(manifest.counts.pages, manifest.pages.length);
+  assert.ok(manifest.pages.length >= 3, "stub wiki should have >= 3 pages for this fixture");
+  assert.ok(existsSync(path.join(wikiDir, "index.md")));
+  for (const page of manifest.pages) {
+    assert.ok(existsSync(path.join(wikiDir, page.path)), `missing ${page.path}`);
+    const meta = readJson(wikiDir, page.meta);
+    assert.equal(meta.slug, page.slug);
+    assert.ok(Array.isArray(meta.citations) && meta.citations.length >= 1);
+  }
+
+  // _citations.json: bySource/byPage reverse lookup is mutually consistent.
+  const citations = readJson(wikiDir, "_citations.json");
+  assert.equal(citations.schemaVersion, "1.0");
+  assert.ok(Object.keys(citations.bySource).length > 0);
+  for (const [source, slugs] of Object.entries(citations.bySource)) {
+    for (const slug of slugs) {
+      assert.ok(citations.byPage[slug].some((c) => c.path === source));
+    }
+  }
+
+  // ── the parity gate: the regen hook reads the fresh wiki as "fresh" ──
+  result = runRegen(["status", "testrepo", "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  let status = JSON.parse(result.stdout);
+  assert.equal(status.freshness, "fresh", `expected fresh, got: ${status.reason}`);
+  assert.equal(status.fingerprint.manifest, status.fingerprint.live);
+
+  // ── refuses to overwrite without --force ──
+  result = runGenerate(["--repo", repoDir, "--out", wikiDir]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--force/);
+
+  // ── regen round-trip: source change => stale => regenerate via this CLI ──
+  writeFileSync(path.join(repoDir, "src", "extra.ts"), "export const extra = 3;\n");
+  status = JSON.parse(runRegen(["status", "testrepo", "--json"]).stdout);
+  assert.equal(status.freshness, "stale");
+
+  const generatorTemplate = `${JSON.stringify(process.execPath)} --experimental-strip-types scripts/covenwiki-generate.ts generate --repo {repo} --out {out}`;
+  result = runRegen(["regenerate", "testrepo", "--json", "--generator", generatorTemplate]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(tailJson(result.stdout).action, "regenerated");
+  status = JSON.parse(runRegen(["status", "testrepo", "--json"]).stdout);
+  assert.equal(status.freshness, "fresh", `round-trip should end fresh, got: ${status.reason}`);
+  assert.ok(readJson(wikiDir, "manifest.json").pages.some((p) => p.slug === "source-layout"));
+
+  // ── cli backend: fake model drives outline + page skills ──
+  const cliWikiDir = path.join(wikisDir, "testrepo-cli");
+  const modelCmd = `${JSON.stringify(process.execPath)} ${JSON.stringify(fakeModelScript)}`;
+  result = runGenerate(
+    ["--repo", repoDir, "--out", cliWikiDir, "--backend", "cli", "--model-cmd", modelCmd, "--json"],
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).status, "complete");
+  const cliManifest = readJson(cliWikiDir, "manifest.json");
+  assert.equal(cliManifest.generation.backend, "cli");
+  assert.equal(cliManifest.generation.status, "complete");
+  assert.deepEqual(
+    cliManifest.pages.map((p) => p.slug),
+    ["overview", "source-layout", "documentation-guide"],
+  );
+  assert.match(readFileSync(path.join(cliWikiDir, "pages", "overview.md"), "utf8"), /Fake-model prose/);
+  const overviewMeta = readJson(cliWikiDir, "pages", "overview.meta.json");
+  assert.equal(overviewMeta.citations[0].startLine, 1);
+
+  // env-var backend selection matches the handoff doc invocation.
+  const envWikiDir = path.join(wikisDir, "testrepo-env");
+  result = runGenerate(["--repo", repoDir, "--out", envWikiDir], { COVENWIKI_MODEL_BACKEND: "stub" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(readJson(envWikiDir, "manifest.json").generation.backend, "stub");
+
+  // ── fail-closed: rule-violating model output writes nothing ──
+  const badWikiDir = path.join(wikisDir, "testrepo-bad");
+  result = runGenerate(
+    ["--repo", repoDir, "--out", badWikiDir, "--backend", "cli", "--model-cmd", modelCmd],
+    { FAKE_MODEL_MODE: "bad-outline" },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /outline failed validation/);
+  assert.match(result.stderr, /folder-of-one|not in the file inventory/);
+  assert.ok(!existsSync(badWikiDir), "failed run must not leave a wiki behind");
+  assert.deepEqual(
+    readdirSync(wikisDir).filter((name) => name.includes("testrepo-bad")),
+    [],
+    "failed run must not leave staging dirs behind",
+  );
+
+  console.log("covenwiki-generate CLI e2e: all assertions passed");
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/scripts/covenwiki-generate.ts
+++ b/scripts/covenwiki-generate.ts
@@ -1,0 +1,468 @@
+#!/usr/bin/env node --experimental-strip-types
+// CovenWiki v0 Phase 1 — generator CLI (Route B, cave-whji).
+//
+// The orchestrator from the plan §4 Phase 1: reads a local repo, hydrates
+// evidence, runs the covenwiki-outline + covenwiki-page skills (or the
+// deterministic stub backend), validates fail-closed, and writes the wiki:
+//
+//   <out>/manifest.json          render contract (docs/covenwiki-manifest.schema.json)
+//   <out>/index.md               human index
+//   <out>/pages/<slug>.md        page prose
+//   <out>/pages/<slug>.meta.json citations / coverageNotes / relatedPages
+//   <out>/_citations.json        source⇄page reverse lookup (Phase 3 incremental regen)
+//
+// Backends:
+//   stub  deterministic, no model — real structure, placeholder prose
+//   cli   pipes each skill prompt to --model-cmd (stdin) and parses the JSON reply
+//
+// Fingerprint parity: source.fingerprint is computeSourceFingerprint from
+// src/lib/covenwiki-regen.ts over statInventory from scripts/covenwiki-fs.ts —
+// the exact code path `covenwiki-regen status` uses, so a freshly generated
+// wiki always reads as "fresh".
+//
+// Slug rule (render contract): manifest.slug == wiki directory name. A
+// trailing ".tmp" on --out is stripped so `covenwiki-regen regenerate` can
+// build into <wiki>.tmp and atomically swap.
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeSourceFingerprint, validateWikiManifest } from "../src/lib/covenwiki-regen.ts";
+import {
+  buildCitationsIndex,
+  buildIndexMarkdown,
+  buildStubOutline,
+  buildStubPage,
+  buildWikiManifestData,
+  extractJsonPayload,
+  scaleForInventory,
+  slugify,
+  validateOutline,
+  validatePageDoc,
+  PAGE_BUDGETS,
+  WORD_TARGETS,
+  type Outline,
+  type OutlinePage,
+  type PageDoc,
+  type Scale,
+} from "../src/lib/covenwiki-generate.ts";
+import { statInventory } from "./covenwiki-fs.ts";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_SKILLS_DIR = path.join(SCRIPT_DIR, "..", ".agents", "skills");
+const DEFAULT_WIKIS_DIR = path.join(homedir(), ".coven", "wikis");
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const EVIDENCE_MAX_FILES_PER_PAGE = 8;
+const EVIDENCE_MAX_CHARS_PER_FILE = 12_000;
+const EVIDENCE_MAX_CHARS_PER_PAGE = 48_000;
+const INVENTORY_MAX_PATHS_IN_PROMPT = 1_500;
+
+type Backend = "stub" | "cli";
+
+type Options = {
+  repo: string;
+  out: string | null;
+  slug: string | null;
+  backend: Backend;
+  modelCmd: string | null;
+  skillsDir: string;
+  force: boolean;
+  json: boolean;
+};
+
+function printHelp() {
+  console.log(`Usage: node --experimental-strip-types scripts/covenwiki-generate.ts generate --repo <path> [options]
+
+Generates a source-cited wiki for one local repo (CovenWiki Route B Phase 1).
+
+Options:
+  --repo <path>        repo root to document (required)
+  --out <dir>          output wiki directory (default: ~/.coven/wikis/<slug>;
+                       a trailing ".tmp" is stripped from the slug so the
+                       Phase 3 regen hook can build into <wiki>.tmp)
+  --slug <slug>        wiki slug (default: derived from --out or --repo)
+  --backend <b>        stub | cli (default: $COVENWIKI_MODEL_BACKEND or stub)
+  --model-cmd <cmd>    (cli) shell command run per skill call; receives the
+                       prompt on stdin, must print a JSON payload
+                       (default: $COVENWIKI_MODEL_CMD)
+  --skills-dir <dir>   where covenwiki-outline/ + covenwiki-page/ SKILL.md live
+                       (default: <repo checkout>/.agents/skills)
+  --force              replace an existing wiki at --out (atomic swap)
+  --json               print a machine-readable run summary
+  -h, --help           show this help`);
+}
+
+function parseArgs(argv: string[]): Options {
+  const first = argv[0];
+  if (!first || first === "-h" || first === "--help") {
+    printHelp();
+    process.exit(first ? 0 : 1);
+  }
+  if (first !== "generate") throw new Error(`unknown command: ${first} (expected generate)`);
+  const envBackend = process.env.COVENWIKI_MODEL_BACKEND;
+  const opts: Options = {
+    repo: "",
+    out: null,
+    slug: null,
+    backend: envBackend === "cli" ? "cli" : "stub",
+    modelCmd: process.env.COVENWIKI_MODEL_CMD ?? null,
+    skillsDir: DEFAULT_SKILLS_DIR,
+    force: false,
+    json: false,
+  };
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--repo":
+        opts.repo = requireValue(argv, ++i, arg);
+        break;
+      case "--out":
+        opts.out = requireValue(argv, ++i, arg);
+        break;
+      case "--slug":
+        opts.slug = requireValue(argv, ++i, arg);
+        break;
+      case "--backend": {
+        const value = requireValue(argv, ++i, arg);
+        if (value !== "stub" && value !== "cli") throw new Error(`--backend must be stub or cli, got: ${value}`);
+        opts.backend = value;
+        break;
+      }
+      case "--model-cmd":
+        opts.modelCmd = requireValue(argv, ++i, arg);
+        break;
+      case "--skills-dir":
+        opts.skillsDir = requireValue(argv, ++i, arg);
+        break;
+      case "--force":
+        opts.force = true;
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unsupported argument: ${arg}`);
+    }
+  }
+  if (!opts.repo) throw new Error("generate requires --repo <path>");
+  if (opts.backend === "cli" && !opts.modelCmd) {
+    throw new Error("--backend cli requires --model-cmd (or $COVENWIKI_MODEL_CMD)");
+  }
+  return opts;
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value === undefined) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+/** manifest.slug == wiki dir name; strip regen's ".tmp" staging suffix. */
+function resolveSlug(opts: Options, repoRoot: string): string {
+  if (opts.slug) {
+    if (!SLUG_RE.test(opts.slug)) throw new Error(`--slug must be lowercase URL-friendly, got: ${opts.slug}`);
+    return opts.slug;
+  }
+  if (opts.out) {
+    const base = path.basename(path.resolve(opts.out)).replace(/\.tmp$/, "");
+    if (!SLUG_RE.test(base)) {
+      throw new Error(`cannot derive a slug from --out directory "${base}" — pass --slug <slug>`);
+    }
+    return base;
+  }
+  return slugify(path.basename(repoRoot));
+}
+
+// ─── Skill invocation (cli backend) ─────────────────────────────────────────
+
+function loadSkill(skillsDir: string, name: string): string {
+  const skillPath = path.join(skillsDir, name, "SKILL.md");
+  if (!existsSync(skillPath)) {
+    throw new Error(`skill not found: ${skillPath} (pass --skills-dir)`);
+  }
+  return readFileSync(skillPath, "utf8");
+}
+
+function buildPrompt(skillText: string, inputLabel: string, payload: unknown): string {
+  return [
+    skillText.trim(),
+    "",
+    "---",
+    "",
+    `## ${inputLabel}`,
+    "",
+    "```json",
+    JSON.stringify(payload, null, 2),
+    "```",
+    "",
+    "Return ONLY the JSON object described in the output contract above.",
+  ].join("\n");
+}
+
+function invokeModel(modelCmd: string, prompt: string, label: string): unknown {
+  const result = spawnSync(modelCmd, {
+    shell: true,
+    input: prompt,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(`model command failed for ${label} (exit ${result.status ?? "signal"})${stderr ? `: ${stderr.slice(0, 400)}` : ""}`);
+  }
+  try {
+    return extractJsonPayload(result.stdout ?? "");
+  } catch (error) {
+    throw new Error(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+type Evidence = { path: string; totalLines: number; excerpt: string };
+
+/** Read page sources from disk, capped per file and per page (IA rule 39: hydrate before drafting). */
+function hydrateEvidence(repoRoot: string, sourcePaths: string[]): Evidence[] {
+  const evidence: Evidence[] = [];
+  let budget = EVIDENCE_MAX_CHARS_PER_PAGE;
+  for (const src of sourcePaths.slice(0, EVIDENCE_MAX_FILES_PER_PAGE)) {
+    if (budget <= 0) break;
+    let text: string;
+    try {
+      text = readFileSync(path.join(repoRoot, src), "utf8");
+    } catch {
+      continue; // unreadable/binary sources are simply not evidence
+    }
+    if (text.includes("\u0000")) continue;
+    const cap = Math.min(EVIDENCE_MAX_CHARS_PER_FILE, budget);
+    const excerpt = text.length > cap ? `${text.slice(0, cap)}\n… (truncated)` : text;
+    budget -= excerpt.length;
+    evidence.push({ path: src, totalLines: text.split("\n").length, excerpt });
+  }
+  return evidence;
+}
+
+function readmeExcerpt(repoRoot: string, inventoryPaths: string[]): string | null {
+  const readme = inventoryPaths.find((p) => /^readme\.md$/i.test(p));
+  if (!readme) return null;
+  try {
+    return readFileSync(path.join(repoRoot, readme), "utf8").slice(0, 4_000);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Pipeline ────────────────────────────────────────────────────────────────
+
+type Pipeline = {
+  outline: Outline;
+  pages: PageDoc[];
+};
+
+function runStubPipeline(repoName: string, inventoryPaths: string[], scale: Scale): Pipeline {
+  const outline = buildStubOutline({ repoName, inventoryPaths });
+  const outlineErrors = validateOutline(outline, { inventoryPaths, scale });
+  if (outlineErrors.length > 0) {
+    throw new Error(`stub outline failed validation: ${outlineErrors.join("; ")}`);
+  }
+  const pages = outline.pages.map((page) => buildStubPage(page, outline));
+  failOnPageErrors(pages, outline, inventoryPaths, 1);
+  return { outline, pages };
+}
+
+function runCliPipeline(
+  opts: Options,
+  repoRoot: string,
+  repoName: string,
+  inventoryPaths: string[],
+  scale: Scale,
+): Pipeline {
+  const outlineSkill = loadSkill(opts.skillsDir, "covenwiki-outline");
+  const pageSkill = loadSkill(opts.skillsDir, "covenwiki-page");
+  const modelCmd = opts.modelCmd!;
+
+  const inventoryForPrompt = inventoryPaths.slice(0, INVENTORY_MAX_PATHS_IN_PROMPT);
+  const outlinePayload = {
+    repoName,
+    repoRoot,
+    scale,
+    pageBudget: PAGE_BUDGETS[scale],
+    wordTarget: WORD_TARGETS[scale],
+    fileCount: inventoryPaths.length,
+    inventoryTruncated: inventoryPaths.length > inventoryForPrompt.length,
+    inventoryPaths: inventoryForPrompt,
+    readmeExcerpt: readmeExcerpt(repoRoot, inventoryPaths),
+  };
+  const outlineRaw = invokeModel(modelCmd, buildPrompt(outlineSkill, "Repository input", outlinePayload), "covenwiki-outline");
+  const outlineErrors = validateOutline(outlineRaw, { inventoryPaths, scale });
+  if (outlineErrors.length > 0) {
+    throw new Error(`outline failed validation: ${outlineErrors.join("; ")}`);
+  }
+  const outline = outlineRaw as Outline;
+
+  const pageSlugs = outline.pages.map((p) => p.slug);
+  const pages: PageDoc[] = [];
+  for (const page of outline.pages) {
+    const payload = {
+      page: { slug: page.slug, title: page.title, purpose: page.purpose, priority: page.priority },
+      wordTarget: WORD_TARGETS[scale],
+      outline: {
+        title: outline.title,
+        summary: outline.summary,
+        pages: outline.pages.map((p) => ({ slug: p.slug, title: p.title, purpose: p.purpose })),
+      },
+      evidence: hydrateEvidence(repoRoot, page.sourcePaths),
+    };
+    const raw = invokeModel(modelCmd, buildPrompt(pageSkill, "Page input", payload), `covenwiki-page ${page.slug}`);
+    const errors = validatePageDoc(raw, { inventoryPaths, pageSlugs, minCitations: 1 });
+    if (errors.length > 0) {
+      throw new Error(`page "${page.slug}" failed validation: ${errors.join("; ")}`);
+    }
+    const doc = raw as PageDoc;
+    if (doc.slug !== page.slug) {
+      throw new Error(`page skill returned slug "${doc.slug}" for requested page "${page.slug}"`);
+    }
+    pages.push(doc);
+  }
+  return { outline, pages };
+}
+
+function failOnPageErrors(pages: PageDoc[], outline: Outline, inventoryPaths: string[], minCitations: number): void {
+  const pageSlugs = outline.pages.map((p) => p.slug);
+  for (const page of pages) {
+    const errors = validatePageDoc(page, { inventoryPaths, pageSlugs, minCitations });
+    if (errors.length > 0) {
+      throw new Error(`page "${page.slug}" failed validation: ${errors.join("; ")}`);
+    }
+  }
+}
+
+// ─── Output ──────────────────────────────────────────────────────────────────
+
+function writeWiki(outDir: string, pipeline: Pipeline, manifest: ReturnType<typeof buildWikiManifestData>): void {
+  mkdirSync(path.join(outDir, "pages"), { recursive: true });
+  writeFileSync(path.join(outDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  writeFileSync(path.join(outDir, "index.md"), buildIndexMarkdown(manifest));
+  writeFileSync(
+    path.join(outDir, "_citations.json"),
+    `${JSON.stringify(buildCitationsIndex(pipeline.pages, manifest.generation.generatedAt), null, 2)}\n`,
+  );
+  for (const page of pipeline.pages) {
+    writeFileSync(path.join(outDir, "pages", `${page.slug}.md`), page.markdown.endsWith("\n") ? page.markdown : `${page.markdown}\n`);
+    const meta = {
+      slug: page.slug,
+      title: page.title,
+      citations: page.citations,
+      coverageNotes: page.coverageNotes,
+      relatedPages: page.relatedPages,
+    };
+    writeFileSync(path.join(outDir, "pages", `${page.slug}.meta.json`), `${JSON.stringify(meta, null, 2)}\n`);
+  }
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const repoRoot = path.resolve(opts.repo);
+  if (!existsSync(repoRoot) || !statSync(repoRoot).isDirectory()) {
+    throw new Error(`repo root not found or not a directory: ${repoRoot}`);
+  }
+
+  const slug = resolveSlug(opts, repoRoot);
+  const outDir = path.resolve(opts.out ?? path.join(DEFAULT_WIKIS_DIR, slug));
+  if (existsSync(outDir) && !opts.force) {
+    throw new Error(`output already exists: ${outDir} (use --force to replace)`);
+  }
+
+  const inventory = statInventory(repoRoot);
+  if (inventory.length === 0) throw new Error(`repo has no indexable files: ${repoRoot}`);
+  const inventoryPaths = inventory.map((e) => e.path).sort();
+  const fingerprint = computeSourceFingerprint(inventory);
+  const scale = scaleForInventory(inventory.length);
+  const repoName = path.basename(repoRoot);
+
+  const pipeline =
+    opts.backend === "stub"
+      ? runStubPipeline(repoName, inventoryPaths, scale)
+      : runCliPipeline(opts, repoRoot, repoName, inventoryPaths, scale);
+
+  const manifest = buildWikiManifestData({
+    slug,
+    outline: pipeline.outline,
+    pages: pipeline.pages,
+    repoRoot,
+    fingerprint,
+    fileCount: inventory.length,
+    backend: opts.backend,
+    generatedAt: new Date().toISOString(),
+    scale,
+    models: opts.backend === "cli" ? { outline: opts.modelCmd!, page: opts.modelCmd! } : {},
+  });
+
+  // Self-check against the Phase 3 consumer's validator before any write.
+  const manifestErrors = validateWikiManifest(manifest);
+  if (manifestErrors.length > 0) {
+    throw new Error(`assembled manifest failed the regen-hook validator: ${manifestErrors.join("; ")}`);
+  }
+
+  // Build in a staging dir, then promote atomically (backup-swap on --force).
+  const stagingDir = `${outDir}.build-${process.pid}`;
+  rmSync(stagingDir, { recursive: true, force: true });
+  try {
+    writeWiki(stagingDir, pipeline, manifest);
+    if (existsSync(outDir)) {
+      const backupDir = `${outDir}.old-${process.pid}`;
+      rmSync(backupDir, { recursive: true, force: true });
+      renameSync(outDir, backupDir);
+      try {
+        renameSync(stagingDir, outDir);
+      } catch (error) {
+        renameSync(backupDir, outDir);
+        throw error;
+      }
+      rmSync(backupDir, { recursive: true, force: true });
+    } else {
+      mkdirSync(path.dirname(outDir), { recursive: true });
+      renameSync(stagingDir, outDir);
+    }
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+
+  const summary = {
+    slug,
+    out: outDir,
+    backend: opts.backend,
+    scale,
+    status: manifest.generation.status,
+    pages: manifest.counts.pages,
+    fingerprint,
+    fileCount: inventory.length,
+  };
+  if (opts.json) console.log(JSON.stringify(summary, null, 2));
+  else {
+    console.log(`generated ${slug} → ${outDir}`);
+    console.log(`backend=${summary.backend} scale=${summary.scale} status=${summary.status} pages=${summary.pages}`);
+    console.log(`fingerprint=${summary.fingerprint} fileCount=${summary.fileCount}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`covenwiki-generate: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/covenwiki-regen.ts
+++ b/scripts/covenwiki-regen.ts
@@ -21,7 +21,6 @@
 // template: {repo}, {out}, {slug} are substituted before shell execution.
 import { createHash } from "node:crypto";
 import {
-  readdirSync,
   readFileSync,
   statSync,
   writeFileSync,
@@ -33,6 +32,7 @@ import {
 import { homedir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { statInventory, walk } from "./covenwiki-fs.ts";
 import {
   buildManifest,
   buildWikiStatus,
@@ -48,7 +48,6 @@ import {
   validateWikiManifest,
   type Manifest,
   type SourceEntry,
-  type StatEntry,
   type WikiManifest,
 } from "../src/lib/covenwiki-regen.ts";
 
@@ -72,7 +71,6 @@ type Options = {
   dryRun: boolean;
 };
 
-const SKIP_DIRS = new Set([".git", "node_modules", ".worktrees", ".next", "target"]);
 const DEFAULT_WIKIS_DIR = path.join(homedir(), ".coven", "wikis");
 const DEFAULT_GENERATOR = "covenwiki generate --repo {repo} --out {out}";
 
@@ -184,16 +182,6 @@ function requireValue(argv: string[], index: number, flag: string): string {
   return value;
 }
 
-function walk(root: string, out: string[]) {
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
-    if (entry.name.startsWith(".") && entry.isDirectory()) continue;
-    if (SKIP_DIRS.has(entry.name)) continue;
-    const full = path.join(root, entry.name);
-    if (entry.isDirectory()) walk(full, out);
-    else if (entry.isFile()) out.push(full);
-  }
-}
-
 /** scan: hash the source roots into a content manifest. */
 function scan(opts: Options): Manifest {
   const files: string[] = [];
@@ -215,20 +203,6 @@ function loadPreviousManifest(stateFile: string): Manifest | null {
 }
 
 // ─── Wiki commands (plan S1–S4) ─────────────────────────────────────────────
-
-/** Stat-only inventory of a repo root, mirroring the fingerprint contract. */
-function statInventory(repoRoot: string): StatEntry[] {
-  const files: string[] = [];
-  walk(repoRoot, files);
-  return files.map((file) => {
-    const st = statSync(file);
-    return {
-      path: path.relative(repoRoot, file).split(path.sep).join("/"),
-      size: st.size,
-      mtimeMs: st.mtimeMs,
-    };
-  });
-}
 
 type LiveSource = { fingerprint: string | null; fileCount: number | null };
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -82,6 +82,8 @@ export const SUITES = {
     "scripts/coven-hfr-export.test.mjs",
     "src/lib/covenwiki-regen.test.ts",
     "scripts/covenwiki-regen-cli.test.mjs",
+    "src/lib/covenwiki-generate.test.ts",
+    "scripts/covenwiki-generate-cli.test.mjs",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/familiar-roster-guard.test.ts",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -68,7 +68,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_200/, "runtime closure must stay below 5,200 files");
+assert.match(closureSource, /fileCount: 5_250/, "runtime closure must stay below 5,250 files");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -171,7 +171,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_200;/,
+  /const MAX_FILE_COUNT: u64 = 5_250;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -36,7 +36,10 @@ export const SIDECAR_DYNAMIC_PACKAGES = Object.freeze([
 ]);
 
 export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
-  fileCount: 5_200,
+  // Headroom over the ~5.2k baseline: .agents/skills is a runtime root, so
+  // each first-party skill shipped to familiars adds a file here (covenwiki
+  // skills landed 2026-07-14). Raise deliberately, never reflexively.
+  fileCount: 5_250,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount < 5_200);
+  assert.ok(metrics.fileCount < 5_250);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_200,
+    fileCount: 5_250,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -13,7 +13,7 @@ const MANIFEST_SCHEMA_VERSION: u32 = 3;
 const ARCHIVE_FORMAT: &str = "tar.zst";
 const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-const MAX_FILE_COUNT: u64 = 5_200;
+const MAX_FILE_COUNT: u64 = 5_250;
 const MIN_FREE_SPACE_RESERVE_BYTES: u64 = 64 * 1024 * 1024;
 const CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const CACHE_LOCK_RETRY: Duration = Duration::from_millis(100);
@@ -1280,7 +1280,7 @@ mod tests {
         let mut value: serde_json::Value =
             serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
                 .expect("parse manifest");
-        value["fileCount"] = serde_json::json!(5_200);
+        value["fileCount"] = serde_json::json!(5_250);
         fs::write(
             &manifest_path,
             serde_json::to_vec(&value).expect("serialize budget manifest"),
@@ -1290,7 +1290,7 @@ mod tests {
             read_manifest(&manifest_path)
                 .expect("current runtime file-count budget should be accepted")
                 .file_count,
-            5_200
+            5_250
         );
         fs::remove_dir_all(root).expect("remove test root");
     }

--- a/src/lib/covenwiki-generate.test.ts
+++ b/src/lib/covenwiki-generate.test.ts
@@ -1,0 +1,372 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildCitationsIndex,
+  buildIndexMarkdown,
+  buildStubOutline,
+  buildStubPage,
+  buildWikiManifestData,
+  countProseWords,
+  extractJsonPayload,
+  scaleForInventory,
+  slugify,
+  validateOutline,
+  validatePageDoc,
+  PAGE_BUDGETS,
+  WORD_TARGETS,
+} from "./covenwiki-generate.ts";
+import { parseWikiManifest, validateWikiManifest } from "./covenwiki-regen.ts";
+
+const INVENTORY = [
+  "README.md",
+  "package.json",
+  "src/index.ts",
+  "src/session.ts",
+  "src/util.ts",
+  "tests/session.test.ts",
+  "docs/getting-started.md",
+  "docs/concepts.md",
+  "tsconfig.json",
+  ".github/workflows/ci.yml",
+];
+
+function validOutline(overrides = {}) {
+  return {
+    title: "Testrepo",
+    summary: "A test repository.",
+    navigation: [
+      { title: "Overview", slug: "overview", children: [] },
+      { title: "Source Layout", slug: "source-layout", children: [] },
+      { title: "Testing Signals", slug: "testing-signals", children: [] },
+    ],
+    pages: [
+      { slug: "overview", title: "Overview", purpose: "Entry point.", priority: "required", sourcePaths: ["README.md"] },
+      { slug: "source-layout", title: "Source Layout", purpose: "Source map.", priority: "recommended", sourcePaths: ["src/index.ts"] },
+      { slug: "testing-signals", title: "Testing Signals", purpose: "Tests.", priority: "optional", sourcePaths: ["tests/session.test.ts"] },
+    ],
+    concepts: [],
+    coverageNotes: [],
+    ...overrides,
+  };
+}
+
+// ─── scale + slug helpers ────────────────────────────────────────────────────
+
+test("scaleForInventory follows the IA §3 thresholds", () => {
+  assert.equal(scaleForInventory(10), "compact");
+  assert.equal(scaleForInventory(24), "compact");
+  assert.equal(scaleForInventory(25), "small");
+  assert.equal(scaleForInventory(49), "small");
+  assert.equal(scaleForInventory(50), "medium");
+  assert.equal(scaleForInventory(400), "medium");
+  assert.equal(scaleForInventory(401), "large");
+});
+
+test("budgets and word targets cover every scale", () => {
+  for (const scale of ["compact", "small", "medium", "large"]) {
+    assert.equal(PAGE_BUDGETS[scale].length, 2);
+    assert.equal(WORD_TARGETS[scale].length, 2);
+    assert.ok(PAGE_BUDGETS[scale][0] <= PAGE_BUDGETS[scale][1]);
+  }
+});
+
+test("slugify produces URL-friendly slugs", () => {
+  assert.equal(slugify("Coven Cave"), "coven-cave");
+  assert.equal(slugify("My_Repo.Name"), "my-repo-name");
+  assert.equal(slugify("---"), "wiki");
+});
+
+// ─── outline validation ─────────────────────────────────────────────────────
+
+test("validateOutline accepts a rule-compliant outline", () => {
+  const errors = validateOutline(validOutline(), { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.deepEqual(errors, []);
+});
+
+test("validateOutline requires the overview page", () => {
+  const outline = validOutline();
+  outline.pages = outline.pages.filter((p) => p.slug !== "overview");
+  outline.navigation = outline.navigation.filter((n) => n.slug !== "overview");
+  const errors = validateOutline(outline, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes('"overview"')));
+});
+
+test("validateOutline rejects folder-of-one group nodes", () => {
+  const outline = validOutline({
+    navigation: [
+      { title: "Overview", slug: "overview", children: [] },
+      {
+        title: "Group",
+        slug: null,
+        children: [{ title: "Source Layout", slug: "source-layout", children: [] }],
+      },
+      { title: "Testing Signals", slug: "testing-signals", children: [] },
+    ],
+  });
+  const errors = validateOutline(outline, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes("folder-of-one")));
+});
+
+test("validateOutline rejects nav slugs without pages and unreachable pages", () => {
+  const ghost = validOutline();
+  ghost.navigation.push({ title: "Ghost", slug: "ghost-page", children: [] });
+  let errors = validateOutline(ghost, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes('unknown page slug "ghost-page"')));
+
+  const orphan = validOutline();
+  orphan.navigation = orphan.navigation.filter((n) => n.slug !== "testing-signals");
+  errors = validateOutline(orphan, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes('"testing-signals" is unreachable')));
+});
+
+test("validateOutline rejects invented source paths, bad slugs, duplicates", () => {
+  const outline = validOutline();
+  outline.pages[1].sourcePaths = ["src/does-not-exist.ts"];
+  outline.pages[2].slug = "Testing_Signals";
+  outline.navigation[2].slug = "Testing_Signals";
+  let errors = validateOutline(outline, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes("not in the file inventory")));
+  assert.ok(errors.some((e) => e.includes("lowercase URL-friendly")));
+
+  const dup = validOutline();
+  dup.pages[2] = { ...dup.pages[2], slug: "overview" };
+  errors = validateOutline(dup, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes("duplicates")));
+});
+
+test("validateOutline enforces the scale page budget and hard minimum", () => {
+  const tooMany = validOutline();
+  for (let i = 0; i < 3; i += 1) {
+    const slug = `extra-${i}`;
+    tooMany.pages.push({ slug, title: `Extra ${i}`, purpose: "x", priority: "optional", sourcePaths: ["README.md"] });
+    tooMany.navigation.push({ title: `Extra ${i}`, slug, children: [] });
+  }
+  let errors = validateOutline(tooMany, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes("exceeds the compact-scale budget")));
+
+  const tooFew = validOutline();
+  tooFew.pages = tooFew.pages.slice(0, 1);
+  tooFew.navigation = tooFew.navigation.slice(0, 1);
+  errors = validateOutline(tooFew, { inventoryPaths: INVENTORY, scale: "compact" });
+  assert.ok(errors.some((e) => e.includes("hard minimum")));
+
+  // Tiny repos (README-only) may legitimately have one page.
+  errors = validateOutline(
+    validOutline({
+      navigation: [{ title: "Overview", slug: "overview", children: [] }],
+      pages: [{ slug: "overview", title: "Overview", purpose: "Entry.", priority: "required", sourcePaths: ["README.md"] }],
+    }),
+    { inventoryPaths: ["README.md"], scale: "compact" },
+  );
+  assert.deepEqual(errors, []);
+});
+
+// ─── page validation ─────────────────────────────────────────────────────────
+
+function validPage(overrides = {}) {
+  return {
+    slug: "overview",
+    title: "Overview",
+    markdown: "# Overview\n\nSome prose about the project.\n\n## Relevant source files\n\n- `README.md`\n",
+    citations: [{ path: "README.md", startLine: null, endLine: null }],
+    coverageNotes: [],
+    relatedPages: ["source-layout"],
+    ...overrides,
+  };
+}
+
+const PAGE_OPTS = { inventoryPaths: INVENTORY, pageSlugs: ["overview", "source-layout"], minCitations: 1 };
+
+test("validatePageDoc accepts a valid page", () => {
+  assert.deepEqual(validatePageDoc(validPage(), PAGE_OPTS), []);
+});
+
+test("validatePageDoc enforces H1, citations, and related pages", () => {
+  let errors = validatePageDoc(validPage({ markdown: "no heading here" }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("H1")));
+
+  errors = validatePageDoc(validPage({ citations: [] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("at least 1 citation")));
+
+  errors = validatePageDoc(validPage({ citations: [{ path: "/etc/passwd", startLine: null, endLine: null }] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("repository-relative")));
+
+  errors = validatePageDoc(validPage({ citations: [{ path: "nope.md", startLine: null, endLine: null }] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("not in the file inventory")));
+
+  errors = validatePageDoc(validPage({ citations: [{ path: "README.md", startLine: 0, endLine: null }] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("positive integer or null")));
+
+  errors = validatePageDoc(validPage({ relatedPages: ["ghost"] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes('unknown page "ghost"')));
+
+  errors = validatePageDoc(validPage({ relatedPages: ["overview"] }), PAGE_OPTS);
+  assert.ok(errors.some((e) => e.includes("itself")));
+});
+
+// ─── word counting ───────────────────────────────────────────────────────────
+
+test("countProseWords counts only prose", () => {
+  const markdown = [
+    "# Title",
+    "",
+    "One two three four five.",
+    "",
+    "```js",
+    "const ignored = 'entirely';",
+    "```",
+    "",
+    "| a | table |",
+    "| - | ----- |",
+    "",
+    "Sources: README.md",
+    "",
+    "Six seven [eight](http://x) `nine` ten.",
+  ].join("\n");
+  // "nine" is inline code (stripped); link text "eight" counts.
+  assert.equal(countProseWords(markdown), 9);
+});
+
+// ─── stub backend ────────────────────────────────────────────────────────────
+
+test("buildStubOutline passes its own validator and cites only inventory", () => {
+  const outline = buildStubOutline({ repoName: "testrepo", inventoryPaths: INVENTORY });
+  const errors = validateOutline(outline, { inventoryPaths: INVENTORY, scale: scaleForInventory(INVENTORY.length) });
+  assert.deepEqual(errors, []);
+  assert.ok(outline.pages.length >= 3);
+  assert.equal(outline.pages[0].slug, "overview");
+});
+
+test("buildStubOutline handles a README-only repo", () => {
+  const outline = buildStubOutline({ repoName: "tiny", inventoryPaths: ["README.md"] });
+  const errors = validateOutline(outline, { inventoryPaths: ["README.md"], scale: "compact" });
+  assert.deepEqual(errors, []);
+  assert.equal(outline.pages.length, 1);
+});
+
+test("buildStubPage passes page validation and cites the outline sources", () => {
+  const outline = buildStubOutline({ repoName: "testrepo", inventoryPaths: INVENTORY });
+  for (const entry of outline.pages) {
+    const page = buildStubPage(entry, outline);
+    const errors = validatePageDoc(page, {
+      inventoryPaths: INVENTORY,
+      pageSlugs: outline.pages.map((p) => p.slug),
+      minCitations: 1,
+    });
+    assert.deepEqual(errors, []);
+    assert.deepEqual(page.citations.map((c) => c.path), entry.sourcePaths);
+  }
+});
+
+// ─── assembly ────────────────────────────────────────────────────────────────
+
+function assembled() {
+  const outline = buildStubOutline({ repoName: "testrepo", inventoryPaths: INVENTORY });
+  const pages = outline.pages.map((p) => buildStubPage(p, outline));
+  const manifest = buildWikiManifestData({
+    slug: "testrepo",
+    outline,
+    pages,
+    repoRoot: "/tmp/testrepo",
+    fingerprint: "0123456789abcdef",
+    fileCount: INVENTORY.length,
+    backend: "stub",
+    generatedAt: "2026-07-14T00:00:00.000Z",
+    scale: "compact",
+  });
+  return { outline, pages, manifest };
+}
+
+test("assembled manifest satisfies the Phase 3 regen-hook validator", () => {
+  const { manifest } = assembled();
+  assert.deepEqual(validateWikiManifest(manifest), []);
+  const parsed = parseWikiManifest(JSON.stringify(manifest));
+  assert.equal(parsed.slug, "testrepo");
+  assert.equal(parsed.source.fingerprint, "0123456789abcdef");
+});
+
+test("manifest counts, paths, and word targets are consistent", () => {
+  const { manifest } = assembled();
+  assert.equal(manifest.schemaVersion, "1.0");
+  assert.equal(manifest.counts.pages, manifest.pages.length);
+  assert.equal(
+    manifest.counts.required + manifest.counts.recommended + manifest.counts.optional,
+    manifest.pages.length,
+  );
+  assert.deepEqual(manifest.generation.wordTarget, WORD_TARGETS.compact);
+  assert.equal(manifest.generation.status, "stub");
+  for (const page of manifest.pages) {
+    assert.equal(page.path, `pages/${page.slug}.md`);
+    assert.equal(page.meta, `pages/${page.slug}.meta.json`);
+    assert.equal(typeof page.wordCount, "number");
+  }
+});
+
+test("cli backend marks generation complete and records models", () => {
+  const { outline, pages } = assembled();
+  const manifest = buildWikiManifestData({
+    slug: "testrepo",
+    outline,
+    pages,
+    repoRoot: "/tmp/testrepo",
+    fingerprint: "0123456789abcdef",
+    fileCount: INVENTORY.length,
+    backend: "cli",
+    generatedAt: "2026-07-14T00:00:00.000Z",
+    scale: "compact",
+    models: { outline: "fake-model", page: "fake-model" },
+  });
+  assert.equal(manifest.generation.status, "complete");
+  assert.equal(manifest.generation.models.outline, "fake-model");
+});
+
+test("buildCitationsIndex builds the source⇄page reverse lookup", () => {
+  const { pages, manifest } = assembled();
+  const index = buildCitationsIndex(pages, manifest.generation.generatedAt);
+  assert.equal(index.schemaVersion, "1.0");
+  assert.deepEqual(index.bySource["README.md"], ["overview"]);
+  for (const [source, slugs] of Object.entries(index.bySource)) {
+    for (const slug of slugs) {
+      assert.ok(index.byPage[slug].some((c) => c.path === source), `${slug} must cite ${source}`);
+    }
+  }
+  for (const [slug, citations] of Object.entries(index.byPage)) {
+    for (const citation of citations) {
+      assert.ok(index.bySource[citation.path].includes(slug));
+    }
+  }
+});
+
+test("buildIndexMarkdown renders the nav tree with group headers", () => {
+  const { manifest } = assembled();
+  const md = buildIndexMarkdown(manifest);
+  assert.ok(md.startsWith(`# ${manifest.title}`));
+  assert.ok(md.includes("- [Overview](pages/overview.md)"));
+
+  const grouped = {
+    ...manifest,
+    navigation: [
+      { title: "Overview", slug: "overview", children: [] },
+      {
+        title: "Guides",
+        slug: null,
+        children: [
+          { title: "A", slug: "a", children: [] },
+          { title: "B", slug: "b", children: [] },
+        ],
+      },
+    ],
+  };
+  const groupedMd = buildIndexMarkdown(grouped);
+  assert.ok(groupedMd.includes("- Guides\n  - [A](pages/a.md)"));
+});
+
+// ─── model output recovery ───────────────────────────────────────────────────
+
+test("extractJsonPayload handles bare, fenced, and wrapped JSON", () => {
+  assert.deepEqual(extractJsonPayload('{"a":1}'), { a: 1 });
+  assert.deepEqual(extractJsonPayload('Here you go:\n```json\n{"a":1}\n```\nDone.'), { a: 1 });
+  assert.deepEqual(extractJsonPayload('Sure!\n\n{"a":{"b":2}}\n\nAnything else?'), { a: { b: 2 } });
+  assert.throws(() => extractJsonPayload("no json here"), /parseable JSON/);
+});

--- a/src/lib/covenwiki-generate.ts
+++ b/src/lib/covenwiki-generate.ts
@@ -1,0 +1,580 @@
+// CovenWiki v0 Phase 1 — generation core (Route B, cave-whji).
+//
+// Pure logic only: no filesystem, no process spawning. The CLI wrapper
+// (scripts/covenwiki-generate.ts) owns I/O and model invocation so everything
+// here is unit-testable with plain data.
+//
+// Pipeline pieces (Route B plan §3/§4 Phase 1):
+//   scaleForInventory / budgets — repo-scale → page-count + word targets
+//   buildStubOutline/Page       — deterministic no-model backend ("stub")
+//   validateOutline             — fail-closed IA-rule checks on outline JSON
+//   validatePageDoc             — fail-closed checks on page JSON + citations
+//   buildWikiManifestData       — assemble the manifest.json contract
+//   buildCitationsIndex         — _citations.json: source⇄page reverse lookup
+//   countProseWords             — prose-only metric behind pages[].wordCount
+//   extractJsonPayload          — lenient JSON recovery from model output
+//
+// Contract: the manifest handoff doc (2026-07-03) + docs/covenwiki-manifest.schema.json.
+// The emitted manifest must always satisfy validateWikiManifest from
+// src/lib/covenwiki-regen.ts — the Phase 3 regen hook consumes it as-is.
+
+import type { WikiManifest, WikiNavNode, WikiPageEntry } from "./covenwiki-regen.ts";
+
+export const MANIFEST_SCHEMA_VERSION = "1.0";
+export const GENERATOR_NAME = "covenwiki-generate";
+export const GENERATOR_VERSION = "0.1.0";
+
+export type Scale = "compact" | "small" | "medium" | "large";
+
+/** IA rules §3: target page counts by repo scale. */
+export const PAGE_BUDGETS: Record<Scale, [number, number]> = {
+  compact: [3, 4],
+  small: [3, 5],
+  medium: [6, 10],
+  large: [16, 48],
+};
+
+/** IA rules §6: prose-only word targets per page by repo scale. */
+export const WORD_TARGETS: Record<Scale, [number, number]> = {
+  compact: [450, 700],
+  small: [450, 700],
+  medium: [650, 950],
+  large: [1200, 1600],
+};
+
+export function scaleForInventory(fileCount: number): Scale {
+  if (fileCount < 25) return "compact";
+  if (fileCount < 50) return "small";
+  if (fileCount <= 400) return "medium";
+  return "large";
+}
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function slugify(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "wiki";
+}
+
+export type Citation = {
+  path: string;
+  startLine: number | null;
+  endLine: number | null;
+};
+
+export type OutlinePage = {
+  slug: string;
+  title: string;
+  purpose: string;
+  priority: "required" | "recommended" | "optional";
+  sourcePaths: string[];
+};
+
+/** The covenwiki-outline skill's JSON output contract. */
+export type Outline = {
+  title: string;
+  summary: string;
+  navigation: WikiNavNode[];
+  pages: OutlinePage[];
+  concepts: string[];
+  coverageNotes: string[];
+};
+
+/** The covenwiki-page skill's JSON output contract. */
+export type PageDoc = {
+  slug: string;
+  title: string;
+  markdown: string;
+  citations: Citation[];
+  coverageNotes: string[];
+  relatedPages: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+const PRIORITIES = new Set(["required", "recommended", "optional"]);
+
+function collectNavSlugs(nodes: WikiNavNode[], out: string[]): void {
+  for (const node of nodes) {
+    if (node.slug !== null) out.push(node.slug);
+    collectNavSlugs(node.children ?? [], out);
+  }
+}
+
+function validateNavShape(nodes: unknown, at: string, errors: string[]): void {
+  if (!Array.isArray(nodes)) {
+    errors.push(`${at} must be an array`);
+    return;
+  }
+  nodes.forEach((node, i) => {
+    const here = `${at}[${i}]`;
+    if (!isRecord(node)) {
+      errors.push(`${here} must be an object`);
+      return;
+    }
+    if (typeof node.title !== "string" || node.title === "") errors.push(`${here}.title must be a non-empty string`);
+    if (node.slug !== null && typeof node.slug !== "string") errors.push(`${here}.slug must be a string or null`);
+    if (node.slug === null) {
+      // IA rules 7/34: a group header must actually group things.
+      if (!Array.isArray(node.children) || node.children.length < 2) {
+        errors.push(`${here} is a folder-of-one: group nodes (slug: null) need >= 2 children`);
+      }
+    }
+    validateNavShape(node.children, `${here}.children`, errors);
+  });
+}
+
+export type OutlineValidationOptions = {
+  /** Repo-relative inventory paths; citations/sourcePaths must resolve here. */
+  inventoryPaths: string[];
+  scale: Scale;
+  /** Override the hard-minimum page count (IA rule 13 heuristic by default). */
+  minPages?: number;
+};
+
+/**
+ * Fail-closed validation of outline JSON against the code-enforceable subset
+ * of the IA rules: overview presence (rule 6), nav integrity (31–34), slug
+ * format (33), folder-of-one (7/34), page budget ceiling (§3), source paths
+ * resolving into the inventory (26).
+ */
+export function validateOutline(data: unknown, opts: OutlineValidationOptions): string[] {
+  const errors: string[] = [];
+  if (!isRecord(data)) return ["outline must be a JSON object"];
+
+  if (typeof data.title !== "string" || data.title === "") errors.push("title must be a non-empty string");
+  if (typeof data.summary !== "string" || data.summary === "") errors.push("summary must be a non-empty string");
+  if (data.concepts !== undefined && !stringArray(data.concepts)) errors.push("concepts must be an array of strings");
+  if (data.coverageNotes !== undefined && !stringArray(data.coverageNotes)) errors.push("coverageNotes must be an array of strings");
+
+  validateNavShape(data.navigation, "navigation", errors);
+
+  const inventory = new Set(opts.inventoryPaths);
+  const slugs = new Set<string>();
+  if (!Array.isArray(data.pages)) errors.push("pages must be an array");
+  else {
+    data.pages.forEach((page, i) => {
+      const here = `pages[${i}]`;
+      if (!isRecord(page)) {
+        errors.push(`${here} must be an object`);
+        return;
+      }
+      if (typeof page.slug !== "string" || !SLUG_RE.test(page.slug)) {
+        errors.push(`${here}.slug must be lowercase URL-friendly (a-z0-9, dash-separated)`);
+      } else if (slugs.has(page.slug)) {
+        errors.push(`${here}.slug duplicates "${page.slug}"`);
+      } else {
+        slugs.add(page.slug);
+      }
+      if (typeof page.title !== "string" || page.title === "") errors.push(`${here}.title must be a non-empty string`);
+      if (typeof page.purpose !== "string" || page.purpose === "") errors.push(`${here}.purpose must be a non-empty string`);
+      if (typeof page.priority !== "string" || !PRIORITIES.has(page.priority)) {
+        errors.push(`${here}.priority must be one of required|recommended|optional`);
+      }
+      if (!stringArray(page.sourcePaths)) errors.push(`${here}.sourcePaths must be an array of strings`);
+      else {
+        for (const src of page.sourcePaths) {
+          if (!inventory.has(src)) errors.push(`${here}.sourcePaths cites "${src}" which is not in the file inventory`);
+        }
+      }
+    });
+
+    if (!slugs.has("overview")) errors.push('pages must include a root "overview" page (IA rule 6)');
+
+    const [, maxPages] = PAGE_BUDGETS[opts.scale];
+    const minPages = opts.minPages ?? (opts.inventoryPaths.length >= 10 ? 3 : 1);
+    if (data.pages.length > maxPages) {
+      errors.push(`pages.length ${data.pages.length} exceeds the ${opts.scale}-scale budget of ${maxPages}`);
+    }
+    if (data.pages.length < minPages) {
+      errors.push(`pages.length ${data.pages.length} is below the hard minimum of ${minPages} (IA rule 13)`);
+    }
+  }
+
+  // IA rule 32: every string navigation slug must be a real page slug.
+  if (Array.isArray(data.navigation)) {
+    const navSlugs: string[] = [];
+    collectNavSlugs(data.navigation as WikiNavNode[], navSlugs);
+    for (const slug of navSlugs) {
+      if (!slugs.has(slug)) errors.push(`navigation links to unknown page slug "${slug}"`);
+    }
+    for (const slug of slugs) {
+      if (!navSlugs.includes(slug)) errors.push(`page "${slug}" is unreachable from navigation`);
+    }
+  }
+
+  return errors;
+}
+
+export type PageValidationOptions = {
+  inventoryPaths: string[];
+  /** All outline page slugs; relatedPages must resolve here. */
+  pageSlugs: string[];
+  /** Minimum citations per page; 1 for stub, raise for real backends. */
+  minCitations?: number;
+};
+
+/** Fail-closed validation of page JSON: citations resolve (IA rules 26–29), relatedPages resolve, markdown shape. */
+export function validatePageDoc(data: unknown, opts: PageValidationOptions): string[] {
+  const errors: string[] = [];
+  if (!isRecord(data)) return ["page must be a JSON object"];
+
+  if (typeof data.slug !== "string" || !SLUG_RE.test(data.slug)) errors.push("slug must be lowercase URL-friendly");
+  if (typeof data.title !== "string" || data.title === "") errors.push("title must be a non-empty string");
+  if (typeof data.markdown !== "string" || data.markdown.trim() === "") errors.push("markdown must be a non-empty string");
+  else if (!/^#\s+\S/.test(data.markdown.trimStart())) errors.push("markdown must start with an H1 title (IA rule 18)");
+
+  const inventory = new Set(opts.inventoryPaths);
+  const minCitations = opts.minCitations ?? 1;
+  if (!Array.isArray(data.citations)) errors.push("citations must be an array");
+  else {
+    if (data.citations.length < minCitations) {
+      errors.push(`page needs at least ${minCitations} citation(s) (IA rule 28)`);
+    }
+    data.citations.forEach((citation, i) => {
+      const here = `citations[${i}]`;
+      if (!isRecord(citation)) {
+        errors.push(`${here} must be an object`);
+        return;
+      }
+      if (typeof citation.path !== "string" || citation.path === "") {
+        errors.push(`${here}.path must be a non-empty string`);
+      } else if (citation.path.startsWith("/") || /^[a-z]+:\/\//i.test(citation.path)) {
+        errors.push(`${here}.path must be repository-relative (IA rule 27)`);
+      } else if (!inventory.has(citation.path)) {
+        errors.push(`${here}.path "${citation.path}" is not in the file inventory (IA rule 26)`);
+      }
+      for (const key of ["startLine", "endLine"] as const) {
+        const value = citation[key];
+        if (value !== null && (typeof value !== "number" || !Number.isInteger(value) || value < 1)) {
+          errors.push(`${here}.${key} must be a positive integer or null (IA rule 29)`);
+        }
+      }
+    });
+  }
+
+  if (data.coverageNotes !== undefined && !stringArray(data.coverageNotes)) errors.push("coverageNotes must be an array of strings");
+  const known = new Set(opts.pageSlugs);
+  if (data.relatedPages !== undefined) {
+    if (!stringArray(data.relatedPages)) errors.push("relatedPages must be an array of strings");
+    else {
+      for (const related of data.relatedPages) {
+        if (!known.has(related)) errors.push(`relatedPages references unknown page "${related}"`);
+        if (isRecord(data) && related === data.slug) errors.push("relatedPages must not reference the page itself");
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Prose-only word count (IA rules 21/§6): fenced code, table rows, headings,
+ * list-of-path ornaments, and `Sources:` lines do not count toward the target.
+ */
+export function countProseWords(markdown: string): number {
+  let inFence = false;
+  let words = 0;
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trim();
+    if (/^(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (line === "" || line.startsWith("#") || line.startsWith("|")) continue;
+    if (/^sources?\s*:/i.test(line)) continue;
+    const prose = line
+      .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/`[^`]*`/g, " ");
+    const matches = prose.match(/[A-Za-z0-9'’-]+/g);
+    words += matches ? matches.length : 0;
+  }
+  return words;
+}
+
+// ─── Stub backend (deterministic, no model) ─────────────────────────────────
+
+export type StubInput = {
+  repoName: string;
+  inventoryPaths: string[];
+};
+
+function firstMatch(paths: string[], patterns: RegExp[]): string | null {
+  for (const pattern of patterns) {
+    const hit = paths.find((p) => pattern.test(p));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/**
+ * Deterministic outline for the stub backend: scale-budgeted, rule-compliant
+ * (overview always; conceptual groupings, never per-file pages; every page
+ * cites only inventory paths). Structure is real; prose is placeholder.
+ */
+export function buildStubOutline(input: StubInput): Outline {
+  const paths = [...input.inventoryPaths].sort();
+  const pages: OutlinePage[] = [];
+
+  const readme = firstMatch(paths, [/^readme\.md$/i]);
+  const packageMeta = firstMatch(paths, [/^package\.json$/, /^Cargo\.toml$/, /^pyproject\.toml$/, /^go\.mod$/]);
+  const overviewSources = [readme, packageMeta].filter((p): p is string => p !== null);
+  if (overviewSources.length === 0) overviewSources.push(...paths.slice(0, 2));
+  pages.push({
+    slug: "overview",
+    title: "Overview",
+    purpose: "Entry point: what the project is, how the wiki is organized.",
+    priority: "required",
+    sourcePaths: overviewSources,
+  });
+
+  const sourceFiles = paths.filter((p) => /^(src|lib|crates|app|cmd|pkg)\//.test(p)).slice(0, 6);
+  if (sourceFiles.length > 0) {
+    pages.push({
+      slug: "source-layout",
+      title: "Source Layout",
+      purpose: "Map the main source tree to the systems it implements.",
+      priority: "recommended",
+      sourcePaths: sourceFiles,
+    });
+  }
+
+  const testFiles = paths.filter((p) => /(^|\/)(tests?|__tests__|spec)\//.test(p) || /\.(test|spec)\.[a-z]+$/.test(p)).slice(0, 6);
+  if (testFiles.length > 0) {
+    pages.push({
+      slug: "testing-signals",
+      title: "Testing Signals",
+      purpose: "What the test suite covers and how to run it.",
+      priority: "optional",
+      sourcePaths: testFiles,
+    });
+  }
+
+  const docFiles = paths.filter((p) => /^docs\/.*\.mdx?$/i.test(p)).slice(0, 6);
+  if (docFiles.length > 0) {
+    pages.push({
+      slug: "documentation-guide",
+      title: "Documentation Guide",
+      purpose: "Tour of the first-party docs and where each topic lives.",
+      priority: "optional",
+      sourcePaths: docFiles,
+    });
+  }
+
+  const configFiles = paths
+    .filter((p) => !p.includes("/") && /\.(json|toml|ya?ml|config\.[a-z]+)$/i.test(p) && p !== packageMeta)
+    .slice(0, 5);
+  if (pages.length < 3 && configFiles.length > 0) {
+    pages.push({
+      slug: "build-and-configuration",
+      title: "Build and Configuration",
+      purpose: "Build tooling and configuration surface at the repo root.",
+      priority: "optional",
+      sourcePaths: configFiles,
+    });
+  }
+
+  const [, maxPages] = PAGE_BUDGETS[scaleForInventory(paths.length)];
+  const kept = pages.slice(0, maxPages);
+
+  return {
+    title: input.repoName,
+    summary: `Source-grounded wiki for ${input.repoName} (stub backend: structure is real, prose is placeholder).`,
+    navigation: kept.map((page) => ({ title: page.title, slug: page.slug, children: [] })),
+    pages: kept,
+    concepts: [],
+    coverageNotes: ["stub backend: page prose is placeholder; regenerate with the cli backend for real content"],
+  };
+}
+
+/** Deterministic placeholder page for the stub backend (structure-only prose). */
+export function buildStubPage(page: OutlinePage, outline: Outline): PageDoc {
+  const others = outline.pages.map((p) => p.slug).filter((slug) => slug !== page.slug);
+  const lines = [
+    `# ${page.title}`,
+    "",
+    `${page.purpose} This page is a stub-backend placeholder; regenerate with the cli backend for source-grounded prose.`,
+    "",
+    "## Relevant source files",
+    "",
+    ...page.sourcePaths.map((src) => `- \`${src}\``),
+  ];
+  return {
+    slug: page.slug,
+    title: page.title,
+    markdown: `${lines.join("\n")}\n`,
+    citations: page.sourcePaths.map((src) => ({ path: src, startLine: null, endLine: null })),
+    coverageNotes: ["stub backend placeholder — prose target not attempted"],
+    relatedPages: others.slice(0, 3),
+  };
+}
+
+// ─── Assembly (manifest.json, _citations.json) ──────────────────────────────
+
+export type GeneratedWikiManifest = WikiManifest & {
+  generator: string;
+  generatorVersion: string;
+  summary: string;
+  index: string;
+  concepts: string[];
+  generation: WikiManifest["generation"] & {
+    scale: Scale;
+    models: { outline?: string; page?: string };
+    wordTarget: [number, number];
+  };
+};
+
+export type ManifestInput = {
+  slug: string;
+  outline: Outline;
+  pages: PageDoc[];
+  repoRoot: string;
+  fingerprint: string;
+  fileCount: number;
+  backend: "stub" | "cli";
+  generatedAt: string;
+  scale: Scale;
+  models?: { outline?: string; page?: string };
+};
+
+/** Assemble the manifest.json payload per the Phase 2 render contract. */
+export function buildWikiManifestData(input: ManifestInput): GeneratedWikiManifest {
+  const byPriority = { required: 0, recommended: 0, optional: 0 };
+  const wordCounts = new Map(input.pages.map((p) => [p.slug, countProseWords(p.markdown)]));
+  const pages: WikiPageEntry[] = input.outline.pages.map((page) => {
+    byPriority[page.priority] += 1;
+    return {
+      slug: page.slug,
+      title: page.title,
+      purpose: page.purpose,
+      priority: page.priority,
+      path: `pages/${page.slug}.md`,
+      meta: `pages/${page.slug}.meta.json`,
+      sourcePaths: page.sourcePaths,
+      wordCount: wordCounts.get(page.slug) ?? 0,
+    } as WikiPageEntry;
+  });
+
+  return {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    generator: GENERATOR_NAME,
+    generatorVersion: GENERATOR_VERSION,
+    slug: input.slug,
+    title: input.outline.title,
+    summary: input.outline.summary,
+    index: "index.md",
+    source: {
+      kind: "local",
+      repoRoot: input.repoRoot,
+      revision: null,
+      fingerprint: input.fingerprint,
+      fileCount: input.fileCount,
+    },
+    generation: {
+      generatedAt: input.generatedAt,
+      backend: input.backend,
+      scale: input.scale,
+      status: input.backend === "stub" ? "stub" : "complete",
+      models: input.models ?? {},
+      wordTarget: WORD_TARGETS[input.scale],
+    },
+    navigation: input.outline.navigation,
+    concepts: input.outline.concepts,
+    pages,
+    counts: {
+      pages: pages.length,
+      required: byPriority.required,
+      recommended: byPriority.recommended,
+      optional: byPriority.optional,
+    },
+  };
+}
+
+export type CitationsIndex = {
+  schemaVersion: "1.0";
+  generatedAt: string;
+  /** Source path -> page slugs citing it (sorted). Phase 3 reverse lookup. */
+  bySource: Record<string, string[]>;
+  /** Page slug -> its citations. */
+  byPage: Record<string, Citation[]>;
+};
+
+/**
+ * _citations.json — the source⇄page mapping the Phase 3 incremental regen
+ * needs to translate "this source changed" into "these pages regenerate"
+ * (outline-driven wikis have no 1:1 path↔page relationship; this index is
+ * the real mapping).
+ */
+export function buildCitationsIndex(pages: PageDoc[], generatedAt: string): CitationsIndex {
+  const bySource: Record<string, Set<string>> = {};
+  const byPage: Record<string, Citation[]> = {};
+  for (const page of [...pages].sort((a, b) => a.slug.localeCompare(b.slug))) {
+    byPage[page.slug] = page.citations;
+    for (const citation of page.citations) {
+      (bySource[citation.path] ??= new Set()).add(page.slug);
+    }
+  }
+  const bySourceSorted: Record<string, string[]> = {};
+  for (const key of Object.keys(bySource).sort()) {
+    bySourceSorted[key] = [...bySource[key]].sort();
+  }
+  return { schemaVersion: "1.0", generatedAt, bySource: bySourceSorted, byPage };
+}
+
+/** Render a human index.md from the outline (nav tree as nested links). */
+export function buildIndexMarkdown(manifest: GeneratedWikiManifest): string {
+  const lines = [`# ${manifest.title}`, "", manifest.summary, ""];
+  const renderNodes = (nodes: WikiNavNode[], depth: number) => {
+    for (const node of nodes) {
+      const indent = "  ".repeat(depth);
+      lines.push(node.slug ? `${indent}- [${node.title}](pages/${node.slug}.md)` : `${indent}- ${node.title}`);
+      renderNodes(node.children ?? [], depth + 1);
+    }
+  };
+  renderNodes(manifest.navigation, 0);
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ─── Model output recovery ──────────────────────────────────────────────────
+
+/**
+ * Recover a JSON payload from model output: exact JSON, a ```json fence, or
+ * the outermost brace span. Model harnesses love to wrap JSON in prose.
+ */
+export function extractJsonPayload(text: string): unknown {
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // fall through to fence / brace recovery
+  }
+  const fence = trimmed.match(/```(?:json)?\s*\n([\s\S]*?)\n\s*```/);
+  if (fence) {
+    try {
+      return JSON.parse(fence[1]);
+    } catch {
+      // fall through
+    }
+  }
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    } catch {
+      // fall through
+    }
+  }
+  throw new Error("model output did not contain a parseable JSON payload");
+}

--- a/src/lib/covenwiki-regen.ts
+++ b/src/lib/covenwiki-regen.ts
@@ -317,10 +317,13 @@ export type WikiManifest = {
  * The 16-hex stat digest that is the Phase 3 staleness key: sha256 over the
  * sorted source inventory (path + size + mtime), truncated to 16 hex chars.
  *
- * Contract: manifest handoff doc (2026-07-03), `source.fingerprint`. The
- * reference implementation lives in the covenwiki-generate CLI; byte-parity
- * with it must be verified before the daemon wires `status` polling — any
- * inventory or format drift shows up as a permanent false "stale".
+ * Contract: manifest handoff doc (2026-07-03), `source.fingerprint`, pinned
+ * in docs/covenwiki-manifest.schema.json. Both writers share one code path:
+ * the covenwiki-generate CLI and the covenwiki-regen CLI each compute this
+ * function over `statInventory` from scripts/covenwiki-fs.ts, so generator
+ * and staleness check cannot drift (a drift would show up as a permanent
+ * false "stale"). Parity is asserted end-to-end in
+ * scripts/covenwiki-generate-cli.test.mjs.
  */
 export function computeSourceFingerprint(entries: StatEntry[]): string {
   const lines = entries


### PR DESCRIPTION
## What

CovenWiki Route B **Phase 1** (plan §4): the generator side of CovenWiki v0. Closes the loop with the Phase 3 regen hook that landed in #3064/#3145.

- **Prompt IP as skills** — `.agents/skills/covenwiki-outline/SKILL.md` + `covenwiki-page/SKILL.md`: the extracted IA rules as prompt specs with strict JSON I/O contracts (hard rules mirrored by code validators).
- **Core lib** (`src/lib/covenwiki-generate.ts`, pure): repo-scale → page budgets/word targets, fail-closed outline+page validators (overview required, no folder-of-one, nav↔page integrity, citations must resolve to the file inventory), deterministic stub backend, manifest + `_citations.json` assembly, prose-only word counting, lenient model-JSON recovery.
- **Orchestrator CLI** (`scripts/covenwiki-generate.ts`): inventory → hydrate evidence → outline skill → page skill per page → validate → atomic write to `~/.coven/wikis/<slug>/`. Backends: `stub` (no model) and `cli` (`--model-cmd` receives prompts on stdin). Honors `COVENWIKI_MODEL_BACKEND`/`COVENWIKI_MODEL_CMD`.
- **Manifest schema deliverable** — `docs/covenwiki-manifest.schema.json` (render contract for Cody's Phase 2 route; explicit deliverable per the plan risk table).
- **Fingerprint parity is now structural** — `scripts/covenwiki-fs.ts` extracts `walk`/`statInventory` from the regen CLI; the generator imports `computeSourceFingerprint` from the regen lib over that same inventory. Discharges the S5 byte-parity caveat tracked in cave-r3cy. `_citations.json` (source⇄page reverse lookup) is the mapping cave-r3cy's incremental regen needs.

## Verification

- `src/lib/covenwiki-generate.test.ts` — 21 unit tests
- `scripts/covenwiki-generate-cli.test.mjs` — e2e: stub generation contract, **regen `status` reads a fresh wiki as `fresh`** (parity gate), **regen `regenerate` round-trip through `<wiki>.tmp`** (slug `.tmp`-stripping), cli backend via fake model command, fail-closed bad-model run leaves nothing behind
- Existing regen suites still green after the fs extraction; `pnpm typecheck` clean; `check:tests-wired` green
- Smoke: `OpenCoven/coven` repo (826 files) → 4-page stub wiki; `covenwiki-regen status coven` = fresh

## Beads

- Implements **cave-whji** (claimed by sage)
- Unblocks **cave-r3cy** (citations reverse-lookup + parity gate)