### PR TITLE
Research Desk minimum intent requirement + frontmatter tag dedupe

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15824,6 +15824,7 @@ button.research-plan-chip:focus-visible {
 .research-runtime-note, .research-mission-error { grid-column: 1 / -1; font-size: 10.5px; }
 .research-runtime-note { color: oklch(0.8 0.1 75); }
 .research-mission-error { color: var(--destructive, oklch(0.68 0.18 25)); }
+.research-intent-minimum { margin-top: 4px; font-size: 10.5px; color: var(--text-muted); }
 
 .research-desk__workspace {
   display: grid;

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/research-mission-routing";
 import {
   RESEARCH_BOUND_LIMITS,
+  RESEARCH_INTENT_MIN_LENGTH,
   RESEARCH_MISSION_MODES,
   type CreateResearchMissionInput,
   type ResearchBounds,
@@ -51,6 +52,8 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
   const inferred = useMemo(() => inferResearchMissionMode(intent), [intent]);
   const effectiveMode = mode === "auto" ? inferred.mode : mode;
   const plan = useMemo(() => defaultResearchPlan(effectiveMode), [effectiveMode]);
+  const trimmedIntent = intent.trim();
+  const intentTooShort = trimmedIntent.length > 0 && trimmedIntent.length < RESEARCH_INTENT_MIN_LENGTH;
 
   useEffect(() => {
     setBounds({ ...plan.bounds });
@@ -70,7 +73,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
   const start = async (event: React.FormEvent) => {
     event.preventDefault();
     const trimmed = intent.trim();
-    if (!trimmed || submitting) return;
+    if (trimmed.length < RESEARCH_INTENT_MIN_LENGTH || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -107,9 +110,18 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
           onChange={(event) => setIntent(event.target.value)}
           placeholder="Compare approaches, map a field, draft a paper, or run bounded experiments…"
           rows={3}
-          aria-invalid={Boolean(error)}
-          aria-describedby={error ? "research-mission-error" : "research-plan-review"}
+          aria-invalid={Boolean(error) || intentTooShort}
+          aria-describedby={error
+            ? "research-mission-error"
+            : intentTooShort
+              ? "research-intent-minimum"
+              : "research-plan-review"}
         />
+        {intentTooShort ? (
+          <p id="research-intent-minimum" className="research-intent-minimum">
+            Add at least {RESEARCH_INTENT_MIN_LENGTH} characters so the familiar has a real question to investigate.
+          </p>
+        ) : null}
       </div>
 
       <div className="research-mission-composer__controls">
@@ -131,7 +143,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
           size="sm"
           leadingIcon="ph:play"
           loading={submitting}
-          disabled={!intent.trim()}
+          disabled={trimmedIntent.length < RESEARCH_INTENT_MIN_LENGTH}
         >
           Start research
         </Button>

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -30,6 +30,18 @@ test("composer makes Auto routing and finite bounds reviewable", () => {
   assert.doesNotMatch(composer, /max=\{1440\}/);
 });
 
+test("composer enforces the shared minimum intent requirement", () => {
+  // Submit stays disabled and the guard bails until the trimmed intent meets
+  // the same RESEARCH_INTENT_MIN_LENGTH the server validator enforces.
+  assert.match(composer, /disabled=\{trimmedIntent\.length < RESEARCH_INTENT_MIN_LENGTH\}/);
+  assert.match(composer, /trimmed\.length < RESEARCH_INTENT_MIN_LENGTH \|\| submitting/);
+  // Too-short input explains itself accessibly instead of failing silently.
+  assert.match(composer, /id="research-intent-minimum"/);
+  assert.match(composer, /aria-invalid=\{Boolean\(error\) \|\| intentTooShort\}/);
+  assert.match(composer, /"research-intent-minimum"\s*:\s*"research-plan-review"/);
+  assert.match(css, /\.research-intent-minimum/);
+});
+
 test("plan chips are honest about interactivity", () => {
   // The three bound chips are buttons that open Review bounds and focus the
   // matching input…
@@ -172,7 +184,7 @@ test("polling is abortable, foreground-aware, and container responsive", () => {
 });
 
 test("forms expose errors and narrow outputs become keyboard tabs", () => {
-  assert.match(composer, /aria-invalid=\{Boolean\(error\)\}/);
+  assert.match(composer, /aria-invalid=\{Boolean\(error\) \|\| intentTooShort\}/);
   assert.match(composer, /role="alert"/);
   assert.match(ledger, /<Tabs<"artifacts" \| "sources">/);
   assert.match(ledger, /role="tabpanel"/);

--- a/src/lib/md-frontmatter.test.ts
+++ b/src/lib/md-frontmatter.test.ts
@@ -34,9 +34,10 @@ import {
   assert.deepEqual(parseMdDocument(out), doc, "stable round-trip");
 }
 
-// String tags normalize; malformed YAML degrades to body.
+// String tags normalize + dedupe; malformed YAML degrades to body.
 {
-  assert.deepEqual(parseMdDocument("---\ntags: a, b b\n---\nx").tags, ["a", "b", "b"]);
+  assert.deepEqual(parseMdDocument("---\ntags: a, b b\n---\nx").tags, ["a", "b"], "duplicates collapse");
+  assert.deepEqual(parseMdDocument("---\ntags: [brief, brief, notes]\n---\nx").tags, ["brief", "notes"]);
   const bad = parseMdDocument("---\n: [unclosed\n---\nbody");
   assert.equal(bad.hasFrontmatter, false, "malformed yaml → treated as body");
   assert.match(bad.body, /unclosed/);
@@ -62,5 +63,6 @@ import {
 // normalizeMdTags edge cases.
 assert.deepEqual(normalizeMdTags(undefined), []);
 assert.deepEqual(normalizeMdTags([1, " b ", ""]), ["1", "b"]);
+assert.deepEqual(normalizeMdTags(["a", "a", "b"]), ["a", "b"], "array tags dedupe");
 
 console.log("md-frontmatter.test: ok");

--- a/src/lib/md-frontmatter.ts
+++ b/src/lib/md-frontmatter.ts
@@ -14,7 +14,7 @@ export type MdDocument = {
   hasFrontmatter: boolean;
   /** `title:` frontmatter value, when present and a non-empty string. */
   title: string | null;
-  /** Normalized `tags:` list (array or comma/space separated string). */
+  /** Normalized, deduped `tags:` list (array or comma/space separated string). */
   tags: string[];
   /** Every other frontmatter key, preserved for round-tripping. */
   rest: Record<string, unknown>;
@@ -25,14 +25,16 @@ export type MdDocument = {
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
 export function normalizeMdTags(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map((t) => String(t).trim()).filter(Boolean);
-  if (typeof value === "string") {
-    return value
+  let tags: string[] = [];
+  if (Array.isArray(value)) tags = value.map((t) => String(t).trim()).filter(Boolean);
+  else if (typeof value === "string") {
+    tags = value
       .split(/[,\s]+/)
       .map((t) => t.trim())
       .filter(Boolean);
   }
-  return [];
+  // Dedupe (first occurrence wins): duplicate tags break React keys downstream.
+  return [...new Set(tags)];
 }
 
 /** Parse raw markdown (with optional YAML frontmatter) into an MdDocument.

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -9,6 +9,7 @@ import {
   describeResearchSchedule,
   normalizeResearchBounds,
   RESEARCH_BOUND_LIMITS,
+  RESEARCH_INTENT_MIN_LENGTH,
   researchBoundReadings,
   researchContinueLabel,
   researchIntentAddsContext,
@@ -126,6 +127,42 @@ test("mission creation validates familiar, intent, mode, and bounded input", () 
       bounds,
     }).ok,
     false,
+  );
+});
+
+test("intent below the minimum never launches a real session", () => {
+  const valid = {
+    familiarId: "sage",
+    mode: "brief",
+    modeSource: "auto",
+    deliverable: "brief",
+    bounds: {
+      wallClockMinutes: 20,
+      maxIterations: 1,
+      sourceTarget: 6,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+    },
+  };
+  // Accidental one-word launches are rejected even when everything else is valid.
+  const short = validateCreateResearchMissionInput({ ...valid, intent: "x" });
+  assert.equal(short.ok, false);
+  assert.match((short as { error: string }).error, /at least|between 8/i);
+  assert.equal(
+    validateCreateResearchMissionInput({ ...valid, intent: "abcdefg" }).ok,
+    false,
+    "7 chars is below the minimum",
+  );
+  // Whitespace padding cannot satisfy the minimum.
+  assert.equal(
+    validateCreateResearchMissionInput({ ...valid, intent: "  ab   " }).ok,
+    false,
+  );
+  // The boundary passes.
+  assert.equal(RESEARCH_INTENT_MIN_LENGTH, 8);
+  assert.equal(
+    validateCreateResearchMissionInput({ ...valid, intent: "a".repeat(RESEARCH_INTENT_MIN_LENGTH) }).ok,
+    true,
   );
 });
 

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -188,6 +188,12 @@ export type CreateResearchMissionResult =
 
 const FAMILIAR_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 
+/** Minimum meaningful research intent — blocks accidental one-word launches
+ *  that would still spend a real familiar session. Enforced by the create
+ *  validator (server) and the desk composer (client). */
+export const RESEARCH_INTENT_MIN_LENGTH = 8;
+export const RESEARCH_INTENT_MAX_LENGTH = 10_000;
+
 export function validateCreateResearchMissionInput(
   input: unknown,
 ): CreateResearchMissionResult {
@@ -200,8 +206,11 @@ export function validateCreateResearchMissionInput(
     return { ok: false, error: "invalid familiar id" };
   }
   const intent = typeof value.intent === "string" ? value.intent.trim() : "";
-  if (!intent || intent.length > 10_000) {
-    return { ok: false, error: "intent must be between 1 and 10000 characters" };
+  if (intent.length < RESEARCH_INTENT_MIN_LENGTH || intent.length > RESEARCH_INTENT_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `intent must be between ${RESEARCH_INTENT_MIN_LENGTH} and ${RESEARCH_INTENT_MAX_LENGTH} characters`,
+    };
   }
   if (!(RESEARCH_MISSION_MODES as readonly unknown[]).includes(value.mode)) {
     return { ok: false, error: "invalid research mode" };


### PR DESCRIPTION
## What

Two small correctness fixes from the same session:

### Research Desk: minimum intent requirement
Any non-empty intent (even `"x"`) could launch a real familiar research mission. Now a shared `RESEARCH_INTENT_MIN_LENGTH = 8` is enforced end-to-end:

- **Server** — `validateCreateResearchMissionInput` rejects trimmed intents under 8 chars (guards `POST /api/research/missions`); new `RESEARCH_INTENT_MAX_LENGTH` replaces the inline 10 000 literal.
- **Client** — the mission composer disables **Start research** below the minimum, bails in the submit guard, and shows an accessible hint (`aria-invalid`, `aria-describedby` → `#research-intent-minimum`).
- Retry/continue/automation re-runs operate on stored missions and are unaffected.

### MdEditor: dedupe frontmatter tags
Docs with repeated YAML tags (e.g. `tags: [brief, brief]`) crashed the Grimoire editor with duplicate React `key={tag}`. `normalizeMdTags` now dedupes (first occurrence wins); affected docs self-heal on save.

## Tests

- `research-missions.test.ts`: rejects 1-char/7-char/whitespace-padded intents even when everything else is valid; boundary at exactly 8 passes.
- `researcher-surface.test.ts`: pins composer wiring (disabled state, submit guard, hint id, aria attributes, CSS rule).
- `md-frontmatter.test.ts`: dedupe pins for string and array tag forms.

## Validation

- `pnpm typecheck` clean
- `pnpm test:app` — 731 test files green
- Targeted research + md-frontmatter + missions route tests pass
- Code review agent pass: no bypass paths, no consumers relying on duplicate tags, aria wiring verified