### PR TITLE
Add advanced CodeQL coverage for Swift

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,3 +85,8 @@ jobs:
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          # Default setup rejects advanced SARIF uploads. Keep the migration
+          # workflow green in analysis-only mode until an administrator
+          # disables default setup and sets this repository variable to always.
+          upload: ${{ vars.CODEQL_ADVANCED_UPLOAD || 'never' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,85 @@
+name: CodeQL Advanced
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 2"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            runner: ubuntu-latest
+            timeout: 15
+          - language: javascript-typescript
+            build-mode: none
+            runner: ubuntu-latest
+            timeout: 20
+          - language: python
+            build-mode: none
+            runner: ubuntu-latest
+            timeout: 15
+          - language: rust
+            build-mode: none
+            runner: ubuntu-latest
+            timeout: 20
+          - language: swift
+            build-mode: manual
+            runner: macos-15
+            timeout: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Install XcodeGen
+        if: matrix.language == 'swift'
+        run: brew install xcodegen
+
+      - name: Generate and build the iOS project
+        if: matrix.language == 'swift'
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+        run: |
+          set -euo pipefail
+          xcodegen generate --spec apps/ios/CovenCave/project.yml
+          xcodebuild \
+            -project apps/ios/CovenCave/CovenCave.xcodeproj \
+            -scheme CovenCave \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/CovenCaveDerivedData" \
+            CODE_SIGNING_ALLOWED=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            ARCHS=arm64 \
+            build
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
           - language: swift
             build-mode: manual
             runner: macos-15
-            timeout: 30
+            timeout: 40
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,17 +51,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Install build tooling before CodeQL initializes its Swift tracer. On
+      # Apple Silicon, Homebrew rejects installs invoked through Rosetta.
+      - name: Install XcodeGen
+        if: matrix.language == 'swift'
+        run: brew install xcodegen
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      - name: Install XcodeGen
-        if: matrix.language == 'swift'
-        run: brew install xcodegen
 
       - name: Generate and build the iOS project
         if: matrix.language == 'swift'

--- a/docs/codeql.md
+++ b/docs/codeql.md
@@ -1,0 +1,31 @@
+# CodeQL configuration
+
+The advanced workflow is configured to scan GitHub Actions,
+JavaScript/TypeScript, Python, Rust, and Swift. It is required because the
+native iOS project is generated from
+`apps/ios/CovenCave/project.yml`; default setup cannot run `xcodegen` before
+Swift autobuild searches for an Xcode project.
+
+## Activating advanced setup
+
+GitHub default setup overrides checked-in CodeQL workflows and rejects their
+result uploads. A repository administrator must perform this transition after
+`.github/workflows/codeql.yml` reaches `main`:
+
+1. In **Settings > Security > Code security**, disable CodeQL default setup.
+2. In **Actions**, enable the **CodeQL Advanced** workflow if GitHub left it
+   disabled, then run it with **Run workflow** on `main`.
+3. Confirm all five `Analyze (...)` jobs succeed and that the latest code
+   scanning analyses contain these categories:
+   `/language:actions`, `/language:javascript-typescript`, `/language:python`,
+   `/language:rust`, and `/language:swift`.
+4. Add an active branch ruleset for `main` with **Require code scanning
+   results** set to tool `CodeQL`, security threshold **High or higher**, and
+   alerts threshold **None**. Do not remove the existing required CI checks.
+5. Open a pull request and confirm merge is blocked until the CodeQL analysis
+   finishes, and when a new High or Critical security result is reported.
+
+If the advanced workflow cannot upload results, first verify that default setup
+is disabled. Re-enable default setup immediately if the advanced workflow
+cannot be made healthy, so the existing four-language security coverage is not
+left inactive.

--- a/docs/codeql.md
+++ b/docs/codeql.md
@@ -9,23 +9,30 @@ Swift autobuild searches for an Xcode project.
 ## Activating advanced setup
 
 GitHub default setup overrides checked-in CodeQL workflows and rejects their
-result uploads. A repository administrator must perform this transition after
+result uploads. Until cutover, the advanced workflow defaults
+`CODEQL_ADVANCED_UPLOAD` to `never`, so it can prove that every language builds
+and analyzes without making the migration pull request fail at upload time. A
+repository administrator must perform this transition after
 `.github/workflows/codeql.yml` reaches `main`:
 
 1. In **Settings > Security > Code security**, disable CodeQL default setup.
-2. In **Actions**, enable the **CodeQL Advanced** workflow if GitHub left it
+2. In **Settings > Secrets and variables > Actions > Variables**, create the
+   repository variable `CODEQL_ADVANCED_UPLOAD` with value `always`.
+3. In **Actions**, enable the **CodeQL Advanced** workflow if GitHub left it
    disabled, then run it with **Run workflow** on `main`.
-3. Confirm all five `Analyze (...)` jobs succeed and that the latest code
+4. Confirm all five `Analyze (...)` jobs succeed and that the latest code
    scanning analyses contain these categories:
    `/language:actions`, `/language:javascript-typescript`, `/language:python`,
    `/language:rust`, and `/language:swift`.
-4. Add an active branch ruleset for `main` with **Require code scanning
+5. Add an active branch ruleset for `main` with **Require code scanning
    results** set to tool `CodeQL`, security threshold **High or higher**, and
    alerts threshold **None**. Do not remove the existing required CI checks.
-5. Open a pull request and confirm merge is blocked until the CodeQL analysis
+6. Open a pull request and confirm merge is blocked until the CodeQL analysis
    finishes, and when a new High or Critical security result is reported.
 
 If the advanced workflow cannot upload results, first verify that default setup
-is disabled. Re-enable default setup immediately if the advanced workflow
+is disabled and `CODEQL_ADVANCED_UPLOAD` is `always`. For rollback, set the
+variable to `never` before re-enabling default setup so the two configurations
+do not compete. Re-enable default setup immediately if the advanced workflow
 cannot be made healthy, so the existing four-language security coverage is not
 left inactive.


### PR DESCRIPTION
## Summary

- add a checked-in advanced CodeQL workflow for Actions, JavaScript/TypeScript, Python, Rust, and Swift
- generate the native iOS Xcode project with XcodeGen and build it on macOS so Swift is extracted
- stage SARIF uploads behind `CODEQL_ADVANCED_UPLOAD` so the migration remains compatible while default setup is active
- give the Swift job a 40-minute timeout based on repeated ~29-minute native analysis runs
- document the administrator cutover, rollback, verification, and High/Critical merge-protection steps

## Merge status

Merged into `main` on 2026-07-16 as squash commit `346d5a4fb952fbb8a22cfd73fee832b7769f2c29`.

The remote branch and clean local PR worktree were removed after merge.

## Validation

### Pull request head

- `actionlint .github/workflows/codeql.yml`
- parsed the workflow with PyYAML and asserted the Swift/manual/macos-15 matrix leg and staged upload mode
- `git diff --check`
- [advanced run 29522028302](https://github.com/OpenCoven/coven-cave/actions/runs/29522028302) passed all five language legs on head `3997f75`:
  - Actions 38s
  - Python 43s
  - Rust 1m57s
  - JavaScript/TypeScript 2m31s
  - Swift 28m54s, including XcodeGen, the full native `xcodebuild`, extraction, and security queries
- [standard CI run 29522028215](https://github.com/OpenCoven/coven-cave/actions/runs/29522028215) passed Frontend, Rust, E2E, cross-environment, and sidecar checks on Linux, macOS, and Windows
- independent review found no actionable defects

### Post-merge `main`

- [CI run 29524666031](https://github.com/OpenCoven/coven-cave/actions/runs/29524666031) passed all jobs
- [CodeQL Advanced run 29524666095](https://github.com/OpenCoven/coven-cave/actions/runs/29524666095):
  - Actions, JavaScript/TypeScript, Python, and Rust passed
  - Swift native build/analysis is in progress

## Remaining administrator activation

The workflow defaults to `upload: never` while GitHub default setup remains active. To finish #3285, a repository administrator must:

1. disable CodeQL default setup
2. set the repository Actions variable `CODEQL_ADVANCED_UPLOAD=always`
3. rerun **CodeQL Advanced** on `main` and confirm all five uploaded analysis categories
4. activate the High/Critical CodeQL ruleset described in `docs/codeql.md`
5. make the documented Code Quality enable/disable billing decision

@BunsDev is tagged for these administrator-only steps.

Part of #3285.

## Subsequent CodeQL remediation

- [PR #3291](https://github.com/OpenCoven/coven-cave/pull/3291) merged into `main` as `8863bec8ff0d899b6b72aaf7851580818baa7c9d`.
- It replaced the polynomial trailing-slash normalization in both Omnigent config and runtime paths, with adversarial regression coverage.
- Post-merge standard CodeQL runs [29525105586](https://github.com/OpenCoven/coven-cave/actions/runs/29525105586) and [29525105483](https://github.com/OpenCoven/coven-cave/actions/runs/29525105483) passed on `main`.
- GitHub marked high-severity code-scanning alert [#125](https://github.com/OpenCoven/coven-cave/security/code-scanning/125) fixed at 2026-07-16T18:46:43Z.

This does not change the remaining administrator activation steps above: advanced SARIF upload and High/Critical enforcement still require the documented repository-setting cutover.