### PR TITLE
feat(crafts): unified progressive create flow — describe-first, preview-before-save (cave-gwfe)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13445,6 +13445,19 @@ details[open] > .cave-edit-card__summary::before {
   color: var(--text-muted);
   font-size: 12px;
 }
+/* Crafts grid lifecycle groups: local drafts above the published catalog. */
+.craft-grid-group { display: grid; gap: 10px; }
+.craft-grid-group + .craft-grid-group { margin-top: 20px; }
+.craft-grid-group__head { display: grid; gap: 2px; }
+.craft-grid-group__head h3 {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.craft-grid-group__head p { margin: 0; color: var(--text-muted); font-size: 11.5px; }
 .craft-dossier {
   display: flex;
   width: min(760px, 100vw);

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -329,6 +329,10 @@ export function MarketplaceViewSurface({
     () => sortPlugins(filterPlugins(plugins, { query, kind: "craft" }), sort),
     [plugins, query, sort],
   );
+  // Lifecycle grouping (docs/craft-ux.md F11): local drafts surface as their
+  // own strip above the published catalog instead of interleaving with it.
+  const draftCrafts = useMemo(() => craftPlugins.filter((plugin) => plugin.draft), [craftPlugins]);
+  const publishedCrafts = useMemo(() => craftPlugins.filter((plugin) => !plugin.draft), [craftPlugins]);
 
   const selectedPlugin = useMemo(() => plugins.find((p) => p.id === selected) ?? null, [plugins, selected]);
   const configuringPlugin = useMemo(() => plugins.find((p) => p.id === configuringId) ?? null, [plugins, configuringId]);
@@ -818,19 +822,52 @@ export function MarketplaceViewSurface({
               subtitle={query ? "Try a different Craft name or capability." : "Audited Research Crafts will appear here when they are enabled."}
             />
           ) : (
-            <div className="marketplace-category-grid" aria-label="Available Crafts">
-              {craftPlugins.map((plugin) => (
-                <MarketplaceCard
-                  key={plugin.id}
-                  plugin={plugin}
-                  busy={busyIds.has(plugin.id)}
-                  onOpen={setSelected}
-                  onAdd={add}
-                  onRemove={remove}
-                  onConfigure={setConfiguringId}
-                />
-              ))}
-            </div>
+            <>
+              {draftCrafts.length > 0 ? (
+                <section className="craft-grid-group" aria-labelledby="craft-drafts-heading">
+                  <div className="craft-grid-group__head">
+                    <h3 id="craft-drafts-heading">Your drafts</h3>
+                    <p>Local and reversible — review, refine, and publish when ready.</p>
+                  </div>
+                  <div className="marketplace-category-grid" aria-label="Draft Crafts">
+                    {draftCrafts.map((plugin) => (
+                      <MarketplaceCard
+                        key={plugin.id}
+                        plugin={plugin}
+                        busy={busyIds.has(plugin.id)}
+                        onOpen={setSelected}
+                        onAdd={add}
+                        onRemove={remove}
+                        onConfigure={setConfiguringId}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+              {publishedCrafts.length > 0 ? (
+                <section className="craft-grid-group" aria-labelledby="craft-published-heading">
+                  {draftCrafts.length > 0 ? (
+                    <div className="craft-grid-group__head">
+                      <h3 id="craft-published-heading">Published</h3>
+                      <p>Versioned Crafts from the audited catalog, installable and equippable.</p>
+                    </div>
+                  ) : null}
+                  <div className="marketplace-category-grid" aria-label="Available Crafts">
+                    {publishedCrafts.map((plugin) => (
+                      <MarketplaceCard
+                        key={plugin.id}
+                        plugin={plugin}
+                        busy={busyIds.has(plugin.id)}
+                        onOpen={setSelected}
+                        onAdd={add}
+                        onRemove={remove}
+                        onConfigure={setConfiguringId}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+            </>
           )}
         </div>
       ) : section === "skills" ? (

--- a/src/components/marketplace/craft-create-drawer.tsx
+++ b/src/components/marketplace/craft-create-drawer.tsx
@@ -8,6 +8,11 @@ import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { buildCraftAgentPrompt } from "@/lib/craft-agent-prompt";
+import { buildCraftDraftFromRoles } from "@/lib/craft-draft";
+import {
+  CraftDraftPreview,
+  extractionLedgerGroups,
+} from "@/components/marketplace/craft-draft-preview";
 import type { RoleEntry } from "@/app/api/roles/route";
 
 type RolesResponse = {
@@ -22,14 +27,31 @@ type DraftResponse = {
   error?: string;
 };
 
-/** Two ways in: hand-pick roles, or describe the Craft and let a familiar
- *  build it agentically through the drafts API. */
+/** Two ways in: describe the Craft and let a familiar build it agentically
+ *  through the drafts API, or hand-pick roles. Describe leads for first-time
+ *  users; the last-used mode is remembered so power users land back on
+ *  Pick roles (docs/craft-ux.md, CP2). */
 type CreateMode = "extract" | "describe";
 
 const CREATE_MODES: ReadonlyArray<TabItem<CreateMode>> = [
-  { id: "extract", label: "Pick roles", icon: "ph:stack" },
   { id: "describe", label: "Describe it", icon: "ph:sparkle" },
+  { id: "extract", label: "Pick roles", icon: "ph:stack" },
 ];
+
+const MODE_MEMORY_KEY = "cave:craft-create:mode";
+
+function initialCreateMode(): CreateMode {
+  if (typeof window === "undefined") return "describe";
+  try {
+    return window.localStorage.getItem(MODE_MEMORY_KEY) === "extract" ? "extract" : "describe";
+  } catch {
+    return "describe";
+  }
+}
+
+/** Pick-roles is a two-step flow: select roles, then preview the real
+ *  extraction ledger before anything is written. */
+type ExtractStep = "select" | "preview";
 
 type Props = {
   open: boolean;
@@ -39,7 +61,8 @@ type Props = {
 
 export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const [mode, setMode] = useState<CreateMode>("extract");
+  const [mode, setMode] = useState<CreateMode>(initialCreateMode);
+  const [step, setStep] = useState<ExtractStep>("select");
   const [roles, setRoles] = useState<RoleEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,8 +80,21 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
   useFocusTrap(open, ref, { onEscape: onClose });
 
   useEffect(() => {
-    if (!open) setAwaiting(false);
+    if (!open) {
+      setAwaiting(false);
+      setStep("select");
+    }
   }, [open]);
+
+  const chooseMode = useCallback((next: CreateMode) => {
+    setMode(next);
+    setStep("select");
+    try {
+      window.localStorage.setItem(MODE_MEMORY_KEY, next);
+    } catch {
+      // Mode memory is a convenience; private mode may refuse it.
+    }
+  }, []);
 
   const checkForArrivedDraft = useCallback(async () => {
     try {
@@ -157,6 +193,18 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
     });
   }, []);
 
+  // Preview-before-save (docs/craft-ux.md F3): the extraction builder is pure
+  // and client-importable, so the real ledger renders before anything is
+  // written. Save still POSTs; the server rebuild stays authoritative.
+  const previewDraft = useMemo(() => {
+    if (!familiar || selectedRoles.length === 0) return null;
+    try {
+      return buildCraftDraftFromRoles({ familiar, roles: selectedRoles });
+    } catch {
+      return null;
+    }
+  }, [familiar, selectedRoles]);
+
   const save = useCallback(async () => {
     if (!familiar || selectedRoleIds.size === 0) return;
     setSaving(true);
@@ -224,7 +272,9 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
             <h2 className="craft-create-drawer__title">Create Craft</h2>
             <p className="craft-create-drawer__subtitle">
               {mode === "extract"
-                ? "Extract a reusable bundle from a familiar's roles."
+                ? step === "preview"
+                  ? "Review the extracted bundle before saving the draft."
+                  : "Extract a reusable bundle from a familiar's roles."
                 : "Describe the Craft — a familiar builds and verifies the draft for you."}
             </p>
           </div>
@@ -236,7 +286,7 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
         <Tabs
           items={CREATE_MODES}
           value={mode}
-          onChange={setMode}
+          onChange={chooseMode}
           ariaLabel="How to create this Craft"
           variant="segment"
           size="sm"
@@ -301,6 +351,28 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
               </div>
             ) : null}
           </>
+        ) : step === "preview" ? (
+          <>
+            <section className="craft-create-drawer__roles" aria-label="Draft preview">
+              <h3>Draft preview</h3>
+              {previewDraft ? (
+                <>
+                  <p className="craft-create-drawer__status">
+                    <strong>{previewDraft.plugin.displayName}</strong>
+                    {" · "}
+                    {selectedRoles.length} {selectedRoles.length === 1 ? "role" : "roles"} from {familiar}.
+                    Review the extracted bundle, then save.
+                  </p>
+                  <CraftDraftPreview
+                    groups={extractionLedgerGroups(previewDraft.extraction.ledger)}
+                    ariaLabel="Extraction preview"
+                  />
+                </>
+              ) : (
+                <p className="craft-create-drawer__status">Select at least one role to preview the draft.</p>
+              )}
+            </section>
+          </>
         ) : (
           <>
             <label className="craft-create-drawer__field">
@@ -339,8 +411,8 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
               )}
             </section>
 
-            <section className="craft-draft-ledger" aria-label="Extraction preview">
-              <h3>Extraction preview</h3>
+            <section className="craft-draft-ledger" aria-label="Selection summary">
+              <h3>Selection summary</h3>
               <div className="craft-draft-ledger__stats">
                 <span><strong>{counts.components}</strong> components</span>
                 <span><strong>{counts.skills}</strong> skills</span>
@@ -363,16 +435,31 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
             >
               {awaiting ? "Drafting…" : "Draft with familiar"}
             </Button>
+          ) : step === "preview" ? (
+            <>
+              <Button variant="secondary" size="sm" leadingIcon="ph:arrow-left" onClick={() => setStep("select")}>
+                Adjust roles
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                leadingIcon="ph:package-bold"
+                loading={saving}
+                disabled={!previewDraft}
+                onClick={save}
+              >
+                Save draft
+              </Button>
+            </>
           ) : (
             <Button
               variant="primary"
               size="sm"
-              leadingIcon="ph:package-bold"
-              loading={saving}
+              leadingIcon="ph:magnifying-glass-bold"
               disabled={!familiar || selectedRoleIds.size === 0}
-              onClick={save}
+              onClick={() => setStep("preview")}
             >
-              Save draft
+              Preview draft
             </Button>
           )}
         </div>

--- a/src/components/marketplace/craft-draft-preview.tsx
+++ b/src/components/marketplace/craft-draft-preview.tsx
@@ -1,0 +1,63 @@
+import type { CraftDraft } from "@/lib/craft-draft";
+import type { CraftSpecification } from "@/lib/marketplace-catalog";
+
+/** One shared shape for everywhere a draft Craft's contents render: the
+ *  create drawer's preview-before-save step and the draft detail dialog
+ *  (docs/craft-ux.md, CP2). Groups mirror the extraction ledger categories. */
+export type CraftDraftPreviewGroup = {
+  id: string;
+  title: string;
+  items: string[];
+};
+
+/** Groups from a client- or server-built draft's extraction ledger. */
+export function extractionLedgerGroups(
+  ledger: CraftDraft["extraction"]["ledger"],
+): CraftDraftPreviewGroup[] {
+  return [
+    { id: "components", title: "Required components", items: ledger.components.map((entry) => entry.id) },
+    { id: "capabilities", title: "Capabilities", items: ledger.capabilities.map((entry) => entry.id) },
+    { id: "skills", title: "Skills", items: ledger.skills.map((entry) => entry.id) },
+    { id: "prompts", title: "Prompts", items: ledger.prompts.map((entry) => entry.id) },
+    { id: "workflows", title: "Workflows", items: ledger.workflows.map((entry) => entry.id) },
+  ];
+}
+
+/** Groups from a stored draft plugin's craft specification (the marketplace
+ *  card model carries the spec, not the extraction ledger). */
+export function craftSpecGroups(craft: CraftSpecification | undefined): CraftDraftPreviewGroup[] {
+  return [
+    { id: "components", title: "Required components", items: craft?.components.required ?? [] },
+    { id: "capabilities", title: "Capabilities", items: craft?.requiredCapabilities ?? [] },
+    { id: "skills", title: "Skills", items: (craft?.bundled.skills ?? []).map((item) => item.id) },
+    { id: "prompts", title: "Prompts", items: (craft?.bundled.prompts ?? []).map((item) => item.id) },
+    { id: "workflows", title: "Workflows", items: (craft?.bundled.workflows ?? []).map((item) => item.id) },
+  ];
+}
+
+export function CraftDraftPreview({
+  groups,
+  ariaLabel = "Draft extraction ledger",
+}: {
+  groups: CraftDraftPreviewGroup[];
+  ariaLabel?: string;
+}) {
+  return (
+    <div className="craft-draft-ledger" aria-label={ariaLabel}>
+      {groups.map((group) => (
+        <section key={group.id}>
+          <h3>{group.title}</h3>
+          {group.items.length ? (
+            <div className="flex flex-wrap gap-1.5">
+              {group.items.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
+          ) : (
+            <p>No entries</p>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/marketplace/crafts-marketplace.test.ts
+++ b/src/components/marketplace/crafts-marketplace.test.ts
@@ -50,6 +50,26 @@ assert.match(createDrawer, /initialPrompt: buildCraftAgentPrompt\(\{ description
 assert.match(createDrawer, /Draft with familiar/, "describe mode has an explicit agentic CTA");
 assert.match(createDrawer, /What happens next/, "describe mode explains the agentic loop");
 
+// ── One-flow authoring (docs/craft-ux.md CP2) ────────────────────────────────
+// Describe-first with last-used memory; pick-roles previews the REAL
+// extraction ledger (client-side pure synthesis) before anything is written;
+// one shared preview component renders draft contents in the drawer and the
+// detail; the Crafts grid separates local drafts from the published catalog.
+assert.match(createDrawer, /\{ id: "describe"[\s\S]*?\{ id: "extract"/, "describe leads the creation-mode tabs");
+assert.match(createDrawer, /MODE_MEMORY_KEY = "cave:craft-create:mode"/, "the last-used creation mode is remembered");
+assert.match(createDrawer, /buildCraftDraftFromRoles\(\{ familiar, roles: selectedRoles \}\)/, "pick-roles synthesizes the real draft client-side for preview");
+assert.match(createDrawer, /Preview draft/, "role selection advances to a preview step before saving");
+assert.match(createDrawer, /Adjust roles/, "the preview step returns to selection without losing state");
+assert.match(createDrawer, /extractionLedgerGroups\(previewDraft\.extraction\.ledger\)/, "the preview renders the extraction ledger, not just counts");
+{
+  const draftPreview = await readFile(new URL("./craft-draft-preview.tsx", import.meta.url), "utf8");
+  assert.match(draftPreview, /export function CraftDraftPreview/, "draft contents render through one shared component");
+  assert.match(draftPreview, /craft-draft-ledger/, "the shared preview keeps the stable ledger styling hook");
+}
+assert.match(detail, /<CraftDraftPreview groups=\{craftSpecGroups\(craft\)\}/, "draft detail renders the same shared preview");
+assert.match(view, /Your drafts/, "the Crafts grid groups local drafts above the published catalog");
+assert.match(css, /\.craft-grid-group \{/, "Craft lifecycle groups have a stable visual hook");
+
 // ── Describe-it closes its loop (cave-46wg) ──────────────────────────────────
 // The dispatched brief is no longer fire-and-forget: the drawer snapshots the
 // drafts store, polls while waiting, and hands an ARRIVED draft to the same

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -17,6 +17,10 @@ import {
   type CraftDraftBriefInput,
 } from "@/lib/craft-agent-prompt";
 import { CraftDetail, type CraftActionError } from "@/components/marketplace/craft-detail";
+import {
+  CraftDraftPreview,
+  craftSpecGroups,
+} from "@/components/marketplace/craft-draft-preview";
 import { KnowledgePackDetail } from "@/components/marketplace/knowledge-pack-detail";
 
 type PackPrompt = PromptOption;
@@ -241,13 +245,7 @@ function DraftCraftDetail({
           </button>
         </div>
 
-        <div className="craft-draft-ledger" aria-label="Draft extraction ledger">
-          <DraftLedgerGroup title="Required components" items={craft?.components.required ?? []} />
-          <DraftLedgerGroup title="Capabilities" items={craft?.requiredCapabilities ?? []} />
-          <DraftLedgerGroup title="Skills" items={skills.map((item) => item.id)} />
-          <DraftLedgerGroup title="Prompts" items={prompts.map((item) => item.id)} />
-          <DraftLedgerGroup title="Workflows" items={workflows.map((item) => item.id)} />
-        </div>
+        <CraftDraftPreview groups={craftSpecGroups(craft)} ariaLabel="Draft extraction ledger" />
 
         <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-3 py-2 text-[12px] text-[var(--text-muted)]">
           Drafts are local and reversible. Review the extracted bundle before publishing or installing it as a versioned Craft.
@@ -301,22 +299,6 @@ function DraftCraftDetail({
   );
 }
 
-function DraftLedgerGroup({ title, items }: { title: string; items: string[] }) {
-  return (
-    <section>
-      <h3>{title}</h3>
-      {items.length ? (
-        <div className="flex flex-wrap gap-1.5">
-          {items.map((item) => (
-            <span key={item}>{item}</span>
-          ))}
-        </div>
-      ) : (
-        <p>No entries</p>
-      )}
-    </section>
-  );
-}
 
 function StandardMarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Checkpoint 2 of the craft-ux-simplification goal

Implements the basic-path slice of [docs/craft-ux.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/craft-ux.md) (merged in #3188).

### Changes
- **Describe-first drawer (F6).** The agentic "Describe it" mode leads the tabs and is the default; the last-used mode is remembered (`localStorage`, `cave:craft-create:mode`) so returning power users land on Pick roles.
- **Preview before save (F3).** Pick-roles becomes a two-step flow: select → preview. The preview renders the **real extraction ledger** (client-side synthesis via the pure `buildCraftDraftFromRoles`) plus the derived draft name; "Adjust roles" returns to selection with state intact. Save still POSTs — the server rebuild stays authoritative. The old counts strip stays on the select step as a live selection summary.
- **One shared preview component.** New `CraftDraftPreview` (+ `extractionLedgerGroups` / `craftSpecGroups`) renders draft contents identically in the drawer preview and `DraftCraftDetail`; the detail's private flat-chip ledger is deleted.
- **Crafts grid lifecycle grouping (F11).** Local drafts render as a "Your drafts" strip above the published catalog.

### Verification
- `pnpm test:app` — 716 files pass (pins updated in `crafts-marketplace.test.ts`)
- `pnpm typecheck` — clean
- No API or route changes; `tests/marketplace-crafts.spec.ts` (e2e) does not exercise the drawer and is unaffected.

Bead: `cave-gwfe`. Next: CP3 (power layer — origin badges, adjust-roles seeding of saved drafts, rename).
