### PR TITLE
feat(covenwiki): citations reverse-lookup planning for incremental regen (cave-r3cy)

### DIFF
--- a/scripts/covenwiki-regen-cli.test.mjs
+++ b/scripts/covenwiki-regen-cli.test.mjs
@@ -1,11 +1,13 @@
 // End-to-end coverage for the plan-semantics wiki commands (S1–S4) of
-// scripts/covenwiki-regen.ts: status freshness reporting, regenerate no-op on
-// fresh, the fail-closed validate-then-swap, and the non-local refusal.
+// scripts/covenwiki-regen.ts — status freshness reporting, regenerate no-op on
+// fresh, the fail-closed validate-then-swap, the non-local refusal — plus the
+// incremental stages' citations reverse-lookup mode (--citations).
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const dir = mkdtempSync(path.join(tmpdir(), "covenwiki-regen-cli-"));
 const repoDir = path.join(dir, "repo");
@@ -173,6 +175,91 @@ try {
   result = run(["status", "../escape"]);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /invalid slug/);
+
+  // ── incremental stages: citations reverse-lookup mode (--citations) ──
+  // An outline-driven source repo: pages do NOT mirror file paths, and a
+  // non-markdown source (src/util.ts) is cited by a page — both impossible
+  // to plan correctly under path-stemming.
+  const stagesRepo = path.join(dir, "stages-repo");
+  mkdirSync(path.join(stagesRepo, "docs"), { recursive: true });
+  mkdirSync(path.join(stagesRepo, "src"), { recursive: true });
+  writeFileSync(path.join(stagesRepo, "docs", "a.md"), "alpha v1\n");
+  writeFileSync(path.join(stagesRepo, "src", "util.ts"), "export const u = 1;\n");
+  const citationsFile = path.join(stagesRepo, "_citations.json");
+  writeFileSync(
+    citationsFile,
+    JSON.stringify({
+      schemaVersion: "1.0",
+      generatedAt: "2026-07-14T00:00:00.000Z",
+      bySource: { "docs/a.md": ["getting-started", "overview"], "src/util.ts": ["api-surface"] },
+      byPage: {},
+    }),
+  );
+  const scriptPath = path.join(fileURLToPath(new URL("..", import.meta.url)), "scripts", "covenwiki-regen.ts");
+  const stageArgs = ["--source", "docs", "--source", "src", "--state", ".cw/state.json"];
+  const runStages = (args) =>
+    spawnSync(process.execPath, ["--experimental-strip-types", scriptPath, ...args, ...stageArgs], {
+      cwd: stagesRepo,
+      encoding: "utf8",
+    });
+
+  // Baseline state, then edit one cited markdown source.
+  result = runStages(["run"]);
+  assert.equal(result.status, 0, result.stderr);
+  writeFileSync(path.join(stagesRepo, "docs", "a.md"), "alpha v2\n");
+
+  // With --citations: actions target the citing outline slugs, not the "a" stem.
+  result = runStages(["plan", "--citations", citationsFile, "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  let planOut = JSON.parse(result.stdout).plan;
+  assert.deepEqual(
+    planOut.actions.map((a) => [a.kind, a.page]),
+    [
+      ["regenerate-page", "getting-started"],
+      ["regenerate-page", "overview"],
+      ["rebuild-index", null],
+    ],
+  );
+
+  // Without --citations the legacy stemming still maps docs/a.md -> "a".
+  result = runStages(["plan", "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  planOut = JSON.parse(result.stdout).plan;
+  assert.deepEqual(
+    planOut.actions.map((a) => [a.kind, a.page]),
+    [
+      ["regenerate-page", "a"],
+      ["rebuild-index", null],
+    ],
+  );
+
+  // Cited non-markdown source maps to its page; removed source regenerates
+  // (never remove-page) — the two semantic fixes over stemming.
+  result = runStages(["run"]);
+  assert.equal(result.status, 0, result.stderr);
+  writeFileSync(path.join(stagesRepo, "src", "util.ts"), "export const u = 2;\n");
+  rmSync(path.join(stagesRepo, "docs", "a.md"));
+  result = runStages(["plan", "--citations", citationsFile, "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  planOut = JSON.parse(result.stdout).plan;
+  assert.deepEqual(
+    planOut.actions.map((a) => [a.kind, a.page, a.reason]),
+    [
+      ["regenerate-page", "api-surface", "changed"],
+      ["regenerate-page", "getting-started", "source removed"],
+      ["regenerate-page", "overview", "source removed"],
+      ["rebuild-index", null, "cited sources changed"],
+    ],
+  );
+
+  // Fail-closed: a malformed citations file aborts instead of degrading to stemming.
+  writeFileSync(citationsFile, JSON.stringify({ schemaVersion: "2.0", bySource: {} }));
+  result = runStages(["plan", "--citations", citationsFile]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /schemaVersion/);
+  result = runStages(["plan", "--citations", path.join(stagesRepo, "nope.json")]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /citations file not found/);
 
   console.log("covenwiki-regen CLI: all assertions passed");
 } finally {

--- a/scripts/covenwiki-regen.ts
+++ b/scripts/covenwiki-regen.ts
@@ -13,7 +13,9 @@
 // Incremental stages (S6 groundwork; content-hash based):
 //   scan   hash every file under the source roots -> manifest JSON
 //   diff   compare a fresh scan against the saved state; --check for hooks
-//   plan   print the regeneration actions the diff implies
+//   plan   print the regeneration actions the diff implies. With --citations
+//          (a generated wiki's _citations.json) page actions come from the
+//          source⇄page reverse lookup; otherwise legacy path-stemming applies
 //   run    execute the plan (optional --generator), then persist new state
 //
 // Wikis resolve as <wikis-dir>/<slug>/manifest.json (default ~/.coven/wikis),
@@ -40,6 +42,7 @@ import {
   diffManifests,
   formatWikiStatus,
   nextState,
+  parseCitationsIndex,
   parseState,
   parseWikiManifest,
   planRegeneration,
@@ -49,6 +52,7 @@ import {
   type Manifest,
   type SourceEntry,
   type WikiManifest,
+  type CitationsBySource,
 } from "../src/lib/covenwiki-regen.ts";
 
 const STAGES = ["scan", "diff", "plan", "run"] as const;
@@ -65,6 +69,7 @@ type Options = {
   sources: string[];
   state: string;
   fullRebuild: string[];
+  citations: string | null;
   generator: string | null;
   json: boolean;
   check: boolean;
@@ -96,6 +101,10 @@ Options:
                          run: shell command; receives the plan JSON on stdin
   --source <path>        (stages) source root to scan (repeatable; default: docs)
   --state <file>         (stages) state file (default: .covenwiki/state.json)
+  --citations <file>     (stages) _citations.json from a generated wiki; page
+                         actions come from its bySource reverse lookup instead
+                         of path-stemming. Run from the repo root (or match the
+                         citation paths) so scanned paths line up
   --full-rebuild <path>  (stages) path or dir/ prefix that forces a full rebuild (repeatable)
   --json                 emit machine-readable JSON instead of text
   --check                (diff/plan) exit 1 when regeneration is needed
@@ -120,6 +129,7 @@ function parseArgs(argv: string[]): Options {
     sources: [],
     state: ".covenwiki/state.json",
     fullRebuild: [],
+    citations: null,
     generator: null,
     json: false,
     check: false,
@@ -139,6 +149,9 @@ function parseArgs(argv: string[]): Options {
         break;
       case "--state":
         opts.state = requireValue(argv, ++i, arg);
+        break;
+      case "--citations":
+        opts.citations = requireValue(argv, ++i, arg);
         break;
       case "--full-rebuild":
         opts.fullRebuild.push(requireValue(argv, ++i, arg));
@@ -200,6 +213,13 @@ function scan(opts: Options): Manifest {
 function loadPreviousManifest(stateFile: string): Manifest | null {
   if (!existsSync(stateFile)) return null;
   return parseState(readFileSync(stateFile, "utf8")).manifest;
+}
+
+/** Load the wiki's _citations.json for reverse-lookup planning (null = stemming fallback). */
+function loadCitations(opts: Options): CitationsBySource | null {
+  if (!opts.citations) return null;
+  if (!existsSync(opts.citations)) throw new Error(`citations file not found: ${opts.citations}`);
+  return parseCitationsIndex(readFileSync(opts.citations, "utf8"));
 }
 
 // ─── Wiki commands (plan S1–S4) ─────────────────────────────────────────────
@@ -368,7 +388,11 @@ function main() {
 
   const previous = loadPreviousManifest(opts.state);
   const diff = diffManifests(previous, manifest);
-  const plan = planRegeneration(diff, { sourceRoots: opts.sources, fullRebuildPaths: opts.fullRebuild });
+  const plan = planRegeneration(diff, {
+    sourceRoots: opts.sources,
+    fullRebuildPaths: opts.fullRebuild,
+    citationsBySource: loadCitations(opts),
+  });
 
   if (opts.command === "diff" || opts.command === "plan") {
     if (opts.json) {

--- a/src/lib/covenwiki-generate.test.ts
+++ b/src/lib/covenwiki-generate.test.ts
@@ -16,7 +16,7 @@ import {
   PAGE_BUDGETS,
   WORD_TARGETS,
 } from "./covenwiki-generate.ts";
-import { parseWikiManifest, validateWikiManifest } from "./covenwiki-regen.ts";
+import { parseCitationsIndex, parseWikiManifest, validateWikiManifest } from "./covenwiki-regen.ts";
 
 const INVENTORY = [
   "README.md",
@@ -336,6 +336,13 @@ test("buildCitationsIndex builds the source⇄page reverse lookup", () => {
       assert.ok(index.bySource[citation.path].includes(slug));
     }
   }
+});
+
+test("parseCitationsIndex round-trips buildCitationsIndex output (producer⇄consumer parity)", () => {
+  const { pages, manifest } = assembled();
+  const index = buildCitationsIndex(pages, manifest.generation.generatedAt);
+  const bySource = parseCitationsIndex(`${JSON.stringify(index, null, 2)}\n`);
+  assert.deepEqual(bySource, index.bySource);
 });
 
 test("buildIndexMarkdown renders the nav tree with group headers", () => {

--- a/src/lib/covenwiki-regen.test.ts
+++ b/src/lib/covenwiki-regen.test.ts
@@ -10,6 +10,7 @@ import {
   isStale,
   nextState,
   pageIdForSource,
+  parseCitationsIndex,
   parseState,
   parseWikiManifest,
   planRegeneration,
@@ -156,6 +157,108 @@ test("planRegeneration routes non-page sources to the index rebuild", () => {
   assert.deepEqual(
     plan.actions.map((a) => a.kind),
     ["rebuild-index"],
+  );
+});
+
+// S3 — plan, citations reverse-lookup mode (_citations.json bySource)
+
+const BY_SOURCE = {
+  "README.md": ["overview"],
+  "src/session.ts": ["overview", "session-model"],
+  "docs/guide.md": ["guide"],
+};
+
+test("citations mode: a changed source regenerates every page citing it", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["src/session.ts"], removed: [], unchangedCount: 2, dirty: true },
+    { sourceRoots: ROOTS, citationsBySource: BY_SOURCE },
+  );
+  assert.deepEqual(
+    plan.actions.map((a) => [a.kind, a.page]),
+    [
+      ["regenerate-page", "overview"],
+      ["regenerate-page", "session-model"],
+      ["rebuild-index", null],
+    ],
+  );
+  // The point of the mode: page ids are outline slugs, never path stems.
+  assert.ok(!plan.actions.some((a) => a.page === "session"));
+});
+
+test("citations mode: non-markdown cited sources map to pages (stemming never could)", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["src/session.ts"], removed: [], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS, citationsBySource: { "src/session.ts": ["api-surface"] } },
+  );
+  assert.deepEqual(plan.actions[0], {
+    kind: "regenerate-page",
+    page: "api-surface",
+    sources: ["src/session.ts"],
+    reason: "changed",
+  });
+});
+
+test("citations mode: removed sources regenerate citing pages, never remove-page", () => {
+  const plan = planRegeneration(
+    { added: [], changed: [], removed: ["docs/guide.md"], unchangedCount: 2, dirty: true },
+    { sourceRoots: ROOTS, citationsBySource: BY_SOURCE },
+  );
+  assert.deepEqual(
+    plan.actions.map((a) => [a.kind, a.page, a.reason]),
+    [
+      ["regenerate-page", "guide", "source removed"],
+      ["rebuild-index", null, "cited sources changed"],
+    ],
+  );
+});
+
+test("citations mode: uncited changes are index-only and flag an outline refresh", () => {
+  const plan = planRegeneration(
+    { added: ["docs/brand-new.md"], changed: ["assets/logo.png"], removed: [], unchangedCount: 3, dirty: true },
+    { sourceRoots: ROOTS, citationsBySource: BY_SOURCE },
+  );
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0].kind, "rebuild-index");
+  assert.match(plan.actions[0].reason, /outline refresh/);
+});
+
+test("citations mode: multiple triggers for one page merge into one action", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["README.md"], removed: ["src/session.ts"], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS, citationsBySource: BY_SOURCE },
+  );
+  const overview = plan.actions.find((a) => a.page === "overview");
+  assert.deepEqual(overview.sources, ["README.md", "src/session.ts"]);
+  assert.equal(overview.reason, "changed, source removed");
+  assert.equal(plan.actions.filter((a) => a.page === "overview").length, 1);
+});
+
+test("citations mode: fullRebuildPaths still wins over the reverse lookup", () => {
+  const plan = planRegeneration(
+    { added: [], changed: ["templates/wiki.hbs", "README.md"], removed: [], unchangedCount: 0, dirty: true },
+    { sourceRoots: ROOTS, fullRebuildPaths: ["templates/"], citationsBySource: BY_SOURCE },
+  );
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0].kind, "full-rebuild");
+});
+
+test("parseCitationsIndex accepts the generated shape and strips it to bySource", () => {
+  const raw = JSON.stringify({
+    schemaVersion: "1.0",
+    generatedAt: "2026-07-14T00:00:00.000Z",
+    bySource: { "README.md": ["overview"] },
+    byPage: { overview: [{ path: "README.md", startLine: null, endLine: null }] },
+  });
+  assert.deepEqual(parseCitationsIndex(raw), { "README.md": ["overview"] });
+});
+
+test("parseCitationsIndex fails closed on malformed input", () => {
+  assert.throws(() => parseCitationsIndex("not json"), /not valid JSON/);
+  assert.throws(() => parseCitationsIndex('{"schemaVersion":"2.0","bySource":{}}'), /schemaVersion/);
+  assert.throws(() => parseCitationsIndex('{"schemaVersion":"1.0"}'), /bySource/);
+  assert.throws(
+    () => parseCitationsIndex('{"schemaVersion":"1.0","bySource":{"a.md":"overview"}}'),
+    /array of page slugs/,
   );
 });
 

--- a/src/lib/covenwiki-regen.ts
+++ b/src/lib/covenwiki-regen.ts
@@ -13,7 +13,12 @@
 // Incremental layer (S6 groundwork; predates the step plan):
 //   scan — buildManifest: content hashes for every wiki source file
 //   diff — diffManifests: compare a scan against the last persisted state
-//   plan — planRegeneration: turn a diff into concrete regeneration actions
+//   plan — planRegeneration: turn a diff into concrete regeneration actions.
+//         Two mapping modes: when a generated wiki's _citations.json is
+//         provided (parseCitationsIndex -> PlanOptions.citationsBySource),
+//         page actions come from the source⇄page reverse lookup — the correct
+//         mapping for outline-driven wikis, where sources never map 1:1 to
+//         pages. Without it, the legacy path-stemming fallback applies.
 //   run  — nextState/summarizePlan: state handoff + report for the executor
 
 import { createHash } from "node:crypto";
@@ -103,8 +108,11 @@ export function diffManifests(previous: Manifest | null, next: Manifest): Manife
 }
 
 /**
- * Map a source path to a wiki page id: strip the matching source root and the
- * markdown extension. Non-markdown sources return null (index-only impact).
+ * Fallback mapping (no citations index): map a source path to a wiki page id
+ * by stripping the matching source root and the markdown extension.
+ * Non-markdown sources return null (index-only impact). Only valid for wikis
+ * whose pages mirror source files 1:1 — outline-driven CovenWiki output does
+ * not; use the _citations.json reverse lookup for those.
  */
 export function pageIdForSource(path: string, sourceRoots: string[]): string | null {
   const ext = PAGE_EXTENSIONS.find((e) => path.toLowerCase().endsWith(e));
@@ -125,6 +133,36 @@ export function pageIdForSource(path: string, sourceRoots: string[]): string | n
   return id || null;
 }
 
+/** Source path -> page slugs citing it (the bySource half of _citations.json). */
+export type CitationsBySource = Record<string, string[]>;
+
+/**
+ * Parse the _citations.json a generated wiki ships (CitationsIndex in
+ * src/lib/covenwiki-generate.ts) down to its bySource reverse lookup.
+ * Fail-closed: a malformed index must not silently degrade to path-stemming.
+ */
+export function parseCitationsIndex(raw: string): CitationsBySource {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error("_citations.json is not valid JSON");
+  }
+  if (!isRecord(data)) throw new Error("_citations.json must be a JSON object");
+  if (data.schemaVersion !== "1.0") {
+    throw new Error(`unsupported _citations.json schemaVersion (expected "1.0")`);
+  }
+  if (!isRecord(data.bySource)) throw new Error("_citations.json is missing the bySource mapping");
+  const out: CitationsBySource = {};
+  for (const [path, slugs] of Object.entries(data.bySource)) {
+    if (!Array.isArray(slugs) || !slugs.every((s) => typeof s === "string")) {
+      throw new Error(`_citations.json bySource["${path}"] must be an array of page slugs`);
+    }
+    out[path] = [...slugs];
+  }
+  return out;
+}
+
 export type PlanOptions = {
   sourceRoots: string[];
   /**
@@ -132,6 +170,13 @@ export type PlanOptions = {
    * full rebuild — e.g. templates or wiki config shared by every page.
    */
   fullRebuildPaths?: string[];
+  /**
+   * The bySource mapping from a generated wiki's _citations.json
+   * (source path -> page slugs citing it). When present, page actions come
+   * from this reverse lookup instead of path-stemming. Source paths in the
+   * diff must use the same base as the citation paths (repo-relative).
+   */
+  citationsBySource?: CitationsBySource | null;
 };
 
 function matchesFullRebuild(path: string, patterns: string[]): boolean {
@@ -160,6 +205,65 @@ export function planRegeneration(diff: ManifestDiff, opts: PlanOptions): RegenPl
     };
   }
 
+  return opts.citationsBySource
+    ? planWithCitations(diff, opts.citationsBySource)
+    : planWithPathStemming(diff, opts);
+}
+
+/**
+ * Citations mode: derive page actions from the source⇄page reverse lookup.
+ * Semantics differ from stemming on purpose:
+ * - a changed/added/removed source regenerates *every* page citing it;
+ * - removed sources never emit remove-page — pages are outline units, so only
+ *   an outline change (full generate) removes a page. Regenerating the citing
+ *   pages lets them repair or drop the dead citation;
+ * - sources cited by no page (and genuinely new files) only affect the index;
+ *   the rebuild-index reason flags that an outline refresh may be due.
+ */
+function planWithCitations(diff: ManifestDiff, bySource: CitationsBySource): RegenPlan {
+  const pages = new Map<string, { sources: string[]; reasons: Set<string> }>();
+  let uncited = 0;
+  const record = (path: string, reason: string) => {
+    const slugs = bySource[path] ?? [];
+    if (slugs.length === 0) {
+      uncited += 1;
+      return;
+    }
+    for (const slug of slugs) {
+      const slot = pages.get(slug) ?? { sources: [], reasons: new Set<string>() };
+      slot.sources.push(path);
+      slot.reasons.add(reason);
+      pages.set(slug, slot);
+    }
+  };
+  for (const path of diff.added) record(path, "added");
+  for (const path of diff.changed) record(path, "changed");
+  for (const path of diff.removed) record(path, "source removed");
+
+  const actions: RegenAction[] = [];
+  for (const page of [...pages.keys()].sort()) {
+    const slot = pages.get(page)!;
+    actions.push({
+      kind: "regenerate-page",
+      page,
+      sources: [...new Set(slot.sources)].sort(),
+      reason: [...slot.reasons].sort().join(", "),
+    });
+  }
+  actions.push({
+    kind: "rebuild-index",
+    page: null,
+    sources: [],
+    reason:
+      uncited > 0
+        ? "uncited sources changed — outline refresh may be needed"
+        : "cited sources changed",
+  });
+  return { dirty: true, actions };
+}
+
+/** Legacy fallback: 1:1 path-stemming for wikis whose pages mirror source files. */
+function planWithPathStemming(diff: ManifestDiff, opts: PlanOptions): RegenPlan {
   const actions: RegenAction[] = [];
   const pages = new Map<string, { sources: string[]; reasons: Set<string> }>();
   const record = (path: string, reason: string) => {


### PR DESCRIPTION
## What

Item 1 of **cave-r3cy**: the incremental regen stages (`scan/diff/plan/run`) can now derive page actions from a generated wiki's `_citations.json` (shipped since #3157) instead of path-stemming.

**Why:** outline-driven wikis never map sources 1:1 to pages — `pageIdForSource` stemming produced wrong actions for real CovenWiki output (wrong page ids, no mapping at all for cited non-markdown sources).

**Citations-mode semantics** (documented on `planWithCitations`):
- changed/added/removed source ⇒ `regenerate-page` for **every page citing it** (bySource reverse lookup)
- removed sources **never** emit `remove-page` — pages are outline units; regenerating citing pages lets them repair dead citations
- uncited changes are index-only; the `rebuild-index` reason flags that an outline refresh may be due
- `fullRebuildPaths` still wins; no citations file ⇒ legacy stemming, semantics unchanged
- `parseCitationsIndex` is **fail-closed**: a malformed index aborts rather than silently degrading to stemming

CLI: `--citations <file>` on the stages.

## Verification

- `src/lib/covenwiki-regen.test.ts`: 40/40 (8 new: citing-page fanout, non-markdown mapping, no-remove-page, uncited⇒index-only, merge/dedupe, full-rebuild precedence, parser accept/fail-closed)
- `src/lib/covenwiki-generate.test.ts`: 22/22 (new producer⇄consumer parity test — `parseCitationsIndex` round-trips `buildCitationsIndex` output)
- `scripts/covenwiki-regen-cli.test.mjs`: extended with a stages section — slug-targeted actions vs stemming back-compat side by side, cited `.ts` source mapping, removed-source regeneration, malformed/missing citations abort
- `covenwiki-generate` e2e unchanged-green; `pnpm typecheck` clean; `check:tests-wired` green

## Beads

Implements item 1 of **cave-r3cy** (claimed by sage). Item 2 (state-substrate decision) is a plan-doc amendment recorded on the bead, not a code change.