### PR TITLE
fix(research): never start a mission with an invalid project root; intelligent retry config

### DIFF
--- a/src/app/api/research/missions/route.test.ts
+++ b/src/app/api/research/missions/route.test.ts
@@ -12,6 +12,14 @@ test("create route is local-only, bounded, and guarded", () => {
   assert.match(route, /createAndStart/);
 });
 
+test("an explicit project root is resolved before the mission exists", () => {
+  // A mission must never be created pointing at a root its sessions can't
+  // run in — that used to surface later as an opaque "invalid project root".
+  assert.match(route, /normalizeProjectRoot\(validated\.value\.projectRoot\)/);
+  assert.match(route, /is not an allowed project path/);
+  assert.match(route, /validated\.value\.projectRoot = resolved/);
+});
+
 test("list requires a familiar and reconciles persisted missions", () => {
   assert.match(route, /familiarId required/);
   assert.match(route, /listAndReconcileResearchMissions/);

--- a/src/app/api/research/missions/route.ts
+++ b/src/app/api/research/missions/route.ts
@@ -7,7 +7,7 @@ import {
   makeProductionResearchMissionRunner,
 } from "@/lib/server/research-mission-runner";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
-import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
+import { MAX_SESSION_JSON_BYTES, normalizeProjectRoot } from "@/lib/server/session-security";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -34,6 +34,18 @@ export async function POST(req: Request) {
   const validated = validateCreateResearchMissionInput(parsed.body);
   if (!validated.ok) {
     return NextResponse.json({ ok: false, error: validated.error }, { status: 400 });
+  }
+  // Resolve an explicit project root before the mission exists, so a mission is
+  // never created pointing at a root its sessions can't run in.
+  if (validated.value.projectRoot) {
+    const resolved = normalizeProjectRoot(validated.value.projectRoot);
+    if (!resolved) {
+      return NextResponse.json({
+        ok: false,
+        error: `Project root "${validated.value.projectRoot}" is not an allowed project path. Add it as a Cave project first, or leave it empty to use the mission workspace.`,
+      }, { status: 400 });
+    }
+    validated.value.projectRoot = resolved;
   }
   const mission = await makeProductionResearchMissionRunner().createAndStart(validated.value);
   return NextResponse.json({ ok: true, mission });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15685,7 +15685,7 @@ details[open] > .cave-edit-card__summary::before {
 .research-mission-actions { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 6px; margin-top: 10px; }
 .research-retry-config { flex-basis: 100%; display: grid; gap: 5px; font-size: 10px; color: var(--text-muted); }
 .research-retry-config label { width: fit-content; }
-.research-retry-config input { display: block; width: 100%; padding: 7px 8px; font-size: 12px; font-family: var(--font-mono); color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
+.research-retry-config input { display: block; width: 100%; padding: 7px 8px; font-size: 16px; font-family: var(--font-mono); color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
 .research-retry-config input:focus-visible { outline: var(--ring-width) solid var(--ring-focus); outline-offset: 1px; }
 .research-retry-config p { color: var(--text-muted); }
 .research-refine-control { flex-basis: 100%; padding-top: 2px; font-size: 10px; color: var(--text-muted); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15683,6 +15683,11 @@ details[open] > .cave-edit-card__summary::before {
 .research-automation__controls { display: flex; flex-wrap: wrap; gap: 6px; }
 .research-automation__stop { color: oklch(0.84 0.1 75) !important; }
 .research-mission-actions { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 6px; margin-top: 10px; }
+.research-retry-config { flex-basis: 100%; display: grid; gap: 5px; font-size: 10px; color: var(--text-muted); }
+.research-retry-config label { width: fit-content; }
+.research-retry-config input { display: block; width: 100%; padding: 7px 8px; font-size: 12px; font-family: var(--font-mono); color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
+.research-retry-config input:focus-visible { outline: var(--ring-width) solid var(--ring-focus); outline-offset: 1px; }
+.research-retry-config p { color: var(--text-muted); }
 .research-refine-control { flex-basis: 100%; padding-top: 2px; font-size: 10px; color: var(--text-muted); }
 .research-refine-control summary { width: fit-content; cursor: pointer; }
 .research-refine-control textarea { display: block; width: 100%; min-height: 58px; margin: 7px 0 6px; resize: vertical; padding: 7px 8px; font-size: 16px; color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Icon } from "@/lib/icon";
@@ -69,6 +69,14 @@ export function ResearchMissionDetail({
   const [busy, setBusy] = useState(false);
   const [direction, setDirection] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
+  // null = untouched; the retry payload then adapts to the failure instead.
+  const [retryRoot, setRetryRoot] = useState<string | null>(null);
+  const missionId = mission?.id ?? null;
+
+  useEffect(() => {
+    setRetryRoot(null);
+    setActionError(null);
+  }, [missionId]);
 
   if (!mission) {
     return (
@@ -83,6 +91,21 @@ export function ResearchMissionDetail({
   const iteration = mission.iterations.at(-1);
   const sessionId = iteration?.sessionId;
   const actions = allowedResearchActions(mission);
+  // Root-blocked failures get a self-healing Retry: untouched config clears the
+  // rejected root so the retried iteration runs in the mission workspace.
+  const rootFailure = mission.status === "failed" && /project root/i.test(mission.lastError ?? "");
+  const showRetryConfig = actions.includes("retry") && (rootFailure || Boolean(mission.projectRoot));
+  const retryRootValue = retryRoot ?? mission.projectRoot ?? "";
+  const plannedRetry: { action: "retry"; projectRoot?: string | null } = (() => {
+    if (retryRoot !== null) return { action: "retry", projectRoot: retryRoot.trim() || null };
+    if (rootFailure && mission.projectRoot) return { action: "retry", projectRoot: null };
+    return { action: "retry" };
+  })();
+  const retryLabel = plannedRetry.projectRoot === undefined
+    ? "Retry"
+    : plannedRetry.projectRoot === null
+      ? (mission.projectRoot ? "Retry in workspace" : "Retry")
+      : plannedRetry.projectRoot === mission.projectRoot ? "Retry" : "Retry with new root";
   const elapsedMinutes = mission.startedAt
     ? Math.max(0, Math.round((Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt)) / 60_000))
     : 0;
@@ -103,6 +126,7 @@ export function ResearchMissionDetail({
         return;
       }
       if (input.action === "refine") setDirection("");
+      if (input.action === "retry") setRetryRoot(null);
       announce(`Research ${input.action} applied.`);
     } finally {
       setBusy(false);
@@ -271,15 +295,34 @@ export function ResearchMissionDetail({
 
           {actions.length > 0 ? (
             <div className="research-mission-actions" aria-label="Research mission actions">
+              {showRetryConfig ? (
+                <div className="research-retry-config">
+                  <label htmlFor="research-retry-root">Retry project root</label>
+                  <input
+                    id="research-retry-root"
+                    type="text"
+                    value={retryRootValue}
+                    placeholder="Leave empty to run in the mission workspace"
+                    spellCheck={false}
+                    onChange={(event) => setRetryRoot(event.target.value)}
+                  />
+                  {rootFailure ? (
+                    <p>
+                      The last run could not start in its project root. Retry runs in the
+                      mission workspace unless a valid root is set above.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               {actions.filter((action) => action !== "refine").map((action) => (
                 <Button
                   key={action}
                   size="xs"
                   variant={action === "continue" || action === "retry" ? "primary" : action === "cancel" ? "danger-ghost" : "ghost"}
                   disabled={busy}
-                  onClick={() => void runAction({ action })}
+                  onClick={() => void runAction(action === "retry" ? plannedRetry : { action })}
                 >
-                  {ACTION_LABELS[action] ?? action}
+                  {action === "retry" ? retryLabel : ACTION_LABELS[action] ?? action}
                 </Button>
               ))}
               {actions.includes("refine") ? (

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -64,6 +64,21 @@ test("checkpoint lifecycle controls are explicit and server-backed", () => {
   assert.match(surface, /research\.act/);
 });
 
+test("retry adapts to project-root failures with a visible config", () => {
+  // Failure class detection drives the retry payload…
+  assert.match(detail, /rootFailure = mission\.status === "failed" && \/project root\/i\.test\(mission\.lastError \?\? ""\)/);
+  assert.match(detail, /\{ action: "retry", projectRoot: null \}/);
+  assert.match(detail, /projectRoot: retryRoot\.trim\(\) \|\| null/);
+  // …the button label says what the retry will actually do…
+  assert.match(detail, /Retry in workspace/);
+  assert.match(detail, /Retry with new root/);
+  assert.match(detail, /runAction\(action === "retry" \? plannedRetry : \{ action \}\)/);
+  // …and the root is editable with an honest workspace fallback.
+  assert.match(detail, /id="research-retry-root"/);
+  assert.match(detail, /Leave empty to run in the mission workspace/);
+  assert.match(css, /\.research-retry-config input/);
+});
+
 test("autoresearch schedules use standard paused Automation controls", () => {
   assert.match(detail, /Create schedule/);
   assert.match(detail, /Run now/);

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -168,7 +168,16 @@ export type CreateResearchMissionInput = {
 };
 
 export type ResearchMissionActionInput =
-  | { action: ResearchMissionAction; direction?: string }
+  | {
+    action: ResearchMissionAction;
+    direction?: string;
+    /**
+     * Retry-only project root override: a path re-targets the retried
+     * iteration (validated server-side against allowed project roots), null
+     * clears a configured root so the retry runs in the mission workspace.
+     */
+    projectRoot?: string | null;
+  }
   | { action: "attach-source"; source: ResearchSourceDraft }
   | { action: "update-source"; sourceId: string; patch: ResearchSourcePatch }
   | { action: "reject-artifact"; artifactKey: string; reason: string };

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -61,6 +61,47 @@ try {
     await realpath(path.join(savedProjectRoot, "docs")),
     "saved Cave project roots are allowed for file tree browsing",
   );
+
+  // Research mission workspaces live under cave state, not a registered
+  // project; they must still be valid session roots (research runs failed
+  // with "invalid project root" without this).
+  const missionWorkspace = path.join(
+    process.env.COVEN_HOME,
+    "cave",
+    "research-missions",
+    "research-fixture",
+  );
+  await mkdir(missionWorkspace, { recursive: true });
+  assert.equal(
+    resolveAllowedProjectPath(missionWorkspace),
+    await realpath(missionWorkspace),
+    "research mission workspaces are allowed project roots",
+  );
+
+  // Allowed roots must be computed per call: a project saved after module
+  // load was invisible until restart, failing sessions with "invalid project root".
+  const lateProjectRoot = path.join(tmp, "Documents", "GitHub", "OpenCoven", "late-project");
+  await mkdir(lateProjectRoot, { recursive: true });
+  assert.equal(
+    resolveAllowedProjectPath(lateProjectRoot),
+    null,
+    "unregistered roots stay rejected",
+  );
+  await writeFile(
+    process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+    JSON.stringify({
+      version: 1,
+      projects: [
+        { id: "docs", name: "Coven Docs", root: savedProjectRoot },
+        { id: "late", name: "Late Project", root: lateProjectRoot },
+      ],
+    }),
+  );
+  assert.equal(
+    resolveAllowedProjectPath(lateProjectRoot),
+    await realpath(lateProjectRoot),
+    "projects saved after startup are allowed without a server restart",
+  );
 } finally {
   restoreEnv();
   await rm(tmp, { recursive: true, force: true });

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 import { covenHome, caveHome, covenWorkspaceRoot } from "@/lib/coven-paths";
+import { researchMissionsRoot } from "@/lib/server/research-mission-store";
 
 function realpathOrResolve(value: string): string {
   const resolved = path.resolve(value);
@@ -41,22 +42,31 @@ function savedCaveProjectRoots(): string[] {
   }
 }
 
-const ALLOWED_ROOTS = Array.from(
-  new Set(
-    [
-      process.env.WORKSPACE_ROOT,
-      process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
-      covenWorkspaceRoot(),
-      // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
-      process.env.OPENCLAW_WORKSPACE_ROOT,
-      path.join(homedir(), ".openclaw", "workspace"),
-      process.cwd(),
-      ...savedCaveProjectRoots(),
-    ]
-      .filter((value): value is string => Boolean(value))
-      .map(realpathOrResolve),
-  ),
-);
+// Computed per call, never cached at module load: saved Cave projects and
+// research mission workspaces are created at runtime, and a snapshot taken at
+// import time silently rejected them ("invalid project root") until the next
+// server restart.
+function allowedProjectRoots(): string[] {
+  return Array.from(
+    new Set(
+      [
+        process.env.WORKSPACE_ROOT,
+        process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
+        covenWorkspaceRoot(),
+        // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
+        process.env.OPENCLAW_WORKSPACE_ROOT,
+        path.join(homedir(), ".openclaw", "workspace"),
+        process.cwd(),
+        // Research mission workspaces host bounded research sessions and live
+        // under cave state rather than a registered project root.
+        researchMissionsRoot(),
+        ...savedCaveProjectRoots(),
+      ]
+        .filter((value): value is string => Boolean(value))
+        .map(realpathOrResolve),
+    ),
+  );
+}
 
 function isWithinRoot(candidate: string, root: string): boolean {
   return candidate === root || candidate.startsWith(root + path.sep);
@@ -76,7 +86,7 @@ function relativeWithinRoot(candidate: string, root: string): string | null {
 
 export function resolveAllowedProjectSubpath(value: string): { root: string; relativePath: string } | null {
   const candidate = realpathOrResolve(normalizeLegacyCovenWorkspacePath(value));
-  for (const root of ALLOWED_ROOTS) {
+  for (const root of allowedProjectRoots()) {
     if (isWithinRoot(candidate, root)) {
       const relativePath = relativeWithinRoot(candidate, root);
       if (relativePath !== null) {

--- a/src/lib/server/research-mission-runner.test.ts
+++ b/src/lib/server/research-mission-runner.test.ts
@@ -78,6 +78,7 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     readAutomationCheckpoint: async () => ({ transcript: "", token: "", at: NOW.toISOString() }),
     fingerprintMission: async () => "checkpoint-before",
     missionWorkspacePath: (id) => `/tmp/research-missions/${id}`,
+    resolveProjectRoot: async (root) => root,
     now: () => NOW,
     randomId: () => "mission-1",
     ...overrides,
@@ -165,6 +166,37 @@ test("launch failure remains persisted and retryable", async () => {
   assert.equal(result.lastError, "daemon offline");
   assert.ok(allowedResearchActions(result).includes("retry"));
   assert.equal(saved.at(-1)?.status, "failed");
+});
+
+test("the default project root is the pre-resolved mission workspace", async () => {
+  const roots: Array<string | null> = [];
+  const runner = makeResearchMissionRunner(deps({
+    resolveProjectRoot: async (root) => `/resolved${root}`,
+    startFlow: async (_flow, options) => {
+      roots.push(options.projectRoot);
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+  const result = await runner.createAndStart(INPUT);
+  assert.deepEqual(roots, ["/resolved/tmp/research-missions/mission-1"]);
+  assert.equal(result.status, "running");
+});
+
+test("an unallowed configured project root fails fast with an actionable error", async () => {
+  let starts = 0;
+  const runner = makeResearchMissionRunner(deps({
+    resolveProjectRoot: async () => null,
+    startFlow: async () => {
+      starts += 1;
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+  const result = await runner.createAndStart({ ...INPUT, projectRoot: "/missing/repo" });
+  assert.equal(starts, 0, "no session may launch against an invalid project root");
+  assert.equal(result.status, "failed");
+  assert.match(result.lastError ?? "", /"\/missing\/repo" is not an allowed project path/);
+  assert.match(result.lastError ?? "", /mission workspace/);
+  assert.ok(allowedResearchActions(result).includes("retry"));
 });
 
 test("travel launch remains honestly queued", async () => {
@@ -706,6 +738,60 @@ test("retry relaunches the failed iteration even when the mission limit is one",
   assert.equal(starts, 1);
   assert.equal(result.iterations.length, 1);
   assert.equal(result.iterations[0].status, "running");
+});
+
+test("retry clears a rejected project root and reruns in the mission workspace", async () => {
+  let stored = checkpointMission({
+    mode: "brief",
+    status: "failed",
+    projectRoot: "/missing/repo",
+    iterations: [{ number: 1, status: "failed", finishedAt: NOW.toISOString() }],
+  });
+  const roots: Array<string | null> = [];
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    resolveProjectRoot: async (root) => root === "/missing/repo" ? null : root,
+    startFlow: async (_flow, options) => {
+      roots.push(options.projectRoot);
+      return { ok: true, executor: "session", sessionId: "retry-session", run: RUN };
+    },
+  }));
+  const result = await runner.act(stored.id, { action: "retry", projectRoot: null });
+  assert.deepEqual(roots, ["/tmp/research-missions/mission-actions"]);
+  assert.equal(result.projectRoot, undefined, "the invalid root must not survive the retry");
+  assert.equal(result.status, "running");
+});
+
+test("retry validates a project root override before persisting it", async () => {
+  let stored = checkpointMission({
+    mode: "brief",
+    status: "failed",
+    iterations: [{ number: 1, status: "failed", finishedAt: NOW.toISOString() }],
+  });
+  const roots: Array<string | null> = [];
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    resolveProjectRoot: async (root) => (
+      root === "/repos/app" || root === "/real/repos/app" ? "/real/repos/app" : null
+    ),
+    startFlow: async (_flow, options) => {
+      roots.push(options.projectRoot);
+      return { ok: true, executor: "session", sessionId: "retry-session", run: RUN };
+    },
+  }));
+  await assert.rejects(
+    () => runner.act(stored.id, { action: "retry", projectRoot: "/not/allowed" }),
+    /"\/not\/allowed" is not an allowed project path/,
+  );
+  assert.deepEqual(roots, [], "an invalid override must not launch anything");
+  assert.equal(stored.status, "failed");
+
+  const result = await runner.act(stored.id, { action: "retry", projectRoot: "/repos/app" });
+  assert.deepEqual(roots, ["/real/repos/app"]);
+  assert.equal(result.projectRoot, "/real/repos/app");
+  assert.equal(result.status, "running");
 });
 
 test("completed automation runs validate evidence and publish Knowledge", async () => {

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -90,6 +90,8 @@ export type ResearchMissionRunnerDeps = {
   readAutomationCheckpoint(id: string): Promise<{ transcript: string; token: string; at: string }>;
   fingerprintMission(id: string): Promise<string>;
   missionWorkspacePath(id: string): string;
+  /** Resolve a candidate project root to a normalized allowed path, or null. */
+  resolveProjectRoot(root: string): Promise<string | null>;
   now(): Date;
   randomId(): string;
 };
@@ -416,6 +418,51 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     return updated;
   };
 
+  /**
+   * Resolve the project root an iteration will run in before any session is
+   * spawned. A configured-but-unallowed root fails fast with an actionable
+   * message (the flow executor would only say "invalid project root"); the
+   * default mission workspace always resolves.
+   */
+  const missionStartTarget = async (
+    mission: ResearchMission,
+  ): Promise<{ ok: true; projectRoot: string } | { ok: false; error: string }> => {
+    if (mission.projectRoot) {
+      const resolved = await deps.resolveProjectRoot(mission.projectRoot);
+      if (resolved) return { ok: true, projectRoot: resolved };
+      return {
+        ok: false,
+        error: `Project root "${mission.projectRoot}" is not an allowed project path. Retry in the mission workspace, or set a valid root (an existing Cave project or workspace folder).`,
+      };
+    }
+    const workspace = deps.missionWorkspacePath(mission.id);
+    const resolved = await deps.resolveProjectRoot(workspace);
+    return { ok: true, projectRoot: resolved ?? workspace };
+  };
+
+  /**
+   * Apply a retry-time project root override: a string is validated and
+   * persisted, null/empty clears the configured root so the mission falls
+   * back to its own workspace.
+   */
+  const applyProjectRootOverride = async (
+    mission: ResearchMission,
+    override: string | null,
+  ): Promise<ResearchMission> => {
+    const trimmed = override?.trim() ?? "";
+    if (!trimmed) return { ...mission, projectRoot: undefined };
+    if (trimmed.length > 2_000 || trimmed.includes("\0")) {
+      throw new Error("invalid project root override");
+    }
+    const resolved = await deps.resolveProjectRoot(trimmed);
+    if (!resolved) {
+      throw new Error(
+        `Project root "${trimmed}" is not an allowed project path. Add it as a Cave project first, or leave it empty to use the mission workspace.`,
+      );
+    }
+    return { ...mission, projectRoot: resolved };
+  };
+
   const startNextIteration = async (mission: ResearchMission): Promise<ResearchMission> => {
     const stopReason = stopBeforeNextIteration(mission, deps.now());
     if (stopReason) {
@@ -447,10 +494,10 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       artifacts: workingArtifact ? [workingArtifact, ...mission.artifacts] : mission.artifacts,
     };
     await deps.saveMission(next);
-    const flow = buildResearchMissionFlow(next, number);
-    const result = await deps.startFlow(flow, {
-      projectRoot: next.projectRoot ?? researchMissionWorkspacePath(next.id),
-    });
+    const target = await missionStartTarget(next);
+    const result = target.ok
+      ? await deps.startFlow(buildResearchMissionFlow(next, number), { projectRoot: target.projectRoot })
+      : { ok: false, error: target.error };
     next = applyStartResult(next, result, deps.now());
     await deps.saveMission(next);
     return next;
@@ -489,9 +536,12 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       } : iteration),
     };
     await deps.saveMission(retried);
-    const result = await deps.startFlow(buildResearchMissionFlow(retried, current.number), {
-      projectRoot: retried.projectRoot ?? deps.missionWorkspacePath(retried.id),
-    });
+    const target = await missionStartTarget(retried);
+    const result = target.ok
+      ? await deps.startFlow(buildResearchMissionFlow(retried, current.number), {
+        projectRoot: target.projectRoot,
+      })
+      : { ok: false, error: target.error };
     retried = applyStartResult(retried, result, deps.now());
     await deps.saveMission(retried);
     return retried;
@@ -541,6 +591,9 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         return startNextIteration(mission);
       }
       if (input.action === "retry") {
+        if (input.projectRoot !== undefined) {
+          mission = await applyProjectRootOverride(mission, input.projectRoot);
+        }
         return retryCurrentIteration(mission);
       }
       if (input.action === "continue") {
@@ -812,10 +865,10 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       let mission = createMissionRecord(input, deps.randomId(), deps.now());
       mission = await deps.createWorkspace(mission);
       await deps.saveMission(mission);
-      const flow = buildResearchMissionFlow(mission, 1);
-      const result = await deps.startFlow(flow, {
-        projectRoot: mission.projectRoot ?? researchMissionWorkspacePath(mission.id),
-      });
+      const target = await missionStartTarget(mission);
+      const result = target.ok
+        ? await deps.startFlow(buildResearchMissionFlow(mission, 1), { projectRoot: target.projectRoot })
+        : { ok: false, error: target.error };
       mission = applyStartResult(mission, result, deps.now());
       await deps.saveMission(mission);
       return mission;
@@ -1014,6 +1067,10 @@ export function makeProductionResearchMissionRunner() {
       return hash.digest("hex");
     },
     missionWorkspacePath: researchMissionWorkspacePath,
+    resolveProjectRoot: async (root) => {
+      const { normalizeProjectRoot } = await import("./session-security.ts");
+      return normalizeProjectRoot(root);
+    },
     now: () => new Date(),
     randomId: () => `research-${crypto.randomUUID()}`,
   };


### PR DESCRIPTION
## Problem

Research missions failed at **Scope** with an opaque `invalid project root`. Root cause: missions default their session cwd to the mission workspace under `~/.coven/cave/research-missions/<id>`, but `project-paths.ts` snapshotted `ALLOWED_ROOTS` at module load — the research-missions root was never included, and Cave projects saved after boot were invisible until a server restart. Every default research run was doomed.

## Fix

- **`src/lib/server/project-paths.ts`** — `allowedProjectRoots()` computed per call; includes `researchMissionsRoot()` and fresh `projects.json` roots.
- **`src/lib/server/research-mission-runner.ts`** — `missionStartTarget` pre-resolves the effective root before any session spawns. A configured-but-unallowed root fails fast with an actionable message instead of the opaque executor error. `retry` accepts a `projectRoot` override: a path is validated + persisted, `null`/empty clears the configured root so the retry runs in the mission workspace.
- **`POST /api/research/missions`** — rejects an invalid `projectRoot` with guidance *before* the mission exists.
- **`research-mission-detail.tsx`** — dynamic Retry: root-class failures reveal an editable project-root config; button label/payload adapt (`Retry` / `Retry in workspace` / `Retry with new root`).

## Validation

- `research-mission-runner.test.ts` (29 pass; 4 new), `project-paths.test.ts` (research workspace allowed; late-saved project allowed without restart)
- surface/route/client/store suites (25 pass), `api-contracts.test.ts`, `harness-routing.test.ts`, `pnpm typecheck` — all green
- **Live verification**: the actual failed mission (`research-31921a3f`) retried through the patched server → `running`, trigger succeeded, scope in progress.