### PR TITLE
fix(dashboard): needs-attention reads live from the poll + honest caught-up state (cave-456r)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -200,6 +200,26 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
   assert.match(inbox, /actedIdsRef\.current\.add\(item\.id\)/, "single actions register the acted id");
   assert.match(inbox, /ids\.forEach\(\(id\) => actedIdsRef\.current\.add\(id\)\)/, "bulk actions register acted ids");
 }
+// ── The model is live, not a first-paint fossil (cave-456r) ──────────────────
+// cave-bzch's adoption only matters if fresh props ever arrive: the server
+// model is just the seed — each poll pulls the full inbox and rebuilds the
+// model client-side, so cleared items leave, newly fired ones appear, and
+// caught-up flips truthfully.
+assert.match(cockpit, /getJson<\{ items: InboxItem\[\] \}>\("\/api\/inbox"\)/, "cockpit polls the full inbox (fired items included), not just status=pending");
+assert.match(cockpit, /if \(r\?\.items\) put\("inbox", r\.items\)/, "a failed inbox poll keeps the last known good list instead of flashing 'all clear'");
+assert.match(cockpit, /buildDashboardModel\(data\.inbox, new Date\(\)\)/, "each poll rebuilds the dashboard model from the live inbox");
+assert.match(cockpit, /i\.status === "pending"/, "agenda derivation keeps the pending filter the old query param provided");
+{
+  const inbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
+  // Caught up is a designed state: the section stays (stable grid slot, calm
+  // all-clear read) instead of vanishing — and the bare-widget mount means no
+  // outer Panel is left husking a stale count over an empty body.
+  assert.match(cockpit, /case "needs": return <ActionInbox initialItems=\{model\.needsAttention\} \/>;/, "needs widget mounts ActionInbox bare — no double chrome, no husk Panel");
+  assert.doesNotMatch(inbox, /if \(items\.length === 0\) return null/, "an empty list no longer unmounts the section");
+  assert.match(inbox, /All clear — nothing needs you right now\./, "caught-up renders an honest all-clear state");
+  assert.match(inbox, /caughtUp \? "ph:check-circle-bold" : "ph:warning-circle"/, "the section icon relaxes when caught up");
+  assert.match(inbox, /\{caughtUp \? null : <span className="dr-count">\{items\.length\}<\/span>\}/, "the live count hides at zero instead of reading 0");
+}
 // The workspace SSE 'updated' branch bails on content-equal echoes, so an
 // optimistic complete/dismiss/snooze doesn't trigger one redundant re-render
 // of every inboxItemsWithEphemeral consumer.

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -8,6 +8,7 @@ import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
 import { SnoozeMenu, minutesUntilTomorrowMorning, type SnoozeOption } from "@/components/snooze-menu";
+import { EmptyState } from "@/components/daily-report-ui";
 import { useAnnouncer } from "@/components/ui/live-region";
 
 type Action = "done" | "dismiss" | "snooze";
@@ -111,16 +112,19 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     }
   }
 
-  if (items.length === 0) return null;
+  // Caught up is a designed state, not a disappearance: keep the section (and
+  // the grid slot stable) with a calm all-clear read. Clearing the last item
+  // lands here immediately — the moment deserves better than a layout jump.
+  const caughtUp = items.length === 0;
 
   return (
     <section className="dr-section" aria-label="Needs you">
       <div className="dr-section__head">
         <h2 className="dr-section__title">
-          <Icon name="ph:warning-circle" aria-hidden />
+          <Icon name={caughtUp ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
           Needs you
         </h2>
-        <span className="dr-count">{items.length}</span>
+        {caughtUp ? null : <span className="dr-count">{items.length}</span>}
         {items.length > 1 ? (
           <button
             type="button"
@@ -166,6 +170,9 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
         </div>
       ) : null}
       <div className="dr-list">
+        {caughtUp ? (
+          <EmptyState icon="ph:check-circle-bold">All clear — nothing needs you right now.</EmptyState>
+        ) : null}
         {items.map((item) => {
           const whenIso = item.firedAt ?? item.updatedAt;
           const when = relativeTime(whenIso);

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import type { DashboardModel } from "@/lib/dashboard-model";
+import { buildDashboardModel, type DashboardModel } from "@/lib/dashboard-model";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { GitHubItem } from "@/lib/github-tasks";
@@ -53,13 +53,13 @@ type CockpitData = {
   cards: Card[];
   familiars: Familiar[];
   github: GitHubItem[];
-  upcoming: InboxItem[];
+  inbox: InboxItem[];
   sessions: SessionRow[];
   memory: CovenMemoryEntry[];
   space: SpaceUsageArea[];
 };
 
-const EMPTY: CockpitData = { cards: [], familiars: [], github: [], upcoming: [], sessions: [], memory: [], space: [] };
+const EMPTY: CockpitData = { cards: [], familiars: [], github: [], inbox: [], sessions: [], memory: [], space: [] };
 
 const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsLast7d: 0, hasActiveSession: false };
 
@@ -90,7 +90,7 @@ const TRENDS_KEY = "cave:cockpit:trends:v2";
 
 // ─── Root ───────────────────────────────────────────────────────────────────────
 
-export function DashboardCockpit({ model }: { model: DashboardModel }) {
+export function DashboardCockpit({ model: initialModel }: { model: DashboardModel }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick();    // keep the "Updated Nm ago" pill honest between polls
   const [data, setData] = useState<CockpitData>(EMPTY);
@@ -122,7 +122,11 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     };
     void getJson<{ cards: Card[] }>("/api/board").then((r) => put("cards", r?.cards ?? []));
     void getJson<{ familiars: Familiar[] }>("/api/familiars").then((r) => put("familiars", r?.familiars ?? []));
-    void getJson<{ items: InboxItem[] }>("/api/inbox?status=pending").then((r) => put("upcoming", r?.items ?? []));
+    // The needs-attention/caught-up read derives from this list — keep the
+    // last known good copy on a failed poll rather than flashing "all clear".
+    void getJson<{ items: InboxItem[] }>("/api/inbox").then((r) => {
+      if (r?.items) put("inbox", r.items);
+    });
     void getJson<{ sessions: SessionRow[] }>("/api/sessions/list").then((r) => put("sessions", r?.sessions ?? []));
     void getJson<{ entries: CovenMemoryEntry[] }>("/api/coven-memory").then((r) => put("memory", r?.entries ?? []));
     void getJson<{ areas: SpaceUsageArea[] }>("/api/space-usage").then((r) => put("space", r?.areas ?? []));
@@ -144,6 +148,17 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   useEffect(() => { load(); }, [load]);
   usePausablePoll(load, 30_000);
 
+  // The server-rendered model is only the first-paint seed — each poll
+  // rebuilds it from the fresh inbox so needs-attention/caught-up, today's
+  // report, and recent reports stay live. (The old frozen snapshot husked the
+  // needs panel: cleared items lingered ~forever, newly fired ones never
+  // appeared, and the count badge lied.)
+  const inboxReady = ready.has("inbox");
+  const model = useMemo(
+    () => (inboxReady ? buildDashboardModel(data.inbox, new Date()) : initialModel),
+    [inboxReady, data.inbox, initialModel],
+  );
+
   const now = model.date;
   const nowMs = now.getTime();
 
@@ -162,8 +177,8 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     (g) => g.kind === "review_request" || (g.kind === "pr" && g.state !== "closed"),
   );
 
-  const upcoming = data.upcoming
-    .filter((i) => i.kind === "reminder" && i.fireAt && new Date(i.fireAt).getTime() > nowMs)
+  const upcoming = data.inbox
+    .filter((i) => i.kind === "reminder" && i.status === "pending" && i.fireAt && new Date(i.fireAt).getTime() > nowMs)
     .sort((a, b) => new Date(a.fireAt!).getTime() - new Date(b.fireAt!).getTime())
     .slice(0, 5);
 
@@ -357,7 +372,6 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   };
 
   const isVisible = (id: string) => {
-    if (id === "needs") return !model.caughtUp;
     if (id === "signals") return signals.length > 0;
     if (id === "confidence") return heatmapRows.length > 0;
     return true;
@@ -376,10 +390,10 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
         <Panel title="Performance matrix" icon="ph:squares-four" href="/dashboard/familiars/growth">
           <ConfidencePanel rows={heatmapRows} />
         </Panel>);
-      case "needs": return model.caughtUp ? null : (
-        <Panel title="Needs attention" icon="ph:warning-circle" count={model.needsAttention.length}>
-          <ActionInbox initialItems={model.needsAttention} />
-        </Panel>);
+      // Bare like "today": ActionInbox owns its section chrome (title, live
+      // count, select toggle) — a wrapping Panel double-headered the widget
+      // and its frozen count husked after the last item was cleared.
+      case "needs": return <ActionInbox initialItems={model.needsAttention} />;
       case "board": return (
         <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">
           <BoardSnapshot byStatus={byStatus} total={data.cards.length} active={activeCards} loaded={ready.has("cards")} familiars={data.familiars} />
@@ -413,7 +427,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
         </Panel>);
       case "agenda": return (
         <Panel title="Up next" icon="ph:calendar-bold" count={upcoming.length || undefined} href="/?mode=calendar">
-          <AgendaPanel items={upcoming} now={now} loaded={ready.has("upcoming")} />
+          <AgendaPanel items={upcoming} now={now} loaded={ready.has("inbox")} />
         </Panel>);
       default: return null;
     }

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -21,7 +21,7 @@ export const DEFAULT_LAYOUT: Layout = {
 export const PANEL_TITLES: Record<string, string> = {
   usage: "Activity over time",
   signals: "Signals",
-  needs: "Needs attention",
+  needs: "Needs you",
   board: "Board",
   today: "Today summary",
   confidence: "Performance matrix",

--- a/tests/dashboard-cockpit.spec.ts
+++ b/tests/dashboard-cockpit.spec.ts
@@ -62,7 +62,7 @@ const SPACE_AREAS = [
   { id: "journal", label: "Journal", relPath: "~/.coven/journal", exists: false, bytes: 0, files: 0, lastModifiedMs: null, truncated: false },
 ];
 
-async function gotoDashboard(page: Page) {
+async function gotoDashboard(page: Page, inboxItems: unknown[] = []) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
@@ -73,7 +73,7 @@ async function gotoDashboard(page: Page) {
   await page.route("**/api/github/assigned", (route) => route.fulfill({ json: { items: GH_ASSIGNED } }));
   await page.route("**/api/space-usage", (route) => route.fulfill({ json: { ok: true, areas: SPACE_AREAS } }));
   await page.route("**/api/board", (route) => route.fulfill({ json: { cards: [] } }));
-  await page.route("**/api/inbox**", (route) => route.fulfill({ json: { items: [] } }));
+  await page.route("**/api/inbox**", (route) => route.fulfill({ json: { items: inboxItems } }));
   await page.route("**/api/coven-memory", (route) => route.fulfill({ json: { entries: [] } }));
   await page.route("**/api/retro-runs**", (route) => route.fulfill({ json: { snapshot: null } }));
   await page.goto("/dashboard");
@@ -154,4 +154,29 @@ test("signals dedupe same-URL PRs, lead with the stalest, and cap with an overfl
   const more = page.locator("a.cockpit-signal--more");
   await expect(more).toContainText("+2 more");
   await expect(more).toHaveAttribute("href", "/?mode=github");
+});
+
+// ── Needs you — live from the poll, honest when caught up (cave-456r) ────────
+// The model used to be a first-paint server snapshot: fired items appearing
+// after load never rendered, and clearing the last item husked the panel.
+// These pin the client-built model path end-to-end.
+
+test("caught up: the Needs you section stays, reading all clear", async ({ page }) => {
+  await gotoDashboard(page); // inbox mocked empty
+  const needs = page.locator('section[aria-label="Needs you"]');
+  await expect(needs).toBeVisible();
+  await expect(needs).toContainText("All clear — nothing needs you right now.");
+  await expect(needs.locator(".dr-count")).toHaveCount(0);
+});
+
+test("a fired reminder from the poll renders in Needs you with a live count", async ({ page }) => {
+  const nowIso = new Date(NOW).toISOString();
+  await gotoDashboard(page, [{
+    id: "r-fired", kind: "reminder", status: "fired", title: "Water the familiars",
+    createdAt: nowIso, updatedAt: nowIso, firedAt: nowIso, recurrence: "none", source: "user",
+  }]);
+  const needs = page.locator('section[aria-label="Needs you"]');
+  await expect(needs.locator(".dr-row__title")).toContainText("Water the familiars");
+  await expect(needs.locator(".dr-count")).toHaveText("1");
+  await expect(needs).not.toContainText("All clear");
 });


### PR DESCRIPTION
## What

Unfreezes the dashboard's needs-attention surface and gives caught-up a designed state.

## The bug

The cockpit polls its data sources every 30s, but the **DashboardModel is built once on the server** and never refreshed. Everything reading it froze at first paint:

- cave-bzch made `ActionInbox` adopt fresh `needsAttention` props — but fresh props never arrived (constant server prop identity), so the machinery idled.
- Items done/dismissed on other surfaces lingered on the dashboard until a full reload; reminders that fired after page load never appeared.
- `isVisible("needs")`, the panel count badge, and the "Needs you" KPI all reported the snapshot.
- Clearing the last item was the worst read: `ActionInbox` returned `null` but the frozen outer Panel stayed — a husk reading **"Needs attention 3"** over an empty body.
- Double chrome: the Panel header ("Needs attention" + count) wrapped ActionInbox's own "Needs you" section head (icon + count + Select).

## The fix

1. **Live model** — the server model is the first-paint seed; each poll pulls the **full** `/api/inbox` (fired items included — `?status=pending` missed them) and rebuilds the model client-side with `buildDashboardModel(items, new Date())`, memoized per poll. Today's report + recent reports unfreeze too. A **failed poll keeps the last known good list** instead of flashing "all clear". The agenda derivation keeps the `pending` filter the old query param provided.
2. **Single chrome, no husk** — the needs widget mounts `ActionInbox` bare (same precedent as `today`); the section owns its title/count/select, all live-local.
3. **Caught-up is a designed state** — the section stays (stable grid slot, no layout jump at the moment of triumph): check icon, count hidden at zero, calm *"All clear — nothing needs you right now."* `PANEL_TITLES.needs` → "Needs you" so drag announcements speak the visible name.

## Tests

- `dashboard-page.test.ts`: new live-model pin block (full-inbox poll, last-known-good guard, client rebuild, pending filter, bare mount, all-clear state, count-hides-at-zero).
- `tests/dashboard-cockpit.spec.ts` (e2e, daemon-less): two new tests — caught-up all-clear on an empty inbox, and a polled fired reminder rendering with a live count. **8/8 pass locally** (desktop project).
- Targeted node suites pass (dashboard-page, dashboard-model, cockpit-polish, cockpit-format, snooze-menu, a11y-audit, growth wiring); `pnpm typecheck` clean.

Bead: cave-456r · Goal: dashboard-command-center