### PR TITLE
feat(research): composer plan chips are honest about interactivity

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15780,6 +15780,25 @@ details[open] > .cave-edit-card__summary::before {
   background: color-mix(in oklch, var(--bg-raised) 65%, transparent);
 }
 
+/* Only the bound chips are interactive; they must look it. */
+button.research-plan-chip { cursor: pointer; color: var(--text-secondary); }
+button.research-plan-chip:hover {
+  color: var(--research-accent);
+  border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
+}
+button.research-plan-chip:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+
+/* The inference explanation is prose, not a control — keep it plain. */
+.research-plan-chip--note {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
 .research-plan-chip--mode {
   color: var(--research-accent);
   border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -44,6 +44,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
   const [intent, setIntent] = useState("");
   const [mode, setMode] = useState<"auto" | ResearchMissionMode>("auto");
   const [bounds, setBounds] = useState<ResearchBounds>(defaultResearchPlan("brief").bounds);
+  const [boundsOpen, setBoundsOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,6 +58,13 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
 
   const updateBound = <K extends keyof ResearchBounds>(key: K, value: ResearchBounds[K]) => {
     setBounds((current) => ({ ...current, [key]: value }));
+  };
+
+  // A bound chip is a shortcut into the Review-bounds disclosure: open it,
+  // then focus the matching input once it is visible.
+  const focusBound = (inputId: string) => {
+    setBoundsOpen(true);
+    requestAnimationFrame(() => document.getElementById(inputId)?.focus());
   };
 
   const start = async (event: React.FormEvent) => {
@@ -131,21 +139,47 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
 
       <div id="research-plan-review" className="research-plan-review">
         <span className="research-plan-chip research-plan-chip--mode">{MODE_LABELS[effectiveMode]}</span>
-        <span className="research-plan-chip">
+        <span className="research-plan-chip research-plan-chip--note">
           {mode === "auto" ? inferred.reason : "Selected manually"}
         </span>
         <span className="research-plan-chip">{plan.deliverables.join(" + ")}</span>
-        <span className="research-plan-chip">{bounds.maxIterations} iteration{bounds.maxIterations === 1 ? "" : "s"}</span>
-        <span className="research-plan-chip">{bounds.wallClockMinutes} min</span>
-        <span className="research-plan-chip">{bounds.sourceTarget} sources</span>
+        <button
+          type="button"
+          className="research-plan-chip"
+          title="Edit in Review bounds"
+          onClick={() => focusBound("research-bound-iterations")}
+        >
+          {bounds.maxIterations} iteration{bounds.maxIterations === 1 ? "" : "s"}
+        </button>
+        <button
+          type="button"
+          className="research-plan-chip"
+          title="Edit in Review bounds"
+          onClick={() => focusBound("research-bound-minutes")}
+        >
+          {bounds.wallClockMinutes} min
+        </button>
+        <button
+          type="button"
+          className="research-plan-chip"
+          title="Edit in Review bounds"
+          onClick={() => focusBound("research-bound-sources")}
+        >
+          {bounds.sourceTarget} sources
+        </button>
       </div>
 
-      <details className="research-bounds-disclosure">
+      <details
+        className="research-bounds-disclosure"
+        open={boundsOpen}
+        onToggle={(event) => setBoundsOpen(event.currentTarget.open)}
+      >
         <summary>Review bounds</summary>
         <div className="research-bounds-grid">
           <label>
             <span>Minutes</span>
             <input
+              id="research-bound-minutes"
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.wallClockMinutes}
@@ -156,6 +190,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
           <label>
             <span>Iterations</span>
             <input
+              id="research-bound-iterations"
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.maxIterations}
@@ -173,6 +208,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
           <label>
             <span>Source target</span>
             <input
+              id="research-bound-sources"
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.sourceTarget}

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -30,6 +30,25 @@ test("composer makes Auto routing and finite bounds reviewable", () => {
   assert.doesNotMatch(composer, /max=\{1440\}/);
 });
 
+test("plan chips are honest about interactivity", () => {
+  // The three bound chips are buttons that open Review bounds and focus the
+  // matching input…
+  assert.match(composer, /const focusBound = \(inputId: string\) => \{/);
+  assert.match(composer, /setBoundsOpen\(true\);\s*requestAnimationFrame\(\(\) => document\.getElementById\(inputId\)\?\.focus\(\)\)/);
+  for (const id of ["research-bound-minutes", "research-bound-iterations", "research-bound-sources"]) {
+    assert.match(composer, new RegExp(`focusBound\\("${id}"\\)`));
+    assert.match(composer, new RegExp(`id="${id}"`));
+  }
+  // …the disclosure stays in sync when toggled natively…
+  assert.match(composer, /open=\{boundsOpen\}/);
+  assert.match(composer, /onToggle=\{\(event\) => setBoundsOpen\(event\.currentTarget\.open\)\}/);
+  // …and the inference explanation reads as prose, not a control.
+  assert.match(composer, /research-plan-chip--note/);
+  assert.match(css, /button\.research-plan-chip \{ cursor: pointer;/);
+  assert.match(css, /button\.research-plan-chip:focus-visible/);
+  assert.match(css, /\.research-plan-chip--note \{[^}]*border-color: transparent/);
+});
+
 test("mission list and evidence trajectory expose semantic state", () => {
   assert.match(list, /aria-current=\{selected/);
   assert.match(detail, /aria-label="Research progress"/);


### PR DESCRIPTION
## What

Slice 6 (final) of the `research-desk-ux-uplift` goal (bead `cave-g4e1`). The composer's plan-review chips (`Brief · safe default… · 1 iteration · 20 min · 6 sources`) looked tappable but were static `<span>`s, while the editable bounds hid in the collapsed **Review bounds** disclosure below them.

## How

- The three **bound chips** (iterations / minutes / sources) become `<button type="button">`s that open the disclosure and focus the matching input:
  - disclosure `open` is state-controlled and synced with native summary toggles via `onToggle`
  - bound inputs gain ids (`research-bound-minutes/-iterations/-sources`); focus lands via `requestAnimationFrame` once visible
- **Interactive affordance only where it's true**: button chips get `cursor: pointer`, hover accent, and a `:focus-visible` ring; the **inferred-reason chip** (`safe default for an ambiguous request`) is styled as plain prose (`--note`: borderless, unboxed) so it no longer masquerades as a control.
- Mode and deliverable chips stay informational spans.

## Testing

- Wiring pins: `focusBound` + rAF focus, per-chip `focusBound("<id>")` + matching input ids, `open={boundsOpen}` + `onToggle` sync, `--note` class, CSS affordance pins.
- `pnpm typecheck` ✓ · targeted `node --test` 16/16 ✓ · `pnpm test:app` 724 files ✓
