### PR TITLE
feat(permissions): delayed acceptance with undo window for grant proposals

### DIFF
--- a/src/app/api/grant-proposals/[id]/route.ts
+++ b/src/app/api/grant-proposals/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import {
   ProjectAccessDeniedError,
   resolveGrantProposal,
+  undoGrantProposal,
 } from "@/lib/project-permissions";
 
 export const dynamic = "force-dynamic";
@@ -34,20 +35,25 @@ export async function PATCH(
   }
   const rejected = rejectRelayedApproval(payload);
   if (rejected) return rejected;
-  const decision = payload.decision === "accepted" || payload.decision === "rejected"
-    ? payload.decision
-    : null;
+  const decision =
+    payload.decision === "accepted" ||
+    payload.decision === "rejected" ||
+    payload.decision === "undo"
+      ? payload.decision
+      : null;
   if (!decision) {
     return NextResponse.json(
-      { ok: false, error: "decision must be accepted or rejected" },
+      { ok: false, error: "decision must be accepted, rejected, or undo" },
       { status: 400 },
     );
   }
   try {
-    const proposal = await resolveGrantProposal({
-      proposalId: params.id,
-      decision,
-    });
+    const proposal = decision === "undo"
+      ? await undoGrantProposal({ proposalId: params.id })
+      : await resolveGrantProposal({
+          proposalId: params.id,
+          decision,
+        });
     return NextResponse.json({ ok: true, proposal });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/app/api/project-grants/route.test.ts
+++ b/src/app/api/project-grants/route.test.ts
@@ -19,13 +19,18 @@ assert.match(
 );
 assert.match(
   permissions,
-  /grantProposal\.status = input\.decision === "accepted" \? "accepted" : "rejected"/,
-  "proposal resolution should persist accepted/rejected state",
+  /grantProposal\.status = "accepting";[\s\S]{0,240}GRANT_ACCEPT_UNDO_WINDOW_MS/,
+  "accepting a proposal should park it in the undo window instead of granting instantly",
 );
 assert.match(
   permissions,
-  /if \(input\.decision === "accepted"\)[\s\S]*ensureProjectGrant/,
-  "accepting a proposal should create the target project grant",
+  /export function materializeDueGrantProposals\([\s\S]*?ensureProjectGrant\(/,
+  "the grant should materialize only when the undo window elapses",
+);
+assert.match(
+  permissions,
+  /export async function undoGrantProposal\(/,
+  "permission core should expose human undo inside the acceptance window",
 );
 
 assert.match(grantsRoute, /export async function GET\(/, "project grants route should list grants");

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -186,7 +186,7 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
   );
 
   const resolveProposal = useCallback(
-    async (id: string, decision: "accepted" | "rejected") => {
+    async (id: string, decision: "accepted" | "rejected" | "undo") => {
       setResolving((s) => new Set(s).add(id));
       try {
         const res = await fetch(`/api/grant-proposals/${id}`, {
@@ -469,6 +469,32 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
         <SettingsGroup label={`Access requests (${pendingProposals.length})`}>
           {pendingProposals.map((p) => {
             const busy = resolving.has(p.id);
+            if (p.status === "accepting") {
+              return (
+                <div key={p.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0">
+                    <p className="text-[13px] text-[var(--text-primary)]">
+                      Granting <span className="font-medium">{projectName(p.projectId)}</span> to
+                      this familiar
+                    </p>
+                    <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                      <FinalizeCountdown finalizesAt={p.finalizesAt} onElapsed={load} />
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      onClick={() => resolveProposal(p.id, "undo")}
+                      disabled={busy}
+                      aria-label={`Undo granting ${projectName(p.projectId)} to ${familiar.display_name}`}
+                    >
+                      <Icon name="ph:arrow-counter-clockwise" width={14} height={14} aria-hidden />
+                      Undo
+                    </Button>
+                  </div>
+                </div>
+              );
+            }
             return (
               <div key={p.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
                 <div className="min-w-0">
@@ -567,5 +593,42 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
         </SettingsGroup>
       )}
     </div>
+  );
+}
+
+// Live undo-window countdown for an `accepting` proposal (cave-6mdg). Ticks
+// once a second; when the deadline passes it fires `onElapsed` exactly once so
+// the parent reloads — the proposal now reads `accepted` and the grant shows
+// up in the matrix.
+function FinalizeCountdown({
+  finalizesAt,
+  onElapsed,
+}: {
+  finalizesAt?: string;
+  onElapsed: () => void | Promise<void>;
+}) {
+  const deadline = finalizesAt ? Date.parse(finalizesAt) : NaN;
+  const [now, setNow] = useState(() => Date.now());
+  const remainingMs = Number.isFinite(deadline) ? deadline - now : 0;
+  const elapsed = remainingMs <= 0;
+
+  useEffect(() => {
+    if (elapsed) {
+      void onElapsed();
+      return;
+    }
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+    // onElapsed is a stable useCallback in the parent; re-arming on `elapsed`
+    // keeps exactly one interval alive and fires the reload once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elapsed]);
+
+  if (elapsed) return <>Grant finalized</>;
+  const seconds = Math.max(1, Math.ceil(remainingMs / 1000));
+  return (
+    <>
+      Accepted — takes effect in {seconds}s. Undo to keep it pending.
+    </>
   );
 }

--- a/src/lib/pausable-poll-discipline.test.ts
+++ b/src/lib/pausable-poll-discipline.test.ts
@@ -37,6 +37,7 @@ const RAW_INTERVAL_ALLOWLIST = new Map([
   ["components/home/home-feed.tsx", "minute ticker for relative timestamps; no network"],
   ["components/calendar-view.tsx", "wall-clock minute ticker for the now-line; no network"],
   ["components/chat-view.tsx", "1s elapsed ticker on the streaming meta line; no network"],
+  ["components/familiar-studio-projects-tab.tsx", "30s grant-undo countdown while an accepting row is visible; no network"],
   ["components/update-available.tsx", "6-hour recheck cadence; a hidden-tab skip would defer updates for days"],
   ["components/onboarding-overlay.tsx", "modal-scoped 2s install polls; only run while the overlay is open mid-setup"],
   ["lib/use-pausable-poll.ts", "the shared hook's own interval (it self-guards via document.hidden)"],

--- a/src/lib/permissions-console.test.ts
+++ b/src/lib/permissions-console.test.ts
@@ -90,12 +90,14 @@ const proposals: ConsoleProposal[] = [
   { id: "1", proposedBy: SUPREME, targetFamiliarId: "zelda", projectId: "p-web", status: "pending", createdAt: "2026-01-02T00:00:00Z" },
   { id: "2", proposedBy: SUPREME, targetFamiliarId: "atlas", projectId: "p-api", status: "accepted", createdAt: "2026-01-01T00:00:00Z" },
   { id: "3", proposedBy: SUPREME, targetFamiliarId: "atlas", projectId: "p-web", status: "pending", createdAt: "2026-01-01T00:00:00Z" },
+  { id: "4", proposedBy: SUPREME, targetFamiliarId: "zelda", projectId: "p-api", status: "accepting", createdAt: "2026-01-03T00:00:00Z", finalizesAt: "2026-01-03T00:00:30Z" },
 ];
 const split = splitProposals(proposals);
-assert.deepEqual(split.pending.map((p) => p.id), ["3", "1"], "pending is oldest-first (FIFO queue)");
-assert.deepEqual(split.resolved.map((p) => p.id), ["2"], "resolved excludes pending");
-assert.equal(pendingProposalCount(proposals), 2);
+assert.deepEqual(split.pending.map((p) => p.id), ["3", "1", "4"], "actionable inbox keeps accepting rows (undo) FIFO");
+assert.deepEqual(split.resolved.map((p) => p.id), ["2"], "resolved excludes pending/accepting");
+assert.equal(pendingProposalCount(proposals), 2, "accepting rows don't count as awaiting a decision");
 assert.equal(proposalStatusMeta("pending").tone, "pending");
+assert.equal(proposalStatusMeta("accepting").tone, "pending");
 assert.equal(proposalStatusMeta("accepted").tone, "positive");
 assert.equal(proposalStatusMeta("rejected").tone, "negative");
 

--- a/src/lib/permissions-console.ts
+++ b/src/lib/permissions-console.ts
@@ -37,7 +37,7 @@ export type ConsoleAccessGroup = {
   updatedAt?: string;
 };
 
-export type ProposalStatus = "pending" | "accepted" | "rejected";
+export type ProposalStatus = "pending" | "accepting" | "accepted" | "rejected";
 export type ConsoleProposal = {
   id: string;
   proposedBy: string;
@@ -46,6 +46,8 @@ export type ConsoleProposal = {
   access?: ProjectAccessLevel;
   status: ProposalStatus;
   createdAt: string;
+  /** End of the undo window while `accepting`; the grant lands when it passes. */
+  finalizesAt?: string;
 };
 
 export type AuditDecision = "allow" | "deny";
@@ -162,18 +164,20 @@ export function isSupreme(
 }
 
 /**
- * Split proposals into the actionable inbox (pending, oldest first so the human
- * works the queue FIFO) and the resolved history (newest first).
+ * Split proposals into the actionable inbox (pending awaiting a decision plus
+ * accepting inside their undo window, oldest first so the human works the
+ * queue FIFO) and the resolved history (newest first).
  */
 export function splitProposals(proposals: ConsoleProposal[]): {
   pending: ConsoleProposal[];
   resolved: ConsoleProposal[];
 } {
+  const actionable = (p: ConsoleProposal) => p.status === "pending" || p.status === "accepting";
   const pending = proposals
-    .filter((p) => p.status === "pending")
+    .filter(actionable)
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   const resolved = proposals
-    .filter((p) => p.status !== "pending")
+    .filter((p) => !actionable(p))
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   return { pending, resolved };
 }
@@ -192,6 +196,8 @@ export function proposalStatusMeta(status: ProposalStatus): {
   switch (status) {
     case "accepted":
       return { label: "Accepted", icon: "ph:check-circle-fill", tone: "positive" };
+    case "accepting":
+      return { label: "Granting…", icon: "ph:hourglass", tone: "pending" };
     case "rejected":
       return { label: "Rejected", icon: "ph:x-circle-fill", tone: "negative" };
     default:

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -23,7 +23,10 @@ try {
     listAccessibleProjects,
     loadProjectPermissions,
     requiredAccessLevel,
+    resolveGrantProposal,
+    undoGrantProposal,
     updateAccessGroup,
+    GRANT_ACCEPT_UNDO_WINDOW_MS,
     ProjectAccessDeniedError,
   } = await import("./project-permissions.ts");
 
@@ -262,6 +265,64 @@ try {
     "deleting the group drops its grants (direct read remains, not write)",
   );
   await assertProjectAccess({ familiarId: "quill" }, "docs", "chat");
+
+  // ── Delayed acceptance: accept → undo window → finalize (cave-6mdg) ────────
+  const undoable = await createGrantProposal({
+    proposedBy: "supreme",
+    targetFamiliarId: "ember",
+    projectId: "docs",
+  });
+  const accepting = await resolveGrantProposal({ proposalId: undoable.id, decision: "accepted" });
+  assert.equal(accepting.status, "accepting", "accepting parks the proposal in the undo window");
+  assert.ok(accepting.finalizesAt, "the undo window records its deadline");
+  const windowMs = Date.parse(accepting.finalizesAt) - Date.parse(accepting.acceptedAt);
+  assert.equal(windowMs, GRANT_ACCEPT_UNDO_WINDOW_MS, "window spans GRANT_ACCEPT_UNDO_WINDOW_MS");
+  assert.equal(
+    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs", "supreme"),
+    false,
+    "no grant materializes while the undo window is open",
+  );
+  await assert.rejects(
+    () => resolveGrantProposal({ proposalId: undoable.id, decision: "accepted" }),
+    ProjectAccessDeniedError,
+    "an accepting proposal cannot be re-resolved",
+  );
+
+  const undone = await undoGrantProposal({ proposalId: undoable.id });
+  assert.equal(undone.status, "pending", "undo returns the proposal to the human's queue");
+  assert.equal(undone.finalizesAt, undefined, "undo clears the window deadline");
+  assert.equal(
+    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs", "supreme"),
+    false,
+    "undone acceptance leaves no grant behind",
+  );
+  await assert.rejects(
+    () => undoGrantProposal({ proposalId: undoable.id }),
+    ProjectAccessDeniedError,
+    "undo only applies inside an open window",
+  );
+
+  // Re-accept, then age the window out on disk: the next load materializes it.
+  await resolveGrantProposal({ proposalId: undoable.id, decision: "accepted" });
+  const permissionsPath = process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE;
+  const raw = JSON.parse(await readFile(permissionsPath, "utf8"));
+  const stored = raw.grantProposals.find((p) => p.id === undoable.id);
+  stored.finalizesAt = new Date(Date.now() - 1_000).toISOString();
+  await writeFile(permissionsPath, JSON.stringify(raw, null, 2), "utf8");
+
+  const finalized = await loadProjectPermissions();
+  const finalizedProposal = finalized.grantProposals.find((p) => p.id === undoable.id);
+  assert.equal(finalizedProposal.status, "accepted", "an elapsed window finalizes on load");
+  assert.equal(
+    canAccessProject(finalized, { familiarId: "ember" }, "docs", "supreme"),
+    true,
+    "the grant materializes once the window elapses",
+  );
+  await assert.rejects(
+    () => undoGrantProposal({ proposalId: undoable.id }),
+    ProjectAccessDeniedError,
+    "a finalized grant can no longer be undone via the proposal",
+  );
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -63,9 +63,20 @@ export type GrantProposal = {
   projectId: string;
   /** Level the grant will carry when accepted; legacy proposals imply "write". */
   access?: ProjectAccessLevel;
-  status: "pending" | "accepted" | "rejected";
+  status: "pending" | "accepting" | "accepted" | "rejected";
   createdAt: string;
+  /** Set when the human accepts; the grant only materializes at `finalizesAt`. */
+  acceptedAt?: string;
+  /** End of the undo window. Absent on legacy/pending/rejected proposals. */
+  finalizesAt?: string;
 };
+
+/**
+ * Delayed acceptance (cave-6mdg): accepting a proposal opens a short undo
+ * window instead of granting instantly. The grant materializes lazily once
+ * the window elapses; until then the human can undo back to `pending`.
+ */
+export const GRANT_ACCEPT_UNDO_WINDOW_MS = 30_000;
 
 export type PermissionAuditReason =
   | "grant"
@@ -204,7 +215,7 @@ export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> 
     Partial<ProjectPermissionsFile> & { version?: number }
   >(permissionsFilePath());
   if (!parsed) return emptyFile();
-  return {
+  const file: ProjectPermissionsFile = {
     version: 2,
     projectGrants: Array.isArray(parsed.projectGrants)
       ? parsed.projectGrants
@@ -219,6 +230,37 @@ export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> 
     grantProposals: Array.isArray(parsed.grantProposals) ? parsed.grantProposals : [],
     permissionAudit: Array.isArray(parsed.permissionAudit) ? parsed.permissionAudit : [],
   };
+  materializeDueGrantProposals(file, new Date());
+  return file;
+}
+
+/**
+ * Flip `accepting` proposals whose undo window has elapsed to `accepted` and
+ * materialize their grants. Runs in-memory on every load — reads converge on
+ * the finalized state even if nothing writes; the next save persists it.
+ * Returns true when anything changed.
+ */
+export function materializeDueGrantProposals(
+  file: ProjectPermissionsFile,
+  now: Date,
+): boolean {
+  let changed = false;
+  for (const proposal of file.grantProposals) {
+    if (proposal.status !== "accepting") continue;
+    const finalizesAt = proposal.finalizesAt ? Date.parse(proposal.finalizesAt) : NaN;
+    // Malformed/missing deadline: fail safe by finalizing (the human already
+    // accepted; losing the undo window beats losing the decision).
+    if (Number.isFinite(finalizesAt) && finalizesAt > now.getTime()) continue;
+    proposal.status = "accepted";
+    ensureProjectGrant(file, {
+      familiarId: proposal.targetFamiliarId,
+      projectId: proposal.projectId,
+      source: "human",
+      access: normalizeAccessLevel(proposal.access),
+    });
+    changed = true;
+  }
+  return changed;
 }
 
 async function saveProjectPermissions(file: ProjectPermissionsFile): Promise<void> {
@@ -503,16 +545,48 @@ export async function resolveGrantProposal(input: {
     if (grantProposal.status !== "pending") {
       throw new ProjectAccessDeniedError("grant proposal is already resolved");
     }
-    grantProposal.status = input.decision === "accepted" ? "accepted" : "rejected";
     if (input.decision === "accepted") {
-      ensureProjectGrant(file, {
-        familiarId: grantProposal.targetFamiliarId,
-        projectId: grantProposal.projectId,
-        source: "human",
-        // Legacy pending proposals predate levels — they meant full access.
-        access: normalizeAccessLevel(grantProposal.access),
-      });
+      // Delayed acceptance: no grant yet — the proposal parks in `accepting`
+      // until the undo window elapses (materialized on the next load), so the
+      // human can undo before it takes effect.
+      const now = new Date();
+      grantProposal.status = "accepting";
+      grantProposal.acceptedAt = now.toISOString();
+      grantProposal.finalizesAt = new Date(
+        now.getTime() + GRANT_ACCEPT_UNDO_WINDOW_MS,
+      ).toISOString();
+    } else {
+      grantProposal.status = "rejected";
     }
+    await saveProjectPermissions(file);
+    return grantProposal;
+  });
+}
+
+/**
+ * Revert an accepted-but-not-yet-finalized proposal back to `pending`. Only
+ * possible during the undo window — once `finalizesAt` passes, loads have
+ * already materialized the grant and the proposal reads as `accepted`.
+ */
+export async function undoGrantProposal(input: { proposalId: string }): Promise<GrantProposal> {
+  return withWriteMutex(async () => {
+    const file = await loadProjectPermissions();
+    const grantProposal = file.grantProposals.find((proposal) => proposal.id === input.proposalId);
+    if (!grantProposal) {
+      throw new ProjectAccessDeniedError("grant proposal not found");
+    }
+    // Load already finalized due proposals, so `accepting` here is guaranteed
+    // to still be inside its window.
+    if (grantProposal.status !== "accepting") {
+      throw new ProjectAccessDeniedError(
+        grantProposal.status === "accepted"
+          ? "grant already finalized — revoke the grant instead"
+          : "grant proposal is not awaiting finalization",
+      );
+    }
+    grantProposal.status = "pending";
+    delete grantProposal.acceptedAt;
+    delete grantProposal.finalizesAt;
     await saveProjectPermissions(file);
     return grantProposal;
   });


### PR DESCRIPTION
## What

Accepting a grant proposal no longer takes effect instantly. The proposal parks in a new **`accepting`** status for a **30s undo window** (`GRANT_ACCEPT_UNDO_WINDOW_MS`); the human can **Undo** during the window — back to `pending`, and the grant never exists. Once the window elapses, the grant materializes and the proposal reads `accepted` ("phases out" into a real grant).

## How

- **`project-permissions.ts`**
  - `GrantProposal` gains `accepting` status + `acceptedAt`/`finalizesAt`.
  - `resolveGrantProposal(accepted)` → parks in the window, **no grant yet**; access checks stay deny until finalization.
  - `materializeDueGrantProposals(file, now)` runs inside every `loadProjectPermissions()` — in-memory, idempotent, so **reads converge on the finalized state even if nothing writes**; the next save persists it. Missing/malformed deadline fails safe by finalizing (the human did accept).
  - `undoGrantProposal` reverts to `pending` inside the window; after finalization it refuses with a pointer to revoking the grant instead.
- **`PATCH /api/grant-proposals/[id]`** accepts `decision: "undo"`; the existing human-only `rejectRelayedApproval` guard applies unchanged (familiars can't undo either).
- **Familiar Studio → Projects tab**: accepting rows stay in the actionable inbox with a live per-second countdown ("Accepted — takes effect in Ns. Undo to keep it pending.") and an **Undo** button; when the window elapses the list reloads and the grant appears in the matrix.
- **`permissions-console.ts`**: `accepting` joins `ProposalStatus`; `splitProposals` keeps accepting rows actionable (FIFO); `pendingProposalCount` (badge) still counts only truly-pending rows; `proposalStatusMeta("accepting")` = "Granting…".

## Assumptions (autopilot)

- 30s window as the default balance between "undo-able" and "not annoying"; constant is exported for future configurability.
- Undo returns to `pending` (re-decidable) rather than `rejected` — undo means "take back my decision", not "decide the other way".

## Testing

- `project-permissions.test.ts`: full lifecycle — accept opens window sized exactly `GRANT_ACCEPT_UNDO_WINDOW_MS`, **no grant during window**, re-resolve refused, undo restores pending + clears deadline + leaves no grant, aged-out window (disk-edited `finalizesAt`) **materializes on load**, post-finalize undo refused.
- `permissions-console.test.ts`: accepting bucket/meta/badge-count behavior.
- Countdown ticker allowlisted in `pausable-poll-discipline.test.ts` with reason (non-network 1s ticker, only while an accepting row is visible).
- `pnpm typecheck` clean; app suite + api-contracts green.

Bead: cave-6mdg. Sibling PR #3190 (global stop phrase) covers the other half of the safety-controls objective.