### PR TITLE
fix(chat): address chat↔GitHub code-review findings (cave-m0r6/r0gt/jqke/a3cl)

### DIFF
--- a/src/components/chat-stage-header-wiring.test.ts
+++ b/src/components/chat-stage-header-wiring.test.ts
@@ -22,7 +22,11 @@ assert.match(header, /if \(!snapshot\) return null;/, "renders nothing without a
 assert.match(header, /usePausablePoll\(.*\{\s*\n?\s*enabled: Boolean\(projectRoot && branch && snapshot\?\.pr\),/s, "re-polls only while an open PR anchors the stage");
 
 // Mounted between the top bar and the transcript.
-assert.match(chatView, /<RunActivityStrip[^>]*\/>\s*\n\s*<ChatStageHeader projectRoot=\{activeProjectRoot\} onOpenUrl=\{onOpenUrl\} \/>/, "header mounts after the activity strip, before the transcript");
+assert.match(
+  chatView,
+  /<ChatStageHeader projectRoot=\{session\?\.project_root \?\? projectRoot \?\? null\} onOpenUrl=\{onOpenUrl\} \/>/,
+  "header keys on the SESSION root — the same derivation the rail badge listeners use (cave-r0gt)",
+);
 
 // Review follow-up (#3173): no cross-project stale bleed.
 assert.match(header, /keyRef\.current !== key/, "bridge state resets when (projectRoot, branch) changes");

--- a/src/components/chat-stage-header.tsx
+++ b/src/components/chat-stage-header.tsx
@@ -16,7 +16,8 @@ import { useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useChangesSummary } from "@/lib/use-changes-summary";
-import { resolveStageForBranch, STAGE_CHECKS_EVENT, type StageSnapshot, type StageStep } from "@/lib/stage-model";
+import { resolveStageForBranch, type StageSnapshot, type StageStep } from "@/lib/stage-model";
+import { publishStageChecks } from "@/lib/use-stage-checks-badge";
 import type { PullRequestSummary } from "@/lib/beads-pr-management";
 import type { MergedPrRef, ReadyBead } from "@/lib/beads-work-queue";
 
@@ -111,20 +112,22 @@ export function ChatStageHeader({
   const { branch } = useChangesSummary(projectRoot ?? undefined, Boolean(projectRoot));
   const snapshot = useStageSnapshot(projectRoot, branch);
 
-  // Broadcast the failing-checks signal for the code rail's badge (design §6):
+  // Publish the failing-checks signal for the code rail's badge (design §6):
   // the header already holds the stage snapshot, so the rail never re-fetches
-  // the PR bridge. Dispatch fires on every signal change; the CLEAR fires only
-  // on unmount / root change (separate effect) so listeners never see a
-  // transient false between consecutive true states.
+  // the PR bridge. publishStageChecks records state for LATE-MOUNTING
+  // listeners (a rail opened after checks went red — cave-r0gt) and
+  // broadcasts for live ones; the CLEAR fires only on unmount / root change
+  // (separate effect) so listeners never see a transient false between
+  // consecutive true states.
   const failing = Boolean(snapshot?.pr && snapshot.pr.checkStatus === "failing");
   useEffect(() => {
     if (!projectRoot) return;
-    window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot, failing } }));
+    publishStageChecks(projectRoot, failing);
   }, [projectRoot, failing]);
   useEffect(() => {
     if (!projectRoot) return;
     return () => {
-      window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot, failing: false } }));
+      publishStageChecks(projectRoot, false);
     };
   }, [projectRoot]);
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -171,9 +171,10 @@ export function ChatSurface({
   // manual collapse (see below) so the rail snaps back to the session.
   const [browseRootOverride, setBrowseRootOverride] = useState<string | null>(null);
   const effectiveRailRoot = browseRootOverride ?? railProjectRoot;
-  // Failing-checks cue for the COLLAPSED reopen strip (cave-fpqx.12) — same
-  // stage-header broadcast the mounted rail's badge listens to.
-  const reopenChecksFailing = useStageChecksBadge(effectiveRailRoot);
+  // Failing-checks cue for the COLLAPSED reopen strip (cave-fpqx.12) — keyed
+  // on the SESSION root (the stage header's key, cave-r0gt); the badge is
+  // about the session's PR, not a browsed root.
+  const reopenChecksFailing = useStageChecksBadge(railProjectRoot);
 
   // changeCount = number of pending working-tree files for the rail's effective
   // project root. Mirrors session-changes-panel's /api/changes fetch (files

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5231,7 +5231,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         {hasLinkedChips ? linkedContextRow : null}
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
-      <ChatStageHeader projectRoot={activeProjectRoot} onOpenUrl={onOpenUrl} />
+      {/* Stage header keys on the SESSION's root — the same source the rail
+          badge listeners use (chat-surface railProjectRoot) — so publisher
+          and listener can't drift onto different derivations (cave-r0gt). */}
+      <ChatStageHeader projectRoot={session?.project_root ?? projectRoot ?? null} onOpenUrl={onOpenUrl} />
       <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>
       <FileLinkResolverContext.Provider value={fileLinkResolver}>
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">

--- a/src/components/github-action-card.tsx
+++ b/src/components/github-action-card.tsx
@@ -31,7 +31,9 @@ export function describeGitHubAction(a: GitHubActionDescriptor): string {
     case "issue-create":
       return `Create issue “${a.title ?? ""}” in ${a.repo}`;
     case "issue-state":
-      return `Close or reopen ${target}`;
+      // state is parse-required (actionFromAttrs) — the card says exactly
+      // which direction fires (review finding, cave-jqke).
+      return a.state === "open" ? `Reopen ${target}` : `Close ${target}`;
     case "review":
       return a.event === "APPROVE"
         ? `Approve ${target}`
@@ -70,20 +72,23 @@ export async function fireGitHubAction(a: GitHubActionDescriptor): Promise<strin
       return post("/api/github/comment", { repo: a.repo, number: a.number, body: a.body });
     case "resolve":
     case "unresolve": {
-      // The marker carries the PR number; resolving needs the thread node id —
-      // look it up through the comments route (threads ride PR scope).
+      // The marker must name the target comment (databaseId) — resolving "the
+      // first unresolved thread" on a multi-thread PR marks the wrong thread
+      // (review finding, cave-jqke).
+      if (!a.threadId) return "no thread specified — the proposal must carry a thread id";
       try {
         const res = await fetch(
           `/api/github/comments?repo=${encodeURIComponent(a.repo)}&number=${a.number}&isPull=1`,
           { cache: "no-store" },
         );
         const data = (await res.json().catch(() => null)) as
-          | { ok: true; reviewThreads: { id: string; isResolved: boolean }[] }
+          | { ok: true; reviewThreads: { id: string; isResolved: boolean; comments?: { id: string }[] }[] }
           | null;
         if (!data || data.ok !== true) return "could not load review threads";
         const want = a.kind === "resolve";
-        const thread = data.reviewThreads.find((t) => t.isResolved !== want);
-        if (!thread) return want ? "no unresolved threads" : "no resolved threads";
+        const thread = data.reviewThreads.find((t) => t.comments?.some((c) => c.id === a.threadId));
+        if (!thread) return "target thread not found on this PR";
+        if (thread.isResolved === want) return want ? "thread already resolved" : "thread already unresolved";
         return post("/api/github/resolve-thread", { threadId: thread.id, resolved: want });
       } catch {
         return "network error";
@@ -92,11 +97,9 @@ export async function fireGitHubAction(a: GitHubActionDescriptor): Promise<strin
     case "issue-create":
       return post("/api/github/issue", { repo: a.repo, title: a.title, body: a.body ?? "" });
     case "issue-state":
-      // The proposal's note carries intent; the state itself rides `body` as
-      // "open"/"closed" per the marker contract — default to closing.
       return post(
         "/api/github/issue",
-        { repo: a.repo, number: a.number, state: a.body === "open" ? "open" : "closed" },
+        { repo: a.repo, number: a.number, state: a.state === "open" ? "open" : "closed" },
         "PATCH",
       );
     case "review":

--- a/src/components/workspace-rail-checks-badge.test.ts
+++ b/src/components/workspace-rail-checks-badge.test.ts
@@ -12,21 +12,26 @@ const hook = readFileSync(new URL("../lib/use-stage-checks-badge.ts", import.met
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 const railLogic = readFileSync(new URL("../lib/code-rail.ts", import.meta.url), "utf8");
 
-// Broadcast side: the header owns the snapshot; fires on change AND resets on
-// unmount so a stale red dot can't outlive its cause.
+// Publish side: the header owns the snapshot; publishStageChecks records the
+// state for late-mounting listeners AND broadcasts; the clear fires only on
+// unmount/root change (no transient false between true states).
 assert.match(header, /snapshot\?\.pr && snapshot\.pr\.checkStatus === "failing"/, "failing signal derives from the stage snapshot's PR rollup");
-assert.match(header, /window\.dispatchEvent\(new CustomEvent\(STAGE_CHECKS_EVENT, \{ detail: \{ projectRoot, failing \} \}\)\);\s*\n\s*\}, \[projectRoot, failing\]\);/, "header broadcasts on every signal change");
-assert.match(header, /detail: \{ projectRoot, failing: false \}[\s\S]{0,40}\}, \[projectRoot\]\);/, "the clear fires only on unmount/root change — no transient false between true states");
+assert.match(header, /publishStageChecks\(projectRoot, failing\);\s*\n\s*\}, \[projectRoot, failing\]\);/, "header publishes on every signal change");
+assert.match(header, /publishStageChecks\(projectRoot, false\);[\s\S]{0,40}\}, \[projectRoot\]\);/, "the clear fires only on unmount/root change");
 
-// Listener side: filtered by project root, resets when the root changes.
-assert.match(hook, /d\?\.projectRoot === projectRoot/, "hook filters events to its project root");
-assert.match(hook, /setFailing\(false\);\s*\n\s*if \(!projectRoot\) return;/, "hook resets on root change");
+// Listener side: store replay at mount (a rail opened AFTER checks went red
+// still shows the dot — cave-r0gt), root-filtered, normalized roots.
+assert.match(hook, /export function publishStageChecks/, "publish records state + broadcasts");
+assert.match(hook, /stageChecksState\.set\(root, failing\)/, "module store is the replay source");
+assert.match(hook, /useState\(\(\) => \(root \? \(stageChecksState\.get\(root\) \?\? false\) : false\)\)/, "listeners initialize from the store, not false");
+assert.match(hook, /d\?\.projectRoot === root/, "hook filters events to its project root");
+assert.match(hook, /function normalizeRoot/, "roots normalize on both sides so derivations can't drift on slashes");
 
 // Rail strip badge + a11y label; collapsed reopen strip too.
 assert.match(rail, /useStageChecksBadge\(projectRoot\)/, "rail reads the badge signal");
 assert.match(rail, /workspace-rail__badge--alert/, "rail renders the alert dot");
 assert.match(rail, /"Changes — PR checks failing"/, "changes tab announces the failing state");
-assert.match(surface, /useStageChecksBadge\(effectiveRailRoot\)/, "collapsed reopen strip reads the same signal");
+assert.match(surface, /useStageChecksBadge\(railProjectRoot\)/, "collapsed reopen strip keys on the session root (cave-r0gt)");
 assert.match(surface, /"Show code rail — PR checks failing"/, "reopen strip announces the failing state");
 assert.match(css, /\.workspace-rail__badge--alert \{/, "alert dot styled");
 

--- a/src/lib/github-blocks.test.ts
+++ b/src/lib/github-blocks.test.ts
@@ -264,3 +264,37 @@ test("slice: quoted title containing '>' stays atomic (no early tag close)", () 
     { kind: "card", descriptor: { kind: "issue", repo: "a/b", number: 5, title: "fix a > b" } },
   ]);
 });
+
+// ── Review-fix pins (cave-m0r6, cave-jqke) ───────────────────────────────────
+
+test("strip: partial tail with '>' inside an open quoted attr stays hidden", () => {
+  assert.equal(
+    stripGitHubMarkers('Working on <coven:github kind="pr" repo="o/r" number="7" title="fix: a -> b'),
+    "Working on ",
+  );
+});
+
+test("slice/strip: fenced markers are example text — literal, no cards, fence intact", () => {
+  const text = 'Example:\n```xml\n<coven:github-action kind="merge" repo="o/r" number="7" />\n```\ndone';
+  const pieces = sliceGitHubBlocks(text);
+  assert.ok(pieces.every((p) => p.kind === "text"), "no card/action pieces from fenced markers");
+  const joined = pieces.map((p) => (p.kind === "text" ? p.text : "")).join("");
+  assert.ok(joined.includes('<coven:github-action kind="merge"'), "fenced marker stays literal");
+  assert.equal(stripGitHubMarkers(text), text, "strip leaves fenced markers alone");
+  // Unclosed trailing fence protects through the text end (streaming).
+  const streaming = 'look:\n```\n<coven:github kind="pr" repo="o/r" number="7" />';
+  assert.equal(stripGitHubMarkers(streaming), streaming);
+});
+
+test("action attrs: issue-state requires an explicit state; resolve accepts a thread id", () => {
+  // No state → malformed, dropped (never 'default to close').
+  const noState = sliceGitHubBlocks('<coven:github-action kind="issue-state" repo="a/b" number="7" />');
+  assert.ok(noState.every((p) => p.kind === "text"));
+  const open = sliceGitHubBlocks('<coven:github-action kind="issue-state" repo="a/b" number="7" state="open" />');
+  assert.equal((open[0] as { action: { state?: string } }).action.state, "open");
+  const resolve = sliceGitHubBlocks('<coven:github-action kind="resolve" repo="a/b" number="7" thread="5551" />');
+  assert.equal((resolve[0] as { action: { threadId?: string } }).action.threadId, "5551");
+  // Non-numeric thread ids drop to undefined (the card then refuses to fire).
+  const badThread = sliceGitHubBlocks('<coven:github-action kind="resolve" repo="a/b" number="7" thread="abc" />');
+  assert.equal((badThread[0] as { action: { threadId?: string } }).action.threadId, undefined);
+});

--- a/src/lib/github-blocks.ts
+++ b/src/lib/github-blocks.ts
@@ -79,6 +79,13 @@ export type GitHubActionDescriptor = {
   method?: "squash" | "merge" | "rebase";
   /** Review verdict (review). */
   event?: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+  /** Explicit issue state (issue-state) — required so the proposal card can
+   *  say exactly which direction fires (review finding, cave-jqke). */
+  state?: "open" | "closed";
+  /** Target review-comment databaseId (resolve/unresolve) — the same id
+   *  `#discussion_r<id>` URLs carry; without it the card refuses to fire
+   *  rather than picking an arbitrary thread (review finding, cave-jqke). */
+  threadId?: string;
   /** Comment/review/issue body text. */
   body?: string;
   /** Issue title (issue-create). */
@@ -118,12 +125,20 @@ function actionFromAttrs(attrs: Record<string, string>): GitHubActionDescriptor 
   switch (kind as GitHubActionKind) {
     case "comment":
     case "reply":
-    case "resolve":
-    case "unresolve":
       return number ? { kind: kind as GitHubActionKind, ...base, number } : null;
+    case "resolve":
+    case "unresolve": {
+      if (!number) return null;
+      const threadRaw = attrs.thread?.trim();
+      const threadId = threadRaw && /^\d+$/.test(threadRaw) ? threadRaw : undefined;
+      return { kind: kind as GitHubActionKind, ...base, number, threadId };
+    }
     case "issue-state": {
       if (!number) return null;
-      return { kind: "issue-state", ...base, number };
+      // Direction must be explicit — a proposal that doesn't say which way it
+      // flips the issue is malformed, not "default to close".
+      const state = attrs.state === "open" ? "open" : attrs.state === "closed" ? "closed" : null;
+      return state ? { kind: "issue-state", ...base, number, state } : null;
     }
     case "issue-create": {
       const title = attrs.title?.trim();
@@ -260,19 +275,63 @@ export function parseGitHubUrl(url: string): GitHubBlockDescriptor | null {
   return runId ? { kind: "run", repo, runId } : null;
 }
 
+/** True when an UNQUOTED `>` exists at/after `from` — quote-aware so a `>`
+ *  inside a still-open attribute value (`title="a -> b`) doesn't read as the
+ *  tag's close while the marker is mid-stream (review finding, cave-m0r6). */
+function hasUnquotedGt(s: string, from: number): boolean {
+  let inQuote = false;
+  for (let i = from; i < s.length; i++) {
+    const c = s[i];
+    if (c === '"') inQuote = !inQuote;
+    else if (c === ">" && !inQuote) return true;
+  }
+  return false;
+}
+
+/** Character ranges covered by ```/~~~ fences (delimiters included). Fenced
+ *  marker syntax is example text, never live cards (review finding,
+ *  cave-m0r6); an unclosed trailing fence protects through the text end. */
+export function fencedRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let offset = 0;
+  let fenceStart = -1;
+  for (const line of text.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      if (fenceStart === -1) fenceStart = offset;
+      else {
+        ranges.push([fenceStart, offset + line.length]);
+        fenceStart = -1;
+      }
+    }
+    offset += line.length + 1;
+  }
+  if (fenceStart !== -1) ranges.push([fenceStart, text.length]);
+  return ranges;
+}
+
+function inRanges(ranges: Array<[number, number]>, index: number): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end);
+}
+
 /**
  * Streaming-safe strip: remove complete `<coven:github…>` markers and hide a
  * PARTIAL marker at the very end of the text (the stream may cut mid-tag —
- * raw tag fragments must never flash). Cards are not mounted while streaming;
- * they appear when the turn settles (same contract as canvas artifacts).
+ * raw tag fragments must never flash). Fenced markers are example text and
+ * stay literal. Cards are not mounted while streaming; they appear when the
+ * turn settles (same contract as canvas artifacts).
  */
 export function stripGitHubMarkers(text: string): string {
   if (!text || !text.includes("<coven:g")) return text;
-  let out = text.replace(MARKER_RE, "");
+  const fences = fencedRanges(text);
+  MARKER_RE.lastIndex = 0;
+  let out = text.replace(MARKER_RE, (m, _action, _attrs, index: number) =>
+    inRanges(fences, index) ? m : "",
+  );
   // Partial tail: an unterminated `<coven:github…` (or any prefix of the tag
-  // name) with no closing `>` after it hides from the visible stream.
+  // name) with no UNQUOTED closing `>` after it hides from the visible
+  // stream — unless it sits inside a fence, where it's example text.
   const tail = out.lastIndexOf("<coven:g");
-  if (tail !== -1 && out.indexOf(">", tail) === -1) {
+  if (tail !== -1 && !hasUnquotedGt(out, tail) && !inRanges(fencedRanges(out), tail)) {
     const frag = out.slice(tail);
     if ("<coven:github-action".startsWith(frag.slice(0, "<coven:github-action".length)) || frag.startsWith("<coven:github")) {
       out = out.slice(0, tail);
@@ -306,9 +365,14 @@ export function sliceGitHubBlocks(text: string): GitHubTextPiece[] {
   };
 
   if (text.includes("<coven:github")) {
+    // Fenced markers are example text — leave them literal instead of
+    // splitting the fence and mounting a live (possibly armed action) card
+    // (review finding, cave-m0r6).
+    const fences = fencedRanges(text);
     MARKER_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = MARKER_RE.exec(text)) !== null) {
+      if (inRanges(fences, m.index)) continue;
       pushText(text.slice(cursor, m.index));
       cursor = m.index + m[0].length;
       const isAction = Boolean(m[1]);

--- a/src/lib/skill-blocks.test.ts
+++ b/src/lib/skill-blocks.test.ts
@@ -91,3 +91,17 @@ test("extract: quoted note containing '>' stays atomic (no early tag close)", ()
   assert.deepEqual(updates, [{ name: "brainstorming", stage: "running", note: "a > b flow" }]);
   assert.equal(visible, "x  y");
 });
+
+// ── Review-fix pins (cave-m0r6) ──────────────────────────────────────────────
+
+test("extract: partial tail with '>' inside an open quoted note stays hidden", () => {
+  const { visible } = extractSkillMarkers('text <coven:skill name="x" stage="running" note="step 2 -> 3');
+  assert.equal(visible, "text ");
+});
+
+test("extract: fenced skill markers are example text — literal, no updates", () => {
+  const text = 'Docs:\n```\n<coven:skill name="brainstorming" stage="running" />\n```\nend';
+  const { visible, updates } = extractSkillMarkers(text);
+  assert.deepEqual(updates, []);
+  assert.equal(visible, text);
+});

--- a/src/lib/skill-blocks.ts
+++ b/src/lib/skill-blocks.ts
@@ -16,6 +16,8 @@
  * src/components/skill-stage-card.tsx.
  */
 
+import { fencedRanges } from "./github-blocks.ts";
+
 export type SkillStage = "loaded" | "running" | "done" | "error";
 
 export type SkillStageUpdate = {
@@ -53,8 +55,12 @@ export function extractSkillMarkers(text: string): { visible: string; updates: S
   let visible = text;
 
   if (text.includes("<coven:skill")) {
+    // Fenced markers are example text — stay literal, no updates
+    // (review finding, cave-m0r6; same contract as coven:github).
+    const fences = fencedRanges(text);
     MARKER_RE.lastIndex = 0;
-    visible = text.replace(MARKER_RE, (_m, rawAttrs: string) => {
+    visible = text.replace(MARKER_RE, (m, rawAttrs: string, index: number) => {
+      if (fences.some(([start, end]) => index >= start && index < end)) return m;
       const attrs = parseAttrs(rawAttrs ?? "");
       const name = attrs.name?.trim();
       const stage = attrs.stage?.trim();
@@ -72,9 +78,15 @@ export function extractSkillMarkers(text: string): { visible: string; updates: S
   }
 
   // Partial tail: an unterminated `<coven:skill…` (or any prefix of the tag
-  // name) with no closing `>` hides from the visible stream.
+  // name) with no UNQUOTED closing `>` hides from the visible stream — a `>`
+  // inside a still-open quoted note must not read as the tag close (review
+  // finding, cave-m0r6). Fenced tails are example text and stay literal.
   const tail = visible.lastIndexOf("<coven:s");
-  if (tail !== -1 && visible.indexOf(">", tail) === -1) {
+  if (
+    tail !== -1 &&
+    !hasUnquotedGtAfter(visible, tail) &&
+    !fencedRanges(visible).some(([start, end]) => tail >= start && tail < end)
+  ) {
     const frag = visible.slice(tail);
     if ("<coven:skill".startsWith(frag.slice(0, "<coven:skill".length))) {
       visible = visible.slice(0, tail);
@@ -82,6 +94,16 @@ export function extractSkillMarkers(text: string): { visible: string; updates: S
   }
 
   return { visible, updates: [...byName.values()] };
+}
+
+function hasUnquotedGtAfter(s: string, from: number): boolean {
+  let inQuote = false;
+  for (let i = from; i < s.length; i++) {
+    const c = s[i];
+    if (c === '"') inQuote = !inQuote;
+    else if (c === ">" && !inQuote) return true;
+  }
+  return false;
 }
 
 // buildSkillPrompt (src/lib/slash-skill.ts) shapes — anchored so ordinary

--- a/src/lib/stage-model.test.ts
+++ b/src/lib/stage-model.test.ts
@@ -130,3 +130,25 @@ test("changes-requested review reads failed", () => {
   assert.ok(snap);
   assert.equal(step(snap, "review").state, "failed");
 });
+
+test("reused branch: an open PR suppresses the old merged ref (no contradictory pipeline)", () => {
+  const merged: MergedPrRef = {
+    number: 100,
+    title: "old shipped thing",
+    url: "https://github.com/o/r/pull/100",
+    beadIds: [],
+    mergedAt: "2026-07-14T12:00:00Z",
+    headRefName: "feat/x",
+  };
+  const snap = resolveStageForBranch({
+    branch: "feat/x",
+    open: [pr({ number: 105, headRefName: "feat/x", lane: "needs-review", checkStatus: "pending" })],
+    merged: [merged],
+    beads: [],
+  });
+  assert.ok(snap);
+  assert.equal(snap.lane, "needs-review");
+  assert.equal(snap.mergedRef, null, "old merged PR must not leak into an open-PR stage");
+  assert.equal(step(snap, "merged").state, "pending");
+  assert.ok(!step(snap, "merged").detail.startsWith("Merged"), "no 'Merged <date>' beside active checks");
+});

--- a/src/lib/stage-model.ts
+++ b/src/lib/stage-model.ts
@@ -73,7 +73,11 @@ export function resolveStageForBranch(args: {
   if (!branch) return null;
 
   const pr = args.open.find((p) => p.headRefName === branch) ?? null;
-  const mergedByBranch = args.merged.find((m) => m.headRefName === branch) ?? null;
+  // A reused branch can carry BOTH an open PR and a recently-merged one; when
+  // an open PR anchors the stage the old merged ref must not leak in, or the
+  // pipeline reads "merged ✓" beside active checks/review (review finding,
+  // cave-a3cl). Merged refs only matter for post-merge stages.
+  const mergedByBranch = pr ? null : (args.merged.find((m) => m.headRefName === branch) ?? null);
   const beadIds = new Set<string>(
     [...(pr?.beadIds ?? []), ...beadIdsInBranch(branch), ...(mergedByBranch?.beadIds ?? [])].map((s) =>
       s.toLowerCase(),

--- a/src/lib/use-stage-checks-badge.ts
+++ b/src/lib/use-stage-checks-badge.ts
@@ -1,27 +1,55 @@
 "use client";
 
 /**
- * Failing-checks badge signal for the code rail (cave-fpqx.12, design
- * docs/chat-github-integration.md §6). The chat stage header owns the stage
- * snapshot and broadcasts STAGE_CHECKS_EVENT whenever the failing signal
- * changes; this hook is the listener side, filtered to one project root, so
- * the rail never re-fetches the PR bridge itself.
+ * Failing-checks badge signal for the code rail (cave-fpqx.12; replay fix
+ * cave-r0gt). The chat stage header owns the stage snapshot and PUBLISHES the
+ * failing signal through publishStageChecks — which records it in a
+ * module-level store and broadcasts STAGE_CHECKS_EVENT. Listeners initialize
+ * FROM THE STORE at mount, so a rail that mounts after the broadcast (it was
+ * collapsed when checks went red — the exact moment the user clicks the
+ * reopen strip) still shows the current state; the event keeps already-
+ * mounted listeners live. Roots are normalized on both sides so dispatcher
+ * and listener derivations can't drift on a trailing slash.
  */
 
 import { useEffect, useState } from "react";
 import { STAGE_CHECKS_EVENT } from "@/lib/stage-model";
 
+function normalizeRoot(root: string): string {
+  let out = root;
+  while (out.length > 1 && out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
+
+// Current failing-signal per project root — the replay source for listeners
+// that mount after the broadcast. Module-level, session-lifetime.
+const stageChecksState = new Map<string, boolean>();
+
+/** Publish the failing signal for a root: record for late-mounting listeners
+ *  and broadcast for live ones. The stage header is the only producer. */
+export function publishStageChecks(projectRoot: string, failing: boolean): void {
+  const root = normalizeRoot(projectRoot);
+  stageChecksState.set(root, failing);
+  window.dispatchEvent(new CustomEvent(STAGE_CHECKS_EVENT, { detail: { projectRoot: root, failing } }));
+}
+
 export function useStageChecksBadge(projectRoot: string | null | undefined): boolean {
-  const [failing, setFailing] = useState(false);
+  const root = projectRoot ? normalizeRoot(projectRoot) : null;
+  // Initialize from the store so a listener mounting after the broadcast
+  // reads the current state instead of defaulting to false (cave-r0gt).
+  const [failing, setFailing] = useState(() => (root ? (stageChecksState.get(root) ?? false) : false));
   useEffect(() => {
-    setFailing(false);
-    if (!projectRoot) return;
+    if (!root) {
+      setFailing(false);
+      return;
+    }
+    setFailing(stageChecksState.get(root) ?? false);
     const handler = (e: Event) => {
       const d = (e as CustomEvent).detail as { projectRoot?: string; failing?: boolean } | undefined;
-      if (d?.projectRoot === projectRoot) setFailing(Boolean(d.failing));
+      if (d?.projectRoot === root) setFailing(Boolean(d.failing));
     };
     window.addEventListener(STAGE_CHECKS_EVENT, handler);
     return () => window.removeEventListener(STAGE_CHECKS_EVENT, handler);
-  }, [projectRoot]);
+  }, [root]);
   return failing;
 }


### PR DESCRIPTION
Fixes all four findings from the post-ship `/review` of the chat↔GitHub integration (epic `cave-fpqx`):

| Bead | Fix |
|---|---|
| `cave-m0r6` | **Marker scanners**: quote-aware partial-tail hiding (a `>` inside a still-open attr like `title="a -> b"` no longer flashes the raw fragment mid-stream) + the fence guard now covers the **marker pass and strips** — fenced `coven:github`/`coven:skill` syntax stays literal example text instead of splitting the fence and mounting a live (possibly armed action) card; unclosed trailing fences protect through the stream tail |
| `cave-r0gt` | **Rail badge**: `publishStageChecks` records state in a module store **and** broadcasts — a rail mounting after checks went red (the exact moment the user clicks the reopen dot) replays the current state instead of initializing false forever; publisher + listeners now key on the same normalized **session-root** derivation |
| `cave-jqke` | **Proposal cards**: `issue-state` requires an explicit `state` attr (card says exactly *Close #N* / *Reopen #N*; no hidden default-to-close); `resolve`/`unresolve` carry a thread comment id and **refuse to fire** without one instead of resolving an arbitrary first-unresolved thread |
| `cave-a3cl` | **stage-model**: an open PR suppresses a reused branch's old merged ref — the pipeline can't read *merged ✓* beside active checks/review |

## Verification
12 new behavioral cases (43 total across the three libs, all green); wiring pins updated for the publish/replay contract and session-root keying; full `pnpm test:app` **719 files green**; cards e2e (`tests/github-chat-cards.spec.ts`) passing; `pnpm typecheck` clean.