### PR TITLE
feat(theme): add Snow — frost-blue palette ported from tweakcn Frosty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Features
+- **Theme: Snow** — a frost-blue palette ported from tweakcn's "Frosty" (powder-sky accents on midnight-navy ice in dark mode; near-white slate surfaces in light), joining the preset roster across desktop and iOS with soft 1rem-radius chrome. Light-mode primary/presence pairs, the destructive red, and the dark accent text are retuned to hold WCAG 2.1 AA per the theme contrast audit.
+
 ## [0.1.1] - 2026-07-15
 
 ### Features

--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -49,7 +49,7 @@ struct ThemeOption: Identifiable, Equatable {
 }
 
 enum ThemeRoster {
-    /// All 16 desktop presets, in the desktop's roster order.
+    /// All 20 desktop presets, in the desktop's roster order.
     static let all: [ThemeOption] = [
         .init("coven", "Coven", "Lavender-inked grimoire. The house default.",
               accentDark: "#9a8ecd", accentLight: "#6F62A8", bgDark: "#08060f", bgLight: "#f7f5fe"),
@@ -83,6 +83,8 @@ enum ThemeRoster {
               accentDark: "#1d7449", accentLight: "#279c6b", bgDark: "#121212", bgLight: "#fcfcfc"),
         .init("trucker", "Trucker", "Roadside evergreen, blacktop panels, cab lights.",
               accentDark: "#21704a", accentLight: "#005735", bgDark: "#020504", bgLight: "#f5fcf9"),
+        .init("snow", "Snow", "First-snow hush. Powder-blue over midnight ice.",
+              accentDark: "#4aade5", accentLight: "#1b6ca8", bgDark: "#03152d", bgLight: "#f8fafc"),
         .init("contrast", "High Contrast", "Maximum-legibility ward. Nothing whispered.",
               accentDark: "#ffd60a", accentLight: "#0f62fe", bgDark: "#000000", bgLight: "#ffffff"),
         .init("beacon", "Beacon", "Signal-fire blue-orange; colorblind-considerate.",

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -80,13 +80,14 @@ color.
   `:focus-visible` via the `.focus-ring` / `.focus-ring-inset` utilities.
 
 ### Theming
-`data-theme` (16 palettes: coven, tide, grove, ember, bloom, dusk, mist, hex,
-bane, slate, ghosty, claymorphism, claude, pastel-dreams, meatseeks, trucker)
+`data-theme` (20 palettes: coven, tide, grove, ember, bloom, dusk, mist, hex,
+bane, slate, ghosty, claymorphism, claude, pastel-dreams, meatseeks, trucker,
+snow, contrast, beacon, solstice)
 × `data-mode` (dark/light) are orthogonal attributes on `:root`, hydrated by
 `theme-script.tsx`. External shadcn themes import via tweakcn and are enriched
 with the Cave's derived semantic tokens (`settings-shell.tsx` →
 `enrichTweakcnTheme`). **Consequence: never hardcode a color; every surface
-must survive all 32 palette×mode combinations.**
+must survive all 40 palette×mode combinations.**
 
 ## 3. Signature idioms
 

--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -194,7 +194,7 @@
 
   try {
     var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
-    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","pastel-dreams","meatseeks","trucker","contrast","beacon","solstice","custom"];
+    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","pastel-dreams","meatseeks","trucker","snow","contrast","beacon","solstice","custom"];
     var theme = String(stored("coven-theme", themePrefs.id || "coven"));
     if (rename[theme]) theme = rename[theme];
     if (!isChoice(theme, valid)) theme = "coven";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4326,6 +4326,98 @@ html[data-backdrop-on] .glass-overlay {
   --chart-5: #a8f0cc;
 }
 
+/* ---- Snow (tweakcn "Frosty") — powder-blue light over midnight ice ----
+   Ported from https://tweakcn.com/themes/cmrm843zo000304jm0x7la5rk with
+   AA fixes: light primary/presence text pairs flipped to navy-on-sky or
+   deepened to #1b6ca8, destructive darkened, dark accent-foreground
+   brightened a step — see theme-contrast-audit.test.ts. */
+[data-theme="snow"] {
+  --font-sans: var(--font-manrope), "Plus Jakarta Sans", ui-sans-serif, system-ui, sans-serif;
+  --radius: 1rem;
+  --radius-control: 12px;
+  --radius-card: 16px;
+  --radius-panel: 20px;
+  --shadow-color: #000000;
+  --shadow-popover: 0 8px 20px 0 #00000066;
+  --cave-reading-leading: 1.6;
+  --cave-reading-tracking: 0;
+  --cave-reading-weight: 400;
+  --background: #03152d;
+  --foreground: #f8fafc;
+  --card: #0a1e36;
+  --card-foreground: #f8fafc;
+  --popover: #0a1e36;
+  --popover-foreground: #f8fafc;
+  --primary: #2f658e;
+  --primary-foreground: #ffffff;
+  --secondary: #162e4a;
+  --secondary-foreground: #f8fafc;
+  --muted: #0d2542;
+  --muted-foreground: #94a3b8;
+  --accent: #1e3a5f;
+  --accent-foreground: #5eb8ea;
+  --destructive: #991b1b;
+  --destructive-foreground: #ffffff;
+  --border: #1e293b;
+  --input: #1e293b;
+  --ring: #4aade5;
+  --accent-presence: #4aade5;
+  --accent-presence-foreground: #03152d;
+  --accent-presence-soft: color-mix(in oklch, #4aade5 78%, transparent);
+  --accent-faint: color-mix(in oklch, #4aade5 14%, transparent);
+  --bg-base: var(--background);
+  --bg-panel: #020d1c;
+  --bg-raised: var(--card);
+  --bg-elevated: var(--secondary);
+  --bg-hover: var(--accent);
+  --border-strong: #4a7099;
+  --ring-focus: color-mix(in oklch, #4aade5 55%, var(--foreground) 45%);
+  --chart-1: #4aade5;
+  --chart-2: #38bdf8;
+  --chart-3: #0ea5e9;
+  --chart-4: #f8fafc;
+  --chart-5: #475569;
+}
+[data-theme="snow"][data-mode="light"] {
+  --shadow-color: #03152d;
+  --shadow-popover: 0 4px 16px 0 #03152d0a;
+  --background: #f8fafc;
+  --foreground: #03152d;
+  --card: #ffffff;
+  --card-foreground: #03152d;
+  --popover: #ffffff;
+  --popover-foreground: #03152d;
+  --primary: #4aade5;
+  --primary-foreground: #03152d;
+  --secondary: #e0f2fe;
+  --secondary-foreground: #03152d;
+  --muted: #f1f5f9;
+  --muted-foreground: #475569;
+  --accent: #f0f9ff;
+  --accent-foreground: #1b6ca8;
+  --destructive: #b91c1c;
+  --destructive-foreground: #ffffff;
+  --border: #e2e8f0;
+  --input: #f1f5f9;
+  --ring: #1b6ca8;
+  --accent-presence: #1b6ca8;
+  --accent-presence-foreground: #ffffff;
+  --accent-presence-soft: color-mix(in oklch, #4aade5 78%, transparent);
+  --accent-faint: color-mix(in oklch, #4aade5 14%, transparent);
+  --bg-base: var(--background);
+  --bg-panel: #ffffff;
+  --bg-raised: var(--card);
+  --bg-elevated: var(--secondary);
+  --bg-hover: var(--accent);
+  --border-strong: #64748b;
+  --ring-focus: color-mix(in oklch, #1b6ca8 55%, var(--foreground) 45%);
+  --chart-1: #4aade5;
+  --chart-2: #03152d;
+  --chart-3: #0ea5e9;
+  --chart-4: #7dd3fc;
+  --chart-5: #cbd5e1;
+}
+
 /* ---- Slate (ink-and-bone 270) — no color, no mercy ---- */
 [data-theme="slate"] {
   --background: oklch(0.05 0.000 0);

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -51,7 +51,7 @@ console.log("globals.css.test.ts (task 3) OK");
 const otherThemes = [
   "tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate",
   "ghosty", "claymorphism", "claude", "pastel-dreams", "meatseeks", "trucker",
-  "contrast", "beacon", "solstice",
+  "snow", "contrast", "beacon", "solstice",
 ];
 for (const id of otherThemes) {
   const darkRe = new RegExp(`\\[data-theme="${id}"\\]\\s*\\{`);

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -95,7 +95,7 @@ for (const legacy of ["mood-c", "sky", "orchid", "midnight"]) {
 for (const id of [
   "coven", "tide", "grove", "ember", "bloom", "dusk", "mist", "hex",
   "bane", "slate", "ghosty", "claymorphism", "claude", "pastel-dreams",
-  "meatseeks", "trucker", "contrast", "beacon", "solstice", "custom",
+  "meatseeks", "trucker", "snow", "contrast", "beacon", "solstice", "custom",
 ]) {
   assert.ok(bootScript.includes(`"${id}"`), `pre-paint theme allowlist contains ${id}`);
 }

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import { THEME_IDS, THEME_META, getSwatches } from "./theme-palettes.ts";
 import { LEGACY_THEME_RENAME, COVEN_THEME_KEY, COVEN_MODE_KEY } from "./theme-storage.ts";
 
-// 19 themes, coven is the default (first).
-assert.equal(THEME_IDS.length, 19);
+// 20 themes, coven is the default (first).
+assert.equal(THEME_IDS.length, 20);
 assert.equal(THEME_IDS[0], "coven");
 assert.deepEqual(
   [...THEME_IDS].sort(),
@@ -25,6 +25,7 @@ assert.deepEqual(
     "mist",
     "pastel-dreams",
     "slate",
+    "snow",
     "solstice",
     "tide",
     "trucker",
@@ -77,6 +78,9 @@ assert.equal(THEME_META.meatseeks.name, "Meatseeks");
 assert.equal(THEME_META.trucker.name, "Trucker");
 assert.equal(THEME_META.trucker.accentDark, "#21704a");
 assert.equal(THEME_META.trucker.accentLight, "#005735");
+assert.equal(THEME_META.snow.name, "Snow");
+assert.equal(THEME_META.snow.accentDark, "#4aade5");
+assert.equal(THEME_META.snow.accentLight, "#1b6ca8");
 assert.equal(THEME_META.contrast.name, "High Contrast");
 assert.equal(THEME_META.contrast.accentDark, "#ffd60a");
 assert.equal(THEME_META.contrast.accentLight, "#0f62fe");

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -1,5 +1,5 @@
 /**
- * 19-theme roster metadata + swatch lookup for the appearance settings UI.
+ * 20-theme roster metadata + swatch lookup for the appearance settings UI.
  * The actual palette CSS lives in `src/app/globals.css`; this module
  * mirrors the accent values and a representative background swatch
  * per (theme, mode) so the settings grid can preview each card.
@@ -28,6 +28,7 @@ export const THEME_IDS = [
   "pastel-dreams",
   "meatseeks",
   "trucker",
+  "snow",
   "contrast",
   "beacon",
   "solstice",
@@ -142,6 +143,12 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     description: "Roadside evergreen, blacktop panels, and clean cab lights.",
     hue: 156, accentDark: "#21704a", accentLight: "#005735",
     bgDark: "#020504", bgLight: "#f5fcf9",
+  },
+  snow: {
+    name: "Snow",
+    description: "First-snow hush. Powder-blue light over midnight ice.",
+    hue: 237, accentDark: "#4aade5", accentLight: "#1b6ca8",
+    bgDark: "#03152d", bgLight: "#f8fafc",
   },
   contrast: {
     name: "High Contrast",


### PR DESCRIPTION
## What

Adds **Snow**, the 20th preset theme, ported from tweakcn's ["Frosty"](https://tweakcn.com/themes/cmrm843zo000304jm0x7la5rk): powder-sky accent (`#4aade5`) over midnight-navy ice (`#03152d`) in dark mode, near-white slate surfaces (`#f8fafc`) in light, soft 1rem-radius chrome, Manrope sans (closest loaded face to Plus Jakarta Sans).

## WCAG AA retunes

Per the audit policy in `theme-palettes.ts` (the palette bends, not the thresholds):

- light `--primary-foreground` flips to navy-on-sky (white-on-#4AADE5 was 2.5:1)
- light accent text / ring / `--accent-presence` deepen to `#1b6ca8` (5.2–5.6:1)
- light `--destructive` darkens `#ef4444` → `#b91c1c` (6.5:1 with white)
- dark `--accent-foreground` brightens `#4aade5` → `#5eb8ea` (4.6 → 5.2:1 headroom)
- dark `--accent-presence-foreground` is navy on the sky fill (7.3:1)

## Registration points

- `src/app/globals.css` — `[data-theme="snow"]` dark + light blocks (grouped with the tweakcn ports)
- `src/lib/theme-palettes.ts` — `THEME_IDS` + `THEME_META` (+ tests)
- `public/scripts/theme-init.js` + `theme-script.test.ts` — pre-paint allowlists
- `apps/ios/.../ThemeRoster.swift` — iOS mirror (order parity pinned by `ios-theme-override.test.ts`)
- `docs/coven-design-language.md`, `CHANGELOG.md`

## Verification

- `theme-contrast-audit.test.ts` — **813 pairs across 20 themes × 2 modes, 0 failures**
- `theme-palettes`, `globals.css`, `theme-script`, `ios-theme-override`, `preferences-schema` tests all pass
- Typecheck failures are pre-existing stale `.next/dev` artifacts (verified identical on clean baseline)