### PR TITLE
Force read-only permission for automatic reply recommendations

### DIFF
--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -93,6 +93,18 @@ describe("streamFamiliarText", () => {
     );
   });
 
+  it("forwards read-only permission mode when provided", async () => {
+    let body = "";
+    globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {
+      body = init.body ?? "";
+      return sseResponse([frame({ kind: "done" })]);
+    }) as typeof fetch;
+
+    await streamFamiliarText({ familiarId: "nova", prompt: "p", permissionMode: "read" });
+
+    assert.equal(JSON.parse(body).permissionMode, "read");
+  });
+
   it("returns the created session id from stream frames", async () => {
     globalThis.fetch = (async () => sseResponse([
       frame({ kind: "session", sessionId: "sess-created" }),

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -23,6 +23,10 @@ export async function streamFamiliarText(opts: {
   projectRoot?: string;
   reasoningEffort?: string;
   responseSpeed?: string;
+  /** Advisory permission mode forwarded to the chat bridge. Use "read" for
+   *  hidden/meta generations so prompt-injected transcript text cannot trigger
+   *  privileged tool execution. */
+  permissionMode?: "read" | "full";
   modelOverride?: string;
   modelOverrideScope?: "next-message" | "session";
   /** Session provenance — set by generator surfaces (e.g. "journal") so the
@@ -50,6 +54,7 @@ export async function streamFamiliarText(opts: {
         ...(opts.projectRoot ? { projectRoot: opts.projectRoot } : {}),
         ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
         ...(opts.responseSpeed ? { responseSpeed: opts.responseSpeed } : {}),
+        ...(opts.permissionMode ? { permissionMode: opts.permissionMode } : {}),
         ...(opts.modelOverride ? { modelOverride: opts.modelOverride } : {}),
         ...(opts.modelOverrideScope ? { modelOverrideScope: opts.modelOverrideScope } : {}),
         // Provenance for generated runs (journal narratives, …) so the chat

--- a/src/lib/use-reply-recommendation.ts
+++ b/src/lib/use-reply-recommendation.ts
@@ -122,6 +122,10 @@ export function useReplyRecommendation({
       origin: "enhance",
       reasoningEffort: "low",
       responseSpeed: "fast",
+      // Recommendations are hidden, automatic meta-runs over untrusted
+      // transcript text. Force read-only so prompt injection cannot escalate
+      // into privileged harness actions before explicit user intent.
+      permissionMode: "read",
       signal: controller.signal,
       onText: (text) => {
         if (gen !== generationRef.current) return;


### PR DESCRIPTION
### Motivation
- Automatic quick-chat reply recommendations were issuing hidden agent runs via `/api/chat/send` using untrusted transcript text without restricting permission mode, which could allow prompt-injection to trigger privileged harness actions before explicit user intent.

### Description
- Add an advisory `permissionMode` option to `streamFamiliarText` and forward it in the POST body to `/api/chat/send`.
- Force the automatic recommendation meta-run in `useReplyRecommendation` to call `streamFamiliarText` with `permissionMode: "read"` so hidden suggestions run read-only.
- Add a targeted unit test in `src/lib/familiar-stream.test.ts` that asserts the `permissionMode` field is forwarded when provided.

### Testing
- Ran `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/familiar-stream.test.ts` and the test file passed (11/11).
- Ran `pnpm typecheck` and TypeScript reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5261b4c24c832781a3752a96083510)