### PR TITLE
feat(runtimes): policy-exclude coven-code from Cave runtime surfaces

### DIFF
--- a/scripts/sync-runtimes.mjs
+++ b/scripts/sync-runtimes.mjs
@@ -28,6 +28,12 @@ const REGISTRY_REPO = "OpenCoven/coven-runtimes";
 const INDEX_PATH = "crates/coven-runtime-registry/canonical/index.json";
 const SUPPORTED_INDEX_FORMAT = "1";
 
+// Cave-side policy exclusions. These ids stay accepted upstream but are not
+// runtimes Cave should offer: Coven Code is the app/tool Cave installs and
+// updates itself (onboarding + OpenCoven tools), not a familiar harness
+// choice — harness-adapters.test.ts pins the same stance for summoning.
+export const CAVE_EXCLUDED_RUNTIME_IDS = new Set(["coven-code"]);
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_PATH = path.join(scriptDir, "..", "src", "lib", "runtime-registry.gen.ts");
 
@@ -116,6 +122,7 @@ export function pickAcceptedRuntimes(index) {
   const picked = [];
   const problems = [];
   for (const id of Object.keys(index.runtimes).sort()) {
+    if (CAVE_EXCLUDED_RUNTIME_IDS.has(id)) continue; // Cave-side policy, see above
     const entries = index.runtimes[id];
     if (!Array.isArray(entries)) {
       problems.push(`${id}: entries is not an array`);

--- a/scripts/sync-runtimes.test.mjs
+++ b/scripts/sync-runtimes.test.mjs
@@ -1,6 +1,6 @@
 // Tests for scripts/sync-runtimes.mjs — fixture-driven, no network.
 import assert from "node:assert/strict";
-import { compareSemver, pickAcceptedRuntimes, renderModule, validateAdapter } from "./sync-runtimes.mjs";
+import { CAVE_EXCLUDED_RUNTIME_IDS, compareSemver, pickAcceptedRuntimes, renderModule, validateAdapter } from "./sync-runtimes.mjs";
 
 const adapter = (id, extra = {}) => ({
   id,
@@ -59,6 +59,23 @@ assert.equal(compareSemver("2.0.0+build.5", "2.0.0"), 0, "release build metadata
     picked.map((p) => `${p.id}@${p.version}`),
     ["a@1.0.0"],
     "yanked versions are skipped for latest; fully-yanked runtimes are omitted",
+  );
+}
+
+// ── Cave-side policy exclusions ──────────────────────────────────────────────
+{
+  assert.ok(CAVE_EXCLUDED_RUNTIME_IDS.has("coven-code"), "coven-code is policy-excluded");
+  const picked = pickAcceptedRuntimes({
+    format: "1",
+    runtimes: {
+      "coven-code": [entry("coven-code", "1.0.0")],
+      keeper: [entry("keeper", "1.0.0")],
+    },
+  });
+  assert.deepEqual(
+    picked.map((p) => p.id),
+    ["keeper"],
+    "policy-excluded runtimes never reach the generated module, even when accepted upstream",
   );
 }
 

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -88,6 +88,10 @@ const curatedIds = ["codex", "claude", "copilot", "hermes", "openclaw"];
   assert.ok(registryIds.length > 0, "registry-synced runtimes extend the curated seed");
   assert.deepEqual(registryIds, [...registryIds].sort(), "registry additions are alphabetical");
   assert.ok(!registryIds.some((id) => curatedIds.includes(id)), "curated ids never duplicate");
+  assert.ok(
+    !ids.includes("coven-code"),
+    "coven-code is policy-excluded from runtime surfaces (app/tool install, not a harness)",
+  );
   for (const adapter of COMPATIBILITY_ADAPTERS.slice(curatedIds.length)) {
     assert.equal(adapter.source, "registry", `${adapter.id} carries the registry source tag`);
     assert.equal(adapter.chatSupported, true, `registry-accepted ${adapter.id} is chat-trusted`);

--- a/src/lib/runtime-registry.gen.ts
+++ b/src/lib/runtime-registry.gen.ts
@@ -105,63 +105,6 @@ export const REGISTRY_RUNTIMES: RegistryRuntime[] = [
     }
   },
   {
-    "id": "coven-code",
-    "label": "Coven Code",
-    "binary": "coven-code",
-    "installHint": "npm install -g @opencoven/coven-code (or download a release archive from https://github.com/OpenCoven/coven-code/releases), then ensure `coven-code` is on PATH.",
-    "version": "1.0.1",
-    "homepage": "https://github.com/OpenCoven/coven-code",
-    "description": "Coven Code adapter. One-shot via `--print <prompt>`, JSONL streaming via `--print --input-format stream-json --output-format stream-json` (long-lived: one turn per stdin user frame, exits on stdin EOF; the positional prompt is ignored in this mode, matching Claude Code). Session pre-assignment/resume via `--session-id`/`--resume`. Think maps to `--thinking <TOKENS>`, speed to `--effort <LEVEL>`. Interactive launches must not append a prompt: a positional prompt switches coven-code into print mode.",
-    "modelFlag": "--model",
-    "capabilities": {
-      "stream": true,
-      "preassignedSessionId": true,
-      "think": true,
-      "speed": true
-    },
-    "adapterManifest": {
-      "adapters": [
-        {
-          "id": "coven-code",
-          "label": "Coven Code",
-          "executable": "coven-code",
-          "interactive_prompt_prefix_args": [],
-          "non_interactive_prompt_prefix_args": [
-            "--print"
-          ],
-          "install_hint": "npm install -g @opencoven/coven-code (or download a release archive from https://github.com/OpenCoven/coven-code/releases), then ensure `coven-code` is on PATH.",
-          "system_prompt_flag": "--append-system-prompt",
-          "model_flag": "--model",
-          "capabilities": {
-            "stream": true,
-            "preassigned_session_id": true,
-            "think": true,
-            "speed": true
-          },
-          "sandbox": {
-            "flag": "--permission-mode",
-            "full": "bypass-permissions",
-            "read_only": "plan"
-          },
-          "stream_args": {
-            "prefix_args": [
-              "--print",
-              "--input-format",
-              "stream-json",
-              "--output-format",
-              "stream-json"
-            ],
-            "session_id_flag": "--session-id",
-            "resume_flag": "--resume"
-          },
-          "version": "1.0.1",
-          "homepage": "https://github.com/OpenCoven/coven-code",
-          "description": "Coven Code adapter. One-shot via `--print <prompt>`, JSONL streaming via `--print --input-format stream-json --output-format stream-json` (long-lived: one turn per stdin user frame, exits on stdin EOF; the positional prompt is ignored in this mode, matching Claude Code). Session pre-assignment/resume via `--session-id`/`--resume`. Think maps to `--thinking <TOKENS>`, speed to `--effort <LEVEL>`. Interactive launches must not append a prompt: a positional prompt switches coven-code into print mode."
-        }
-      ]
-    }
-  },
-  {
     "id": "hermes",
     "label": "Hermes Agent",
     "binary": "hermes-coven",


### PR DESCRIPTION
## What

Removes **coven-code** from Cave's runtime surfaces. It still enters `COMPATIBILITY_ADAPTERS` via the synced registry module even though the repo's own stance (pinned in `harness-adapters.test.ts`) is that *Coven Code is an app/tool install, not a familiar runtime choice* — Cave installs/updates it through onboarding and the OpenCoven tools surfaces, which are untouched.

## How

- `scripts/sync-runtimes.mjs`: new exported `CAVE_EXCLUDED_RUNTIME_IDS` (`coven-code`), applied in `pickAcceptedRuntimes` — a **Cave-side policy filter**, so the exclusion survives future `bot/sync-runtimes` regenerations without needing an upstream yank.
- `src/lib/runtime-registry.gen.ts`: regenerated via `node scripts/sync-runtimes.mjs` (3 runtimes remain: copilot, hermes, opencode); `--check` drift guard passes.
- Tests: sync fixture proves an upstream-accepted excluded id never reaches the module; harness test asserts `COMPATIBILITY_ADAPTERS` carries no coven-code.

## Testing

- `node scripts/sync-runtimes.test.mjs` ok; `harness-adapters`/`openclaw-agents` tests green; `node scripts/sync-runtimes.mjs --check` reports up-to-date; `pnpm typecheck` clean.

Bead: cave-4e8l