### PR TITLE
Fix CodeQL trailing-slash ReDoS

### DIFF
--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -426,8 +426,14 @@ function normalizeStringRecord(input: unknown): Record<string, string> {
   return out;
 }
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
 export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
-  const rawUrl = typeof input?.baseUrl === "string" ? input.baseUrl.trim().replace(/\/+$/, "") : "";
+  const rawUrl = typeof input?.baseUrl === "string" ? trimTrailingSlashes(input.baseUrl.trim()) : "";
   let baseUrl = rawUrl;
   if (rawUrl) {
     try {

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -15,7 +15,6 @@ import {
   isSshRuntime,
   normalizeFamiliarRuntime,
 } from "./familiar-runtime.ts";
-import { normalizeOmnigentBaseUrl } from "./omnigent/token.ts";
 import type { UserProfile } from "./user-profile-shared.ts";
 
 const CONFIG_PATH = path.join(caveHome(), "config.json");
@@ -427,8 +426,23 @@ function normalizeStringRecord(input: unknown): Record<string, string> {
   return out;
 }
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
 export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
-  const baseUrl = typeof input?.baseUrl === "string" ? normalizeOmnigentBaseUrl(input.baseUrl) : "";
+  const rawUrl = typeof input?.baseUrl === "string" ? trimTrailingSlashes(input.baseUrl.trim()) : "";
+  let baseUrl = rawUrl;
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl.includes("://") ? rawUrl : `https://${rawUrl}`);
+      baseUrl = `${parsed.protocol}//${parsed.host}`;
+    } catch {
+      baseUrl = rawUrl;
+    }
+  }
   return {
     baseUrl,
     defaultAgentId: typeof input?.defaultAgentId === "string" ? input.defaultAgentId.trim() : "",

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -15,6 +15,7 @@ import {
   isSshRuntime,
   normalizeFamiliarRuntime,
 } from "./familiar-runtime.ts";
+import { normalizeOmnigentBaseUrl } from "./omnigent/token.ts";
 import type { UserProfile } from "./user-profile-shared.ts";
 
 const CONFIG_PATH = path.join(caveHome(), "config.json");
@@ -426,23 +427,8 @@ function normalizeStringRecord(input: unknown): Record<string, string> {
   return out;
 }
 
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value[end - 1] === "/") end -= 1;
-  return value.slice(0, end);
-}
-
 export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
-  const rawUrl = typeof input?.baseUrl === "string" ? trimTrailingSlashes(input.baseUrl.trim()) : "";
-  let baseUrl = rawUrl;
-  if (rawUrl) {
-    try {
-      const parsed = new URL(rawUrl.includes("://") ? rawUrl : `https://${rawUrl}`);
-      baseUrl = `${parsed.protocol}//${parsed.host}`;
-    } catch {
-      baseUrl = rawUrl;
-    }
-  }
+  const baseUrl = typeof input?.baseUrl === "string" ? normalizeOmnigentBaseUrl(input.baseUrl) : "";
   return {
     baseUrl,
     defaultAgentId: typeof input?.defaultAgentId === "string" ? input.defaultAgentId.trim() : "",

--- a/src/lib/omnigent/client.test.ts
+++ b/src/lib/omnigent/client.test.ts
@@ -18,6 +18,11 @@ test("normalizeOmnigentBaseUrl adds https when scheme missing", () => {
   assert.equal(normalizeOmnigentBaseUrl("omnigent.example.com"), "https://omnigent.example.com");
 });
 
+test("normalizeOmnigentBaseUrl handles adversarial slash runs in linear time", () => {
+  const repeatedSlashes = `bad host${"/".repeat(25_000)}!`;
+  assert.equal(normalizeOmnigentBaseUrl(repeatedSlashes), repeatedSlashes);
+});
+
 test("pickDefaultAgentId prefers preferred id then claude-native-ui", () => {
   const agents = [
     { id: "ag_a", name: "polly" },

--- a/src/lib/omnigent/client.test.ts
+++ b/src/lib/omnigent/client.test.ts
@@ -65,6 +65,19 @@ test("normalizeOmnigentConfig keeps hostMap, hostWorkspaceMap, exposeHostsInComp
   assert.equal(cfg.exposeHostsInComposer, false);
 });
 
+test("normalizeOmnigentConfig removes trailing slashes without a backtracking regex", async () => {
+  const { normalizeOmnigentConfig } = await import("../cave-config.ts");
+
+  assert.equal(
+    normalizeOmnigentConfig({ baseUrl: "https://omni.example.com////" }).baseUrl,
+    "https://omni.example.com",
+  );
+  assert.equal(normalizeOmnigentConfig({ baseUrl: "bad host///" }).baseUrl, "bad host");
+
+  const repeatedSlashes = `bad host${"/".repeat(25_000)}!`;
+  assert.equal(normalizeOmnigentConfig({ baseUrl: repeatedSlashes }).baseUrl, repeatedSlashes);
+});
+
 test("resolveWorkspaceForHost prefers host_id then name then hostMap alias", async () => {
   const { resolveWorkspaceForHost } = await import("./workspace-resolve.ts");
   const maps = {

--- a/src/lib/omnigent/token.ts
+++ b/src/lib/omnigent/token.ts
@@ -6,6 +6,12 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
 export type OmnigentAuthResolution = {
   /** Bearer token when available (JWT, env, or minted Databricks OAuth). */
   token: string | null;
@@ -18,7 +24,7 @@ export type OmnigentAuthResolution = {
 };
 
 export function normalizeOmnigentBaseUrl(url: string): string {
-  const trimmed = url.trim().replace(/\/+$/, "");
+  const trimmed = trimTrailingSlashes(url.trim());
   if (!trimmed) return "";
   try {
     const parsed = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);


### PR DESCRIPTION
## Summary

- replace the ambiguous trailing-slash regular expression in Omnigent URL normalization with a linear character scan
- preserve normalization behavior for valid URLs and malformed fallback values
- add regression coverage for repeated trailing slashes and adversarial non-matching slash runs

## Root cause

`normalizeOmnigentConfig` applied `/\/+$/` to the user-provided `baseUrl`. On a long run of slashes followed by a non-slash character, the JavaScript regex engine can retry the match from each slash and take polynomial time.

The replacement walks backward over trailing slashes once and performs a single slice, avoiding backtracking.

## Security alert

Resolves [CodeQL alert 125](https://github.com/OpenCoven/coven-cave/security/code-scanning/125) after the post-merge main-branch scan.

Tracked by Bead `cave-862.1` under the CodeQL-hardening work.

## Verification

- `node --experimental-strip-types src/lib/omnigent/client.test.ts` (11/11 passed)
- `node --experimental-strip-types src/lib/cave-config.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm check:tests-wired` (1,018 test files wired)
- `git diff --check`
