### PR TITLE
refactor(dashboard): extract per-familiar contract fetch into useFamiliarContracts hook (cave-hwux)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -648,6 +648,7 @@ export const SUITES = {
     "src/lib/composer-history.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/use-changes-summary.test.ts",
+    "src/lib/use-familiar-contracts.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
     "src/components/composer-density.test.ts",
     "src/lib/memory-rows.test.ts",

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -14,12 +14,14 @@ assert.match(page, /dr-page/, "dashboard should use the shared surface styling")
 const cockpitUrl = new URL("../components/dashboard/dashboard-cockpit.tsx", import.meta.url);
 assert.equal(existsSync(cockpitUrl), true, "DashboardCockpit component should exist");
 // The cockpit is split across the data/layout root, the presentational panel
-// layer, and the pure label helpers (cave-tsoz) — this contract covers the
-// whole surface, so read the split as one source.
+// layer, the pure label helpers (cave-tsoz), and the contract-fetch hook
+// (cave-hwux) — this contract covers the whole surface, so read the split as
+// one source.
 const cockpit = [
   readFileSync(cockpitUrl, "utf8"),
   readFileSync(new URL("../components/dashboard/cockpit-panels.tsx", import.meta.url), "utf8"),
   readFileSync(new URL("../lib/dashboard-cockpit-format.ts", import.meta.url), "utf8"),
+  readFileSync(new URL("../lib/use-familiar-contracts.ts", import.meta.url), "utf8"),
 ].join("\n");
 
 // The cockpit folds the original triage/summary zones in…
@@ -51,6 +53,11 @@ assert.match(cockpit, /deriveConfidenceScore/, "confidence reuses the shared sco
 assert.match(cockpit, /deriveGrowthReport/, "confidence composes the growth report for scoring");
 assert.match(cockpit, /\/api\/retro-runs/, "confidence pulls the shared retro-runs snapshot");
 assert.match(cockpit, /\/api\/familiars\/\$\{encodeURIComponent\(id\)\}\/contract/, "confidence pulls each familiar's contract");
+assert.match(
+  readFileSync(cockpitUrl, "utf8"),
+  /useFamiliarContracts\(data\.familiars\)/,
+  "the root sources contracts/retro through the extracted hook (cave-hwux), not an inline effect",
+);
 
 // ── Insights reframe: the dashboard leads with coven-wide analytics ──
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -23,8 +23,7 @@ import {
 import { deriveConfidenceScore, type ConfidenceScore } from "@/lib/familiar-confidence";
 import { deriveGrowthReport } from "@/lib/familiar-growth-signals";
 import { buildFamiliarCardStats, type FamiliarCardStats, type CovenMemoryEntry } from "@/components/familiars-view-stats";
-import type { ContractReport } from "@/lib/familiar-contract";
-import type { RetroRunsSnapshot } from "@/lib/retro-runs";
+import { useFamiliarContracts } from "@/lib/use-familiar-contracts";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
@@ -63,11 +62,6 @@ type CockpitData = {
 const EMPTY: CockpitData = { cards: [], familiars: [], github: [], upcoming: [], sessions: [], memory: [], space: [] };
 
 const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsLast7d: 0, hasActiveSession: false };
-
-// Contracts are fetched per-familiar; bound the fan-out for large covens. Rows
-// beyond the cap still show activity/health (which need no contract) — they
-// just read "—" for confidence.
-const CONTRACT_FETCH_CAP = 12;
 
 // A KPI tile's visual props plus the data plumbing the root owns: which trend
 // metric feeds its sparkline and which fetch source gates its loading state.
@@ -183,29 +177,11 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
 
   // ── Per-familiar contract fetch (bounded) + one shared retro-runs snapshot.
   //    Keyed on the visible familiar set; rows recompute from live sessions. ──
-  const [confidenceRaw, setConfidenceRaw] = useState<{
-    contractsById: Map<string, ContractReport | null>; snapshot: RetroRunsSnapshot | null;
-  } | null>(null);
-  const contractFams = data.familiars.slice(0, CONTRACT_FETCH_CAP);
-  const contractKey = contractFams.map((f) => f.id).join(",");
-  const contractFetchedCount = contractFams.length;
-  const contractFetchPartial = data.familiars.length > contractFetchedCount;
-  useEffect(() => {
-    if (!contractKey) { setConfidenceRaw(null); return; }
-    let alive = true;
-    const ids = contractKey.split(",");
-    void Promise.all([
-      getJson<{ snapshot?: RetroRunsSnapshot }>("/api/retro-runs"),
-      ...ids.map((id) => getJson<{ report?: ContractReport }>(`/api/familiars/${encodeURIComponent(id)}/contract`)),
-    ]).then(([retro, ...contracts]) => {
-      if (!alive || !aliveRef.current) return;
-      const contractsById = new Map<string, ContractReport | null>();
-      ids.forEach((id, i) => contractsById.set(id, contracts[i]?.report ?? null));
-      setConfidenceRaw({ contractsById, snapshot: retro?.snapshot ?? null });
-    });
-    return () => { alive = false; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contractKey]);
+  const {
+    contracts: confidenceRaw,
+    fetchedCount: contractFetchedCount,
+    partial: contractFetchPartial,
+  } = useFamiliarContracts(data.familiars);
 
   // ── Per-familiar insight rows (+ full confidence for the heatmap). Growth and
   //    activity derive from sessions/memory for every familiar; confidence only

--- a/src/lib/use-familiar-contracts.test.ts
+++ b/src/lib/use-familiar-contracts.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// useFamiliarContracts is the cockpit's confidence raw material: per-familiar
+// contract reports + the shared retro-runs snapshot, fanned out with a bound
+// so a large coven can't stampede the daemon (cave-hwux — extracted from the
+// dashboard-cockpit root's inline effect).
+const src = readFileSync(new URL("./use-familiar-contracts.ts", import.meta.url), "utf8");
+
+assert.match(src, /CONTRACT_FETCH_CAP = 12/, "contract fan-out stays bounded at 12 familiars");
+assert.match(
+  src,
+  /familiars\.slice\(0, CONTRACT_FETCH_CAP\)/,
+  "the cap truncates the familiar set before any URL is built",
+);
+assert.match(
+  src,
+  /partial = familiars\.length > fetchedCount/,
+  "`partial` is true exactly when the cap left familiars unscored — callers surface honest coverage",
+);
+assert.match(src, /\/api\/retro-runs/, "one shared retro-runs snapshot rides the same batch");
+assert.match(
+  src,
+  /`\/api\/familiars\/\$\{encodeURIComponent\(id\)\}\/contract`/,
+  "per-familiar contract endpoint, id URL-encoded",
+);
+assert.match(src, /cache: "no-store"/, "contract data is live — never the HTTP cache");
+// One effect-scoped cancelled guard covers both unmount and a key change; the
+// old inline version needed a second component-level aliveRef plus an
+// exhaustive-deps disable.
+assert.match(src, /let alive = true/, "effect-scoped cancelled guard exists");
+assert.match(src, /if \(!alive\) return/, "a stale batch (unmount or familiar-set change) is dropped");
+assert.match(src, /alive = false/, "cleanup cancels the in-flight batch");
+assert.doesNotMatch(src, /eslint-disable/, "no exhaustive-deps escape hatch — the key is the only dep");
+assert.match(src, /\}, \[key\]\);/, "refetch is keyed on the visible familiar-id set");
+assert.match(
+  src,
+  /if \(!key\)[\s\S]{0,40}setContracts\(null\)/,
+  "an empty roster resets to null instead of fetching",
+);
+// Failed fetches resolve null (never throw) so one bad familiar can't sink
+// the whole Promise.all batch.
+assert.match(src, /if \(!res\.ok\) return null/, "non-OK responses resolve null");
+assert.match(src, /catch \{\s*return null;/, "network errors resolve null");
+assert.match(src, /reports\[i\]\?\.report \?\? null/, "a missing report is stored as an explicit null row");
+
+console.log("use-familiar-contracts.test.ts: ok");

--- a/src/lib/use-familiar-contracts.ts
+++ b/src/lib/use-familiar-contracts.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ContractReport } from "@/lib/familiar-contract";
+import type { RetroRunsSnapshot } from "@/lib/retro-runs";
+
+/**
+ * Per-familiar contract reports + the shared retro-runs snapshot — the raw
+ * material for confidence scoring (dashboard cockpit heatmap/insight rows).
+ *
+ * Contracts are fetched per-familiar; the fan-out is bounded for large covens.
+ * Familiars beyond the cap still show activity/health (which need no
+ * contract) — they just read "—" for confidence. `partial` tells the caller
+ * to say so honestly (KPI coverage subs).
+ *
+ * Refetches when the visible familiar-id set changes; a stale in-flight batch
+ * for a previous set (or an unmounted tree) is dropped by the effect-scoped
+ * cancelled guard.
+ */
+export const CONTRACT_FETCH_CAP = 12;
+
+export type FamiliarContracts = {
+  contractsById: Map<string, ContractReport | null>;
+  snapshot: RetroRunsSnapshot | null;
+};
+
+async function getJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function useFamiliarContracts(familiars: readonly { id: string }[]): {
+  /** Null until the first batch lands (and when there are no familiars). */
+  contracts: FamiliarContracts | null;
+  /** How many familiars were actually fetched (≤ CONTRACT_FETCH_CAP). */
+  fetchedCount: number;
+  /** True when the cap left some familiars unscored. */
+  partial: boolean;
+} {
+  const [contracts, setContracts] = useState<FamiliarContracts | null>(null);
+  const capped = familiars.slice(0, CONTRACT_FETCH_CAP);
+  const key = capped.map((f) => f.id).join(",");
+  const fetchedCount = capped.length;
+  const partial = familiars.length > fetchedCount;
+
+  useEffect(() => {
+    if (!key) {
+      setContracts(null);
+      return;
+    }
+    let alive = true;
+    const ids = key.split(",");
+    void Promise.all([
+      getJson<{ snapshot?: RetroRunsSnapshot }>("/api/retro-runs"),
+      ...ids.map((id) => getJson<{ report?: ContractReport }>(`/api/familiars/${encodeURIComponent(id)}/contract`)),
+    ]).then(([retro, ...reports]) => {
+      if (!alive) return;
+      const contractsById = new Map<string, ContractReport | null>();
+      ids.forEach((id, i) => contractsById.set(id, reports[i]?.report ?? null));
+      setContracts({ contractsById, snapshot: retro?.snapshot ?? null });
+    });
+    return () => {
+      alive = false;
+    };
+  }, [key]);
+
+  return { contracts, fetchedCount, partial };
+}


### PR DESCRIPTION
## What

Extracts the cockpit root's inline contract/confidence fetch effect into `src/lib/use-familiar-contracts.ts`, per the `use-*.ts` hook convention.

## Why

The root (`dashboard-cockpit.tsx`) inlined a ~25-line effect that fanned out `GET /api/retro-runs` + capped per-familiar `GET /api/familiars/{id}/contract` requests, with **two** liveness guards (effect-local `alive` + component `aliveRef`) and an `eslint-disable react-hooks/exhaustive-deps`. Flagged in the dashboard-command-center audit as the remaining data-plumbing lump after the cave-tsoz split (#3165).

## How

- Hook owns `CONTRACT_FETCH_CAP` (12), the familiar-id key, the parallel batch, and **one** effect-scoped cancelled guard covering unmount + key change — the eslint-disable is gone.
- Returns `{ contracts, fetchedCount, partial }`; the root destructures to its existing names (`confidenceRaw` / `contractFetchedCount` / `contractFetchPartial`) so downstream derivation (perFamiliar rows, vitals, KPI coverage subs, `vitalsReady`) is byte-identical.
- No behavior change: same endpoints, same cap, same null-on-failure batching, same refetch keying.

## Tests

- `src/lib/use-familiar-contracts.test.ts` (registered in run-tests.mjs): pins cap, honest `partial` coverage, URL shapes, `no-store`, cancelled guard, no eslint escape hatch, null-on-failure rows.
- `dashboard-page.test.ts`: the cockpit-split contract now includes the hook source; new pin asserts the root consumes `useFamiliarContracts(data.familiars)`.
- Verified: 4 targeted test files pass, `pnpm typecheck` clean, `check-tests-wired` green.

Bead: cave-hwux · Goal: dashboard-command-center