### PR TITLE
feat(fleet): hide all Fleet buttons unless an Omnigent auth token is present

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -624,6 +624,7 @@ export const SUITES = {
     "src/lib/font-wiring.test.ts",
     "src/lib/cave-config.test.ts",
     "src/lib/omnigent/client.test.ts",
+    "src/lib/omnigent/fleet-gate.test.ts",
     "src/lib/omnigent/ward-preflight.test.ts",
     "src/lib/cave-config-state-race.test.ts",
     "src/lib/cave-config-write-race.test.ts",

--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -40,6 +40,9 @@ async function omnigentHostOptions(
   if (!config.omnigent.baseUrl || !config.omnigent.exposeHostsInComposer) return [];
   try {
     const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
+    // Fleet gate: no auth token (tokenless local mode) → no omnigent options
+    // in the chip. Mirrors isFleetTokenPresent in @/lib/omnigent/fleet-gate.
+    if (!client.authenticated || client.authMode === "none") return [];
     const hosts = await client.listHosts();
     return hosts.map((h) => {
       const online = (h.status ?? "").toLowerCase() === "online";

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -9,6 +9,7 @@ import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge, formatTimeoutBadge } from "@/components/ui/lifecycle-badge";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useFleetTokenEnabled } from "@/lib/omnigent/use-fleet-gate";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import type { GitHubItem } from "@/lib/github-tasks";
 import {
@@ -1315,6 +1316,8 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
   // when you actually need to dispatch/cancel or read the timestamps.
   const [lifecycleOpen, setLifecycleOpen] = useState(false);
   const [newLabel, setNewLabel] = useState("");
+  // Fleet buttons stay hidden without an Omnigent auth token (cave-cfvv).
+  const fleetEnabled = useFleetTokenEnabled();
 
   const session = sessions.find((s) => s.id === card.sessionId) ?? null;
   const moves = NEXT_MOVES[card.lifecycle] ?? [];
@@ -1591,32 +1594,34 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                     {chatLinking ? "Starting…" : chatLinkError ? "Retry" : "Start"}
                     <Icon name="ph:arrow-right-bold" width={11} />
                   </button>
-                  <button
-                    type="button"
-                    className="board-drawer-chat-cta"
-                    title="Run on Omnigent fleet"
-                    onClick={() => {
-                      void (async () => {
-                        const { startOmnigentRunFromBrowser } = await import("@/lib/omnigent/browser-run");
-                        const { openExternalUrl } = await import("@/lib/open-external");
-                        const result = await startOmnigentRunFromBrowser({
-                          prompt: card.title,
-                          familiarId: card.familiarId ?? undefined,
-                          boardCardId: card.id,
-                          title: card.title,
-                          source: "cave-board",
-                        });
-                        if (!result.ok) {
-                          window.alert(result.error);
-                          return;
-                        }
-                        void openExternalUrl(result.webUrl);
-                      })();
-                    }}
-                  >
-                    Fleet
-                    <Icon name="ph:desktop" width={11} />
-                  </button>
+                  {fleetEnabled ? (
+                    <button
+                      type="button"
+                      className="board-drawer-chat-cta"
+                      title="Run on Omnigent fleet"
+                      onClick={() => {
+                        void (async () => {
+                          const { startOmnigentRunFromBrowser } = await import("@/lib/omnigent/browser-run");
+                          const { openExternalUrl } = await import("@/lib/open-external");
+                          const result = await startOmnigentRunFromBrowser({
+                            prompt: card.title,
+                            familiarId: card.familiarId ?? undefined,
+                            boardCardId: card.id,
+                            title: card.title,
+                            source: "cave-board",
+                          });
+                          if (!result.ok) {
+                            window.alert(result.error);
+                            return;
+                          }
+                          void openExternalUrl(result.webUrl);
+                        })();
+                      }}
+                    >
+                      Fleet
+                      <Icon name="ph:desktop" width={11} />
+                    </button>
+                  ) : null}
                 </div>
               </div>
             )}

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -11,6 +11,7 @@ import { StandardSelect, type StandardSelectGroup } from "@/components/ui/select
 import { catalogForRuntime } from "@/lib/runtime-models";
 import { FamiliarAsanaSection } from "@/components/familiar-asana-section";
 import { IconButton } from "@/components/ui/icon-button";
+import { useFleetTokenEnabled } from "@/lib/omnigent/use-fleet-gate";
 import {
   DEFAULT_OPENAI_VOICE_ID,
   OPENAI_REALTIME_VOICES,
@@ -44,6 +45,8 @@ function runtimeLabel(runtimeId: string | null | undefined, harnesses: HarnessRe
 
 export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
+  // Fleet defaults card stays hidden without an Omnigent auth token (cave-cfvv).
+  const fleetEnabled = useFleetTokenEnabled();
   const [draftHarness, setDraftHarness] = useState(familiar.harnessOverride ?? "");
   const [draftModel, setDraftModel] = useState(familiar.model ?? "");
   // Explicit "Custom..." mode. Without this flag an empty draft is ambiguous:
@@ -516,6 +519,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
             </label>
           </section>
 
+          {fleetEnabled ? (
           <section className="familiar-studio-brain__card">
             <h3 className="familiar-studio-brain__card-title">Omnigent fleet</h3>
             <p className="familiar-studio-brain__hint">
@@ -606,6 +610,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
               </label>
             </div>
           </section>
+          ) : null}
 
           {toast ? <p className="familiar-studio-brain__toast">{toast}</p> : null}
         </div>

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -619,7 +619,7 @@ function OmnigentSettingsGroup() {
       </SettingControlRow>
       <SettingControlRow
         label="Show fleet in Host chip"
-        hint="When on, Chat and Home Host pickers list Omnigent hosts (omnigent:…) so a send can start a fleet session."
+        hint="When on — and an Omnigent auth token is present — Chat and Home Host pickers list Omnigent hosts (omnigent:…) so a send can start a fleet session. Without a token, no Fleet buttons appear anywhere."
       >
         <label className="flex items-center gap-2 text-[12px]">
           <input

--- a/src/lib/omnigent/fleet-gate.test.ts
+++ b/src/lib/omnigent/fleet-gate.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isFleetTokenPresent } from "./fleet-gate.ts";
+
+test("hidden when Omnigent is not configured", () => {
+  assert.equal(isFleetTokenPresent({ configured: false, authenticated: true, authMode: "jwt" }), false);
+  assert.equal(isFleetTokenPresent({}), false);
+});
+
+test("hidden for null/undefined status payloads", () => {
+  assert.equal(isFleetTokenPresent(null), false);
+  assert.equal(isFleetTokenPresent(undefined), false);
+});
+
+test("hidden for tokenless local mode even when status reports authenticated", () => {
+  // /api/omnigent/status reports authenticated=true for authMode "none" when
+  // the server is online — the gate must still hide Fleet UI without a token.
+  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode: "none" }), false);
+  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true }), false);
+});
+
+test("hidden when configured but no credential material resolved", () => {
+  assert.equal(isFleetTokenPresent({ configured: true, authenticated: false, authMode: "jwt" }), false);
+});
+
+test("shown for jwt, env, and databricks credential material", () => {
+  for (const authMode of ["jwt", "env", "databricks"]) {
+    assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode }), true);
+  }
+});

--- a/src/lib/omnigent/fleet-gate.ts
+++ b/src/lib/omnigent/fleet-gate.ts
@@ -1,0 +1,23 @@
+/**
+ * Fleet visibility gate.
+ *
+ * Fleet-launching UI — the board "Fleet" button, `omnigent:<host_id>` host-chip
+ * options, and the per-familiar fleet defaults card — must stay hidden unless
+ * the configured Omnigent server resolved real credential material (JWT, env
+ * token, or a Databricks pointer). Tokenless local mode (authMode "none")
+ * keeps the /api/omnigent/* proxies usable for API callers but surfaces no
+ * Fleet buttons anywhere.
+ */
+
+export type FleetGateStatus = {
+  configured?: boolean;
+  authenticated?: boolean;
+  authMode?: string;
+};
+
+/** True only when Omnigent is configured AND an auth token is present. */
+export function isFleetTokenPresent(status: FleetGateStatus | null | undefined): boolean {
+  if (!status?.configured) return false;
+  if ((status.authMode ?? "none") === "none") return false;
+  return status.authenticated === true;
+}

--- a/src/lib/omnigent/use-fleet-gate.ts
+++ b/src/lib/omnigent/use-fleet-gate.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { isFleetTokenPresent } from "./fleet-gate.ts";
+
+// One status probe per page load — gate callers (board drawer, familiar
+// studio) mount repeatedly and /api/omnigent/status does a remote health call.
+let cached: Promise<boolean> | null = null;
+
+function probeFleetToken(): Promise<boolean> {
+  cached ??= fetch("/api/omnigent/status", { cache: "no-store" })
+    .then((r) => r.json())
+    .then((j: unknown) => isFleetTokenPresent(j as Parameters<typeof isFleetTokenPresent>[0]))
+    .catch(() => false);
+  return cached;
+}
+
+/**
+ * True only when Omnigent is configured with an auth token — the condition
+ * for showing any Fleet button. Defaults to false (hidden) until proven.
+ */
+export function useFleetTokenEnabled(): boolean {
+  const [enabled, setEnabled] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    void probeFleetToken().then((v) => {
+      if (alive) setEnabled(v);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return enabled;
+}


### PR DESCRIPTION
## Summary

Per follow-up to #3231: **no Fleet-launching UI renders unless the configured Omnigent server resolves an auth token** (JWT in `~/.omnigent/auth_tokens.json`, `OMNIGENT_TOKEN` env, or a Databricks pointer). Tokenless local mode (`authMode: "none"`) keeps `/api/omnigent/*` proxies usable for API callers but shows no Fleet buttons anywhere.

**Gated surfaces**
- `omnigent:<host_id>` host-chip options (`/api/hosts` returns none without a token — covers Chat + Home composers)
- Board inspector **Fleet** run button
- Familiar Studio brain tab **Omnigent fleet** defaults card

**Stays visible:** Settings → Omnigent fleet group — it's where the server is configured and auth status is displayed; its toggle hint now documents the token requirement.

**Mechanics**
- `isFleetTokenPresent` pure predicate (`src/lib/omnigent/fleet-gate.ts`) — explicitly rejects `authMode: "none"` even though `/api/omnigent/status` reports it as `authenticated` when online
- `useFleetTokenEnabled` hook — hidden-by-default, one status probe per page load
- Server-side mirror in `/api/hosts` via `client.authenticated && authMode !== "none"`

## Test plan
- [x] `pnpm typecheck`
- [x] `src/lib/omnigent/fleet-gate.test.ts` (5 tests) — registered in run-tests.mjs
- [x] `node scripts/check-tests-wired.mjs`

Bead: cave-cfvv