### PR TITLE
fix(research): cancel treats an already-gone session as stopped (cave-malz)

### DIFF
--- a/src/lib/server/research-mission-runner.test.ts
+++ b/src/lib/server/research-mission-runner.test.ts
@@ -7,6 +7,7 @@ import { allowedResearchActions, type ResearchMission } from "../research-missio
 import {
   makeResearchMissionRunner,
   parseResearchSourcesFile,
+  sessionAlreadyGone,
   type ResearchMissionRunnerDeps,
 } from "./research-mission-runner.ts";
 
@@ -902,4 +903,17 @@ test("malformed sources checkpoint the mission instead of publishing", async () 
   const result = await runner.reconcile(stored);
   assert.equal(result.status, "checkpoint");
   assert.match(result.lastError ?? "", /sources\.json is malformed/);
+});
+
+test("cancel treats an already-gone session as stopped (cave-malz)", () => {
+  // 4xx: the daemon no longer knows the session (dead, pruned, or a
+  // Cave-direct session that never existed daemon-side); 0: no daemon at all.
+  assert.equal(sessionAlreadyGone({ ok: false, status: 404 }), true);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 410 }), true);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 0 }), true);
+  // A live daemon actively erroring may still be running the session.
+  assert.equal(sessionAlreadyGone({ ok: false, status: 500 }), false);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 502 }), false);
+  // A successful kill was a genuinely running session, not a gone one.
+  assert.equal(sessionAlreadyGone({ ok: true, status: 200 }), false);
 });

--- a/src/lib/server/research-mission-runner.test.ts
+++ b/src/lib/server/research-mission-runner.test.ts
@@ -906,11 +906,17 @@ test("malformed sources checkpoint the mission instead of publishing", async () 
 });
 
 test("cancel treats an already-gone session as stopped (cave-malz)", () => {
-  // 4xx: the daemon no longer knows the session (dead, pruned, or a
-  // Cave-direct session that never existed daemon-side); 0: no daemon at all.
+  // Verified against the live daemon: an already-exited session kills as 409;
+  // unknown/pruned (and Cave-direct) sessions are 404/410; 0 = no daemon.
   assert.equal(sessionAlreadyGone({ ok: false, status: 404 }), true);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 409 }), true);
   assert.equal(sessionAlreadyGone({ ok: false, status: 410 }), true);
   assert.equal(sessionAlreadyGone({ ok: false, status: 0 }), true);
+  // Auth/rate-limit rejections: the daemon or hub is alive and the session
+  // may still be running — cancel stays blocked.
+  assert.equal(sessionAlreadyGone({ ok: false, status: 401 }), false);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 403 }), false);
+  assert.equal(sessionAlreadyGone({ ok: false, status: 429 }), false);
   // A live daemon actively erroring may still be running the session.
   assert.equal(sessionAlreadyGone({ ok: false, status: 500 }), false);
   assert.equal(sessionAlreadyGone({ ok: false, status: 502 }), false);

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -954,6 +954,20 @@ export function parseResearchSourcesFile(raw: string): ResearchSourceRef[] {
   });
 }
 
+/**
+ * True when a failed kill response means the session is already not running —
+ * the daemon no longer knows it (4xx: dead, pruned, or a Cave-direct session
+ * that never existed on the daemon) or there is no daemon to be running it
+ * (status 0). Cancel's goal state is "nothing running", which is already true
+ * in every one of those cases; only a live daemon actively erroring (5xx)
+ * keeps a cancel blocked. Without this, a mission whose session died out from
+ * under it was uncancellable — cancel threw forever (cave-malz).
+ */
+export function sessionAlreadyGone(response: { ok: boolean; status: number }): boolean {
+  if (response.ok) return false;
+  return response.status === 0 || (response.status >= 400 && response.status < 500);
+}
+
 export function makeProductionResearchMissionRunner() {
   const deps: ResearchMissionRunnerDeps = {
     createWorkspace: createResearchMissionWorkspace,
@@ -994,7 +1008,9 @@ export function makeProductionResearchMissionRunner() {
         path: `/api/v1/sessions/${encodeURIComponent(sessionId)}/kill`,
         timeoutMs: 4_000,
       });
-      if (!response.ok) throw new Error(response.error ?? "Research session could not be cancelled");
+      if (!response.ok && !sessionAlreadyGone(response)) {
+        throw new Error(response.error ?? "Research session could not be cancelled");
+      }
     },
     createAutomation: async (input) => {
       const { createCodexAutomation } = await import("../codex-automations.ts");

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -955,17 +955,21 @@ export function parseResearchSourcesFile(raw: string): ResearchSourceRef[] {
 }
 
 /**
- * True when a failed kill response means the session is already not running —
- * the daemon no longer knows it (4xx: dead, pruned, or a Cave-direct session
- * that never existed on the daemon) or there is no daemon to be running it
- * (status 0). Cancel's goal state is "nothing running", which is already true
- * in every one of those cases; only a live daemon actively erroring (5xx)
- * keeps a cancel blocked. Without this, a mission whose session died out from
- * under it was uncancellable — cancel threw forever (cave-malz).
+ * True when a failed kill response means the session is already not running.
+ * Verified against the live daemon: killing an already-exited session returns
+ * 409; a session the daemon never knew (pruned, or a Cave-direct session that
+ * never existed daemon-side) is 404/410; status 0 means there is no daemon to
+ * be running it at all. Cancel's goal state is "nothing running", which is
+ * already true in each of those cases. Auth/rate-limit rejections (401/403/
+ * 429) and daemon errors (5xx) stay blocking — the daemon or hub is alive and
+ * the session may genuinely still be running (cave-malz).
  */
 export function sessionAlreadyGone(response: { ok: boolean; status: number }): boolean {
   if (response.ok) return false;
-  return response.status === 0 || (response.status >= 400 && response.status < 500);
+  return response.status === 0
+    || response.status === 404
+    || response.status === 409
+    || response.status === 410;
 }
 
 export function makeProductionResearchMissionRunner() {


### PR DESCRIPTION
Follow-up to #3169 (bead cave-malz) — the second half of the stuck research loop from the incident screenshot.

## The bug

`killSession` threw on ANY failed daemon kill — including 404s for sessions the daemon no longer knows (died out from under the mission, pruned, or Cave-direct sessions from #3169 that never existed daemon-side) and status 0 (no daemon at all). Since a running mission's only allowed action is **cancel**, a mission whose session died was permanently stuck: every cancel returned "Research session could not be cancelled" and the mission stayed `running` forever. Both real stuck missions from the copilot-spawn incident hit exactly this.

## The fix

`sessionAlreadyGone` (exported, tested): a 4xx or status-0 kill failure means the goal state — nothing running — is already true, so cancel proceeds. Only a live daemon actively erroring (5xx) keeps a cancel blocked, since the session may genuinely still be burning tokens.

Follow-up filed: cave-ibb7 (reconcile should mark running missions with dead sessions as failed, enabling Retry directly).

## Verification

- `research-mission-runner.test.ts`: 30/30 (new sessionAlreadyGone cases: 404/410/0 → gone; 500/502 → blocked; ok → not gone)
- `pnpm typecheck` clean

Bead: cave-malz
