### PR TITLE
fix(flows): direct-spawn copilot flow sessions — daemon splits unquoted prompts (cave-lhc0)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -169,6 +169,7 @@ export const SUITES = {
     "src/lib/flow/flow-webhook.test.ts",
     "src/lib/flow/flow-progress.test.ts",
     "src/lib/server/flow-executor.test.ts",
+    "src/lib/server/flow-copilot-session.test.ts",
     "src/lib/server/research-mission-store.test.ts",
     "src/lib/server/research-mission-runner.test.ts",
     "src/lib/flow/flow-execution-data.test.ts",

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+// Direct copilot spawn for flow sessions (cave-lhc0): the run must launch the
+// CLI with a real argv (prompt as ONE argument after -p) and persist the
+// finished transcript as a Cave conversation under its session id — where the
+// flow transcript endpoint and the research-mission reconcile look first.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, chmodSync, writeFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TMP = mkdtempSync(join(tmpdir(), "flow-copilot-session-"));
+process.env.HOME = TMP;
+
+// A fake copilot binary (node shebang) that records its full argv (to
+// cwd/argv.json) and emits two JSONL frames like the real CLI's stream mode.
+const FAKE = join(TMP, "fake-copilot");
+writeFileSync(FAKE, `#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
+const { join } = require("node:path");
+writeFileSync(join(process.cwd(), "argv.json"), JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({ type: "assistant.message_delta", data: { messageId: "m1", deltaContent: "@@research-control\\n" } }));
+console.log(JSON.stringify({ type: "assistant.message", data: { messageId: "m1", content: "done.\\n@@research-control\\n{\\"decision\\":\\"complete\\",\\"reason\\":\\"ok\\",\\"confidence\\":1}" } }));
+`);
+chmodSync(FAKE, 0o755);
+
+const { startCopilotFlowRun } = await import("./flow-copilot-session.ts");
+
+const SPEC = {
+  executable: FAKE,
+  prefixArgs: ["--output-format", "json", "--stream", "on", "-p"],
+  sessionIdFlag: "--session-id",
+  resumeFlag: "--resume",
+  modelFlag: "--model",
+  sandboxFullArgs: ["--allow-all"],
+  sandboxReadOnlyArgs: [],
+};
+
+test("spawns with the prompt as one argv element and persists the transcript", async () => {
+  const argvOut = join(TMP, "argv.json");
+  const prompt = "Mission: cave-test\nIteration 1 of 3.\nGather sources and print markers.";
+  const { sessionId, done } = startCopilotFlowRun({
+    spec: SPEC,
+    prompt,
+    projectRoot: TMP,
+    familiarId: "sage",
+    familiarName: "Sage",
+    familiarRole: "Researcher",
+  });
+  assert.match(sessionId, /^[0-9a-f-]{36}$/);
+  await done;
+
+  // The multi-word prompt traveled as exactly one argv element after -p.
+  const argv = JSON.parse(readFileSync(argvOut, "utf8"));
+  const promptIndex = argv.indexOf("-p") + 1;
+  assert.ok(promptIndex > 0, "prompt flag present");
+  assert.match(argv[promptIndex], /Mission: cave-test/);
+  assert.match(argv[promptIndex], /Gather sources and print markers\./);
+  assert.match(argv[promptIndex], /\[Identity: You are Sage, a Researcher\./);
+  assert.equal(argv.length, promptIndex + 1, "nothing trails the prompt argument");
+  assert.ok(argv.includes("--session-id"), "fresh session id is pre-assigned");
+
+  // The finished transcript is a Cave conversation under the session id, with
+  // the assistant's final content (trailing control markers intact).
+  const convPath = join(TMP, ".coven", "cave", "conversations", `${sessionId}.json`);
+  const conv = JSON.parse(readFileSync(convPath, "utf8"));
+  const roles = conv.turns.map((t) => t.role);
+  assert.deepEqual(roles, ["user", "assistant"]);
+  assert.match(conv.turns[1].text, /@@research-control/);
+  assert.match(conv.turns[1].text, /"decision":"complete"/);
+  assert.ok(!conv.turns[1].isError, "successful run is not an error turn");
+});
+
+test("a failed spawn persists an error turn instead of dropping the run", async () => {
+  const badSpec = { ...SPEC, executable: join(TMP, "does-not-exist-bin") };
+  const { sessionId, done } = startCopilotFlowRun({
+    spec: badSpec,
+    prompt: "hello",
+    projectRoot: TMP,
+    familiarId: null,
+  });
+  await done;
+  const convPath = join(TMP, ".coven", "cave", "conversations", `${sessionId}.json`);
+  const conv = JSON.parse(readFileSync(convPath, "utf8"));
+  const assistant = conv.turns.find((t) => t.role === "assistant");
+  assert.ok(assistant.isError, "failure is an error turn");
+  assert.match(assistant.text, /copilot exited|ENOENT/);
+});

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -3,14 +3,17 @@
 // CLI with a real argv (prompt as ONE argument after -p) and persist the
 // finished transcript as a Cave conversation under its session id — where the
 // flow transcript endpoint and the research-mission reconcile look first.
-import { test } from "node:test";
+import { test, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, chmodSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, readFileSync, chmodSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+const REAL_HOME = process.env.HOME;
 const TMP = mkdtempSync(join(tmpdir(), "flow-copilot-session-"));
 process.env.HOME = TMP;
+
+after(() => { process.env.HOME = REAL_HOME; });
 
 // A fake copilot binary (node shebang) that records its full argv (to
 // cwd/argv.json) and emits two JSONL frames like the real CLI's stream mode.
@@ -85,4 +88,28 @@ test("a failed spawn persists an error turn instead of dropping the run", async 
   const assistant = conv.turns.find((t) => t.role === "assistant");
   assert.ok(assistant.isError, "failure is an error turn");
   assert.match(assistant.text, /copilot exited|ENOENT/);
+});
+
+test("a non-zero exit with partial output keeps the text AND the exit diagnostics", async () => {
+  const PARTIAL = join(TMP, "fake-copilot-partial");
+  writeFileSync(PARTIAL, `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "assistant.message", data: { messageId: "m1", content: "partial findings before the crash" } }));
+console.error("boom: model backend dropped");
+process.exit(3);
+`);
+  chmodSync(PARTIAL, 0o755);
+  const { sessionId, done } = startCopilotFlowRun({
+    spec: { ...SPEC, executable: PARTIAL },
+    prompt: "hello",
+    projectRoot: TMP,
+    familiarId: null,
+  });
+  await done;
+  const convPath = join(TMP, ".coven", "cave", "conversations", `${sessionId}.json`);
+  const conv = JSON.parse(readFileSync(convPath, "utf8"));
+  const assistant = conv.turns.find((t) => t.role === "assistant");
+  assert.ok(assistant.isError, "non-zero exit is an error even with partial output");
+  assert.match(assistant.text, /partial findings before the crash/);
+  assert.match(assistant.text, /copilot exited with code 3/);
+  assert.match(assistant.text, /boom: model backend dropped/);
 });

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -1,0 +1,148 @@
+// Direct copilot spawn for flow sessions (cave-lhc0).
+//
+// The daemon's nonInteractive session launch mangles multi-word prompts for
+// the copilot adapter (the CLI reports "your prompt was not quoted, so the
+// extra words were treated as separate arguments"), which broke every
+// copilot-familiar flow — including each bounded research-mission iteration.
+// Chat hit the same daemon deficiency and answers it by spawning the CLI
+// directly with a real argv (src/app/api/chat/send/route.ts, cave-yesg);
+// this gives flow sessions the same escape hatch.
+//
+// The spawned run persists its transcript as a Cave conversation under the
+// flow's session id, which is exactly where the flow transcript endpoint
+// (/api/flows/session-transcript) and the research-mission reconcile
+// (parseResearchControl over conversation turns) already look first.
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { randomUUID } from "node:crypto";
+import { saveConversation } from "../cave-conversations.ts";
+import {
+  buildCopilotStreamArgs,
+  copilotIdentityPreamble,
+  parseCopilotChatEvent,
+  type CopilotStreamSpec,
+} from "../copilot-stream.ts";
+import { harnessSpawnEnv } from "../harness-spawn-env.ts";
+
+/** One bounded flow iteration should never outlive this. */
+const FLOW_COPILOT_TIMEOUT_MS = 60 * 60_000;
+
+export type CopilotFlowLaunch = {
+  spec: CopilotStreamSpec;
+  prompt: string;
+  projectRoot: string;
+  familiarId: string | null;
+  familiarName?: string;
+  familiarRole?: string;
+};
+
+export type CopilotFlowStart = {
+  sessionId: string;
+  /** Resolves when the one-shot exits and the transcript is persisted. */
+  done: Promise<void>;
+};
+
+/**
+ * Launch one non-interactive copilot run for a compiled flow prompt.
+ * Returns as soon as the process starts; the transcript (user prompt +
+ * assistant output) lands in the Cave conversation when the run finishes, so
+ * pollers see the complete output including any trailing control markers.
+ */
+export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart {
+  const sessionId = randomUUID();
+  const identity = launch.familiarId
+    ? copilotIdentityPreamble(launch.familiarId, launch.familiarName, launch.familiarRole)
+    : "";
+  const prompt = identity ? `${identity}\n\n${launch.prompt}` : launch.prompt;
+  const args = buildCopilotStreamArgs({
+    spec: launch.spec,
+    prompt,
+    resumeSessionId: null,
+    newSessionId: sessionId,
+    model: null,
+    permissionMode: "full",
+  });
+
+  const child = spawn(launch.spec.executable, args, {
+    cwd: launch.projectRoot,
+    env: harnessSpawnEnv(launch.familiarId),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const startedAt = new Date().toISOString();
+  let assistantText = "";
+  const deltaByMessage = new Map<string, string>();
+  let stderrTail = "";
+
+  const rl = createInterface({ input: child.stdout });
+  rl.on("line", (line) => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) return;
+    let raw: unknown;
+    try { raw = JSON.parse(trimmed); } catch { return; }
+    const event = parseCopilotChatEvent(raw);
+    if (!event) return;
+    if (event.kind === "text_delta") {
+      deltaByMessage.set(event.messageId, (deltaByMessage.get(event.messageId) ?? "") + event.text);
+    } else if (event.kind === "message") {
+      // The final frame carries the complete content — prefer it over deltas.
+      deltaByMessage.set(event.messageId, event.content);
+    }
+  });
+
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrTail = (stderrTail + chunk.toString()).slice(-2_000);
+  });
+
+  const timeout = setTimeout(() => {
+    try { child.kill("SIGKILL"); } catch { /* already gone */ }
+  }, FLOW_COPILOT_TIMEOUT_MS);
+  timeout.unref?.();
+
+  const done = new Promise<void>((resolve) => {
+    child.on("error", (err) => {
+      stderrTail = `${stderrTail}\n${err.message}`.slice(-2_000);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      assistantText = [...deltaByMessage.values()].join("\n").trim();
+      const failed = code !== 0 && !assistantText;
+      const finishedAt = new Date().toISOString();
+      const text = failed
+        ? `copilot exited with code ${code ?? "?"}${stderrTail.trim() ? `:\n${stderrTail.trim()}` : ""}`
+        : assistantText;
+      void (async () => {
+        try {
+          const userTurnId = randomUUID();
+          const assistantTurnId = randomUUID();
+          await saveConversation({
+            sessionId,
+            harnessSessionId: sessionId,
+            familiarId: launch.familiarId ?? "",
+            harness: "copilot",
+            createdAt: startedAt,
+            updatedAt: finishedAt,
+            turns: [
+              { id: userTurnId, role: "user", text: prompt, createdAt: startedAt },
+              {
+                id: assistantTurnId,
+                parentId: userTurnId,
+                role: "assistant",
+                text,
+                createdAt: finishedAt,
+                ...(failed ? { isError: true } : {}),
+              },
+            ],
+            activeLeafId: assistantTurnId,
+          });
+        } catch {
+          // Transcript persistence is best-effort; the run itself finished.
+        }
+        resolve();
+      })();
+    });
+  });
+
+  return { sessionId, done };
+}

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -107,11 +107,15 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     child.on("close", (code) => {
       clearTimeout(timeout);
       assistantText = [...deltaByMessage.values()].join("\n").trim();
-      const failed = code !== 0 && !assistantText;
-      const finishedAt = new Date().toISOString();
-      const text = failed
+      // Any non-zero (or missing) exit code is an error — even with partial
+      // output, the run didn't finish cleanly and the diagnostics must not
+      // be dropped. Captured text is preserved ahead of the exit note.
+      const failed = code !== 0;
+      const exitNote = failed
         ? `copilot exited with code ${code ?? "?"}${stderrTail.trim() ? `:\n${stderrTail.trim()}` : ""}`
-        : assistantText;
+        : "";
+      const finishedAt = new Date().toISOString();
+      const text = [assistantText, exitNote].filter(Boolean).join("\n\n");
       void (async () => {
         try {
           const userTurnId = randomUUID();

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -24,6 +24,9 @@ import { flowMissingRequiredInputs } from "@/lib/required-inputs";
 import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import type { FlowRunRecord, FlowRunStepStatus } from "@/lib/flows";
 import { recordFlowRun } from "@/lib/server/flow-store";
+import { startCopilotFlowRun } from "@/lib/server/flow-copilot-session";
+import { copilotStreamSpec } from "@/lib/copilot-stream";
+import { isSshRuntime } from "@/lib/familiar-runtime";
 import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-security";
 import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 
@@ -142,6 +145,68 @@ export async function startFlowSession(
     triggerInput: options.triggerInput,
     mode: options.mode,
   });
+
+  const finishStart = async (sessionId: string): Promise<StartFlowSessionResult> => {
+    await Promise.all([
+      familiarId ? recordSessionFamiliar(sessionId, familiarId) : Promise.resolve(),
+      setSessionTitle(
+        sessionId,
+        options.targetNodeId ? `Flow step: ${flow.name} / ${options.targetNodeId}` : `Flow: ${flow.name}`,
+      ),
+    ]);
+
+    const order = options.targetNodeId ? flowPartialExecutionOrder(flow, options.targetNodeId) : flowExecutionOrder(flow);
+    const byId = new Map(flow.nodes.map((node) => [node.id, node]));
+    const customData = extractFlowCustomData(flow);
+    const redacted = flowRunRedactsData(flow, options.mode ?? "manual");
+    const seenActiveAgentStep = { value: false };
+    const run = await recordFlowRun({
+      flowId: flow.id,
+      flowName: flow.name,
+      status: "running",
+      mode: options.mode ?? "manual",
+      ...(Object.keys(customData).length > 0 ? { customData } : {}),
+      ...(redacted ? { redacted: true } : {}),
+      startedAt: new Date().toISOString(),
+      steps: order.map((stepId) => ({
+        id: stepId,
+        type: byId.get(stepId)?.type ?? "unknown",
+        status: initialFlowRunStepStatus(flow, stepId, seenActiveAgentStep),
+      })),
+      summary: `agent session ${sessionId.slice(0, 8)}`,
+      source: "cave",
+      sessionId,
+      flowSnapshot: flow,
+    });
+
+    return { ok: true, run, sessionId, executor: "session" };
+  };
+
+  // The daemon's nonInteractive launch mangles multi-word prompts for the
+  // copilot adapter (unquoted argv split — the CLI errors with "your prompt
+  // was not quoted"), which broke every copilot flow session, including
+  // research-mission iterations. Chat answers the same daemon deficiency by
+  // spawning the CLI directly with a real argv (cave-yesg); do the same here.
+  // Local runtimes only — SSH runtimes stay on the daemon path to the remote
+  // host. The run persists its transcript as a Cave conversation under the
+  // session id, which is where the flow transcript endpoint and the
+  // research-mission reconcile already look first.
+  const sshBound = "runtime" in binding && isSshRuntime(binding.runtime);
+  if (binding.harness === "copilot" && !sshBound) {
+    const spec = copilotStreamSpec();
+    if (spec) {
+      const { sessionId } = startCopilotFlowRun({
+        spec,
+        prompt,
+        projectRoot,
+        familiarId,
+        familiarName: "display_name" in binding ? binding.display_name : undefined,
+        familiarRole: "role" in binding ? binding.role : undefined,
+      });
+      return finishStart(sessionId);
+    }
+  }
+
   const res = await callDaemon<{ id: string; status: string }>({
     method: "POST",
     path: "/api/v1/sessions",
@@ -170,37 +235,5 @@ export async function startFlowSession(
   }
 
   const sessionId = res.data.id;
-  await Promise.all([
-    familiarId ? recordSessionFamiliar(sessionId, familiarId) : Promise.resolve(),
-    setSessionTitle(
-      sessionId,
-      options.targetNodeId ? `Flow step: ${flow.name} / ${options.targetNodeId}` : `Flow: ${flow.name}`,
-    ),
-  ]);
-
-  const order = options.targetNodeId ? flowPartialExecutionOrder(flow, options.targetNodeId) : flowExecutionOrder(flow);
-  const byId = new Map(flow.nodes.map((node) => [node.id, node]));
-  const customData = extractFlowCustomData(flow);
-  const redacted = flowRunRedactsData(flow, options.mode ?? "manual");
-  const seenActiveAgentStep = { value: false };
-  const run = await recordFlowRun({
-    flowId: flow.id,
-    flowName: flow.name,
-    status: "running",
-    mode: options.mode ?? "manual",
-    ...(Object.keys(customData).length > 0 ? { customData } : {}),
-    ...(redacted ? { redacted: true } : {}),
-    startedAt: new Date().toISOString(),
-    steps: order.map((stepId) => ({
-      id: stepId,
-      type: byId.get(stepId)?.type ?? "unknown",
-      status: initialFlowRunStepStatus(flow, stepId, seenActiveAgentStep),
-    })),
-    summary: `agent session ${sessionId.slice(0, 8)}`,
-    source: "cave",
-    sessionId,
-    flowSnapshot: flow,
-  });
-
-  return { ok: true, run, sessionId, executor: "session" };
+  return finishStart(sessionId);
 }


### PR DESCRIPTION
Fixes the broken research-loop iterations on copilot familiars (bead cave-lhc0).

## The bug

Research-mission iterations run as flow sessions via the daemon's nonInteractive launch. For the copilot adapter the daemon splits the compiled prompt into separate argv words, so the CLI bails before doing anything:

```
error: Invalid command format.
It looks like your prompt was not quoted, so the extra words were treated as separate arguments.
```

Every copilot-familiar flow hit this — research missions surfaced it because each bounded iteration is a flow run ("Flow session output" showing the CLI usage error instead of research output).

## The fix

Chat already dodges this exact daemon deficiency by spawning the copilot CLI directly with a real argv (cave-yesg). Flow sessions now get the same escape hatch:

- **`src/lib/server/flow-copilot-session.ts`** — one-shot direct spawn from the registry stream spec (`--session-id` preassigned, `--allow-all`, prompt as **one** argument after `-p`), chat's identity preamble, JSONL parsed via `parseCopilotChatEvent`, and the finished transcript persisted as a Cave conversation under the session id — exactly where `/api/flows/session-transcript` and the research reconcile (`parseResearchControl`) already look first. Failures persist an `isError` turn (exit code + stderr tail); a 60-minute hard timeout backstops the bounded iteration.
- **`flow-executor`** — copilot bindings on local runtimes route through the direct spawn; SSH runtimes and all other harnesses keep the daemon path. The session-record tail (title, familiar attribution, flow-run record) is shared by both paths.

## Verification

- New behavioral test (fake copilot binary): multi-word prompt travels as exactly one argv element with nothing trailing it; transcript lands with trailing `@@research-control` markers intact; failed spawn persists an error turn instead of dropping the run.
- `pnpm typecheck` clean; check-tests-wired 955; `pnpm test:api` 170; `pnpm test:app` 711.

Bead: cave-lhc0
