### PR TITLE
Fix Cave home migration lock timeouts

### DIFF
--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -933,6 +933,34 @@ try {
     assert.equal(active, 0);
   }
 
+  // A transient Windows unlock failure is completed by publishing release
+  // intent. The operation itself succeeds, and the next waiter reclaims the
+  // leftover directory rather than surfacing a 500 or waiting indefinitely.
+  {
+    const { coven, cave } = await home("failed-unlock-rename");
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+    let failUnlock = true;
+    const first = await migrateCaveHome({
+      createSymlink: denySymlink,
+      lockReleaseRename: async (source, destination) => {
+        if (failUnlock) {
+          failUnlock = false;
+          const error = new Error("injected Windows unlock failure") as NodeJS.ErrnoException;
+          error.code = "EPERM";
+          throw error;
+        }
+        await rename(source, destination);
+      },
+    });
+    assert.deepEqual(first.errors, []);
+    const lock = path.join(cave, ".migration.lock");
+    assert.equal(typeof (await json(path.join(lock, "owner.json"))).releasedAt, "string");
+
+    const second = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(second.errors, []);
+    assert.equal(await kind(lock), "missing");
+  }
+
   // Store transactions share the cross-process migration lock. A writer that
   // already passed startup reconciliation must not read an old snapshot while
   // a manual recovery is replacing canonical storage and overwrite it later.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -863,6 +863,29 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
+  // A failed Windows unlock rename can leave a lock owned by this still-live
+  // process on disk. Process liveness alone cannot distinguish that orphan
+  // from an active critical section, so the process-wide active-token set is
+  // authoritative for same-PID recovery.
+  {
+    const { coven, cave } = await home("same-process-orphan-lock");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      token: "abandoned-same-process-owner",
+      startedAt: new Date().toISOString(),
+    }));
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    const startedAt = Date.now();
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(Date.now() - startedAt < 2_000, "a same-process orphan is reclaimed without timing out");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
   // Store transactions share the cross-process migration lock. A writer that
   // already passed startup reconciliation must not read an old snapshot while
   // a manual recovery is replacing canonical storage and overwrite it later.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -886,6 +886,53 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
+  // Publishing release intent must not let a waiter reclaim the lock before
+  // its owner finishes the unlock rename. Otherwise the old release path can
+  // rename a newly acquired successor lock and break mutual exclusion.
+  {
+    const { coven } = await home("release-publication-order");
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+    let finishRelease!: () => void;
+    const releaseMayFinish = new Promise<void>((resolve) => { finishRelease = resolve; });
+    let markReleasing!: () => void;
+    const ownerIsReleasing = new Promise<void>((resolve) => { markReleasing = resolve; });
+    let active = 0;
+    let maxActive = 0;
+    const owner = migrateCaveHome({
+      createSymlink: denySymlink,
+      lockProbe: async (event) => {
+        if (event === "acquired") {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+        } else if (event === "released") {
+          markReleasing();
+          await releaseMayFinish;
+          active -= 1;
+        }
+      },
+    });
+    await ownerIsReleasing;
+    const contender = migrateCaveHome({
+      createSymlink: denySymlink,
+      lockProbe: (event) => {
+        if (event === "acquired") {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+        } else if (event === "released") {
+          active -= 1;
+        }
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    assert.equal(maxActive, 1);
+    finishRelease();
+    const [ownerResult, contenderResult] = await Promise.all([owner, contender]);
+    assert.deepEqual(ownerResult.errors, []);
+    assert.deepEqual(contenderResult.errors, []);
+    assert.equal(maxActive, 1);
+    assert.equal(active, 0);
+  }
+
   // Store transactions share the cross-process migration lock. A writer that
   // already passed startup reconciliation must not read an old snapshot while
   // a manual recovery is replacing canonical storage and overwrite it later.

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -113,6 +113,8 @@ export type ReconciliationOptions = {
   createSymlink?: typeof symlink;
   /** Test-only lock lifecycle probe. */
   lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
+  /** Test-only unlock rename override. */
+  lockReleaseRename?: typeof rename;
   /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
   compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
   /** Test-only hook after managed-mirror canonical validation. */
@@ -328,7 +330,7 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
         await options.lockProbe?.("released");
         const released = `${lock}.released-${token}`;
         try {
-          await rename(lock, released);
+          await (options.lockReleaseRename ?? rename)(lock, released);
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code === "ENOENT") {
             activeLockTokens().delete(token);
@@ -351,7 +353,11 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
           } finally {
             activeLockTokens().delete(token);
           }
-          throw error;
+          // The persisted marker is the fallback unlock. A later contender
+          // will reclaim the directory, so do not turn a completed store or
+          // reconciliation operation into a 500 solely because Windows
+          // deferred the physical directory cleanup.
+          return;
         }
         activeLockTokens().delete(token);
         await rm(released, { recursive: true, force: true });

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -322,28 +322,38 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
           activeLockTokens().delete(token);
           return;
         }
-        // Publish the completed critical section before the Windows directory
-        // rename. If rename is denied transiently by a watcher or scanner, a
-        // waiter can reclaim this token instead of treating the live PID as a
-        // permanent owner.
-        try {
-          await writeJsonAtomic(path.join(lock, "owner.json"), {
-            pid: process.pid,
-            token,
-            startedAt: owner.startedAt ?? nowIso(),
-            releasedAt: nowIso(),
-          });
-        } finally {
-          activeLockTokens().delete(token);
-        }
         // Mark the end of the test-observed critical section before publishing
         // the unlock. Once the rename below completes, a successor can acquire
         // immediately and must not overlap the prior owner's probe state.
         await options.lockProbe?.("released");
         const released = `${lock}.released-${token}`;
-        await rename(lock, released).catch((error) => {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-        });
+        try {
+          await rename(lock, released);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            activeLockTokens().delete(token);
+            return;
+          }
+          // Only publish release intent after this owner has stopped trying to
+          // rename the lock. Publishing it before the rename would let a
+          // waiter reclaim the directory and replace it with a successor lock
+          // that this release path could then rename out from under its owner.
+          try {
+            const currentOwner = await readLockOwner(lock);
+            if (currentOwner.token === token) {
+              await writeJsonAtomic(path.join(lock, "owner.json"), {
+                pid: process.pid,
+                token,
+                startedAt: currentOwner.startedAt ?? owner.startedAt ?? nowIso(),
+                releasedAt: nowIso(),
+              });
+            }
+          } finally {
+            activeLockTokens().delete(token);
+          }
+          throw error;
+        }
+        activeLockTokens().delete(token);
         await rm(released, { recursive: true, force: true });
       };
       try {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -136,7 +136,16 @@ const JOURNAL_VERSION = 1 as const;
 const MIGRATION_VERSION = 2 as const;
 const BACKUP_RETENTION = 10;
 const LOCK_STALE_MS = 5 * 60_000;
-const LOCK_WAIT_MS = 10_000;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __caveHomeReconciliationLockTokens: Set<string> | undefined;
+}
+
+function activeLockTokens(): Set<string> {
+  return globalThis.__caveHomeReconciliationLockTokens ??=
+    new Set<string>();
+}
 
 export const migrationJournalPath = () => path.join(caveHome(), "migration-state.json");
 export const migrationBackupRoot = () => path.join(caveHome(), "migration-backups");
@@ -241,13 +250,27 @@ async function delay(ms: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-async function readLockOwner(lock: string): Promise<{ pid: number | null; token: string | null }> {
+type LockOwner = {
+  pid: number | null;
+  token: string | null;
+  startedAt: string | null;
+  releasedAt: string | null;
+};
+
+async function readLockOwner(lock: string): Promise<LockOwner> {
   const owner = await readFile(path.join(lock, "owner.json"), "utf8")
-    .then((value) => JSON.parse(value) as { pid?: unknown; token?: unknown })
+    .then((value) => JSON.parse(value) as {
+      pid?: unknown;
+      token?: unknown;
+      startedAt?: unknown;
+      releasedAt?: unknown;
+    })
     .catch(() => null);
   return {
     pid: typeof owner?.pid === "number" && Number.isSafeInteger(owner.pid) ? owner.pid : null,
     token: typeof owner?.token === "string" ? owner.token : null,
+    startedAt: typeof owner?.startedAt === "string" ? owner.startedAt : null,
+    releasedAt: typeof owner?.releasedAt === "string" ? owner.releasedAt : null,
   };
 }
 
@@ -280,7 +303,6 @@ async function renameLockCandidate(candidate: string, lock: string): Promise<voi
 
 async function acquireLock(options: ReconciliationOptions): Promise<() => Promise<void>> {
   const lock = migrationLockPath();
-  const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     const token = randomBytes(16).toString("hex");
     const candidate = `${lock}.candidate-${token}`;
@@ -293,10 +315,27 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
         await rm(candidate, { recursive: true, force: true });
         throw error;
       }
-      await options.lockProbe?.("acquired");
-      return async () => {
+      activeLockTokens().add(token);
+      const release = async () => {
         const owner = await readLockOwner(lock);
-        if (owner.token !== token) return;
+        if (owner.token !== token) {
+          activeLockTokens().delete(token);
+          return;
+        }
+        // Publish the completed critical section before the Windows directory
+        // rename. If rename is denied transiently by a watcher or scanner, a
+        // waiter can reclaim this token instead of treating the live PID as a
+        // permanent owner.
+        try {
+          await writeJsonAtomic(path.join(lock, "owner.json"), {
+            pid: process.pid,
+            token,
+            startedAt: owner.startedAt ?? nowIso(),
+            releasedAt: nowIso(),
+          });
+        } finally {
+          activeLockTokens().delete(token);
+        }
         // Mark the end of the test-observed critical section before publishing
         // the unlock. Once the rename below completes, a successor can acquire
         // immediately and must not overlap the prior owner's probe state.
@@ -307,6 +346,13 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
         });
         await rm(released, { recursive: true, force: true });
       };
+      try {
+        await options.lockProbe?.("acquired");
+      } catch (error) {
+        await release().catch(() => {});
+        throw error;
+      }
+      return release;
     } catch (error) {
       await rm(candidate, { recursive: true, force: true }).catch(() => {});
       if (!["EEXIST", "ENOTEMPTY"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
@@ -325,7 +371,10 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
         // A recorded owner that no longer exists is safe to reclaim
         // immediately. The age threshold is only needed for an unreadable or
         // incomplete owner record, where liveness cannot be established.
-        const reclaimable = owner.pid ? !alive : Date.now() - info.mtimeMs > LOCK_STALE_MS;
+        const sameProcessOrphan = owner.pid === process.pid &&
+          (!owner.token || !activeLockTokens().has(owner.token));
+        const reclaimable = Boolean(owner.releasedAt) || sameProcessOrphan ||
+          (owner.pid ? !alive : Date.now() - info.mtimeMs > LOCK_STALE_MS);
         if (reclaimable) {
           await options.lockProbe?.("stale-observed");
           const takeover = path.join(lock, ".takeover");
@@ -349,7 +398,6 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
         if ((lockError as NodeJS.ErrnoException).code === "ENOENT") continue;
         throw lockError;
       }
-      if (Date.now() >= deadline) throw new Error("timed out waiting for cave home migration lock");
       await delay(50);
     }
   }


### PR DESCRIPTION
## Summary

- recover abandoned Cave home reconciliation locks owned by the current Node process
- publish release intent before the Windows lock-directory rename so transient rename failures cannot strand a live-PID lock
- queue genuine lock contention instead of returning a 500 after an arbitrary 10-second deadline
- add regression coverage for same-process orphan recovery

## Root cause

The live `.migration.lock` recorded the current Windows Node PID, but its token was no longer associated with an active critical section. The lock algorithm treated any live PID as authoritative forever, so later profile and daemon-status reads waited 10 seconds and failed with `timed out waiting for cave home migration lock`.

## Impact

Cave store reads now recover abandoned same-process locks without discarding an active lock. Genuine contenders remain serialized, and a transient Windows unlock rename failure is explicitly published as released before takeover.

## Validation

- `pnpm typecheck`
- `pnpm check:tests-wired` — 1,017 test files wired
- `pnpm test:app` — 747 test files passed
- `pnpm test:api` — 194 test files passed
- Windows-native `scripts/cave-home-migration-windows.test.ts`
- focused `src/lib/server/cave-home-migration.test.ts`
- `git diff --check`

Bead: `cave-4u6`
