### PR TITLE
fix(studio): Reflection + Asana pills become shared settings-switch toggles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6845,7 +6845,7 @@ a.mobile-handoff__link:hover {
 .familiar-studio-brain__row { display: flex; flex-direction: column; gap: 6px; }
 .familiar-studio-brain__label { font-size: var(--text-2xs); font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
 .familiar-studio-brain__hint { margin: 6px 0 0; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
-.familiar-studio-brain__switch { align-self: flex-start; cursor: pointer; }
+
 .familiar-studio-brain__control { display: flex; min-width: 0; gap: 6px; align-items: flex-start; }
 
 /* Asana section (Familiar Studio → Brain): inline connect + per-agent controls. */

--- a/src/components/familiar-asana-section.tsx
+++ b/src/components/familiar-asana-section.tsx
@@ -204,13 +204,9 @@ export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar 
                 aria-checked={enabled}
                 aria-label="Work with Asana tasks"
                 onClick={toggleEnabled}
-                className={`familiar-studio-brain__switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
-                  enabled
-                    ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
-                    : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
-                }`}
+                className={`settings-switch focus-ring${enabled ? " is-on" : ""}`}
               >
-                {enabled ? "On" : "Off"}
+                <span className="settings-switch__knob" aria-hidden />
               </button>
             </div>
           </div>

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -131,7 +131,7 @@ assert.match(source, /if \("autoSelfReport" in patch\) setDraftAutoSelfReport/, 
 // and the Asana section's enable row.
 assert.match(
   source,
-  /settings-switch focus-ring\$\{draftAutoSelfReport \? " is-on" : ""\}/,
+  /settings-switch focus-ring[\s\S]{0,40}draftAutoSelfReport \? " is-on" : ""/,
   "auto self-report renders the shared settings-switch toggle",
 );
 assert.match(source, /settings-switch__knob/, "the toggle carries the track knob");

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -126,6 +126,21 @@ assert.match(source, /role="switch"[\s\S]{0,80}aria-checked=\{draftAutoSelfRepor
 assert.match(source, /autoSelfReport: next \? true : null/, "off deletes the config key instead of writing false");
 assert.match(source, /if \("autoSelfReport" in patch\) setDraftAutoSelfReport/, "failed saves revert the toggle draft");
 
+// 2026-07-15: the On/Off pill became the shared settings-switch track/knob
+// toggle (same control as Settings → General), for both the Reflection card
+// and the Asana section's enable row.
+assert.match(
+  source,
+  /settings-switch focus-ring\$\{draftAutoSelfReport \? " is-on" : ""\}/,
+  "auto self-report renders the shared settings-switch toggle",
+);
+assert.match(source, /settings-switch__knob/, "the toggle carries the track knob");
+assert.doesNotMatch(
+  source,
+  /draftAutoSelfReport \? "On" : "Off"/,
+  "the pill-button On/Off text form is gone",
+);
+
 // ── Voice picker: traits + preview (2026-07-15) ──────────────────────────────
 // The OpenAI voice menu is sourced from the shared realtime-voice catalog so
 // every option carries a perceived gender/accent/vibe detail line, and both

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -554,6 +554,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                   type="button"
                   role="switch"
                   aria-checked={draftAutoSelfReport}
+                  aria-label="Auto self-report"
                   onClick={() => {
                     const next = !draftAutoSelfReport;
                     setDraftAutoSelfReport(next);
@@ -561,13 +562,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                     // default is false), keeping the file free of no-op entries.
                     void save({ autoSelfReport: next ? true : null });
                   }}
-                  className={`familiar-studio-brain__switch rounded-[var(--radius-pill)] border px-3 py-1.5 text-[12px] transition-colors ${
-                    draftAutoSelfReport
-                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
-                      : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
-                  }`}
+                  className={`settings-switch focus-ring${draftAutoSelfReport ? " is-on" : ""}`}
                 >
-                  {draftAutoSelfReport ? "On" : "Off"}
+                  <span className="settings-switch__knob" aria-hidden />
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## What

The **Reflection → Auto self-report** control in Settings → Familiars (Brain tab) rendered as an On/Off pill **button**; it's now the shared **settings-switch** track/knob toggle used across Settings. The Asana section's enable row — the only other instance of the same pill pattern — is converted too, so the tab stays consistent.

## How

- `familiar-studio-brain-tab.tsx` + `familiar-asana-section.tsx`: pill classes → `settings-switch focus-ring` + `settings-switch__knob` (already global via `globals.css` → `dashboard.css`). `role="switch"`/`aria-checked` semantics and the config write path (`null` deletes the key; failed saves revert the draft) are unchanged; each control keeps an explicit `aria-label` since the knob has no text.
- Removed the now-orphaned `.familiar-studio-brain__switch` rule from `globals.css`.
- Test pins: brain-tab test asserts the settings-switch form and that the On/Off pill text is gone; existing switch/config pins still pass.

## Testing

- Targeted: `familiar-studio-brain-tab`, `asana-task-field`, `settings-shell-polish`, `glass-overlay-chrome` tests green; `pnpm typecheck` clean.

Bead: cave-s21k