### PR TITLE
feat(crafts): teaching dead ends, in-place recovery, lifecycle clarity (cave-17i8)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13495,6 +13495,35 @@ details[open] > .cave-edit-card__summary::before {
 .craft-draft-plan-status[data-state="ok"] span { display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); }
 .craft-draft-plan-status summary { cursor: pointer; color: var(--text-secondary); font-weight: 600; }
 .craft-draft-plan-status ul { margin: 6px 0 0; padding-left: 16px; display: grid; gap: 4px; }
+/* Draft lifecycle strip (docs/craft-ux.md F8). */
+.craft-lifecycle-strip {
+  display: grid;
+  gap: 6px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  padding: 9px 11px;
+}
+.craft-lifecycle-strip ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.craft-lifecycle-strip li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+.craft-lifecycle-strip li small { font-size: 9.5px; letter-spacing: 0.08em; }
+.craft-lifecycle-strip li[aria-current="step"] { color: var(--text-primary); font-weight: 650; }
+.craft-lifecycle-strip li + li::before { content: "→"; margin-right: 10px; color: var(--text-muted); }
+.craft-lifecycle-strip p { margin: 0; color: var(--text-muted); font-size: 11.5px; line-height: 1.5; }
 .craft-dossier {
   display: flex;
   width: min(760px, 100vw);
@@ -13670,6 +13699,33 @@ details[open] > .cave-edit-card__summary::before {
   padding: 8px 10px;
 }
 .craft-create-drawer__name::placeholder { color: var(--text-muted); }
+.craft-create-drawer__hint {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: normal;
+}
+.craft-create-drawer__teach {
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  border: 1px dashed var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  padding: 10px 12px;
+}
+.craft-create-drawer__teach p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.5; }
+.craft-create-drawer__retry {
+  margin-left: 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 11.5px;
+  font-weight: 700;
+  text-decoration: underline;
+  padding: 0 2px;
+  cursor: pointer;
+}
 /* "What happens next" — quiet numbered steps for the agentic path. */
 .craft-create-drawer__how { display: grid; gap: 6px; }
 .craft-create-drawer__how h3 {

--- a/src/components/marketplace/craft-create-drawer.tsx
+++ b/src/components/marketplace/craft-create-drawer.tsx
@@ -7,6 +7,8 @@ import { StandardSelect } from "@/components/ui/select";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { buildCraftAgentPrompt } from "@/lib/craft-agent-prompt";
 import {
   clearCraftArrivalWatch,
@@ -101,6 +103,10 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
   // current picks instead of destroying them.
   const selectionsByFamiliar = useRef(new Map<string, ReadonlySet<string>>());
   const appliedSeedId = useRef<string | null>(null);
+  // Roles fetch recovery (docs/craft-ux.md CP5): bumping the nonce re-runs
+  // the load instead of leaving a dead-end error.
+  const [rolesNonce, setRolesNonce] = useState(0);
+  const { announce } = useAnnouncer();
   useFocusTrap(open, ref, { onEscape: onClose });
 
   useEffect(() => {
@@ -193,7 +199,15 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
         if (!ctl.signal.aborted) setLoaded(true);
       });
     return () => ctl.abort();
-  }, [open]);
+  }, [open, rolesNonce]);
+
+  // Teaching dead ends (docs/craft-ux.md F7): roles live in the familiar
+  // studio's Brain tab — send the user there instead of stranding them.
+  const openRoleStudio = useCallback(() => {
+    openFamiliarStudioSettingsTab("brain", familiar || undefined);
+    onClose();
+  }, [familiar, onClose]);
+  const noRolesAnywhere = loaded && !error && roles.length === 0;
 
   const familiarOptions = useMemo(
     () => [...new Set(roles.map((role) => role.familiar))].sort().map((id) => ({ value: id, label: id })),
@@ -381,7 +395,28 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
         {error ? (
           <p role="alert" className="craft-create-drawer__alert">
             {error}
+            {roles.length === 0 ? (
+              <button
+                type="button"
+                className="focus-ring craft-create-drawer__retry"
+                onClick={() => setRolesNonce((nonce) => nonce + 1)}
+              >
+                Retry
+              </button>
+            ) : null}
           </p>
+        ) : null}
+
+        {noRolesAnywhere ? (
+          <div role="status" className="craft-create-drawer__teach">
+            <p>
+              No roles yet — a Craft bundles what a familiar&apos;s roles already equip, so there&apos;s nothing to
+              extract or describe until a familiar has at least one role.
+            </p>
+            <Button variant="secondary" size="sm" leadingIcon="ph:brain" onClick={openRoleStudio}>
+              Set up roles in the familiar studio
+            </Button>
+          </div>
         ) : null}
 
         {mode === "describe" ? (
@@ -480,6 +515,9 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
                 options={familiarOptions}
                 className="focus-ring craft-create-drawer__select"
               />
+              <em className="craft-create-drawer__hint">
+                A Craft bundles roles from one familiar — switching keeps each familiar&apos;s picks.
+              </em>
             </label>
 
             <section className="craft-create-drawer__roles" aria-label="Roles to extract">
@@ -487,7 +525,15 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
               {!loaded ? (
                 <p className="craft-create-drawer__status">Loading roles...</p>
               ) : visibleRoles.length === 0 ? (
-                <p className="craft-create-drawer__status">No roles found for this familiar.</p>
+                <div className="craft-create-drawer__teach">
+                  <p>
+                    No roles found for this familiar. Roles are defined in the familiar studio&apos;s Brain tab —
+                    each one lists the skills, tools, and workflows a Craft can bundle.
+                  </p>
+                  <Button variant="secondary" size="sm" leadingIcon="ph:brain" onClick={openRoleStudio}>
+                    Open the familiar studio
+                  </Button>
+                </div>
               ) : (
                 <div className="craft-create-drawer__role-list">
                   {visibleRoles.map((role) => (
@@ -526,14 +572,22 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
               variant="primary"
               size="sm"
               leadingIcon="ph:sparkle"
-              disabled={!goal.trim() || awaiting}
+              disabled={!goal.trim() || awaiting || noRolesAnywhere}
               onClick={() => void draftWithFamiliar()}
             >
               {awaiting ? "Drafting…" : "Draft with familiar"}
             </Button>
           ) : step === "preview" ? (
             <>
-              <Button variant="secondary" size="sm" leadingIcon="ph:arrow-left" onClick={() => setStep("select")}>
+              <Button
+                variant="secondary"
+                size="sm"
+                leadingIcon="ph:arrow-left"
+                onClick={() => {
+                  setStep("select");
+                  announce("Back to role selection", "polite");
+                }}
+              >
                 Adjust roles
               </Button>
               <Button
@@ -553,7 +607,10 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
               size="sm"
               leadingIcon="ph:magnifying-glass-bold"
               disabled={!familiar || selectedRoleIds.size === 0}
-              onClick={() => setStep("preview")}
+              onClick={() => {
+                setStep("preview");
+                announce("Draft preview ready", "polite");
+              }}
             >
               Preview draft
             </Button>

--- a/src/components/marketplace/craft-detail.tsx
+++ b/src/components/marketplace/craft-detail.tsx
@@ -358,13 +358,17 @@ export function CraftDetail({
                     const key = `${role.familiar}:${role.id}`;
                     const checked = role.crafts.includes(plugin.id);
                     const canAttach = current || checked;
+                    // Inline disabled reason (docs/craft-ux.md F10): the "why"
+                    // used to live only in the far-away footer status.
+                    const installFirst = !canAttach ? " (install the Craft first)" : "";
                     return (
                       <div key={key} className="craft-role-row" data-selected={selectedRoleKey === key || undefined}>
                         <input
                           type="checkbox"
                           checked={checked}
                           disabled={roleBusy === key || !canAttach}
-                          aria-label={`${checked ? "Detach" : "Equip"} ${plugin.displayName} ${checked ? "from" : "on"} ${role.name}`}
+                          title={!canAttach ? "Install the Craft first to equip Roles" : undefined}
+                          aria-label={`${checked ? "Detach" : "Equip"} ${plugin.displayName} ${checked ? "from" : "on"} ${role.name}${installFirst}`}
                           onFocus={() => setSelectedRoleKey(key)}
                           onChange={(event) => void attachRole(role, event.target.checked)}
                         />

--- a/src/components/marketplace/crafts-marketplace.test.ts
+++ b/src/components/marketplace/crafts-marketplace.test.ts
@@ -123,6 +123,21 @@ assert.match(detail, /draftDiagnostics/, "draft detail reads the honest draft di
   assert.match(arrivalLib, /CRAFT_ARRIVAL_MAX_AGE_MS/, "stale watches drop instead of spinning forever");
 }
 
+// ── Dead ends teach, errors recover, controls explain (docs/craft-ux.md CP5) ─
+assert.match(createDrawer, /openFamiliarStudioSettingsTab\("brain"/, "role dead-ends link to where roles are actually made");
+assert.match(createDrawer, /noRolesAnywhere/, "describe mode warns before dispatching a build that cannot succeed");
+assert.match(createDrawer, /craft-create-drawer__teach/, "teaching empty states use a stable styling hook");
+assert.match(createDrawer, /setRolesNonce/, "a failed roles load offers in-place retry");
+assert.match(createDrawer, /bundles roles from one familiar/, "the one-familiar constraint is stated, not discovered by loss");
+assert.match(createDrawer, /announce\("Draft preview ready", "polite"\)/, "step transitions are announced");
+{
+  const craftDetailSource = await readFile(craftDetailUrl, "utf8");
+  assert.match(craftDetailSource, /install the Craft first/, "disabled equip rows carry their reason inline");
+}
+assert.match(detail, /craft-lifecycle-strip/, "draft detail shows the Draft → Published → Installed → Equipped road");
+assert.match(detail, /human-reviewed catalog PR/, "the road to equipping names the publication reality");
+assert.match(css, /\.craft-lifecycle-strip \{/, "the lifecycle strip has a stable visual hook");
+
 // ── Describe-it closes its loop (cave-46wg) ──────────────────────────────────
 // The dispatched brief is no longer fire-and-forget: the drawer snapshots the
 // drafts store, polls while waiting, and hands an ARRIVED draft to the same

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -318,6 +318,23 @@ function DraftCraftDetail({
           </button>
         </div>
 
+        {/* Lifecycle strip (docs/craft-ux.md F8): where this draft stands and
+            what the road to equipping actually is. */}
+        <div className="craft-lifecycle-strip" aria-label="Craft lifecycle">
+          <ol>
+            {["Draft", "Published", "Installed", "Equipped"].map((stage, index) => (
+              <li key={stage} aria-current={index === 0 ? "step" : undefined}>
+                <small>{String(index + 1).padStart(2, "0")}</small>
+                <span>{stage}</span>
+              </li>
+            ))}
+          </ol>
+          <p>
+            Publishing is a human-reviewed catalog PR — <strong>Prepare for catalog</strong> drafts it with a
+            familiar. Installing and equipping unlock once the Craft ships in the catalog.
+          </p>
+        </div>
+
         <div role="status" className="craft-draft-plan-status" data-state={planState.kind}>
           {planState.kind === "loading" ? (
             <span>Checking the draft's install plan…</span>


### PR DESCRIPTION
## Checkpoint 5 of the craft-ux-simplification goal

Empty states teach, errors recover in place, controls explain themselves ([docs/craft-ux.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/craft-ux.md) CP5).

### Changes
- **Teaching dead ends (F7).** The no-roles-for-familiar state and a new zero-roles-anywhere notice explain what roles are and link straight to the familiar studio's Brain tab (`openFamiliarStudioSettingsTab("brain", …)` — the shipped navigation since the hub's Roles section was retired). Describe mode disables dispatch when the build cannot succeed instead of letting it fail in another surface.
- **Error recovery in place.** A failed roles load offers an inline Retry (nonce refetch) instead of stranding the drawer.
- **One-familiar rule stated (F9).** Hint under the familiar selector; switching keeps each familiar's picks (retention shipped in CP3).
- **Inline disabled reasons (F10).** Dossier equip rows carry "install the Craft first" in `title` + `aria-label`, not just the far-away footer.
- **Lifecycle clarity (F8).** Draft detail gains a Draft → Published → Installed → Equipped strip (`aria-current="step"` on Draft) naming the human-reviewed catalog-PR road to equipping.
- **A11y.** Stepper transitions announced through the shared live region.

### Verification
- `pnpm test:app` — 718 files pass; `pnpm typecheck` — clean
- Pins added in `crafts-marketplace.test.ts` (studio link, zero-roles guard, retry, hint, announcements, lifecycle strip, install-first reason)

Bead: `cave-17i8`. Next: CP6 (docs + e2e polish — final checkpoint).
