### PR TITLE
Fix duplicate session polling in Recent Activity

### DIFF
--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -39,14 +39,19 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /<RecentActivityRollup sessions=\{sessions\} activeSessionId=\{activeSessionId\} onOpenSession=\{onOpenSession\} \/>/,
+  /<RecentActivityRollup[\s\S]{0,180}sessions=\{sessions\}[\s\S]{0,120}selectedFamiliarIds=\{selectedFamiliarIds\}/,
   "the mounted sidebar passes Workspace-owned sessions into Recent Activity",
 );
 assert.match(source, /sessions: SessionRow\[\]/, "Recent Activity requires the shared sessions prop");
 assert.match(
   source,
-  /sessions\.filter\(\(session\) => !session\.archived_at\)\.slice\(0, MAX_ROWS\)/,
-  "Recent Activity derives its visible recent slice from the shared stream",
+  /familiarInScope\(selectedFamiliarIds, session\.familiarId\)/,
+  "Recent Activity filters the shared stream against single- and multi-familiar scope",
+);
+assert.match(
+  source,
+  /\[sessions, selectedFamiliarIds\]/,
+  "Recent Activity re-derives rows whenever the persistent familiar selection changes",
 );
 assert.doesNotMatch(source, /fetch\s*\(/, "Recent Activity performs no mount-time session request");
 assert.doesNotMatch(source, /usePausablePoll|setInterval|POLL_MS/, "Recent Activity owns no refresh interval");

--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./recent-activity-rollup.tsx", import.meta.url), "utf8");
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 
 // The collapse state persists across reloads and remounts via localStorage,
 // but defaults to open for SSR / first paint so the markup hydrates cleanly.
@@ -27,22 +29,40 @@ assert.match(
   "the header toggle writes through the persisting handler",
 );
 
-// This rollup polls the same heavy /api/sessions/list as the shell, so it must
-// pause while the user is typing — otherwise it re-introduces the mobile typing
-// lag the shell polls were gated to avoid.
+// The always-mounted Workspace/sidebar tree has one session-list owner. The
+// Workspace refreshes it every four seconds and passes that state through the
+// sidebar; RecentActivityRollup must never add a mount or interval request.
+assert.match(
+  workspace,
+  /usePausablePoll\(\(\) => void loadSessions\(\), 4000, \{\s*pauseWhileInputActive: true,?\s*\}\)/,
+  "Workspace owns the four-second session refresh interval",
+);
+assert.match(
+  sidebar,
+  /<RecentActivityRollup sessions=\{sessions\} activeSessionId=\{activeSessionId\} onOpenSession=\{onOpenSession\} \/>/,
+  "the mounted sidebar passes Workspace-owned sessions into Recent Activity",
+);
+assert.match(source, /sessions: SessionRow\[\]/, "Recent Activity requires the shared sessions prop");
 assert.match(
   source,
-  /usePausablePoll\(\(\) => void load\(\), POLL_MS, \{ pauseWhileInputActive: true \}\)/,
-  "the sessions poll pauses during active input composition",
+  /sessions\.filter\(\(session\) => !session\.archived_at\)\.slice\(0, MAX_ROWS\)/,
+  "Recent Activity derives its visible recent slice from the shared stream",
+);
+assert.doesNotMatch(source, /fetch\s*\(/, "Recent Activity performs no mount-time session request");
+assert.doesNotMatch(source, /usePausablePoll|setInterval|POLL_MS/, "Recent Activity owns no refresh interval");
+assert.equal(
+  [...workspace.matchAll(/fetch\(`\/api\/sessions\/list\$\{scope\}`/g)].length,
+  1,
+  "the mounted Workspace/sidebar path has one session-list request per refresh",
 );
 
-// The poll is guarded like every other polled surface: a monotonic reqId drops
-// a superseded overlapping load, and arrayContentEqual keeps the previous
-// reference when an idle tick rebuilds an identical list (no needless re-render
-// of this always-mounted sidebar rollup).
-assert.match(source, /const loadReqRef = useRef\(0\)/, "the rollup poll tracks a request id");
-assert.match(source, /const reqId = \+\+loadReqRef\.current;/, "each load bumps the request id");
-assert.match(source, /if \(reqId !== loadReqRef\.current\) return;/, "a superseded load drops its writes");
-assert.match(source, /setSessions\(\(prev\) => \(arrayContentEqual\(prev, next\) \? prev : next\)\)/, "an unchanged poll keeps the previous sessions reference");
+// Foreground five-minute schedule: Workspace makes one mount request plus 75
+// four-second ticks. The removed rollup made one mount request plus 20
+// fifteen-second ticks (97 before, 76 after).
+const fiveMinutesMs = 5 * 60_000;
+const workspaceRequests = 1 + fiveMinutesMs / 4_000;
+const removedRollupRequests = 1 + fiveMinutesMs / 15_000;
+assert.equal(workspaceRequests, 76, "one Workspace owner makes 76 requests in five foreground minutes");
+assert.equal(workspaceRequests + removedRollupRequests, 97, "the previous duplicate schedule made 97 requests");
 
 console.log("recent-activity-rollup.test.ts: ok");

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
-import { usePausablePoll } from "@/lib/use-pausable-poll";
-import { arrayContentEqual } from "@/lib/array-content-equal";
 import { relativeTime } from "@/lib/relative-time";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
@@ -15,12 +13,11 @@ import type { SessionRow } from "@/lib/types";
  * each row shows the task title, the model it ran on, its project, a `+N −N`
  * diff stat, and a relative time; the active session gets a left accent bar.
  *
- * Data comes from `/api/sessions/list` (polled), which is also what feeds the
- * ephemeral top-right inbox toast — so an item flashes as a toast, then settles
- * here in the roll-up. Self-contained: it owns its own fetch + collapse state.
+ * Data comes from Workspace's shared, familiar-scoped session stream. Workspace
+ * is the shell's sole `/api/sessions/list` polling owner; this roll-up only
+ * derives the recent visible slice and owns its collapse state.
  */
 
-const POLL_MS = 15_000;
 const MAX_ROWS = 8;
 // Remember whether the roll-up is collapsed across reloads and remounts.
 const OPEN_STORAGE_KEY = "cave:recent-activity:open";
@@ -36,17 +33,16 @@ function projectLabel(root: string | undefined): string {
 }
 
 type Props = {
+  sessions: SessionRow[];
   activeSessionId?: string | null;
   onOpenSession?: (id: string) => void;
 };
 
-export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) {
+export function RecentActivityRollup({ sessions, activeSessionId, onOpenSession }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
-  const [sessions, setSessions] = useState<SessionRow[]>([]);
   // Default open for SSR + first paint, then hydrate the saved preference after
   // mount so the server and client markup match.
   const [open, setOpen] = useState(true);
-  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     try {
@@ -69,38 +65,15 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
     });
   };
 
-  // This rollup is mounted in the sidebar for the whole app lifetime and polls
-  // the heavy /api/sessions/list every 15s. Guard the poll the way every other
-  // polled surface does: a monotonic reqId drops a superseded overlapping load
-  // (mount vs poll vs visibility-return), and arrayContentEqual keeps the
-  // previous reference when an idle tick rebuilds an identical list so the row
-  // list doesn't re-render for nothing.
-  const loadReqRef = useRef(0);
-  const load = useCallback(async () => {
-    const reqId = ++loadReqRef.current;
-    try {
-      const res = await fetch("/api/sessions/list", { cache: "no-store" });
-      const json = await res.json();
-      if (reqId !== loadReqRef.current) return; // superseded by a newer load
-      const rows: SessionRow[] = Array.isArray(json?.sessions) ? json.sessions : [];
-      const next = rows.filter((s) => !s.archived_at).slice(0, MAX_ROWS);
-      setSessions((prev) => (arrayContentEqual(prev, next) ? prev : next));
-      setLoaded(true);
-    } catch {
-      if (reqId === loadReqRef.current) setLoaded(true);
-    }
-  }, []);
-  useEffect(() => {
-    void load();
-  }, [load]);
-  // Pauses in a hidden tab; refreshes on return. Also pauses while the user is
-  // typing — this polls the same heavy /api/sessions/list the shell does, so it
-  // must not compete with mobile composition.
-  usePausablePoll(() => void load(), POLL_MS, { pauseWhileInputActive: true });
+  // Recent Activity intentionally follows the active Workspace familiar scope.
+  // That keeps every sessions surface permission-consistent and avoids restoring
+  // the roll-up's former unscoped request through a second store or fetch path.
+  const rows = useMemo(
+    () => sessions.filter((session) => !session.archived_at).slice(0, MAX_ROWS),
+    [sessions],
+  );
 
-  const rows = useMemo(() => sessions, [sessions]);
-
-  if (loaded && rows.length === 0) return null;
+  if (rows.length === 0) return null;
 
   return (
     <section className="recent-activity">

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { familiarInScope } from "@/lib/familiar-multiselect";
 import { relativeTime } from "@/lib/relative-time";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
@@ -34,11 +35,12 @@ function projectLabel(root: string | undefined): string {
 
 type Props = {
   sessions: SessionRow[];
+  selectedFamiliarIds?: ReadonlySet<string>;
   activeSessionId?: string | null;
   onOpenSession?: (id: string) => void;
 };
 
-export function RecentActivityRollup({ sessions, activeSessionId, onOpenSession }: Props) {
+export function RecentActivityRollup({ sessions, selectedFamiliarIds, activeSessionId, onOpenSession }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   // Default open for SSR + first paint, then hydrate the saved preference after
   // mount so the server and client markup match.
@@ -69,8 +71,15 @@ export function RecentActivityRollup({ sessions, activeSessionId, onOpenSession 
   // That keeps every sessions surface permission-consistent and avoids restoring
   // the roll-up's former unscoped request through a second store or fetch path.
   const rows = useMemo(
-    () => sessions.filter((session) => !session.archived_at).slice(0, MAX_ROWS),
-    [sessions],
+    () =>
+      sessions
+        .filter(
+          (session) =>
+            !session.archived_at &&
+            (!selectedFamiliarIds || familiarInScope(selectedFamiliarIds, session.familiarId)),
+        )
+        .slice(0, MAX_ROWS),
+    [sessions, selectedFamiliarIds],
   );
 
   if (rows.length === 0) return null;

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -301,7 +301,7 @@ assert.match(
 // the active-row accent) or clicking a recent session silently does nothing.
 assert.match(
   source,
-  /<RecentActivityRollup\b[^/]*\bonOpenSession=\{onOpenSession\}/,
+  /<RecentActivityRollup\b[^/]*\bsessions=\{sessions\}[^/]*\bonOpenSession=\{onOpenSession\}/,
   "Recent Activity must receive onOpenSession so selecting an item navigates to it",
 );
 assert.match(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -301,13 +301,18 @@ assert.match(
 // the active-row accent) or clicking a recent session silently does nothing.
 assert.match(
   source,
-  /<RecentActivityRollup\b[^/]*\bsessions=\{sessions\}[^/]*\bonOpenSession=\{onOpenSession\}/,
+  /<RecentActivityRollup\b[\s\S]{0,220}\bsessions=\{sessions\}[\s\S]{0,180}\bonOpenSession=\{onOpenSession\}/,
   "Recent Activity must receive onOpenSession so selecting an item navigates to it",
 );
 assert.match(
   source,
-  /<RecentActivityRollup\b[^/]*\bactiveSessionId=\{activeSessionId\}/,
+  /<RecentActivityRollup\b[\s\S]{0,220}\bactiveSessionId=\{activeSessionId\}/,
   "Recent Activity must receive activeSessionId to highlight the open session",
+);
+assert.match(
+  source,
+  /<RecentActivityRollup\b[\s\S]{0,220}\bselectedFamiliarIds=\{selectedFamiliarIds\}/,
+  "Recent Activity must receive the persistent familiar selection so multi-scope stays honest",
 );
 
 // "New chat" is the left panel's top CTA: it sits directly under the wordmark

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -329,7 +329,12 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           </>
         )}
 
-        <RecentActivityRollup sessions={sessions} activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
+        <RecentActivityRollup
+          sessions={sessions}
+          selectedFamiliarIds={selectedFamiliarIds}
+          activeSessionId={activeSessionId}
+          onOpenSession={onOpenSession}
+        />
       </div>
 
       {/* Bottom: Dashboard + Settings, then the version line — shared with the

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -329,7 +329,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           </>
         )}
 
-        <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
+        <RecentActivityRollup sessions={sessions} activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>
 
       {/* Bottom: Dashboard + Settings, then the version line — shared with the


### PR DESCRIPTION
## Summary

- remove Recent Activity's independent `/api/sessions/list` fetch and 15-second poll
- derive its eight visible rows from Workspace-owned session state passed through `SidebarMinimal`
- make Recent Activity intentionally follow the active Workspace familiar scope
- add regression coverage enforcing one Workspace polling owner

## Root cause

The always-mounted Workspace and sidebar each owned a session-list request cycle. The sidebar therefore repeated expensive server, JSON, Git, network, and render work for data Workspace already held.

## Impact

Over five foreground minutes, the scheduled session-list request count drops from 97 to 76: 21 fewer requests, or 21.6%. The rollup also drops its duplicate request sequencing and component session state.

## Validation

- `pnpm typecheck`
- `pnpm check:tests-wired` (1,011 test files wired)
- `pnpm test:app` (747 test files)
- `git diff --check`

Fixes #3265