### PR TITLE
feat(dashboard): GitHub empty state bridges to Connect GitHub (cave-a3n2)

### DIFF
--- a/src/components/dashboard/cockpit-panels.tsx
+++ b/src/components/dashboard/cockpit-panels.tsx
@@ -31,7 +31,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { openExternalUrl } from "@/lib/open-external";
 import {
   HEALTH_META, STATUS_META, STATUS_ORDER, TIER_TONE, TREND_DAYS,
-  confidenceColor, prettyFactor, shortRepo, whenLabel,
+  confidenceColor, githubEmptyState, prettyFactor, shortRepo, whenLabel,
 } from "@/lib/dashboard-cockpit-format";
 
 // ─── Coven insight banner ────────────────────────────────────────────────────────
@@ -371,9 +371,21 @@ export function AgentsPanel({ familiars, sessions, loaded }: { familiars: Famili
 const GH_ICON: Record<GitHubItem["kind"], IconName> = {
   pr: "ph:git-pull-request", review_request: "ph:git-pull-request", issue: "ph:circle", notification: "ph:bell",
 };
-export function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }) {
+export function GithubPanel({ items, loaded, connected }: {
+  items: GitHubItem[]; loaded: boolean; connected: boolean | null;
+}) {
   if (!loaded) return <PanelSkeleton rows={3} />;
-  if (items.length === 0) return <EmptyState icon="ph:github-logo">No GitHub activity, or no token configured.</EmptyState>;
+  if (items.length === 0) {
+    const empty = githubEmptyState(connected);
+    return (
+      <EmptyState icon="ph:github-logo">
+        {empty.copy}
+        {empty.showConnect ? (
+          <a className="cockpit-connect focus-ring" href="/?mode=github">Connect GitHub</a>
+        ) : null}
+      </EmptyState>
+    );
+  }
   return (
     <ul className="cockpit-gh">
       {items.slice(0, 6).map((g) => (

--- a/src/components/dashboard/dashboard-cockpit-polish.test.ts
+++ b/src/components/dashboard/dashboard-cockpit-polish.test.ts
@@ -75,4 +75,22 @@ assert.match(
   "Good-tone note is a wash over hairline, not a heavy green banner",
 );
 
+// ── GitHub empty state names the fix only when it IS the fix ─────────────────
+// The cockpit probes /api/github/pat (hasPat only — never the token) and the
+// panel offers Connect GitHub solely on a proven-disconnected probe; a failed
+// probe keeps the ambiguous copy instead of prescribing a fix that may not apply.
+assert.match(cockpit, /getJson<\{ hasPat: boolean \}>\("\/api\/github\/pat"\)/, "cockpit probes token presence");
+assert.match(cockpit, /connected=\{ghConnected\}/, "probe result reaches the GitHub panel");
+assert.match(panels, /githubEmptyState\(connected\)/, "empty copy derives from the shared truthful helper");
+assert.match(
+  panels,
+  /<a className="cockpit-connect focus-ring" href="\/\?mode=github">Connect GitHub<\/a>/,
+  "disconnected empty state carries the connect affordance into the GitHub surface",
+);
+assert.doesNotMatch(
+  panels,
+  /No GitHub activity, or no token configured/,
+  "the hedged dead-end copy no longer lives in the panel itself",
+);
+
 console.log("dashboard-cockpit-polish.test.ts: ok");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -106,6 +106,10 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   // Truthful freshness: stamped when fetched data actually lands (not render
   // time), so a backgrounded tab shows real staleness when you come back.
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  // GitHub token probe (never the token itself): true/false from /api/github/pat,
+  // null while unresolved or when the probe fails — the panel's empty state only
+  // offers "Connect GitHub" on a proven false, never on a guess.
+  const [ghConnected, setGhConnected] = useState<boolean | null>(null);
 
   // Keep setState off an unmounted tree: the polled `load` may resolve after
   // unmount. A ref survives across the stable `load` identity.
@@ -135,6 +139,10 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       const ghMap = new Map<string, GitHubItem>();
       for (const it of [...(ghAct?.items ?? []), ...(ghAssigned?.items ?? [])]) ghMap.set(it.id, it);
       put("github", [...ghMap.values()]);
+    });
+    void getJson<{ hasPat: boolean }>("/api/github/pat").then((r) => {
+      if (!aliveRef.current) return;
+      setGhConnected(typeof r?.hasPat === "boolean" ? r.hasPat : null);
     });
   }, []);
 
@@ -425,7 +433,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       }
       case "github": return (
         <Panel title="GitHub" icon="ph:github-logo" count={data.github.length || undefined} hint={prsToReview.length ? `${prsToReview.length} to review` : undefined} href="/?mode=github">
-          <GithubPanel items={data.github} loaded={ready.has("github")} />
+          <GithubPanel items={data.github} loaded={ready.has("github")} connected={ghConnected} />
         </Panel>);
       case "agenda": return (
         <Panel title="Up next" icon="ph:calendar-bold" count={upcoming.length || undefined} href="/?mode=calendar">

--- a/src/lib/dashboard-cockpit-format.test.ts
+++ b/src/lib/dashboard-cockpit-format.test.ts
@@ -8,6 +8,7 @@ import {
   contractSub,
   coverageSub,
   dayKey,
+  githubEmptyState,
   panelTitle,
   prettyFactor,
   reconcileLayout,
@@ -66,6 +67,16 @@ test("whenLabel is calendar-relative for upcoming reminders", () => {
   assert.match(whenLabel(at(tomorrow, 9), now), /^Tmrw /);
   const nextWeek = new Date(now); nextWeek.setDate(now.getDate() + 6);
   assert.match(whenLabel(at(nextWeek, 9), now), /^Jul 20 /);
+});
+
+test("githubEmptyState: connect affordance only when the token probe proves disconnected", () => {
+  assert.deepEqual(githubEmptyState(false), { copy: "GitHub isn't connected.", showConnect: true });
+  assert.deepEqual(githubEmptyState(true), { copy: "No GitHub activity right now.", showConnect: false });
+  // Probe failed → neither claim is honest; no affordance for a fix that may not apply.
+  assert.deepEqual(githubEmptyState(null), {
+    copy: "No GitHub activity, or no token configured.",
+    showConnect: false,
+  });
 });
 
 test("small formatters: shortRepo, prettyFactor, confidenceColor clamps", () => {

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -155,3 +155,15 @@ export function confidenceColor(value: number): string {
 export function longDate(now: Date): string {
   return now.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
 }
+
+/** Truthful empty state for the GitHub panel, keyed on the token probe
+ *  (`GET /api/github/pat` → hasPat). `null` = the probe itself failed, so
+ *  neither "connected" nor "not connected" can honestly be claimed — keep the
+ *  ambiguous copy rather than fabricate certainty. Only the known-disconnected
+ *  branch offers the connect affordance; showing it to a connected user whose
+ *  feed is merely quiet would name the wrong fix. */
+export function githubEmptyState(connected: boolean | null): { copy: string; showConnect: boolean } {
+  if (connected === false) return { copy: "GitHub isn't connected.", showConnect: true };
+  if (connected === true) return { copy: "No GitHub activity right now.", showConnect: false };
+  return { copy: "No GitHub activity, or no token configured.", showConnect: false };
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -614,6 +614,12 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-ghrow__title { flex: 1; min-width: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cockpit-ghrow__meta { display: inline-flex; align-items: center; gap: 6px; flex: 0 0 auto; }
 .cockpit-ghrow__repo { font-size: 10.5px; color: var(--text-muted); }
+/* Empty-state bridge: shown only when the token probe proves GitHub is
+   disconnected — deep-links to the GitHub surface, which owns the PAT flow. */
+.cockpit-connect { display: inline-flex; align-items: center; margin-left: 8px; padding: 2px 9px; border-radius: 999px;
+  font-size: 11px; font-weight: 600; text-decoration: none;
+  color: var(--accent-presence-foreground); background: var(--accent-presence); }
+.cockpit-connect:hover { filter: brightness(1.08); }
 
 /* Agenda */
 .cockpit-agendarow { display: flex; align-items: baseline; gap: 10px; padding: 6px 4px; }


### PR DESCRIPTION
## What

The cockpit's GitHub panel empty state hedged — **"No GitHub activity, or no token configured."** — naming the fix while offering no way to apply it, and conflating two different situations (quiet feed vs. missing connection).

## How

- **Probe**: `dashboard-cockpit.tsx` now fetches `GET /api/github/pat` alongside its other independent loads → `ghConnected: boolean | null` (`hasPat` boolean only — the token itself never reaches the client), `aliveRef`-guarded like every other source.
- **Truthful vocabulary** (`githubEmptyState()` in `dashboard-cockpit-format.ts`):
  - probe proves **disconnected** → *"GitHub isn't connected."* + a **Connect GitHub** pill deep-linking to `/?mode=github`, the surface that owns the PAT modal/flow
  - probe proves **connected** → *"No GitHub activity right now."* (no affordance for a fix that doesn't apply)
  - probe **failed** → the previous ambiguous copy stays, with no affordance — never prescribe a fix on a guess
- **Styling**: `.cockpit-connect` pill uses `--accent-presence`/`--accent-presence-foreground` + the global `focus-ring` class, per conventions.

## Tests

- Behavioral: three-branch table for `githubEmptyState()` in `dashboard-cockpit-format.test.ts`
- Wiring pins: probe → prop → CTA chain and dead-end-copy removal in `dashboard-cockpit-polish.test.ts`
- Existing `dashboard-page.test.ts` contract (`/api/github` pull, `/?mode=github` drill) untouched and green

## Verification

- `pnpm typecheck` ✅
- targeted `node --test`: dashboard-cockpit-format, dashboard-cockpit-polish, dashboard-page ✅

Bead: cave-a3n2 · Goal: dashboard-command-center (slice 2)
