### PR TITLE
refactor(dashboard): split the cockpit monolith — pure format lib + panel layer, semantic <time> stamps (cave-tsoz)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -203,6 +203,7 @@ export const SUITES = {
     "src/lib/daily-note.test.ts",
     "src/components/familiar-daily-notes.test.ts",
     "src/lib/dashboard-model.test.ts",
+    "src/lib/dashboard-cockpit-format.test.ts",
     "src/lib/dashboard-analytics.test.ts",
     "src/lib/coven-analytics.test.ts",
     "src/app/dashboard-page.test.ts",

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -13,7 +13,14 @@ assert.match(page, /dr-page/, "dashboard should use the shared surface styling")
 
 const cockpitUrl = new URL("../components/dashboard/dashboard-cockpit.tsx", import.meta.url);
 assert.equal(existsSync(cockpitUrl), true, "DashboardCockpit component should exist");
-const cockpit = readFileSync(cockpitUrl, "utf8");
+// The cockpit is split across the data/layout root, the presentational panel
+// layer, and the pure label helpers (cave-tsoz) — this contract covers the
+// whole surface, so read the split as one source.
+const cockpit = [
+  readFileSync(cockpitUrl, "utf8"),
+  readFileSync(new URL("../components/dashboard/cockpit-panels.tsx", import.meta.url), "utf8"),
+  readFileSync(new URL("../lib/dashboard-cockpit-format.ts", import.meta.url), "utf8"),
+].join("\n");
 
 // The cockpit folds the original triage/summary zones in…
 assert.match(cockpit, /ActionInbox/, "cockpit keeps the action inbox (triage) panel");

--- a/src/components/dashboard/cockpit-panels.tsx
+++ b/src/components/dashboard/cockpit-panels.tsx
@@ -1,0 +1,584 @@
+"use client";
+
+// Presentational panel layer for the dashboard cockpit — extracted from
+// dashboard-cockpit.tsx (cave-tsoz). Each panel owns its skeleton and empty
+// state; the cockpit root owns data fetching, derivation, and layout. Pure
+// label/vocab helpers live in @/lib/dashboard-cockpit-format.
+
+import { useMemo, useState, type ReactNode, type CSSProperties } from "react";
+import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
+import { AuthedImage } from "@/components/ui/authed-image";
+import type { Card, CardStatus } from "@/lib/cave-board-types";
+import type { Familiar, SessionRow } from "@/lib/types";
+import type { GitHubItem } from "@/lib/github-tasks";
+import type { InboxItem } from "@/lib/cave-inbox";
+import { relativeTime } from "@/lib/daily-report";
+import { EmptyState } from "@/components/daily-report-ui";
+import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
+import { DonutChart } from "@/components/ui/charts/donut-chart";
+import { Heatmap } from "@/components/ui/charts/heatmap";
+import {
+  familiarMiniProfiles, familiarLoadSeries, type DashboardSignal,
+  defaultInsightOrder, sortInsightRows, filterInsightRows, type InsightSortKey, type SortDir,
+  sortSpaceRows, formatBytes, type SpaceSortKey, type SpaceUsageRow,
+} from "@/lib/dashboard-analytics";
+import type { FamiliarInsightRow } from "@/lib/coven-analytics";
+import type { ConfidenceFactor } from "@/lib/familiar-confidence";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { openExternalUrl } from "@/lib/open-external";
+import {
+  HEALTH_META, STATUS_META, STATUS_ORDER, TIER_TONE, TREND_DAYS,
+  confidenceColor, prettyFactor, shortRepo, whenLabel,
+} from "@/lib/dashboard-cockpit-format";
+
+// ─── Coven insight banner ────────────────────────────────────────────────────────
+
+const INSIGHT_ICON: Record<"good" | "warn" | "bad", IconName> = {
+  good: "ph:check-circle-bold", warn: "ph:warning-circle", bad: "ph:warning-fill",
+};
+export function CovenInsightBanner({ insight }: { insight: { headline: string; detail: string; tone: "good" | "warn" | "bad" } }) {
+  return (
+    <div className={`coven-insight coven-insight--${insight.tone}`} role="note">
+      <Icon name={INSIGHT_ICON[insight.tone]} className="coven-insight__icon" aria-hidden />
+      <span className="coven-insight__text">
+        <b>{insight.headline}.</b> {insight.detail}
+      </span>
+    </div>
+  );
+}
+
+// ─── Panel wrapper ───────────────────────────────────────────────────────────────
+
+export function Panel({ title, icon, count, hint, href, children }: {
+  title: string; icon: IconName; count?: number; hint?: string; href?: string; children: ReactNode;
+}) {
+  return (
+    <section className="cockpit-panel" aria-label={title}>
+      <div className="cockpit-panel__head">
+        <span className="cockpit-panel__title">
+          <Icon name={icon} className="cockpit-panel__icon" aria-hidden />
+          {title}
+          {count != null ? <span className="cockpit-panel__count">{count}</span> : null}
+        </span>
+        {hint ? <span className="cockpit-panel__hint">{hint}</span> : null}
+        {href ? (
+          <a className="cockpit-panel__more" href={href} aria-label={`Open ${title}`}>
+            <Icon name="ph:arrow-right-bold" aria-hidden />
+          </a>
+        ) : null}
+      </div>
+      <div className="cockpit-panel__body">{children}</div>
+    </section>
+  );
+}
+
+// ─── Sortable widget wrapper ─────────────────────────────────────────────────────
+
+export function SortableWidget({ id, title, children }: { id: string; title: string; children: ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const reduceMotion = usePrefersReducedMotion();
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    // dnd-kit drives the settle animation via an inline JS transition that the
+    // global reduced-motion CSS reset can't reach — drop it so panels snap into
+    // place instead of sliding when the user asks for less motion.
+    transition: reduceMotion ? undefined : transition,
+    zIndex: isDragging ? 20 : undefined,
+    opacity: isDragging ? 0.92 : undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style} className={`cockpit-sortable${isDragging ? " is-dragging" : ""}`}>
+      <button type="button" className="cockpit-grip" aria-label={`Drag to rearrange: ${title}`} {...attributes} {...listeners}>
+        <Icon name="ph:dots-six-vertical" aria-hidden />
+      </button>
+      {children}
+    </div>
+  );
+}
+
+// ─── Vitals KPI tile ─────────────────────────────────────────────────────────────
+
+export type KpiTileProps = {
+  icon: IconName; value: number | null; suffix?: string; label: string; sub?: string;
+  accent: "rose" | "lavender" | "green" | "blue" | "amber" | "teal";
+  good: "up" | "down"; href?: string; loading: boolean; series: SparkPoint[];
+};
+const KPI_ACCENT: Record<KpiTileProps["accent"], string> = {
+  rose: "var(--color-danger)", lavender: "var(--accent-presence)", green: "var(--color-success)",
+  blue: "var(--color-info)", amber: "var(--color-warning)", teal: "oklch(0.68 0.12 190)",
+};
+
+export function KpiTile({ icon, value, suffix, label, sub, accent, good, href, loading, series }: KpiTileProps) {
+  const color = KPI_ACCENT[accent];
+  const pts = series.map((p) => p.value).filter((v): v is number => v != null);
+  const delta = pts.length >= 2 ? pts[pts.length - 1] - pts[0] : 0;
+  // Color the delta by meaning, not direction: a rise in a "good=up" metric is
+  // progress (success); a rise in a "good=down" metric (Needs you) is load.
+  const beneficial = delta === 0 ? null : (delta > 0) === (good === "up");
+  const display = loading || value == null ? "—" : `${value}${suffix ?? ""}`;
+  const inner = (
+    <>
+      <span className="cockpit-kpi__top">
+        <span className="cockpit-kpi__icon" style={{ ["--kpi" as string]: color }}>
+          <Icon name={icon} aria-hidden />
+        </span>
+        {!loading && delta !== 0 ? (
+          <span
+            className={`cockpit-kpi__delta cockpit-kpi__delta--${beneficial ? "good" : "bad"}`}
+            title={`${delta > 0 ? "+" : ""}${delta}${suffix ?? ""} over ${TREND_DAYS} days`}
+          >
+            {delta > 0 ? "▲" : "▼"} {Math.abs(delta)}{suffix ?? ""}
+          </span>
+        ) : null}
+      </span>
+      <span className="cockpit-kpi__value">{display}</span>
+      <span className="cockpit-kpi__label">{label}</span>
+      {sub ? <span className="cockpit-kpi__sub">{sub}</span> : null}
+      {/* No wave without data — loading or empty, a flatline under "—" reads
+          as a dead metric (cave-m4oq). One accent for every trend: the wave is
+          texture, the tile icon carries the semantic tint. */}
+      {value == null ? null : (
+        <Sparkline points={series} color="var(--accent-presence)" height={22} />
+      )}
+    </>
+  );
+  return href ? <a className="cockpit-kpi" href={href}>{inner}</a> : <div className="cockpit-kpi">{inner}</div>;
+}
+
+// ─── Familiar insights table (centerpiece) ────────────────────────────────────────
+
+/** Sortable column headers: click cycles default → desc → asc (numeric) or
+ *  default → asc → desc (name). The "default" order keeps the curated ranking
+ *  (confidence, then activity). */
+type InsightSort = { key: InsightSortKey; dir: SortDir } | null;
+
+export function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; loaded: boolean }) {
+  const [sort, setSort] = useState<InsightSort>(null);
+  const [query, setQuery] = useState("");
+  const visible = useMemo(() => {
+    const filtered = filterInsightRows(rows, query);
+    return sort ? sortInsightRows(filtered, sort.key, sort.dir) : defaultInsightOrder(filtered);
+  }, [rows, sort, query]);
+
+  const cycleSort = (key: InsightSortKey, firstDir: SortDir) => {
+    setSort((prev) => {
+      if (!prev || prev.key !== key) return { key, dir: firstDir };
+      const second: SortDir = firstDir === "desc" ? "asc" : "desc";
+      return prev.dir === firstDir ? { key, dir: second } : null; // third click restores curated order
+    });
+  };
+  const ariaSort = (key: InsightSortKey): "ascending" | "descending" | "none" =>
+    sort?.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
+  const sortHeader = (key: InsightSortKey, label: string, firstDir: SortDir) => (
+    <button type="button" className={`cockpit-sorthead${sort?.key === key ? " is-sorted" : ""}`} onClick={() => cycleSort(key, firstDir)}>
+      {label}
+      <Icon name={sort?.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
+    </button>
+  );
+
+  if (!loaded) return <PanelSkeleton rows={4} />;
+  if (rows.length === 0) return <EmptyState icon="ph:users-three-bold">No familiars in your coven yet.</EmptyState>;
+  return (
+    <>
+      {rows.length > 3 ? (
+        <div className="cockpit-fam__tools">
+          <label className="cockpit-fam__filter">
+            <Icon name="ph:magnifying-glass" aria-hidden />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter familiars…"
+              aria-label="Filter familiars by name, role, or health"
+            />
+          </label>
+          {query && visible.length !== rows.length ? (
+            <span className="cockpit-fam__matchcount" role="status">{visible.length}/{rows.length}</span>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="cockpit-fam" role="table" aria-label="Familiar insights">
+        <div className="cockpit-fam__head" role="row">
+          <span role="columnheader" aria-sort={ariaSort("name")}>{sortHeader("name", "Familiar", "asc")}</span>
+          <span role="columnheader" aria-sort={ariaSort("confidence")}>{sortHeader("confidence", "Confidence", "desc")}</span>
+          <span role="columnheader" aria-sort={ariaSort("sessions")}>{sortHeader("sessions", "Activity", "desc")}</span>
+          <span role="columnheader" className="cockpit-fam__trendcol">7-day sessions</span>
+          <span role="columnheader" className="cockpit-fam__contractcol" aria-sort={ariaSort("contract")}>{sortHeader("contract", "Contract", "desc")}</span>
+          <span role="columnheader" className="cockpit-fam__lastcol" aria-sort={ariaSort("lastActive")}>{sortHeader("lastActive", "Last active", "desc")}</span>
+        </div>
+        {visible.length === 0 ? (
+          <p className="cockpit-muted cockpit-fam__nomatch">No familiars match “{query}”.</p>
+        ) : null}
+        {visible.map((r) => (
+        <a key={r.id} className="cockpit-fam__row" role="row" href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}>
+          <span className="cockpit-fam__who" role="cell">
+            <span className="cockpit-fam__avatar" style={{ background: r.color }}>
+              <AuthedImage src={r.avatarUrl} alt="" fallback={r.emoji || r.name.slice(0, 1).toUpperCase()} />
+              {r.active ? <span className="cockpit-fam__on" title="Active session" /> : null}
+            </span>
+            <span className="cockpit-fam__id">
+              <b className="cockpit-fam__name" title={r.name}>{r.name}</b>
+              <span className="cockpit-fam__role" title={r.role}>{r.role}</span>
+            </span>
+          </span>
+          <span className="cockpit-fam__conf" role="cell">
+            {r.confidenceScore != null ? (
+              <>
+                <span className="cockpit-fam__score">{r.confidenceScore}</span>
+                {r.confidenceLabel ? <Badge tone={TIER_TONE[r.confidenceLabel] ?? "calm"}>{r.confidenceLabel}</Badge> : null}
+              </>
+            ) : <span className="cockpit-fam__dash" title="No contract fetched yet">—</span>}
+          </span>
+          <span className="cockpit-fam__act" role="cell">
+            {r.health ? <Badge tone={HEALTH_META[r.health].tone}>{HEALTH_META[r.health].label}</Badge> : null}
+            <span className="cockpit-fam__sessions">{r.sessions7d}<i>/7d</i></span>
+          </span>
+          <span className="cockpit-fam__trend cockpit-fam__trendcol" role="cell">
+            {r.trend.length ? <Sparkline points={r.trend} color="var(--accent-presence)" height={22} /> : <span className="cockpit-fam__dash">—</span>}
+          </span>
+          <span className="cockpit-fam__contract cockpit-fam__contractcol" role="cell">
+            {r.contractTotal > 0 ? (
+              <span className={`cockpit-fam__ratio${r.contractPass === r.contractTotal ? " is-pass" : " is-warn"}`}>
+                <Icon name={r.contractPass === r.contractTotal ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
+                {r.contractPass}/{r.contractTotal}
+              </span>
+            ) : <span className="cockpit-fam__dash">—</span>}
+          </span>
+          <span className="cockpit-fam__last cockpit-fam__lastcol" role="cell">
+            {r.lastActiveAt ? <time dateTime={r.lastActiveAt}>{relativeTime(r.lastActiveAt) || "just now"}</time> : <span className="cockpit-fam__dash">never</span>}
+          </span>
+        </a>
+      ))}
+      </div>
+    </>
+  );
+}
+
+function Badge({ tone, children }: { tone: "good" | "warn" | "bad" | "calm"; children: ReactNode }) {
+  return <span className={`cockpit-badge cockpit-badge--${tone}`}>{children}</span>;
+}
+
+// ─── Usage over time ───────────────────────────────────────────────────────────────
+
+export function UsagePanel({ series, load, loaded, total, delta }: {
+  series: SparkPoint[]; load: ReturnType<typeof familiarLoadSeries>; loaded: boolean; total: number; delta: number;
+}) {
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  const any = series.some((p) => (p.value ?? 0) > 0);
+  if (!any) return <EmptyState icon="ph:graph-bold">No sessions in the last 14 days.</EmptyState>;
+  return (
+    <div className="cockpit-usage">
+      <div className="cockpit-usage__figure">
+        <span className="cockpit-usage__big">{total}</span>
+        <span className="cockpit-usage__unit">sessions this week</span>
+        <span className={`cockpit-usage__delta cockpit-usage__delta--${delta >= 0 ? "up" : "down"}`}>
+          {delta > 0 ? `▲ ${delta}` : delta < 0 ? `▼ ${Math.abs(delta)}` : "level"} vs last week
+        </span>
+      </div>
+      <div className="cockpit-usage__spark"><Sparkline points={series} color="var(--accent-presence)" height={48} /></div>
+      {load.length > 0 ? (
+        <ul className="cockpit-usage__legend">
+          {load.map((s) => (
+            <li key={s.id}><span className="cockpit-dot" style={{ background: s.color }} />{s.label}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+// ─── Board snapshot ──────────────────────────────────────────────────────────────
+
+export function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
+  byStatus: Map<CardStatus, number>; total: number; active: Card[]; loaded: boolean; familiars: Familiar[];
+}) {
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  if (total === 0) return <EmptyState icon="ph:kanban-bold">No cards on the board yet.</EmptyState>;
+  const segs = STATUS_ORDER.map((s) => ({ s, n: byStatus.get(s) ?? 0 })).filter((x) => x.n > 0);
+  const famName = (id: string | null) => familiars.find((f) => f.id === id)?.display_name;
+  return (
+    <>
+      <DonutChart
+        data={segs.map(({ s, n }) => ({ label: STATUS_META[s].label, value: n, color: STATUS_META[s].color }))}
+        size={132}
+        thickness={18}
+        ariaLabel={`Board status: ${segs.map(({ s, n }) => `${STATUS_META[s].label} ${n}`).join(", ")}`}
+      />
+      <div className="cockpit-bar__legend">
+        {segs.map(({ s, n }) => (
+          <span key={s} className="cockpit-legend">
+            <span className="cockpit-dot" style={{ background: STATUS_META[s].color }} />
+            {STATUS_META[s].label} <b>{n}</b>
+          </span>
+        ))}
+      </div>
+      {active.length > 0 ? (
+        <ul className="cockpit-cards">
+          {active.slice(0, 6).map((c) => (
+            <li key={c.id}>
+              <a className="cockpit-cardrow" href={`/#card-${c.id}`}>
+                <span className="cockpit-dot" style={{ background: STATUS_META[c.status].color }} />
+                <span className="cockpit-cardrow__title" title={c.title}>{c.title}</span>
+                {famName(c.familiarId) ? <span className="cockpit-cardrow__who">{famName(c.familiarId)}</span> : null}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="cockpit-muted">Nothing actively in flight.</p>}
+    </>
+  );
+}
+
+// ─── Familiars roster ──────────────────────────────────────────────────────────────
+
+export function AgentsPanel({ familiars, sessions, loaded }: { familiars: Familiar[]; sessions: SessionRow[]; loaded: boolean }) {
+  const profiles = useMemo(() => familiarMiniProfiles(familiars, sessions, Date.now()), [familiars, sessions]);
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  if (familiars.length === 0) return <EmptyState icon="ph:sparkle">No familiars configured.</EmptyState>;
+  return (
+    <ul className="cockpit-agents">
+      {familiars.slice(0, 6).map((f) => {
+        const active = (f.active_sessions ?? 0) > 0;
+        const p = profiles.find((x) => x.id === f.id);
+        return (
+          <li key={f.id} className="cockpit-agent">
+            {/* The whole row drills into the familiar's analytics page. */}
+            <a className="cockpit-agent__link" href={`/dashboard/familiars/${encodeURIComponent(f.id)}/analytics`}>
+              <span className="cockpit-agent__avatar" style={{ background: f.color || "var(--accent-presence)" }}>
+                {f.emoji || (f.display_name || "?").slice(0, 1).toUpperCase()}
+                {active ? <span className="cockpit-agent__on" /> : null}
+              </span>
+              <span className="cockpit-agent__body">
+                <span className="cockpit-agent__name" title={f.display_name}>{f.display_name}</span>
+                <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
+              </span>
+              {p ? <span className="cockpit-agent__count">{p.sessionsLast7d}/7d</span> : null}
+              {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color="var(--accent-presence)" height={20} /></span> : null}
+              {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ─── GitHub ──────────────────────────────────────────────────────────────────────
+
+const GH_ICON: Record<GitHubItem["kind"], IconName> = {
+  pr: "ph:git-pull-request", review_request: "ph:git-pull-request", issue: "ph:circle", notification: "ph:bell",
+};
+export function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }) {
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  if (items.length === 0) return <EmptyState icon="ph:github-logo">No GitHub activity, or no token configured.</EmptyState>;
+  return (
+    <ul className="cockpit-gh">
+      {items.slice(0, 6).map((g) => (
+        <li key={g.id}>
+          <a
+            className="cockpit-ghrow"
+            href={g.url}
+            onClick={(event) => {
+              event.preventDefault();
+              openExternalUrl(g.url);
+            }}
+          >
+            <Icon name={GH_ICON[g.kind]} className="cockpit-ghrow__icon" aria-hidden />
+            <span className="cockpit-ghrow__title" title={g.title}>{g.title}</span>
+            <span className="cockpit-ghrow__meta">
+              {checkDot(g.checkStatus)}
+              <span className="cockpit-ghrow__repo">{shortRepo(g.repo)}{g.number ? ` #${g.number}` : ""}</span>
+            </span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+function checkDot(s: GitHubItem["checkStatus"]) {
+  if (!s) return null;
+  const color = s === "passing" ? "var(--color-success)" : s === "failing" ? "var(--color-danger)" : "var(--color-warning)";
+  return <span className="cockpit-dot" style={{ background: color }} title={`Checks: ${s}`} role="img" aria-label={`Checks ${s}`} />;
+}
+// ─── Agenda ──────────────────────────────────────────────────────────────────────
+
+export function AgendaPanel({ items, now, loaded }: { items: InboxItem[]; now: Date; loaded: boolean }) {
+  if (!loaded) return <PanelSkeleton rows={2} />;
+  if (items.length === 0) return <EmptyState icon="ph:calendar-bold">Nothing scheduled ahead.</EmptyState>;
+  return (
+    <ul className="cockpit-agenda">
+      {items.map((i) => (
+        <li key={i.id} className="cockpit-agendarow">
+          <time className="cockpit-agendarow__when" dateTime={i.fireAt!}>{whenLabel(i.fireAt!, now)}</time>
+          <span className="cockpit-agendarow__title" title={i.title}>{i.title}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+// ─── Signals ─────────────────────────────────────────────────────────────────────
+
+const SIGNAL_ICON: Record<DashboardSignal["severity"], IconName> = { warn: "ph:warning", info: "ph:info" };
+
+// Keep the panel scannable: the stalest drift leads, the long tail collapses
+// into a drill-through instead of swamping the column.
+const SIGNALS_CAP = 8;
+
+export function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
+  const shown = signals.slice(0, SIGNALS_CAP);
+  const hidden = signals.length - shown.length;
+  return (
+    <ul className="cockpit-signals">
+      {shown.map((s) => {
+        const inner = (
+          <>
+            <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
+            <span className="cockpit-signal__text">{s.text}</span>
+          </>
+        );
+        return (
+          <li key={s.id}>
+            {s.href ? (
+              // An actionable signal takes you to where you can act on it —
+              // the stalled PR, the board, the familiar's analytics.
+              <a
+                className={`cockpit-signal cockpit-signal--${s.severity} cockpit-signal--link`}
+                href={s.href}
+                onClick={s.external ? (event) => { event.preventDefault(); openExternalUrl(s.href!); } : undefined}
+              >
+                {inner}
+              </a>
+            ) : (
+              <span className={`cockpit-signal cockpit-signal--${s.severity}`}>{inner}</span>
+            )}
+          </li>
+        );
+      })}
+      {hidden > 0 ? (
+        <li>
+          <a className="cockpit-signal cockpit-signal--more" href="/?mode=github">
+            <Icon name="ph:arrow-right-bold" className="cockpit-signal__icon" aria-hidden />
+            <span className="cockpit-signal__text">+{hidden} more — review on the GitHub surface</span>
+          </a>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+// ─── Confidence / performance heatmap ────────────────────────────────────────────
+
+export type ConfidenceRow = { id: string; name: string; score: number; factors: ConfidenceFactor[] };
+
+export function ConfidencePanel({ rows }: { rows: ConfidenceRow[] }) {
+  const cols = rows[0]?.factors.map((f) => prettyFactor(f.label)) ?? [];
+  // Cell value = the factor's normalized 0..1 strength (raw score ÷ 100).
+  const cells = rows.flatMap((r) =>
+    r.factors.map((f) => ({ row: r.name, col: prettyFactor(f.label), value: f.value / 100 })),
+  );
+  return (
+    <div className="cockpit-confidence">
+      <div className="cockpit-confidence__cols" style={{ ["--cols" as string]: cols.length }}>
+        {cols.map((c) => <span key={c}>{c}</span>)}
+      </div>
+      <div className="cockpit-confidence__grid">
+        <div className="cockpit-confidence__rows">
+          {rows.map((r) => (
+            <a
+              key={r.id}
+              href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}
+              title={`${r.name}: confidence ${r.score} — open analytics`}
+            >
+              {r.name}
+            </a>
+          ))}
+        </div>
+        <Heatmap
+          rows={rows.map((r) => r.name)}
+          cols={cols}
+          cells={cells}
+          colorFor={confidenceColor}
+          height={Math.max(72, rows.length * 26)}
+          ariaLabel={`Confidence factors by familiar: ${rows.map((r) => `${r.name} ${r.score}`).join(", ")}`}
+          cellTitle={(c) => `${c.row} · ${c.col}: ${Math.round(c.value * 100)}/100`}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Space usage ─────────────────────────────────────────────────────────────────
+
+type SpaceSort = { key: SpaceSortKey; dir: SortDir };
+
+/** Local disk footprint per `~/.coven` area: sortable rows, share bars, and a
+ *  cleanup drill-through per area. Figures come from the bounded server scan. */
+export function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loaded: boolean }) {
+  const [sort, setSort] = useState<SpaceSort>({ key: "bytes", dir: "desc" });
+  const sorted = useMemo(() => sortSpaceRows(rows, sort.key, sort.dir), [rows, sort]);
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  if (rows.length === 0) return <EmptyState icon="ph:database-bold">No local coven data found.</EmptyState>;
+
+  const cycle = (key: SpaceSortKey, firstDir: SortDir) =>
+    setSort((prev) => prev.key === key
+      ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+      : { key, dir: firstDir });
+  const ariaSort = (key: SpaceSortKey): "ascending" | "descending" | "none" =>
+    sort.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
+  const head = (key: SpaceSortKey, label: string, firstDir: SortDir) => (
+    <button type="button" className={`cockpit-sorthead${sort.key === key ? " is-sorted" : ""}`} onClick={() => cycle(key, firstDir)}>
+      {label}
+      <Icon name={sort.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
+    </button>
+  );
+
+  return (
+    <div className="cockpit-space" role="table" aria-label="Local space usage by area">
+      <div className="cockpit-space__head" role="row">
+        <span role="columnheader" aria-sort={ariaSort("label")}>{head("label", "Area", "asc")}</span>
+        <span role="columnheader" aria-sort={ariaSort("bytes")}>{head("bytes", "Size", "desc")}</span>
+        <span role="columnheader" className="cockpit-space__filescol" aria-sort={ariaSort("files")}>{head("files", "Files", "desc")}</span>
+        <span role="columnheader" className="cockpit-space__lastcol" aria-sort={ariaSort("lastModified")}>{head("lastModified", "Updated", "desc")}</span>
+      </div>
+      {sorted.map((r) => {
+        const inner = (
+          <>
+            <span className="cockpit-space__area" role="cell" title={r.relPath}>
+              <b>{r.label}</b>
+              <span className="cockpit-space__path">{r.relPath}</span>
+            </span>
+            <span className="cockpit-space__size" role="cell">
+              <b>{formatBytes(r.bytes)}{r.truncated ? "+" : ""}</b>
+              <span className="cockpit-space__bar" aria-hidden>
+                <i style={{ width: `${Math.max(2, r.sharePct)}%` }} />
+              </span>
+            </span>
+            <span className="cockpit-space__files cockpit-space__filescol" role="cell">{r.files}{r.truncated ? "+" : ""}</span>
+            <span className="cockpit-space__last cockpit-space__lastcol" role="cell">
+              {r.lastModifiedMs ? <time dateTime={new Date(r.lastModifiedMs).toISOString()}>{relativeTime(new Date(r.lastModifiedMs).toISOString()) || "just now"}</time> : "—"}
+            </span>
+          </>
+        );
+        // Areas a surface owns drill into that surface; the rest are plain rows.
+        return r.href ? (
+          <a key={r.id} className="cockpit-space__row cockpit-space__row--link" role="row" href={r.href} title={r.actionLabel ?? undefined}>
+            {inner}
+          </a>
+        ) : (
+          <span key={r.id} className="cockpit-space__row" role="row">{inner}</span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Bits ────────────────────────────────────────────────────────────────────────
+
+function PanelSkeleton({ rows }: { rows: number }) {
+  return <div className="cockpit-skel">{Array.from({ length: rows }).map((_, i) => <span key={i} className="cockpit-skel__row" />)}</div>;
+}
+
+

--- a/src/components/dashboard/cockpit-panels.tsx
+++ b/src/components/dashboard/cockpit-panels.tsx
@@ -544,6 +544,7 @@ export function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loade
         <span role="columnheader" className="cockpit-space__lastcol" aria-sort={ariaSort("lastModified")}>{head("lastModified", "Updated", "desc")}</span>
       </div>
       {sorted.map((r) => {
+        const lastModifiedIso = r.lastModifiedMs ? new Date(r.lastModifiedMs).toISOString() : null;
         const inner = (
           <>
             <span className="cockpit-space__area" role="cell" title={r.relPath}>
@@ -558,7 +559,7 @@ export function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loade
             </span>
             <span className="cockpit-space__files cockpit-space__filescol" role="cell">{r.files}{r.truncated ? "+" : ""}</span>
             <span className="cockpit-space__last cockpit-space__lastcol" role="cell">
-              {r.lastModifiedMs ? <time dateTime={new Date(r.lastModifiedMs).toISOString()}>{relativeTime(new Date(r.lastModifiedMs).toISOString()) || "just now"}</time> : "—"}
+              {lastModifiedIso ? <time dateTime={lastModifiedIso}>{relativeTime(lastModifiedIso) || "just now"}</time> : "—"}
             </span>
           </>
         );

--- a/src/components/dashboard/dashboard-cockpit-polish.test.ts
+++ b/src/components/dashboard/dashboard-cockpit-polish.test.ts
@@ -1,43 +1,66 @@
 // @ts-nocheck
 // Dashboard cockpit polish (cave-m4oq): empty KPI tiles teach instead of
 // shrugging, no fake flatlines under missing data, one-accent trend waves,
-// and a quiet insight note instead of a heavy banner.
+// and a quiet insight note instead of a heavy banner. The cockpit is split
+// across the root (data + layout), cockpit-panels.tsx (presentation), and
+// dashboard-cockpit-format.ts (pure labels) — cave-tsoz.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const cockpit = readFileSync(new URL("./dashboard-cockpit.tsx", import.meta.url), "utf8");
+const panels = readFileSync(new URL("./cockpit-panels.tsx", import.meta.url), "utf8");
+const format = readFileSync(new URL("../../lib/dashboard-cockpit-format.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../../styles/dashboard.css", import.meta.url), "utf8");
 
 // ── Empty tiles teach the action that fills them ─────────────────────────────
-assert.match(cockpit, /fills in after the first retro run/, "Retro tile teaches when empty");
-assert.match(cockpit, /fills in once familiars have contracts/, "Contract tile teaches when empty");
+assert.match(format, /fills in after the first retro run/, "Retro tile teaches when empty");
+assert.match(format, /fills in once familiars have contracts/, "Contract tile teaches when empty");
 assert.match(cockpit, /fills in after growth reviews/, "Confidence tile teaches when empty");
 for (const shrug of ["no retro runs", "no contracts", "no scores yet"]) {
-  assert.doesNotMatch(cockpit, new RegExp(`"${shrug}"`), `dead-end sub "${shrug}" is gone`);
+  for (const [name, src] of [["cockpit", cockpit], ["panels", panels], ["format", format]]) {
+    assert.doesNotMatch(src, new RegExp(`"${shrug}"`), `dead-end sub "${shrug}" is gone from ${name}`);
+  }
 }
 
 // ── No fake flatline under a metric with no data ─────────────────────────────
 assert.match(
-  cockpit,
+  panels,
   /\{value == null \? null : \(\s*\n\s*<Sparkline points=\{series\} color="var\(--accent-presence\)" height=\{22\} \/>/,
   "KPI tiles skip the sparkline while the metric has no data, and use the shared accent",
 );
 
 // ── One accent for every trend wave ──────────────────────────────────────────
 assert.match(
-  cockpit,
+  panels,
   /<Sparkline points=\{r\.trend\} color="var\(--accent-presence\)" height=\{22\} \/>/,
   "Familiar-insight rows draw one-accent sparklines (identity color stays on the avatar)",
 );
 assert.match(
-  cockpit,
+  panels,
   /<Sparkline points=\{p\.trend\} color="var\(--accent-presence\)" height=\{20\} \/>/,
   "Agent-panel trends draw one-accent sparklines",
 );
 assert.doesNotMatch(
-  cockpit,
+  panels,
   /<Sparkline[^>]*color=\{r\.color\}/,
   "No per-row rainbow sparkline remains",
+);
+
+// ── Timestamps are semantic <time> elements (cave-tsoz) ──────────────────────
+assert.match(
+  panels,
+  /<time className="cockpit-agendarow__when" dateTime=\{i\.fireAt!\}>/,
+  "agenda reminders carry machine-readable datetimes",
+);
+assert.match(
+  panels,
+  /<time dateTime=\{r\.lastActiveAt\}>\{relativeTime\(r\.lastActiveAt\)/,
+  "insight rows' last-active is a semantic time element",
+);
+assert.match(
+  panels,
+  /<time dateTime=\{new Date\(r\.lastModifiedMs\)\.toISOString\(\)\}>/,
+  "space-usage Updated column is a semantic time element",
 );
 
 // ── Insight banner reads as a quiet note ─────────────────────────────────────

--- a/src/components/dashboard/dashboard-cockpit-polish.test.ts
+++ b/src/components/dashboard/dashboard-cockpit-polish.test.ts
@@ -59,7 +59,7 @@ assert.match(
 );
 assert.match(
   panels,
-  /<time dateTime=\{new Date\(r\.lastModifiedMs\)\.toISOString\(\)\}>/,
+  /<time dateTime=\{lastModifiedIso\}>\{relativeTime\(lastModifiedIso\)/,
   "space-usage Updated column is a semantic time element",
 );
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import type { IconName } from "@/lib/icon";
-import { AuthedImage } from "@/components/ui/authed-image";
 import type { DashboardModel } from "@/lib/dashboard-model";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar, SessionRow } from "@/lib/types";
@@ -12,28 +10,23 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import { relativeTime } from "@/lib/daily-report";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { SectionHead, EmptyState, QuickLink } from "@/components/daily-report-ui";
-import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
-import { DonutChart } from "@/components/ui/charts/donut-chart";
 import { TrendChart } from "@/components/ui/charts/trend-chart";
-import { Heatmap } from "@/components/ui/charts/heatmap";
 import {
-  familiarMiniProfiles, familiarLoadSeries, dashboardSignals, type DashboardSignal, type FamiliarMiniProfile,
-  defaultInsightOrder, sortInsightRows, filterInsightRows, type InsightSortKey, type SortDir,
-  spaceUsageRows, sortSpaceRows, formatBytes, type SpaceSortKey, type SpaceUsageRow,
+  familiarMiniProfiles, familiarLoadSeries, dashboardSignals, type FamiliarMiniProfile,
+  spaceUsageRows, formatBytes,
 } from "@/lib/dashboard-analytics";
 import type { SpaceUsageArea } from "@/lib/server/space-usage";
 import {
   deriveCovenVitals, deriveCovenInsight, covenSessionsSeries,
   type FamiliarInsightRow, type CovenVitals,
 } from "@/lib/coven-analytics";
-import { deriveConfidenceScore, type ConfidenceScore, type ConfidenceFactor } from "@/lib/familiar-confidence";
+import { deriveConfidenceScore, type ConfidenceScore } from "@/lib/familiar-confidence";
 import { deriveGrowthReport } from "@/lib/familiar-growth-signals";
 import { buildFamiliarCardStats, type FamiliarCardStats, type CovenMemoryEntry } from "@/components/familiars-view-stats";
 import type { ContractReport } from "@/lib/familiar-contract";
 import type { RetroRunsSnapshot } from "@/lib/retro-runs";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useMinuteTick } from "@/lib/use-minute-tick";
-import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
 import { TodaySummary } from "@/components/dashboard/today-summary";
 import { RecentReports } from "@/components/dashboard/recent-reports";
@@ -42,10 +35,18 @@ import {
   type Announcements, type DragEndEvent,
 } from "@dnd-kit/core";
 import {
-  SortableContext, useSortable, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy,
+  SortableContext, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { openExternalUrl } from "@/lib/open-external";
+import {
+  AgendaPanel, AgentsPanel, BoardSnapshot, ConfidencePanel, CovenInsightBanner,
+  FamiliarInsightsTable, GithubPanel, KpiTile, Panel, SignalsPanel, SortableWidget,
+  SpaceUsagePanel, UsagePanel, type ConfidenceRow, type KpiTileProps,
+} from "@/components/dashboard/cockpit-panels";
+import {
+  DEFAULT_LAYOUT, STATUS_ORDER, coverageSub, contractSub, dayKey, longDate, panelTitle,
+  reconcileLayout, retroSub, seriesFor, wowSub,
+  type DaySnap, type Layout, type TrendKey, type TrendStore,
+} from "@/lib/dashboard-cockpit-format";
 
 // ─── Data shapes (client-fetched) ──────────────────────────────────────────────
 
@@ -68,44 +69,16 @@ const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, las
 // just read "—" for confidence.
 const CONTRACT_FETCH_CAP = 12;
 
+// A KPI tile's visual props plus the data plumbing the root owns: which trend
+// metric feeds its sparkline and which fetch source gates its loading state.
+type KpiSpec = Omit<KpiTileProps, "loading" | "series"> & {
+  metric: TrendKey;
+  src?: keyof CockpitData;
+};
+
 // Draggable secondary panels — order per column, persisted to localStorage. The
 // insights hero (vitals + coven read + familiar table) is fixed above the grid.
 const LAYOUT_KEY = "cave:cockpit:layout:v2";
-type Layout = { main: string[]; rail: string[] };
-const DEFAULT_LAYOUT: Layout = {
-  main: ["usage", "signals", "needs", "board", "today"],
-  rail: ["confidence", "agents", "load", "space", "github", "agenda"],
-};
-
-// Human titles for drag-and-drop announcements + grip labels (mirrors each
-// widget's <Panel title>). dnd-kit's defaults read the raw ids, which are
-// semantic but terse — screen readers should hear the visible panel names.
-const PANEL_TITLES: Record<string, string> = {
-  usage: "Activity over time",
-  signals: "Signals",
-  needs: "Needs attention",
-  board: "Board",
-  today: "Today summary",
-  confidence: "Performance matrix",
-  agents: "Familiars",
-  load: "Familiar load",
-  space: "Space usage",
-  github: "GitHub",
-  agenda: "Up next",
-};
-const panelTitle = (id: unknown): string => PANEL_TITLES[String(id)] ?? String(id);
-
-/** Merge a saved order with the defaults: keep known ids in saved order, append
- *  any new defaults, drop anything unknown (survives version changes). */
-function reconcileLayout(stored: Partial<Layout>): Layout {
-  const fix = (saved: string[] | undefined, def: string[]) => {
-    const s = (saved ?? []).filter((id) => def.includes(id));
-    for (const id of def) if (!s.includes(id)) s.push(id);
-    return s;
-  };
-  return { main: fix(stored.main, DEFAULT_LAYOUT.main), rail: fix(stored.rail, DEFAULT_LAYOUT.rail) };
-}
-
 async function getJson<T>(url: string): Promise<T | null> {
   try {
     const res = await fetch(url, { cache: "no-store" });
@@ -119,52 +92,7 @@ async function getJson<T>(url: string): Promise<T | null> {
 // ─── 7-day vitals trends (persisted client-side, keyed by day) ────────────────────
 
 const TRENDS_KEY = "cave:cockpit:trends:v2";
-const TREND_DAYS = 7;
-type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contract" | "needs";
-type DaySnap = Record<TrendKey, number>;
-type TrendStore = Record<string, DaySnap>; // "YYYY-MM-DD" -> snapshot
-
-function dayKey(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-/** Last `TREND_DAYS` points for one metric, oldest→newest; null value for missing days. */
-function seriesFor(store: TrendStore, key: TrendKey, now: Date): SparkPoint[] {
-  const out: SparkPoint[] = [];
-  for (let i = TREND_DAYS - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(now.getDate() - i);
-    const v = store[dayKey(d)]?.[key];
-    out.push({
-      label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
-      value: typeof v === "number" ? v : null,
-    });
-  }
-  return out;
-}
-
 // ─── Status vocab ──────────────────────────────────────────────────────────────
-
-const STATUS_META: Record<CardStatus, { label: string; color: string }> = {
-  running: { label: "In progress", color: "var(--color-success)" },
-  review: { label: "In review", color: "var(--color-info)" },
-  blocked: { label: "Blocked", color: "var(--color-danger)" },
-  inbox: { label: "Inbox", color: "var(--accent-presence)" },
-  backlog: { label: "Backlog", color: "var(--text-muted)" },
-  done: { label: "Done", color: "color-mix(in oklch, var(--color-success) 55%, var(--text-muted))" },
-};
-const STATUS_ORDER: CardStatus[] = ["running", "review", "blocked", "inbox", "backlog", "done"];
-
-const HEALTH_META: Record<NonNullable<FamiliarInsightRow["health"]>, { label: string; tone: "good" | "warn" | "bad" | "calm" }> = {
-  active: { label: "Active", tone: "good" },
-  steady: { label: "Steady", tone: "calm" },
-  quiet: { label: "Quiet", tone: "warn" },
-  stalled: { label: "Stalled", tone: "bad" },
-};
-
-const TIER_TONE: Record<string, "good" | "warn" | "bad" | "calm"> = {
-  Trusted: "good", Reliable: "calm", Developing: "warn", Low: "bad",
-};
 
 // ─── Root ───────────────────────────────────────────────────────────────────────
 
@@ -594,602 +522,4 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       </footer>
     </div>
   );
-}
-
-// ─── Coven insight banner ────────────────────────────────────────────────────────
-
-const INSIGHT_ICON: Record<"good" | "warn" | "bad", IconName> = {
-  good: "ph:check-circle-bold", warn: "ph:warning-circle", bad: "ph:warning-fill",
-};
-function CovenInsightBanner({ insight }: { insight: { headline: string; detail: string; tone: "good" | "warn" | "bad" } }) {
-  return (
-    <div className={`coven-insight coven-insight--${insight.tone}`} role="note">
-      <Icon name={INSIGHT_ICON[insight.tone]} className="coven-insight__icon" aria-hidden />
-      <span className="coven-insight__text">
-        <b>{insight.headline}.</b> {insight.detail}
-      </span>
-    </div>
-  );
-}
-
-// ─── Panel wrapper ───────────────────────────────────────────────────────────────
-
-function Panel({ title, icon, count, hint, href, children }: {
-  title: string; icon: IconName; count?: number; hint?: string; href?: string; children: ReactNode;
-}) {
-  return (
-    <section className="cockpit-panel" aria-label={title}>
-      <div className="cockpit-panel__head">
-        <span className="cockpit-panel__title">
-          <Icon name={icon} className="cockpit-panel__icon" aria-hidden />
-          {title}
-          {count != null ? <span className="cockpit-panel__count">{count}</span> : null}
-        </span>
-        {hint ? <span className="cockpit-panel__hint">{hint}</span> : null}
-        {href ? (
-          <a className="cockpit-panel__more" href={href} aria-label={`Open ${title}`}>
-            <Icon name="ph:arrow-right-bold" aria-hidden />
-          </a>
-        ) : null}
-      </div>
-      <div className="cockpit-panel__body">{children}</div>
-    </section>
-  );
-}
-
-// ─── Sortable widget wrapper ─────────────────────────────────────────────────────
-
-function SortableWidget({ id, title, children }: { id: string; title: string; children: ReactNode }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
-  const reduceMotion = usePrefersReducedMotion();
-  const style: CSSProperties = {
-    transform: CSS.Translate.toString(transform),
-    // dnd-kit drives the settle animation via an inline JS transition that the
-    // global reduced-motion CSS reset can't reach — drop it so panels snap into
-    // place instead of sliding when the user asks for less motion.
-    transition: reduceMotion ? undefined : transition,
-    zIndex: isDragging ? 20 : undefined,
-    opacity: isDragging ? 0.92 : undefined,
-  };
-  return (
-    <div ref={setNodeRef} style={style} className={`cockpit-sortable${isDragging ? " is-dragging" : ""}`}>
-      <button type="button" className="cockpit-grip" aria-label={`Drag to rearrange: ${title}`} {...attributes} {...listeners}>
-        <Icon name="ph:dots-six-vertical" aria-hidden />
-      </button>
-      {children}
-    </div>
-  );
-}
-
-// ─── Vitals KPI tile ─────────────────────────────────────────────────────────────
-
-type KpiSpec = {
-  icon: IconName; value: number | null; suffix?: string; label: string; sub?: string;
-  accent: "rose" | "lavender" | "green" | "blue" | "amber" | "teal";
-  metric: TrendKey; good: "up" | "down"; src?: keyof CockpitData; href?: string;
-};
-const KPI_ACCENT: Record<KpiSpec["accent"], string> = {
-  rose: "var(--color-danger)", lavender: "var(--accent-presence)", green: "var(--color-success)",
-  blue: "var(--color-info)", amber: "var(--color-warning)", teal: "oklch(0.68 0.12 190)",
-};
-
-function KpiTile({ icon, value, suffix, label, sub, accent, good, href, loading, series }: KpiSpec & { loading: boolean; series: SparkPoint[] }) {
-  const color = KPI_ACCENT[accent];
-  const pts = series.map((p) => p.value).filter((v): v is number => v != null);
-  const delta = pts.length >= 2 ? pts[pts.length - 1] - pts[0] : 0;
-  // Color the delta by meaning, not direction: a rise in a "good=up" metric is
-  // progress (success); a rise in a "good=down" metric (Needs you) is load.
-  const beneficial = delta === 0 ? null : (delta > 0) === (good === "up");
-  const display = loading || value == null ? "—" : `${value}${suffix ?? ""}`;
-  const inner = (
-    <>
-      <span className="cockpit-kpi__top">
-        <span className="cockpit-kpi__icon" style={{ ["--kpi" as string]: color }}>
-          <Icon name={icon} aria-hidden />
-        </span>
-        {!loading && delta !== 0 ? (
-          <span
-            className={`cockpit-kpi__delta cockpit-kpi__delta--${beneficial ? "good" : "bad"}`}
-            title={`${delta > 0 ? "+" : ""}${delta}${suffix ?? ""} over ${TREND_DAYS} days`}
-          >
-            {delta > 0 ? "▲" : "▼"} {Math.abs(delta)}{suffix ?? ""}
-          </span>
-        ) : null}
-      </span>
-      <span className="cockpit-kpi__value">{display}</span>
-      <span className="cockpit-kpi__label">{label}</span>
-      {sub ? <span className="cockpit-kpi__sub">{sub}</span> : null}
-      {/* No wave without data — loading or empty, a flatline under "—" reads
-          as a dead metric (cave-m4oq). One accent for every trend: the wave is
-          texture, the tile icon carries the semantic tint. */}
-      {value == null ? null : (
-        <Sparkline points={series} color="var(--accent-presence)" height={22} />
-      )}
-    </>
-  );
-  return href ? <a className="cockpit-kpi" href={href}>{inner}</a> : <div className="cockpit-kpi">{inner}</div>;
-}
-
-function wowSub(delta: number): string {
-  if (delta > 0) return `▲ ${delta} vs last week`;
-  if (delta < 0) return `▼ ${Math.abs(delta)} vs last week`;
-  return "level with last week";
-}
-function retroSub(v: CovenVitals): string {
-  const runs = v.retroAccepted + v.retroReverted;
-  // Teach, don't shrug: name the action that fills the tile (cave-m4oq).
-  if (runs === 0) return "fills in after the first retro run";
-  return `${v.retroAccepted}/${runs} accepted`;
-}
-function contractSub(v: CovenVitals): string {
-  if (v.contractTotal === 0) return "fills in once familiars have contracts";
-  return `${v.contractPass}/${v.contractTotal} passing`;
-}
-function coverageSub(base: string, fetched: number, total: number, verb: "scored" | "checked"): string {
-  if (total <= fetched) return base;
-  return `${base} · first ${fetched}/${total} ${verb}`;
-}
-
-// ─── Familiar insights table (centerpiece) ────────────────────────────────────────
-
-/** Sortable column headers: click cycles default → desc → asc (numeric) or
- *  default → asc → desc (name). The "default" order keeps the curated ranking
- *  (confidence, then activity). */
-type InsightSort = { key: InsightSortKey; dir: SortDir } | null;
-
-function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; loaded: boolean }) {
-  const [sort, setSort] = useState<InsightSort>(null);
-  const [query, setQuery] = useState("");
-  const visible = useMemo(() => {
-    const filtered = filterInsightRows(rows, query);
-    return sort ? sortInsightRows(filtered, sort.key, sort.dir) : defaultInsightOrder(filtered);
-  }, [rows, sort, query]);
-
-  const cycleSort = (key: InsightSortKey, firstDir: SortDir) => {
-    setSort((prev) => {
-      if (!prev || prev.key !== key) return { key, dir: firstDir };
-      const second: SortDir = firstDir === "desc" ? "asc" : "desc";
-      return prev.dir === firstDir ? { key, dir: second } : null; // third click restores curated order
-    });
-  };
-  const ariaSort = (key: InsightSortKey): "ascending" | "descending" | "none" =>
-    sort?.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
-  const sortHeader = (key: InsightSortKey, label: string, firstDir: SortDir) => (
-    <button type="button" className={`cockpit-sorthead${sort?.key === key ? " is-sorted" : ""}`} onClick={() => cycleSort(key, firstDir)}>
-      {label}
-      <Icon name={sort?.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
-    </button>
-  );
-
-  if (!loaded) return <PanelSkeleton rows={4} />;
-  if (rows.length === 0) return <EmptyState icon="ph:users-three-bold">No familiars in your coven yet.</EmptyState>;
-  return (
-    <>
-      {rows.length > 3 ? (
-        <div className="cockpit-fam__tools">
-          <label className="cockpit-fam__filter">
-            <Icon name="ph:magnifying-glass" aria-hidden />
-            <input
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Filter familiars…"
-              aria-label="Filter familiars by name, role, or health"
-            />
-          </label>
-          {query && visible.length !== rows.length ? (
-            <span className="cockpit-fam__matchcount" role="status">{visible.length}/{rows.length}</span>
-          ) : null}
-        </div>
-      ) : null}
-      <div className="cockpit-fam" role="table" aria-label="Familiar insights">
-        <div className="cockpit-fam__head" role="row">
-          <span role="columnheader" aria-sort={ariaSort("name")}>{sortHeader("name", "Familiar", "asc")}</span>
-          <span role="columnheader" aria-sort={ariaSort("confidence")}>{sortHeader("confidence", "Confidence", "desc")}</span>
-          <span role="columnheader" aria-sort={ariaSort("sessions")}>{sortHeader("sessions", "Activity", "desc")}</span>
-          <span role="columnheader" className="cockpit-fam__trendcol">7-day sessions</span>
-          <span role="columnheader" className="cockpit-fam__contractcol" aria-sort={ariaSort("contract")}>{sortHeader("contract", "Contract", "desc")}</span>
-          <span role="columnheader" className="cockpit-fam__lastcol" aria-sort={ariaSort("lastActive")}>{sortHeader("lastActive", "Last active", "desc")}</span>
-        </div>
-        {visible.length === 0 ? (
-          <p className="cockpit-muted cockpit-fam__nomatch">No familiars match “{query}”.</p>
-        ) : null}
-        {visible.map((r) => (
-        <a key={r.id} className="cockpit-fam__row" role="row" href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}>
-          <span className="cockpit-fam__who" role="cell">
-            <span className="cockpit-fam__avatar" style={{ background: r.color }}>
-              <AuthedImage src={r.avatarUrl} alt="" fallback={r.emoji || r.name.slice(0, 1).toUpperCase()} />
-              {r.active ? <span className="cockpit-fam__on" title="Active session" /> : null}
-            </span>
-            <span className="cockpit-fam__id">
-              <b className="cockpit-fam__name" title={r.name}>{r.name}</b>
-              <span className="cockpit-fam__role" title={r.role}>{r.role}</span>
-            </span>
-          </span>
-          <span className="cockpit-fam__conf" role="cell">
-            {r.confidenceScore != null ? (
-              <>
-                <span className="cockpit-fam__score">{r.confidenceScore}</span>
-                {r.confidenceLabel ? <Badge tone={TIER_TONE[r.confidenceLabel] ?? "calm"}>{r.confidenceLabel}</Badge> : null}
-              </>
-            ) : <span className="cockpit-fam__dash" title="No contract fetched yet">—</span>}
-          </span>
-          <span className="cockpit-fam__act" role="cell">
-            {r.health ? <Badge tone={HEALTH_META[r.health].tone}>{HEALTH_META[r.health].label}</Badge> : null}
-            <span className="cockpit-fam__sessions">{r.sessions7d}<i>/7d</i></span>
-          </span>
-          <span className="cockpit-fam__trend cockpit-fam__trendcol" role="cell">
-            {r.trend.length ? <Sparkline points={r.trend} color="var(--accent-presence)" height={22} /> : <span className="cockpit-fam__dash">—</span>}
-          </span>
-          <span className="cockpit-fam__contract cockpit-fam__contractcol" role="cell">
-            {r.contractTotal > 0 ? (
-              <span className={`cockpit-fam__ratio${r.contractPass === r.contractTotal ? " is-pass" : " is-warn"}`}>
-                <Icon name={r.contractPass === r.contractTotal ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
-                {r.contractPass}/{r.contractTotal}
-              </span>
-            ) : <span className="cockpit-fam__dash">—</span>}
-          </span>
-          <span className="cockpit-fam__last cockpit-fam__lastcol" role="cell">
-            {r.lastActiveAt ? (relativeTime(r.lastActiveAt) || "just now") : <span className="cockpit-fam__dash">never</span>}
-          </span>
-        </a>
-      ))}
-      </div>
-    </>
-  );
-}
-
-function Badge({ tone, children }: { tone: "good" | "warn" | "bad" | "calm"; children: ReactNode }) {
-  return <span className={`cockpit-badge cockpit-badge--${tone}`}>{children}</span>;
-}
-
-// ─── Usage over time ───────────────────────────────────────────────────────────────
-
-function UsagePanel({ series, load, loaded, total, delta }: {
-  series: SparkPoint[]; load: ReturnType<typeof familiarLoadSeries>; loaded: boolean; total: number; delta: number;
-}) {
-  if (!loaded) return <PanelSkeleton rows={3} />;
-  const any = series.some((p) => (p.value ?? 0) > 0);
-  if (!any) return <EmptyState icon="ph:graph-bold">No sessions in the last 14 days.</EmptyState>;
-  return (
-    <div className="cockpit-usage">
-      <div className="cockpit-usage__figure">
-        <span className="cockpit-usage__big">{total}</span>
-        <span className="cockpit-usage__unit">sessions this week</span>
-        <span className={`cockpit-usage__delta cockpit-usage__delta--${delta >= 0 ? "up" : "down"}`}>
-          {delta > 0 ? `▲ ${delta}` : delta < 0 ? `▼ ${Math.abs(delta)}` : "level"} vs last week
-        </span>
-      </div>
-      <div className="cockpit-usage__spark"><Sparkline points={series} color="var(--accent-presence)" height={48} /></div>
-      {load.length > 0 ? (
-        <ul className="cockpit-usage__legend">
-          {load.map((s) => (
-            <li key={s.id}><span className="cockpit-dot" style={{ background: s.color }} />{s.label}</li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  );
-}
-
-// ─── Board snapshot ──────────────────────────────────────────────────────────────
-
-function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
-  byStatus: Map<CardStatus, number>; total: number; active: Card[]; loaded: boolean; familiars: Familiar[];
-}) {
-  if (!loaded) return <PanelSkeleton rows={3} />;
-  if (total === 0) return <EmptyState icon="ph:kanban-bold">No cards on the board yet.</EmptyState>;
-  const segs = STATUS_ORDER.map((s) => ({ s, n: byStatus.get(s) ?? 0 })).filter((x) => x.n > 0);
-  const famName = (id: string | null) => familiars.find((f) => f.id === id)?.display_name;
-  return (
-    <>
-      <DonutChart
-        data={segs.map(({ s, n }) => ({ label: STATUS_META[s].label, value: n, color: STATUS_META[s].color }))}
-        size={132}
-        thickness={18}
-        ariaLabel={`Board status: ${segs.map(({ s, n }) => `${STATUS_META[s].label} ${n}`).join(", ")}`}
-      />
-      <div className="cockpit-bar__legend">
-        {segs.map(({ s, n }) => (
-          <span key={s} className="cockpit-legend">
-            <span className="cockpit-dot" style={{ background: STATUS_META[s].color }} />
-            {STATUS_META[s].label} <b>{n}</b>
-          </span>
-        ))}
-      </div>
-      {active.length > 0 ? (
-        <ul className="cockpit-cards">
-          {active.slice(0, 6).map((c) => (
-            <li key={c.id}>
-              <a className="cockpit-cardrow" href={`/#card-${c.id}`}>
-                <span className="cockpit-dot" style={{ background: STATUS_META[c.status].color }} />
-                <span className="cockpit-cardrow__title" title={c.title}>{c.title}</span>
-                {famName(c.familiarId) ? <span className="cockpit-cardrow__who">{famName(c.familiarId)}</span> : null}
-              </a>
-            </li>
-          ))}
-        </ul>
-      ) : <p className="cockpit-muted">Nothing actively in flight.</p>}
-    </>
-  );
-}
-
-// ─── Familiars roster ──────────────────────────────────────────────────────────────
-
-function AgentsPanel({ familiars, sessions, loaded }: { familiars: Familiar[]; sessions: SessionRow[]; loaded: boolean }) {
-  const profiles = useMemo(() => familiarMiniProfiles(familiars, sessions, Date.now()), [familiars, sessions]);
-  if (!loaded) return <PanelSkeleton rows={3} />;
-  if (familiars.length === 0) return <EmptyState icon="ph:sparkle">No familiars configured.</EmptyState>;
-  return (
-    <ul className="cockpit-agents">
-      {familiars.slice(0, 6).map((f) => {
-        const active = (f.active_sessions ?? 0) > 0;
-        const p = profiles.find((x) => x.id === f.id);
-        return (
-          <li key={f.id} className="cockpit-agent">
-            {/* The whole row drills into the familiar's analytics page. */}
-            <a className="cockpit-agent__link" href={`/dashboard/familiars/${encodeURIComponent(f.id)}/analytics`}>
-              <span className="cockpit-agent__avatar" style={{ background: f.color || "var(--accent-presence)" }}>
-                {f.emoji || (f.display_name || "?").slice(0, 1).toUpperCase()}
-                {active ? <span className="cockpit-agent__on" /> : null}
-              </span>
-              <span className="cockpit-agent__body">
-                <span className="cockpit-agent__name" title={f.display_name}>{f.display_name}</span>
-                <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
-              </span>
-              {p ? <span className="cockpit-agent__count">{p.sessionsLast7d}/7d</span> : null}
-              {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color="var(--accent-presence)" height={20} /></span> : null}
-              {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
-            </a>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-// ─── GitHub ──────────────────────────────────────────────────────────────────────
-
-const GH_ICON: Record<GitHubItem["kind"], IconName> = {
-  pr: "ph:git-pull-request", review_request: "ph:git-pull-request", issue: "ph:circle", notification: "ph:bell",
-};
-function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }) {
-  if (!loaded) return <PanelSkeleton rows={3} />;
-  if (items.length === 0) return <EmptyState icon="ph:github-logo">No GitHub activity, or no token configured.</EmptyState>;
-  return (
-    <ul className="cockpit-gh">
-      {items.slice(0, 6).map((g) => (
-        <li key={g.id}>
-          <a
-            className="cockpit-ghrow"
-            href={g.url}
-            onClick={(event) => {
-              event.preventDefault();
-              openExternalUrl(g.url);
-            }}
-          >
-            <Icon name={GH_ICON[g.kind]} className="cockpit-ghrow__icon" aria-hidden />
-            <span className="cockpit-ghrow__title" title={g.title}>{g.title}</span>
-            <span className="cockpit-ghrow__meta">
-              {checkDot(g.checkStatus)}
-              <span className="cockpit-ghrow__repo">{shortRepo(g.repo)}{g.number ? ` #${g.number}` : ""}</span>
-            </span>
-          </a>
-        </li>
-      ))}
-    </ul>
-  );
-}
-function checkDot(s: GitHubItem["checkStatus"]) {
-  if (!s) return null;
-  const color = s === "passing" ? "var(--color-success)" : s === "failing" ? "var(--color-danger)" : "var(--color-warning)";
-  return <span className="cockpit-dot" style={{ background: color }} title={`Checks: ${s}`} role="img" aria-label={`Checks ${s}`} />;
-}
-function shortRepo(repo: string): string {
-  const slash = repo.lastIndexOf("/");
-  return slash >= 0 ? repo.slice(slash + 1) : repo;
-}
-
-// ─── Agenda ──────────────────────────────────────────────────────────────────────
-
-function AgendaPanel({ items, now, loaded }: { items: InboxItem[]; now: Date; loaded: boolean }) {
-  if (!loaded) return <PanelSkeleton rows={2} />;
-  if (items.length === 0) return <EmptyState icon="ph:calendar-bold">Nothing scheduled ahead.</EmptyState>;
-  return (
-    <ul className="cockpit-agenda">
-      {items.map((i) => (
-        <li key={i.id} className="cockpit-agendarow">
-          <span className="cockpit-agendarow__when">{whenLabel(i.fireAt!, now)}</span>
-          <span className="cockpit-agendarow__title" title={i.title}>{i.title}</span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-function whenLabel(iso: string, now: Date): string {
-  const d = new Date(iso);
-  const sameDay = d.toDateString() === now.toDateString();
-  const time = d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
-  if (sameDay) return `Today ${time}`;
-  const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
-  if (d.toDateString() === tomorrow.toDateString()) return `Tmrw ${time}`;
-  return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric" })} ${time}`;
-}
-
-// ─── Signals ─────────────────────────────────────────────────────────────────────
-
-const SIGNAL_ICON: Record<DashboardSignal["severity"], IconName> = { warn: "ph:warning", info: "ph:info" };
-
-// Keep the panel scannable: the stalest drift leads, the long tail collapses
-// into a drill-through instead of swamping the column.
-const SIGNALS_CAP = 8;
-
-function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
-  const shown = signals.slice(0, SIGNALS_CAP);
-  const hidden = signals.length - shown.length;
-  return (
-    <ul className="cockpit-signals">
-      {shown.map((s) => {
-        const inner = (
-          <>
-            <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
-            <span className="cockpit-signal__text">{s.text}</span>
-          </>
-        );
-        return (
-          <li key={s.id}>
-            {s.href ? (
-              // An actionable signal takes you to where you can act on it —
-              // the stalled PR, the board, the familiar's analytics.
-              <a
-                className={`cockpit-signal cockpit-signal--${s.severity} cockpit-signal--link`}
-                href={s.href}
-                onClick={s.external ? (event) => { event.preventDefault(); openExternalUrl(s.href!); } : undefined}
-              >
-                {inner}
-              </a>
-            ) : (
-              <span className={`cockpit-signal cockpit-signal--${s.severity}`}>{inner}</span>
-            )}
-          </li>
-        );
-      })}
-      {hidden > 0 ? (
-        <li>
-          <a className="cockpit-signal cockpit-signal--more" href="/?mode=github">
-            <Icon name="ph:arrow-right-bold" className="cockpit-signal__icon" aria-hidden />
-            <span className="cockpit-signal__text">+{hidden} more — review on the GitHub surface</span>
-          </a>
-        </li>
-      ) : null}
-    </ul>
-  );
-}
-
-// ─── Confidence / performance heatmap ────────────────────────────────────────────
-
-type ConfidenceRow = { id: string; name: string; score: number; factors: ConfidenceFactor[] };
-
-/** Pretty label for a confidence factor key (e.g. "accept_rate" → "Accept"). */
-function prettyFactor(label: string): string {
-  const base = label.replace(/_score$/, "").replace(/_rate$/, "");
-  return base.split("_").map((w) => w.slice(0, 1).toUpperCase() + w.slice(1)).join(" ");
-}
-
-/** 0 → danger, 1 → success, ramped through color-mix in oklch. */
-function confidenceColor(value: number): string {
-  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
-  return `color-mix(in oklch, var(--color-success) ${pct}%, var(--color-danger))`;
-}
-
-function ConfidencePanel({ rows }: { rows: ConfidenceRow[] }) {
-  const cols = rows[0]?.factors.map((f) => prettyFactor(f.label)) ?? [];
-  // Cell value = the factor's normalized 0..1 strength (raw score ÷ 100).
-  const cells = rows.flatMap((r) =>
-    r.factors.map((f) => ({ row: r.name, col: prettyFactor(f.label), value: f.value / 100 })),
-  );
-  return (
-    <div className="cockpit-confidence">
-      <div className="cockpit-confidence__cols" style={{ ["--cols" as string]: cols.length }}>
-        {cols.map((c) => <span key={c}>{c}</span>)}
-      </div>
-      <div className="cockpit-confidence__grid">
-        <div className="cockpit-confidence__rows">
-          {rows.map((r) => (
-            <a
-              key={r.id}
-              href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}
-              title={`${r.name}: confidence ${r.score} — open analytics`}
-            >
-              {r.name}
-            </a>
-          ))}
-        </div>
-        <Heatmap
-          rows={rows.map((r) => r.name)}
-          cols={cols}
-          cells={cells}
-          colorFor={confidenceColor}
-          height={Math.max(72, rows.length * 26)}
-          ariaLabel={`Confidence factors by familiar: ${rows.map((r) => `${r.name} ${r.score}`).join(", ")}`}
-          cellTitle={(c) => `${c.row} · ${c.col}: ${Math.round(c.value * 100)}/100`}
-        />
-      </div>
-    </div>
-  );
-}
-
-// ─── Space usage ─────────────────────────────────────────────────────────────────
-
-type SpaceSort = { key: SpaceSortKey; dir: SortDir };
-
-/** Local disk footprint per `~/.coven` area: sortable rows, share bars, and a
- *  cleanup drill-through per area. Figures come from the bounded server scan. */
-function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loaded: boolean }) {
-  const [sort, setSort] = useState<SpaceSort>({ key: "bytes", dir: "desc" });
-  const sorted = useMemo(() => sortSpaceRows(rows, sort.key, sort.dir), [rows, sort]);
-  if (!loaded) return <PanelSkeleton rows={3} />;
-  if (rows.length === 0) return <EmptyState icon="ph:database-bold">No local coven data found.</EmptyState>;
-
-  const cycle = (key: SpaceSortKey, firstDir: SortDir) =>
-    setSort((prev) => prev.key === key
-      ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
-      : { key, dir: firstDir });
-  const ariaSort = (key: SpaceSortKey): "ascending" | "descending" | "none" =>
-    sort.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
-  const head = (key: SpaceSortKey, label: string, firstDir: SortDir) => (
-    <button type="button" className={`cockpit-sorthead${sort.key === key ? " is-sorted" : ""}`} onClick={() => cycle(key, firstDir)}>
-      {label}
-      <Icon name={sort.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
-    </button>
-  );
-
-  return (
-    <div className="cockpit-space" role="table" aria-label="Local space usage by area">
-      <div className="cockpit-space__head" role="row">
-        <span role="columnheader" aria-sort={ariaSort("label")}>{head("label", "Area", "asc")}</span>
-        <span role="columnheader" aria-sort={ariaSort("bytes")}>{head("bytes", "Size", "desc")}</span>
-        <span role="columnheader" className="cockpit-space__filescol" aria-sort={ariaSort("files")}>{head("files", "Files", "desc")}</span>
-        <span role="columnheader" className="cockpit-space__lastcol" aria-sort={ariaSort("lastModified")}>{head("lastModified", "Updated", "desc")}</span>
-      </div>
-      {sorted.map((r) => {
-        const inner = (
-          <>
-            <span className="cockpit-space__area" role="cell" title={r.relPath}>
-              <b>{r.label}</b>
-              <span className="cockpit-space__path">{r.relPath}</span>
-            </span>
-            <span className="cockpit-space__size" role="cell">
-              <b>{formatBytes(r.bytes)}{r.truncated ? "+" : ""}</b>
-              <span className="cockpit-space__bar" aria-hidden>
-                <i style={{ width: `${Math.max(2, r.sharePct)}%` }} />
-              </span>
-            </span>
-            <span className="cockpit-space__files cockpit-space__filescol" role="cell">{r.files}{r.truncated ? "+" : ""}</span>
-            <span className="cockpit-space__last cockpit-space__lastcol" role="cell">
-              {r.lastModifiedMs ? (relativeTime(new Date(r.lastModifiedMs).toISOString()) || "just now") : "—"}
-            </span>
-          </>
-        );
-        // Areas a surface owns drill into that surface; the rest are plain rows.
-        return r.href ? (
-          <a key={r.id} className="cockpit-space__row cockpit-space__row--link" role="row" href={r.href} title={r.actionLabel ?? undefined}>
-            {inner}
-          </a>
-        ) : (
-          <span key={r.id} className="cockpit-space__row" role="row">{inner}</span>
-        );
-      })}
-    </div>
-  );
-}
-
-// ─── Bits ────────────────────────────────────────────────────────────────────────
-
-function PanelSkeleton({ rows }: { rows: number }) {
-  return <div className="cockpit-skel">{Array.from({ length: rows }).map((_, i) => <span key={i} className="cockpit-skel__row" />)}</div>;
-}
-
-function longDate(now: Date): string {
-  return now.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
 }

--- a/src/lib/authed-image.test.ts
+++ b/src/lib/authed-image.test.ts
@@ -166,7 +166,8 @@ for (const rel of [
   "../components/familiar-growth-view.tsx",
   "../components/familiar-analytics-view.tsx",
   "../components/familiars-view.tsx",
-  "../components/dashboard/dashboard-cockpit.tsx",
+  // The cockpit's avatar-rendering rows live in its presentational panel layer.
+  "../components/dashboard/cockpit-panels.tsx",
 ]) {
   const src = read(rel);
   assert.match(src, /AuthedImage/, `${rel} renders avatars via <AuthedImage>`);

--- a/src/lib/dashboard-cockpit-format.test.ts
+++ b/src/lib/dashboard-cockpit-format.test.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  DEFAULT_LAYOUT,
+  PANEL_TITLES,
+  confidenceColor,
+  contractSub,
+  coverageSub,
+  dayKey,
+  panelTitle,
+  prettyFactor,
+  reconcileLayout,
+  retroSub,
+  seriesFor,
+  shortRepo,
+  whenLabel,
+  wowSub,
+} from "./dashboard-cockpit-format.ts";
+
+test("reconcileLayout keeps saved order, appends new defaults, drops unknown ids", () => {
+  const stored = { main: ["board", "usage", "retired-widget"], rail: undefined };
+  const layout = reconcileLayout(stored);
+  // Saved order leads; every remaining default follows; the unknown id is gone.
+  assert.deepEqual(layout.main.slice(0, 2), ["board", "usage"]);
+  assert.deepEqual([...layout.main].sort(), [...DEFAULT_LAYOUT.main].sort());
+  assert.ok(!layout.main.includes("retired-widget"));
+  assert.deepEqual(layout.rail, DEFAULT_LAYOUT.rail);
+});
+
+test("every default widget has a human drag-announcement title", () => {
+  for (const id of [...DEFAULT_LAYOUT.main, ...DEFAULT_LAYOUT.rail]) {
+    assert.ok(PANEL_TITLES[id], `missing PANEL_TITLES entry for "${id}"`);
+  }
+  assert.equal(panelTitle("board"), "Board");
+  assert.equal(panelTitle("not-a-widget"), "not-a-widget");
+});
+
+test("seriesFor yields 7 points oldest→newest with nulls for missing days", () => {
+  const now = new Date(2026, 6, 14, 12, 0, 0);
+  const store = { [dayKey(now)]: { sessions: 5 }, "2026-07-12": { sessions: 2 } };
+  const series = seriesFor(store, "sessions", now);
+  assert.equal(series.length, 7);
+  assert.equal(series.at(-1).value, 5); // today last
+  assert.equal(series.at(-3).value, 2); // two days back
+  assert.equal(series[0].value, null); // missing day is a gap, not a fake zero
+});
+
+test("KPI sub-lines teach instead of shrugging", () => {
+  assert.equal(retroSub({ retroAccepted: 0, retroReverted: 0 }), "fills in after the first retro run");
+  assert.equal(retroSub({ retroAccepted: 3, retroReverted: 1 }), "3/4 accepted");
+  assert.equal(contractSub({ contractTotal: 0, contractPass: 0 }), "fills in once familiars have contracts");
+  assert.equal(contractSub({ contractTotal: 5, contractPass: 4 }), "4/5 passing");
+  assert.equal(wowSub(2), "▲ 2 vs last week");
+  assert.equal(wowSub(-3), "▼ 3 vs last week");
+  assert.equal(wowSub(0), "level with last week");
+  assert.equal(coverageSub("Trusted", 12, 20, "scored"), "Trusted · first 12/20 scored");
+  assert.equal(coverageSub("Trusted", 12, 12, "scored"), "Trusted");
+});
+
+test("whenLabel is calendar-relative for upcoming reminders", () => {
+  const now = new Date(2026, 6, 14, 9, 0, 0);
+  const at = (d: Date, h: number) => { const c = new Date(d); c.setHours(h, 30, 0, 0); return c.toISOString(); };
+  assert.match(whenLabel(at(now, 15), now), /^Today /);
+  const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
+  assert.match(whenLabel(at(tomorrow, 9), now), /^Tmrw /);
+  const nextWeek = new Date(now); nextWeek.setDate(now.getDate() + 6);
+  assert.match(whenLabel(at(nextWeek, 9), now), /^Jul 20 /);
+});
+
+test("small formatters: shortRepo, prettyFactor, confidenceColor clamps", () => {
+  assert.equal(shortRepo("OpenCoven/coven-cave"), "coven-cave");
+  assert.equal(shortRepo("bare-repo"), "bare-repo");
+  assert.equal(prettyFactor("accept_rate"), "Accept");
+  assert.equal(prettyFactor("contract_score"), "Contract");
+  assert.equal(prettyFactor("memory_freshness"), "Memory Freshness");
+  assert.match(confidenceColor(1.4), /100%/); // clamped high
+  assert.match(confidenceColor(-2), /\b0%/);  // clamped low
+  assert.match(confidenceColor(0.5), /50%/);
+});

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -1,6 +1,6 @@
 // Pure formatting + vocab helpers for the dashboard cockpit — extracted from
-// dashboard-cockpit.tsx (cave-tsoz) so the pieces the KPI tiles, panels, and
-// layout persistence share are testable without a React tree.
+// dashboard-cockpit.tsx (cave-tsoz) so the pieces that the KPI tiles, panels,
+// and layout persistence share are testable without a React tree.
 
 import type { SparkPoint } from "@/components/ui/sparkline";
 import type { CardStatus } from "@/lib/cave-board-types";
@@ -49,7 +49,9 @@ export function reconcileLayout(stored: Partial<Layout>): Layout {
 
 export const TREND_DAYS = 7;
 export type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contract" | "needs";
-export type DaySnap = Record<TrendKey, number>;
+// Persisted JSON can legitimately miss keys for a day (older snapshots predate
+// newer metrics) — seriesFor already reads missing values as gaps.
+export type DaySnap = Partial<Record<TrendKey, number>>;
 export type TrendStore = Record<string, DaySnap>; // "YYYY-MM-DD" -> snapshot
 
 export function dayKey(d: Date): string {

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -1,0 +1,155 @@
+// Pure formatting + vocab helpers for the dashboard cockpit — extracted from
+// dashboard-cockpit.tsx (cave-tsoz) so the pieces the KPI tiles, panels, and
+// layout persistence share are testable without a React tree.
+
+import type { SparkPoint } from "@/components/ui/sparkline";
+import type { CardStatus } from "@/lib/cave-board-types";
+import type { CovenVitals, FamiliarInsightRow } from "@/lib/coven-analytics";
+
+// ─── Draggable panel layout ──────────────────────────────────────────────────
+
+export type Layout = { main: string[]; rail: string[] };
+
+export const DEFAULT_LAYOUT: Layout = {
+  main: ["usage", "signals", "needs", "board", "today"],
+  rail: ["confidence", "agents", "load", "space", "github", "agenda"],
+};
+
+// Human titles for drag-and-drop announcements + grip labels (mirrors each
+// widget's <Panel title>). dnd-kit's defaults read the raw ids, which are
+// semantic but terse — screen readers should hear the visible panel names.
+export const PANEL_TITLES: Record<string, string> = {
+  usage: "Activity over time",
+  signals: "Signals",
+  needs: "Needs attention",
+  board: "Board",
+  today: "Today summary",
+  confidence: "Performance matrix",
+  agents: "Familiars",
+  load: "Familiar load",
+  space: "Space usage",
+  github: "GitHub",
+  agenda: "Up next",
+};
+
+export const panelTitle = (id: unknown): string => PANEL_TITLES[String(id)] ?? String(id);
+
+/** Merge a saved order with the defaults: keep known ids in saved order, append
+ *  any new defaults, drop anything unknown (survives version changes). */
+export function reconcileLayout(stored: Partial<Layout>): Layout {
+  const fix = (saved: string[] | undefined, def: string[]) => {
+    const s = (saved ?? []).filter((id) => def.includes(id));
+    for (const id of def) if (!s.includes(id)) s.push(id);
+    return s;
+  };
+  return { main: fix(stored.main, DEFAULT_LAYOUT.main), rail: fix(stored.rail, DEFAULT_LAYOUT.rail) };
+}
+
+// ─── 7-day vitals trends (persisted client-side, keyed by day) ────────────────
+
+export const TREND_DAYS = 7;
+export type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contract" | "needs";
+export type DaySnap = Record<TrendKey, number>;
+export type TrendStore = Record<string, DaySnap>; // "YYYY-MM-DD" -> snapshot
+
+export function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** Last `TREND_DAYS` points for one metric, oldest→newest; null value for missing days. */
+export function seriesFor(store: TrendStore, key: TrendKey, now: Date): SparkPoint[] {
+  const out: SparkPoint[] = [];
+  for (let i = TREND_DAYS - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(now.getDate() - i);
+    const v = store[dayKey(d)]?.[key];
+    out.push({
+      label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
+      value: typeof v === "number" ? v : null,
+    });
+  }
+  return out;
+}
+
+// ─── Status vocab ──────────────────────────────────────────────────────────────
+
+export const STATUS_META: Record<CardStatus, { label: string; color: string }> = {
+  running: { label: "In progress", color: "var(--color-success)" },
+  review: { label: "In review", color: "var(--color-info)" },
+  blocked: { label: "Blocked", color: "var(--color-danger)" },
+  inbox: { label: "Inbox", color: "var(--accent-presence)" },
+  backlog: { label: "Backlog", color: "var(--text-muted)" },
+  done: { label: "Done", color: "color-mix(in oklch, var(--color-success) 55%, var(--text-muted))" },
+};
+export const STATUS_ORDER: CardStatus[] = ["running", "review", "blocked", "inbox", "backlog", "done"];
+
+export const HEALTH_META: Record<NonNullable<FamiliarInsightRow["health"]>, { label: string; tone: "good" | "warn" | "bad" | "calm" }> = {
+  active: { label: "Active", tone: "good" },
+  steady: { label: "Steady", tone: "calm" },
+  quiet: { label: "Quiet", tone: "warn" },
+  stalled: { label: "Stalled", tone: "bad" },
+};
+
+export const TIER_TONE: Record<string, "good" | "warn" | "bad" | "calm"> = {
+  Trusted: "good", Reliable: "calm", Developing: "warn", Low: "bad",
+};
+
+// ─── KPI sub-lines ─────────────────────────────────────────────────────────────
+
+export function wowSub(delta: number): string {
+  if (delta > 0) return `▲ ${delta} vs last week`;
+  if (delta < 0) return `▼ ${Math.abs(delta)} vs last week`;
+  return "level with last week";
+}
+
+export function retroSub(v: CovenVitals): string {
+  const runs = v.retroAccepted + v.retroReverted;
+  // Teach, don't shrug: name the action that fills the tile (cave-m4oq).
+  if (runs === 0) return "fills in after the first retro run";
+  return `${v.retroAccepted}/${runs} accepted`;
+}
+
+export function contractSub(v: CovenVitals): string {
+  if (v.contractTotal === 0) return "fills in once familiars have contracts";
+  return `${v.contractPass}/${v.contractTotal} passing`;
+}
+
+export function coverageSub(base: string, fetched: number, total: number, verb: "scored" | "checked"): string {
+  if (total <= fetched) return base;
+  return `${base} · first ${fetched}/${total} ${verb}`;
+}
+
+// ─── Small formatters ──────────────────────────────────────────────────────────
+
+/** Calendar-relative label for an upcoming reminder: "Today 3:00 PM",
+ *  "Tmrw 9:15 AM", then "Jul 18 9:15 AM" past tomorrow. */
+export function whenLabel(iso: string, now: Date): string {
+  const d = new Date(iso);
+  const sameDay = d.toDateString() === now.toDateString();
+  const time = d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  if (sameDay) return `Today ${time}`;
+  const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
+  if (d.toDateString() === tomorrow.toDateString()) return `Tmrw ${time}`;
+  return `${d.toLocaleDateString(undefined, { month: "short", day: "numeric" })} ${time}`;
+}
+
+export function shortRepo(repo: string): string {
+  const slash = repo.lastIndexOf("/");
+  return slash >= 0 ? repo.slice(slash + 1) : repo;
+}
+
+/** Pretty label for a confidence factor key (e.g. "accept_rate" → "Accept"). */
+export function prettyFactor(label: string): string {
+  const base = label.replace(/_score$/, "").replace(/_rate$/, "");
+  return base.split("_").map((w) => w.slice(0, 1).toUpperCase() + w.slice(1)).join(" ");
+}
+
+/** 0 → danger, 1 → success, ramped through color-mix in oklch. */
+export function confidenceColor(value: number): string {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  return `color-mix(in oklch, var(--color-success) ${pct}%, var(--color-danger))`;
+}
+
+export function longDate(now: Date): string {
+  return now.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+}


### PR DESCRIPTION
Slice 1 of the dashboard-command-center goal (bead cave-tsoz): split the ~1,200-line cockpit monolith along its natural seams — the #3149 chat-familiar-view extraction is the pattern.

## What changed

- **`src/lib/dashboard-cockpit-format.ts`** — pure, DOM-free helpers + vocab: layout reconciliation (`reconcileLayout` + `DEFAULT_LAYOUT`/`PANEL_TITLES`), the trend store (`dayKey`/`seriesFor` + types), status/health/tier vocab, KPI sub-lines (`wowSub`/`retroSub`/`contractSub`/`coverageSub`), `whenLabel`, `shortRepo`, `prettyFactor`, `confidenceColor`, `longDate`.
- **`src/components/dashboard/cockpit-panels.tsx`** — the presentational layer (insight banner, Panel/SortableWidget wrappers, KPI tile, the familiar-insights centerpiece table, and the Usage/Board/Agents/GitHub/Agenda/Signals/Confidence/SpaceUsage panels), each still owning its skeleton and empty state.
- **`dashboard-cockpit.tsx` (~600 lines now)** keeps what the root owns: independent source fetches, derivation, trends persistence, drag orchestration + announcements, and the page frame.
- **Semantic timestamps:** agenda when-labels, insight rows' last-active, and space-usage Updated are now `<time dateTime>` elements.

## Behavior

No visual or behavioral change beyond the `<time>` semantics — layout persistence keys, poll cadence, drag announcements, and all copy are untouched. `KpiSpec` stays root-side (`Omit<KpiTileProps, "loading" | "series"> & { metric, src }`), so the tile's visual contract and the root's data plumbing are separately typed.

## Tests

- New `src/lib/dashboard-cockpit-format.test.ts` (6 behavioral tests): saved-layout reconciliation, drag-title coverage for every default widget, 7-point trend series with honest gaps (null ≠ fake zero), teach-state KPI sub-lines, calendar-relative when-labels, formatter clamps. Wired in run-tests.
- `dashboard-page.test.ts` reads the split as one contract; `dashboard-cockpit-polish.test.ts` pins each concern where it now lives + the new `<time>` semantics; `authed-image.test.ts` consumer list points at the panel layer.

## Verification

- Dashboard suites (11 files incl. new): pass
- `pnpm typecheck` clean; check-tests-wired 952
- `pnpm test:app`: 708 files pass

Bead: cave-tsoz (goal: dashboard-command-center, .copilot/goals.md)
