### PR TITLE
Cache and decouple GitHub task polling

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -869,6 +869,7 @@ export const SUITES = {
     "src/lib/session-list-merge.test.ts",
     "src/lib/session-git-enrich.test.ts",
     "src/lib/server/chat-work-branch.test.ts",
+    "src/lib/github-tasks-cache.test.ts",
     "src/lib/swr-cache.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -98,7 +98,7 @@ const contracts: RouteContract[] = [
   { route: "/github/review", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/github/runs", methods: ["GET"], kind: "json" },
   { route: "/github/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
-  { route: "/github/tasks", methods: ["GET"], kind: "json" },
+  { route: "/github/tasks", methods: ["GET", "POST"], kind: "json" },
   { route: "/github/worktree", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/grant-proposals/[id]", methods: ["PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/grant-proposals", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
@@ -576,6 +576,16 @@ for (const contract of contracts) {
     githubTasksSource,
     /if \(!endpoint\) \{[\s\S]*?return NextResponse\.json\(\{[\s\S]*?ok: false,[\s\S]*?tasks: \[\],[\s\S]*?\}\);/,
     "/github/tasks: missing optional task endpoint should be a quiet ok:false payload, not a browser-console 503",
+  );
+  assert.match(
+    githubTasksSource,
+    /export async function POST\(\)[\s\S]*respondWithTasks\(true\)/,
+    "/github/tasks: explicit refreshes bypass the fresh TTL entry",
+  );
+  assert.match(
+    githubTasksSource,
+    /forceGitHubTasksRefresh\(endpoint\)[\s\S]*getGitHubTasks\(endpoint\)/,
+    "/github/tasks: both forced and automatic reads use the shared process cache",
   );
 }
 

--- a/src/app/api/github/tasks/route.ts
+++ b/src/app/api/github/tasks/route.ts
@@ -1,9 +1,20 @@
 import { NextResponse } from "next/server";
+import { forceGitHubTasksRefresh, getGitHubTasks } from "@/lib/github-tasks-cache";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET() {
+  return respondWithTasks(false);
+}
+
+/** Explicit/user-initiated refreshes bypass a fresh TTL entry, while still
+ * joining any upstream request already in flight. */
+export async function POST() {
+  return respondWithTasks(true);
+}
+
+async function respondWithTasks(force: boolean) {
   const endpoint = githubTasksEndpoint();
   if (!endpoint) {
     return NextResponse.json({
@@ -14,20 +25,15 @@ export async function GET() {
   }
 
   try {
-    const res = await fetch(endpoint, { cache: "no-store" });
-    const data = await res.json().catch(() => null);
-    if (!res.ok || data == null) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `coven-github returned ${res.status}`,
-          tasks: [],
-        },
-        { status: 502 },
-      );
-    }
-
-    return NextResponse.json(data);
+    const result = force
+      ? await forceGitHubTasksRefresh(endpoint)
+      : await getGitHubTasks(endpoint);
+    return NextResponse.json(result.data, {
+      headers: {
+        "x-coven-cache": result.source,
+        "x-coven-cache-freshness": result.freshness,
+      },
+    });
   } catch (e) {
     return NextResponse.json(
       {

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -110,8 +110,13 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const githubTasksPromise = fetch\("\/api\/github\/tasks"/,
-  "Workspace polls GitHub task context because GitHub is visible by default",
+  /usePausablePoll\(\(\) => void loadGitHubTasks\(\), GITHUB_TASKS_POLL_MS/,
+  "Workspace refreshes GitHub task context on its dedicated slow cadence",
+);
+assert.doesNotMatch(
+  workspace,
+  /const loadSessions = useCallback[\s\S]*?fetch\("\/api\/github\/tasks"/,
+  "The four-second session poll must not fetch GitHub tasks",
 );
 
 console.log("chat-all-familiars-project-list.test.ts: ok");

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -118,5 +118,10 @@ assert.doesNotMatch(
   /const loadSessions = useCallback[\s\S]*?fetch\("\/api\/github\/tasks"/,
   "The four-second session poll must not fetch GitHub tasks",
 );
+assert.match(
+  workspace,
+  /startedDuringForcedRefresh[\s\S]*?forceEpoch !== loadGitHubTasksForceEpochRef\.current/,
+  "A scheduled read cannot supersede an explicit GitHub task refresh",
+);
 
 console.log("chat-all-familiars-project-list.test.ts: ok");

--- a/src/components/github-action-popover-chat-launch.test.ts
+++ b/src/components/github-action-popover-chat-launch.test.ts
@@ -6,6 +6,12 @@ const src = readFileSync(new URL("./github-action-popover.tsx", import.meta.url)
 
 assert.match(
   src,
+  /if \(result\.ok\) \{[\s\S]{0,180}onComplete\?\.\(\);[\s\S]{0,80}setTimeout\(onClose/,
+  "successful board changes notify the caller before the popover closes",
+);
+
+assert.match(
+  src,
   /detail: \{ familiarId: selected, initialPrompt \}/,
   "GitHub chat popover should launch chats through initialPrompt (the event contract ChatSurface consumes)",
 );

--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -28,6 +28,7 @@ type Props = {
   familiarsFailed?: boolean;
   cardsFailed?: boolean;
   onClose: () => void;
+  onComplete?: () => void;
 };
 
 // ── Feedback banner ────────────────────────────────────────────────────────────
@@ -63,11 +64,13 @@ function BoardMode({
   cards,
   cardsFailed = false,
   onClose,
+  onComplete,
 }: {
   item: GitHubItem;
   cards: Card[];
   cardsFailed?: boolean;
   onClose: () => void;
+  onComplete?: () => void;
 }) {
   const [query, setQuery] = useState("");
   const [busy, setBusy] = useState(false);
@@ -97,6 +100,7 @@ function BoardMode({
     setBusy(false);
     if (result.ok) {
       setFeedback({ status: "success", message: "Link added to card." });
+      onComplete?.();
       setTimeout(onClose, 1200);
     } else {
       setFeedback({ status: "error", message: result.error ?? "Failed." });
@@ -110,6 +114,7 @@ function BoardMode({
     setBusy(false);
     if (result.ok) {
       setFeedback({ status: "success", message: "Card created." });
+      onComplete?.();
       setTimeout(onClose, 1200);
     } else {
       setFeedback({ status: "error", message: result.error ?? "Failed." });
@@ -320,6 +325,7 @@ export function GitHubActionPopover({
   familiarsFailed = false,
   cardsFailed = false,
   onClose,
+  onComplete,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -403,7 +409,13 @@ export function GitHubActionPopover({
 
       {/* Mode content */}
       {mode === "board" && (
-        <BoardMode item={item} cards={cards} cardsFailed={cardsFailed} onClose={onClose} />
+        <BoardMode
+          item={item}
+          cards={cards}
+          cardsFailed={cardsFailed}
+          onClose={onClose}
+          onComplete={onComplete}
+        />
       )}
       {(mode === "chat" || mode === "assign") && (
         <FamiliarPicker

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -281,6 +281,7 @@ assert.match(source, /function schedulePoll\(ms: number\)[\s\S]{0,160}?document\
 assert.match(source, /addEventListener\("visibilitychange", onVis\)/, "polling resumes when the tab returns to the foreground");
 assert.match(source, /refreshActivity\(\);\s*\n\s*refreshLinkedWork\(\);/, "⌘R refreshes activity and linked work together");
 assert.match(source, /const refreshLinkedWork = useCallback\([\s\S]{0,180}reloadCards\(\);[\s\S]{0,80}onTasksRefresh\?\.\(\)/, "linked-work refresh updates both cards and shell task context");
+assert.match(source, /onClose=\{close\}\s*\n\s*onComplete=\{onAfterLink\}/, "closing the task popover without a change does not force-refresh linked work");
 
 // Memoised so a re-render doesn't re-filter the (potentially large) item set.
 assert.match(source, /const filtered = useMemo\(/, "the kind-filtered set is memoised");

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -279,7 +279,8 @@ assert.match(source, /\}, \[sorted\.length\]\);/, "row-nav listeners rebind when
 // the manual/⌘R refresh keeps the linked-task chips in sync.
 assert.match(source, /function schedulePoll\(ms: number\)[\s\S]{0,160}?document\.hidden\) return/, "polling is skipped while the tab is hidden");
 assert.match(source, /addEventListener\("visibilitychange", onVis\)/, "polling resumes when the tab returns to the foreground");
-assert.match(source, /refreshActivity\(\);\s*\n\s*reloadCards\(\);/, "⌘R refreshes activity (via refreshActivity) AND reloads the linked-task cards");
+assert.match(source, /refreshActivity\(\);\s*\n\s*refreshLinkedWork\(\);/, "⌘R refreshes activity and linked work together");
+assert.match(source, /const refreshLinkedWork = useCallback\([\s\S]{0,180}reloadCards\(\);[\s\S]{0,80}onTasksRefresh\?\.\(\)/, "linked-work refresh updates both cards and shell task context");
 
 // Memoised so a re-render doesn't re-filter the (potentially large) item set.
 assert.match(source, /const filtered = useMemo\(/, "the kind-filtered set is memoised");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -737,7 +737,6 @@ function AddToBoardAction({
   }
   function close() {
     setMode(null);
-    onAfterLink();
   }
 
   return (
@@ -761,6 +760,7 @@ function AddToBoardAction({
             cards={cards}
             cardsFailed={cardsFailed}
             onClose={close}
+            onComplete={onAfterLink}
           />
         </div>
       )}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -94,6 +94,8 @@ function orgOf(repo: string): string {
 type Props = {
   onJumpToSession?: (sessionId: string, familiarId?: string | null) => void;
   onFocusCard?: (cardId: string) => void;
+  /** Refresh the shell's cached GitHub assignment/session enrichment. */
+  onTasksRefresh?: () => void;
   /** Deep-link target from a GitHub-event inbox notification — opens that
    *  PR/issue's detail natively, even when it isn't in the activity list. */
   initialTarget?: GitHubItemTarget | null;
@@ -144,7 +146,8 @@ function useCards(): { cards: Card[]; cardsFailed: boolean; reload: () => void }
       });
     return () => { cancelled = true; };
   }, [tick]);
-  return { cards, cardsFailed, reload: () => setTick((t) => t + 1) };
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+  return { cards, cardsFailed, reload };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -2404,7 +2407,7 @@ const COLS: ColDef[] = [
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Props = {}) {
+export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initialTarget }: Props = {}) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [activity, setActivity] = useState<ActivityResult | null>(null);
   const [patStatus, setPatStatus] = useState<PatStatus | null>(null);
@@ -2440,6 +2443,10 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
 
   const { familiars, familiarsFailed } = useFamiliars();
   const { cards, cardsFailed, reload: reloadCards } = useCards();
+  const refreshLinkedWork = useCallback(() => {
+    reloadCards();
+    onTasksRefresh?.();
+  }, [reloadCards, onTasksRefresh]);
   const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
   const resolvedById = useMemo(
     () => new Map(resolvedFamiliars.map((f) => [f.id, f])),
@@ -2540,11 +2547,11 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
       if (tag === "INPUT" || tag === "TEXTAREA") return;
       e.preventDefault();
       refreshActivity();
-      reloadCards(); // keep the linked-task chips fresh too (parity with the toolbar refresh)
+      refreshLinkedWork(); // keep linked cards and shell task context fresh too
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [refreshLinkedWork]);
 
   const items = activity?.items ?? [];
   const filtered = useMemo(
@@ -2901,7 +2908,7 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
             size="sm"
             onClick={() => {
               refreshActivity();
-              reloadCards();
+              refreshLinkedWork();
             }}
             title="Refresh (⌘R)"
             aria-label="Refresh GitHub activity"
@@ -3015,7 +3022,7 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
                 counts={counts}
                 onJumpToSession={onJumpToSession}
                 onFocusCard={onFocusCard}
-                onAfterLink={reloadCards}
+                onAfterLink={refreshLinkedWork}
               />
             }
           >
@@ -3217,7 +3224,7 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
                             familiarsFailed={familiarsFailed}
                             cardsFailed={cardsFailed}
                             onJumpToSession={onJumpToSession}
-                            onAfterLink={reloadCards}
+                            onAfterLink={refreshLinkedWork}
                           />
                           <AddToBoardAction
                             item={item}
@@ -3225,7 +3232,7 @@ export function GitHubView({ onJumpToSession, onFocusCard, initialTarget }: Prop
                             cards={cards}
                             familiarsFailed={familiarsFailed}
                             cardsFailed={cardsFailed}
-                            onAfterLink={reloadCards}
+                            onAfterLink={refreshLinkedWork}
                           />
                           <SafeMergeAction
                             item={item}

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -63,8 +63,8 @@ assert.doesNotMatch(
 );
 assert.match(
   workspace,
-  /setSessions\([\s\S]{0,120}baseSessions[\s\S]{0,40}\);[\s\S]{0,260}setSessionsLoaded\(true\);[\s\S]{0,600}githubTasksPromise/,
-  "Workspace renders base chat sessions before applying optional GitHub task context",
+  /const visibleSessions = githubTasksRef\.current[\s\S]{0,180}attachGitHubTaskContext\(baseSessions[\s\S]{0,700}setSessionsLoaded\(true\)/,
+  "Workspace renders sessions immediately with any last-known-good GitHub task context",
 );
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -178,6 +178,12 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
 // ChatRouter writes the hash (syncUrlHash); Workspace owns restore + popstate.
 const CHAT_HASH_PREFIX = "#chat-";
 
+// GitHub task context is low-churn. At five minutes, uninterrupted idle
+// foreground use makes at most 12 Cave requests/hour instead of piggybacking on
+// the four-second session poll (~900/hour). usePausablePoll also pauses this in
+// hidden windows and while the user is composing input.
+const GITHUB_TASKS_POLL_MS = 5 * 60_000;
+
 function readChatHash(): string | null {
   if (typeof window === "undefined") return null;
   const hash = window.location.hash;
@@ -295,6 +301,9 @@ export function Workspace() {
   // change, so a stale in-flight load must not paint the previous familiar's
   // sessions.
   const loadSessionsReqRef = useRef(0);
+  const loadGitHubTasksReqRef = useRef(0);
+  const baseSessionsRef = useRef<SessionRow[]>([]);
+  const githubTasksRef = useRef<unknown>(null);
   const [daemonRunning, setDaemonRunning] = useState<boolean>(false);
   const { pushBanner, dismissBanner } = useShellBanners();
   const [responseNeeded, setResponseNeeded] = useState<Set<string>>(new Set());
@@ -863,6 +872,31 @@ export function Workspace() {
     selectFamiliarScope(id);
   }, [selectFamiliarScope]);
 
+  const loadGitHubTasks = useCallback(async (force = false) => {
+    const reqId = ++loadGitHubTasksReqRef.current;
+    try {
+      const res = await fetch("/api/github/tasks", {
+        method: force ? "POST" : "GET",
+        cache: "no-store",
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json || json.ok === false || reqId !== loadGitHubTasksReqRef.current) return;
+
+      githubTasksRef.current = json;
+      setGithubAssignedCount(Array.isArray(json.tasks) ? json.tasks.length : 0);
+      setSessions((currentSessions) => {
+        const baseSessions = baseSessionsRef.current.length > 0
+          ? baseSessionsRef.current
+          : currentSessions;
+        const enriched = attachGitHubTaskContext(baseSessions, json);
+        return sameSessionList(currentSessions, enriched) ? currentSessions : enriched;
+      });
+    } catch {
+      // Keep the last-known-good count and session context. The next scheduled
+      // or explicit refresh will retry without blanking GitHub metadata.
+    }
+  }, []);
+
   const loadSessions = useCallback(() => {
     // Sequence guard. loadSessions runs from mount, the 4s poll, the
     // familiars-refresh event, and — because `activeId` is a dep — re-fires
@@ -878,9 +912,6 @@ export function Workspace() {
 
     return (async () => {
       let baseSessionsApplied = false;
-      const githubTasksPromise = fetch("/api/github/tasks", { cache: "no-store" })
-        .then((res) => (res.ok ? res.json() : null))
-        .catch(() => null);
       try {
         // Scope the session list to the active familiar's granted projects so
         // every surface fed by `sessions` enforces the familiar→projects map.
@@ -899,24 +930,16 @@ export function Workspace() {
 
         setSessionsError(false);
         const baseSessions = (json.sessions ?? []) as SessionRow[];
+        baseSessionsRef.current = baseSessions;
+        const visibleSessions = githubTasksRef.current
+          ? attachGitHubTaskContext(baseSessions, githubTasksRef.current)
+          : baseSessions;
         // The 4s poll rebuilds a fresh array each tick; keep the previous
         // reference when nothing changed so an unchanged list doesn't re-render
         // every sessions consumer (chat list, rails, badges) for nothing.
-        setSessions((prev) => (sameSessionList(prev, baseSessions) ? prev : baseSessions));
+        setSessions((prev) => (sameSessionList(prev, visibleSessions) ? prev : visibleSessions));
         setSessionsLoaded(true);
         baseSessionsApplied = true;
-
-        const githubTasksJson = await githubTasksPromise;
-        if (githubTasksJson && isCurrent()) {
-          setGithubAssignedCount(Array.isArray(githubTasksJson.tasks) ? githubTasksJson.tasks.length : 0);
-          setSessions((currentSessions) => {
-            const enriched = attachGitHubTaskContext(
-              currentSessions.length > 0 ? currentSessions : baseSessions,
-              githubTasksJson,
-            );
-            return sameSessionList(currentSessions, enriched) ? currentSessions : enriched;
-          });
-        }
       } catch {
         if (isCurrent()) setSessionsError(true); // transient — poll retries
       } finally {
@@ -928,7 +951,8 @@ export function Workspace() {
   useEffect(() => {
     loadFamiliars();
     loadSessions();
-  }, [loadFamiliars, loadSessions]);
+    void loadGitHubTasks();
+  }, [loadFamiliars, loadSessions, loadGitHubTasks]);
   // Composers rebind a familiar's runtime through /api/config (the runtime
   // chip). Surfaces reading the roster's familiar.harness (e.g. the chat
   // empty-state identity line) shouldn't wait for the next natural reload —
@@ -939,6 +963,9 @@ export function Workspace() {
     return () => window.removeEventListener("cave:familiars-refresh", onFamiliarsRefresh);
   }, [loadFamiliars]);
   usePausablePoll(() => void loadSessions(), 4000, {
+    pauseWhileInputActive: true,
+  });
+  usePausablePoll(() => void loadGitHubTasks(), GITHUB_TASKS_POLL_MS, {
     pauseWhileInputActive: true,
   });
 
@@ -2561,6 +2588,7 @@ export function Workspace() {
         onJumpToSession={openFamiliarSession}
         onFocusCard={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
         initialTarget={githubTarget}
+        onTasksRefresh={() => void loadGitHubTasks(true)}
       />
     ) : mode === "marketplace" || mode === "roles" || mode === "capabilities" ? (
       // Roles and Marketplace merged into one hub. The "roles"/"capabilities"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -302,6 +302,8 @@ export function Workspace() {
   // sessions.
   const loadSessionsReqRef = useRef(0);
   const loadGitHubTasksReqRef = useRef(0);
+  const loadGitHubTasksForceEpochRef = useRef(0);
+  const loadGitHubTasksForceInFlightRef = useRef(0);
   const baseSessionsRef = useRef<SessionRow[]>([]);
   const githubTasksRef = useRef<unknown>(null);
   const [daemonRunning, setDaemonRunning] = useState<boolean>(false);
@@ -874,13 +876,23 @@ export function Workspace() {
 
   const loadGitHubTasks = useCallback(async (force = false) => {
     const reqId = ++loadGitHubTasksReqRef.current;
+    const forceEpoch = force
+      ? ++loadGitHubTasksForceEpochRef.current
+      : loadGitHubTasksForceEpochRef.current;
+    const startedDuringForcedRefresh = !force && loadGitHubTasksForceInFlightRef.current > 0;
+    if (force) loadGitHubTasksForceInFlightRef.current += 1;
     try {
       const res = await fetch("/api/github/tasks", {
         method: force ? "POST" : "GET",
         cache: "no-store",
       });
       const json = await res.json().catch(() => null);
-      if (!res.ok || !json || json.ok === false || reqId !== loadGitHubTasksReqRef.current) return;
+      const superseded = force
+        ? forceEpoch !== loadGitHubTasksForceEpochRef.current
+        : startedDuringForcedRefresh ||
+          forceEpoch !== loadGitHubTasksForceEpochRef.current ||
+          reqId !== loadGitHubTasksReqRef.current;
+      if (!res.ok || !json || json.ok === false || superseded) return;
 
       githubTasksRef.current = json;
       setGithubAssignedCount(Array.isArray(json.tasks) ? json.tasks.length : 0);
@@ -894,6 +906,8 @@ export function Workspace() {
     } catch {
       // Keep the last-known-good count and session context. The next scheduled
       // or explicit refresh will retry without blanking GitHub metadata.
+    } finally {
+      if (force) loadGitHubTasksForceInFlightRef.current -= 1;
     }
   }, []);
 

--- a/src/lib/github-tasks-cache.test.ts
+++ b/src/lib/github-tasks-cache.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { createGitHubTasksCache, GITHUB_TASKS_TTL_MS } from "./github-tasks-cache.ts";
+
+const endpoint = "https://coven-github.test/api/github/tasks";
+let now = 1_000;
+let calls = 0;
+let releaseFirst: (response: Response) => void = () => {};
+const firstResponse = new Promise<Response>((resolve) => { releaseFirst = resolve; });
+
+const responses: Array<Promise<Response> | Response> = [
+  firstResponse,
+  new Response(JSON.stringify({ ok: true, tasks: [{ id: "new" }] }), {
+    status: 200,
+    headers: { "content-type": "application/json", etag: '"tasks-v2"' },
+  }),
+  new Response(null, { status: 304 }),
+  new Response(JSON.stringify({ ok: false, error: "offline" }), {
+    status: 503,
+    headers: { "content-type": "application/json" },
+  }),
+];
+
+const requestHeaders: Headers[] = [];
+const cache = createGitHubTasksCache({
+  now: () => now,
+  fetcher: async (_input, init) => {
+    calls += 1;
+    requestHeaders.push(new Headers(init?.headers));
+    return await responses.shift()!;
+  },
+});
+
+const coldA = cache.read(endpoint);
+const coldB = cache.read(endpoint);
+assert.equal(calls, 1, "simultaneous cold clients share one upstream request");
+releaseFirst(new Response(JSON.stringify({ ok: true, tasks: [{ id: "old" }] }), {
+  status: 200,
+  headers: { "content-type": "application/json", etag: '"tasks-v1"' },
+}));
+assert.deepEqual(await coldA, await coldB);
+
+await cache.read(endpoint);
+assert.equal(calls, 1, "fresh reads stay inside the one-minute TTL");
+
+now += GITHUB_TASKS_TTL_MS + 1;
+const stale = await cache.read(endpoint);
+assert.equal(stale.freshness, "stale", "stale data is served immediately while revalidating");
+await new Promise((resolve) => setImmediate(resolve));
+assert.equal(calls, 2, "one background refresh runs after the TTL");
+assert.equal(requestHeaders[1]?.get("if-none-match"), '"tasks-v1"', "revalidation sends the upstream ETag");
+
+const revalidated = await cache.read(endpoint, { force: true });
+assert.equal(revalidated.source, "revalidated");
+assert.equal(requestHeaders[2]?.get("if-none-match"), '"tasks-v2"');
+
+const fallback = await cache.read(endpoint, { force: true });
+assert.equal(fallback.freshness, "stale", "a failed forced refresh keeps last-known-good data");
+assert.deepEqual(fallback.data, { ok: true, tasks: [{ id: "new" }] });
+
+console.log("github-tasks-cache.test.ts: ok");

--- a/src/lib/github-tasks-cache.ts
+++ b/src/lib/github-tasks-cache.ts
@@ -1,0 +1,101 @@
+export const GITHUB_TASKS_TTL_MS = 60_000;
+
+type CacheEntry = {
+  endpoint: string;
+  data: unknown;
+  etag: string | null;
+  fetchedAt: number;
+};
+
+export type GitHubTasksCacheResult = {
+  data: unknown;
+  freshness: "fresh" | "stale";
+  source: "hit" | "upstream" | "revalidated" | "stale";
+};
+
+type CacheOptions = {
+  ttlMs?: number;
+  now?: () => number;
+  fetcher?: typeof fetch;
+};
+
+/**
+ * Process-local cache for coven-github's task feed. A factory keeps the cache
+ * independently testable; the exported singleton below is shared by every
+ * request handled by this Cave server process.
+ */
+export function createGitHubTasksCache(options: CacheOptions = {}) {
+  const ttlMs = options.ttlMs ?? GITHUB_TASKS_TTL_MS;
+  const now = options.now ?? Date.now;
+  const fetcher: typeof fetch = options.fetcher ?? ((input, init) => fetch(input, init));
+  let cached: CacheEntry | null = null;
+  let inFlight: Promise<{ data: unknown; source: "upstream" | "revalidated" }> | null = null;
+
+  async function refresh(endpoint: string): Promise<{ data: unknown; source: "upstream" | "revalidated" }> {
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      const previous = cached?.endpoint === endpoint ? cached : null;
+      const headers: HeadersInit = previous?.etag ? { "If-None-Match": previous.etag } : {};
+      const res = await fetcher(endpoint, { cache: "no-store", headers });
+
+      if (res.status === 304 && previous) {
+        cached = { ...previous, fetchedAt: now() };
+        return { data: previous.data, source: "revalidated" as const };
+      }
+
+      const data = await res.json().catch(() => null);
+      if (!res.ok || data == null || (typeof data === "object" && "ok" in data && data.ok === false)) {
+        throw new Error(`coven-github returned ${res.status}`);
+      }
+
+      cached = {
+        endpoint,
+        data,
+        etag: res.headers.get("etag"),
+        fetchedAt: now(),
+      };
+      return { data, source: "upstream" as const };
+    })().finally(() => {
+      inFlight = null;
+    });
+
+    return inFlight;
+  }
+
+  async function read(endpoint: string, opts: { force?: boolean } = {}): Promise<GitHubTasksCacheResult> {
+    const previous = cached?.endpoint === endpoint ? cached : null;
+
+    if (!opts.force && previous) {
+      if (now() - previous.fetchedAt < ttlMs) {
+        return { data: previous.data, freshness: "fresh", source: "hit" };
+      }
+
+      // Stale-while-revalidate: callers get useful task context immediately,
+      // and every simultaneous caller joins the same background refresh.
+      void refresh(endpoint).catch(() => undefined);
+      return { data: previous.data, freshness: "stale", source: "stale" };
+    }
+
+    try {
+      const result = await refresh(endpoint);
+      return { ...result, freshness: "fresh" };
+    } catch (error) {
+      // An upstream failure must not erase the last-known-good task context.
+      if (previous) return { data: previous.data, freshness: "stale", source: "stale" };
+      throw error;
+    }
+  }
+
+  return { read };
+}
+
+const githubTasksCache = createGitHubTasksCache();
+
+export function getGitHubTasks(endpoint: string) {
+  return githubTasksCache.read(endpoint);
+}
+
+export function forceGitHubTasksRefresh(endpoint: string) {
+  return githubTasksCache.read(endpoint, { force: true });
+}


### PR DESCRIPTION
Closes #3267.

## What changed

- decouple GitHub task enrichment from the four-second session polling loop
- poll GitHub task context on a pausable five-minute client cadence, reducing uninterrupted foreground traffic from roughly 900 Cave requests/hour to at most 12
- add a one-minute process-local server TTL with stale-while-revalidate, in-flight request coalescing, and ETag/304 revalidation
- preserve last-known-good task context when the upstream service fails
- provide a forced refresh path for explicit GitHub refresh and linking actions
- add focused cache tests and update API/component contract coverage

## Why

GitHub task refreshes were piggybacking on the session loop even though the data changes much less frequently. That generated an upstream request every four seconds for every foreground client. Separating the cadences and sharing a short server-side cache removes that unnecessary load while keeping explicit user refreshes immediate.

## Validation

- `pnpm typecheck`
- `pnpm check:tests-wired` — 1,012 tests wired
- `pnpm test:api` — 191 test files passed
- `pnpm test:app` — 747 test files passed
- focused GitHub task cache and component contract tests
- `git diff --check`
