### PR TITLE
feat(chat): global stop phrase halts a running task from the composer

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -386,6 +386,7 @@ export const SUITES = {
     "src/lib/prompt-enhancer.test.ts",
     "src/lib/prompt-placeholders.test.ts",
     "src/lib/prompt-prefs.test.ts",
+    "src/lib/stop-phrase.test.ts",
     "src/lib/use-prompt-enhance.test.ts",
     "src/lib/reply-recommendation.test.ts",
     "src/lib/comux-projects.test.ts",

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -317,7 +317,7 @@ async function main() {
           accentSeed: { L: 0.63, a: 0.12, b: -0.08 },
         },
       },
-      general: { newsHeadlines: false },
+      general: { newsHeadlines: false, stopPhrase: "halt" },
       phone: { mobileMode: false },
     };
     const savePreferences = await fetch(`${baseUrl}/api/preferences`, {

--- a/src-tauri/resources/server/placeholder.txt
+++ b/src-tauri/resources/server/placeholder.txt
@@ -1,0 +1,1 @@
+generated at release build time

--- a/src-tauri/resources/server/placeholder.txt
+++ b/src-tauri/resources/server/placeholder.txt
@@ -1,1 +1,0 @@
-generated at release build time

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4,6 +4,7 @@ import { createContext, forwardRef, Fragment, memo, useCallback, useContext, use
 import { createPortal } from "react-dom";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import type { FeedbackContext } from "@/lib/message-feedback";
+import { matchesStopPhrase, readStopPhrase } from "@/lib/stop-phrase";
 import { RichText } from "@/components/rich-text";
 import { FileLinkResolverContext, MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
 import { resolveFileRefTarget, type FileRef } from "@/lib/file-ref";
@@ -4471,6 +4472,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const text = (override ?? input).trim();
     if (!text && attachments.length === 0) return;
     if (attachments.length === 0 && intentFromSlash(text)) return;
+    // Global stop phrase (cave-uf2x): while a task is running, typing the
+    // configured phrase is a command — halt the turn (same path as the Stop
+    // button) instead of leaving the draft stranded behind the busy bail.
+    if (busy && matchesStopPhrase(text, readStopPhrase())) {
+      cancelSend();
+      setInput("");
+      clearDraft();
+      return;
+    }
     // CHAT-D5-01: sendRaw early-returns while a response is streaming, so
     // clearing the composer first would silently destroy the typed message
     // (and staged attachments). Bail before touching state — slash intents

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -28,6 +28,12 @@ import { UpdateSettingsRow } from "@/components/update-available";
 import { classifyAboutDaemonStatus, type AboutDaemonState } from "@/lib/about-status";
 import { useIsMobile } from "@/lib/use-viewport";
 import { useHomeNewsEnabled, writeHomeNewsEnabled } from "@/lib/home-news-pref";
+import {
+  DEFAULT_STOP_PHRASE,
+  STOP_PHRASE_MAX_LENGTH,
+  useStopPhrase,
+  writeStopPhrase,
+} from "@/lib/stop-phrase";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
 import { ColorPicker, type ColorSwatch } from "@/components/ui/color-picker";
 import { Popover } from "@/components/ui/popover";
@@ -389,6 +395,9 @@ function GeneralSection() {
       <SettingsGroup label="Home">
         <HomeNewsToggle />
       </SettingsGroup>
+      <SettingsGroup label="Chat">
+        <StopPhraseField />
+      </SettingsGroup>
       <SettingsGroup label="Startup">
         <SettingsRow label="Launch at login" description="Start CovenCave when you log in." comingSoon />
         <SettingsRow label="Open to" description="Which view to show on launch." comingSoon />
@@ -419,6 +428,39 @@ function HomeNewsToggle() {
       >
         <span className="settings-switch__knob" aria-hidden />
       </button>
+    </SettingsRow>
+  );
+}
+
+// The stop phrase is a safety valve: while a familiar is mid-task, typing
+// this exact phrase in any chat composer halts the run (the composer's busy
+// bail otherwise swallows plain sends). Commit on blur/Enter; clearing the
+// field disables interception.
+function StopPhraseField() {
+  const saved = useStopPhrase();
+  const [draft, setDraft] = useState<string | null>(null);
+  const value = draft ?? saved;
+  const commit = () => {
+    if (draft !== null && draft.trim() !== saved) writeStopPhrase(draft);
+    setDraft(null);
+  };
+  return (
+    <SettingsRow
+      label="Stop phrase"
+      description="Typing this in the composer while a task is running stops it. Leave empty to disable."
+    >
+      <input
+        value={value}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+        }}
+        placeholder={DEFAULT_STOP_PHRASE}
+        maxLength={STOP_PHRASE_MAX_LENGTH}
+        aria-label="Stop phrase"
+        className="focus-ring w-full max-w-sm rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-secondary)] outline-none"
+      />
     </SettingsRow>
   );
 }

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -92,6 +92,8 @@ export type CavePreferences = {
   };
   general: {
     newsHeadlines: boolean;
+    /** Composer phrase that halts a running chat task; "" disables it. */
+    stopPhrase: string;
   };
   phone: {
     mobileMode: boolean;
@@ -125,6 +127,15 @@ const DEFAULT_THEME: CaveThemePreferences = {
   updatedAt: "",
 };
 
+/** Default composer stop phrase; "" (after trim) turns the feature off. */
+export const DEFAULT_STOP_PHRASE = "stop";
+const STOP_PHRASE_MAX_LENGTH = 64;
+
+function normalizeStopPhrase(value: unknown): string {
+  if (typeof value !== "string") return DEFAULT_STOP_PHRASE;
+  return value.trim().slice(0, STOP_PHRASE_MAX_LENGTH);
+}
+
 export function createDefaultPreferences(initialized = false): CavePreferences {
   return {
     version: CAVE_PREFERENCES_VERSION,
@@ -154,7 +165,7 @@ export function createDefaultPreferences(initialized = false): CavePreferences {
         image: { present: false, mime: null, updatedAt: "" },
       },
     },
-    general: { newsHeadlines: true },
+    general: { newsHeadlines: true, stopPhrase: DEFAULT_STOP_PHRASE },
     phone: { mobileMode: true },
   };
 }
@@ -361,7 +372,10 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
         },
       },
     },
-    general: { newsHeadlines: general.newsHeadlines !== false },
+    general: {
+      newsHeadlines: general.newsHeadlines !== false,
+      stopPhrase: normalizeStopPhrase(general.stopPhrase),
+    },
     phone: { mobileMode: phone.mobileMode !== false },
   };
 }
@@ -578,10 +592,16 @@ export function validatePreferencesPatch(value: unknown): CavePreferencesPatch {
 
   if (Object.hasOwn(input, "general")) {
     const general = strictRecord(input.general, "general");
-    assertAllowedKeys(general, ["newsHeadlines"], "general");
-    patch.general = Object.hasOwn(general, "newsHeadlines")
-      ? { newsHeadlines: strictBoolean(general.newsHeadlines, "general.newsHeadlines") }
-      : {};
+    assertAllowedKeys(general, ["newsHeadlines", "stopPhrase"], "general");
+    const generalPatch: NonNullable<CavePreferencesPatch["general"]> = {};
+    if (Object.hasOwn(general, "newsHeadlines")) {
+      generalPatch.newsHeadlines = strictBoolean(general.newsHeadlines, "general.newsHeadlines");
+    }
+    if (Object.hasOwn(general, "stopPhrase")) {
+      if (typeof general.stopPhrase !== "string") fail("general.stopPhrase", "must be a string");
+      generalPatch.stopPhrase = normalizeStopPhrase(general.stopPhrase);
+    }
+    patch.general = generalPatch;
   }
   if (Object.hasOwn(input, "phone")) {
     const phone = strictRecord(input.phone, "phone");

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -129,7 +129,8 @@ const DEFAULT_THEME: CaveThemePreferences = {
 
 /** Default composer stop phrase; "" (after trim) turns the feature off. */
 export const DEFAULT_STOP_PHRASE = "stop";
-const STOP_PHRASE_MAX_LENGTH = 64;
+/** Longest phrase the preference stores; UI and matcher share this bound. */
+export const STOP_PHRASE_MAX_LENGTH = 64;
 
 function normalizeStopPhrase(value: unknown): string {
   if (typeof value !== "string") return DEFAULT_STOP_PHRASE;

--- a/src/lib/stop-phrase.test.ts
+++ b/src/lib/stop-phrase.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  DEFAULT_STOP_PHRASE,
+  matchesStopPhrase,
+  normalizeStopUtterance,
+} from "./stop-phrase.ts";
+import {
+  applyPreferencesPatch,
+  createDefaultPreferences,
+  normalizeCavePreferences,
+  validatePreferencesPatch,
+} from "./preferences-schema.ts";
+
+// ── Matching semantics ────────────────────────────────────────────────────────
+
+test("matchesStopPhrase: exact phrase matches through case/whitespace/punctuation", () => {
+  assert.equal(matchesStopPhrase("stop", "stop"), true);
+  assert.equal(matchesStopPhrase("Stop", "stop"), true);
+  assert.equal(matchesStopPhrase("  STOP!  ", "stop"), true);
+  assert.equal(matchesStopPhrase("stop.", "stop"), true);
+  assert.equal(matchesStopPhrase("stop…", "stop"), true);
+  assert.equal(matchesStopPhrase("halt  right   there", "Halt right there"), true);
+});
+
+test("matchesStopPhrase: containing the phrase is NOT a match — instructions pass through", () => {
+  assert.equal(matchesStopPhrase("stop using tabs", "stop"), false);
+  assert.equal(matchesStopPhrase("please stop", "stop"), false);
+  assert.equal(matchesStopPhrase("stopwatch", "stop"), false);
+  assert.equal(matchesStopPhrase("don't stop", "stop"), false);
+});
+
+test("matchesStopPhrase: empty/blank phrase disables matching entirely", () => {
+  assert.equal(matchesStopPhrase("stop", ""), false);
+  assert.equal(matchesStopPhrase("", ""), false);
+  assert.equal(matchesStopPhrase("stop", "   "), false);
+  // Punctuation-only phrase normalizes to empty → off.
+  assert.equal(matchesStopPhrase("!!!", "!!!"), false);
+});
+
+test("matchesStopPhrase: oversized composer text short-circuits without matching", () => {
+  const huge = `stop ${"x".repeat(500)}`;
+  assert.equal(matchesStopPhrase(huge, "stop"), false);
+});
+
+test("normalizeStopUtterance canonicalizes case, whitespace, trailing punctuation", () => {
+  assert.equal(normalizeStopUtterance("  Stop  That!! "), "stop that");
+  assert.equal(normalizeStopUtterance("STOP."), "stop");
+  assert.equal(normalizeStopUtterance(""), "");
+});
+
+// ── Preference schema plumbing ────────────────────────────────────────────────
+
+test("preferences default stopPhrase and survive normalize/patch round-trips", () => {
+  const defaults = createDefaultPreferences();
+  assert.equal(defaults.general.stopPhrase, DEFAULT_STOP_PHRASE);
+
+  // Legacy files without the field normalize to the default.
+  const legacy = normalizeCavePreferences({ general: { newsHeadlines: false } });
+  assert.equal(legacy.general.stopPhrase, DEFAULT_STOP_PHRASE);
+
+  // A patch can change it; empty string persists (that is the off switch).
+  const custom = applyPreferencesPatch(defaults, { general: { stopPhrase: "halt" } });
+  assert.equal(custom.general.stopPhrase, "halt");
+  const disabled = applyPreferencesPatch(custom, { general: { stopPhrase: "" } });
+  assert.equal(disabled.general.stopPhrase, "");
+  assert.equal(disabled.general.newsHeadlines, true);
+});
+
+test("validatePreferencesPatch validates stopPhrase as a trimmed bounded string", () => {
+  const parsed = validatePreferencesPatch({ general: { stopPhrase: `  halt${"x".repeat(200)}` } });
+  const phrase = parsed.general?.stopPhrase ?? "";
+  assert.equal(phrase.length, 64);
+  assert.equal(phrase.startsWith("halt"), true);
+  assert.throws(() => validatePreferencesPatch({ general: { stopPhrase: 7 } }));
+});
+
+// ── Wiring pins ───────────────────────────────────────────────────────────────
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+test("chat composer send() intercepts the stop phrase before the busy bail", () => {
+  const src = readFileSync(path.join(repoRoot, "src/components/chat-view.tsx"), "utf8");
+  assert.match(src, /matchesStopPhrase, readStopPhrase \} from "@\/lib\/stop-phrase"/);
+  const intercept = src.indexOf("busy && matchesStopPhrase(text, readStopPhrase())");
+  assert.ok(intercept > 0, "send() consults the stop phrase while busy");
+  const bail = src.indexOf("if (busy) return;", intercept);
+  assert.ok(bail > intercept, "intercept sits before the CHAT-D5-01 busy bail");
+  const between = src.slice(intercept, bail);
+  assert.match(between, /cancelSend\(\)/);
+});
+
+test("Settings → General exposes the stop phrase field", () => {
+  const src = readFileSync(path.join(repoRoot, "src/components/settings-shell.tsx"), "utf8");
+  assert.match(src, /<StopPhraseField \/>/);
+  assert.match(src, /writeStopPhrase\(draft\)/);
+  assert.match(src, /aria-label="Stop phrase"/);
+});

--- a/src/lib/stop-phrase.ts
+++ b/src/lib/stop-phrase.ts
@@ -23,12 +23,9 @@ import {
   subscribeAppPreferences,
   updateAppPreferences,
 } from "./app-preferences.ts";
-import { DEFAULT_STOP_PHRASE } from "./preferences-schema.ts";
+import { DEFAULT_STOP_PHRASE, STOP_PHRASE_MAX_LENGTH } from "./preferences-schema.ts";
 
-export { DEFAULT_STOP_PHRASE };
-
-/** Longest phrase the preference stores; also bounds matcher inputs. */
-export const STOP_PHRASE_MAX_LENGTH = 64;
+export { DEFAULT_STOP_PHRASE, STOP_PHRASE_MAX_LENGTH };
 
 /**
  * Canonical form used on both sides of the comparison: lowercase, collapsed

--- a/src/lib/stop-phrase.ts
+++ b/src/lib/stop-phrase.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Global stop phrase — a safety valve for running chat tasks.
+ *
+ * While a familiar is mid-task the composer normally swallows plain sends
+ * (CHAT-D5-01 keeps the draft intact instead of destroying it). Typing the
+ * configured stop phrase is the exception: it is treated as a command, not a
+ * prompt — the running turn is cancelled exactly as if the Stop button were
+ * pressed. The phrase lives in the synced preferences file
+ * (`general.stopPhrase`, default "stop"); Settings → General owns the input.
+ * Clearing the phrase disables the interception entirely.
+ *
+ * Matching is deliberately exact (after normalization): "stop" halts the
+ * task, but "stop using tabs" is an instruction for the model and must never
+ * be intercepted.
+ */
+
+import { useSyncExternalStore } from "react";
+
+import {
+  readAppPreferences,
+  subscribeAppPreferences,
+  updateAppPreferences,
+} from "./app-preferences.ts";
+import { DEFAULT_STOP_PHRASE } from "./preferences-schema.ts";
+
+export { DEFAULT_STOP_PHRASE };
+
+/** Longest phrase the preference stores; also bounds matcher inputs. */
+export const STOP_PHRASE_MAX_LENGTH = 64;
+
+/**
+ * Canonical form used on both sides of the comparison: lowercase, collapsed
+ * whitespace, and trailing sentence punctuation dropped so "Stop!" and
+ * "stop." still read as the bare phrase.
+ */
+export function normalizeStopUtterance(raw: string): string {
+  if (typeof raw !== "string") return "";
+  return raw
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.!?…]+$/u, "")
+    .trim();
+}
+
+/**
+ * True when `text` IS the stop phrase (not merely contains it). An empty or
+ * unset phrase never matches — that is the off switch.
+ */
+export function matchesStopPhrase(text: string, phrase: string): boolean {
+  const normalizedPhrase = normalizeStopUtterance(phrase);
+  if (!normalizedPhrase) return false;
+  if (typeof text !== "string" || text.length > STOP_PHRASE_MAX_LENGTH * 4) return false;
+  return normalizeStopUtterance(text) === normalizedPhrase;
+}
+
+const listeners = new Set<() => void>();
+let cached: string | null = null;
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+export function readStopPhrase(): string {
+  if (cached === null) cached = readAppPreferences().general.stopPhrase;
+  return cached;
+}
+
+export function writeStopPhrase(phrase: string) {
+  const next = phrase.trim().slice(0, STOP_PHRASE_MAX_LENGTH);
+  cached = next;
+  updateAppPreferences({ general: { stopPhrase: next } });
+  notify();
+}
+
+subscribeAppPreferences(() => {
+  cached = null;
+  notify();
+});
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** Live view of the phrase — re-renders subscribers when Settings edits it. */
+export function useStopPhrase(): string {
+  return useSyncExternalStore(subscribe, readStopPhrase, () => DEFAULT_STOP_PHRASE);
+}


### PR DESCRIPTION
## What

Typing the configured **stop phrase** (default `stop`) in a chat composer **while a task is running** now cancels the turn — same path as the Stop button (`cancelSend()` → `/api/chat/stop` + local abort) — instead of the send being silently swallowed by the CHAT-D5-01 busy bail.

## How

- **`src/lib/stop-phrase.ts`** — pure matcher + pref plumbing:
  - Exact match only, after normalization (lowercase, collapsed whitespace, trailing `.!?…` stripped): `Stop!` halts, but `stop using tabs` / `please stop` are instructions and pass through untouched.
  - Empty phrase = feature off. Oversized composer text short-circuits.
  - `readStopPhrase()`/`writeStopPhrase()`/`useStopPhrase()` over the synced app-preferences store.
- **`preferences-schema.ts`** — `general.stopPhrase` (default `stop`; trimmed, 64-char cap; `""` persists as the off switch) + strict patch validation; legacy files without the field normalize to the default.
- **`chat-view.tsx`** — intercept in `send()` after slash intents, before the busy bail; reads the pref at call time (no extra re-renders in the big component). Draft/attachments untouched when not matching; matching clears the composer.
- **Settings → General → Chat** — `Stop phrase` input, commit on blur/Enter, placeholder shows the default.

## Assumptions (autopilot)

- "Global" = every ChatView mount (chat page, workspace, board dock…) via the shared composer path; a voice-loop stop phrase is a natural follow-up, kept out of this diff.
- Only intercepts **while busy** — when idle the phrase is a normal message.

## Testing

- `src/lib/stop-phrase.test.ts` (registered in run-tests.mjs): matcher behavior, schema round-trips/validation, wiring pins (intercept sits before the busy bail; settings field present).
- `pnpm typecheck` clean; `pnpm test:app` 717 files green.

Bead: cave-uf2x