### PR TITLE
fix(research): terminal missions render a truthful evidence trajectory

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/lib/icon";
 import {
   allowedResearchActions,
   describeResearchSchedule,
+  researchPhaseStatuses,
   type ResearchMission,
   type ResearchMissionAction,
   type ResearchMissionActionInput,
@@ -35,6 +36,8 @@ const PHASES = [
   ["publish", "Publish"],
 ] as const;
 
+const PHASE_IDS = PHASES.map(([id]) => id);
+
 const ACTION_LABELS: Partial<Record<ResearchMissionAction, string>> = {
   continue: "Continue",
   retry: "Retry",
@@ -44,18 +47,6 @@ const ACTION_LABELS: Partial<Record<ResearchMissionAction, string>> = {
   cancel: "Cancel run",
   archive: "Archive",
 };
-
-function phaseStatus(
-  mission: ResearchMission,
-  phase: string,
-): "pending" | "running" | "succeeded" | "failed" | "skipped" {
-  const iteration = mission.iterations.at(-1);
-  const step = iteration?.steps?.find((item) => item.id === phase);
-  if (step) return step.status;
-  if (mission.status === "completed") return "succeeded";
-  if (mission.status === "failed" && phase === "scope") return "failed";
-  return "pending";
-}
 
 export function ResearchMissionDetail({
   mission,
@@ -199,9 +190,13 @@ export function ResearchMissionDetail({
             </span>
           </div>
           <ol className="research-phase-list" aria-label="Research progress">
-            {PHASES.map(([id, label]) => {
-              const status = phaseStatus(mission, id);
+            {researchPhaseStatuses(mission, PHASE_IDS).map((status, index) => {
+              const [id, label] = PHASES[index];
               const step = iteration?.steps?.find((item) => item.id === id);
+              // A stale step detail ("Searching sources…") contradicts a
+              // reconciled status; show the detail only when the status is
+              // still the step's own report.
+              const reconciled = status !== (step?.status ?? "pending");
               return (
                 <li key={id} className={`research-phase research-phase--${status}`}>
                   <span className="research-phase__node" aria-hidden>
@@ -209,7 +204,7 @@ export function ResearchMissionDetail({
                   </span>
                   <div>
                     <strong>{label}</strong>
-                    <span>{step?.detail || status}</span>
+                    <span>{reconciled ? status : step?.detail || status}</span>
                   </div>
                 </li>
               );

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -36,6 +36,19 @@ test("mission list and evidence trajectory expose semantic state", () => {
   assert.match(ledger, /Open in Grimoire/);
 });
 
+test("evidence trajectory statuses come from the shared terminal-truthful reconciler", () => {
+  // The old local heuristic trusted stale step snapshots over terminal mission
+  // status (completed missions rendered "Scope running / rest pending") and
+  // pinned every failure on scope. The reconciled statuses are computed by
+  // researchPhaseStatuses (behaviorally tested in research-missions.test.ts).
+  assert.match(detail, /researchPhaseStatuses\(mission, PHASE_IDS\)/);
+  assert.doesNotMatch(detail, /function phaseStatus\(/);
+  assert.doesNotMatch(detail, /mission\.status === "failed" && phase === "scope"/);
+  // Stale step details must not contradict a reconciled status.
+  assert.match(detail, /const reconciled = status !== \(step\?\.status \?\? "pending"\)/);
+  assert.match(detail, /\{reconciled \? status : step\?\.detail \|\| status\}/);
+});
+
 test("timestamps are relative and schedules read as prose, not raw data", () => {
   assert.match(list, /relativeTime\(mission\.updatedAt\)/);
   assert.match(detail, /relativeTime\(mission\.updatedAt\)/);

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -9,6 +9,7 @@ import {
   describeResearchSchedule,
   normalizeResearchBounds,
   RESEARCH_BOUND_LIMITS,
+  researchPhaseStatuses,
   validateCreateResearchMissionInput,
 } from "./research-missions.ts";
 
@@ -159,4 +160,204 @@ test("automation schedules are described in human terms, not raw RRULE", () => {
   assert.equal(describeResearchSchedule(""), "Not scheduled");
   assert.equal(describeResearchSchedule(null), "Not scheduled");
   assert.equal(describeResearchSchedule(undefined), "Not scheduled");
+});
+
+// --- researchPhaseStatuses: terminal missions must not lie about progress ---
+
+const PHASE_IDS = ["scope", "gather", "challenge", "synthesize", "control", "publish"];
+
+type PhaseSeed = Record<string, "pending" | "running" | "succeeded" | "failed" | "skipped">;
+
+function missionWithPhases(
+  missionStatus: string,
+  iterationStatus: string | null,
+  steps: PhaseSeed | null,
+) {
+  return {
+    status: missionStatus,
+    iterations: iterationStatus === null ? [] : [{
+      number: 1,
+      status: iterationStatus,
+      ...(steps === null ? {} : {
+        steps: Object.entries(steps).map(([id, status]) => ({ id, type: "agent", status })),
+      }),
+    }],
+  } as Parameters<typeof researchPhaseStatuses>[0];
+}
+
+test("completed mission with a stale step snapshot reads fully succeeded", () => {
+  // Screenshot repro: mission COMPLETED while steps still say scope running,
+  // everything else pending.
+  const mission = missionWithPhases("completed", "completed", {
+    scope: "running",
+    gather: "pending",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "succeeded", "succeeded", "succeeded", "succeeded", "succeeded"],
+  );
+});
+
+test("success reconciliation preserves explicit failed and skipped step reports", () => {
+  const mission = missionWithPhases("completed", "completed", {
+    scope: "succeeded",
+    gather: "skipped",
+    challenge: "failed",
+    synthesize: "running",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "skipped", "failed", "succeeded", "succeeded", "succeeded"],
+  );
+});
+
+test("failed mission marks the phase where the run died, not always scope", () => {
+  const mission = missionWithPhases("failed", "failed", {
+    scope: "succeeded",
+    gather: "succeeded",
+    challenge: "running",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "succeeded", "failed", "skipped", "skipped", "skipped"],
+  );
+});
+
+test("failed mission keeps an explicit failed step and does not invent a second failure", () => {
+  const mission = missionWithPhases("failed", "failed", {
+    scope: "succeeded",
+    gather: "failed",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "failed", "skipped", "skipped", "skipped", "skipped"],
+  );
+});
+
+test("failed mission without step data fails scope and skips the rest", () => {
+  const mission = missionWithPhases("failed", "failed", null);
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["failed", "skipped", "skipped", "skipped", "skipped", "skipped"],
+  );
+});
+
+test("cancelled mid-run phases read skipped, finished work stays succeeded", () => {
+  const mission = missionWithPhases("cancelled", "cancelled", {
+    scope: "succeeded",
+    gather: "running",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "skipped", "skipped", "skipped", "skipped", "skipped"],
+  );
+});
+
+test("mission archived while its iteration snapshot still said running settles as skipped", () => {
+  const mission = missionWithPhases("archived", "running", {
+    scope: "succeeded",
+    gather: "running",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "skipped", "skipped", "skipped", "skipped", "skipped"],
+  );
+});
+
+test("an archived completed mission still reads as a success trajectory", () => {
+  const mission = missionWithPhases("archived", "completed", {
+    scope: "succeeded",
+    gather: "running",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "succeeded", "succeeded", "succeeded", "succeeded", "succeeded"],
+  );
+});
+
+test("checkpoint iterations settle like success — the run finished its loop", () => {
+  const mission = missionWithPhases("checkpoint", "checkpoint", {
+    scope: "succeeded",
+    gather: "succeeded",
+    challenge: "succeeded",
+    synthesize: "running",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "succeeded", "succeeded", "succeeded", "succeeded", "succeeded"],
+  );
+});
+
+test("live missions pass raw step statuses through unchanged", () => {
+  const mission = missionWithPhases("running", "running", {
+    scope: "succeeded",
+    gather: "running",
+    challenge: "pending",
+    synthesize: "pending",
+    control: "pending",
+    publish: "pending",
+  });
+  assert.deepEqual(
+    researchPhaseStatuses(mission, PHASE_IDS),
+    ["succeeded", "running", "pending", "pending", "pending", "pending"],
+  );
+  // Queued mission with no iterations yet: everything pending.
+  assert.deepEqual(
+    researchPhaseStatuses(missionWithPhases("queued", null, null), PHASE_IDS),
+    ["pending", "pending", "pending", "pending", "pending", "pending"],
+  );
+});
+
+test("acceptance: no terminal mission ever renders a running or pending phase", () => {
+  const staleSnapshots: Array<PhaseSeed | null> = [
+    null,
+    { scope: "running" },
+    { scope: "succeeded", gather: "running", challenge: "pending" },
+    { scope: "pending", gather: "pending", challenge: "pending", synthesize: "pending", control: "pending", publish: "pending" },
+    { scope: "succeeded", gather: "failed", challenge: "running" },
+  ];
+  const settledIterations = ["completed", "checkpoint", "failed", "cancelled", "running", null];
+  for (const missionStatus of ["completed", "failed", "cancelled", "archived"]) {
+    for (const iterationStatus of settledIterations) {
+      for (const steps of staleSnapshots) {
+        const statuses = researchPhaseStatuses(
+          missionWithPhases(missionStatus, iterationStatus, steps),
+          PHASE_IDS,
+        );
+        for (const status of statuses) {
+          assert.ok(
+            status !== "running" && status !== "pending",
+            `${missionStatus}/${iterationStatus} with ${JSON.stringify(steps)} leaked "${status}"`,
+          );
+        }
+      }
+    }
+  }
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -337,6 +337,71 @@ export function allowedResearchActions(
   return [];
 }
 
+export type ResearchPhaseStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
+
+type ResearchPhaseOutcome = "success" | "failure" | "cancelled" | null;
+
+function settledPhaseOutcome(
+  mission: Pick<ResearchMission, "status">,
+  iteration: Pick<ResearchIteration, "status"> | undefined,
+): ResearchPhaseOutcome {
+  // A finished iteration knows its own outcome; prefer it so an archived
+  // completed mission still reads as a success trajectory.
+  if (iteration?.status === "completed" || iteration?.status === "checkpoint") return "success";
+  if (iteration?.status === "failed") return "failure";
+  if (iteration?.status === "cancelled") return "cancelled";
+  // Otherwise settle by terminal mission status (covers stale iteration
+  // snapshots, e.g. a mission archived while its iteration still said running).
+  if (mission.status === "completed") return "success";
+  if (mission.status === "failed") return "failure";
+  if (mission.status === "cancelled" || mission.status === "archived") return "cancelled";
+  return null;
+}
+
+/**
+ * Reconciled phase statuses for the latest iteration, in phase order.
+ *
+ * Step snapshots only sync while a flow run is live, so terminal missions keep
+ * whatever was last written (often "scope running, rest pending"). A settled
+ * run must never render a running or pending phase:
+ * - success (completed / checkpoint) — the run finished every chained phase,
+ *   so stale running/pending phases read succeeded; explicit failed/skipped
+ *   step reports are preserved.
+ * - failure — the first stale running/pending phase is where the run died and
+ *   reads failed (unless a step already reported failed); stale phases before
+ *   the failure point read succeeded (the sequential chain reached it) and
+ *   later unfinished phases read skipped.
+ * - cancelled/archived mid-run — unfinished phases read skipped.
+ * Live missions pass raw step statuses through unchanged.
+ */
+export function researchPhaseStatuses(
+  mission: Pick<ResearchMission, "status" | "iterations">,
+  phaseIds: readonly string[],
+): ResearchPhaseStatus[] {
+  const iteration = mission.iterations.at(-1);
+  const raw = phaseIds.map((phase): ResearchPhaseStatus =>
+    iteration?.steps?.find((step) => step.id === phase)?.status ?? "pending");
+  const outcome = settledPhaseOutcome(mission, iteration);
+  if (outcome === null) return raw;
+  if (outcome === "success") {
+    return raw.map((status) => status === "running" || status === "pending" ? "succeeded" : status);
+  }
+  if (outcome === "cancelled") {
+    return raw.map((status) => status === "running" || status === "pending" ? "skipped" : status);
+  }
+  const explicitFailure = raw.indexOf("failed");
+  const firstUnfinished = raw.findIndex((status) => status === "running" || status === "pending");
+  const failureAt = explicitFailure !== -1
+    ? explicitFailure
+    : firstUnfinished;
+  return raw.map((status, index) => {
+    if (status !== "running" && status !== "pending") return status;
+    if (index < failureAt) return "succeeded";
+    if (index === failureAt) return "failed";
+    return "skipped";
+  });
+}
+
 /**
  * Human-readable schedule for an autoresearch Automation link. Understands the
  * daily/weekly RRULEs the desk itself creates; anything else falls back to the


### PR DESCRIPTION
## What

Slice 1 of the `research-desk-ux-uplift` goal (bead `cave-8q40`). A completed Research Desk mission rendered **COMPLETED** in its eyebrow while the evidence trajectory still read *Scope running / everything else pending* (2026-07-15 screenshot audit). Failed missions also always pinned the failure on the scope phase regardless of where the run died.

## Why

Iteration step snapshots only sync while a flow run is live (`research-mission-runner.ts` sync path); `reconcileCompletedRun` and the failure paths never finalize them. The detail component's local `phaseStatus` heuristic trusted the stale `step.status` over the mission's terminal status.

## How

- New pure `researchPhaseStatuses(mission, phaseIds)` reconciler in `src/lib/research-missions.ts`:
  - **success** (completed / checkpoint-settled iterations): stale running/pending phases read *succeeded*; explicit failed/skipped step reports survive
  - **failure**: first stale phase reads *failed* (explicit failed steps win), earlier stale phases read *succeeded*, later ones *skipped*; no step data ⇒ scope fails, rest skip
  - **cancelled/archived mid-run**: unfinished phases read *skipped*
  - **live missions**: raw statuses pass through unchanged
- `research-mission-detail.tsx` consumes the reconciler and suppresses stale step details whenever a status was reconciled, so prose never contradicts the node tone.

## Testing

- 11 behavioral tests in `src/lib/research-missions.test.ts` incl. the screenshot repro and a property sweep asserting **no terminal mission ever renders a running or pending phase** (acceptance criterion).
- Wiring pins in `researcher-surface.test.ts` (reconciler import, old heuristic gone, detail-suppression guard).
- `pnpm typecheck` ✓ · targeted `node --test` runs ✓ · `pnpm test:app` 717 files ✓

Subsumes `research-desk-polish` NEXT CANDIDATE (e).