### PR TITLE
fix(research): Continue label mirrors every runner stop gate

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -329,7 +329,7 @@ export function ResearchMissionDetail({
                   size="xs"
                   variant={
                     action === "continue"
-                      ? (continueInfo.beyondPlan ? "ghost" : "primary")
+                      ? (continueInfo.gated ? "ghost" : "primary")
                       : action === "retry" ? "primary" : action === "cancel" ? "danger-ghost" : "ghost"
                   }
                   disabled={busy}

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -110,10 +110,10 @@ test("the action bar reads decision-first with a consequence-labeled Continue", 
   const actionsIndex = detail.indexOf("research-mission-actions");
   assert.ok(bannerIndex !== -1 && actionsIndex !== -1 && bannerIndex < actionsIndex);
   // Continue says which iteration it starts (researchContinueLabel is
-  // behaviorally tested in the lib suite) and demotes itself when the runner
-  // would refuse a beyond-plan iteration.
+  // behaviorally tested in the lib suite) and demotes itself when any runner
+  // stop gate — iteration, wall-clock, cost policy, spend — already refuses.
   assert.match(detail, /researchContinueLabel\(mission\)/);
-  assert.match(detail, /continueInfo\.beyondPlan \? "ghost" : "primary"/);
+  assert.match(detail, /continueInfo\.gated \? "ghost" : "primary"/);
   assert.match(detail, /"aria-label": continueInfo\.description, title: continueInfo\.description/);
   assert.match(detail, /continueInfo\.label/);
 });

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -554,22 +554,71 @@ test("source status counts drive the triage filters", () => {
 // --- researchContinueLabel: Continue must say what it will actually do ---
 
 test("Continue is labeled with its real consequence", () => {
-  const withinPlan = researchContinueLabel({
-    iterations: [{ number: 1, status: "checkpoint" }],
-    bounds: { maxIterations: 3, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false },
-  });
+  const bounds = { maxIterations: 3, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false };
+  const startedAt = "2026-07-15T00:00:00Z";
+  const tenMinutesIn = Date.parse("2026-07-15T00:10:00Z");
+  const withinPlan = researchContinueLabel(
+    { iterations: [{ number: 1, status: "checkpoint" }], bounds, startedAt },
+    tenMinutesIn,
+  );
   assert.equal(withinPlan.label, "Continue (i2/3)");
-  assert.equal(withinPlan.beyondPlan, false);
-  assert.match(withinPlan.description, /starts iteration 2 of 3/);
+  assert.equal(withinPlan.gated, false);
+  // Even ungated, the sentence is a request, not a promise — the runner
+  // re-checks its stop gates with live clocks.
+  assert.match(withinPlan.description, /asks the runner to start iteration 2 of 3/);
+  assert.match(withinPlan.description, /stop gates are re-checked/);
 
   // Screenshot repro: a completed 1/1 brief offered a primary Continue that
   // the runner would refuse (stopBeforeNextIteration: iteration limit).
-  const beyond = researchContinueLabel({
-    iterations: [{ number: 1, status: "completed" }],
-    bounds: { maxIterations: 1, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false },
-  });
+  const beyond = researchContinueLabel(
+    {
+      iterations: [{ number: 1, status: "completed" }],
+      bounds: { ...bounds, maxIterations: 1 },
+      startedAt,
+    },
+    tenMinutesIn,
+  );
   assert.equal(beyond.label, "Continue (i2/1)");
-  assert.equal(beyond.beyondPlan, true);
+  assert.equal(beyond.gated, true);
   assert.match(beyond.description, /past the planned 1/);
   assert.match(beyond.description, /iteration limit/);
+});
+
+test("Continue reports every runner stop gate, not just the iteration limit", () => {
+  const bounds = { maxIterations: 3, wallClockMinutes: 20, sourceTarget: 6, checkpointEvery: 1, stopWhenCostUnavailable: false };
+  const startedAt = "2026-07-15T00:00:00Z";
+  const iterations = [{ number: 1, status: "checkpoint" as const, finishedAt: "2026-07-15T00:10:00Z", costUsd: 5 }];
+
+  // Wall-clock budget spent (>= gate, live clock): in-plan Continue is gated.
+  const wallClock = researchContinueLabel(
+    { iterations, bounds, startedAt },
+    Date.parse("2026-07-15T00:20:00Z"),
+  );
+  assert.equal(wallClock.gated, true);
+  assert.match(wallClock.description, /wall-clock budget is spent/);
+  // One millisecond under the budget stays ungated.
+  assert.equal(
+    researchContinueLabel({ iterations, bounds, startedAt }, Date.parse("2026-07-15T00:20:00Z") - 1).gated,
+    false,
+  );
+
+  // Reported spend at the cap (>= gate, exact equality refuses).
+  const spend = researchContinueLabel(
+    { iterations, bounds: { ...bounds, maxSpendUsd: 5 }, startedAt },
+    Date.parse("2026-07-15T00:10:00Z"),
+  );
+  assert.equal(spend.gated, true);
+  assert.match(spend.description, /reported spend has reached the \$5 cap/);
+
+  // Missing-cost policy: a finished iteration without costUsd pauses for review.
+  const noCost = researchContinueLabel(
+    {
+      iterations: [{ number: 1, status: "checkpoint" as const, finishedAt: "2026-07-15T00:10:00Z" }],
+      bounds: { ...bounds, stopWhenCostUnavailable: true },
+      startedAt,
+    },
+    Date.parse("2026-07-15T00:10:00Z"),
+  );
+  assert.equal(noCost.gated, true);
+  assert.match(noCost.description, /finished without reporting cost/);
 });

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -437,30 +437,62 @@ export type ResearchContinueLabel = {
   label: string;
   /** Full-sentence consequence for the button's aria-label and title. */
   description: string;
-  /** Next iteration would exceed the plan — the runner refuses it. */
-  beyondPlan: boolean;
+  /** A stop gate already refuses the next iteration — pressing starts nothing. */
+  gated: boolean;
 };
 
 /**
  * What pressing Continue will actually do.
  *
- * The runner gates every new iteration on stopBeforeNextIteration, so a
- * Continue past bounds.maxIterations does not start anything — it re-settles
- * the mission at the iteration limit. The button must say so instead of
- * offering a primary action that dead-ends (e.g. a completed 1/1 brief).
+ * The runner gates every new iteration on stopBeforeNextIteration
+ * (src/lib/server/research-mission-runner.ts): iteration count, wall-clock
+ * budget, missing-cost policy, and the reported-spend cap. A Continue past
+ * any of those starts nothing — it re-settles the mission at the limit. This
+ * mirrors those gates (same >= comparisons) so the button can say which gate
+ * refuses instead of promising an iteration; keep the two in sync. Even when
+ * no gate is known-exceeded, the description stays a request — the runner
+ * re-checks with live clocks.
  */
 export function researchContinueLabel(
-  mission: Pick<ResearchMission, "iterations" | "bounds">,
+  mission: Pick<ResearchMission, "iterations" | "bounds" | "startedAt">,
+  nowMs: number = Date.now(),
 ): ResearchContinueLabel {
   const next = mission.iterations.length + 1;
   const max = mission.bounds.maxIterations;
-  const beyondPlan = next > max;
+  const label = `Continue (i${next}/${max})`;
+  const refusal = (why: string) => ({
+    label,
+    description: `Continue would ask for iteration ${next}, but ${why}`,
+    gated: true,
+  });
+  if (next > max) {
+    return {
+      label,
+      description: `Continue would ask for iteration ${next}, past the planned ${max} — the runner stops at the iteration limit instead of starting it.`,
+      gated: true,
+    };
+  }
+  const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
+  if (Number.isFinite(startedAt) && nowMs - startedAt >= mission.bounds.wallClockMinutes * 60_000) {
+    return refusal(`the ${mission.bounds.wallClockMinutes}-minute wall-clock budget is spent — the runner pauses at the limit instead of starting it.`);
+  }
+  if (
+    mission.bounds.stopWhenCostUnavailable &&
+    mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
+  ) {
+    return refusal("an iteration finished without reporting cost — the runner pauses for review instead of starting it.");
+  }
+  const reportedSpend = mission.iterations
+    .map((iteration) => iteration.costUsd)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+    .reduce((sum, value) => sum + value, 0);
+  if (mission.bounds.maxSpendUsd !== undefined && reportedSpend >= mission.bounds.maxSpendUsd) {
+    return refusal(`reported spend has reached the $${mission.bounds.maxSpendUsd} cap — the runner pauses at the limit instead of starting it.`);
+  }
   return {
-    label: `Continue (i${next}/${max})`,
-    description: beyondPlan
-      ? `Continue would ask for iteration ${next}, past the planned ${max} — the runner stops at the iteration limit instead of starting it.`
-      : `Continue starts iteration ${next} of ${max} planned.`,
-    beyondPlan,
+    label,
+    description: `Continue asks the runner to start iteration ${next} of ${max} planned — stop gates are re-checked first.`,
+    gated: false,
   };
 }
 


### PR DESCRIPTION
## What

Review follow-up to #3217 (`research-desk-ux-uplift` slice 5). A post-merge code review found the **in-plan** Continue branch asserting a consequence the runner can refuse:

> `researchContinueLabel` only models the iteration-count gate. … `stopBeforeNextIteration` also refuses on wall-clock, spend ≥ cap, and cost-unavailable. In those states `startNextIteration` starts nothing and flips the mission to `paused` with a `lastError` — the opposite of what the label promises.

Concretely: a default autoresearch checkpoint (240 min / 6 iterations) reviewed the next morning offered a **primary** Continue announced as "starts iteration 2 of 6 planned"; pressing it pauses the mission with "Wall-clock limit reached".

## How

- `researchContinueLabel` now mirrors **all four** runner gates (same `>=` comparisons as `stopBeforeNextIteration`; documented as a kept-in-sync mirror): iteration limit, wall-clock budget (live clock via an injectable `nowMs`), missing-cost policy, reported-spend cap.
- Each refusal names its gate ("…the 20-minute wall-clock budget is spent — the runner pauses at the limit instead of starting it").
- `beyondPlan` generalizes to `gated`; the button demotes primary→ghost for **every** known refusal, not just the iteration limit.
- Even ungated, the sentence is a request, not a promise: "Continue asks the runner to start iteration N of M planned — stop gates are re-checked first."

## Testing

- New behavioral test covering wall-clock (incl. 1 ms-under boundary), spend-at-cap (exact `>=` equality), and missing-cost gates; existing test updated to the request-phrasing and `gated`.
- Wiring pin updated (`continueInfo.gated ? "ghost" : "primary"`).
- `pnpm typecheck` ✓ · targeted `node --test` 45/45 ✓ · `pnpm test:app` 724 files ✓
