### PR TITLE
fix(analytics): vital-capability status uses the latest report, not worst-ever (cave-hdkx)

### DIFF
--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   aggregateResponseConfidenceEvents,
+  aggregateThreadSignals,
   buildReflectTranscript,
   buildThreadReflectPrompt,
   buildThreadSignalResolutionPrompt,
@@ -225,5 +226,67 @@ describe("buildThreadReflectPrompt", () => {
       const p = buildThreadSignalResolutionPrompt({ kind, severity: "info", sourceId: "t", title: "t", detail: "d" });
       assert.doesNotMatch(p, /undefined/, `${kind} resolves to a label`);
     }
+  });
+});
+
+describe("aggregateThreadSignals vital capabilities", () => {
+  function reportWithVital(
+    id: string,
+    reportedAt: string,
+    vital: ThreadSelfReport["capabilitiesVital"],
+  ): ThreadSelfReport {
+    return { ...fullReport(), id, sessionId: id, reportedAt, capabilitiesVital: vital };
+  }
+
+  it("uses the latest report's currentState per capability, so recovered capabilities stop surfacing as missing", () => {
+    // Regression: a capability broken in one old session (e.g. the pre-#2985
+    // copilot permission regression) must not pin `status: missing` after
+    // newer reports observe it available (cave-hdkx).
+    const stale = reportWithVital("session-old", "2026-07-12T01:39:00.000Z", [
+      { name: "command execution for builds/tests", currentState: "missing", notes: "Denied by permission layer." },
+    ]);
+    const recovered = reportWithVital("session-new", "2026-07-14T21:30:00.000Z", [
+      { name: "command execution for builds/tests", currentState: "available", notes: "cargo/pnpm/node verified." },
+    ]);
+    // Order of the input array must not matter — only reportedAt recency.
+    for (const reports of [
+      [stale, recovered],
+      [recovered, stale],
+    ]) {
+      const aggregate = aggregateThreadSignals(reports);
+      assert.deepEqual(aggregate.capabilitiesVital, [
+        { name: "command execution for builds/tests", currentState: "available", notes: "cargo/pnpm/node verified." },
+      ]);
+    }
+  });
+
+  it("keeps a newest-report degradation visible", () => {
+    const wasFine = reportWithVital("session-old", "2026-07-10T08:00:00.000Z", [
+      { name: "GitHub CLI", currentState: "available", notes: "Authenticated." },
+    ]);
+    const nowBroken = reportWithVital("session-new", "2026-07-14T09:00:00.000Z", [
+      { name: "GitHub CLI", currentState: "missing", notes: "Token expired." },
+    ]);
+    const aggregate = aggregateThreadSignals([wasFine, nowBroken]);
+    assert.deepEqual(aggregate.capabilitiesVital, [
+      { name: "GitHub CLI", currentState: "missing", notes: "Token expired." },
+    ]);
+  });
+
+  it("tracks distinct capability names independently", () => {
+    const a = reportWithVital("session-a", "2026-07-13T10:00:00.000Z", [
+      { name: "shell command execution", currentState: "available" },
+    ]);
+    const b = reportWithVital("session-b", "2026-07-14T10:00:00.000Z", [
+      { name: "artifact capture", currentState: "degraded", notes: "Flaky screenshots." },
+    ]);
+    const aggregate = aggregateThreadSignals([b, a]);
+    assert.deepEqual(
+      new Map(aggregate.capabilitiesVital.map((c) => [c.name, c.currentState])),
+      new Map([
+        ["shell command execution", "available"],
+        ["artifact capture", "degraded"],
+      ]),
+    );
   });
 });

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -271,7 +271,6 @@ export function buildThreadSignalResolutionPrompt(item: ThreadSignalReviewItem):
 export const THREAD_SIGNALS_EMPTY_STATE = "No thread reports yet. Use 'Reflect on this thread' to generate the first one.";
 
 const IMPORTANCE_WEIGHT: Record<CapabilityImportance, number> = { "nice-to-have": 1, important: 2, blocking: 3 };
-const STATE_WEIGHT: Record<CapabilityState, number> = { available: 1, degraded: 2, missing: 3 };
 
 function libAvg(values: number[]): number {
   if (values.length === 0) return 0;
@@ -362,8 +361,11 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
     for (const s of r.skillsNeedingClarity) if (!clarity.has(s.skillId)) clarity.set(s.skillId, s);
     for (const s of r.skillsNeedingAccess) if (!access.has(s.skillId)) access.set(s.skillId, s);
     for (const c of r.capabilitiesVital) {
-      const prev = capVital.get(c.name);
-      if (!prev || STATE_WEIGHT[c.currentState] > STATE_WEIGHT[prev.currentState]) capVital.set(c.name, c);
+      // Latest report wins: `currentState` is a *current* observation, and
+      // reports iterate newest-first. Letting an older, worse state override
+      // (the old STATE_WEIGHT behavior) pinned long-fixed capabilities at
+      // "missing" for the whole report window (cave-hdkx).
+      if (!capVital.has(c.name)) capVital.set(c.name, c);
     }
     for (const c of r.capabilitiesLacking) {
       const prev = capLacking.get(c.name);


### PR DESCRIPTION
## Problem
The Thread Signals **Capabilities vital** table (and the Resolve prompt it launches) reported `command execution for builds/tests — status: missing` for familiar cody, days after the underlying issue was fixed by #2985 (2026-07-12 13:35Z). Source report: `479efb6d`, filed 01:39Z that day — 12h before the fix merged.

Root cause: `aggregateThreadSignals` used worst-state-wins (`STATE_WEIGHT`) for `capabilitiesVital.currentState`, so a single stale `missing` observation pinned the row at critical for the entire 30-report window, regardless of newer `available` observations. `currentState` is a *current* observation — showing an old worse state as current is factually wrong and spawns resolution threads for already-fixed gaps.

## Fix
Latest-report-wins per capability name: reports already iterate newest-first, so keep first-seen per name and drop the `STATE_WEIGHT` override (now unused). `capabilitiesLacking` and `persistentBlockers` keep their importance/frequency semantics — those are complaint aggregates, not current-state claims.

## Tests
New `aggregateThreadSignals vital capabilities` suite in `thread-self-report.test.ts` (red on old code):
- recovered capability no longer reports `missing` (input order independent)
- newest-report degradation still surfaces
- distinct names tracked independently

`node scripts/run-tests.mjs app`: 707 test files pass. `tsc --noEmit` clean.

Bead: cave-hdkx