### PR TITLE
fix(research): saved-links store survives corruption; dedupe key handles query strings

### DIFF
--- a/src/app/api/research/links/route.ts
+++ b/src/app/api/research/links/route.ts
@@ -17,7 +17,14 @@ const MAX_BODY_BYTES = 64 * 1024;
 export async function GET(req: Request) {
   const forbidden = rejectNonLocalRequest(req);
   if (forbidden) return forbidden;
-  return NextResponse.json({ ok: true, links: await listSavedLinks() });
+  try {
+    return NextResponse.json({ ok: true, links: await listSavedLinks() });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "failed to read the saved-links store" },
+      { status: 500 },
+    );
+  }
 }
 
 type SaveBody = {
@@ -56,7 +63,15 @@ export async function POST(req: Request) {
     );
   }
   const source = parsed.body.source === "desk" ? "desk" : "chat";
-  const result = await saveResearchLinks(urls, source);
+  let result;
+  try {
+    result = await saveResearchLinks(urls, source);
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "failed to write the saved-links store" },
+      { status: 500 },
+    );
+  }
   return NextResponse.json({
     ok: true,
     added: result.added,
@@ -74,7 +89,15 @@ export async function DELETE(req: Request) {
   if (!id) {
     return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });
   }
-  const removed = await removeSavedLink(id);
+  let removed: boolean;
+  try {
+    removed = await removeSavedLink(id);
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "failed to write the saved-links store" },
+      { status: 500 },
+    );
+  }
   if (!removed) {
     return NextResponse.json({ ok: false, error: "link not found" }, { status: 404 });
   }

--- a/src/lib/link-organizer.test.ts
+++ b/src/lib/link-organizer.test.ts
@@ -63,6 +63,16 @@ test("normalizeLinkUrl produces one key per page", () => {
     normalizeLinkUrl("https://example.com/a#section"),
     normalizeLinkUrl("https://example.com/a"),
   );
+  // Trailing slash must vanish even with a query string after it, and
+  // doubled separators must collapse (review finding on 972bf1cd).
+  assert.equal(
+    normalizeLinkUrl("https://example.com/blog/?p=1"),
+    normalizeLinkUrl("https://example.com/blog?p=1"),
+  );
+  assert.equal(
+    normalizeLinkUrl("https://example.com/path//"),
+    normalizeLinkUrl("https://example.com/path"),
+  );
   assert.notEqual(
     normalizeLinkUrl("https://example.com/a?q=1"),
     normalizeLinkUrl("https://example.com/a"),

--- a/src/lib/link-organizer.ts
+++ b/src/lib/link-organizer.ts
@@ -201,8 +201,12 @@ export function normalizeLinkUrl(rawUrl: string): string {
   }
   url.hash = "";
   url.hostname = url.hostname.toLowerCase();
+  // Normalize the pathname itself (not the serialized string) so trailing
+  // slashes disappear even when a query string follows: /blog/?p=1 and
+  // /blog?p=1 must produce the same key. Collapse doubled separators too.
+  const collapsed = url.pathname.replace(/\/{2,}/g, "/");
+  url.pathname = collapsed !== "/" ? collapsed.replace(/\/+$/, "") : "/";
   let out = url.toString();
-  if (url.pathname !== "/" && out.endsWith("/")) out = out.slice(0, -1);
   if (url.pathname === "/" && !url.search && out.endsWith("/")) out = out.slice(0, -1);
   return out;
 }

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -76,7 +76,7 @@ test("one save is bounded to MAX_LINKS_PER_SAVE", async () => {
   assert.equal(result.added.length, MAX_LINKS_PER_SAVE);
 });
 
-// ── corruption safety (review finding on 972cd) ──────────────────────────────
+// ── corruption safety (review finding on 972bf1cd) ───────────────────────────
 
 test("a corrupt store file is preserved aside, never silently wiped by a save", async () => {
   const target = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE!;

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
@@ -74,4 +74,36 @@ test("one save is bounded to MAX_LINKS_PER_SAVE", async () => {
   const urls = Array.from({ length: MAX_LINKS_PER_SAVE + 10 }, (_, i) => `https://bulk.example.com/item-${i}`);
   const result = await saveResearchLinks(urls, "desk");
   assert.equal(result.added.length, MAX_LINKS_PER_SAVE);
+});
+
+// ── corruption safety (review finding on 972cd) ──────────────────────────────
+
+test("a corrupt store file is preserved aside, never silently wiped by a save", async () => {
+  const target = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE!;
+  await saveResearchLinks(["https://example.com/pre-corruption"], "desk");
+  // Hand-edit the file into invalid JSON (trailing comma).
+  const valid = await readFile(target, "utf8");
+  await writeFile(target, valid.replace(/\}\s*$/, "},"), "utf8");
+
+  const result = await saveResearchLinks(["https://example.com/post-corruption"], "desk");
+  assert.equal(result.added.length, 1);
+
+  // The malformed bytes were snapshotted beside the store before the rewrite.
+  const siblings = await readdir(path.dirname(target));
+  const backups = siblings.filter((name) => name.includes(".corrupt-"));
+  assert.ok(backups.length >= 1, "malformed file preserved as .corrupt-<ts>");
+  const backup = await readFile(path.join(path.dirname(target), backups[0]), "utf8");
+  assert.match(backup, /pre-corruption/, "the backup holds the pre-corruption content");
+});
+
+test("unreadable stores surface errors instead of reading as empty", async () => {
+  const previous = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE;
+  // Point the store AT A DIRECTORY: reads fail with EISDIR (not ENOENT).
+  process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE = tmp;
+  try {
+    await assert.rejects(() => listSavedLinks(), /EISDIR|illegal operation/i);
+    await assert.rejects(() => saveResearchLinks(["https://example.com/x"], "desk"));
+  } finally {
+    process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE = previous;
+  }
 });

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -65,15 +65,35 @@ function normalizeStoredLink(value: unknown): SavedLink | null {
 }
 
 async function loadFile(): Promise<ResearchLinksFile> {
+  let text: string;
   try {
-    const parsed = JSON.parse(await readFile(researchLinksPath(), "utf8")) as Partial<ResearchLinksFile>;
-    const links = Array.isArray(parsed?.links)
-      ? parsed.links.map(normalizeStoredLink).filter((link): link is SavedLink => link !== null)
-      : [];
-    return { version: 1, links };
+    text = await readFile(researchLinksPath(), "utf8");
+  } catch (error) {
+    // Only a missing file means "empty store". Transient read failures
+    // (EACCES/EMFILE/EIO) must surface — otherwise the next save would
+    // read-modify-write an empty result and silently wipe every saved link.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyFile();
+    throw error;
+  }
+  let parsed: Partial<ResearchLinksFile>;
+  try {
+    parsed = JSON.parse(text) as Partial<ResearchLinksFile>;
   } catch {
+    // Hand-edited into invalid JSON: preserve the malformed bytes beside the
+    // store (preferences-store pattern) before any rewrite can replace them.
+    await preserveMalformedFile();
     return emptyFile();
   }
+  const links = Array.isArray(parsed?.links)
+    ? parsed.links.map(normalizeStoredLink).filter((link): link is SavedLink => link !== null)
+    : [];
+  return { version: 1, links };
+}
+
+async function preserveMalformedFile(): Promise<void> {
+  const source = researchLinksPath();
+  const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
+  await copyFile(source, `${source}.corrupt-${suffix}`).catch(() => {});
 }
 
 async function saveFile(file: ResearchLinksFile): Promise<void> {


### PR DESCRIPTION
## What

Fixes the two verified findings from the `/review` of #3214 (`972bf1cd`):

1. **One save could silently wipe the whole link store.** `loadFile()` swallowed every read/parse failure as "empty store", so after a hand-edit typo (trailing comma) or a transient IO failure (EACCES/EIO), the next `/save`'s read-modify-write **overwrote the store with just the new links and reported success**. Now:
   - only **ENOENT** reads as empty;
   - **malformed JSON** is preserved beside the store as `research-links.json.corrupt-<ts>` (the `preferences-store` pattern) before any rewrite;
   - **other IO errors propagate** — GET/POST/DELETE answer a clean `{ok:false}` 500 instead of pretending the save worked.
2. **Dedupe missed trailing-slash + query-string spellings.** `normalizeLinkUrl` trimmed the trailing slash off the *serialized* URL, so `/blog/?p=1` vs `/blog?p=1` (and `/path//` vs `/path`) produced different keys → duplicate shelf rows for the same page. The **pathname itself** is now normalized (trailing slashes dropped, doubled separators collapsed) before serialization; root-path and query-significance behavior unchanged.

## Testing

- `research-links.test.ts`: corruption round-trip — pre-corruption content lands in a `.corrupt-<ts>` snapshot and the save still succeeds; unreadable store (EISDIR) **rejects** instead of reading as empty.
- `link-organizer.test.ts`: `/blog/?p=1` ≡ `/blog?p=1`, `/path//` ≡ `/path`, query strings still significant.
- `pnpm typecheck` clean; **test:app 724 / test:api 186 files green**.

Bead: cave-an77 · Review: code-review agent findings on commit `972bf1cd`