### PR TITLE
fix(mobile): packaged app pairs phones without a dev checkout (cave-gzje)

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -131,15 +131,12 @@ function nativeAppBackendUrl(req: Request) {
   const configured = normalizeLoopbackBackend(process.env.COVEN_CAVE_NATIVE_APP_BACKEND_URL);
   if (configured) return configured;
 
-  // The packaged desktop app runs an authenticated sidecar on a random loopback
-  // port. The native SwiftUI iOS app is tokenless and trusts Tailscale instead,
-  // so publishing the packaged port makes the iPhone hit 401. In bundled mode,
-  // reconcile the native route against the tokenless app server started by
-  // `pnpm mobile:tailscale:app` instead of the packaged sidecar itself.
-  if (process.env.COVEN_CAVE_BUNDLE === "1" && process.env.COVEN_CAVE_TAILNET_TRUST !== "1") {
-    return "http://127.0.0.1:3000";
-  }
-
+  // Tokenless native-app mode (`pnpm mobile:tailscale:app` sets
+  // COVEN_CAVE_TAILNET_TRUST=1): tailnet membership is the trust boundary, so
+  // the server publishes itself bare. In every token-gated mode — the packaged
+  // bundle above all — app-start publishes THIS server and mints signed
+  // invites instead (see ensureNativeAppServe), so there is no separate
+  // backend to point at.
   return backendUrl();
 }
 
@@ -183,6 +180,16 @@ async function verifyNativeAppBackend(req: Request, backend: string) {
 
 function mobileAccessSecret() {
   return process.env.COVEN_CAVE_ACCESS_TOKEN?.trim() ?? "";
+}
+
+// The native route trusts the tailnet only when something explicitly says so:
+// the dev script's tokenless server (COVEN_CAVE_TAILNET_TRUST=1) or an
+// operator-configured backend override. Everywhere else — the packaged bundle
+// first and foremost — pairing rides SIGNED invites minted from the access
+// secret, so a packaged user needs no dev checkout to pair a phone (cave-gzje).
+function nativeTokenlessMode() {
+  if (process.env.COVEN_CAVE_TAILNET_TRUST === "1") return true;
+  return Boolean(normalizeLoopbackBackend(process.env.COVEN_CAVE_NATIVE_APP_BACKEND_URL));
 }
 
 function mobileAccessUnavailableResponse() {
@@ -276,7 +283,39 @@ async function ensureNativeAppServe(req: Request, chatId?: string | null) {
   // deep-link fragment so one scan opens THIS conversation. The bare host
   // (nativeHost/serveUrl) stays clean — the native app pairs on the host,
   // not the fragment.
-  const qrTarget = withChatFragment(discovery.serveUrl, chatId);
+  //
+  // Token-gated servers (the packaged bundle, or a token-gated dev session)
+  // additionally mint the signed invite the tokenless flow never needed: the
+  // QR/link carry `coven_access_token` so Safari pairs via the cookie
+  // exchange and the native scanner auto-connects via CaveInvite, and
+  // `appInviteUrl` is the covencave:// deep link with the long-lived token.
+  // Without this a packaged user's scan lands on a 401 (cave-gzje).
+  let invitePayload: {
+    inviteUrl: string;
+    appUrl: string;
+    appInviteUrl: string;
+    appTokenExpiresAt: number;
+    expiresAt: number;
+    expiresAtIso: string;
+  } | null = null;
+  let qrTarget = withChatFragment(discovery.serveUrl, chatId);
+  if (!nativeTokenlessMode()) {
+    const invite = await createMobileInvite({
+      baseUrl: discovery.serveUrl,
+      accessSecret: mobileAccessSecret(),
+      sidecarToken: process.env.COVEN_CAVE_AUTH_TOKEN,
+      ttlMs: MOBILE_INVITE_TTL_MS,
+    });
+    qrTarget = withChatFragment(invite.url, chatId);
+    invitePayload = {
+      inviteUrl: qrTarget,
+      appUrl: qrTarget,
+      appInviteUrl: invite.appInviteUrl,
+      appTokenExpiresAt: invite.appTokenExpiresAt,
+      expiresAt: invite.expiresAt,
+      expiresAtIso: invite.expiresAtIso,
+    };
+  }
   const qrSvg = await QRCode.toString(qrTarget, {
     type: "svg",
     margin: 1,
@@ -289,6 +328,7 @@ async function ensureNativeAppServe(req: Request, chatId?: string | null) {
     backendUrl: backend,
     serveUrl: discovery.serveUrl,
     url: qrTarget,
+    ...(invitePayload ?? {}),
     nativeUrl: discovery.serveUrl,
     nativeHost: discovery.host,
     discoverySource: discovery.source,

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -70,7 +70,29 @@ assert.match(handoffRoute, /nativeUrl/, "API should return the full Tailscale Se
 assert.match(handoffRoute, /ensureNativeAppServe/, "API should share one reconcile path for stale Tailscale Serve targets");
 assert.match(handoffRoute, /nativeAppBackendUrl/, "native mobile mode should choose a backend separately from invite handoff");
 assert.match(handoffRoute, /COVEN_CAVE_NATIVE_APP_BACKEND_URL/, "native mobile mode should allow an explicit loopback backend override");
-assert.match(handoffRoute, /COVEN_CAVE_BUNDLE === "1"[\s\S]*http:\/\/127\.0\.0\.1:3000/, "bundled desktop app must publish the tokenless native backend, not its authenticated sidecar port");
+// cave-gzje: the packaged bundle publishes ITS OWN sidecar and mints signed
+// invites — it must not depend on a dev checkout's tokenless :3000 server.
+assert.doesNotMatch(
+  handoffRoute,
+  /http:\/\/127\.0\.0\.1:3000/,
+  "bundled app-start must not hard-depend on the dev checkout's tokenless :3000 server",
+);
+assert.match(handoffRoute, /function nativeTokenlessMode\(\)/, "the tokenless/invite trust decision should be a single named predicate");
+assert.match(
+  handoffRoute,
+  /if \(!nativeTokenlessMode\(\)\) \{[\s\S]*?createMobileInvite\(\{[\s\S]*?accessSecret: mobileAccessSecret\(\),[\s\S]*?sidecarToken: process\.env\.COVEN_CAVE_AUTH_TOKEN/,
+  "token-gated app-start mints the signed invite the packaged phone pairs with",
+);
+assert.match(
+  handoffRoute,
+  /qrTarget = withChatFragment\(invite\.url, chatId\)/,
+  "the token-gated app-start QR is the SIGNED invite, still carrying the chat fragment",
+);
+assert.match(
+  handoffRoute,
+  /appInviteUrl: invite\.appInviteUrl/,
+  "app-start returns the covencave:// deep link so the Copy-app-link button works",
+);
 assert.match(handoffRoute, /verifyNativeAppBackend/, "native mobile mode should verify the tokenless backend before publishing Serve");
 assert.match(handoffRoute, /\/api\/familiars/, "native backend readiness should use the same lightweight endpoint as the iOS connection probe");
 assert.match(handoffRoute, /pnpm mobile:tailscale:app/, "native backend readiness errors should point to the documented app-mode command");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1966,7 +1966,9 @@ function describeMobileHandoffError(raw: string): { headline: string; hint: stri
       hint: "Open Tailscale and sign in — pairing resumes here automatically.",
     };
   }
-  if (text.includes("serve")) {
+  // Word-boundary match: backend errors mentioning a "server" must not be
+  // misdiagnosed as Tailscale Serve failures (cave-gzje).
+  if (/\bserve\b/.test(text)) {
     return {
       headline: "Tailscale Serve couldn’t start",
       hint: "Retry below; if it keeps failing, quit and reopen Tailscale.",

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -243,6 +243,11 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.match(route, /withChatFragment\(discovery\.serveUrl, chatId\)/, "app-start QR target carries the chat fragment");
   assert.match(route, /ensureNativeAppServe\(req, chatId\)/, "POST threads chatId into app-start");
   assert.match(route, /lastSeenAt: await readMobileLastSeen\(\)/, "handoff responses expose the paired-device beat");
+  // cave-gzje: on token-gated servers (the packaged bundle above all),
+  // app-start mints the signed invite instead of the bare host, so a packaged
+  // scan pairs instead of landing on a 401.
+  assert.match(route, /qrTarget = withChatFragment\(invite\.url, chatId\)/, "token-gated app-start swaps the QR target to the signed invite");
+  assert.match(route, /expiresAtIso: invite\.expiresAtIso/, "token-gated app-start exposes the invite expiry");
 
   const refresh = read("../app/api/mobile-token/refresh/route.ts");
   assert.match(refresh, /await recordMobileSeen\(\);/, "a successful token refresh records the paired-device beat");

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -57,6 +57,20 @@ assert.doesNotMatch(
 );
 assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless-tailnet CSRF guard");
 assert.match(source, /missing request source/, "tokenless tailnet GET webhooks should reject absent Origin and Referer headers");
+// cave-gzje: a verified signed mobile invite is the paired phone's credential.
+// The final sidecar gate must admit it (the phone can never learn the
+// webview's per-launch token), and the webhook-GET missing-source guard must
+// extend to mobile-cookie-authenticated requests in exchange.
+assert.match(
+  source,
+  /if \(!sidecarAuthenticated && !mobileAccessAuthenticated\) \{/,
+  "the sidecar gate must admit mobile-access-authenticated requests — packaged phones hold no sidecar token",
+);
+assert.match(
+  source,
+  /\(\(tailnetTrusted && !sidecarToken\) \|\| mobileAccessAuthenticated\) &&\s*isProductionWebhookGet/,
+  "the webhook-GET missing-source guard must also cover mobile-cookie-authenticated requests",
+);
 
 // Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the
 // sidecar token in the CSRF-immune CUSTOM HEADER bypasses the origin/referer gate

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -227,12 +227,13 @@ export async function proxy(req: NextRequest) {
     // request starts an agent-backed flow. In tokenless Tailscale mode there is
     // no sidecar secret to prove the caller is first-party, and browsers can
     // issue cross-site GET navigations/subresources with both Origin and
-    // Referer omitted (for example via Referrer-Policy: no-referrer). Require a
+    // Referer omitted (for example via Referrer-Policy: no-referrer). The same
+    // applies to a request authenticated only by the mobile-access cookie
+    // (SameSite=Lax still rides top-level GET navigations). Require a
     // same-origin source header for that narrow state-changing GET surface so
     // absent headers cannot bypass the CSRF gate.
     if (
-      tailnetTrusted &&
-      !sidecarToken &&
+      ((tailnetTrusted && !sidecarToken) || mobileAccessAuthenticated) &&
       isProductionWebhookGet(req.nextUrl.pathname, req.method) &&
       !origin &&
       !referer
@@ -256,7 +257,14 @@ export async function proxy(req: NextRequest) {
       : nextWithMobileAccessMarker(req, mobileAccessMarker);
   }
 
-  if (!sidecarAuthenticated) {
+  if (!sidecarAuthenticated && !mobileAccessAuthenticated) {
+    // A verified signed mobile invite is the paired phone's credential: the
+    // token is minted by this desktop from its access secret and already
+    // passed mobileAccessGate above. Requiring the webview's per-launch
+    // sidecar token ON TOP would 401 every native REST call in the packaged
+    // bundle — the phone can never learn that token — which is exactly the
+    // "packaged app cannot pair" failure (cave-gzje). CSRF stays covered: the
+    // Origin/Referer gates above ran for every non-header-trusted request.
     return jsonError(401, "unauthorized");
   }
 


### PR DESCRIPTION
Phase **O1** of docs/ios-connection-cloud-plan.md (umbrella cave-rku9): un-orphan the signed-invite token model. Prerequisite C0 (persisted mobile secret, cave-y482) landed in #2933/#2935/#3187 — invites now survive desktop restarts, so this wiring completes packaged pairing.

## Problem
All three desktop pairing entry points POST `action:app-start`, which in bundle mode required a **tokenless dev server on :3000** (`pnpm mobile:tailscale:app`) — packaged users hit a 503 telling them to run a pnpm command they don't have. Meanwhile the complete signed-invite branch (`mobileHandoff()`) was orphaned: no UI called it, and Settings' Copy-link buttons read fields app-start never returned. Worse: even a phone holding a valid signed token had every REST call 401'd in bundle mode, because the proxy's final gate demanded the webview's per-launch sidecar token — which a phone can never learn.

## Fix
1. **`mobile-handoff/route.ts`** — `app-start` now branches on `nativeTokenlessMode()`: tokenless (dev script `COVEN_CAVE_TAILNET_TRUST=1` / explicit backend override) keeps today's bare-host reconcile; token-gated servers (the packaged bundle) publish **their own sidecar** through Serve and mint the signed invite — tokened QR (Safari cookie exchange; native `CaveInvite` auto-connect) + `appInviteUrl` + expiry. The dead Copy buttons revive; `.needsAuth` heals by re-scan; the `lastSeenAt` paired signal can finally fire on the UI-driven flow.
2. **`proxy.ts`** — the final sidecar gate admits requests that passed mobile-access verification (`!sidecarAuthenticated && !mobileAccessAuthenticated`). The signed token is minted by this desktop from its access secret and already cleared `mobileAccessGate`. CSRF posture is unchanged: the header-keyed CSRF bypass stays sidecar-only, origin/referer gates still run, and the webhook-GET missing-source guard is **extended** to mobile-cookie-authenticated requests (SameSite=Lax rides top-level GET navigations).
3. **`settings-shell.tsx`** — `includes("serve")` → `/\bserve\b/` so errors mentioning a *server* stop being misdiagnosed as 'Tailscale Serve couldn't start' (the humanized-copy bug called out in the plan).

## Verification
- `pnpm test:app`: **716/716 files pass** (includes updated pins in `src/lib/mobile-handoff.test.ts`, `src/components/mobile-handoff.test.ts`, `src/middleware.test.ts`)
- `pnpm typecheck` clean
- iOS side needs no changes: `CaveInvite.parse` already handles tokened https QRs and `covencave://` links; PTY upgrades already honor signed tokens (`server.ts`).