### PR TITLE
fix(projects): reject unsafe project roots

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { deleteProject, patchProject } from "@/lib/cave-projects";
+import { isAllowedNewProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +26,9 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     const trimmed = body.root.trim();
     if (trimmed.length === 0) {
       return NextResponse.json({ ok: false, error: "root cannot be empty" }, { status: 400 });
+    }
+    if (!isAllowedNewProjectRoot(trimmed)) {
+      return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
     }
     patch.root = trimmed;
   }

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -18,10 +18,13 @@ assert.match(listRoute, /isValidFamiliarId\(familiarId\)/, "GET /api/projects sh
 assert.match(listRoute, /filterProjectsForFamiliar\(projects, familiarId\)/, "GET /api/projects should filter projects server-side for familiars");
 assert.match(listRoute, /export async function POST\(req: Request\)/, "projects route should expose POST");
 assert.match(listRoute, /name and root are required/, "POST /api/projects should validate required fields");
+assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects should validate roots before persisting them");
+assert.match(listRoute, /root must be inside an allowed workspace/, "POST /api/projects should reject unsafe roots");
 assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 when creating");
 
 assert.match(itemRoute, /export async function PUT/, "project item route should expose PUT");
 assert.match(itemRoute, /export async function DELETE/, "project item route should expose DELETE");
+assert.match(itemRoute, /isAllowedNewProjectRoot\(trimmed\)/, "PUT /api/projects/[id] should validate root patches before persisting them");
 assert.match(itemRoute, /nothing to update/, "PUT /api/projects/[id] should reject empty patches");
 assert.match(itemRoute, /not found/, "project item route should return not-found errors");
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { isAllowedNewProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +33,9 @@ export async function POST(req: Request) {
   const root = String(body.root ?? "").trim();
   if (!name || !root) {
     return NextResponse.json({ ok: false, error: "name and root are required" }, { status: 400 });
+  }
+  if (!isAllowedNewProjectRoot(root)) {
+    return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
   }
 
   const project = await createProject({

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -47,7 +47,7 @@ try {
     }),
   );
 
-  const { resolveAllowedProjectPath } = await import("./project-paths.ts");
+  const { isAllowedNewProjectRoot, resolveAllowedProjectPath } = await import("./project-paths.ts");
   const legacy = path.join(process.env.COVEN_HOME, "workspace", "familiars", "sage");
 
   assert.equal(
@@ -60,6 +60,11 @@ try {
     resolveAllowedProjectPath(path.join(savedProjectRoot, "docs")),
     await realpath(path.join(savedProjectRoot, "docs")),
     "saved Cave project roots are allowed for file tree browsing",
+  );
+  assert.equal(
+    isAllowedNewProjectRoot(savedProjectRoot),
+    false,
+    "saved Cave projects must not expand the trusted base for new project registration",
   );
 
   // Research mission workspaces live under cave state, not a registered
@@ -101,6 +106,11 @@ try {
     resolveAllowedProjectPath(lateProjectRoot),
     await realpath(lateProjectRoot),
     "projects saved after startup are allowed without a server restart",
+  );
+  assert.equal(
+    isAllowedNewProjectRoot(lateProjectRoot),
+    false,
+    "late saved projects do not authorize more arbitrary project roots",
   );
 } finally {
   restoreEnv();

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -46,26 +46,29 @@ function savedCaveProjectRoots(): string[] {
 // research mission workspaces are created at runtime, and a snapshot taken at
 // import time silently rejected them ("invalid project root") until the next
 // server restart.
+function builtInProjectRoots(): string[] {
+  return [
+    process.env.WORKSPACE_ROOT,
+    process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
+    covenWorkspaceRoot(),
+    // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
+    process.env.OPENCLAW_WORKSPACE_ROOT,
+    path.join(homedir(), ".openclaw", "workspace"),
+    process.cwd(),
+    // Research mission workspaces host bounded research sessions and live
+    // under cave state rather than a registered project root.
+    researchMissionsRoot(),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .map(realpathOrResolve);
+}
+
+function uniqueRoots(roots: string[]): string[] {
+  return Array.from(new Set(roots));
+}
+
 function allowedProjectRoots(): string[] {
-  return Array.from(
-    new Set(
-      [
-        process.env.WORKSPACE_ROOT,
-        process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
-        covenWorkspaceRoot(),
-        // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
-        process.env.OPENCLAW_WORKSPACE_ROOT,
-        path.join(homedir(), ".openclaw", "workspace"),
-        process.cwd(),
-        // Research mission workspaces host bounded research sessions and live
-        // under cave state rather than a registered project root.
-        researchMissionsRoot(),
-        ...savedCaveProjectRoots(),
-      ]
-        .filter((value): value is string => Boolean(value))
-        .map(realpathOrResolve),
-    ),
-  );
+  return uniqueRoots([...builtInProjectRoots(), ...savedCaveProjectRoots().map(realpathOrResolve)]);
 }
 
 function isWithinRoot(candidate: string, root: string): boolean {
@@ -101,4 +104,9 @@ export function resolveAllowedProjectSubpath(value: string): { root: string; rel
 export function resolveAllowedProjectPath(value: string): string | null {
   const subpath = resolveAllowedProjectSubpath(value);
   return subpath ? path.join(subpath.root, subpath.relativePath) : null;
+}
+
+export function isAllowedNewProjectRoot(value: string): boolean {
+  const candidate = realpathOrResolve(normalizeLegacyCovenWorkspacePath(value));
+  return uniqueRoots(builtInProjectRoots()).some((root) => isWithinRoot(candidate, root));
 }


### PR DESCRIPTION
### Motivation

- Prevent saved Cave project roots from immediately expanding the server's trusted allowlist, which allowed newly persisted arbitrary roots to become effective for file access and edits.
- Preserve dynamic resolution so saved projects and research mission workspaces remain browseable without granting them the ability to authorize new project registrations.

### Description

- Separate built-in trusted roots from saved Cave project roots by adding `builtInProjectRoots()` and `uniqueRoots()` and keeping saved roots for resolution only in `allowedProjectRoots()`.
- Add `isAllowedNewProjectRoot(value: string)` to validate new or updated project roots only against the built-in trusted root set.
- Enforce the new guard in `POST /api/projects` and `PUT /api/projects/[id]` so creating or patching a project root rejects unsafe roots with a `403` error.
- Update tests to assert that saved projects remain browseable but do not expand the trusted base and that the routes validate roots before persisting (`src/lib/server/project-paths.test.ts` and `src/app/api/projects/route.test.ts`).

### Testing

- Ran `pnpm typecheck` and it completed successfully.
- Ran `pnpm test:api`; the modified tests (`src/lib/server/project-paths.test.ts` and `src/app/api/projects/route.test.ts`) executed and passed, while the full API test suite later failed due to a missing system `zstd` dependency in `scripts/sidecar-archive-manifest.test.mjs` in this environment.
- Verified the new `isAllowedNewProjectRoot` guard is exported and exercised by the updated `POST`/`PUT` handlers via the added assertions in the route tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56f93738c483278344715efed03afb)