### PR TITLE
fix(voice): clamp brain-call turns to the proxy's per-message cap (review follow-up to #3159)

### DIFF
--- a/src/app/api/voice/local/chat/route.ts
+++ b/src/app/api/voice/local/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server.js";
-import { buildLocalBrainMessages, DEFAULT_LOCAL_MODEL, localLlmBaseUrl } from "../../../../../lib/voice/local-loop.ts";
+import { buildLocalBrainMessages, DEFAULT_LOCAL_MODEL, localLlmBaseUrl, MAX_BRAIN_CONTENT_CHARS } from "../../../../../lib/voice/local-loop.ts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,7 +11,10 @@ export const dynamic = "force-dynamic";
 type BrainTurn = { role?: string; content?: string };
 
 const MAX_MESSAGES = 64;
-const MAX_CONTENT_CHARS = 8_000;
+// One shared per-message cap with buildLocalBrainMessages (the in-app client
+// truncates to it before posting), so the client can never assemble a payload
+// this proxy rejects; direct callers exceeding it still get a hard 400.
+const MAX_CONTENT_CHARS = MAX_BRAIN_CONTENT_CHARS;
 
 export async function POST(req: Request) {
   let body: { model?: string; messages?: BrainTurn[] };

--- a/src/lib/voice/local-loop.test.ts
+++ b/src/lib/voice/local-loop.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_LOCAL_MODEL,
   localLlmBaseUrl,
   localVoiceProvider,
+  MAX_BRAIN_CONTENT_CHARS,
   probeLocalLlm,
 } from "./local-loop.ts";
 
@@ -33,6 +34,25 @@ test("buildLocalBrainMessages leads with the persona and caps the turn tail", ()
   assert.equal(messages.length, 25); // system + capped tail
   assert.equal(messages.at(-1).content, "turn 29"); // newest turns win
   assert.equal(messages[1].content, "turn 6"); // oldest six dropped
+});
+
+test("buildLocalBrainMessages clamps oversized turns and drops empty ones (review #3159)", () => {
+  // The conversation seed is raw chat history: code-heavy replies exceed the
+  // proxy's per-message cap and stored turns can be empty. One bad turn must
+  // not 400 the whole brain call — clamp and drop here, the single assembly
+  // point, so the client can never build a payload the proxy rejects.
+  const messages = buildLocalBrainMessages("You are Milo.", [
+    { role: "user", content: "x".repeat(MAX_BRAIN_CONTENT_CHARS + 5_000) },
+    { role: "assistant", content: "   " },
+    { role: "assistant", content: "" },
+    { role: "user", content: "still here?" },
+  ]);
+  assert.equal(messages.length, 3); // system + clamped turn + real turn (empties dropped)
+  assert.equal(messages[1].content.length, MAX_BRAIN_CONTENT_CHARS);
+  assert.ok(messages[1].content.endsWith("…"), "truncation is marked, not silent");
+  assert.equal(messages.at(-1).content, "still here?");
+  // The clamp and the proxy limit are the same constant — they cannot drift.
+  assert.equal(MAX_BRAIN_CONTENT_CHARS, 8_000);
 });
 
 // ── Reachability probe ───────────────────────────────────────────────────────

--- a/src/lib/voice/local-loop.ts
+++ b/src/lib/voice/local-loop.ts
@@ -29,6 +29,12 @@ export const DEFAULT_LOCAL_MODEL = "llama3.2";
 /** Rolling turn cap for the brain call — enough context, bounded payload. */
 const MAX_BRAIN_TURNS = 24;
 
+/** Per-turn content cap, shared with the /api/voice/local/chat proxy so the
+ *  client can never assemble a payload the server rejects. Chat-history seed
+ *  turns routinely exceed this (code-heavy replies) — they get truncated for
+ *  the voice brain, never dropped mid-conversation. */
+export const MAX_BRAIN_CONTENT_CHARS = 8_000;
+
 export type LocalBrainTurn = { role: "user" | "assistant"; content: string };
 
 /** Resolve the loopback LLM base URL (COVEN_LOCAL_LLM_URL wins, no trailing slash). */
@@ -38,13 +44,24 @@ export function localLlmBaseUrl(envValue?: string | null): string {
   return base;
 }
 
-/** System prompt + capped turn tail, in OpenAI chat-completions shape. */
+/** System prompt + capped turn tail, in OpenAI chat-completions shape.
+ *  Every turn is clamped to the proxy's per-message cap and empty turns are
+ *  dropped — the raw conversation seed (hydrateForVoiceCall) is untruncated
+ *  chat history, and one oversized or empty turn must not 400 the whole brain
+ *  call (review finding on #3159). */
 export function buildLocalBrainMessages(
   instructions: string,
   turns: readonly LocalBrainTurn[],
   maxTurns: number = MAX_BRAIN_TURNS,
 ): Array<{ role: "system" | "user" | "assistant"; content: string }> {
-  const tail = turns.slice(-maxTurns);
+  const tail = turns
+    .filter((t) => t.content.trim().length > 0)
+    .map((t) =>
+      t.content.length > MAX_BRAIN_CONTENT_CHARS
+        ? { role: t.role, content: `${t.content.slice(0, MAX_BRAIN_CONTENT_CHARS - 1)}…` }
+        : t,
+    )
+    .slice(-maxTurns);
   return [{ role: "system" as const, content: instructions }, ...tail];
 }
 


### PR DESCRIPTION
## What

Re-lands the second review finding from #3159 (the fix commit `7eb75c8d` was orphaned when the PR squash-merged mid-push).

The local voice provider's conversation seed is **raw chat history** — code-heavy replies exceed the proxy's 8k per-message cap and stored turns can be empty, so one bad turn made `/api/voice/local/chat` 400 (`invalid_content`) on **every** brain call, killing the session with an unactionable `PROVIDER_ERROR`.

## Fix

- `buildLocalBrainMessages` (the single assembly point) truncates oversized turns to the shared cap — ellipsis-marked, never silent — and drops empty turns.
- The proxy imports the same `MAX_BRAIN_CONTENT_CHARS` constant, so the client clamp and server limit **cannot drift**; direct callers exceeding the cap still get the hard 400 contract (route tests unchanged).
- Behavioral tests: clamp + ellipsis marker, empty-turn drop, constant equality with the proxy limit.

## Verification
- voice suites + api-contracts (15 tests) pass on post-merge main · `pnpm typecheck` clean · full `pnpm test:app` passed pre-cherry-pick (707 files, identical content)