### PR TITLE
docs: VERIFY re-audit — chat↔GitHub integration shipped (cave-fpqx.5)

### DIFF
--- a/docs/chat-github-integration.md
+++ b/docs/chat-github-integration.md
@@ -1,6 +1,7 @@
 # Chat ↔ GitHub Integration — Design
 
-**Status:** Approved (brainstorm, 2026-07-14) · **Goal:** `chat-github-power-integration`
+**Status:** Shipped (all waves merged 2026-07-15; VERIFY re-audit below)
+· **Goal:** `chat-github-power-integration`
 · **Epic:** `cave-fpqx` · **PLAN bead:** `cave-fpqx.2`
 · **Evidence base:** [capability map](specs/2026-07-14-chat-github-capability-map.md) (DISCOVER, PR #3160)
 
@@ -203,15 +204,15 @@ incrementally; no app-code dependency on adoption.
 
 ## §9 Implementation beads (one-PR units, dep-chained under cave-fpqx)
 
-| Bead | Wave | Scope | Depends on |
+| Bead | Wave | Scope | Shipped |
 | --- | --- | --- | --- |
-| W1a | 1 | `github-blocks.ts` (markers + unfurl + tiers) · IssueCard/PRCard read-only · segment dispatch wiring · tests | — |
-| W1b | 1 | Checks rollup strip · ReviewThreadCard · CommitCard/RunCard · 30s pending poll · detail popovers | W1a |
-| W2a | 2 | Routes: `issue`, `commit`, `runs` (+contracts/tests) · T1 actions live on cards | W1a |
-| W2b | 2 | Routes: `review`, `merge`, `rerun`, `dispatch` · confirm-card lifecycle · agent proposal cards · e2e spec | W1b, W2a |
-| W3 | 3 | `stage-model.ts` extraction (queue refactored onto it) · `chat-stage-header` · wiring + tests | W1b |
-| W4 | 4 | `<coven:skill>` marker + SkillStageCard · `/skill` deterministic card · filter-ordering pin | W1a |
-| W5 | 5 | Rail failing-checks badge from stage-model | W3 |
+| W1a | 1 | `github-blocks.ts` (markers + unfurl + tiers) · IssueCard/PRCard read-only · segment dispatch wiring · tests | PR #3166 |
+| W1b | 1 | Checks rollup strip · ReviewThreadCard · 30s pending poll · in-place expansion | PR #3167 |
+| W2a | 2 | Routes: `issue`, `commit`, `runs` (+contracts/tests) · T1 actions live on cards | PR #3170 |
+| W2b | 2 | Routes: `review`, `merge`, `rerun`, `dispatch` · confirm-card lifecycle · agent proposal cards · e2e spec | PR #3183 |
+| W3 | 3 | `stage-model.ts` extraction (queue refactored onto it) · `chat-stage-header` · wiring + tests | PR #3173 + #3174 |
+| W4 | 4 | `<coven:skill>` marker + SkillStageCard · `/skill` deterministic card · filter-ordering pin | PR #3175 |
+| W5 | 5 | Rail failing-checks badge from the stage broadcast | PR #3178 |
 
 Each bead carries: this doc's section anchors, `external-ref` to its PR once
 open, and verification evidence at close (MAP phase `cave-fpqx.3` is the
@@ -221,12 +222,33 @@ the capability map after the waves land).
 ## Acceptance criteria (from the goal, restated testably)
 
 1. Pasting an issue/PR URL in chat renders a live card; comment/close from it
-   without leaving the conversation (W1a/W2a).
+   without leaving the conversation (W1a/W2a). ✅ (e2e: URL → hydrated card)
 2. Merge/review/re-run/dispatch reachable from cards behind tier-2 confirm;
-   agent-emitted actions always appear as proposal cards (W2b).
+   agent-emitted actions always appear as proposal cards (W2b). ✅ (e2e:
+   confirm strip fires the exact payload; proposals never auto-fire)
 3. A repo-linked session shows the stage header; its lanes match the familiar
-   work queue for the same bead/PR (W3).
+   work queue for the same bead/PR (W3). ✅ (one shared stage-model)
 4. `/skill` and agent-emitted `<coven:skill>` markers render stage cards
-   (W4).
+   (W4). ✅
 5. Every wave lands as a green-checks PR with wired tests; capability map
-   updated at VERIFY (`cave-fpqx.5`).
+   updated at VERIFY (`cave-fpqx.5`). ✅
+
+## VERIFY re-audit (2026-07-15, cave-fpqx.5)
+
+All five acceptance criteria hold on `main`; the DISCOVER capability map's
+seven-gap summary is fully closed (see the postscript in
+[the capability map](specs/2026-07-14-chat-github-capability-map.md)).
+Residual gaps, filed as follow-up beads rather than blocking the epic:
+
+- **Commit/Run card hydration** — `/api/github/commit` and `/runs` exist
+  (W2a) but the cards still render attrs-only; hydrate them the way PR/issue
+  cards do.
+- **Review-thread reply** — thread cards resolve/unresolve but can't reply in
+  place (needs the review-comment reply endpoint); agent `reply` proposals
+  fall back to conversation comments.
+- **Marker adoption directive** — nothing teaches agents to emit
+  `<coven:github>` / `<coven:skill>` markers yet; a prompt directive à la
+  `buildNextPathsDirective` would drive organic usage.
+- **Failing-tint consistency** — the stage header's ✕ and the card checks
+  strip use `--color-warning`; the W5 rail dot uses `--color-danger`; pick
+  one failing tint.

--- a/docs/specs/2026-07-14-chat-github-capability-map.md
+++ b/docs/specs/2026-07-14-chat-github-capability-map.md
@@ -165,3 +165,28 @@ Stage exists in silos, none rendered inside the chat thread:
 
 Required checks (live-verified 2026-07-14): Frontend build, Rust check,
 E2E (Playwright), Cross-environment required, Sidecar runtime required.
+
+---
+
+## Postscript: VERIFY re-audit (2026-07-15, cave-fpqx.5)
+
+Every gap in §7 closed across seven merged waves (all required checks green;
+design: [chat-github-integration.md](../chat-github-integration.md)):
+
+| §7 gap | Shipped by |
+| --- | --- |
+| 1. Inline GitHub cards in the transcript | W1a #3166 (markers + bare-line unfurl + Issue/PR cards) · W1b #3167 (checks strip, review threads, in-place expansion) |
+| 2. GitHub write actions | W2a #3170 (issue create/state, commit, runs + tier-1 card actions) · W2b #3183 (review/merge/rerun/dispatch, tier-2 confirm strip, agent proposal cards that never auto-fire, daemon-less e2e) |
+| 3. Rail GitHub-awareness | W5 #3178 (failing-checks badge on the rail strip + collapsed reopen, fed by the stage broadcast — reveal resolver untouched) |
+| 4. Skill-stage surfacing | W4 #3175 (`<coven:skill>` markers → SkillStageCard on streaming+settled turns; deterministic `/skill` invoked card; AssistantFilter passthrough pinned) |
+| 5. Unified stage chip | W3 #3173+#3174 (`stage-model.ts` shared by queue + new chat stage header: bead → PR → checks → review → merged) |
+
+Updated capability verdicts: §1 rail GitHub signals EXISTS (badge);
+§2 inline issue/PR/check/review cards EXISTS; §4 write side EXISTS
+(issue create/close, PR create remains out of scope by design, review
+submit, merge, re-run, dispatch); §5 in-thread skill stage EXISTS;
+§6 unified stage model + in-thread stage EXISTS.
+
+Residual follow-ups (non-blocking, filed as beads): commit/run card
+hydration, review-thread in-place reply, marker adoption prompt directive,
+failing-tint consistency.


### PR DESCRIPTION
**VERIFY** — the final phase of the **chat-github-power-integration** goal (epic `cave-fpqx`, bead `cave-fpqx.5`).

- Design doc → **Status: Shipped**, wave→PR table (W1a #3166 · W1b #3167 · W2a #3170 · W2b #3183 · W3 #3173+#3174 · W4 #3175 · W5 #3178), acceptance criteria checked with their e2e/test evidence.
- Capability map → VERIFY postscript closing all seven DISCOVER gaps with updated EXISTS verdicts.
- Four residual follow-ups recorded (commit/run hydration, thread reply, marker adoption directive, failing-tint consistency) — filed as beads, non-blocking.

Docs-only. Closes out the epic.