### PR TITLE
fix(dashboard): Needs-you counts stay truthful past the display cap (cave-ckxk)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -230,7 +230,8 @@ assert.match(cockpit, /i\.status === "pending"/, "agenda derivation keeps the pe
   const inbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
   const model = readFileSync(new URL("../lib/dashboard-model.ts", import.meta.url), "utf8");
   assert.match(model, /openCount: breakdown\.openItems\.length/, "the model carries the uncapped open total");
-  assert.match(inbox, /const liveTotal = Math\.max\(0, openCount - \(initialItems\.length - items\.length\)\)/, "the widget derives a live total that tracks optimistic removals");
+  assert.match(inbox, /const optimisticRemovals = Math\.max\(0, initialItems\.length - items\.length\)/, "the removal delta clamps at 0 so a failed-action revert can't overshoot");
+  assert.match(inbox, /const liveTotal = Math\.max\(0, openCount - optimisticRemovals\)/, "the widget derives a live total that tracks optimistic removals");
   assert.match(inbox, /const caughtUp = liveTotal === 0/, "all-clear reads the uncapped total, not the visible page");
   assert.match(inbox, /const hidden = Math\.max\(0, liveTotal - items\.length\)/, "overflow counts the items beyond the visible cap");
   assert.match(inbox, /\+\{hidden\} more — open Rituals/, "overflow drills through instead of silently truncating");

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -206,7 +206,7 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
 // model client-side, so cleared items leave, newly fired ones appear, and
 // caught-up flips truthfully.
 assert.match(cockpit, /getJson<\{ items: InboxItem\[\] \}>\("\/api\/inbox"\)/, "cockpit polls the full inbox (fired items included), not just status=pending");
-assert.match(cockpit, /if \(r\?\.items\) put\("inbox", r\.items\)/, "a failed inbox poll keeps the last known good list instead of flashing 'all clear'");
+assert.match(cockpit, /if \(r\?\.items\) \{\s*\n\s*put\("inbox", r\.items\);/, "a failed inbox poll keeps the last known good list instead of flashing 'all clear'");
 assert.match(cockpit, /buildDashboardModel\(data\.inbox, new Date\(\)\)/, "each poll rebuilds the dashboard model from the live inbox");
 assert.match(cockpit, /i\.status === "pending"/, "agenda derivation keeps the pending filter the old query param provided");
 {
@@ -214,11 +214,32 @@ assert.match(cockpit, /i\.status === "pending"/, "agenda derivation keeps the pe
   // Caught up is a designed state: the section stays (stable grid slot, calm
   // all-clear read) instead of vanishing — and the bare-widget mount means no
   // outer Panel is left husking a stale count over an empty body.
-  assert.match(cockpit, /case "needs": return <ActionInbox initialItems=\{model\.needsAttention\} \/>;/, "needs widget mounts ActionInbox bare — no double chrome, no husk Panel");
+  assert.match(cockpit, /case "needs": return <ActionInbox initialItems=\{model\.needsAttention\} openCount=\{model\.openCount\} onOpenCount=\{setLiveOpen\} \/>;/, "needs widget mounts ActionInbox bare — no double chrome, no husk Panel");
   assert.doesNotMatch(inbox, /if \(items\.length === 0\) return null/, "an empty list no longer unmounts the section");
   assert.match(inbox, /All clear — nothing needs you right now\./, "caught-up renders an honest all-clear state");
   assert.match(inbox, /caughtUp \? "ph:check-circle-bold" : "ph:warning-circle"/, "the section icon relaxes when caught up");
-  assert.match(inbox, /\{caughtUp \? null : <span className="dr-count">\{items\.length\}<\/span>\}/, "the live count hides at zero instead of reading 0");
+  assert.match(inbox, /\{caughtUp \? null : <span className="dr-count">\{liveTotal\}<\/span>\}/, "the live count hides at zero instead of reading 0");
+}
+// ── Counts are truthful past the display cap (cave-ckxk) ─────────────────────
+// needsAttention is capped at 8 for display; the true open total is
+// DashboardModel.openCount. The widget badge, its caught-up read, and the
+// Needs-you vital all use the uncapped total — an emptied visible page with
+// more items behind it is NOT "all clear" — and overflow drills into the
+// owning Rituals surface instead of silently truncating.
+{
+  const inbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
+  const model = readFileSync(new URL("../lib/dashboard-model.ts", import.meta.url), "utf8");
+  assert.match(model, /openCount: breakdown\.openItems\.length/, "the model carries the uncapped open total");
+  assert.match(inbox, /const liveTotal = Math\.max\(0, openCount - \(initialItems\.length - items\.length\)\)/, "the widget derives a live total that tracks optimistic removals");
+  assert.match(inbox, /const caughtUp = liveTotal === 0/, "all-clear reads the uncapped total, not the visible page");
+  assert.match(inbox, /const hidden = Math\.max\(0, liveTotal - items\.length\)/, "overflow counts the items beyond the visible cap");
+  assert.match(inbox, /\+\{hidden\} more — open Rituals/, "overflow drills through instead of silently truncating");
+  assert.match(inbox, /className="dash-inbox__more focus-ring" href="\/\?mode=inbox"/, "the drill-through targets the Rituals surface");
+  assert.match(inbox, /onOpenCountRef\.current\?\.\(liveTotal\)/, "the widget reports its live total up");
+  assert.match(cockpit, /value: liveOpen \?\? model\.openCount, label: "Needs you"/, "the Needs-you vital reads the uncapped live total");
+  assert.match(cockpit, /metric: "needs", good: "down", href: "\/\?mode=inbox"/, "the Needs-you vital drills into Rituals like every other tile");
+  assert.match(cockpit, /needs: model\.openCount/, "trend snapshots record the uncapped total");
+  assert.doesNotMatch(cockpit, /model\.needsAttention\.length/, "nothing reads the capped list length as if it were the open total");
 }
 // The workspace SSE 'updated' branch bails on content-equal echoes, so an
 // optimistic complete/dismiss/snooze doesn't trigger one redundant re-render

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -26,7 +26,14 @@ const ACTION_PAST_TENSE: Record<Action, string> = {
   snooze: "Snoozed",
 };
 
-export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
+export function ActionInbox({ initialItems, openCount, onOpenCount }: {
+  /** Visible rows — the model caps these for display. */
+  initialItems: InboxItem[];
+  /** True number of open items (uncapped) as of the same model snapshot. */
+  openCount: number;
+  /** Reports the live open total up so the Needs-you vital tracks optimistic actions. */
+  onOpenCount?: (n: number) => void;
+}) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick();    // keep the per-item "Nm ago" labels current; the parent
                       // cockpit re-fetches the list itself every 30s.
@@ -45,6 +52,17 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     }
   }, [initialItems]);
   const { announce } = useAnnouncer();
+  // Live open total: the uncapped count minus rows removed optimistically but
+  // not yet reflected in the incoming model snapshot. Self-corrects when the
+  // fresh model lands (openCount drops, acted ids leave `initialItems`).
+  const liveTotal = Math.max(0, openCount - (initialItems.length - items.length));
+  const onOpenCountRef = useRef(onOpenCount);
+  onOpenCountRef.current = onOpenCount;
+  useEffect(() => {
+    onOpenCountRef.current?.(liveTotal);
+  }, [liveTotal]);
+  // Open items beyond the visible (capped) rows — the next poll promotes them.
+  const hidden = Math.max(0, liveTotal - items.length);
   // Bulk triage: select several items and done/dismiss/snooze them together.
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
@@ -115,7 +133,9 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   // Caught up is a designed state, not a disappearance: keep the section (and
   // the grid slot stable) with a calm all-clear read. Clearing the last item
   // lands here immediately — the moment deserves better than a layout jump.
-  const caughtUp = items.length === 0;
+  // Reads the uncapped total: with more open items than visible rows, an
+  // emptied page is NOT all clear.
+  const caughtUp = liveTotal === 0;
 
   return (
     <section className="dr-section" aria-label="Needs you">
@@ -124,7 +144,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           <Icon name={caughtUp ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
           Needs you
         </h2>
-        {caughtUp ? null : <span className="dr-count">{items.length}</span>}
+        {caughtUp ? null : <span className="dr-count">{liveTotal}</span>}
         {items.length > 1 ? (
           <button
             type="button"
@@ -236,6 +256,12 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           );
         })}
       </div>
+      {hidden > 0 ? (
+        <a className="dash-inbox__more focus-ring" href="/?mode=inbox">
+          <Icon name="ph:arrow-right-bold" aria-hidden />
+          +{hidden} more — open Rituals
+        </a>
+      ) : null}
     </section>
   );
 }

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -54,8 +54,11 @@ export function ActionInbox({ initialItems, openCount, onOpenCount }: {
   const { announce } = useAnnouncer();
   // Live open total: the uncapped count minus rows removed optimistically but
   // not yet reflected in the incoming model snapshot. Self-corrects when the
-  // fresh model lands (openCount drops, acted ids leave `initialItems`).
-  const liveTotal = Math.max(0, openCount - (initialItems.length - items.length));
+  // fresh model lands (openCount drops, acted ids leave `initialItems`). The
+  // removal delta clamps at 0: a failed action reverting to a pre-poll `items`
+  // array must never push the total past the authoritative snapshot count.
+  const optimisticRemovals = Math.max(0, initialItems.length - items.length);
+  const liveTotal = Math.max(0, openCount - optimisticRemovals);
   const onOpenCountRef = useRef(onOpenCount);
   onOpenCountRef.current = onOpenCount;
   useEffect(() => {

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -104,6 +104,10 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
   // null while unresolved or when the probe fails — the panel's empty state only
   // offers "Connect GitHub" on a proven false, never on a guess.
   const [ghConnected, setGhConnected] = useState<boolean | null>(null);
+  // Live open total reported up by the ActionInbox — keeps the Needs-you vital
+  // honest through optimistic done/dismiss/snooze between polls. Reset when a
+  // fresh inbox lands (the rebuilt model is then authoritative).
+  const [liveOpen, setLiveOpen] = useState<number | null>(null);
 
   // Keep setState off an unmounted tree: the polled `load` may resolve after
   // unmount. A ref survives across the stable `load` identity.
@@ -125,7 +129,10 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
     // The needs-attention/caught-up read derives from this list — keep the
     // last known good copy on a failed poll rather than flashing "all clear".
     void getJson<{ items: InboxItem[] }>("/api/inbox").then((r) => {
-      if (r?.items) put("inbox", r.items);
+      if (r?.items) {
+        put("inbox", r.items);
+        if (aliveRef.current) setLiveOpen(null);
+      }
     });
     void getJson<{ sessions: SessionRow[] }>("/api/sessions/list").then((r) => put("sessions", r?.sessions ?? []));
     void getJson<{ entries: CovenMemoryEntry[] }>("/api/coven-memory").then((r) => put("memory", r?.entries ?? []));
@@ -281,7 +288,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
     { icon: "ph:heartbeat", value: vitals.sessions7d, label: "Sessions · 7d", sub: wowSub(vitals.sessionsWowDelta), accent: "lavender", metric: "sessions", good: "up", src: "sessions", href: "/?mode=agents" },
     { icon: "ph:flag-checkered", value: acceptPct, suffix: "%", label: "Retro accept rate", sub: retroSub(vitals), accent: "blue", metric: "accept", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:list-checks-bold", value: contractPct, suffix: "%", label: "Contract health", sub: contractFetchPartial ? contractCoverageSub : contractSub(vitals), accent: "amber", metric: "contract", good: "up", href: "/dashboard/familiars/growth" },
-    { icon: "ph:warning-circle", value: model.needsAttention.length, label: "Needs you", sub: model.caughtUp ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down" },
+    { icon: "ph:warning-circle", value: liveOpen ?? model.openCount, label: "Needs you", sub: (liveOpen ?? model.openCount) === 0 ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down", href: "/?mode=inbox" },
   ];
 
   // ── 7-day vitals trends: load history; snapshot today once the feeding data
@@ -299,7 +306,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       sessions: vitals.sessions7d,
       accept: acceptPct ?? 0,
       contract: contractPct ?? 0,
-      needs: model.needsAttention.length,
+      needs: model.openCount,
     };
     setTrends((prev) => {
       const store: TrendStore = { ...prev, [dayKey(now)]: snap };
@@ -309,7 +316,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       return store;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.needsAttention.length]);
+  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount]);
 
   // ── Draggable secondary layout ──
   const sensors = useSensors(
@@ -393,7 +400,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       // Bare like "today": ActionInbox owns its section chrome (title, live
       // count, select toggle) — a wrapping Panel double-headered the widget
       // and its frozen count husked after the last item was cleared.
-      case "needs": return <ActionInbox initialItems={model.needsAttention} />;
+      case "needs": return <ActionInbox initialItems={model.needsAttention} openCount={model.openCount} onOpenCount={setLiveOpen} />;
       case "board": return (
         <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">
           <BoardSnapshot byStatus={byStatus} total={data.cards.length} active={activeCards} loaded={ready.has("cards")} familiars={data.familiars} />

--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -36,6 +36,7 @@ function summary(slug) {
   const model = buildDashboardModel([summary("2026-06-19")], now);
   assert.equal(model.caughtUp, true, "no open items => caught up");
   assert.equal(model.needsAttention.length, 0);
+  assert.equal(model.openCount, 0, "openCount is 0 when caught up");
 }
 
 // busy when a response is pending today
@@ -48,13 +49,14 @@ function summary(slug) {
   assert.equal(model.needsAttention.length, 1);
 }
 
-// needsAttention is capped at 8
+// needsAttention is capped at 8, but openCount reports the true total
 {
   const many = Array.from({ length: 12 }, (_, i) =>
     item({ id: `r${i}`, kind: "response-needed", status: "pending" }),
   );
   const model = buildDashboardModel(many, now);
   assert.equal(model.needsAttention.length, 8, "needsAttention capped at 8");
+  assert.equal(model.openCount, 12, "openCount is uncapped");
   assert.equal(model.caughtUp, false);
 }
 

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -39,6 +39,8 @@ export type DashboardModel = {
   caughtUp: boolean;
   /** Open, actionable items — same set the old "Needs attention" list showed, capped. */
   needsAttention: InboxItem[];
+  /** True number of open items — `needsAttention` is capped for display, this isn't. */
+  openCount: number;
   /** Today's generated summary narrative, or null before one exists. */
   todaySummary: TodaySummary | null;
   featuredReport: RecentReport | null;
@@ -75,6 +77,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
     date: now,
     caughtUp: breakdown.openItems.length === 0,
     needsAttention: breakdown.openItems.slice(0, NEEDS_ATTENTION_CAP),
+    openCount: breakdown.openItems.length,
     todaySummary,
     featuredReport,
     recentReports: reports.filter((r) => r.slug !== featuredReport?.slug),

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -69,6 +69,16 @@
   flex: 0 0 auto;
 }
 
+/* Open items beyond the visible cap drill through to the Rituals surface. */
+.dash-inbox__more {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 8px; padding: 7px 10px; border-radius: 8px;
+  font-size: 0.8rem; font-weight: 600; color: var(--text-muted);
+  text-decoration: none; border: 1px dashed var(--border-hairline);
+}
+.dash-inbox__more:hover { color: var(--text-primary); border-color: var(--accent-presence); }
+.dash-inbox__more svg { width: 13px; height: 13px; flex: 0 0 auto; }
+
 .dash-act {
   display: inline-flex;
   align-items: center;

--- a/tests/dashboard-cockpit.spec.ts
+++ b/tests/dashboard-cockpit.spec.ts
@@ -180,3 +180,54 @@ test("a fired reminder from the poll renders in Needs you with a live count", as
   await expect(needs.locator(".dr-count")).toHaveText("1");
   await expect(needs).not.toContainText("All clear");
 });
+
+const openResponse = (id: string, title: string) => {
+  const nowIso = new Date(NOW).toISOString();
+  return {
+    id, kind: "response-needed", title, status: "pending",
+    createdAt: nowIso, updatedAt: nowIso, firedAt: nowIso, recurrence: null, source: "agent",
+  };
+};
+
+test("clearing the last visible item lands on the all-clear moment", async ({ page }) => {
+  await gotoDashboard(page, [openResponse("r1", "Reply to Sage"), openResponse("r2", "Review the plan")]);
+  const needs = page.locator('section[aria-label="Needs you"]');
+  await expect(needs.locator(".dr-count")).toHaveText("2");
+
+  // Acting removes the row optimistically and the badge tracks it. (The POST
+  // hits the same **/api/inbox** mock — the buttons only check res.ok.)
+  await needs.locator(".dash-inbox__row", { hasText: "Reply to Sage" }).getByRole("button", { name: "Done" }).click();
+  await expect(needs.locator(".dash-inbox__row")).toHaveCount(1);
+  await expect(needs.locator(".dr-count")).toHaveText("1");
+
+  await needs.locator(".dash-inbox__row").getByRole("button", { name: "Done" }).click();
+  await expect(needs).toContainText("All clear — nothing needs you right now.");
+  await expect(needs.locator(".dr-count")).toHaveCount(0);
+});
+
+test("counts stay truthful past the display cap, with an overflow drill-through", async ({ page }) => {
+  const items = Array.from({ length: 10 }, (_, i) => openResponse(`r${i + 1}`, `Open item ${i + 1}`));
+  await gotoDashboard(page, items);
+  const needs = page.locator('section[aria-label="Needs you"]');
+
+  // Badge reads the uncapped total; the visible list is capped and the
+  // overflow drills into the owning Rituals surface.
+  await expect(needs.locator(".dr-count")).toHaveText("10");
+  await expect(needs.locator(".dash-inbox__row")).toHaveCount(8);
+  const more = needs.locator("a.dash-inbox__more");
+  await expect(more).toContainText("+2 more");
+  await expect(more).toHaveAttribute("href", "/?mode=inbox");
+
+  // The Needs-you vital shows the same uncapped total and drills through.
+  const kpi = page.locator(".cockpit-kpi", { hasText: "Needs you" });
+  await expect(kpi.locator(".cockpit-kpi__value")).toHaveText("10");
+  await expect(kpi).toHaveAttribute("href", "/?mode=inbox");
+
+  // Clearing all 8 visible rows is NOT all clear — 2 open items remain.
+  await needs.getByRole("button", { name: "Select" }).click();
+  await needs.getByRole("button", { name: "Select all" }).click();
+  await needs.getByRole("button", { name: "Done 8" }).click();
+  await expect(needs.locator(".dash-inbox__row")).toHaveCount(0);
+  await expect(needs).not.toContainText("All clear");
+  await expect(needs.locator(".dr-count")).toHaveText("2");
+});


### PR DESCRIPTION
Follow-up to #3241 (cave-456r), which made the needs-attention model live (this session built the same core fix in parallel as #3243, closed superseded; these are the deltas #3241 didn't cover, rebuilt on its bare-widget architecture).

## Problem — everything reads the capped list

`needsAttention` is capped at 8 for display, but the widget badge, its all-clear read, and the Needs-you vital all read `needsAttention.length`:

- with 12 open items, the badge and the vital said **8**
- clearing the visible page flashed **'All clear — nothing needs you right now.'** over 4 hidden open items (`caughtUp = items.length === 0`)
- overflow past the cap was silently truncated — no path to the rest
- Needs-you was the only vital with no drill-in `href`

## Fix

- `DashboardModel.openCount` — uncapped open total (unit-tested: 12 items → cap 8, openCount 12)
- ActionInbox derives `liveTotal = openCount − optimistic removals` for its badge + caught-up read, reports it up (`onOpenCount`) so the Needs-you vital tracks done/dismiss/snooze between polls (reset when a fresh poll lands), and renders **'+N more — open Rituals'** (`/?mode=inbox`, `.focus-ring`) when open items exceed the visible cap
- Needs-you vital + trend snapshots read the uncapped total; tile deep-links `/?mode=inbox`

## Verification

- `pnpm test:app` — 730 files pass (model unit tests + page-contract pins for every behavior above)
- `pnpm typecheck` — clean
- Playwright `tests/dashboard-cockpit.spec.ts` — **10/10** locally, incl. 2 new: clearing the last visible item lands on the all-clear moment (badge 2→1→gone); bulk-clearing a capped page with items behind it does **not** read all clear (badge 10→2, overflow row stays, KPI 10 + href)

Bead: cave-ckxk