### PR TITLE
feat(research): decision-first action bar with a consequence-labeled Continue

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -8,6 +8,7 @@ import {
   allowedResearchActions,
   describeResearchSchedule,
   researchBoundReadings,
+  researchContinueLabel,
   researchIntentAddsContext,
   researchPhaseStatuses,
   type ResearchMission,
@@ -99,6 +100,7 @@ export function ResearchMissionDetail({
     : plannedRetry.projectRoot === null
       ? (mission.projectRoot ? "Retry in workspace" : "Retry")
       : plannedRetry.projectRoot === mission.projectRoot ? "Retry" : "Retry with new root";
+  const continueInfo = researchContinueLabel(mission);
   const runAction = async (input: ResearchMissionActionInput) => {
     setBusy(true);
     setActionError(null);
@@ -287,6 +289,19 @@ export function ResearchMissionDetail({
             </section>
           ) : null}
 
+          {/* Why the run stopped reads before what to do about it. */}
+          {mission.lastError ? (
+            <div className="research-mission-stop" role="status">
+              <Icon name="ph:warning" width={14} height={14} aria-hidden />
+              <span>{mission.lastError}</span>
+            </div>
+          ) : iteration?.decisionReason ? (
+            <div className="research-mission-decision" role="status">
+              <span>{iteration.decision ?? "checkpoint"}</span>
+              <p>{iteration.decisionReason}</p>
+            </div>
+          ) : null}
+
           {actions.length > 0 ? (
             <div className="research-mission-actions" aria-label="Research mission actions">
               {showRetryConfig ? (
@@ -312,11 +327,20 @@ export function ResearchMissionDetail({
                 <Button
                   key={action}
                   size="xs"
-                  variant={action === "continue" || action === "retry" ? "primary" : action === "cancel" ? "danger-ghost" : "ghost"}
+                  variant={
+                    action === "continue"
+                      ? (continueInfo.beyondPlan ? "ghost" : "primary")
+                      : action === "retry" ? "primary" : action === "cancel" ? "danger-ghost" : "ghost"
+                  }
                   disabled={busy}
+                  {...(action === "continue"
+                    ? { "aria-label": continueInfo.description, title: continueInfo.description }
+                    : {})}
                   onClick={() => void runAction(action === "retry" ? plannedRetry : { action })}
                 >
-                  {action === "retry" ? retryLabel : ACTION_LABELS[action] ?? action}
+                  {action === "continue"
+                    ? continueInfo.label
+                    : action === "retry" ? retryLabel : ACTION_LABELS[action] ?? action}
                 </Button>
               ))}
               {actions.includes("refine") ? (
@@ -341,18 +365,6 @@ export function ResearchMissionDetail({
             </div>
           ) : null}
           {actionError ? <p className="research-mission-error" role="alert">{actionError}</p> : null}
-
-          {mission.lastError ? (
-            <div className="research-mission-stop" role="status">
-              <Icon name="ph:warning" width={14} height={14} aria-hidden />
-              <span>{mission.lastError}</span>
-            </div>
-          ) : iteration?.decisionReason ? (
-            <div className="research-mission-decision" role="status">
-              <span>{iteration.decision ?? "checkpoint"}</span>
-              <p>{iteration.decisionReason}</p>
-            </div>
-          ) : null}
         </div>
 
         <ResearchEvidenceLedger mission={mission} onAction={onAction} onOpenUrl={onOpenUrl} />

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -84,6 +84,21 @@ test("checkpoint lifecycle controls are explicit and server-backed", () => {
   assert.match(surface, /research\.act/);
 });
 
+test("the action bar reads decision-first with a consequence-labeled Continue", () => {
+  // Why the run stopped renders before what to do about it: the stop and
+  // decision banners sit above the action row in source order.
+  const bannerIndex = detail.indexOf("research-mission-stop");
+  const actionsIndex = detail.indexOf("research-mission-actions");
+  assert.ok(bannerIndex !== -1 && actionsIndex !== -1 && bannerIndex < actionsIndex);
+  // Continue says which iteration it starts (researchContinueLabel is
+  // behaviorally tested in the lib suite) and demotes itself when the runner
+  // would refuse a beyond-plan iteration.
+  assert.match(detail, /researchContinueLabel\(mission\)/);
+  assert.match(detail, /continueInfo\.beyondPlan \? "ghost" : "primary"/);
+  assert.match(detail, /"aria-label": continueInfo\.description, title: continueInfo\.description/);
+  assert.match(detail, /continueInfo\.label/);
+});
+
 test("retry adapts to project-root failures with a visible config", () => {
   // Failure class detection drives the retry payload…
   assert.match(detail, /rootFailure = mission\.status === "failed" && \/project root\/i\.test\(mission\.lastError \?\? ""\)/);

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeResearchBounds,
   RESEARCH_BOUND_LIMITS,
   researchBoundReadings,
+  researchContinueLabel,
   researchIntentAddsContext,
   researchPhaseStatuses,
   researchSourceStatusCounts,
@@ -548,4 +549,27 @@ test("source status counts drive the triage filters", () => {
     ]),
     { candidate: 2, used: 1, conflicting: 0, rejected: 1 },
   );
+});
+
+// --- researchContinueLabel: Continue must say what it will actually do ---
+
+test("Continue is labeled with its real consequence", () => {
+  const withinPlan = researchContinueLabel({
+    iterations: [{ number: 1, status: "checkpoint" }],
+    bounds: { maxIterations: 3, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false },
+  });
+  assert.equal(withinPlan.label, "Continue (i2/3)");
+  assert.equal(withinPlan.beyondPlan, false);
+  assert.match(withinPlan.description, /starts iteration 2 of 3/);
+
+  // Screenshot repro: a completed 1/1 brief offered a primary Continue that
+  // the runner would refuse (stopBeforeNextIteration: iteration limit).
+  const beyond = researchContinueLabel({
+    iterations: [{ number: 1, status: "completed" }],
+    bounds: { maxIterations: 1, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false },
+  });
+  assert.equal(beyond.label, "Continue (i2/1)");
+  assert.equal(beyond.beyondPlan, true);
+  assert.match(beyond.description, /past the planned 1/);
+  assert.match(beyond.description, /iteration limit/);
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -432,6 +432,38 @@ export function researchSourceStatusCounts(
   return counts;
 }
 
+export type ResearchContinueLabel = {
+  /** Compact button text in the desk's iN/M vocabulary. */
+  label: string;
+  /** Full-sentence consequence for the button's aria-label and title. */
+  description: string;
+  /** Next iteration would exceed the plan — the runner refuses it. */
+  beyondPlan: boolean;
+};
+
+/**
+ * What pressing Continue will actually do.
+ *
+ * The runner gates every new iteration on stopBeforeNextIteration, so a
+ * Continue past bounds.maxIterations does not start anything — it re-settles
+ * the mission at the iteration limit. The button must say so instead of
+ * offering a primary action that dead-ends (e.g. a completed 1/1 brief).
+ */
+export function researchContinueLabel(
+  mission: Pick<ResearchMission, "iterations" | "bounds">,
+): ResearchContinueLabel {
+  const next = mission.iterations.length + 1;
+  const max = mission.bounds.maxIterations;
+  const beyondPlan = next > max;
+  return {
+    label: `Continue (i${next}/${max})`,
+    description: beyondPlan
+      ? `Continue would ask for iteration ${next}, past the planned ${max} — the runner stops at the iteration limit instead of starting it.`
+      : `Continue starts iteration ${next} of ${max} planned.`,
+    beyondPlan,
+  };
+}
+
 export type ResearchBoundReading = {
   id: "time" | "sources" | "checkpoint" | "spend";
   label: string;


### PR DESCRIPTION
## What

Slice 5 of the `research-desk-ux-uplift` goal (bead `cave-pzae`). In the 2026-07-15 screenshot audit the **Continue / Archive** buttons rendered above the `COMPLETE` explanation — "what to do next" before "why it stopped". And Continue on a completed 1/1 brief was a primary button that the runner would actually refuse.

## How

- **Decision-first order**: the `lastError` stop banner and checkpoint/complete decision banner now render above `research-mission-actions` (both carry their own `margin-top`, so the reorder is style-safe).
- **Consequence-labeled Continue**: new pure `researchContinueLabel(mission)` in `src/lib/research-missions.ts` — verified against the runner: `startNextIteration` gates on `stopBeforeNextIteration`, so a beyond-plan Continue starts nothing and re-settles at "Iteration limit reached". The button now reads `Continue (i2/3)` in the desk's `iN/M` vocabulary with a full-sentence `aria-label`/`title`; a beyond-plan Continue demotes from primary to ghost and says the runner stops at the iteration limit.

## Testing

- Behavioral tests for within-plan and beyond-plan labels (screenshot repro: completed 1/1 brief).
- Wiring pins: banner-before-actions source order, `beyondPlan` variant demotion, aria/title pass-through.
- `pnpm typecheck` ✓ · targeted `node --test` 43/43 ✓ · `pnpm test:app` 722 files ✓
