### PR TITLE
feat(omnigent): per-host workspace map for multi-machine runs

### DIFF
--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -500,11 +500,35 @@ function parseExecutorUrls(text: string): string[] {
   );
 }
 
+/** Parse "host = /abs/path" or "host=/abs/path" lines into a map. */
+function parseHostWorkspaceText(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const val = line.slice(eq + 1).trim();
+    if (key && val) out[key] = val;
+  }
+  return out;
+}
+
+function formatHostWorkspaceText(map: Record<string, string> | undefined): string {
+  if (!map || typeof map !== "object") return "";
+  return Object.entries(map)
+    .filter(([k, v]) => k.trim() && v.trim())
+    .map(([k, v]) => `${k.trim()}=${v.trim()}`)
+    .join("\n");
+}
+
 /** Omnigent fleet connection — the config surface for the host chip and remote runs. */
 function OmnigentSettingsGroup() {
   const { announce } = useAnnouncer();
   const [baseUrl, setBaseUrl] = useState("");
   const [workspace, setWorkspace] = useState("");
+  const [hostWorkspaceText, setHostWorkspaceText] = useState("");
   const [exposeHosts, setExposeHosts] = useState(true);
   const [statusLine, setStatusLine] = useState<string>("");
   const [saving, setSaving] = useState(false);
@@ -520,6 +544,7 @@ function OmnigentSettingsGroup() {
           omnigent?: {
             baseUrl?: string;
             defaultWorkspace?: string;
+            hostWorkspaceMap?: Record<string, string>;
             exposeHostsInComposer?: boolean;
           };
         };
@@ -528,6 +553,7 @@ function OmnigentSettingsGroup() {
         const o = j.config?.omnigent;
         setBaseUrl(o?.baseUrl ?? "");
         setWorkspace(o?.defaultWorkspace ?? "");
+        setHostWorkspaceText(formatHostWorkspaceText(o?.hostWorkspaceMap));
         setExposeHosts(o?.exposeHostsInComposer !== false);
       })
       .catch(() => {});
@@ -566,6 +592,7 @@ function OmnigentSettingsGroup() {
           omnigent: {
             baseUrl: baseUrl.trim(),
             defaultWorkspace: workspace.trim(),
+            hostWorkspaceMap: parseHostWorkspaceText(hostWorkspaceText),
             exposeHostsInComposer: exposeHosts,
           },
         }),
@@ -606,7 +633,7 @@ function OmnigentSettingsGroup() {
       </SettingControlRow>
       <SettingControlRow
         label="Default workspace"
-        hint="Absolute path on the Omnigent host used when Chat/Board start a run without an override."
+        hint="Fallback absolute path when the selected host has no entry in the host workspace map."
       >
         <input
           value={workspace}
@@ -614,6 +641,20 @@ function OmnigentSettingsGroup() {
           aria-label="Default Omnigent workspace"
           placeholder="/home/you/project"
           className="w-full min-w-[260px] max-w-md rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none"
+          spellCheck={false}
+        />
+      </SettingControlRow>
+      <SettingControlRow
+        label="Host workspace map"
+        hint="One path per host so MacBook, Studio, and Linux can differ. Keys: host_id, host name, or hostMap alias. Format: host=/abs/path (one per line)."
+      >
+        <textarea
+          value={hostWorkspaceText}
+          onChange={(e) => setHostWorkspaceText(e.target.value)}
+          aria-label="Omnigent host workspace map"
+          placeholder={"Macbook-Pro-5.local=/Users/you/Developer/1_Projects/coven-cave\nAndrews-Mac-Studio.local=/Users/you/Developer/1_Projects/hydra\nubuntu-root=/root/work"}
+          rows={4}
+          className="w-full min-w-[260px] max-w-md resize-y rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none"
           spellCheck={false}
         />
       </SettingControlRow>

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -40,6 +40,7 @@ const DEFAULT_CONFIG: CaveConfig = {
     defaultHostId: "",
     defaultWorkspace: "",
     hostMap: {},
+    hostWorkspaceMap: {},
     exposeHostsInComposer: true,
   },
   remoteHosts: [],
@@ -217,6 +218,8 @@ export type CaveOmnigentConfig = {
   defaultHostId: string;
   defaultWorkspace: string;
   hostMap: Record<string, string>;
+  /** host_id / name / hostMap alias → absolute workspace path on that host. */
+  hostWorkspaceMap: Record<string, string>;
   exposeHostsInComposer: boolean;
 };
 
@@ -407,6 +410,17 @@ export function normalizeMultiHostConfig(input: Partial<CaveMultiHostConfig> | u
   return { mode, hubUrl, executorUrls };
 }
 
+function normalizeStringRecord(input: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!input || typeof input !== "object" || Array.isArray(input)) return out;
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    const key = typeof k === "string" ? k.trim() : "";
+    const val = typeof v === "string" ? v.trim() : "";
+    if (key && val) out[key] = val;
+  }
+  return out;
+}
+
 export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
   const rawUrl = typeof input?.baseUrl === "string" ? input.baseUrl.trim().replace(/\/+$/, "") : "";
   let baseUrl = rawUrl;
@@ -418,20 +432,13 @@ export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | und
       baseUrl = rawUrl;
     }
   }
-  const hostMap: Record<string, string> = {};
-  if (input?.hostMap && typeof input.hostMap === "object" && !Array.isArray(input.hostMap)) {
-    for (const [k, v] of Object.entries(input.hostMap)) {
-      const key = typeof k === "string" ? k.trim() : "";
-      const val = typeof v === "string" ? v.trim() : "";
-      if (key && val) hostMap[key] = val;
-    }
-  }
   return {
     baseUrl,
     defaultAgentId: typeof input?.defaultAgentId === "string" ? input.defaultAgentId.trim() : "",
     defaultHostId: typeof input?.defaultHostId === "string" ? input.defaultHostId.trim() : "",
     defaultWorkspace: typeof input?.defaultWorkspace === "string" ? input.defaultWorkspace.trim() : "",
-    hostMap,
+    hostMap: normalizeStringRecord(input?.hostMap),
+    hostWorkspaceMap: normalizeStringRecord(input?.hostWorkspaceMap),
     exposeHostsInComposer: input?.exposeHostsInComposer !== false,
   };
 }

--- a/src/lib/omnigent/client.test.ts
+++ b/src/lib/omnigent/client.test.ts
@@ -47,16 +47,51 @@ test("omnigent host option ids round-trip", async () => {
   assert.equal(isOmnigentHostOptionId("local"), false);
 });
 
-test("normalizeOmnigentConfig keeps hostMap and exposeHostsInComposer", async () => {
+test("normalizeOmnigentConfig keeps hostMap, hostWorkspaceMap, exposeHostsInComposer", async () => {
   const { normalizeOmnigentConfig } = await import("../cave-config.ts");
   const cfg = normalizeOmnigentConfig({
     baseUrl: "https://omni.example.com/",
     hostMap: { "ubuntu-root": "host_9" },
+    hostWorkspaceMap: {
+      host_9: "/root/work",
+      "Macbook-Pro-5.local": "/Users/a/proj",
+    },
     exposeHostsInComposer: false,
   });
   assert.equal(cfg.baseUrl, "https://omni.example.com");
   assert.equal(cfg.hostMap["ubuntu-root"], "host_9");
+  assert.equal(cfg.hostWorkspaceMap.host_9, "/root/work");
+  assert.equal(cfg.hostWorkspaceMap["Macbook-Pro-5.local"], "/Users/a/proj");
   assert.equal(cfg.exposeHostsInComposer, false);
+});
+
+test("resolveWorkspaceForHost prefers host_id then name then hostMap alias", async () => {
+  const { resolveWorkspaceForHost } = await import("./workspace-resolve.ts");
+  const maps = {
+    hostMap: {
+      "ubuntu-root": "host_linux",
+      "Macbook-Pro-5.local": "host_mbp",
+    },
+    hostWorkspaceMap: {
+      host_studio: "/Users/a/Studio/proj",
+      "Andrews-Mac-Studio.local": "/Users/a/Studio/by-name",
+      "ubuntu-root": "/root/ubuntu-work",
+    },
+  };
+
+  assert.equal(
+    resolveWorkspaceForHost(maps, "host_studio", "ignored"),
+    "/Users/a/Studio/proj",
+  );
+  assert.equal(
+    resolveWorkspaceForHost(maps, "host_other", "Andrews-Mac-Studio.local"),
+    "/Users/a/Studio/by-name",
+  );
+  assert.equal(
+    resolveWorkspaceForHost(maps, "host_linux", "ubuntu-root"),
+    "/root/ubuntu-work",
+  );
+  assert.equal(resolveWorkspaceForHost(maps, "host_mbp", "Macbook-Pro-5.local"), undefined);
 });
 
 test("resolveOmnigentAuth reads JWT and rejects expired", async () => {

--- a/src/lib/omnigent/run.ts
+++ b/src/lib/omnigent/run.ts
@@ -17,8 +17,10 @@ import {
   runWardPreflight,
   WardPreflightError,
 } from "./ward-preflight.ts";
+import { resolveWorkspaceForHost } from "./workspace-resolve.ts";
 
 export { WardPreflightError };
+export { resolveWorkspaceForHost } from "./workspace-resolve.ts";
 
 export type OmnigentRunRequest = {
   prompt: string;
@@ -130,14 +132,16 @@ export async function createOmnigentRun(
     hostId = resolveHostIdFromMap(config, rawHost) || pickDefaultHostId(hosts) || undefined;
     if (!hostId) throw new Error("No online Omnigent host available");
 
+    const hostMeta = hosts.find((h) => h.host_id === hostId);
     workspace =
       (request.workspace && request.workspace.trim()) ||
       (fam.workspace && fam.workspace.trim()) ||
+      resolveWorkspaceForHost(config.omnigent, hostId, hostMeta?.name) ||
       config.omnigent.defaultWorkspace ||
       undefined;
     if (!workspace || !workspace.startsWith("/")) {
       throw new Error(
-        "workspace must be an absolute path on the host (set defaultWorkspace or pass workspace)",
+        "workspace must be an absolute path on the host (set hostWorkspaceMap or defaultWorkspace)",
       );
     }
   } else {

--- a/src/lib/omnigent/types.ts
+++ b/src/lib/omnigent/types.ts
@@ -70,6 +70,12 @@ export type CaveOmnigentConfig = {
    */
   hostMap: Record<string, string>;
   /**
+   * Absolute workspace path keyed by Omnigent host_id, host name, or hostMap alias.
+   * Used after the run host is resolved; falls back to defaultWorkspace.
+   * e.g. { "host_854c…": "/Users/…/coven-cave", "ubuntu-root": "/root/work" }
+   */
+  hostWorkspaceMap: Record<string, string>;
+  /**
    * When true, /api/hosts includes Omnigent fleet hosts (omnigent:<host_id>)
    * in the composer Host chip so Chat/Home can run on the fleet.
    */

--- a/src/lib/omnigent/workspace-resolve.ts
+++ b/src/lib/omnigent/workspace-resolve.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure host → workspace resolution for Omnigent runs (no @/ imports; unit-testable).
+ */
+
+export type HostWorkspaceMaps = {
+  hostWorkspaceMap?: Record<string, string>;
+  hostMap?: Record<string, string>;
+};
+
+/**
+ * Resolve absolute workspace for a chosen Omnigent host.
+ * Lookup order for map keys: host_id → host name → hostMap aliases that point at this host.
+ */
+export function resolveWorkspaceForHost(
+  maps: HostWorkspaceMaps,
+  hostId: string | undefined,
+  hostName?: string | null,
+): string | undefined {
+  if (!hostId) return undefined;
+  const map = maps.hostWorkspaceMap ?? {};
+  const take = (key: string | undefined | null): string | undefined => {
+    if (!key) return undefined;
+    const v = map[key]?.trim();
+    return v || undefined;
+  };
+
+  const byId = take(hostId);
+  if (byId) return byId;
+
+  const byName = take(hostName ?? undefined);
+  if (byName) return byName;
+
+  for (const [alias, mappedId] of Object.entries(maps.hostMap ?? {})) {
+    if (mappedId === hostId) {
+      const byAlias = take(alias);
+      if (byAlias) return byAlias;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds `omnigent.hostWorkspaceMap` so Chat/Board Omnigent runs pick a workspace path **per host** instead of one global default (which broke when Mac Studio lacked the MacBook path).

**Resolve order** (external hosts): request workspace → familiar override → `hostWorkspaceMap` (by `host_id`, host name, or `hostMap` alias) → `defaultWorkspace`.

## UI

Settings → Omnigent fleet → **Host workspace map**  
Lines like:

```
Macbook-Pro-5.local=/Users/you/Developer/1_Projects/coven-cave
Andrews-Mac-Studio.local=/Users/you/Developer/1_Projects/<studio-repo>
ubuntu-root=/root/work
```

## Test plan

- [x] `node --experimental-strip-types --test src/lib/omnigent/client.test.ts` (10 tests)
- [ ] Set map for MacBook + Studio; Host chip → Studio → send without 400
- [ ] Host without map entry still uses defaultWorkspace