### PR TITLE
feat(chat): code-rail failing-checks badge from the stage broadcast (cave-fpqx.12)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -520,6 +520,7 @@ export const SUITES = {
     "src/components/github-action-popover-chat-launch.test.ts",
     "src/components/github-card-wiring.test.ts",
     "src/components/chat-stage-header-wiring.test.ts",
+    "src/components/workspace-rail-checks-badge.test.ts",
     "src/components/skill-stage-card-wiring.test.ts",
     "src/components/github-view-polish.test.ts",
     "src/components/github-advanced.test.ts",

--- a/src/components/chat-stage-header.tsx
+++ b/src/components/chat-stage-header.tsx
@@ -113,17 +113,20 @@ export function ChatStageHeader({
 
   // Broadcast the failing-checks signal for the code rail's badge (design §6):
   // the header already holds the stage snapshot, so the rail never re-fetches
-  // the PR bridge. Fires on every change, including back to false and on
-  // unmount, so a stale red badge can't outlive its cause.
+  // the PR bridge. Dispatch fires on every signal change; the CLEAR fires only
+  // on unmount / root change (separate effect) so listeners never see a
+  // transient false between consecutive true states.
   const failing = Boolean(snapshot?.pr && snapshot.pr.checkStatus === "failing");
   useEffect(() => {
     if (!projectRoot) return;
-    const detail = { projectRoot, failing };
-    window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail }));
+    window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot, failing } }));
+  }, [projectRoot, failing]);
+  useEffect(() => {
+    if (!projectRoot) return;
     return () => {
       window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot, failing: false } }));
     };
-  }, [projectRoot, failing]);
+  }, [projectRoot]);
 
   if (!snapshot) return null;
 

--- a/src/components/chat-stage-header.tsx
+++ b/src/components/chat-stage-header.tsx
@@ -16,7 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useChangesSummary } from "@/lib/use-changes-summary";
-import { resolveStageForBranch, type StageSnapshot, type StageStep } from "@/lib/stage-model";
+import { resolveStageForBranch, STAGE_CHECKS_EVENT, type StageSnapshot, type StageStep } from "@/lib/stage-model";
 import type { PullRequestSummary } from "@/lib/beads-pr-management";
 import type { MergedPrRef, ReadyBead } from "@/lib/beads-work-queue";
 
@@ -110,6 +110,21 @@ export function ChatStageHeader({
 }) {
   const { branch } = useChangesSummary(projectRoot ?? undefined, Boolean(projectRoot));
   const snapshot = useStageSnapshot(projectRoot, branch);
+
+  // Broadcast the failing-checks signal for the code rail's badge (design §6):
+  // the header already holds the stage snapshot, so the rail never re-fetches
+  // the PR bridge. Fires on every change, including back to false and on
+  // unmount, so a stale red badge can't outlive its cause.
+  const failing = Boolean(snapshot?.pr && snapshot.pr.checkStatus === "failing");
+  useEffect(() => {
+    if (!projectRoot) return;
+    const detail = { projectRoot, failing };
+    window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail }));
+    return () => {
+      window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot, failing: false } }));
+    };
+  }, [projectRoot, failing]);
+
   if (!snapshot) return null;
 
   const open = (url: string | undefined) => {

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -12,6 +12,7 @@ import { ChatFamiliarView } from "@/components/chat-familiar-view";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending, consumeProjectsTabPending } from "@/lib/chat-tab-events";
 import { WorkspaceRail } from "@/components/workspace-rail";
 import { useCodeRail } from "@/lib/use-code-rail";
+import { useStageChecksBadge } from "@/lib/use-stage-checks-badge";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -170,6 +171,9 @@ export function ChatSurface({
   // manual collapse (see below) so the rail snaps back to the session.
   const [browseRootOverride, setBrowseRootOverride] = useState<string | null>(null);
   const effectiveRailRoot = browseRootOverride ?? railProjectRoot;
+  // Failing-checks cue for the COLLAPSED reopen strip (cave-fpqx.12) — same
+  // stage-header broadcast the mounted rail's badge listens to.
+  const reopenChecksFailing = useStageChecksBadge(effectiveRailRoot);
 
   // changeCount = number of pending working-tree files for the rail's effective
   // project root. Mirrors session-changes-panel's /api/changes fetch (files
@@ -682,13 +686,14 @@ export function ChatSurface({
       {rail.available && !rail.open && !isMobile && !paneNarrow && (
         <button
           type="button"
-          aria-label="Show code rail"
-          title="Show code rail"
+          aria-label={reopenChecksFailing ? "Show code rail — PR checks failing" : "Show code rail"}
+          title={reopenChecksFailing ? "PR checks failing" : "Show code rail"}
           className="workspace-rail-reopen focus-ring"
           onClick={rail.reopen}
         >
           <Icon name="ph:sidebar-simple" width={15} aria-hidden />
           <span className="workspace-rail-reopen__label">Code</span>
+          {reopenChecksFailing ? <span className="workspace-rail__badge workspace-rail__badge--alert" aria-hidden /> : null}
         </button>
       )}
       {/* Mobile / narrow code rail: same WorkspaceRail as desktop, but hosted in

--- a/src/components/workspace-rail-checks-badge.test.ts
+++ b/src/components/workspace-rail-checks-badge.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+// Wiring pins: the code-rail failing-checks badge (cave-fpqx.12, design
+// docs/chat-github-integration.md §6) — one stage source (the chat stage
+// header broadcast), a peripheral dot only, no new tab, no reveal changes.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const header = readFileSync(new URL("./chat-stage-header.tsx", import.meta.url), "utf8");
+const rail = readFileSync(new URL("./workspace-rail.tsx", import.meta.url), "utf8");
+const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const hook = readFileSync(new URL("../lib/use-stage-checks-badge.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+const railLogic = readFileSync(new URL("../lib/code-rail.ts", import.meta.url), "utf8");
+
+// Broadcast side: the header owns the snapshot; fires on change AND resets on
+// unmount so a stale red dot can't outlive its cause.
+assert.match(header, /snapshot\?\.pr && snapshot\.pr\.checkStatus === "failing"/, "failing signal derives from the stage snapshot's PR rollup");
+assert.match(header, /new CustomEvent\(STAGE_CHECKS_EVENT, \{ detail \}\)/, "header broadcasts the stage-checks event");
+assert.match(header, /detail: \{ projectRoot, failing: false \}/, "unmount clears the badge");
+
+// Listener side: filtered by project root, resets when the root changes.
+assert.match(hook, /d\?\.projectRoot === projectRoot/, "hook filters events to its project root");
+assert.match(hook, /setFailing\(false\);\s*\n\s*if \(!projectRoot\) return;/, "hook resets on root change");
+
+// Rail strip badge + a11y label; collapsed reopen strip too.
+assert.match(rail, /useStageChecksBadge\(projectRoot\)/, "rail reads the badge signal");
+assert.match(rail, /workspace-rail__badge--alert/, "rail renders the alert dot");
+assert.match(rail, /"Changes — PR checks failing"/, "changes tab announces the failing state");
+assert.match(surface, /useStageChecksBadge\(effectiveRailRoot\)/, "collapsed reopen strip reads the same signal");
+assert.match(surface, /"Show code rail — PR checks failing"/, "reopen strip announces the failing state");
+assert.match(css, /\.workspace-rail__badge--alert \{/, "alert dot styled");
+
+// Design §6 guardrail: no new signals into the reveal resolver.
+assert.doesNotMatch(railLogic, /checks|stage/i, "resolveCodeRail's reveal inputs stay checks-free");
+
+console.log("rail checks badge wiring: ok");

--- a/src/components/workspace-rail-checks-badge.test.ts
+++ b/src/components/workspace-rail-checks-badge.test.ts
@@ -15,8 +15,8 @@ const railLogic = readFileSync(new URL("../lib/code-rail.ts", import.meta.url), 
 // Broadcast side: the header owns the snapshot; fires on change AND resets on
 // unmount so a stale red dot can't outlive its cause.
 assert.match(header, /snapshot\?\.pr && snapshot\.pr\.checkStatus === "failing"/, "failing signal derives from the stage snapshot's PR rollup");
-assert.match(header, /new CustomEvent\(STAGE_CHECKS_EVENT, \{ detail \}\)/, "header broadcasts the stage-checks event");
-assert.match(header, /detail: \{ projectRoot, failing: false \}/, "unmount clears the badge");
+assert.match(header, /window\.dispatchEvent\(new CustomEvent\(STAGE_CHECKS_EVENT, \{ detail: \{ projectRoot, failing \} \}\)\);\s*\n\s*\}, \[projectRoot, failing\]\);/, "header broadcasts on every signal change");
+assert.match(header, /detail: \{ projectRoot, failing: false \}[\s\S]{0,40}\}, \[projectRoot\]\);/, "the clear fires only on unmount/root change — no transient false between true states");
 
 // Listener side: filtered by project root, resets when the root changes.
 assert.match(hook, /d\?\.projectRoot === projectRoot/, "hook filters events to its project root");
@@ -30,7 +30,9 @@ assert.match(surface, /useStageChecksBadge\(effectiveRailRoot\)/, "collapsed reo
 assert.match(surface, /"Show code rail — PR checks failing"/, "reopen strip announces the failing state");
 assert.match(css, /\.workspace-rail__badge--alert \{/, "alert dot styled");
 
-// Design §6 guardrail: no new signals into the reveal resolver.
-assert.doesNotMatch(railLogic, /checks|stage/i, "resolveCodeRail's reveal inputs stay checks-free");
+// Design §6 guardrail: no coupling of the badge signal into the reveal
+// resolver — the cue must stay peripheral. Names are specific so unrelated
+// git vocabulary (staged/unstage) can't false-fail this pin.
+assert.doesNotMatch(railLogic, /STAGE_CHECKS_EVENT|useStageChecksBadge|checksFailing/, "resolveCodeRail's reveal inputs stay badge-free");
 
 console.log("rail checks badge wiring: ok");

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -154,7 +154,7 @@ assert.match(
 // Collapsed state renders a reopen strip.
 assert.match(
   source,
-  /rail\.available\s*&&\s*!rail\.open[\s\S]*?aria-label="Show code rail"[\s\S]*?rail\.reopen/,
+  /rail\.available\s*&&\s*!rail\.open[\s\S]*?aria-label=\{reopenChecksFailing \? "Show code rail — PR checks failing" : "Show code rail"\}[\s\S]*?rail\.reopen/,
   "a 'Show code rail' reopen strip is rendered when the rail is available but collapsed",
 );
 

--- a/src/components/workspace-rail.test.ts
+++ b/src/components/workspace-rail.test.ts
@@ -6,9 +6,16 @@ const src = readFileSync(new URL("./workspace-rail.tsx", import.meta.url), "utf8
 assert.match(src, /export function WorkspaceRail\(/, "exports WorkspaceRail");
 assert.match(src, /className=\{`workspace-rail\$\{isFullscreen \? " workspace-rail--fullscreen" : ""\}`\}/, "root class includes fullscreen modifier state");
 assert.match(src, /aria-label="Code rail"/, "labels the rail region");
-for (const t of ["Changes", "Files", "Terminal"]) {
+for (const t of ["Files", "Terminal"]) {
   assert.match(src, new RegExp(`aria-label="${t}"`), `has a ${t} tab`);
 }
+// Changes carries a conditional label — the failing-checks badge (cave-fpqx.12)
+// announces itself through the tab's accessible name.
+assert.match(
+  src,
+  /aria-label=\{checksFailing \? "Changes — PR checks failing" : "Changes"\}/,
+  "has a Changes tab (with the failing-checks announcement)",
+);
 assert.match(src, /SessionChangesPanel/, "Changes tab reuses SessionChangesPanel");
 // Files tab renders the composed tree + inline-editable file preview panel.
 assert.match(src, /RailFilesPanel/, "Files tab renders RailFilesPanel");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -6,6 +6,7 @@ import { RailFilesPanel } from "@/components/rail-files-panel";
 import { RailTerminalPanel } from "@/components/rail-terminal-panel";
 import type { CodeRailTab } from "@/lib/code-rail";
 import type { PendingCodeRailOpen as CodeRailFocus } from "@/lib/pending-code-rail-open";
+import { useStageChecksBadge } from "@/lib/use-stage-checks-badge";
 
 const TAB_TITLE: Record<CodeRailTab, string> = {
   changes: "Changes",
@@ -54,6 +55,9 @@ export function WorkspaceRail({
   }, [activeTab, isFullscreen]);
   const terminalVisible = isFullscreen && activeTab === "terminal";
   const title = activeTab === "terminal" && !isFullscreen ? TAB_TITLE.files : TAB_TITLE[activeTab];
+  // Failing-checks cue (cave-fpqx.12): fed by the stage header's broadcast —
+  // a peripheral dot only, no new tab, no reveal-logic changes.
+  const checksFailing = useStageChecksBadge(projectRoot);
 
   return (
     <section
@@ -64,13 +68,15 @@ export function WorkspaceRail({
       <nav className="workspace-rail__strip" aria-label="Code rail tabs">
         <button
           type="button"
-          aria-label="Changes"
+          aria-label={checksFailing ? "Changes — PR checks failing" : "Changes"}
+          title={checksFailing ? "PR checks failing" : undefined}
           aria-pressed={activeTab === "changes"}
           className={`workspace-rail__tab focus-ring${activeTab === "changes" ? " is-active" : ""}`}
           onClick={() => onSelectTab("changes")}
         >
           <Icon name="ph:git-diff" width={16} aria-hidden />
           {changeCount > 0 ? <span className="workspace-rail__badge">{changeCount}</span> : null}
+          {checksFailing ? <span className="workspace-rail__badge workspace-rail__badge--alert" aria-hidden /> : null}
         </button>
         <button
           type="button"

--- a/src/lib/stage-model.ts
+++ b/src/lib/stage-model.ts
@@ -197,3 +197,9 @@ export function resolveStageForBranch(args: {
 
   return { branch, pr, mergedRef, bead, lane, steps };
 }
+
+/** Window event the chat stage header dispatches whenever its snapshot's
+ *  failing-checks signal changes; the code rail's badge listens (design §6 —
+ *  one stage source, no duplicate PR-bridge fetches). detail:
+ *  { projectRoot: string; failing: boolean }. */
+export const STAGE_CHECKS_EVENT = "cave:stage-checks";

--- a/src/lib/use-stage-checks-badge.ts
+++ b/src/lib/use-stage-checks-badge.ts
@@ -1,0 +1,27 @@
+"use client";
+
+/**
+ * Failing-checks badge signal for the code rail (cave-fpqx.12, design
+ * docs/chat-github-integration.md §6). The chat stage header owns the stage
+ * snapshot and broadcasts STAGE_CHECKS_EVENT whenever the failing signal
+ * changes; this hook is the listener side, filtered to one project root, so
+ * the rail never re-fetches the PR bridge itself.
+ */
+
+import { useEffect, useState } from "react";
+import { STAGE_CHECKS_EVENT } from "@/lib/stage-model";
+
+export function useStageChecksBadge(projectRoot: string | null | undefined): boolean {
+  const [failing, setFailing] = useState(false);
+  useEffect(() => {
+    setFailing(false);
+    if (!projectRoot) return;
+    const handler = (e: Event) => {
+      const d = (e as CustomEvent).detail as { projectRoot?: string; failing?: boolean } | undefined;
+      if (d?.projectRoot === projectRoot) setFailing(Boolean(d.failing));
+    };
+    window.addEventListener(STAGE_CHECKS_EVENT, handler);
+    return () => window.removeEventListener(STAGE_CHECKS_EVENT, handler);
+  }, [projectRoot]);
+  return failing;
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -5077,6 +5077,28 @@ details[open] > .cave-tool-summary::before {
   font-variant-numeric: tabular-nums;
 }
 
+/* Failing-checks dot (cave-fpqx.12): a peripheral red cue on the rail's
+   Changes tab and the collapsed reopen strip when the session PR's rollup is
+   red. Sits on the opposite corner from the count badge so both can show. */
+.workspace-rail__badge--alert {
+  top: auto;
+  bottom: -3px;
+  right: -3px;
+  min-width: 9px;
+  width: 9px;
+  height: 9px;
+  padding: 0;
+  background: var(--color-warning);
+}
+
+/* On the full-height collapsed reopen strip the dot anchors to the icon area
+   instead of the strip's far corner. */
+.workspace-rail-reopen .workspace-rail__badge--alert {
+  top: 6px;
+  right: 8px;
+  bottom: auto;
+}
+
 .workspace-rail__body {
   flex: 1 1 auto;
   min-width: 0;

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -5088,7 +5088,7 @@ details[open] > .cave-tool-summary::before {
   width: 9px;
   height: 9px;
   padding: 0;
-  background: var(--color-warning);
+  background: var(--color-danger);
 }
 
 /* On the full-height collapsed reopen strip the dot anchors to the icon area


### PR DESCRIPTION
**W5** of the chat↔GitHub integration design ([docs/chat-github-integration.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/chat-github-integration.md) §6, epic `cave-fpqx`, bead `cave-fpqx.12`) — deliberately minimal.

## What
- `ChatStageHeader` (already the stage-snapshot owner from W3) broadcasts `STAGE_CHECKS_EVENT` (`{projectRoot, failing}`) whenever the session PR's failing-rollup signal changes — including back to `false` and on unmount, so a stale red dot can't outlive its cause. **Zero extra PR-bridge fetches.**
- `useStageChecksBadge(projectRoot)` — listener hook, root-filtered, resets on root change.
- Badge sites: the rail's **Changes tab** (small warning dot opposite the count badge, label → *"Changes — PR checks failing"*) and the **collapsed reopen strip** (*"Show code rail — PR checks failing"*).
- Design §6 guardrail **pinned by test**: `resolveCodeRail`'s reveal inputs stay checks-free — this is a peripheral cue, not a reveal signal; no new tab.

## Verification
Wiring-pin suite `workspace-rail-checks-badge.test.ts` (broadcast + unmount-clear, root filtering, both badge sites, a11y labels, reveal guardrail), registered in `run-tests.mjs`; `workspace-rail`/`workspace-rail-wiring` pins updated for the conditional labels. Full `pnpm test:app` green (**716 files**); `pnpm typecheck` clean.