### PR TITLE
fix(flows): preserve hub routing for copilot sessions

### DIFF
--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -36,4 +36,10 @@ assert.match(
   "first non-local executable node should start as running until live markers arrive",
 );
 
+assert.match(
+  source,
+  /const hubAuthority = config\.multiHost\?\.mode === "hub";[\s\S]*binding\.harness === "copilot" && !sshBound && !hubAuthority/,
+  "direct copilot flow spawn must not bypass configured hub authority",
+);
+
 console.log("flow-executor.test.ts: ok");

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -187,12 +187,15 @@ export async function startFlowSession(
   // was not quoted"), which broke every copilot flow session, including
   // research-mission iterations. Chat answers the same daemon deficiency by
   // spawning the CLI directly with a real argv (cave-yesg); do the same here.
-  // Local runtimes only — SSH runtimes stay on the daemon path to the remote
-  // host. The run persists its transcript as a Cave conversation under the
+  // Local daemon authority only — hub mode must keep routing through
+  // callDaemon(), where daemonTargetForConfig/loadDaemonTarget preserve the
+  // configured hub execution boundary. SSH runtimes also stay on the daemon path
+  // to the remote host. The run persists its transcript as a Cave conversation under the
   // session id, which is where the flow transcript endpoint and the
   // research-mission reconcile already look first.
   const sshBound = "runtime" in binding && isSshRuntime(binding.runtime);
-  if (binding.harness === "copilot" && !sshBound) {
+  const hubAuthority = config.multiHost?.mode === "hub";
+  if (binding.harness === "copilot" && !sshBound && !hubAuthority) {
     const spec = copilotStreamSpec();
     if (spec) {
       const { sessionId } = startCopilotFlowRun({


### PR DESCRIPTION
### Motivation
- A recent direct-spawn fast path for Copilot flow sessions bypassed the configured hub daemon routing and could spawn a full-permission Copilot CLI locally when `multiHost.mode` is `"hub"`, allowing remote triggers to execute against the user's workstation.

### Description
- Gate the direct Copilot spawn fast path on daemon authority so it only runs when the config is not in hub mode by requiring `!hubAuthority` before calling `startCopilotFlowRun` in `src/lib/server/flow-executor.ts`.
- Clarified the surrounding comment to emphasize that hub-mode must continue to route through `callDaemon()`/daemon target resolution.
- Added a regression assertion in `src/lib/server/flow-executor.test.ts` to ensure the direct Copilot spawn does not bypass configured hub authority.

### Testing
- Ran `node --experimental-strip-types src/lib/server/flow-executor.test.ts` and the static regression check passed.
- Ran `git diff --check` as a quick validation and it passed without issues.
- Attempted to run `src/lib/server/flow-copilot-session.test.ts` but the test run failed in this environment due to missing runtime dependencies (`yaml` package) and Corepack/pnpm network provisioning, so the copilot-session integration tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a570e7cf6c08327b878a3e1fe4a70cd)