### PR TITLE
fix(threads): Phase 4 review follow-ups — adapter meta validation, fail-closed pending listing, inclusive budget boundary

### DIFF
--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,7 +97,7 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount < 5_440);
+  assert.ok(metrics.fileCount <= 5_440);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
     fileCount: 5_440,

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -148,7 +148,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount < 5_440);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_440);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src/lib/threads-adapters.test.ts
+++ b/src/lib/threads-adapters.test.ts
@@ -188,6 +188,18 @@ describe("fixtures adapter — proposals", () => {
     assert.equal(res.meta.verified, true);
   });
 
+  it("an unreadable pending listing fails closed, never throws", async () => {
+    // A regular file where the dir should be: existsSync passes, readdir throws.
+    const notADir = path.join(tempDir("phase4-pending-unreadable-"), "pending");
+    writeFileSync(notADir, "not a directory");
+    const broken = new FixturesThreadsAdapter({ pendingDir: notADir });
+    const res = await broken.proposals();
+    assert.equal(res.blocked, true);
+    assert.equal(res.why, "no-fixture");
+    assert.equal(res.meta.verified, false);
+    assert.equal(res.data, null);
+  });
+
   it("R5: approve and reject refuse in fixtures mode — no daemon, no decision", async () => {
     for (const envelope of [await adapter.approve(), await adapter.reject()]) {
       assert.equal(envelope.blocked, true);
@@ -363,6 +375,20 @@ describe("daemon adapter — proposals and decisions", () => {
     const blocked = await gone.proposals();
     assert.equal(blocked.blocked, true);
     assert.equal(blocked.why, "daemon-unavailable");
+  });
+
+  it("an unreadable pending listing fails closed in daemon mode too, never throws", async () => {
+    const home = tempDir("phase4-home-unreadable-");
+    writeFileSync(path.join(home, "pending"), "not a directory");
+    const adapter = new DaemonThreadsAdapter({
+      call: async () => ({ ok: false, status: 0, data: null }),
+      covenHomeDir: home,
+    });
+    const res = await adapter.proposals();
+    assert.equal(res.blocked, true);
+    assert.equal(res.why, "unparseable");
+    assert.equal(res.meta.verified, false);
+    assert.equal(res.data, null);
   });
 
   it("approve forwards to the daemon and never touches the pending file itself", async () => {

--- a/src/lib/threads-adapters.ts
+++ b/src/lib/threads-adapters.ts
@@ -69,10 +69,18 @@ function pendingDirCursor(dir: string): string {
   return `pending:${createHash("sha256").update(listing.join("\n")).digest("hex").slice(0, 16)}`;
 }
 
-function readPendingDir(dir: string): ProposalView[] {
-  const files = readdirSync(dir)
-    .filter((f) => f.endsWith(".json"))
-    .sort();
+function readPendingDir(dir: string): ProposalView[] | null {
+  // null = the listing itself could not be verified (unreadable dir, not a
+  // dir, permissions). Callers fail closed — a throw here would 500 the route
+  // instead of rendering blocked.
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+  } catch {
+    return null;
+  }
   return files.map((file) => {
     try {
       const raw: unknown = JSON.parse(readFileSync(path.join(dir, file), "utf8"));
@@ -245,7 +253,11 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
     if (!existsSync(this.pendingDir)) {
       return blockedEnvelope("no-fixture", this.meta("pending:absent", false));
     }
-    return okEnvelope(readPendingDir(this.pendingDir), this.meta(pendingDirCursor(this.pendingDir), true));
+    const listed = readPendingDir(this.pendingDir);
+    if (listed === null) {
+      return blockedEnvelope("no-fixture", this.meta("pending:unreadable", false));
+    }
+    return okEnvelope(listed, this.meta(pendingDirCursor(this.pendingDir), true));
   }
 
   // §3.7 / R5: in fixtures mode there is no daemon to forward to — the action
@@ -414,7 +426,13 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
       if (existsSync(this.home)) return okEnvelope([], this.meta("pending:empty", true));
       return blockedEnvelope("daemon-unavailable", this.meta("pending:absent", false));
     }
-    return okEnvelope(readPendingDir(pendingDir), this.meta(pendingDirCursor(pendingDir), true));
+    const listed = readPendingDir(pendingDir);
+    if (listed === null) {
+      // The staging area exists but its listing cannot be verified: blocked,
+      // never a throw and never an empty-healthy answer.
+      return blockedEnvelope("unparseable", this.meta("pending:unreadable", false));
+    }
+    return okEnvelope(listed, this.meta(pendingDirCursor(pendingDir), true));
   }
 
   private async decide(

--- a/src/lib/weave-rail.test.ts
+++ b/src/lib/weave-rail.test.ts
@@ -145,6 +145,17 @@ describe("surfaceStateFromPayload — envelope to render state", () => {
     assert.equal(state.kind, "blocked");
   });
 
+  it("R8: a meta with an unknown adapter is a contract violation — blocked, decisions stay off", () => {
+    const forged = { ...meta(), adapter: "mystery" } as unknown as ThreadsMeta;
+    const state = surfaceStateFromPayload<WeaveSummary[]>(
+      { data: weaves, meta: forged, blocked: false },
+      FRESH,
+    );
+    assert.equal(state.kind, "blocked");
+    assert.equal(state.kind === "blocked" ? state.why : "", "meta-missing");
+    assert.equal(decisionsEnabled(state), false);
+  });
+
   it("R11: not-found blocks with its own message, never an empty-healthy list", () => {
     const state = surfaceStateFromPayload<WeaveSummary[]>(blockedEnvelope("not-found", meta()), FRESH);
     assert.equal(state.kind, "blocked");

--- a/src/lib/weave-rail.ts
+++ b/src/lib/weave-rail.ts
@@ -159,7 +159,8 @@ export function surfaceStateFromPayload<T>(payload: unknown, now: Date = new Dat
     typeof meta.observedAt !== "string" ||
     typeof meta.staleAfter !== "string" ||
     typeof meta.sourceCursor !== "string" ||
-    typeof meta.verified !== "boolean"
+    typeof meta.verified !== "boolean" ||
+    (meta.adapter !== "daemon" && meta.adapter !== "fixtures")
   ) {
     return { kind: "blocked", why: "meta-missing", message: blockedMessage("meta-missing"), meta: null };
   }


### PR DESCRIPTION
Resolves the five [copilot-pull-request-reviewer findings on #3223](https://github.com/OpenCoven/coven-cave/pull/3223#pullrequestreview-4489878849) that arrived before the merge (17ecdc4e):

1. **`surfaceStateFromPayload` never validated `meta.adapter`** — a missing/garbage adapter could render fresh+ready with no fixture banner and `decisionsEnabled()` true. Now an unknown adapter is an R8 contract violation → blocked, decisions off. Test: unknown-adapter case in `weave-rail.test.ts`.
2. **`FixturesThreadsAdapter.proposals()` could throw** — `readPendingDir` used bare `readdirSync`; an existing-but-unreadable pending dir would 500 the route. Now the listing failure fails closed (`no-fixture`, `pending:unreadable` cursor, `verified:false`). Test: ENOTDIR case (regular file where the dir should be).
3. **`DaemonThreadsAdapter.proposals()` — same hazard**, fails closed as `unparseable` (staging area exists but its listing cannot be verified). Test: daemon-mode ENOTDIR case.
4. **`sidecar-runtime-smoke.mjs` boundary off-by-one** — asserted `fileCount < 5_440` while `verifySidecarRuntime` and the Rust extractor enforce the budget inclusively (reject only `> MAX`). Now `<=`.
5. **`sidecar-runtime-closure.test.mjs` — same boundary**, now `<=`, consistent with `SIDECAR_RUNTIME_BUDGETS.fileCount` semantics everywhere.

**Validation**: targeted suites (threads-adapters 33/33, weave-rail 56 asserts, proposals e2e 10/10, closure test, bundle-deps pin) green · `pnpm typecheck` clean · `pnpm test:app` **744/744**.

Epic threads-986.17 hygiene: keeps the merged Phase 4 surfaces conformant with spec §4 (R8) fail-closed rules.