### PR TITLE
fix(mcp-client): require trusted config for stdio servers

### DIFF
--- a/marketplace/plugins/mcp-client/skills/mcp-client/SKILL.md
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/SKILL.md
@@ -16,10 +16,11 @@ This skill is located at: `.claude/skills/mcp-client/`
 ## Configuration
 
 The script looks for config in this order:
-1. `MCP_CONFIG_PATH` env var (custom path)
+1. `MCP_CONFIG_PATH` env var (custom path for trusted config files)
 2. **`references/mcp-config.json`** (this skill's config - recommended)
-3. `.mcp.json` in project root
-4. `~/.claude.json`
+3. `~/.claude.json`
+
+Project-local `.mcp.json` files are not auto-discovered because they can define executable stdio servers. To use a workspace config, inspect it first and pass it explicitly with `MCP_CONFIG_PATH=/path/to/.mcp.json`.
 
 **Your config file:** `.claude/skills/mcp-client/references/mcp-config.json`
 
@@ -44,7 +45,7 @@ python .claude/skills/mcp-client/scripts/mcp_client.py call <server> <tool> '{"a
 
 ## Workflow
 
-1. **Check config exists** - Run `servers` command. If error, create `.mcp.json`
+1. **Check config exists** - Run `servers` command. If error, create `references/mcp-config.json` in this skill or set `MCP_CONFIG_PATH` to a trusted config file.
 2. **List servers** - See what MCP servers are configured
 3. **List tools** - Get tool schemas from a specific server
 4. **Call tool** - Execute a tool with arguments
@@ -101,7 +102,7 @@ Config file format (`references/mcp-config.json`):
 
 **Transport detection:**
 - `url` + `api_key` → FastMCP with Bearer auth (Zapier)
-- `command` + `args` → stdio (local servers like sequential-thinking)
+- `command` + `args` → stdio (local servers like sequential-thinking). Stdio servers receive only a minimal launch environment plus explicit per-server `env` values, not the caller's full environment.
 - `url` ending in `/sse` → SSE transport
 - `url` ending in `/mcp` → Streamable HTTP
 
@@ -112,7 +113,7 @@ Errors return JSON:
 {"error": "message", "type": "configuration|validation|connection"}
 ```
 
-- `configuration` - Config file not found. Create `.mcp.json`
+- `configuration` - Config file not found. Create `references/mcp-config.json` in this skill, set `MCP_CONFIG`, or set `MCP_CONFIG_PATH` to a trusted config file.
 - `validation` - Invalid server or tool name
 - `connection` - Failed to connect to server
 

--- a/marketplace/plugins/mcp-client/skills/mcp-client/scripts/mcp_client.py
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/scripts/mcp_client.py
@@ -11,8 +11,11 @@ Supports all MCP transports:
 Config Resolution (priority order):
 1. MCP_CONFIG_PATH env var (path to config file)
 2. MCP_CONFIG env var (inline JSON)
-3. .mcp.json in current directory
+3. references/mcp-config.json in this skill
 4. ~/.claude.json (Claude Code user config)
+
+Project-local .mcp.json files are intentionally not auto-discovered because
+they can define executable stdio servers.
 
 Usage:
     python mcp_client.py servers                           # List configured servers
@@ -51,12 +54,7 @@ def find_config_file() -> Optional[Path]:
     if skill_config.exists():
         return skill_config
 
-    # Priority 3: .mcp.json in current directory
-    local_config = Path(".mcp.json")
-    if local_config.exists():
-        return local_config
-
-    # Priority 4: ~/.claude.json (Claude Code config)
+    # Priority 3: ~/.claude.json (Claude Code config)
     claude_config = Path.home() / ".claude.json"
     if claude_config.exists():
         return claude_config
@@ -79,7 +77,9 @@ def load_config() -> dict:
     if not config_path:
         raise FileNotFoundError(
             "No MCP config found. Set MCP_CONFIG_PATH, MCP_CONFIG, "
-            "or create .mcp.json in the current directory."
+            "create references/mcp-config.json in this skill, or configure ~/.claude.json. "
+            "Project-local .mcp.json files are not auto-discovered; use "
+            "MCP_CONFIG_PATH explicitly only for trusted workspace configs."
         )
 
     with open(config_path) as f:
@@ -87,6 +87,29 @@ def load_config() -> dict:
 
     # Handle both formats: {"mcpServers": {...}} and direct {...}
     return config.get("mcpServers", config)
+
+
+def build_stdio_env(config_env: Optional[dict[str, str]]) -> dict[str, str]:
+    """Build a minimal environment for stdio MCP subprocesses.
+
+    Stdio MCP server definitions are executable commands, so they must not
+    receive the caller's full secret-bearing environment by default. Preserve a
+    small set of non-secret process-launch variables for command lookup and
+    platform compatibility, then apply explicit per-server env values.
+    """
+    env: dict[str, str] = {}
+
+    if path := os.environ.get("PATH"):
+        env["PATH"] = path
+
+    for name in ("SYSTEMROOT", "SystemRoot", "WINDIR", "COMSPEC", "PATHEXT"):
+        if value := os.environ.get(name):
+            env[name] = value
+
+    if config_env:
+        env.update({str(key): str(value) for key, value in config_env.items()})
+
+    return env
 
 
 def get_server_config(servers: dict, server_name: str) -> dict:
@@ -162,10 +185,10 @@ async def create_session(config: dict):
         from mcp import ClientSession, StdioServerParameters
         from mcp.client.stdio import stdio_client
 
-        # Build environment with current env + config env
-        env = {**os.environ}
-        if config_env := config.get("env"):
-            env.update(config_env)
+        # Do not pass the caller's full environment to config-supplied stdio
+        # commands. Repository-controlled MCP configs can otherwise exfiltrate
+        # inherited API keys and tokens as soon as a session is opened.
+        env = build_stdio_env(config.get("env"))
 
         server_params = StdioServerParameters(
             command=config["command"],
@@ -316,8 +339,11 @@ Examples:
 Config sources (checked in order):
     1. MCP_CONFIG_PATH environment variable
     2. MCP_CONFIG environment variable (inline JSON)
-    3. .mcp.json in current directory
-    4. ~/.claude.json"""
+    3. references/mcp-config.json in this skill
+    4. ~/.claude.json
+
+Project-local .mcp.json files are not auto-discovered; pass trusted workspace
+configs explicitly with MCP_CONFIG_PATH."""
     print(usage)
 
 


### PR DESCRIPTION
### Motivation
- Prevent execution of repository-controlled MCP stdio servers and accidental exfiltration of secret-bearing process environment by removing automatic trust of project-local `.mcp.json` files. 
- Ensure stdio subprocesses launched from MCP configs do not inherit the caller's full environment by default.

### Description
- Stop auto-discovering project-local `.mcp.json` by changing `find_config_file()` to prefer `MCP_CONFIG_PATH`, the skill-local `references/mcp-config.json`, and `~/.claude.json`, and no longer return `./.mcp.json` implicitly. 
- Add `build_stdio_env()` to construct a minimal, non-secret environment (preserving `PATH` and a small set of platform lookup vars plus explicit per-server `env` values) and use it for `stdio` transport instead of forwarding `os.environ`. 
- Update `create_session()` to pass the restricted env to `StdioServerParameters` for `stdio` transports. 
- Update CLI/help/error messages and the vendored `SKILL.md` to document that project-local `.mcp.json` files are not auto-discovered and that trusted workspace configs must be supplied explicitly via `MCP_CONFIG_PATH`.

### Testing
- `python -m py_compile marketplace/plugins/mcp-client/skills/mcp-client/scripts/mcp_client.py` — succeeded. 
- Import-time assertion test that `build_stdio_env()` preserves explicit per-server env and omits inherited secret envs (assertions passed). 
- Temporary-workspace functional check running the vendored `mcp_client.py servers` with only a local `.mcp.json` present — produced the expected configuration error and did not auto-load the workspace `.mcp.json`. 
- `git diff --check` produced no whitespace/patch errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c6ee6518c83279f9efc2a6882bddb)