### PR TITLE
feat(inbox): group repeating-schedule notifications + past-due filter

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -311,6 +311,7 @@ export const SUITES = {
     "src/components/daily-summary-notifications.test.ts",
     "src/components/fire-and-forget-fetch.test.ts",
     "src/components/notification-bell-mutations.test.ts",
+    "src/components/notification-bell-series.test.ts",
     "src/components/surface-error-states.test.ts",
     "src/components/glass-overlay-chrome.test.ts",
     "src/components/surface-loading-states.test.ts",

--- a/src/components/notification-bell-mutations.test.ts
+++ b/src/components/notification-bell-mutations.test.ts
@@ -66,11 +66,20 @@ assert.doesNotMatch(
 );
 
 // Ephemeral response-needed rows (eph:*) are client-synthesized — there is
-// nothing to mark read server-side, so markRead must skip them.
+// nothing to mark read server-side, so markRead must skip them. It takes the
+// full id set of a collapsed series row and still issues ONE bulk POST.
 assert.match(
   src,
-  /const markRead = useCallback\(\s*\n\s*async \(id: string\) => \{\s*\n\s*if \(id\.startsWith\("eph:"\)\) return;/,
+  /const markRead = useCallback\(\s*\n\s*async \(ids: string\[\]\) => \{\s*\n\s*const real = ids\.filter\(\(id\) => !id\.startsWith\("eph:"\)\);\s*\n\s*if \(real\.length === 0\) return;/,
   "markRead skips ephemeral response-needed rows",
+);
+
+// Dismissing a collapsed repeating-schedule row clears the WHOLE series in one
+// atomic bulk POST — never a per-occurrence fan-out.
+assert.match(
+  src,
+  /const dismiss = useCallback\(\s*\n\s*async \(ids: string\[\]\) => \{[\s\S]*?"\/api\/inbox\/bulk"[\s\S]*?action: "dismiss", ids: real/,
+  "dismiss takes the series id set through one bulk POST",
 );
 
 // The badge counts unread from the SAME items the list shows (one shared

--- a/src/components/notification-bell-series.test.ts
+++ b/src/components/notification-bell-series.test.ts
@@ -1,0 +1,92 @@
+// @ts-nocheck
+// Notification bell: occurrences of the same repeating schedule collapse into
+// ONE row, and past-due reminders are clearly filterable (cave-w7z0). The
+// scheduler spawns a fresh sibling item per refire of a recurring schedule, so
+// without collapsing, a daily stand-up buries the bell in near-identical rows.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
+
+// ── Series grouping rides the pure lib, not ad-hoc component logic ──────────
+assert.match(
+  src,
+  /import \{ collapseInboxSeries, isInboxItemPastDue, isInboxItemUnread, unreadInboxCount \} from "@\/lib\/inbox-feed"/,
+  "series collapse and the past-due predicate come from the pure inbox-feed lib",
+);
+assert.match(
+  src,
+  /const grouped = useMemo\(\(\) => collapseInboxSeries\(feed\), \[feed\]\)/,
+  "the feed collapses same-schedule occurrences before rendering",
+);
+assert.match(
+  src,
+  /recent\.map\(\(group\) => \{\s*\n\s*const it = group\.latest;/,
+  "rows render the group's most recent occurrence",
+);
+
+// ── Collapsed rows surface their series: count badge + series-wide actions ──
+assert.match(
+  src,
+  /notification-bell__series-count[\s\S]{0,400}×\{seriesCount\}/,
+  "a collapsed row shows how many notifications it groups",
+);
+assert.match(
+  src,
+  /const unread = group\.items\.some\(isInboxItemUnread\)/,
+  "a row is unread when ANY occurrence in its series is unread",
+);
+assert.match(
+  src,
+  /void markRead\(unreadIdsInGroup\)/,
+  "Read acknowledges every unread occurrence in the series",
+);
+assert.match(
+  src,
+  /void dismiss\(group\.items\.map\(\(m\) => m\.id\)\)/,
+  "Dismiss clears the whole series, not just the visible occurrence",
+);
+assert.match(
+  src,
+  /\{seriesCount > 1 \? "Dismiss all" : "Dismiss"\}/,
+  "the dismiss button says what it will do to a collapsed series",
+);
+
+// ── Past due is a first-class, clearly visible filter ────────────────────────
+assert.match(
+  src,
+  /type KindFilter = "all" \| "past-due" \| ItemKind/,
+  "past-due is a first-class filter state",
+);
+assert.match(
+  src,
+  /const pastDueGroups = useMemo\(\s*\n\s*\(\) => grouped\.filter\(\(g\) => g\.items\.some\(\(i\) => isInboxItemPastDue\(i\)\)\)/,
+  "past-due groups derive from the shared predicate",
+);
+assert.match(
+  src,
+  /notification-bell__past-due-chip[\s\S]{0,700}Past due <span aria-hidden className="opacity-70">\{pastDueGroups\.length\}/,
+  "the Past due chip is visible with a live count",
+);
+assert.match(
+  src,
+  /--color-warning/,
+  "the past-due affordances use the warning hue so they read at a glance",
+);
+assert.match(
+  src,
+  /notification-bell__past-due-tag[\s\S]{0,260}>\s*\n\s*Past due/,
+  "past-due rows carry an inline tag even outside the filter",
+);
+assert.match(
+  src,
+  /if \(kindFilter === "past-due" && pastDueGroups\.length === 0\) setKindFilter\("all"\)/,
+  "clearing the last past-due item exits the filter instead of stranding an empty list",
+);
+assert.match(
+  src,
+  /kindChips\.length > 1 \|\| pastDueGroups\.length > 0/,
+  "the filter row appears whenever there is something past due, even with one kind",
+);
+
+console.log("notification-bell-series.test.ts: ok");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -7,7 +7,7 @@ import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { InboxItem, ItemKind } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import { MUTABLE_KINDS, type InboxPrefs, type MutableKind, type SoundMode } from "@/lib/inbox-prefs-shape";
-import { isInboxItemUnread, unreadInboxCount } from "@/lib/inbox-feed";
+import { collapseInboxSeries, isInboxItemPastDue, isInboxItemUnread, unreadInboxCount } from "@/lib/inbox-feed";
 import { normalizeInboxTitle } from "@/lib/inbox-title";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -23,7 +23,7 @@ type Props = {
   onPrefsChanged: () => void;
 };
 
-type KindFilter = "all" | ItemKind;
+type KindFilter = "all" | "past-due" | ItemKind;
 
 const KIND_FILTERS: { kind: ItemKind; label: string }[] = [
   { kind: "response-needed", label: "Waiting" },
@@ -159,17 +159,40 @@ export function NotificationBell({
     return [...ephemeral, ...firedSorted];
   }, [items]);
 
-  const recent = useMemo(
-    () =>
-      (kindFilter === "all" ? feed : feed.filter((i) => i.kind === kindFilter)).slice(0, 30),
-    [feed, kindFilter],
+  // Collapse every occurrence of the same repeating schedule into ONE row —
+  // a daily stand-up that fired five times reads "×5", not five entries
+  // burying everything else (cave-w7z0).
+  const grouped = useMemo(() => collapseInboxSeries(feed), [feed]);
+
+  // Past due = reminders whose moment passed and are still waiting (the pure
+  // isInboxItemPastDue predicate). A group is past due when any member is.
+  const pastDueGroups = useMemo(
+    () => grouped.filter((g) => g.items.some((i) => isInboxItemPastDue(i))),
+    [grouped],
   );
+
+  // Filtering to zero must never strand the user: when the last past-due item
+  // is handled, the chip disappears — fall back to All instead of an empty
+  // list with no way out.
+  useEffect(() => {
+    if (kindFilter === "past-due" && pastDueGroups.length === 0) setKindFilter("all");
+  }, [kindFilter, pastDueGroups.length]);
+
+  const recent = useMemo(() => {
+    const filtered =
+      kindFilter === "all"
+        ? grouped
+        : kindFilter === "past-due"
+          ? pastDueGroups
+          : grouped.filter((g) => g.latest.kind === kindFilter);
+    return filtered.slice(0, 30);
+  }, [grouped, pastDueGroups, kindFilter]);
 
   // Only offer chips for kinds that actually have notifications — an empty
   // filter is a dead end, not a management tool.
   const kindChips = useMemo(
-    () => KIND_FILTERS.filter(({ kind }) => feed.some((i) => i.kind === kind)),
-    [feed],
+    () => KIND_FILTERS.filter(({ kind }) => grouped.some((g) => g.latest.kind === kind)),
+    [grouped],
   );
 
   // Badge and list share one unread definition (unreadInboxCount) so they can
@@ -183,17 +206,19 @@ export function NotificationBell({
   );
 
   // Acknowledge without resolving: reading quiets the badge, the item stays
-  // listed until dismissed/done. Ephemeral response-needed rows (eph:*) are
-  // client-synthesized and have nothing to mark server-side.
+  // listed until dismissed/done. Takes the whole id set of a series row — one
+  // atomic bulk POST, not a per-occurrence fan-out. Ephemeral response-needed
+  // rows (eph:*) are client-synthesized and have nothing to mark server-side.
   const markRead = useCallback(
-    async (id: string) => {
-      if (id.startsWith("eph:")) return;
+    async (ids: string[]) => {
+      const real = ids.filter((id) => !id.startsWith("eph:"));
+      if (real.length === 0) return;
       await mutate(
         () =>
           fetch("/api/inbox/bulk", {
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ action: "read", ids: [id] }),
+            body: JSON.stringify({ action: "read", ids: real }),
           }),
         "Mark read failed — check your connection.",
       );
@@ -223,10 +248,20 @@ export function NotificationBell({
     return () => window.removeEventListener("pointerdown", onDown);
   }, [open]);
 
+  // Dismiss a row — for a collapsed repeating-schedule row that's EVERY
+  // occurrence in the series, as one atomic bulk POST (single file write +
+  // broadcast server-side, same shape as clear-all).
   const dismiss = useCallback(
-    async (id: string) => {
+    async (ids: string[]) => {
+      const real = ids.filter((id) => !id.startsWith("eph:"));
+      if (real.length === 0) return;
       await mutate(
-        () => fetch(`/api/inbox/${id}/dismiss`, { method: "POST" }),
+        () =>
+          fetch("/api/inbox/bulk", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ action: "dismiss", ids: real }),
+          }),
         "Dismiss failed — check your connection.",
       );
     },
@@ -442,16 +477,18 @@ export function NotificationBell({
               </ul>
             </div>
           ) : null}
-          {kindChips.length > 1 ? (
+          {kindChips.length > 1 || pastDueGroups.length > 0 ? (
             <div
               role="group"
-              aria-label="Filter notifications by kind"
+              aria-label="Filter notifications"
               className="notification-bell__filters flex flex-wrap gap-1 border-b border-[var(--border-hairline)] px-3 py-2"
             >
               {[{ kind: "all" as const, label: "All" }, ...kindChips].map(({ kind, label }) => {
                 const active = kindFilter === kind;
                 const count =
-                  kind === "all" ? feed.length : feed.filter((i) => i.kind === kind).length;
+                  kind === "all"
+                    ? grouped.length
+                    : grouped.filter((g) => g.latest.kind === kind).length;
                 return (
                   <button
                     key={kind}
@@ -467,6 +504,22 @@ export function NotificationBell({
                   </button>
                 );
               })}
+              {pastDueGroups.length > 0 ? (
+                // Warning-tinted so the overdue slice is findable at a glance —
+                // this is a status filter, not a kind, hence the distinct hue.
+                <button
+                  onClick={() => setKindFilter("past-due")}
+                  aria-pressed={kindFilter === "past-due"}
+                  title="Only reminders whose time has passed and are still waiting on you"
+                  className={`notification-bell__past-due-chip focus-ring rounded-full border px-2 py-0.5 text-[10px] transition-colors ${
+                    kindFilter === "past-due"
+                      ? "border-[color-mix(in_oklch,var(--color-warning)_55%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] text-[var(--text-primary)]"
+                      : "border-[color-mix(in_oklch,var(--color-warning)_45%,transparent)] text-[var(--color-warning)] hover:bg-[color-mix(in_oklch,var(--color-warning)_12%,transparent)]"
+                  }`}
+                >
+                  Past due <span aria-hidden className="opacity-70">{pastDueGroups.length}</span>
+                </button>
+              ) : null}
             </div>
           ) : null}
           <ul className="notification-bell__list max-h-[420px] overflow-y-auto p-2 text-xs">
@@ -475,10 +528,16 @@ export function NotificationBell({
                 {kindFilter === "all" ? "No notifications." : "Nothing in this filter."}
               </li>
             ) : null}
-            {recent.map((it) => {
+            {recent.map((group) => {
+              const it = group.latest;
+              const seriesCount = group.items.length;
               const fname = it.familiarId ? familiarName(it.familiarId) : null;
               const muted = it.familiarId ? prefs.mutedFamiliars.includes(it.familiarId) : false;
-              const unread = isInboxItemUnread(it);
+              const unread = group.items.some(isInboxItemUnread);
+              const pastDue = group.items.some((m) => isInboxItemPastDue(m));
+              const unreadIdsInGroup = group.items
+                .filter(isInboxItemUnread)
+                .map((m) => m.id);
               return (
                 <li
                   key={it.id}
@@ -515,6 +574,20 @@ export function NotificationBell({
                           </>
                         ) : null}
                         <div className="truncate text-[12px] font-medium text-[var(--text-primary)]" title={normalizeInboxTitle(it.title)}>{normalizeInboxTitle(it.title)}</div>
+                        {seriesCount > 1 ? (
+                          <span
+                            className="notification-bell__series-count shrink-0 rounded-full border border-[var(--border-strong)] bg-[var(--bg-raised)] px-1.5 text-[9px] font-semibold leading-4 text-[var(--text-secondary)]"
+                            title={`${seriesCount} notifications from this repeating schedule, grouped`}
+                          >
+                            ×{seriesCount}
+                            <span className="sr-only"> notifications from this repeating schedule</span>
+                          </span>
+                        ) : null}
+                        {pastDue ? (
+                          <span className="notification-bell__past-due-tag shrink-0 rounded-full border border-[color-mix(in_oklch,var(--color-warning)_45%,transparent)] px-1.5 text-[9px] font-semibold leading-4 text-[var(--color-warning)]">
+                            Past due
+                          </span>
+                        ) : null}
                       </div>
                       {it.body ? (
                         <div className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-[var(--text-muted)]">
@@ -547,10 +620,13 @@ export function NotificationBell({
                       <BellBtn
                         primary
                         onClick={() => {
-                          // Opening acknowledges the item, but the parent's
-                          // onOpenItem handler already marks it read (every
-                          // open-path funnels through markInboxItemRead) — so
-                          // the bell must not POST a second, redundant read.
+                          // Opening acknowledges the row. The parent's
+                          // onOpenItem handler marks the opened item read
+                          // (every open-path funnels through
+                          // markInboxItemRead), so only the OTHER unread
+                          // occurrences of a collapsed series need a read here.
+                          const others = unreadIdsInGroup.filter((id) => id !== it.id);
+                          if (others.length > 0) void markRead(others);
                           setOpen(false);
                           onOpenItem(it);
                         }}
@@ -560,8 +636,12 @@ export function NotificationBell({
                     ) : null}
                     {unread && it.kind !== "response-needed" ? (
                       <BellBtn
-                        onClick={() => void markRead(it.id)}
-                        title="Mark as read — keeps the notification, quiets the badge"
+                        onClick={() => void markRead(unreadIdsInGroup)}
+                        title={
+                          seriesCount > 1
+                            ? "Mark every notification from this schedule as read — keeps them, quiets the badge"
+                            : "Mark as read — keeps the notification, quiets the badge"
+                        }
                       >
                         Read
                       </BellBtn>
@@ -571,7 +651,16 @@ export function NotificationBell({
                         <BellBtn onClick={() => void snooze(it.id)} title="Snooze 10 minutes">
                           Snooze
                         </BellBtn>
-                        <BellBtn onClick={() => void dismiss(it.id)}>Dismiss</BellBtn>
+                        <BellBtn
+                          onClick={() => void dismiss(group.items.map((m) => m.id))}
+                          title={
+                            seriesCount > 1
+                              ? `Dismiss all ${seriesCount} notifications from this schedule`
+                              : undefined
+                          }
+                        >
+                          {seriesCount > 1 ? "Dismiss all" : "Dismiss"}
+                        </BellBtn>
                       </>
                     ) : null}
                   </div>

--- a/src/lib/inbox-feed.test.ts
+++ b/src/lib/inbox-feed.test.ts
@@ -2,10 +2,13 @@
 import assert from "node:assert/strict";
 import {
   buildInboxGroups,
+  collapseInboxSeries,
   groupInboxFeed,
   INBOX_GROUP_BY_OPTIONS,
   inboxActivityTime,
   inboxKindLabel,
+  inboxSeriesKey,
+  isInboxItemPastDue,
   isInboxItemUnread,
   unreadInboxCount,
 } from "./inbox-feed.ts";
@@ -201,6 +204,68 @@ const item = (over = {}) => ({
 // ── the group-by options cover every mode exactly once ──────────────────────
 {
   assert.deepEqual(INBOX_GROUP_BY_OPTIONS.map((o) => o.value), ["attention", "kind", "familiar"]);
+}
+
+// ── inboxSeriesKey: recurring items share a key, one-shots have none ────────
+{
+  const rec = { type: "daily", hour: 9, minute: 0 };
+  const a = item({ id: "a", title: "Stand-up", recurrence: rec, familiarId: "f1" });
+  const b = item({ id: "b", title: "  stand-up ", recurrence: rec, familiarId: "f1" });
+  assert.equal(inboxSeriesKey(a), inboxSeriesKey(b), "same schedule → same key (title normalized)");
+  assert.equal(inboxSeriesKey(item({ recurrence: { type: "none" } })), null, "one-shots have no series");
+  assert.equal(inboxSeriesKey(item({ recurrence: undefined, kind: "response-needed" })), null, "missing recurrence → no series");
+  assert.notEqual(
+    inboxSeriesKey(a),
+    inboxSeriesKey(item({ id: "c", title: "Stand-up", recurrence: rec, familiarId: "f2" })),
+    "same schedule under a different familiar is a different series",
+  );
+  assert.notEqual(
+    inboxSeriesKey(a),
+    inboxSeriesKey(item({ id: "d", title: "Stand-up", recurrence: { type: "daily", hour: 10, minute: 0 }, familiarId: "f1" })),
+    "a different recurrence spec is a different series",
+  );
+}
+
+// ── collapseInboxSeries: occurrences of one schedule become one group ───────
+{
+  const rec = { type: "daily", hour: 9, minute: 0 };
+  const groups = collapseInboxSeries([
+    item({ id: "new", title: "Stand-up", recurrence: rec, status: "fired", firedAt: "2026-06-03T09:00:00Z" }),
+    item({ id: "solo", title: "One-shot", status: "fired", firedAt: "2026-06-02T12:00:00Z" }),
+    item({ id: "old", title: "Stand-up", recurrence: rec, status: "fired", firedAt: "2026-06-01T09:00:00Z" }),
+  ]);
+  assert.equal(groups.length, 2, "three items collapse to two rows");
+  assert.deepEqual(groups[0].items.map((i) => i.id), ["new", "old"], "series holds every occurrence, input order kept");
+  assert.equal(groups[0].latest.id, "new", "the newest occurrence fronts the group");
+  assert.equal(groups[1].key, null, "the one-shot passes through as a singleton");
+  assert.deepEqual(groups[1].items.map((i) => i.id), ["solo"]);
+}
+
+// ── collapseInboxSeries: latest wins by activity time, not input order ──────
+{
+  const rec = { type: "interval", everyMs: 60_000 };
+  const groups = collapseInboxSeries([
+    item({ id: "older", title: "Ping", recurrence: rec, status: "fired", firedAt: "2026-06-01T00:00:00Z" }),
+    item({ id: "newer", title: "Ping", recurrence: rec, status: "fired", firedAt: "2026-06-05T00:00:00Z" }),
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].latest.id, "newer", "latest is by activity, even when input isn't sorted");
+  assert.equal(groups[0].key, inboxSeriesKey(groups[0].latest), "the group key matches its members'");
+}
+
+// ── isInboxItemPastDue: due moment passed + still waiting on the user ───────
+{
+  const now = Date.parse("2026-06-10T12:00:00Z");
+  const pastDue = (over) => isInboxItemPastDue(item(over), now);
+  assert.equal(pastDue({ status: "fired", fireAt: "2026-06-10T09:00:00Z", firedAt: "2026-06-10T09:00:00Z" }), true, "fired reminder past its time is past due");
+  assert.equal(pastDue({ status: "pending", fireAt: "2026-06-10T09:00:00Z" }), true, "a pending reminder whose fireAt slipped by is past due (missed while quit)");
+  assert.equal(pastDue({ status: "pending", fireAt: "2026-06-11T09:00:00Z" }), false, "an upcoming reminder is not past due");
+  assert.equal(pastDue({ status: "done", fireAt: "2026-06-10T09:00:00Z" }), false, "resolved reminders are never past due");
+  assert.equal(pastDue({ status: "dismissed", fireAt: "2026-06-10T09:00:00Z" }), false, "dismissed reminders are never past due");
+  assert.equal(pastDue({ status: "fired", fireAt: null, firedAt: "2026-06-10T09:00:00Z" }), true, "fired with no fireAt falls back to firedAt");
+  assert.equal(pastDue({ kind: "agent", status: "fired", fireAt: "2026-06-10T09:00:00Z" }), false, "announcement kinds have no due moment");
+  assert.equal(pastDue({ kind: "daily-summary", status: "fired", firedAt: "2026-06-10T09:00:00Z" }), false, "daily summaries are never past due");
+  assert.equal(pastDue({ status: "pending", fireAt: null }), false, "no due time → not past due");
 }
 
 console.log("inbox-feed.test.ts passed");

--- a/src/lib/inbox-feed.ts
+++ b/src/lib/inbox-feed.ts
@@ -76,6 +76,80 @@ export function unreadInboxCount(items: readonly InboxItem[]): number {
   return count;
 }
 
+// ── Repeating-schedule series + past-due (notification helpers) ──────────────
+
+/**
+ * Stable identity for "occurrences of the same repeating schedule". The
+ * scheduler refires a recurring item by spawning a fresh sibling per
+ * occurrence (new id, same shape — see inbox-scheduler's tick), so the
+ * notifications of one schedule share everything BUT their id. The key is
+ * kind + normalized title + recurrence spec + familiar; non-recurring items
+ * have no series and return null. Siblings are spread-copies of one object,
+ * so JSON.stringify over the recurrence is order-stable within a series.
+ */
+export function inboxSeriesKey(item: InboxItem): string | null {
+  const rec = item.recurrence;
+  if (!rec || rec.type === "none") return null;
+  const title = (item.title ?? "").trim().toLowerCase();
+  return `${item.kind}|${title}|${JSON.stringify(rec)}|${item.familiarId ?? ""}`;
+}
+
+export type InboxSeriesGroup = {
+  /** Series key, or null when the row is a non-recurring singleton. */
+  key: string | null;
+  /** The most recent member — the face of the row. */
+  latest: InboxItem;
+  /** Every member, input order preserved (newest first in a recent-first feed). */
+  items: InboxItem[];
+};
+
+/**
+ * Collapse a feed so every notification from one repeating schedule forms a
+ * single group — a daily stand-up that fired five times is one row, not five.
+ * Order-preserving: a series occupies the position of its first member in the
+ * input; non-recurring items pass through as singleton groups. `latest` is
+ * the member with the newest activity regardless of input order.
+ */
+export function collapseInboxSeries(items: readonly InboxItem[]): InboxSeriesGroup[] {
+  const groups: InboxSeriesGroup[] = [];
+  const byKey = new Map<string, InboxSeriesGroup>();
+  for (const item of items) {
+    const key = inboxSeriesKey(item);
+    if (!key) {
+      groups.push({ key: null, latest: item, items: [item] });
+      continue;
+    }
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.items.push(item);
+      if (inboxActivityTime(item) > inboxActivityTime(existing.latest)) {
+        existing.latest = item;
+      }
+    } else {
+      const group: InboxSeriesGroup = { key, latest: item, items: [item] };
+      byKey.set(key, group);
+      groups.push(group);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Past due = a schedule whose moment has passed and is still waiting on the
+ * user: a fired reminder that hasn't been resolved, or a pending reminder
+ * whose fireAt slipped by (missed while Cave was quit). Snoozing moves fireAt
+ * forward, so a snoozed reminder isn't past due until it comes back around.
+ * Announcement kinds (agent, daily-summary, response-needed) have no due
+ * moment and are never past due.
+ */
+export function isInboxItemPastDue(item: InboxItem, nowMs: number = Date.now()): boolean {
+  if (item.kind !== "reminder") return false;
+  if (item.status !== "fired" && item.status !== "pending") return false;
+  const dueIso = item.fireAt ?? item.firedAt;
+  const due = dueIso ? Date.parse(dueIso) : NaN;
+  return Number.isFinite(due) && due <= nowMs;
+}
+
 /** Human label for an inbox item kind (used by the feed's kind badge). */
 export function inboxKindLabel(kind: ItemKind): string {
   switch (kind) {


### PR DESCRIPTION
## What

Bead: cave-w7z0

The inbox scheduler refires a recurring schedule by spawning a fresh sibling item per occurrence, so the notification bell filled with one near-identical row per refire and offered no way to isolate schedules that slipped past their time.

### Series grouping
- `inbox-feed.ts` (pure lib): `inboxSeriesKey` (kind + normalized title + recurrence spec + familiar), `collapseInboxSeries` (order-preserving; newest occurrence fronts the group), `isInboxItemPastDue`.
- The bell collapses all occurrences of one repeating schedule into a single row with a **×N** count badge.
- **Read** / **Dismiss** act on the whole series via one atomic `/api/inbox/bulk` POST (no per-item fan-out); **Dismiss** relabels to **Dismiss all** when collapsed; **Open** acknowledges the other unread occurrences.

### Past due filter
- A warning-tinted **Past due** chip with a live count joins the filter row whenever any reminder's moment has passed and it's still waiting (fired-and-unresolved, or pending with a slipped `fireAt`). Announcement kinds (agent / daily-summary / response-needed) are never past due.
- Past-due rows carry an inline warning tag even outside the filter.
- Emptying the filter (dismissing the last past-due item) falls back to **All** instead of stranding an empty list.

## Verification
- `pnpm typecheck` ✓
- `pnpm test:app` — 731 files ✓ (new unit coverage in `inbox-feed.test.ts`; new guard `notification-bell-series.test.ts` wired into `run-tests.mjs`; `check:tests-wired` ✓)
- `notification-bell-mutations.test.ts` updated: `markRead`/`dismiss` now take a series id set through one bulk POST (eph:* skip preserved).