### PR TITLE
fix(dashboard): growth/analytics sub-pages drop stale load settles + Growth freshness stamp (cave-5p5m)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10039,6 +10039,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: transparent;
 }
 .growth-hero { margin-bottom: 18px; }
+/* Truthful freshness stamp beside the refresh action (fa-topbar__updated kin). */
+.growth-hero__updated {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  align-self: center;
+}
 /* Roster health triage — how many familiars need attention, at a glance. */
 .growth-triage {
   display: flex;

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -336,6 +336,19 @@ function mockFetchFor(score: "low" | "trusted") {
 }
 
 describe("FamiliarAnalyticsView", () => {
+  it("drops stale load settles and resets to skeleton on a familiar switch (cave-5p5m)", () => {
+    // Loads interleave (mount, familiar switch, manual refresh, 60s poll,
+    // on-focus refresh); App Router client nav can reuse the component
+    // instance across /familiars/A/analytics → /B/analytics, so a slow A
+    // response must never land its data — or error, or freshness stamp —
+    // under B's URL, and B must open on a skeleton, not A's numbers.
+    assert.match(source, /const gen = \+\+generation\.current/);
+    assert.match(source, /if \(generation\.current !== gen\) return;/);
+    assert.match(source, /if \(generation\.current === gen\) \{\s*setLoading\(false\);/);
+    assert.match(source, /setData\(null\);\s*setUpdatedAt\(null\);\s*void load\(\);/, "familiar switch drops the previous model + stamp");
+    assert.match(source, /aria-busy=\{loading \|\| refreshing\}/, "busy covers full loads, not just quiet refreshes");
+  });
+
   it("builds a renderable model; with no thread reports confidence is unmeasured, not Low", async () => {
     mockFetchFor("low");
     const data = await loadFamiliarAnalyticsData("cody");

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   buildFamiliarAnalyticsModel,
   loadFamiliarAnalyticsData,
@@ -51,25 +51,42 @@ export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
   const { announce } = useAnnouncer();
 
+  // Loads interleave (mount, familiar switch, manual refresh, 60s poll,
+  // on-focus refresh): only the latest issued load may write state, so a slow
+  // stale response — possibly for a *previous* familiarId — can't land its
+  // data, error, or freshness stamp over a newer one.
+  const generation = useRef(0);
+
   // `silent` marks the recurring background poll: it refreshes the data and
   // freshness stamp but never announces (a 60s AT announcement loop is noise).
   const load = useCallback(async ({ quiet = false, silent = false } = {}) => {
+    const gen = ++generation.current;
     if (quiet) setRefreshing(true);
     else setLoading(true);
     setError(null);
     try {
-      setData(await loadFamiliarAnalyticsData(familiarId));
+      const next = await loadFamiliarAnalyticsData(familiarId);
+      if (generation.current !== gen) return;
+      setData(next);
       setUpdatedAt(new Date().toISOString());
       if (quiet && !silent) announce("Analytics refreshed.");
     } catch (err) {
+      if (generation.current !== gen) return;
       setError(err instanceof Error ? err.message : "analytics data unavailable");
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (generation.current === gen) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
   }, [announce, familiarId]);
 
   useEffect(() => {
+    // A new familiar means a fresh page: drop the previous familiar's model
+    // (skeleton, not their numbers under the new URL) and stamp. The
+    // generation bump inside load() retires any in-flight response.
+    setData(null);
+    setUpdatedAt(null);
     void load();
   }, [load]);
 
@@ -90,7 +107,7 @@ export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
   }
 
   return (
-    <main className="fa-page" aria-busy={refreshing}>
+    <main className="fa-page" aria-busy={loading || refreshing}>
       {error ? (
         <div className="retro-callout" role="alert">
           <Icon name="ph:warning-circle" aria-hidden />

--- a/src/components/familiar-growth-view.test.ts
+++ b/src/components/familiar-growth-view.test.ts
@@ -43,6 +43,21 @@ describe("Familiar growth view", () => {
     assert.match(view, /announce\("Growth data refreshed\."\)/);
   });
 
+  it("drops stale load settles — only the latest issued load writes state (cave-5p5m)", () => {
+    // Mount, manual refresh, 60s poll, and on-focus refresh interleave; an
+    // older slower response must not overwrite fresher data or raise a stale
+    // error over it.
+    assert.match(view, /const gen = \+\+generation\.current/);
+    assert.match(view, /if \(generation\.current !== gen\) return;/);
+    assert.match(view, /if \(generation\.current === gen\) \{\s*setLoading\(false\);/);
+  });
+
+  it("carries a truthful freshness stamp, set when data lands (cave-5p5m)", () => {
+    assert.match(view, /setUpdatedAt\(new Date\(\)\.toISOString\(\)\)/, "stamped on load settle, not render");
+    assert.match(view, /Updated <RelativeTime iso=\{updatedAt\} \/>/, "renders as a semantic relative time");
+    assert.match(globals, /\.growth-hero__updated/, "the stamp has its own class");
+  });
+
   it("marks the selected roster row for assistive tech", () => {
     assert.match(view, /aria-pressed=\{selectedItem\}/);
   });

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PulseBars } from "@/components/ui/pulse-bars";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { AuthedImage } from "@/components/ui/authed-image";
+import { RelativeTime } from "@/components/ui/relative-time";
 import {
   buildFamiliarCardStats,
   type CovenMemoryEntry,
@@ -121,10 +122,19 @@ export function FamiliarGrowthView({
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
+  // Truthful freshness stamp — set when a load actually lands (server-provided
+  // initial data is stamped at mount), never faked at render time.
+  const [updatedAt, setUpdatedAt] = useState<string | null>(() => (initialData ? new Date().toISOString() : null));
   const { announce } = useAnnouncer();
+
+  // Loads interleave (mount, manual refresh, 60s poll, on-focus refresh):
+  // only the latest issued load may write state, so a slower stale response
+  // can't overwrite fresher data — or raise a stale error over it.
+  const generation = useRef(0);
 
   // `silent` marks the recurring background poll — refresh without announcing.
   const load = useCallback(async ({ quiet = false, silent = false } = {}) => {
+    const gen = ++generation.current;
     if (quiet) setRefreshing(true);
     else setLoading(true);
     try {
@@ -134,6 +144,7 @@ export function FamiliarGrowthView({
         getJson<CovenMemoryResponse>("/api/coven-memory"),
         getJson<RetroApiResponse>("/api/retro-runs"),
       ]);
+      if (generation.current !== gen) return;
 
       const nextData: FamiliarGrowthInitialData = {
         familiars: familiarsJson.familiars ?? [],
@@ -150,15 +161,19 @@ export function FamiliarGrowthView({
 
       setData(nextData);
       setNow(Date.now());
+      setUpdatedAt(new Date().toISOString());
       setError(errors.length > 0 ? errors.join(" · ") : null);
       // Selection is reconciled against the attention-sorted roster below, so
       // a fresh load lands on the familiar that most needs attention.
       if (quiet && !silent) announce("Growth data refreshed.");
     } catch (err) {
+      if (generation.current !== gen) return;
       setError(err instanceof Error ? err.message : "growth data unavailable");
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (generation.current === gen) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
   }, [announce]);
 
@@ -249,6 +264,11 @@ export function FamiliarGrowthView({
           ) : null}
         </div>
         <div className="retro-hero__actions">
+          {updatedAt ? (
+            <span className="growth-hero__updated">
+              Updated <RelativeTime iso={updatedAt} />
+            </span>
+          ) : null}
           <button
             type="button"
             className="retro-icon-btn"


### PR DESCRIPTION
## What

Sub-page audit slice for `dashboard-command-center`: fetch discipline on `/dashboard/familiars/growth` and `/dashboard/familiars/[id]/analytics`, plus a truthful freshness stamp on Growth.

## The bugs

Both views run `load()` from four interleaving sources — mount, manual refresh, 60s `usePausablePoll`, and the on-focus refresh — with **no ordering guard**:

- A slower, older response could settle after a newer one and overwrite fresher data, or raise a stale error banner over good data.
- **Analytics**: `load` closes over `familiarId`; App Router client nav can reuse the component instance, so a slow familiar-A response could land A's numbers/error/stamp under B's URL. While a full (non-quiet) load was in flight the page silently kept showing the previous model — `aria-busy` only tracked `refreshing`.
- **Growth** is a live triage surface (60s poll, refresh button) but had no "Updated Nm ago" stamp — the cockpit and analytics both carry one.

## The fix

- **Generation counter** in both views: only the latest issued load writes state; stale settles drop data, error, stamp, and loading flags.
- **Analytics**: familiar switch resets to the skeleton (model + stamp cleared) and the generation bump retires any in-flight response; `aria-busy={loading || refreshing}`.
- **Growth**: `Updated <RelativeTime/>` stamp in the hero actions, stamped when a load lands (mount-stamped for server-provided `initialData`), never faked at render. `.growth-hero__updated` mirrors `fa-topbar__updated`.

## Tests

Pins extended in `familiar-growth-view.test.ts` + `familiar-analytics-view.test.ts` (70/70 pass across the four targeted suites); `pnpm typecheck` clean.

Bead: cave-5p5m · Goal: dashboard-command-center