### PR TITLE
fix(spawn): scrub sidecar-internal env from every child process (cave-o01k)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -177,12 +177,14 @@ function validateCwd(raw) {
   return raw;
 }
 const PTY_ENV_DROPPED = /* @__PURE__ */ new Set(["NODE_ENV", "INIT_CWD", "PNPM_SCRIPT_SRC_DIR"]);
+const PTY_ENV_DROPPED_PREFIXES = ["COVEN_CAVE_", "__NEXT_PRIVATE_"];
 function sanitizedEnv() {
   const env = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value === void 0) continue;
     if (/^npm_/i.test(key)) continue;
     if (PTY_ENV_DROPPED.has(key)) continue;
+    if (PTY_ENV_DROPPED_PREFIXES.some((prefix) => key.startsWith(prefix))) continue;
     env[key] = value;
   }
   return env;

--- a/server.ts
+++ b/server.ts
@@ -288,6 +288,12 @@ function validateCwd(raw: string | undefined): string | undefined {
 // the user had set them. Strip the package-manager lifecycle namespace —
 // and the server's own NODE_ENV — before handing the env to a user shell.
 const PTY_ENV_DROPPED = new Set(["NODE_ENV", "INIT_CWD", "PNPM_SCRIPT_SRC_DIR"]);
+// Sidecar-internal namespaces (cave-o01k): the packaged app's serialized Next
+// config breaks builds run from the terminal, and the sidecar auth tokens are
+// secrets that would 401-gate a dev server inheriting them. Mirrors
+// scrubSidecarInternalEnv in src/lib/coven-bin.ts (this file stays
+// import-free of src/ so the packaged sidecar can run it standalone).
+const PTY_ENV_DROPPED_PREFIXES = ["COVEN_CAVE_", "__NEXT_PRIVATE_"];
 
 function sanitizedEnv(): Record<string, string> {
   const env: Record<string, string> = {};
@@ -295,6 +301,7 @@ function sanitizedEnv(): Record<string, string> {
     if (value === undefined) continue;
     if (/^npm_/i.test(key)) continue;
     if (PTY_ENV_DROPPED.has(key)) continue;
+    if (PTY_ENV_DROPPED_PREFIXES.some((prefix) => key.startsWith(prefix))) continue;
     env[key] = value;
   }
   return env;

--- a/src/app/api/beads/prs/route.ts
+++ b/src/app/api/beads/prs/route.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { NextResponse } from "next/server";
+import { scrubSidecarInternalEnv } from "@/lib/coven-bin";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { resolveRepoRoot } from "@/lib/server/issue-worktree-provision";
 import {
@@ -35,7 +36,7 @@ const MERGED_PR_LIMIT = "30";
 async function ghPrList(repoRoot: string, args: string[]): Promise<unknown> {
   const { stdout } = await execFileAsync("gh", args, {
     cwd: repoRoot, // cwd's repo → gh targets the right OWNER/REPO without hardcoding
-    env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+    env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }),
     timeout: GH_TIMEOUT_MS,
     maxBuffer: MAX_GH_BUFFER,
   });

--- a/src/app/api/beads/route.ts
+++ b/src/app/api/beads/route.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import path from "node:path";
 import { promisify } from "node:util";
 import { NextResponse } from "next/server";
+import { scrubSidecarInternalEnv } from "@/lib/coven-bin";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
 import { resolveRepoRoot } from "@/lib/server/issue-worktree-provision";
@@ -57,7 +58,7 @@ async function runBd(repoRoot: string, beadsDir: string, args: string[]) {
   try {
     const { stdout, stderr } = await execFileAsync("bd", args, {
       cwd: repoRoot,
-      env: { ...process.env, BEADS_DIR: beadsDir, BD_NON_INTERACTIVE: "1" },
+      env: scrubSidecarInternalEnv({ ...process.env, BEADS_DIR: beadsDir, BD_NON_INTERACTIVE: "1" }),
       timeout: BD_TIMEOUT_MS,
       maxBuffer: MAX_BD_BUFFER,
     });

--- a/src/app/api/skills/directory/install/route.ts
+++ b/src/app/api/skills/directory/install/route.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { NextResponse } from "next/server";
+import { scrubSidecarInternalEnv } from "@/lib/coven-bin";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   listSkillDirectoryEntriesWithLocal,
@@ -79,7 +80,7 @@ export async function POST(req: Request) {
       cwd: process.cwd(),
       timeout: INSTALL_TIMEOUT_MS,
       maxBuffer: MAX_INSTALL_BUFFER,
-      env: { ...process.env, npm_config_yes: "true" },
+      env: scrubSidecarInternalEnv({ ...process.env, npm_config_yes: "true" }),
     });
     return NextResponse.json({
       ok: true,

--- a/src/app/api/skills/directory/use/route.ts
+++ b/src/app/api/skills/directory/use/route.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { NextResponse } from "next/server";
+import { scrubSidecarInternalEnv } from "@/lib/coven-bin";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   listSkillDirectoryEntriesWithLocal,
@@ -73,7 +74,7 @@ export async function POST(req: Request) {
       cwd: process.cwd(),
       timeout: USE_TIMEOUT_MS,
       maxBuffer: MAX_USE_BUFFER,
-      env: { ...process.env, npm_config_yes: "true" },
+      env: scrubSidecarInternalEnv({ ...process.env, npm_config_yes: "true" }),
     });
     const prompt = stdout.trim();
     if (!prompt) {

--- a/src/lib/branch-pr-context.ts
+++ b/src/lib/branch-pr-context.ts
@@ -11,6 +11,7 @@
 // so an unauthenticated machine doesn't hammer gh.
 
 import { execFile } from "node:child_process";
+import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import type { SessionPullRequestContext } from "@/lib/types";
 
 const PR_URL_RE = /https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/;
@@ -47,7 +48,7 @@ const defaultRunner: BranchPrRunner = (root, branch) =>
     execFile(
       "gh",
       ["pr", "view", branch, "--json", "number,url,state,isDraft"],
-      { cwd: root, timeout: 10_000, env: { ...process.env, GH_PROMPT_DISABLED: "1" } },
+      { cwd: root, timeout: 10_000, env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }) },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { covenAdapterDirsEnvValue, covenLaunchCommandForBinary, pickWindowsLauncher, windowsPathFromRegQuery } from "./coven-bin.ts";
+import { covenAdapterDirsEnvValue, covenLaunchCommandForBinary, pickWindowsLauncher, scrubSidecarInternalEnv, windowsPathFromRegQuery } from "./coven-bin.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 
@@ -40,6 +40,65 @@ assert.match(
   /FORBIDDEN_SPAWN_ENV_KEYS = \["GITHUB_PAT", "GITHUB_PERSONAL_ACCESS_TOKEN"\]/,
   "coven child processes strip both legacy and marketplace GitHub token env vars",
 );
+
+// ── cave-o01k: sidecar-internal env never reaches children ────────────────────
+// Packaged-app children inherited __NEXT_PRIVATE_STANDALONE_CONFIG (breaks any
+// `next build`/dev server a session runs — the JSON config has no
+// generateBuildId function and bakes CI paths) and COVEN_CAVE_* auth/bundle
+// state (401-gates an inherited dev server; the tokens are secrets).
+assert.match(
+  source,
+  /SIDECAR_INTERNAL_ENV_PREFIXES = \["COVEN_CAVE_", "__NEXT_PRIVATE_"\]/,
+  "the sidecar-internal namespaces are scrubbed by prefix, so new COVEN_CAVE_* vars stay contained",
+);
+assert.match(
+  source,
+  /return scrubSidecarInternalEnv\(env\);\s*\}/,
+  "covenSpawnEnv routes through the shared scrub, so agents/CLI probes/installers are all covered",
+);
+{
+  const env = scrubSidecarInternalEnv({
+    PATH: "/usr/bin",
+    HOME: "/Users/witch",
+    COVEN_CAVE_BUNDLE: "1",
+    COVEN_CAVE_AUTH_TOKEN: "sidecar-secret",
+    COVEN_CAVE_ACCESS_TOKEN: "mobile-secret",
+    COVEN_CAVE_PTY_DETACH_GRACE_MS: "1000",
+    __NEXT_PRIVATE_STANDALONE_CONFIG: "{\"distDir\":\"/Users/runner/work\"}",
+    __NEXT_PRIVATE_ORIGIN: "http://127.0.0.1:3000",
+    GITHUB_PAT: "ghp_x",
+    MY_APP_TOKEN: "kept",
+  });
+  assert.deepEqual(
+    env,
+    { PATH: "/usr/bin", HOME: "/Users/witch", MY_APP_TOKEN: "kept" },
+    "scrubSidecarInternalEnv drops every COVEN_CAVE_*/__NEXT_PRIVATE_* var and forbidden token keys, keeping user env intact",
+  );
+}
+// Every other spawn site that spreads process.env wraps it in the scrub —
+// gh/bd/npx/tailscale/vault children run user-visible (or arbitrary,
+// via npx postinstall) code and must not see sidecar secrets either.
+for (const rel of [
+  "../app/api/beads/prs/route.ts",
+  "../app/api/beads/route.ts",
+  "../app/api/skills/directory/install/route.ts",
+  "../app/api/skills/directory/use/route.ts",
+  "./branch-pr-context.ts",
+  "./mobile-handoff.ts",
+  "./vault.ts",
+]) {
+  const spawnSite = await readFile(new URL(rel, import.meta.url), "utf8");
+  assert.match(
+    spawnSite,
+    /scrubSidecarInternalEnv\(\{ \.\.\.process\.env/,
+    `${rel} scrubs sidecar-internal env before spawning`,
+  );
+  assert.doesNotMatch(
+    spawnSite,
+    /env: \{ \.\.\.process\.env/,
+    `${rel} has no unscrubbed process.env spread left`,
+  );
+}
 
 assert.match(
   source,

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -42,6 +42,32 @@ export type CovenLaunchCommand = {
 
 const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT", "GITHUB_PERSONAL_ACCESS_TOKEN"] as const;
 
+// Sidecar-internal env namespaces that must never reach child processes
+// (cave-o01k). The packaged app's Next standalone config override breaks any
+// `next build`/dev server a session runs (JSON config has no generateBuildId
+// function, and its baked CI paths are wrong for the user's machine), and the
+// sidecar's own auth/bundle state 401-gates a dev server that inherits it —
+// the tokens are secrets that arbitrary child processes (npx postinstalls,
+// harness sessions, user shells) have no business seeing.
+const SIDECAR_INTERNAL_ENV_PREFIXES = ["COVEN_CAVE_", "__NEXT_PRIVATE_"] as const;
+
+/**
+ * Remove Cave/sidecar-internal variables (and forbidden token keys) from a
+ * spawn env, in place. Every path that hands the server's env to a child —
+ * agents, CLI probes, installers, terminals — must pass through this.
+ */
+export function scrubSidecarInternalEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  for (const key of Object.keys(env)) {
+    if (SIDECAR_INTERNAL_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+      delete env[key];
+    }
+  }
+  for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
+    delete env[key];
+  }
+  return env;
+}
+
 const HOME = os.homedir();
 
 function nodeNvmBinDirs(): string[] {
@@ -380,10 +406,7 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
   if (env.NPM_CONFIG_LOGLEVEL === undefined && env.npm_config_loglevel === undefined) {
     env.NPM_CONFIG_LOGLEVEL = "error";
   }
-  for (const key of FORBIDDEN_SPAWN_ENV_KEYS) {
-    delete env[key];
-  }
-  return env;
+  return scrubSidecarInternalEnv(env);
 }
 
 export function refreshCovenSpawnEnv(): NodeJS.ProcessEnv {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
+import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import { appTokenTtlMs } from "./mobile-token-refresh.ts";
 
 export const MOBILE_INVITE_TTL_MS = 8 * 60 * 60 * 1000;
@@ -135,7 +136,7 @@ export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
     cachedTailscalePath = joined || process.env.PATH || "";
   }
 
-  return { ...process.env, PATH: cachedTailscalePath };
+  return scrubSidecarInternalEnv({ ...process.env, PATH: cachedTailscalePath });
 }
 
 type TailscaleSelfStatus = {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -24,6 +24,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import { caveHome } from "./coven-paths.ts";
 import { readEnvLocalAll, readEnvLocalValue } from "./env-file.ts";
 import { getLocalEncryptedSecret, hasLocalEncryptedSecret } from "./local-encrypted-vault.ts";
@@ -242,7 +243,7 @@ function resolverEnv(): NodeJS.ProcessEnv {
   ];
   const current = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
   const merged = [...current, ...candidates.filter((dir) => !current.includes(dir))];
-  return { ...process.env, PATH: merged.join(delimiter) };
+  return scrubSidecarInternalEnv({ ...process.env, PATH: merged.join(delimiter) });
 }
 
 /** Base timeout for a `<cli> read` call, and the longer allowance for the

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -112,6 +112,19 @@ assert.match(
   /\^npm_/,
   "sanitizer strips the npm_* lifecycle/config namespace",
 );
+// cave-o01k: terminals must not inherit the sidecar's internal namespaces —
+// the serialized Next standalone config breaks builds run from the shell,
+// and the sidecar auth tokens are secrets that would 401-gate a dev server.
+assert.match(
+  src,
+  /PTY_ENV_DROPPED_PREFIXES = \["COVEN_CAVE_", "__NEXT_PRIVATE_"\]/,
+  "sanitizer drops the sidecar-internal env namespaces (cave-o01k)",
+);
+assert.match(
+  src,
+  /PTY_ENV_DROPPED_PREFIXES\.some\(\(prefix\) => key\.startsWith\(prefix\)\)/,
+  "the prefix drop is applied per key in sanitizedEnv",
+);
 assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");


### PR DESCRIPTION
## What

Children of the packaged app (agent sessions, terminals, CLI probes, installers) no longer inherit sidecar-internal environment.

## The bug (observed in cave-rprf.5)

Every child spawned from the packaged CovenCave.app inherited:
- `__NEXT_PRIVATE_STANDALONE_CONFIG` — the sidecar's JSON-serialized Next config with baked CI paths (`/Users/runner/...`). A `pnpm build` run inside a session fails with `TypeError: generate is not a function` because the env override replaces `next.config.ts` and JSON can't carry `generateBuildId`.
- `COVEN_CAVE_AUTH_TOKEN` / `COVEN_CAVE_ACCESS_TOKEN` / `COVEN_CAVE_BUNDLE` — a dev server started from a session inherits the access-token gate and **401s every local API call**; the tokens are secrets visible to arbitrary children (npx postinstall scripts included).

## The fix

- **`scrubSidecarInternalEnv()`** (coven-bin.ts): deletes the `COVEN_CAVE_*` + `__NEXT_PRIVATE_*` namespaces by prefix — future sidecar vars stay contained — plus the existing forbidden GitHub-token keys. `covenSpawnEnv()` routes through it → agents (via harnessSpawnEnv), CLI probes, installers, openclaw, tools-status all covered.
- **PTY terminals** (server.ts `sanitizedEnv()`): drops the same prefixes; kept inline because server.ts must stay import-free of `src/` for the packaged sidecar. `server.mjs` regenerated (`pnpm build:server`).
- **All seven remaining direct `{...process.env}` spawn spreads** wrap in the scrub: beads (`bd`/`gh`), skills directory install/use (`npx` — runs arbitrary postinstall code), branch-pr-context (`gh`), mobile-handoff (`tailscale`), vault (secret-manager CLIs).

No child reads `COVEN_CAVE_*` legitimately (verified: all readers are in-process server/client code; the coven daemon uses its own `~/.coven` auth).

## Tests

- Behavioral: `scrubSidecarInternalEnv` drops the namespaces + forbidden keys, keeps user env intact.
- Wiring pins: all seven spread sites must call the scrub; no unscrubbed `env: {...process.env` remains; PTY prefix pins in server-pty-ws.test.ts.
- `pnpm test:api` 187/187 with isolated HOME (elevenlabs tts = known non-hermetic cave-k7i3, fails on main too); `pnpm typecheck` clean.

Bead: cave-o01k · Queue: coven-cave-flagship-hardening (priority 2: packaged-app reliability)