### PR TITLE
fix(canvas): open-in-browser ships a sandboxed carrier tab instead of a blocked data: URL (cave-e3ia)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -359,6 +359,7 @@ export const SUITES = {
     "src/components/calendar-overflow-pill.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-artifacts.test.ts",
+    "src/lib/artifact-open.test.ts",
     "src/lib/refine-suggestions.test.ts",
     "src/lib/canvas-react-harness.test.ts",
     "src/lib/canvas-generate.test.ts",

--- a/src/components/chat-artifact-viewer.test.ts
+++ b/src/components/chat-artifact-viewer.test.ts
@@ -19,8 +19,12 @@ assert.doesNotMatch(src, /cave:navigate-mode/, "artifact viewer no longer deep-l
 assert.match(src, /Saved to Canvas/, "after save, confirms inline instead of navigating");
 assert.doesNotMatch(src, /new\s+Blob\s*\(\s*\[\s*srcDoc\b/, "open-in-browser must not create same-origin blob URLs from untrusted artifacts");
 assert.doesNotMatch(src, /URL\s*\.\s*createObjectURL\s*\(/, "open-in-browser must not use same-origin object URLs for untrusted artifacts");
-assert.match(src, /data:text\/html;charset=utf-8,/, "open-in-browser uses an opaque-origin data URL");
-assert.match(src, /encodeURIComponent\s*\(\s*srcDoc\s*\)/, "open-in-browser must encode artifact HTML when building the data URL");
+// Top-level data: URLs are silently blocked as navigations by every engine
+// (window.open returns null without throwing) — the mechanism shipped dead
+// once (cave-e3ia) and must not come back.
+assert.doesNotMatch(src, /data:text\/html/, "open-in-browser must not rely on blocked top-level data: navigations");
+assert.match(src, /openArtifactInTab\s*\(\s*srcDoc\s*\)/, "open-in-browser routes through the sandboxed carrier (artifact-open.ts)");
+assert.match(src, /Pop-up blocked/, "popup blocking is surfaced to the user instead of failing silently");
 
 // Expand-to-fullscreen: a toggle action enters a fullscreen overlay, Escape
 // exits, and — critically — the overlay is PORTALED to document.body so it

--- a/src/components/chat-artifact-viewer.tsx
+++ b/src/components/chat-artifact-viewer.tsx
@@ -15,6 +15,7 @@ import {
   type ArtifactKind,
 } from "@/lib/canvas-artifacts";
 import { buildReactSrcDoc } from "@/lib/canvas-react-harness";
+import { openArtifactInTab } from "@/lib/artifact-open";
 import { generateArtifactCode } from "@/lib/canvas-generate";
 import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import { highlightToHtml } from "@/components/message-bubble";
@@ -97,14 +98,13 @@ export function ChatArtifactViewer({ initialCode, kind: initialKind, title, fami
   }, [code]);
 
   const openInBrowser = useCallback(() => {
-    try {
-      // Keep untrusted artifact HTML out of Cave's origin. A blob: URL created
-      // here would inherit the privileged app origin; a top-level data: URL gets
-      // an opaque origin, matching the iframe preview's isolation boundary.
-      const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(srcDoc)}`;
-      window.open(dataUrl, "_blank", "noopener,noreferrer");
-    } catch {
-      /* popup blocked — the inline preview still works */
+    // Keep untrusted artifact HTML out of Cave's origin, and actually open —
+    // blob:/object URLs would inherit the privileged app origin, while the
+    // previous top-level data: URL was silently blocked as a navigation by
+    // every engine (cave-e3ia). The carrier confines the artifact to a
+    // sandboxed opaque-origin srcdoc iframe, same boundary as the preview.
+    if (!openArtifactInTab(srcDoc)) {
+      setRuntimeError("Pop-up blocked — allow pop-ups for Cave to open the artifact in a tab.");
     }
   }, [srcDoc]);
 

--- a/src/lib/artifact-open.test.ts
+++ b/src/lib/artifact-open.test.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+// Behavioral tests for the artifact open-in-tab carrier (cave-e3ia): the
+// escaping is the security boundary that keeps untrusted artifact HTML inside
+// the sandboxed srcdoc attribute, so it gets exercised for real here.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ARTIFACT_CARRIER_SANDBOX,
+  buildArtifactCarrierHtml,
+  escapeHtmlAttribute,
+  openArtifactInTab,
+} from "./artifact-open.ts";
+
+test("escapeHtmlAttribute neutralizes every attribute-breaking character", () => {
+  assert.equal(
+    escapeHtmlAttribute(`"><script>alert(1)</script>&'`),
+    "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&amp;&#39;",
+  );
+  // & first: pre-escaped entities must not double-unescape downstream.
+  assert.equal(escapeHtmlAttribute("&quot;"), "&amp;quot;");
+});
+
+test("carrier confines the artifact to an escaped srcdoc attribute", () => {
+  const hostile = `"><iframe src=x onload=alert(document.domain)>`;
+  const html = buildArtifactCarrierHtml(hostile);
+  // The raw payload must never appear outside the escaped attribute value.
+  assert.ok(!html.includes(hostile), "raw artifact HTML must not appear in the carrier");
+  assert.ok(
+    html.includes(`srcdoc="${escapeHtmlAttribute(hostile)}"`),
+    "artifact travels only as the escaped srcdoc value",
+  );
+  // Exactly one iframe: the carrier's own. A second iframe tag would mean the
+  // payload broke out of the attribute.
+  assert.equal(html.match(/<iframe\b/g)?.length, 1, "hostile payload must not add elements to the carrier");
+});
+
+test("carrier iframe keeps the opaque-origin sandbox boundary", () => {
+  const html = buildArtifactCarrierHtml("<h1>hi</h1>");
+  assert.ok(html.includes(`sandbox="${ARTIFACT_CARRIER_SANDBOX}"`), "sandbox attribute present");
+  assert.ok(!ARTIFACT_CARRIER_SANDBOX.includes("allow-same-origin"), "sandbox must NOT grant same-origin");
+  assert.ok(html.includes('referrerpolicy="no-referrer"'), "iframe must not leak a referrer");
+  assert.ok(html.includes('<meta name="referrer" content="no-referrer">'), "carrier must not leak a referrer");
+});
+
+test("openArtifactInTab writes the carrier, closes the doc, and severs opener", () => {
+  const writes = [];
+  let closed = false;
+  const fakeWindow = {
+    document: {
+      write: (markup) => writes.push(markup),
+      close: () => {
+        closed = true;
+      },
+    },
+    opener: {},
+  };
+  const ok = openArtifactInTab("<p>artifact</p>", () => fakeWindow);
+  assert.equal(ok, true);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0], buildArtifactCarrierHtml("<p>artifact</p>"));
+  assert.equal(closed, true, "document must be closed so the page finishes loading");
+  assert.equal(fakeWindow.opener, null, "opener must be severed after writing");
+});
+
+test("openArtifactInTab reports popup blocking instead of failing silently", () => {
+  // The data:-URL predecessor returned null from window.open without throwing,
+  // which is exactly how the feature shipped dead (cave-e3ia). Blocking must
+  // be observable to the caller.
+  assert.equal(openArtifactInTab("<p>x</p>", () => null), false);
+});

--- a/src/lib/artifact-open.ts
+++ b/src/lib/artifact-open.ts
@@ -1,0 +1,74 @@
+/**
+ * Open-in-tab carrier for untrusted chat artifacts (cave-e3ia).
+ *
+ * Two hard constraints shape this module:
+ *
+ * 1. Untrusted artifact HTML must never run in Cave's origin. A blob:/object
+ *    URL minted by the app inherits the privileged app origin, so those are
+ *    banned outright (regression-pinned in chat-artifact-viewer.test.ts).
+ * 2. A top-level `data:text/html` navigation — the previous approach — is
+ *    blocked by every engine we ship to (Chromium 60+, Firefox 59+, WebKit
+ *    incl. Tauri's WKWebView), and blocked *silently*: window.open returns
+ *    null without throwing, so the feature was a dead no-op (cave-e3ia).
+ *
+ * The working mechanism: open an app-controlled about:blank carrier document
+ * and confine the artifact to a sandboxed `srcdoc` iframe WITHOUT
+ * `allow-same-origin` — the exact opaque-origin boundary the inline preview
+ * uses. Only trusted, app-authored markup is written to the carrier itself;
+ * the untrusted payload travels solely inside an HTML-escaped attribute
+ * value.
+ */
+
+/** Escape a string for safe embedding inside a double-quoted HTML attribute.
+ *  `&` must be escaped first; `<`/`>` are escaped too so the value can never
+ *  terminate the surrounding tag even if a parser mishandles quotes. */
+export function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** Sandbox grants for the carried artifact — kept identical to the inline
+ *  preview iframe in chat-artifact-viewer.tsx. Never add allow-same-origin:
+ *  the opaque origin IS the isolation boundary. */
+export const ARTIFACT_CARRIER_SANDBOX = "allow-scripts allow-popups allow-modals";
+
+/** Build the full carrier document. Everything outside the srcdoc attribute
+ *  is static app-authored markup; the artifact HTML appears only as an
+ *  escaped attribute value. */
+export function buildArtifactCarrierHtml(artifactHtml: string): string {
+  return [
+    "<!doctype html>",
+    '<html><head><meta charset="utf-8">',
+    '<meta name="referrer" content="no-referrer">',
+    "<title>Cave artifact</title>",
+    "<style>html,body{margin:0;height:100%;background:#111}iframe{border:0;width:100%;height:100%;display:block}</style>",
+    "</head><body>",
+    `<iframe sandbox="${ARTIFACT_CARRIER_SANDBOX}" referrerpolicy="no-referrer" srcdoc="${escapeHtmlAttribute(artifactHtml)}"></iframe>`,
+    "</body></html>",
+  ].join("");
+}
+
+/** Open `artifactHtml` in a new tab inside the sandboxed carrier. Returns
+ *  false when the popup was blocked (callers should surface that — the old
+ *  data:-URL path failed silently, which is how cave-e3ia shipped dead).
+ *  The opener handle is severed AFTER writing the carrier: the carrier is
+ *  trusted app markup, and the sandboxed artifact inside it never receives
+ *  an opener of its own. */
+export function openArtifactInTab(
+  artifactHtml: string,
+  opener: (url: string, target: string) => Window | null = (url, target) => window.open(url, target),
+): boolean {
+  const w = opener("about:blank", "_blank");
+  if (!w) return false;
+  try {
+    w.document.write(buildArtifactCarrierHtml(artifactHtml));
+    w.document.close();
+  } finally {
+    w.opener = null;
+  }
+  return true;
+}


### PR DESCRIPTION
Fixes **cave-e3ia** (P1), the remaining finding from the post-merge review of #3196.

## Problem

#3196 replaced the same-origin blob URL in "Open in browser" with a top-level `data:text/html` navigation — but every engine we ship to (Chromium 60+, Firefox 59+, WebKit incl. Tauri's WKWebView) **silently blocks** top-frame `data:` navigations: `window.open` returns `null` without throwing, the `catch` fallback never fired, and the feature shipped as a dead no-op that only *looked* isolated.

## Fix

Open an **app-authored `about:blank` carrier document** and confine the artifact to an **escaped `srcdoc` attribute on a sandboxed iframe** (`allow-scripts allow-popups allow-modals`, never `allow-same-origin`) — the identical opaque-origin boundary the inline preview already uses. The opener handle is severed after writing the trusted carrier; the sandboxed artifact never receives one. Popup blocking now surfaces through the runtime-error overlay instead of failing silently.

- `src/lib/artifact-open.ts` — `escapeHtmlAttribute` (`&` first, quotes + angle brackets), `buildArtifactCarrierHtml`, `openArtifactInTab`
- `chat-artifact-viewer.tsx` — routes through `openArtifactInTab(srcDoc)`, surfaces blocked popups
- Source pins updated: `data:text/html` is now **forbidden** in the viewer; blob/object-URL bans stay; carrier usage pinned
- New behavioral tests include an attribute-breakout attempt (`"><iframe …>`) proving the payload can't escape the srcdoc value

## Validation

- `node --test src/lib/artifact-open.test.ts src/components/chat-artifact-viewer.test.ts` → 6/6
- **Real-browser verification (Playwright, Chromium + WebKit):** popup opens, artifact script executes, frame origin is opaque (`"null"`) — vs. the old path which opened nothing
- `pnpm typecheck` clean; `check-tests-wired` green (test registered in SUITES)