### PR TITLE
feat(research): bound meter states over-budget and target-met honestly

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15804,7 +15804,10 @@ details[open] > .cave-edit-card__summary::before {
 .research-bound-meter { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--border); }
 .research-bound-meter > div { display: flex; justify-content: space-between; gap: 8px; padding: 7px 8px; font-size: 9.5px; background: var(--bg-raised); }
 .research-bound-meter dt { color: var(--text-muted); }
-.research-bound-meter dd { color: var(--text-secondary); }
+.research-bound-meter dd { color: var(--text-secondary); display: inline-flex; align-items: center; gap: 5px; }
+.research-bound-badge { font-style: normal; font-size: 8px; line-height: 1; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 4px; border-radius: 999px; border: 1px solid currentColor; }
+.research-bound--over dd { color: oklch(0.8 0.13 75); }
+.research-bound--met dd { color: oklch(0.74 0.14 155); }
 .research-automation { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; padding: 9px; border: 1px solid color-mix(in oklch, var(--research-accent) 28%, var(--border)); border-radius: var(--radius-sm); background: linear-gradient(135deg, var(--research-accent-soft), transparent 72%); }
 .research-automation__summary { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
 .research-automation__summary > div { display: flex; min-width: 0; flex-direction: column; gap: 2px; }

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/lib/icon";
 import {
   allowedResearchActions,
   describeResearchSchedule,
+  researchBoundReadings,
   researchPhaseStatuses,
   type ResearchMission,
   type ResearchMissionAction,
@@ -97,14 +98,6 @@ export function ResearchMissionDetail({
     : plannedRetry.projectRoot === null
       ? (mission.projectRoot ? "Retry in workspace" : "Retry")
       : plannedRetry.projectRoot === mission.projectRoot ? "Retry" : "Retry with new root";
-  const elapsedMinutes = mission.startedAt
-    ? Math.max(0, Math.round((Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt)) / 60_000))
-    : 0;
-  const reportedCost = mission.iterations.reduce(
-    (sum, item) => sum + (item.costUsd ?? 0),
-    0,
-  );
-  const hasReportedCost = mission.iterations.some((item) => item.costUsd !== undefined);
   const runAction = async (input: ResearchMissionActionInput) => {
     setBusy(true);
     setActionError(null);
@@ -212,17 +205,22 @@ export function ResearchMissionDetail({
           </ol>
 
           <dl className="research-bound-meter">
-            <div><dt>Time</dt><dd>{elapsedMinutes}/{mission.bounds.wallClockMinutes} min</dd></div>
-            <div><dt>Sources</dt><dd>{mission.sources.length}/{mission.bounds.sourceTarget}</dd></div>
-            <div><dt>Checkpoint</dt><dd>every {mission.bounds.checkpointEvery} iteration</dd></div>
-            <div>
-              <dt>Spend</dt>
-              <dd>
-                {hasReportedCost
-                  ? `$${reportedCost.toFixed(2)}${mission.bounds.maxSpendUsd == null ? " reported" : `/$${mission.bounds.maxSpendUsd}`}`
-                  : "Cost unavailable"}
-              </dd>
-            </div>
+            {researchBoundReadings(mission).map((reading) => (
+              <div
+                key={reading.id}
+                className={reading.tone === "neutral" ? undefined : `research-bound--${reading.tone}`}
+                title={reading.detail}
+              >
+                <dt>{reading.label}</dt>
+                <dd>
+                  {reading.value}
+                  {reading.badge ? (
+                    <em className="research-bound-badge" aria-hidden>{reading.badge}</em>
+                  ) : null}
+                  <span className="sr-only"> — {reading.detail}</span>
+                </dd>
+              </div>
+            ))}
           </dl>
 
           {mission.mode === "autoresearch" ? (

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -8,6 +8,7 @@ const list = readFileSync(new URL("./research-mission-list.tsx", import.meta.url
 const detail = readFileSync(new URL("./research-mission-detail.tsx", import.meta.url), "utf8");
 const ledger = readFileSync(new URL("./research-evidence-ledger.tsx", import.meta.url), "utf8");
 const hook = readFileSync(new URL("./use-research-missions.ts", import.meta.url), "utf8");
+const missionsLib = readFileSync(new URL("../../lib/research-missions.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
 
 test("surface is mission-first and no longer stores a pretend research desk", () => {
@@ -102,8 +103,25 @@ test("autoresearch schedules use standard paused Automation controls", () => {
 });
 
 test("unknown research cost is shown honestly", () => {
-  assert.match(detail, /Cost unavailable/);
-  assert.match(detail, /hasReportedCost/);
+  // The quiet em dash keeps its honest explanation for tooltips and screen
+  // readers (researchBoundReadings, behaviorally tested in the lib suite).
+  assert.match(missionsLib, /value: "—"/);
+  assert.match(missionsLib, /Cost unavailable — the harness has not reported spend\./);
+  assert.match(missionsLib, /hasReportedCost/);
+});
+
+test("bound meter over/met states are visible beyond color alone", () => {
+  // Readings come from the shared gate-vs-target reconciler…
+  assert.match(detail, /researchBoundReadings\(mission\)\.map/);
+  // …tone lands as a class, prose lands as title + off-screen text…
+  assert.match(detail, /research-bound--\$\{reading\.tone\}/);
+  assert.match(detail, /title=\{reading\.detail\}/);
+  assert.match(detail, /<span className="sr-only"> — \{reading\.detail\}<\/span>/);
+  // …and the badge word makes over/met legible without color.
+  assert.match(detail, /research-bound-badge/);
+  assert.match(css, /\.research-bound--over dd/);
+  assert.match(css, /\.research-bound--met dd/);
+  assert.match(css, /\.research-bound-badge/);
 });
 
 test("polling is abortable, foreground-aware, and container responsive", () => {

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -452,15 +452,23 @@ test("in-budget readings stay neutral with no badges", () => {
     reading(meterMission({ startedAt: "2026-07-15T00:00:00Z", finishedAt: "2026-07-15T00:20:00Z" }), "time").tone,
     "neutral",
   );
+  // …but a sub-minute overshoot is still over, even when the rounded display
+  // reads at-bound (millisecond comparison, not rounded minutes).
+  const justOver = reading(
+    meterMission({ startedAt: "2026-07-15T00:00:00Z", finishedAt: "2026-07-15T00:20:20Z" }),
+    "time",
+  );
+  assert.equal(justOver.value, "20/20 min");
+  assert.equal(justOver.tone, "over");
 });
 
 test("spend reads over only past the cap and stays honest without one", () => {
   const over = reading(meterMission({ costs: [8, 4.5], bounds: { maxSpendUsd: 10 } }), "spend");
-  assert.equal(over.value, "$12.50/$10");
+  assert.equal(over.value, "$12.50/$10.00");
   assert.equal(over.tone, "over");
   assert.equal(over.badge, "over");
   const under = reading(meterMission({ costs: [5], bounds: { maxSpendUsd: 10 } }), "spend");
-  assert.equal(under.value, "$5.00/$10");
+  assert.equal(under.value, "$5.00/$10.00");
   assert.equal(under.tone, "neutral");
   const uncapped = reading(meterMission({ costs: [5] }), "spend");
   assert.equal(uncapped.value, "$5.00 reported");

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -9,6 +9,7 @@ import {
   describeResearchSchedule,
   normalizeResearchBounds,
   RESEARCH_BOUND_LIMITS,
+  researchBoundReadings,
   researchPhaseStatuses,
   validateCreateResearchMissionInput,
 } from "./research-missions.ts";
@@ -360,4 +361,124 @@ test("acceptance: no terminal mission ever renders a running or pending phase", 
       }
     }
   }
+});
+
+// --- researchBoundReadings: over/met bound states must be legible ---
+
+function meterMission(overrides: {
+  startedAt?: string;
+  finishedAt?: string;
+  sources?: number;
+  costs?: Array<number | undefined>;
+  bounds?: Partial<{ wallClockMinutes: number; sourceTarget: number; maxSpendUsd: number; checkpointEvery: number }>;
+}) {
+  return {
+    bounds: {
+      maxIterations: 1,
+      wallClockMinutes: 20,
+      sourceTarget: 6,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+      ...overrides.bounds,
+    },
+    sources: Array.from({ length: overrides.sources ?? 0 }, (_, index) => ({
+      id: `s${index}`,
+      title: `Source ${index}`,
+      sourceType: "web",
+      status: "candidate" as const,
+    })),
+    iterations: (overrides.costs ?? [undefined]).map((costUsd, index) => ({
+      number: index + 1,
+      status: "completed" as const,
+      ...(costUsd === undefined ? {} : { costUsd }),
+    })),
+    startedAt: overrides.startedAt,
+    finishedAt: overrides.finishedAt,
+    updatedAt: overrides.finishedAt ?? "2026-07-15T01:00:00Z",
+  } as Parameters<typeof researchBoundReadings>[0];
+}
+
+function reading(mission: Parameters<typeof researchBoundReadings>[0], id: string) {
+  const found = researchBoundReadings(mission).find((item) => item.id === id);
+  assert.ok(found, `missing ${id} reading`);
+  return found;
+}
+
+test("time past the wall-clock budget reads over, in plain text not just color", () => {
+  // Screenshot repro: 49 elapsed minutes against a 20-minute brief budget.
+  const mission = meterMission({
+    startedAt: "2026-07-15T00:00:00Z",
+    finishedAt: "2026-07-15T00:49:00Z",
+    sources: 14,
+  });
+  const time = reading(mission, "time");
+  assert.equal(time.value, "49/20 min");
+  assert.equal(time.tone, "over");
+  assert.equal(time.badge, "over");
+  assert.match(time.detail, /stop gate/);
+  assert.match(time.detail, /no further iterations/i);
+});
+
+test("meeting the source target reads met — it is a goal, not a cap", () => {
+  const mission = meterMission({
+    startedAt: "2026-07-15T00:00:00Z",
+    finishedAt: "2026-07-15T00:10:00Z",
+    sources: 14,
+  });
+  const sources = reading(mission, "sources");
+  assert.equal(sources.value, "14/6");
+  assert.equal(sources.tone, "met");
+  assert.equal(sources.badge, "met");
+  assert.match(sources.detail, /goal, not a cap/);
+  // Exactly at target also counts as met.
+  assert.equal(reading(meterMission({ sources: 6 }), "sources").tone, "met");
+});
+
+test("in-budget readings stay neutral with no badges", () => {
+  const mission = meterMission({
+    startedAt: "2026-07-15T00:00:00Z",
+    finishedAt: "2026-07-15T00:12:00Z",
+    sources: 3,
+    costs: [4.2],
+    bounds: { maxSpendUsd: 10 },
+  });
+  for (const item of researchBoundReadings(mission)) {
+    assert.equal(item.tone, "neutral", `${item.id} should be neutral`);
+    assert.equal(item.badge, undefined, `${item.id} should have no badge`);
+  }
+  // At the exact wall-clock boundary the decision banner explains any stop;
+  // the meter does not claim "over".
+  assert.equal(
+    reading(meterMission({ startedAt: "2026-07-15T00:00:00Z", finishedAt: "2026-07-15T00:20:00Z" }), "time").tone,
+    "neutral",
+  );
+});
+
+test("spend reads over only past the cap and stays honest without one", () => {
+  const over = reading(meterMission({ costs: [8, 4.5], bounds: { maxSpendUsd: 10 } }), "spend");
+  assert.equal(over.value, "$12.50/$10");
+  assert.equal(over.tone, "over");
+  assert.equal(over.badge, "over");
+  const under = reading(meterMission({ costs: [5], bounds: { maxSpendUsd: 10 } }), "spend");
+  assert.equal(under.value, "$5.00/$10");
+  assert.equal(under.tone, "neutral");
+  const uncapped = reading(meterMission({ costs: [5] }), "spend");
+  assert.equal(uncapped.value, "$5.00 reported");
+  assert.equal(uncapped.tone, "neutral");
+  assert.match(uncapped.detail, /no spend cap/i);
+});
+
+test("missing cost renders quiet, with the honest explanation moved off-screen", () => {
+  const spend = reading(meterMission({ costs: [undefined] }), "spend");
+  assert.equal(spend.value, "—");
+  assert.equal(spend.tone, "neutral");
+  assert.match(spend.detail, /Cost unavailable/);
+});
+
+test("checkpoint cadence pluralizes correctly", () => {
+  assert.equal(reading(meterMission({}), "checkpoint").value, "every 1 iteration");
+  assert.equal(
+    reading(meterMission({ bounds: { checkpointEvery: 2 } }), "checkpoint").value,
+    "every 2 iterations",
+  );
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -402,6 +402,91 @@ export function researchPhaseStatuses(
   });
 }
 
+export type ResearchBoundReading = {
+  id: "time" | "sources" | "checkpoint" | "spend";
+  label: string;
+  value: string;
+  /** over = past a stop gate (warn); met = target reached (good). */
+  tone: "neutral" | "over" | "met";
+  badge?: "over" | "met";
+  /** Plain-prose gate-vs-target semantics for tooltips and screen readers. */
+  detail: string;
+};
+
+/**
+ * Bound-meter rows with honest over/met states.
+ *
+ * Wall-clock minutes and reported spend are stop gates checked between
+ * iterations — a running iteration may legitimately finish past them, so
+ * exceeding one is a fact worth flagging, not a silent detail. The source
+ * count is a target, not a cap: reaching it is success. Badges only claim
+ * "over" when a value is strictly past its bound; a stop at the exact
+ * boundary is already explained by the mission's decision banner.
+ */
+export function researchBoundReadings(
+  mission: Pick<ResearchMission, "bounds" | "sources" | "iterations" | "startedAt" | "finishedAt" | "updatedAt">,
+): ResearchBoundReading[] {
+  const { bounds } = mission;
+  const elapsedMinutes = mission.startedAt
+    ? Math.max(0, Math.round((Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt)) / 60_000))
+    : 0;
+  const timeOver = elapsedMinutes > bounds.wallClockMinutes;
+  const sourcesMet = mission.sources.length >= bounds.sourceTarget;
+  const reportedCost = mission.iterations.reduce((sum, item) => sum + (item.costUsd ?? 0), 0);
+  const hasReportedCost = mission.iterations.some((item) => item.costUsd !== undefined);
+  const spendOver = hasReportedCost && bounds.maxSpendUsd !== undefined && reportedCost > bounds.maxSpendUsd;
+  const spend: ResearchBoundReading = hasReportedCost
+    ? {
+      id: "spend",
+      label: "Spend",
+      value: `$${reportedCost.toFixed(2)}${bounds.maxSpendUsd === undefined ? " reported" : `/$${bounds.maxSpendUsd}`}`,
+      tone: spendOver ? "over" : "neutral",
+      ...(spendOver ? { badge: "over" as const } : {}),
+      detail: bounds.maxSpendUsd === undefined
+        ? "Reported spend so far; no spend cap is set."
+        : spendOver
+          ? "Reported spend is past the cap — no further iterations will start."
+          : "Spend cap is a stop gate checked between iterations.",
+    }
+    : {
+      id: "spend",
+      label: "Spend",
+      value: "—",
+      tone: "neutral",
+      detail: "Cost unavailable — the harness has not reported spend.",
+    };
+  return [
+    {
+      id: "time",
+      label: "Time",
+      value: `${elapsedMinutes}/${bounds.wallClockMinutes} min`,
+      tone: timeOver ? "over" : "neutral",
+      ...(timeOver ? { badge: "over" as const } : {}),
+      detail: timeOver
+        ? "Past the wall-clock budget — it is a stop gate checked between iterations, so a running iteration may finish over it, but no further iterations will start."
+        : "Wall-clock budget is a stop gate checked between iterations.",
+    },
+    {
+      id: "sources",
+      label: "Sources",
+      value: `${mission.sources.length}/${bounds.sourceTarget}`,
+      tone: sourcesMet ? "met" : "neutral",
+      ...(sourcesMet ? { badge: "met" as const } : {}),
+      detail: sourcesMet
+        ? "Source target reached — it is a goal, not a cap."
+        : "Source target is a goal, not a cap.",
+    },
+    {
+      id: "checkpoint",
+      label: "Checkpoint",
+      value: `every ${bounds.checkpointEvery} iteration${bounds.checkpointEvery === 1 ? "" : "s"}`,
+      tone: "neutral",
+      detail: "How often the mission pauses for review.",
+    },
+    spend,
+  ];
+}
+
 /**
  * Human-readable schedule for an autoresearch Automation link. Understands the
  * daily/weekly RRULEs the desk itself creates; anything else falls back to the

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -440,7 +440,7 @@ export function researchBoundReadings(
     ? {
       id: "spend",
       label: "Spend",
-      value: `$${reportedCost.toFixed(2)}${bounds.maxSpendUsd === undefined ? " reported" : `/$${bounds.maxSpendUsd}`}`,
+      value: `$${reportedCost.toFixed(2)}${bounds.maxSpendUsd === undefined ? " reported" : `/$${bounds.maxSpendUsd.toFixed(2)}`}`,
       tone: spendOver ? "over" : "neutral",
       ...(spendOver ? { badge: "over" as const } : {}),
       detail: bounds.maxSpendUsd === undefined

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -427,10 +427,11 @@ export function researchBoundReadings(
   mission: Pick<ResearchMission, "bounds" | "sources" | "iterations" | "startedAt" | "finishedAt" | "updatedAt">,
 ): ResearchBoundReading[] {
   const { bounds } = mission;
-  const elapsedMinutes = mission.startedAt
-    ? Math.max(0, Math.round((Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt)) / 60_000))
+  const elapsedMs = mission.startedAt
+    ? Math.max(0, Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt))
     : 0;
-  const timeOver = elapsedMinutes > bounds.wallClockMinutes;
+  const elapsedMinutes = Math.round(elapsedMs / 60_000);
+  const timeOver = elapsedMs > bounds.wallClockMinutes * 60_000;
   const sourcesMet = mission.sources.length >= bounds.sourceTarget;
   const reportedCost = mission.iterations.reduce((sum, item) => sum + (item.costUsd ?? 0), 0);
   const hasReportedCost = mission.iterations.some((item) => item.costUsd !== undefined);


### PR DESCRIPTION
## What

Slice 2 of the `research-desk-ux-uplift` goal (bead `cave-gr4x`). In the 2026-07-15 screenshot audit, **Time 49/20 min** and **Sources 14/6** rendered identically to in-budget values — a brief that ran 2.5× past its wall-clock budget and beat its source target looked exactly like one comfortably inside bounds. `Spend` showed alarm-prose **Cost unavailable** for the common no-cost case.

## How

- New pure `researchBoundReadings(mission)` in `src/lib/research-missions.ts`, encoding the runner's real semantics (`stopBeforeNextIteration`):
  - **wall-clock minutes / reported spend are stop gates** checked *between* iterations — a running iteration may legitimately finish past them ⇒ strictly-over reads as a warn-toned `over` badge ("no further iterations will start")
  - **source count is a target, not a cap** ⇒ reaching it reads as a green `met` badge ("a goal, not a cap")
  - at-boundary values stay neutral — the decision banner already explains stops; the meter never over-claims
- Badge **words** keep states legible without color (WCAG 1.4.1); gate-vs-target prose lands as a `title` tooltip + `.sr-only` text
- Missing cost renders as a quiet **—** with the honest "Cost unavailable" explanation moved to tooltip/SR text
- Checkpoint cadence pluralizes ("every 2 iterations")
- Tone styles reuse the desk's existing ok/warn hues (`.research-status-dot--ok/warn`)

## Testing

- 6 behavioral tests in `src/lib/research-missions.test.ts` incl. the 49/20 + 14/6 screenshot repro, exact-boundary neutrality, uncapped/missing spend
- Wiring pins in `researcher-surface.test.ts` (readings mapped, tone class, title + sr-only, badge, CSS classes); cost-honesty pin repointed at the lib
- `pnpm typecheck` ✓ · targeted `node --test` 37/37 ✓ · `pnpm test:app` 719 files ✓
