### PR TITLE
Fix CodeQL familiar contract path alert

### DIFF
--- a/src/lib/server/familiar-contract-files.test.ts
+++ b/src/lib/server/familiar-contract-files.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { isValidFamiliarId } from "./familiar-contract-files.ts";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  isValidFamiliarId,
+  readFamiliarContractFiles,
+} from "./familiar-contract-files.ts";
 
 // Accepts ordinary familiar slugs.
 for (const ok of ["sage", "echo", "kitty", "nova", "my-familiar", "agent_01", "A1"]) {
@@ -23,6 +29,46 @@ for (const bad of [
   "x".repeat(65),
 ]) {
   assert.equal(isValidFamiliarId(bad), false, `${JSON.stringify(bad)} must be rejected`);
+}
+
+await assert.rejects(
+  readFamiliarContractFiles("../outside"),
+  /invalid familiar id/,
+  "the filesystem reader must reject traversal before resolving a workspace",
+);
+
+const originalCovenHome = process.env.COVEN_HOME;
+const root = await mkdtemp(path.join(tmpdir(), "coven-contract-files-"));
+const declaredWorkspace = path.join(root, "declared-workspace");
+
+try {
+  process.env.COVEN_HOME = root;
+  await mkdir(declaredWorkspace, { recursive: true });
+  await writeFile(
+    path.join(root, "familiars.toml"),
+    `[[familiar]]\nid = "voice_agent"\nworkspace = "${declaredWorkspace}"\n`,
+    "utf8",
+  );
+  await writeFile(path.join(declaredWorkspace, "SOUL.md"), "declared soul", "utf8");
+  await writeFile(path.join(declaredWorkspace, "IDENTITY.md"), "declared identity", "utf8");
+  await writeFile(path.join(declaredWorkspace, "ward.toml"), "[ward]", "utf8");
+  await writeFile(path.join(declaredWorkspace, "MEMORY.md"), "declared memory", "utf8");
+
+  const loaded = await readFamiliarContractFiles("voice_agent");
+  assert.equal(loaded.workspace, declaredWorkspace, "sanitizing the id must preserve declared workspaces");
+  assert.deepEqual(loaded.files, {
+    soul: "declared soul",
+    identity: "declared identity",
+    ward: "[ward]",
+    memory: "declared memory",
+  });
+} finally {
+  if (originalCovenHome === undefined) {
+    delete process.env.COVEN_HOME;
+  } else {
+    process.env.COVEN_HOME = originalCovenHome;
+  }
+  await rm(root, { recursive: true, force: true });
 }
 
 console.log("familiar-contract-files.test.ts: ok");

--- a/src/lib/server/familiar-contract-files.ts
+++ b/src/lib/server/familiar-contract-files.ts
@@ -47,7 +47,11 @@ export async function readFamiliarContractFiles(id: string): Promise<LoadedContr
   if (!isValidFamiliarId(id)) {
     throw new Error("invalid familiar id");
   }
-  const workspace = await familiarWorkspace(id);
+  // Keep declared-workspace lookup behavior while making the path barrier
+  // recognizable to CodeQL. The slug guard rejects separators and dots;
+  // basename is therefore behavior-preserving for every accepted id.
+  const safeId = path.basename(id);
+  const workspace = await familiarWorkspace(safeId);
 
   const readContractFile = async (name: string): Promise<string | null> => {
     try {


### PR DESCRIPTION
## Summary

- pass a basename-sanitized familiar id into contract workspace resolution after the existing strict slug validation
- preserve declared workspace lookup for every accepted familiar id
- add regression coverage for traversal rejection and declared workspace reads

## Root cause

CodeQL traces `familiarId` from the voice-session request into `readFile` through `familiarWorkspace`. The existing `isValidFamiliarId` allow-list is a valid runtime barrier, but CodeQL does not recognize the custom validator as a sanitizer.

Using `path.basename` after validation keeps runtime behavior unchanged while making the barrier explicit to CodeQL.

## Impact

Valid familiar ids and custom paths declared in `familiars.toml` continue to resolve exactly as before. Path-shaped ids are still rejected before workspace resolution.

## Validation

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/familiar-contract-files.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:api` (194 files)
- `git diff --check`

## Tracking

Part of #3285.

Expected outcome: the next CodeQL analysis no longer reports [code-scanning alert #122](https://github.com/OpenCoven/coven-cave/security/code-scanning/122). The alert will only close after this reaches `main` and a default-branch scan completes.