### PR TITLE
fix(flows): pass addDirs to the copilot flow spawn — heal main typecheck (cave-k4cc)

### DIFF
--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -62,6 +62,9 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     newSessionId: sessionId,
     model: null,
     permissionMode: "full",
+    // Flow runs have no granted-roots concept; the spawn cwd (projectRoot)
+    // is already trusted and must not be listed (cave-n1yc contract).
+    addDirs: [],
   });
 
   const child = spawn(launch.spec.executable, args, {


### PR DESCRIPTION
Current `main` fails `pnpm typecheck`: **semantic conflict** between #3169 (new `startCopilotFlowRun` call site, `bfebca02`) and #3171 (required `addDirs` on `CopilotStreamLaunch`, `2b0f815c`) — merged near-simultaneously from different sessions, so neither PR's CI saw the combination (push-event runs satisfy required contexts without the base merge).

One-line fix: `addDirs: []` on the flow spawn. Flow runs have no granted-roots concept and the spawn cwd (projectRoot) is already trusted per the cave-n1yc contract — this preserves pre-#3171 flow behavior exactly.

Verified: `flow-copilot-session.test.ts` 3/3 green; `pnpm typecheck` clean. Bead `cave-k4cc`.