### PR TITLE
fix(research): reconcile detects finished and dead sessions — no more missions stuck running (cave-ibb7)

### DIFF
--- a/src/app/api/flows/session-transcript/route.test.ts
+++ b/src/app/api/flows/session-transcript/route.test.ts
@@ -3,6 +3,13 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+// The three-source transcript chain moved to the shared resolver so the
+// research-mission reconcile can read the same transcripts server-side
+// (cave-ibb7); the route is now a thin wrapper over it.
+const resolver = await readFile(
+  new URL("../../../../lib/server/flow-session-transcript.ts", import.meta.url),
+  "utf8",
+);
 
 assert.match(route, /export async function GET\(req: Request\)/, "route should expose a GET handler");
 assert.match(
@@ -10,23 +17,30 @@ assert.match(
   /isSafeConversationSessionId\(sessionId\)[\s\S]*status: 400/,
   "route should reject unsafe session ids",
 );
+assert.match(route, /flowSessionTranscript\(sessionId\)/, "route should delegate to the shared transcript resolver");
 assert.match(
   route,
-  /loadConversation\(sessionId\)[\s\S]*assistantTranscript\(conversation\)[\s\S]*found: true/,
-  "route should read persisted Cave conversations",
-);
-assert.match(
-  route,
-  /loadConversationFromJsonl\(sessionId, familiarId\)[\s\S]*assistantTranscript\(jsonlConversation\)[\s\S]*found: true/,
-  "route should fall back to OpenClaw JSONL transcripts",
-);
-assert.match(route, /callDaemon<\{ events: CovenEvent\[\] \}>/, "route should read daemon events for live flow sessions");
-assert.match(route, /eventOutputTranscript/, "route should convert daemon output events into a pollable transcript");
-assert.match(route, /stripAnsi/, "daemon PTY output should be ANSI-stripped before progress parsing");
-assert.match(
-  route,
-  /NextResponse\.json\(\{ ok: true, transcript: "", found: false \}\)/,
+  /NextResponse\.json\(\{ ok: true, transcript, found: Boolean\(transcript\.trim\(\)\) \}\)/,
   "missing flow transcripts should return an empty successful payload instead of HTTP 404",
+);
+
+assert.match(
+  resolver,
+  /loadConversation\(sessionId\)[\s\S]*assistantTranscript\(conversation\)/,
+  "resolver should read persisted Cave conversations first",
+);
+assert.match(
+  resolver,
+  /loadConversationFromJsonl\(sessionId, familiarId\)[\s\S]*assistantTranscript\(jsonlConversation\)/,
+  "resolver should fall back to OpenClaw JSONL transcripts",
+);
+assert.match(resolver, /callDaemon<\{ events: CovenEvent\[\] \}>/, "resolver should read daemon events for live flow sessions");
+assert.match(resolver, /eventOutputTranscript/, "resolver should convert daemon output events into a pollable transcript");
+assert.match(resolver, /stripAnsi/, "daemon PTY output should be ANSI-stripped before progress parsing");
+assert.match(
+  resolver,
+  /sessionOwned\?\.\[sessionId\]|sessionFamiliar\?\.\[sessionId\]/,
+  "daemon events stay gated on Cave session ownership",
 );
 // (use-flow-run client pins left with the retired flow components — cave-c3yt.)
 

--- a/src/app/api/flows/session-transcript/route.ts
+++ b/src/app/api/flows/session-transcript/route.ts
@@ -1,52 +1,15 @@
 import { NextResponse } from "next/server";
-import { isSafeConversationSessionId, loadConversation } from "../../../../lib/cave-conversations.ts";
-import { loadState } from "../../../../lib/cave-config.ts";
-import { callDaemon } from "../../../../lib/coven-daemon.ts";
-import { loadConversationFromJsonl } from "../../../../lib/openclaw-conversation.ts";
-import { stripAnsi } from "../../../../lib/ansi.ts";
+import { isSafeConversationSessionId } from "../../../../lib/cave-conversations.ts";
+import { flowSessionTranscript } from "../../../../lib/server/flow-session-transcript.ts";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-type CovenEvent = {
-  kind: string;
-  payload_json: string;
-};
-
-function assistantTranscript(conversation: { turns?: Array<{ role?: string; text?: string }> } | null): string {
-  return (conversation?.turns ?? [])
-    .filter((turn) => turn.role === "assistant")
-    .map((turn) => turn.text ?? "")
-    .join("\n");
-}
-
-function eventOutputTranscript(events: CovenEvent[]): string {
-  const parts: string[] = [];
-  for (const event of events) {
-    if (event.kind !== "output") continue;
-    try {
-      const payload = JSON.parse(event.payload_json) as { data?: unknown };
-      if (typeof payload.data === "string") parts.push(stripAnsi(payload.data));
-    } catch {
-      // Ignore malformed daemon payloads; the next poll can still catch up.
-    }
-  }
-  return parts.join("");
-}
-
-async function daemonEventTranscript(sessionId: string): Promise<string> {
-  const res = await callDaemon<{ events: CovenEvent[] }>({
-    path: `/api/v1/events?sessionId=${encodeURIComponent(sessionId)}&afterSeq=0&limit=500`,
-    timeoutMs: 4000,
-  });
-  if (!res.ok || !res.data?.events) return "";
-  return eventOutputTranscript(res.data.events);
-}
-
 /**
  * Flow execution polling endpoint. A live flow run can have a daemon session id
  * before Cave has a persisted conversation or OpenClaw JSONL transcript for it,
- * so the final fallback reads the daemon's PTY event stream directly.
+ * so the shared resolver falls back to the daemon's PTY event stream (the same
+ * chain the research-mission reconcile reads server-side — cave-ibb7).
  * Return an empty 200 in that normal gap so browser polling does not emit 404
  * resource errors while the session is still coming up.
  */
@@ -56,32 +19,6 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: false, error: "invalid session id" }, { status: 400 });
   }
 
-  const conversation = await loadConversation(sessionId);
-  const conversationTranscript = assistantTranscript(conversation);
-  if (conversationTranscript.trim()) {
-    return NextResponse.json({ ok: true, transcript: conversationTranscript, found: true });
-  }
-
-  const state = await loadState();
-  const familiarId = state.sessionFamiliar[sessionId];
-  if (familiarId) {
-    const jsonlConversation = await loadConversationFromJsonl(sessionId, familiarId);
-    const jsonlTranscript = assistantTranscript(jsonlConversation);
-    if (jsonlTranscript.trim()) {
-      return NextResponse.json({ ok: true, transcript: jsonlTranscript, found: true });
-    }
-  }
-
-  const owned =
-    Boolean(state.sessionOwned?.[sessionId]) ||
-    Boolean(state.sessionFamiliar?.[sessionId]) ||
-    Boolean(state.sessionTitles?.[sessionId]);
-  if (owned) {
-    const eventTranscript = await daemonEventTranscript(sessionId);
-    if (eventTranscript.trim()) {
-      return NextResponse.json({ ok: true, transcript: eventTranscript, found: true });
-    }
-  }
-
-  return NextResponse.json({ ok: true, transcript: "", found: false });
+  const transcript = await flowSessionTranscript(sessionId);
+  return NextResponse.json({ ok: true, transcript, found: Boolean(transcript.trim()) });
 }

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -115,10 +115,14 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
   timeout.unref?.();
 
   const done = new Promise<void>((resolve) => {
-    child.on("error", (err) => {
-      stderrTail = `${stderrTail}\n${err.message}`.slice(-2_000);
-    });
-    child.on("close", (code) => {
+    // "close" is the normal finalizer; a failed spawn emits "error" and, on
+    // some platforms, never "close" — finalize from whichever fires first so
+    // ACTIVE_RUNS can't leak a phantom "running" session and `done` always
+    // resolves.
+    let finalized = false;
+    const finalize = (code: number | null) => {
+      if (finalized) return;
+      finalized = true;
       clearTimeout(timeout);
       ACTIVE_RUNS.delete(sessionId);
       assistantText = [...deltaByMessage.values()].join("\n").trim();
@@ -160,7 +164,14 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
         }
         resolve();
       })();
+    };
+    child.on("error", (err) => {
+      stderrTail = `${stderrTail}\n${err.message}`.slice(-2_000);
+      // Give a same-tick "close" the chance to carry the real exit code;
+      // finalize from here only if it never arrives.
+      setImmediate(() => finalize(null));
     });
+    child.on("close", (code) => finalize(code));
   });
 
   return { sessionId, done };

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -43,6 +43,16 @@ export type CopilotFlowStart = {
   done: Promise<void>;
 };
 
+// Live Cave-direct runs, keyed by session id. These sessions never exist on
+// the daemon, so this in-process registry is the only "still running" signal
+// the research-mission reconcile can consult (cave-ibb7). A server restart
+// clears it — correctly: non-detached children die with the server.
+const ACTIVE_RUNS = new Set<string>();
+
+export function isCopilotFlowRunActive(sessionId: string): boolean {
+  return ACTIVE_RUNS.has(sessionId);
+}
+
 /**
  * Launch one non-interactive copilot run for a compiled flow prompt.
  * Returns as soon as the process starts; the transcript (user prompt +
@@ -72,6 +82,7 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     env: harnessSpawnEnv(launch.familiarId),
     stdio: ["ignore", "pipe", "pipe"],
   });
+  ACTIVE_RUNS.add(sessionId);
 
   const startedAt = new Date().toISOString();
   let assistantText = "";
@@ -109,6 +120,7 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     });
     child.on("close", (code) => {
       clearTimeout(timeout);
+      ACTIVE_RUNS.delete(sessionId);
       assistantText = [...deltaByMessage.values()].join("\n").trim();
       // Any non-zero (or missing) exit code is an error — even with partial
       // output, the run didn't finish cleanly and the diagnostics must not

--- a/src/lib/server/flow-session-transcript.ts
+++ b/src/lib/server/flow-session-transcript.ts
@@ -1,0 +1,80 @@
+// Shared flow-session transcript resolution (cave-ibb7). A flow session's
+// output can live in three places, in order of preference: the persisted Cave
+// conversation, the OpenClaw JSONL transcript, or (before either exists) the
+// daemon's PTY event stream. The flows/session-transcript route has always
+// walked this chain for the Executions view; the research-mission reconcile
+// now needs the same chain server-side to read control markers from sessions
+// whose flow-run record never flipped out of "running".
+
+import { loadConversation } from "../cave-conversations.ts";
+import { loadState } from "../cave-config.ts";
+import { callDaemon } from "../coven-daemon.ts";
+import { loadConversationFromJsonl } from "../openclaw-conversation.ts";
+import { stripAnsi } from "../ansi.ts";
+
+type CovenEvent = {
+  kind: string;
+  payload_json: string;
+};
+
+export function assistantTranscript(
+  conversation: { turns?: Array<{ role?: string; text?: string }> } | null,
+): string {
+  return (conversation?.turns ?? [])
+    .filter((turn) => turn.role === "assistant")
+    .map((turn) => turn.text ?? "")
+    .join("\n");
+}
+
+function eventOutputTranscript(events: CovenEvent[]): string {
+  const parts: string[] = [];
+  for (const event of events) {
+    if (event.kind !== "output") continue;
+    try {
+      const payload = JSON.parse(event.payload_json) as { data?: unknown };
+      if (typeof payload.data === "string") parts.push(stripAnsi(payload.data));
+    } catch {
+      // Ignore malformed daemon payloads; the next poll can still catch up.
+    }
+  }
+  return parts.join("");
+}
+
+async function daemonEventTranscript(sessionId: string): Promise<string> {
+  const res = await callDaemon<{ events: CovenEvent[] }>({
+    path: `/api/v1/events?sessionId=${encodeURIComponent(sessionId)}&afterSeq=0&limit=500`,
+    timeoutMs: 4000,
+  });
+  if (!res.ok || !res.data?.events) return "";
+  return eventOutputTranscript(res.data.events);
+}
+
+/**
+ * Best transcript available for a flow session right now; "" when nothing has
+ * surfaced yet. Daemon events are only consulted for sessions Cave owns, the
+ * same ownership gate the transcript route applies.
+ */
+export async function flowSessionTranscript(sessionId: string): Promise<string> {
+  const conversation = await loadConversation(sessionId);
+  const conversationText = assistantTranscript(conversation);
+  if (conversationText.trim()) return conversationText;
+
+  const state = await loadState();
+  const familiarId = state.sessionFamiliar[sessionId];
+  if (familiarId) {
+    const jsonlConversation = await loadConversationFromJsonl(sessionId, familiarId);
+    const jsonlTranscript = assistantTranscript(jsonlConversation);
+    if (jsonlTranscript.trim()) return jsonlTranscript;
+  }
+
+  const owned =
+    Boolean(state.sessionOwned?.[sessionId]) ||
+    Boolean(state.sessionFamiliar?.[sessionId]) ||
+    Boolean(state.sessionTitles?.[sessionId]);
+  if (owned) {
+    const eventTranscript = await daemonEventTranscript(sessionId);
+    if (eventTranscript.trim()) return eventTranscript;
+  }
+
+  return "";
+}

--- a/src/lib/server/research-mission-runner.test.ts
+++ b/src/lib/server/research-mission-runner.test.ts
@@ -8,6 +8,7 @@ import {
   makeResearchMissionRunner,
   parseResearchSourcesFile,
   sessionAlreadyGone,
+  withinStartupGrace,
   type ResearchMissionRunnerDeps,
 } from "./research-mission-runner.ts";
 
@@ -59,6 +60,8 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     }),
     loadFlowRun: async () => null,
     loadConversation: async () => null,
+    sessionState: async () => "unknown",
+    readSessionTranscript: async () => "",
     readMissionFile: async () => null,
     readSources: async () => [],
     publishKnowledge: async (entry) => entry,
@@ -922,4 +925,77 @@ test("cancel treats an already-gone session as stopped (cave-malz)", () => {
   assert.equal(sessionAlreadyGone({ ok: false, status: 502 }), false);
   // A successful kill was a genuinely running session, not a gone one.
   assert.equal(sessionAlreadyGone({ ok: true, status: 200 }), false);
+});
+
+// ── Dead/finished session detection during flow reconcile (cave-ibb7) ─────────
+// The flow-run record only says a run STARTED; nothing flips it when the
+// underlying agent session ends. Reconcile probes the session itself.
+
+test("a finished session reconciles from its transcript while the flow run still says running", async () => {
+  const published: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "running" }),
+    sessionState: async () => "finished",
+    readSessionTranscript: async () => [
+      "@@research-control",
+      '{"decision":"complete","reason":"Enough evidence","confidence":0.9}',
+      "@@research-artifacts-written",
+    ].join("\n"),
+    readMissionFile: async (_id, relativePath) =>
+      relativePath === "artifacts/primary.md" ? "# Evidence-backed answer\n" : null,
+    publishKnowledge: async (entry) => {
+      published.push(entry.body);
+      return entry;
+    },
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+  assert.equal(result.status, "completed");
+  assert.equal(result.iterations[0].status, "completed");
+  assert.equal(published.length, 1);
+});
+
+test("a dead session fails the mission with Retry enabled instead of hanging", async () => {
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "running" }),
+    sessionState: async () => "gone",
+    // Two minutes after start — safely past the startup grace window.
+    now: () => new Date(NOW.getTime() + 120_000),
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations[0].status, "failed");
+  assert.match(result.lastError ?? "", /Retry starts a fresh iteration/);
+  assert.ok(allowedResearchActions(result).includes("retry"), "failed missions offer Retry");
+});
+
+test("a gone-looking session within startup grace stays running (registration races)", async () => {
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "running" }),
+    sessionState: async () => "gone",
+    // deps.now() === iteration.startedAt — inside the grace window.
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+  assert.equal(result.status, "running");
+});
+
+test("an unknown session state (daemon unreachable) changes nothing", async () => {
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "running" }),
+    sessionState: async () => "unknown",
+    now: () => new Date(NOW.getTime() + 120_000),
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+  assert.equal(result.status, "running");
+});
+
+test("withinStartupGrace bounds the dead-session verdict", () => {
+  const now = new Date("2026-07-15T00:10:00Z");
+  assert.equal(withinStartupGrace("2026-07-15T00:09:30Z", now), true);  // 30s old
+  assert.equal(withinStartupGrace("2026-07-15T00:08:00Z", now), false); // 2m old
+  assert.equal(withinStartupGrace(undefined, now), false);
+  assert.equal(withinStartupGrace("not-a-date", now), false);
 });

--- a/src/lib/server/research-mission-runner.test.ts
+++ b/src/lib/server/research-mission-runner.test.ts
@@ -941,6 +941,22 @@ test("a finished session reconciles from its transcript while the flow run still
       '{"decision":"complete","reason":"Enough evidence","confidence":0.9}',
       "@@research-artifacts-written",
     ].join("\n"),
+    // The transcript override must not cost the mission its reported spend —
+    // costUsd still comes from the persisted conversation turns.
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: "narrative without markers",
+        costUsd: 1.25,
+        createdAt: NOW.toISOString(),
+      }],
+    }),
     readMissionFile: async (_id, relativePath) =>
       relativePath === "artifacts/primary.md" ? "# Evidence-backed answer\n" : null,
     publishKnowledge: async (entry) => {
@@ -952,6 +968,7 @@ test("a finished session reconciles from its transcript while the flow run still
   const result = await runner.reconcile(started);
   assert.equal(result.status, "completed");
   assert.equal(result.iterations[0].status, "completed");
+  assert.equal(result.iterations[0].costUsd, 1.25);
   assert.equal(published.length, 1);
 });
 
@@ -996,6 +1013,9 @@ test("withinStartupGrace bounds the dead-session verdict", () => {
   const now = new Date("2026-07-15T00:10:00Z");
   assert.equal(withinStartupGrace("2026-07-15T00:09:30Z", now), true);  // 30s old
   assert.equal(withinStartupGrace("2026-07-15T00:08:00Z", now), false); // 2m old
+  // Clock skew gets grace, but far-future bad data can't suppress detection.
+  assert.equal(withinStartupGrace("2026-07-15T00:10:30Z", now), true);  // 30s ahead
+  assert.equal(withinStartupGrace("2026-07-15T00:20:00Z", now), false); // 10m ahead
   assert.equal(withinStartupGrace(undefined, now), false);
   assert.equal(withinStartupGrace("not-a-date", now), false);
 });

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -224,7 +224,10 @@ export function withinStartupGrace(startedAt: string | undefined, now: Date): bo
   if (!startedAt) return false;
   const started = Date.parse(startedAt);
   if (Number.isNaN(started)) return false;
-  return now.getTime() - started < SESSION_STARTUP_GRACE_MS;
+  // Symmetric window: a slightly-future startedAt (clock skew) still gets
+  // grace, but a far-future one (bad data) can't suppress dead-session
+  // detection indefinitely.
+  return Math.abs(now.getTime() - started) < SESSION_STARTUP_GRACE_MS;
 }
 
 function conversationTranscript(conversation: ConversationFile | null): string {
@@ -343,7 +346,11 @@ async function reconcileCompletedRun(
   transcriptOverride?: string,
 ): Promise<ResearchMission> {
   const iteration = mission.iterations[iterationIndex];
-  const conversation = transcriptOverride === undefined && iteration.sessionId
+  // The conversation is loaded even when a transcript override is supplied:
+  // the override only replaces the transcript TEXT — reported cost still
+  // lives on the conversation turns and must keep feeding costUsd (and with
+  // it stopWhenCostUnavailable / maxSpendUsd policy).
+  const conversation = iteration.sessionId
     ? await deps.loadConversation(iteration.sessionId)
     : null;
   const control = parseResearchControl(transcriptOverride ?? conversationTranscript(conversation));

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -75,6 +75,19 @@ export type ResearchMissionRunnerDeps = {
   ): Promise<ResearchFlowStartResult>;
   loadFlowRun(id: string): Promise<FlowRunRecord | null>;
   loadConversation(sessionId: string): Promise<ConversationFile | null>;
+  /**
+   * Liveness of the agent session carrying the current iteration:
+   * - "running": still working — leave the mission running.
+   * - "finished": exited cleanly — reconcile from its transcript now (the
+   *   flow-run record alone never flips, so without this probe a finished
+   *   iteration reads "running" forever — cave-ibb7).
+   * - "gone": died, was killed, or the daemon no longer knows it — the
+   *   mission fails with Retry enabled instead of hanging.
+   * - "unknown": can't tell (daemon unreachable) — change nothing.
+   */
+  sessionState(sessionId: string): Promise<"running" | "finished" | "gone" | "unknown">;
+  /** Best transcript available for a flow session (conversation → JSONL → daemon events). */
+  readSessionTranscript(sessionId: string): Promise<string>;
   readMissionFile(id: string, relativePath: string): Promise<string | null>;
   readSources(id: string): Promise<ResearchSourceRef[]>;
   publishKnowledge(entry: KnowledgeEntry): Promise<KnowledgeEntry>;
@@ -201,6 +214,17 @@ function applyStartResult(
       startedAt: result.run?.startedAt ?? timestamp,
     } : item),
   };
+}
+
+/** A just-started session may not be observable yet — don't declare a
+ *  running iteration dead within its first minute (registration races). */
+const SESSION_STARTUP_GRACE_MS = 60_000;
+
+export function withinStartupGrace(startedAt: string | undefined, now: Date): boolean {
+  if (!startedAt) return false;
+  const started = Date.parse(startedAt);
+  if (Number.isNaN(started)) return false;
+  return now.getTime() - started < SESSION_STARTUP_GRACE_MS;
 }
 
 function conversationTranscript(conversation: ConversationFile | null): string {
@@ -824,6 +848,36 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     const run = await deps.loadFlowRun(iteration.flowRunId);
     if (!run) return mission;
     if (run.status === "running" || run.status === "queued") {
+      // The flow-run record only says the run was STARTED — nothing flips it
+      // when the underlying agent session ends, so probe the session itself
+      // (cave-ibb7). A finished session reconciles from its transcript; a dead
+      // one fails the mission with Retry enabled instead of hanging forever.
+      if (run.status === "running" && iteration.sessionId) {
+        const state = await deps.sessionState(iteration.sessionId);
+        if (state === "finished") {
+          const transcript = await deps.readSessionTranscript(iteration.sessionId);
+          const reconciled = await reconcileCompletedRun(mission, iterationIndex, deps, transcript);
+          await deps.saveMission(reconciled);
+          return reconciled;
+        }
+        if (state === "gone" && !withinStartupGrace(iteration.startedAt, deps.now())) {
+          const timestamp = deps.now().toISOString();
+          const failed: ResearchMission = {
+            ...mission,
+            status: "failed",
+            updatedAt: timestamp,
+            lastError: "The research session ended without reporting — Retry starts a fresh iteration.",
+            iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
+              ...item,
+              status: "failed",
+              finishedAt: timestamp,
+              summary: "Session ended without control markers",
+            } : item),
+          };
+          await deps.saveMission(failed);
+          return failed;
+        }
+      }
       const activeStatus: "running" | "queued" = run.status === "queued" ? "queued" : "running";
       const synced: ResearchMission = {
         ...mission,
@@ -1015,6 +1069,40 @@ export function makeProductionResearchMissionRunner() {
       if (!response.ok && !sessionAlreadyGone(response)) {
         throw new Error(response.error ?? "Research session could not be cancelled");
       }
+    },
+    sessionState: async (sessionId) => {
+      // Cave-direct copilot runs never exist on the daemon — the in-process
+      // registry is their only live signal (flow-copilot-session, cave-lhc0).
+      const { isCopilotFlowRunActive } = await import("./flow-copilot-session.ts");
+      if (isCopilotFlowRunActive(sessionId)) return "running";
+      // A persisted conversation with assistant output means the run finished
+      // and its transcript is readable (direct runs write it at close).
+      const { loadConversation } = await import("../cave-conversations.ts");
+      const conversation = await loadConversation(sessionId);
+      if (conversation?.turns?.some((turn) => turn.role === "assistant" && turn.text?.trim())) {
+        return "finished";
+      }
+      const { callDaemon } = await import("../coven-daemon.ts");
+      const res = await callDaemon<Array<{ id: string; status?: string; exit_code?: number | null }>>({
+        path: "/api/v1/sessions",
+        timeoutMs: 4_000,
+      });
+      if (!res.ok || !Array.isArray(res.data)) return "unknown";
+      const session = res.data.find((item) => item.id === sessionId);
+      if (!session) return "gone";
+      const status = (session.status ?? "").toLowerCase();
+      if (status === "completed" && (session.exit_code ?? 0) === 0) return "finished";
+      if (
+        ["failed", "killed", "exited", "dead", "stopped", "cancelled"].includes(status) ||
+        (session.exit_code ?? 0) !== 0
+      ) {
+        return "gone";
+      }
+      return "running";
+    },
+    readSessionTranscript: async (sessionId) => {
+      const { flowSessionTranscript } = await import("./flow-session-transcript.ts");
+      return flowSessionTranscript(sessionId);
     },
     createAutomation: async (input) => {
       const { createCodexAutomation } = await import("../codex-automations.ts");


### PR DESCRIPTION
Completes the research-loop reliability arc (#3169 → #3177 → this; bead cave-ibb7).

## The bug

The flow-run record only records that a run **started** — nothing flips it when the underlying agent session ends. Two live-verified consequences:

- A mission whose session **finished cleanly** stayed `running` forever (observed tonight: daemon session `completed`, exit 0 — mission still `running`, markers never parsed).
- A mission whose session **died** hung with no Retry (the original incident) — its only allowed action was cancel.

## The fix

When the flow run reads `running`, reconcile now probes the session itself via a new `sessionState` dep:

| state | production signal | reconcile behavior |
|---|---|---|
| `running` | in-process Cave-direct registry (`isCopilotFlowRunActive`, new) or daemon list status | unchanged sync |
| `finished` | persisted conversation with assistant output, or daemon `completed` + exit 0 | `reconcileCompletedRun` over the real transcript — markers complete/checkpoint as normal |
| `gone` | daemon `failed`/`killed`/nonzero exit, or absent from the list | mission + iteration **fail** with an actionable `lastError`; **Retry enabled** |
| `unknown` | daemon unreachable | change nothing |

A 60s startup grace (`withinStartupGrace`, exported/tested) avoids racing session registration.

Transcripts come from a new shared resolver **`flow-session-transcript.ts`** (Cave conversation → OpenClaw JSONL → daemon PTY events, ownership-gated) — extracted from the `/api/flows/session-transcript` route, which is now a thin wrapper, so the desk view and the reconcile read the same chain.

## Verification

- Runner suite 35 + transcript-route pins + copilot-session: 39/39
- New tests: finished-session reconcile publishes from the transcript; dead session fails with Retry; grace window holds; unknown holds; grace bounds
- `pnpm typecheck` clean; `pnpm test:api` 174; `pnpm test:app` 716

Bead: cave-ibb7
