### PR TITLE
fix(ios): widen bare-host discovery to ports 3000-3010 (cave-y482)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -75,7 +75,11 @@ struct CaveConnection: Codable, Equatable {
             add("https://\(hostname):8443")   // Tailscale Serve's usual TLS port
             add("https://\(hostname)")        // bare 443
         } else {
-            for port in ["3000", "4500", "4555", "8443"] { add("http://\(hostname):\(port)") }
+            // The desktop falls back through 3000-3010 when ports are taken
+            // (scripts/dev-app.sh / server.ts PORT), so probe the whole range —
+            // discovery is concurrent, so the extra candidates cost no wall time.
+            for port in 3000...3010 { add("http://\(hostname):\(port)") }
+            for port in ["4500", "4555", "8443"] { add("http://\(hostname):\(port)") }
             add("https://\(hostname):8443")
         }
         return out

--- a/scripts/ios-port-discovery.test.mjs
+++ b/scripts/ios-port-discovery.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Bare-host port discovery (bead cave-y482 part 3): the desktop dev wrapper
+// walks ports 3000-3010 when earlier ones are taken (scripts/dev-app.sh), so
+// a phone that paired against :3000 must rediscover the desktop when it comes
+// back on :3001+. Discovery probes candidates concurrently, so the widened
+// range costs no wall-clock time — but every port in the wrapper's range must
+// actually be a candidate, in ascending order, without disturbing the legacy
+// alternates or the ordered .ok adjudication that relocation depends on.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const connection = await read("apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift");
+const devScript = await read("scripts/dev-app.sh");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+
+// --- CaveConnection: the full wrapper range is probed ------------------------
+assert.match(
+  connection,
+  /for port in 3000\.\.\.3010 \{ add\("http:\/\/\\\(hostname\):\\\(port\)"\) \}/,
+  "bare-host discovery must probe the whole 3000-3010 dev-wrapper port range",
+);
+assert.match(
+  connection,
+  /for port in \["4500", "4555", "8443"\] \{ add\("http:\/\/\\\(hostname\):\\\(port\)"\) \}/,
+  "legacy alternate ports stay probed after the 3000-3010 range",
+);
+assert.match(
+  connection,
+  /for port in 3000\.\.\.3010[\s\S]*?for port in \["4500", "4555", "8443"\]/,
+  "the 3000-3010 range must come first so lower dev ports win adjudication",
+);
+
+// --- The Swift range and the wrapper's range must not drift ------------------
+const seq = devScript.match(/seq (\d+) (\d+)/);
+assert.ok(seq, "dev-app.sh should scan a port range via seq");
+assert.equal(seq[1], "3000", "wrapper range start pinned to the Swift candidates");
+assert.equal(seq[2], "3010", "wrapper range end pinned to the Swift candidates");
+
+// --- Discovery semantics the widened range relies on -------------------------
+assert.match(
+  model,
+  /withTaskGroup[\s\S]*?group\.addTask \{ \(index, await Self\.probe\(base\)\) \}/,
+  "candidates must still be probed concurrently — 14 candidates, one probe's wall time",
+);
+assert.match(
+  model,
+  /for \(index, result\) in results\.enumerated\(\)[\s\S]*?case \.ok: return \.found\(candidates\[index\]\)/,
+  "adjudication stays in candidate order so the configured/lowest port wins",
+);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -964,6 +964,7 @@ export const SUITES = {
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connection-stability.test.mjs",
     "scripts/ios-reconnect-pill.test.mjs",
+    "scripts/ios-port-discovery.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",
     "scripts/ios-offline-compose.test.mjs",
     "scripts/ios-operator-profile.test.mjs",


### PR DESCRIPTION
Part 3 of 3 for **cave-y482** (Connection C0, umbrella cave-rku9 / docs/ios-connection-cloud-plan.md). Parts 1–2 landed in #2933 / #2935.

## Problem
`scripts/dev-app.sh` (and `server.ts` via `PORT`) fall back through **3000–3010** when ports are occupied, but `CaveConnection.candidateBaseURLs` only probed `:3000` for bare hosts — a desktop that relocated to 3001+ looked unreachable from the phone and forced manual host re-entry.

## Fix
- Probe the full `3000...3010` range first (ascending, so lower ports win the ordered adjudication), then the legacy `4500/4555/8443` alternates. Discovery probes concurrently (`withTaskGroup`), so the wall-clock cost is still one probe round.
- Existing relocation flow persists the working port + shows the 'Connected on port N' toast — unchanged.

## Verification
- New pin: `scripts/ios-port-discovery.test.mjs` — asserts the range, ordering, legacy alternates, concurrency + ordered adjudication, and pins `dev-app.sh`'s `seq 3000 3010` so the two ranges can't drift apart.
- `pnpm test:mobile`: **80/80 files pass** (new pin included; registered in run-tests.mjs + check-tests-wired green).
- `xcrun swiftc -parse` clean on the edited file (Swift compile is not in PR CI, matching parts 1–2 practice).