### PR TITLE
fix(crafts): describe-mode 'Preferred familiar' lists the full roster — roleless familiars included (cave-k75p)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -238,6 +238,7 @@ export const SUITES = {
     "src/lib/theme-token-hex.test.ts",
     "src/components/roles-tools-navigation.test.ts",
     "src/components/marketplace/crafts-marketplace.test.ts",
+    "src/components/marketplace/craft-create-drawer.test.ts",
     "src/lib/craft-agent-prompt.test.ts",
     "src/components/marketplace/skill-builder.test.ts",
     "src/lib/skill-templates.test.ts",

--- a/src/components/marketplace/craft-create-drawer.test.ts
+++ b/src/components/marketplace/craft-create-drawer.test.ts
@@ -1,0 +1,56 @@
+// The Craft create drawer has two familiar selects with different
+// contracts: describe mode dispatches an agentic build brief that ANY
+// familiar can take (roles not required — a fresh summon like kitty must be
+// offerable), while extract mode bundles existing roles and rightly lists
+// only familiars that have some. These pins hold that split (regression:
+// the describe dropdown used to be roles-derived, hiding roleless
+// familiars entirely).
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const drawer = await readFile(new URL("./craft-create-drawer.tsx", import.meta.url), "utf8");
+
+// Roster load: the full familiar list arrives from /api/familiars while the
+// drawer is open, and a failed fetch degrades to roles-derived options
+// instead of erroring the drawer.
+assert.match(
+  drawer,
+  /fetch\("\/api\/familiars", \{ cache: "no-store", signal: ctl\.signal \}\)/,
+  "the drawer loads the full familiar roster",
+);
+assert.match(
+  drawer,
+  /json\.familiars\.map\(\(f\) => f\.id\)\.filter\(\(id\): id is string => Boolean\(id\)\)/,
+  "roster ids are extracted defensively",
+);
+assert.match(
+  drawer,
+  /Roster is an enrichment; describe mode falls back to roles-derived/,
+  "a failed roster fetch is tolerated, not surfaced as a drawer error",
+);
+
+// Describe options = union(roster, roles familiars), so the list is never
+// SMALLER than the extract list even when the roster fetch failed.
+assert.match(
+  drawer,
+  /new Set\(\[\.\.\.rosterIds, \.\.\.roles\.map\(\(role\) => role\.familiar\)\]\)/,
+  "describe options union the roster with roles-derived familiars",
+);
+assert.match(
+  drawer,
+  /options=\{\[\{ value: "", label: "Let the familiar decide" \}, \.\.\.describeFamiliarOptions\]\}/,
+  "the describe-mode preferred-familiar select offers the full roster",
+);
+
+// Extract mode must stay roles-derived: there is nothing to extract from a
+// familiar with no roles (its dead-end is the teaching state, not an option).
+assert.match(
+  drawer,
+  /options=\{familiarOptions\}/,
+  "the extract-mode familiar select stays roles-derived",
+);
+assert.match(
+  drawer,
+  /No roles found for this familiar\. Roles are defined in the familiar studio/,
+  "a roleless familiar in extract mode lands on the teaching state",
+);

--- a/src/components/marketplace/craft-create-drawer.tsx
+++ b/src/components/marketplace/craft-create-drawer.tsx
@@ -83,6 +83,10 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
   const [mode, setMode] = useState<CreateMode>(initialCreateMode);
   const [step, setStep] = useState<ExtractStep>("select");
   const [roles, setRoles] = useState<RoleEntry[]>([]);
+  // Full familiar roster for describe mode: any familiar can take an agentic
+  // build brief, including ones with no roles yet (extract mode stays
+  // roles-derived — there is nothing to extract from a roleless familiar).
+  const [rosterIds, setRosterIds] = useState<string[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [familiar, setFamiliar] = useState("");
@@ -201,6 +205,22 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
     return () => ctl.abort();
   }, [open, rolesNonce]);
 
+  useEffect(() => {
+    if (!open) return;
+    const ctl = new AbortController();
+    fetch("/api/familiars", { cache: "no-store", signal: ctl.signal })
+      .then(async (res) => {
+        const json = (await res.json()) as { ok?: boolean; familiars?: Array<{ id?: string }> };
+        if (!json.ok || !Array.isArray(json.familiars)) return;
+        setRosterIds(json.familiars.map((f) => f.id).filter((id): id is string => Boolean(id)));
+      })
+      .catch(() => {
+        // Roster is an enrichment; describe mode falls back to roles-derived
+        // familiars, which is never worse than the extract list.
+      });
+    return () => ctl.abort();
+  }, [open]);
+
   // Teaching dead ends (docs/craft-ux.md F7): roles live in the familiar
   // studio's Brain tab — send the user there instead of stranding them.
   const openRoleStudio = useCallback(() => {
@@ -212,6 +232,15 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
   const familiarOptions = useMemo(
     () => [...new Set(roles.map((role) => role.familiar))].sort().map((id) => ({ value: id, label: id })),
     [roles],
+  );
+  // Describe mode lists every familiar (union survives a failed roster
+  // fetch); a roles-less familiar like a fresh summon is a valid builder.
+  const describeFamiliarOptions = useMemo(
+    () =>
+      [...new Set([...rosterIds, ...roles.map((role) => role.familiar)])]
+        .sort()
+        .map((id) => ({ value: id, label: id })),
+    [rosterIds, roles],
   );
   const visibleRoles = useMemo(
     () => roles.filter((role) => role.familiar === familiar),
@@ -437,7 +466,7 @@ export function CraftCreateDrawer({ open, onClose, onCreated, seed = null }: Pro
                 label="Preferred familiar"
                 value={familiar}
                 onChange={chooseFamiliar}
-                options={[{ value: "", label: "Let the familiar decide" }, ...familiarOptions]}
+                options={[{ value: "", label: "Let the familiar decide" }, ...describeFamiliarOptions]}
                 className="focus-ring craft-create-drawer__select"
               />
             </label>


### PR DESCRIPTION
## What

**User report (screenshot):** `kitty` missing from the *Preferred familiar (optional)* dropdown in the Craft create drawer.

**Cause:** both familiar selects derived their options from `/api/roles` — familiars with no roles yet never appeared. But describe mode dispatches an **agentic build brief** (`buildCraftAgentPrompt` → chat); any familiar can take that job, roles are not a prerequisite.

**Fix:**
- Drawer fetches `/api/familiars` while open; the describe dropdown offers `union(roster, roles-derived)` — a failed roster fetch degrades to exactly the previous list, never worse.
- **Extract mode intentionally stays roles-derived**: there is nothing to extract from a roleless familiar. Reaching extract with one selected (via mode switch) lands on the existing *No roles found for this familiar* teach state with the studio button.
- New `craft-create-drawer.test.ts` pins the split contract (roster fetch + defensive id extraction + tolerated failure, union options, describe vs extract select sources, teach state).

## Verification
- Targeted drawer tests ✓ · `pnpm typecheck` ✓ · `check-tests-wired` 990 ✓

Bead: cave-k75p.