### PR TITLE
feat(chat): sticky familiar-tab hero

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6292,12 +6292,28 @@ a.mobile-handoff__link:hover {
   container-type: inline-size;
 }
 
+.chat-familiar-view {
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-top: 112px;
+}
+
+.chat-familiar-view :is(a, button, [tabindex]):focus {
+  scroll-margin-top: 112px;
+}
+
 .familiar-tab__hero {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: flex;
   align-items: flex-start;
   gap: 14px;
-  padding: 12px 2px 16px;
+  margin-inline: -16px;
+  padding: 12px 18px 16px;
   border-bottom: 1px solid var(--border-hairline);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 .familiar-tab__avatar {

--- a/src/components/familiar-tab-hero.test.ts
+++ b/src/components/familiar-tab-hero.test.ts
@@ -71,6 +71,19 @@ test("wide-canvas layout: container-query grid, two columns >=900px, single belo
   assert.ok(cols.length >= 2, "capability sections split into two source-ordered columns");
 });
 
+test("sticky hero pins inside the Familiar tab scroll region without hiding focus", () => {
+  assert.match(
+    src,
+    /className="chat-familiar-view flex h-full min-h-0 flex-col overflow-y-auto"[\s\S]{0,120}?aria-label="Familiar profile"/,
+    "the section remains the labelled scroll container",
+  );
+  assert.match(css, /\.chat-familiar-view \{[^}]*-webkit-overflow-scrolling: touch/, "touch momentum scroll remains enabled");
+  assert.match(css, /\.chat-familiar-view \{[^}]*scroll-padding-top: 112px/, "scroll container reserves space for the pinned hero");
+  assert.match(css, /\.chat-familiar-view :is\(a, button, \[tabindex\]\):focus \{[^}]*scroll-margin-top: 112px/, "focused controls scroll clear of the hero");
+  assert.match(css, /\.familiar-tab__hero \{[^}]*position: sticky;[\s\S]*?top: 0;[\s\S]*?z-index: 2/, "hero pins at the top of the tab");
+  assert.match(css, /\.familiar-tab__hero \{[\s\S]*?background: var\(--glass-raised\);[\s\S]*?backdrop-filter/, "sticky band keeps the glass treatment over scrolled content");
+});
+
 test("the chat surface gives the tab a wide canvas and threads presence", () => {
   assert.match(
     chatSurface,


### PR DESCRIPTION
## Before
- The Familiar tab hero scrolled away with the capability grid, so identity/context disappeared while reviewing long familiar capability lists.

## After
- The identity hero is a CSS sticky glass band inside the existing labelled Familiar profile scroll container.
- The scroll region keeps iOS momentum scrolling and reserves sticky-header space so focused links/buttons do not land hidden under the pinned hero.
- Added source-regex pins for the sticky structure and focus/touch safeguards.

## Tests
- node --experimental-strip-types --no-warnings --import ./scripts/test-alias-register.mjs --test src/components/familiar-tab-hero.test.ts
- pnpm typecheck
- pnpm test:app (741 app test files)