### PR TITLE
fix(chat): backfill project_root for local-only chats so new chats group under their project (cave-9nj1)

### DIFF
--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -166,9 +166,13 @@ async function computeSessionsList(
     loadProjects(),
   ]);
   const localConversations = await listConversations();
+  // Backfill for local-only chat rows (UI chats the daemon never sees):
+  // map the conversation's recorded cwd to its registered project root so
+  // the sidebar's project groups pick new chats up immediately.
+  const projectRootForCwd = (cwd: string) => projectForRoot(cwd, projects)?.root ?? null;
   if (!res.ok || !res.data) {
     const localSessions = await applyAutoArchiveSweep(
-      localConversationSessionRows(localConversations, state, includeArchived),
+      localConversationSessionRows(localConversations, state, includeArchived, projectRootForCwd),
       state,
       includeArchived,
     );
@@ -206,6 +210,7 @@ async function computeSessionsList(
       state,
       includeArchived,
       isValidDaemonProjectRoot: isKnownProjectOrValidDir,
+      projectRootForCwd,
     }),
     state,
     includeArchived,

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -393,4 +393,52 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
   assert.equal(byId.get("local-branched")?.workBranch, "feat/local-work", "local-only rows carry their recorded branch too");
 }
 
+// Project backfill (cave-9nj1): sidebar/rail project groups key on
+// project_root, and UI chats exist only as local conversations — so a row's
+// project_root must be backfilled from the conversation's recorded runtime
+// cwd ("local:<cwd>") when that cwd maps to a registered project. Chats in a
+// familiar workspace / unregistered dir (and ssh runtimes) stay "" so they
+// keep landing in the "No project" bucket.
+{
+  const bareState = { sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {} };
+  const projectRootForCwd = (cwd) => (cwd === "/Users/example/repo" ? "/Users/example/repo" : null);
+  const conv = (sessionId, runtime) => ({
+    sessionId,
+    familiarId: "nova",
+    harness: "codex",
+    title: "Chat",
+    updatedAt: "2026-06-08T20:05:00.000Z",
+    ...(runtime ? { runtime } : {}),
+  });
+  const rows = localConversationSessionRows(
+    [
+      conv("in-project", "local:/Users/example/repo"),
+      conv("workspace", "local:/Users/example/.coven/workspaces/familiars/nova"),
+      conv("remote", "ssh:host:/srv/repo"),
+      conv("no-runtime"),
+    ],
+    bareState,
+    false,
+    projectRootForCwd,
+  );
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  assert.equal(byId.get("in-project")?.project_root, "/Users/example/repo", "registered-project cwd backfills project_root");
+  assert.equal(byId.get("workspace")?.project_root, "", "unregistered cwd (familiar workspace) stays No-project");
+  assert.equal(byId.get("remote")?.project_root, "", "ssh runtimes have no local project root");
+  assert.equal(byId.get("no-runtime")?.project_root, "", "conversations without a runtime stay No-project");
+
+  const mergedBackfill = mergeSessionRows({
+    daemonSessions: [],
+    localConversations: [conv("in-project", "local:/Users/example/repo")],
+    state: bareState,
+    includeArchived: false,
+    projectRootForCwd,
+  });
+  assert.equal(
+    mergedBackfill[0]?.project_root,
+    "/Users/example/repo",
+    "mergeSessionRows threads the resolver through to local-only rows",
+  );
+}
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -32,11 +32,24 @@ type MergeOptions = {
   state: CaveState;
   includeArchived: boolean;
   isValidDaemonProjectRoot?: (projectRoot: string) => boolean;
+  /** Map a local conversation's recorded cwd to a registered project root
+   *  (null = no registered project). See localConversationToSession. */
+  projectRootForCwd?: (cwd: string) => string | null;
 };
+
+/** Extract the local cwd from a conversation runtime ("local:<cwd>").
+ *  Kept dependency-free here (rather than importing the server work-branch
+ *  helper) so this module stays pure and unit-testable. */
+function conversationLocalCwd(runtime: string | undefined): string | null {
+  if (!runtime?.startsWith("local:")) return null;
+  const cwd = runtime.slice("local:".length).trim();
+  return cwd || null;
+}
 
 function localConversationToSession(
   conv: LocalConversationSummary,
   state: CaveState,
+  projectRootForCwd?: (cwd: string) => string | null,
 ): SessionRow {
   const keep = Boolean(state.sessionKeep?.[conv.sessionId]);
   const extendedUntil = state.sessionArchiveExtendedUntil?.[conv.sessionId] ?? null;
@@ -44,9 +57,17 @@ function localConversationToSession(
     state.sessionTitles[conv.sessionId] ?? sanitizeSessionTitle(conv.title) ?? "Chat";
   const familiarId = state.sessionFamiliar[conv.sessionId] ?? conv.familiarId ?? null;
   const status = conv.status ?? "completed";
+  // Sidebar/rail project groups key on project_root. A UI chat only exists as
+  // a local conversation (the daemon never sees it), so without this backfill
+  // every new chat lands in the "No project" bucket instead of its project's
+  // folder. Only registered-project cwds map — a chat running in the
+  // familiar's own workspace (or any unregistered dir) stays No-project by
+  // design (see resolveChatProjectSelection in chat-projects.ts).
+  const cwd = conversationLocalCwd(conv.runtime);
+  const projectRoot = (cwd ? projectRootForCwd?.(cwd) : null) ?? "";
   return {
     id: conv.sessionId,
-    project_root: "",
+    project_root: projectRoot,
     harness: conv.harness ?? "chat",
     ...(conv.model ? { model: conv.model } : {}),
     ...(conv.runtime ? { runtime: conv.runtime } : {}),
@@ -74,9 +95,10 @@ export function localConversationSessionRows(
   localConversations: LocalConversationSummary[],
   state: CaveState,
   includeArchived: boolean,
+  projectRootForCwd?: (cwd: string) => string | null,
 ): SessionRow[] {
   return localConversations
-    .map((conv) => localConversationToSession(conv, state))
+    .map((conv) => localConversationToSession(conv, state, projectRootForCwd))
     .filter((row) => visibleSession(row, state, includeArchived))
     .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
 }
@@ -87,6 +109,7 @@ export function mergeSessionRows({
   state,
   includeArchived,
   isValidDaemonProjectRoot,
+  projectRootForCwd,
 }: MergeOptions): SessionRow[] {
   const seen = new Set<string>();
   const rows: SessionRow[] = [];
@@ -156,7 +179,7 @@ export function mergeSessionRows({
     if (visibleSession(row, state, includeArchived)) rows.push(row);
   }
 
-  for (const row of localConversationSessionRows(localConversations, state, includeArchived)) {
+  for (const row of localConversationSessionRows(localConversations, state, includeArchived, projectRootForCwd)) {
     if (seen.has(row.id)) continue;
     rows.push(row);
   }


### PR DESCRIPTION
## Problem

New chat sessions don't populate the project chats list in the sidepanel — they land in the **No project** bucket until/unless the coven daemon happens to track them.

**Root cause:** sidebar/rail project groups (`deriveChatProjectGroups`) key on `session.project_root`, but UI chats exist only as local conversation files. `localConversationToSession()` hardcoded `project_root: ""` (src/lib/session-list-merge.ts), while the conversation's cwd was only recorded as `runtime: "local:<cwd>"`.

## Fix

- `session-list-merge.ts`: parse the local cwd from `conv.runtime` and map it through an injected `projectRootForCwd` resolver; registered-project cwds backfill `project_root`, everything else stays `""`.
- `sessions/list/route.ts`: inject the resolver (`projectForRoot` over loaded projects) in both the merged and daemon-degraded paths.
- Familiar-workspace / unregistered cwds intentionally stay **No project** (matches `resolveChatProjectSelection` semantics); ssh runtimes untouched. Daemon-tracked rows keep their authoritative root.

Also fixes the project picker showing 'No project' for these chats, since it reads the same `project_root`.

## Verification

- `pnpm typecheck` clean
- `pnpm test:api`: 130 pass; sole failure is `voice/elevenlabs/tts` env test which fails identically on clean `origin/main` (pre-existing)
- New unit coverage in `session-list-merge.test.ts` (registered cwd, workspace cwd, ssh, no-runtime, merge passthrough)
- Route-source wiring tests pass with alias loader: session-project-scope, chat-list-pr-badge, task-archive-nudge-wiring, chat/workspace sidebar wiring

Bead: cave-9nj1