### PR TITLE
Fix lossless Cave home migration on Windows

### DIFF
--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+if (process.platform !== "win32") {
+  console.log("cave-home-migration-windows.test.ts: skipped (not Windows)");
+  process.exit(0);
+}
+
+const root = await mkdtemp(path.join(tmpdir(), "cave-home-windows-"));
+process.env.COVEN_HOME = path.join(root, ".coven");
+delete process.env.COVEN_CAVE_HOME;
+
+const { migrateCaveHome } = await import("../src/lib/server/cave-home-migration.ts");
+const { caveHomeMigrationStatus } = await import("../src/lib/server/cave-home-migration-status.ts");
+
+try {
+  await mkdir(process.env.COVEN_HOME, { recursive: true });
+  const legacy = path.join(process.env.COVEN_HOME, "cave-config.json");
+  const canonical = path.join(process.env.COVEN_HOME, "cave", "config.json");
+  await writeFile(legacy, '{"windows":true}', "utf8");
+  const result = await migrateCaveHome();
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(JSON.parse(await readFile(canonical, "utf8")), { windows: true });
+  const bridge = await lstat(legacy);
+  assert.ok(bridge.isSymbolicLink() || bridge.isFile(), "Windows uses a link when permitted or an ordinary managed mirror");
+  assert.equal((await caveHomeMigrationStatus()).migrated, true, "compatibility bridge never creates a false conflict");
+  console.log("cave-home-migration-windows.test.ts: ok");
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -27,6 +27,28 @@ try {
   const bridge = await lstat(legacy);
   assert.ok(bridge.isSymbolicLink() || bridge.isFile(), "Windows uses a link when permitted or an ordinary managed mirror");
   assert.equal((await caveHomeMigrationStatus()).migrated, true, "compatibility bridge never creates a false conflict");
+
+  // On Windows, renaming a candidate directory over an existing lock reports
+  // EPERM rather than EEXIST. A contender must wait for the owner instead of
+  // treating ordinary lock contention as a migration failure.
+  let markAcquired;
+  const acquired = new Promise((resolve) => { markAcquired = resolve; });
+  let releaseOwner;
+  const ownerMayFinish = new Promise((resolve) => { releaseOwner = resolve; });
+  const owner = migrateCaveHome({
+    lockProbe: async (event) => {
+      if (event !== "acquired") return;
+      markAcquired();
+      await ownerMayFinish;
+    },
+  });
+  await acquired;
+  const contender = migrateCaveHome();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  releaseOwner();
+  const [ownerResult, contenderResult] = await Promise.all([owner, contender]);
+  assert.deepEqual(ownerResult.errors, []);
+  assert.deepEqual(contenderResult.errors, []);
   console.log("cave-home-migration-windows.test.ts: ok");
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1055,6 +1055,7 @@ export const SUITES = {
   conformance: [
     "scripts/cross-environment.test.ts",
     "scripts/windows-native-browser-regression.test.mjs",
+    "scripts/cave-home-migration-windows.test.ts",
   ],
 };
 
@@ -1066,6 +1067,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "scripts/cave-home-migration-windows.test.ts",
   "src/lib/omnigent/ward-preflight.test.ts",
   "src/lib/cave-inbox-bulk.test.ts",
   "src/app/api/prompts/route.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -34,7 +34,7 @@ const contracts: RouteContract[] = [
   { route: "/board", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/canvas", methods: ["GET", "PUT", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/capabilities", methods: ["GET"], kind: "json" },
-  { route: "/cave-home-migration", methods: ["GET", "POST"], kind: "json" },
+  { route: "/cave-home-migration", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/changes", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/model-state", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/cave-home-migration/route.test.ts
+++ b/src/app/api/cave-home-migration/route.test.ts
@@ -16,12 +16,12 @@ assert.match(
 );
 assert.match(
   source,
-  /export async function GET\(\)[\s\S]*?status: await caveHomeMigrationStatus\(\)/,
+  /export async function GET\(req: Request\)[\s\S]*?rejectNonLocalRequest\(req\)[\s\S]*?status: await caveHomeMigrationStatus\(\)/,
   "GET reports pending/conflicts/migrated status for the banner qualification check",
 );
 assert.match(
   source,
-  /export async function POST\(request: Request\)[\s\S]*?await migrateCaveHome\(options\)/,
+  /export async function POST\(req: Request\)[\s\S]*?rejectNonLocalRequest\(req\)[\s\S]*?await migrateCaveHome\(options\)/,
   "POST runs the transactional reconciliation with validated options",
 );
 assert.match(
@@ -37,6 +37,6 @@ assert.match(
 assert.match(source, /force-dynamic/, "status must never be served from the route cache");
 assert.match(source, /ACTIONS = new Set<ReconciliationAction>/, "review actions are allowlisted");
 assert.match(source, /Unknown legacy migration entry/, "action requests are restricted to the shared manifest");
-assert.match(source, /request\.json\(\)\.catch\(\(\) => null\)/, "body-less legacy POST requests remain compatible");
+assert.match(source, /req\.body[\s\S]*readJsonBody<[^>]+>\(req, MAX_ACTION_BODY_BYTES\)[\s\S]*: null/, "actions are bounded while body-less legacy POST requests remain compatible");
 
 console.log("cave-home-migration route.test.ts: ok");

--- a/src/app/api/cave-home-migration/route.test.ts
+++ b/src/app/api/cave-home-migration/route.test.ts
@@ -6,7 +6,7 @@ const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /import \{ migrateCaveHome \} from "@\/lib\/server\/cave-home-migration"/,
+  /import \{ CAVE_HOME_MIGRATIONS, migrateCaveHome \} from "@\/lib\/server\/cave-home-migration"/,
   "POST must reuse the boot-time migration implementation, not a parallel one",
 );
 assert.match(
@@ -21,8 +21,8 @@ assert.match(
 );
 assert.match(
   source,
-  /export async function POST\(\)[\s\S]*?await migrateCaveHome\(\)/,
-  "POST runs the idempotent migration on demand",
+  /export async function POST\(request: Request\)[\s\S]*?await migrateCaveHome\(options\)/,
+  "POST runs the transactional reconciliation with validated options",
 );
 assert.match(
   source,
@@ -35,5 +35,8 @@ assert.match(
   "POST ok reflects whether the migration finished without errors",
 );
 assert.match(source, /force-dynamic/, "status must never be served from the route cache");
+assert.match(source, /ACTIONS = new Set<ReconciliationAction>/, "review actions are allowlisted");
+assert.match(source, /Unknown legacy migration entry/, "action requests are restricted to the shared manifest");
+assert.match(source, /request\.json\(\)\.catch\(\(\) => null\)/, "body-less legacy POST requests remain compatible");
 
 console.log("cave-home-migration route.test.ts: ok");

--- a/src/app/api/cave-home-migration/route.ts
+++ b/src/app/api/cave-home-migration/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { CAVE_HOME_MIGRATIONS, migrateCaveHome } from "@/lib/server/cave-home-migration";
 import { caveHomeMigrationStatus } from "@/lib/server/cave-home-migration-status";
 import type { ReconciliationAction } from "@/lib/server/cave-home-reconciliation";
+import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,14 +19,24 @@ export const runtime = "nodejs";
  * ("qualified participants" — status.pending non-empty) can finish the move
  * with one click instead of waiting for the next restart.
  */
-export async function GET() {
+const MAX_ACTION_BODY_BYTES = 1024;
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
   return NextResponse.json({ ok: true, status: await caveHomeMigrationStatus() });
 }
 
 const ACTIONS = new Set<ReconciliationAction>(["merge", "keep-canonical", "recover-legacy", "defer"]);
 
-export async function POST(request: Request) {
-  const body = await request.json().catch(() => null) as { action?: unknown; legacy?: unknown } | null;
+export async function POST(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+  const parsed = req.body
+    ? await readJsonBody<{ action?: unknown; legacy?: unknown }>(req, MAX_ACTION_BODY_BYTES)
+    : null;
+  if (parsed && !parsed.ok) return parsed.response;
+  const body = parsed?.body ?? null;
   let options: { action?: ReconciliationAction; legacy?: string } = {};
   if (body) {
     if (typeof body.action !== "string" || !ACTIONS.has(body.action as ReconciliationAction)) {

--- a/src/app/api/cave-home-migration/route.ts
+++ b/src/app/api/cave-home-migration/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
-import { migrateCaveHome } from "@/lib/server/cave-home-migration";
+import { CAVE_HOME_MIGRATIONS, migrateCaveHome } from "@/lib/server/cave-home-migration";
 import { caveHomeMigrationStatus } from "@/lib/server/cave-home-migration-status";
+import type { ReconciliationAction } from "@/lib/server/cave-home-reconciliation";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -21,8 +22,21 @@ export async function GET() {
   return NextResponse.json({ ok: true, status: await caveHomeMigrationStatus() });
 }
 
-export async function POST() {
-  const result = await migrateCaveHome();
+const ACTIONS = new Set<ReconciliationAction>(["merge", "keep-canonical", "recover-legacy", "defer"]);
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null) as { action?: unknown; legacy?: unknown } | null;
+  let options: { action?: ReconciliationAction; legacy?: string } = {};
+  if (body) {
+    if (typeof body.action !== "string" || !ACTIONS.has(body.action as ReconciliationAction)) {
+      return NextResponse.json({ ok: false, error: "Unsupported migration action" }, { status: 400 });
+    }
+    if (typeof body.legacy !== "string" || !CAVE_HOME_MIGRATIONS.some((entry) => entry.legacy === body.legacy)) {
+      return NextResponse.json({ ok: false, error: "Unknown legacy migration entry" }, { status: 400 });
+    }
+    options = { action: body.action as ReconciliationAction, legacy: body.legacy };
+  }
+  const result = await migrateCaveHome(options);
   const status = await caveHomeMigrationStatus();
   return NextResponse.json({ ok: result.errors.length === 0, result, status });
 }

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
 import {
-  loadInbox,
-  saveInbox,
   withInboxLock,
   type InboxItem,
 } from "@/lib/cave-inbox";
@@ -96,8 +94,8 @@ export async function POST(req: Request) {
     cardsCompleted: board ? completedCardsForDay(board.cards, now) : undefined,
   };
 
-  const result = await withInboxLock(async () => {
-    const file = await loadInbox();
+  const result = await withInboxLock(async ({ load, save }) => {
+    const file = await load();
     const draft = buildDailySummaryContent({
       items: file.items,
       sessions,
@@ -124,7 +122,7 @@ export async function POST(req: Request) {
         updatedAt: now.toISOString(),
       };
       file.items = file.items.map((item) => (item.id === existing.id ? refreshed : item));
-      await saveInbox(file);
+      await save(file);
       return { item: refreshed, created: false };
     }
 
@@ -148,7 +146,7 @@ export async function POST(req: Request) {
       auto: draft.auto,
     };
     file.items.push(next);
-    await saveInbox(file);
+    await save(file);
     return { item: next, created: true };
   });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5037,6 +5037,150 @@ button:active > .edge-rail-chip {
   opacity: 1;
 }
 
+.cave-migration-review-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: color-mix(in oklch, black 54%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.cave-migration-review {
+  width: min(760px, 100%);
+  max-height: min(780px, calc(100vh - 48px));
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-panel);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-lg);
+}
+
+.cave-migration-review__header,
+.cave-migration-review__footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.cave-migration-review__header h2 {
+  margin: 0 0 6px;
+  font-size: var(--text-lg);
+}
+
+.cave-migration-review__header p,
+.cave-migration-file p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.cave-migration-file__diff {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.cave-migration-review button {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  padding: 6px 10px;
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.cave-migration-review button:hover:not(:disabled) {
+  border-color: var(--accent-presence);
+}
+
+.cave-migration-review button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.cave-migration-review__files {
+  overflow: auto;
+  padding: 12px 20px 20px;
+}
+
+.cave-migration-file {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.cave-migration-file__heading,
+.cave-migration-file__actions,
+.cave-migration-review__footer > div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.cave-migration-file__heading {
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.cave-migration-file__heading span {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.cave-migration-file dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.cave-migration-file dl > div {
+  padding: 8px 10px;
+  border-radius: var(--radius-control);
+  background: var(--bg-subtle);
+}
+
+.cave-migration-file dt {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.cave-migration-file dd {
+  margin: 2px 0 0;
+  font-size: var(--text-sm);
+}
+
+.cave-migration-file__backup {
+  overflow-wrap: anywhere;
+  margin-bottom: 10px !important;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs) !important;
+}
+
+.cave-migration-review__footer {
+  align-items: center;
+  border-top: 1px solid var(--border-hairline);
+  border-bottom: 0;
+}
+
+.cave-migration-review__footer > span {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
 @media (max-width: 767px) {
   .shell-banner {
     gap: 8px;
@@ -5058,6 +5202,25 @@ button:active > .edge-rail-chip {
     min-width: var(--touch-target);
     border-radius: 10px;
     -webkit-tap-highlight-color: transparent;
+  }
+
+  .cave-migration-review-backdrop {
+    align-items: end;
+    padding: 0;
+  }
+
+  .cave-migration-review {
+    max-height: 92vh;
+    border-radius: var(--radius-panel) var(--radius-panel) 0 0;
+  }
+
+  .cave-migration-file dl {
+    grid-template-columns: 1fr;
+  }
+
+  .cave-migration-review__footer {
+    align-items: stretch;
+    flex-direction: column;
   }
 }
 

--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -4,100 +4,34 @@ import { readFile } from "node:fs/promises";
 
 const src = await readFile(new URL("./cave-home-migration-banner.tsx", import.meta.url), "utf8");
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
-const status = await readFile(
-  new URL("../lib/server/cave-home-migration-status.ts", import.meta.url),
-  "utf8",
-);
+const status = await readFile(new URL("../lib/server/cave-home-migration-status.ts", import.meta.url), "utf8");
+const reconciliation = await readFile(new URL("../lib/server/cave-home-reconciliation.ts", import.meta.url), "utf8");
+const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 const runner = await readFile(new URL("../../scripts/run-tests.mjs", import.meta.url), "utf8");
 
-assert.match(
-  src,
-  /export function CaveHomeMigrationBannerTrigger/,
-  "exports a shell banner trigger for the cave home migration",
-);
-assert.match(src, /pushBanner\(/, "trigger publishes through the shared shell banner system");
-assert.match(
-  src,
-  /\/api\/cave-home-migration/,
-  "trigger qualifies participants through the migration status route",
-);
-assert.match(
-  src,
-  /if \(pending\.length > 0\)/,
-  "fixable pending files take precedence over conflict surfacing",
-);
-assert.match(
-  src,
-  /dismissedMigrationBanner\(pending\)/,
-  "pending banner respects per-set dismissal",
-);
-assert.match(
-  src,
-  /conflicts\.length > 0 && !dismissedConflictsBanner\(conflicts\)/,
-  "unfixable conflicts surface as a review banner instead of staying invisible (cave-lzx3)",
-);
-assert.match(
-  src,
-  /coven-cave:cave-home-migration:conflicts-dismissed:/,
-  "conflict dismissal persists per conflict set so new conflicts re-surface",
-);
-assert.match(
-  src,
-  /the ~\/\.coven\/cave versions win\. Review and remove the legacy/,
-  "conflicts banner states the outcome and the next step",
-);
-assert.match(
-  src,
-  /left for manual review/,
-  "a run that finishes with collisions hands off to the review path, not a clean success",
-);
-assert.match(src, /severity: "warning"/, "pending legacy files warrant a warning banner");
-assert.match(src, /Migrate now/, "banner exposes a one-click migrate button");
-assert.match(
-  src,
-  /method: "POST"/,
-  "migrate button runs the migration through the API route",
-);
-assert.match(
-  src,
-  /coven-cave:cave-home-migration:dismissed:/,
-  "banner dismissal persists per pending set so new stragglers re-surface",
-);
-assert.match(src, /Retry migration/, "failed runs keep an actionable retry button");
-assert.match(
-  src,
-  /Cave files migrated|nothing left to migrate/,
-  "successful runs confirm the outcome in place",
-);
-assert.match(
-  shell,
-  /CaveHomeMigrationBannerTrigger/,
-  "Shell imports and mounts the cave home migration banner trigger",
-);
-assert.match(
-  status,
-  /export async function caveHomeMigrationStatus/,
-  "qualification logic lives in the shared server status module",
-);
-assert.match(
-  status,
-  /CAVE_HOME_MIGRATIONS/,
-  "status derives from the migration manifest, never a parallel file list",
-);
-assert.match(
-  runner,
-  /src\/components\/cave-home-migration-banner\.test\.ts/,
-  "banner test is wired into the test:app suite (scripts/run-tests.mjs)",
-);
-assert.match(
-  runner,
-  /src\/lib\/server\/cave-home-migration-status\.test\.ts/,
-  "status test is wired into the test:app suite (scripts/run-tests.mjs)",
-);
-assert.match(
-  runner,
-  /src\/app\/api\/cave-home-migration\/route\.test\.ts/,
-  "route test is wired into the test:app suite (scripts/run-tests.mjs)",
-);
+assert.match(src, /export function CaveHomeMigrationBannerTrigger/, "exports the shell migration trigger");
+assert.match(src, /pushBanner\(/, "publishes through the shared shell banner system");
+assert.match(src, /Review files/, "count warning opens a review workflow");
+assert.match(src, /Both copies are preserved until you choose/, "banner communicates the data-safety model");
+assert.match(src, /status\.details\.map/, "review names every affected file");
+assert.match(src, /legacyMtimeMs/, "review shows legacy timestamps");
+assert.match(src, /canonicalMtimeMs/, "review shows canonical timestamps");
+assert.match(src, /detail\.differences\.map/, "review shows a bounded content-difference summary");
+assert.match(src, /Merge safely/, "review offers safe schema merge");
+assert.match(src, /Keep current/, "review offers canonical selection");
+assert.match(src, /Recover legacy/, "review offers legacy recovery");
+assert.match(src, /Open backup folder/, "review exposes verified recovery bundles");
+assert.match(src, /return "Defer"/, "review lets users defer ambiguous decisions");
+assert.match(src, /shell_open_path/, "desktop opens the absolute backup directory through the validated command");
+assert.match(src, /JSON\.stringify\(\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry");
+assert.match(src, /review-dismissed:/, "dismissal is keyed by the exact review set");
+assert.match(css, /\.cave-migration-review/, "review workflow has responsive shell styling");
+assert.match(shell, /CaveHomeMigrationBannerTrigger/, "Shell mounts the migration trigger");
+assert.match(status, /caveHomeReconciliationStatus\(CAVE_HOME_MIGRATIONS\)/, "qualification stays centralized");
+assert.match(reconciliation, /migration-state\.json/, "reconciliation persists an atomic journal");
+assert.match(reconciliation, /migration-backups/, "reconciliation creates recovery bundles");
+assert.match(runner, /src\/components\/cave-home-migration-banner\.test\.ts/, "banner regression is wired");
+assert.match(runner, /src\/lib\/server\/cave-home-migration-status\.test\.ts/, "status regression is wired");
+assert.match(runner, /src\/app\/api\/cave-home-migration\/route\.test\.ts/, "route regression is wired");
 
 console.log("cave-home-migration-banner.test.ts: ok");

--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -23,6 +23,7 @@ assert.match(src, /Recover legacy/, "review offers legacy recovery");
 assert.match(src, /Open backup folder/, "review exposes verified recovery bundles");
 assert.match(src, /return "Defer"/, "review lets users defer ambiguous decisions");
 assert.match(src, /shell_open_path/, "desktop opens the absolute backup directory through the validated command");
+assert.match(src, /usePausablePoll\(\(\) => void refresh\(\), 30_000/, "managed mirrors are rechecked for stale legacy writes while Cave remains open");
 assert.match(src, /JSON\.stringify\(\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry");
 assert.match(src, /review-dismissed:/, "dismissal is keyed by the exact review set");
 assert.match(css, /\.cave-migration-review/, "review workflow has responsive shell styling");

--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -26,6 +26,8 @@ assert.match(src, /shell_open_path/, "desktop opens the absolute backup director
 assert.match(src, /usePausablePoll\(\(\) => void refresh\(\), 30_000/, "managed mirrors are rechecked for stale legacy writes while Cave remains open");
 assert.match(src, /JSON\.stringify\(\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry");
 assert.match(src, /review-dismissed:/, "dismissal is keyed by the exact review set");
+assert.match(src, /detail\.legacyHash \?\? "missing"/, "a changed legacy mirror re-surfaces after an earlier dismissal");
+assert.match(src, /detail\.canonicalHash \?\? "missing"/, "a changed canonical copy re-surfaces after an earlier dismissal");
 assert.match(css, /\.cave-migration-review/, "review workflow has responsive shell styling");
 assert.match(shell, /CaveHomeMigrationBannerTrigger/, "Shell mounts the migration trigger");
 assert.match(status, /caveHomeReconciliationStatus\(CAVE_HOME_MIGRATIONS\)/, "qualification stays centralized");

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -42,20 +42,28 @@ type RunPayload = StatusPayload & {
 };
 
 const MIGRATION_BANNER_ID = "cave-home-migration";
-const CONFLICT_DISMISS_KEY = (names: string[]) =>
-  `coven-cave:cave-home-migration:review-dismissed:${[...names].sort().join("|")}`;
+const CONFLICT_DISMISS_KEY = (details: MigrationDetail[]) =>
+  `coven-cave:cave-home-migration:review-dismissed:${details
+    .map((detail) => [
+      detail.legacy,
+      detail.state,
+      detail.legacyHash ?? "missing",
+      detail.canonicalHash ?? "missing",
+    ].join(":"))
+    .sort()
+    .join("|")}`;
 
-function dismissed(names: string[]): boolean {
+function dismissed(details: MigrationDetail[]): boolean {
   try {
-    return window.localStorage.getItem(CONFLICT_DISMISS_KEY(names)) === "1";
+    return window.localStorage.getItem(CONFLICT_DISMISS_KEY(details)) === "1";
   } catch {
     return false;
   }
 }
 
-function rememberDismissal(names: string[]): void {
+function rememberDismissal(details: MigrationDetail[]): void {
   try {
-    window.localStorage.setItem(CONFLICT_DISMISS_KEY(names), "1");
+    window.localStorage.setItem(CONFLICT_DISMISS_KEY(details), "1");
   } catch {
     // Private browsing can reject storage. Dismissal still lasts this mount.
   }
@@ -99,7 +107,7 @@ export function CaveHomeMigrationBannerTrigger() {
       setReviewOpen(false);
       return;
     }
-    if (dismissed(names)) return;
+    if (dismissed(next.details)) return;
     const conflicts = next.conflicts.length;
     pushBanner({
       id: MIGRATION_BANNER_ID,
@@ -108,7 +116,7 @@ export function CaveHomeMigrationBannerTrigger() {
         ? `${conflicts} Cave data conflict${conflicts === 1 ? " needs" : "s need"} review. Both copies are preserved until you choose.`
         : `${next.pending.length} legacy Cave file${next.pending.length === 1 ? " is" : "s are"} ready for safe migration.`,
       cta: { label: "Review files", onClick: () => setReviewOpen(true) },
-      onDismiss: () => rememberDismissal(names),
+      onDismiss: () => rememberDismissal(next.details),
     });
   }, [dismissBanner, pushBanner]);
 

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -1,197 +1,218 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useShellBanners } from "@/lib/shell-banners";
+
+type MigrationAction = "merge" | "keep-canonical" | "recover-legacy" | "defer";
+
+type MigrationDetail = {
+  legacy: string;
+  next: string;
+  strategy: "inbox" | "state" | "preferences" | "directory" | "manual";
+  legacyPath: string;
+  canonicalPath: string;
+  legacyHash?: string;
+  canonicalHash?: string;
+  legacyMtimeMs?: number;
+  canonicalMtimeMs?: number;
+  state: "pending" | "unresolved" | "managed";
+  summary: string;
+  differences: string[];
+  backupPath?: string;
+  actions: MigrationAction[];
+};
 
 type MigrationStatus = {
   pending: string[];
   conflicts: string[];
   migrated: boolean;
+  details: MigrationDetail[];
+  backupRoot: string;
+  journalPath: string;
 };
 
-type StatusPayload = { ok?: boolean; status?: MigrationStatus };
+type StatusPayload = { ok?: boolean; status?: MigrationStatus; error?: string };
 type RunPayload = StatusPayload & {
   result?: {
     moved?: string[];
-    merged?: Array<{ legacy: string; files?: number; collisions?: number }>;
+    resolved?: string[];
     errors?: Array<{ legacy: string; error: string }>;
   };
 };
 
 const MIGRATION_BANNER_ID = "cave-home-migration";
+const CONFLICT_DISMISS_KEY = (names: string[]) =>
+  `coven-cave:cave-home-migration:review-dismissed:${[...names].sort().join("|")}`;
 
-/** Dismissal is keyed by the exact pending set, so NEW stragglers re-surface. */
-const MIGRATION_DISMISS_KEY = (pending: string[]) =>
-  `coven-cave:cave-home-migration:dismissed:${[...pending].sort().join("|")}`;
-
-function dismissedMigrationBanner(pending: string[]): boolean {
-  if (typeof window === "undefined") return false;
+function dismissed(names: string[]): boolean {
   try {
-    return window.localStorage.getItem(MIGRATION_DISMISS_KEY(pending)) === "1";
+    return window.localStorage.getItem(CONFLICT_DISMISS_KEY(names)) === "1";
   } catch {
     return false;
   }
 }
 
-function dismissMigrationBanner(pending: string[]): void {
-  if (typeof window === "undefined") return;
+function rememberDismissal(names: string[]): void {
   try {
-    window.localStorage.setItem(MIGRATION_DISMISS_KEY(pending), "1");
+    window.localStorage.setItem(CONFLICT_DISMISS_KEY(names), "1");
   } catch {
-    /* private mode */
+    // Private browsing can reject storage. Dismissal still lasts this mount.
   }
 }
 
-/** Conflict dismissal is namespaced apart from pending, keyed by the exact set. */
-const MIGRATION_CONFLICTS_DISMISS_KEY = (conflicts: string[]) =>
-  `coven-cave:cave-home-migration:conflicts-dismissed:${[...conflicts].sort().join("|")}`;
+function formatTime(value?: number): string {
+  if (!value) return "Missing";
+  return new Date(value).toLocaleString();
+}
 
-function dismissedConflictsBanner(conflicts: string[]): boolean {
-  if (typeof window === "undefined") return false;
+function actionLabel(action: MigrationAction): string {
+  if (action === "merge") return "Merge safely";
+  if (action === "keep-canonical") return "Keep current";
+  if (action === "recover-legacy") return "Recover legacy";
+  return "Defer";
+}
+
+async function openBackupFolder(path: string): Promise<boolean> {
+  if (!("__TAURI_INTERNALS__" in window)) return false;
   try {
-    return window.localStorage.getItem(MIGRATION_CONFLICTS_DISMISS_KEY(conflicts)) === "1";
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("shell_open_path", { path });
+    return true;
   } catch {
     return false;
   }
 }
 
-function dismissConflictsBanner(conflicts: string[]): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(MIGRATION_CONFLICTS_DISMISS_KEY(conflicts), "1");
-  } catch {
-    /* private mode */
-  }
-}
-
-function pendingBannerTitle(pending: string[]): string {
-  const count = pending.length;
-  return `${count} legacy Cave file${count === 1 ? "" : "s"} in ~/.coven still need${count === 1 ? "s" : ""} to move into ~/.coven/cave.`;
-}
-
-function conflictsBannerTitle(conflicts: string[]): string {
-  const count = conflicts.length;
-  return `${count} legacy Cave file${count === 1 ? "" : "s"} in ~/.coven conflict${count === 1 ? "s" : ""} with migrated copies — the ~/.coven/cave versions win. Review and remove the legacy cop${count === 1 ? "y" : "ies"}.`;
-}
-
-/**
- * Shell banner for "qualified participants" of the cave home migration:
- * machines where the boot-time migration (instrumentation.ts) errored or was
- * interrupted, leaving real legacy `cave-*` files at the top of `~/.coven`.
- *
- * Everyone else — fresh installs and machines the boot migration already
- * cleaned — never sees it. The CTA runs the same idempotent migration on
- * demand, reports the outcome in place, and clears once nothing is pending.
- *
- * Unfixable conflicts (legacy and migrated copies both real — cave-lzx3) get
- * a CTA-less review banner instead of staying invisible forever; dismissal is
- * keyed per conflict set so new conflicts re-surface.
- */
 export function CaveHomeMigrationBannerTrigger() {
   const { pushBanner, dismissBanner } = useShellBanners();
+  const [status, setStatus] = useState<MigrationStatus | null>(null);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [working, setWorking] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const publish = useCallback((next: MigrationStatus) => {
+    setStatus(next);
+    const names = [...next.pending, ...next.conflicts];
+    if (names.length === 0) {
+      dismissBanner(MIGRATION_BANNER_ID);
+      setReviewOpen(false);
+      return;
+    }
+    if (dismissed(names)) return;
+    const conflicts = next.conflicts.length;
+    pushBanner({
+      id: MIGRATION_BANNER_ID,
+      severity: "warning",
+      title: conflicts > 0
+        ? `${conflicts} Cave data conflict${conflicts === 1 ? " needs" : "s need"} review. Both copies are preserved until you choose.`
+        : `${next.pending.length} legacy Cave file${next.pending.length === 1 ? " is" : "s are"} ready for safe migration.`,
+      cta: { label: "Review files", onClick: () => setReviewOpen(true) },
+      onDismiss: () => rememberDismissal(names),
+    });
+  }, [dismissBanner, pushBanner]);
+
+  const refresh = useCallback(async () => {
+    const response = await fetch("/api/cave-home-migration", { cache: "no-store" });
+    if (!response.ok) return;
+    const payload = await response.json() as StatusPayload;
+    if (payload.ok && payload.status) publish(payload.status);
+  }, [publish]);
 
   useEffect(() => {
     let cancelled = false;
-
-    const showPendingBanner = (pending: string[]) => {
-      pushBanner({
-        id: MIGRATION_BANNER_ID,
-        severity: "warning",
-        title: pendingBannerTitle(pending),
-        cta: {
-          label: "Migrate now",
-          onClick: () => {
-            void runMigration();
-          },
-        },
-        onDismiss: () => dismissMigrationBanner(pending),
-      });
-    };
-
-    // No button — nothing safe to run. Destination wins by design (cave-lzx3);
-    // the user resolves conflicts by reviewing and deleting the legacy copies.
-    const showConflictsBanner = (conflicts: string[]) => {
-      pushBanner({
-        id: MIGRATION_BANNER_ID,
-        severity: "warning",
-        title: conflictsBannerTitle(conflicts),
-        onDismiss: () => dismissConflictsBanner(conflicts),
-      });
-    };
-
-    const runMigration = async () => {
-      try {
-        const res = await fetch("/api/cave-home-migration", { method: "POST" });
-        const json = (await res.json()) as RunPayload;
-        if (cancelled) return;
-        const remaining = json.status?.pending ?? [];
-        const errors = json.result?.errors ?? [];
-        if (remaining.length === 0 && errors.length === 0) {
-          const moved = json.result?.moved?.length ?? 0;
-          const mergedFiles = (json.result?.merged ?? []).reduce((n, m) => n + (m.files ?? 0), 0);
-          const conflictsAfter = json.status?.conflicts ?? [];
-          if (conflictsAfter.length > 0) {
-            // The run finished but same-name collisions remain — hand off to
-            // the review path instead of claiming a clean finish.
-            pushBanner({
-              id: MIGRATION_BANNER_ID,
-              severity: "warning",
-              title: `Cave files migrated — moved ${moved} file${moved === 1 ? "" : "s"}${mergedFiles > 0 ? ` and merged ${mergedFiles} more` : ""}; ${conflictsAfter.length} conflict${conflictsAfter.length === 1 ? "" : "s"} left for manual review in ~/.coven.`,
-              onDismiss: () => dismissConflictsBanner(conflictsAfter),
-            });
-            return;
-          }
-          pushBanner({
-            id: MIGRATION_BANNER_ID,
-            severity: "info",
-            title:
-              moved > 0 || mergedFiles > 0
-                ? `Cave files migrated — moved ${moved} file${moved === 1 ? "" : "s"}${mergedFiles > 0 ? ` and merged ${mergedFiles} more` : ""} into ~/.coven/cave.`
-                : "Cave files are already in ~/.coven/cave — nothing left to migrate.",
-          });
-          return;
-        }
-        pushBanner({
-          id: MIGRATION_BANNER_ID,
-          severity: "error",
-          title: `Cave file migration could not finish — ${remaining.length} file${remaining.length === 1 ? "" : "s"} still pending${errors.length > 0 ? ` (first error: ${errors[0].error})` : ""}.`,
-          cta: {
-            label: "Retry migration",
-            onClick: () => {
-              void runMigration();
-            },
-          },
-          onDismiss: () => dismissMigrationBanner(remaining),
-        });
-      } catch {
-        /* Route unreachable — leave the current banner in place for a retry. */
-      }
-    };
-
     void fetch("/api/cave-home-migration", { cache: "no-store" })
-      .then(async (res) => (res.ok ? ((await res.json()) as StatusPayload) : null))
-      .then((json) => {
-        if (cancelled || !json?.ok || !json.status) return;
-        const pending = json.status.pending ?? [];
-        const conflicts = json.status.conflicts ?? [];
-        if (pending.length > 0) {
-          // Fixable files take precedence — one banner at a time.
-          if (!dismissedMigrationBanner(pending)) showPendingBanner(pending);
-          return;
-        }
-        if (conflicts.length > 0 && !dismissedConflictsBanner(conflicts)) {
-          showConflictsBanner(conflicts);
-        }
+      .then(async (response) => response.ok ? await response.json() as StatusPayload : null)
+      .then((payload) => {
+        if (!cancelled && payload?.ok && payload.status) publish(payload.status);
       })
-      .catch(() => {
-        /* Status checks are best-effort. */
-      });
-
+      .catch(() => {});
     return () => {
       cancelled = true;
       dismissBanner(MIGRATION_BANNER_ID);
     };
-  }, [pushBanner, dismissBanner]);
+  }, [dismissBanner, publish]);
 
-  return null;
+  const runAction = async (detail: MigrationDetail, action: MigrationAction) => {
+    setWorking(`${detail.legacy}:${action}`);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/cave-home-migration", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ legacy: detail.legacy, action }),
+      });
+      const payload = await response.json() as RunPayload;
+      if (!response.ok || !payload.status) throw new Error(payload.error ?? "Migration request failed");
+      publish(payload.status);
+      const firstError = payload.result?.errors?.[0];
+      setNotice(firstError ? `${firstError.legacy}: ${firstError.error}` : `${detail.legacy}: ${actionLabel(action)} complete.`);
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : "Migration request failed");
+      await refresh();
+    } finally {
+      setWorking(null);
+    }
+  };
+
+  if (!reviewOpen || !status) return null;
+
+  return (
+    <div className="cave-migration-review-backdrop" role="presentation" onMouseDown={(event) => {
+      if (event.target === event.currentTarget) setReviewOpen(false);
+    }}>
+      <section className="cave-migration-review" role="dialog" aria-modal="true" aria-labelledby="cave-migration-title">
+        <header className="cave-migration-review__header">
+          <div>
+            <h2 id="cave-migration-title">Review Cave data migration</h2>
+            <p>Canonical storage is <code>~/.coven/cave</code>. Cave verifies a recovery bundle before changing either divergent copy.</p>
+          </div>
+          <button type="button" aria-label="Close migration review" onClick={() => setReviewOpen(false)}>×</button>
+        </header>
+
+        <div className="cave-migration-review__files">
+          {status.details.map((detail) => (
+            <article className="cave-migration-file" key={detail.legacy}>
+              <div className="cave-migration-file__heading">
+                <strong>{detail.legacy}</strong>
+                <span>{detail.strategy === "manual" ? "Manual decision" : `${detail.strategy} reconciliation`}</span>
+              </div>
+              <p>{detail.summary}</p>
+              <ul className="cave-migration-file__diff">
+                {detail.differences.map((difference) => <li key={difference}>{difference}</li>)}
+              </ul>
+              <dl>
+                <div><dt>Legacy</dt><dd>{formatTime(detail.legacyMtimeMs)}</dd></div>
+                <div><dt>Canonical</dt><dd>{formatTime(detail.canonicalMtimeMs)}</dd></div>
+              </dl>
+              {detail.backupPath ? <p className="cave-migration-file__backup">Recovery bundle: {detail.backupPath}</p> : null}
+              <div className="cave-migration-file__actions">
+                {detail.actions.map((action) => (
+                  <button
+                    type="button"
+                    key={action}
+                    disabled={working !== null}
+                    onClick={() => void runAction(detail, action)}
+                  >
+                    {working === `${detail.legacy}:${action}`
+                      ? "Working…"
+                      : action === "merge" && detail.state === "pending" ? "Migrate safely" : actionLabel(action)}
+                  </button>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <footer className="cave-migration-review__footer">
+          <span role="status">{notice}</span>
+          <div>
+            <button type="button" onClick={() => void openBackupFolder(status.backupRoot).then((ok) => {
+              if (!ok) setNotice(`Backups are stored at ${status.backupRoot}`);
+            })}>Open backup folder</button>
+            <button type="button" onClick={() => setReviewOpen(false)}>Close</button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
 }

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useShellBanners } from "@/lib/shell-banners";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 
 type MigrationAction = "merge" | "keep-canonical" | "recover-legacy" | "defer";
 
@@ -117,6 +118,11 @@ export function CaveHomeMigrationBannerTrigger() {
     const payload = await response.json() as StatusPayload;
     if (payload.ok && payload.status) publish(payload.status);
   }, [publish]);
+
+  // Ordinary Windows mirrors can be changed by an older tool after Cave has
+  // started. Re-check while the shell is visible so those writes are surfaced
+  // without requiring an app restart.
+  usePausablePoll(() => void refresh(), 30_000, { pauseWhileInputActive: true });
 
   useEffect(() => {
     let cancelled = false;

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -306,7 +306,7 @@ export type CaveState = {
 };
 
 export async function loadConfig(): Promise<CaveConfig> {
-  await ensureCaveHomeReconciled();
+  await ensureCaveHomeReconciled("cave-config.json");
   try {
     const raw = await readFile(CONFIG_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveConfig>;
@@ -698,7 +698,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
 }
 
 export async function loadState(): Promise<CaveState> {
-  await ensureCaveHomeReconciled();
+  await ensureCaveHomeReconciled("cave-state.json");
   try {
     const raw = await readFile(STATE_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveState>;
@@ -719,7 +719,7 @@ export async function loadState(): Promise<CaveState> {
 }
 
 async function saveState(state: CaveState): Promise<void> {
-  await ensureCaveHomeReconciled();
+  await ensureCaveHomeReconciled("cave-state.json");
   await mkdir(path.dirname(STATE_PATH), { recursive: true });
   await writeJsonAtomic(STATE_PATH, state);
 }

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -2,6 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { ensureCaveHomeReconciled } from "./server/cave-home-migration.ts";
 import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
@@ -305,6 +306,7 @@ export type CaveState = {
 };
 
 export async function loadConfig(): Promise<CaveConfig> {
+  await ensureCaveHomeReconciled();
   try {
     const raw = await readFile(CONFIG_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveConfig>;
@@ -696,6 +698,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
 }
 
 export async function loadState(): Promise<CaveState> {
+  await ensureCaveHomeReconciled();
   try {
     const raw = await readFile(STATE_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveState>;
@@ -716,6 +719,7 @@ export async function loadState(): Promise<CaveState> {
 }
 
 async function saveState(state: CaveState): Promise<void> {
+  await ensureCaveHomeReconciled();
   await mkdir(path.dirname(STATE_PATH), { recursive: true });
   await writeJsonAtomic(STATE_PATH, state);
 }

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -2,7 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
-import { ensureCaveHomeReconciled } from "./server/cave-home-migration.ts";
+import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
 import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
@@ -86,7 +86,7 @@ export async function recordKnowledgePackSeed(
   target: { target: "vault" | "project"; root?: string },
 ): Promise<string> {
   return withConfigLock(async () => {
-    const cfg = await loadConfig();
+    const cfg = await loadConfigUnlocked();
     const seededAt = new Date().toISOString();
     const nextEntry: KnowledgePackSeedEntry = {
       id: packId,
@@ -305,8 +305,7 @@ export type CaveState = {
   travel: CaveTravelState;
 };
 
-export async function loadConfig(): Promise<CaveConfig> {
-  await ensureCaveHomeReconciled("cave-config.json");
+async function loadConfigUnlocked(): Promise<CaveConfig> {
   try {
     const raw = await readFile(CONFIG_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveConfig>;
@@ -366,6 +365,10 @@ export async function loadConfig(): Promise<CaveConfig> {
   } catch {
     return defaultConfig();
   }
+}
+
+export function loadConfig(): Promise<CaveConfig> {
+  return withCaveHomeReconciledStore("cave-config.json", loadConfigUnlocked);
 }
 
 /** Split an embedded access token out of `config.multiHost.hubUrl` into the
@@ -562,7 +565,7 @@ async function withConfigLock<T>(fn: () => Promise<T>): Promise<T> {
   configMutex = new Promise<void>((resolve) => { release = resolve; });
   try {
     await previous.catch(() => {});
-    return await fn();
+    return await withCaveHomeReconciledStore("cave-config.json", fn);
   } finally {
     release();
   }
@@ -570,7 +573,7 @@ async function withConfigLock<T>(fn: () => Promise<T>): Promise<T> {
 
 export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
   return withConfigLock(async () => {
-  const current = await loadConfig();
+  const current = await loadConfigUnlocked();
   const updated: CaveConfig = {
     ...current,
     ...patch,
@@ -635,7 +638,7 @@ export async function installMarketplacePlugin(
   metadata: MarketplaceInstallMetadata = {},
 ): Promise<string> {
   return withConfigLock(async () => {
-  const cfg = await loadConfig();
+  const cfg = await loadConfigUnlocked();
   const installedAt = new Date().toISOString();
   const updated: CaveConfig = {
     ...cfg,
@@ -662,7 +665,7 @@ export async function installMarketplacePlugin(
 
 export async function uninstallMarketplacePlugin(pluginName: string): Promise<void> {
   return withConfigLock(async () => {
-  const cfg = await loadConfig();
+  const cfg = await loadConfigUnlocked();
   const installed = { ...cfg.marketplace.installed };
   delete installed[pluginName];
   const updated: CaveConfig = {
@@ -697,8 +700,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
   };
 }
 
-export async function loadState(): Promise<CaveState> {
-  await ensureCaveHomeReconciled("cave-state.json");
+async function loadStateUnlocked(): Promise<CaveState> {
   try {
     const raw = await readFile(STATE_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<CaveState>;
@@ -718,8 +720,11 @@ export async function loadState(): Promise<CaveState> {
   }
 }
 
-async function saveState(state: CaveState): Promise<void> {
-  await ensureCaveHomeReconciled("cave-state.json");
+export function loadState(): Promise<CaveState> {
+  return withCaveHomeReconciledStore("cave-state.json", loadStateUnlocked);
+}
+
+async function saveStateUnlocked(state: CaveState): Promise<void> {
   await mkdir(path.dirname(STATE_PATH), { recursive: true });
   await writeJsonAtomic(STATE_PATH, state);
 }
@@ -737,20 +742,22 @@ async function updateState<T>(
   stateMutex = new Promise<void>((resolve) => { release = resolve; });
   try {
     await previous.catch(() => {});
-    const state = await loadState();
-    const result = await mutator(state);
-    await saveState(state);
-    return result;
+    return await withCaveHomeReconciledStore("cave-state.json", async () => {
+      const state = await loadStateUnlocked();
+      const result = await mutator(state);
+      await saveStateUnlocked(state);
+      return result;
+    });
   } finally {
     release();
   }
 }
 
 export async function recordOwnedSession(sessionId: string): Promise<void> {
-  const state = await loadState();
-  state.sessionOwned[sessionId] = new Date().toISOString();
   try {
-    await saveState(state);
+    await updateState((state) => {
+      state.sessionOwned[sessionId] = new Date().toISOString();
+    });
   } catch {
     /* best effort */
   }
@@ -1015,7 +1022,7 @@ export async function upsertRoleConfig(
   active: boolean,
 ): Promise<void> {
   return withConfigLock(async () => {
-  const cfg = await loadConfig();
+  const cfg = await loadConfigUnlocked();
   const now = new Date().toISOString();
   const idx = cfg.roles.findIndex(r => r.id === roleId && r.familiar === familiar);
   if (idx >= 0) {

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -119,7 +119,7 @@ async function saveInboxUnlocked(file: InboxFile): Promise<void> {
   await writeJsonAtomic(INBOX_PATH, file);
 }
 
-export function loadInbox(): Promise<InboxFile> {
+export async function loadInbox(): Promise<InboxFile> {
   return withCaveHomeReconciledStore("cave-inbox.json", loadInboxUnlocked);
 }
 

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -102,7 +102,7 @@ async function ensureDir() {
 }
 
 export async function loadInbox(): Promise<InboxFile> {
-  await ensureCaveHomeReconciled();
+  await ensureCaveHomeReconciled("cave-inbox.json");
   try {
     const raw = await readFile(INBOX_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<InboxFile>;
@@ -116,7 +116,7 @@ export async function loadInbox(): Promise<InboxFile> {
 }
 
 export async function saveInbox(file: InboxFile): Promise<void> {
-  await ensureCaveHomeReconciled();
+  await ensureCaveHomeReconciled("cave-inbox.json");
   await ensureDir();
   await writeJsonAtomic(INBOX_PATH, file);
 }

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -4,6 +4,7 @@ import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
 import type { DailyReportPayload } from "./daily-report-facts.ts";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { ensureCaveHomeReconciled } from "./server/cave-home-migration.ts";
 
 const INBOX_PATH = path.join(caveHome(), "inbox.json");
 
@@ -101,6 +102,7 @@ async function ensureDir() {
 }
 
 export async function loadInbox(): Promise<InboxFile> {
+  await ensureCaveHomeReconciled();
   try {
     const raw = await readFile(INBOX_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<InboxFile>;
@@ -114,6 +116,7 @@ export async function loadInbox(): Promise<InboxFile> {
 }
 
 export async function saveInbox(file: InboxFile): Promise<void> {
+  await ensureCaveHomeReconciled();
   await ensureDir();
   await writeJsonAtomic(INBOX_PATH, file);
 }

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -4,7 +4,7 @@ import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
 import type { DailyReportPayload } from "./daily-report-facts.ts";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
-import { ensureCaveHomeReconciled } from "./server/cave-home-migration.ts";
+import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
 
 const INBOX_PATH = path.join(caveHome(), "inbox.json");
 
@@ -101,8 +101,7 @@ async function ensureDir() {
   await mkdir(path.dirname(INBOX_PATH), { recursive: true });
 }
 
-export async function loadInbox(): Promise<InboxFile> {
-  await ensureCaveHomeReconciled("cave-inbox.json");
+async function loadInboxUnlocked(): Promise<InboxFile> {
   try {
     const raw = await readFile(INBOX_PATH, "utf8");
     const parsed = JSON.parse(raw) as Partial<InboxFile>;
@@ -115,10 +114,17 @@ export async function loadInbox(): Promise<InboxFile> {
   }
 }
 
-export async function saveInbox(file: InboxFile): Promise<void> {
-  await ensureCaveHomeReconciled("cave-inbox.json");
+async function saveInboxUnlocked(file: InboxFile): Promise<void> {
   await ensureDir();
   await writeJsonAtomic(INBOX_PATH, file);
+}
+
+export function loadInbox(): Promise<InboxFile> {
+  return withCaveHomeReconciledStore("cave-inbox.json", loadInboxUnlocked);
+}
+
+export function saveInbox(file: InboxFile): Promise<void> {
+  return withCaveHomeReconciledStore("cave-inbox.json", () => saveInboxUnlocked(file));
 }
 
 // Serialize all read-modify-write sequences against the inbox file. Without
@@ -131,9 +137,15 @@ declare global {
   var __inboxWriteChain: Promise<unknown> | undefined;
 }
 
-export function withInboxLock<T>(fn: () => Promise<T>): Promise<T> {
+export function withInboxLock<T>(
+  fn: (store: { load: typeof loadInboxUnlocked; save: typeof saveInboxUnlocked }) => Promise<T>,
+): Promise<T> {
   const prev = globalThis.__inboxWriteChain ?? Promise.resolve();
-  const next = prev.then(fn, fn);
+  const run = () => withCaveHomeReconciledStore(
+    "cave-inbox.json",
+    () => fn({ load: loadInboxUnlocked, save: saveInboxUnlocked }),
+  );
+  const next = prev.then(run, run);
   globalThis.__inboxWriteChain = next.catch(() => undefined);
   return next;
 }
@@ -155,7 +167,7 @@ export type NewItemInput = {
 
 export async function createItem(input: NewItemInput): Promise<InboxItem> {
   return withInboxLock(async () => {
-    const file = await loadInbox();
+    const file = await loadInboxUnlocked();
     const now = new Date().toISOString();
     const status: ItemStatus =
       (input.kind === "agent" || input.kind === "daily-summary") && !input.fireAt ? "fired" : "pending";
@@ -181,7 +193,7 @@ export async function createItem(input: NewItemInput): Promise<InboxItem> {
       readAt: null,
     };
     file.items.push(item);
-    await saveInbox(file);
+    await saveInboxUnlocked(file);
     return item;
   });
 }
@@ -191,7 +203,7 @@ export async function updateItem(
   patch: Partial<Omit<InboxItem, "id" | "createdAt">>,
 ): Promise<InboxItem | null> {
   return withInboxLock(async () => {
-    const file = await loadInbox();
+    const file = await loadInboxUnlocked();
     const idx = file.items.findIndex((i) => i.id === id);
     if (idx < 0) return null;
     const current = file.items[idx];
@@ -203,18 +215,18 @@ export async function updateItem(
       updatedAt: new Date().toISOString(),
     };
     file.items[idx] = next;
-    await saveInbox(file);
+    await saveInboxUnlocked(file);
     return next;
   });
 }
 
 export async function deleteItem(id: string): Promise<boolean> {
   return withInboxLock(async () => {
-    const file = await loadInbox();
+    const file = await loadInboxUnlocked();
     const before = file.items.length;
     file.items = file.items.filter((i) => i.id !== id);
     if (file.items.length === before) return false;
-    await saveInbox(file);
+    await saveInboxUnlocked(file);
     return true;
   });
 }
@@ -265,7 +277,7 @@ export async function applyBulkAction(
   ids: string[] | null,
 ): Promise<BulkResult> {
   return withInboxLock(async () => {
-    const file = await loadInbox();
+    const file = await loadInboxUnlocked();
     const nowIso = new Date().toISOString();
     const idSet = ids ? new Set(ids) : null;
     const targeted = (item: InboxItem) =>
@@ -301,7 +313,7 @@ export async function applyBulkAction(
       });
     }
 
-    if (updated.length > 0 || deletedIds.length > 0) await saveInbox(file);
+    if (updated.length > 0 || deletedIds.length > 0) await saveInboxUnlocked(file);
     return { updated, deletedIds };
   });
 }

--- a/src/lib/inbox-scheduler.ts
+++ b/src/lib/inbox-scheduler.ts
@@ -1,7 +1,6 @@
 import {
   computeNextOccurrence,
   loadInbox,
-  saveInbox,
   withInboxLock,
   type InboxItem,
 } from "@/lib/cave-inbox";
@@ -64,9 +63,9 @@ export async function snapshot(): Promise<InboxItem[]> {
 }
 
 async function tick(): Promise<void> {
-  const fired = await withInboxLock(async () => {
+  const fired = await withInboxLock(async ({ load, save }) => {
     const now = Date.now();
-    const file = await loadInbox();
+    const file = await load();
 
     const dueIdx: number[] = [];
     for (let i = 0; i < file.items.length; i++) {
@@ -115,7 +114,7 @@ async function tick(): Promise<void> {
       }
     }
 
-    await saveInbox(file);
+    await save(file);
     return out;
   });
 

--- a/src/lib/server/cave-home-migration-status.test.ts
+++ b/src/lib/server/cave-home-migration-status.test.ts
@@ -25,7 +25,7 @@ try {
   status = await caveHomeMigrationStatus();
   assert.deepEqual(status.pending, ["cave-config.json"]);
   assert.equal(status.details[0].state, "pending");
-  assert.deepEqual(status.details[0].actions, ["merge", "defer"]);
+  assert.deepEqual(status.details[0].actions, ["merge"]);
   assert.match(status.details[0].differences[0], /only source/);
 
   await mkdir(cave, { recursive: true });

--- a/src/lib/server/cave-home-migration-status.test.ts
+++ b/src/lib/server/cave-home-migration-status.test.ts
@@ -1,92 +1,47 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-// Isolated to a temp COVEN_HOME so it never touches the real ~/.coven.
-const tmpHome = await mkdtemp(path.join(tmpdir(), "cave-home-migration-status-"));
-process.env.HOME = tmpHome;
-process.env.COVEN_HOME = path.join(tmpHome, ".coven");
+const root = await mkdtemp(path.join(tmpdir(), "cave-home-migration-status-"));
+process.env.COVEN_HOME = path.join(root, ".coven");
 delete process.env.COVEN_CAVE_HOME;
 
-const covenDir = process.env.COVEN_HOME;
-const caveDir = path.join(covenDir, "cave");
-
+const coven = process.env.COVEN_HOME;
+const cave = path.join(coven, "cave");
 const { caveHomeMigrationStatus } = await import("./cave-home-migration-status.ts");
-const { caveHome } = await import("../coven-paths.ts");
-
-// SAFETY GATE — never operate outside the temp home.
-assert.ok(caveHome().startsWith(tmpHome), `refusing: caveHome ${caveHome()} not under temp home`);
 
 try {
-  // Fresh home: nothing legacy, machine does not qualify for the banner.
-  {
-    const status = await caveHomeMigrationStatus();
-    assert.deepEqual(status.pending, [], "fresh home has nothing pending");
-    assert.deepEqual(status.conflicts, [], "fresh home has no conflicts");
-    assert.equal(status.migrated, true, "fresh home reads as migrated");
-  }
+  await mkdir(coven, { recursive: true });
+  let status = await caveHomeMigrationStatus();
+  assert.deepEqual(status.pending, []);
+  assert.deepEqual(status.conflicts, []);
+  assert.equal(status.migrated, true);
+  assert.ok(status.backupRoot.endsWith(path.join("cave", "migration-backups")));
+  assert.ok(status.journalPath.endsWith(path.join("cave", "migration-state.json")));
 
-  await mkdir(caveDir, { recursive: true });
+  await writeFile(path.join(coven, "cave-config.json"), "{}");
+  status = await caveHomeMigrationStatus();
+  assert.deepEqual(status.pending, ["cave-config.json"]);
+  assert.equal(status.details[0].state, "pending");
+  assert.deepEqual(status.details[0].actions, ["merge", "defer"]);
+  assert.match(status.details[0].differences[0], /only source/);
 
-  // A real legacy file with a free destination is PENDING — the banner's
-  // "Migrate now" button can move it.
-  await writeFile(path.join(covenDir, "cave-config.json"), '{"version":1}', "utf8");
-  // A legacy file whose destination already exists is a CONFLICT — destination
-  // wins by design, left for manual review.
-  await writeFile(path.join(covenDir, "cave-state.json"), '{"legacy":true}', "utf8");
-  await writeFile(path.join(caveDir, "state.json"), '{"current":true}', "utf8");
-  // A symlinked legacy path is an already-migrated compat bridge — not counted.
-  await writeFile(path.join(caveDir, "board.json"), '{"cards":[]}', "utf8");
-  await symlink(path.join("cave", "board.json"), path.join(covenDir, "cave-board.json"));
-  // A daemon-owned sibling sharing the prefix is out of manifest scope.
-  await writeFile(path.join(covenDir, "cave-coven-calls.json"), "[]", "utf8");
-
-  {
-    const status = await caveHomeMigrationStatus();
-    assert.deepEqual(status.pending, ["cave-config.json"], "movable legacy file is pending");
-    assert.deepEqual(status.conflicts, ["cave-state.json"], "occupied destination is a conflict");
-    assert.equal(status.migrated, false, "legacy leftovers mean not migrated");
-  }
-
-  // After the pending file moves (destination filled, legacy bridged), only
-  // the conflict remains — pending clears, so the banner clears with it.
-  await rm(path.join(covenDir, "cave-config.json"));
-  await writeFile(path.join(caveDir, "config.json"), '{"version":1}', "utf8");
-  await symlink(path.join("cave", "config.json"), path.join(covenDir, "cave-config.json"));
-
-  {
-    const status = await caveHomeMigrationStatus();
-    assert.deepEqual(status.pending, [], "bridged legacy path is no longer pending");
-    assert.deepEqual(status.conflicts, ["cave-state.json"], "conflict persists until manual review");
-    assert.equal(status.migrated, false, "conflicts still count as unmigrated");
-  }
-
-  // Directory pairs mirror the migrator's per-file merge (cave-lzx3): a legacy
-  // dir whose children all fit the destination drains in one run — that's
-  // PENDING, so the banner button can fix it. A same-name child (ignoring
-  // Finder junk) makes it a CONFLICT.
-  await mkdir(path.join(covenDir, "cave-conversations"));
-  await mkdir(path.join(caveDir, "conversations"));
-  await writeFile(path.join(covenDir, "cave-conversations", "sess-a.json"), "{}", "utf8");
-  await writeFile(path.join(covenDir, "cave-conversations", ".DS_Store"), "junk", "utf8");
-
-  {
-    const status = await caveHomeMigrationStatus();
-    assert.ok(status.pending.includes("cave-conversations"), "drainable dir pair is pending");
-    assert.ok(!status.conflicts.includes("cave-conversations"), "drainable dir pair is not a conflict");
-  }
-
-  await writeFile(path.join(caveDir, "conversations", "sess-a.json"), "{}", "utf8");
-
-  {
-    const status = await caveHomeMigrationStatus();
-    assert.ok(status.conflicts.includes("cave-conversations"), "same-name child makes the dir a conflict");
-    assert.ok(!status.pending.includes("cave-conversations"), "colliding dir is no longer pending");
-  }
+  await mkdir(cave, { recursive: true });
+  await writeFile(path.join(cave, "config.json"), '{"canonical":true}');
+  status = await caveHomeMigrationStatus();
+  assert.deepEqual(status.pending, []);
+  assert.deepEqual(status.conflicts, ["cave-config.json"]);
+  assert.equal(status.details[0].strategy, "manual");
+  assert.equal(status.details[0].legacyPath, path.join(coven, "cave-config.json"));
+  assert.equal(status.details[0].canonicalPath, path.join(cave, "config.json"));
+  assert.equal(typeof status.details[0].legacyMtimeMs, "number");
+  assert.equal(typeof status.details[0].canonicalMtimeMs, "number");
+  assert.deepEqual(status.details[0].actions, ["keep-canonical", "recover-legacy", "defer"]);
+  assert.match(status.details[0].differences[0], /Changed top-level fields/);
 
   console.log("cave-home-migration-status.test.ts: ok");
 } finally {
-  await rm(tmpHome, { recursive: true, force: true });
+  await rm(root, { recursive: true, force: true });
 }

--- a/src/lib/server/cave-home-migration-status.ts
+++ b/src/lib/server/cave-home-migration-status.ts
@@ -1,79 +1,13 @@
-import { lstat, readdir } from "node:fs/promises";
-import path from "node:path";
-import { caveHome, covenHome } from "@/lib/coven-paths";
-import { CAVE_HOME_MIGRATIONS } from "@/lib/server/cave-home-migration";
+import {
+  caveHomeReconciliationStatus,
+  type CaveHomeReconciliationStatus,
+} from "./cave-home-reconciliation.ts";
+import { CAVE_HOME_MIGRATIONS } from "./cave-home-migration.ts";
 
-/**
- * Qualification check for the cave home migration shell banner.
- *
- * The boot-time cave home migration (instrumentation.ts) normally clears every
- * legacy `~/.coven/cave-*` entry, so a machine only *qualifies* for the banner
- * when that run errored or was interrupted and real legacy files remain:
- *
- *  - `pending`   — one `migrateCaveHome()` run clears it: a real legacy entry
- *                  whose destination under `~/.coven/cave/` is free, or a
- *                  legacy DIRECTORY whose children all fit the destination
- *                  (the migrator drains those per-file — cave-lzx3). These are
- *                  what the banner's "Migrate now" button fixes.
- *  - `conflicts` — legacy entry and destination both exist and can't be
- *                  auto-merged (same-name children, or a file pair).
- *                  Destination wins by design; the legacy copy is left for
- *                  manual review and surfaced as a review banner.
- *
- * Symlinked legacy paths are already-migrated compat bridges, not candidates.
- */
-export type CaveHomeMigrationStatus = {
-  pending: string[];
-  conflicts: string[];
-  /** True when no legacy entry remains as a real (non-symlink) path. */
-  migrated: boolean;
-};
+/** Backward-compatible status shape plus detailed review metadata. */
+export type CaveHomeMigrationStatus = CaveHomeReconciliationStatus;
 
-async function pathState(target: string): Promise<"missing" | "symlink" | "file" | "dir"> {
-  try {
-    const st = await lstat(target);
-    return st.isSymbolicLink() ? "symlink" : st.isDirectory() ? "dir" : "file";
-  } catch {
-    return "missing";
-  }
-}
-
-/** Mirrors mergeDirEntry: `.DS_Store` never blocks a drain. */
-async function dirHasCollisions(legacyDir: string, nextDir: string): Promise<boolean> {
-  for (const name of await readdir(legacyDir)) {
-    if (name === ".DS_Store") continue;
-    if ((await pathState(path.join(nextDir, name))) !== "missing") return true;
-  }
-  return false;
-}
-
+/** Central qualification/status check shared by startup, API, and UI. */
 export async function caveHomeMigrationStatus(): Promise<CaveHomeMigrationStatus> {
-  const pending: string[] = [];
-  const conflicts: string[] = [];
-  for (const entry of CAVE_HOME_MIGRATIONS) {
-    const legacyPath = path.join(covenHome(), entry.legacy);
-    const legacyState = await pathState(legacyPath);
-    if (legacyState === "missing" || legacyState === "symlink") continue;
-    const nextPath = path.join(caveHome(), entry.next);
-    const nextState = await pathState(nextPath);
-    if (nextState === "missing") {
-      pending.push(entry.legacy);
-      continue;
-    }
-    if (legacyState === "dir" && nextState === "dir") {
-      // A drainable dir pair is fixable by one run — pending, not a conflict.
-      try {
-        (await dirHasCollisions(legacyPath, nextPath)) ? conflicts.push(entry.legacy) : pending.push(entry.legacy);
-      } catch {
-        conflicts.push(entry.legacy); // unreadable dir: don't promise the button fixes it
-      }
-      continue;
-    }
-    conflicts.push(entry.legacy);
-  }
-  return {
-    pending,
-    conflicts,
-    migrated: pending.length === 0 && conflicts.length === 0,
-  };
+  return caveHomeReconciliationStatus(CAVE_HOME_MIGRATIONS);
 }

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -689,6 +689,23 @@ try {
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
+  // A process crash leaves a fresh lock directory behind. Its recorded dead
+  // owner is enough to reclaim immediately instead of blocking stores.
+  {
+    const { coven, cave } = await home("fresh-dead-lock");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" }));
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    const startedAt = Date.now();
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(Date.now() - startedAt < 2_000, "a crashed owner is reclaimed without waiting for the stale-age threshold");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
   // Competing stale-lock observers serialize through an exclusive takeover
   // claim; neither can remove the successor lock after the first reclaims it.
   {

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -95,6 +95,31 @@ try {
     assert.equal(JSON.stringify(manifest).includes("older-tool"), false, "backup metadata never logs file contents");
   }
 
+  // A damaged canonical copy must never overwrite the last known-good managed
+  // mirror, and the status endpoint must surface the repair instead of hiding it.
+  {
+    const { coven, cave } = await home("damaged-canonical-mirror");
+    await writeFile(path.join(coven, "cave-config.json"), '{"knownGood":true}', "utf8");
+    assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
+    await writeFile(path.join(cave, "config.json"), "not-json", "utf8");
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { knownGood: true });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
+  // If the canonical side is deleted after startup, an unchanged managed
+  // mirror is still pending recovery rather than falsely reported as migrated.
+  {
+    const { coven, cave } = await home("missing-canonical-mirror");
+    await writeFile(path.join(coven, "cave-config.json"), '{"recoverable":true}', "utf8");
+    assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
+    await rm(path.join(cave, "config.json"));
+    const status = await caveHomeMigrationStatus();
+    assert.equal(status.pending.includes("cave-config.json"), true);
+    assert.equal(status.migrated, false);
+  }
+
   // Inbox records merge by stable ID; the newer revision/timestamp wins.
   {
     const { coven, cave } = await home("inbox");

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -520,7 +520,9 @@ try {
   }
 
   // Deferring a divergent pair retains a verified recovery source in the
-  // journal instead of making its bundle eligible for retention pruning.
+  // journal instead of making its bundle eligible for retention pruning. A
+  // later canonical failure must still fail the store gate rather than letting
+  // deferral turn missing data into a default-store overwrite.
   {
     const { coven, cave } = await home("deferred-backup");
     await mkdir(cave, { recursive: true });
@@ -536,6 +538,26 @@ try {
     const entry = journal.entries["cave-config.json"];
     assert.equal(entry.decision, "deferred");
     assert.equal(await kind(path.join(cave, "migration-backups", entry.backupId)), "dir");
+    await rm(path.join(cave, "config.json"));
+    const retry = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.equal(retry.errors.some((error) => error.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { source: "legacy" });
+  }
+
+  // A legacy-only file is the sole usable store, so a crafted defer request
+  // cannot suppress migration and let readers continue against missing
+  // canonical storage.
+  {
+    const { coven, cave } = await home("defer-pending");
+    await writeFile(path.join(coven, "cave-config.json"), JSON.stringify({ source: "only-copy" }));
+    const result = await migrateCaveHome({
+      legacy: "cave-config.json",
+      action: "defer",
+      createSymlink: denySymlink,
+    });
+    assert.equal(result.errors.some((error) => error.legacy === "cave-config.json"), true);
+    assert.equal(await kind(path.join(cave, "config.json")), "missing");
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { source: "only-copy" });
   }
 
   // Malformed JSON never overwrites either side and remains reviewable.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -587,6 +587,33 @@ try {
     assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [{ id: "safe" }] });
     assert.equal(await readFile(path.join(coven, "cave-inbox.json"), "utf8"), "not-json");
   }
+  // The status surface offers Recover legacy when canonical storage is an
+  // invalid symlink. Retire that exact link safely instead of advertising an
+  // action that can never replace it; the link target itself remains intact.
+  {
+    const { coven, cave } = await home("canonical-symlink-recovery");
+    const legacyPath = path.join(coven, "cave-config.json");
+    const canonicalPath = path.join(cave, "config.json");
+    const foreignPath = path.join(cave, "foreign-config.json");
+    await mkdir(cave, { recursive: true });
+    await writeFile(legacyPath, '{"source":"legacy"}');
+    await writeFile(foreignPath, '{"source":"foreign"}');
+    await symlink(path.basename(foreignPath), canonicalPath, "file");
+    assert.deepEqual(
+      (await caveHomeMigrationStatus()).details.find((detail) => detail.legacy === "cave-config.json")?.actions,
+      ["recover-legacy"],
+    );
+
+    const result = await migrateCaveHome({
+      legacy: "cave-config.json",
+      action: "recover-legacy",
+      createSymlink: denySymlink,
+    });
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(await json(canonicalPath), { source: "legacy" });
+    assert.deepEqual(await json(foreignPath), { source: "foreign" });
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
   {
     const { coven, cave } = await home("malformed-identical");
     await mkdir(cave, { recursive: true });

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -132,7 +132,29 @@ try {
     assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
     assert.deepEqual(await json(path.join(cave, "config.json")), { source: "startup" });
     assert.deepEqual(await json(legacyPath), { source: "older-tool" });
+    assert.equal((await readdir(coven)).some((name) => name.includes("migration-retired")), false);
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
+  // A canonical writer can also race bridge installation. If it changes the
+  // validated canonical bytes, keep the original legacy copy at its ordinary
+  // path instead of replacing it with the unvalidated canonical write.
+  {
+    const { coven, cave } = await home("canonical-pre-bridge-write");
+    const legacyPath = path.join(coven, "cave-config.json");
+    const canonicalPath = path.join(cave, "config.json");
+    await mkdir(cave, { recursive: true });
+    await writeFile(legacyPath, '{"source":"known-good"}', "utf8");
+    await writeFile(canonicalPath, '{"source":"known-good"}', "utf8");
+    const result = await migrateCaveHome({
+      createSymlink: denySymlink,
+      compatibilityProbe: async () => {
+        await writeFile(canonicalPath, "not-json", "utf8");
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(legacyPath), { source: "known-good" });
+    assert.equal(await readFile(canonicalPath, "utf8"), "not-json");
   }
 
   // The directory fallback must also fail closed if an old tool recreates the
@@ -169,6 +191,27 @@ try {
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
   }
 
+  // Canonical data can change after validation but before a managed mirror is
+  // refreshed. Stage and hash-check the exact validated snapshot before
+  // retiring the last known-good mirror.
+  {
+    const { coven, cave } = await home("canonical-mirror-refresh-race");
+    const legacyPath = path.join(coven, "cave-config.json");
+    const canonicalPath = path.join(cave, "config.json");
+    await writeFile(legacyPath, '{"knownGood":true}', "utf8");
+    assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
+    await writeFile(canonicalPath, '{"newer":true}', "utf8");
+    const result = await migrateCaveHome({
+      createSymlink: denySymlink,
+      managedMirrorProbe: async () => {
+        await writeFile(canonicalPath, "not-json", "utf8");
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(legacyPath), { knownGood: true });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
   // If the canonical side is deleted after startup, an unchanged managed
   // mirror is still pending recovery rather than falsely reported as migrated.
   {
@@ -201,24 +244,41 @@ try {
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
-  // State maps and queued work are unioned without dropping legacy-only keys.
+  // Append-only state maps and queued work are unioned without dropping
+  // legacy-only keys.
   {
     const { coven, cave } = await home("state");
     await mkdir(cave, { recursive: true });
     const legacy = baseState();
-    legacy.sessionTitles.legacy = "Legacy session";
     legacy.sessionFamiliar.legacy = "nova";
     legacy.travel.offlineQueue.push({ id: "legacy-work", kind: "job", summary: "Legacy", createdAt: "2026-01-01T00:00:00Z", status: "pending" });
     const canonical = baseState();
-    canonical.sessionTitles.current = "Current session";
     canonical.sessionFamiliar.current = "salem";
     canonical.travel.offlineQueue.push({ id: "current-work", kind: "job", summary: "Current", createdAt: "2026-02-01T00:00:00Z", status: "pending" });
     await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
     await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
     await migrateCaveHome({ createSymlink: denySymlink });
     const merged = await json(path.join(cave, "state.json"));
-    assert.deepEqual(Object.keys(merged.sessionTitles).sort(), ["current", "legacy"]);
+    assert.deepEqual(Object.keys(merged.sessionFamiliar).sort(), ["current", "legacy"]);
     assert.deepEqual(merged.travel.offlineQueue.map((item) => item.id).sort(), ["current-work", "legacy-work"]);
+  }
+
+  // Session titles, archive markers, and keep markers delete keys during
+  // ordinary user actions. A one-sided key cannot be distinguished from a
+  // later deletion, so preserve both snapshots for explicit review.
+  {
+    const { coven, cave } = await home("state-ambiguous-deleted-key");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    legacy.sessionArchived.session = "2026-01-01T00:00:00Z";
+    const canonical = baseState();
+    canonical.sessionFamiliar.current = "salem";
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-state.json"));
+    assert.deepEqual((await json(path.join(cave, "state.json"))).sessionArchived, {});
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
   }
 
   // Queue statuses have no revision and can move from failed back to syncing

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -114,6 +114,27 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { source: "startup" });
     assert.deepEqual(await json(legacyPath), { source: "older-tool" });
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
+  // The directory fallback must also fail closed if an old tool recreates the
+  // legacy directory after removal but before the compatibility copy starts.
+  {
+    const { coven, cave } = await home("windows-directory-mirror-race");
+    const legacyPath = path.join(coven, "cave-conversations");
+    await mkdir(legacyPath, { recursive: true });
+    await writeFile(path.join(legacyPath, "startup.json"), "startup");
+    const concurrentWriter: typeof denySymlink = async () => {
+      await mkdir(legacyPath, { recursive: true });
+      await writeFile(path.join(legacyPath, "older-tool.json"), "older-tool");
+      const error = new Error("legacy directory was recreated") as NodeJS.ErrnoException;
+      error.code = "EEXIST";
+      throw error;
+    };
+    const result = await migrateCaveHome({ createSymlink: concurrentWriter });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-conversations"), true);
+    assert.equal(await readFile(path.join(cave, "conversations", "startup.json"), "utf8"), "startup");
+    assert.equal(await readFile(path.join(legacyPath, "older-tool.json"), "utf8"), "older-tool");
+    assert.equal(await kind(path.join(legacyPath, "startup.json")), "missing");
   }
 
   // A damaged canonical copy must never overwrite the last known-good managed
@@ -464,6 +485,48 @@ try {
     assert.deepEqual(second.errors, []);
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Competing stale-lock observers serialize through an exclusive takeover
+  // claim; neither can remove the successor lock after the first reclaims it.
+  {
+    const { coven, cave } = await home("stale-lock-takeover");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" }));
+    const stale = new Date(Date.now() - 10 * 60_000);
+    await utimes(lock, stale, stale);
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    let staleObservers = 0;
+    let releaseObservers!: () => void;
+    const bothObserved = new Promise<void>((resolve) => { releaseObservers = resolve; });
+    let active = 0;
+    let maxActive = 0;
+    const lockProbe = async (event: "stale-observed" | "acquired" | "released") => {
+      if (event === "stale-observed") {
+        staleObservers += 1;
+        if (staleObservers === 2) releaseObservers();
+        await bothObserved;
+      } else if (event === "acquired") {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      } else {
+        active -= 1;
+      }
+    };
+    const [first, second] = await Promise.all([
+      migrateCaveHome({ createSymlink: denySymlink, lockProbe }),
+      migrateCaveHome({ createSymlink: denySymlink, lockProbe }),
+    ]);
+    assert.deepEqual(first.errors, []);
+    assert.deepEqual(second.errors, []);
+    assert.equal(staleObservers, 2);
+    assert.equal(maxActive, 1);
+    assert.equal(active, 0);
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
   // Store readers fail closed on a bad migration, then retry on the next call

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -296,6 +296,25 @@ try {
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
+  // Deferring a divergent pair retains a verified recovery source in the
+  // journal instead of making its bundle eligible for retention pruning.
+  {
+    const { coven, cave } = await home("deferred-backup");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-config.json"), JSON.stringify({ source: "legacy" }));
+    await writeFile(path.join(cave, "config.json"), JSON.stringify({ source: "canonical" }));
+    const result = await migrateCaveHome({
+      legacy: "cave-config.json",
+      action: "defer",
+      createSymlink: denySymlink,
+    });
+    assert.equal(result.backedUp.length, 1);
+    const journal = await json(path.join(cave, "migration-state.json"));
+    const entry = journal.entries["cave-config.json"];
+    assert.equal(entry.decision, "deferred");
+    assert.equal(await kind(path.join(cave, "migration-backups", entry.backupId)), "dir");
+  }
+
   // Malformed JSON never overwrites either side and remains reviewable.
   {
     const { coven, cave } = await home("malformed");
@@ -306,6 +325,22 @@ try {
     assert.equal(await readFile(path.join(coven, "cave-inbox.json"), "utf8"), "not-json");
     assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [] });
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-inbox.json"), true);
+  }
+  // Explicit recovery also validates the verified legacy backup before it
+  // replaces a good canonical store.
+  {
+    const { coven, cave } = await home("malformed-recovery");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-inbox.json"), "not-json");
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [{ id: "safe" }] }));
+    const result = await migrateCaveHome({
+      legacy: "cave-inbox.json",
+      action: "recover-legacy",
+      createSymlink: denySymlink,
+    });
+    assert.equal(result.errors.length, 1);
+    assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [{ id: "safe" }] });
+    assert.equal(await readFile(path.join(coven, "cave-inbox.json"), "utf8"), "not-json");
   }
   {
     const { coven, cave } = await home("malformed-identical");

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -263,24 +263,38 @@ try {
     assert.equal(status.migrated, false);
   }
 
-  // Inbox records merge by stable ID; the newer revision/timestamp wins.
+  // Inbox records present in both snapshots merge by stable ID; the newer
+  // revision/timestamp wins.
   {
     const { coven, cave } = await home("inbox");
     await mkdir(cave, { recursive: true });
     await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "legacy-only", title: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
       { id: "shared", title: "newer", revision: 2, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-03-01T00:00:00Z" },
     ] }));
     await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "canonical-only", title: "canonical", createdAt: "2026-02-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
       { id: "shared", title: "older", revision: 1, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
     ] }));
     const result = await migrateCaveHome({ createSymlink: denySymlink });
     assert.deepEqual(result.errors, []);
     const merged = await json(path.join(cave, "inbox.json"));
-    assert.deepEqual(merged.items.map((item) => item.id), ["legacy-only", "shared", "canonical-only"]);
+    assert.deepEqual(merged.items.map((item) => item.id), ["shared"]);
     assert.equal(merged.items.find((item) => item.id === "shared").title, "newer");
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Inbox deletion removes an ID without leaving a tombstone. A one-sided
+  // item may therefore be either a new item or one deleted from the other
+  // snapshot, so automatic union must leave both files for explicit review.
+  {
+    const { coven, cave } = await home("inbox-ambiguous-deletion");
+    await mkdir(cave, { recursive: true });
+    const deleted = { id: "deleted", title: "Removed", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" };
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [deleted] }));
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [] }));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-inbox.json"));
+    assert.deepEqual((await json(path.join(cave, "inbox.json"))).items, [], "deleted canonical item is not resurrected");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-inbox.json"), true);
   }
 
   // Append-only state maps and queued work are unioned without dropping
@@ -485,10 +499,10 @@ try {
     const { coven, cave } = await home("merge-canonical-race");
     await mkdir(cave, { recursive: true });
     await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      { id: "shared", title: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-03-01T00:00:00Z" },
     ] }));
     await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "canonical", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z" },
+      { id: "shared", title: "canonical", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
     ] }));
     const late = { version: 1, items: [
       { id: "late", createdAt: "2026-01-03T00:00:00Z", updatedAt: "2026-01-03T00:00:00Z" },
@@ -588,10 +602,10 @@ try {
     const { coven, cave } = await home(`fault-${boundary}`);
     await mkdir(cave, { recursive: true });
     await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      { id: "shared", title: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-03-01T00:00:00Z" },
     ] }));
     await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
-      { id: "canonical", createdAt: "2026-02-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
+      { id: "shared", title: "canonical", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
     ] }));
     if (boundary.includes("journal")) await assert.rejects(migrateCaveHome({ faultAt: boundary, createSymlink: denySymlink }));
     else assert.ok((await migrateCaveHome({ faultAt: boundary, createSymlink: denySymlink })).errors.length > 0);

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 const roots: string[] = [];
 const { ensureCaveHomeReconciled, migrateCaveHome } = await import("./cave-home-migration.ts");
+const { reconcileCaveHome } = await import("./cave-home-reconciliation.ts");
 const { caveHomeMigrationStatus } = await import("./cave-home-migration-status.ts");
 const { createDefaultPreferences } = await import("../preferences-schema.ts");
 
@@ -381,6 +382,27 @@ try {
       })).errors, []);
     }
     assert.ok((await readdir(path.join(cave, "migration-backups"))).length <= 10);
+  }
+
+  // More than the retention limit can become unresolved in one transaction.
+  // Protect bundles recorded in the in-memory journal before it is committed,
+  // rather than pruning an earlier conflict while processing a later one.
+  {
+    const { coven, cave } = await home("same-run-retention");
+    await mkdir(cave, { recursive: true });
+    const entries = Array.from({ length: 11 }, (_, index) => ({
+      legacy: `legacy-${index}.json`, next: `canonical-${index}.json`, strategy: "manual" as const,
+    }));
+    for (let index = 0; index < entries.length; index += 1) {
+      await writeFile(path.join(coven, entries[index].legacy), JSON.stringify({ legacy: index }));
+      await writeFile(path.join(cave, entries[index].next), JSON.stringify({ canonical: index }));
+    }
+    assert.deepEqual((await reconcileCaveHome(entries, { createSymlink: denySymlink })).errors, []);
+    const journal = await json(path.join(cave, "migration-state.json"));
+    for (const entry of entries) {
+      const backupId = journal.entries[entry.legacy].backupId;
+      assert.equal(await kind(path.join(cave, "migration-backups", backupId)), "dir", `${entry.legacy} keeps its recovery bundle`);
+    }
   }
 
   // A malformed or unsupported journal fails closed before touching either

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -95,6 +95,26 @@ try {
     assert.equal(JSON.stringify(manifest).includes("older-tool"), false, "backup metadata never logs file contents");
   }
 
+  // An old tool can recreate the ordinary legacy file after reconciliation
+  // removes it but before the compatibility bridge is installed. Never let
+  // the mirror fallback overwrite that concurrent write.
+  {
+    const { coven, cave } = await home("windows-mirror-race");
+    const legacyPath = path.join(coven, "cave-config.json");
+    await writeFile(legacyPath, '{"source":"startup"}', "utf8");
+    const concurrentWriter: typeof denySymlink = async () => {
+      await writeFile(legacyPath, '{"source":"older-tool"}', "utf8");
+      const error = new Error("legacy path was recreated") as NodeJS.ErrnoException;
+      error.code = "EEXIST";
+      throw error;
+    };
+    const result = await migrateCaveHome({ createSymlink: concurrentWriter });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(path.join(cave, "config.json")), { source: "startup" });
+    assert.deepEqual(await json(legacyPath), { source: "older-tool" });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
   // A damaged canonical copy must never overwrite the last known-good managed
   // mirror, and the status endpoint must surface the repair instead of hiding it.
   {

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -65,6 +65,23 @@ try {
     await mkdir(cave, { recursive: true });
     await writeFile(path.join(cave, "config.json"), "{}", "utf8");
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Do not treat an arbitrary or broken legacy symlink as a completed
+  // compatibility bridge. Its target may contain the only remaining data.
+  {
+    const { coven, cave } = await home("foreign-legacy-symlink");
+    const foreign = path.join(coven, "foreign-config.json");
+    await mkdir(cave, { recursive: true });
+    await writeFile(foreign, '{"source":"foreign"}', "utf8");
+    await writeFile(path.join(cave, "config.json"), '{"source":"canonical"}', "utf8");
+    await symlink(path.basename(foreign), path.join(coven, "cave-config.json"), "file");
+    const status = await caveHomeMigrationStatus();
+    assert.equal(status.conflicts.includes("cave-config.json"), true);
+    assert.deepEqual(status.details.find((detail) => detail.legacy === "cave-config.json")?.actions, ["defer"]);
+    const result = await migrateCaveHome();
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(foreign), { source: "foreign" });
   }
 
   // Legacy-only data moves to canonical storage. On normal Windows, a verified
@@ -155,6 +172,28 @@ try {
     assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
     assert.deepEqual(await json(legacyPath), { source: "known-good" });
     assert.equal(await readFile(canonicalPath, "utf8"), "not-json");
+  }
+
+  // A symlink can be installed before canonical validation notices a late
+  // invalid write. Remove that attempted link and restore the original legacy
+  // pathname instead of hiding the recoverable bytes in a retired file.
+  {
+    const { coven, cave } = await home("canonical-post-link-write");
+    const legacyPath = path.join(coven, "cave-config.json");
+    const canonicalPath = path.join(cave, "config.json");
+    await mkdir(cave, { recursive: true });
+    await writeFile(legacyPath, '{"source":"known-good"}', "utf8");
+    await writeFile(canonicalPath, '{"source":"known-good"}', "utf8");
+    const result = await migrateCaveHome({
+      createSymlink: async (target, linkPath, type) => {
+        await symlink(target, linkPath, type);
+        await writeFile(canonicalPath, "not-json", "utf8");
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(legacyPath), { source: "known-good" });
+    assert.equal(await readFile(canonicalPath, "utf8"), "not-json");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
   }
 
   // The directory fallback must also fail closed if an old tool recreates the
@@ -412,6 +451,58 @@ try {
     await migrateCaveHome({ legacy: "cave-state.json", action: "recover-legacy", createSymlink: denySymlink });
     assert.equal((await json(path.join(cave, "state.json"))).sessionTitles.shared, "Legacy title");
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Explicit recovery must not overwrite a canonical write that lands after
+  // the recovery bundle is verified.
+  {
+    const { coven, cave } = await home("recovery-canonical-race");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    const canonical = baseState();
+    legacy.sessionTitles.shared = "Legacy title";
+    canonical.sessionTitles.shared = "Canonical title";
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({
+      legacy: "cave-state.json",
+      action: "recover-legacy",
+      createSymlink: denySymlink,
+      resolutionProbe: async (canonicalPath) => {
+        const late = baseState();
+        late.sessionTitles.shared = "Late canonical title";
+        await writeFile(canonicalPath, JSON.stringify(late));
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-state.json"), true);
+    assert.equal((await json(path.join(cave, "state.json"))).sessionTitles.shared, "Late canonical title");
+    assert.equal((await json(path.join(coven, "cave-state.json"))).sessionTitles.shared, "Legacy title");
+  }
+
+  // Automatic JSON merge has the same late-writer boundary: preserve the new
+  // canonical snapshot and leave the pair reviewable rather than replacing it.
+  {
+    const { coven, cave } = await home("merge-canonical-race");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "canonical", createdAt: "2026-01-02T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z" },
+    ] }));
+    const late = { version: 1, items: [
+      { id: "late", createdAt: "2026-01-03T00:00:00Z", updatedAt: "2026-01-03T00:00:00Z" },
+    ] };
+    const result = await migrateCaveHome({
+      legacy: "cave-inbox.json",
+      createSymlink: denySymlink,
+      resolutionProbe: async (canonicalPath) => {
+        await writeFile(canonicalPath, JSON.stringify(late));
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-inbox.json"), true);
+    assert.deepEqual(await json(path.join(cave, "inbox.json")), late);
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-inbox.json"), true);
   }
 
   // Deferring a divergent pair retains a verified recovery source in the

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 const roots: string[] = [];
-const { ensureCaveHomeReconciled, migrateCaveHome } = await import("./cave-home-migration.ts");
+const { ensureCaveHomeReconciled, migrateCaveHome, withCaveHomeReconciledStore } = await import("./cave-home-migration.ts");
 const { reconcileCaveHome } = await import("./cave-home-reconciliation.ts");
 const { caveHomeMigrationStatus } = await import("./cave-home-migration-status.ts");
 const { createDefaultPreferences } = await import("../preferences-schema.ts");
@@ -861,6 +861,44 @@ try {
     assert.equal(maxActive, 1);
     assert.equal(active, 0);
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
+  // Store transactions share the cross-process migration lock. A writer that
+  // already passed startup reconciliation must not read an old snapshot while
+  // a manual recovery is replacing canonical storage and overwrite it later.
+  {
+    const { coven, cave } = await home("store-transaction-lock");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-config.json"), JSON.stringify({ source: "legacy" }));
+    await writeFile(path.join(cave, "config.json"), JSON.stringify({ source: "canonical" }));
+    const initial = await migrateCaveHome({ legacy: "cave-config.json", createSymlink: denySymlink });
+    globalThis.__caveHomeMigration = Promise.resolve(initial);
+
+    let continueRecovery!: () => void;
+    const recoveryPaused = new Promise<void>((resolve) => { continueRecovery = resolve; });
+    let recoveryReached!: () => void;
+    const atReplacement = new Promise<void>((resolve) => { recoveryReached = resolve; });
+    const recovery = migrateCaveHome({
+      legacy: "cave-config.json",
+      action: "recover-legacy",
+      createSymlink: denySymlink,
+      resolutionProbe: async () => {
+        recoveryReached();
+        await recoveryPaused;
+      },
+    });
+    await atReplacement;
+
+    let storeEntered = false;
+    const store = withCaveHomeReconciledStore("cave-config.json", async () => {
+      storeEntered = true;
+      return json(path.join(cave, "config.json"));
+    });
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    assert.equal(storeEntered, false);
+    continueRecovery();
+    assert.deepEqual((await recovery).errors, []);
+    assert.deepEqual(await store, { source: "legacy" });
   }
 
   // Store readers fail closed on a bad migration, then retry on the next call

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -160,8 +160,8 @@ try {
     assert.deepEqual(merged.travel.offlineQueue.map((item) => item.id).sort(), ["current-work", "legacy-work"]);
   }
 
-  // Preference sections use global revision/timestamp while theme selection
-  // uses its own revision/timestamp.
+  // Theme selection can merge independently because it has its own revision
+  // and timestamp.
   {
     const { coven, cave } = await home("preferences");
     await mkdir(cave, { recursive: true });
@@ -174,14 +174,35 @@ try {
     const canonical = createDefaultPreferences(true);
     canonical.revision = 8;
     canonical.updatedAt = "2026-03-01T00:00:00Z";
-    canonical.general.newsHeadlines = false;
     await writeFile(path.join(coven, "cave-preferences.json"), JSON.stringify(legacy));
     await writeFile(path.join(cave, "preferences.json"), JSON.stringify(canonical));
     await migrateCaveHome({ createSymlink: denySymlink });
     const merged = await json(path.join(cave, "preferences.json"));
-    assert.equal(merged.general.newsHeadlines, false, "newer global section wins");
     assert.equal(merged.appearance.theme.id, "tide", "newer independent theme selection wins");
     assert.equal(merged.revision, 9);
+  }
+
+  // A file-wide revision cannot establish which side owns independent
+  // section edits. Leave both snapshots reviewable instead of letting the
+  // larger revision silently discard a unique change from the other side.
+  {
+    const { coven, cave } = await home("preferences-ambiguous-sections");
+    await mkdir(cave, { recursive: true });
+    const legacy = createDefaultPreferences(true);
+    legacy.revision = 2;
+    legacy.updatedAt = "2026-01-01T00:00:00Z";
+    legacy.general.stopPhrase = "legacy stop";
+    const canonical = createDefaultPreferences(true);
+    canonical.revision = 8;
+    canonical.updatedAt = "2026-03-01T00:00:00Z";
+    canonical.general.newsHeadlines = false;
+    await writeFile(path.join(coven, "cave-preferences.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "preferences.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-preferences.json"));
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-preferences.json"), true);
+    assert.equal((await json(path.join(coven, "cave-preferences.json"))).general.stopPhrase, "legacy stop");
+    assert.equal((await json(path.join(cave, "preferences.json"))).general.newsHeadlines, false);
   }
 
   // Existing Cave-home and per-store path overrides remain authoritative.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -774,11 +774,29 @@ try {
   // after the recoverable input is repaired instead of caching the failure.
   {
     const { coven, cave } = await home("reader-gate-retry");
+    globalThis.__caveHomeMigration = undefined;
     await writeFile(path.join(coven, "cave-inbox.json"), "not-json");
-    await assert.rejects(ensureCaveHomeReconciled(), /cave-inbox\.json/);
+    await assert.rejects(ensureCaveHomeReconciled("cave-inbox.json"), /cave-inbox\.json/);
     await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [] }));
-    await ensureCaveHomeReconciled();
+    await ensureCaveHomeReconciled("cave-inbox.json");
     assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [] });
+  }
+
+  // An unrelated legacy-path problem must not take every gated Cave store
+  // offline or force a full reconciliation pass on every state read.
+  {
+    const { coven, cave } = await home("reader-gate-scoped");
+    globalThis.__caveHomeMigration = undefined;
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(baseState()));
+    await writeFile(path.join(cave, "backdrop.jpg"), "canonical");
+    await writeFile(path.join(coven, "foreign-backdrop.jpg"), "foreign");
+    await symlink("foreign-backdrop.jpg", path.join(coven, "cave-backdrop.jpg"), "file");
+
+    await ensureCaveHomeReconciled("cave-state.json");
+    const cached = await globalThis.__caveHomeMigration;
+    assert.deepEqual(cached?.errors.map((entry) => entry.legacy), ["cave-backdrop.jpg"]);
+    await ensureCaveHomeReconciled("cave-state.json");
   }
 
   console.log("cave-home-migration.test.ts: ok");

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -160,6 +160,24 @@ try {
     assert.deepEqual(merged.travel.offlineQueue.map((item) => item.id).sort(), ["current-work", "legacy-work"]);
   }
 
+  // Queue statuses have no revision and can move from failed back to syncing
+  // on retry, so divergent snapshots must not be ranked as if monotonic.
+  {
+    const { coven, cave } = await home("state-ambiguous-queue-status");
+    await mkdir(cave, { recursive: true });
+    const item = { id: "shared-work", kind: "job", summary: "Shared", createdAt: "2026-01-01T00:00:00Z" };
+    const legacy = baseState();
+    legacy.travel.offlineQueue.push({ ...item, status: "failed", lastError: "old failure" });
+    const canonical = baseState();
+    canonical.travel.offlineQueue.push({ ...item, status: "syncing" });
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-state.json"));
+    assert.equal((await json(path.join(cave, "state.json"))).travel.offlineQueue[0].status, "syncing");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
+  }
+
   // Theme selection can merge independently because it has its own revision
   // and timestamp.
   {
@@ -218,6 +236,24 @@ try {
     assert.equal((await json(process.env.COVEN_PREFERENCES_PATH)).revision, 3);
     assert.equal((await json(path.join(process.env.COVEN_CAVE_HOME, "migration-state.json"))).migrationVersion, 2);
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // An override may intentionally retain the historical path. Treat that
+  // path as canonical instead of deleting it while creating a compat bridge.
+  {
+    const { coven } = await home("legacy-path-override");
+    const legacyPath = path.join(coven, "cave-preferences.json");
+    process.env.COVEN_PREFERENCES_PATH = legacyPath;
+    const preferences = createDefaultPreferences(true);
+    preferences.revision = 4;
+    await writeFile(legacyPath, JSON.stringify(preferences));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.equal(await kind(legacyPath), "file");
+    assert.equal((await json(legacyPath)).revision, 4);
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+    await rm(legacyPath);
+    assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
   }
 
   // Ambiguous state is backed up and left untouched until an explicit recovery.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1,175 +1,324 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-// Isolated to a temp COVEN_HOME so it never touches the real ~/.coven.
-const tmpHome = await mkdtemp(path.join(tmpdir(), "cave-home-migration-"));
-process.env.HOME = tmpHome;
-process.env.COVEN_HOME = path.join(tmpHome, ".coven");
-delete process.env.COVEN_CAVE_HOME;
+const roots: string[] = [];
+const { ensureCaveHomeReconciled, migrateCaveHome } = await import("./cave-home-migration.ts");
+const { caveHomeMigrationStatus } = await import("./cave-home-migration-status.ts");
+const { createDefaultPreferences } = await import("../preferences-schema.ts");
 
-const covenDir = process.env.COVEN_HOME;
-const caveDir = path.join(covenDir, "cave");
+async function home(name: string) {
+  const root = await mkdtemp(path.join(tmpdir(), `cave-home-${name}-`));
+  roots.push(root);
+  process.env.COVEN_HOME = path.join(root, ".coven");
+  delete process.env.COVEN_CAVE_HOME;
+  delete process.env.COVEN_PREFERENCES_PATH;
+  delete process.env.COVEN_THEME_PATH;
+  delete process.env.COVEN_BACKDROP_PATH;
+  await mkdir(process.env.COVEN_HOME, { recursive: true });
+  return { root, coven: process.env.COVEN_HOME, cave: path.join(process.env.COVEN_HOME, "cave") };
+}
 
-const { migrateCaveHome, CAVE_HOME_MIGRATIONS } = await import("./cave-home-migration.ts");
-const { caveHome } = await import("../coven-paths.ts");
+async function json(target: string) {
+  return JSON.parse(await readFile(target, "utf8"));
+}
 
-// SAFETY GATE — never operate outside the temp home.
-assert.ok(caveHome().startsWith(tmpHome), `refusing: caveHome ${caveHome()} not under temp home`);
-
-async function pathKind(target) {
+async function kind(target: string) {
   try {
-    const st = await lstat(target);
-    return st.isSymbolicLink() ? "symlink" : st.isDirectory() ? "dir" : "file";
+    const value = await lstat(target);
+    return value.isSymbolicLink() ? "symlink" : value.isDirectory() ? "dir" : "file";
   } catch {
     return "missing";
   }
 }
 
+async function denySymlink() {
+  const error = new Error("Administrator privilege required") as NodeJS.ErrnoException;
+  error.code = "EPERM";
+  throw error;
+}
+
+const baseState = () => ({
+  sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {},
+  sessionKeep: {}, sessionArchiveExtendedUntil: {}, sessionOwned: {}, mergedPrAutoArchived: {},
+  travel: {
+    manualOffline: false, hubUnreachableSince: null, lastHubReachableAt: null,
+    staleCache: false, localSubdaemonWakeRequestedAt: null, localBindHost: "127.0.0.1",
+    offlineQueue: [],
+  },
+});
+
 try {
-  // Fresh home, nothing to migrate — just creates the cave dir.
+  // Fresh and canonical-only installs are complete and create a durable journal.
   {
+    const { cave } = await home("fresh");
     const result = await migrateCaveHome();
-    assert.deepEqual(result.moved, [], "nothing moved on a fresh home");
-    assert.deepEqual(result.errors, [], "no errors on a fresh home");
-    assert.equal(await pathKind(caveDir), "dir", "cave home is created");
+    assert.deepEqual(result.errors, []);
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+    assert.equal((await json(path.join(cave, "migration-state.json"))).migrationVersion, 2);
+  }
+  {
+    const { cave } = await home("canonical-only");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(cave, "config.json"), "{}", "utf8");
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
-  // Seed a representative legacy layout: files, the conversations dir, and a
-  // daemon-owned sibling that must NOT move.
-  await writeFile(path.join(covenDir, "cave-config.json"), '{"version":1}', "utf8");
-  await writeFile(path.join(covenDir, "cave-board.json"), '{"cards":[]}', "utf8");
-  await mkdir(path.join(covenDir, "cave-conversations"), { recursive: true });
-  await writeFile(path.join(covenDir, "cave-conversations", "sess-1.json"), "{}", "utf8");
-  await writeFile(path.join(covenDir, "cave-coven-calls.json"), "[]", "utf8"); // daemon-owned
-
+  // Legacy-only data moves to canonical storage. On normal Windows, a verified
+  // ordinary mirror replaces the unavailable file symlink and does not warn.
   {
-    const result = await migrateCaveHome();
-    assert.deepEqual(
-      [...result.moved].sort(),
-      ["cave-board.json", "cave-config.json", "cave-conversations"],
-      "moves exactly the seeded cave-owned entries",
-    );
-    assert.deepEqual(result.errors, [], "no errors");
+    const { coven, cave } = await home("windows-mirror");
+    await writeFile(path.join(coven, "cave-config.json"), '{"source":"legacy"}', "utf8");
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(await json(path.join(cave, "config.json")), { source: "legacy" });
+    assert.equal(await kind(path.join(coven, "cave-config.json")), "file");
+    const journal = await json(path.join(cave, "migration-state.json"));
+    assert.equal(journal.entries["cave-config.json"].decision, "moved");
+    assert.equal(journal.entries["cave-config.json"].compatibility, "mirror");
+    assert.equal((await caveHomeMigrationStatus()).migrated, true, "unchanged managed mirror is not a conflict");
 
-    // Files land under cave/ with standardized names, content intact.
-    assert.equal(await readFile(path.join(caveDir, "config.json"), "utf8"), '{"version":1}');
-    assert.equal(await readFile(path.join(caveDir, "board.json"), "utf8"), '{"cards":[]}');
-    assert.equal(
-      await readFile(path.join(caveDir, "conversations", "sess-1.json"), "utf8"),
-      "{}",
-      "conversation files move with their dir",
-    );
-
-    // Daemon-owned sibling untouched.
-    assert.equal(await pathKind(path.join(covenDir, "cave-coven-calls.json")), "file");
-
-    // Compat symlinks bridge the legacy paths (best-effort; POSIX here).
-    assert.equal(await pathKind(path.join(covenDir, "cave-config.json")), "symlink");
-    const linkTarget = await readlink(path.join(covenDir, "cave-config.json"));
-    assert.equal(linkTarget, path.join("cave", "config.json"), "relative link into cave/");
-    assert.equal(
-      await readFile(path.join(covenDir, "cave-config.json"), "utf8"),
-      '{"version":1}',
-      "legacy path still resolves through the link",
-    );
+    await writeFile(path.join(coven, "cave-config.json"), '{"source":"older-tool"}', "utf8");
+    assert.deepEqual((await caveHomeMigrationStatus()).conflicts, ["cave-config.json"], "changed mirror is detected");
+    const resolved = await migrateCaveHome({ legacy: "cave-config.json", action: "keep-canonical", createSymlink: denySymlink });
+    assert.deepEqual(resolved.errors, []);
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { source: "legacy" });
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+    const recovery = path.join(cave, "migration-backups");
+    const bundles = await readdir(recovery);
+    assert.equal(bundles.length, 1);
+    const manifest = await json(path.join(recovery, bundles[0], "manifest.json"));
+    assert.equal(manifest.files.length, 2);
+    assert.ok(manifest.files.every((file) => /^[a-f0-9]{64}$/.test(file.hash)));
+    assert.equal(JSON.stringify(manifest).includes("older-tool"), false, "backup metadata never logs file contents");
   }
 
-  // Idempotent: a second run skips symlinked legacy paths and moves nothing.
+  // Inbox records merge by stable ID; the newer revision/timestamp wins.
   {
-    const result = await migrateCaveHome();
-    assert.deepEqual(result.moved, [], "second run moves nothing");
-    assert.deepEqual(result.errors, [], "second run has no errors");
+    const { coven, cave } = await home("inbox");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "legacy-only", title: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+      { id: "shared", title: "newer", revision: 2, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-03-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "canonical-only", title: "canonical", createdAt: "2026-02-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
+      { id: "shared", title: "older", revision: 1, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    const merged = await json(path.join(cave, "inbox.json"));
+    assert.deepEqual(merged.items.map((item) => item.id), ["legacy-only", "shared", "canonical-only"]);
+    assert.equal(merged.items.find((item) => item.id === "shared").title, "newer");
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
-  // Destination wins: a legacy REAL file alongside an existing destination is
-  // left in place, and the destination is not clobbered.
+  // State maps and queued work are unioned without dropping legacy-only keys.
   {
-    await rm(path.join(covenDir, "cave-state.json"), { force: true });
-    await writeFile(path.join(covenDir, "cave-state.json"), '{"legacy":true}', "utf8");
-    await writeFile(path.join(caveDir, "state.json"), '{"current":true}', "utf8");
-    const result = await migrateCaveHome();
-    assert.ok(!result.moved.includes("cave-state.json"), "conflicting legacy file is not moved");
-    assert.equal(
-      await readFile(path.join(caveDir, "state.json"), "utf8"),
-      '{"current":true}',
-      "existing destination wins",
-    );
-    assert.equal(
-      await readFile(path.join(covenDir, "cave-state.json"), "utf8"),
-      '{"legacy":true}',
-      "conflicting legacy file left for inspection",
-    );
+    const { coven, cave } = await home("state");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    legacy.sessionTitles.legacy = "Legacy session";
+    legacy.sessionFamiliar.legacy = "nova";
+    legacy.travel.offlineQueue.push({ id: "legacy-work", kind: "job", summary: "Legacy", createdAt: "2026-01-01T00:00:00Z", status: "pending" });
+    const canonical = baseState();
+    canonical.sessionTitles.current = "Current session";
+    canonical.sessionFamiliar.current = "salem";
+    canonical.travel.offlineQueue.push({ id: "current-work", kind: "job", summary: "Current", createdAt: "2026-02-01T00:00:00Z", status: "pending" });
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    await migrateCaveHome({ createSymlink: denySymlink });
+    const merged = await json(path.join(cave, "state.json"));
+    assert.deepEqual(Object.keys(merged.sessionTitles).sort(), ["current", "legacy"]);
+    assert.deepEqual(merged.travel.offlineQueue.map((item) => item.id).sort(), ["current-work", "legacy-work"]);
   }
 
-  // Directory conflict → per-file merge (cave-lzx3): legacy-only children move
-  // losslessly, same-name children keep the destination copy and hold the
-  // legacy dir open for review. Finder junk never blocks the drain.
+  // Preference sections use global revision/timestamp while theme selection
+  // uses its own revision/timestamp.
   {
-    await rm(path.join(covenDir, "cave-conversations"), { recursive: true, force: true });
-    await mkdir(path.join(covenDir, "cave-conversations"));
-    await writeFile(path.join(covenDir, "cave-conversations", "sess-legacy.json"), '{"side":"legacy"}', "utf8");
-    await writeFile(path.join(covenDir, "cave-conversations", "sess-both.json"), '{"side":"legacy"}', "utf8");
-    await writeFile(path.join(covenDir, "cave-conversations", ".DS_Store"), "junk", "utf8");
-    await writeFile(path.join(caveDir, "conversations", "sess-both.json"), '{"side":"cave"}', "utf8");
-
-    const result = await migrateCaveHome();
-    assert.deepEqual(
-      result.merged,
-      [{ legacy: "cave-conversations", files: 1, collisions: 1 }],
-      "dir merge reports moved children and collisions",
-    );
-    assert.equal(
-      await readFile(path.join(caveDir, "conversations", "sess-legacy.json"), "utf8"),
-      '{"side":"legacy"}',
-      "legacy-only conversation is recovered into the destination",
-    );
-    assert.equal(
-      await readFile(path.join(caveDir, "conversations", "sess-both.json"), "utf8"),
-      '{"side":"cave"}',
-      "destination wins per colliding child",
-    );
-    assert.equal(
-      await pathKind(path.join(covenDir, "cave-conversations")),
-      "dir",
-      "collision holds the legacy dir open for review",
-    );
-    assert.ok(result.skipped.includes("cave-conversations"), "colliding dir stays skipped");
-    assert.equal(
-      await pathKind(path.join(covenDir, "cave-conversations", ".DS_Store")),
-      "missing",
-      "Finder junk is dropped, never migrated",
-    );
+    const { coven, cave } = await home("preferences");
+    await mkdir(cave, { recursive: true });
+    const legacy = createDefaultPreferences(true);
+    legacy.revision = 2;
+    legacy.updatedAt = "2026-01-01T00:00:00Z";
+    legacy.appearance.theme.id = "tide";
+    legacy.appearance.theme.selectionRevision = 9;
+    legacy.appearance.theme.updatedAt = "2026-04-01T00:00:00Z";
+    const canonical = createDefaultPreferences(true);
+    canonical.revision = 8;
+    canonical.updatedAt = "2026-03-01T00:00:00Z";
+    canonical.general.newsHeadlines = false;
+    await writeFile(path.join(coven, "cave-preferences.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "preferences.json"), JSON.stringify(canonical));
+    await migrateCaveHome({ createSymlink: denySymlink });
+    const merged = await json(path.join(cave, "preferences.json"));
+    assert.equal(merged.general.newsHeadlines, false, "newer global section wins");
+    assert.equal(merged.appearance.theme.id, "tide", "newer independent theme selection wins");
+    assert.equal(merged.revision, 9);
   }
 
-  // Once collisions are resolved the next run drains the dir and bridges it.
+  // Existing Cave-home and per-store path overrides remain authoritative.
   {
-    await rm(path.join(covenDir, "cave-conversations", "sess-both.json"));
-    const result = await migrateCaveHome();
-    assert.ok(result.moved.includes("cave-conversations"), "drained dir counts as moved");
-    assert.equal(
-      await pathKind(path.join(covenDir, "cave-conversations")),
-      "symlink",
-      "drained legacy dir is replaced by the compat bridge",
-    );
-    assert.equal(
-      await readFile(path.join(covenDir, "cave-conversations", "sess-legacy.json"), "utf8"),
-      '{"side":"legacy"}',
-      "legacy path resolves through the bridge",
-    );
+    const { root, coven } = await home("overrides");
+    process.env.COVEN_CAVE_HOME = path.join(root, "custom-cave");
+    process.env.COVEN_PREFERENCES_PATH = path.join(root, "custom-store", "prefs.json");
+    const legacy = createDefaultPreferences(true);
+    legacy.revision = 3;
+    legacy.updatedAt = "2026-04-01T00:00:00Z";
+    await writeFile(path.join(coven, "cave-preferences.json"), JSON.stringify(legacy));
+    await migrateCaveHome({ createSymlink: denySymlink });
+    assert.equal((await json(process.env.COVEN_PREFERENCES_PATH)).revision, 3);
+    assert.equal((await json(path.join(process.env.COVEN_CAVE_HOME, "migration-state.json"))).migrationVersion, 2);
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
   }
 
-  // The manifest never claims daemon-owned ledgers.
-  for (const entry of CAVE_HOME_MIGRATIONS) {
-    assert.ok(
-      !["cave-calendar.json", "cave-coven-calls.json", "cave-voice-calls.json"].includes(entry.legacy),
-      `manifest must not claim daemon-owned ${entry.legacy}`,
-    );
+  // Ambiguous state is backed up and left untouched until an explicit recovery.
+  {
+    const { coven, cave } = await home("ambiguous");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    const canonical = baseState();
+    legacy.sessionTitles.shared = "Legacy title";
+    canonical.sessionTitles.shared = "Canonical title";
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const first = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(first.skipped.includes("cave-state.json"));
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
+    assert.equal((await json(path.join(cave, "state.json"))).sessionTitles.shared, "Canonical title");
+    await migrateCaveHome({ legacy: "cave-state.json", action: "recover-legacy", createSymlink: denySymlink });
+    assert.equal((await json(path.join(cave, "state.json"))).sessionTitles.shared, "Legacy title");
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Malformed JSON never overwrites either side and remains reviewable.
+  {
+    const { coven, cave } = await home("malformed");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-inbox.json"), "not-json");
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [] }));
+    await migrateCaveHome({ createSymlink: denySymlink });
+    assert.equal(await readFile(path.join(coven, "cave-inbox.json"), "utf8"), "not-json");
+    assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [] });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-inbox.json"), true);
+  }
+  {
+    const { coven, cave } = await home("malformed-identical");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-config.json"), "not-json");
+    await writeFile(path.join(cave, "config.json"), "not-json");
+    assert.equal((await migrateCaveHome({ createSymlink: denySymlink })).errors.length, 1);
+    assert.equal(await readFile(path.join(coven, "cave-config.json"), "utf8"), "not-json");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
+  // Directory merge copies legacy-only children but preserves divergent
+  // collisions for review after a verified backup.
+  {
+    const { coven, cave } = await home("directory");
+    await mkdir(path.join(coven, "cave-conversations"), { recursive: true });
+    await mkdir(path.join(cave, "conversations"), { recursive: true });
+    await writeFile(path.join(coven, "cave-conversations", "legacy.json"), "legacy-only");
+    await writeFile(path.join(coven, "cave-conversations", "shared.json"), "legacy");
+    await writeFile(path.join(cave, "conversations", "shared.json"), "canonical");
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.merged.find((entry) => entry.legacy === "cave-conversations"), {
+      legacy: "cave-conversations", files: 1, collisions: 1,
+    });
+    assert.equal(await readFile(path.join(cave, "conversations", "legacy.json"), "utf8"), "legacy-only");
+    assert.equal(await readFile(path.join(cave, "conversations", "shared.json"), "utf8"), "canonical");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-conversations"), true);
+  }
+
+  // Every write boundary resumes idempotently. Backup-boundary faults return
+  // an entry error; journal-boundary faults reject after releasing the lock.
+  for (const boundary of [
+    "after-backup-directory", "after-backup-legacy", "after-backup-canonical",
+    "after-backup-manifest", "after-merge-write", "before-journal-write", "after-journal-write",
+  ]) {
+    const { coven, cave } = await home(`fault-${boundary}`);
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "legacy", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [
+      { id: "canonical", createdAt: "2026-02-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    if (boundary.includes("journal")) await assert.rejects(migrateCaveHome({ faultAt: boundary, createSymlink: denySymlink }));
+    else assert.ok((await migrateCaveHome({ faultAt: boundary, createSymlink: denySymlink })).errors.length > 0);
+    const resumed = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(resumed.errors, [], `resume after ${boundary}`);
+    assert.equal((await caveHomeMigrationStatus()).migrated, true, `complete after ${boundary}`);
+  }
+
+  // A failure after atomic canonical installation resumes through the
+  // identical-copy path while the original legacy bytes remain available.
+  {
+    const { coven, cave } = await home("fault-after-legacy-move");
+    await writeFile(path.join(coven, "cave-config.json"), '{"durable":true}');
+    const failed = await migrateCaveHome({ faultAt: "after-legacy-move", createSymlink: denySymlink });
+    assert.equal(failed.errors.length, 1);
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { durable: true });
+    assert.deepEqual(await json(path.join(cave, "config.json")), { durable: true });
+    assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Completed backup bundles are bounded while the active recovery bundle is
+  // retained and remains hash-verifiable.
+  {
+    const { coven, cave } = await home("retention");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(cave, "config.json"), '{"canonical":true}');
+    for (let index = 0; index < 13; index += 1) {
+      await writeFile(path.join(coven, "cave-config.json"), JSON.stringify({ legacy: index }));
+      assert.deepEqual((await migrateCaveHome({
+        legacy: "cave-config.json", action: "keep-canonical", createSymlink: denySymlink,
+      })).errors, []);
+    }
+    assert.ok((await readdir(path.join(cave, "migration-backups"))).length <= 10);
+  }
+
+  // A malformed or unsupported journal fails closed before touching either
+  // data copy; it is never silently replaced with a fresh journal.
+  {
+    const { coven, cave } = await home("corrupt-journal");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(cave, "migration-state.json"), "not-json");
+    await writeFile(path.join(coven, "cave-config.json"), '{"untouched":true}');
+    await assert.rejects(migrateCaveHome({ createSymlink: denySymlink }));
+    assert.deepEqual(await json(path.join(coven, "cave-config.json")), { untouched: true });
+    assert.equal(await kind(path.join(cave, "config.json")), "missing");
+  }
+
+  // Two processes entering concurrently serialize on the filesystem lock.
+  {
+    const { coven, cave } = await home("concurrent");
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+    const [first, second] = await Promise.all([
+      migrateCaveHome({ createSymlink: denySymlink }),
+      migrateCaveHome({ createSymlink: denySymlink }),
+    ]);
+    assert.deepEqual(first.errors, []);
+    assert.deepEqual(second.errors, []);
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // Store readers fail closed on a bad migration, then retry on the next call
+  // after the recoverable input is repaired instead of caching the failure.
+  {
+    const { coven, cave } = await home("reader-gate-retry");
+    await writeFile(path.join(coven, "cave-inbox.json"), "not-json");
+    await assert.rejects(ensureCaveHomeReconciled(), /cave-inbox\.json/);
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [] }));
+    await ensureCaveHomeReconciled();
+    assert.deepEqual(await json(path.join(cave, "inbox.json")), { version: 1, items: [] });
   }
 
   console.log("cave-home-migration.test.ts: ok");
 } finally {
-  await rm(tmpHome, { recursive: true, force: true });
+  for (const root of roots) await rm(root, { recursive: true, force: true });
 }

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -297,6 +297,20 @@ try {
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-inbox.json"), true);
   }
 
+  // Duplicate IDs inside one snapshot are malformed. Collapsing them through
+  // a Map would silently discard one record during automatic reconciliation.
+  {
+    const { coven, cave } = await home("inbox-duplicate-id");
+    await mkdir(cave, { recursive: true });
+    const first = { id: "duplicate", title: "first", revision: 1, updatedAt: "2026-01-01T00:00:00Z" };
+    const second = { id: "duplicate", title: "second", revision: 2, updatedAt: "2026-02-01T00:00:00Z" };
+    await writeFile(path.join(coven, "cave-inbox.json"), JSON.stringify({ version: 1, items: [first, second] }));
+    await writeFile(path.join(cave, "inbox.json"), JSON.stringify({ version: 1, items: [first] }));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-inbox.json"));
+    assert.deepEqual((await json(path.join(cave, "inbox.json"))).items, [first]);
+  }
+
   // Append-only state maps and queued work are unioned without dropping
   // legacy-only keys.
   {
@@ -350,6 +364,25 @@ try {
     assert.ok(result.skipped.includes("cave-state.json"));
     assert.equal((await json(path.join(cave, "state.json"))).travel.offlineQueue[0].status, "syncing");
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
+  }
+
+  // A duplicate queue ID within one snapshot is likewise ambiguous and must
+  // not be deduplicated as though it were the same item from both snapshots.
+  {
+    const { coven, cave } = await home("state-duplicate-queue-id");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    legacy.travel.offlineQueue.push(
+      { id: "duplicate", status: "pending" },
+      { id: "duplicate", status: "failed" },
+    );
+    const canonical = baseState();
+    canonical.travel.offlineQueue.push({ id: "duplicate", status: "pending" });
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-state.json"));
+    assert.deepEqual((await json(path.join(cave, "state.json"))).travel.offlineQueue, canonical.travel.offlineQueue);
   }
 
   // Travel mode can transition in both directions. Without a transition
@@ -539,6 +572,8 @@ try {
     assert.equal(entry.decision, "deferred");
     assert.equal(await kind(path.join(cave, "migration-backups", entry.backupId)), "dir");
     await rm(path.join(cave, "config.json"));
+    globalThis.__caveHomeMigration = Promise.resolve(result);
+    await assert.rejects(ensureCaveHomeReconciled("cave-config.json"), /canonical path is missing/);
     const retry = await migrateCaveHome({ createSymlink: denySymlink });
     assert.equal(retry.errors.some((error) => error.legacy === "cave-config.json"), true);
     assert.deepEqual(await json(path.join(coven, "cave-config.json")), { source: "legacy" });

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -659,8 +659,9 @@ try {
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
   }
 
-  // Directory merge copies legacy-only children but preserves divergent
-  // collisions for review after a verified backup.
+  // Directory entries can be deleted, so automatic reconciliation must not
+  // resurrect a legacy-only child. An explicit merge may copy it while still
+  // preserving divergent collisions for review after a verified backup.
   {
     const { coven, cave } = await home("directory");
     await mkdir(path.join(coven, "cave-conversations"), { recursive: true });
@@ -669,7 +670,17 @@ try {
     await writeFile(path.join(coven, "cave-conversations", "shared.json"), "legacy");
     await writeFile(path.join(cave, "conversations", "shared.json"), "canonical");
     const result = await migrateCaveHome({ createSymlink: denySymlink });
-    assert.deepEqual(result.merged.find((entry) => entry.legacy === "cave-conversations"), {
+    assert.equal(result.merged.find((entry) => entry.legacy === "cave-conversations"), undefined);
+    assert.equal(await kind(path.join(cave, "conversations", "legacy.json")), "missing");
+    assert.equal(await readFile(path.join(cave, "conversations", "shared.json"), "utf8"), "canonical");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-conversations"), true);
+
+    const merged = await migrateCaveHome({
+      legacy: "cave-conversations",
+      action: "merge",
+      createSymlink: denySymlink,
+    });
+    assert.deepEqual(merged.merged.find((entry) => entry.legacy === "cave-conversations"), {
       legacy: "cave-conversations", files: 1, collisions: 1,
     });
     assert.equal(await readFile(path.join(cave, "conversations", "legacy.json"), "utf8"), "legacy-only");

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -116,6 +116,25 @@ try {
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
   }
 
+  // A stale writer can also change the existing legacy path after its backup
+  // was verified but before bridge installation starts. Preserve that write
+  // instead of deleting it as though it were the snapshot we inspected.
+  {
+    const { coven, cave } = await home("windows-pre-bridge-write");
+    const legacyPath = path.join(coven, "cave-config.json");
+    await writeFile(legacyPath, '{"source":"startup"}', "utf8");
+    const result = await migrateCaveHome({
+      createSymlink: denySymlink,
+      compatibilityProbe: async () => {
+        await writeFile(legacyPath, '{"source":"older-tool"}', "utf8");
+      },
+    });
+    assert.equal(result.errors.some((entry) => entry.legacy === "cave-config.json"), true);
+    assert.deepEqual(await json(path.join(cave, "config.json")), { source: "startup" });
+    assert.deepEqual(await json(legacyPath), { source: "older-tool" });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
+  }
+
   // The directory fallback must also fail closed if an old tool recreates the
   // legacy directory after removal but before the compatibility copy starts.
   {
@@ -217,6 +236,24 @@ try {
     const result = await migrateCaveHome({ createSymlink: denySymlink });
     assert.ok(result.skipped.includes("cave-state.json"));
     assert.equal((await json(path.join(cave, "state.json"))).travel.offlineQueue[0].status, "syncing");
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
+  }
+
+  // Travel mode can transition in both directions. Without a transition
+  // revision, an older true value must not override a newer return-online
+  // snapshot during an otherwise mergeable state reconciliation.
+  {
+    const { coven, cave } = await home("state-ambiguous-travel-mode");
+    await mkdir(cave, { recursive: true });
+    const legacy = baseState();
+    legacy.travel.manualOffline = true;
+    legacy.travel.staleCache = true;
+    const canonical = baseState();
+    await writeFile(path.join(coven, "cave-state.json"), JSON.stringify(legacy));
+    await writeFile(path.join(cave, "state.json"), JSON.stringify(canonical));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-state.json"));
+    assert.equal((await json(path.join(cave, "state.json"))).travel.manualOffline, false);
     assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-state.json"), true);
   }
 

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -647,6 +647,26 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { durable: true });
     assert.deepEqual((await migrateCaveHome({ createSymlink: denySymlink })).errors, []);
     assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // A real process termination does not run the replacement finally blocks.
+  // Recover an atomically retired path before migration classifies either side
+  // as missing, then resume the ordinary reconciliation flow.
+  {
+    const { coven, cave } = await home("crash-after-retirement");
+    const legacyPath = path.join(coven, "cave-config.json");
+    const canonicalPath = path.join(cave, "config.json");
+    await mkdir(cave, { recursive: true });
+    await writeFile(legacyPath, '{"source":"legacy"}');
+    await writeFile(canonicalPath, '{"source":"canonical"}');
+    await rename(legacyPath, path.join(coven, ".cave-config.json.migration-retired-123-deadbeef"));
+    await rename(canonicalPath, path.join(cave, ".config.json.migration-retired-123-deadbeef"));
+
+    const resumed = await migrateCaveHome({ legacy: "cave-config.json", createSymlink: denySymlink });
+    assert.deepEqual(resumed.errors, []);
+    assert.deepEqual(await json(legacyPath), { source: "legacy" });
+    assert.deepEqual(await json(canonicalPath), { source: "canonical" });
+    assert.equal((await caveHomeMigrationStatus()).conflicts.includes("cave-config.json"), true);
   }
 
   // Completed backup bundles are bounded while the active recovery bundle is

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -1,5 +1,6 @@
 import {
   reconcileCaveHome,
+  validateCaveHomeReconciliationStore,
   type CaveHomeReconciliationEntry,
   type CaveHomeReconciliationResult,
   type ReconciliationOptions,
@@ -91,4 +92,5 @@ export async function ensureCaveHomeReconciled(legacy?: string): Promise<void> {
   if (failures.length > 0) {
     throw new Error(`Cave home reconciliation failed for ${failures.map((entry) => entry.legacy).join(", ")}`);
   }
+  if (legacy) await validateCaveHomeReconciliationStore(CAVE_HOME_MIGRATIONS, legacy);
 }

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -60,16 +60,9 @@ export function migrateCaveHomeOnce(): Promise<CaveHomeMigrationResult> {
   if (!globalThis.__caveHomeMigration) {
     const run = migrateCaveHome();
     globalThis.__caveHomeMigration = run;
-    void run.then(
-      (result) => {
-        if (result.errors.length > 0 && globalThis.__caveHomeMigration === run) {
-          globalThis.__caveHomeMigration = undefined;
-        }
-      },
-      () => {
-        if (globalThis.__caveHomeMigration === run) globalThis.__caveHomeMigration = undefined;
-      },
-    );
+    void run.catch(() => {
+      if (globalThis.__caveHomeMigration === run) globalThis.__caveHomeMigration = undefined;
+    });
   }
   return globalThis.__caveHomeMigration;
 }
@@ -80,9 +73,22 @@ export function migrateCaveHomeOnce(): Promise<CaveHomeMigrationResult> {
  * failure must stop a store from reading defaults and overwriting recoverable
  * legacy data.
  */
-export async function ensureCaveHomeReconciled(): Promise<void> {
+export async function ensureCaveHomeReconciled(legacy?: string): Promise<void> {
+  const alreadyStarted = Boolean(globalThis.__caveHomeMigration);
   const result = await migrateCaveHomeOnce();
-  if (result.errors.length > 0) {
-    throw new Error(`Cave home reconciliation failed for ${result.errors.map((entry) => entry.legacy).join(", ")}`);
+  let failures = legacy ? result.errors.filter((entry) => entry.legacy === legacy) : result.errors;
+  if (failures.length > 0 && alreadyStarted) {
+    const retry = await migrateCaveHome(legacy ? { legacy } : {});
+    failures = legacy ? retry.errors.filter((entry) => entry.legacy === legacy) : retry.errors;
+    if (failures.length === 0) {
+      if (legacy) {
+        result.errors = result.errors.filter((entry) => entry.legacy !== legacy);
+      } else {
+        globalThis.__caveHomeMigration = Promise.resolve(retry);
+      }
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Cave home reconciliation failed for ${failures.map((entry) => entry.legacy).join(", ")}`);
   }
 }

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -1,6 +1,7 @@
 import {
   reconcileCaveHome,
   validateCaveHomeReconciliationStore,
+  withCaveHomeReconciliationLock,
   type CaveHomeReconciliationEntry,
   type CaveHomeReconciliationResult,
   type ReconciliationOptions,
@@ -93,4 +94,18 @@ export async function ensureCaveHomeReconciled(legacy?: string): Promise<void> {
     throw new Error(`Cave home reconciliation failed for ${failures.map((entry) => entry.legacy).join(", ")}`);
   }
   if (legacy) await validateCaveHomeReconciliationStore(CAVE_HOME_MIGRATIONS, legacy);
+}
+
+/** Keep a store read or read-modify-write transaction outside migration replacements. */
+export async function withCaveHomeReconciledStore<T>(
+  legacy: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  await ensureCaveHomeReconciled(legacy);
+  return withCaveHomeReconciliationLock(async () => {
+    // Another process may have reconciled the entry between the preflight and
+    // lock acquisition. Revalidate preserved stores while we own the lock.
+    await validateCaveHomeReconciliationStore(CAVE_HOME_MIGRATIONS, legacy);
+    return operation();
+  });
 }

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -1,234 +1,88 @@
-import { lstat, mkdir, readdir, rename, rm, rmdir, symlink } from "node:fs/promises";
-import path from "node:path";
-import { caveHome, covenHome } from "@/lib/coven-paths";
+import {
+  reconcileCaveHome,
+  type CaveHomeReconciliationEntry,
+  type CaveHomeReconciliationResult,
+  type ReconciliationOptions,
+} from "./cave-home-reconciliation.ts";
 
 /**
- * Startup migration of cave-owned state into the dedicated cave home.
+ * Cave-owned legacy paths and their canonical names/strategies.
  *
- * Historically Cave scattered its files across the top level of `~/.coven`
- * as `cave-*.json` siblings of daemon-owned state. `migrateCaveHome()` moves
- * each of those into `caveHome()` (default `~/.coven/cave/`) under a
- * standardized name, then leaves a best-effort relative symlink at the legacy
- * path so external readers (daemon surfaces, scripts, older builds) keep
- * resolving until they catch up.
- *
- * Deliberately NOT migrated: files owned by other processes that merely share
- * the `cave-` prefix — `cave-calendar.json`, `cave-coven-calls.json`,
- * `cave-voice-calls.json` (daemon ledgers) — and ad-hoc user backups
- * (`*.bak.*`, `*.smoke-backup-*`).
- *
- * Semantics per entry (idempotent, crash-safe):
- *  - legacy path missing            → nothing to do
- *  - legacy path is a symlink       → already migrated (or user-bridged); skip
- *  - legacy AND destination are both real directories
- *                                   → per-file merge: children that only exist
- *                                     on the legacy side move over (lossless —
- *                                     each conversation is its own file);
- *                                     same-name children keep the destination
- *                                     copy. A fully drained legacy dir is
- *                                     replaced by the compat symlink.
- *  - destination already exists     → destination wins; legacy left untouched
- *  - otherwise                      → rename(legacy → cave/<name>), then
- *                                     best-effort compat symlink at legacy
- *
- * Every step is best-effort: a single failed entry is recorded and skipped so
- * one bad file can never block server boot or the rest of the migration.
+ * Entries with schema-aware strategies are merged automatically when safe.
+ * Directory children are merged by name. Every other entry is explicitly
+ * manual: differing copies are backed up and left unresolved until the user
+ * chooses which copy to keep. Daemon-owned ledgers and ad-hoc backups are not
+ * included in this manifest.
  */
-
-export type CaveHomeMigrationEntry = {
-  /** Name under `covenHome()` (legacy location). */
-  legacy: string;
-  /** Standardized name under `caveHome()`. */
-  next: string;
-};
-
-export const CAVE_HOME_MIGRATIONS: readonly CaveHomeMigrationEntry[] = [
-  { legacy: "cave-config.json", next: "config.json" },
-  { legacy: "cave-state.json", next: "state.json" },
-  { legacy: "cave-board.json", next: "board.json" },
-  { legacy: "cave-canvas.json", next: "canvas.json" },
-  { legacy: "cave-inbox.json", next: "inbox.json" },
-  { legacy: "cave-inbox-prefs.json", next: "inbox-prefs.json" },
-  { legacy: "cave-projects.json", next: "projects.json" },
-  { legacy: "cave-project-permissions.json", next: "project-permissions.json" },
-  { legacy: "cave-permission-config.json", next: "permission-config.json" },
-  { legacy: "cave-automation-runs.json", next: "automation-runs.json" },
-  { legacy: "cave-removed-familiars.json", next: "removed-familiars.json" },
-  { legacy: "cave-preferences.json", next: "preferences.json" },
-  // Write-intent sidecar dir for preferences (see preferences-store.ts).
-  { legacy: "cave-preferences.json.locks", next: "preferences.json.locks" },
-  { legacy: "cave-theme.json", next: "theme.json" },
-  { legacy: "cave-message-feedback.json", next: "message-feedback.json" },
-  { legacy: "cave-mobile-paired.json", next: "mobile-paired.json" },
-  { legacy: "cave-salem-pathfinder.json", next: "salem-pathfinder.json" },
-  { legacy: "cave-backdrop.jpg", next: "backdrop.jpg" },
-  { legacy: "cave-conversations", next: "conversations" },
+export const CAVE_HOME_MIGRATIONS: readonly CaveHomeReconciliationEntry[] = [
+  { legacy: "cave-config.json", next: "config.json", strategy: "manual" },
+  { legacy: "cave-state.json", next: "state.json", strategy: "state" },
+  { legacy: "cave-board.json", next: "board.json", strategy: "manual" },
+  { legacy: "cave-canvas.json", next: "canvas.json", strategy: "manual" },
+  { legacy: "cave-inbox.json", next: "inbox.json", strategy: "inbox" },
+  { legacy: "cave-inbox-prefs.json", next: "inbox-prefs.json", strategy: "manual" },
+  { legacy: "cave-projects.json", next: "projects.json", strategy: "manual" },
+  { legacy: "cave-project-permissions.json", next: "project-permissions.json", strategy: "manual" },
+  { legacy: "cave-permission-config.json", next: "permission-config.json", strategy: "manual" },
+  { legacy: "cave-automation-runs.json", next: "automation-runs.json", strategy: "manual" },
+  { legacy: "cave-removed-familiars.json", next: "removed-familiars.json", strategy: "manual" },
+  { legacy: "cave-preferences.json", next: "preferences.json", strategy: "preferences" },
+  { legacy: "cave-preferences.json.locks", next: "preferences.json.locks", strategy: "directory" },
+  { legacy: "cave-theme.json", next: "theme.json", strategy: "manual" },
+  { legacy: "cave-message-feedback.json", next: "message-feedback.json", strategy: "manual" },
+  { legacy: "cave-mobile-paired.json", next: "mobile-paired.json", strategy: "manual" },
+  { legacy: "cave-salem-pathfinder.json", next: "salem-pathfinder.json", strategy: "manual" },
+  { legacy: "cave-backdrop.jpg", next: "backdrop.jpg", strategy: "manual" },
+  { legacy: "cave-conversations", next: "conversations", strategy: "directory" },
 ];
 
-export type CaveHomeMigrationDirMerge = {
-  /** Legacy dir name under `covenHome()`. */
-  legacy: string;
-  /** Children moved out of the legacy dir into its destination. */
-  files: number;
-  /** Same-name children left behind (destination copy wins per file). */
-  collisions: number;
-};
-
-export type CaveHomeMigrationResult = {
-  moved: string[];
-  linked: string[];
-  skipped: string[];
-  merged: CaveHomeMigrationDirMerge[];
-  errors: Array<{ legacy: string; error: string }>;
-};
-
-async function pathState(target: string): Promise<"missing" | "symlink" | "file" | "dir"> {
-  try {
-    const st = await lstat(target);
-    return st.isSymbolicLink() ? "symlink" : st.isDirectory() ? "dir" : "file";
-  } catch {
-    return "missing";
-  }
-}
-
-// Compat bridge for external readers. Relative target so the link survives a
-// moved home dir. Best-effort: symlink creation can fail on Windows without
-// elevation — the migration itself already succeeded.
-async function bridgeLegacyPath(
-  entry: CaveHomeMigrationEntry,
-  legacyPath: string,
-  nextPath: string,
-  kind: "file" | "dir",
-  result: CaveHomeMigrationResult,
-): Promise<void> {
-  try {
-    const relativeTarget = path.relative(path.dirname(legacyPath), nextPath);
-    await symlink(relativeTarget, legacyPath, kind === "dir" ? "junction" : "file");
-    result.linked.push(entry.legacy);
-  } catch {
-    /* best-effort */
-  }
-}
+export type CaveHomeMigrationEntry = CaveHomeReconciliationEntry;
+export type CaveHomeMigrationDirMerge = CaveHomeReconciliationResult["merged"][number];
+export type CaveHomeMigrationResult = CaveHomeReconciliationResult;
 
 /**
- * Both sides of a directory entry exist — e.g. an old build recreated
- * `cave-conversations/` after migration (cave-lzx3). Children are independent
- * files keyed by name, so legacy-only ones move over losslessly; same-name
- * children keep the destination copy (the same destination-wins rule applied
- * per file) and hold the legacy dir open for review.
+ * Run lossless reconciliation. All filesystem mutation is serialized through
+ * a cross-process lock and committed to the durable migration journal.
  */
-async function mergeDirEntry(
-  entry: CaveHomeMigrationEntry,
-  legacyPath: string,
-  nextPath: string,
-  result: CaveHomeMigrationResult,
-): Promise<void> {
-  const merge: CaveHomeMigrationDirMerge = { legacy: entry.legacy, files: 0, collisions: 0 };
-  try {
-    for (const name of await readdir(legacyPath)) {
-      // Finder metadata must never hold the compat bridge hostage.
-      if (name === ".DS_Store") {
-        await rm(path.join(legacyPath, name), { force: true });
-        continue;
-      }
-      if ((await pathState(path.join(nextPath, name))) === "missing") {
-        try {
-          await rename(path.join(legacyPath, name), path.join(nextPath, name));
-          merge.files += 1;
-        } catch (error) {
-          result.errors.push({ legacy: `${entry.legacy}/${name}`, error: String(error) });
-        }
-      } else {
-        merge.collisions += 1;
-      }
-    }
-    result.merged.push(merge);
-    if ((await readdir(legacyPath)).length === 0) {
-      await rmdir(legacyPath);
-      result.moved.push(entry.legacy);
-      await bridgeLegacyPath(entry, legacyPath, nextPath, "dir", result);
-    } else {
-      result.skipped.push(entry.legacy);
-    }
-  } catch (error) {
-    result.errors.push({ legacy: entry.legacy, error: String(error) });
-  }
-}
-
-async function migrateEntry(
-  entry: CaveHomeMigrationEntry,
-  result: CaveHomeMigrationResult,
-): Promise<void> {
-  const legacyPath = path.join(covenHome(), entry.legacy);
-  const nextPath = path.join(caveHome(), entry.next);
-
-  const legacyState = await pathState(legacyPath);
-  if (legacyState === "missing" || legacyState === "symlink") {
-    result.skipped.push(entry.legacy);
-    return;
-  }
-  const nextState = await pathState(nextPath);
-
-  if (nextState !== "missing") {
-    if (legacyState === "dir" && nextState === "dir") {
-      await mergeDirEntry(entry, legacyPath, nextPath, result);
-      return;
-    }
-    // Destination wins — a newer build already wrote there. Leave the legacy
-    // file for the user to inspect rather than clobbering either side.
-    result.skipped.push(entry.legacy);
-    return;
-  }
-
-  try {
-    await rename(legacyPath, nextPath);
-    result.moved.push(entry.legacy);
-  } catch (error) {
-    result.errors.push({ legacy: entry.legacy, error: String(error) });
-    return;
-  }
-
-  await bridgeLegacyPath(entry, legacyPath, nextPath, legacyState, result);
-}
-
-/** Run the full migration once. Safe to call repeatedly (idempotent). */
-export async function migrateCaveHome(): Promise<CaveHomeMigrationResult> {
-  const result: CaveHomeMigrationResult = { moved: [], linked: [], skipped: [], merged: [], errors: [] };
-  try {
-    await mkdir(caveHome(), { recursive: true });
-  } catch (error) {
-    result.errors.push({ legacy: "(cave home)", error: String(error) });
-    return result;
-  }
-  for (const entry of CAVE_HOME_MIGRATIONS) {
-    await migrateEntry(entry, result);
-  }
-  if (result.moved.length > 0) {
-    console.log(
-      `[cave-home-migration] moved ${result.moved.length} legacy file(s) into ${caveHome()}: ${result.moved.join(", ")}`,
-    );
-  }
-  for (const merge of result.merged) {
-    if (merge.files > 0 || merge.collisions > 0) {
-      console.log(
-        `[cave-home-migration] merged ${merge.files} file(s) from ${merge.legacy} into ${caveHome()}` +
-          (merge.collisions > 0 ? ` (${merge.collisions} name collision(s) left for review)` : ""),
-      );
-    }
-  }
-  for (const failure of result.errors) {
-    console.warn(`[cave-home-migration] ${failure.legacy}: ${failure.error}`);
-  }
+export async function migrateCaveHome(options: ReconciliationOptions = {}): Promise<CaveHomeMigrationResult> {
+  const result = await reconcileCaveHome(CAVE_HOME_MIGRATIONS, options);
+  for (const error of result.errors) console.warn(`[cave-home-migration] ${error.legacy}: ${error.error}`);
   return result;
 }
 
-// One migration per process; survives Next dev hot-reloads via globalThis.
 declare global {
   // eslint-disable-next-line no-var
   var __caveHomeMigration: Promise<CaveHomeMigrationResult> | undefined;
 }
 
+/** One startup reconciliation per process; the durable lock/journal provide cross-process safety. */
 export function migrateCaveHomeOnce(): Promise<CaveHomeMigrationResult> {
-  globalThis.__caveHomeMigration ??= migrateCaveHome();
+  if (!globalThis.__caveHomeMigration) {
+    const run = migrateCaveHome();
+    globalThis.__caveHomeMigration = run;
+    void run.then(
+      (result) => {
+        if (result.errors.length > 0 && globalThis.__caveHomeMigration === run) {
+          globalThis.__caveHomeMigration = undefined;
+        }
+      },
+      () => {
+        if (globalThis.__caveHomeMigration === run) globalThis.__caveHomeMigration = undefined;
+      },
+    );
+  }
   return globalThis.__caveHomeMigration;
+}
+
+/**
+ * Reader/writer gate for Cave-owned stores. Unresolved divergent copies are
+ * safe because canonical storage remains authoritative, but an I/O or schema
+ * failure must stop a store from reading defaults and overwriting recoverable
+ * legacy data.
+ */
+export async function ensureCaveHomeReconciled(): Promise<void> {
+  const result = await migrateCaveHomeOnce();
+  if (result.errors.length > 0) {
+    throw new Error(`Cave home reconciliation failed for ${result.errors.map((entry) => entry.legacy).join(", ")}`);
+  }
 }

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -623,14 +623,19 @@ async function mergeJson(strategy: ReconciliationStrategy, legacyPath: string, c
   return { ok: false, summary: "This file type requires an explicit choice." };
 }
 
-async function validateCanonical(entry: CaveHomeReconciliationEntry, canonicalPath: string): Promise<void> {
-  const info = await pathInfo(canonicalPath);
+async function validateCanonical(
+  entry: CaveHomeReconciliationEntry,
+  canonicalPath: string,
+  knownInfo?: PathInfo,
+): Promise<void> {
+  const info = knownInfo ?? await pathInfo(canonicalPath);
   if (info.kind === "missing" || info.kind === "symlink") throw new Error("canonical path is missing");
   if (entry.strategy === "directory") {
     if (info.kind !== "dir") throw new Error("canonical directory is invalid");
     await readdir(canonicalPath);
     return;
   }
+  if (info.kind !== "file") throw new Error("canonical file is invalid");
   if (entry.strategy === "inbox" || entry.strategy === "state" || entry.strategy === "preferences" || entry.next.endsWith(".json")) {
     const parsed = JSON.parse(await readFile(canonicalPath, "utf8")) as unknown;
     if (entry.strategy === "inbox") {
@@ -685,6 +690,9 @@ async function syncManagedMirror(
   const canonicalInfo = await pathInfo(canonicalPath);
   if (legacyInfo.kind === "missing" || canonicalInfo.kind === "missing") return null;
   if (!prior.managedMirrorHash || legacyInfo.hash !== prior.managedMirrorHash) return null;
+  // Do not replace the last known-good mirror until the newer canonical copy
+  // passes the same schema/type checks used by the initial migration.
+  await validateCanonical(entry, canonicalPath, canonicalInfo);
   const current: MigrationJournalEntry = {
     ...prior,
     legacyHash: legacyInfo.hash,
@@ -924,7 +932,12 @@ export async function caveHomeReconciliationStatus(
     if (legacyInfo.kind === "missing" || legacyInfo.kind === "symlink") continue;
     const canonicalInfo = await pathInfo(canonicalPath);
     const prior = journal.entries[entry.legacy];
-    const managed = Boolean(prior?.managedMirrorHash && legacyInfo.hash === prior.managedMirrorHash);
+    const canonicalValid = await validateCanonical(entry, canonicalPath, canonicalInfo).then(() => true, () => false);
+    const managed = Boolean(
+      canonicalValid &&
+      prior?.managedMirrorHash &&
+      legacyInfo.hash === prior.managedMirrorHash,
+    );
     if (managed) continue;
     const isPending = canonicalInfo.kind === "missing";
     (isPending ? pending : conflicts).push(entry.legacy);

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1217,7 +1217,16 @@ async function reconcileEntry(
   }
 
   let merged: MergeOutcome;
-  if (entry.strategy === "directory") merged = (await reconcileDirectory(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, result, options)).outcome;
+  if (entry.strategy === "directory") {
+    // Files in migrated directories are not append-only (conversations, for
+    // example, can be deleted). A child present only in the legacy snapshot is
+    // therefore ambiguous: it may be a new file or a stale file deleted from
+    // canonical storage. Do not resurrect it until the user explicitly asks
+    // to merge the two directory snapshots.
+    merged = options.action === "merge"
+      ? (await reconcileDirectory(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, result, options)).outcome
+      : { ok: false, summary: "Directory entries differ and require an explicit merge or whole-directory choice." };
+  }
   else if (["inbox", "state", "preferences"].includes(entry.strategy)) {
     // Merge the exact snapshots recorded in the verified bundle. Reading the
     // live paths here would let an uncoordinated store writer change either

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -301,35 +301,37 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
       if (!["EEXIST", "ENOTEMPTY"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
       try {
         const info = await stat(lock);
-        if (Date.now() - info.mtimeMs > LOCK_STALE_MS) {
-          const owner = await readLockOwner(lock);
-          let alive = false;
-          if (owner.pid) {
-            try {
-              process.kill(owner.pid, 0);
-              alive = true;
-            } catch (ownerError) {
-              alive = (ownerError as NodeJS.ErrnoException).code === "EPERM";
-            }
+        const owner = await readLockOwner(lock);
+        let alive = false;
+        if (owner.pid) {
+          try {
+            process.kill(owner.pid, 0);
+            alive = true;
+          } catch (ownerError) {
+            alive = (ownerError as NodeJS.ErrnoException).code === "EPERM";
           }
-          if (!alive) {
-            await options.lockProbe?.("stale-observed");
-            const takeover = path.join(lock, ".takeover");
-            const takeoverToken = randomBytes(16).toString("hex");
-            try {
-              await writeFile(takeover, JSON.stringify({ takeoverToken, ownerToken: owner.token }), { flag: "wx" });
-              const currentOwner = await readLockOwner(lock);
-              if (currentOwner.token !== owner.token) {
-                await rm(takeover, { force: true });
-              } else {
-                const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
-                await rename(lock, reclaimed);
-                await rm(reclaimed, { recursive: true, force: true });
-                continue;
-              }
-            } catch (takeoverError) {
-              if (!["EEXIST", "ENOENT"].includes((takeoverError as NodeJS.ErrnoException).code ?? "")) throw takeoverError;
+        }
+        // A recorded owner that no longer exists is safe to reclaim
+        // immediately. The age threshold is only needed for an unreadable or
+        // incomplete owner record, where liveness cannot be established.
+        const reclaimable = owner.pid ? !alive : Date.now() - info.mtimeMs > LOCK_STALE_MS;
+        if (reclaimable) {
+          await options.lockProbe?.("stale-observed");
+          const takeover = path.join(lock, ".takeover");
+          const takeoverToken = randomBytes(16).toString("hex");
+          try {
+            await writeFile(takeover, JSON.stringify({ takeoverToken, ownerToken: owner.token }), { flag: "wx" });
+            const currentOwner = await readLockOwner(lock);
+            if (currentOwner.token !== owner.token) {
+              await rm(takeover, { force: true });
+            } else {
+              const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
+              await rename(lock, reclaimed);
+              await rm(reclaimed, { recursive: true, force: true });
+              continue;
             }
+          } catch (takeoverError) {
+            if (!["EEXIST", "ENOENT"].includes((takeoverError as NodeJS.ErrnoException).code ?? "")) throw takeoverError;
           }
         }
       } catch (lockError) {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1,0 +1,961 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  copyFile,
+  cp,
+  lstat,
+  mkdir,
+  readFile,
+  readlink,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+} from "node:fs/promises";
+import path from "node:path";
+
+import { caveHome, covenHome } from "../coven-paths.ts";
+import { normalizeCavePreferences, type CavePreferences } from "../preferences-schema.ts";
+import { writeJsonAtomic } from "./atomic-write.ts";
+
+export type ReconciliationStrategy = "inbox" | "state" | "preferences" | "directory" | "manual";
+
+export type CaveHomeReconciliationEntry = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+};
+
+export type ReconciliationDecision =
+  | "absent"
+  | "moved"
+  | "linked"
+  | "managed-mirror"
+  | "identical"
+  | "merged"
+  | "kept-canonical"
+  | "recovered-legacy"
+  | "unresolved"
+  | "deferred";
+
+export type MigrationJournalEntry = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+  legacyPath: string;
+  canonicalPath: string;
+  legacyHash?: string;
+  canonicalHash?: string;
+  legacyMtimeMs?: number;
+  canonicalMtimeMs?: number;
+  decision: ReconciliationDecision;
+  compatibility?: "symlink" | "mirror";
+  managedMirrorHash?: string;
+  backupId?: string;
+  decidedAt: string;
+  summary?: string;
+};
+
+export type MigrationJournal = {
+  version: 1;
+  migrationVersion: 2;
+  updatedAt: string;
+  entries: Record<string, MigrationJournalEntry>;
+};
+
+export type CaveHomeConflictDetail = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+  legacyPath: string;
+  canonicalPath: string;
+  legacyHash?: string;
+  canonicalHash?: string;
+  legacyMtimeMs?: number;
+  canonicalMtimeMs?: number;
+  state: "pending" | "unresolved" | "managed";
+  summary: string;
+  differences: string[];
+  backupPath?: string;
+  actions: Array<"merge" | "keep-canonical" | "recover-legacy" | "defer">;
+};
+
+export type CaveHomeReconciliationStatus = {
+  pending: string[];
+  conflicts: string[];
+  migrated: boolean;
+  details: CaveHomeConflictDetail[];
+  backupRoot: string;
+  journalPath: string;
+};
+
+export type CaveHomeReconciliationResult = {
+  moved: string[];
+  linked: string[];
+  skipped: string[];
+  merged: Array<{ legacy: string; files: number; collisions: number }>;
+  backedUp: string[];
+  resolved: string[];
+  errors: Array<{ legacy: string; error: string }>;
+};
+
+export type ReconciliationAction = "merge" | "keep-canonical" | "recover-legacy" | "defer";
+
+export type ReconciliationOptions = {
+  action?: ReconciliationAction;
+  legacy?: string;
+  /** Test-only fault boundary. Production callers must omit it. */
+  faultAt?: string;
+  /** Test-only compatibility bridge override. */
+  createSymlink?: typeof symlink;
+};
+
+type PathInfo = {
+  kind: "missing" | "symlink" | "file" | "dir";
+  hash?: string;
+  mtimeMs?: number;
+  size?: number;
+};
+
+type MergeOutcome =
+  | { ok: true; value: unknown; summary: string }
+  | { ok: false; summary: string };
+
+const JOURNAL_VERSION = 1 as const;
+const MIGRATION_VERSION = 2 as const;
+const BACKUP_RETENTION = 10;
+const LOCK_STALE_MS = 5 * 60_000;
+const LOCK_WAIT_MS = 10_000;
+
+export const migrationJournalPath = () => path.join(caveHome(), "migration-state.json");
+export const migrationBackupRoot = () => path.join(caveHome(), "migration-backups");
+const migrationLockPath = () => path.join(caveHome(), ".migration.lock");
+
+function canonicalPathFor(entry: CaveHomeReconciliationEntry): string {
+  const override = entry.next === "preferences.json"
+    ? process.env.COVEN_PREFERENCES_PATH?.trim()
+    : entry.next === "theme.json"
+      ? process.env.COVEN_THEME_PATH?.trim()
+      : entry.next === "backdrop.jpg"
+        ? process.env.COVEN_BACKDROP_PATH?.trim()
+        : undefined;
+  return override || path.join(caveHome(), entry.next);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function fault(options: ReconciliationOptions, boundary: string): void {
+  if (options.faultAt === boundary) throw new Error(`injected migration fault at ${boundary}`);
+}
+
+async function sha256File(target: string): Promise<string> {
+  return createHash("sha256").update(await readFile(target)).digest("hex");
+}
+
+async function sha256Dir(target: string): Promise<string> {
+  const hash = createHash("sha256");
+  for (const name of (await readdir(target)).sort()) {
+    if (name === ".DS_Store") continue;
+    const child = path.join(target, name);
+    const info = await lstat(child);
+    hash.update(name);
+    if (info.isSymbolicLink()) hash.update(`l:${await readlink(child)}`);
+    else hash.update(info.isDirectory() ? `d:${await sha256Dir(child)}` : `f:${await sha256File(child)}`);
+  }
+  return hash.digest("hex");
+}
+
+async function pathInfo(target: string): Promise<PathInfo> {
+  try {
+    const info = await lstat(target);
+    if (info.isSymbolicLink()) return { kind: "symlink", mtimeMs: info.mtimeMs, size: info.size };
+    if (info.isDirectory()) return { kind: "dir", hash: await sha256Dir(target), mtimeMs: info.mtimeMs, size: info.size };
+    return { kind: "file", hash: await sha256File(target), mtimeMs: info.mtimeMs, size: info.size };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
+    throw error;
+  }
+}
+
+async function readJournal(): Promise<MigrationJournal> {
+  try {
+    const parsed = JSON.parse(await readFile(migrationJournalPath(), "utf8")) as Partial<MigrationJournal>;
+    if (parsed.version !== JOURNAL_VERSION || parsed.migrationVersion !== MIGRATION_VERSION || !parsed.entries) {
+      throw new Error("unsupported migration journal");
+    }
+    return parsed as MigrationJournal;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { version: JOURNAL_VERSION, migrationVersion: MIGRATION_VERSION, updatedAt: "", entries: {} };
+    }
+    throw error;
+  }
+}
+
+async function commitJournal(journal: MigrationJournal, options: ReconciliationOptions): Promise<void> {
+  fault(options, "before-journal-write");
+  journal.updatedAt = nowIso();
+  await writeJsonAtomic(migrationJournalPath(), journal);
+  fault(options, "after-journal-write");
+  const reread = JSON.parse(await readFile(migrationJournalPath(), "utf8")) as MigrationJournal;
+  if (JSON.stringify(reread) !== JSON.stringify(journal)) {
+    throw new Error("migration journal verification failed");
+  }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireLock(): Promise<() => Promise<void>> {
+  const lock = migrationLockPath();
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      await mkdir(lock);
+      try {
+        await writeJsonAtomic(path.join(lock, "owner.json"), { pid: process.pid, startedAt: nowIso() });
+      } catch (error) {
+        await rm(lock, { recursive: true, force: true });
+        throw error;
+      }
+      return async () => { await rm(lock, { recursive: true, force: true }); };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        const info = await stat(lock);
+        if (Date.now() - info.mtimeMs > LOCK_STALE_MS) {
+          const owner = await readFile(path.join(lock, "owner.json"), "utf8")
+            .then((value) => JSON.parse(value) as { pid?: unknown })
+            .catch(() => null);
+          const pid = typeof owner?.pid === "number" && Number.isSafeInteger(owner.pid) ? owner.pid : null;
+          let alive = false;
+          if (pid) {
+            try {
+              process.kill(pid, 0);
+              alive = true;
+            } catch (ownerError) {
+              alive = (ownerError as NodeJS.ErrnoException).code === "EPERM";
+            }
+          }
+          if (!alive) {
+            await rm(lock, { recursive: true, force: true });
+            continue;
+          }
+        }
+      } catch {
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error("timed out waiting for cave home migration lock");
+      await delay(50);
+    }
+  }
+}
+
+async function pruneBackups(): Promise<void> {
+  await mkdir(migrationBackupRoot(), { recursive: true });
+  const journal = await readJournal();
+  const protectedIds = new Set(
+    Object.values(journal.entries)
+      .filter((entry) => entry.decision === "unresolved" || entry.decision === "deferred")
+      .map((entry) => entry.backupId)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const directories: Array<{ name: string; mtimeMs: number }> = [];
+  for (const name of await readdir(migrationBackupRoot())) {
+    const target = path.join(migrationBackupRoot(), name);
+    const info = await lstat(target).catch(() => null);
+    if (info?.isDirectory()) directories.push({ name, mtimeMs: info.mtimeMs });
+  }
+  directories.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  // Leave room for the bundle about to be created. Never prune a bundle that
+  // is the only recovery source for an unresolved/deferred decision.
+  const removable = directories.filter((candidate) => !protectedIds.has(candidate.name));
+  const removeCount = Math.max(0, directories.length - (BACKUP_RETENTION - 1));
+  for (const stale of removeCount > 0 ? removable.slice(-removeCount) : []) {
+    await rm(path.join(migrationBackupRoot(), stale.name), { recursive: true, force: true });
+  }
+}
+
+async function copyPath(source: string, destination: string, kind: PathInfo["kind"]): Promise<void> {
+  if (kind === "dir") await cp(source, destination, { recursive: true, errorOnExist: true });
+  else await copyFile(source, destination);
+}
+
+async function copyPathAtomically(
+  source: string,
+  destination: string,
+  kind: PathInfo["kind"],
+  expectedHash?: string,
+): Promise<void> {
+  const temporary = path.join(
+    path.dirname(destination),
+    `.${path.basename(destination)}.migration-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  try {
+    await copyPath(source, temporary, kind);
+    const copied = await pathInfo(temporary);
+    if (!expectedHash || copied.hash !== expectedHash) throw new Error("migration copy verification failed");
+    await rename(temporary, destination);
+  } catch (error) {
+    await rm(temporary, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+async function createRecoveryBundle(
+  entry: CaveHomeReconciliationEntry,
+  legacyPath: string,
+  canonicalPath: string,
+  legacyInfo: PathInfo,
+  canonicalInfo: PathInfo,
+  options: ReconciliationOptions,
+): Promise<{ id: string; directory: string }> {
+  await pruneBackups();
+  const id = `${nowIso().replace(/[:.]/g, "-")}-${randomBytes(4).toString("hex")}`;
+  const directory = path.join(migrationBackupRoot(), id);
+  await mkdir(directory, { recursive: true });
+  fault(options, "after-backup-directory");
+
+  const files: Array<{ role: string; sourcePath: string; storedPath: string; hash: string; size?: number }> = [];
+  for (const [role, source, info] of [
+    ["legacy", legacyPath, legacyInfo],
+    ["canonical", canonicalPath, canonicalInfo],
+  ] as const) {
+    if (info.kind === "missing" || info.kind === "symlink") continue;
+    const storedName = `${role}-${path.basename(source)}`;
+    const storedPath = path.join(directory, storedName);
+    await copyPath(source, storedPath, info.kind);
+    const storedInfo = await pathInfo(storedPath);
+    if (!info.hash || storedInfo.hash !== info.hash) throw new Error(`backup verification failed for ${role}`);
+    files.push({ role, sourcePath: source, storedPath: storedName, hash: info.hash, size: info.size });
+    fault(options, `after-backup-${role}`);
+  }
+  const manifest = {
+    version: 1,
+    createdAt: nowIso(),
+    entry: { legacy: entry.legacy, next: entry.next, strategy: entry.strategy },
+    files,
+  };
+  await writeJsonAtomic(path.join(directory, "manifest.json"), manifest);
+  const verified = JSON.parse(await readFile(path.join(directory, "manifest.json"), "utf8")) as typeof manifest;
+  if (JSON.stringify(verified) !== JSON.stringify(manifest)) throw new Error("backup manifest verification failed");
+  fault(options, "after-backup-manifest");
+  return { id, directory };
+}
+
+async function restoreBundleRole(directory: string, role: "legacy" | "canonical", destination: string): Promise<void> {
+  const manifest = JSON.parse(await readFile(path.join(directory, "manifest.json"), "utf8")) as {
+    files?: Array<{ role?: string; storedPath?: string; hash?: string }>;
+  };
+  const file = manifest.files?.find((candidate) => candidate.role === role);
+  if (!file?.storedPath || !file.hash) throw new Error(`verified ${role} backup is unavailable`);
+  const source = path.resolve(directory, file.storedPath);
+  if (path.dirname(source) !== path.resolve(directory)) throw new Error(`${role} backup path is invalid`);
+  const sourceInfo = await pathInfo(source);
+  if (sourceInfo.hash !== file.hash) throw new Error(`${role} backup hash changed before recovery`);
+  const destinationInfo = await pathInfo(destination);
+  await rm(destination, { recursive: destinationInfo.kind === "dir", force: true });
+  await copyPath(source, destination, sourceInfo.kind);
+  if ((await pathInfo(destination)).hash !== file.hash) throw new Error(`${role} recovery verification failed`);
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function parseDate(value: unknown): number {
+  return typeof value === "string" && Number.isFinite(Date.parse(value)) ? Date.parse(value) : 0;
+}
+
+async function describeDifferences(
+  entry: CaveHomeReconciliationEntry,
+  legacyPath: string,
+  canonicalPath: string,
+  legacyInfo: PathInfo,
+  canonicalInfo: PathInfo,
+): Promise<string[]> {
+  if (canonicalInfo.kind === "missing") return ["Canonical copy is missing; the legacy copy is the only source."];
+  if (legacyInfo.kind !== canonicalInfo.kind) return [`Path types differ: ${legacyInfo.kind} and ${canonicalInfo.kind}.`];
+  if (legacyInfo.hash === canonicalInfo.hash) return ["Contents are identical."];
+  if (entry.strategy === "directory" && legacyInfo.kind === "dir") {
+    const legacyNames = new Set(await readdir(legacyPath));
+    const canonicalNames = new Set(await readdir(canonicalPath));
+    const legacyOnly = [...legacyNames].filter((name) => !canonicalNames.has(name)).length;
+    const canonicalOnly = [...canonicalNames].filter((name) => !legacyNames.has(name)).length;
+    const shared = [...legacyNames].filter((name) => canonicalNames.has(name)).length;
+    return [`Directory entries: ${legacyOnly} legacy-only, ${canonicalOnly} canonical-only, ${shared} shared.`];
+  }
+  if (entry.next.endsWith(".json")) {
+    try {
+      const legacy = record(JSON.parse(await readFile(legacyPath, "utf8")));
+      const canonical = record(JSON.parse(await readFile(canonicalPath, "utf8")));
+      if (!legacy || !canonical) return ["JSON shapes differ."];
+      const keys = [...new Set([...Object.keys(legacy), ...Object.keys(canonical)])]
+        .filter((key) => JSON.stringify(legacy[key]) !== JSON.stringify(canonical[key]));
+      return keys.length > 0
+        ? [`Changed top-level fields: ${keys.slice(0, 8).join(", ")}${keys.length > 8 ? `, and ${keys.length - 8} more` : ""}.`]
+        : ["JSON formatting or ordering differs; parsed values match."];
+    } catch {
+      return ["One or both copies are not valid JSON."];
+    }
+  }
+  return [`Binary contents differ (${legacyInfo.size ?? 0} bytes legacy, ${canonicalInfo.size ?? 0} bytes canonical).`];
+}
+
+function mergeInbox(legacy: unknown, canonical: unknown): MergeOutcome {
+  const left = record(legacy);
+  const right = record(canonical);
+  if (!left || !right || !Array.isArray(left.items) || !Array.isArray(right.items)) {
+    return { ok: false, summary: "Inbox data is malformed and requires review." };
+  }
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const raw of [...left.items, ...right.items]) {
+    const item = record(raw);
+    if (!item || typeof item.id !== "string" || !item.id) return { ok: false, summary: "Inbox item without a stable ID requires review." };
+    const existing = byId.get(item.id);
+    if (!existing) {
+      byId.set(item.id, item);
+      continue;
+    }
+    if (JSON.stringify(existing) === JSON.stringify(item)) continue;
+    const existingRevision = typeof existing.revision === "number" ? existing.revision : 0;
+    const itemRevision = typeof item.revision === "number" ? item.revision : 0;
+    const existingTime = parseDate(existing.updatedAt) || parseDate(existing.createdAt);
+    const itemTime = parseDate(item.updatedAt) || parseDate(item.createdAt);
+    if (existingRevision === itemRevision && existingTime === itemTime) {
+      return { ok: false, summary: `Inbox item ${item.id} differs without a newer revision or timestamp.` };
+    }
+    if (itemRevision > existingRevision || (itemRevision === existingRevision && itemTime > existingTime)) byId.set(item.id, item);
+  }
+  const items = [...byId.values()].sort((a, b) => parseDate(a.createdAt) - parseDate(b.createdAt));
+  return { ok: true, value: { ...right, version: Math.max(Number(left.version) || 1, Number(right.version) || 1), items }, summary: `Merged ${items.length} inbox item(s) by stable ID.` };
+}
+
+const STATE_MAPS = [
+  "sessionFamiliar",
+  "sessionTitles",
+  "sessionArchived",
+  "sessionSacrificed",
+  "sessionKeep",
+  "sessionArchiveExtendedUntil",
+  "sessionOwned",
+  "mergedPrAutoArchived",
+] as const;
+
+const TIMESTAMP_STATE_MAPS = new Set<string>([
+  "sessionArchived",
+  "sessionSacrificed",
+  "sessionKeep",
+  "sessionArchiveExtendedUntil",
+  "sessionOwned",
+]);
+
+function mergeRecordMap(
+  name: string,
+  leftValue: unknown,
+  rightValue: unknown,
+): { ok: true; value: Record<string, unknown> } | { ok: false; summary: string } {
+  const left = record(leftValue);
+  const right = record(rightValue);
+  if (!left || !right) return { ok: false, summary: `State map ${name} is malformed.` };
+  const value = { ...left, ...right };
+  for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) {
+    if (!(key in left) || !(key in right) || JSON.stringify(left[key]) === JSON.stringify(right[key])) continue;
+    if (!TIMESTAMP_STATE_MAPS.has(name)) return { ok: false, summary: `State map ${name} has an ambiguous value for ${key}.` };
+    const leftTime = parseDate(left[key]);
+    const rightTime = parseDate(right[key]);
+    if (!leftTime || !rightTime || leftTime === rightTime) return { ok: false, summary: `State map ${name} has an ambiguous timestamp for ${key}.` };
+    value[key] = leftTime > rightTime ? left[key] : right[key];
+  }
+  return { ok: true, value };
+}
+
+function mergeTravel(leftValue: unknown, rightValue: unknown): MergeOutcome {
+  const left = record(leftValue);
+  const right = record(rightValue);
+  if (!left || !right) return { ok: false, summary: "Travel state is malformed." };
+  const leftQueue = Array.isArray(left.offlineQueue) ? left.offlineQueue : [];
+  const rightQueue = Array.isArray(right.offlineQueue) ? right.offlineQueue : [];
+  const queue = new Map<string, Record<string, unknown>>();
+  const rank: Record<string, number> = { pending: 0, syncing: 1, failed: 2, synced: 3 };
+  for (const raw of [...leftQueue, ...rightQueue]) {
+    const item = record(raw);
+    if (!item || typeof item.id !== "string") return { ok: false, summary: "Queued travel work without a stable ID requires review." };
+    const existing = queue.get(item.id);
+    if (!existing) queue.set(item.id, item);
+    else if (JSON.stringify(existing) !== JSON.stringify(item)) {
+      const samePayload = JSON.stringify({ ...existing, status: undefined, lastError: undefined }) === JSON.stringify({ ...item, status: undefined, lastError: undefined });
+      if (!samePayload) return { ok: false, summary: `Queued travel work ${item.id} differs and requires review.` };
+      if ((rank[String(item.status)] ?? -1) > (rank[String(existing.status)] ?? -1)) queue.set(item.id, item);
+    }
+  }
+  const latestReachability = parseDate(left.lastHubReachableAt) > parseDate(right.lastHubReachableAt) ? left : right;
+  return {
+    ok: true,
+    value: {
+      ...left,
+      ...right,
+      manualOffline: left.manualOffline === true || right.manualOffline === true,
+      staleCache: left.staleCache === true || right.staleCache === true,
+      lastHubReachableAt: latestReachability.lastHubReachableAt ?? null,
+      hubUnreachableSince: left.hubUnreachableSince ?? right.hubUnreachableSince ?? null,
+      localSubdaemonWakeRequestedAt: left.localSubdaemonWakeRequestedAt ?? right.localSubdaemonWakeRequestedAt ?? null,
+      localBindHost: "127.0.0.1",
+      offlineQueue: [...queue.values()],
+    },
+    summary: `Merged ${queue.size} queued travel item(s).`,
+  };
+}
+
+function mergeState(legacy: unknown, canonical: unknown): MergeOutcome {
+  const left = record(legacy);
+  const right = record(canonical);
+  if (!left || !right) return { ok: false, summary: "State data is malformed and requires review." };
+  const value: Record<string, unknown> = { ...left, ...right };
+  for (const name of STATE_MAPS) {
+    const merged = mergeRecordMap(name, left[name] ?? {}, right[name] ?? {});
+    if (!merged.ok) return merged;
+    value[name] = merged.value;
+  }
+  const travel = mergeTravel(left.travel ?? {}, right.travel ?? {});
+  if (!travel.ok) return travel;
+  value.travel = travel.value;
+  return { ok: true, value, summary: "Merged state maps by stable session and queue keys." };
+}
+
+const PREFERENCE_SECTIONS = [
+  ["appearance", "fonts"],
+  ["appearance", "screenScale"],
+  ["appearance", "reading"],
+  ["appearance", "datetime"],
+  ["appearance", "recentColors"],
+  ["appearance", "cornerRadius"],
+  ["appearance", "backdrop"],
+  ["general"],
+  ["phone"],
+] as const;
+
+function preferenceScore(value: CavePreferences): [number, number] {
+  return [value.revision, parseDate(value.updatedAt)];
+}
+
+function newerPreference(left: CavePreferences, right: CavePreferences): "left" | "right" | "tie" {
+  const [leftRevision, leftTime] = preferenceScore(left);
+  const [rightRevision, rightTime] = preferenceScore(right);
+  if (leftRevision !== rightRevision) return leftRevision > rightRevision ? "left" : "right";
+  if (leftTime !== rightTime) return leftTime > rightTime ? "left" : "right";
+  return "tie";
+}
+
+function getNested(value: Record<string, unknown>, keys: readonly string[]): unknown {
+  let cursor: unknown = value;
+  for (const key of keys) cursor = record(cursor)?.[key];
+  return cursor;
+}
+
+function setNested(value: Record<string, unknown>, keys: readonly string[], child: unknown): void {
+  let cursor = value;
+  for (const key of keys.slice(0, -1)) {
+    cursor[key] = { ...(record(cursor[key]) ?? {}) };
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[keys[keys.length - 1]] = child;
+}
+
+function validPreferences(value: unknown): CavePreferences | null {
+  const raw = record(value);
+  if (
+    !raw || raw.version !== 1 || typeof raw.initialized !== "boolean" ||
+    typeof raw.revision !== "number" || !Number.isSafeInteger(raw.revision) || raw.revision < 0 ||
+    typeof raw.updatedAt !== "string" || !record(raw.appearance) || !record(raw.general) || !record(raw.phone)
+  ) return null;
+  return normalizeCavePreferences(raw);
+}
+
+function mergePreferences(legacy: unknown, canonical: unknown): MergeOutcome {
+  const left = validPreferences(legacy);
+  const right = validPreferences(canonical);
+  if (!left || !right) return { ok: false, summary: "Preferences data is malformed and requires review." };
+  const globalChoice = newerPreference(left, right);
+  const output = structuredClone(right) as unknown as Record<string, unknown>;
+  for (const keys of PREFERENCE_SECTIONS) {
+    const leftValue = getNested(left as unknown as Record<string, unknown>, keys);
+    const rightValue = getNested(right as unknown as Record<string, unknown>, keys);
+    if (JSON.stringify(leftValue) === JSON.stringify(rightValue)) continue;
+    if (globalChoice === "tie") return { ok: false, summary: `Preferences section ${keys.join(".")} differs at the same revision and timestamp.` };
+    setNested(output, keys, globalChoice === "left" ? leftValue : rightValue);
+  }
+  const leftTheme = left.appearance.theme;
+  const rightTheme = right.appearance.theme;
+  if (JSON.stringify(leftTheme) !== JSON.stringify(rightTheme)) {
+    const leftTime = parseDate(leftTheme.updatedAt);
+    const rightTime = parseDate(rightTheme.updatedAt);
+    if (leftTime === rightTime && leftTheme.selectionRevision === rightTheme.selectionRevision) {
+      return { ok: false, summary: "Theme preferences differ at the same revision and timestamp." };
+    }
+    (output.appearance as Record<string, unknown>).theme =
+      leftTheme.selectionRevision > rightTheme.selectionRevision ||
+      (leftTheme.selectionRevision === rightTheme.selectionRevision && leftTime > rightTime)
+        ? leftTheme : rightTheme;
+  }
+  const merged = normalizeCavePreferences(output);
+  merged.initialized = left.initialized || right.initialized;
+  merged.revision = Math.max(left.revision, right.revision) + 1;
+  merged.updatedAt = nowIso();
+  return { ok: true, value: merged, summary: "Merged independent preference sections by revision and timestamp." };
+}
+
+async function mergeJson(strategy: ReconciliationStrategy, legacyPath: string, canonicalPath: string): Promise<MergeOutcome> {
+  let legacy: unknown;
+  let canonical: unknown;
+  try {
+    legacy = JSON.parse(await readFile(legacyPath, "utf8"));
+    canonical = JSON.parse(await readFile(canonicalPath, "utf8"));
+  } catch {
+    return { ok: false, summary: "One or both JSON files are malformed and require review." };
+  }
+  if (strategy === "inbox") return mergeInbox(legacy, canonical);
+  if (strategy === "state") return mergeState(legacy, canonical);
+  if (strategy === "preferences") return mergePreferences(legacy, canonical);
+  return { ok: false, summary: "This file type requires an explicit choice." };
+}
+
+async function validateCanonical(entry: CaveHomeReconciliationEntry, canonicalPath: string): Promise<void> {
+  const info = await pathInfo(canonicalPath);
+  if (info.kind === "missing" || info.kind === "symlink") throw new Error("canonical path is missing");
+  if (entry.strategy === "directory") {
+    if (info.kind !== "dir") throw new Error("canonical directory is invalid");
+    await readdir(canonicalPath);
+    return;
+  }
+  if (entry.strategy === "inbox" || entry.strategy === "state" || entry.strategy === "preferences" || entry.next.endsWith(".json")) {
+    const parsed = JSON.parse(await readFile(canonicalPath, "utf8")) as unknown;
+    if (entry.strategy === "inbox") {
+      const value = record(parsed);
+      if (!value || !Array.isArray(value.items) || value.items.some((item) => typeof record(item)?.id !== "string")) throw new Error("canonical inbox validation failed");
+    } else if (entry.strategy === "state") {
+      const value = record(parsed);
+      if (!value || STATE_MAPS.some((key) => !record(value[key] ?? {})) || !record(value.travel ?? {})) throw new Error("canonical state validation failed");
+    } else if (entry.strategy === "preferences" && !validPreferences(parsed)) {
+      throw new Error("canonical preferences validation failed");
+    }
+  }
+}
+
+async function ensureCompatibility(
+  entry: CaveHomeReconciliationEntry,
+  legacyPath: string,
+  canonicalPath: string,
+  journalEntry: MigrationJournalEntry,
+  result: CaveHomeReconciliationResult,
+  options: ReconciliationOptions,
+): Promise<void> {
+  const canonicalInfo = await pathInfo(canonicalPath);
+  if (canonicalInfo.kind === "missing" || canonicalInfo.kind === "symlink") throw new Error("canonical path unavailable for compatibility bridge");
+  const existingLegacy = await pathInfo(legacyPath);
+  await rm(legacyPath, { recursive: existingLegacy.kind === "dir", force: true });
+  const createLink = options.createSymlink ?? symlink;
+  try {
+    const relative = path.relative(path.dirname(legacyPath), canonicalPath);
+    await createLink(relative, legacyPath, canonicalInfo.kind === "dir" ? "junction" : "file");
+    result.linked.push(entry.legacy);
+    journalEntry.compatibility = "symlink";
+    journalEntry.managedMirrorHash = undefined;
+  } catch {
+    await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
+    const mirror = await pathInfo(legacyPath);
+    if (mirror.hash !== canonicalInfo.hash) throw new Error("compatibility mirror verification failed");
+    journalEntry.compatibility = "mirror";
+    journalEntry.managedMirrorHash = mirror.hash;
+  }
+}
+
+async function syncManagedMirror(
+  entry: CaveHomeReconciliationEntry,
+  legacyPath: string,
+  canonicalPath: string,
+  prior: MigrationJournalEntry,
+  result: CaveHomeReconciliationResult,
+  options: ReconciliationOptions,
+): Promise<MigrationJournalEntry | null> {
+  const legacyInfo = await pathInfo(legacyPath);
+  const canonicalInfo = await pathInfo(canonicalPath);
+  if (legacyInfo.kind === "missing" || canonicalInfo.kind === "missing") return null;
+  if (!prior.managedMirrorHash || legacyInfo.hash !== prior.managedMirrorHash) return null;
+  const current: MigrationJournalEntry = {
+    ...prior,
+    legacyHash: legacyInfo.hash,
+    canonicalHash: canonicalInfo.hash,
+    legacyMtimeMs: legacyInfo.mtimeMs,
+    canonicalMtimeMs: canonicalInfo.mtimeMs,
+    decidedAt: nowIso(),
+  };
+  if (legacyInfo.hash !== canonicalInfo.hash) {
+    await rm(legacyPath, { recursive: legacyInfo.kind === "dir", force: true });
+    await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
+    const mirror = await pathInfo(legacyPath);
+    if (mirror.hash !== canonicalInfo.hash) throw new Error("managed mirror refresh failed");
+    current.legacyHash = mirror.hash;
+    current.managedMirrorHash = mirror.hash;
+  }
+  current.compatibility = "mirror";
+  current.summary = "Compatibility mirror is managed and unchanged by legacy tools.";
+  result.skipped.push(entry.legacy);
+  fault(options, "after-managed-mirror");
+  return current;
+}
+
+async function reconcileDirectory(
+  entry: CaveHomeReconciliationEntry,
+  legacyPath: string,
+  canonicalPath: string,
+  legacyInfo: PathInfo,
+  canonicalInfo: PathInfo,
+  result: CaveHomeReconciliationResult,
+  options: ReconciliationOptions,
+): Promise<{ outcome: MergeOutcome; files: number; collisions: number }> {
+  if (legacyInfo.kind !== "dir" || canonicalInfo.kind !== "dir") return { outcome: { ok: false, summary: "Path types differ and require review." }, files: 0, collisions: 0 };
+  let files = 0;
+  let collisions = 0;
+  for (const name of await readdir(legacyPath)) {
+    if (name === ".DS_Store") continue;
+    const legacyChild = path.join(legacyPath, name);
+    const canonicalChild = path.join(canonicalPath, name);
+    const left = await pathInfo(legacyChild);
+    const right = await pathInfo(canonicalChild);
+    if (left.kind === "symlink") {
+      collisions += 1;
+      continue;
+    }
+    if (right.kind === "missing") {
+      await copyPathAtomically(legacyChild, canonicalChild, left.kind, left.hash);
+      files += 1;
+    } else if (left.hash !== right.hash) collisions += 1;
+  }
+  result.merged.push({ legacy: entry.legacy, files, collisions });
+  if (collisions > 0) return { outcome: { ok: false, summary: `${collisions} directory collision(s) require review.` }, files, collisions };
+  return { outcome: { ok: true, value: null, summary: `Merged ${files} legacy-only directory entr${files === 1 ? "y" : "ies"}.` }, files, collisions };
+}
+
+async function reconcileEntry(
+  entry: CaveHomeReconciliationEntry,
+  journal: MigrationJournal,
+  result: CaveHomeReconciliationResult,
+  options: ReconciliationOptions,
+): Promise<void> {
+  if (options.legacy && options.legacy !== entry.legacy) return;
+  const legacyPath = path.join(covenHome(), entry.legacy);
+  const canonicalPath = canonicalPathFor(entry);
+  await mkdir(path.dirname(canonicalPath), { recursive: true });
+  let legacyInfo = await pathInfo(legacyPath);
+  let canonicalInfo = await pathInfo(canonicalPath);
+  const prior = journal.entries[entry.legacy];
+
+  if (prior?.decision === "deferred" && !options.action) {
+    result.skipped.push(entry.legacy);
+    return;
+  }
+
+  if (prior?.managedMirrorHash) {
+    const managed = await syncManagedMirror(entry, legacyPath, canonicalPath, prior, result, options);
+    if (managed) {
+      journal.entries[entry.legacy] = managed;
+      return;
+    }
+  }
+
+  const journalEntry: MigrationJournalEntry = {
+    legacy: entry.legacy,
+    next: entry.next,
+    strategy: entry.strategy,
+    legacyPath,
+    canonicalPath,
+    legacyHash: legacyInfo.hash,
+    canonicalHash: canonicalInfo.hash,
+    legacyMtimeMs: legacyInfo.mtimeMs,
+    canonicalMtimeMs: canonicalInfo.mtimeMs,
+    decision: "absent",
+    decidedAt: nowIso(),
+  };
+
+  if (options.action === "defer") {
+    journalEntry.decision = "deferred";
+    journalEntry.summary = "User deferred this migration; existing copies remain in place.";
+    journal.entries[entry.legacy] = journalEntry;
+    result.skipped.push(entry.legacy);
+    return;
+  }
+
+  if (legacyInfo.kind === "missing" || legacyInfo.kind === "symlink") {
+    journalEntry.decision = legacyInfo.kind === "symlink" ? "linked" : "absent";
+    journalEntry.summary = legacyInfo.kind === "symlink" ? "Legacy path is a compatibility link." : "No legacy data remains.";
+    journal.entries[entry.legacy] = journalEntry;
+    result.skipped.push(entry.legacy);
+    return;
+  }
+
+  if (canonicalInfo.kind === "missing") {
+    // Keep the legacy source intact until a fully copied and hash-verified
+    // canonical sibling has been atomically installed. A crash can therefore
+    // resume through the ordinary identical-copies path without data loss.
+    await validateCanonical(entry, legacyPath);
+    await copyPathAtomically(legacyPath, canonicalPath, legacyInfo.kind, legacyInfo.hash);
+    fault(options, "after-legacy-move");
+    await validateCanonical(entry, canonicalPath);
+    result.moved.push(entry.legacy);
+    journalEntry.decision = "moved";
+    journalEntry.summary = "Moved legacy data into the canonical Cave home.";
+    await ensureCompatibility(entry, legacyPath, canonicalPath, journalEntry, result, options);
+    legacyInfo = await pathInfo(legacyPath);
+    canonicalInfo = await pathInfo(canonicalPath);
+    journalEntry.legacyHash = legacyInfo.hash;
+    journalEntry.canonicalHash = canonicalInfo.hash;
+    journalEntry.legacyMtimeMs = legacyInfo.mtimeMs;
+    journalEntry.canonicalMtimeMs = canonicalInfo.mtimeMs;
+    journal.entries[entry.legacy] = journalEntry;
+    return;
+  }
+
+  if (legacyInfo.hash && legacyInfo.hash === canonicalInfo.hash) {
+    await validateCanonical(entry, canonicalPath);
+    journalEntry.decision = "identical";
+    journalEntry.summary = "Legacy and canonical data are identical.";
+    await ensureCompatibility(entry, legacyPath, canonicalPath, journalEntry, result, options);
+    journal.entries[entry.legacy] = journalEntry;
+    result.resolved.push(entry.legacy);
+    return;
+  }
+
+  const backup = await createRecoveryBundle(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, options);
+  result.backedUp.push(backup.directory);
+  journalEntry.backupId = backup.id;
+
+  if (options.action === "keep-canonical" || options.action === "recover-legacy") {
+    if (options.action === "recover-legacy") {
+      // Restore from the verified bundle, not the live legacy path, so an old
+      // writer cannot change the selected bytes between backup and recovery.
+      await restoreBundleRole(backup.directory, "legacy", canonicalPath);
+      journalEntry.decision = "recovered-legacy";
+      journalEntry.summary = "Recovered the legacy copy into canonical storage after verified backup.";
+    } else {
+      journalEntry.decision = "kept-canonical";
+      journalEntry.summary = "Kept the canonical copy after verified backup.";
+    }
+    fault(options, "after-resolution-write");
+    await validateCanonical(entry, canonicalPath);
+    await ensureCompatibility(entry, legacyPath, canonicalPath, journalEntry, result, options);
+    const finalCanonical = await pathInfo(canonicalPath);
+    const finalLegacy = await pathInfo(legacyPath);
+    journalEntry.canonicalHash = finalCanonical.hash;
+    journalEntry.legacyHash = finalLegacy.hash;
+    journal.entries[entry.legacy] = journalEntry;
+    result.resolved.push(entry.legacy);
+    return;
+  }
+
+  let merged: MergeOutcome;
+  if (entry.strategy === "directory") merged = (await reconcileDirectory(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, result, options)).outcome;
+  else if (["inbox", "state", "preferences"].includes(entry.strategy)) merged = await mergeJson(entry.strategy, legacyPath, canonicalPath);
+  else merged = { ok: false, summary: "This file has no lossless automatic merge and requires an explicit choice." };
+
+  if (merged.ok && (options.action === "merge" || !options.action)) {
+    if (entry.strategy !== "directory") await writeJsonAtomic(canonicalPath, merged.value);
+    fault(options, "after-merge-write");
+    await validateCanonical(entry, canonicalPath);
+    journalEntry.decision = "merged";
+    journalEntry.summary = merged.summary;
+    await ensureCompatibility(entry, legacyPath, canonicalPath, journalEntry, result, options);
+    const finalCanonical = await pathInfo(canonicalPath);
+    const finalLegacy = await pathInfo(legacyPath);
+    journalEntry.canonicalHash = finalCanonical.hash;
+    journalEntry.legacyHash = finalLegacy.hash;
+    journalEntry.canonicalMtimeMs = finalCanonical.mtimeMs;
+    journalEntry.legacyMtimeMs = finalLegacy.mtimeMs;
+    journal.entries[entry.legacy] = journalEntry;
+    result.resolved.push(entry.legacy);
+    return;
+  }
+
+  journalEntry.decision = options.action === "merge" ? "unresolved" : "unresolved";
+  journalEntry.summary = merged.summary;
+  journal.entries[entry.legacy] = journalEntry;
+  result.skipped.push(entry.legacy);
+}
+
+export async function reconcileCaveHome(
+  entries: readonly CaveHomeReconciliationEntry[],
+  options: ReconciliationOptions = {},
+): Promise<CaveHomeReconciliationResult> {
+  const result: CaveHomeReconciliationResult = {
+    moved: [], linked: [], skipped: [], merged: [], backedUp: [], resolved: [], errors: [],
+  };
+  await mkdir(caveHome(), { recursive: true });
+  const release = await acquireLock();
+  try {
+    const journal = await readJournal();
+    for (const entry of entries) {
+      try {
+        await reconcileEntry(entry, journal, result, options);
+      } catch (error) {
+        result.errors.push({ legacy: entry.legacy, error: String(error) });
+      }
+    }
+    await commitJournal(journal, options);
+  } finally {
+    await release();
+  }
+  return result;
+}
+
+export async function caveHomeReconciliationStatus(
+  entries: readonly CaveHomeReconciliationEntry[],
+): Promise<CaveHomeReconciliationStatus> {
+  const journal = await readJournal();
+  const pending: string[] = [];
+  const conflicts: string[] = [];
+  const details: CaveHomeConflictDetail[] = [];
+  for (const entry of entries) {
+    const legacyPath = path.join(covenHome(), entry.legacy);
+    const canonicalPath = canonicalPathFor(entry);
+    const legacyInfo = await pathInfo(legacyPath);
+    if (legacyInfo.kind === "missing" || legacyInfo.kind === "symlink") continue;
+    const canonicalInfo = await pathInfo(canonicalPath);
+    const prior = journal.entries[entry.legacy];
+    const managed = Boolean(prior?.managedMirrorHash && legacyInfo.hash === prior.managedMirrorHash);
+    if (managed) continue;
+    const isPending = canonicalInfo.kind === "missing";
+    (isPending ? pending : conflicts).push(entry.legacy);
+    const backupPath = prior?.backupId ? path.join(migrationBackupRoot(), prior.backupId) : undefined;
+    details.push({
+      legacy: entry.legacy,
+      next: entry.next,
+      strategy: entry.strategy,
+      legacyPath,
+      canonicalPath,
+      legacyHash: legacyInfo.hash,
+      canonicalHash: canonicalInfo.hash,
+      legacyMtimeMs: legacyInfo.mtimeMs,
+      canonicalMtimeMs: canonicalInfo.mtimeMs,
+      state: isPending ? "pending" : "unresolved",
+      summary: prior?.summary ?? (isPending ? "Legacy data is ready to move." : "Legacy and canonical data differ."),
+      differences: await describeDifferences(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo),
+      backupPath,
+      actions: isPending
+        ? ["merge", "defer"]
+        : entry.strategy === "manual"
+          ? ["keep-canonical", "recover-legacy", "defer"]
+          : ["merge", "keep-canonical", "recover-legacy", "defer"],
+    });
+  }
+  return {
+    pending,
+    conflicts,
+    migrated: pending.length === 0 && conflicts.length === 0,
+    details,
+    backupRoot: migrationBackupRoot(),
+    journalPath: migrationJournalPath(),
+  };
+}

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import {
   copyFile,
   cp,
@@ -285,7 +286,7 @@ async function pruneBackups(): Promise<void> {
 
 async function copyPath(source: string, destination: string, kind: PathInfo["kind"]): Promise<void> {
   if (kind === "dir") await cp(source, destination, { recursive: true, errorOnExist: true });
-  else await copyFile(source, destination);
+  else await copyFile(source, destination, fsConstants.COPYFILE_EXCL);
 }
 
 async function copyPathAtomically(

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -112,6 +112,8 @@ export type ReconciliationOptions = {
   createSymlink?: typeof symlink;
   /** Test-only lock lifecycle probe. */
   lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
+  /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
+  compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
 };
 
 type PathInfo = {
@@ -289,8 +291,9 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
             }
           }
         }
-      } catch {
-        continue;
+      } catch (lockError) {
+        if ((lockError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw lockError;
       }
       if (Date.now() >= deadline) throw new Error("timed out waiting for cave home migration lock");
       await delay(50);
@@ -545,17 +548,22 @@ function mergeTravel(leftValue: unknown, rightValue: unknown): MergeOutcome {
       return { ok: false, summary: `Queued travel work ${item.id} differs and requires review.` };
     }
   }
+  for (const field of ["manualOffline", "staleCache", "hubUnreachableSince", "localSubdaemonWakeRequestedAt"] as const) {
+    if (JSON.stringify(left[field]) !== JSON.stringify(right[field])) {
+      return { ok: false, summary: `Travel state ${field} differs without a transition revision and requires review.` };
+    }
+  }
   const latestReachability = parseDate(left.lastHubReachableAt) > parseDate(right.lastHubReachableAt) ? left : right;
   return {
     ok: true,
     value: {
       ...left,
       ...right,
-      manualOffline: left.manualOffline === true || right.manualOffline === true,
-      staleCache: left.staleCache === true || right.staleCache === true,
+      manualOffline: left.manualOffline === true,
+      staleCache: left.staleCache === true,
       lastHubReachableAt: latestReachability.lastHubReachableAt ?? null,
-      hubUnreachableSince: left.hubUnreachableSince ?? right.hubUnreachableSince ?? null,
-      localSubdaemonWakeRequestedAt: left.localSubdaemonWakeRequestedAt ?? right.localSubdaemonWakeRequestedAt ?? null,
+      hubUnreachableSince: left.hubUnreachableSince ?? null,
+      localSubdaemonWakeRequestedAt: left.localSubdaemonWakeRequestedAt ?? null,
       localBindHost: "127.0.0.1",
       offlineQueue: [...queue.values()],
     },
@@ -695,7 +703,14 @@ async function ensureCompatibility(
 ): Promise<void> {
   const canonicalInfo = await pathInfo(canonicalPath);
   if (canonicalInfo.kind === "missing" || canonicalInfo.kind === "symlink") throw new Error("canonical path unavailable for compatibility bridge");
+  await options.compatibilityProbe?.(legacyPath);
   const existingLegacy = await pathInfo(legacyPath);
+  if (
+    existingLegacy.kind === "missing" || existingLegacy.kind === "symlink" ||
+    !journalEntry.legacyHash || existingLegacy.hash !== journalEntry.legacyHash
+  ) {
+    throw new Error("legacy data changed before compatibility bridge installation");
+  }
   await rm(legacyPath, { recursive: existingLegacy.kind === "dir", force: true });
   const createLink = options.createSymlink ?? symlink;
   try {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 import {
   copyFile,
   cp,
+  link,
   lstat,
   mkdir,
   readFile,
@@ -116,6 +117,8 @@ export type ReconciliationOptions = {
   compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
   /** Test-only hook after managed-mirror canonical validation. */
   managedMirrorProbe?: (canonicalPath: string) => void | Promise<void>;
+  /** Test-only hook before an explicit/automatic canonical replacement. */
+  resolutionProbe?: (canonicalPath: string) => void | Promise<void>;
 };
 
 type PathInfo = {
@@ -152,6 +155,15 @@ function canonicalPathFor(entry: CaveHomeReconciliationEntry): string {
 
 function samePath(left: string, right: string): boolean {
   return path.relative(path.resolve(left), path.resolve(right)) === "";
+}
+
+async function isCanonicalCompatibilityLink(legacyPath: string, canonicalPath: string): Promise<boolean> {
+  try {
+    const target = await readlink(legacyPath);
+    return samePath(path.resolve(path.dirname(legacyPath), target), canonicalPath);
+  } catch {
+    return false;
+  }
 }
 
 function nowIso(): string {
@@ -346,7 +358,12 @@ async function copyPathAtomically(
     await copyPath(source, temporary, kind);
     const copied = await pathInfo(temporary);
     if (!expectedHash || copied.hash !== expectedHash) throw new Error("migration copy verification failed");
-    await rename(temporary, destination);
+    // A hard link publishes a file snapshot atomically but, unlike rename(2),
+    // fails when a concurrent writer already created the destination. Directory
+    // rename already fails when the competing directory contains data.
+    if (copied.kind === "file") await link(temporary, destination);
+    else await rename(temporary, destination);
+    await rm(temporary, { recursive: copied.kind === "dir", force: true }).catch(() => {});
   } catch (error) {
     await rm(temporary, { recursive: true, force: true }).catch(() => {});
     throw error;
@@ -357,9 +374,10 @@ async function retireExpectedPath(
   target: string,
   expected: PathInfo,
   probe?: () => void | Promise<void>,
+  label = "legacy",
 ): Promise<string> {
   if (!expected.hash || expected.kind === "missing" || expected.kind === "symlink") {
-    throw new Error("legacy path is unavailable for replacement");
+    throw new Error(`${label} path is unavailable for replacement`);
   }
   await probe?.();
   const retired = path.join(
@@ -378,8 +396,8 @@ async function retireExpectedPath(
     await rename(retired, target);
   }
   throw new Error(targetMissing
-    ? "legacy data changed during compatibility bridge installation"
-    : `legacy data changed during compatibility bridge installation; preserved at ${retired}`);
+    ? `${label} data changed during replacement`
+    : `${label} data changed during replacement; preserved at ${retired}`);
 }
 
 async function createRecoveryBundle(
@@ -440,12 +458,42 @@ async function verifiedBundleRole(
   return { source, hash: file.hash, info: sourceInfo };
 }
 
-async function restoreBundleRole(directory: string, role: "legacy" | "canonical", destination: string): Promise<void> {
-  const { source, hash, info: sourceInfo } = await verifiedBundleRole(directory, role);
-  const destinationInfo = await pathInfo(destination);
-  await rm(destination, { recursive: destinationInfo.kind === "dir", force: true });
-  await copyPath(source, destination, sourceInfo.kind);
-  if ((await pathInfo(destination)).hash !== hash) throw new Error(`${role} recovery verification failed`);
+async function replaceExpectedPath(
+  source: string,
+  sourceInfo: PathInfo,
+  destination: string,
+  expectedDestination: PathInfo,
+  verificationError: string,
+): Promise<void> {
+  const retired = await retireExpectedPath(destination, expectedDestination, undefined, "canonical");
+  let installed = false;
+  try {
+    await copyPathAtomically(source, destination, sourceInfo.kind, sourceInfo.hash);
+    if (!sourceInfo.hash || (await pathInfo(destination)).hash !== sourceInfo.hash) throw new Error(verificationError);
+    installed = true;
+  } finally {
+    if (installed) {
+      await rm(retired, { recursive: true, force: true });
+    } else if ((await pathInfo(destination)).kind === "missing") {
+      await rename(retired, destination);
+    }
+  }
+}
+
+async function restoreBundleRole(
+  directory: string,
+  role: "legacy" | "canonical",
+  destination: string,
+  expectedDestination: PathInfo,
+): Promise<void> {
+  const { source, info: sourceInfo } = await verifiedBundleRole(directory, role);
+  await replaceExpectedPath(
+    source,
+    sourceInfo,
+    destination,
+    expectedDestination,
+    `${role} recovery verification failed`,
+  );
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -779,6 +827,18 @@ async function ensureCompatibility(
       journalEntry.managedMirrorHash = undefined;
       installed = true;
     } catch {
+      // A link may have been created successfully before validation detected a
+      // concurrent/invalid canonical change. Remove that attempted bridge
+      // before entering the ordinary-file fallback; otherwise copyFile/cp can
+      // follow the link and leave the retired legacy bytes hidden.
+      if ((await pathInfo(legacyPath)).kind === "symlink") {
+        await rm(legacyPath, { recursive: true, force: true });
+      }
+      const fallbackCanonical = await pathInfo(canonicalPath);
+      await validateCanonical(entry, canonicalPath, fallbackCanonical);
+      if (fallbackCanonical.kind !== canonicalInfo.kind || fallbackCanonical.hash !== canonicalInfo.hash) {
+        throw new Error("canonical data changed during compatibility bridge installation");
+      }
       await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
       const mirror = await pathInfo(legacyPath);
       if (mirror.hash !== canonicalInfo.hash) throw new Error("compatibility mirror verification failed");
@@ -959,9 +1019,21 @@ async function reconcileEntry(
     return;
   }
 
-  if (legacyInfo.kind === "missing" || legacyInfo.kind === "symlink") {
-    journalEntry.decision = legacyInfo.kind === "symlink" ? "linked" : "absent";
-    journalEntry.summary = legacyInfo.kind === "symlink" ? "Legacy path is a compatibility link." : "No legacy data remains.";
+  if (legacyInfo.kind === "missing") {
+    journalEntry.decision = "absent";
+    journalEntry.summary = "No legacy data remains.";
+    journal.entries[entry.legacy] = journalEntry;
+    result.skipped.push(entry.legacy);
+    return;
+  }
+
+  if (legacyInfo.kind === "symlink") {
+    if (!await isCanonicalCompatibilityLink(legacyPath, canonicalPath)) {
+      throw new Error("legacy symlink does not target canonical storage");
+    }
+    await validateCanonical(entry, canonicalPath, canonicalInfo);
+    journalEntry.decision = "linked";
+    journalEntry.summary = "Legacy path is a verified compatibility link.";
     journal.entries[entry.legacy] = journalEntry;
     result.skipped.push(entry.legacy);
     return;
@@ -1021,7 +1093,8 @@ async function reconcileEntry(
       // writer cannot change the selected bytes between backup and recovery.
       const legacyBackup = await verifiedBundleRole(backup.directory, "legacy");
       await validateCanonical(entry, legacyBackup.source, legacyBackup.info);
-      await restoreBundleRole(backup.directory, "legacy", canonicalPath);
+      await options.resolutionProbe?.(canonicalPath);
+      await restoreBundleRole(backup.directory, "legacy", canonicalPath, canonicalInfo);
       journalEntry.decision = "recovered-legacy";
       journalEntry.summary = "Recovered the legacy copy into canonical storage after verified backup.";
     } else {
@@ -1042,11 +1115,38 @@ async function reconcileEntry(
 
   let merged: MergeOutcome;
   if (entry.strategy === "directory") merged = (await reconcileDirectory(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, result, options)).outcome;
-  else if (["inbox", "state", "preferences"].includes(entry.strategy)) merged = await mergeJson(entry.strategy, legacyPath, canonicalPath);
+  else if (["inbox", "state", "preferences"].includes(entry.strategy)) {
+    // Merge the exact snapshots recorded in the verified bundle. Reading the
+    // live paths here would let an uncoordinated store writer change either
+    // input after backup verification.
+    const legacyBackup = await verifiedBundleRole(backup.directory, "legacy");
+    const canonicalBackup = await verifiedBundleRole(backup.directory, "canonical");
+    merged = await mergeJson(entry.strategy, legacyBackup.source, canonicalBackup.source);
+  }
   else merged = { ok: false, summary: "This file has no lossless automatic merge and requires an explicit choice." };
 
   if (merged.ok && (options.action === "merge" || !options.action)) {
-    if (entry.strategy !== "directory") await writeJsonAtomic(canonicalPath, merged.value);
+    if (entry.strategy !== "directory") {
+      const staged = path.join(
+        path.dirname(canonicalPath),
+        `.${path.basename(canonicalPath)}.migration-merge-${process.pid}-${randomBytes(6).toString("hex")}`,
+      );
+      try {
+        await writeJsonAtomic(staged, merged.value);
+        const stagedInfo = await pathInfo(staged);
+        await validateCanonical(entry, staged, stagedInfo);
+        await options.resolutionProbe?.(canonicalPath);
+        await replaceExpectedPath(
+          staged,
+          stagedInfo,
+          canonicalPath,
+          canonicalInfo,
+          "merged canonical verification failed",
+        );
+      } finally {
+        await rm(staged, { recursive: true, force: true }).catch(() => {});
+      }
+    }
     fault(options, "after-merge-write");
     await validateCanonical(entry, canonicalPath);
     journalEntry.decision = "merged";
@@ -1105,10 +1205,14 @@ export async function caveHomeReconciliationStatus(
     const legacyPath = path.join(covenHome(), entry.legacy);
     const canonicalPath = canonicalPathFor(entry);
     const legacyInfo = await pathInfo(legacyPath);
-    if (legacyInfo.kind === "missing" || legacyInfo.kind === "symlink") continue;
+    if (legacyInfo.kind === "missing") continue;
     const canonicalInfo = await pathInfo(canonicalPath);
     const prior = journal.entries[entry.legacy];
     const canonicalValid = await validateCanonical(entry, canonicalPath, canonicalInfo).then(() => true, () => false);
+    if (
+      legacyInfo.kind === "symlink" && canonicalValid &&
+      await isCanonicalCompatibilityLink(legacyPath, canonicalPath)
+    ) continue;
     if (samePath(legacyPath, canonicalPath) && canonicalValid) continue;
     const managed = Boolean(
       canonicalValid &&
@@ -1116,7 +1220,7 @@ export async function caveHomeReconciliationStatus(
       legacyInfo.hash === prior.managedMirrorHash,
     );
     if (managed) continue;
-    const isPending = canonicalInfo.kind === "missing";
+    const isPending = canonicalInfo.kind === "missing" && legacyInfo.kind !== "symlink";
     (isPending ? pending : conflicts).push(entry.legacy);
     const backupPath = prior?.backupId ? path.join(migrationBackupRoot(), prior.backupId) : undefined;
     details.push({
@@ -1130,10 +1234,14 @@ export async function caveHomeReconciliationStatus(
       legacyMtimeMs: legacyInfo.mtimeMs,
       canonicalMtimeMs: canonicalInfo.mtimeMs,
       state: isPending ? "pending" : "unresolved",
-      summary: prior?.summary ?? (isPending ? "Legacy data is ready to move." : "Legacy and canonical data differ."),
+      summary: legacyInfo.kind === "symlink"
+        ? "Legacy symlink is not a valid compatibility bridge and requires review."
+        : prior?.summary ?? (isPending ? "Legacy data is ready to move." : "Legacy and canonical data differ."),
       differences: await describeDifferences(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo),
       backupPath,
-      actions: isPending
+      actions: legacyInfo.kind === "symlink"
+        ? ["defer"]
+        : isPending
         ? ["merge", "defer"]
         : entry.strategy === "manual"
           ? ["keep-canonical", "recover-legacy", "defer"]

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -429,6 +429,21 @@ async function retireExpectedPath(
     : `${label} data changed during replacement; preserved at ${retired}`);
 }
 
+async function restoreInterruptedRetirement(target: string): Promise<void> {
+  if ((await pathInfo(target)).kind !== "missing") return;
+  const parent = path.dirname(target);
+  const prefix = `.${path.basename(target)}.migration-retired-`;
+  const retired = (await readdir(parent).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  })).filter((name) => name.startsWith(prefix));
+  if (retired.length === 0) return;
+  if (retired.length > 1) {
+    throw new Error(`multiple interrupted replacements require review for ${target}`);
+  }
+  await rename(path.join(parent, retired[0]), target);
+}
+
 async function createRecoveryBundle(
   entry: CaveHomeReconciliationEntry,
   legacyPath: string,
@@ -1017,6 +1032,12 @@ async function reconcileEntry(
   const legacyPath = path.join(covenHome(), entry.legacy);
   const canonicalPath = canonicalPathFor(entry);
   await mkdir(path.dirname(canonicalPath), { recursive: true });
+  // A hard process termination can bypass finally blocks after the atomic
+  // retirement rename. Restore the sole preserved copy before classifying the
+  // entry; otherwise a missing legacy path can be journaled as complete, or a
+  // missing canonical path can be rebuilt from an older compatibility copy.
+  await restoreInterruptedRetirement(legacyPath);
+  await restoreInterruptedRetirement(canonicalPath);
   let legacyInfo = await pathInfo(legacyPath);
   let canonicalInfo = await pathInfo(canonicalPath);
   const prior = journal.entries[entry.legacy];

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -243,6 +243,33 @@ async function readLockOwner(lock: string): Promise<{ pid: number | null; token:
   };
 }
 
+async function renameLockCandidate(candidate: string, lock: string): Promise<void> {
+  try {
+    await rename(candidate, lock);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? "";
+    // Windows reports EPERM (rather than EEXIST/ENOTEMPTY) when a directory
+    // rename targets the already-held lock directory. Only translate it when
+    // the destination really exists so unrelated permission failures still
+    // fail closed.
+    if (["EACCES", "EPERM"].includes(code)) {
+      const lockExists = await stat(lock).then(
+        () => true,
+        (statError) => {
+          if ((statError as NodeJS.ErrnoException).code === "ENOENT") return false;
+          throw statError;
+        },
+      );
+      if (lockExists) {
+        const contention = new Error("cave home migration lock is already held") as NodeJS.ErrnoException;
+        contention.code = "EEXIST";
+        throw contention;
+      }
+    }
+    throw error;
+  }
+}
+
 async function acquireLock(options: ReconciliationOptions): Promise<() => Promise<void>> {
   const lock = migrationLockPath();
   const deadline = Date.now() + LOCK_WAIT_MS;
@@ -253,7 +280,7 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
       await mkdir(candidate);
       try {
         await writeJsonAtomic(path.join(candidate, "owner.json"), { pid: process.pid, token, startedAt: nowIso() });
-        await rename(candidate, lock);
+        await renameLockCandidate(candidate, lock);
       } catch (error) {
         await rm(candidate, { recursive: true, force: true });
         throw error;
@@ -544,6 +571,25 @@ function mergeInbox(legacy: unknown, canonical: unknown): MergeOutcome {
   const right = record(canonical);
   if (!left || !right || !Array.isArray(left.items) || !Array.isArray(right.items)) {
     return { ok: false, summary: "Inbox data is malformed and requires review." };
+  }
+  const leftIds = new Set<string>();
+  const rightIds = new Set<string>();
+  for (const [items, ids] of [[left.items, leftIds], [right.items, rightIds]] as const) {
+    for (const raw of items) {
+      const item = record(raw);
+      if (!item || typeof item.id !== "string" || !item.id) {
+        return { ok: false, summary: "Inbox item without a stable ID requires review." };
+      }
+      ids.add(item.id);
+    }
+  }
+  for (const id of new Set([...leftIds, ...rightIds])) {
+    if (!leftIds.has(id) || !rightIds.has(id)) {
+      // Inbox items can be deleted outright. Without a file-level revision or
+      // tombstone, a one-sided ID may be either a new item or a later deletion;
+      // unioning snapshots can silently resurrect an item the user removed.
+      return { ok: false, summary: `Inbox item ${id} has ambiguous presence and requires review.` };
+    }
   }
   const byId = new Map<string, Record<string, unknown>>();
   for (const raw of [...left.items, ...right.items]) {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -114,6 +114,8 @@ export type ReconciliationOptions = {
   lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
   /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
   compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
+  /** Test-only hook after managed-mirror canonical validation. */
+  managedMirrorProbe?: (canonicalPath: string) => void | Promise<void>;
 };
 
 type PathInfo = {
@@ -351,6 +353,35 @@ async function copyPathAtomically(
   }
 }
 
+async function retireExpectedPath(
+  target: string,
+  expected: PathInfo,
+  probe?: () => void | Promise<void>,
+): Promise<string> {
+  if (!expected.hash || expected.kind === "missing" || expected.kind === "symlink") {
+    throw new Error("legacy path is unavailable for replacement");
+  }
+  await probe?.();
+  const retired = path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.migration-retired-${process.pid}-${randomBytes(6).toString("hex")}`,
+  );
+  await rename(target, retired);
+  const retiredInfo = await pathInfo(retired);
+  if (retiredInfo.kind === expected.kind && retiredInfo.hash === expected.hash) return retired;
+
+  // The pathname may have changed after its final inspection but before the
+  // atomic rename. Put those bytes back when the old pathname is still vacant;
+  // otherwise keep the retired copy so neither concurrent writer is lost.
+  const targetMissing = (await pathInfo(target)).kind === "missing";
+  if (targetMissing) {
+    await rename(retired, target);
+  }
+  throw new Error(targetMissing
+    ? "legacy data changed during compatibility bridge installation"
+    : `legacy data changed during compatibility bridge installation; preserved at ${retired}`);
+}
+
 async function createRecoveryBundle(
   entry: CaveHomeReconciliationEntry,
   legacyPath: string,
@@ -508,6 +539,12 @@ const TIMESTAMP_STATE_MAPS = new Set<string>([
   "sessionOwned",
 ]);
 
+const DELETABLE_STATE_MAPS = new Set<string>([
+  "sessionTitles",
+  "sessionArchived",
+  "sessionKeep",
+]);
+
 function mergeRecordMap(
   name: string,
   leftValue: unknown,
@@ -518,7 +555,17 @@ function mergeRecordMap(
   if (!left || !right) return { ok: false, summary: `State map ${name} is malformed.` };
   const value = { ...left, ...right };
   for (const key of new Set([...Object.keys(left), ...Object.keys(right)])) {
-    if (!(key in left) || !(key in right) || JSON.stringify(left[key]) === JSON.stringify(right[key])) continue;
+    if (!(key in left) || !(key in right)) {
+      // These maps delete keys for ordinary user actions (clear title,
+      // summon/unarchive, unmark keep). A key present in only one snapshot may
+      // therefore be either an addition or a later deletion; unioning it can
+      // silently resurrect state that the user already removed.
+      if (DELETABLE_STATE_MAPS.has(name)) {
+        return { ok: false, summary: `State map ${name} has ambiguous presence for ${key}.` };
+      }
+      continue;
+    }
+    if (JSON.stringify(left[key]) === JSON.stringify(right[key])) continue;
     if (!TIMESTAMP_STATE_MAPS.has(name)) return { ok: false, summary: `State map ${name} has an ambiguous value for ${key}.` };
     const leftTime = parseDate(left[key]);
     const rightTime = parseDate(right[key]);
@@ -703,7 +750,6 @@ async function ensureCompatibility(
 ): Promise<void> {
   const canonicalInfo = await pathInfo(canonicalPath);
   if (canonicalInfo.kind === "missing" || canonicalInfo.kind === "symlink") throw new Error("canonical path unavailable for compatibility bridge");
-  await options.compatibilityProbe?.(legacyPath);
   const existingLegacy = await pathInfo(legacyPath);
   if (
     existingLegacy.kind === "missing" || existingLegacy.kind === "symlink" ||
@@ -711,20 +757,54 @@ async function ensureCompatibility(
   ) {
     throw new Error("legacy data changed before compatibility bridge installation");
   }
-  await rm(legacyPath, { recursive: existingLegacy.kind === "dir", force: true });
+  const retired = await retireExpectedPath(
+    legacyPath,
+    existingLegacy,
+    () => options.compatibilityProbe?.(legacyPath),
+  );
   const createLink = options.createSymlink ?? symlink;
+  let installed = false;
   try {
-    const relative = path.relative(path.dirname(legacyPath), canonicalPath);
-    await createLink(relative, legacyPath, canonicalInfo.kind === "dir" ? "junction" : "file");
-    result.linked.push(entry.legacy);
-    journalEntry.compatibility = "symlink";
-    journalEntry.managedMirrorHash = undefined;
-  } catch {
-    await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
-    const mirror = await pathInfo(legacyPath);
-    if (mirror.hash !== canonicalInfo.hash) throw new Error("compatibility mirror verification failed");
-    journalEntry.compatibility = "mirror";
-    journalEntry.managedMirrorHash = mirror.hash;
+    try {
+      const relative = path.relative(path.dirname(legacyPath), canonicalPath);
+      await createLink(relative, legacyPath, canonicalInfo.kind === "dir" ? "junction" : "file");
+      const linkedCanonical = await pathInfo(canonicalPath);
+      await validateCanonical(entry, canonicalPath, linkedCanonical);
+      if (linkedCanonical.kind !== canonicalInfo.kind || linkedCanonical.hash !== canonicalInfo.hash) {
+        await rm(legacyPath, { recursive: true, force: true });
+        throw new Error("canonical data changed during compatibility link installation");
+      }
+      result.linked.push(entry.legacy);
+      journalEntry.compatibility = "symlink";
+      journalEntry.managedMirrorHash = undefined;
+      installed = true;
+    } catch {
+      await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
+      const mirror = await pathInfo(legacyPath);
+      if (mirror.hash !== canonicalInfo.hash) throw new Error("compatibility mirror verification failed");
+      journalEntry.compatibility = "mirror";
+      journalEntry.managedMirrorHash = mirror.hash;
+      installed = true;
+    }
+  } finally {
+    if (installed) {
+      await rm(retired, { recursive: true, force: true });
+    } else {
+      const failedLegacy = await pathInfo(legacyPath);
+      if (failedLegacy.kind === "missing") {
+        await rename(retired, legacyPath);
+      } else {
+        const currentCanonical = await pathInfo(canonicalPath);
+        if (
+          failedLegacy.kind === currentCanonical.kind &&
+          failedLegacy.hash && failedLegacy.hash === currentCanonical.hash &&
+          failedLegacy.hash !== existingLegacy.hash
+        ) {
+          await rm(legacyPath, { recursive: failedLegacy.kind === "dir", force: true });
+          await rename(retired, legacyPath);
+        }
+      }
+    }
   }
 }
 
@@ -752,12 +832,33 @@ async function syncManagedMirror(
     decidedAt: nowIso(),
   };
   if (legacyInfo.hash !== canonicalInfo.hash) {
-    await rm(legacyPath, { recursive: legacyInfo.kind === "dir", force: true });
-    await copyPath(canonicalPath, legacyPath, canonicalInfo.kind);
-    const mirror = await pathInfo(legacyPath);
-    if (mirror.hash !== canonicalInfo.hash) throw new Error("managed mirror refresh failed");
-    current.legacyHash = mirror.hash;
-    current.managedMirrorHash = mirror.hash;
+    await options.managedMirrorProbe?.(canonicalPath);
+    const staged = path.join(
+      path.dirname(legacyPath),
+      `.${path.basename(legacyPath)}.migration-refresh-${process.pid}-${randomBytes(6).toString("hex")}`,
+    );
+    await copyPathAtomically(canonicalPath, staged, canonicalInfo.kind, canonicalInfo.hash);
+    try {
+      await validateCanonical(entry, staged);
+      const retired = await retireExpectedPath(legacyPath, legacyInfo);
+      let installed = false;
+      try {
+        await copyPath(staged, legacyPath, canonicalInfo.kind);
+        const mirror = await pathInfo(legacyPath);
+        if (mirror.hash !== canonicalInfo.hash) throw new Error("managed mirror refresh failed");
+        current.legacyHash = mirror.hash;
+        current.managedMirrorHash = mirror.hash;
+        installed = true;
+      } finally {
+        if (installed) {
+          await rm(retired, { recursive: true, force: true });
+        } else if ((await pathInfo(legacyPath)).kind === "missing") {
+          await rename(retired, legacyPath);
+        }
+      }
+    } finally {
+      await rm(staged, { recursive: true, force: true });
+    }
   }
   current.compatibility = "mirror";
   current.summary = "Compatibility mirror is managed and unchanged by legacy tools.";

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -142,6 +142,10 @@ function canonicalPathFor(entry: CaveHomeReconciliationEntry): string {
   return override || path.join(caveHome(), entry.next);
 }
 
+function samePath(left: string, right: string): boolean {
+  return path.relative(path.resolve(left), path.resolve(right)) === "";
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -480,16 +484,17 @@ function mergeTravel(leftValue: unknown, rightValue: unknown): MergeOutcome {
   const leftQueue = Array.isArray(left.offlineQueue) ? left.offlineQueue : [];
   const rightQueue = Array.isArray(right.offlineQueue) ? right.offlineQueue : [];
   const queue = new Map<string, Record<string, unknown>>();
-  const rank: Record<string, number> = { pending: 0, syncing: 1, failed: 2, synced: 3 };
   for (const raw of [...leftQueue, ...rightQueue]) {
     const item = record(raw);
     if (!item || typeof item.id !== "string") return { ok: false, summary: "Queued travel work without a stable ID requires review." };
     const existing = queue.get(item.id);
     if (!existing) queue.set(item.id, item);
     else if (JSON.stringify(existing) !== JSON.stringify(item)) {
-      const samePayload = JSON.stringify({ ...existing, status: undefined, lastError: undefined }) === JSON.stringify({ ...item, status: undefined, lastError: undefined });
-      if (!samePayload) return { ok: false, summary: `Queued travel work ${item.id} differs and requires review.` };
-      if ((rank[String(item.status)] ?? -1) > (rank[String(existing.status)] ?? -1)) queue.set(item.id, item);
+      // Queue status is not monotonic: failed work can be retried and return
+      // to syncing. Without an item revision or transition timestamp, ranking
+      // statuses can replace a newer retry with an older failed snapshot (or
+      // suppress work as already synced). Preserve both files for review.
+      return { ok: false, summary: `Queued travel work ${item.id} differs and requires review.` };
     }
   }
   const latestReachability = parseDate(left.lastHubReachableAt) > parseDate(right.lastHubReachableAt) ? left : right;
@@ -787,6 +792,18 @@ async function reconcileEntry(
     return;
   }
 
+  // A supported per-store override may intentionally keep the canonical file
+  // at its historical legacy path. In that case there is no bridge to create:
+  // removing the "legacy" side would remove the canonical file itself.
+  if (samePath(legacyPath, canonicalPath)) {
+    await validateCanonical(entry, canonicalPath, canonicalInfo);
+    journalEntry.decision = "identical";
+    journalEntry.summary = "The configured canonical path is already the legacy path.";
+    journal.entries[entry.legacy] = journalEntry;
+    result.resolved.push(entry.legacy);
+    return;
+  }
+
   if (canonicalInfo.kind === "missing") {
     // Keep the legacy source intact until a fully copied and hash-verified
     // canonical sibling has been atomically installed. A crash can therefore
@@ -915,6 +932,7 @@ export async function caveHomeReconciliationStatus(
     const canonicalInfo = await pathInfo(canonicalPath);
     const prior = journal.entries[entry.legacy];
     const canonicalValid = await validateCanonical(entry, canonicalPath, canonicalInfo).then(() => true, () => false);
+    if (samePath(legacyPath, canonicalPath) && canonicalValid) continue;
     const managed = Boolean(
       canonicalValid &&
       prior?.managedMirrorHash &&

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -608,6 +608,9 @@ function mergeInbox(legacy: unknown, canonical: unknown): MergeOutcome {
       if (!item || typeof item.id !== "string" || !item.id) {
         return { ok: false, summary: "Inbox item without a stable ID requires review." };
       }
+      if (ids.has(item.id)) {
+        return { ok: false, summary: `Inbox contains duplicate item ID ${item.id} and requires review.` };
+      }
       ids.add(item.id);
     }
   }
@@ -703,6 +706,19 @@ function mergeTravel(leftValue: unknown, rightValue: unknown): MergeOutcome {
   if (!left || !right) return { ok: false, summary: "Travel state is malformed." };
   const leftQueue = Array.isArray(left.offlineQueue) ? left.offlineQueue : [];
   const rightQueue = Array.isArray(right.offlineQueue) ? right.offlineQueue : [];
+  for (const items of [leftQueue, rightQueue]) {
+    const ids = new Set<string>();
+    for (const raw of items) {
+      const item = record(raw);
+      if (!item || typeof item.id !== "string" || !item.id) {
+        return { ok: false, summary: "Queued travel work without a stable ID requires review." };
+      }
+      if (ids.has(item.id)) {
+        return { ok: false, summary: `Travel queue contains duplicate item ID ${item.id} and requires review.` };
+      }
+      ids.add(item.id);
+    }
+  }
   const queue = new Map<string, Record<string, unknown>>();
   for (const raw of [...leftQueue, ...rightQueue]) {
     const item = record(raw);
@@ -1347,4 +1363,20 @@ export async function caveHomeReconciliationStatus(
     backupRoot: migrationBackupRoot(),
     journalPath: migrationJournalPath(),
   };
+}
+
+/** Fail closed when a previously preserved conflict loses its canonical store. */
+export async function validateCaveHomeReconciliationStore(
+  entries: readonly CaveHomeReconciliationEntry[],
+  legacy: string,
+): Promise<void> {
+  const entry = entries.find((candidate) => candidate.legacy === legacy);
+  if (!entry) return;
+  const prior = (await readJournal()).entries[legacy];
+  if (
+    prior?.decision !== "unresolved" &&
+    prior?.decision !== "deferred" &&
+    !prior?.managedMirrorHash
+  ) return;
+  await validateCanonical(entry, canonicalPathFor(entry));
 }

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -12,6 +12,7 @@ import {
   rm,
   stat,
   symlink,
+  writeFile,
 } from "node:fs/promises";
 import path from "node:path";
 
@@ -109,6 +110,8 @@ export type ReconciliationOptions = {
   faultAt?: string;
   /** Test-only compatibility bridge override. */
   createSymlink?: typeof symlink;
+  /** Test-only lock lifecycle probe. */
+  lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
 };
 
 type PathInfo = {
@@ -214,40 +217,76 @@ async function delay(ms: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-async function acquireLock(): Promise<() => Promise<void>> {
+async function readLockOwner(lock: string): Promise<{ pid: number | null; token: string | null }> {
+  const owner = await readFile(path.join(lock, "owner.json"), "utf8")
+    .then((value) => JSON.parse(value) as { pid?: unknown; token?: unknown })
+    .catch(() => null);
+  return {
+    pid: typeof owner?.pid === "number" && Number.isSafeInteger(owner.pid) ? owner.pid : null,
+    token: typeof owner?.token === "string" ? owner.token : null,
+  };
+}
+
+async function acquireLock(options: ReconciliationOptions): Promise<() => Promise<void>> {
   const lock = migrationLockPath();
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
+    const token = randomBytes(16).toString("hex");
+    const candidate = `${lock}.candidate-${token}`;
     try {
-      await mkdir(lock);
+      await mkdir(candidate);
       try {
-        await writeJsonAtomic(path.join(lock, "owner.json"), { pid: process.pid, startedAt: nowIso() });
+        await writeJsonAtomic(path.join(candidate, "owner.json"), { pid: process.pid, token, startedAt: nowIso() });
+        await rename(candidate, lock);
       } catch (error) {
-        await rm(lock, { recursive: true, force: true });
+        await rm(candidate, { recursive: true, force: true });
         throw error;
       }
-      return async () => { await rm(lock, { recursive: true, force: true }); };
+      await options.lockProbe?.("acquired");
+      return async () => {
+        const owner = await readLockOwner(lock);
+        if (owner.token !== token) return;
+        const released = `${lock}.released-${token}`;
+        await rename(lock, released).catch((error) => {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        });
+        await rm(released, { recursive: true, force: true });
+        await options.lockProbe?.("released");
+      };
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      await rm(candidate, { recursive: true, force: true }).catch(() => {});
+      if (!["EEXIST", "ENOTEMPTY"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
       try {
         const info = await stat(lock);
         if (Date.now() - info.mtimeMs > LOCK_STALE_MS) {
-          const owner = await readFile(path.join(lock, "owner.json"), "utf8")
-            .then((value) => JSON.parse(value) as { pid?: unknown })
-            .catch(() => null);
-          const pid = typeof owner?.pid === "number" && Number.isSafeInteger(owner.pid) ? owner.pid : null;
+          const owner = await readLockOwner(lock);
           let alive = false;
-          if (pid) {
+          if (owner.pid) {
             try {
-              process.kill(pid, 0);
+              process.kill(owner.pid, 0);
               alive = true;
             } catch (ownerError) {
               alive = (ownerError as NodeJS.ErrnoException).code === "EPERM";
             }
           }
           if (!alive) {
-            await rm(lock, { recursive: true, force: true });
-            continue;
+            await options.lockProbe?.("stale-observed");
+            const takeover = path.join(lock, ".takeover");
+            const takeoverToken = randomBytes(16).toString("hex");
+            try {
+              await writeFile(takeover, JSON.stringify({ takeoverToken, ownerToken: owner.token }), { flag: "wx" });
+              const currentOwner = await readLockOwner(lock);
+              if (currentOwner.token !== owner.token) {
+                await rm(takeover, { force: true });
+              } else {
+                const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
+                await rename(lock, reclaimed);
+                await rm(reclaimed, { recursive: true, force: true });
+                continue;
+              }
+            } catch (takeoverError) {
+              if (!["EEXIST", "ENOENT"].includes((takeoverError as NodeJS.ErrnoException).code ?? "")) throw takeoverError;
+            }
           }
         }
       } catch {
@@ -284,7 +323,7 @@ async function pruneBackups(journal: MigrationJournal): Promise<void> {
 }
 
 async function copyPath(source: string, destination: string, kind: PathInfo["kind"]): Promise<void> {
-  if (kind === "dir") await cp(source, destination, { recursive: true, errorOnExist: true });
+  if (kind === "dir") await cp(source, destination, { recursive: true, errorOnExist: true, force: false });
   else await copyFile(source, destination, fsConstants.COPYFILE_EXCL);
 }
 
@@ -922,7 +961,7 @@ export async function reconcileCaveHome(
     moved: [], linked: [], skipped: [], merged: [], backedUp: [], resolved: [], errors: [],
   };
   await mkdir(caveHome(), { recursive: true });
-  const release = await acquireLock();
+  const release = await acquireLock(options);
   try {
     const journal = await readJournal();
     for (const entry of entries) {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1022,6 +1022,10 @@ async function reconcileEntry(
   const prior = journal.entries[entry.legacy];
 
   if (prior?.decision === "deferred" && !options.action) {
+    // Deferral may stop automatic reconciliation, but it must not bypass the
+    // reader/writer gate. A missing or malformed canonical store would make
+    // callers fall back to defaults and later overwrite recoverable data.
+    await validateCanonical(entry, canonicalPath, canonicalInfo);
     result.skipped.push(entry.legacy);
     return;
   }
@@ -1050,6 +1054,9 @@ async function reconcileEntry(
   };
 
   if (options.action === "defer") {
+    // Cave continues to read and write canonical storage while a decision is
+    // deferred, so only allow deferral when that authoritative copy is usable.
+    await validateCanonical(entry, canonicalPath, canonicalInfo);
     if (
       !samePath(legacyPath, canonicalPath) &&
       legacyInfo.kind !== "missing" && legacyInfo.kind !== "symlink" &&
@@ -1288,12 +1295,16 @@ export async function caveHomeReconciliationStatus(
       differences: await describeDifferences(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo),
       backupPath,
       actions: legacyInfo.kind === "symlink"
-        ? ["defer"]
+        ? canonicalValid ? ["defer"] : []
         : isPending
-        ? ["merge", "defer"]
+        ? ["merge"]
         : entry.strategy === "manual"
-          ? ["keep-canonical", "recover-legacy", "defer"]
-          : ["merge", "keep-canonical", "recover-legacy", "defer"],
+          ? canonicalValid
+            ? ["keep-canonical", "recover-legacy", "defer"]
+            : ["recover-legacy"]
+          : canonicalValid
+            ? ["merge", "keep-canonical", "recover-legacy", "defer"]
+            : ["merge", "recover-legacy"],
     });
   }
   return {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -259,9 +259,8 @@ async function acquireLock(): Promise<() => Promise<void>> {
   }
 }
 
-async function pruneBackups(): Promise<void> {
+async function pruneBackups(journal: MigrationJournal): Promise<void> {
   await mkdir(migrationBackupRoot(), { recursive: true });
-  const journal = await readJournal();
   const protectedIds = new Set(
     Object.values(journal.entries)
       .filter((entry) => entry.decision === "unresolved" || entry.decision === "deferred")
@@ -316,9 +315,10 @@ async function createRecoveryBundle(
   canonicalPath: string,
   legacyInfo: PathInfo,
   canonicalInfo: PathInfo,
+  journal: MigrationJournal,
   options: ReconciliationOptions,
 ): Promise<{ id: string; directory: string }> {
-  await pruneBackups();
+  await pruneBackups(journal);
   const id = `${nowIso().replace(/[:.]/g, "-")}-${randomBytes(4).toString("hex")}`;
   const directory = path.join(migrationBackupRoot(), id);
   await mkdir(directory, { recursive: true });
@@ -837,7 +837,7 @@ async function reconcileEntry(
     return;
   }
 
-  const backup = await createRecoveryBundle(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, options);
+  const backup = await createRecoveryBundle(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, journal, options);
   result.backedUp.push(backup.directory);
   journalEntry.backupId = backup.id;
 

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -538,31 +538,10 @@ const PREFERENCE_SECTIONS = [
   ["phone"],
 ] as const;
 
-function preferenceScore(value: CavePreferences): [number, number] {
-  return [value.revision, parseDate(value.updatedAt)];
-}
-
-function newerPreference(left: CavePreferences, right: CavePreferences): "left" | "right" | "tie" {
-  const [leftRevision, leftTime] = preferenceScore(left);
-  const [rightRevision, rightTime] = preferenceScore(right);
-  if (leftRevision !== rightRevision) return leftRevision > rightRevision ? "left" : "right";
-  if (leftTime !== rightTime) return leftTime > rightTime ? "left" : "right";
-  return "tie";
-}
-
 function getNested(value: Record<string, unknown>, keys: readonly string[]): unknown {
   let cursor: unknown = value;
   for (const key of keys) cursor = record(cursor)?.[key];
   return cursor;
-}
-
-function setNested(value: Record<string, unknown>, keys: readonly string[], child: unknown): void {
-  let cursor = value;
-  for (const key of keys.slice(0, -1)) {
-    cursor[key] = { ...(record(cursor[key]) ?? {}) };
-    cursor = cursor[key] as Record<string, unknown>;
-  }
-  cursor[keys[keys.length - 1]] = child;
 }
 
 function validPreferences(value: unknown): CavePreferences | null {
@@ -579,14 +558,17 @@ function mergePreferences(legacy: unknown, canonical: unknown): MergeOutcome {
   const left = validPreferences(legacy);
   const right = validPreferences(canonical);
   if (!left || !right) return { ok: false, summary: "Preferences data is malformed and requires review." };
-  const globalChoice = newerPreference(left, right);
   const output = structuredClone(right) as unknown as Record<string, unknown>;
   for (const keys of PREFERENCE_SECTIONS) {
     const leftValue = getNested(left as unknown as Record<string, unknown>, keys);
     const rightValue = getNested(right as unknown as Record<string, unknown>, keys);
     if (JSON.stringify(leftValue) === JSON.stringify(rightValue)) continue;
-    if (globalChoice === "tie") return { ok: false, summary: `Preferences section ${keys.join(".")} differs at the same revision and timestamp.` };
-    setNested(output, keys, globalChoice === "left" ? leftValue : rightValue);
+    // Preferences have one file-wide revision, not a revision per section. If
+    // two writers changed different sections, choosing every value from the
+    // snapshot with the larger global revision would silently discard the
+    // other writer's independent change. Only theme has its own revision, so
+    // any other divergent section needs an explicit whole-file decision.
+    return { ok: false, summary: `Preferences section ${keys.join(".")} differs without an independent revision and requires review.` };
   }
   const leftTheme = left.appearance.theme;
   const rightTheme = right.appearance.theme;

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -194,7 +194,15 @@ async function sha256Dir(target: string): Promise<string> {
 async function pathInfo(target: string): Promise<PathInfo> {
   try {
     const info = await lstat(target);
-    if (info.isSymbolicLink()) return { kind: "symlink", mtimeMs: info.mtimeMs, size: info.size };
+    if (info.isSymbolicLink()) {
+      const linkTarget = await readlink(target);
+      return {
+        kind: "symlink",
+        hash: createHash("sha256").update(`symlink\0${linkTarget}`).digest("hex"),
+        mtimeMs: info.mtimeMs,
+        size: info.size,
+      };
+    }
     if (info.isDirectory()) return { kind: "dir", hash: await sha256Dir(target), mtimeMs: info.mtimeMs, size: info.size };
     return { kind: "file", hash: await sha256File(target), mtimeMs: info.mtimeMs, size: info.size };
   } catch (error) {
@@ -289,12 +297,15 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
       return async () => {
         const owner = await readLockOwner(lock);
         if (owner.token !== token) return;
+        // Mark the end of the test-observed critical section before publishing
+        // the unlock. Once the rename below completes, a successor can acquire
+        // immediately and must not overlap the prior owner's probe state.
+        await options.lockProbe?.("released");
         const released = `${lock}.released-${token}`;
         await rename(lock, released).catch((error) => {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         });
         await rm(released, { recursive: true, force: true });
-        await options.lockProbe?.("released");
       };
     } catch (error) {
       await rm(candidate, { recursive: true, force: true }).catch(() => {});
@@ -405,7 +416,7 @@ async function retireExpectedPath(
   probe?: () => void | Promise<void>,
   label = "legacy",
 ): Promise<string> {
-  if (!expected.hash || expected.kind === "missing" || expected.kind === "symlink") {
+  if (!expected.hash || expected.kind === "missing") {
     throw new Error(`${label} path is unavailable for replacement`);
   }
   await probe?.();

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -355,6 +355,17 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
   }
 }
 
+/** Serialize a Cave store operation with reconciliation in every process. */
+export async function withCaveHomeReconciliationLock<T>(operation: () => Promise<T>): Promise<T> {
+  await mkdir(caveHome(), { recursive: true });
+  const release = await acquireLock({});
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
 async function pruneBackups(journal: MigrationJournal): Promise<void> {
   await mkdir(migrationBackupRoot(), { recursive: true });
   const protectedIds = new Set(

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -351,7 +351,10 @@ async function createRecoveryBundle(
   return { id, directory };
 }
 
-async function restoreBundleRole(directory: string, role: "legacy" | "canonical", destination: string): Promise<void> {
+async function verifiedBundleRole(
+  directory: string,
+  role: "legacy" | "canonical",
+): Promise<{ source: string; hash: string; info: PathInfo }> {
   const manifest = JSON.parse(await readFile(path.join(directory, "manifest.json"), "utf8")) as {
     files?: Array<{ role?: string; storedPath?: string; hash?: string }>;
   };
@@ -361,10 +364,15 @@ async function restoreBundleRole(directory: string, role: "legacy" | "canonical"
   if (path.dirname(source) !== path.resolve(directory)) throw new Error(`${role} backup path is invalid`);
   const sourceInfo = await pathInfo(source);
   if (sourceInfo.hash !== file.hash) throw new Error(`${role} backup hash changed before recovery`);
+  return { source, hash: file.hash, info: sourceInfo };
+}
+
+async function restoreBundleRole(directory: string, role: "legacy" | "canonical", destination: string): Promise<void> {
+  const { source, hash, info: sourceInfo } = await verifiedBundleRole(directory, role);
   const destinationInfo = await pathInfo(destination);
   await rm(destination, { recursive: destinationInfo.kind === "dir", force: true });
   await copyPath(source, destination, sourceInfo.kind);
-  if ((await pathInfo(destination)).hash !== file.hash) throw new Error(`${role} recovery verification failed`);
+  if ((await pathInfo(destination)).hash !== hash) throw new Error(`${role} recovery verification failed`);
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -774,10 +782,21 @@ async function reconcileEntry(
     legacyMtimeMs: legacyInfo.mtimeMs,
     canonicalMtimeMs: canonicalInfo.mtimeMs,
     decision: "absent",
+    backupId: prior?.backupId,
     decidedAt: nowIso(),
   };
 
   if (options.action === "defer") {
+    if (
+      !samePath(legacyPath, canonicalPath) &&
+      legacyInfo.kind !== "missing" && legacyInfo.kind !== "symlink" &&
+      canonicalInfo.kind !== "missing" && canonicalInfo.kind !== "symlink" &&
+      legacyInfo.hash !== canonicalInfo.hash
+    ) {
+      const backup = await createRecoveryBundle(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, journal, options);
+      result.backedUp.push(backup.directory);
+      journalEntry.backupId = backup.id;
+    }
     journalEntry.decision = "deferred";
     journalEntry.summary = "User deferred this migration; existing copies remain in place.";
     journal.entries[entry.legacy] = journalEntry;
@@ -845,6 +864,8 @@ async function reconcileEntry(
     if (options.action === "recover-legacy") {
       // Restore from the verified bundle, not the live legacy path, so an old
       // writer cannot change the selected bytes between backup and recovery.
+      const legacyBackup = await verifiedBundleRole(backup.directory, "legacy");
+      await validateCanonical(entry, legacyBackup.source, legacyBackup.info);
       await restoreBundleRole(backup.directory, "legacy", canonicalPath);
       journalEntry.decision = "recovered-legacy";
       journalEntry.summary = "Recovered the legacy copy into canonical storage after verified backup.";

--- a/src/lib/server/preferences-store.ts
+++ b/src/lib/server/preferences-store.ts
@@ -15,6 +15,7 @@ import {
   type CustomThemeData,
 } from "@/lib/preferences-schema";
 import { writeJsonAtomic } from "@/lib/server/atomic-write";
+import { ensureCaveHomeReconciled } from "./cave-home-migration.ts";
 
 export function preferencesPath(): string {
   const override = process.env.COVEN_PREFERENCES_PATH?.trim();
@@ -235,7 +236,10 @@ async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
 
 /** Load the canonical snapshot, seeding it once from cave-theme.json when possible. */
 export function loadPreferences(): Promise<CavePreferences> {
-  return withPreferencesLock(async () => (await loadPreferencesUnlocked({ seedLegacy: true })).preferences);
+  return withPreferencesLock(async () => {
+    await ensureCaveHomeReconciled();
+    return (await loadPreferencesUnlocked({ seedLegacy: true })).preferences;
+  });
 }
 
 export class PreferencesConflictError extends Error {
@@ -256,6 +260,7 @@ export function updatePreferences(
   mutator: (current: CavePreferences) => CavePreferencesPatch | null | Promise<CavePreferencesPatch | null>,
 ): Promise<CavePreferences> {
   return withPreferencesLock(async () => {
+    await ensureCaveHomeReconciled();
     const release = await acquirePreferencesFileLock();
     try {
       const disk = await loadPreferencesUnlocked({ seedLegacy: true });

--- a/src/lib/server/preferences-store.ts
+++ b/src/lib/server/preferences-store.ts
@@ -15,7 +15,7 @@ import {
   type CustomThemeData,
 } from "@/lib/preferences-schema";
 import { writeJsonAtomic } from "@/lib/server/atomic-write";
-import { ensureCaveHomeReconciled } from "./cave-home-migration.ts";
+import { withCaveHomeReconciledStore } from "./cave-home-migration.ts";
 
 export function preferencesPath(): string {
   const override = process.env.COVEN_PREFERENCES_PATH?.trim();
@@ -236,10 +236,10 @@ async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
 
 /** Load the canonical snapshot, seeding it once from cave-theme.json when possible. */
 export function loadPreferences(): Promise<CavePreferences> {
-  return withPreferencesLock(async () => {
-    await ensureCaveHomeReconciled("cave-preferences.json");
-    return (await loadPreferencesUnlocked({ seedLegacy: true })).preferences;
-  });
+  return withPreferencesLock(() => withCaveHomeReconciledStore(
+    "cave-preferences.json",
+    async () => (await loadPreferencesUnlocked({ seedLegacy: true })).preferences,
+  ));
 }
 
 export class PreferencesConflictError extends Error {
@@ -259,8 +259,7 @@ export class PreferencesConflictError extends Error {
 export function updatePreferences(
   mutator: (current: CavePreferences) => CavePreferencesPatch | null | Promise<CavePreferencesPatch | null>,
 ): Promise<CavePreferences> {
-  return withPreferencesLock(async () => {
-    await ensureCaveHomeReconciled("cave-preferences.json");
+  return withPreferencesLock(() => withCaveHomeReconciledStore("cave-preferences.json", async () => {
     const release = await acquirePreferencesFileLock();
     try {
       const disk = await loadPreferencesUnlocked({ seedLegacy: true });
@@ -277,7 +276,7 @@ export function updatePreferences(
     } finally {
       await release();
     }
-  });
+  }));
 }
 
 export function patchPreferences(patch: CavePreferencesPatch): Promise<CavePreferences> {

--- a/src/lib/server/preferences-store.ts
+++ b/src/lib/server/preferences-store.ts
@@ -237,7 +237,7 @@ async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
 /** Load the canonical snapshot, seeding it once from cave-theme.json when possible. */
 export function loadPreferences(): Promise<CavePreferences> {
   return withPreferencesLock(async () => {
-    await ensureCaveHomeReconciled();
+    await ensureCaveHomeReconciled("cave-preferences.json");
     return (await loadPreferencesUnlocked({ seedLegacy: true })).preferences;
   });
 }
@@ -260,7 +260,7 @@ export function updatePreferences(
   mutator: (current: CavePreferences) => CavePreferencesPatch | null | Promise<CavePreferencesPatch | null>,
 ): Promise<CavePreferences> {
   return withPreferencesLock(async () => {
-    await ensureCaveHomeReconciled();
+    await ensureCaveHomeReconciled("cave-preferences.json");
     const release = await acquirePreferencesFileLock();
     try {
       const disk = await loadPreferencesUnlocked({ seedLegacy: true });


### PR DESCRIPTION
## What changed

- replace destination-wins startup migration with a cross-process locked, atomic reconciliation journal
- create verified, hash-manifested recovery bundles before changing divergent data and retain unresolved recovery sources
- merge inbox, session state, preferences, and directory data with explicit per-schema strategies; leave ambiguous data unresolved
- support non-elevated Windows with hash-tracked ordinary compatibility mirrors when file symlinks are unavailable
- gate the primary config/state, inbox, and preferences readers and writers on reconciliation
- add a file-by-file review dialog with timestamps, bounded diff summaries, merge/keep/recover/defer actions, and backup-folder access
- preserve `COVEN_HOME`, `COVEN_CAVE_HOME`, `COVEN_PREFERENCES_PATH`, `COVEN_THEME_PATH`, and `COVEN_BACKDROP_PATH` behavior

## Root cause

The old migration moved only when the canonical destination was absent. If both copies existed it always kept the canonical copy, even when the legacy copy contained unique user data. It also silently ignored file-symlink failures. On non-elevated Windows with Developer Mode disabled, those symlinks require administrator privilege, leaving ordinary legacy files that later appeared as permanent conflicts.

## User impact

Upgrades are now lossless and resumable. Cave validates and journals decisions, preserves both divergent inputs in a verified recovery bundle, detects writes made through old-tool compatibility mirrors, and asks the user to resolve only cases that cannot be merged safely.

## Validation

- `pnpm typecheck`
- `pnpm check:tests-wired` (1010 test files wired)
- `pnpm test:app` (746 files)
- `pnpm test:api` (189 files)
- `pnpm test:mobile` (80 files)
- `pnpm test:conformance` (Linux checks passed; Windows-only migration case wired for `windows-latest`)
- `pnpm test:supply-chain`
- `pnpm build` (passed, including bundle budgets)
- `git diff --check`

The repository has no lint script or ESLint/Biome dependency, so there is no separate local lint command.

Fixes #3269

Bead: `cave-l30`
