### PR TITLE
feat(crafts): power layer in-flow — attribution, draft editing, rename (cave-x22o)

### DIFF
--- a/src/app/api/marketplace/crafts-routes.test.ts
+++ b/src/app/api/marketplace/crafts-routes.test.ts
@@ -37,6 +37,7 @@ assert.match(drafts, /readJsonBody/, "draft creation uses the bounded JSON-body 
 assert.match(drafts, /familiar and roleIds required/, "draft creation validates familiar + roleIds");
 assert.match(drafts, /role\.familiar === familiar/, "draft roles are scoped to the requested familiar");
 assert.match(drafts, /buildCraftDraftFromRoles/, "drafts are built through the shared role-composition builder");
+assert.match(drafts, /displayName\.trim\(\)\.slice\(0, 120\)/, "the optional operator rename is trimmed and bounded");
 
 assert.match(genericInstall, /kind\s*===\s*["']craft["']/, "generic track-only install refuses Crafts");
 assert.match(genericUninstall, /kind\s*===\s*["']craft["']/, "generic state-only uninstall refuses Crafts");

--- a/src/app/api/marketplace/crafts/drafts/route.ts
+++ b/src/app/api/marketplace/crafts/drafts/route.ts
@@ -12,6 +12,7 @@ const MAX_BODY_BYTES = 16 * 1024;
 type DraftBody = {
   familiar?: unknown;
   roleIds?: unknown;
+  displayName?: unknown;
 };
 
 export async function GET(req: Request) {
@@ -30,6 +31,10 @@ export async function POST(req: Request) {
   const roleIds = Array.isArray(parsed.body.roleIds)
     ? parsed.body.roleIds.filter((id): id is string => typeof id === "string").map((id) => id.trim()).filter(Boolean)
     : [];
+  // Optional operator rename (docs/craft-ux.md F12) — bounded, never the id.
+  const displayName = typeof parsed.body.displayName === "string"
+    ? parsed.body.displayName.trim().slice(0, 120)
+    : "";
   if (!familiar || roleIds.length === 0) {
     return NextResponse.json(
       { ok: false, error: "familiar and roleIds required" },
@@ -45,7 +50,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: "no matching roles" }, { status: 404 });
   }
 
-  const draft = buildCraftDraftFromRoles({ familiar, roles });
+  const draft = buildCraftDraftFromRoles({ familiar, roles, displayName: displayName || undefined });
   await saveCraftDraft(draft);
   return NextResponse.json({ ok: true, draft });
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13624,6 +13624,15 @@ details[open] > .cave-edit-card__summary::before {
   padding: 8px 10px;
 }
 .craft-create-drawer__goal::placeholder { color: var(--text-muted); }
+.craft-create-drawer__name {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control, 8px);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 8px 10px;
+}
+.craft-create-drawer__name::placeholder { color: var(--text-muted); }
 /* "What happens next" — quiet numbered steps for the agentic path. */
 .craft-create-drawer__how { display: grid; gap: 6px; }
 .craft-create-drawer__how h3 {
@@ -13748,12 +13757,19 @@ details[open] > .cave-edit-card__summary::before {
 .craft-draft-ledger p { margin: 0; color: var(--text-muted); font-size: 11px; }
 .craft-draft-ledger span {
   display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
   border: 1px solid var(--border-hairline);
   border-radius: 6px;
   background: var(--bg-base);
   color: var(--text-secondary);
   font-size: 10.5px;
   padding: 4px 6px;
+}
+.craft-draft-ledger__origin {
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 1.3;
 }
 .craft-draft-ledger__stats {
   display: grid;

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -22,7 +22,7 @@ import { useAnnouncer } from "@/components/ui/live-region";
 import { MarketplaceCard } from "@/components/marketplace/marketplace-card";
 import { MarketplaceDetail } from "@/components/marketplace/marketplace-detail";
 import type { CraftActionError } from "@/components/marketplace/craft-detail";
-import { CraftCreateDrawer } from "@/components/marketplace/craft-create-drawer";
+import { CraftCreateDrawer, type CraftDrawerSeed } from "@/components/marketplace/craft-create-drawer";
 import { MarketplaceConfigure } from "@/components/marketplace/marketplace-configure";
 import { CollectionStrip } from "@/components/marketplace/collection-strip";
 import { SkillBuilder } from "@/components/marketplace/skill-builder";
@@ -145,6 +145,8 @@ export function MarketplaceViewSurface({
   const [collectionId, setCollectionId] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [creatingCraft, setCreatingCraft] = useState(false);
+  // Editing an existing draft reopens the create drawer pre-seeded (F5).
+  const [craftSeed, setCraftSeed] = useState<CraftDrawerSeed | null>(null);
   const [craftErrors, setCraftErrors] = useState<Record<string, CraftActionError | undefined>>({});
   // Ids with an install/uninstall in flight. A Set (not a scalar) so two
   // concurrent installs each keep their own busy state — with a scalar, the
@@ -781,7 +783,10 @@ export function MarketplaceViewSurface({
                   variant="primary"
                   size="sm"
                   leadingIcon="ph:package-bold"
-                  onClick={() => setCreatingCraft(true)}
+                  onClick={() => {
+                    setCraftSeed(null);
+                    setCreatingCraft(true);
+                  }}
                 >
                   Create Craft
                 </Button>
@@ -920,6 +925,11 @@ export function MarketplaceViewSurface({
             setSelected(null);
             void load();
           }}
+          onAdjustRoles={(seed) => {
+            setSelected(null);
+            setCraftSeed(seed);
+            setCreatingCraft(true);
+          }}
         />
       ) : null}
 
@@ -935,9 +945,14 @@ export function MarketplaceViewSurface({
 
       <CraftCreateDrawer
         open={creatingCraft}
-        onClose={() => setCreatingCraft(false)}
+        seed={craftSeed}
+        onClose={() => {
+          setCreatingCraft(false);
+          setCraftSeed(null);
+        }}
         onCreated={(id) => {
           setCreatingCraft(false);
+          setCraftSeed(null);
           void load().then(() => setSelected(id));
           announce("Craft draft saved", "polite");
         }}

--- a/src/components/marketplace/craft-create-drawer.tsx
+++ b/src/components/marketplace/craft-create-drawer.tsx
@@ -53,13 +53,25 @@ function initialCreateMode(): CreateMode {
  *  extraction ledger before anything is written. */
 type ExtractStep = "select" | "preview";
 
+/** Seed for editing an existing draft in place (docs/craft-ux.md F5):
+ *  the drawer opens on the preview step with the draft's familiar, roles,
+ *  and name; saving replaces the stored draft (delete + recreate — the
+ *  drafts store's native semantics). */
+export type CraftDrawerSeed = {
+  draftId: string;
+  familiar: string;
+  roleIds: string[];
+  displayName?: string;
+};
+
 type Props = {
   open: boolean;
   onClose: () => void;
   onCreated: (id: string) => void;
+  seed?: CraftDrawerSeed | null;
 };
 
-export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
+export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [mode, setMode] = useState<CreateMode>(initialCreateMode);
   const [step, setStep] = useState<ExtractStep>("select");
@@ -77,14 +89,37 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
   // to the same onCreated the manual path uses.
   const [awaiting, setAwaiting] = useState(false);
   const baselineDraftIds = useRef<ReadonlySet<string>>(new Set());
+  // Rename (F12): empty means "use the derived name". Seeded edits start from
+  // the stored draft's name so a rename survives an adjust-roles round trip.
+  const [customName, setCustomName] = useState("");
+  // Per-familiar selection retention (F9): switching familiars stashes the
+  // current picks instead of destroying them.
+  const selectionsByFamiliar = useRef(new Map<string, ReadonlySet<string>>());
+  const appliedSeedId = useRef<string | null>(null);
   useFocusTrap(open, ref, { onEscape: onClose });
 
   useEffect(() => {
     if (!open) {
       setAwaiting(false);
       setStep("select");
+      setCustomName("");
+      selectionsByFamiliar.current = new Map();
+      appliedSeedId.current = null;
     }
   }, [open]);
+
+  // Editing an existing draft (F5): apply the seed once per open — mode
+  // flips to pick-roles (without touching the remembered preference), the
+  // draft's roles pre-select, and the flow lands on the preview step.
+  useEffect(() => {
+    if (!open || !seed || appliedSeedId.current === seed.draftId) return;
+    appliedSeedId.current = seed.draftId;
+    setMode("extract");
+    setFamiliar(seed.familiar);
+    setSelectedRoleIds(new Set(seed.roleIds));
+    setCustomName(seed.displayName ?? "");
+    setStep("preview");
+  }, [open, seed]);
 
   const chooseMode = useCallback((next: CreateMode) => {
     setMode(next);
@@ -180,9 +215,12 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
   }, [selectedRoles]);
 
   const chooseFamiliar = useCallback((next: string) => {
-    setFamiliar(next);
-    setSelectedRoleIds(new Set());
-  }, []);
+    setFamiliar((current) => {
+      if (current) selectionsByFamiliar.current.set(current, selectedRoleIds);
+      return next;
+    });
+    setSelectedRoleIds(selectionsByFamiliar.current.get(next) ?? new Set());
+  }, [selectedRoleIds]);
 
   const toggleRole = useCallback((roleId: string) => {
     setSelectedRoleIds((current) => {
@@ -199,21 +237,36 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
   const previewDraft = useMemo(() => {
     if (!familiar || selectedRoles.length === 0) return null;
     try {
-      return buildCraftDraftFromRoles({ familiar, roles: selectedRoles });
+      return buildCraftDraftFromRoles({
+        familiar,
+        roles: selectedRoles,
+        displayName: customName.trim() || undefined,
+      });
     } catch {
       return null;
     }
-  }, [familiar, selectedRoles]);
+  }, [customName, familiar, selectedRoles]);
 
   const save = useCallback(async () => {
     if (!familiar || selectedRoleIds.size === 0) return;
     setSaving(true);
     setError(null);
     try {
+      // Seeded edits are recreate-and-replace (F5): drop the stored draft
+      // first so a role change that shifts the derived id leaves no orphan.
+      if (seed && appliedSeedId.current === seed.draftId) {
+        await fetch(`/api/marketplace/crafts/drafts?id=${encodeURIComponent(seed.draftId)}`, {
+          method: "DELETE",
+        }).catch(() => {});
+      }
       const res = await fetch("/api/marketplace/crafts/drafts", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ familiar, roleIds: [...selectedRoleIds] }),
+        body: JSON.stringify({
+          familiar,
+          roleIds: [...selectedRoleIds],
+          ...(customName.trim() ? { displayName: customName.trim() } : {}),
+        }),
       });
       const json = (await res.json()) as DraftResponse;
       if (!json.ok || !json.draft?.id) throw new Error(json.error ?? "draft create failed");
@@ -223,7 +276,7 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [familiar, onCreated, selectedRoleIds]);
+  }, [customName, familiar, onCreated, seed, selectedRoleIds]);
 
   /** Describe mode: hand the goal to a familiar as a complete agentic build
    *  prompt (role discovery → draft → plan verification), the same
@@ -363,6 +416,17 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
                     {selectedRoles.length} {selectedRoles.length === 1 ? "role" : "roles"} from {familiar}.
                     Review the extracted bundle, then save.
                   </p>
+                  <label className="craft-create-drawer__field">
+                    <span>Name (optional)</span>
+                    <input
+                      type="text"
+                      className="focus-ring craft-create-drawer__name"
+                      value={customName}
+                      maxLength={120}
+                      onChange={(e) => setCustomName(e.target.value)}
+                      placeholder={previewDraft.plugin.displayName}
+                    />
+                  </label>
                   <CraftDraftPreview
                     groups={extractionLedgerGroups(previewDraft.extraction.ledger)}
                     ariaLabel="Extraction preview"
@@ -448,7 +512,7 @@ export function CraftCreateDrawer({ open, onClose, onCreated }: Props) {
                 disabled={!previewDraft}
                 onClick={save}
               >
-                Save draft
+                {seed && appliedSeedId.current === seed.draftId ? "Save changes" : "Save draft"}
               </Button>
             </>
           ) : (

--- a/src/components/marketplace/craft-draft-preview.tsx
+++ b/src/components/marketplace/craft-draft-preview.tsx
@@ -1,37 +1,60 @@
-import type { CraftDraft } from "@/lib/craft-draft";
+import type { CraftDraft, CraftDraftLedgerEntry } from "@/lib/craft-draft";
 import type { CraftSpecification } from "@/lib/marketplace-catalog";
 
 /** One shared shape for everywhere a draft Craft's contents render: the
  *  create drawer's preview-before-save step and the draft detail dialog
- *  (docs/craft-ux.md, CP2). Groups mirror the extraction ledger categories. */
+ *  (docs/craft-ux.md, CP2). Groups mirror the extraction ledger categories.
+ *  Items optionally carry provenance (docs/craft-ux.md F4, CP3): which roles
+ *  contributed the entry and through what origin (Direct vs via a Craft). */
+export type CraftDraftPreviewItem = {
+  id: string;
+  hint?: string;
+};
+
 export type CraftDraftPreviewGroup = {
   id: string;
   title: string;
-  items: string[];
+  items: CraftDraftPreviewItem[];
 };
 
-/** Groups from a client- or server-built draft's extraction ledger. */
+function ledgerHint(entry: CraftDraftLedgerEntry): string | undefined {
+  const origins = entry.origins.filter(Boolean);
+  const roles = entry.roles.filter(Boolean);
+  if (origins.length === 0 && roles.length === 0) return undefined;
+  if (origins.length === 0) return roles.join(", ");
+  if (roles.length === 0) return origins.join(", ");
+  return `${origins.join(", ")} · ${roles.join(", ")}`;
+}
+
+function ledgerItems(entries: CraftDraftLedgerEntry[]): CraftDraftPreviewItem[] {
+  return entries.map((entry) => ({ id: entry.id, hint: ledgerHint(entry) }));
+}
+
+/** Groups from a client- or server-built draft's extraction ledger — the
+ *  attributed form ("why is this in my bundle?"). */
 export function extractionLedgerGroups(
   ledger: CraftDraft["extraction"]["ledger"],
 ): CraftDraftPreviewGroup[] {
   return [
-    { id: "components", title: "Required components", items: ledger.components.map((entry) => entry.id) },
-    { id: "capabilities", title: "Capabilities", items: ledger.capabilities.map((entry) => entry.id) },
-    { id: "skills", title: "Skills", items: ledger.skills.map((entry) => entry.id) },
-    { id: "prompts", title: "Prompts", items: ledger.prompts.map((entry) => entry.id) },
-    { id: "workflows", title: "Workflows", items: ledger.workflows.map((entry) => entry.id) },
+    { id: "components", title: "Required components", items: ledgerItems(ledger.components) },
+    { id: "capabilities", title: "Capabilities", items: ledgerItems(ledger.capabilities) },
+    { id: "skills", title: "Skills", items: ledgerItems(ledger.skills) },
+    { id: "prompts", title: "Prompts", items: ledgerItems(ledger.prompts) },
+    { id: "workflows", title: "Workflows", items: ledgerItems(ledger.workflows) },
   ];
 }
 
 /** Groups from a stored draft plugin's craft specification (the marketplace
- *  card model carries the spec, not the extraction ledger). */
+ *  card model carries the spec, not the extraction ledger) — unattributed
+ *  fallback when the full draft isn't loaded. */
 export function craftSpecGroups(craft: CraftSpecification | undefined): CraftDraftPreviewGroup[] {
+  const bare = (ids: readonly string[]): CraftDraftPreviewItem[] => ids.map((id) => ({ id }));
   return [
-    { id: "components", title: "Required components", items: craft?.components.required ?? [] },
-    { id: "capabilities", title: "Capabilities", items: craft?.requiredCapabilities ?? [] },
-    { id: "skills", title: "Skills", items: (craft?.bundled.skills ?? []).map((item) => item.id) },
-    { id: "prompts", title: "Prompts", items: (craft?.bundled.prompts ?? []).map((item) => item.id) },
-    { id: "workflows", title: "Workflows", items: (craft?.bundled.workflows ?? []).map((item) => item.id) },
+    { id: "components", title: "Required components", items: bare(craft?.components.required ?? []) },
+    { id: "capabilities", title: "Capabilities", items: bare(craft?.requiredCapabilities ?? []) },
+    { id: "skills", title: "Skills", items: bare((craft?.bundled.skills ?? []).map((item) => item.id)) },
+    { id: "prompts", title: "Prompts", items: bare((craft?.bundled.prompts ?? []).map((item) => item.id)) },
+    { id: "workflows", title: "Workflows", items: bare((craft?.bundled.workflows ?? []).map((item) => item.id)) },
   ];
 }
 
@@ -50,7 +73,10 @@ export function CraftDraftPreview({
           {group.items.length ? (
             <div className="flex flex-wrap gap-1.5">
               {group.items.map((item) => (
-                <span key={item}>{item}</span>
+                <span key={item.id} title={item.hint}>
+                  {item.id}
+                  {item.hint ? <small className="craft-draft-ledger__origin">{item.hint}</small> : null}
+                </span>
               ))}
             </div>
           ) : (

--- a/src/components/marketplace/crafts-marketplace.test.ts
+++ b/src/components/marketplace/crafts-marketplace.test.ts
@@ -57,7 +57,7 @@ assert.match(createDrawer, /What happens next/, "describe mode explains the agen
 // detail; the Crafts grid separates local drafts from the published catalog.
 assert.match(createDrawer, /\{ id: "describe"[\s\S]*?\{ id: "extract"/, "describe leads the creation-mode tabs");
 assert.match(createDrawer, /MODE_MEMORY_KEY = "cave:craft-create:mode"/, "the last-used creation mode is remembered");
-assert.match(createDrawer, /buildCraftDraftFromRoles\(\{ familiar, roles: selectedRoles \}\)/, "pick-roles synthesizes the real draft client-side for preview");
+assert.match(createDrawer, /buildCraftDraftFromRoles\(\{\s*familiar,\s*roles: selectedRoles,/, "pick-roles synthesizes the real draft client-side for preview");
 assert.match(createDrawer, /Preview draft/, "role selection advances to a preview step before saving");
 assert.match(createDrawer, /Adjust roles/, "the preview step returns to selection without losing state");
 assert.match(createDrawer, /extractionLedgerGroups\(previewDraft\.extraction\.ledger\)/, "the preview renders the extraction ledger, not just counts");
@@ -66,9 +66,36 @@ assert.match(createDrawer, /extractionLedgerGroups\(previewDraft\.extraction\.le
   assert.match(draftPreview, /export function CraftDraftPreview/, "draft contents render through one shared component");
   assert.match(draftPreview, /craft-draft-ledger/, "the shared preview keeps the stable ledger styling hook");
 }
-assert.match(detail, /<CraftDraftPreview groups=\{craftSpecGroups\(craft\)\}/, "draft detail renders the same shared preview");
+assert.match(detail, /<CraftDraftPreview\s+groups=\{fullDraft \? extractionLedgerGroups\(fullDraft\.extraction\.ledger\) : craftSpecGroups\(craft\)\}/, "draft detail renders the same shared preview, attributed when the full draft loads");
 assert.match(view, /Your drafts/, "the Crafts grid groups local drafts above the published catalog");
 assert.match(css, /\.craft-grid-group \{/, "Craft lifecycle groups have a stable visual hook");
+
+// ── Power layer in-flow (docs/craft-ux.md CP3) ───────────────────────────────
+// The extraction ledger's provenance reaches the screen (F4); a saved draft
+// reopens the drawer pre-seeded for in-place editing (F5); switching familiars
+// retains each familiar's picks (F9); drafts can be renamed without moving
+// their identity (F12).
+{
+  const draftPreview = await readFile(new URL("./craft-draft-preview.tsx", import.meta.url), "utf8");
+  assert.match(draftPreview, /ledgerHint/, "ledger items carry origin + role attribution");
+  assert.match(draftPreview, /craft-draft-ledger__origin/, "attribution renders on a stable styling hook");
+}
+assert.match(createDrawer, /export type CraftDrawerSeed/, "draft editing seeds the drawer through a shared shape");
+assert.match(createDrawer, /appliedSeedId/, "a seed applies once per open, not on every render");
+assert.match(createDrawer, /setStep\("preview"\)/, "seeded edits land on the preview step");
+assert.match(createDrawer, /selectionsByFamiliar/, "switching familiars stashes the current role picks");
+assert.match(createDrawer, /displayName: customName\.trim\(\) \|\| undefined/, "the preview renders the operator's rename live");
+assert.match(createDrawer, /Save changes/, "seeded edits label the save as an edit");
+assert.match(createDrawer, /method: "DELETE"/, "seeded saves are recreate-and-replace");
+assert.match(detail, /onAdjustRoles/, "draft detail can hand off to the seeded drawer");
+assert.match(detail, /Adjust roles/, "adjusting roles is an explicit action");
+assert.match(detail, /deriveCraftDisplayName/, "only operator-chosen names survive the adjust round trip");
+assert.match(view, /setCraftSeed\(seed\)/, "the hub routes the seed from detail to drawer");
+{
+  const craftDraftLib = await readFile(new URL("../../lib/craft-draft.ts", import.meta.url), "utf8");
+  assert.match(craftDraftLib, /displayName\?: string/, "the draft builder accepts an optional operator name");
+  assert.match(craftDraftLib, /const id = slugify\(`\$\{cleanFamiliar\}-\$\{roleNames\.join\("-"\)\}`\)/, "renames never move the draft's derived identity");
+}
 
 // ── Describe-it closes its loop (cave-46wg) ──────────────────────────────────
 // The dispatched brief is no longer fire-and-forget: the drawer snapshots the

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -17,10 +17,13 @@ import {
   type CraftDraftBriefInput,
 } from "@/lib/craft-agent-prompt";
 import { CraftDetail, type CraftActionError } from "@/components/marketplace/craft-detail";
+import type { CraftDrawerSeed } from "@/components/marketplace/craft-create-drawer";
 import {
   CraftDraftPreview,
   craftSpecGroups,
+  extractionLedgerGroups,
 } from "@/components/marketplace/craft-draft-preview";
+import { deriveCraftDisplayName, type CraftDraft } from "@/lib/craft-draft";
 import { KnowledgePackDetail } from "@/components/marketplace/knowledge-pack-detail";
 
 type PackPrompt = PromptOption;
@@ -43,6 +46,9 @@ type Props = {
   onActionCleared?: () => void;
   /** Fired after a local draft Craft is deleted so the hub can refresh. */
   onDraftDeleted?: () => void;
+  /** Reopens the create drawer seeded with this draft's roles for in-place
+   *  editing (docs/craft-ux.md F5). */
+  onAdjustRoles?: (seed: CraftDrawerSeed) => void;
 };
 
 function kindIcon(kind: MarketplacePlugin["kind"]) {
@@ -120,7 +126,14 @@ function detailDecisionItems(plugin: MarketplacePlugin) {
 
 export function MarketplaceDetail(props: Props) {
   if (props.plugin.kind === "craft" && props.plugin.draft) {
-    return <DraftCraftDetail plugin={props.plugin} onClose={props.onClose} onDeleted={props.onDraftDeleted} />;
+    return (
+      <DraftCraftDetail
+        plugin={props.plugin}
+        onClose={props.onClose}
+        onDeleted={props.onDraftDeleted}
+        onAdjustRoles={props.onAdjustRoles}
+      />
+    );
   }
   if (props.plugin.kind === "craft") {
     return (
@@ -145,10 +158,12 @@ function DraftCraftDetail({
   plugin,
   onClose,
   onDeleted,
+  onAdjustRoles,
 }: {
   plugin: MarketplacePlugin;
   onClose: () => void;
   onDeleted?: () => void;
+  onAdjustRoles?: (seed: CraftDrawerSeed) => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   useFocusTrap(true, ref, { onEscape: onClose });
@@ -161,11 +176,41 @@ function DraftCraftDetail({
   const [armedDelete, setArmedDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The card model carries only the craft spec; the drafts store has the
+  // attributed extraction ledger and role ids (docs/craft-ux.md F4/F5).
+  // Best-effort — the spec-based view remains the fallback.
+  const [fullDraft, setFullDraft] = useState<CraftDraft | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    const id = plugin.draftId ?? plugin.id;
+    fetch("/api/marketplace/crafts/drafts", { cache: "no-store", signal: controller.signal })
+      .then((res) => res.json())
+      .then((json: { ok?: boolean; drafts?: CraftDraft[] }) => {
+        if (controller.signal.aborted || !json.ok || !Array.isArray(json.drafts)) return;
+        setFullDraft(json.drafts.find((draft) => draft.id === id) ?? null);
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [plugin.draftId, plugin.id]);
   useEffect(() => {
     if (!armedDelete) return;
     const t = window.setTimeout(() => setArmedDelete(false), 4000);
     return () => window.clearTimeout(t);
   }, [armedDelete]);
+
+  const adjustRoles = useCallback(() => {
+    if (!fullDraft || !onAdjustRoles) return;
+    const roleNames = fullDraft.extraction.roles.map((role) => role.name);
+    const derived = deriveCraftDisplayName(fullDraft.extraction.familiar, roleNames);
+    onAdjustRoles({
+      draftId: fullDraft.id,
+      familiar: fullDraft.extraction.familiar,
+      roleIds: fullDraft.extraction.roles.map((role) => role.id),
+      // Only carry a name the operator actually chose — a derived name should
+      // keep re-deriving as the role set changes.
+      displayName: plugin.displayName !== derived ? plugin.displayName : undefined,
+    });
+  }, [fullDraft, onAdjustRoles, plugin.displayName]);
 
   /** The refine/publish briefs carry the draft's identity + ledger shape
    *  (cave-46wg) so the familiar starts from what exists. */
@@ -245,7 +290,10 @@ function DraftCraftDetail({
           </button>
         </div>
 
-        <CraftDraftPreview groups={craftSpecGroups(craft)} ariaLabel="Draft extraction ledger" />
+        <CraftDraftPreview
+          groups={fullDraft ? extractionLedgerGroups(fullDraft.extraction.ledger) : craftSpecGroups(craft)}
+          ariaLabel="Draft extraction ledger"
+        />
 
         <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-3 py-2 text-[12px] text-[var(--text-muted)]">
           Drafts are local and reversible. Review the extracted bundle before publishing or installing it as a versioned Craft.
@@ -258,6 +306,18 @@ function DraftCraftDetail({
         ) : null}
 
         <div className="mt-auto flex flex-wrap items-center gap-2 border-t border-[var(--border-hairline)] pt-3">
+          {onAdjustRoles ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              leadingIcon="ph:stack"
+              disabled={!fullDraft}
+              onClick={adjustRoles}
+              title="Reopen the create flow with this draft's roles pre-selected"
+            >
+              Adjust roles
+            </Button>
+          ) : null}
           <Button
             variant="secondary"
             size="sm"

--- a/src/lib/craft-draft.test.ts
+++ b/src/lib/craft-draft.test.ts
@@ -65,6 +65,25 @@ const reversedDraft = buildCraftDraftFromRoles({
   now: "2026-07-12T09:00:00.000Z",
 });
 
+// Rename (docs/craft-ux.md F12): an operator-chosen displayName replaces the
+// derived name but never moves the draft's identity (id stays derived).
+const renamedDraft = buildCraftDraftFromRoles({
+  familiar: "cody",
+  roles: roleInputs,
+  now: "2026-07-12T09:00:00.000Z",
+  displayName: "  Review Loadout  ",
+});
+assert.equal(renamedDraft.plugin.displayName, "Review Loadout");
+assert.equal(renamedDraft.id, "cody-implementation-review");
+assert.equal(renamedDraft.plugin.draftId, "cody-implementation-review");
+const blankNameDraft = buildCraftDraftFromRoles({
+  familiar: "cody",
+  roles: roleInputs,
+  now: "2026-07-12T09:00:00.000Z",
+  displayName: "   ",
+});
+assert.equal(blankNameDraft.plugin.displayName, "Cody Implementation + Review");
+
 assert.equal(draft.id, "cody-implementation-review");
 assert.equal(draft.plugin.kind, "craft");
 assert.equal(draft.plugin.draft, true);

--- a/src/lib/craft-draft.ts
+++ b/src/lib/craft-draft.ts
@@ -140,14 +140,24 @@ function workflowResource(id: string): CraftWorkflowResource {
   };
 }
 
+/** The mechanical name a draft gets from its familiar + role names — also
+ *  the reference point for "was this draft renamed?" (docs/craft-ux.md F12). */
+export function deriveCraftDisplayName(familiar: string, roleNames: readonly string[]): string {
+  return `${titleCase(familiar.trim())} ${roleNames.join(" + ")}`;
+}
+
 export function buildCraftDraftFromRoles({
   familiar,
   roles,
   now = new Date().toISOString(),
+  displayName,
 }: {
   familiar: string;
   roles: CraftDraftRoleInput[];
   now?: string;
+  /** Optional operator-chosen name (docs/craft-ux.md F12). The derived name
+   *  stays the id/slug source so renames never move the draft's identity. */
+  displayName?: string;
 }): CraftDraft {
   const cleanFamiliar = familiar.trim();
   if (!cleanFamiliar) throw new Error("familiar is required");
@@ -156,7 +166,9 @@ export function buildCraftDraftFromRoles({
 
   const roleNames = orderedRoles.map((role) => role.name.trim() || role.id);
   const roleIds = orderedRoles.map((role) => role.id.trim()).filter(Boolean);
-  const displayName = `${titleCase(cleanFamiliar)} ${roleNames.join(" + ")}`;
+  const derivedName = deriveCraftDisplayName(cleanFamiliar, roleNames);
+  const customName = displayName?.trim();
+  const finalName = customName || derivedName;
   const id = slugify(`${cleanFamiliar}-${roleNames.join("-")}`);
 
   const ledgers = {
@@ -221,7 +233,7 @@ export function buildCraftDraftFromRoles({
       id,
       draftId: id,
       draft: true,
-      displayName,
+      displayName: finalName,
       description: `Draft Craft extracted from ${roleNames.length === 1 ? `${roleNames[0]} role` : `${roleNames.length} roles`} for ${titleCase(cleanFamiliar)}.`,
       category: "Draft Crafts",
       author: "Local Cave",


### PR DESCRIPTION
## Checkpoint 3 of the craft-ux-simplification goal

The power layer of [docs/craft-ux.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/craft-ux.md), in-flow — deepening the unified drawer from #3189 without adding a second dialog.

### Changes
- **Attribution on screen (F4).** `CraftDraftPreview` items now carry the extraction ledger's provenance (`Direct` / `via <Craft>` · contributing roles) as chip hints. The draft detail fetches the full draft from the drafts store and renders the attributed ledger; the spec-based view stays as fallback.
- **Draft editing in place (F5).** "Adjust roles" on draft detail reopens the create drawer seeded (`CraftDrawerSeed`) with the draft's familiar, roles, and name — landing directly on the preview step. Save becomes recreate-and-replace (guarded `DELETE` + `POST`), matching the store's semantics; the CTA reads "Save changes".
- **Per-familiar selection retention (F9 partial).** Switching familiars stashes the current role picks and restores them on return instead of destroying them.
- **Rename without identity moves (F12).** Optional name field on the preview step, rendered live in the derived-name line. `POST /api/marketplace/crafts/drafts` accepts a trimmed, 120-char-bounded `displayName`; the derived name remains the id/slug source (`deriveCraftDisplayName`), and only operator-chosen names survive an adjust round trip.

### Verification
- `pnpm test:app` — 716 files pass; `pnpm test:api` — 182 files pass; `pnpm typecheck` — clean
- New unit cases in `craft-draft.test.ts` (rename keeps id; blank rename falls back to derived)
- Pins updated in `crafts-marketplace.test.ts` + `crafts-routes.test.ts`

Bead: `cave-x22o`. Next: CP4 (close the describe loop honestly — draft-aware plan + persistent arrival).
