### PR TITLE
feat(research): source ledger triages at scale

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15851,6 +15851,19 @@ details[open] > .cave-edit-card__summary::before {
 .research-artifact-reject input, .research-source-attach input { width: 100%; min-width: 0; padding: 5px 6px; font-size: 16px; color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
 .research-artifact-reject input { margin: 6px 0; }
 .research-source-attach { display: grid; gap: 5px; margin-bottom: 8px; }
+.research-source-attach-disclosure { margin-bottom: 8px; font-size: 10px; color: var(--text-muted); }
+.research-source-attach-disclosure summary { width: fit-content; cursor: pointer; }
+.research-source-attach-disclosure[open] summary { margin-bottom: 7px; }
+.research-source-filters { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px; }
+.research-source-filters button { display: inline-flex; align-items: center; gap: 4px; padding: 3px 7px; font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); border: 1px solid var(--border); border-radius: 999px; background: transparent; cursor: pointer; }
+.research-source-filters button span { color: var(--text-secondary); }
+.research-source-filters button[aria-pressed="true"] { color: var(--research-accent); border-color: color-mix(in oklch, var(--research-accent) 45%, transparent); background: var(--research-accent-soft); }
+.research-source-filters button[aria-pressed="true"] span { color: inherit; }
+.research-source-filters button:disabled { opacity: 0.45; cursor: default; }
+.research-source-filters button:focus-visible { outline: var(--ring-width) solid var(--ring-focus); outline-offset: 1px; }
+.research-source-card button.research-source-card__title { gap: 5px; font-size: 11px; color: var(--text-primary); text-align: left; }
+.research-source-card button.research-source-card__title:hover { color: var(--research-accent); }
+.research-source-card button.research-source-card__title svg { color: var(--research-accent); flex-shrink: 0; }
 .research-source-revise { display: flex; align-items: center; gap: 6px; font-size: 9.5px; color: var(--text-muted); }
 .research-source-revise select { min-width: 0; padding: 2px 4px; font-size: 16px; color: var(--text-secondary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
 .research-source-status { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 8.5px !important; text-transform: uppercase; }

--- a/src/components/role-surfaces/research-evidence-ledger.test.ts
+++ b/src/components/role-surfaces/research-evidence-ledger.test.ts
@@ -10,7 +10,28 @@ test("evidence ledger exposes visible statuses and source revision", () => {
   }
   assert.match(source, /attach-source/);
   assert.match(source, /update-source/);
-  assert.match(source, /Open source/);
+});
+
+test("sources triage at scale: filters, quiet attach, title-open affordance", () => {
+  // Status chips carry live counts and a pressed state; empty statuses can't
+  // be selected into a dead-end view.
+  assert.match(source, /researchSourceStatusCounts\(mission\.sources\)/);
+  assert.match(source, /aria-label="Filter sources by status"/);
+  assert.match(source, /aria-pressed=\{sourceFilter === "all"\}/);
+  assert.match(source, /aria-pressed=\{sourceFilter === status\}/);
+  assert.match(source, /disabled=\{sourceCounts\[status\] === 0\}/);
+  // Switching missions resets the filter instead of leaking it.
+  assert.match(source, /setSourceFilter\("all"\);\s*\}, \[mission\.id\]\)/);
+  // The filtered-out view says why it is empty.
+  assert.match(source, /No \{sourceFilter\} sources\./);
+  // The attach form waits behind a disclosure instead of topping the list.
+  assert.match(source, /<details className="research-source-attach-disclosure">\s*<summary>Attach source<\/summary>/);
+  // The card title is the open affordance; the separate button is gone.
+  assert.match(source, /className="research-source-card__title"/);
+  assert.match(source, /onClick=\{\(\) => onOpenUrl\(source\.url!\)\}/);
+  assert.doesNotMatch(source, />Open source</);
+  // The per-card status control keeps an accessible per-source name.
+  assert.match(source, /<span className="sr-only">Status of \{source\.title\}<\/span>/);
 });
 
 test("artifact rejection is explicit and append-preserving", () => {

--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { openGrimoireDoc } from "@/lib/grimoire-link";
-import type {
-  ResearchMission,
-  ResearchMissionActionInput,
-  ResearchSourceRef,
+import {
+  researchSourceStatusCounts,
+  type ResearchMission,
+  type ResearchMissionActionInput,
+  type ResearchSourceRef,
 } from "@/lib/research-missions";
 import { relativeTime } from "@/lib/relative-time";
 
@@ -34,6 +35,16 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [outputTab, setOutputTab] = useState<"artifacts" | "sources">("artifacts");
+  const [sourceFilter, setSourceFilter] = useState<"all" | ResearchSourceRef["status"]>("all");
+
+  useEffect(() => {
+    setSourceFilter("all");
+  }, [mission.id]);
+
+  const sourceCounts = researchSourceStatusCounts(mission.sources);
+  const visibleSources = sourceFilter === "all"
+    ? mission.sources
+    : mission.sources.filter((source) => source.status === sourceFilter);
 
   const act = async (input: ResearchMissionActionInput) => {
     setBusy(true);
@@ -155,36 +166,75 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
         hidden={outputTab !== "sources"}
       >
         <h3>Sources</h3>
-        <form className="research-source-attach" onSubmit={attach}>
-          <input
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-            placeholder="Source title"
-            aria-label="Source title"
-          />
-          <input
-            value={url}
-            onChange={(event) => setUrl(event.target.value)}
-            placeholder="https://…"
-            aria-label="Source URL"
-          />
-          <Button type="submit" size="xs" variant="ghost" disabled={busy || !title.trim() || !url.trim()}>
-            Attach source
-          </Button>
-        </form>
+        <details className="research-source-attach-disclosure">
+          <summary>Attach source</summary>
+          <form className="research-source-attach" onSubmit={attach}>
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Source title"
+              aria-label="Source title"
+            />
+            <input
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder="https://…"
+              aria-label="Source URL"
+            />
+            <Button type="submit" size="xs" variant="ghost" disabled={busy || !title.trim() || !url.trim()}>
+              Attach
+            </Button>
+          </form>
+        </details>
+        {mission.sources.length > 0 ? (
+          <div className="research-source-filters" role="group" aria-label="Filter sources by status">
+            <button
+              type="button"
+              aria-pressed={sourceFilter === "all"}
+              onClick={() => setSourceFilter("all")}
+            >
+              all <span>{mission.sources.length}</span>
+            </button>
+            {SOURCE_STATUSES.map((status) => (
+              <button
+                key={status}
+                type="button"
+                aria-pressed={sourceFilter === status}
+                disabled={sourceCounts[status] === 0}
+                onClick={() => setSourceFilter(status)}
+              >
+                {status} <span>{sourceCounts[status]}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
         {mission.sources.length === 0 ? (
           <p className="research-output-empty">The familiar’s source ledger is still empty.</p>
+        ) : visibleSources.length === 0 ? (
+          <p className="research-output-empty">No {sourceFilter} sources.</p>
         ) : (
           <ul>
-            {mission.sources.map((source) => (
+            {visibleSources.map((source) => (
               <li key={source.id} className="research-source-card">
                 <span className={`research-source-status research-source-status--${source.status}`}>
                   <i aria-hidden />{source.status}
                 </span>
-                <strong>{source.title}</strong>
+                {source.url ? (
+                  <button
+                    type="button"
+                    className="research-source-card__title"
+                    onClick={() => onOpenUrl(source.url!)}
+                  >
+                    <strong>{source.title}</strong>
+                    <Icon name="ph:arrow-square-out" width={11} height={11} aria-hidden />
+                    <span className="sr-only"> — opens the source</span>
+                  </button>
+                ) : (
+                  <strong>{source.title}</strong>
+                )}
                 {source.claim ? <p>{source.claim}</p> : null}
                 <label className="research-source-revise">
-                  <span>Status</span>
+                  <span className="sr-only">Status of {source.title}</span>
                   <select
                     value={source.status}
                     disabled={busy}
@@ -197,9 +247,7 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
                     {SOURCE_STATUSES.map((status) => <option key={status}>{status}</option>)}
                   </select>
                 </label>
-                {source.url ? (
-                  <button type="button" onClick={() => onOpenUrl(source.url!)}>Open source</button>
-                ) : source.localPath ? <span>{source.localPath}</span> : null}
+                {!source.url && source.localPath ? <span>{source.localPath}</span> : null}
               </li>
             ))}
           </ul>

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -12,6 +12,7 @@ import {
   researchBoundReadings,
   researchIntentAddsContext,
   researchPhaseStatuses,
+  researchSourceStatusCounts,
   validateCreateResearchMissionInput,
 } from "./research-missions.ts";
 
@@ -528,5 +529,23 @@ test("truncated and customized titles keep the informative intent line", () => {
       intent: "Compare approaches to automated self-performance evaluation for agents",
     }),
     true,
+  );
+});
+
+test("source status counts drive the triage filters", () => {
+  assert.deepEqual(researchSourceStatusCounts([]), {
+    candidate: 0,
+    used: 0,
+    conflicting: 0,
+    rejected: 0,
+  });
+  assert.deepEqual(
+    researchSourceStatusCounts([
+      { status: "candidate" },
+      { status: "candidate" },
+      { status: "used" },
+      { status: "rejected" },
+    ]),
+    { candidate: 2, used: 1, conflicting: 0, rejected: 1 },
   );
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -418,6 +418,20 @@ export function researchIntentAddsContext(
   return normalize(mission.intent) !== normalize(mission.title);
 }
 
+/** Per-status source tallies for the evidence ledger's triage filters. */
+export function researchSourceStatusCounts(
+  sources: ReadonlyArray<Pick<ResearchSourceRef, "status">>,
+): Record<ResearchSourceRef["status"], number> {
+  const counts: Record<ResearchSourceRef["status"], number> = {
+    candidate: 0,
+    used: 0,
+    conflicting: 0,
+    rejected: 0,
+  };
+  for (const source of sources) counts[source.status] += 1;
+  return counts;
+}
+
 export type ResearchBoundReading = {
   id: "time" | "sources" | "checkpoint" | "spend";
   label: string;


### PR DESCRIPTION
## What

Slice 4 of the `research-desk-ux-uplift` goal (bead `cave-m4f7`). In the 2026-07-15 screenshot audit, a 14-source mission rendered 14 heavy cards under a permanently pinned attach form — no filtering, a full labeled `Status` select **and** a separate `Open source` button on every card.

## How

- **Status filter chips with live counts** (`all` / `candidate` / `used` / `conflicting` / `rejected`) above the list — `aria-pressed` active state, zero-count statuses disabled so filters can't dead-end, filter resets on mission switch, filtered-empty view explains itself. Counts from a pure `researchSourceStatusCounts` helper in `src/lib/research-missions.ts`.
- **Attach form collapsed** behind an `Attach source` disclosure instead of topping the list.
- **Card title is the open affordance** (external-link icon + off-screen "opens the source" hint); the separate `Open source` button is gone. `localPath`-only sources keep their path line.
- **Compact status control**: the visible `Status` label is dropped; the select keeps an accessible per-source name ("Status of *title*").

## Testing

- Behavioral test for `researchSourceStatusCounts`; ledger pins updated for chips/disclosure/title-button/sr-only label (old `Open source` pin removed).
- `pnpm typecheck` ✓ · targeted `node --test` 44/44 ✓ · `pnpm test:app` 721 files ✓
