### PR TITLE
fix(chat): stage header identity guard + shared bead-id pattern (follow-up to #3173)

### DIFF
--- a/src/components/chat-stage-header-wiring.test.ts
+++ b/src/components/chat-stage-header-wiring.test.ts
@@ -24,4 +24,8 @@ assert.match(header, /usePausablePoll\(.*\{\s*\n?\s*enabled: Boolean\(projectRoo
 // Mounted between the top bar and the transcript.
 assert.match(chatView, /<RunActivityStrip[^>]*\/>\s*\n\s*<ChatStageHeader projectRoot=\{activeProjectRoot\} onOpenUrl=\{onOpenUrl\} \/>/, "header mounts after the activity strip, before the transcript");
 
+// Review follow-up (#3173): no cross-project stale bleed.
+assert.match(header, /keyRef\.current !== key/, "bridge state resets when (projectRoot, branch) changes");
+assert.match(header, /\{ \.\.\.EMPTY_BRIDGE, loaded: true \}/, "fetch failures clear stage data instead of preserving another project's");
+
 console.log("chat stage header wiring: ok");

--- a/src/components/chat-stage-header.tsx
+++ b/src/components/chat-stage-header.tsx
@@ -12,7 +12,7 @@
  * already covers bare branch context.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useChangesSummary } from "@/lib/use-changes-summary";
@@ -29,12 +29,27 @@ type BridgeState = {
   loaded: boolean;
 };
 
+const EMPTY_BRIDGE: BridgeState = { open: [], merged: [], beads: [], loaded: false };
+
 function useStageSnapshot(projectRoot: string | null | undefined, branch: string | null): StageSnapshot | null {
-  const [state, setState] = useState<BridgeState>({ open: [], merged: [], beads: [], loaded: false });
+  const [state, setState] = useState<BridgeState>(EMPTY_BRIDGE);
   const [tick, setTick] = useState(0);
+  // Identity guard: when the (projectRoot, branch) pair changes, drop the
+  // previous pair's data BEFORE fetching so a stale stage can't render for
+  // the wrong project/session while the new fetch is in flight.
+  const keyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!projectRoot || !branch) return;
+    if (!projectRoot || !branch) {
+      keyRef.current = null;
+      setState(EMPTY_BRIDGE);
+      return;
+    }
+    const key = `${projectRoot}\u0000${branch}`;
+    if (keyRef.current !== key) {
+      keyRef.current = key;
+      setState(EMPTY_BRIDGE);
+    }
     let cancelled = false;
     (async () => {
       try {
@@ -54,7 +69,9 @@ function useStageSnapshot(projectRoot: string | null | undefined, branch: string
           loaded: true,
         });
       } catch {
-        if (!cancelled) setState((prev) => ({ ...prev, loaded: true }));
+        // Clear rather than preserve: a failed fetch hides the header (it's
+        // optional chrome) instead of showing another project's stage.
+        if (!cancelled) setState({ ...EMPTY_BRIDGE, loaded: true });
       }
     })();
     return () => {

--- a/src/lib/beads-pr-management.ts
+++ b/src/lib/beads-pr-management.ts
@@ -76,6 +76,15 @@ export function classifyPullRequest(pr: GitHubPullRequestInput): PrLane {
   return "needs-review";
 }
 
+/** Bead ids mentioned in any text (lowercased, deduped, sorted). The ONE
+ *  bead-id pattern — branch parsing (stage-model) and PR parsing share it so
+ *  they cannot drift. */
+export function beadIdsInText(text: string): string[] {
+  const ids = new Set<string>();
+  for (const match of text.matchAll(BEAD_ID_RE)) ids.add(match[0].toLowerCase());
+  return [...ids].sort();
+}
+
 export function extractBeadIds(pr: GitHubPullRequestInput): string[] {
   const chunks = [
     pr.title,
@@ -85,7 +94,7 @@ export function extractBeadIds(pr: GitHubPullRequestInput): string[] {
   ];
   const ids = new Set<string>();
   for (const chunk of chunks) {
-    for (const match of chunk.matchAll(BEAD_ID_RE)) ids.add(match[0].toLowerCase());
+    for (const id of beadIdsInText(chunk)) ids.add(id);
   }
   return [...ids].sort();
 }

--- a/src/lib/stage-model.ts
+++ b/src/lib/stage-model.ts
@@ -5,6 +5,7 @@
 // (beads-pr-management); bead truth from `bd ready --json` rows. This module
 // only joins and labels — it never re-derives check/review state.
 import type { PullRequestSummary } from "./beads-pr-management.ts";
+import { beadIdsInText } from "./beads-pr-management.ts";
 import type { MergedPrRef, ReadyBead, WorkQueueLaneKey } from "./beads-work-queue.ts";
 
 /** PR-bridge lane → queue/stage lane. Extracted from beads-work-queue (which
@@ -50,12 +51,10 @@ export type StageSnapshot = {
   steps: StageStep[];
 };
 
-const BEAD_ID_RE = /\bcave-[a-z0-9]+(?:\.\d+)?\b/gi;
-
-/** Bead ids a branch name carries (e.g. feat/foo-cave-ab12). */
+/** Bead ids a branch name carries (e.g. feat/foo-cave-ab12). Shares the ONE
+ *  bead-id pattern with PR parsing (beads-pr-management.beadIdsInText). */
 export function beadIdsInBranch(branch: string): string[] {
-  const m = branch.match(BEAD_ID_RE);
-  return m ? m.map((s) => s.toLowerCase()) : [];
+  return beadIdsInText(branch);
 }
 
 /**


### PR DESCRIPTION
Post-merge Copilot review follow-up on #3173 (bead `cave-fpqx.10`):

1. **No cross-project stale bleed** — `useStageSnapshot` resets its bridge state the moment `(projectRoot, branch)` changes (identity keyRef) and **clears** on fetch failure instead of preserving the previous project's arrays; a failed fetch hides the header (optional chrome) rather than showing another session's stage.
2. **One bead-id pattern** — `beadIdsInText` exported from `beads-pr-management` and consumed by both `extractBeadIds` (PR parsing) and `stage-model.beadIdsInBranch` (branch parsing); the duplicated regex is gone, drift is impossible.

Pins added to `chat-stage-header-wiring.test.ts`; stage-model + beads-pr-management + beads-work-queue suites green; typecheck clean.