### PR TITLE
feat(voice): native macOS STT via SFSpeechRecognizer — packaged-app ears (cave-0ogg)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -867,6 +867,7 @@ export const SUITES = {
     "src/lib/voice/registry.test.ts",
     "src/lib/voice/local-loop.test.ts",
     "src/lib/voice/speech-loop.test.ts",
+    "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",
     "src/lib/voice/elevenlabs.test.ts",
     "src/lib/voice/hydrate-instructions.test.ts",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -79,9 +79,13 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "fs2",
  "log",
  "objc2",
+ "objc2-avf-audio",
+ "objc2-foundation",
+ "objc2-speech",
  "once_cell",
  "parking_lot",
  "portable-pty",
@@ -2483,6 +2487,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-core-audio-types",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2521,28 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2548,6 +2600,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2623,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2619,6 +2698,19 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-speech"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eb609f9d2a25e0f8b76954f3acaa58348ce2a91285fe867643b2224ac4d263"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-media",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,3 +72,11 @@ window-vibrancy = "0.6"
 # Raw msg_send access to NSWindow's standard buttons (traffic-light
 # show/hide follows the side panel); already in the tree via tauri/wry.
 objc2 = "0.6"
+# Native speech-to-text for local voice calls (speech.rs): WKWebView has no
+# SpeechRecognition, so the packaged app captures the mic with AVAudioEngine
+# and transcribes with SFSpeechRecognizer. Same objc2 0.6 generation as the
+# bindings already in the tree via tauri/wry.
+objc2-foundation = "0.3"
+objc2-speech = "0.3"
+objc2-avf-audio = "0.3"
+block2 = "0.6"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	Hardened-runtime entitlements for the notarized macOS build
+	(release.yml signs with runtime hardening; without audio-input the
+	hardened app is denied the microphone regardless of TCC consent).
+	-->
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	Merged into the generated macOS bundle Info.plist by tauri-bundler.
+	Voice calls capture the microphone (WebView getUserMedia for cloud
+	providers; AVAudioEngine in src-tauri/src/speech.rs for the native
+	local engine) and transcribe with SFSpeechRecognizer — macOS kills
+	the process on first use of either without these usage descriptions.
+	-->
+	<key>NSMicrophoneUsageDescription</key>
+	<string>CovenCave uses the microphone for voice calls with your familiars.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>CovenCave transcribes your voice on this Mac so local voice calls work without any cloud service.</string>
+</dict>
+</plist>

--- a/src-tauri/capabilities/loopback-speech.json
+++ b/src-tauri/capabilities/loopback-speech.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "loopback-speech",
+  "description": "allows only the trusted main loopback webview to run native speech recognition for local voice calls",
+  "webviews": [
+    "main"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:*/*",
+      "http://127.0.0.1:*/*",
+      "http://[\\:\\:1]:*/*"
+    ]
+  },
+  "permissions": [
+    "allow-speech-stt-available",
+    "allow-speech-stt-start",
+    "allow-speech-stt-finish",
+    "allow-speech-stt-stop"
+  ]
+}

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -19,4 +19,8 @@ permissions = [
   "allow-sidecar-startup-status",
   "allow-retry-sidecar-startup",
   "allow-cancel-sidecar-startup",
+  "allow-speech-stt-available",
+  "allow-speech-stt-start",
+  "allow-speech-stt-finish",
+  "allow-speech-stt-stop",
 ]

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -18,11 +18,16 @@ const loopbackWindowDragCapability = JSON.parse(
 const loopbackUpdaterCapability = JSON.parse(
   readFileSync(new URL("../capabilities/loopback-updater.json", import.meta.url), "utf8"),
 );
+const loopbackSpeechCapability = JSON.parse(
+  readFileSync(new URL("../capabilities/loopback-speech.json", import.meta.url), "utf8"),
+);
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
+const speechPermissions = readFileSync(new URL("./speech.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
 const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 const libRust = readFileSync(new URL("../src/lib.rs", import.meta.url), "utf8");
+const nativeSttTs = readFileSync(new URL("../../src/lib/voice/native-stt.ts", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
 const shellTsx = readFileSync(new URL("../../src/components/shell.tsx", import.meta.url), "utf8");
@@ -48,6 +53,10 @@ const requiredPermissionIds = [
   "allow-sidecar-startup-status",
   "allow-retry-sidecar-startup",
   "allow-cancel-sidecar-startup",
+  "allow-speech-stt-available",
+  "allow-speech-stt-start",
+  "allow-speech-stt-finish",
+  "allow-speech-stt-stop",
 ];
 
 const requiredCommands = [
@@ -552,4 +561,80 @@ test("pty_start keeps process authority native-side", () => {
   assert.match(ptyRust, /let command = default_shell\(\);/);
   assert.match(ptyRust, /let args = default_shell_args\(\);/);
   assert.doesNotMatch(ptyRust, /options\.command|options\.args|options\.env/);
+});
+
+test("native speech recognition is scoped to the trusted main webview", () => {
+  const speechPermissionIds = [
+    ["allow-speech-stt-available", "speech_stt_available"],
+    ["allow-speech-stt-start", "speech_stt_start"],
+    ["allow-speech-stt-finish", "speech_stt_finish"],
+    ["allow-speech-stt-stop", "speech_stt_stop"],
+  ];
+
+  for (const [permission, command] of speechPermissionIds) {
+    assert.match(
+      speechPermissions,
+      new RegExp(String.raw`identifier\s*=\s*"${permission}"[\s\S]{0,240}commands\.allow\s*=\s*\[[^\]]*"${command}"`),
+      `${permission} must map to ${command}`,
+    );
+    assert.match(
+      libRust,
+      new RegExp(String.raw`speech::${command}`),
+      `${command} must be registered in the desktop invoke handler`,
+    );
+    assert.match(
+      nativeSttTs,
+      new RegExp(String.raw`"${command}"`),
+      `the JS ears must drive ${command} (or drop the unused permission)`,
+    );
+  }
+
+  // Dev + packaged sidecar loopback origins get speech through their own
+  // capability, main webview only — never native browser children.
+  assert.deepEqual(loopbackSpeechCapability.webviews, ["main"]);
+  assert.equal(loopbackSpeechCapability.windows, undefined);
+  for (const [permission] of speechPermissionIds) {
+    assert.ok(
+      loopbackSpeechCapability.permissions.includes(permission),
+      `loopback-speech should grant ${permission}`,
+    );
+  }
+  assert.ok(capabilityAllowsOrigin(loopbackSpeechCapability, "http://127.0.0.1:3000/"));
+  assert.ok(capabilityAllowsOrigin(loopbackSpeechCapability, "http://localhost:64203/"));
+  assert.equal(
+    capabilityAllowsOrigin(loopbackSpeechCapability, "http://example.com:64203/"),
+    false,
+    "remote non-loopback origins must not run the microphone",
+  );
+  assertCapabilityDoesNotGrant(loopbackSpeechCapability, [
+    "default",
+    "allow-pty-start",
+    "allow-browser-navigate",
+    "allow-shell-open",
+  ]);
+  assertCapabilityDoesNotGrant(browserChildReportingCapability, [
+    "allow-speech-stt-available",
+    "allow-speech-stt-start",
+    "allow-speech-stt-finish",
+    "allow-speech-stt-stop",
+  ]);
+
+  // The event channel name is duplicated across the language boundary — a
+  // rename on either side must break this pin, not voice calls at runtime.
+  const rustEventName = readFileSync(new URL("../src/speech.rs", import.meta.url), "utf8")
+    .match(/STT_EVENT: &str = "([^"]+)"/)?.[1];
+  assert.equal(rustEventName, "speech-stt:event");
+  assert.match(
+    nativeSttTs,
+    /STT_EVENT = "speech-stt:event"/,
+    "the JS ears must listen on the exact channel speech.rs emits",
+  );
+
+  // The mic pipeline stays native-side: the renderer names a session and a
+  // locale, never an audio device, file, or model path.
+  assert.doesNotMatch(
+    readFileSync(new URL("../src/speech.rs", import.meta.url), "utf8"),
+    /options\.device|device_id|model_path/,
+    "renderer must not choose capture devices or model files",
+  );
 });

--- a/src-tauri/permissions/speech.toml
+++ b/src-tauri/permissions/speech.toml
@@ -1,0 +1,19 @@
+[[permission]]
+identifier = "allow-speech-stt-available"
+description = "Allows probing whether native speech recognition is supported."
+commands.allow = ["speech_stt_available"]
+
+[[permission]]
+identifier = "allow-speech-stt-start"
+description = "Allows starting a native speech recognition session (microphone capture + transcription)."
+commands.allow = ["speech_stt_start"]
+
+[[permission]]
+identifier = "allow-speech-stt-finish"
+description = "Allows ending the audio of a native speech recognition session to obtain its final transcript."
+commands.allow = ["speech_stt_finish"]
+
+[[permission]]
+identifier = "allow-speech-stt-stop"
+description = "Allows cancelling and tearing down a native speech recognition session."
+commands.allow = ["speech_stt_stop"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2488,6 +2488,8 @@ mod browser;
 mod pty;
 #[cfg(all(desktop, target_os = "windows"))]
 mod sidecar_archive;
+#[cfg(desktop)]
+mod speech;
 #[cfg(all(desktop, target_os = "windows"))]
 mod windows_process_job;
 
@@ -2949,6 +2951,10 @@ pub fn run() {
             shell_open_path,
             shell_pick_directory,
             set_traffic_lights_visible,
+            speech::speech_stt_available,
+            speech::speech_stt_start,
+            speech::speech_stt_finish,
+            speech::speech_stt_stop,
             #[cfg(target_os = "windows")]
             sidecar_startup_status,
             #[cfg(target_os = "windows")]

--- a/src-tauri/src/speech.rs
+++ b/src-tauri/src/speech.rs
@@ -1,0 +1,373 @@
+// Native speech-to-text engine for local voice calls (cave-0ogg).
+//
+// WKWebView ships no SpeechRecognition, so the packaged macOS app cannot run
+// the ears half of the local voice loop (src/lib/voice/speech-loop.ts) in the
+// webview. This module owns the ears natively: AVAudioEngine taps the mic and
+// feeds an SFSpeechAudioBufferRecognitionRequest; partial and final
+// transcripts stream back to the main webview as `speech-stt:event` events.
+//
+// Surfaced as tauri::commands (all fire-and-forget except `available`;
+// engine failures arrive as `error` events so the JS ears own retry policy):
+//   speech_stt_available() -> SttAvailability
+//   speech_stt_start(session, lang)   spin up mic tap + recognition task
+//   speech_stt_finish(session)        end audio; a `final` event follows
+//   speech_stt_stop(session)          cancel + tear down, no final
+//
+// Events emitted to the frontend (all carry the u32 session id so the JS
+// side can drop stale events from a torn-down session):
+//   speech-stt:event { session, kind: "partial"|"final"|"error"|"end",
+//                      text?, code?, message? }
+//
+// Endpointing (deciding the user finished a sentence) deliberately lives in
+// the JS ears (src/lib/voice/native-stt.ts) — SFSpeechRecognizer streams
+// partials until endAudio, so the testable partial-stability timer upstream
+// calls `speech_stt_finish` instead of this module guessing silence.
+//
+// Threading: every AVFoundation/Speech object is created and torn down on
+// the main thread (they are not Send); commands hop via
+// AppHandle::run_on_main_thread and the live session lives in a
+// thread-local. The audio tap and recognition callbacks arrive on Apple's
+// internal queues — appendAudioPCMBuffer is documented safe from the tap
+// thread, and result handling re-dispatches to the main thread before
+// touching session state.
+
+use serde::Serialize;
+use tauri::AppHandle;
+
+#[derive(Serialize)]
+pub struct SttAvailability {
+    pub supported: bool,
+    /// Human-readable reason when unsupported (platform, denied permission).
+    pub reason: Option<String>,
+}
+
+pub const STT_EVENT: &str = "speech-stt:event";
+
+#[derive(Clone, Serialize)]
+pub struct SttEvent {
+    pub session: u32,
+    /// "partial" | "final" | "error" | "end"
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[tauri::command]
+pub fn speech_stt_available() -> SttAvailability {
+    #[cfg(target_os = "macos")]
+    {
+        SttAvailability { supported: true, reason: None }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        SttAvailability {
+            supported: false,
+            reason: Some("native speech recognition is only wired up on macOS".into()),
+        }
+    }
+}
+
+#[tauri::command]
+pub fn speech_stt_start(app: AppHandle, session: u32, lang: Option<String>) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::start(app, session, lang);
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, session, lang);
+        Err("native speech recognition is only wired up on macOS".into())
+    }
+}
+
+#[tauri::command]
+pub fn speech_stt_finish(app: AppHandle, session: u32) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::finish(app, session);
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, session);
+        Ok(())
+    }
+}
+
+#[tauri::command]
+pub fn speech_stt_stop(app: AppHandle, session: u32) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::stop(app, session);
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, session);
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::cell::RefCell;
+    use std::ptr::NonNull;
+
+    use block2::RcBlock;
+    use log::{info, warn};
+    use objc2::rc::Retained;
+    use objc2::{AnyThread, MainThreadMarker};
+    use objc2_avf_audio::{AVAudioEngine, AVAudioPCMBuffer, AVAudioTime};
+    use objc2_foundation::{NSError, NSLocale, NSString};
+    use objc2_speech::{
+        SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
+        SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
+    };
+    use tauri::{AppHandle, Emitter};
+
+    use super::{SttEvent, STT_EVENT};
+
+    struct ActiveStt {
+        session: u32,
+        engine: Retained<AVAudioEngine>,
+        request: Retained<SFSpeechAudioBufferRecognitionRequest>,
+        task: Retained<SFSpeechRecognitionTask>,
+        // Kept alive for the duration of the task.
+        _recognizer: Retained<SFSpeechRecognizer>,
+    }
+
+    thread_local! {
+        /// The one live recognition session; only the main thread touches it.
+        static ACTIVE: RefCell<Option<ActiveStt>> = const { RefCell::new(None) };
+    }
+
+    fn emit(app: &AppHandle, event: SttEvent) {
+        if let Err(err) = app.emit(STT_EVENT, event) {
+            warn!("speech_stt: event emit failed: {err}");
+        }
+    }
+
+    fn emit_error(app: &AppHandle, session: u32, code: &'static str, message: String) {
+        emit(app, SttEvent { session, kind: "error", text: None, code: Some(code), message: Some(message) });
+        emit(app, SttEvent { session, kind: "end", text: None, code: None, message: None });
+    }
+
+    /// Tear down the active session if it matches `session`. Main thread only.
+    fn teardown_if_current(session: u32) {
+        ACTIVE.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            if slot.as_ref().is_some_and(|a| a.session == session) {
+                if let Some(active) = slot.take() {
+                    unsafe {
+                        active.task.cancel();
+                        active.request.endAudio();
+                        active.engine.stop();
+                        active.engine.inputNode().removeTapOnBus(0);
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn start(app: AppHandle, session: u32, lang: Option<String>) {
+        let app2 = app.clone();
+        let run = app.run_on_main_thread(move || match unsafe { SFSpeechRecognizer::authorizationStatus() } {
+            SFSpeechRecognizerAuthorizationStatus::Authorized => start_engine(app2, session, lang),
+            SFSpeechRecognizerAuthorizationStatus::Denied
+            | SFSpeechRecognizerAuthorizationStatus::Restricted => {
+                emit_error(
+                    &app2,
+                    session,
+                    "stt_permission_denied",
+                    "Speech recognition permission is denied — allow it in System Settings → Privacy & Security → Speech Recognition.".into(),
+                );
+            }
+            _ => {
+                // Not determined: ask, then continue on the main thread.
+                let app3 = app2.clone();
+                let handler = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+                    let app4 = app3.clone();
+                    let lang = lang.clone();
+                    let _ = app3.run_on_main_thread(move || {
+                        if status == SFSpeechRecognizerAuthorizationStatus::Authorized {
+                            start_engine(app4, session, lang);
+                        } else {
+                            emit_error(
+                                &app4,
+                                session,
+                                "stt_permission_denied",
+                                "Speech recognition permission was not granted.".into(),
+                            );
+                        }
+                    });
+                });
+                unsafe { SFSpeechRecognizer::requestAuthorization(&handler) };
+            }
+        });
+        if let Err(err) = run {
+            warn!("speech_stt_start[{session}]: main-thread dispatch failed: {err}");
+        }
+    }
+
+    /// Main-thread body: build recognizer + request + mic tap, start the task.
+    fn start_engine(app: AppHandle, session: u32, lang: Option<String>) {
+        debug_assert!(MainThreadMarker::new().is_some());
+        // A newer session replaces any live one (the JS ears serialize this,
+        // but a stray overlap must not leak a running engine).
+        ACTIVE.with(|slot| {
+            if let Some(active) = slot.borrow_mut().take() {
+                unsafe {
+                    active.task.cancel();
+                    active.engine.stop();
+                    active.engine.inputNode().removeTapOnBus(0);
+                }
+            }
+        });
+
+        let recognizer = lang
+            .filter(|l| !l.trim().is_empty())
+            .and_then(|l| {
+                let locale = NSLocale::localeWithLocaleIdentifier(&NSString::from_str(l.trim()));
+                unsafe { SFSpeechRecognizer::initWithLocale(SFSpeechRecognizer::alloc(), &locale) }
+            })
+            .or_else(|| Some(unsafe { SFSpeechRecognizer::new() }))
+            .filter(|r| unsafe { r.isAvailable() });
+        let Some(recognizer) = recognizer else {
+            emit_error(
+                &app,
+                session,
+                "stt_unavailable",
+                "macOS speech recognition is unavailable for this language right now.".into(),
+            );
+            return;
+        };
+
+        let request = unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
+        unsafe {
+            request.setShouldReportPartialResults(true);
+            // Prefer the on-device dictation model when this Mac has it — the
+            // local provider's promise is "no cloud". Machines without the
+            // model fall back to Apple's system dictation service.
+            if recognizer.supportsOnDeviceRecognition() {
+                request.setRequiresOnDeviceRecognition(true);
+            }
+        }
+
+        let engine = unsafe { AVAudioEngine::new() };
+        let input = unsafe { engine.inputNode() };
+        let format = unsafe { input.outputFormatForBus(0) };
+        {
+            let request = request.clone();
+            let tap = RcBlock::new(
+                move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
+                    // Documented-safe from the tap's audio thread.
+                    unsafe { request.appendAudioPCMBuffer(buffer.as_ref()) };
+                },
+            );
+            let tap_ptr = &*tap as *const _ as *mut _;
+            unsafe { input.installTapOnBus_bufferSize_format_block(0, 4096, Some(&format), tap_ptr) };
+        }
+
+        unsafe { engine.prepare() };
+        if let Err(err) = unsafe { engine.startAndReturnError() } {
+            unsafe { input.removeTapOnBus(0) };
+            emit_error(
+                &app,
+                session,
+                "stt_mic_failed",
+                format!("The microphone could not be started: {}", err.localizedDescription()),
+            );
+            return;
+        }
+
+        let handler_app = app.clone();
+        let handler = RcBlock::new(
+            move |result: *mut SFSpeechRecognitionResult, error: *mut NSError| {
+                // Runs on an Apple-owned queue: read what we need, then hop to
+                // the main thread for any session-state change.
+                let mut final_text: Option<String> = None;
+                let mut partial_text: Option<String> = None;
+                if let Some(result) = unsafe { result.as_ref() } {
+                    let text = unsafe { result.bestTranscription().formattedString() }.to_string();
+                    if unsafe { result.isFinal() } {
+                        final_text = Some(text);
+                    } else {
+                        partial_text = Some(text);
+                    }
+                }
+                let errored = !error.is_null() && final_text.is_none();
+                let message = unsafe { error.as_ref() }.map(|e| e.localizedDescription().to_string());
+
+                if let Some(text) = partial_text {
+                    emit(&handler_app, SttEvent { session, kind: "partial", text: Some(text), code: None, message: None });
+                    return;
+                }
+
+                let app = handler_app.clone();
+                let _ = handler_app.run_on_main_thread(move || {
+                    // Only the live session may speak; a cancelled task's
+                    // trailing error callback must stay silent.
+                    let is_current = ACTIVE
+                        .with(|slot| slot.borrow().as_ref().is_some_and(|a| a.session == session));
+                    if !is_current {
+                        return;
+                    }
+                    teardown_if_current(session);
+                    if let Some(text) = final_text {
+                        emit(&app, SttEvent { session, kind: "final", text: Some(text), code: None, message: None });
+                        emit(&app, SttEvent { session, kind: "end", text: None, code: None, message: None });
+                    } else if errored {
+                        emit_error(
+                            &app,
+                            session,
+                            "stt_failed",
+                            message.unwrap_or_else(|| "speech recognition failed".into()),
+                        );
+                    } else {
+                        emit(&app, SttEvent { session, kind: "end", text: None, code: None, message: None });
+                    }
+                });
+            },
+        );
+        let task = unsafe { recognizer.recognitionTaskWithRequest_resultHandler(&request, &handler) };
+
+        info!("speech_stt[{session}]: engine started (on-device={})", unsafe {
+            recognizer.supportsOnDeviceRecognition()
+        });
+        ACTIVE.with(|slot| {
+            *slot.borrow_mut() = Some(ActiveStt { session, engine, request, task, _recognizer: recognizer });
+        });
+    }
+
+    pub fn finish(app: AppHandle, session: u32) {
+        let run = app.run_on_main_thread(move || {
+            ACTIVE.with(|slot| {
+                let slot = slot.borrow();
+                if let Some(active) = slot.as_ref().filter(|a| a.session == session) {
+                    unsafe {
+                        // Stop capturing immediately; the final result arrives
+                        // through the task handler, which tears down the rest.
+                        active.engine.stop();
+                        active.engine.inputNode().removeTapOnBus(0);
+                        active.request.endAudio();
+                    }
+                }
+            });
+        });
+        if let Err(err) = run {
+            warn!("speech_stt_finish[{session}]: main-thread dispatch failed: {err}");
+        }
+    }
+
+    pub fn stop(app: AppHandle, session: u32) {
+        let run = app.run_on_main_thread(move || teardown_if_current(session));
+        if let Err(err) = run {
+            warn!("speech_stt_stop[{session}]: main-thread dispatch failed: {err}");
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,6 +55,9 @@
     "iOS": {
       "developmentTeam": "9LR8Z8UQ9X"
     },
+    "macOS": {
+      "entitlements": "./Entitlements.plist"
+    },
     "android": {
       "debugApplicationIdSuffix": ".debug"
     }

--- a/src/lib/voice/elevenlabs.ts
+++ b/src/lib/voice/elevenlabs.ts
@@ -20,6 +20,7 @@ import type {
 } from "./types.ts";
 import { VoiceConnectError } from "./types.ts";
 import { connectSpeechLoop, type SpeechMouth } from "./speech-loop.ts";
+import { resolvePreferredEars } from "./native-stt.ts";
 import {
   createFamiliarSpeechBrain,
   FAMILIAR_BRAIN_ERROR_HINT,
@@ -192,6 +193,7 @@ async function connect(
 
   return connectSpeechLoop({
     mic,
+    ears: await resolvePreferredEars(),
     mouth: createElevenLabsMouth({
       voiceId: connection.voiceId || DEFAULT_ELEVENLABS_VOICE_ID,
       modelId: connection.modelId || DEFAULT_ELEVENLABS_MODEL_ID,

--- a/src/lib/voice/familiar-brain.ts
+++ b/src/lib/voice/familiar-brain.ts
@@ -29,6 +29,7 @@ import {
 } from "./speech-loop.ts";
 import { streamFamiliarText } from "../familiar-stream.ts";
 import { extractNextPaths } from "../next-paths.ts";
+import { resolvePreferredEars } from "./native-stt.ts";
 
 export const FAMILIAR_BRAIN_ERROR_HINT =
   "The familiar's runtime didn't answer — check that its harness is installed and signed in, or try the turn again.";
@@ -116,6 +117,7 @@ async function connect(
   return connectSpeechLoop({
     mic,
     voiceName: connection.voice,
+    ears: await resolvePreferredEars(),
     callbacks,
     brainErrorCode: "familiar_brain_failed",
     brainErrorHint: FAMILIAR_BRAIN_ERROR_HINT,

--- a/src/lib/voice/local-loop.ts
+++ b/src/lib/voice/local-loop.ts
@@ -3,9 +3,10 @@
 // The realtime cloud providers ARE the conversational brain; a local call
 // assembles its own loop out of three local parts (the shared scaffold lives
 // in speech-loop.ts):
-//   ears  — SpeechRecognition where the WebView has it (Chrome web builds).
-//           WKWebView has none: native SFSpeechRecognizer (cave-0ogg) and the
-//           sidecar Whisper engine (cave-vony) are the tracked follow-ups.
+//   ears  — SpeechRecognition where the WebView has it (Chrome web builds);
+//           the desktop app's WKWebView has none, so the Tauri shell hears
+//           through native SFSpeechRecognizer (native-stt.ts). The sidecar
+//           Whisper engine (cave-vony) is the tracked follow-up.
 //   brain — an OpenAI-compatible loopback server (Ollama / LM Studio) proxied
 //           through /api/voice/local/chat so CORS and base-url config stay
 //           server-owned. `voiceModel` names the local model.
@@ -24,6 +25,7 @@ import type {
 } from "./types.ts";
 import { VoiceConnectError } from "./types.ts";
 import { connectSpeechLoop } from "./speech-loop.ts";
+import { resolvePreferredEars } from "./native-stt.ts";
 
 export const DEFAULT_LOCAL_LLM_BASE = "http://127.0.0.1:11434";
 export const DEFAULT_LOCAL_MODEL = "llama3.2";
@@ -131,6 +133,7 @@ async function connect(
   return connectSpeechLoop({
     mic,
     voiceName: connection.voice,
+    ears: await resolvePreferredEars(),
     callbacks,
     brainErrorCode: "local_brain_failed",
     brainErrorHint: "The local model call failed — is the loopback server still running?",

--- a/src/lib/voice/native-stt.test.ts
+++ b/src/lib/voice/native-stt.test.ts
@@ -1,0 +1,254 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createNativeSttEars,
+  nativeSttAvailable,
+  STT_EVENT,
+} from "./native-stt.ts";
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function fakeTimers() {
+  let nextId = 0;
+  const pending = new Map();
+  return {
+    setTimeout: (fn, ms) => {
+      const handle = ++nextId;
+      pending.set(handle, { fn, ms });
+      return handle;
+    },
+    clearTimeout: (handle) => {
+      pending.delete(handle);
+    },
+    /** Fire the (single) pending timer scheduled with `ms`. */
+    fire(ms) {
+      const entry = [...pending.entries()].find(([, t]) => t.ms === ms);
+      assert.ok(entry, `no pending timer with ms=${ms}`);
+      pending.delete(entry[0]);
+      entry[1].fn();
+    },
+    countByMs(ms) {
+      return [...pending.values()].filter((t) => t.ms === ms).length;
+    },
+    get size() {
+      return pending.size;
+    },
+  };
+}
+
+function fakeBridge() {
+  const calls = [];
+  let handler = null;
+  let unlistened = 0;
+  return {
+    calls,
+    /** Commands invoked, as "cmd" strings. */
+    get commands() {
+      return calls.map(([cmd]) => cmd);
+    },
+    argsFor(cmd) {
+      return calls.filter(([c]) => c === cmd).map(([, args]) => args);
+    },
+    emit(payload) {
+      handler?.({ payload });
+    },
+    get unlistened() {
+      return unlistened;
+    },
+    bridge: {
+      async invoke(cmd, args) {
+        calls.push([cmd, args]);
+        if (cmd === "speech_stt_available") return { supported: true };
+        return undefined;
+      },
+      async listen(event, h) {
+        assert.equal(event, STT_EVENT);
+        handler = h;
+        return () => {
+          unlistened += 1;
+          handler = null;
+        };
+      },
+    },
+  };
+}
+
+function collector() {
+  const partials = [];
+  const finals = [];
+  const errors = [];
+  return {
+    partials,
+    finals,
+    errors,
+    handlers: {
+      onPartial: (t) => partials.push(t),
+      onFinal: (t) => finals.push(t),
+      onError: (code, hint) => errors.push({ code, hint }),
+    },
+  };
+}
+
+function makeEars({ lang } = {}) {
+  const fx = fakeBridge();
+  const timers = fakeTimers();
+  const got = collector();
+  const ears = createNativeSttEars(fx.bridge, {
+    lang,
+    stabilityMs: 1_000,
+    maxUtteranceMs: 9_000,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  })(got.handlers);
+  return { fx, timers, got, ears };
+}
+
+test("listen starts a native session; stable partial finishes it; final restarts", async () => {
+  const { fx, timers, got, ears } = makeEars({ lang: "en-US" });
+
+  ears.listen();
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_start"), [{ session: 1, lang: "en-US" }]);
+
+  fx.emit({ session: 1, kind: "partial", text: "open the" });
+  fx.emit({ session: 1, kind: "partial", text: "open the grimoire" });
+  assert.deepEqual(got.partials, ["open the", "open the grimoire"]);
+
+  // The transcript went quiet: the stability timer ends the utterance.
+  timers.fire(1_000);
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_finish"), [{ session: 1 }]);
+
+  fx.emit({ session: 1, kind: "final", text: "open the grimoire" });
+  fx.emit({ session: 1, kind: "end" });
+  await tick();
+  assert.deepEqual(got.finals, ["open the grimoire"]);
+  // One-shot native task: a fresh session keeps the ears open.
+  assert.deepEqual(fx.argsFor("speech_stt_start").at(-1), { session: 2, lang: "en-US" });
+  assert.deepEqual(got.errors, []);
+});
+
+test("events from a stale session are dropped", async () => {
+  const { fx, timers, got, ears } = makeEars();
+  ears.listen();
+  await tick();
+
+  fx.emit({ session: 99, kind: "partial", text: "ghost" });
+  fx.emit({ session: 99, kind: "final", text: "ghost" });
+  assert.deepEqual(got.partials, []);
+  assert.deepEqual(got.finals, []);
+  assert.equal(timers.size, 0);
+});
+
+test("hush stops the native session and blocks the auto-restart", async () => {
+  const { fx, got, ears } = makeEars();
+  ears.listen();
+  await tick();
+  fx.emit({ session: 1, kind: "partial", text: "hello" });
+
+  ears.hush();
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_stop"), [{ session: 1 }]);
+
+  // The torn-down task's trailing end must not resurrect listening.
+  fx.emit({ session: 1, kind: "end" });
+  await tick();
+  assert.equal(fx.argsFor("speech_stt_start").length, 1);
+  assert.deepEqual(got.errors, []);
+
+  // A fresh listen() opens a new numbered session.
+  ears.listen();
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_start").at(-1), { session: 2, lang: null });
+});
+
+test("engine errors surface once and stop listening until asked again", async () => {
+  const { fx, got, ears } = makeEars();
+  ears.listen();
+  await tick();
+
+  fx.emit({
+    session: 1,
+    kind: "error",
+    code: "stt_permission_denied",
+    message: "Speech recognition permission is denied",
+  });
+  fx.emit({ session: 1, kind: "end" });
+  await tick();
+  assert.deepEqual(got.errors, [
+    { code: "stt_permission_denied", hint: "Speech recognition permission is denied" },
+  ]);
+  // No auto-restart after an error — the loop owns retry UX.
+  assert.equal(fx.argsFor("speech_stt_start").length, 1);
+});
+
+test("an empty final is not brained but listening continues", async () => {
+  const { fx, got, ears } = makeEars();
+  ears.listen();
+  await tick();
+
+  fx.emit({ session: 1, kind: "final", text: "   " });
+  await tick();
+  assert.deepEqual(got.finals, []);
+  assert.equal(fx.argsFor("speech_stt_start").length, 2);
+});
+
+test("the utterance cap finishes a transcript that never stabilizes", async () => {
+  const { fx, timers, ears } = makeEars();
+  ears.listen();
+  await tick();
+
+  // A noisy room: partials keep changing, each resetting stability — but the
+  // cap timer is scheduled once and survives the resets.
+  fx.emit({ session: 1, kind: "partial", text: "a" });
+  fx.emit({ session: 1, kind: "partial", text: "ab" });
+  fx.emit({ session: 1, kind: "partial", text: "abc" });
+  assert.equal(timers.countByMs(9_000), 1);
+
+  timers.fire(9_000);
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_finish"), [{ session: 1 }]);
+});
+
+test("close tears down the session and the event channel", async () => {
+  const { fx, got, ears } = makeEars();
+  ears.listen();
+  await tick();
+
+  ears.close();
+  await tick();
+  assert.deepEqual(fx.argsFor("speech_stt_stop"), [{ session: 1 }]);
+  assert.equal(fx.unlistened, 1);
+
+  ears.listen();
+  await tick();
+  assert.equal(fx.argsFor("speech_stt_start").length, 1, "closed ears must not restart");
+  assert.deepEqual(got.errors, []);
+});
+
+test("nativeSttAvailable reflects the probe and never throws", async () => {
+  assert.equal(
+    await nativeSttAvailable({
+      invoke: async () => ({ supported: true }),
+      listen: async () => () => {},
+    }),
+    true,
+  );
+  assert.equal(
+    await nativeSttAvailable({
+      invoke: async () => ({ supported: false, reason: "not macOS" }),
+      listen: async () => () => {},
+    }),
+    false,
+  );
+  assert.equal(
+    await nativeSttAvailable({
+      invoke: async () => {
+        throw new Error("no ipc");
+      },
+      listen: async () => () => {},
+    }),
+    false,
+  );
+});

--- a/src/lib/voice/native-stt.ts
+++ b/src/lib/voice/native-stt.ts
@@ -1,0 +1,216 @@
+// Native macOS speech-to-text ears for the local voice loop (cave-0ogg).
+//
+// WKWebView ships no SpeechRecognition, so in the packaged desktop app the
+// ears half of the speech loop runs natively: src-tauri/src/speech.rs taps
+// the mic with AVAudioEngine and streams SFSpeechRecognizer transcripts back
+// as `speech-stt:event` events. This module is the JS half of that pair — a
+// SpeechEars implementation over the Tauri command bridge.
+//
+// ENDPOINTING LIVES HERE, not in Rust: SFSpeechRecognizer streams partials
+// until it is told the utterance is over (`speech_stt_finish` → endAudio →
+// one final result). The user "finished a sentence" when the partial
+// transcript stops changing for PARTIAL_STABILITY_MS — a testable timer
+// policy — with MAX_UTTERANCE_MS as the runaway cap. Each utterance is one
+// numbered native session; stale events from a torn-down session are
+// dropped by id.
+
+import type { SpeechEars, SpeechEarsFactory, SpeechEarsHandlers } from "./speech-loop.ts";
+
+/** Event channel mirrored from src-tauri/src/speech.rs. */
+export const STT_EVENT = "speech-stt:event";
+
+/** A partial transcript unchanged for this long ends the utterance. */
+export const PARTIAL_STABILITY_MS = 1_200;
+
+/** Hard cap per utterance so a noisy room can't hold the brain hostage. */
+export const MAX_UTTERANCE_MS = 30_000;
+
+export type SttEventPayload = {
+  session: number;
+  kind: "partial" | "final" | "error" | "end";
+  text?: string;
+  code?: string;
+  message?: string;
+};
+
+export type NativeSttBridge = {
+  invoke<T = unknown>(cmd: string, args?: Record<string, unknown>): Promise<T>;
+  listen<T>(event: string, handler: (e: { payload: T }) => void): Promise<() => void>;
+};
+
+/** Load the Tauri bridge, or null outside the desktop shell. */
+export async function loadNativeSttBridge(): Promise<NativeSttBridge | null> {
+  if (typeof window === "undefined") return null;
+  if (!(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__) return null;
+  const [{ invoke }, { listen }] = await Promise.all([
+    import("@tauri-apps/api/core"),
+    import("@tauri-apps/api/event"),
+  ]);
+  return { invoke, listen };
+}
+
+/** Ask the native side whether it has a speech engine (macOS only today). */
+export async function nativeSttAvailable(bridge: NativeSttBridge): Promise<boolean> {
+  try {
+    const availability = await bridge.invoke<{ supported?: boolean }>("speech_stt_available");
+    return availability?.supported === true;
+  } catch {
+    return false;
+  }
+}
+
+export type NativeSttEarsOptions = {
+  /** BCP-47 tag for the recognizer locale; empty for the system default. */
+  lang?: string;
+  stabilityMs?: number;
+  maxUtteranceMs?: number;
+  /** Injectable timers for tests. */
+  setTimeout?: (fn: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+};
+
+/**
+ * SpeechEars over the native macOS engine. One factory per voice call; each
+ * `listen()`→final cycle is one numbered native session, auto-restarted
+ * while listening is wanted (mirrors WebSpeech's onend→restart contract).
+ */
+export function createNativeSttEars(
+  bridge: NativeSttBridge,
+  opts: NativeSttEarsOptions = {},
+): SpeechEarsFactory {
+  const stabilityMs = opts.stabilityMs ?? PARTIAL_STABILITY_MS;
+  const maxUtteranceMs = opts.maxUtteranceMs ?? MAX_UTTERANCE_MS;
+  const schedule = opts.setTimeout ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
+  const unschedule = opts.clearTimeout ?? ((handle: unknown) => clearTimeout(handle as number));
+
+  return (handlers: SpeechEarsHandlers): SpeechEars => {
+    let wanted = false;
+    let closed = false;
+    let current = 0; // 0 = no live native session
+    let counter = 0;
+    let stabilityTimer: unknown = null;
+    let capTimer: unknown = null;
+    let unlisten: (() => void) | null = null;
+
+    const clearTimers = () => {
+      if (stabilityTimer !== null) { unschedule(stabilityTimer); stabilityTimer = null; }
+      if (capTimer !== null) { unschedule(capTimer); capTimer = null; }
+    };
+
+    const finishUtterance = (session: number) => {
+      clearTimers();
+      if (session !== current) return;
+      void bridge.invoke("speech_stt_finish", { session }).catch(() => { /* torn down */ });
+    };
+
+    const onEvent = (payload: SttEventPayload) => {
+      if (closed || payload.session !== current) return;
+      if (payload.kind === "partial") {
+        const text = payload.text ?? "";
+        // Every fresh partial resets the "sentence over" clock.
+        if (stabilityTimer !== null) unschedule(stabilityTimer);
+        const session = current;
+        stabilityTimer = schedule(() => finishUtterance(session), stabilityMs);
+        if (capTimer === null) {
+          capTimer = schedule(() => finishUtterance(session), maxUtteranceMs);
+        }
+        if (text.trim()) handlers.onPartial(text);
+        return;
+      }
+      if (payload.kind === "final") {
+        clearTimers();
+        current = 0;
+        const text = (payload.text ?? "").trim();
+        if (text) handlers.onFinal(text);
+        // The native task is one-shot — keep listening for the next turn.
+        if (wanted) start();
+        return;
+      }
+      if (payload.kind === "error") {
+        clearTimers();
+        current = 0;
+        // Engine failures end the listening state; the loop owns retry UX.
+        wanted = false;
+        handlers.onError(payload.code ?? "stt_failed", payload.message);
+        return;
+      }
+      // "end" without a final (cancelled task, empty audio): restart if the
+      // loop still wants ears open.
+      if (payload.kind === "end" && current !== 0) {
+        clearTimers();
+        current = 0;
+        if (wanted) start();
+      }
+    };
+
+    const subscribed: Promise<void> = bridge
+      .listen<SttEventPayload>(STT_EVENT, (e) => onEvent(e.payload))
+      .then((stop) => {
+        if (closed) stop();
+        else unlisten = stop;
+      })
+      .catch(() => {
+        handlers.onError("stt_unavailable", "The native speech event channel could not be opened.");
+      });
+
+    const start = () => {
+      if (closed || !wanted || current !== 0) return;
+      const session = ++counter;
+      current = session;
+      void subscribed.then(() => {
+        if (closed || !wanted || current !== session) return;
+        bridge
+          .invoke("speech_stt_start", { session, lang: opts.lang ?? null })
+          .catch((err) => {
+            if (closed || current !== session) return;
+            current = 0;
+            wanted = false;
+            handlers.onError(
+              "stt_unavailable",
+              err instanceof Error ? err.message : String(err),
+            );
+          });
+      });
+    };
+
+    const stopCurrent = () => {
+      clearTimers();
+      if (current === 0) return;
+      const session = current;
+      current = 0;
+      void bridge.invoke("speech_stt_stop", { session }).catch(() => { /* already gone */ });
+    };
+
+    return {
+      listen() {
+        if (closed) return;
+        wanted = true;
+        start();
+      },
+      hush() {
+        wanted = false;
+        stopCurrent();
+      },
+      close() {
+        closed = true;
+        wanted = false;
+        stopCurrent();
+        unlisten?.();
+        unlisten = null;
+      },
+    };
+  };
+}
+
+/**
+ * The ears the current window should use: the native macOS engine inside the
+ * Tauri shell, undefined elsewhere (the loop falls back to WebSpeech).
+ */
+export async function resolvePreferredEars(): Promise<SpeechEarsFactory | undefined> {
+  const bridge = await loadNativeSttBridge();
+  if (!bridge) return undefined;
+  if (!(await nativeSttAvailable(bridge))) return undefined;
+  return createNativeSttEars(bridge, {
+    lang: typeof navigator !== "undefined" ? navigator.language || undefined : undefined,
+  });
+}

--- a/src/lib/voice/speech-loop.test.ts
+++ b/src/lib/voice/speech-loop.test.ts
@@ -2,9 +2,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  connectSpeechLoop,
   createSentenceChunker,
+  createWebSpeechEars,
   MIN_SPOKEN_SENTENCE_CHARS,
 } from "./speech-loop.ts";
+import { VoiceConnectError } from "./types.ts";
 
 test("emits each completed sentence exactly once as text accumulates", () => {
   const chunker = createSentenceChunker(10);
@@ -50,4 +53,242 @@ test("question and ellipsis breaks with closing quotes are honored", () => {
     chunker.push('"Shall we begin the ritual?" She nodded once… And then'),
     ['"Shall we begin the ritual?"', "She nodded once…"],
   );
+});
+
+// ── connectSpeechLoop with injected ears (the seam native-stt plugs into) ──
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function fakeEars() {
+  const log = [];
+  let handlers = null;
+  return {
+    log,
+    get handlers() {
+      return handlers;
+    },
+    factory: (h) => {
+      handlers = h;
+      return {
+        listen: () => log.push("listen"),
+        hush: () => log.push("hush"),
+        close: () => log.push("close"),
+      };
+    },
+  };
+}
+
+function fakeMic() {
+  const stopped = [];
+  const track = { enabled: true, stop: () => stopped.push("mic") };
+  return { stopped, track, stream: { getAudioTracks: () => [track] } };
+}
+
+function fakeMouth() {
+  const spoken = [];
+  return {
+    spoken,
+    mouth: {
+      async speak(text) {
+        spoken.push(text);
+      },
+      cancel() {
+        spoken.push("<cancel>");
+      },
+    },
+  };
+}
+
+function loopFixture({ brain } = {}) {
+  const ears = fakeEars();
+  const mic = fakeMic();
+  const mouth = fakeMouth();
+  const events = { userFinals: [], assistantFinals: [], errors: [] };
+  const session = connectSpeechLoop({
+    mic: mic.stream,
+    ears: ears.factory,
+    mouth: mouth.mouth,
+    callbacks: {
+      onUserTranscriptFinal: (t) => events.userFinals.push(t),
+      onAssistantTranscriptFinal: (t) => events.assistantFinals.push(t),
+      onPartialTranscript: () => {},
+      onError: (err) => events.errors.push(err),
+      onDisconnect: () => {},
+    },
+    brain: brain ?? (async (userText, speak) => {
+      const reply = `heard: ${userText}`;
+      speak(reply);
+      return reply;
+    }),
+    brainErrorCode: "test_brain_failed",
+    brainErrorHint: "the test brain broke",
+  });
+  return { ears, mic, mouth, events, session };
+}
+
+test("a user final runs the brain, hushes while speaking, listens after the queue drains", async () => {
+  const { ears, mouth, events } = loopFixture();
+  assert.deepEqual(ears.log, ["listen"]);
+
+  ears.handlers.onFinal("summon the cat");
+  await tick();
+  await tick();
+
+  assert.deepEqual(events.userFinals, ["summon the cat"]);
+  assert.deepEqual(events.assistantFinals, ["heard: summon the cat"]);
+  assert.deepEqual(mouth.spoken, ["heard: summon the cat"]);
+  // listen (start) → hush (mouth takes over) → listen (queue drained).
+  assert.deepEqual(ears.log, ["listen", "hush", "listen"]);
+  assert.deepEqual(events.errors, []);
+});
+
+test("empty and whitespace finals never reach the brain", async () => {
+  let brainCalls = 0;
+  const { ears, events } = loopFixture({
+    brain: async () => {
+      brainCalls += 1;
+      return "";
+    },
+  });
+  ears.handlers.onFinal("   ");
+  await tick();
+  assert.equal(brainCalls, 0);
+  assert.deepEqual(events.userFinals, []);
+});
+
+test("ears errors surface as VoiceConnectError with the engine's hint", () => {
+  const { ears, events } = loopFixture();
+  ears.handlers.onError("stt_permission_denied", "allow it in System Settings");
+  assert.equal(events.errors.length, 1);
+  assert.ok(events.errors[0] instanceof VoiceConnectError);
+  assert.equal(events.errors[0].message, "stt_permission_denied");
+  assert.equal(events.errors[0].hint, "allow it in System Settings");
+});
+
+test("mute hushes the ears and disables the mic; unmute listens again", () => {
+  const { ears, mic, session } = loopFixture();
+  session.setMuted(true);
+  assert.equal(mic.track.enabled, false);
+  assert.deepEqual(ears.log, ["listen", "hush"]);
+  session.setMuted(false);
+  assert.equal(mic.track.enabled, true);
+  assert.deepEqual(ears.log, ["listen", "hush", "listen"]);
+});
+
+test("close tears down ears, mouth, and mic tracks", async () => {
+  const { ears, mic, mouth, session } = loopFixture();
+  await session.close();
+  assert.ok(ears.log.includes("close"));
+  assert.deepEqual(mouth.spoken, ["<cancel>"]);
+  assert.deepEqual(mic.stopped, ["mic"]);
+});
+
+test("without injected ears and without a window engine the loop refuses with stt_unavailable", () => {
+  assert.equal(createWebSpeechEars(), null);
+  const mic = fakeMic();
+  assert.throws(
+    () =>
+      connectSpeechLoop({
+        mic: mic.stream,
+        callbacks: {
+          onUserTranscriptFinal: () => {},
+          onAssistantTranscriptFinal: () => {},
+          onPartialTranscript: () => {},
+          onError: () => {},
+          onDisconnect: () => {},
+        },
+        brain: async () => "",
+        brainErrorCode: "x",
+        brainErrorHint: "y",
+      }),
+    (err) => err instanceof VoiceConnectError && err.message === "stt_unavailable",
+  );
+});
+
+// ── createWebSpeechEars over a stubbed window.SpeechRecognition ────────────
+
+class FakeRecognition {
+  static instances = [];
+  constructor() {
+    this.started = 0;
+    this.stopped = 0;
+    this.onresult = null;
+    this.onerror = null;
+    this.onend = null;
+    FakeRecognition.instances.push(this);
+  }
+  start() {
+    this.started += 1;
+  }
+  stop() {
+    this.stopped += 1;
+  }
+}
+
+function withFakeWindow(fn) {
+  globalThis.window = { SpeechRecognition: FakeRecognition };
+  try {
+    return fn();
+  } finally {
+    delete globalThis.window;
+    FakeRecognition.instances = [];
+  }
+}
+
+test("web ears restart after a silence self-stop, but never after hush or close", () => {
+  withFakeWindow(() => {
+    const got = { finals: [], partials: [], errors: [] };
+    const ears = createWebSpeechEars()({
+      onPartial: (t) => got.partials.push(t),
+      onFinal: (t) => got.finals.push(t),
+      onError: (code) => got.errors.push(code),
+    });
+    const recognition = FakeRecognition.instances[0];
+
+    ears.listen();
+    assert.equal(recognition.started, 1);
+    // The engine stopped itself after silence — ears keep listening.
+    recognition.onend();
+    assert.equal(recognition.started, 2);
+
+    ears.hush();
+    recognition.onend?.();
+    assert.equal(recognition.started, 2, "hushed ears must not restart");
+
+    ears.listen();
+    assert.equal(recognition.started, 3);
+    ears.close();
+    assert.equal(recognition.onend, null);
+    assert.equal(recognition.stopped >= 2, true);
+  });
+});
+
+test("web ears route finals, partials, and non-routine errors", () => {
+  withFakeWindow(() => {
+    const got = { finals: [], partials: [], errors: [] };
+    const ears = createWebSpeechEars()({
+      onPartial: (t) => got.partials.push(t),
+      onFinal: (t) => got.finals.push(t),
+      onError: (code) => got.errors.push(code),
+    });
+    ears.listen();
+    const recognition = FakeRecognition.instances[0];
+
+    recognition.onresult({
+      resultIndex: 0,
+      results: [
+        { isFinal: false, 0: { transcript: "light the " } },
+        { isFinal: true, 0: { transcript: "light the candles " } },
+      ],
+    });
+    assert.deepEqual(got.partials, ["light the "]);
+    assert.deepEqual(got.finals, ["light the candles"]);
+
+    // Routine pauses stay silent; real failures surface with an stt_ code.
+    recognition.onerror({ error: "no-speech" });
+    recognition.onerror({ error: "aborted" });
+    assert.deepEqual(got.errors, []);
+    recognition.onerror({ error: "audio-capture" });
+    assert.deepEqual(got.errors, ["stt_audio-capture"]);
+  });
 });

--- a/src/lib/voice/speech-loop.ts
+++ b/src/lib/voice/speech-loop.ts
@@ -1,13 +1,17 @@
 // Shared client speech loop — the ears and mouth of a decomposed voice call.
 //
 // The local provider (local-loop.ts) established the shape: a voice call is
-// ears (SpeechRecognition) → brain (a swappable async turn) → mouth
-// (speechSynthesis), half-duplex so the mic never transcribes the
+// ears (a swappable SpeechEars engine) → brain (a swappable async turn) →
+// mouth (speechSynthesis), half-duplex so the mic never transcribes the
 // synthesizer. This module extracts that scaffold so any brain can plug in:
 //
 //   local     — POST /api/voice/local/chat (loopback Ollama / LM Studio)
 //   familiar  — a real chat turn through the familiar's own harness runtime
 //               (familiar-brain.ts), the "true voice" mode
+//
+// Ears default to WebSpeech (SpeechRecognition, Chromium web builds); the
+// Tauri shell swaps in the native macOS engine (native-stt.ts) because
+// WKWebView ships no recognition engine.
 //
 // The mouth is an utterance QUEUE, not a single call: a streaming brain can
 // speak sentence-chunks as they arrive (latency win — the familiar starts
@@ -128,7 +132,82 @@ export function resolveSpeechRecognition(): (new () => SpeechRecognitionLike) | 
 }
 
 export const STT_UNAVAILABLE_HINT =
-  "This window has no speech recognition engine. Native on-device recognition and the sidecar Whisper engine are on the roadmap — until then, this voice mode needs a Chromium browser, or pick a cloud voice provider in Familiar Studio → Brain.";
+  "This window has no speech recognition engine. The desktop app hears through native macOS recognition; on the web this voice mode needs a Chromium browser. The sidecar Whisper engine is on the roadmap — or pick a cloud voice provider in Familiar Studio → Brain.";
+
+/** Callbacks the loop hands to an ears implementation. */
+export type SpeechEarsHandlers = {
+  onPartial(text: string): void;
+  onFinal(text: string): void;
+  /** Non-routine engine failure; surfaced to the call as a VoiceConnectError. */
+  onError(code: string, hint?: string): void;
+};
+
+/** The ears half of the loop — a swappable capture+transcribe engine.
+ *  `listen()` and `hush()` are idempotent; the loop owns WHEN to listen
+ *  (half-duplex policy), the ears own HOW (WebSpeech today, the native
+ *  macOS SFSpeechRecognizer engine in the Tauri shell, sidecar Whisper
+ *  later). An ears implementation that stops itself (silence timeouts,
+ *  one-shot recognition tasks) must restart while it is in the listening
+ *  state, and must never restart after `hush()`/`close()`. */
+export type SpeechEars = {
+  listen(): void;
+  hush(): void;
+  close(): void;
+};
+
+export type SpeechEarsFactory = (handlers: SpeechEarsHandlers) => SpeechEars;
+
+/** WebSpeech ears — SpeechRecognition where the WebView has it (Chromium
+ *  web builds). Returns null when this window has no engine. */
+export function createWebSpeechEars(): SpeechEarsFactory | null {
+  const Recognition = resolveSpeechRecognition();
+  if (!Recognition) return null;
+  return (handlers) => {
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang =
+      typeof navigator !== "undefined" ? navigator.language || "en-US" : "en-US";
+    let wanted = false;
+
+    recognition.onresult = (event) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const transcript = result[0]?.transcript ?? "";
+        if (!transcript.trim()) continue;
+        if (result.isFinal) handlers.onFinal(transcript.trim());
+        else handlers.onPartial(transcript);
+      }
+    };
+    recognition.onerror = (event) => {
+      // "no-speech" and "aborted" are routine pauses, not call failures.
+      if (event.error === "no-speech" || event.error === "aborted") return;
+      handlers.onError(`stt_${event.error ?? "failed"}`);
+    };
+    // Recognition engines stop themselves after silence — keep listening.
+    recognition.onend = () => {
+      if (wanted) {
+        try { recognition.start(); } catch { /* already started */ }
+      }
+    };
+
+    return {
+      listen() {
+        wanted = true;
+        try { recognition.start(); } catch { /* already started */ }
+      },
+      hush() {
+        wanted = false;
+        try { recognition.stop(); } catch { /* already stopped */ }
+      },
+      close() {
+        wanted = false;
+        recognition.onend = null;
+        try { recognition.stop(); } catch { /* already stopped */ }
+      },
+    };
+  };
+}
 
 export type SpeechLoopOptions = {
   mic: MediaStream;
@@ -137,6 +216,8 @@ export type SpeechLoopOptions = {
   voiceName?: string;
   /** Custom mouth (e.g. ElevenLabs TTS). Defaults to the system synthesizer. */
   mouth?: SpeechMouth;
+  /** Custom ears (e.g. the native macOS engine). Defaults to WebSpeech. */
+  ears?: SpeechEarsFactory;
   callbacks: VoiceCallbacks;
   brain: SpeechBrain;
   /** Machine code reported when the brain throws a non-VoiceConnectError. */
@@ -147,11 +228,12 @@ export type SpeechLoopOptions = {
 
 /**
  * Wire ears → brain → mouth into a LiveSession. Throws VoiceConnectError
- * (`stt_unavailable`) when the WebView has no recognition engine.
+ * (`stt_unavailable`) when no ears are supplied and the WebView has no
+ * recognition engine.
  */
 export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
-  const Recognition = resolveSpeechRecognition();
-  if (!Recognition) {
+  const earsFactory = opts.ears ?? createWebSpeechEars();
+  if (!earsFactory) {
     throw new VoiceConnectError("stt_unavailable", STT_UNAVAILABLE_HINT);
   }
   const { mic, callbacks } = opts;
@@ -167,17 +249,27 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
   let speaking = false;
   let onQueueDrained: (() => void) | null = null;
 
-  const recognition = new Recognition();
-  recognition.continuous = true;
-  recognition.interimResults = true;
-  recognition.lang = typeof navigator !== "undefined" ? navigator.language || "en-US" : "en-US";
+  const ears = earsFactory({
+    onPartial: (text) => {
+      if (!closed) callbacks.onPartialTranscript("user", text);
+    },
+    onFinal: (text) => {
+      if (closed || !text.trim()) return;
+      const trimmed = text.trim();
+      callbacks.onUserTranscriptFinal(trimmed);
+      void askBrain(trimmed);
+    },
+    onError: (code, hint) => {
+      if (!closed) callbacks.onError(new VoiceConnectError(code, hint));
+    },
+  });
 
   const listen = () => {
     if (closed || muted || speaking) return;
-    try { recognition.start(); } catch { /* already started */ }
+    ears.listen();
   };
   const hush = () => {
-    try { recognition.stop(); } catch { /* already stopped */ }
+    ears.hush();
   };
 
   const speakNext = () => {
@@ -255,36 +347,14 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
   };
 
   // ── Ears ───────────────────────────────────────────────────────────────────
-  recognition.onresult = (event) => {
-    if (closed) return;
-    for (let i = event.resultIndex; i < event.results.length; i++) {
-      const result = event.results[i];
-      const transcript = result[0]?.transcript ?? "";
-      if (!transcript.trim()) continue;
-      if (result.isFinal) {
-        const text = transcript.trim();
-        callbacks.onUserTranscriptFinal(text);
-        void askBrain(text);
-      } else {
-        callbacks.onPartialTranscript("user", transcript);
-      }
-    }
-  };
-  recognition.onerror = (event) => {
-    if (closed) return;
-    // "no-speech" and "aborted" are routine pauses, not call failures.
-    if (event.error === "no-speech" || event.error === "aborted") return;
-    callbacks.onError(new VoiceConnectError(`stt_${event.error ?? "failed"}`));
-  };
-  // Recognition engines stop themselves after silence — keep listening.
-  recognition.onend = () => { listen(); };
-
   listen();
 
   return {
     // The mouth is the system synthesizer, not a network audio track — the
-    // overlay's <audio> element gets a valid, silent stream.
-    inboundAudio: new MediaStream(),
+    // overlay's <audio> element gets a valid, silent stream. (Guarded for
+    // non-browser environments, where no element will ever play it.)
+    inboundAudio:
+      typeof MediaStream === "undefined" ? ({} as MediaStream) : new MediaStream(),
     setMuted(next: boolean) {
       muted = next;
       for (const track of mic.getAudioTracks()) track.enabled = !next;
@@ -293,8 +363,7 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
     },
     async close() {
       closed = true;
-      recognition.onend = null;
-      hush();
+      ears.close();
       utterances.length = 0;
       mouth.cancel();
       for (const track of mic.getAudioTracks()) track.stop();


### PR DESCRIPTION
## What

The packaged desktop app could not run the ears half of the speech loop — WKWebView ships no `SpeechRecognition`, so **local**, **familiar (true voice)**, and **ElevenLabs** voice calls all failed with `stt_unavailable`. This PR gives the Tauri shell native ears.

### Rust engine (`src-tauri/src/speech.rs`)
- `AVAudioEngine` mic tap → `SFSpeechAudioBufferRecognitionRequest` → `SFSpeechRecognizer` task; partial/final/error transcripts stream to the main webview as `speech-stt:event`.
- **On-device recognition is required whenever the Mac has the dictation model** — the local provider's promise is no-cloud. Machines without the model fall back to the system dictation service.
- All Speech objects live on the main thread (`run_on_main_thread` + thread-local); the audio-tap and result callbacks follow Apple's documented threading contract. Non-macOS targets compile a stub (`supported: false`) so the ubuntu `Rust check` passes.
- Commands: `speech_stt_available` / `start` / `finish` / `stop`, session-numbered so stale events from a torn-down task are dropped.

### TS seam (`speech-loop.ts` + `native-stt.ts`)
- Ears become a swappable `SpeechEars` interface (exact mirror of the existing `SpeechMouth` seam). WebSpeech remains the web default; `resolvePreferredEars()` swaps in the native engine inside the Tauri shell for all three speech-loop providers.
- **Endpointing lives in TS, not Rust**: a partial transcript unchanged for 1.2s ends the utterance (→ `speech_stt_finish` → `endAudio` → final), with a 30s runaway cap. Testable timer policy — 8 behavioral tests with injected bridge + timers.
- The ears seam also made `connectSpeechLoop` itself testable: 7 new loop-integration tests (half-duplex hush/listen ordering, mute, teardown, error surfacing) + 2 WebSpeech-ears tests.

### Permission surface
- `permissions/speech.toml` + default set (packaged origin) + new `loopback-speech` capability (dev/sidecar loopback), **main webview only**.
- `desktop-permissions.test.mjs` pins permission ↔ command ↔ invoke-handler ↔ JS-caller parity, the cross-language event channel name, and that the renderer can never name a capture device or model path.

### Packaging (the actual packaged-app unblock)
- `src-tauri/Info.plist`: `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` — macOS kills the process on first TCC use without them, which also affected the **existing** getUserMedia voice path in packaged builds.
- `src-tauri/Entitlements.plist` (wired via `bundle.macOS.entitlements`): `com.apple.security.device.audio-input` for the hardened-runtime notarized build.

## Verification
- `cargo check --locked` ✓, `cargo build` ✓ (Speech/AVFAudio linking), `cargo test tests::mobile_access_token` ✓
- `pnpm typecheck` ✓ · `pnpm test:app` 724 files ✓ · `pnpm test:api` 187 files ✓ (isolated $HOME; the elevenlabs tts vault test reads the real user vault and is env-flaky locally, pre-existing)
- desktop-permissions guard: 13/13 ✓ · check-tests-wired ✓
- ⚠️ Manual follow-up: a live mic session in the Tauri shell (`bash scripts/dev-app.sh` + Ollama) — automated coverage stops at the command/event contract.

Bead: cave-0ogg (goal: local-voice-engines). Sidecar Whisper/Piper engines remain tracked as cave-vony.