### PR TITLE
feat(research-desk): keyboard nav on mission list

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -34,6 +34,7 @@ export const SUITES = {
     "src/lib/role-surfaces.test.ts",
     "src/lib/research-missions.test.ts",
     "src/lib/research-mission-client.test.ts",
+    "src/lib/roving-list.test.ts",
     "src/lib/research-artifact-contract.test.ts",
     "src/lib/role-surface-state.test.ts",
     "src/components/role-surface-shell.test.ts",

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { Icon } from "@/lib/icon";
 import type { ResearchMission } from "@/lib/research-missions";
 import { relativeTime } from "@/lib/relative-time";
+import { nextRovingId, resolveRovingId, type RovingKey } from "@/lib/roving-list";
 
 type Props = {
   missions: ResearchMission[];
@@ -20,7 +22,30 @@ const STATUS_TONE: Partial<Record<ResearchMission["status"], string>> = {
   completed: "ok",
 };
 
+const ROVING_KEYS = new Set<string>(["ArrowDown", "ArrowUp", "Home", "End"]);
+
 export function ResearchMissionList({ missions, selectedId, loading, onSelect }: Props) {
+  const missionIds = useMemo(() => missions.map((mission) => mission.id), [missions]);
+  const [rovingId, setRovingId] = useState<string | null>(() => resolveRovingId(missionIds, selectedId, selectedId));
+  const buttonRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  useEffect(() => {
+    setRovingId((current) => resolveRovingId(missionIds, current, selectedId));
+  }, [missionIds, selectedId]);
+
+  const focusMission = (id: string | null) => {
+    if (!id) return;
+    requestAnimationFrame(() => buttonRefs.current.get(id)?.focus());
+  };
+
+  const onListKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    if (!ROVING_KEYS.has(event.key)) return;
+    event.preventDefault();
+    const nextId = nextRovingId(missionIds, rovingId, event.key as RovingKey);
+    setRovingId(nextId);
+    focusMission(nextId);
+  };
+
   return (
     <nav className="research-mission-nav" aria-label="Research missions">
       <div className="research-mission-nav__head">
@@ -36,7 +61,7 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
           <span>Describe an investigation to start the first one.</span>
         </div>
       ) : (
-        <ul className="research-mission-nav__list">
+        <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
           {missions.map((mission) => {
             const selected = mission.id === selectedId;
             const iteration = mission.iterations.at(-1);
@@ -44,9 +69,21 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
               <li key={mission.id}>
                 <button
                   type="button"
-                  className={`research-mission-row${selected ? " is-selected" : ""}`}
+                  ref={(node) => {
+                    if (node) {
+                      buttonRefs.current.set(mission.id, node);
+                    } else {
+                      buttonRefs.current.delete(mission.id);
+                    }
+                  }}
+                  className={`research-mission-row focus-ring${selected ? " is-selected" : ""}`}
                   aria-current={selected ? "true" : undefined}
-                  onClick={() => onSelect(mission.id)}
+                  tabIndex={mission.id === rovingId ? 0 : -1}
+                  onFocus={() => setRovingId(mission.id)}
+                  onClick={() => {
+                    setRovingId(mission.id);
+                    onSelect(mission.id);
+                  }}
                 >
                   <span className="research-mission-row__top">
                     <span className={`research-status-dot research-status-dot--${STATUS_TONE[mission.status] ?? "muted"}`} aria-hidden />

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -61,6 +61,16 @@ test("plan chips are honest about interactivity", () => {
   assert.match(css, /\.research-plan-chip--note \{[^}]*border-color: transparent/);
 });
 
+
+test("mission list uses roving tabindex keyboard navigation", () => {
+  assert.match(list, /resolveRovingId\(missionIds, current, selectedId\)/);
+  assert.match(list, /nextRovingId\(missionIds, rovingId, event\.key as RovingKey\)/);
+  assert.match(list, /tabIndex=\{mission\.id === rovingId \? 0 : -1\}/);
+  assert.match(list, /onKeyDown=\{onListKeyDown\}/);
+  assert.match(list, /buttonRefs\.current\.get\(id\)\?\.focus\(\)/);
+  assert.match(list, /research-mission-row focus-ring/);
+});
+
 test("mission list and evidence trajectory expose semantic state", () => {
   assert.match(list, /aria-current=\{selected/);
   assert.match(detail, /aria-label="Research progress"/);

--- a/src/lib/roving-list.test.ts
+++ b/src/lib/roving-list.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nextRovingId, resolveRovingId } from "./roving-list.ts";
+
+test("resolveRovingId keeps the current id stable across refreshes", () => {
+  assert.equal(resolveRovingId(["a", "b", "c"], "b", "a"), "b");
+});
+
+test("resolveRovingId falls back to selection, then first item", () => {
+  assert.equal(resolveRovingId(["a", "b", "c"], "missing", "c"), "c");
+  assert.equal(resolveRovingId(["a", "b"], null, null), "a");
+  assert.equal(resolveRovingId([], "a", "a"), null);
+});
+
+test("nextRovingId moves vertically and clamps at list edges", () => {
+  const ids = ["a", "b", "c"];
+  assert.equal(nextRovingId(ids, "a", "ArrowDown"), "b");
+  assert.equal(nextRovingId(ids, "c", "ArrowDown"), "c");
+  assert.equal(nextRovingId(ids, "c", "ArrowUp"), "b");
+  assert.equal(nextRovingId(ids, "a", "ArrowUp"), "a");
+});
+
+test("nextRovingId supports Home and End jumps", () => {
+  const ids = ["a", "b", "c"];
+  assert.equal(nextRovingId(ids, "b", "Home"), "a");
+  assert.equal(nextRovingId(ids, "b", "End"), "c");
+});

--- a/src/lib/roving-list.ts
+++ b/src/lib/roving-list.ts
@@ -1,0 +1,32 @@
+export type RovingKey = "ArrowDown" | "ArrowUp" | "Home" | "End";
+
+export function resolveRovingId(
+  ids: readonly string[],
+  currentId: string | null,
+  preferredId: string | null,
+): string | null {
+  if (currentId && ids.includes(currentId)) return currentId;
+  if (preferredId && ids.includes(preferredId)) return preferredId;
+  return ids[0] ?? null;
+}
+
+export function nextRovingId(
+  ids: readonly string[],
+  currentId: string | null,
+  key: RovingKey,
+): string | null {
+  if (ids.length === 0) return null;
+  const currentIndex = currentId ? ids.indexOf(currentId) : -1;
+  const index = currentIndex === -1 ? 0 : currentIndex;
+
+  switch (key) {
+    case "ArrowDown":
+      return ids[Math.min(ids.length - 1, index + 1)] ?? null;
+    case "ArrowUp":
+      return ids[Math.max(0, index - 1)] ?? null;
+    case "Home":
+      return ids[0] ?? null;
+    case "End":
+      return ids.at(-1) ?? null;
+  }
+}


### PR DESCRIPTION
## Summary
- add roving tabindex state for Research Desk mission rows keyed by mission id
- support ArrowUp/ArrowDown and Home/End focus movement without changing Enter/Space selection behavior
- add pure roving-list tests plus source-regex wiring checks

## Test evidence
- node --experimental-strip-types --no-warnings --import ./scripts/test-alias-register.mjs --test src/lib/roving-list.test.ts src/components/role-surfaces/researcher-surface.test.ts
- pnpm typecheck
- pnpm test:app

Bead: cave-pwev

Candidate d: not included; filed follow-up bead cave-k4kp.