### PR TITLE
fix(dashboard): needs-attention triage is live, single-headed, and honest when cleared (cave-ckxk)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -200,6 +200,37 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
   assert.match(inbox, /actedIdsRef\.current\.add\(item\.id\)/, "single actions register the acted id");
   assert.match(inbox, /ids\.forEach\(\(id\) => actedIdsRef\.current\.add\(id\)\)/, "bulk actions register acted ids");
 }
+
+// ── Needs-attention is live, single-headed, and honest when cleared (cave-ckxk) ──
+// The server-rendered model used to be the only model — the poll refreshed
+// every panel EXCEPT needs-attention/Needs-you/today-summary. The cockpit now
+// rebuilds the model from the live inbox each poll, so the cave-bzch adoption
+// above actually has fresh props to adopt.
+{
+  const inbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
+  const root = readFileSync(cockpitUrl, "utf8");
+  assert.match(root, /getJson<\{ items: InboxItem\[\] \}>\("\/api\/inbox"\)/, "the poll fetches the full live inbox");
+  assert.match(root, /setLiveModel\(buildDashboardModel\(r\.items, new Date\(\)\)\)/, "each poll rebuilds the dashboard model client-side");
+  assert.match(root, /const model = liveModel \?\? initialModel;/, "the server model is only the first frame");
+  assert.match(root, /if \(!r\?\.items \|\| !aliveRef\.current\) return;/, "a failed inbox fetch keeps the last good model instead of wiping to caught-up");
+  // Truthful counts: the vital + panel badge read the uncapped open total, and
+  // track optimistic actions through the count the widget reports up.
+  assert.match(root, /value: liveOpen \?\? model\.openCount/, "the Needs-you vital reads the uncapped live open count");
+  assert.match(root, /count=\{liveOpen \?\? model\.openCount\}/, "the panel badge reads the uncapped live open count");
+  assert.match(root, /onOpenCount=\{setLiveOpen\}/, "the widget reports its live count up to the root");
+  assert.doesNotMatch(root, /model\.needsAttention\.length/, "nothing reads the capped list length as if it were the open total");
+  // Single header: the cockpit Panel owns the title/count; the widget carries
+  // only its own controls, so the panel no longer double-headers.
+  assert.doesNotMatch(inbox, /dr-section__head/, "the widget dropped its internal duplicate header");
+  assert.doesNotMatch(inbox, /Needs you\s*<\/h2>/, "no second heading inside the panel");
+  // The caught-up moment: clearing the last row confirms instead of leaving a
+  // hollow panel with a stale count.
+  assert.match(inbox, /items\.length === 0 && liveTotal === 0 \?/, "an emptied list renders the caught-up state");
+  assert.match(inbox, /all caught up/, "the caught-up copy confirms the clear");
+  // Open items beyond the visible cap drill through to the owning surface.
+  assert.match(inbox, /\+\{hidden\} more — open Rituals/, "overflow beyond the cap drills into Rituals");
+  assert.match(inbox, /href="\/\?mode=inbox"/, "the drill-through targets the Rituals surface");
+}
 // The workspace SSE 'updated' branch bails on content-equal echoes, so an
 // optimistic complete/dismiss/snooze doesn't trigger one redundant re-render
 // of every inboxItemsWithEphemeral consumer.

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -7,6 +7,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
+import { EmptyState } from "@/components/daily-report-ui";
 import { SnoozeMenu, minutesUntilTomorrowMorning, type SnoozeOption } from "@/components/snooze-menu";
 import { useAnnouncer } from "@/components/ui/live-region";
 
@@ -25,7 +26,14 @@ const ACTION_PAST_TENSE: Record<Action, string> = {
   snooze: "Snoozed",
 };
 
-export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
+export function ActionInbox({ initialItems, openCount, onOpenCount }: {
+  /** Visible rows — the model caps these for display. */
+  initialItems: InboxItem[];
+  /** True number of open items (uncapped) as of the same model snapshot. */
+  openCount: number;
+  /** Reports the live open total up so the panel badge/KPI track optimistic actions. */
+  onOpenCount?: (n: number) => void;
+}) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick();    // keep the per-item "Nm ago" labels current; the parent
                       // cockpit re-fetches the list itself every 30s.
@@ -44,6 +52,17 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     }
   }, [initialItems]);
   const { announce } = useAnnouncer();
+  // Live open total: the uncapped count minus rows removed optimistically but
+  // not yet reflected in the incoming model snapshot. Self-corrects when the
+  // fresh model lands (openCount drops, the removed rows rejoin `items`' base).
+  const liveTotal = Math.max(0, openCount - (initialItems.length - items.length));
+  const onOpenCountRef = useRef(onOpenCount);
+  onOpenCountRef.current = onOpenCount;
+  useEffect(() => {
+    onOpenCountRef.current?.(liveTotal);
+  }, [liveTotal]);
+  // Open items beyond the visible (capped) rows — the next poll promotes them.
+  const hidden = Math.max(0, liveTotal - items.length);
   // Bulk triage: select several items and done/dismiss/snooze them together.
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
@@ -111,17 +130,12 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     }
   }
 
-  if (items.length === 0) return null;
-
   return (
-    <section className="dr-section" aria-label="Needs you">
-      <div className="dr-section__head">
-        <h2 className="dr-section__title">
-          <Icon name="ph:warning-circle" aria-hidden />
-          Needs you
-        </h2>
-        <span className="dr-count">{items.length}</span>
-        {items.length > 1 ? (
+    <div className="dash-inbox">
+      {/* The cockpit Panel owns the title + count — this bar only carries the
+          list's own controls, so the widget no longer double-headers. */}
+      {items.length > 1 ? (
+        <div className="dash-inbox__bar">
           <button
             type="button"
             className="dash-act dash-inbox__select-toggle"
@@ -131,8 +145,8 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
             <Icon name="ph:list-checks-bold" aria-hidden />
             {selectMode ? "Done" : "Select"}
           </button>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       {selectMode ? (
         <div className="dash-inbox__bulkbar">
           <div className="dash-inbox__bulkbar-left">
@@ -165,6 +179,13 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           {error}
         </div>
       ) : null}
+      {items.length === 0 && liveTotal === 0 ? (
+        // The caught-up moment: clearing the last row confirms instead of
+        // leaving a hollow panel. The next poll retires the panel entirely.
+        <EmptyState icon="ph:check-circle">
+          You&apos;re all caught up — nothing needs you right now.
+        </EmptyState>
+      ) : (
       <div className="dr-list">
         {items.map((item) => {
           const whenIso = item.firedAt ?? item.updatedAt;
@@ -229,7 +250,14 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           );
         })}
       </div>
-    </section>
+      )}
+      {hidden > 0 ? (
+        <a className="dash-inbox__more focus-ring" href="/?mode=inbox">
+          <Icon name="ph:arrow-right-bold" aria-hidden />
+          +{hidden} more — open Rituals
+        </a>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import type { DashboardModel } from "@/lib/dashboard-model";
+import { buildDashboardModel, type DashboardModel } from "@/lib/dashboard-model";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { GitHubItem } from "@/lib/github-tasks";
@@ -90,10 +90,19 @@ const TRENDS_KEY = "cave:cockpit:trends:v2";
 
 // ─── Root ───────────────────────────────────────────────────────────────────────
 
-export function DashboardCockpit({ model }: { model: DashboardModel }) {
+export function DashboardCockpit({ model: initialModel }: { model: DashboardModel }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick();    // keep the "Updated Nm ago" pill honest between polls
   const [data, setData] = useState<CockpitData>(EMPTY);
+  // The server-rendered model is only the first frame — each poll rebuilds it
+  // from the live inbox, so needs-attention, the Needs-you vital, caught-up
+  // state, and today's summary all track reality instead of freezing at load.
+  const [liveModel, setLiveModel] = useState<DashboardModel | null>(null);
+  const model = liveModel ?? initialModel;
+  // Live open total reported up by the ActionInbox — keeps the panel badge and
+  // the Needs-you vital honest through optimistic done/dismiss/snooze, between
+  // polls. Reset when a fresh model lands (the model is then authoritative).
+  const [liveOpen, setLiveOpen] = useState<number | null>(null);
   // Each source populates independently so a panel renders the moment its data
   // lands — the slow ones (sessions) never block the fast ones (board, familiars).
   const [ready, setReady] = useState<ReadonlySet<keyof CockpitData>>(new Set());
@@ -122,7 +131,15 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     };
     void getJson<{ cards: Card[] }>("/api/board").then((r) => put("cards", r?.cards ?? []));
     void getJson<{ familiars: Familiar[] }>("/api/familiars").then((r) => put("familiars", r?.familiars ?? []));
-    void getJson<{ items: InboxItem[] }>("/api/inbox?status=pending").then((r) => put("upcoming", r?.items ?? []));
+    void getJson<{ items: InboxItem[] }>("/api/inbox").then((r) => {
+      put("upcoming", (r?.items ?? []).filter((i) => i.status === "pending"));
+      // Transient failure — keep the last good model rather than wiping to
+      // "caught up" on a fetch hiccup.
+      if (!r?.items || !aliveRef.current) return;
+      // Rebuild the whole dashboard model from the live inbox (pure, client-safe).
+      setLiveModel(buildDashboardModel(r.items, new Date()));
+      setLiveOpen(null);
+    });
     void getJson<{ sessions: SessionRow[] }>("/api/sessions/list").then((r) => put("sessions", r?.sessions ?? []));
     void getJson<{ entries: CovenMemoryEntry[] }>("/api/coven-memory").then((r) => put("memory", r?.entries ?? []));
     void getJson<{ areas: SpaceUsageArea[] }>("/api/space-usage").then((r) => put("space", r?.areas ?? []));
@@ -266,7 +283,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     { icon: "ph:heartbeat", value: vitals.sessions7d, label: "Sessions · 7d", sub: wowSub(vitals.sessionsWowDelta), accent: "lavender", metric: "sessions", good: "up", src: "sessions", href: "/?mode=agents" },
     { icon: "ph:flag-checkered", value: acceptPct, suffix: "%", label: "Retro accept rate", sub: retroSub(vitals), accent: "blue", metric: "accept", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:list-checks-bold", value: contractPct, suffix: "%", label: "Contract health", sub: contractFetchPartial ? contractCoverageSub : contractSub(vitals), accent: "amber", metric: "contract", good: "up", href: "/dashboard/familiars/growth" },
-    { icon: "ph:warning-circle", value: model.needsAttention.length, label: "Needs you", sub: model.caughtUp ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down" },
+    { icon: "ph:warning-circle", value: liveOpen ?? model.openCount, label: "Needs you", sub: (liveOpen ?? model.openCount) === 0 ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down", href: "/?mode=inbox" },
   ];
 
   // ── 7-day vitals trends: load history; snapshot today once the feeding data
@@ -284,7 +301,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       sessions: vitals.sessions7d,
       accept: acceptPct ?? 0,
       contract: contractPct ?? 0,
-      needs: model.needsAttention.length,
+      needs: model.openCount,
     };
     setTrends((prev) => {
       const store: TrendStore = { ...prev, [dayKey(now)]: snap };
@@ -294,7 +311,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       return store;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.needsAttention.length]);
+  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount]);
 
   // ── Draggable secondary layout ──
   const sensors = useSensors(
@@ -377,8 +394,8 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <ConfidencePanel rows={heatmapRows} />
         </Panel>);
       case "needs": return model.caughtUp ? null : (
-        <Panel title="Needs attention" icon="ph:warning-circle" count={model.needsAttention.length}>
-          <ActionInbox initialItems={model.needsAttention} />
+        <Panel title="Needs attention" icon="ph:warning-circle" count={liveOpen ?? model.openCount} href="/?mode=inbox">
+          <ActionInbox initialItems={model.needsAttention} openCount={model.openCount} onOpenCount={setLiveOpen} />
         </Panel>);
       case "board": return (
         <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">

--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -36,6 +36,7 @@ function summary(slug) {
   const model = buildDashboardModel([summary("2026-06-19")], now);
   assert.equal(model.caughtUp, true, "no open items => caught up");
   assert.equal(model.needsAttention.length, 0);
+  assert.equal(model.openCount, 0, "openCount is 0 when caught up");
 }
 
 // busy when a response is pending today
@@ -48,13 +49,14 @@ function summary(slug) {
   assert.equal(model.needsAttention.length, 1);
 }
 
-// needsAttention is capped at 8
+// needsAttention is capped at 8, but openCount reports the true total
 {
   const many = Array.from({ length: 12 }, (_, i) =>
     item({ id: `r${i}`, kind: "response-needed", status: "pending" }),
   );
   const model = buildDashboardModel(many, now);
   assert.equal(model.needsAttention.length, 8, "needsAttention capped at 8");
+  assert.equal(model.openCount, 12, "openCount is uncapped");
   assert.equal(model.caughtUp, false);
 }
 

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -39,6 +39,8 @@ export type DashboardModel = {
   caughtUp: boolean;
   /** Open, actionable items — same set the old "Needs attention" list showed, capped. */
   needsAttention: InboxItem[];
+  /** True number of open items — `needsAttention` is capped for display, this isn't. */
+  openCount: number;
   /** Today's generated summary narrative, or null before one exists. */
   todaySummary: TodaySummary | null;
   featuredReport: RecentReport | null;
@@ -75,6 +77,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
     date: now,
     caughtUp: breakdown.openItems.length === 0,
     needsAttention: breakdown.openItems.slice(0, NEEDS_ATTENTION_CAP),
+    openCount: breakdown.openItems.length,
     todaySummary,
     featuredReport,
     recentReports: reports.filter((r) => r.slug !== featuredReport?.slug),

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -47,6 +47,7 @@
 .dash-inbox__row[role="checkbox"] { cursor: pointer; }
 
 /* bulk triage: select toggle + bar + row checkbox */
+.dash-inbox__bar { display: flex; justify-content: flex-end; margin-bottom: 8px; }
 .dash-inbox__select-toggle { margin-left: auto; }
 .dash-inbox__bulkbar {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
@@ -68,6 +69,16 @@
   gap: 6px;
   flex: 0 0 auto;
 }
+
+/* Open items beyond the visible cap drill through to the Rituals surface. */
+.dash-inbox__more {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 8px; padding: 7px 10px; border-radius: 8px;
+  font-size: 0.8rem; font-weight: 600; color: var(--text-muted);
+  text-decoration: none; border: 1px dashed var(--border-hairline);
+}
+.dash-inbox__more:hover { color: var(--text-primary); border-color: var(--accent-presence); }
+.dash-inbox__more svg { width: 13px; height: 13px; flex: 0 0 auto; }
 
 .dash-act {
   display: inline-flex;

--- a/tests/dashboard-cockpit.spec.ts
+++ b/tests/dashboard-cockpit.spec.ts
@@ -3,8 +3,10 @@ import { expect, test, type Page } from "@playwright/test";
 // Dashboard cockpit (cave-89b / cave-2it) — pins the interaction contracts of
 // the /dashboard analytics surface: the sortable + filterable Familiar
 // Insights table, the Space usage panel (sortable rows, cleanup links, honest
-// truncation), and the Signals strip (dedupe-by-URL, stalest-first, capped
-// with a drill-through overflow row).
+// truncation), the Signals strip (dedupe-by-URL, stalest-first, capped with a
+// drill-through overflow row), and the Needs-attention panel (live from the
+// mocked inbox — the model rebuilds client-side each poll (cave-ckxk), so
+// page.route fully determines what needs you).
 //
 // Daemon-less (COVEN_CAVE_E2E=1): every data source the cockpit polls is
 // mocked via page.route, so the spec fully determines what renders. The
@@ -62,7 +64,21 @@ const SPACE_AREAS = [
   { id: "journal", label: "Journal", relPath: "~/.coven/journal", exists: false, bytes: 0, files: 0, lastModifiedMs: null, truncated: false },
 ];
 
-async function gotoDashboard(page: Page) {
+// Open inbox items for the Needs-attention panel: pending responses dated
+// "now" so breakdownForDay counts them as open today.
+const openItem = (id: string, title: string) => ({
+  id,
+  kind: "response-needed",
+  title,
+  status: "pending",
+  createdAt: new Date(NOW).toISOString(),
+  updatedAt: new Date(NOW).toISOString(),
+  firedAt: new Date(NOW).toISOString(),
+  recurrence: null,
+  source: "agent",
+});
+
+async function gotoDashboard(page: Page, inboxItems: Array<Record<string, unknown>> = []) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
@@ -73,7 +89,9 @@ async function gotoDashboard(page: Page) {
   await page.route("**/api/github/assigned", (route) => route.fulfill({ json: { items: GH_ASSIGNED } }));
   await page.route("**/api/space-usage", (route) => route.fulfill({ json: { ok: true, areas: SPACE_AREAS } }));
   await page.route("**/api/board", (route) => route.fulfill({ json: { cards: [] } }));
-  await page.route("**/api/inbox**", (route) => route.fulfill({ json: { items: [] } }));
+  // Serves the GET list and any POST /api/inbox/<id>/<action> the triage
+  // buttons fire (they only check res.ok).
+  await page.route("**/api/inbox**", (route) => route.fulfill({ json: { items: inboxItems } }));
   await page.route("**/api/coven-memory", (route) => route.fulfill({ json: { entries: [] } }));
   await page.route("**/api/retro-runs**", (route) => route.fulfill({ json: { snapshot: null } }));
   await page.goto("/dashboard");
@@ -154,4 +172,44 @@ test("signals dedupe same-URL PRs, lead with the stalest, and cap with an overfl
   const more = page.locator("a.cockpit-signal--more");
   await expect(more).toContainText("+2 more");
   await expect(more).toHaveAttribute("href", "/?mode=github");
+});
+
+test("needs-attention triages live and confirms when cleared", async ({ page }) => {
+  await gotoDashboard(page, [openItem("r1", "Reply to Sage"), openItem("r2", "Review the plan")]);
+  const panel = page.locator('.cockpit-panel[aria-label="Needs attention"]');
+  await expect(panel).toBeVisible();
+
+  // One header: the Panel chrome owns title + count — the widget no longer
+  // renders its own "Needs you" section head inside it.
+  await expect(panel.locator(".cockpit-panel__count")).toHaveText("2");
+  await expect(panel.locator(".dr-section__head")).toHaveCount(0);
+
+  // Acting removes the row optimistically and the badge tracks it.
+  await panel.locator(".dash-inbox__row", { hasText: "Reply to Sage" }).getByRole("button", { name: "Done" }).click();
+  await expect(panel.locator(".dash-inbox__row")).toHaveCount(1);
+  await expect(panel.locator(".cockpit-panel__count")).toHaveText("1");
+
+  // Clearing the last row confirms instead of leaving a hollow panel.
+  await panel.locator(".dash-inbox__row").getByRole("button", { name: "Done" }).click();
+  await expect(panel.locator(".dr-empty")).toContainText("all caught up");
+  await expect(panel.locator(".cockpit-panel__count")).toHaveText("0");
+});
+
+test("needs-attention shows the true open total and drills overflow into Rituals", async ({ page }) => {
+  const items = Array.from({ length: 10 }, (_, i) => openItem(`r${i + 1}`, `Open item ${i + 1}`));
+  await gotoDashboard(page, items);
+  const panel = page.locator('.cockpit-panel[aria-label="Needs attention"]');
+  await expect(panel).toBeVisible();
+
+  // The badge and the Needs-you vital read the uncapped total; the visible
+  // list is capped and the overflow drills into the owning surface.
+  await expect(panel.locator(".cockpit-panel__count")).toHaveText("10");
+  await expect(panel.locator(".dash-inbox__row")).toHaveCount(8);
+  const more = panel.locator("a.dash-inbox__more");
+  await expect(more).toContainText("+2 more");
+  await expect(more).toHaveAttribute("href", "/?mode=inbox");
+
+  const kpi = page.locator(".cockpit-kpi", { hasText: "Needs you" });
+  await expect(kpi.locator(".cockpit-kpi__value")).toHaveText("10");
+  await expect(kpi).toHaveAttribute("href", "/?mode=inbox");
 });


### PR DESCRIPTION
## Problem (dashboard-command-center goal — needs-attention/caught-up UX pass)

- **Frozen model**: `buildDashboardModel` ran once server-side and was never refreshed — the cockpit's 30s poll updated every panel **except** Needs attention, the Needs-you vital, caught-up state, and Today's summary. The cave-bzch 'adopt fresh `initialItems`' effect in ActionInbox could never fire because its prop never changed.
- **Double header**: `Panel "Needs attention" [N]` wrapped ActionInbox's own `dr-section` head ("Needs you N" + Select) — two names, two counts, one list.
- **No caught-up moment**: clearing the last row returned `null`, leaving a hollow panel with a stale count until reload. The sister daily-report surface has an explicit caught-up state; the cockpit didn't.
- **Dishonest count, dead-end tile**: the Needs-you vital showed the capped-at-8 `needsAttention.length`, not the true open total, and was the only KPI tile without a drill-in.

## Fix

- Cockpit rebuilds the model client-side from `/api/inbox` on the existing 30s poll (`liveModel ?? initialModel`; a failed fetch keeps the last good model instead of wiping to caught-up). The one inbox fetch also feeds the agenda's pending items.
- `DashboardModel.openCount` (uncapped) feeds the vital + panel badge; both track optimistic done/dismiss/snooze between polls via the live count ActionInbox reports up.
- ActionInbox: internal header → slim select bar (Panel chrome owns title/count); emptied list renders a **caught-up confirmation**; open items beyond the visible cap render **"+N more — open Rituals"** (`/?mode=inbox`); Needs-you vital + panel head deep-link the same surface.

## Verification

- `pnpm test:app` — 730 files pass (model + page-contract pins updated/added)
- `pnpm typecheck` — clean
- Playwright `tests/dashboard-cockpit.spec.ts` — 8/8 pass locally, incl. 2 new tests: live triage + caught-up confirmation; uncapped badge/vital + overflow drill-through (the mocked `/api/inbox` now fully determines the panel — it couldn't before this fix)

Bead: cave-ckxk