### PR TITLE
fix(research): mission header no longer prints the intent twice

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -8,6 +8,7 @@ import {
   allowedResearchActions,
   describeResearchSchedule,
   researchBoundReadings,
+  researchIntentAddsContext,
   researchPhaseStatuses,
   type ResearchMission,
   type ResearchMissionAction,
@@ -160,7 +161,7 @@ export function ResearchMissionDetail({
             <time dateTime={mission.updatedAt}>updated {relativeTime(mission.updatedAt) || "just now"}</time>
           </span>
           <h2 id="research-mission-title">{mission.title}</h2>
-          <p>{mission.intent}</p>
+          {researchIntentAddsContext(mission) ? <p>{mission.intent}</p> : null}
         </div>
         {sessionId ? (
           <Button

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -37,6 +37,12 @@ test("mission list and evidence trajectory expose semantic state", () => {
   assert.match(ledger, /Open in Grimoire/);
 });
 
+test("the mission header does not print the intent twice", () => {
+  // Short intents become the title verbatim (missionTitle), so the intent
+  // paragraph only renders when it adds information beyond the title.
+  assert.match(detail, /\{researchIntentAddsContext\(mission\) \? <p>\{mission\.intent\}<\/p> : null\}/);
+});
+
 test("evidence trajectory statuses come from the shared terminal-truthful reconciler", () => {
   // The old local heuristic trusted stale step snapshots over terminal mission
   // status (completed missions rendered "Scope running / rest pending") and

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeResearchBounds,
   RESEARCH_BOUND_LIMITS,
   researchBoundReadings,
+  researchIntentAddsContext,
   researchPhaseStatuses,
   validateCreateResearchMissionInput,
 } from "./research-missions.ts";
@@ -488,5 +489,44 @@ test("checkpoint cadence pluralizes correctly", () => {
   assert.equal(
     reading(meterMission({ bounds: { checkpointEvery: 2 } }), "checkpoint").value,
     "every 2 iterations",
+  );
+});
+
+// --- researchIntentAddsContext: the header must not repeat itself ---
+
+test("intent identical to the title adds nothing — the header shows it once", () => {
+  // Screenshot repro: short intents become the title verbatim.
+  assert.equal(
+    researchIntentAddsContext({
+      title: "Optimizing Agents via Automated Self-Performance Evaluations",
+      intent: "Optimizing Agents via Automated Self-Performance Evaluations",
+    }),
+    false,
+  );
+  // Whitespace and case differences are still the same sentence.
+  assert.equal(
+    researchIntentAddsContext({
+      title: "Compare local-first note apps",
+      intent: "  compare   Local-first note APPS ",
+    }),
+    false,
+  );
+});
+
+test("truncated and customized titles keep the informative intent line", () => {
+  const longIntent = `Compare ${"very ".repeat(20)}long approaches to agent evaluation across benchmarks`;
+  assert.equal(
+    researchIntentAddsContext({
+      title: `${longIntent.replace(/\s+/g, " ").slice(0, 77)}…`,
+      intent: longIntent,
+    }),
+    true,
+  );
+  assert.equal(
+    researchIntentAddsContext({
+      title: "Agent self-evaluation brief",
+      intent: "Compare approaches to automated self-performance evaluation for agents",
+    }),
+    true,
   );
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -402,6 +402,22 @@ export function researchPhaseStatuses(
   });
 }
 
+/**
+ * Whether the mission intent says anything the title does not.
+ *
+ * missionTitle copies a short intent verbatim (and truncates a long one with
+ * an ellipsis), so most detail headers would otherwise print the same
+ * sentence twice. Comparison normalizes whitespace and case; truncated and
+ * explicitly customized titles keep the intent line because the full
+ * sentence still carries information.
+ */
+export function researchIntentAddsContext(
+  mission: Pick<ResearchMission, "title" | "intent">,
+): boolean {
+  const normalize = (text: string) => text.replace(/\s+/g, " ").trim().toLowerCase();
+  return normalize(mission.intent) !== normalize(mission.title);
+}
+
 export type ResearchBoundReading = {
   id: "time" | "sources" | "checkpoint" | "spend";
   label: string;


### PR DESCRIPTION
## What

Slice 3 of the `research-desk-ux-uplift` goal (bead `cave-7tdh`). The mission detail header printed the same sentence twice — `missionTitle` (runner) copies a short intent verbatim into `title`, and the header rendered `<h2>{title}</h2>` followed by `<p>{intent}</p>` (2026-07-15 screenshot audit: "Optimizing Agents via Automated Self-Performance Evaluations" twice, back to back).

## How

- New pure `researchIntentAddsContext(mission)` in `src/lib/research-missions.ts`: normalized whitespace/case comparison of intent vs title.
- `research-mission-detail.tsx` renders the intent paragraph only when it adds information — truncated titles (`…`) and explicit custom titles keep the full intent visible.

## Testing

- Behavioral tests: verbatim + whitespace/case-variant intents suppress (screenshot repro); truncated and customized titles keep the line.
- Wiring pin in `researcher-surface.test.ts`.
- `pnpm typecheck` ✓ · targeted `node --test` 40/40 ✓ · `pnpm test:app` 721 files ✓
