### PR TITLE
fix(server): ship #3200's sidecar PTY auth in server.mjs + guard twin parity

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -117,10 +117,12 @@ test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-com
       releaseWorkflow.indexOf('gh release upload "$RELEASE_TAG" "${APPIMAGE}.sig" --clobber'),
     "the repacked AppImage itself must be uploaded before its regenerated signature",
   );
-  const stripStep = releaseWorkflow.slice(
-    releaseWorkflow.indexOf("name: Strip bundled GLib from AppImage"),
-    releaseWorkflow.indexOf("name: Upload and re-sign stripped AppImage"),
-  );
+  const stripStepStart = releaseWorkflow.indexOf("name: Strip bundled GLib/libmount from AppImage");
+  const stripStepEnd = releaseWorkflow.indexOf("name: Upload and re-sign stripped AppImage");
+  assert.ok(stripStepStart !== -1, "strip step must exist under its exact name");
+  assert.ok(stripStepEnd > stripStepStart, "upload/re-sign step must follow the strip step");
+  const stripStep = releaseWorkflow.slice(stripStepStart, stripStepEnd);
+  assert.ok(stripStep.length > 0, "strip-step slice must be non-empty for the secret-isolation guard to mean anything");
   assert.doesNotMatch(stripStep, /GH_TOKEN/);
   assert.doesNotMatch(stripStep, /TAURI_SIGNING_PRIVATE_KEY/);
 });

--- a/server.mjs
+++ b/server.mjs
@@ -19,9 +19,11 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   }
 }
 const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
+const SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN ?? "";
 const ACCESS_COOKIE = "coven_cave_access";
 const LEGACY_ACCESS_COOKIE = "coven_access_token";
 const ACCESS_QUERY_PARAM = "coven_access_token";
+const SIDECAR_QUERY_PARAM = "covenCaveToken";
 const sessions = /* @__PURE__ */ new Map();
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
 const DETACH_GRACE_MS = (() => {
@@ -57,10 +59,16 @@ function timingSafeEqualString(a, b) {
   }
   return diff === 0;
 }
-function isExpectedToken(value) {
+function isExpectedAccessToken(value) {
   if (!ACCESS_TOKEN || !value) return false;
   if (timingSafeEqualString(value, ACCESS_TOKEN)) return true;
   return isValidSignedAccessToken(value, ACCESS_TOKEN);
+}
+function isExpectedSidecarToken(value) {
+  return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
+}
+function isExpectedPtyToken(value) {
+  return isExpectedAccessToken(value) || isExpectedSidecarToken(value);
 }
 function isValidSignedAccessToken(value, secret) {
   const parts = value.split(".");
@@ -109,11 +117,18 @@ function isAllowedUpgradeSource(req, tokenAuthenticated = false) {
   }
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
+function firstQueryValue(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+function isPtyAuthRequired() {
+  return Boolean(ACCESS_TOKEN || SIDECAR_TOKEN);
+}
 function isAuthorized(req, query) {
-  if (!ACCESS_TOKEN) return false;
-  const queryToken = Array.isArray(query[ACCESS_QUERY_PARAM]) ? query[ACCESS_QUERY_PARAM][0] : query[ACCESS_QUERY_PARAM];
-  const candidates = [bearerToken(req), queryToken, ...getTokensFromCookie(req.headers.cookie)];
-  return candidates.some(isExpectedToken);
+  if (!isPtyAuthRequired()) return false;
+  const queryToken = firstQueryValue(query[ACCESS_QUERY_PARAM]);
+  const sidecarQueryToken = firstQueryValue(query[SIDECAR_QUERY_PARAM]);
+  const candidates = [bearerToken(req), queryToken, sidecarQueryToken, ...getTokensFromCookie(req.headers.cookie)];
+  return candidates.some(isExpectedPtyToken);
 }
 function defaultShell() {
   if (process.platform === "darwin") return "/bin/zsh";
@@ -322,13 +337,13 @@ server.on("upgrade", (req, socket, head) => {
     });
     return;
   }
-  const tokenAuthenticated = ACCESS_TOKEN ? isAuthorized(req, query) : false;
+  const tokenAuthenticated = isPtyAuthRequired() ? isAuthorized(req, query) : false;
   if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     socket.destroy();
     return;
   }
-  if (ACCESS_TOKEN && !tokenAuthenticated) {
+  if (isPtyAuthRequired() && !tokenAuthenticated) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -266,4 +266,29 @@ assert.match(
 assert.match(src, /server\.keepAliveTimeout = 75_000/, "server extends the idle keep-alive window past client reuse");
 assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds keepAliveTimeout");
 
+// Twin parity: `pnpm start` runs the committed server.mjs, not server.ts, so a
+// server.ts security fix that skips `pnpm build:server` silently ships nothing
+// (PR #3200's sidecar-token gate initially missed the twin exactly this way).
+// Transpile server.ts with the same flags as the build:server script and
+// require the committed artifact to match byte-for-byte.
+{
+  const { buildSync } = await import("esbuild");
+  const serverTsUrl = new URL("../server.ts", import.meta.url);
+  const out = buildSync({
+    entryPoints: [serverTsUrl.pathname],
+    bundle: false,
+    platform: "node",
+    target: "node22",
+    format: "esm",
+    write: false,
+  });
+  const generated = out.outputFiles[0].text;
+  const committed = readFileSync(new URL("../server.mjs", import.meta.url), "utf8");
+  assert.equal(
+    committed,
+    generated,
+    "server.mjs must be regenerated from server.ts (run `pnpm build:server` and commit the result)",
+  );
+}
+
 console.log("server-pty-ws.test.ts OK");


### PR DESCRIPTION
Post-merge code review of #3196/#3199/#3200/#3201 surfaced two high-confidence issues; this PR fixes both.

## 1. server.mjs never got #3200's fix (High)

#3200 patched `server.ts` only, but `pnpm start` runs the committed transpiled twin `server.mjs`. That file still had the pre-#3200 auth: with only `COVEN_CAVE_AUTH_TOKEN` configured (native Tailscale sidecar mode), loopback-Host PTY upgrades got a shell with **no credential**, and legitimate `covenCaveToken` clients 403'd at the host gate — the exact vulnerability #3200 was meant to close.

- Regenerated `server.mjs` via `pnpm build:server` (diff is precisely the missing #3200 logic: `SIDECAR_TOKEN`, `SIDECAR_QUERY_PARAM`, `isExpectedSidecarToken`, `isPtyAuthRequired`, both upgrade-handler gates).
- Added a **twin-parity assertion** to `src/server-pty-ws.test.ts`: transpiles `server.ts` in-memory with the same esbuild flags as `build:server` and requires the committed artifact to match byte-for-byte. Verified it fails against the drifted file and passes after regeneration.

## 2. Vacuous secret-isolation guard in release test (Medium)

`scripts/release-macos-signing.test.mjs` sliced the AppImage strip step by its **old** name ("Strip bundled GLib from AppImage"); after the step was renamed to "Strip bundled GLib/libmount from AppImage", `indexOf` returned -1 and the `GH_TOKEN`/`TAURI_SIGNING_PRIVATE_KEY` isolation asserts ran against an empty string. Now uses the exact step name and asserts the slice is non-empty first.

## Validation
- `node --experimental-strip-types --test src/server-pty-ws.test.ts` → pass (and fails correctly against the pre-fix server.mjs)
- `node --test scripts/release-macos-signing.test.mjs` → 10/10
- `pnpm typecheck` → clean

A third review finding — #3196's "Open in browser" `window.open(data:…)` being blocked as top-frame navigation by all engines (silent no-op) — is tracked as bead **cave-e3ia**; it needs a mechanism decision (sandboxed carrier vs OS opener), not a hotfix.