### PR TITLE
fix(persistence): atomic conversation writes + hub token out of cave-config (cave-1v95)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -621,6 +621,7 @@ export const SUITES = {
     "src/lib/cave-config.test.ts",
     "src/lib/cave-config-state-race.test.ts",
     "src/lib/cave-config-write-race.test.ts",
+    "src/lib/hub-access-token.test.ts",
     "src/lib/font-storage.test.ts",
     "src/lib/font-css-vars.test.ts",
     "src/components/font-boot.test.ts",

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -521,9 +521,11 @@ export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
           })
         : current.chatAutoArchive,
   };
-  // Never persist an embedded hub access token (cave-1v95): pasting the
-  // tokened invite URL stays the pairing UX, but the credential goes to the
-  // local encrypted vault and only the clean URL reaches config.json.
+  // Split an embedded hub access token out before persisting (cave-1v95):
+  // pasting the tokened invite URL stays the pairing UX, but the credential
+  // goes to the local encrypted vault and only the clean URL reaches
+  // config.json. Best-effort by design — if the vault write fails, the
+  // embedded token is kept in place so hub connectivity never breaks.
   sanitizeMultiHostHubToken(updated);
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
   await writeJsonAtomic(CONFIG_PATH, updated);

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -2,6 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
   extendUntilIso,
@@ -272,7 +273,7 @@ export async function loadConfig(): Promise<CaveConfig> {
   try {
     const raw = await readFile(CONFIG_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveConfig>;
-    return {
+    const config: CaveConfig = {
       version: parsed.version ?? 1,
       defaults: { ...DEFAULT_CONFIG.defaults, ...(parsed.defaults ?? {}) },
       familiars: parsed.familiars ?? {},
@@ -315,9 +316,27 @@ export async function loadConfig(): Promise<CaveConfig> {
         ? { chatAutoArchive: normalizeChatAutoArchivePolicy(parsed.chatAutoArchive) }
         : {}),
     };
+    // Self-healing migration (cave-1v95): a pre-existing config may still
+    // embed the hub access token in multiHost.hubUrl. Move it to the local
+    // encrypted vault and rewrite the file once, so config.json stops being a
+    // credential store. Best-effort — a failed vault write keeps the embedded
+    // token working exactly as before.
+    if (sanitizeMultiHostHubToken(config)) {
+      await writeJsonAtomic(CONFIG_PATH, config).catch(() => {});
+    }
+    return config;
   } catch {
     return defaultConfig();
   }
+}
+
+/** Split an embedded access token out of `config.multiHost.hubUrl` into the
+ *  local encrypted vault, in place. Returns whether the URL was rewritten. */
+function sanitizeMultiHostHubToken(config: Pick<CaveConfig, "multiHost">): boolean {
+  const { url, token } = splitHubAccessToken(config.multiHost.hubUrl);
+  if (!token || !rememberHubAccessToken(token)) return false;
+  config.multiHost = { ...config.multiHost, hubUrl: url };
+  return true;
 }
 
 export function normalizeRemoteHosts(input: CaveRemoteHost[] | undefined): CaveRemoteHost[] {
@@ -502,6 +521,10 @@ export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
           })
         : current.chatAutoArchive,
   };
+  // Never persist an embedded hub access token (cave-1v95): pasting the
+  // tokened invite URL stays the pairing UX, but the credential goes to the
+  // local encrypted vault and only the clean URL reaches config.json.
+  sanitizeMultiHostHubToken(updated);
   await mkdir(path.dirname(CONFIG_PATH), { recursive: true });
   await writeJsonAtomic(CONFIG_PATH, updated);
   return updated;

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -357,4 +357,36 @@ console.log("cave-conversations.test.ts: ok");
   const again = await searchConversations("unique-marker-bbb");
   assert.equal(again.length, 1, "repeat search via the cache returns the same hit");
 }
+
+// ── Atomic persistence (cave-1v95): no torn writes, no temp residue ──────────
+{
+  const { readdir, readFile } = await import("node:fs/promises");
+  const { CONV_DIR } = await import("./cave-conversations.ts");
+  await saveConversation({
+    sessionId: "atomic-check",
+    familiarId: "charm",
+    harness: "codex",
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+    turns: [],
+  });
+  const entries = await readdir(CONV_DIR);
+  assert.ok(entries.includes("atomic-check.json"), "the conversation file lands");
+  assert.equal(
+    entries.filter((name) => name.endsWith(".tmp")).length,
+    0,
+    "atomic replace leaves no temp residue behind",
+  );
+  const source = await readFile(new URL("./cave-conversations.ts", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /writeJsonAtomic\(pathFor\(conv\.sessionId\), conv\)/,
+    "saveConversation must go through the atomic writer",
+  );
+  assert.doesNotMatch(
+    source,
+    /writeFile\(pathFor/,
+    "plain writeFile on a conversation path would reintroduce torn writes",
+  );
+}
 console.log("cave-conversations cache test OK");

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile, appendFile, readdir, stat, unlink } from "node:fs/promises";
+import { mkdir, readFile, appendFile, readdir, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
 import type { SessionOrigin } from "./types.ts";
@@ -147,7 +148,10 @@ export async function loadConversation(sessionId: string): Promise<ConversationF
 export async function saveConversation(conv: ConversationFile): Promise<void> {
   await ensureDir();
   conv.updatedAt = new Date().toISOString();
-  await writeFile(pathFor(conv.sessionId), JSON.stringify(conv, null, 2), "utf8");
+  // Atomic replace (cave-1v95): conversations are the highest-churn store —
+  // a crash mid-write must leave the previous transcript intact, never a
+  // torn half-JSON that loadConversation silently drops.
+  await writeJsonAtomic(pathFor(conv.sessionId), conv);
 }
 
 export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<void> {

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -4,6 +4,7 @@ import { request as httpsRequest } from "node:https";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { CaveConfig } from "./cave-config.ts";
+import { storedHubAccessToken } from "./hub-access-token.ts";
 
 type SocketPathResolverOptions = {
   platform?: NodeJS.Platform;
@@ -97,7 +98,11 @@ function hubTargetFromUrl(rawUrl: string): Extract<DaemonTarget, { mode: "hub" }
   const normalized = normalizeHubUrl(rawUrl);
   if (!normalized) return null;
   const url = new URL(normalized);
-  const accessToken = url.searchParams.get("coven_access_token")?.trim() || undefined;
+  // An embedded token (a freshly pasted invite URL, or an env-provided URL)
+  // wins; otherwise fall back to the out-of-config custody the config
+  // sanitizer maintains (cave-1v95): env override, then the encrypted vault.
+  const embedded = url.searchParams.get("coven_access_token")?.trim();
+  const accessToken = embedded || storedHubAccessToken() || undefined;
   url.search = "";
   url.hash = "";
   return {

--- a/src/lib/hub-access-token.test.ts
+++ b/src/lib/hub-access-token.test.ts
@@ -63,6 +63,10 @@ const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
   process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = "v1.env";
   assert.equal(storedHubAccessToken(), "v1.env", "an explicit env override wins over the vault");
   delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+  assert.equal(rememberHubAccessToken("   "), false, "blank tokens are refused, not parked in the vault");
+  assert.equal(storedHubAccessToken(), "v1.vaulted", "a refused write leaves prior custody intact");
+  assert.equal(rememberHubAccessToken("  v1.padded \n"), true, "padded input is trimmed before storage");
+  assert.equal(storedHubAccessToken(), "v1.padded", "custody resolves trimmed, never truthy-but-padded");
 }
 
 // ── saveConfig never persists the embedded token ──────────────────────────────

--- a/src/lib/hub-access-token.test.ts
+++ b/src/lib/hub-access-token.test.ts
@@ -1,0 +1,123 @@
+// @ts-nocheck
+// Hub access token custody (cave-1v95, persistence P0): the signed hub token
+// must never be persisted inside cave-config.json's multiHost.hubUrl. Pasting
+// a tokened invite URL stays the pairing UX, but the credential is split into
+// the local encrypted vault on write (and lazily on load, for pre-existing
+// configs), and the daemon target resolves it back from custody.
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const home = await mkdtemp(path.join(tmpdir(), "cave-hub-token-"));
+process.env.HOME = home;
+process.env.COVEN_HOME = path.join(home, ".coven");
+delete process.env.COVEN_CAVE_HOME;
+delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+
+const { splitHubAccessToken, storedHubAccessToken, rememberHubAccessToken, HUB_ACCESS_TOKEN_KEY } =
+  await import("./hub-access-token.ts");
+const { getLocalEncryptedSecret } = await import("./local-encrypted-vault.ts");
+const { loadConfig, saveConfig } = await import("./cave-config.ts");
+const { daemonTargetForConfig } = await import("./coven-daemon.ts");
+const { writeJsonAtomic } = await import("./server/atomic-write.ts");
+
+const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
+
+// ── splitHubAccessToken is pure and conservative ─────────────────────────────
+{
+  const split = splitHubAccessToken(
+    "https://cave.tailnet.example.ts.net/?coven_access_token=v1.tok&covenCaveToken=sidecar",
+  );
+  assert.equal(split.token, "v1.tok", "the embedded access token is extracted");
+  assert.doesNotMatch(split.url, /coven_access_token|v1\.tok/, "the cleaned URL drops the credential");
+  assert.match(split.url, /covenCaveToken=sidecar/, "unrelated query params survive the split");
+
+  assert.deepEqual(
+    splitHubAccessToken("https://hub.example:8787"),
+    { url: "https://hub.example:8787" },
+    "a token-free URL is returned untouched",
+  );
+  const bare = splitHubAccessToken("hub.tailnet:8787?coven_access_token=v1.bare");
+  assert.equal(bare.token, "v1.bare", "scheme-less hub hosts still split");
+  assert.doesNotMatch(bare.url, /^https?:\/\//, "scheme-less input stays scheme-less");
+  assert.doesNotMatch(bare.url, /coven_access_token/, "scheme-less input is cleaned too");
+  assert.deepEqual(splitHubAccessToken(""), { url: "" }, "empty input passes through");
+  assert.deepEqual(
+    splitHubAccessToken("::not a url::"),
+    { url: "::not a url::" },
+    "unparseable input is left for the caller's own URL handling",
+  );
+}
+
+// ── vault custody round-trip with env override precedence ────────────────────
+{
+  assert.equal(storedHubAccessToken(), null, "no custody yet → null");
+  assert.equal(rememberHubAccessToken("v1.vaulted"), true, "vault write succeeds");
+  assert.equal(storedHubAccessToken(), "v1.vaulted", "vault value resolves");
+  assert.equal(
+    getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY),
+    "v1.vaulted",
+    "the token lives in the encrypted local vault",
+  );
+  process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = "v1.env";
+  assert.equal(storedHubAccessToken(), "v1.env", "an explicit env override wins over the vault");
+  delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+}
+
+// ── saveConfig never persists the embedded token ──────────────────────────────
+{
+  const saved = await saveConfig({
+    multiHost: {
+      mode: "hub",
+      hubUrl: "https://hub.tailnet.example.ts.net/?coven_access_token=v1.saved",
+      executorUrls: [],
+    },
+  });
+  assert.doesNotMatch(saved.multiHost.hubUrl, /coven_access_token|v1\.saved/, "the in-memory result is clean");
+  const onDisk = await readFile(CONFIG_PATH, "utf8");
+  assert.doesNotMatch(onDisk, /coven_access_token|v1\.saved/, "config.json never contains the credential");
+  assert.equal(getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY), "v1.saved", "the credential moved to the vault");
+}
+
+// ── the daemon target resolves the token back from custody ───────────────────
+{
+  const target = daemonTargetForConfig(await loadConfig());
+  assert.equal(target.mode, "hub");
+  assert.equal(target.url, "https://hub.tailnet.example.ts.net");
+  assert.equal(target.accessToken, "v1.saved", "hub requests still authenticate after the split");
+}
+
+// ── a freshly pasted (embedded) token wins over stale custody ─────────────────
+{
+  const target = daemonTargetForConfig({
+    multiHost: {
+      mode: "hub",
+      hubUrl: "https://hub.tailnet.example.ts.net/?coven_access_token=v1.pasted",
+      executorUrls: [],
+    },
+  });
+  assert.equal(target.accessToken, "v1.pasted", "an embedded token outranks the vaulted one");
+}
+
+// ── loadConfig self-heals a legacy config that still embeds the token ─────────
+{
+  const legacy = await loadConfig();
+  await writeJsonAtomic(CONFIG_PATH, {
+    ...legacy,
+    multiHost: {
+      mode: "hub",
+      hubUrl: "https://hub.tailnet.example.ts.net/?coven_access_token=v1.legacy",
+      executorUrls: [],
+    },
+  });
+  const migrated = await loadConfig();
+  assert.doesNotMatch(migrated.multiHost.hubUrl, /coven_access_token|v1\.legacy/, "load returns the clean URL");
+  assert.equal(getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY), "v1.legacy", "the legacy token moved to the vault");
+  const rewritten = await readFile(CONFIG_PATH, "utf8");
+  assert.doesNotMatch(rewritten, /coven_access_token|v1\.legacy/, "the file itself is rewritten clean");
+  const target = daemonTargetForConfig(migrated);
+  assert.equal(target.accessToken, "v1.legacy", "hub auth survives the migration");
+}
+
+console.log("hub-access-token.test.ts OK");

--- a/src/lib/hub-access-token.ts
+++ b/src/lib/hub-access-token.ts
@@ -37,24 +37,29 @@ export function splitHubAccessToken(rawUrl: string): { url: string; token?: stri
 }
 
 /** The hub access token from its out-of-config homes: explicit env override
- *  first, then the local encrypted vault. */
+ *  first, then the local encrypted vault. Values are trimmed; blank custody
+ *  resolves to null rather than a truthy-but-invalid credential. */
 export function storedHubAccessToken(): string | null {
   const env = process.env[HUB_ACCESS_TOKEN_KEY]?.trim();
   if (env) return env;
   try {
-    return getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY);
+    return getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY)?.trim() || null;
   } catch {
     return null;
   }
 }
 
 /** Persist the hub access token to the local encrypted vault (0600 key file,
- *  AES-256-GCM store — see local-encrypted-vault.ts). Best-effort: a vault
- *  write failure must not take config saves down with it; the caller keeps
- *  the embedded token in that case. Returns whether the token is stored. */
+ *  AES-256-GCM store — see local-encrypted-vault.ts). Trims first and refuses
+ *  blank values, so a caller can never park an invalid truthy credential.
+ *  Best-effort: a vault write failure must not take config saves down with
+ *  it; the caller keeps the embedded token in that case. Returns whether the
+ *  token is stored. */
 export function rememberHubAccessToken(token: string): boolean {
+  const trimmed = token.trim();
+  if (!trimmed) return false;
   try {
-    setLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY, token);
+    setLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY, trimmed);
     return true;
   } catch {
     return false;

--- a/src/lib/hub-access-token.ts
+++ b/src/lib/hub-access-token.ts
@@ -1,0 +1,62 @@
+import { getLocalEncryptedSecret, setLocalEncryptedSecret } from "./local-encrypted-vault.ts";
+
+/**
+ * Hub access token custody (cave-1v95, persistence P0).
+ *
+ * The server-hub invite URL historically carried its signed access token as a
+ * `?coven_access_token=…` query param, and that WHOLE URL was persisted into
+ * cave-config.json — turning a plain config file into a credential store and
+ * making every config backup a secret leak. The token now lives in the local
+ * encrypted vault under {@link HUB_ACCESS_TOKEN_KEY}; the config keeps only
+ * the clean URL. Embedded tokens are still accepted on input (pasting the
+ * invite URL is the UX) and win over the stored token, but they are split out
+ * before anything touches disk.
+ */
+export const HUB_ACCESS_TOKEN_KEY = "COVEN_CAVE_HUB_ACCESS_TOKEN";
+
+/** Split an embedded `coven_access_token` out of a hub URL. Pure: returns the
+ *  URL unchanged (and no token) when there is nothing to split — including
+ *  unparseable input, which the caller's own URL handling will surface. */
+export function splitHubAccessToken(rawUrl: string): { url: string; token?: string } {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return { url: rawUrl };
+  let url: URL;
+  try {
+    url = new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`);
+  } catch {
+    return { url: rawUrl };
+  }
+  const token = url.searchParams.get("coven_access_token")?.trim();
+  if (!token) return { url: rawUrl };
+  url.searchParams.delete("coven_access_token");
+  // Preserve the user's scheme spelling: only re-serialize what we parsed.
+  const cleaned = /^https?:\/\//i.test(trimmed)
+    ? url.toString()
+    : url.toString().replace(/^http:\/\//i, "");
+  return { url: cleaned.replace(/\?$/, ""), token };
+}
+
+/** The hub access token from its out-of-config homes: explicit env override
+ *  first, then the local encrypted vault. */
+export function storedHubAccessToken(): string | null {
+  const env = process.env[HUB_ACCESS_TOKEN_KEY]?.trim();
+  if (env) return env;
+  try {
+    return getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the hub access token to the local encrypted vault (0600 key file,
+ *  AES-256-GCM store — see local-encrypted-vault.ts). Best-effort: a vault
+ *  write failure must not take config saves down with it; the caller keeps
+ *  the embedded token in that case. Returns whether the token is stored. */
+export function rememberHubAccessToken(token: string): boolean {
+  try {
+    setLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY, token);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Phase **P0** of docs/ios-connection-cloud-plan.md Thread 3 (umbrella cave-rku9): independent hygiene wins gating any backup story. Unblocks cave-166o (P1 encrypted export/restore).

## 1. Torn-write risk on the highest-churn store
`cave-conversations.ts#saveConversation` persisted with plain `writeFile` — a crash mid-write leaves a half-JSON that `loadConversation` silently drops (the transcript vanishes). Now goes through the existing `writeJsonAtomic` (unique temp + atomic rename), matching what board/config/inbox already use. `cave-inbox.ts` was already migrated by an earlier change — verified, no work needed.

## 2. Hub access token embedded in cave-config.json
`multiHost.hubUrl` persisted the **whole invite URL including `?coven_access_token=…`** — making a plain config file a credential store and every config backup a secret leak (`coven-daemon.ts` extracted it at read time).

New **`src/lib/hub-access-token.ts`**:
- `splitHubAccessToken` — pure splitter, conservative on unparseable input, preserves unrelated query params and scheme-less spelling
- custody: local encrypted vault (AES-256-GCM, 0600 key file — existing `local-encrypted-vault.ts`), env override `COVEN_CAVE_HUB_ACCESS_TOKEN` honored first

Wiring:
- `saveConfig` splits the token out before anything touches disk (pasting the tokened invite URL stays the pairing UX)
- `loadConfig` self-heals legacy configs: token → vault, file rewritten clean once (best-effort; a failed vault write keeps the embedded token working as before)
- `hubTargetFromUrl` resolves: embedded URL token (fresh paste wins) → env → vault, so hub auth keeps working before/during/after migration

## Verification
- New `src/lib/hub-access-token.test.ts`: split purity, custody round-trip + env precedence, save-side stripping (on-disk grep), load-side legacy migration (file rewritten), daemon-target auth continuity, paste-wins precedence
- `cave-conversations.test.ts`: atomic-writer pin + no-temp-residue behavioral check
- `pnpm test:app` **722/722**, `pnpm typecheck` clean, check-tests-wired green