### PR TITLE
Fix Windows updater diagnostics and spaced-path regression

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -179,6 +179,21 @@ assert.match(
   /args: \[\.\.\.launch\.fixedArgs, "install", "-g", target\.packageName\][\s\S]*?shell: false/,
   "npm installs preserve fixed argv and never pass npm.cmd through cmd.exe",
 );
+assert.match(
+  source,
+  /npm discovery: runnable launcher found on Cave PATH\./,
+  "the retained trace records npm discovery without copying its local path",
+);
+assert.match(
+  source,
+  /Installer launch: npm-cli\.js via Node with fixed argv; shell disabled\./,
+  "the retained trace records the shell-free fixed-argv Windows launch mode",
+);
+assert.doesNotMatch(
+  source,
+  /appendTrace\([^\n]*(?:plan\.command|launch\.command|npmResult\.path)/,
+  "retained trace markers never include discovered machine-local command paths",
+);
 
 assert.match(
   source,
@@ -208,6 +223,11 @@ assert.match(
   source,
   /job\.verification = verification/,
   "the polled job carries sanitized path/version verification evidence to the UI",
+);
+assert.match(
+  source,
+  /Post-install verification:[\s\S]*?package=[\s\S]*?executable=[\s\S]*?compatible=[\s\S]*?latest=/,
+  "the retained trace records only safe post-install verification booleans",
 );
 
 assert.match(
@@ -298,8 +318,18 @@ assert.match(
 
 assert.match(
   source,
-  /function finishInstallJobError\([\s\S]*?npmLease\?\.release\(\)/,
-  "terminal job error paths release the global npm lease",
+  /function releaseNpmLease\([\s\S]*?npmLease\.release\(\);[\s\S]*?Global npm lane: released\./,
+  "terminal job paths release the global npm lease and retain that fact",
+);
+assert.match(
+  source,
+  /function finishInstallJobError\([\s\S]*?releaseNpmLease\(job, npmLease\)/,
+  "preparation error paths use the traced global npm lease release",
+);
+assert.match(
+  source,
+  /Installer process: exited with code \$\{code\}\./,
+  "the retained trace records the installer process exit code",
 );
 
 assert.match(
@@ -336,6 +366,11 @@ assert.match(
   source,
   /slice\(-OUTPUT_CAP\)/,
   "job output is capped, not unbounded",
+);
+assert.match(
+  source,
+  /function installJobTail\([\s\S]*?CLIENT_TAIL_CAP[\s\S]*?outputBudget[\s\S]*?job\.output\.slice\(-outputBudget\)/,
+  "the client tail keeps stable trace facts plus bounded raw output",
 );
 
 assert.match(

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -214,6 +214,8 @@ type SpawnPlan = {
   command: string;
   args: string[];
   shell: boolean;
+  /** Sanitized, path-free facts retained independently from npm output. */
+  traceLines: string[];
 };
 
 function sleep(ms: number) {
@@ -270,6 +272,12 @@ async function spawnPlanFor(
       // to C:\Program and exits 1. npmLaunchCommandForPath remaps the shim to
       // `node npm-cli.js`, preserving fixed argv without cmd.exe.
       shell: false,
+      traceLines: [
+        "npm discovery: runnable launcher found on Cave PATH.",
+        launch.fixedArgs.length > 0
+          ? "Installer launch: npm-cli.js via Node with fixed argv; shell disabled."
+          : "Installer launch: direct npm executable with fixed argv; shell disabled.",
+      ],
     };
   }
   // kind === "script" — run the harness's official installer exactly as its
@@ -280,12 +288,14 @@ async function spawnPlanFor(
       command: "powershell",
       args: ["-NoProfile", "-Command", target.windows],
       shell: false,
+      traceLines: ["Installer launch: pinned PowerShell allowlist script; nested shell disabled."],
     };
   }
   return {
     command: "bash",
     args: ["-lc", target.posix],
     shell: false,
+    traceLines: ["Installer launch: pinned POSIX allowlist script."],
   };
 }
 
@@ -296,6 +306,8 @@ type InstallJob = {
   finishedAt?: number;
   /** Raw interleaved stdout+stderr, capped to OUTPUT_CAP. */
   output: string;
+  /** Sanitized lifecycle facts that must survive a long raw-output tail. */
+  trace: string[];
   ok?: boolean;
   code?: number | null;
   binaryPath?: string | null;
@@ -312,6 +324,9 @@ type InstallJob = {
  *  long installs (Hermes bootstraps a Python toolchain) from growing
  *  unbounded in memory. */
 const OUTPUT_CAP = 8_192;
+const CLIENT_TAIL_CAP = 2_000;
+const TRACE_LINE_CAP = 240;
+const TRACE_LINES_CAP = 8;
 
 // Next dev re-evaluates this module on HMR; a plain module-level Map would
 // orphan running jobs. globalThis survives re-evaluation.
@@ -381,6 +396,41 @@ function npmBusyResponse(owner: InstallTarget) {
 
 function appendOutput(job: InstallJob, chunk: string) {
   job.output = redactSensitiveInstallOutput(job.output + stripAnsi(chunk)).slice(-OUTPUT_CAP);
+}
+
+function appendTrace(job: InstallJob, line: string) {
+  const safeLine = redactSensitiveInstallOutput(stripAnsi(line))
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, TRACE_LINE_CAP);
+  if (!safeLine) return;
+  job.trace = [...job.trace, safeLine].slice(-TRACE_LINES_CAP);
+}
+
+/** Keep lifecycle facts stable while retaining the most useful raw output. */
+function installJobTail(job: InstallJob): string {
+  const trace = job.trace.join("\n").slice(-CLIENT_TAIL_CAP);
+  const separator = trace && job.output ? "\n" : "";
+  const outputBudget = Math.max(0, CLIENT_TAIL_CAP - trace.length - separator.length);
+  return `${trace}${separator}${job.output.slice(-outputBudget)}`;
+}
+
+function releaseNpmLease(job: InstallJob, npmLease?: NpmInstallLease) {
+  if (!npmLease) return;
+  npmLease.release();
+  appendTrace(job, "Global npm lane: released.");
+}
+
+function verificationTraceLine(verification: OpenCovenToolVerification): string {
+  const yesNo = (value: boolean | null) =>
+    value === null ? "unknown" : value ? "yes" : "no";
+  return (
+    "Post-install verification: " +
+    `package=${yesNo(verification.packageVerified)}; ` +
+    `executable=${yesNo(verification.executableVerified)}; ` +
+    `compatible=${yesNo(verification.compatible)}; ` +
+    `latest=${yesNo(verification.latestSatisfied)}.`
+  );
 }
 
 function runCommand(
@@ -518,7 +568,7 @@ function installFailureHint(targetName: InstallTarget, output: string): string |
 }
 
 function jobView(job: InstallJob) {
-  const tail = job.output.slice(-2000);
+  const tail = installJobTail(job);
   const elapsedMs = (job.finishedAt ?? Date.now()) - job.startedAt;
   if (job.status === "running") {
     return {
@@ -562,7 +612,7 @@ function finishInstallJobError(
   job.ok = false;
   job.error = safeMessage ?? installStartErrorMessage(err);
   job.cancel = undefined;
-  npmLease?.release();
+  releaseNpmLease(job, npmLease);
 }
 
 function installerOutcomeError(
@@ -597,7 +647,7 @@ async function finishInstallJob(
   npmLease?: NpmInstallLease,
 ) {
   if (job.status !== "running") {
-    npmLease?.release();
+    releaseNpmLease(job, npmLease);
     return;
   }
   try {
@@ -670,6 +720,14 @@ async function finishInstallJob(
     const installOk = verification
       ? isVerifiedOpenCovenInstallSuccess(code, verification)
       : !installError && code === 0 && !!installed.path;
+    if (isOpenCovenToolInstallTarget(targetName)) {
+      appendTrace(
+        job,
+        verification
+          ? verificationTraceLine(verification)
+          : "Post-install verification: skipped because the installer did not succeed.",
+      );
+    }
 
     // Hermes has no positional prompt slot, so the harness's `-- "<prompt>"`
     // convention needs the hermes-coven shim to remap it onto -q. This remains
@@ -719,7 +777,7 @@ async function finishInstallJob(
     appendOutput(job, `${job.error}\n`);
   } finally {
     job.cancel = undefined;
-    npmLease?.release();
+    releaseNpmLease(job, npmLease);
   }
 }
 
@@ -755,6 +813,14 @@ async function runInstallJob(
     if (finalized) return;
     finalized = true;
     clearTimers();
+    appendTrace(
+      job,
+      launchError
+        ? "Installer process: did not start."
+        : code === null
+          ? `Installer process: ended by signal ${signal ?? "unknown"}.`
+          : `Installer process: exited with code ${code}.`,
+    );
     await finishInstallJob(
       targetName,
       target,
@@ -803,6 +869,8 @@ async function runInstallJob(
       clearTimers();
       const safeMessage =
         "Cave could not safely stop the local daemon before updating the CLI. The update was not started.";
+      appendTrace(job, "Installer process: not started because daemon preparation failed.");
+      appendTrace(job, "Post-install verification: skipped because the installer did not start.");
       finishInstallJobError(
         job,
         new Error(job.daemon?.detail ?? safeMessage),
@@ -973,7 +1041,10 @@ export async function POST(req: Request) {
     kind: target.kind,
     startedAt: Date.now(),
     output: "",
+    trace: [],
   };
+  for (const line of plan.traceLines) appendTrace(job, line);
+  if (npmLease) appendTrace(job, "Global npm lane: reserved for this installer.");
   jobs.set(targetName, job);
 
   void runInstallJob(targetName, target, plan, job, npmLease);

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   route,
-  /async function finishInstallJob\([\s\S]*?recoverDaemonAfterCliInstall\(targetName, job\)[\s\S]*?finally \{[\s\S]*?npmLease\?\.release\(\);/,
-  "the shared npm lease should be released only after daemon recovery finishes",
+  /async function finishInstallJob\([\s\S]*?recoverDaemonAfterCliInstall\(targetName, job\)[\s\S]*?finally \{[\s\S]*?releaseNpmLease\(job, npmLease\);/,
+  "the shared npm lease should be released and traced only after daemon recovery finishes",
 );
 
 assert.doesNotMatch(

--- a/src/lib/opencoven-tools-latest-check.test.ts
+++ b/src/lib/opencoven-tools-latest-check.test.ts
@@ -1,13 +1,10 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { test } from "node:test";
 import {
   OPEN_COVEN_TOOLS,
   checkNpmLatestVersion,
   composeOpenCovenToolStatus,
+  npmLaunchCommandForPath,
   npmViewLaunchCommandForPath,
   openCovenToolReadinessStatuses,
 } from "./opencoven-tools-status.ts";
@@ -49,28 +46,29 @@ test("local readiness completes without waiting for a blocked registry probe", a
   assert.equal(registryCalls, 1);
 });
 
-async function windowsNpmShim() {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "coven-npm-view-"));
-  const npmCli = path.join(dir, "node_modules", "npm", "bin", "npm-cli.js");
-  const npmCmd = path.join(dir, "npm.cmd");
-  await mkdir(path.dirname(npmCli), { recursive: true });
-  await writeFile(npmCli, "process.stdout.write('\\\"0.0.54\\\"');\n");
-  await writeFile(npmCmd, "@ECHO off\r\nREM npm shim\r\n");
-  return { npmCli, npmCmd };
+function windowsNpmShim() {
+  const npmCmd = String.raw`C:\Program Files\nodejs\npm.cmd`;
+  const npmCli = String.raw`C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js`;
+  const fileExists = (candidate: string) => candidate === npmCli;
+  return { npmCli, npmCmd, fileExists };
 }
 
 test("Windows npm.cmd latest checks launch npm-cli.js through Node with fixed argv", async () => {
-  const { npmCli, npmCmd } = await windowsNpmShim();
-  assert.deepEqual(npmViewLaunchCommandForPath(npmCmd, "win32"), {
+  const { npmCli, npmCmd, fileExists } = windowsNpmShim();
+  assert.deepEqual(npmLaunchCommandForPath(npmCmd, "win32", fileExists), {
     command: process.execPath,
     fixedArgs: [npmCli],
   });
+  assert.deepEqual(npmViewLaunchCommandForPath(npmCmd, "win32", fileExists), {
+    command: process.execPath,
+    fixedArgs: [npmCli],
+  }, "the compatibility alias uses the same spaced-path-safe mapping");
 
   const result = await checkNpmLatestVersion(OPEN_COVEN_TOOLS[0], {
     platform: "win32",
     now: () => checkedAt,
     resolveNpmPath: async () => npmCmd,
-    fileExists: existsSync,
+    fileExists,
     env: () => ({ ...process.env, PATH: "C:\\fake" }),
     execFile: async (command, args, options) => {
       assert.equal(command, process.execPath, "Windows never passes npm.cmd to execFile");

--- a/src/lib/opencoven-tools-resolve.test.ts
+++ b/src/lib/opencoven-tools-resolve.test.ts
@@ -320,23 +320,28 @@ test("isNodeModulesPackagePath demands a node_modules/<package> tail", () => {
 });
 
 test("npmGlobalPrefixFromNpmPath routes Windows npm.cmd through node npm-cli.js", async () => {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "coven-npm-prefix-"));
-  const npmCli = path.join(dir, "node_modules", "npm", "bin", "npm-cli.js");
-  const npmCmd = path.join(dir, "npm.cmd");
-  await mkdir(path.dirname(npmCli), { recursive: true });
-  await writeFile(npmCli, "process.stdout.write('C:\\\\Users\\\\dev\\\\npm-global\\n');\n");
-  await writeFile(npmCmd, "@ECHO off\r\nREM npm shim\r\n");
+  const npmCmd = String.raw`C:\Program Files\nodejs\npm.cmd`;
+  const npmCli = String.raw`C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js`;
 
   // The .cmd shim itself is never exec'd (Node >= 21.7 rejects it without a
-  // shell); the launch remap runs npm-cli.js with Cave's own Node, so this
-  // works — and is asserted — even from a POSIX test host.
+  // shell); the launch remap runs npm-cli.js with Cave's own Node. Inject the
+  // process boundary so a POSIX CI host still proves literal Windows path
+  // semantics, including the space in Program Files.
   const prefix = await npmGlobalPrefixFromNpmPath(
     npmCmd,
     { ...process.env },
     "win32",
+    {
+      fileExists: (candidate) => candidate === npmCli,
+      execFile: async (command, args, options) => {
+        assert.equal(command, process.execPath);
+        assert.deepEqual(args, [npmCli, "prefix", "-g"]);
+        assert.equal(options.timeout, 5000);
+        return { stdout: "C:\\Users\\dev\\npm-global\n", stderr: "" };
+      },
+    },
   );
   assert.equal(prefix, "C:\\Users\\dev\\npm-global");
-  await rm(dir, { recursive: true, force: true });
 });
 
 test("removeLauncherFile deletes files but refuses directories", async () => {

--- a/src/lib/opencoven-tools-resolve.ts
+++ b/src/lib/opencoven-tools-resolve.ts
@@ -20,6 +20,17 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+type NpmPrefixExecFile = (
+  command: string,
+  args: readonly string[],
+  options: { env: NodeJS.ProcessEnv; timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+const defaultNpmPrefixExecFile: NpmPrefixExecFile = async (command, args, options) => {
+  const { stdout, stderr } = await execFileAsync(command, args, options);
+  return { stdout: String(stdout), stderr: String(stderr) };
+};
+
 /**
  * Stale-launcher remediation for the OpenCoven tool Update/Repair flow.
  *
@@ -96,11 +107,19 @@ export async function npmGlobalPrefixFromNpmPath(
   npmPath: string,
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
+  dependencies: {
+    fileExists?: (file: string) => boolean;
+    execFile?: NpmPrefixExecFile;
+  } = {},
 ): Promise<string | null> {
-  const launch = npmViewLaunchCommandForPath(npmPath, platform);
+  const launch = npmViewLaunchCommandForPath(
+    npmPath,
+    platform,
+    dependencies.fileExists,
+  );
   if (!launch) return null;
   try {
-    const { stdout } = await execFileAsync(
+    const { stdout } = await (dependencies.execFile ?? defaultNpmPrefixExecFile)(
       launch.command,
       [...launch.fixedArgs, "prefix", "-g"],
       { env, timeout: 5000 },

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -322,8 +322,9 @@ export function npmLaunchCommandForPath(
   if (platform !== "win32" || !/\.(cmd|bat)$/i.test(npmPath)) {
     return { command: npmPath, fixedArgs: [] };
   }
-  const npmCli = path.join(
-    path.dirname(npmPath),
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const npmCli = pathApi.join(
+    pathApi.dirname(npmPath),
     "node_modules",
     "npm",
     "bin",


### PR DESCRIPTION
Closes #3258

## What changed

- retain sanitized, path-free updater lifecycle facts independently from bounded npm output
- report npm discovery, shell-free fixed-argv launch mode, process result, post-install verification, and global npm-lane release in the UI/copyable diagnostics tail
- keep the client tail bounded at 2,000 characters while preserving the existing 8 KiB raw-output cap and secret redaction
- make Windows path handling use `path.win32` when the target platform is injected
- add literal `C:\Program Files\nodejs\npm.cmd` regression coverage for both latest-version and global-prefix probes, proving `node npm-cli.js` fixed-argv execution with no shell

## Root cause

PR #3260 corrected the Windows `.cmd` launch failure, but the completion audit found two acceptance gaps: lifecycle facts could still be displaced by long npm output, and the automated Windows tests used host-native temporary paths instead of a literal spaced Windows path.

## Verification

- `pnpm typecheck`
- `pnpm test:app` — 747 test files passed
- `pnpm test:api` — 190 test files passed
- `pnpm build` — production build and bundle budget passed
- real Windows isolated-prefix API proof:
  - seeded `@opencoven/cli@0.0.54`
  - onboarding status reported update required to 0.1.1
  - POST started and completed with exit code 0
  - package/executable/compatible/latest verification all passed
  - daemon remained safely stopped and npm lane released
  - copied diagnostics tail was 514 characters and contained no local command path
  - refreshed status and the isolated binary both reported 0.1.1

This PR must remain draft until every required check and review finding is resolved.