### PR TITLE
Name the Cave runtime host when summoning a familiar

### DIFF
--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { readdir } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import path from "node:path";
 import { pickVersionLine } from "@/lib/harness-version";
 import {
@@ -162,5 +162,5 @@ export async function GET() {
   );
   const covenReports = (await covenSupportsAdapterList()) ? await loadCovenAdapterSummaries() : [];
   const harnesses: AdapterReport[] = mergeAdapterReports(reports, covenReports);
-  return NextResponse.json({ ok: true, harnesses });
+  return NextResponse.json({ ok: true, runtimeHost: hostname(), harnesses });
 }

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -224,6 +224,7 @@ export function buildFamiliarAnalyticsModel(
         familiar,
         stats,
         retroState: retroStateFor(data.retroSnapshot, familiar.id),
+        now,
       })
     : null;
   const confidence = deriveThreadConfidence(data.threadReports);

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -421,11 +421,11 @@ describe("FamiliarAnalyticsView", () => {
   it("renders the heal request count and keeps thread analytics present", async () => {
     mockFetchFor("trusted");
     const data = await loadFamiliarAnalyticsData("cody");
-    // Pin the clock so the fixture's June 25 activity does not become an
-    // additional inactivity heal request as wall-clock time advances.
-    const model = buildFamiliarAnalyticsModel(data, Date.parse("2026-06-25T20:00:00.000Z"));
+    // Pin the clock nine days after the fixture's June 25 activity: this keeps
+    // the intended session-gap request without eventually adding stale memory.
+    const model = buildFamiliarAnalyticsModel(data, Date.parse("2026-07-04T20:00:00.000Z"));
 
-    assert.equal(model.healRequests.length, 2);
+    assert.equal(model.healRequests.length, 1);
     assert.equal(model.threadReports.length, 1);
     assert.match(source, /escalateBlockers\(model\.familiarId, threadSignalsAggregate, model\.healRequests\)/);
     assert.match(source, /healRequests\.length === 1 \? "request" : "requests"/);

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -87,6 +87,11 @@ assert.match(
 );
 assert.match(
   source,
+  /vessel === "local"\s*\n\s*\? \{ runtime: \{ kind: "local" \} \}/,
+  "summoning a local familiar explicitly binds it to the Cave host",
+);
+assert.match(
+  source,
   /openclawAgentId: selectedAgent\.id/,
   "summoning from an OpenClaw agent sends openclawAgentId",
 );

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -17,6 +17,10 @@ const css = await readFile(
   new URL("../styles/summoning-circle.css", import.meta.url),
   "utf8",
 );
+const harnessesRoute = await readFile(
+  new URL("../app/api/harnesses/route.ts", import.meta.url),
+  "utf8",
+);
 
 // ── Creation posts to the app route, never the onboarding one ───────────────
 assert.match(
@@ -40,6 +44,31 @@ assert.match(
   source,
   /fetch\("\/api\/harnesses"/,
   "local/SSH vessels list installed runtimes from /api/harnesses",
+);
+assert.match(
+  harnessesRoute,
+  /runtimeHost: hostname\(\)/,
+  "the harness probe reports the hostname of the Cave runtime host",
+);
+assert.match(
+  source,
+  /title: localHost \? `Local runtime — \$\{localHost\}` : "This Cave host"/,
+  "the local vessel names the Cave runtime host and has an unambiguous fallback",
+);
+assert.match(
+  source,
+  /Runs on \$\{localHost\}, the host serving this Cave\./,
+  "the local vessel explains what the hostname identifies",
+);
+assert.match(
+  source,
+  /` on \$\{localHost \?\? "this Cave host"\}`/,
+  "the summoning recap uses the same runtime hostname or fallback",
+);
+assert.doesNotMatch(
+  source,
+  /title: "This machine"/,
+  "the ambiguous local vessel label must not return",
 );
 assert.match(
   source,

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -312,6 +312,7 @@ function SummoningRite({
   // Stage I — the vessel.
   const [vessel, setVessel] = useState<VesselKind | null>(draftVessel);
   const [harnesses, setHarnesses] = useState<HarnessReport[] | null>(null);
+  const [localHost, setLocalHost] = useState<string | null>(null);
   const [harness, setHarness] = useState<string | null>(
     draft?.harness && isSummonableLocalHarness(draft.harness)
       ? draft.harness
@@ -373,11 +374,20 @@ function SummoningRite({
     (async () => {
       try {
         const res = await fetch("/api/harnesses", { cache: "no-store" });
-        const json = (await res.json()) as { ok?: boolean; harnesses?: (HarnessReport & { binary?: string })[] };
+        const json = (await res.json()) as {
+          ok?: boolean;
+          runtimeHost?: unknown;
+          harnesses?: (HarnessReport & { binary?: string })[];
+        };
         if (cancelled) return;
-        if (res.ok && json.ok !== false && (json.harnesses ?? []).length > 0) {
-          setHarnesses(json.harnesses!.filter((h) => h.chatSupported && isSummonableLocalHarness(h.id)));
-          return;
+        if (res.ok && json.ok !== false) {
+          const runtimeHost =
+            typeof json.runtimeHost === "string" ? json.runtimeHost.trim() : "";
+          setLocalHost(runtimeHost || null);
+          if ((json.harnesses ?? []).length > 0) {
+            setHarnesses(json.harnesses!.filter((h) => h.chatSupported && isSummonableLocalHarness(h.id)));
+            return;
+          }
         }
         throw new Error("empty");
       } catch {
@@ -660,6 +670,7 @@ function SummoningRite({
                 {stage === 0 ? (
                   <StageVessel
                     vessel={vessel}
+                    localHost={localHost}
                     setVessel={(v) => {
                       setVessel(v);
                       setError(null);
@@ -718,7 +729,9 @@ function SummoningRite({
                       vessel === "openclaw"
                         ? `OpenClaw · ${selectedAgent?.displayName ?? agentId ?? ""}`
                         : `${(harnesses ?? []).find((h) => h.id === harness)?.label ?? harness ?? ""}${
-                            vessel === "ssh" ? ` over SSH · ${sshHost.trim()}` : " on this machine"
+                            vessel === "ssh"
+                              ? ` over SSH · ${sshHost.trim()}`
+                              : ` on ${localHost ?? "this Cave host"}`
                           }`
                     }
                     name={name.trim()}
@@ -794,6 +807,7 @@ function SummoningRite({
 
 function StageVessel({
   vessel,
+  localHost,
   setVessel,
   harnesses,
   harness,
@@ -813,6 +827,7 @@ function StageVessel({
   onTestSsh,
 }: {
   vessel: VesselKind | null;
+  localHost: string | null;
   setVessel: (v: VesselKind) => void;
   harnesses: HarnessReport[] | null;
   harness: string | null;
@@ -832,7 +847,14 @@ function StageVessel({
   onTestSsh: () => void;
 }) {
   const vessels: { kind: VesselKind; icon: IconName; title: string; hint: string }[] = [
-    { kind: "local", icon: "ph:desktop", title: "This machine", hint: "Runs on a runtime installed here." },
+    {
+      kind: "local",
+      icon: "ph:desktop",
+      title: localHost ? `Local runtime — ${localHost}` : "This Cave host",
+      hint: localHost
+        ? `Runs on ${localHost}, the host serving this Cave.`
+        : "Runs on the host serving this Cave.",
+    },
     { kind: "ssh", icon: "ph:globe", title: "A remote machine", hint: "Reaches over SSH to a host you name." },
     { kind: "openclaw", icon: "ph:robot", title: "An OpenClaw agent", hint: "Bridge an agent you already keep." },
   ];

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -548,7 +548,9 @@ function SummoningRite({
                     command: sshCommand.trim(),
                   },
                 }
-              : {}),
+              : vessel === "local"
+                ? { runtime: { kind: "local" } }
+                : {}),
           },
         }),
       });

--- a/src/lib/cave-config.test.ts
+++ b/src/lib/cave-config.test.ts
@@ -209,6 +209,32 @@ try {
   assert.equal(config.bindingFor(cfg, "missing").autoSelfReport, false);
 
   await config.saveConfig({
+    defaults: {
+      runtime: { kind: "ssh", host: "build-box", cwd: "/srv/work", command: "coven" },
+    },
+    familiars: {
+      local: { runtime: { kind: "local" } },
+    },
+  });
+  cfg = await config.loadConfig();
+  assert.deepEqual(
+    cfg.familiars.local.runtime,
+    { kind: "local" },
+    "an explicit local runtime must survive config persistence",
+  );
+  const explicitLocalBinding = config.bindingFor(cfg, "local");
+  assert.deepEqual(
+    explicitLocalBinding.runtime,
+    { kind: "local" },
+    "an explicit local familiar binding must override a workspace SSH default",
+  );
+  assert.deepEqual(
+    config.bindingFor(cfg, "missing").runtime,
+    { kind: "ssh", host: "build-box", cwd: "/srv/work", command: "coven" },
+    "familiars without an explicit runtime must continue to inherit the workspace default",
+  );
+
+  await config.saveConfig({
     familiars: {
       nova: {
         voiceProvider: null,
@@ -224,7 +250,7 @@ try {
     role: "review familiar",
   });
 
-  await config.saveConfig({ familiars: { nova: null } });
+  await config.saveConfig({ familiars: { nova: null, local: null } });
   cfg = await config.loadConfig();
   assert.equal(cfg.familiars.nova, undefined);
 } finally {

--- a/src/lib/onboarding-familiars.test.ts
+++ b/src/lib/onboarding-familiars.test.ts
@@ -170,12 +170,23 @@ assert.throws(
   /SSH runtime needs a host/,
 );
 
-// Non-ssh runtime input is ignored entirely.
-assert.equal(
+// An explicit local runtime must survive normalization so it can override a
+// workspace-level SSH default in the persisted familiar binding.
+assert.deepEqual(
   normalizeFamiliarDraft({
     displayName: "Local",
     description: "Stays on this machine.",
     runtime: { kind: "local" },
+  }).runtime,
+  { kind: "local" },
+);
+
+// Unknown runtime kinds remain ignored for compatibility with older callers.
+assert.equal(
+  normalizeFamiliarDraft({
+    displayName: "Unknown Runtime",
+    description: "Does not request a supported runtime override.",
+    runtime: { kind: "unsupported" },
   }).runtime,
   undefined,
 );

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -2,7 +2,7 @@ import { isTrustedOnboardingHarness } from "./harness-adapters.ts";
 import {
   isSshRuntime,
   normalizeFamiliarRuntime,
-  type SshFamiliarRuntime,
+  type FamiliarRuntime,
 } from "./familiar-runtime.ts";
 import { defaultModelForRuntime } from "./runtime-models.ts";
 
@@ -15,9 +15,9 @@ export type OnboardingFamiliarDraft = {
   harness: string;
   model: string;
   openclawAgentId?: string;
-  /** Optional remote runtime. Persisted to cave-config.json (the binding
+  /** Optional runtime override. Persisted to cave-config.json (the binding
    *  source chat reads), never to familiars.toml. */
-  runtime?: SshFamiliarRuntime;
+  runtime?: FamiliarRuntime;
 };
 
 export type OnboardingFamiliarInput = {
@@ -98,8 +98,9 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
   // A runtime request is all-or-nothing: a partial/invalid SSH config must
   // fail loudly here instead of silently degrading to a local familiar the
   // user believes is remote.
-  let runtime: SshFamiliarRuntime | undefined;
-  if (input.runtime && cleanText(input.runtime.kind) === "ssh") {
+  let runtime: FamiliarRuntime | undefined;
+  const runtimeKind = cleanText(input.runtime?.kind);
+  if (input.runtime && runtimeKind === "ssh") {
     const normalized = normalizeFamiliarRuntime({
       kind: "ssh",
       host: input.runtime.host ?? "",
@@ -112,6 +113,8 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
       );
     }
     runtime = normalized;
+  } else if (runtimeKind === "local") {
+    runtime = { kind: "local" };
   }
 
   return {


### PR DESCRIPTION
## Summary

- replace the ambiguous **This machine** vessel label with **Local runtime — `hostname`**
- explain that the hostname identifies the host serving Cave and running the local harness
- use **This Cave host** as a safe fallback while hostname discovery is unavailable
- carry the same hostname into the final summoning recap
- explicitly persist `{ kind: "local" }` for local summons so an SSH workspace default cannot contradict the selected vessel
- add regression coverage for the hostname copy, local payload, runtime normalization, persistence, and binding precedence

## Why

When Cave connects to remote infrastructure or is viewed from another device, “this machine” can mean the viewing device, the Cave backend host, or the daemon/hub. Local familiar execution happens on the Cave backend host; daemon and hub targeting are separate.

The Summoning Circle already fetches `/api/harnesses` to discover runtimes. This change adds `runtimeHost` to that response, avoiding an extra request and continuing to work for remote Cave clients. The existing `/api/hosts` hostname source is loopback-only.

Selecting the local vessel now also records an explicit local familiar binding. Callers that omit a runtime keep the existing default-inheritance behavior, while OpenClaw remains runtime-free.

## Validation

- focused `familiar-summoning-circle.test.ts`, `onboarding-familiars.test.ts`, and `cave-config.test.ts`
- `corepack pnpm@10.34.0 typecheck`
- `git diff --check`
- full `test:app` run reached 452 passing files, then stopped at the unrelated existing `familiar-analytics-view.test.ts` heal-count assertion (`2 !== 1`); the same test fails identically in isolation

Closes #3281
