### PR TITLE
feat(chat): GitHub card checks strip, in-place expansion, review threads (cave-fpqx.7)

### DIFF
--- a/src/components/github-card-wiring.test.ts
+++ b/src/components/github-card-wiring.test.ts
@@ -56,5 +56,11 @@ assert.match(card, /countChecks\(data\.runs\)/, "strip buckets come from the sha
 assert.match(card, /aria-expanded=\{expanded\}/, "check details expand in place with an accessible toggle");
 assert.match(card, /\/api\/github\/comments\?repo=.*isPull=1/, "review-thread cards hydrate from /api/github/comments");
 assert.match(card, /connect GitHub to see review threads/, "unauthenticated review threads degrade legibly");
+assert.match(
+  card,
+  /t\.comments\.some\(\(c\) => c\.id === descriptor\.threadId\)/,
+  "thread matching uses comment databaseIds (what #discussion_r ids name), not GraphQL node ids",
+);
+assert.match(card, /isFailConclusion\(run\.conclusion\)/, "run glyphs share the fail-conclusion source of truth");
 
 console.log("github chat-card wiring: ok");

--- a/src/components/github-card-wiring.test.ts
+++ b/src/components/github-card-wiring.test.ts
@@ -40,4 +40,21 @@ assert.match(card, /connect GitHub to hydrate/, "unauth state degrades with a co
 assert.match(card, /descriptorUrl\(descriptor\)/, "card links out via the canonical descriptor URL");
 assert.match(card, /res\.status === 401 \|\| res\.status === 403/, "auth failures map to the unauth state");
 
+// W1b (cave-fpqx.7): checks strip + expansion + review threads.
+assert.match(card, /\/api\/github\/checks\?repo=/, "PR cards fetch the checks breakdown");
+assert.match(
+  card,
+  /usePausablePoll\(\(\) => setTick\(\(t\) => t \+ 1\), 30_000, \{ enabled: enabled && pending \}\)/,
+  "checks re-poll every 30s only while the rollup is pending (hidden tabs pause)",
+);
+assert.match(
+  card,
+  /item\.isPull && item\.state === "open" && !item\.merged/,
+  "checks fetch is gated to open, unmerged pull requests",
+);
+assert.match(card, /countChecks\(data\.runs\)/, "strip buckets come from the shared countChecks helper");
+assert.match(card, /aria-expanded=\{expanded\}/, "check details expand in place with an accessible toggle");
+assert.match(card, /\/api\/github\/comments\?repo=.*isPull=1/, "review-thread cards hydrate from /api/github/comments");
+assert.match(card, /connect GitHub to see review threads/, "unauthenticated review threads degrade legibly");
+
 console.log("github chat-card wiring: ok");

--- a/src/components/github-card.tsx
+++ b/src/components/github-card.tsx
@@ -11,6 +11,8 @@
 import { useEffect, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { countChecks, type CheckCounts, type CheckSummary } from "@/lib/github-checks";
 import { descriptorUrl, type GitHubBlockDescriptor } from "@/lib/github-blocks";
 
 type Person = { login: string; avatarUrl: string | null; url: string | null };
@@ -36,6 +38,117 @@ type HydrationState =
   | { phase: "ready"; item: ItemDetail }
   | { phase: "unauth" }
   | { phase: "error" };
+
+type CheckRunDetail = {
+  id: string;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  detailsUrl: string | null;
+};
+
+type ChecksData = { rollup: CheckSummary; counts: CheckCounts; runs: CheckRunDetail[] };
+
+type ChecksState =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "ready"; data: ChecksData }
+  | { phase: "error" };
+
+/** Checks for an OPEN pull request card: one fetch + a 30s pausable re-poll
+ *  while the rollup is pending (github-view idiom — hidden tabs don't spend
+ *  rate limit; refreshes of the same PR are silent). */
+function useCardChecks(repo: string, number: number | undefined, enabled: boolean): ChecksState {
+  const [state, setState] = useState<ChecksState>({ phase: "idle" });
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (!enabled || !number) {
+      setState({ phase: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setState((prev) => (prev.phase === "ready" ? prev : { phase: "loading" }));
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/github/checks?repo=${encodeURIComponent(repo)}&number=${number}`,
+          { cache: "no-store" },
+        );
+        const data = (await res.json().catch(() => null)) as
+          | { ok: true; rollup: CheckSummary; runs: CheckRunDetail[] }
+          | { ok: false }
+          | null;
+        if (cancelled) return;
+        if (!res.ok || !data || data.ok !== true) {
+          // A failed refresh keeps the last good strip.
+          setState((prev) => (prev.phase === "ready" ? prev : { phase: "error" }));
+          return;
+        }
+        setState({
+          phase: "ready",
+          data: { rollup: data.rollup, counts: countChecks(data.runs), runs: data.runs },
+        });
+      } catch {
+        if (!cancelled) setState((prev) => (prev.phase === "ready" ? prev : { phase: "error" }));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, number, enabled, tick]);
+  const pending = state.phase === "ready" && state.data.rollup === "pending";
+  usePausablePoll(() => setTick((t) => t + 1), 30_000, { enabled: enabled && pending });
+  return state;
+}
+
+type ReviewThreadDetail = {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  comments: { author: { login: string } | null; body: string; createdAt: string | null }[];
+};
+
+type ThreadState =
+  | { phase: "loading" }
+  | { phase: "ready"; threads: ReviewThreadDetail[]; authed: boolean }
+  | { phase: "error" };
+
+/** Review threads for a review-thread card — /api/github/comments, PR scope. */
+function useReviewThreads(repo: string, number: number | undefined, enabled: boolean): ThreadState {
+  const [state, setState] = useState<ThreadState>({ phase: "loading" });
+  useEffect(() => {
+    if (!enabled || !number) return;
+    let cancelled = false;
+    setState({ phase: "loading" });
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/github/comments?repo=${encodeURIComponent(repo)}&number=${number}&isPull=1`,
+          { cache: "no-store" },
+        );
+        const data = (await res.json().catch(() => null)) as
+          | { ok: true; authed: boolean; reviewThreads: ReviewThreadDetail[] }
+          | { ok: false }
+          | null;
+        if (cancelled) return;
+        if (!res.ok || !data || data.ok !== true) {
+          setState({ phase: "error" });
+          return;
+        }
+        setState({ phase: "ready", threads: data.reviewThreads ?? [], authed: Boolean(data.authed) });
+      } catch {
+        if (!cancelled) setState({ phase: "error" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, number, enabled]);
+  return state;
+}
 
 function useGitHubItem(repo: string, number: number | undefined, enabled: boolean): HydrationState {
   const [state, setState] = useState<HydrationState>({ phase: "loading" });
@@ -93,6 +206,127 @@ function stateGlyph(d: GitHubBlockDescriptor, item: ItemDetail | null): { icon: 
   };
 }
 
+/** Compact `✓ n · ✕ n · ○ n` strip with a rollup-tinted leading dot. */
+function ChecksStrip({ data }: { data: ChecksData }) {
+  const { rollup, counts } = data;
+  if (!counts.total) return null;
+  const tint =
+    rollup === "failing"
+      ? "var(--color-warning)"
+      : rollup === "passing"
+        ? "var(--color-success)"
+        : "var(--text-secondary)";
+  const label =
+    rollup === "failing" ? "Checks failing" : rollup === "passing" ? "Checks passing" : "Checks running";
+  return (
+    <span className="inline-flex items-center gap-1.5" role="status" aria-label={`${label}: ${counts.passed} passed, ${counts.failed} failed, ${counts.pending} pending`}>
+      <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: tint }} />
+      <span aria-hidden>
+        {counts.passed > 0 ? `✓ ${counts.passed}` : null}
+        {counts.failed > 0 ? `${counts.passed > 0 ? " · " : ""}✕ ${counts.failed}` : null}
+        {counts.pending > 0 ? `${counts.passed + counts.failed > 0 ? " · " : ""}○ ${counts.pending}` : null}
+      </span>
+    </span>
+  );
+}
+
+function checkRunGlyph(run: CheckRunDetail): { icon: IconName; color: string } {
+  if (run.status !== "completed") return { icon: "ph:circle-notch-bold", color: "var(--text-secondary)" };
+  if (run.conclusion === "success") return { icon: "ph:check-circle", color: "var(--color-success)" };
+  if (run.conclusion && ["failure", "timed_out", "action_required", "startup_failure"].includes(run.conclusion))
+    return { icon: "ph:x-circle-fill", color: "var(--color-warning)" };
+  return { icon: "ph:minus-circle", color: "var(--text-secondary)" };
+}
+
+/** Expanded PR section: per-check rows linking to their logs. */
+function CheckRunList({ runs, onOpenUrl }: { runs: CheckRunDetail[]; onOpenUrl?: (url: string) => void }) {
+  if (!runs.length) return <div className="text-[11px] text-[var(--text-secondary)]">No check runs.</div>;
+  return (
+    <ul className="m-0 list-none space-y-1 p-0">
+      {runs.map((run) => {
+        const glyph = checkRunGlyph(run);
+        return (
+          <li key={run.id} className="flex items-center gap-2 text-[11px] text-[var(--text-secondary)]">
+            <span aria-hidden className="inline-flex" style={{ color: glyph.color }}>
+              <Icon name={glyph.icon} width={12} />
+            </span>
+            {run.detailsUrl ? (
+              <button
+                type="button"
+                className="focus-ring min-w-0 truncate text-left hover:underline"
+                onClick={() => {
+                  if (onOpenUrl) onOpenUrl(run.detailsUrl!);
+                  else window.open(run.detailsUrl!, "_blank", "noopener,noreferrer");
+                }}
+                aria-label={`Open logs for ${run.name}`}
+              >
+                {run.name}
+              </button>
+            ) : (
+              <span className="min-w-0 truncate">{run.name}</span>
+            )}
+            <span className="ml-auto shrink-0">{run.status === "completed" ? (run.conclusion ?? "done") : run.status}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/** Hydrated body for a review-thread card: the thread's excerpt + state. */
+function ReviewThreadBody({
+  descriptor,
+  onOpenUrl,
+}: {
+  descriptor: GitHubBlockDescriptor;
+  onOpenUrl?: (url: string) => void;
+}) {
+  const state = useReviewThreads(descriptor.repo, descriptor.number, true);
+  if (state.phase === "loading")
+    return <div className="text-[11px] text-[var(--text-secondary)]" aria-live="polite">loading threads…</div>;
+  if (state.phase === "error")
+    return <div className="text-[11px] text-[var(--text-secondary)]">threads unavailable</div>;
+  if (!state.authed)
+    return <div className="text-[11px] text-[var(--text-secondary)]">connect GitHub to see review threads</div>;
+  const thread = descriptor.threadId
+    ? state.threads.find((t) => t.id.endsWith(descriptor.threadId!)) ?? null
+    : null;
+  const shown = thread ? [thread] : state.threads.filter((t) => !t.isResolved).slice(0, 3);
+  if (!shown.length)
+    return <div className="text-[11px] text-[var(--text-secondary)]">no unresolved review threads</div>;
+  return (
+    <div className="space-y-2">
+      {shown.map((t) => (
+        <div key={t.id} className="rounded border border-[var(--border-hairline)] px-2 py-1.5">
+          <div className="flex items-center gap-2 text-[10px] text-[var(--text-secondary)]">
+            {t.path ? <span className="min-w-0 truncate font-mono">{t.path}</span> : null}
+            <span className="ml-auto shrink-0">{t.isResolved ? "resolved" : t.isOutdated ? "outdated" : "open"}</span>
+          </div>
+          {t.comments[0] ? (
+            <div className="mt-1 line-clamp-3 text-[11px] text-[var(--text-primary)]">
+              {t.comments[0].author?.login ? (
+                <span className="text-[var(--text-secondary)]">{t.comments[0].author.login}: </span>
+              ) : null}
+              {t.comments[0].body}
+            </div>
+          ) : null}
+        </div>
+      ))}
+      <button
+        type="button"
+        className="focus-ring text-[11px] text-[var(--text-secondary)] hover:underline"
+        onClick={() => {
+          const url = descriptorUrl(descriptor);
+          if (onOpenUrl) onOpenUrl(url);
+          else window.open(url, "_blank", "noopener,noreferrer");
+        }}
+      >
+        open on GitHub →
+      </button>
+    </div>
+  );
+}
+
 export function GitHubCard({
   descriptor,
   onOpenUrl,
@@ -105,6 +339,13 @@ export function GitHubCard({
   const item = hydratable && state.phase === "ready" ? state.item : null;
   const url = item?.htmlUrl ?? descriptorUrl(descriptor);
   const glyph = stateGlyph(descriptor, item);
+
+  // Checks strip + expandable run list: OPEN pull requests only — merged and
+  // closed PRs have no live CI story worth a rate-limited fetch.
+  const isOpenPull = Boolean(item && item.isPull && item.state === "open" && !item.merged);
+  const checks = useCardChecks(descriptor.repo, descriptor.number, isOpenPull);
+  const [expanded, setExpanded] = useState(false);
+  const expandable = isOpenPull && checks.phase === "ready" && checks.data.counts.total > 0;
 
   const refText =
     descriptor.kind === "commit"
@@ -151,6 +392,7 @@ export function GitHubCard({
               {item.comments}
             </span>
           ) : null}
+          {checks.phase === "ready" ? <ChecksStrip data={checks.data} /> : null}
           {hydratable && state.phase === "loading" ? <span aria-live="polite">loading…</span> : null}
           {hydratable && state.phase === "unauth" ? <span>connect GitHub to hydrate</span> : null}
           {hydratable && state.phase === "error" ? <span>details unavailable</span> : null}
@@ -172,7 +414,29 @@ export function GitHubCard({
             ))}
           </div>
         ) : null}
+        {descriptor.kind === "review-thread" ? (
+          <div className="mt-2">
+            <ReviewThreadBody descriptor={descriptor} onOpenUrl={onOpenUrl} />
+          </div>
+        ) : null}
+        {expanded && checks.phase === "ready" ? (
+          <div className="mt-2 border-t border-[var(--border-hairline)] pt-2">
+            <CheckRunList runs={checks.data.runs} onOpenUrl={onOpenUrl} />
+          </div>
+        ) : null}
       </div>
+      {expandable ? (
+        <button
+          type="button"
+          className="focus-ring mt-[2px] inline-flex shrink-0 rounded text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse check details" : "Expand check details"}
+          title={expanded ? "Hide checks" : "Show checks"}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <Icon name={expanded ? "ph:caret-up" : "ph:caret-down"} width={13} />
+        </button>
+      ) : null}
       <span aria-hidden className="mt-[3px] inline-flex shrink-0 text-[var(--text-secondary)]">
         <Icon name="ph:github-logo" width={13} />
       </span>

--- a/src/components/github-card.tsx
+++ b/src/components/github-card.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
-import { countChecks, type CheckCounts, type CheckSummary } from "@/lib/github-checks";
+import { countChecks, isFailConclusion, type CheckCounts, type CheckSummary } from "@/lib/github-checks";
 import { descriptorUrl, type GitHubBlockDescriptor } from "@/lib/github-blocks";
 
 type Person = { login: string; avatarUrl: string | null; url: string | null };
@@ -108,7 +108,9 @@ type ReviewThreadDetail = {
   isResolved: boolean;
   isOutdated: boolean;
   path: string | null;
-  comments: { author: { login: string } | null; body: string; createdAt: string | null }[];
+  /** Comment id is the numeric databaseId — the same id `#discussion_r<id>`
+   *  URLs carry, which is what descriptor.threadId matches against. */
+  comments: { id: string; author: { login: string } | null; body: string; createdAt: string | null }[];
 };
 
 type ThreadState =
@@ -233,8 +235,7 @@ function ChecksStrip({ data }: { data: ChecksData }) {
 function checkRunGlyph(run: CheckRunDetail): { icon: IconName; color: string } {
   if (run.status !== "completed") return { icon: "ph:circle-notch-bold", color: "var(--text-secondary)" };
   if (run.conclusion === "success") return { icon: "ph:check-circle", color: "var(--color-success)" };
-  if (run.conclusion && ["failure", "timed_out", "action_required", "startup_failure"].includes(run.conclusion))
-    return { icon: "ph:x-circle-fill", color: "var(--color-warning)" };
+  if (isFailConclusion(run.conclusion)) return { icon: "ph:x-circle-fill", color: "var(--color-warning)" };
   return { icon: "ph:minus-circle", color: "var(--text-secondary)" };
 }
 
@@ -288,8 +289,11 @@ function ReviewThreadBody({
     return <div className="text-[11px] text-[var(--text-secondary)]">threads unavailable</div>;
   if (!state.authed)
     return <div className="text-[11px] text-[var(--text-secondary)]">connect GitHub to see review threads</div>;
+  // descriptor.threadId is the numeric discussion id from #discussion_r<id> —
+  // it identifies a COMMENT (databaseId), not the thread's GraphQL node id, so
+  // match the thread containing that comment.
   const thread = descriptor.threadId
-    ? state.threads.find((t) => t.id.endsWith(descriptor.threadId!)) ?? null
+    ? state.threads.find((t) => t.comments.some((c) => c.id === descriptor.threadId)) ?? null
     : null;
   const shown = thread ? [thread] : state.threads.filter((t) => !t.isResolved).slice(0, 3);
   if (!shown.length)

--- a/src/lib/github-checks.test.ts
+++ b/src/lib/github-checks.test.ts
@@ -125,3 +125,14 @@ console.log("github-checks.test.ts OK");
 }
 
 console.log("github-checks: ok");
+
+// isFailConclusion is the shared single source for fail semantics.
+{
+  const { isFailConclusion } = await import("./github-checks.ts");
+  for (const c of ["failure", "timed_out", "action_required", "startup_failure"]) {
+    assert.equal(isFailConclusion(c), true, c);
+  }
+  for (const c of ["success", "neutral", "skipped", "cancelled", "stale", null, undefined, ""]) {
+    assert.equal(isFailConclusion(c), false, String(c));
+  }
+}

--- a/src/lib/github-checks.test.ts
+++ b/src/lib/github-checks.test.ts
@@ -92,3 +92,36 @@ assert.equal(summarizeChecks([], undefined), null, "no checks + undefined status
 assert.equal(summarizeChecks([], "unknown_state"), null, "unrecognized combined state → null");
 
 console.log("github-checks.test.ts OK");
+
+// ── countChecks (chat GitHub card strip, cave-fpqx.7) ────────────────────────
+
+{
+  const { countChecks } = await import("./github-checks.ts");
+
+  assert.deepEqual(
+    countChecks([
+      { status: "completed", conclusion: "success" },
+      { status: "completed", conclusion: "failure" },
+      { status: "completed", conclusion: "timed_out" },
+      { status: "in_progress", conclusion: null },
+      { status: "queued", conclusion: null },
+    ]),
+    { passed: 1, failed: 2, pending: 2, total: 5 },
+    "buckets: success passes, FAIL_CONCLUSIONS fail, non-completed pend",
+  );
+
+  assert.deepEqual(
+    countChecks([
+      { status: "completed", conclusion: "neutral" },
+      { status: "completed", conclusion: "skipped" },
+      { status: "completed", conclusion: "cancelled" },
+      { status: "completed", conclusion: "stale" },
+    ]),
+    { passed: 4, failed: 0, pending: 0, total: 4 },
+    "non-blocking conclusions count as passed, mirroring summarizeChecks",
+  );
+
+  assert.deepEqual(countChecks([]), { passed: 0, failed: 0, pending: 0, total: 0 }, "empty → zeroed counts");
+}
+
+console.log("github-checks: ok");

--- a/src/lib/github-checks.ts
+++ b/src/lib/github-checks.ts
@@ -59,3 +59,24 @@ export function summarizeChecks(
       return null;
   }
 }
+
+/** Per-bucket counts for a compact checks strip (chat GitHub cards, W1b). */
+export type CheckCounts = { passed: number; failed: number; pending: number; total: number };
+
+/**
+ * Count check-runs into strip buckets using the same conclusion semantics as
+ * summarizeChecks: FAIL_CONCLUSIONS are failures; neutral/skipped/cancelled/
+ * stale/success completions count as passed (non-blocking); anything not yet
+ * completed is pending.
+ */
+export function countChecks(checkRuns: CheckRun[]): CheckCounts {
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+  for (const run of checkRuns) {
+    if (run.status !== "completed") pending += 1;
+    else if (FAIL_CONCLUSIONS.has(run.conclusion ?? "")) failed += 1;
+    else passed += 1;
+  }
+  return { passed, failed, pending, total: checkRuns.length };
+}

--- a/src/lib/github-checks.ts
+++ b/src/lib/github-checks.ts
@@ -25,6 +25,13 @@ const FAIL_CONCLUSIONS = new Set([
   "startup_failure",
 ]);
 
+/** True when a completed check-run's conclusion means a real, blocking failure.
+ *  Single source of truth shared by the rollup, the strip buckets, and any UI
+ *  glyph mapping (chat GitHub cards) so semantics can't drift. */
+export function isFailConclusion(conclusion: string | null | undefined): boolean {
+  return FAIL_CONCLUSIONS.has(conclusion ?? "");
+}
+
 /**
  * Roll up GitHub Actions check-runs (preferred) with the legacy combined
  * commit-status state as a fallback:
@@ -75,7 +82,7 @@ export function countChecks(checkRuns: CheckRun[]): CheckCounts {
   let pending = 0;
   for (const run of checkRuns) {
     if (run.status !== "completed") pending += 1;
-    else if (FAIL_CONCLUSIONS.has(run.conclusion ?? "")) failed += 1;
+    else if (isFailConclusion(run.conclusion)) failed += 1;
     else passed += 1;
   }
   return { passed, failed, pending, total: checkRuns.length };


### PR DESCRIPTION
**W1b** of the chat↔GitHub integration design ([docs/chat-github-integration.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/chat-github-integration.md) §2, epic `cave-fpqx`, bead `cave-fpqx.7`). Builds on #3166 (W1a).

## What
- **Checks strip on PR cards** — open, unmerged PRs fetch `/api/github/checks` and render a compact `✓ n · ✕ n · ○ n` strip with a rollup-tinted dot. Re-polls every 30s via `usePausablePoll` **only while the rollup is pending** (hidden tabs pause; failed refreshes keep the last good strip).
- **In-place expansion** — an `aria-expanded` caret toggles a per-check list (status glyph, name → logs link, conclusion), the design's "compact by default, expandable in place".
- **ReviewThreadCard hydration** — `review-thread` descriptors render the matched thread (or up to 3 unresolved ones) from `/api/github/comments?isPull=1`: path, resolve state, first-comment excerpt; degrades to "connect GitHub to see review threads" unauthenticated.
- **`countChecks`** added to `src/lib/github-checks.ts` — strip buckets with exactly `summarizeChecks`' conclusion semantics (neutral/skipped/cancelled/stale pass; FAIL_CONCLUSIONS fail; non-completed pend).

## Verification
- `github-checks.test.ts`: countChecks bucket cases (fail conclusions, non-blocking conclusions, empty).
- `github-card-wiring.test.ts`: pins for the checks fetch, 30s pending-only poll, open-PR gating, expansion a11y, thread hydration + degradation.
- Full `pnpm test:app` green (**710 files**); `pnpm typecheck` clean.

No new API routes — reuses `/api/github/checks` and `/api/github/comments`.