### PR TITLE
fix(skills): unbreak Draft-with-AI — codex trust check + surfaced assist stderr (cave-rre1)

### DIFF
--- a/src/components/marketplace/skill-builder.tsx
+++ b/src/components/marketplace/skill-builder.tsx
@@ -141,12 +141,12 @@ export function SkillBuilder({ onSaved, onViewSkills, familiars = [] }: Props) {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ description: goal }),
       });
-      const json = (await res.json()) as {
+      const json = (await res.json().catch(() => null)) as {
         ok?: boolean;
         draft?: { name: string; description: string; tags: string[]; instructions: string };
         error?: string;
-      };
-      if (!json.ok || !json.draft) throw new Error(json.error ?? `draft http ${res.status}`);
+      } | null;
+      if (!json?.ok || !json.draft) throw new Error(json?.error ?? `draft http ${res.status}`);
       setName(json.draft.name);
       setDescription(json.draft.description);
       setTagsText(json.draft.tags.join(", "));

--- a/src/lib/server/assist-runner.test.ts
+++ b/src/lib/server/assist-runner.test.ts
@@ -12,7 +12,17 @@ try {
   // --sandbox read-only is pinned INSIDE the module — deliberately not a
   // parameter — so no caller can quietly widen an assist's privileges: assist
   // prompts embed user-pasted and remote-fetched content (cave-c40b).
-  assert.deepEqual(inv.args, ["exec", "--sandbox", "read-only", "--output-last-message", "/tmp/last.txt", "-"]);
+  // --skip-git-repo-check: assists run in a neutral temp dir, which newer
+  // codex refuses as untrusted without the flag; safe under read-only.
+  assert.deepEqual(inv.args, [
+    "exec",
+    "--sandbox",
+    "read-only",
+    "--skip-git-repo-check",
+    "--output-last-message",
+    "/tmp/last.txt",
+    "-",
+  ]);
   assert.equal(inv.stdinPrompt, "PROMPT BODY");
 
   process.env.COVEN_CODEX_BIN = "/opt/custom/codex";

--- a/src/lib/server/assist-runner.ts
+++ b/src/lib/server/assist-runner.ts
@@ -36,7 +36,19 @@ export function buildAssistInvocation(prompt: string, lastMessagePath: string): 
   const command = process.env.COVEN_CODEX_BIN?.trim() || "codex";
   return {
     command,
-    args: ["exec", "--sandbox", "read-only", "--output-last-message", lastMessagePath, "-"],
+    // --skip-git-repo-check: assists deliberately run in a neutral temp dir
+    // (never the repo), which newer codex refuses as "not inside a trusted
+    // directory" without the flag. Safe here because the sandbox is pinned
+    // read-only — the trust check guards writable runs, and this can't write.
+    args: [
+      "exec",
+      "--sandbox",
+      "read-only",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      lastMessagePath,
+      "-",
+    ],
     stdinPrompt: prompt,
   };
 }
@@ -63,6 +75,7 @@ export async function runBoundedAssist(opts: {
   const lastMessagePath = path.join(dir, "last-message.txt");
   try {
     const inv = buildAssistInvocation(opts.prompt, lastMessagePath);
+    let stderrTail = "";
     const spawned = await new Promise<{ code: number | null; error?: string }>((resolve) => {
       let settled = false;
       const settle = (value: { code: number | null; error?: string }) => {
@@ -77,8 +90,13 @@ export async function runBoundedAssist(opts: {
       // attacker-influenceable content; scoped secrets never reach them).
       const child = spawn(inv.command, inv.args, {
         cwd: dir,
-        stdio: ["pipe", "ignore", "ignore"],
+        stdio: ["pipe", "ignore", "pipe"],
         env: harnessSpawnEnv(),
+      });
+      // Keep a bounded stderr tail so a non-zero exit carries its reason
+      // (e.g. codex trust/auth refusals) instead of an opaque exit code.
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderrTail = (stderrTail + chunk.toString("utf8")).slice(-2000);
       });
       const timer = setTimeout(() => {
         child.kill("SIGKILL");
@@ -104,7 +122,13 @@ export async function runBoundedAssist(opts: {
       child.stdin.end();
     });
     if (spawned.error) return { ok: false, error: spawned.error };
-    if (spawned.code !== 0) return { ok: false, error: `codex exec exited with ${spawned.code}` };
+    if (spawned.code !== 0) {
+      const reason = stderrTail.trim().split(/\r?\n/).filter(Boolean).slice(-3).join(" · ").slice(-300);
+      return {
+        ok: false,
+        error: `codex exec exited with ${spawned.code}${reason ? ` — ${reason}` : ""}`,
+      };
+    }
     let lastMessage: string;
     try {
       lastMessage = await readFile(lastMessagePath, "utf8");

--- a/src/lib/server/stitch-sew.test.ts
+++ b/src/lib/server/stitch-sew.test.ts
@@ -34,7 +34,15 @@ try {
   assert.equal(inv.command, "codex");
   // --sandbox read-only pins the run's privileges: the prompt embeds
   // attacker-influenceable remote content, and a distillation needs no tools.
-  assert.deepEqual(inv.args, ["exec", "--sandbox", "read-only", "--output-last-message", "/tmp/last.txt", "-"]);
+  assert.deepEqual(inv.args, [
+    "exec",
+    "--sandbox",
+    "read-only",
+    "--skip-git-repo-check",
+    "--output-last-message",
+    "/tmp/last.txt",
+    "-",
+  ]);
   assert.match(inv.stdinPrompt, /TITLE: <entry title/);
   assert.match(inv.stdinPrompt, /Use 5 retries\./);
 


### PR DESCRIPTION
## What broke

The Build tab's **Draft with AI** button (POST `/api/skills/draft`) — and every other shared assist-runner caller (stitch sew, skill dry-run) — failed with an opaque 502:

```
{"ok":false,"error":"codex exec exited with 1"}
```

## Why

1. **codex trust check**: newer codex CLI refuses to run in the assist runner's deliberately neutral temp-dir cwd (`Not inside a trusted directory and --skip-git-repo-check was not specified`).
2. **Discarded stderr**: the runner spawned with `stdio: [pipe, ignore, ignore]`, so the refusal reason never reached the error message — making this (and any future codex failure) undiagnosable from the button.

## Fix

- Pin `--skip-git-repo-check` inside `buildAssistInvocation` — safe because the sandbox is pinned read-only in the same module; the trust check exists to guard writable runs, and assists can't write.
- Keep a bounded (2 KB) stderr tail and fold the last lines into non-zero-exit errors, so failures self-diagnose in the UI.
- Harden the button's fetch against non-JSON error bodies (`res.json().catch(() => null)`) so proxy/timeout HTML surfaces as `draft http NNN` rather than a parse exception.
- Update the two invocation-pinning tests (assist-runner, stitch-sew).

## Verification

- 9/9 targeted tests pass on this branch; `pnpm typecheck` clean.
- `runBoundedAssist` exercised end-to-end against a real codex 0.144.4: `{"ok":true,"lastMessage":"READY"}`.
- Live `POST /api/skills/draft` returns HTTP 200 with a well-formed draft (name/description/tags/instructions) that fills the Build form.

Bead: cave-rre1 (also records the dev-machine env cleanup: three orphaned stale codex installs shadowing 0.144.4 on the spawn PATH were purged — the stderr surfacing above is what made those visible).