### PR TITLE
fix(chat): forward granted roots on the copilot direct-stream spawn (cave-n1yc)

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -1191,6 +1191,29 @@ assert.match(
   /\.filter\(\(root\) => root && root !== spawnRoot\)/,
   "The spawn cwd is already trusted and must not be re-forwarded",
 );
+// The grant LIST is computed ungated (local runtimes only); the coven-run
+// probe only gates the `coven run --add-dir` forwarding, never the list
+// itself — the copilot direct spawn consumes it without the coven probe.
+assert.match(
+  chatRoute,
+  /const grantDirs = !sshRuntime\s*\n?\s*\? Array\.from\(/,
+  "Granted-root list must be computed independently of the coven run probe",
+);
+assert.match(
+  chatRoute,
+  /const forwardAddDirs = addDirForwardingEnabled && !sshRuntime \? grantDirs : \[\];/,
+  "coven run forwarding stays gated on the --add-dir capability probe",
+);
+// Copilot direct-stream grant forwarding (cave-n1yc): the direct spawn never
+// goes through `coven run`, so it must receive the UNGATED grant list and
+// emit copilot's native repeatable --add-dir pairs itself. Without this,
+// read-only copilot sessions get no granted-root access at all and full
+// sessions ride --allow-all instead of the declared grant boundary.
+assert.match(
+  chatRoute,
+  /return buildCopilotStreamArgs\(\{[\s\S]*?addDirs: grantDirs,[\s\S]*?\}\);/,
+  "The copilot direct spawn must forward the ungated grant list as addDirs",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1366,19 +1366,19 @@ export async function POST(req: Request) {
   // trusted implicitly, so it's excluded. Gated on the `--add-dir` probe and
   // local runtimes only (SSH runtimes own their remote filesystem).
   const spawnRoot = familiarCwd ?? cwd;
-  const forwardAddDirs =
-    addDirForwardingEnabled && !sshRuntime
-      ? Array.from(
-          new Set(
-            [
-              ...grantedProjectRoots,
-              ...(resolvedFamiliarWorkspace ? [resolvedFamiliarWorkspace] : []),
-            ]
-              .map((root) => root.trim())
-              .filter((root) => root && root !== spawnRoot),
-          ),
-        )
-      : [];
+  const grantDirs = !sshRuntime
+    ? Array.from(
+        new Set(
+          [
+            ...grantedProjectRoots,
+            ...(resolvedFamiliarWorkspace ? [resolvedFamiliarWorkspace] : []),
+          ]
+            .map((root) => root.trim())
+            .filter((root) => root && root !== spawnRoot),
+        ),
+      )
+    : [];
+  const forwardAddDirs = addDirForwardingEnabled && !sshRuntime ? grantDirs : [];
   // Copilot tool visibility (cave-yesg): `coven run copilot --stream-json`
   // launches the CLI one-shot (`-s -p`) and pipes raw prose, so tool calls
   // never surface as structured events. When the registry manifest declares
@@ -1427,6 +1427,12 @@ export async function POST(req: Request) {
         newSessionId: resumeSessionId ? null : copilotSessionHint,
         model: cleanModelId(desiredModel),
         permissionMode: body.permissionMode === "read" ? "read" : "full",
+        // Ungated grant list (cave-n1yc): the direct spawn never goes through
+        // `coven run`, so the coven CLI's --add-dir probe must not mask it.
+        // Copilot's native repeatable --add-dir ships in every CLI version
+        // this stream path supports, same trust basis as the manifest's
+        // session/sandbox flags above.
+        addDirs: grantDirs,
       });
     }
     const a = ["run", binding.harness, "--stream-json"];

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -32,6 +32,11 @@ assert.deepEqual(
 assert.equal(spec.sessionIdFlag, "--session-id");
 assert.equal(spec.resumeFlag, "--resume");
 assert.equal(spec.modelFlag, "--model");
+assert.equal(
+  spec.addDirFlag,
+  "--add-dir",
+  "no manifest add_dir_flag override → copilot's native repeatable flag",
+);
 assert.deepEqual(spec.sandboxFullArgs, ["--allow-all"]);
 assert.deepEqual(spec.sandboxReadOnlyArgs, [
   "--deny-tool",
@@ -49,6 +54,7 @@ const freshArgs = buildCopilotStreamArgs({
   newSessionId: "11111111-2222-4333-8444-555555555555",
   model: "openai/gpt-5.5",
   permissionMode: "full",
+  addDirs: ["/Users/example/projects/alpha", "", "/Users/example/.coven/workspaces/familiars/sage"],
 });
 assert.deepEqual(
   freshArgs,
@@ -57,6 +63,10 @@ assert.deepEqual(
     "11111111-2222-4333-8444-555555555555",
     "--model",
     "gpt-5.5",
+    "--add-dir",
+    "/Users/example/projects/alpha",
+    "--add-dir",
+    "/Users/example/.coven/workspaces/familiars/sage",
     "--allow-all",
     "--output-format",
     "json",
@@ -65,7 +75,7 @@ assert.deepEqual(
     "-p",
     "do the thing",
   ],
-  "fresh turns pre-assign the session id, strip the model namespace, map full access to --allow-all, and trail the prompt after -p",
+  "fresh turns pre-assign the session id, strip the model namespace, trust each granted root via repeatable --add-dir (empty entries dropped), map full access to --allow-all, and trail the prompt after -p",
 );
 
 const resumeArgs = buildCopilotStreamArgs({
@@ -75,12 +85,15 @@ const resumeArgs = buildCopilotStreamArgs({
   newSessionId: null,
   model: null,
   permissionMode: "read",
+  addDirs: ["/Users/example/projects/alpha"],
 });
 assert.deepEqual(
   resumeArgs,
   [
     "--resume",
     "aaaa1111-2222-4333-8444-555555555555",
+    "--add-dir",
+    "/Users/example/projects/alpha",
     "--deny-tool",
     "write",
     "--deny-tool",
@@ -92,7 +105,7 @@ assert.deepEqual(
     "-p",
     "continue",
   ],
-  "resumed read-only turns use --resume and the manifest's deny-tool sandbox args",
+  "resumed read-only turns use --resume, still trust granted roots via --add-dir (cave-n1yc: read-only sessions previously got no grant access at all), and keep the manifest's deny-tool sandbox args",
 );
 
 // ── identity preamble (mirror of coven's FamiliarContext) ─────────────────────

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -39,11 +39,18 @@ export type CopilotStreamSpec = {
   resumeFlag: string | null;
   /** Native model flag (`--model`). */
   modelFlag: string | null;
+  /** Repeatable trusted-directory flag (`--add-dir`). */
+  addDirFlag: string;
   /** Full-access sandbox argv (`--allow-all`). */
   sandboxFullArgs: string[];
   /** Read-only sandbox argv (`--deny-tool write --deny-tool shell`). */
   sandboxReadOnlyArgs: string[];
 };
+
+// Copilot CLI's native repeatable trusted-directory flag. Used when the
+// registry manifest doesn't declare an `add_dir_flag` override — the flag has
+// shipped in every CLI version this stream path supports (verified 1.0.70).
+const COPILOT_ADD_DIR_FLAG = "--add-dir";
 
 function stringArray(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
@@ -66,6 +73,7 @@ export function copilotStreamSpec(): CopilotStreamSpec | null {
       id?: unknown;
       executable?: unknown;
       model_flag?: unknown;
+      add_dir_flag?: unknown;
       sandbox?: { full_args?: unknown; read_only_args?: unknown };
       stream_args?: {
         prefix_args?: unknown;
@@ -90,6 +98,10 @@ export function copilotStreamSpec(): CopilotStreamSpec | null {
         ? adapter.stream_args.resume_flag
         : null,
     modelFlag: typeof adapter.model_flag === "string" ? adapter.model_flag : null,
+    addDirFlag:
+      typeof adapter.add_dir_flag === "string" && adapter.add_dir_flag
+        ? adapter.add_dir_flag
+        : COPILOT_ADD_DIR_FLAG,
     sandboxFullArgs: stringArray(adapter.sandbox?.full_args) ?? [],
     sandboxReadOnlyArgs: stringArray(adapter.sandbox?.read_only_args) ?? [],
   };
@@ -125,6 +137,14 @@ export type CopilotStreamLaunch = {
   /** Cleaned model id; a `provider/` namespace is stripped for copilot. */
   model: string | null;
   permissionMode: "full" | "read";
+  /**
+   * Granted directories to trust at the harness level (repeatable
+   * `--add-dir`). Without these the runtime-scope preamble's grants are
+   * prompt-text-only: read-only sessions deny every granted-root access, and
+   * full sessions ride `--allow-all` instead of an explicit trust list
+   * (cave-n1yc). The spawn cwd is already trusted and must not be included.
+   */
+  addDirs: string[];
 };
 
 /** Direct-spawn argv for a copilot JSONL stream turn. Options ride ahead of
@@ -144,6 +164,12 @@ export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
       ? launch.model.slice(launch.model.lastIndexOf("/") + 1)
       : launch.model;
     if (bare) args.push(spec.modelFlag, bare);
+  }
+  // Trust each granted root at the harness level; repeatable native flag.
+  // Emitted for read AND full turns so the grant list stays the declared
+  // boundary regardless of sandbox mode.
+  for (const dir of launch.addDirs) {
+    if (dir) args.push(spec.addDirFlag, dir);
   }
   // Sandbox mapping from the manifest. Full access maps to the declared
   // full_args (`--allow-all`) — without it copilot's programmatic mode


### PR DESCRIPTION
## Summary
Closes the P1 grant-forwarding gap found in fresh-session verification (bead **cave-n1yc**, discovered from cave-t1ta): the copilot direct-stream spawn (cave-yesg) never emitted `--add-dir` pairs, so granted project roots were prompt-text-only on that path.

**Before:** `route.ts` computed `forwardAddDirs` but only the generic `coven run` branch emitted them. `buildCopilotStreamArgs` emitted session/model/sandbox/prefix args only. Verified live (process 9708): zero `--add-dir` pairs in argv; access worked only because `permissionMode=full` → `--allow-all` masked the gap. Read-only copilot sessions got **no** granted-root access; full sessions got **unbounded** access instead of cwd+grants.

**After:**
- `CopilotStreamSpec.addDirFlag`: manifest `add_dir_flag` override honored, native `--add-dir` default (copilot CLI ships it natively; verified live on 1.0.70 with the exact stream argv shape).
- `CopilotStreamLaunch.addDirs`: emitted as repeatable `--add-dir <dir>` pairs ahead of the sandbox args, for **both** read and full turns.
- `route.ts`: grant-list computation (`grantDirs`, ungated, local-only, spawn-cwd excluded) split from the coven-run probe gate (`forwardAddDirs`). The copilot direct spawn consumes the ungated list — it never goes through `coven run`, so the coven CLI's `--add-dir` probe (currently false on installed v0.1.1) must not mask it. Same trust basis as the manifest's session/sandbox flags the stream path already uses unprobed.

## Verification
- `pnpm typecheck` clean
- `pnpm test:api` — 170/170 test files pass
- `pnpm check:tests-wired` clean
- Live argv probe: `copilot --add-dir /tmp --allow-all --output-format json --stream on -p …` → streams JSONL, exit 0
- New coverage: argv builder fresh/full + resume/read grant forwarding, empty-entry drop, spec default; routing source assertions pin ungated list + gated coven-run path + copilot branch forwarding

## Notes
- Coven-run path behavior unchanged (still probe-gated; activates when a coven release ships PR #363).
- Full sessions still pass `--allow-all` per the manifest sandbox mapping — narrowing that is a separate policy question; this PR makes the grant list real at the harness level on the copilot path.