### PR TITLE
feat(chat): widen the conversation reading column to 64rem (cave-973a)

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -94,6 +94,15 @@ assert.match(
   /\.cave-chat-linear \{[^}]*--cave-chat-measure:\s*[\d.]+rem/,
   "the chat surface defines a shared reading measure token",
 );
+// Widened measure (cave-973a): 52rem read as cramped on desktop panes — the
+// column must stay at least 64rem so wide viewports aren't mostly empty flank.
+{
+  const measure = /--cave-chat-measure:\s*([\d.]+)rem/.exec(css);
+  assert.ok(
+    measure && Number(measure[1]) >= 64,
+    `the reading measure stays ≥ 64rem (got ${measure?.[1] ?? "none"})`,
+  );
+}
 const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearThread,

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2705,10 +2705,11 @@ details[open] > .cave-tool-summary::before {
   /* Centered reading column (cave-xsq.1): the conversation + composer share one
      comfortable measure and sit in a centered column — the ChatGPT reading
      model — instead of spanning the full pane (reverses the 2026-06-18
-     full-width choice below). ~52rem ≈ a ~81ch line at 14px. The header stays a
-     full-bleed bar (its divider spans the pane); only the reading/writing column
-     is capped + centered. */
-  --cave-chat-measure: 52rem;
+     full-width choice below). Widened 52rem → 64rem (cave-973a): ~1024px,
+     ~100ch at 14px — wide panes waste less flank while the column still reads
+     as a column. The header stays a full-bleed bar (its divider spans the
+     pane); only the reading/writing column is capped + centered. */
+  --cave-chat-measure: 64rem;
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);


### PR DESCRIPTION
## What

Widens the chat session reading column: `--cave-chat-measure` 52rem → **64rem** (~832px → ~1024px, ~100ch at 14px) in `src/styles/cave-chat.css`.

The transcript and composer share this one token (cave-xsq.1), so both widen together and stay aligned; the header remains a full-bleed bar. The centered-column reading model is preserved — wide desktop panes just waste less flank.

## Why

User request: chat sessions read too narrow on wide viewports — at 1680px the conversation used ~830px with large empty gutters on both sides.

## Before / after (1680px viewport)

| 52rem (before) | 64rem (after) |
|---|---|
| thread 832px, ~55% of pane empty | thread 1024px, composer aligned |

## Pin

`message-bubble-code-header.test.ts` now asserts the measure stays **≥ 64rem** so the widening can't silently regress.

## Verification

- Built app (`pnpm build`) served + Playwright screenshot at 1680px: thread renders 1024px, composer aligned under the column
- 42 tests across the 30 suites that pin `cave-chat.css` — green
- `pnpm typecheck` — green

Bead: cave-973a