### PR TITLE
docs+e2e(crafts): shipped-flow docs, progressive-flow and arrival e2e specs (cave-imo6)

### DIFF
--- a/docs/authoring-assist.md
+++ b/docs/authoring-assist.md
@@ -305,11 +305,12 @@ human-reviewed.
 **Status:** landed — dispatch-time drafts snapshot + visibility-paused
 arrival polling in the create drawer, refine/publish briefs on draft detail,
 and recreate-and-replace draft deletion (guarded `DELETE`). *Correction
-(2026-07-15):* the arrival loop only survives while the drawer stays mounted —
-following the chat it opens unmounts the marketplace and kills the poll — and
-the briefs' plan-verification step cannot resolve local drafts. Both gaps, and
-the flow redesign that closes them, are mapped in
-[`craft-ux.md`](craft-ux.md).
+(2026-07-15):* the arrival loop only survived while the drawer stayed
+mounted, and the briefs' plan-verification step could not resolve local
+drafts. Both gaps were mapped in [`craft-ux.md`](craft-ux.md) and **closed by
+its Checkpoint 4** (PR #3195): the watch now persists in sessionStorage and
+is resumed by the Crafts tab, and `GET /api/marketplace/crafts/plan` is
+draft-aware with honest `draftDiagnostics`.
 
 ## 7 · One assist kit: extract the shared runner and contracts
 

--- a/docs/craft-ux.md
+++ b/docs/craft-ux.md
@@ -278,6 +278,42 @@ CI rules); final usability pass against the success condition.
 multi-familiar Crafts, no redesign of the published-Craft dossier beyond
 F10's inline reasons, no new server state stores.
 
+## Status ledger
+
+All six checkpoints shipped (2026-07-15):
+
+| Checkpoint | PR | Landed |
+|---|---|---|
+| CP1 · Audit + this spec | #3188 | Friction inventory F1–F12; `authoring-assist.md` §6 corrected |
+| CP2 · Unified progressive flow | #3189 | Describe-first + mode memory (F6); preview-before-save on real ledger (F3); shared `CraftDraftPreview`; drafts/published grid grouping (F11) |
+| CP3 · Power layer in-flow | #3193 | Ledger origin/role attribution on screen (F4); seeded Adjust-roles editing (F5); per-familiar selection retention (F9); bounded rename, id stays derived (F12) |
+| CP4 · Close the loop honestly | #3195 | Draft-aware plan + `draftDiagnostics` (F1); sessionStorage arrival watch resumed by drawer + hub, in-flight row, announced arrival (F2); plan-status chip (F8); truthful briefs + `craft-builder` SKILL |
+| CP5 · Dead ends, recovery, a11y | #3202 | Studio-linked teaching empty states + zero-roles dispatch guard (F7); roles-load retry; one-familiar hint (F9); inline install-first reasons (F10); lifecycle strip (F8); announced step transitions |
+| CP6 · Docs + e2e | this PR | `marketplace.md` § Draft Crafts rewritten; e2e specs for the progressive flow + persisted arrival; this ledger |
+
+**Acceptance criteria check** (from the goal):
+
+- *Basic path — describe → preview → save with zero required advanced
+  inputs*: describe is the default tab; one textarea and one button dispatch
+  the build; the arrival opens the draft with its attributed preview. The
+  manual path is select → preview → save with no required extras. ✓
+- *Power path in the same flow*: role composition (per-familiar retention),
+  ledger inspection (origin badges), rename, and draft editing (seeded
+  Adjust roles) all live inside the one drawer/detail pair. ✓
+- *Draft lifecycle visible end-to-end*: in-flight row → arrival announcement
+  → attributed preview → plan-verification chip → lifecycle strip naming the
+  publication road. ✓
+- *Verification honest for drafts*: `GET /crafts/plan` resolves drafts with
+  named `draftDiagnostics`; briefs and skill describe the real contract. ✓
+- *Tests*: unit (`craft-draft`, `craft-arrival`, `craft-draft-plan`), pins
+  (`crafts-marketplace`, `crafts-routes`), e2e
+  (`tests/marketplace-crafts.spec.ts` — daemon-less, `page.route` mocks). ✓
+- *Docs match code*: `marketplace.md`, `authoring-assist.md` §6, this file. ✓
+
+Remaining friction accepted for now: F8's "publish" remains a chat-brief +
+human PR (by design); F11 sorting within groups only; no draft description
+editing (rename only).
+
 *Written 2026-07-15 from the shipped code (Checkpoint 1, bead `cave-lepz`).
 When this map and the code disagree, the code is right — then update this
 map.*

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -125,13 +125,35 @@ bodies; the contract is asserted in `src/app/api/api-contracts.test.ts` and
 
 ### Draft Crafts
 
-The Crafts tab can extract a **reversible local draft Craft** from a
-familiar's selected Roles (`POST /api/marketplace/crafts/drafts`, drawer in
-`src/components/marketplace/craft-create-drawer.tsx`): direct and effective
-skills, tools, MCP servers, plugins, prompts, and workflows are collected with
-origin labels and a review ledger before anything is saved. Drafts are local
-authoring state — publishing one into the catalog still goes through the
-human-reviewed update process below.
+The Crafts tab authors **reversible local draft Crafts** through one
+progressive drawer (`src/components/marketplace/craft-create-drawer.tsx`;
+flow spec in [`craft-ux.md`](craft-ux.md)):
+
+- **Describe it** (default): the operator states a goal; a chat brief carrying
+  the full drafts-API contract dispatches to a familiar
+  (`src/lib/craft-agent-prompt.ts`, mirrored by the `craft-builder` skill).
+  The in-flight build persists as a sessionStorage watch
+  (`src/lib/craft-arrival.ts`) that the drawer *and* the Crafts tab resume —
+  arrival is announced and opens the draft wherever the operator is.
+- **Pick roles** (remembered once chosen): select one familiar's roles —
+  switching familiars retains each familiar's picks — then **preview the real
+  extraction ledger before anything is written** (client-side synthesis via
+  the pure `buildCraftDraftFromRoles`), optionally rename (bounded
+  `displayName`; the id stays derived), and save
+  (`POST /api/marketplace/crafts/drafts`).
+
+Direct and effective skills, tools, MCP servers, plugins, prompts, and
+workflows are collected with origin labels into a review ledger
+(`src/lib/craft-draft.ts`). The draft detail renders that attributed ledger
+(shared `CraftDraftPreview`), shows a lifecycle strip
+(Draft → Published → Installed → Equipped), verifies the draft through the
+**draft-aware plan** — `GET /api/marketplace/crafts/plan` falls back to the
+drafts store and returns `ok: true` plus `draftDiagnostics` naming extracted
+local references that can't verify until publication — and offers Adjust
+roles (seeded re-edit, recreate-and-replace), Refine in chat, Prepare for
+catalog, and guarded delete. Drafts are local authoring state — publishing
+one into the catalog still goes through the human-reviewed update process
+below.
 
 ### Human-Reviewed Upstream Updates
 

--- a/tests/marketplace-crafts.spec.ts
+++ b/tests/marketplace-crafts.spec.ts
@@ -215,3 +215,129 @@ test.describe("Craft Marketplace transactions", () => {
     await expect(dialog.locator(":focus")).toHaveCount(1);
   });
 });
+
+test.describe("Craft authoring: one progressive flow", () => {
+  const roles = [
+    {
+      id: "researcher",
+      name: "Researcher",
+      description: "Deep research and citation",
+      familiar: "nova",
+      skills: ["deep-research"],
+      tools: ["network.http"],
+      mcpServers: ["fetch"],
+      plugins: [],
+      workflows: [],
+      crafts: [],
+      effective: {
+        ...directEffective,
+        skills: [{ id: "deep-research", origin: "direct", originLabel: "Direct" }],
+        mcpServers: [{ id: "fetch", origin: "direct", originLabel: "Direct" }],
+        capabilities: [{ id: "network.http", origin: "direct", originLabel: "Direct" }],
+      },
+    },
+    {
+      id: "scribe",
+      name: "Scribe",
+      description: "Writing and summaries",
+      familiar: "nova",
+      skills: ["summarize"],
+      tools: [],
+      mcpServers: [],
+      plugins: [],
+      workflows: [],
+      crafts: [],
+      effective: {
+        ...directEffective,
+        skills: [{ id: "summarize", origin: "direct", originLabel: "Direct" }],
+        tools: [],
+      },
+    },
+  ];
+
+  test("describe-first default, pick-roles previews the real ledger before saving", async ({ page }) => {
+    const draftPosts: Array<Record<string, unknown>> = [];
+    await page.route(/\/api\/roles(?:\?.*)?$/, (route) => route.fulfill({ json: { ok: true, roles } }));
+    await page.route("**/api/marketplace/crafts/drafts**", async (route) => {
+      if (route.request().method() === "POST") {
+        const body = route.request().postDataJSON() as Record<string, unknown>;
+        draftPosts.push(body);
+        await route.fulfill({ json: { ok: true, draft: { id: "nova-researcher" } } });
+        return;
+      }
+      await route.fulfill({ json: { ok: true, drafts: [] } });
+    });
+
+    await openCrafts(page);
+    await page.getByRole("button", { name: "Create Craft" }).click();
+    const drawer = page.getByRole("dialog", { name: "Create Craft" });
+    await expect(drawer).toBeVisible();
+
+    // Describe leads for first-time users.
+    await expect(drawer.getByRole("tab", { name: "Describe it" })).toHaveAttribute("aria-selected", "true");
+    await expect(drawer.getByRole("button", { name: "Draft with familiar" })).toBeDisabled();
+
+    // Power path: pick roles → preview the REAL extraction ledger → save.
+    await drawer.getByRole("tab", { name: "Pick roles" }).click();
+    await expect(drawer.getByText("A Craft bundles roles from one familiar", { exact: false })).toBeVisible();
+    await drawer.getByRole("checkbox").first().check();
+    const previewButton = drawer.getByRole("button", { name: "Preview draft" });
+    await expect(previewButton).toBeEnabled();
+    await previewButton.click();
+
+    await expect(drawer.getByText("Nova Researcher", { exact: false }).first()).toBeVisible();
+    const ledger = drawer.locator(".craft-draft-ledger");
+    await expect(ledger.getByText("deep-research")).toBeVisible();
+    await expect(ledger.getByText("fetch")).toBeVisible();
+
+    // Adjust roles returns to selection with state intact.
+    await drawer.getByRole("button", { name: "Adjust roles" }).click();
+    await expect(drawer.getByRole("checkbox").first()).toBeChecked();
+    await drawer.getByRole("button", { name: "Preview draft" }).click();
+
+    // Optional rename rides the save; identity stays derived.
+    await drawer.getByLabel("Name (optional)").fill("Research Loadout");
+    await drawer.getByRole("button", { name: "Save draft" }).click();
+    await expect.poll(() => draftPosts.length).toBe(1);
+    expect(draftPosts[0]).toMatchObject({
+      familiar: "nova",
+      roleIds: ["researcher"],
+      displayName: "Research Loadout",
+    });
+  });
+
+  test("a dispatched describe-build survives the drawer and lands on the Crafts tab", async ({ page }) => {
+    let draftsCalls = 0;
+    await page.route(/\/api\/roles(?:\?.*)?$/, (route) => route.fulfill({ json: { ok: true, roles } }));
+    await page.route("**/api/marketplace/crafts/drafts**", async (route) => {
+      draftsCalls += 1;
+      // The familiar's draft "lands" on a later poll tick — the hub only
+      // reads ids from this endpoint to detect arrival.
+      await route.fulfill({ json: { ok: true, drafts: draftsCalls >= 2 ? [{ id: "nova-research-kit" }] : [] } });
+    });
+    // The persisted watch from a dispatch that happened before this page load
+    // (docs/craft-ux.md F2): baseline snapshot is empty, so any draft id is an
+    // arrival.
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem(
+        "cave:craft-create:awaiting",
+        JSON.stringify({ baselineIds: [], dispatchedAt: new Date().toISOString(), goal: "research kit" }),
+      );
+    });
+
+    await openCrafts(page);
+    await expect(page.getByText("A familiar is drafting a Craft from your description", { exact: false })).toBeVisible();
+
+    const arrived = await page.evaluate(async () => {
+      // The 5s poll cadence is real time — nudge it by waiting for the watch
+      // to clear, which is the arrival side-effect.
+      const started = Date.now();
+      while (Date.now() - started < 15_000) {
+        if (window.sessionStorage.getItem("cave:craft-create:awaiting") === null) return true;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      return false;
+    });
+    expect(arrived).toBe(true);
+  });
+});


### PR DESCRIPTION
## Checkpoint 6 (final) of the craft-ux-simplification goal

Docs and e2e coverage for the shipped flow — closes out [docs/craft-ux.md](https://github.com/OpenCoven/coven-cave/blob/main/docs/craft-ux.md)'s checkpoint map (#3188 → #3189 → #3193 → #3195 → #3202 → this).

### Changes
- **`marketplace.md` § Draft Crafts** rewritten for the shipped experience: describe-first drawer with persisted arrival watch, preview-before-save on the real extraction ledger, bounded rename, attributed draft detail with lifecycle strip, and the draft-aware plan (`draftDiagnostics`).
- **`authoring-assist.md` §6** correction updated: the two gaps it recorded (arrival-loop unmount hole, draft plan verification) are closed by CP4 (#3195).
- **`docs/craft-ux.md`** gains the status ledger (checkpoint → PR) and the acceptance-criteria check against shipped code.
- **`tests/marketplace-crafts.spec.ts`**: two new daemon-less specs (per CI rules — onboarding dismissed, `page.route` mocks):
  1. *describe-first default, pick-roles previews the real ledger before saving* — tab default, one-familiar hint, preview showing client-synthesized ledger items, adjust-roles state retention, rename riding the `POST` as bounded `displayName`.
  2. *a dispatched describe-build survives the drawer* — a pre-existing sessionStorage watch renders the Crafts-tab in-flight row and arrival (new draft id on a poll tick) clears the watch.

### Verification
- `pnpm typecheck` + crafts pin suite green locally; the new e2e specs run in the required `E2E (Playwright)` check (the local runner on this shared machine is environment-tainted — hub boot 503s under the raw next-dev harness; CI is authoritative).

Bead: `cave-imo6`. This completes the six-checkpoint goal.
