### PR TITLE
fix(chat): runtime chip menu stays open until a model is picked (cave-bfwk)

### DIFF
--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -99,6 +99,23 @@ assert.match(
   "the model group only renders for runtimes with a curated catalog (hermes/openclaw run their own adapters)",
 );
 
+// ── Two-step pick: a runtime pick keeps the menu open for the model pick ─────
+// Collapsing on the runtime click stranded the switch halfway — the user had
+// to reopen the menu to choose a model. The menu now stays up (the Model group
+// re-lists from the optimistic state flip) and only a model pick, or picking a
+// menu-less runtime with no model step, completes the visit.
+assert.match(
+  chip,
+  /onPickRuntime\(catalog\.runtime\);[\s\S]{0,400}?if \(catalog\.models\.length === 0\) setOpen\(false\);/,
+  "a runtime pick closes the menu only for menu-less runtimes (hermes/openclaw); curated runtimes keep it open until a model is picked",
+);
+const modelRowBlock = chip.match(/\{modelOptions\.map\(\(m\) =>[\s\S]*?\)\)\}/)?.[0] ?? "";
+assert.match(
+  modelRowBlock,
+  /onSelect=\{\(\) => \{\s*\n\s*if \(m\.id !== modelValue\) onPickModel\(m\.id\);\s*\n\s*setOpen\(false\);/,
+  "a model pick completes the runtime→model switch and closes the menu",
+);
+
 // ── Brand marks: real logos for provider runtimes, glyphs for the rest ──────
 assert.match(logo, /codex: OPENAI_PATH,\s*\n\s*claude: ANTHROPIC_PATH,/, "codex and claude carry their providers' brand marks");
 assert.match(logo, /hermes: "ph:plug-bold",\s*\n\s*openclaw: "ph:paw-print-bold",/, "brand-less runtimes reuse the glyph language skill-card established");

--- a/src/components/composer-runtime-chip.tsx
+++ b/src/components/composer-runtime-chip.tsx
@@ -88,7 +88,11 @@ export function ComposerRuntimeChip({
               checked={catalog.runtime === runtime}
               onSelect={() => {
                 if (catalog.runtime !== runtime) onPickRuntime(catalog.runtime);
-                setOpen(false);
+                // Keep the menu open so the model pick completes the switch in
+                // one visit — the Model group re-renders for the new runtime.
+                // Menu-less runtimes (hermes/openclaw) have no model step, so
+                // the pick is complete and the menu closes.
+                if (catalog.models.length === 0) setOpen(false);
               }}
             >
               {runtimeDisplayName(catalog.runtime)}

--- a/tests/composer-runtime-chip.spec.ts
+++ b/tests/composer-runtime-chip.spec.ts
@@ -1,11 +1,13 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// Verifies the composer runtime chip (cave-yq5l / cave-v25g): the chat
-// composer always shows the active runtime's mark + effective model, clicking
-// it opens a Runtime/Model picker with radio semantics, and picking a runtime
-// rebinds the familiar through /api/config — flipping the chip, re-listing
-// the Model group, refetching the familiar roster (cave:familiars-refresh),
-// and catching the empty-state identity line up without a reload.
+// Verifies the composer runtime chip (cave-yq5l / cave-v25g / cave-bfwk): the
+// chat composer always shows the active runtime's mark + effective model,
+// clicking it opens a Runtime/Model picker with radio semantics, and picking a
+// runtime rebinds the familiar through /api/config — flipping the chip,
+// re-listing the Model group in the still-open menu (the pick isn't complete
+// until a model is chosen), refetching the familiar roster
+// (cave:familiars-refresh), and catching the empty-state identity line up
+// without a reload. A model pick then closes the menu.
 //
 // Desktop only (the chip lives in the chat composer). All APIs are mocked;
 // the config mock is stateful so the roster refetch observably changes what
@@ -23,6 +25,7 @@ type Mutable = {
   harness: string;
   effectiveModel: string;
   familiarsServed: number;
+  modelStateServed: number;
   configPatches: Array<Record<string, unknown>>;
 };
 
@@ -31,6 +34,7 @@ async function seed(page: Page): Promise<Mutable> {
     harness: "codex",
     effectiveModel: "openai/gpt-5.5",
     familiarsServed: 0,
+    modelStateServed: 0,
     configPatches: [],
   };
   await page.addInitScript(() => {
@@ -47,8 +51,14 @@ async function seed(page: Page): Promise<Mutable> {
     route.fulfill({ json: { ok: true, sessions: [] } }),
   );
   await page.route("**/api/board**", (route) => route.fulfill({ json: { ok: true, cards: [] } }));
-  await page.route("**/api/chat/model-state**", (route) =>
-    route.fulfill({
+  await page.route("**/api/chat/model-state**", (route) => {
+    if (route.request().method() === "PATCH") {
+      const body = route.request().postDataJSON() as { model?: string };
+      if (body?.model) state.effectiveModel = body.model;
+    } else {
+      state.modelStateServed += 1;
+    }
+    return route.fulfill({
       json: {
         ok: true,
         state: {
@@ -61,8 +71,8 @@ async function seed(page: Page): Promise<Mutable> {
           reason: "e2e",
         },
       },
-    }),
-  );
+    });
+  });
   await page.route("**/api/config", async (route) => {
     if (route.request().method() === "PATCH") {
       const body = route.request().postDataJSON() as {
@@ -109,9 +119,17 @@ test.describe("composer runtime chip", () => {
     // The empty-state identity line reads the roster's familiar.harness.
     await expect(page.locator(".cave-chat-empty-meta")).toContainText("codex");
     const servedBefore = state.familiarsServed;
+    const modelStateGetsBefore = state.modelStateServed;
 
     await chip.click();
-    await page.getByRole("menuitemradio", { name: "Claude Code", exact: true }).click();
+    const menu = page.getByRole("menu", { name: "Runtime and model" });
+    await menu.getByRole("menuitemradio", { name: "Claude Code", exact: true }).click();
+
+    // The menu stays open for the model step — the switch isn't done until a
+    // model is picked, and the Model group re-lists to the new runtime's
+    // catalog in place (cave-bfwk).
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole("menuitemradio", { name: "Claude Sonnet 5", exact: true })).toBeVisible();
 
     // The PATCH carries the harness + that runtime's default model.
     await expect(() => {
@@ -130,9 +148,13 @@ test.describe("composer runtime chip", () => {
     // …so the identity line catches up without a reload.
     await expect(page.locator(".cave-chat-empty-meta")).toContainText("claude", { timeout: 10_000 });
 
-    // The Model group re-lists to the new runtime's catalog.
-    await chip.click();
-    const menu = page.getByRole("menu", { name: "Runtime and model" });
-    await expect(menu.getByRole("menuitemradio", { name: "Claude Sonnet 5", exact: true })).toBeVisible();
+    // Let the runtime pick's reconciling model-state refetch land before the
+    // model pick, so a stale in-flight GET can't overwrite the model PATCH.
+    await expect(() => expect(state.modelStateServed).toBeGreaterThan(modelStateGetsBefore)).toPass({ timeout: 10_000 });
+
+    // Picking a model completes the runtime→model switch and closes the menu.
+    await menu.getByRole("menuitemradio", { name: "Claude Sonnet 5", exact: true }).click();
+    await expect(menu).not.toBeVisible();
+    await expect(chip).toHaveAttribute("aria-label", /Runtime: Claude Code · Model: Claude Sonnet 5/, { timeout: 10_000 });
   });
 });


### PR DESCRIPTION
## What

Picking a runtime in the composer runtime chip (chat + home composers) collapsed the popover immediately, stranding the switch halfway — the user had to reopen the menu to pick a model for the new runtime.

Now the menu stays open after a runtime pick: the Model group re-lists in place from the optimistic state flip, and the menu closes only when a model is picked. Menu-less runtimes (hermes/openclaw, registry runtimes without a curated catalog) have no model step, so picking them still closes the menu — the pick is complete.

## Why

Task: **Patch Runtime-Model Selection** — "When selecting a runtime, the menu collapses, it should not until a model is also selected." Bead: `cave-bfwk`.

## Changes

- `src/components/composer-runtime-chip.tsx` — runtime rows close the popover only when the picked runtime's catalog has no curated models; model rows keep closing it.
- `src/components/composer-runtime-chip.test.ts` — source pins for the two-step pick.
- `tests/composer-runtime-chip.spec.ts` — e2e drives the full two-step switch in one menu visit (runtime pick keeps menu up with the re-listed catalog; model pick PATCHes `/api/chat/model-state` and closes it); model-state mock is now stateful for PATCH; deterministic guard so the runtime pick's reconciling refetch lands before the model pick.

Both composers share the chip, so home gets the fix too. The `ComposerOptionsMenu` runtime/model radio sections already stayed open — no change there.

## Verification

- `node --experimental-strip-types src/components/composer-runtime-chip.test.ts` → ok
- `pnpm typecheck` → clean
- `COVEN_CAVE_E2E=1 playwright test tests/composer-runtime-chip.spec.ts` → 5 passed
- neighboring pin suites (home-composer, home-composer-polish, chat-view-polish) → pass