### PR TITLE
feat(sidebar): PR-status badge on workspace sidebar thread rows

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -150,6 +150,7 @@ export const SUITES = {
     "src/components/chat-sidebar-wiring.test.ts",
     "src/components/workspace-sidebar-wiring.test.ts",
     "src/components/workspace-sidebar-pinned.test.ts",
+    "src/components/workspace-sidebar-pr-badge.test.ts",
     "src/components/workspace-rail.test.ts",
     "src/components/terminal-scope.test.ts",
     "src/components/workspace-rail-motion.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1242,6 +1242,46 @@ tr[role="checkbox"]:focus-visible {
 .cnav__lead.is-accent {
   color: var(--accent-presence);
 }
+/* PR-status badge on thread rows — the workspace-sidebar twin of
+   .chat-list-pr-badge (#2983). Sits as a sibling BEFORE the row's main button
+   (a button can't nest inside a button), aligned over the status-dot gutter;
+   the following button trades its indent for the badge's. GitHub state colors:
+   open green, merged the presence accent, closed red, draft muted. */
+.cnav__pr-badge {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  /* Center the icon over where the 6px dot sits (indent + 3px). */
+  margin-left: calc(var(--cnav-indent) - 5px);
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-success);
+}
+.cnav__thread--flat .cnav__pr-badge {
+  margin-left: 8px;
+}
+.cnav__pr-badge + .cnav__thread-main,
+.cnav__thread--flat .cnav__pr-badge + .cnav__thread-main {
+  /* The badge owns the gutter; keep only the row's internal 8px gap. */
+  padding-left: 8px;
+}
+.cnav__pr-badge:hover {
+  background: color-mix(in oklch, var(--foreground) 10%, transparent);
+}
+.cnav__pr-badge[data-pr-state="merged"] {
+  color: var(--accent-presence);
+}
+.cnav__pr-badge[data-pr-state="closed"] {
+  color: var(--color-danger);
+}
+.cnav__pr-badge[data-pr-state="draft"] {
+  color: var(--text-muted);
+}
 .cnav__thread-title {
   flex: 1;
   min-width: 0;

--- a/src/components/workspace-sidebar-pr-badge.test.ts
+++ b/src/components/workspace-sidebar-pr-badge.test.ts
@@ -1,0 +1,84 @@
+// @ts-nocheck
+// Source pins for the workspace-sidebar PR-status badge — the sidebar twin of
+// the chat list's badge (#2983): thread rows swap the status dot (and the
+// title-heuristic PR/branch glyph) for a clickable GitHub PR-state icon when
+// the session carries real PR context; clicking opens the PR in the in-app
+// browser (new-tab fallback) without opening the chat.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sidebar = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── ThreadRow: real PR context wins the leading slot ─────────────────────────
+assert.match(
+  sidebar,
+  /const prStatus = sessionPrStatus\(session\.pullRequest\);/,
+  "rows derive PR status from the session's pullRequest context (shared lib)",
+);
+assert.match(
+  sidebar,
+  /\{prStatus \? <ThreadPrBadge prStatus=\{prStatus\} onOpenUrl=\{onOpenUrl\} \/> : null\}\s*\n\s*<button/,
+  "the badge renders as a SIBLING before the row's main <button> — never nested inside it",
+);
+assert.match(
+  sidebar,
+  /\{prStatus \? null : glyph \? \(/,
+  "real PR context suppresses the dot AND the title-heuristic glyph",
+);
+
+// ── Pinned rail rows carry the badge too ─────────────────────────────────────
+const pinStart = sidebar.indexOf('aria-label="Pinned threads"');
+assert.ok(pinStart > 0, "the pinned rail section exists");
+const pinnedRail = sidebar.slice(pinStart, sidebar.indexOf('view === "recent"', pinStart));
+assert.match(
+  pinnedRail,
+  /<ThreadPrBadge prStatus=\{prStatus\} onOpenUrl=\{onOpenUrl\} \/>/,
+  "pinned rail rows show the PR badge as well",
+);
+
+// ── Badge behavior mirrors the chat-list badge ───────────────────────────────
+assert.match(
+  sidebar,
+  /data-pr-state=\{prStatus\.key\}/,
+  "the badge carries data-pr-state for state-colored styling",
+);
+assert.match(
+  sidebar,
+  /e\.stopPropagation\(\);\s*\n\s*if \(onOpenUrl\) onOpenUrl\(prStatus\.url\);/,
+  "clicking the badge opens the PR without opening the chat",
+);
+assert.match(
+  sidebar,
+  /window\.open\(prStatus\.url, "_blank", "noopener,noreferrer"\)/,
+  "without an in-app opener the badge falls back to a new tab",
+);
+assert.match(
+  sidebar,
+  /aria-label=\{`Open pull request \(\$\{prStatus\.label\}\)`\}/,
+  "the badge has an accessible name naming the PR and its state",
+);
+
+// ── Wiring: workspace hands the sidebar its in-app URL opener ────────────────
+assert.match(
+  workspace,
+  /<WorkspaceSidebar[\s\S]*?onOpenUrl=\{openUrlInAppBrowser\}/,
+  "workspace passes the in-app browser opener to the chat sidebar",
+);
+
+// ── Styling: GitHub's state colors + gutter alignment ────────────────────────
+for (const state of ["merged", "closed", "draft"]) {
+  assert.match(
+    css,
+    new RegExp(`\\.cnav__pr-badge\\[data-pr-state="${state}"\\]`),
+    `globals.css styles the ${state} PR state`,
+  );
+}
+assert.match(
+  css,
+  /\.cnav__pr-badge \+ \.cnav__thread-main/,
+  "the row button trades its indent for the badge's gutter (no double indent)",
+);
+
+console.log("workspace-sidebar-pr-badge.test.ts passed");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -9,6 +9,7 @@ import { SidebarFooter } from "@/components/sidebar-footer";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
+import { sessionPrStatus, type SessionPrStatus } from "@/lib/session-pr-status";
 import type { SessionRow } from "@/lib/types";
 import { useProjects } from "@/lib/use-projects";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
@@ -53,6 +54,9 @@ type Props = {
   onOpenSessionInSplit?: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
   onDeleteSession: (session: SessionRow) => Promise<void>;
+  /** Opens the thread's pull request in the in-app browser (PR badge click);
+   *  without it the badge falls back to a new tab. Same chain as chat-list. */
+  onOpenUrl?: (url: string) => void;
   /** Badge count for the Scheduled shortcut (from code-sidebar). */
   scheduledCount?: number;
   /** Opens Settings — powers the shared footer so Chat keeps the same
@@ -115,6 +119,36 @@ function threadLeadingIcon(title: string): IconName | null {
   return null;
 }
 
+// PR-status badge in a thread row's leading slot — the workspace-sidebar twin
+// of the chat list's badge (#2983): GitHub state colors, click opens the PR
+// (in-app browser when wired) without opening the chat. Rendered as a sibling
+// of the row's main <button> (never nested inside it — invalid HTML), with CSS
+// aligning it over the status-dot gutter.
+function ThreadPrBadge({
+  prStatus,
+  onOpenUrl,
+}: {
+  prStatus: SessionPrStatus;
+  onOpenUrl?: (url: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="cnav__pr-badge focus-ring"
+      data-pr-state={prStatus.key}
+      title={`Open ${prStatus.label}`}
+      aria-label={`Open pull request (${prStatus.label})`}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (onOpenUrl) onOpenUrl(prStatus.url);
+        else window.open(prStatus.url, "_blank", "noopener,noreferrer");
+      }}
+    >
+      <Icon name={prStatus.icon} width={12} aria-hidden />
+    </button>
+  );
+}
+
 type ThreadRowProps = {
   session: SessionRow;
   active: boolean;
@@ -128,6 +162,8 @@ type ThreadRowProps = {
   project?: { root: string; name: string; color: string | null } | null;
   /** PR/branch glyph from threadLeadingIcon — shown instead of the status dot when truthy. */
   glyph?: IconName | null;
+  /** In-app URL opener for the PR badge (new-tab fallback without it). */
+  onOpenUrl?: (url: string) => void;
   onOpen: () => void;
   /** ⌥↵ / ⌥-click / drag: open beside the current chat in a split pane. */
   onOpenInSplit?: () => void;
@@ -146,6 +182,7 @@ function ThreadRow({
   indent,
   project = null,
   glyph,
+  onOpenUrl,
   onOpen,
   onOpenInSplit,
   onTogglePin,
@@ -154,8 +191,13 @@ function ThreadRow({
   onConfirmDelete,
 }: ThreadRowProps) {
   const title = sessionRailTitle(session);
+  // Real PR context beats the title-heuristic glyph — when the thread's work
+  // reached an actual pull request, the leading slot shows the clickable
+  // state-colored badge instead of the dot or heuristic icon.
+  const prStatus = sessionPrStatus(session.pullRequest);
   return (
     <div className={`cnav__thread${indent === "flat" ? " cnav__thread--flat" : ""}${active ? " is-active" : ""}`}>
+      {prStatus ? <ThreadPrBadge prStatus={prStatus} onOpenUrl={onOpenUrl} /> : null}
       <button
         type="button"
         aria-current={active ? "page" : undefined}
@@ -190,7 +232,7 @@ function ThreadRow({
         }}
         className="cnav__thread-main focus-ring"
       >
-        {glyph ? (
+        {prStatus ? null : glyph ? (
           <Icon name={glyph} width={13} className="cnav__lead" aria-hidden />
         ) : (
           <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
@@ -253,6 +295,7 @@ export function WorkspaceSidebar({
   onOpenSessionInSplit,
   onNewChat,
   onDeleteSession,
+  onOpenUrl,
   scheduledCount,
   onOpenSettings,
 }: Props) {
@@ -546,16 +589,20 @@ export function WorkspaceSidebar({
                 {pinnedSessions.map((session) => {
                   const title = sessionRailTitle(session);
                   const active = activeSessionId === session.id;
+                  const prStatus = sessionPrStatus(session.pullRequest);
                   return (
                     <li key={`pin-${session.id}`}>
                       <div className={`cnav__thread cnav__thread--flat${active ? " is-active" : ""}`}>
+                        {prStatus ? <ThreadPrBadge prStatus={prStatus} onOpenUrl={onOpenUrl} /> : null}
                         <button
                           type="button"
                           aria-current={active ? "page" : undefined}
                           onClick={() => onOpenSession(session)}
                           className="cnav__thread-main focus-ring"
                         >
-                          <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
+                          {prStatus ? null : (
+                            <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
+                          )}
                           <span className="cnav__thread-title" title={title}>{title}</span>
                         </button>
                         <button
@@ -603,6 +650,7 @@ export function WorkspaceSidebar({
                             indent="flat"
                             project={sessionProjectById.get(session.id) ?? null}
                             glyph={threadLeadingIcon(sessionRailTitle(session))}
+                            onOpenUrl={onOpenUrl}
                             onOpen={() => onOpenSession(session)}
                             onOpenInSplit={
                               onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
@@ -712,6 +760,7 @@ export function WorkspaceSidebar({
                                   deleting={deletingSessionId === session.id}
                                   indent="folder"
                                   glyph={glyph}
+                                  onOpenUrl={onOpenUrl}
                                   onOpen={() => onOpenSession(session)}
                                   onOpenInSplit={
                                     onOpenSessionInSplit

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2388,6 +2388,7 @@ export function Workspace() {
         invalidateConversation(session.id);
         await loadSessions();
       }}
+      onOpenUrl={openUrlInAppBrowser}
       scheduledCount={scheduleNeedsCount}
       onOpenSettings={() => {
         shellRef.current?.dismissNavMobile();


### PR DESCRIPTION
Extends the convo-thread PR-status signal (#2983) to the **workspace sidebar** — the third surface listing chat threads.

## What
- **ThreadRow** (Recent + folder views) and the **pinned rail** render the clickable GitHub PR-state badge (open / draft / merged / closed, GitHub state colors) in the leading slot when `sessionPrStatus(session.pullRequest)` resolves; the plain status dot and the title-heuristic `threadLeadingIcon` glyph yield to real PR context.
- Clicking the badge opens the PR in the **in-app browser** (`openUrlInAppBrowser` handed down as the new optional `onOpenUrl` prop), `window.open` new-tab fallback — without opening the chat.
- The row body is a native `<button>`, so the badge is a **sibling before it** (nested buttons are invalid HTML); `.cnav__pr-badge` CSS centers it over the status-dot gutter for both folder (24px) and flat (13px) indents, and the following button trades its indent for the badge's.

## Verification
- `pnpm typecheck` clean
- `pnpm test:app` — 742 test files pass (new: `workspace-sidebar-pr-badge.test.ts`; `workspace-sidebar-wiring`, `workspace-sidebar-pinned`, `chat-list-pr-badge` unaffected)
- `pnpm check:tests-wired` — 1004 files wired

Follow-up candidate: deep-link the badge into the GitHubView PR panel instead of the raw URL.