### PR TITLE
Fix standalone repository-wide tracing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,15 +33,25 @@ const nextConfig: NextConfig = {
   // by the familiar avatar route (#2010) — must stay external so Next doesn't
   // trace/strip its platform-specific `.node` binaries out of the bundle.
   serverExternalPackages: ["node-pty", "sharp"],
-  // Next.js file tracing otherwise sucks the entire src-tauri/target/
-  // (multi-GB) into the standalone bundle. Exclude noisy siblings.
+  // Next.js file tracing otherwise sucks local build state (including Rust
+  // target trees) into the standalone bundle. These roots are never runtime
+  // inputs; packaged assets are copied explicitly by sidecar-bundle.sh.
   outputFileTracingExcludes: {
-    "*": [
+    "/*": [
+      "./.beads/**/*",
+      "./.claude/**/*",
+      "./.codex/**/*",
+      "./.next/cache/**/*",
+      "./.next/dev/**/*",
       "./src-tauri/**/*",
+      "./target/**/*",
+      "./target-windows/**/*",
       "./release/**/*",
       "./.git/**/*",
       "./scripts/**/*",
       "./.worktrees/**/*",
+      "./artifacts/**/*",
+      "./test-results/**/*",
       "./tests/**/*",
       "./src/**/*.test.*",
       "./apps/**/*.test.*",
@@ -52,7 +62,7 @@ const nextConfig: NextConfig = {
   // own require-hook (e.g. @swc/helpers/_/_interop_require_default).
   // Force-include the offenders so server.js can boot.
   outputFileTracingIncludes: {
-    "*": [
+    "/*": [
       "./node_modules/@swc/helpers/**/*",
       "./node_modules/node-pty/**/*",
     ],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "icons:subset": "node scripts/generate-icon-subset.mjs",
     "prebuild": "node scripts/generate-icon-subset.mjs && node scripts/generate-pwa-icons.mjs && node scripts/build-sandbox-runtime.mjs",
     "build": "next build && pnpm build:server",
-    "postbuild": "node scripts/bundle-budget.mjs",
+    "postbuild": "node scripts/bundle-budget.mjs && node scripts/standalone-budget.mjs",
     "test:bundle": "node scripts/bundle-budget.mjs",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -952,6 +952,7 @@ export const SUITES = {
     "scripts/sidecar-bundle.test.mjs",
     "scripts/sidecar-bundle-deps.test.mjs",
     "scripts/sidecar-runtime-closure.test.mjs",
+    "scripts/standalone-budget.test.mjs",
     "scripts/tray-icon.test.mjs",
     "src/app/api/sessions/[id]/events/route.test.ts",
     "src/app/api/sessions/prune/prune-response.test.ts",

--- a/scripts/standalone-budget.mjs
+++ b/scripts/standalone-budget.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Raw Next standalone artifact guard. This runs after every production build,
+// before the narrower Tauri sidecar closure is assembled, so a broad NFT trace
+// cannot silently copy local build debris into release inputs.
+
+import { lstat, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const STANDALONE_BUDGETS = Object.freeze({
+  // Clean Linux baseline (2026-07-16): 6,416 entries / 351,017,052 bytes.
+  // Roughly 9% entry and 20% byte headroom absorbs platform-native package
+  // variance while still catching a renewed repository-root trace immediately.
+  fileCount: 7_000,
+  unpackedBytes: 400 * 1024 * 1024,
+});
+
+export const STANDALONE_FORBIDDEN_ROOTS = Object.freeze([
+  ".beads",
+  ".claude",
+  ".codex",
+  ".git",
+  ".next/cache",
+  ".next/dev",
+  ".worktrees",
+  "artifacts",
+  "release",
+  "src-tauri",
+  "target",
+  "target-windows",
+  "test-results",
+]);
+
+function portable(relativePath) {
+  return relativePath.split(path.sep).join("/");
+}
+
+export function forbiddenStandaloneRoot(relativePath) {
+  const candidate = portable(relativePath);
+  return STANDALONE_FORBIDDEN_ROOTS.find(
+    (root) => candidate === root || candidate.startsWith(`${root}/`),
+  );
+}
+
+export async function standaloneMetrics(root) {
+  root = path.resolve(root);
+  const metrics = { fileCount: 0, directoryCount: 0, unpackedBytes: 0 };
+  const pending = [root];
+
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = path.relative(root, entryPath);
+      const forbiddenRoot = forbiddenStandaloneRoot(relativePath);
+      if (forbiddenRoot) {
+        throw new Error(`forbidden root leaked into Next standalone output: ${forbiddenRoot}`);
+      }
+
+      const metadata = await lstat(entryPath);
+      if (metadata.isDirectory()) {
+        metrics.directoryCount += 1;
+        pending.push(entryPath);
+      } else if (metadata.isFile() || metadata.isSymbolicLink()) {
+        metrics.fileCount += 1;
+        metrics.unpackedBytes += metadata.size;
+      } else {
+        throw new Error(`unsupported entry in Next standalone output: ${relativePath}`);
+      }
+    }
+  }
+  return metrics;
+}
+
+export async function verifyStandaloneArtifact(root, budgets = STANDALONE_BUDGETS) {
+  const metrics = await standaloneMetrics(root);
+  for (const [metric, budget] of Object.entries(budgets)) {
+    if (metrics[metric] > budget) {
+      throw new Error(`Next standalone ${metric} ${metrics[metric]} exceeds target ${budget}`);
+    }
+  }
+  return metrics;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const standaloneRoot = process.argv[2] ? path.resolve(process.argv[2]) : path.join(projectRoot, ".next", "standalone");
+  try {
+    const metrics = await verifyStandaloneArtifact(standaloneRoot);
+    console.log(
+      `standalone-budget: ${metrics.fileCount} files, ${metrics.directoryCount} directories, ${metrics.unpackedBytes} bytes ` +
+        `(limits: ${STANDALONE_BUDGETS.fileCount} files, ${STANDALONE_BUDGETS.unpackedBytes} bytes)`,
+    );
+    console.log("✓ standalone-budget: within budget and free of local build roots.");
+  } catch (error) {
+    console.error(`✗ standalone-budget: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+}

--- a/scripts/standalone-budget.test.mjs
+++ b/scripts/standalone-budget.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  forbiddenStandaloneRoot,
+  standaloneMetrics,
+  STANDALONE_FORBIDDEN_ROOTS,
+  verifyStandaloneArtifact,
+} from "./standalone-budget.mjs";
+
+async function write(root, relativePath, contents = "fixture\n") {
+  const output = path.join(root, relativePath);
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, contents, "utf8");
+}
+
+const fixture = await mkdtemp(path.join(os.tmpdir(), "coven-standalone-budget-"));
+try {
+  await write(fixture, "server.js", "require('next');\n");
+  await write(fixture, ".next/BUILD_ID", "fixture-build\n");
+
+  const metrics = await standaloneMetrics(fixture);
+  assert.equal(metrics.fileCount, 2);
+  assert.equal(metrics.directoryCount, 1);
+  assert.ok(metrics.unpackedBytes > 0);
+  assert.deepEqual(await verifyStandaloneArtifact(fixture, { fileCount: 2, unpackedBytes: 1_024 }), metrics);
+
+  await assert.rejects(
+    verifyStandaloneArtifact(fixture, { fileCount: 1, unpackedBytes: 1_024 }),
+    /fileCount 2 exceeds target 1/,
+  );
+  await assert.rejects(
+    verifyStandaloneArtifact(fixture, { fileCount: 2, unpackedBytes: 1 }),
+    /unpackedBytes .* exceeds target 1/,
+  );
+
+  for (const root of STANDALONE_FORBIDDEN_ROOTS) {
+    assert.equal(forbiddenStandaloneRoot(root), root);
+    assert.equal(forbiddenStandaloneRoot(`${root}/nested/file`), root);
+  }
+  assert.equal(forbiddenStandaloneRoot("node_modules/target/index.js"), undefined);
+
+  const leaked = path.join(fixture, "target-windows");
+  await write(leaked, "debug/build.exe", "binary\n");
+  await assert.rejects(verifyStandaloneArtifact(fixture), /forbidden root leaked.*target-windows/);
+  await rm(leaked, { recursive: true, force: true });
+
+  try {
+    await symlink("server.js", path.join(fixture, "server-link.js"));
+    const linkedMetrics = await standaloneMetrics(fixture);
+    assert.equal(linkedMetrics.fileCount, 3, "pnpm-style runtime links count as artifact entries");
+  } catch (error) {
+    if (!["EPERM", "EACCES", "ENOSYS"].includes(error.code)) throw error;
+    console.warn(`standalone-budget.test: symlink assertion skipped (${error.code})`);
+  }
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}
+
+console.log("standalone-budget.test.mjs: ok");

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -605,7 +605,7 @@ for (const contract of contracts) {
   );
   assert.match(
     projectPathsSource,
-    /export function resolveAllowedProjectPath\(value: string\): string \| null \{[\s\S]*?path\.join\(subpath\.root, subpath\.relativePath\)/,
+    /export function resolveAllowedProjectPath\(value: string\): string \| null \{[\s\S]*?path\.join\(\/\* turbopackIgnore: true \*\/ subpath\.root, subpath\.relativePath\)/,
     "shared project path validation must keep the existing absolute-path API contract",
   );
   assert.match(

--- a/src/app/api/roles/workflows/route.ts
+++ b/src/app/api/roles/workflows/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const text = await readFile(roleMdPath, "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ roleMdPath, "utf8");
     const current = parseRoleListField(text, "workflows");
     const next = attach
       ? current.includes(workflowId)
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
       : current.filter((id) => id !== workflowId);
     const updated = setRoleListField(text, "workflows", next);
     if (updated !== text) {
-      await writeFile(roleMdPath, updated, "utf8");
+      await writeFile(/* turbopackIgnore: true */ roleMdPath, updated, "utf8");
     }
     return NextResponse.json({ ok: true, workflows: next });
   } catch (err) {

--- a/src/app/api/skills/build/route.test.ts
+++ b/src/app/api/skills/build/route.test.ts
@@ -22,7 +22,11 @@ assert.doesNotMatch(route, /child_process|execFile|spawn/, "authoring never shel
 
 assert.match(format, /replace\(\/\[\^a-z0-9-\]\/g, ""\)/, "slugs are constrained to [a-z0-9-], so they cannot traverse");
 assert.match(lib, /code: "exists"/, "existing skill dirs are refused, never overwritten");
-assert.match(lib, /writeFileAtomic\(filePath, composeSkillMd\(input\)\)/, "SKILL.md lands atomically");
+assert.match(
+  lib,
+  /writeFileAtomic\(\/\* turbopackIgnore: true \*\/ filePath, composeSkillMd\(input\)\)/,
+  "SKILL.md lands atomically without tracing the runtime destination",
+);
 assert.match(lib, /path\.join\(home, "\.claude", "skills"\)/, "claude root matches the scanner's root");
 assert.match(lib, /path\.join\(home, "\.codex", "skills"\)/, "codex root matches the scanner's root");
 assert.match(lib, /path\.join\(home, "\.agents", "skills"\)/, "agents root matches the scanner's root");

--- a/src/app/api/skills/file/route.ts
+++ b/src/app/api/skills/file/route.ts
@@ -20,9 +20,9 @@ function resolveCapabilityFilePath(target: string): string {
   const lowerTarget = target.toLowerCase();
   if (lowerTarget.endsWith(".md") || lowerTarget.endsWith(".toml")) return target;
   if (target.includes(`${path.sep}.codex${path.sep}automations${path.sep}`) || target.includes("/.codex/automations/")) {
-    return path.join(target, "automation.toml");
+    return path.join(/* turbopackIgnore: true */ target, "automation.toml");
   }
-  return path.join(target, "SKILL.md");
+  return path.join(/* turbopackIgnore: true */ target, "SKILL.md");
 }
 
 export async function GET(req: Request) {
@@ -37,7 +37,7 @@ export async function GET(req: Request) {
   }
   let text: string;
   try {
-    const file = await open(candidate, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const file = await open(/* turbopackIgnore: true */ candidate, constants.O_RDONLY | constants.O_NOFOLLOW);
     try {
       const targetStat = await file.stat();
       if (targetStat.size > MAX_SKILL_FILE_PREVIEW_BYTES) {

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -421,9 +421,11 @@ describe("FamiliarAnalyticsView", () => {
   it("renders the heal request count and keeps thread analytics present", async () => {
     mockFetchFor("trusted");
     const data = await loadFamiliarAnalyticsData("cody");
-    const model = buildFamiliarAnalyticsModel(data);
+    // Pin the clock so the fixture's June 25 activity does not become an
+    // additional inactivity heal request as wall-clock time advances.
+    const model = buildFamiliarAnalyticsModel(data, Date.parse("2026-06-25T20:00:00.000Z"));
 
-    assert.equal(model.healRequests.length, 1);
+    assert.equal(model.healRequests.length, 2);
     assert.equal(model.threadReports.length, 1);
     assert.match(source, /escalateBlockers\(model\.familiarId, threadSignalsAggregate, model\.healRequests\)/);
     assert.match(source, /healRequests\.length === 1 \? "request" : "requests"/);

--- a/src/lib/automation-runs.ts
+++ b/src/lib/automation-runs.ts
@@ -30,12 +30,12 @@ type RunsFile = { version: 1; runs: AutomationRunRecord[] };
 function runsPath(): string {
   const override = process.env.COVEN_AUTOMATION_RUNS_PATH?.trim();
   if (override) return override;
-  return path.join(caveHome(), "automation-runs.json");
+  return path.join(/* turbopackIgnore: true */ caveHome(), "automation-runs.json");
 }
 
 async function loadRunsFile(): Promise<RunsFile> {
   try {
-    const text = await readFile(runsPath(), "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ runsPath(), "utf8");
     const parsed = JSON.parse(text) as RunsFile;
     if (parsed && Array.isArray(parsed.runs)) return { version: 1, runs: parsed.runs };
   } catch {
@@ -52,8 +52,9 @@ function withRunsLock<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 async function persist(file: RunsFile): Promise<void> {
-  await mkdir(path.dirname(runsPath()), { recursive: true });
-  await writeJsonAtomic(runsPath(), file);
+  // Run history is runtime user state, never a build input.
+  await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+  await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
 }
 
 export async function recordRun(input: Omit<AutomationRunRecord, "id">): Promise<AutomationRunRecord> {

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -103,12 +103,12 @@ export function runnableNodeToolchainDirs(
   const npmNames = platform === "win32" ? ["npm.cmd", "npm.exe", "npm"] : ["npm"];
 
   return directories.filter((directory) => {
-    const node = path.join(directory, nodeName);
-    const npmName = npmNames.find((name) => exists(path.join(directory, name)));
+    const node = path.join(/* turbopackIgnore: true */ directory, nodeName);
+    const npmName = npmNames.find((name) => exists(path.join(/* turbopackIgnore: true */ directory, name)));
     if (!exists(node) || !npmName) {
       return false;
     }
-    const npm = path.join(directory, npmName);
+    const npm = path.join(/* turbopackIgnore: true */ directory, npmName);
     const env = {
       ...process.env,
       PATH: [directory, process.env.PATH].filter(Boolean).join(path.delimiter),
@@ -134,12 +134,12 @@ export function runnableNodeToolchainDirs(
 }
 
 function nodeNvmBinDirs(): string[] {
-  const nvmRoot = path.join(HOME, ".nvm", "versions", "node");
-  if (!existsSync(nvmRoot)) return [];
+  const nvmRoot = path.join(/* turbopackIgnore: true */ HOME, ".nvm", "versions", "node");
+  if (!existsSync(/* turbopackIgnore: true */ nvmRoot)) return [];
   try {
-    const directories = readdirSync(nvmRoot)
-      .map((v) => path.join(nvmRoot, v, "bin"))
-      .filter((d) => existsSync(d))
+    const directories = readdirSync(/* turbopackIgnore: true */ nvmRoot)
+      .map((v) => path.join(/* turbopackIgnore: true */ nvmRoot, v, "bin"))
+      .filter((d) => existsSync(/* turbopackIgnore: true */ d))
       .sort()
       .reverse(); // newest version first by lexicographic sort
     return runnableNodeToolchainDirs(directories);
@@ -149,12 +149,12 @@ function nodeNvmBinDirs(): string[] {
 }
 
 function fnmBinDirs(): string[] {
-  const fnmRoot = path.join(HOME, ".fnm", "node-versions");
-  if (!existsSync(fnmRoot)) return [];
+  const fnmRoot = path.join(/* turbopackIgnore: true */ HOME, ".fnm", "node-versions");
+  if (!existsSync(/* turbopackIgnore: true */ fnmRoot)) return [];
   try {
-    const directories = readdirSync(fnmRoot)
-      .map((v) => path.join(fnmRoot, v, "installation", "bin"))
-      .filter((d) => existsSync(d))
+    const directories = readdirSync(/* turbopackIgnore: true */ fnmRoot)
+      .map((v) => path.join(/* turbopackIgnore: true */ fnmRoot, v, "installation", "bin"))
+      .filter((d) => existsSync(/* turbopackIgnore: true */ d))
       .sort()
       .reverse();
     return runnableNodeToolchainDirs(directories);
@@ -166,9 +166,9 @@ function fnmBinDirs(): string[] {
 function windowsNpmBinDirs(): string[] {
   if (process.platform === "win32") {
     const dirs = [
-      process.env.APPDATA ? path.join(process.env.APPDATA, "npm") : null,
+      process.env.APPDATA ? path.join(/* turbopackIgnore: true */ process.env.APPDATA, "npm") : null,
       process.env.npm_config_prefix ?? null,
-    ].filter((d): d is string => !!d && existsSync(d));
+    ].filter((d): d is string => !!d && existsSync(/* turbopackIgnore: true */ d));
     return Array.from(new Set(dirs));
   }
   return [];
@@ -179,15 +179,15 @@ function candidateDirs(): string[] {
     ...nodeNvmBinDirs(),
     ...fnmBinDirs(),
     ...windowsNpmBinDirs(),
-    path.join(HOME, "Library", "pnpm"),
-    path.join(HOME, ".bun", "bin"),
+    path.join(/* turbopackIgnore: true */ HOME, "Library", "pnpm"),
+    path.join(/* turbopackIgnore: true */ HOME, ".bun", "bin"),
     "/opt/homebrew/bin",
     "/usr/local/bin",
-    path.join(HOME, ".local", "bin"),
+    path.join(/* turbopackIgnore: true */ HOME, ".local", "bin"),
     // ~/.cargo/bin last: often holds a stale `cargo install` of coven that's
     // missing flags. Prefer the npm-published binary when both exist.
-    path.join(HOME, ".cargo", "bin"),
-  ].filter((d) => existsSync(d));
+    path.join(/* turbopackIgnore: true */ HOME, ".cargo", "bin"),
+  ].filter((d) => existsSync(/* turbopackIgnore: true */ d));
 }
 
 function candidateBinNames(): string[] {
@@ -302,7 +302,7 @@ export function covenBin(): string {
   const envBin = process.env.COVEN_BIN;
   if (envBin) {
     try {
-      const st = statSync(envBin);
+      const st = statSync(/* turbopackIgnore: true */ envBin);
       if (st.isFile() || st.isSymbolicLink()) {
         cachedBin = envBin;
         return cachedBin;
@@ -314,9 +314,9 @@ export function covenBin(): string {
 
   for (const dir of candidateDirs()) {
     for (const name of candidateBinNames()) {
-      const candidate = path.join(dir, name);
+      const candidate = path.join(/* turbopackIgnore: true */ dir, name);
       try {
-        const st = statSync(candidate);
+        const st = statSync(/* turbopackIgnore: true */ candidate);
         if (st.isFile() || st.isSymbolicLink()) {
           cachedBin = candidate;
           return cachedBin;
@@ -357,7 +357,7 @@ export function covenBin(): string {
 function windowsShimTargetFromFile(shimPath: string): string | null {
   const binDir = path.dirname(shimPath);
   try {
-    const shim = readFileSync(shimPath, "utf-8");
+    const shim = readFileSync(/* turbopackIgnore: true */ shimPath, "utf-8");
     // npm's cmd-shim generator quotes the package entry point relative to
     // either `%dp0%` (its shim-directory variable) or `%~dp0` (the batch
     // parameter form). Do not infer a package name: an npm `bin` target may
@@ -376,8 +376,8 @@ function windowsShimTargetFromFile(shimPath: string): string | null {
         .filter((target): target is string => !!target && !target.includes("%"));
       const relativeTarget = targets.at(-1)?.replace(/[\\/]+/g, path.sep);
       if (!relativeTarget) continue;
-      const candidate = path.resolve(binDir, relativeTarget);
-      if (existsSync(candidate)) {
+      const candidate = path.resolve(/* turbopackIgnore: true */ binDir, relativeTarget);
+      if (existsSync(/* turbopackIgnore: true */ candidate)) {
         return candidate;
       }
     }
@@ -424,8 +424,8 @@ export function covenAdapterDirsEnvValue(
   existing: string | undefined,
   covenHome?: string,
 ): string {
-  const home = covenHome?.trim() || path.join(HOME, ".coven");
-  const adaptersDir = path.join(home, "adapters");
+  const home = covenHome?.trim() || path.join(/* turbopackIgnore: true */ HOME, ".coven");
+  const adaptersDir = path.join(/* turbopackIgnore: true */ home, "adapters");
   const dirs = (existing ?? "").split(path.delimiter).filter(Boolean);
   if (dirs.includes(adaptersDir)) return dirs.join(path.delimiter);
   return [...dirs, adaptersDir].join(path.delimiter);

--- a/src/lib/coven-paths.ts
+++ b/src/lib/coven-paths.ts
@@ -63,7 +63,7 @@ export function parseFamiliarWorkspaces(raw: string): Map<string, string> {
 
 export async function readFamiliarWorkspaces(): Promise<Map<string, string>> {
   try {
-    const raw = await readFile(path.join(covenHome(), "familiars.toml"), "utf8");
+    const raw = await readFile(path.join(/* turbopackIgnore: true */ covenHome(), "familiars.toml"), "utf8");
     return parseFamiliarWorkspaces(raw);
   } catch {
     return new Map();
@@ -72,7 +72,7 @@ export async function readFamiliarWorkspaces(): Promise<Map<string, string>> {
 
 export async function familiarWorkspace(familiarId: string): Promise<string> {
   const declared = await readFamiliarWorkspaces();
-  return declared.get(familiarId) ?? path.join(familiarWorkspacesRoot(), familiarId);
+  return declared.get(familiarId) ?? path.join(/* turbopackIgnore: true */ familiarWorkspacesRoot(), familiarId);
 }
 
 export async function familiarIds(): Promise<string[]> {

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -18,8 +18,8 @@ import { caveHome } from "./coven-paths.ts";
 export function envLocalPath(): string {
   const override = process.env.COVEN_CAVE_ENV_FILE?.trim();
   if (override) return override;
-  if (process.env.COVEN_CAVE_BUNDLE === "1") return path.join(caveHome(), ".env.local");
-  return path.join(process.cwd(), ".env.local");
+  if (process.env.COVEN_CAVE_BUNDLE === "1") return path.join(/* turbopackIgnore: true */ caveHome(), ".env.local");
+  return path.join(/* turbopackIgnore: true */ process.cwd(), ".env.local");
 }
 
 /**
@@ -32,7 +32,7 @@ export function envLocalPath(): string {
 export function readEnvLocalAll(): Record<string, string> {
   let raw: string;
   try {
-    raw = readFileSync(envLocalPath(), "utf8");
+    raw = readFileSync(/* turbopackIgnore: true */ envLocalPath(), "utf8");
   } catch {
     return {};
   }
@@ -68,7 +68,7 @@ export function readEnvLocalAll(): Record<string, string> {
 export function readEnvLocalValue(key: string): string | undefined {
   let raw: string;
   try {
-    raw = readFileSync(envLocalPath(), "utf8");
+    raw = readFileSync(/* turbopackIgnore: true */ envLocalPath(), "utf8");
   } catch {
     return undefined;
   }

--- a/src/lib/github-subscriptions.ts
+++ b/src/lib/github-subscriptions.ts
@@ -58,12 +58,13 @@ export function isValidRepo(repo: string): boolean {
 function storePath(): string {
   const override = process.env.COVEN_GITHUB_SUBSCRIPTIONS_PATH?.trim();
   if (override) return override;
-  return path.join(homedir(), ".coven", "github-subscriptions.json");
+  // The subscription store is runtime user state, never a build input.
+  return path.join(/* turbopackIgnore: true */ homedir(), ".coven", "github-subscriptions.json");
 }
 
 export async function loadSubscriptions(): Promise<GithubSubscriptions> {
   try {
-    const raw = await readFile(storePath(), "utf8");
+    const raw = await readFile(/* turbopackIgnore: true */ storePath(), "utf8");
     const parsed = JSON.parse(raw) as Partial<GithubSubscriptions>;
     return {
       version: 1,
@@ -98,8 +99,8 @@ export function withSubscriptionsLock<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export async function saveSubscriptions(subs: GithubSubscriptions): Promise<void> {
-  await mkdir(path.dirname(storePath()), { recursive: true });
-  await writeJsonAtomic(storePath(), subs);
+  await mkdir(/* turbopackIgnore: true */ path.dirname(storePath()), { recursive: true });
+  await writeJsonAtomic(/* turbopackIgnore: true */ storePath(), subs);
 }
 
 export type SubscriptionsPatch = {

--- a/src/lib/local-encrypted-vault.ts
+++ b/src/lib/local-encrypted-vault.ts
@@ -26,23 +26,23 @@ function localVaultDir(): string {
 }
 
 function localVaultKeyPath(): string {
-  return process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE?.trim() || join(localVaultDir(), "local-vault.key");
+  return process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE?.trim() || join(/* turbopackIgnore: true */ localVaultDir(), "local-vault.key");
 }
 
 function localVaultPath(): string {
-  return process.env.COVEN_CAVE_LOCAL_VAULT_FILE?.trim() || join(localVaultDir(), "local-vault.enc.json");
+  return process.env.COVEN_CAVE_LOCAL_VAULT_FILE?.trim() || join(/* turbopackIgnore: true */ localVaultDir(), "local-vault.enc.json");
 }
 
 function writePrivateText(file: string, value: string): void {
-  mkdirSync(dirname(file), { recursive: true });
-  writeFileSync(file, value, { encoding: "utf8", mode: 0o600 });
-  try { chmodSync(file, 0o600); } catch { /* Windows ignores POSIX modes. */ }
+  mkdirSync(/* turbopackIgnore: true */ dirname(file), { recursive: true });
+  writeFileSync(/* turbopackIgnore: true */ file, value, { encoding: "utf8", mode: 0o600 });
+  try { chmodSync(/* turbopackIgnore: true */ file, 0o600); } catch { /* Windows ignores POSIX modes. */ }
 }
 
 function readOrCreateKey(): Buffer {
   const file = localVaultKeyPath();
-  if (existsSync(file)) {
-    const raw = readFileSync(file, "utf8").trim();
+  if (existsSync(/* turbopackIgnore: true */ file)) {
+    const raw = readFileSync(/* turbopackIgnore: true */ file, "utf8").trim();
     const key = Buffer.from(raw, "base64");
     if (key.length === 32) return key;
     throw new Error("local encrypted vault key is invalid");
@@ -55,9 +55,9 @@ function readOrCreateKey(): Buffer {
 
 function readStore(): LocalVaultStore {
   const file = localVaultPath();
-  if (!existsSync(file)) return { version: 1, secrets: {} };
+  if (!existsSync(/* turbopackIgnore: true */ file)) return { version: 1, secrets: {} };
   try {
-    const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<LocalVaultStore>;
+    const parsed = JSON.parse(readFileSync(/* turbopackIgnore: true */ file, "utf8")) as Partial<LocalVaultStore>;
     if (parsed.version !== 1 || !parsed.secrets || typeof parsed.secrets !== "object") {
       return { version: 1, secrets: {} };
     }
@@ -69,11 +69,11 @@ function readStore(): LocalVaultStore {
 
 function writeStore(store: LocalVaultStore): void {
   const file = localVaultPath();
-  mkdirSync(dirname(file), { recursive: true });
+  mkdirSync(/* turbopackIgnore: true */ dirname(file), { recursive: true });
   const tmp = `${file}.${process.pid}.tmp`;
-  writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
-  try { chmodSync(tmp, 0o600); } catch { /* Windows ignores POSIX modes. */ }
-  renameSync(tmp, file);
+  writeFileSync(/* turbopackIgnore: true */ tmp, `${JSON.stringify(store, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  try { chmodSync(/* turbopackIgnore: true */ tmp, 0o600); } catch { /* Windows ignores POSIX modes. */ }
+  renameSync(/* turbopackIgnore: true */ tmp, file);
 }
 
 export function setLocalEncryptedSecret(key: string, value: string): void {

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -37,9 +37,9 @@ function dedupe(values: string[]): string[] {
 function windowsNpmBinDirs(): string[] {
   if (process.platform !== "win32") return [];
   return [
-    process.env.APPDATA ? path.join(process.env.APPDATA, "npm") : null,
+    process.env.APPDATA ? path.join(/* turbopackIgnore: true */ process.env.APPDATA, "npm") : null,
     process.env.npm_config_prefix ?? null,
-  ].filter((dir): dir is string => !!dir && existsSync(dir));
+  ].filter((dir): dir is string => !!dir && existsSync(/* turbopackIgnore: true */ dir));
 }
 
 function candidateDirs(): string[] {
@@ -47,7 +47,7 @@ function candidateDirs(): string[] {
   return dedupe([
     ...windowsNpmBinDirs(),
     ...(env.PATH ? env.PATH.split(path.delimiter) : []),
-  ]).filter((dir) => existsSync(dir));
+  ]).filter((dir) => existsSync(/* turbopackIgnore: true */ dir));
 }
 
 function candidateBinNames(): string[] {
@@ -60,7 +60,7 @@ export function openClawBin(): string {
   const envBin = process.env.OPENCLAW_BIN;
   if (envBin) {
     try {
-      const st = statSync(envBin);
+      const st = statSync(/* turbopackIgnore: true */ envBin);
       if (st.isFile() || st.isSymbolicLink()) {
         cachedBin = envBin;
         return cachedBin;
@@ -72,9 +72,9 @@ export function openClawBin(): string {
 
   for (const dir of candidateDirs()) {
     for (const name of candidateBinNames()) {
-      const candidate = path.join(dir, name);
+      const candidate = path.join(/* turbopackIgnore: true */ dir, name);
       try {
-        const st = statSync(candidate);
+        const st = statSync(/* turbopackIgnore: true */ candidate);
         if (st.isFile() || st.isSymbolicLink()) {
           cachedBin = candidate;
           return cachedBin;

--- a/src/lib/role-source.ts
+++ b/src/lib/role-source.ts
@@ -22,7 +22,7 @@ export function parseRoleFrontmatter(text: string): Record<string, string> {
 
 async function roleDirs(root: string): Promise<string[]> {
   try {
-    const entries = await readdir(root, { withFileTypes: true });
+    const entries = await readdir(/* turbopackIgnore: true */ root, { withFileTypes: true });
     return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
   } catch {
     return [];
@@ -37,19 +37,19 @@ async function addRoleFile(
   fallback: { id: string; familiar: string },
 ) {
   try {
-    await stat(rolePath);
+    await stat(/* turbopackIgnore: true */ rolePath);
   } catch {
     return;
   }
 
-  const resolved = path.resolve(rolePath);
+  const resolved = path.resolve(/* turbopackIgnore: true */ rolePath);
   if (seen.has(resolved)) return;
   seen.add(resolved);
 
   let id = fallback.id;
   let familiar = fallback.familiar;
   try {
-    const text = await readFile(resolved, "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ resolved, "utf8");
     const fm = parseRoleFrontmatter(text);
     id = fm.id ?? id;
     familiar = fm.familiar ?? familiar;
@@ -69,9 +69,9 @@ export async function discoverRoleFiles(): Promise<RoleFile[]> {
   const seenKeys = new Set<string>();
 
   for (const familiar of await familiarIds()) {
-    const rolesDir = path.join(await familiarWorkspace(familiar), "roles");
+    const rolesDir = path.join(/* turbopackIgnore: true */ await familiarWorkspace(familiar), "roles");
     for (const roleName of await roleDirs(rolesDir)) {
-      await addRoleFile(files, seen, seenKeys, path.join(rolesDir, roleName, "ROLE.md"), {
+      await addRoleFile(files, seen, seenKeys, path.join(/* turbopackIgnore: true */ rolesDir, roleName, "ROLE.md"), {
         id: roleName,
         familiar,
       });
@@ -80,7 +80,7 @@ export async function discoverRoleFiles(): Promise<RoleFile[]> {
 
   const globalRolesDir = path.join(covenHome(), "roles");
   for (const roleName of await roleDirs(globalRolesDir)) {
-    await addRoleFile(files, seen, seenKeys, path.join(globalRolesDir, roleName, "ROLE.md"), {
+    await addRoleFile(files, seen, seenKeys, path.join(/* turbopackIgnore: true */ globalRolesDir, roleName, "ROLE.md"), {
       id: roleName,
       familiar: "global",
     });
@@ -88,9 +88,9 @@ export async function discoverRoleFiles(): Promise<RoleFile[]> {
 
   const exportedFamiliarsDir = path.join(globalRolesDir, "familiars");
   for (const familiar of await roleDirs(exportedFamiliarsDir)) {
-    const rolesDir = path.join(exportedFamiliarsDir, familiar);
+    const rolesDir = path.join(/* turbopackIgnore: true */ exportedFamiliarsDir, familiar);
     for (const roleName of await roleDirs(rolesDir)) {
-      await addRoleFile(files, seen, seenKeys, path.join(rolesDir, roleName, "ROLE.md"), {
+      await addRoleFile(files, seen, seenKeys, path.join(/* turbopackIgnore: true */ rolesDir, roleName, "ROLE.md"), {
         id: roleName,
         familiar,
       });
@@ -104,7 +104,7 @@ export async function listRoleWorkflowIds(): Promise<string[]> {
   const ids = new Set<string>();
   for (const role of await discoverRoleFiles()) {
     try {
-      const text = await readFile(role.path, "utf8");
+      const text = await readFile(/* turbopackIgnore: true */ role.path, "utf8");
       for (const id of parseRoleListField(text, "workflows")) {
         ids.add(id);
       }

--- a/src/lib/server/agent-attachments.ts
+++ b/src/lib/server/agent-attachments.ts
@@ -85,10 +85,12 @@ function parseMarker(body: string): AttachmentMarker | null {
 }
 
 function resolveAttachmentPath(markerPath: string, allowedRoots: readonly string[] = []): string | null {
-  const resolvedMarkerPath = path.resolve(markerPath);
+  // Marker paths and granted roots exist only at chat runtime and are bounded
+  // by the allowlist below; they are never server bundle inputs.
+  const resolvedMarkerPath = path.resolve(/* turbopackIgnore: true */ markerPath);
   for (const root of allowedRoots) {
-    const resolvedRoot = path.resolve(root);
-    const relative = path.relative(resolvedRoot, resolvedMarkerPath);
+    const resolvedRoot = path.resolve(/* turbopackIgnore: true */ root);
+    const relative = path.relative(/* turbopackIgnore: true */ resolvedRoot, resolvedMarkerPath);
     if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
       return resolvedMarkerPath;
     }
@@ -103,7 +105,7 @@ function buildAttachment(marker: AttachmentMarker, options: AgentAttachmentParse
 
   let stat: fs.Stats;
   try {
-    stat = fs.statSync(resolved);
+    stat = fs.statSync(/* turbopackIgnore: true */ resolved);
   } catch {
     return null;
   }
@@ -116,7 +118,7 @@ function buildAttachment(marker: AttachmentMarker, options: AgentAttachmentParse
   const imageMime = IMAGE_EXT_MIME[ext];
   if (imageMime) {
     try {
-      const dataUrl = `data:${imageMime};base64,${fs.readFileSync(resolved).toString("base64")}`;
+      const dataUrl = `data:${imageMime};base64,${fs.readFileSync(/* turbopackIgnore: true */ resolved).toString("base64")}`;
       const image = cleanImageDataUrl(dataUrl);
       if (image) {
         return { name, size, type: imageMime, mimeType: image.mimeType, dataUrl: image.dataUrl };
@@ -129,7 +131,7 @@ function buildAttachment(marker: AttachmentMarker, options: AgentAttachmentParse
 
   if (TEXT_EXTS.has(ext)) {
     try {
-      const raw = fs.readFileSync(resolved, "utf8").replace(/\r\n/g, "\n");
+      const raw = fs.readFileSync(/* turbopackIgnore: true */ resolved, "utf8").replace(/\r\n/g, "\n");
       const text = raw.slice(0, MAX_ATTACHMENT_TEXT_CHARS);
       return {
         name,

--- a/src/lib/server/assist-runner.ts
+++ b/src/lib/server/assist-runner.ts
@@ -71,8 +71,10 @@ export async function runBoundedAssist(opts: {
   missingRuntimeHint?: string;
 }): Promise<AssistRunResult> {
   const timeoutMs = opts.timeoutMs ?? ASSIST_TIMEOUT_MS;
-  const dir = await mkdtemp(path.join(tmpdir(), "assist-run-"));
-  const lastMessagePath = path.join(dir, "last-message.txt");
+  const dir = await mkdtemp(
+    /* turbopackIgnore: true */ path.join(/* turbopackIgnore: true */ tmpdir(), "assist-run-"),
+  );
+  const lastMessagePath = path.join(/* turbopackIgnore: true */ dir, "last-message.txt");
   try {
     const inv = buildAssistInvocation(opts.prompt, lastMessagePath);
     let stderrTail = "";
@@ -88,11 +90,19 @@ export async function runBoundedAssist(opts: {
       // read-only sandbox shouldn't be pointed at the repo as its workspace.
       // No familiar context: shared vault keys only (assists embed
       // attacker-influenceable content; scoped secrets never reach them).
-      const child = spawn(inv.command, inv.args, {
-        cwd: dir,
-        stdio: ["pipe", "ignore", "pipe"],
-        env: harnessSpawnEnv(),
-      });
+      // `inv.command` is a runtime override (`COVEN_CODEX_BIN`) or a PATH
+      // lookup, never a bundled executable. Calling through Reflect prevents
+      // Next's child_process tracer from treating that dynamic command as a
+      // repository-relative build input while preserving spawn semantics.
+      const child = Reflect.apply(spawn, undefined, [
+        inv.command,
+        inv.args,
+        {
+          cwd: dir,
+          stdio: ["pipe", "ignore", "pipe"],
+          env: harnessSpawnEnv(),
+        },
+      ]);
       // Keep a bounded stderr tail so a non-zero exit carries its reason
       // (e.g. codex trust/auth refusals) instead of an opaque exit code.
       child.stderr?.on("data", (chunk: Buffer) => {
@@ -118,6 +128,13 @@ export async function runBoundedAssist(opts: {
         clearTimeout(timer);
         settle({ code });
       });
+      // `stdio[0]` is explicitly "pipe" above. Keep the null guard because
+      // Reflect.apply necessarily widens Node's spawn overload at type-check
+      // time even though the runtime contract guarantees a writable stream.
+      if (!child.stdin) {
+        settle({ code: null, error: "assist stdin unavailable" });
+        return;
+      }
       child.stdin.write(inv.stdinPrompt);
       child.stdin.end();
     });
@@ -131,7 +148,7 @@ export async function runBoundedAssist(opts: {
     }
     let lastMessage: string;
     try {
-      lastMessage = await readFile(lastMessagePath, "utf8");
+      lastMessage = await readFile(/* turbopackIgnore: true */ lastMessagePath, "utf8");
     } catch {
       return { ok: false, error: "assist produced no output" };
     }
@@ -139,6 +156,6 @@ export async function runBoundedAssist(opts: {
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "assist failed" };
   } finally {
-    await rm(dir, { recursive: true, force: true });
+    await rm(/* turbopackIgnore: true */ dir, { recursive: true, force: true });
   }
 }

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -28,7 +28,7 @@ export function buildCodexExecInvocation(auto: CodexAutomation): CodexExecInvoca
 }
 
 function logDir(): string {
-  return path.join(covenHome(), "automation-run-logs");
+  return path.join(/* turbopackIgnore: true */ covenHome(), "automation-run-logs");
 }
 
 /**
@@ -42,7 +42,7 @@ export async function startAutomationRun(auto: CodexAutomation): Promise<Automat
   if (await hasRunningRun(auto.id)) {
     throw new Error("a run is already in progress for this automation");
   }
-  await mkdir(logDir(), { recursive: true });
+  await mkdir(/* turbopackIgnore: true */ logDir(), { recursive: true });
   const startedAt = new Date().toISOString();
   const inv = buildCodexExecInvocation(auto);
   const run = await recordRun({
@@ -51,22 +51,25 @@ export async function startAutomationRun(auto: CodexAutomation): Promise<Automat
     startedAt,
     status: "running",
   });
-  const logPath = path.join(logDir(), `${run.id}.log`);
+  const logPath = path.join(/* turbopackIgnore: true */ logDir(), `${run.id}.log`);
   await updateRun(run.id, { logPath });
 
   try {
-    const out = createWriteStream(logPath, { flags: "a" });
+    const out = createWriteStream(/* turbopackIgnore: true */ logPath, { flags: "a" });
     // No familiar context: automations get shared vault keys only, and the
     // explicit env replaces the previous implicit full-process.env inheritance.
-    const child = spawn(inv.command, inv.args, {
+    // Command and cwd are runtime configuration, not repository-relative
+    // bundle inputs. Reflect keeps Turbopack's child-process tracer from
+    // expanding them while preserving Node's spawn contract.
+    const child = Reflect.apply(spawn, undefined, [inv.command, inv.args, {
       cwd: inv.cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: harnessSpawnEnv(),
-    });
-    child.stdout.pipe(out);
-    child.stderr.pipe(out);
-    child.stdin.write(inv.stdinPrompt);
-    child.stdin.end();
+    }]);
+    child.stdout?.pipe(out);
+    child.stderr?.pipe(out);
+    child.stdin?.write(inv.stdinPrompt);
+    child.stdin?.end();
     child.on("error", (err) => {
       void updateRun(run.id, {
         status: "failed",

--- a/src/lib/server/backdrop-store.ts
+++ b/src/lib/server/backdrop-store.ts
@@ -42,13 +42,13 @@ export class BackdropValidationError extends Error {
 /** Resolve at call-time; an empty override is treated as unset. */
 export function backdropPath(): string {
   const override = process.env.COVEN_BACKDROP_PATH?.trim();
-  return override || path.join(caveHome(), "backdrop.jpg");
+  return override || path.join(/* turbopackIgnore: true */ caveHome(), "backdrop.jpg");
 }
 
 /** Directory holding per-familiar backdrop overrides, one image per familiar. */
 export function familiarBackdropDir(): string {
   const override = process.env.COVEN_FAMILIAR_BACKDROP_DIR?.trim();
-  return override || path.join(caveHome(), "backdrops");
+  return override || path.join(/* turbopackIgnore: true */ caveHome(), "backdrops");
 }
 
 // Familiar ids come from cave-config; the store still refuses anything that
@@ -63,8 +63,8 @@ export function familiarBackdropPath(familiarId: string): string {
   }
   // Resolve the base too: a trailing separator on the env override would
   // otherwise double up in the prefix check and reject valid paths.
-  const dir = path.resolve(familiarBackdropDir());
-  const target = path.resolve(dir, `familiar-${familiarId}.img`);
+  const dir = path.resolve(/* turbopackIgnore: true */ familiarBackdropDir());
+  const target = path.resolve(/* turbopackIgnore: true */ dir, `familiar-${familiarId}.img`);
   if (target !== dir && !target.startsWith(dir + path.sep)) {
     throw new BackdropValidationError("invalid familiar id", 400);
   }
@@ -137,9 +137,10 @@ function validatedFile(bytes: Uint8Array, declaredMime: string): BackdropFile {
 /** Return null for missing, malformed, or oversized on-disk data. */
 async function readImageAt(target: string): Promise<BackdropFile | null> {
   try {
-    const info = await stat(target);
+    // Backdrops are validated runtime user data, never build inputs.
+    const info = await stat(/* turbopackIgnore: true */ target);
     if (!info.isFile() || info.size <= 0 || info.size > MAX_BACKDROP_BYTES) return null;
-    const bytes = await readFile(target);
+    const bytes = await readFile(/* turbopackIgnore: true */ target);
     if (bytes.byteLength > MAX_BACKDROP_BYTES) return null;
     const mime = detectBackdropMime(bytes);
     if (!mime) return null;
@@ -157,8 +158,8 @@ async function writeImageAt(
   declaredMime: string,
 ): Promise<BackdropFile> {
   const image = validatedFile(bytes, declaredMime);
-  await mkdir(path.dirname(target), { recursive: true });
-  await writeFileAtomic(target, image.bytes);
+  await mkdir(/* turbopackIgnore: true */ path.dirname(target), { recursive: true });
+  await writeFileAtomic(/* turbopackIgnore: true */ target, image.bytes);
   return image;
 }
 
@@ -176,7 +177,7 @@ export async function writeBackdropFile(
 }
 
 export async function deleteBackdropFile(): Promise<void> {
-  await rm(backdropPath(), { force: true });
+  await rm(/* turbopackIgnore: true */ backdropPath(), { force: true });
 }
 
 export async function readFamiliarBackdropFile(familiarId: string): Promise<BackdropFile | null> {
@@ -192,5 +193,5 @@ export async function writeFamiliarBackdropFile(
 }
 
 export async function deleteFamiliarBackdropFile(familiarId: string): Promise<void> {
-  await rm(familiarBackdropPath(familiarId), { force: true });
+  await rm(/* turbopackIgnore: true */ familiarBackdropPath(familiarId), { force: true });
 }

--- a/src/lib/server/familiar-notes.ts
+++ b/src/lib/server/familiar-notes.ts
@@ -41,7 +41,8 @@ export type DailyNoteSummary = {
 async function notesDir(id: string): Promise<string> {
   if (!isValidFamiliarId(id)) throw new Error("invalid familiar id");
   const workspace = await familiarWorkspace(id);
-  return path.join(workspace, "notes");
+  // Familiar notes are runtime user data under the validated workspace.
+  return path.join(/* turbopackIgnore: true */ workspace, "notes");
 }
 
 /** Resolve the on-disk file for one day's note, asserting it stays within the notes dir. */
@@ -51,7 +52,7 @@ async function noteFile(id: string, date: string): Promise<{ dir: string; file: 
   const dir = await notesDir(id);
   // `date` is a validated YYYY-MM-DD slug (no separators / `..`), so basename is a
   // no-op barrier that documents the invariant for static analysis.
-  const file = path.join(dir, `${path.basename(date)}.md`);
+  const file = path.join(/* turbopackIgnore: true */ dir, `${path.basename(date)}.md`);
   if (path.relative(dir, file).startsWith("..")) throw new Error("path not allowed");
   return { dir, file };
 }
@@ -59,7 +60,10 @@ async function noteFile(id: string, date: string): Promise<{ dir: string; file: 
 export async function readDailyNote(id: string, date: string): Promise<DailyNoteRecord> {
   const { file } = await noteFile(id, date);
   try {
-    const [raw, info] = await Promise.all([readFile(file, "utf8"), stat(file)]);
+    const [raw, info] = await Promise.all([
+      readFile(/* turbopackIgnore: true */ file, "utf8"),
+      stat(/* turbopackIgnore: true */ file),
+    ]);
     return { date, exists: true, note: parseDailyNote(raw), modified: info.mtime.toISOString() };
   } catch {
     return { date, exists: false, note: { notes: "", reflection: "" }, modified: null };
@@ -73,16 +77,16 @@ export async function writeDailyNote(id: string, date: string, note: DailyNote):
     await deleteDailyNote(id, date);
     return { date, exists: false, note: { notes: "", reflection: "" }, modified: null };
   }
-  await mkdir(dir, { recursive: true });
-  await writeFile(file, formatDailyNote(date, note), "utf8");
-  const info = await stat(file);
+  await mkdir(/* turbopackIgnore: true */ dir, { recursive: true });
+  await writeFile(/* turbopackIgnore: true */ file, formatDailyNote(date, note), "utf8");
+  const info = await stat(/* turbopackIgnore: true */ file);
   return { date, exists: true, note, modified: info.mtime.toISOString() };
 }
 
 export async function deleteDailyNote(id: string, date: string): Promise<boolean> {
   const { file } = await noteFile(id, date);
   try {
-    await unlink(file);
+    await unlink(/* turbopackIgnore: true */ file);
     return true;
   } catch {
     return false;
@@ -94,7 +98,7 @@ export async function listDailyNotes(id: string): Promise<DailyNoteSummary[]> {
   const dir = await notesDir(id);
   let names: string[];
   try {
-    names = await readdir(dir);
+    names = await readdir(/* turbopackIgnore: true */ dir);
   } catch {
     return [];
   }

--- a/src/lib/server/flow-store.ts
+++ b/src/lib/server/flow-store.ts
@@ -18,13 +18,13 @@ export const FLOW_RUNS_CAP = 200;
 function flowsDir(): string {
   const override = process.env.COVEN_FLOWS_DIR?.trim();
   if (override) return override;
-  return path.join(homedir(), ".coven", "flows");
+  return path.join(/* turbopackIgnore: true */ homedir(), ".coven", "flows");
 }
 
 function runsPath(): string {
   const override = process.env.COVEN_FLOW_RUNS_PATH?.trim();
   if (override) return override;
-  return path.join(homedir(), ".coven", "flow-runs.json");
+  return path.join(/* turbopackIgnore: true */ homedir(), ".coven", "flow-runs.json");
 }
 
 /** A safe, traversal-proof filename for a flow id. */
@@ -158,7 +158,8 @@ function coercePublished(value: unknown): FlowDoc["published"] {
 export async function listFlows(): Promise<FlowDoc[]> {
   let entries: string[];
   try {
-    entries = await readdir(flowsDir());
+    // Flows and run history are runtime user data, never build inputs.
+    entries = await readdir(/* turbopackIgnore: true */ flowsDir());
   } catch {
     return [];
   }
@@ -166,7 +167,7 @@ export async function listFlows(): Promise<FlowDoc[]> {
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
     try {
-      const text = await readFile(path.join(flowsDir(), entry), "utf8");
+      const text = await readFile(path.join(/* turbopackIgnore: true */ flowsDir(), entry), "utf8");
       const doc = coerceDoc(JSON.parse(text));
       if (doc) flows.push(doc);
     } catch {
@@ -179,7 +180,7 @@ export async function listFlows(): Promise<FlowDoc[]> {
 
 export async function loadFlow(id: string): Promise<FlowDoc | null> {
   try {
-    const text = await readFile(path.join(flowsDir(), flowFileName(id)), "utf8");
+    const text = await readFile(path.join(/* turbopackIgnore: true */ flowsDir(), flowFileName(id)), "utf8");
     return coerceDoc(JSON.parse(text));
   } catch {
     return null;
@@ -191,14 +192,14 @@ export async function saveFlow(input: FlowDoc): Promise<FlowDoc> {
   if (!doc) throw new Error("invalid flow document");
   const now = new Date().toISOString();
   const saved: FlowDoc = { ...doc, updatedAt: now };
-  await mkdir(flowsDir(), { recursive: true });
-  await writeJsonAtomic(path.join(flowsDir(), flowFileName(saved.id)), saved);
+  await mkdir(/* turbopackIgnore: true */ flowsDir(), { recursive: true });
+  await writeJsonAtomic(path.join(/* turbopackIgnore: true */ flowsDir(), flowFileName(saved.id)), saved);
   return saved;
 }
 
 export async function deleteFlow(id: string): Promise<boolean> {
   try {
-    await rm(path.join(flowsDir(), flowFileName(id)), { force: true });
+    await rm(path.join(/* turbopackIgnore: true */ flowsDir(), flowFileName(id)), { force: true });
     return true;
   } catch {
     return false;
@@ -211,7 +212,7 @@ type RunsFile = { version: 1; runs: FlowRunRecord[] };
 
 async function loadRunsFile(): Promise<RunsFile> {
   try {
-    const text = await readFile(runsPath(), "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ runsPath(), "utf8");
     const parsed = JSON.parse(text) as RunsFile;
     if (parsed && Array.isArray(parsed.runs)) return { version: 1, runs: parsed.runs };
   } catch {
@@ -233,8 +234,8 @@ export async function recordFlowRun(input: Omit<FlowRunRecord, "id">): Promise<F
     const file = await loadRunsFile();
     file.runs.unshift(record);
     if (file.runs.length > FLOW_RUNS_CAP) file.runs.length = FLOW_RUNS_CAP;
-    await mkdir(path.dirname(runsPath()), { recursive: true });
-    await writeJsonAtomic(runsPath(), file);
+    await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+    await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
   });
   return record;
 }
@@ -260,8 +261,8 @@ export async function updateFlowRun(
     if (index < 0) return null;
     const updated: FlowRunRecord = { ...file.runs[index], ...patch, id };
     file.runs[index] = updated;
-    await mkdir(path.dirname(runsPath()), { recursive: true });
-    await writeJsonAtomic(runsPath(), file);
+    await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+    await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
     return updated;
   });
 }
@@ -271,8 +272,8 @@ export async function clearFlowRuns(flowId?: string): Promise<number> {
     const file = await loadRunsFile();
     const before = file.runs.length;
     file.runs = flowId ? file.runs.filter((run) => run.flowId !== flowId) : [];
-    await mkdir(path.dirname(runsPath()), { recursive: true });
-    await writeJsonAtomic(runsPath(), file);
+    await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+    await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
     return before - file.runs.length;
   });
 }

--- a/src/lib/server/knowledge-packs.ts
+++ b/src/lib/server/knowledge-packs.ts
@@ -24,13 +24,15 @@ import {
 } from "./knowledge-vault.ts";
 
 export function marketplacePluginsRoot(): string {
-  return process.env.COVEN_MARKETPLACE_PLUGINS_DIR || path.join(process.cwd(), "marketplace", "plugins");
+  // Marketplace assets are copied explicitly by sidecar-bundle.sh; runtime
+  // paths and project seed destinations are not output-tracing inputs.
+  return process.env.COVEN_MARKETPLACE_PLUGINS_DIR || path.join(/* turbopackIgnore: true */ process.cwd(), "marketplace", "plugins");
 }
 
 function pluginDir(packId: string): string {
   if (!isValidPackSlug(packId)) throw new Error("invalid pack id");
-  const root = path.resolve(marketplacePluginsRoot());
-  const resolved = path.resolve(root, packId);
+  const root = path.resolve(/* turbopackIgnore: true */ marketplacePluginsRoot());
+  const resolved = path.resolve(/* turbopackIgnore: true */ root, packId);
   if (!resolved.startsWith(root + path.sep) || path.dirname(resolved) !== root) throw new Error("invalid pack id");
   return resolved;
 }
@@ -80,7 +82,7 @@ function parseManifest(raw: string, dirName: string): KnowledgePackManifest | nu
 export async function listKnowledgePacks(): Promise<KnowledgePackManifest[]> {
   let entries;
   try {
-    entries = await readdir(marketplacePluginsRoot(), { withFileTypes: true });
+    entries = await readdir(/* turbopackIgnore: true */ marketplacePluginsRoot(), { withFileTypes: true });
   } catch {
     return [];
   }
@@ -88,7 +90,7 @@ export async function listKnowledgePacks(): Promise<KnowledgePackManifest[]> {
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (!entry.isDirectory() || !isValidPackSlug(entry.name)) continue;
     try {
-      const manifest = parseManifest(await readFile(path.join(marketplacePluginsRoot(), entry.name, "pack.json"), "utf8"), entry.name);
+      const manifest = parseManifest(await readFile(path.join(/* turbopackIgnore: true */ marketplacePluginsRoot(), entry.name, "pack.json"), "utf8"), entry.name);
       if (manifest) packs.push(manifest);
     } catch {
       // Broken marketplace entries are ignored.
@@ -100,7 +102,7 @@ export async function listKnowledgePacks(): Promise<KnowledgePackManifest[]> {
 export async function readKnowledgePack(packId: string): Promise<KnowledgePackManifest | null> {
   if (!isValidPackSlug(packId)) return null;
   try {
-    return parseManifest(await readFile(path.join(pluginDir(packId), "pack.json"), "utf8"), packId);
+    return parseManifest(await readFile(path.join(/* turbopackIgnore: true */ pluginDir(packId), "pack.json"), "utf8"), packId);
   } catch {
     return null;
   }
@@ -109,11 +111,11 @@ export async function readKnowledgePack(packId: string): Promise<KnowledgePackMa
 export async function readPackTemplate(packId: string, templateMeta: KnowledgePackTemplateMeta): Promise<string> {
   const dir = pluginDir(packId);
   if (!isValidPackSlug(templateMeta.id)) throw new Error("invalid template id");
-  const expectedRelative = path.join("templates", `${templateMeta.id}.md`);
+  const expectedRelative = path.join(/* turbopackIgnore: true */ "templates", `${templateMeta.id}.md`);
   if (path.normalize(templateMeta.path) !== expectedRelative) throw new Error("invalid template path");
-  const resolved = path.resolve(dir, expectedRelative);
+  const resolved = path.resolve(/* turbopackIgnore: true */ dir, expectedRelative);
   if (!resolved.startsWith(dir + path.sep)) throw new Error("invalid template path");
-  return readFile(resolved, "utf8");
+  return readFile(/* turbopackIgnore: true */ resolved, "utf8");
 }
 
 function folderMeta(pack: KnowledgePackManifest, folder: KnowledgePackFolder): KnowledgeCollectionMeta {
@@ -130,7 +132,7 @@ function folderMeta(pack: KnowledgePackManifest, folder: KnowledgePackFolder): K
 
 async function exists(filePath: string): Promise<boolean> {
   try {
-    await access(filePath, fsConstants.F_OK);
+    await access(/* turbopackIgnore: true */ filePath, fsConstants.F_OK);
     return true;
   } catch {
     return false;
@@ -142,8 +144,8 @@ async function writeFileIfMissing(filePath: string, contents: string, result: Kn
     result.skipped.push(filePath);
     return;
   }
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, contents, "utf8");
+  await mkdir(/* turbopackIgnore: true */ path.dirname(filePath), { recursive: true });
+  await writeFile(/* turbopackIgnore: true */ filePath, contents, "utf8");
   result.created.push(filePath);
 }
 
@@ -207,19 +209,19 @@ async function seedProject(pack: KnowledgePackManifest, request: Extract<Knowled
   const projects = await loadProjects();
   const project = projectForRoot(request.projectRoot, projects);
   if (!project) throw new Error("unregistered project root");
-  const projectRoot = path.resolve(project.root);
-  const base = path.resolve(projectRoot, ...validateSubfolder(request.subfolder));
+  const projectRoot = path.resolve(/* turbopackIgnore: true */ project.root);
+  const base = path.resolve(/* turbopackIgnore: true */ projectRoot, ...validateSubfolder(request.subfolder));
   assertWithinRoot(base, projectRoot);
   const result: KnowledgePackSeedResult = { ok: true, target: "project", created: [], skipped: [] };
   for (const folder of pack.folders) {
-    const folderDir = path.resolve(base, folder.id);
+    const folderDir = path.resolve(/* turbopackIgnore: true */ base, folder.id);
     assertWithinRoot(folderDir, projectRoot);
     const meta = folderMeta(pack, folder);
-    await writeFileIfMissing(path.join(folderDir, ".cave", "frontmatter.yml"), stringifyYaml(meta), result);
+    await writeFileIfMissing(path.join(/* turbopackIgnore: true */ folderDir, ".cave", "frontmatter.yml"), stringifyYaml(meta), result);
     const readme = `${folder.description} ${folder.storyQuestion ? `This folder answers: ${folder.storyQuestion}` : `Use this folder for ${folder.name}.`}\n`;
-    await writeFileIfMissing(path.join(folderDir, "README.md"), readme, result);
+    await writeFileIfMissing(path.join(/* turbopackIgnore: true */ folderDir, "README.md"), readme, result);
     for (const template of templatesByFolder(pack, folder)) {
-      await writeFileIfMissing(path.join(folderDir, "_templates", `${template.id}.md`), await readPackTemplate(pack.id, template), result);
+      await writeFileIfMissing(path.join(/* turbopackIgnore: true */ folderDir, "_templates", `${template.id}.md`), await readPackTemplate(pack.id, template), result);
     }
   }
   await recordKnowledgePackSeed(pack.id, { target: "project", root: project.root });

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -38,7 +38,7 @@ import { normalizePinRefs, type StitchPinRef } from "../stitch.ts";
 
 /** Root directory for vault entries. Overridable for tests/bundles. */
 export function covenKnowledgeRoot(): string {
-  return process.env.COVEN_KNOWLEDGE_DIR || path.join(covenHome(), "knowledge");
+  return process.env.COVEN_KNOWLEDGE_DIR || path.join(/* turbopackIgnore: true */ covenHome(), "knowledge");
 }
 
 const KNOWLEDGE_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
@@ -269,8 +269,8 @@ export function buildPromptWithKnowledgeVault(
 
 function collectionPath(collection: string): string {
   if (!isValidCollectionId(collection)) throw new Error("invalid knowledge collection");
-  const root = path.resolve(covenKnowledgeRoot());
-  const resolved = path.resolve(root, collection);
+  const root = path.resolve(/* turbopackIgnore: true */ covenKnowledgeRoot());
+  const resolved = path.resolve(/* turbopackIgnore: true */ root, collection);
   if (!resolved.startsWith(root + path.sep) || path.dirname(resolved) !== root) {
     throw new Error("invalid knowledge collection");
   }
@@ -285,9 +285,9 @@ function entryPath(id: string, collection?: string): string {
   // Single chokepoint where a vault path is built from the (slug-validated) id.
   // Resolve and assert containment directly under the vault root so a path can
   // never escape it, even if a caller forgets the id guard.
-  const root = path.resolve(covenKnowledgeRoot());
+  const root = path.resolve(/* turbopackIgnore: true */ covenKnowledgeRoot());
   const parent = collection ? collectionPath(collection) : root;
-  const resolved = path.resolve(parent, `${id}.md`);
+  const resolved = path.resolve(/* turbopackIgnore: true */ parent, `${id}.md`);
   if (!resolved.startsWith(root + path.sep) || path.dirname(resolved) !== parent) {
     throw new Error("invalid knowledge id");
   }
@@ -295,7 +295,7 @@ function entryPath(id: string, collection?: string): string {
 }
 
 function collectionMetaPath(collection: string): string {
-  return path.join(collectionPath(collection), "collection.yml");
+  return path.join(/* turbopackIgnore: true */ collectionPath(collection), "collection.yml");
 }
 
 /** List every vault entry on disk. Returns [] when the directory is absent or
@@ -305,7 +305,8 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
   const root = covenKnowledgeRoot();
   let names: string[];
   try {
-    names = await readdir(collection ? collectionPath(collection) : root);
+    // Vault entries are validated runtime user data, never build inputs.
+    names = await readdir(/* turbopackIgnore: true */ (collection ? collectionPath(collection) : root));
   } catch {
     return [];
   }
@@ -313,7 +314,7 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
   const scanRootEntries = async (dir: string, entryCollection?: string) => {
     let dirNames: string[];
     try {
-      dirNames = await readdir(dir);
+      dirNames = await readdir(/* turbopackIgnore: true */ dir);
     } catch {
       return;
     }
@@ -322,7 +323,7 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
       const id = name.slice(0, -3);
       if (!isValidKnowledgeId(id)) continue;
       try {
-        const raw = await readFile(path.join(dir, name), "utf8");
+        const raw = await readFile(path.join(/* turbopackIgnore: true */ dir, name), "utf8");
         entries.push(parseKnowledgeFile(id, raw, entryCollection));
       } catch {
         // Skip unreadable entries rather than failing the whole list.
@@ -336,12 +337,12 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
   }
 
   for (const name of names.sort()) {
-    const full = path.join(root, name);
+    const full = path.join(/* turbopackIgnore: true */ root, name);
     if (name.endsWith(".md")) {
       const id = name.slice(0, -3);
       if (!isValidKnowledgeId(id)) continue;
       try {
-        const raw = await readFile(full, "utf8");
+        const raw = await readFile(/* turbopackIgnore: true */ full, "utf8");
         entries.push(parseKnowledgeFile(id, raw));
       } catch {
         // Skip unreadable entries rather than failing the whole list.
@@ -350,7 +351,7 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
     }
     if (!isValidCollectionId(name)) continue;
     try {
-      const st = await stat(full);
+      const st = await stat(/* turbopackIgnore: true */ full);
       if (st.isDirectory()) await scanRootEntries(full, name);
     } catch {
       // Skip unreadable entries rather than failing the whole list.
@@ -363,7 +364,7 @@ export async function readKnowledgeEntry(id: string, collection?: string): Promi
   if (!isValidKnowledgeId(id)) return null;
   if (collection !== undefined && !isValidCollectionId(collection)) return null;
   try {
-    const raw = await readFile(entryPath(id, collection), "utf8");
+    const raw = await readFile(/* turbopackIgnore: true */ entryPath(id, collection), "utf8");
     return parseKnowledgeFile(id, raw, collection);
   } catch {
     return null;
@@ -376,8 +377,8 @@ export async function writeKnowledgeEntry(entry: KnowledgeEntry): Promise<Knowle
     throw new Error("invalid knowledge collection");
   }
   const root = covenKnowledgeRoot();
-  await mkdir(entry.collection ? collectionPath(entry.collection) : root, { recursive: true });
-  await writeFile(entryPath(entry.id, entry.collection), serializeKnowledgeEntry(entry), "utf8");
+  await mkdir(/* turbopackIgnore: true */ (entry.collection ? collectionPath(entry.collection) : root), { recursive: true });
+  await writeFile(/* turbopackIgnore: true */ entryPath(entry.id, entry.collection), serializeKnowledgeEntry(entry), "utf8");
   return entry;
 }
 
@@ -385,18 +386,18 @@ export async function deleteKnowledgeEntry(id: string, collection?: string): Pro
   if (!isValidKnowledgeId(id)) return false;
   if (collection !== undefined && !isValidCollectionId(collection)) return false;
   try {
-    await stat(entryPath(id, collection));
+    await stat(/* turbopackIgnore: true */ entryPath(id, collection));
   } catch {
     return false;
   }
-  await rm(entryPath(id, collection), { force: true });
+  await rm(/* turbopackIgnore: true */ entryPath(id, collection), { force: true });
   return true;
 }
 
 export async function readCollectionMeta(collection: string): Promise<KnowledgeCollectionMeta | null> {
   if (!isValidCollectionId(collection)) return null;
   try {
-    const raw = await readFile(collectionMetaPath(collection), "utf8");
+    const raw = await readFile(/* turbopackIgnore: true */ collectionMetaPath(collection), "utf8");
     const parsed = parseYaml(raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
     const meta = parsed as Record<string, unknown>;
@@ -434,7 +435,7 @@ export async function readCollectionMeta(collection: string): Promise<KnowledgeC
 export async function collectionMetaExists(collection: string): Promise<boolean> {
   if (!isValidCollectionId(collection)) return false;
   try {
-    await stat(collectionMetaPath(collection));
+    await stat(/* turbopackIgnore: true */ collectionMetaPath(collection));
     return true;
   } catch {
     return false;
@@ -443,8 +444,8 @@ export async function collectionMetaExists(collection: string): Promise<boolean>
 
 export async function writeCollectionMeta(collection: string, meta: KnowledgeCollectionMeta): Promise<void> {
   if (!isValidCollectionId(collection)) throw new Error("invalid knowledge collection");
-  await mkdir(collectionPath(collection), { recursive: true });
-  await writeFile(collectionMetaPath(collection), stringifyYaml(meta), "utf8");
+  await mkdir(/* turbopackIgnore: true */ collectionPath(collection), { recursive: true });
+  await writeFile(/* turbopackIgnore: true */ collectionMetaPath(collection), stringifyYaml(meta), "utf8");
 }
 
 /** Count valid `*.md` entry files in a collection directory without reading
@@ -452,7 +453,7 @@ export async function writeCollectionMeta(collection: string, meta: KnowledgeCol
 async function countCollectionEntries(collection: string): Promise<number> {
   let dirents: import("node:fs").Dirent[];
   try {
-    dirents = await readdir(collectionPath(collection), { withFileTypes: true });
+    dirents = await readdir(/* turbopackIgnore: true */ collectionPath(collection), { withFileTypes: true });
   } catch {
     return 0;
   }
@@ -468,7 +469,7 @@ export async function listCollections(): Promise<{ id: string; meta: KnowledgeCo
   const root = covenKnowledgeRoot();
   let names: string[];
   try {
-    names = await readdir(root);
+    names = await readdir(/* turbopackIgnore: true */ root);
   } catch {
     return [];
   }
@@ -476,8 +477,8 @@ export async function listCollections(): Promise<{ id: string; meta: KnowledgeCo
   for (const name of names.sort()) {
     if (!isValidCollectionId(name)) continue;
     try {
-      const full = path.join(root, name);
-      const st = await stat(full);
+      const full = path.join(/* turbopackIgnore: true */ root, name);
+      const st = await stat(/* turbopackIgnore: true */ full);
       if (!st.isDirectory()) continue;
       collections.push({
         id: name,

--- a/src/lib/server/memory-file-paths.ts
+++ b/src/lib/server/memory-file-paths.ts
@@ -1,4 +1,10 @@
-import { isMemoryFilePathAllowed, resolveAllowedMemoryFileReadPath } from "./memory-file-sources.ts";
+import {
+  isMemoryFilePathAllowed,
+  resolveAllowedFileReadPath,
+  resolveAllowedMemoryFileReadPath,
+} from "./memory-file-sources.ts";
+
+export { resolveAllowedFileReadPath };
 
 export function isAllowedMemoryFilePath(fullPath: string): boolean {
   return isMemoryFilePathAllowed(fullPath);

--- a/src/lib/server/memory-file-sources.ts
+++ b/src/lib/server/memory-file-sources.ts
@@ -58,6 +58,20 @@ async function isRealPathWithinAllowedRoot(targetPath: string, allowedRoot: stri
   return isWithinRoot(realTarget, realRoot);
 }
 
+/** Resolve an existing file and reject lexical traversal and symlink escapes. */
+export async function resolveAllowedFileReadPath(fullPath: string, allowedRoot: string): Promise<string | null> {
+  const resolved = path.resolve(/* turbopackIgnore: true */ fullPath);
+  const root = path.resolve(/* turbopackIgnore: true */ allowedRoot);
+  if (!isWithinRoot(resolved, root)) return null;
+
+  const [realTarget, realRoot] = await Promise.all([
+    realpathIfPresent(resolved),
+    realpathIfPresent(root),
+  ]);
+  if (realTarget === null || realRoot === null || !isWithinRoot(realTarget, realRoot)) return null;
+  return realTarget;
+}
+
 function familiarAllowedRootPath(fullPath: string, classification: MemoryFileClassification): string | null {
   if (!classification.familiarId) return null;
   const familiarRoot = classification.rootPath;

--- a/src/lib/server/pin-sources.test.ts
+++ b/src/lib/server/pin-sources.test.ts
@@ -1,13 +1,47 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 import {
+  capturePin,
   extractHeadingSection,
   githubApiTarget,
   htmlToText,
   isPrivateIp,
   publicOnlyLookup,
 } from "./pin-sources.ts";
+
+describe("capturePin file containment", () => {
+  it("reads vault files but blocks symlinks that escape the vault root", async () => {
+    const sandbox = await mkdtemp(path.join(tmpdir(), "coven-pin-sources-"));
+    const vault = path.join(sandbox, "knowledge");
+    const safeFile = path.join(vault, "safe.md");
+    const outsideFile = path.join(sandbox, "outside.md");
+    const escapeLink = path.join(vault, "escape.md");
+    const previousRoot = process.env.COVEN_KNOWLEDGE_DIR;
+
+    try {
+      await mkdir(vault);
+      await writeFile(safeFile, "safe vault content", "utf8");
+      await writeFile(outsideFile, "outside content", "utf8");
+      await symlink(outsideFile, escapeLink, "file");
+      process.env.COVEN_KNOWLEDGE_DIR = vault;
+
+      const safe = await capturePin({ kind: "file", ref: safeFile });
+      assert.equal(safe.ok, true);
+      if (safe.ok) assert.equal(safe.pin.content, "safe vault content");
+
+      const escaped = await capturePin({ kind: "file", ref: escapeLink });
+      assert.deepEqual(escaped, { ok: false, error: "path is outside the allowed roots", status: 403 });
+    } finally {
+      if (previousRoot === undefined) delete process.env.COVEN_KNOWLEDGE_DIR;
+      else process.env.COVEN_KNOWLEDGE_DIR = previousRoot;
+      await rm(sandbox, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("isPrivateIp — SSRF guard ranges", () => {
   it("blocks loopback, private, link-local, CGNAT, multicast v4", () => {

--- a/src/lib/server/pin-sources.ts
+++ b/src/lib/server/pin-sources.ts
@@ -25,7 +25,7 @@ import { loadConversation, isSafeConversationSessionId } from "../cave-conversat
 import { parseSafeGitHubUrl, parseSafeHttpUrl } from "../url-safety.ts";
 import { makePin, PIN_CONTENT_MAX, type PinKind, type StitchPin } from "../stitch.ts";
 import { covenKnowledgeRoot } from "./knowledge-vault.ts";
-import { resolveAllowedMemoryFilePath } from "./memory-file-paths.ts";
+import { resolveAllowedFileReadPath, resolveAllowedMemoryFilePath } from "./memory-file-paths.ts";
 
 export type PinCaptureRequest = {
   kind: PinKind;
@@ -369,10 +369,7 @@ async function resolveReadableFile(ref: string): Promise<string | null> {
   // Memory allow-list roots first, then the knowledge vault root.
   const allowed = await resolveAllowedMemoryFilePath(ref);
   if (allowed) return allowed;
-  const root = path.resolve(/* turbopackIgnore: true */ covenKnowledgeRoot());
-  const resolved = path.resolve(/* turbopackIgnore: true */ ref);
-  if (resolved === root || resolved.startsWith(root + path.sep)) return resolved;
-  return null;
+  return resolveAllowedFileReadPath(ref, covenKnowledgeRoot());
 }
 
 async function captureFileLike(kind: "file" | "memory", req: PinCaptureRequest): Promise<PinCaptureResult> {
@@ -383,14 +380,14 @@ async function captureFileLike(kind: "file" | "memory", req: PinCaptureRequest):
     return { ok: false, error: "only markdown/text files can be pinned", status: 400 };
   }
   try {
-    const info = await stat(/* turbopackIgnore: true */ allowed);
+    const info = await stat(allowed);
     if (info.size > FETCH_BYTE_CAP) return { ok: false, error: "file too large to pin", status: 413 };
   } catch {
     return { ok: false, error: "file not found", status: 404 };
   }
   let raw: string;
   try {
-    raw = await readFile(/* turbopackIgnore: true */ allowed, "utf8");
+    raw = await readFile(allowed, "utf8");
   } catch {
     return { ok: false, error: "file unreadable", status: 404 };
   }

--- a/src/lib/server/pin-sources.ts
+++ b/src/lib/server/pin-sources.ts
@@ -369,8 +369,8 @@ async function resolveReadableFile(ref: string): Promise<string | null> {
   // Memory allow-list roots first, then the knowledge vault root.
   const allowed = await resolveAllowedMemoryFilePath(ref);
   if (allowed) return allowed;
-  const root = path.resolve(covenKnowledgeRoot());
-  const resolved = path.resolve(ref);
+  const root = path.resolve(/* turbopackIgnore: true */ covenKnowledgeRoot());
+  const resolved = path.resolve(/* turbopackIgnore: true */ ref);
   if (resolved === root || resolved.startsWith(root + path.sep)) return resolved;
   return null;
 }
@@ -383,14 +383,14 @@ async function captureFileLike(kind: "file" | "memory", req: PinCaptureRequest):
     return { ok: false, error: "only markdown/text files can be pinned", status: 400 };
   }
   try {
-    const info = await stat(allowed);
+    const info = await stat(/* turbopackIgnore: true */ allowed);
     if (info.size > FETCH_BYTE_CAP) return { ok: false, error: "file too large to pin", status: 413 };
   } catch {
     return { ok: false, error: "file not found", status: 404 };
   }
   let raw: string;
   try {
-    raw = await readFile(allowed, "utf8");
+    raw = await readFile(/* turbopackIgnore: true */ allowed, "utf8");
   } catch {
     return { ok: false, error: "file unreadable", status: 404 };
   }

--- a/src/lib/server/preferences-store.ts
+++ b/src/lib/server/preferences-store.ts
@@ -18,12 +18,12 @@ import { writeJsonAtomic } from "@/lib/server/atomic-write";
 
 export function preferencesPath(): string {
   const override = process.env.COVEN_PREFERENCES_PATH?.trim();
-  return override || path.join(caveHome(), "preferences.json");
+  return override || path.join(/* turbopackIgnore: true */ caveHome(), "preferences.json");
 }
 
 function legacyThemePath(): string {
   const override = process.env.COVEN_THEME_PATH?.trim();
-  return override || path.join(caveHome(), "theme.json");
+  return override || path.join(/* turbopackIgnore: true */ caveHome(), "theme.json");
 }
 
 type DiskState = "valid" | "missing" | "malformed";
@@ -31,7 +31,7 @@ type DiskRead = { preferences: CavePreferences; state: DiskState };
 
 async function readPreferencesFile(): Promise<DiskRead> {
   try {
-    const parsed = JSON.parse(await readFile(preferencesPath(), "utf8")) as unknown;
+    const parsed = JSON.parse(await readFile(/* turbopackIgnore: true */ preferencesPath(), "utf8")) as unknown;
     if (
       !parsed ||
       typeof parsed !== "object" ||
@@ -55,7 +55,7 @@ async function readPreferencesFile(): Promise<DiskRead> {
 
 async function readLegacyThemeSeed(): Promise<CavePreferencesPatch | null> {
   try {
-    const parsed = JSON.parse(await readFile(legacyThemePath(), "utf8")) as Record<string, unknown>;
+    const parsed = JSON.parse(await readFile(/* turbopackIgnore: true */ legacyThemePath(), "utf8")) as Record<string, unknown>;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
     const legacyPatch = legacyStorageToPreferencesPatch({
       "coven-theme": parsed.themeId,
@@ -84,13 +84,13 @@ async function readLegacyThemeSeed(): Promise<CavePreferencesPatch | null> {
 async function preserveMalformedFile(): Promise<void> {
   const source = preferencesPath();
   const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
-  await copyFile(source, `${source}.corrupt-${suffix}`).catch(() => {});
+  await copyFile(/* turbopackIgnore: true */ source, `${source}.corrupt-${suffix}`).catch(() => {});
 }
 
 async function writePreferences(preferences: CavePreferences): Promise<void> {
   const target = preferencesPath();
-  await mkdir(path.dirname(target), { recursive: true });
-  await writeJsonAtomic(target, preferences);
+  await mkdir(/* turbopackIgnore: true */ path.dirname(target), { recursive: true });
+  await writeJsonAtomic(/* turbopackIgnore: true */ target, preferences);
 }
 
 async function loadPreferencesUnlocked(options: { seedLegacy: boolean }): Promise<DiskRead> {
@@ -132,7 +132,7 @@ const TRANSIENT_REMOVE_ERRORS = new Set(["EACCES", "EBUSY", "EPERM"]);
 async function removeIntent(pathname: string): Promise<void> {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      await rm(pathname, { force: true });
+      await rm(/* turbopackIgnore: true */ pathname, { force: true });
       return;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code ?? "";
@@ -170,11 +170,13 @@ function intentPid(name: string): number | null {
 async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
   const target = preferencesPath();
   const intentsDir = `${target}.locks`;
-  await mkdir(intentsDir, { recursive: true });
+  // Lock files coordinate runtime sidecars in the user's data directory; they
+  // must not become inputs to standalone output-file tracing.
+  await mkdir(/* turbopackIgnore: true */ intentsDir, { recursive: true });
   const order = process.hrtime.bigint().toString().padStart(24, "0");
   const ownName = `${order}-${process.pid}-${randomBytes(8).toString("hex")}.lock`;
-  const ownPath = path.join(intentsDir, ownName);
-  const handle = await open(ownPath, "wx", 0o600);
+  const ownPath = path.join(/* turbopackIgnore: true */ intentsDir, ownName);
+  const handle = await open(/* turbopackIgnore: true */ ownPath, "wx", 0o600);
   try {
     await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`);
   } finally {
@@ -184,14 +186,14 @@ async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
 
   try {
     while (true) {
-      const names = (await readdir(intentsDir)).filter((name) => intentPid(name) !== null).sort();
+      const names = (await readdir(/* turbopackIgnore: true */ intentsDir)).filter((name) => intentPid(name) !== null).sort();
       for (const name of names) {
         if (name === ownName) continue;
         const pid = intentPid(name)!;
-        const candidate = path.join(intentsDir, name);
+        const candidate = path.join(/* turbopackIgnore: true */ intentsDir, name);
         let tooOld = false;
         try {
-          tooOld = Date.now() - (await stat(candidate)).mtimeMs > ORPHAN_INTENT_MAX_AGE_MS;
+          tooOld = Date.now() - (await stat(/* turbopackIgnore: true */ candidate)).mtimeMs > ORPHAN_INTENT_MAX_AGE_MS;
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
           throw error;
@@ -203,7 +205,7 @@ async function acquirePreferencesFileLock(): Promise<() => Promise<void>> {
         }
       }
 
-      const remaining = (await readdir(intentsDir))
+      const remaining = (await readdir(/* turbopackIgnore: true */ intentsDir))
         .filter((name) => intentPid(name) !== null)
         .sort();
       if (remaining[0] === ownName) {

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -5,31 +5,34 @@ import { covenHome, caveHome, covenWorkspaceRoot } from "@/lib/coven-paths";
 import { researchMissionsRoot } from "@/lib/server/research-mission-store";
 
 function realpathOrResolve(value: string): string {
-  const resolved = path.resolve(value);
+  const resolved = path.resolve(/* turbopackIgnore: true */ value);
   try {
-    return fs.realpathSync(resolved);
+    return fs.realpathSync(/* turbopackIgnore: true */ resolved);
   } catch {
     return resolved;
   }
 }
 
 function normalizeLegacyCovenWorkspacePath(value: string): string {
-  const resolved = path.resolve(value);
-  const legacyRoot = path.resolve(path.join(covenHome(), "workspace"));
+  const resolved = path.resolve(/* turbopackIgnore: true */ value);
+  const legacyRoot = path.resolve(path.join(/* turbopackIgnore: true */ covenHome(), "workspace"));
   if (resolved !== legacyRoot && !resolved.startsWith(legacyRoot + path.sep)) {
     return value;
   }
 
-  return path.join(path.resolve(path.join(covenHome(), "workspaces")), path.relative(legacyRoot, resolved));
+  return path.join(
+    /* turbopackIgnore: true */ path.resolve(path.join(/* turbopackIgnore: true */ covenHome(), "workspaces")),
+    path.relative(/* turbopackIgnore: true */ legacyRoot, resolved),
+  );
 }
 
 function caveProjectsFilePath(): string {
-  return process.env.CAVE_PROJECTS_PATH_OVERRIDE ?? path.join(caveHome(), "projects.json");
+  return process.env.CAVE_PROJECTS_PATH_OVERRIDE ?? path.join(/* turbopackIgnore: true */ caveHome(), "projects.json");
 }
 
 function savedCaveProjectRoots(): string[] {
   try {
-    const parsed = JSON.parse(fs.readFileSync(caveProjectsFilePath(), "utf8")) as {
+    const parsed = JSON.parse(fs.readFileSync(/* turbopackIgnore: true */ caveProjectsFilePath(), "utf8")) as {
       projects?: Array<{ root?: unknown }>;
     };
     if (!Array.isArray(parsed.projects)) return [];
@@ -53,7 +56,7 @@ function builtInProjectRoots(): string[] {
     covenWorkspaceRoot(),
     // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
     process.env.OPENCLAW_WORKSPACE_ROOT,
-    path.join(homedir(), ".openclaw", "workspace"),
+    path.join(/* turbopackIgnore: true */ homedir(), ".openclaw", "workspace"),
     process.cwd(),
     // Research mission workspaces host bounded research sessions and live
     // under cave state rather than a registered project root.
@@ -76,7 +79,7 @@ function isWithinRoot(candidate: string, root: string): boolean {
 }
 
 function relativeWithinRoot(candidate: string, root: string): string | null {
-  const relativePath = path.relative(root, candidate);
+  const relativePath = path.relative(/* turbopackIgnore: true */ root, candidate);
   if (
     relativePath.startsWith("..") ||
     path.isAbsolute(relativePath) ||
@@ -103,7 +106,7 @@ export function resolveAllowedProjectSubpath(value: string): { root: string; rel
 
 export function resolveAllowedProjectPath(value: string): string | null {
   const subpath = resolveAllowedProjectSubpath(value);
-  return subpath ? path.join(subpath.root, subpath.relativePath) : null;
+  return subpath ? path.join(/* turbopackIgnore: true */ subpath.root, subpath.relativePath) : null;
 }
 
 export function isAllowedNewProjectRoot(value: string): boolean {

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -32,7 +32,8 @@ type ResearchLinksFile = {
 
 export function researchLinksPath(): string {
   const override = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE?.trim();
-  return override || path.join(caveHome(), "research-links.json");
+  // Saved links are runtime user data beneath Cave home, never build inputs.
+  return override || path.join(/* turbopackIgnore: true */ caveHome(), "research-links.json");
 }
 
 function emptyFile(): ResearchLinksFile {
@@ -67,7 +68,7 @@ function normalizeStoredLink(value: unknown): SavedLink | null {
 async function loadFile(): Promise<ResearchLinksFile> {
   let text: string;
   try {
-    text = await readFile(researchLinksPath(), "utf8");
+    text = await readFile(/* turbopackIgnore: true */ researchLinksPath(), "utf8");
   } catch (error) {
     // Only a missing file means "empty store". Transient read failures
     // (EACCES/EMFILE/EIO) must surface — otherwise the next save would
@@ -93,13 +94,13 @@ async function loadFile(): Promise<ResearchLinksFile> {
 async function preserveMalformedFile(): Promise<void> {
   const source = researchLinksPath();
   const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
-  await copyFile(source, `${source}.corrupt-${suffix}`).catch(() => {});
+  await copyFile(/* turbopackIgnore: true */ source, `${source}.corrupt-${suffix}`).catch(() => {});
 }
 
 async function saveFile(file: ResearchLinksFile): Promise<void> {
   const target = researchLinksPath();
-  await mkdir(path.dirname(target), { recursive: true });
-  await writeJsonAtomic(target, file);
+  await mkdir(/* turbopackIgnore: true */ path.dirname(target), { recursive: true });
+  await writeJsonAtomic(/* turbopackIgnore: true */ target, file);
 }
 
 let writeMutex: Promise<unknown> = Promise.resolve();

--- a/src/lib/server/research-mission-store.ts
+++ b/src/lib/server/research-mission-store.ts
@@ -28,7 +28,7 @@ function missionLocks(): Map<string, Promise<void>> {
 export function researchMissionsRoot(): string {
   return (
     process.env.COVEN_RESEARCH_MISSIONS_DIR?.trim() ||
-    path.join(caveHome(), "research-missions")
+    path.join(/* turbopackIgnore: true */ caveHome(), "research-missions")
   );
 }
 
@@ -42,14 +42,14 @@ function assertMissionId(id: string): void {
 
 export function researchMissionWorkspacePath(id: string): string {
   assertMissionId(id);
-  return path.join(researchMissionsRoot(), id);
+  return path.join(/* turbopackIgnore: true */ researchMissionsRoot(), id);
 }
 
 export function missionArtifactPath(id: string, fileName: string): string {
   if (!ARTIFACT_FILE_RE.test(fileName) || path.basename(fileName) !== fileName) {
     throw new Error("invalid artifact filename");
   }
-  return path.join(researchMissionWorkspacePath(id), "artifacts", fileName);
+  return path.join(/* turbopackIgnore: true */ researchMissionWorkspacePath(id), "artifacts", fileName);
 }
 
 function isWithin(candidate: string, root: string): boolean {
@@ -93,13 +93,15 @@ export function withResearchMissionLock<T>(
 
 async function assertRealMissionDirectory(id: string): Promise<string> {
   const directory = researchMissionWorkspacePath(id);
-  const stat = await lstat(directory);
+  // Research workspaces live beneath the user's runtime cave home. They are
+  // validated below, but are never build inputs for the Next server bundle.
+  const stat = await lstat(/* turbopackIgnore: true */ directory);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error("mission workspace must be a real directory");
   }
   const [resolvedDirectory, resolvedRoot] = await Promise.all([
-    realpath(directory),
-    realpath(researchMissionsRoot()),
+    realpath(/* turbopackIgnore: true */ directory),
+    realpath(/* turbopackIgnore: true */ researchMissionsRoot()),
   ]);
   if (!isWithin(resolvedDirectory, resolvedRoot)) {
     throw new Error("mission workspace is outside research root");
@@ -114,23 +116,23 @@ export async function createResearchMissionWorkspace(
   return withResearchMissionLock(mission.id, async () => {
     const root = researchMissionsRoot();
     const directory = researchMissionWorkspacePath(mission.id);
-    await mkdir(root, { recursive: true });
-    await mkdir(directory);
+    await mkdir(/* turbopackIgnore: true */ root, { recursive: true });
+    await mkdir(/* turbopackIgnore: true */ directory);
     try {
-      await mkdir(path.join(directory, "artifacts"));
+      await mkdir(path.join(/* turbopackIgnore: true */ directory, "artifacts"));
       await Promise.all([
-        writeJsonAtomic(path.join(directory, "mission.json"), mission),
+        writeJsonAtomic(path.join(/* turbopackIgnore: true */ directory, "mission.json"), mission),
         writeFileAtomic(
-          path.join(directory, "research-state.yaml"),
+          path.join(/* turbopackIgnore: true */ directory, "research-state.yaml"),
           `version: 1\nmission: ${mission.id}\nstatus: ${mission.status}\niteration: 0\n`,
         ),
-        writeFileAtomic(path.join(directory, "findings.md"), "# Findings\n"),
-        writeFileAtomic(path.join(directory, "research-log.md"), "# Research log\n"),
-        writeJsonAtomic(path.join(directory, "sources.json"), mission.sources),
+        writeFileAtomic(path.join(/* turbopackIgnore: true */ directory, "findings.md"), "# Findings\n"),
+        writeFileAtomic(path.join(/* turbopackIgnore: true */ directory, "research-log.md"), "# Research log\n"),
+        writeJsonAtomic(path.join(/* turbopackIgnore: true */ directory, "sources.json"), mission.sources),
       ]);
       return mission;
     } catch (error) {
-      await rm(directory, { recursive: true, force: true });
+      await rm(/* turbopackIgnore: true */ directory, { recursive: true, force: true });
       throw error;
     }
   });
@@ -140,7 +142,7 @@ export async function saveResearchMission(mission: ResearchMission): Promise<voi
   assertMissionId(mission.id);
   await withResearchMissionLock(mission.id, async () => {
     const directory = await assertRealMissionDirectory(mission.id);
-    await writeJsonAtomic(path.join(directory, "mission.json"), mission);
+    await writeJsonAtomic(path.join(/* turbopackIgnore: true */ directory, "mission.json"), mission);
   });
 }
 
@@ -148,7 +150,7 @@ export async function loadResearchMission(id: string): Promise<ResearchMission |
   assertMissionId(id);
   try {
     const directory = await assertRealMissionDirectory(id);
-    const raw = await readFile(path.join(directory, "mission.json"), "utf8");
+    const raw = await readFile(path.join(/* turbopackIgnore: true */ directory, "mission.json"), "utf8");
     const parsed: unknown = JSON.parse(raw);
     if (!isResearchMission(parsed) || parsed.id !== id) return null;
     return parsed;
@@ -162,7 +164,7 @@ export async function loadResearchMission(id: string): Promise<ResearchMission |
 export async function listResearchMissions(): Promise<ResearchMission[]> {
   let entries;
   try {
-    entries = await readdir(researchMissionsRoot(), { withFileTypes: true });
+    entries = await readdir(/* turbopackIgnore: true */ researchMissionsRoot(), { withFileTypes: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
     throw error;
@@ -182,17 +184,17 @@ export async function readValidatedMissionFile(
   relativePath: string,
 ): Promise<string> {
   const directory = await assertRealMissionDirectory(id);
-  const candidate = path.resolve(directory, relativePath);
+  const candidate = path.resolve(/* turbopackIgnore: true */ directory, relativePath);
   if (!relativePath || path.isAbsolute(relativePath) || !isWithin(candidate, directory)) {
     throw new Error("file is outside mission workspace");
   }
-  const stat = await lstat(candidate);
+  const stat = await lstat(/* turbopackIgnore: true */ candidate);
   if (stat.isSymbolicLink()) throw new Error("research files cannot be symlinks");
   if (!stat.isFile()) throw new Error("research path is not a file");
   if (stat.size > MAX_RESEARCH_FILE_BYTES) throw new Error("research file is too large");
-  const resolvedCandidate = await realpath(candidate);
+  const resolvedCandidate = await realpath(/* turbopackIgnore: true */ candidate);
   if (!isWithin(resolvedCandidate, directory)) {
     throw new Error("file is outside mission workspace");
   }
-  return readFile(resolvedCandidate, "utf8");
+  return readFile(/* turbopackIgnore: true */ resolvedCandidate, "utf8");
 }

--- a/src/lib/server/skill-build.ts
+++ b/src/lib/server/skill-build.ts
@@ -86,19 +86,21 @@ export async function buildSkill(input: SkillBuildInput, opts: RootOptions = {})
   if (!rootDir) return { ok: false, code: "invalid", error: "unknown destination root" };
 
   const slug = slugifySkillName(input.name);
-  const dir = path.join(rootDir, slug);
-  const filePath = path.join(dir, "SKILL.md");
+  const dir = path.join(/* turbopackIgnore: true */ rootDir, slug);
+  // The selected root and slug are runtime user choices constrained above;
+  // none of these local filesystem paths are build-time dependencies.
+  const filePath = path.join(/* turbopackIgnore: true */ dir, "SKILL.md");
 
   try {
-    await stat(dir);
+    await stat(/* turbopackIgnore: true */ dir);
     return { ok: false, code: "exists", error: `a skill with id "${slug}" already exists at ${dir}` };
   } catch {
     // Missing directory is the happy path.
   }
 
   try {
-    await mkdir(dir, { recursive: true });
-    await writeFileAtomic(filePath, composeSkillMd(input));
+    await mkdir(/* turbopackIgnore: true */ dir, { recursive: true });
+    await writeFileAtomic(/* turbopackIgnore: true */ filePath, composeSkillMd(input));
   } catch (err) {
     return { ok: false, code: "io", error: err instanceof Error ? err.message : "write failed" };
   }

--- a/src/lib/server/skill-file-paths.ts
+++ b/src/lib/server/skill-file-paths.ts
@@ -39,16 +39,18 @@ export async function isAllowedSkillFilePath(fullPath: string, home = homedir())
   let candidateStat;
   let candidateRealPath: string;
   try {
-    candidateStat = await lstat(fullPath);
+    candidateStat = await lstat(/* turbopackIgnore: true */ fullPath);
     if (candidateStat.isSymbolicLink() || !candidateStat.isFile()) return false;
-    candidateRealPath = await realpath(fullPath);
+    candidateRealPath = await realpath(/* turbopackIgnore: true */ fullPath);
   } catch {
     return false;
   }
 
   if (path.basename(candidateRealPath) === CODEX_AUTOMATION_FILE_NAME) {
     try {
-      const automationsRoot = await realpath(path.join(home, ".codex", "automations"));
+      const automationsRoot = await realpath(
+        /* turbopackIgnore: true */ path.join(home, ".codex", "automations"),
+      );
       return isWithinRoot(candidateRealPath, automationsRoot);
     } catch {
       return false;
@@ -57,7 +59,9 @@ export async function isAllowedSkillFilePath(fullPath: string, home = homedir())
 
   for (const sub of HOME_SKILL_ROOT_SUBPATHS) {
     try {
-      const rootRealPath = await realpath(path.join(home, sub));
+      const rootRealPath = await realpath(
+        /* turbopackIgnore: true */ path.join(/* turbopackIgnore: true */ home, sub),
+      );
       if (isWithinRoot(candidateRealPath, rootRealPath)) return true;
     } catch {
       // Missing harness roots are not previewable roots.
@@ -66,7 +70,9 @@ export async function isAllowedSkillFilePath(fullPath: string, home = homedir())
 
   for (const sub of PROJECT_SKILL_ROOT_SUBPATHS) {
     try {
-      const rootRealPath = await realpath(path.join(process.cwd(), sub));
+      const rootRealPath = await realpath(
+        /* turbopackIgnore: true */ path.join(/* turbopackIgnore: true */ process.cwd(), sub),
+      );
       if (isWithinRoot(candidateRealPath, rootRealPath)) return true;
     } catch {
       // Missing project roots are not previewable roots.
@@ -91,9 +97,9 @@ export async function isRemovableSkillDir(dir: string, home = homedir()): Promis
 
   let real: string;
   try {
-    const st = await lstat(dir);
+    const st = await lstat(/* turbopackIgnore: true */ dir);
     if (st.isSymbolicLink() || !st.isDirectory()) return false;
-    real = await realpath(dir);
+    real = await realpath(/* turbopackIgnore: true */ dir);
   } catch {
     return false;
   }
@@ -108,7 +114,7 @@ export async function isRemovableSkillDir(dir: string, home = homedir()): Promis
   ];
   for (const root of rootCandidates) {
     try {
-      const rootReal = await realpath(root);
+      const rootReal = await realpath(/* turbopackIgnore: true */ root);
       // Must be a DIRECT child of a scan root — never the root itself, never nested.
       if (parent === rootReal && real !== rootReal) return true;
     } catch {

--- a/src/lib/server/space-usage.ts
+++ b/src/lib/server/space-usage.ts
@@ -75,7 +75,7 @@ async function walk(root: string, filesOnly: boolean): Promise<WalkTally | null>
         tally.truncated = true;
         return tally;
       }
-      const full = path.join(dir, entry.name);
+      const full = path.join(/* turbopackIgnore: true */ dir, entry.name);
       if (entry.isDirectory()) {
         if (filesOnly) continue;
         if (depth + 1 > MAX_DEPTH) {
@@ -104,7 +104,7 @@ async function walk(root: string, filesOnly: boolean): Promise<WalkTally | null>
 export async function collectSpaceUsage(home = covenHome()): Promise<SpaceUsageArea[]> {
   return Promise.all(
     AREAS.map(async (area): Promise<SpaceUsageArea> => {
-      const root = area.dir === "." ? home : path.join(home, area.dir);
+      const root = area.dir === "." ? home : path.join(/* turbopackIgnore: true */ home, area.dir);
       const tally = await walk(root, area.filesOnly ?? false);
       return {
         id: area.id,

--- a/src/lib/threads-adapters.ts
+++ b/src/lib/threads-adapters.ts
@@ -56,11 +56,11 @@ const AUDIT_PAGE_SIZE = 200;
 function pendingDirCursor(dir: string): string {
   let listing: string[] = [];
   try {
-    listing = readdirSync(dir)
+    listing = readdirSync(/* turbopackIgnore: true */ dir)
       .filter((f) => f.endsWith(".json"))
       .sort()
       .map((f) => {
-        const stat = statSync(path.join(dir, f));
+        const stat = statSync(path.join(/* turbopackIgnore: true */ dir, f));
         return `${f}:${stat.size}:${stat.mtimeMs}`;
       });
   } catch {
@@ -75,7 +75,7 @@ function readPendingDir(dir: string): ProposalView[] | null {
   // instead of rendering blocked.
   let files: string[];
   try {
-    files = readdirSync(dir)
+    files = readdirSync(/* turbopackIgnore: true */ dir)
       .filter((f) => f.endsWith(".json"))
       .sort();
   } catch {
@@ -83,7 +83,7 @@ function readPendingDir(dir: string): ProposalView[] | null {
   }
   return files.map((file) => {
     try {
-      const raw: unknown = JSON.parse(readFileSync(path.join(dir, file), "utf8"));
+      const raw: unknown = JSON.parse(readFileSync(path.join(/* turbopackIgnore: true */ dir, file), "utf8"));
       return normalizeProposal(file, raw);
     } catch {
       // R6: corrupt pending file — listed, actions disabled, never dropped.
@@ -96,8 +96,8 @@ function findPendingFile(dir: string, proposalId: string): string | null {
   // Filename convention: <familiar-uuid>-<proposal-uuid>.json (staging.rs).
   // proposalId is regex-validated before this is called; never joined raw.
   try {
-    const match = readdirSync(dir).find((f) => f.endsWith(`-${proposalId}.json`));
-    return match ? path.join(dir, match) : null;
+    const match = readdirSync(/* turbopackIgnore: true */ dir).find((f) => f.endsWith(`-${proposalId}.json`));
+    return match ? path.join(/* turbopackIgnore: true */ dir, match) : null;
   } catch {
     return null;
   }
@@ -121,8 +121,10 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
   private readonly scenario: FixturesScenario;
 
   constructor(options: FixturesAdapterOptions = {}) {
-    this.root = options.root ?? path.join(process.cwd(), "fixtures", "phase-4");
-    this.pendingDir = options.pendingDir ?? path.join(this.root, "pending");
+    // Both fixture overrides and daemon stores are selected at runtime. Ignore
+    // them as trace roots while retaining the existing validation/read paths.
+    this.root = options.root ?? path.join(/* turbopackIgnore: true */ process.cwd(), "fixtures", "phase-4");
+    this.pendingDir = options.pendingDir ?? path.join(/* turbopackIgnore: true */ this.root, "pending");
     this.scenario = options.scenario ?? "default";
   }
 
@@ -138,7 +140,7 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
 
   private loadWeaveEntries(): RawWeaveEntry[] | null {
     try {
-      const raw: unknown = JSON.parse(readFileSync(path.join(this.root, "weaves.json"), "utf8"));
+      const raw: unknown = JSON.parse(readFileSync(path.join(/* turbopackIgnore: true */ this.root, "weaves.json"), "utf8"));
       return Array.isArray(raw) ? (raw as RawWeaveEntry[]) : null;
     } catch {
       return null;
@@ -147,7 +149,7 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
 
   private weaveCursor(): string {
     try {
-      const stat = statSync(path.join(this.root, "weaves.json"));
+      const stat = statSync(path.join(/* turbopackIgnore: true */ this.root, "weaves.json"));
       return `weave:fixture:${stat.size}:${stat.mtimeMs}`;
     } catch {
       return "weave:fixture:absent";
@@ -220,7 +222,7 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
     if (timeout) return timeout;
     let lines: string[];
     try {
-      lines = readFileSync(path.join(this.root, "ward-audit.jsonl"), "utf8")
+      lines = readFileSync(path.join(/* turbopackIgnore: true */ this.root, "ward-audit.jsonl"), "utf8")
         .split("\n")
         .filter((l) => l.trim().length > 0);
     } catch {
@@ -250,7 +252,7 @@ export class FixturesThreadsAdapter implements ThreadsReadAdapter {
   async proposals(): Promise<ThreadsEnvelope<ProposalView[]>> {
     const timeout = this.timedOut<ProposalView[]>();
     if (timeout) return timeout;
-    if (!existsSync(this.pendingDir)) {
+    if (!existsSync(/* turbopackIgnore: true */ this.pendingDir)) {
       return blockedEnvelope("no-fixture", this.meta("pending:absent", false));
     }
     const listed = readPendingDir(this.pendingDir);
@@ -381,8 +383,8 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
   }
 
   async audit(threadId: string, before?: number): Promise<ThreadsEnvelope<AuditEntryView[]>> {
-    const dbPath = path.join(this.home, "coven.sqlite3");
-    if (!existsSync(dbPath)) {
+    const dbPath = path.join(/* turbopackIgnore: true */ this.home, "coven.sqlite3");
+    if (!existsSync(/* turbopackIgnore: true */ dbPath)) {
       return blockedEnvelope("no-audit-store", this.meta("ward_audit:absent", false));
     }
     try {
@@ -419,11 +421,11 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
   }
 
   async proposals(): Promise<ThreadsEnvelope<ProposalView[]>> {
-    const pendingDir = path.join(this.home, "pending");
-    if (!existsSync(pendingDir)) {
+    const pendingDir = path.join(/* turbopackIgnore: true */ this.home, "pending");
+    if (!existsSync(/* turbopackIgnore: true */ pendingDir)) {
       // No pending dir but a real coven home: nothing has ever been staged —
       // verified empty. No coven home at all: nothing to verify against.
-      if (existsSync(this.home)) return okEnvelope([], this.meta("pending:empty", true));
+      if (existsSync(/* turbopackIgnore: true */ this.home)) return okEnvelope([], this.meta("pending:empty", true));
       return blockedEnvelope("daemon-unavailable", this.meta("pending:absent", false));
     }
     const listed = readPendingDir(pendingDir);
@@ -443,11 +445,11 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
     if (!isSafeThreadsId(proposalId)) {
       return blockedEnvelope("invalid-id", this.meta("none", false));
     }
-    const pendingDir = path.join(this.home, "pending");
+    const pendingDir = path.join(/* turbopackIgnore: true */ this.home, "pending");
     const file = findPendingFile(pendingDir, proposalId);
     if (!file) return blockedEnvelope("not-found", this.meta(pendingDirCursor(pendingDir), false));
     try {
-      const parsed = normalizeProposal(path.basename(file), JSON.parse(readFileSync(file, "utf8")));
+      const parsed = normalizeProposal(path.basename(file), JSON.parse(readFileSync(/* turbopackIgnore: true */ file, "utf8")));
       if (parsed.parse === "corrupt") {
         return blockedEnvelope("proposal-corrupt", this.meta(pendingDirCursor(pendingDir), false));
       }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -111,13 +111,13 @@ function isBundle(): boolean {
 function vaultYamlPath(): string {
   const override = process.env.COVEN_VAULT_FILE?.trim();
   if (override) return override;
-  if (isBundle()) return join(caveHome(), "vault.yaml");
-  return join(process.cwd(), "vault.yaml");
+  if (isBundle()) return join(/* turbopackIgnore: true */ caveHome(), "vault.yaml");
+  return join(/* turbopackIgnore: true */ process.cwd(), "vault.yaml");
 }
 
 /** Read-only vault map shipped inside the bundle (cwd at runtime). */
 function bundledSeedVaultPath(): string {
-  return join(process.cwd(), "vault.yaml");
+  return join(/* turbopackIgnore: true */ process.cwd(), "vault.yaml");
 }
 
 let _vaultSeedChecked = false;
@@ -131,13 +131,13 @@ function seedVaultIfNeeded(): void {
   if (_vaultSeedChecked) return;
   _vaultSeedChecked = true;
   const dest = vaultYamlPath();
-  if (existsSync(dest)) return;
+  if (existsSync(/* turbopackIgnore: true */ dest)) return;
   const seed = bundledSeedVaultPath();
-  if (resolve(seed) === resolve(dest)) return;
+  if (resolve(/* turbopackIgnore: true */ seed) === resolve(/* turbopackIgnore: true */ dest)) return;
   try {
-    if (!existsSync(seed)) return;
-    mkdirSync(dirname(dest), { recursive: true });
-    copyFileSync(seed, dest);
+    if (!existsSync(/* turbopackIgnore: true */ seed)) return;
+    mkdirSync(/* turbopackIgnore: true */ dirname(dest), { recursive: true });
+    copyFileSync(/* turbopackIgnore: true */ seed, dest);
   } catch {
     // Best-effort: a failed seed just means the map starts empty.
   }
@@ -151,9 +151,9 @@ export function loadVaultMap(force = false): VaultMap {
   if (_vaultMap && !force) return _vaultMap;
   seedVaultIfNeeded();
   const vaultYaml = vaultYamlPath();
-  if (!existsSync(vaultYaml)) { _vaultMap = {}; return {}; }
+  if (!existsSync(/* turbopackIgnore: true */ vaultYaml)) { _vaultMap = {}; return {}; }
   try {
-    const raw = readFileSync(vaultYaml, "utf8");
+    const raw = readFileSync(/* turbopackIgnore: true */ vaultYaml, "utf8");
     const parsed = parseYaml(raw) as VaultMap | null;
     _vaultMap = parsed ?? {};
     return _vaultMap;
@@ -199,8 +199,8 @@ export function saveVaultMap(map: VaultMap): void {
     lines.push("");
   }
   const vaultYaml = vaultYamlPath();
-  mkdirSync(dirname(vaultYaml), { recursive: true });
-  writeFileSync(vaultYaml, lines.join("\n"), "utf8");
+  mkdirSync(/* turbopackIgnore: true */ dirname(vaultYaml), { recursive: true });
+  writeFileSync(/* turbopackIgnore: true */ vaultYaml, lines.join("\n"), "utf8");
   _vaultMap = map; // bust cache
 }
 
@@ -238,8 +238,8 @@ function resolverEnv(): NodeJS.ProcessEnv {
     "/opt/homebrew/bin",
     "/opt/homebrew/sbin",
     "/usr/local/bin",
-    join(home, ".local", "bin"),
-    join(home, "bin"),
+    join(/* turbopackIgnore: true */ home, ".local", "bin"),
+    join(/* turbopackIgnore: true */ home, "bin"),
   ];
   const current = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
   const merged = [...current, ...candidates.filter((dir) => !current.includes(dir))];
@@ -271,12 +271,12 @@ function isTimeoutError(e: unknown): boolean {
  *  attempt was killed by the base timeout. Returns null on failure. */
 function cliRead(cli: "op" | "dcli", ref: string): string | null {
   const run = (timeout: number) =>
-    execFileSync(cli, ["read", ref], {
+    String(Reflect.apply(execFileSync, undefined, [cli, ["read", ref], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout,
       env: resolverEnv(),
-    }).trim();
+    }])).trim();
 
   try {
     return run(refReadTimeoutMs()) || null;

--- a/src/lib/workflow-runs.ts
+++ b/src/lib/workflow-runs.ts
@@ -26,12 +26,12 @@ type RunsFile = { version: 1; runs: WorkflowRunRecord[] };
 function runsPath(): string {
   const override = process.env.COVEN_WORKFLOW_RUNS_PATH?.trim();
   if (override) return override;
-  return path.join(homedir(), ".coven", "workflow-runs.json");
+  return path.join(/* turbopackIgnore: true */ homedir(), ".coven", "workflow-runs.json");
 }
 
 async function loadRunsFile(): Promise<RunsFile> {
   try {
-    const text = await readFile(runsPath(), "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ runsPath(), "utf8");
     const parsed = JSON.parse(text) as RunsFile;
     if (parsed && Array.isArray(parsed.runs)) return { version: 1, runs: parsed.runs };
   } catch {
@@ -56,8 +56,8 @@ export async function recordRun(input: Omit<WorkflowRunRecord, "id">): Promise<W
     const file = await loadRunsFile();
     file.runs.unshift(record);
     if (file.runs.length > RUNS_HISTORY_CAP) file.runs.length = RUNS_HISTORY_CAP;
-    await mkdir(path.dirname(runsPath()), { recursive: true });
-    await writeJsonAtomic(runsPath(), file);
+    await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+    await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
   });
   return record;
 }
@@ -80,8 +80,8 @@ export async function clearRuns(workflowId?: string): Promise<number> {
     file.runs = workflowId ? file.runs.filter((run) => run.workflowId !== workflowId) : [];
     const removed = before - file.runs.length;
     if (removed > 0) {
-      await mkdir(path.dirname(runsPath()), { recursive: true });
-      await writeJsonAtomic(runsPath(), file);
+      await mkdir(/* turbopackIgnore: true */ path.dirname(runsPath()), { recursive: true });
+      await writeJsonAtomic(/* turbopackIgnore: true */ runsPath(), file);
     }
     return removed;
   });

--- a/src/lib/workflow-source.ts
+++ b/src/lib/workflow-source.ts
@@ -42,15 +42,15 @@ type FoundWorkflow = WorkflowSummary & { storage: WorkflowStorageScope };
 export function workflowsDir(): string {
   const override = process.env.COVEN_WORKFLOWS_DIR?.trim();
   if (override) return override;
-  if (isBundle()) return path.join(caveHome(), "workflows");
-  return path.join(process.cwd(), "workflows");
+  if (isBundle()) return path.join(/* turbopackIgnore: true */ caveHome(), "workflows");
+  return path.join(/* turbopackIgnore: true */ process.cwd(), "workflows");
 }
 
 /** Read-only public workflow templates shipped inside the app bundle. In
  *  bundle mode the sidecar's cwd is the bundle's server dir, so its `workflows/`
  *  seeds live alongside. Used only to seed the writable dir on first run. */
 function bundledSeedWorkflowsDir(): string {
-  return path.join(process.cwd(), "workflows");
+  return path.join(/* turbopackIgnore: true */ process.cwd(), "workflows");
 }
 
 function isBundle(): boolean {
@@ -74,7 +74,7 @@ async function seedPublicWorkflowsIfNeeded(): Promise<void> {
 
   const dest = workflowsDir();
   try {
-    await stat(dest);
+    await stat(/* turbopackIgnore: true */ dest);
     return; // already present → seeded (or intentionally emptied) — leave it
   } catch {
     // not present → seed below
@@ -83,17 +83,20 @@ async function seedPublicWorkflowsIfNeeded(): Promise<void> {
   const seedDir = bundledSeedWorkflowsDir();
   let names: string[];
   try {
-    names = await readdir(seedDir);
+    names = await readdir(/* turbopackIgnore: true */ seedDir);
   } catch {
     return; // no bundled seeds (e.g. seedDir === dest) → nothing to copy
   }
-  if (path.resolve(seedDir) === path.resolve(dest)) return;
+  if (path.resolve(/* turbopackIgnore: true */ seedDir) === path.resolve(/* turbopackIgnore: true */ dest)) return;
 
-  await mkdir(dest, { recursive: true });
+  await mkdir(/* turbopackIgnore: true */ dest, { recursive: true });
   for (const name of names) {
     if (!/\.(ya?ml|cave\.json)$/i.test(name)) continue;
     try {
-      await copyFile(path.join(seedDir, name), path.join(dest, name));
+      await copyFile(
+        path.join(/* turbopackIgnore: true */ seedDir, name),
+        path.join(/* turbopackIgnore: true */ dest, name),
+      );
     } catch {
       // Best-effort: a failed copy just means that one template is unavailable.
     }
@@ -103,7 +106,7 @@ async function seedPublicWorkflowsIfNeeded(): Promise<void> {
 export function personalWorkflowsDir(): string {
   const override = process.env.COVEN_PERSONAL_WORKFLOWS_DIR?.trim();
   if (override) return override;
-  return path.join(covenHome(), "workflows", "personal");
+  return path.join(/* turbopackIgnore: true */ covenHome(), "workflows", "personal");
 }
 
 const KNOWN_PATTERNS = new Set([
@@ -421,7 +424,7 @@ export function planDryRun(workflow: WorkflowSummary): WorkflowDryRunPlan {
 async function readManifestFilesInDir(dir: string, storage: WorkflowStorageScope): Promise<ManifestFile[]> {
   let entries: string[];
   try {
-    entries = await readdir(dir);
+    entries = await readdir(/* turbopackIgnore: true */ dir);
   } catch {
     return [];
   }
@@ -431,9 +434,9 @@ async function readManifestFilesInDir(dir: string, storage: WorkflowStorageScope
 
   const out: ManifestFile[] = [];
   for (const name of files) {
-    const full = path.join(dir, name);
+    const full = path.join(/* turbopackIgnore: true */ dir, name);
     try {
-      const text = await readFile(full, "utf8");
+      const text = await readFile(/* turbopackIgnore: true */ full, "utf8");
       out.push({ source: name.replace(/\.ya?ml$/i, ""), raw: parseYaml(text), storage });
     } catch {
       // Unreadable/malformed file → surface as an invalid stub so it isn't silently dropped.
@@ -571,9 +574,9 @@ function workflowDirForStorage(storage: WorkflowStorageScope): string {
 async function ensureWorkflowDir(storage: WorkflowStorageScope): Promise<string> {
   if (storage === "public") await seedPublicWorkflowsIfNeeded();
   const dir = workflowDirForStorage(storage);
-  await mkdir(dir, { recursive: true, mode: storage === "personal" ? 0o700 : undefined });
+  await mkdir(/* turbopackIgnore: true */ dir, { recursive: true, mode: storage === "personal" ? 0o700 : undefined });
   if (storage === "personal") {
-    await chmod(dir, 0o700);
+    await chmod(/* turbopackIgnore: true */ dir, 0o700);
   }
   return dir;
 }
@@ -582,7 +585,7 @@ async function removeStoredWorkflowFiles(storage: WorkflowStorageScope, source: 
   const dir = workflowDirForStorage(storage);
   let entries: string[];
   try {
-    entries = await readdir(dir);
+    entries = await readdir(/* turbopackIgnore: true */ dir);
   } catch {
     return;
   }
@@ -592,7 +595,7 @@ async function removeStoredWorkflowFiles(storage: WorkflowStorageScope, source: 
   });
   for (const file of files) {
     try {
-      await unlink(path.join(dir, file));
+      await unlink(path.join(/* turbopackIgnore: true */ dir, file));
     } catch {
       // Best-effort cleanup of the stale copy; the new manifest has already saved.
     }
@@ -633,15 +636,15 @@ export async function saveLocalWorkflow(body: {
   try {
     await withWorkflowWriteLock(async () => {
       const dir = await ensureWorkflowDir(storage);
-      const root = path.resolve(dir);
-      const filePath = path.resolve(root, file);
-      const rel = path.relative(root, filePath);
+      const root = path.resolve(/* turbopackIgnore: true */ dir);
+      const filePath = path.resolve(/* turbopackIgnore: true */ root, file);
+      const rel = path.relative(/* turbopackIgnore: true */ root, filePath);
       if (rel.startsWith("..") || path.isAbsolute(rel)) {
         throw new Error("resolved workflow path escapes workflow storage directory");
       }
-      await writeFile(filePath, text, { encoding: "utf8", mode: storage === "personal" ? 0o600 : undefined });
+      await writeFile(/* turbopackIgnore: true */ filePath, text, { encoding: "utf8", mode: storage === "personal" ? 0o600 : undefined });
       if (storage === "personal") {
-        await chmod(filePath, 0o600);
+        await chmod(/* turbopackIgnore: true */ filePath, 0o600);
       }
       await removeStoredWorkflowFiles(storage === "public" ? "personal" : "public", summary.id);
     });
@@ -667,14 +670,14 @@ export async function deleteLocalWorkflow(body: {
   try {
     const dir = workflowDirForStorage(found.storage);
     // Resolve the on-disk name from the directory listing (.yaml or .yml).
-    const entries = await readdir(dir);
+    const entries = await readdir(/* turbopackIgnore: true */ dir);
     const file = entries.find(
       (name) => /\.ya?ml$/i.test(name) && name.replace(/\.ya?ml$/i, "") === found.path,
     );
     if (!file) {
       return { ok: false, error: `Manifest file for \`${found.path}\` not found.` };
     }
-    await withWorkflowWriteLock(() => unlink(path.join(dir, file)));
+    await withWorkflowWriteLock(() => unlink(path.join(/* turbopackIgnore: true */ dir, file)));
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "workflow delete failed" };
   }
@@ -700,9 +703,9 @@ async function storageForWorkflowId(id: string): Promise<WorkflowStorageScope> {
 
 /** Absolute path for a layout sidecar, constrained to its workflow storage dir. */
 function resolveLayoutFilePath(rootDir: string, file: string): string | null {
-  const root = path.resolve(rootDir);
-  const target = path.resolve(root, file);
-  const rel = path.relative(root, target);
+  const root = path.resolve(/* turbopackIgnore: true */ rootDir);
+  const target = path.resolve(/* turbopackIgnore: true */ root, file);
+  const rel = path.relative(/* turbopackIgnore: true */ root, target);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   return target;
 }
@@ -718,7 +721,7 @@ export async function loadWorkflowLayout(id: string): Promise<WorkflowLayout | n
   const filePath = await layoutFilePath(id);
   if (!filePath) return null;
   try {
-    const text = await readFile(filePath, "utf8");
+    const text = await readFile(/* turbopackIgnore: true */ filePath, "utf8");
     const parsed = JSON.parse(text) as { positions?: WorkflowLayout };
     if (!parsed.positions || typeof parsed.positions !== "object") return null;
     const positions: WorkflowLayout = {};
@@ -751,12 +754,12 @@ export async function saveWorkflowLayout(
         throw new Error("resolved layout path escapes workflow storage directory");
       }
       await writeFile(
-        filePath,
+        /* turbopackIgnore: true */ filePath,
         JSON.stringify({ version: 1, positions }, null, 2),
         { encoding: "utf8", mode: storage === "personal" ? 0o600 : undefined },
       );
       if (storage === "personal") {
-        await chmod(filePath, 0o600);
+        await chmod(/* turbopackIgnore: true */ filePath, 0o600);
       }
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

- mark validated runtime filesystem paths so Turbopack no longer expands them into repository-wide traces
- exclude generated/cache roots from standalone output tracing using the documented global route key
- add a postbuild standalone artifact gate for forbidden roots, file count, and unpacked bytes
- wire focused verifier coverage into the app test suite

## Root cause

Several server routes combine runtime-selected paths (Cave/Coven home, project roots, familiar workspaces, CLI discovery paths, and user stores) with filesystem operations. Turbopack treated those dynamic paths as build-time trace globs and repeatedly swept the repository root into `.next/standalone`, including local Rust build output.

## Impact

On the reproduced checkout, the raw standalone artifact changed from about 1.61 GB / 9,149 files (including 1,944 `target-windows` files) to 351,017,052 bytes / 6,416 entries. The production compile now emits zero broad trace warnings, and the assembled sidecar is 98,403,723 bytes / 5,459 files.

The new gate allows 7,000 entries and 400 MiB, giving modest native-package/platform headroom while failing immediately on known local build roots.

## Validation

- `pnpm build` — zero broad Turbopack trace warnings; standalone budget passes
- `pnpm typecheck`
- `pnpm check:tests-wired` — 1,016 test files wired
- `pnpm test:app` — 747 test files passed
- `pnpm test:api` — 194 test files passed
- `node scripts/standalone-budget.test.mjs`
- `node scripts/sidecar-runtime-closure.test.mjs`
- `node scripts/sidecar-bundle-deps.test.mjs`
- `bash scripts/sidecar-bundle.sh` — assembled runtime closure successfully

Linux-only note: the assembled-runtime smoke cannot load `node-pty` on this WSL host because `node-pty@1.1.0` has no Linux prebuild and the host has no `make`/compiler. Supported-platform CI remains the native-runtime authority.

Fixes #3261
