### PR TITLE
fix: scrub node toolchain probe env

### DIFF
--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -173,6 +173,44 @@ assert.match(
   ], "Windows npm.cmd is health-checked through its supported shell launch path");
 }
 
+{
+  const secretDir = path.join("/virtual", "nvm", "v24.16.0", "bin");
+  const existing = new Set([path.join(secretDir, "node"), path.join(secretDir, "npm")]);
+  const originalSecretEnv = {
+    COVEN_CAVE_AUTH_TOKEN: process.env.COVEN_CAVE_AUTH_TOKEN,
+    __NEXT_PRIVATE_ORIGIN: process.env.__NEXT_PRIVATE_ORIGIN,
+    GITHUB_PAT: process.env.GITHUB_PAT,
+  };
+  process.env.COVEN_CAVE_AUTH_TOKEN = "sidecar-auth-secret";
+  process.env.__NEXT_PRIVATE_ORIGIN = "http://sidecar.internal";
+  process.env.GITHUB_PAT = "ghp_forbidden_secret";
+  try {
+    const probeEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+    const runnable = runnableNodeToolchainDirs([secretDir], {
+      platform: "linux",
+      exists: (file) => existing.has(file),
+      probe: (_command, _args, options) => probeEnvs.push(options.env),
+    });
+    assert.deepEqual(runnable, [secretDir], "a healthy toolchain still survives");
+    assert.equal(probeEnvs.length, 2, "both node and npm probes receive explicit env");
+    for (const env of probeEnvs) {
+      assert.ok(env, "probe env is provided instead of inheriting process.env");
+      assert.equal(env.COVEN_CAVE_AUTH_TOKEN, undefined, "node/npm probes do not receive sidecar auth tokens");
+      assert.equal(env.__NEXT_PRIVATE_ORIGIN, undefined, "node/npm probes do not receive Next private env");
+      assert.equal(env.GITHUB_PAT, undefined, "node/npm probes do not receive forbidden GitHub token keys");
+      assert.match(env.PATH ?? "", new RegExp(`^${secretDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`), "probe PATH still prioritizes the candidate directory");
+    }
+  } finally {
+    for (const [key, value] of Object.entries(originalSecretEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 assert.match(
   source,
   /function nodeNvmBinDirs\(\)[\s\S]*return runnableNodeToolchainDirs\(directories\)/,

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -109,15 +109,16 @@ export function runnableNodeToolchainDirs(
       return false;
     }
     const npm = path.join(/* turbopackIgnore: true */ directory, npmName);
-    const env = {
+    const env = scrubSidecarInternalEnv({
       ...process.env,
       PATH: [directory, process.env.PATH].filter(Boolean).join(path.delimiter),
-    };
+    });
     try {
       probe(node, ["--version"], {
         timeout: 1500,
         stdio: "ignore",
         windowsHide: true,
+        env,
       });
       probe(npm, ["--version"], {
         timeout: 1500,


### PR DESCRIPTION
### Motivation

- A health-check probe ran candidate `node`/`npm` executables with the raw `process.env` before `covenSpawnEnv()` scrubbed sidecar-internal and forbidden token variables, allowing a malicious local runtime to read/exfiltrate secrets.

### Description

- Sanitize the probe environment by calling `scrubSidecarInternalEnv(...)` when building the `env` used to run `node --version` and `npm --version` in `runnableNodeToolchainDirs()`.
- Pass the sanitized `env` to both the `node` and `npm` probes so neither inherits raw `process.env` while preserving the probe `PATH` precedence for the candidate directory.
- Add a regression test that injects representative sidecar secrets and asserts the probe `env` omits `COVEN_CAVE_*`, `__NEXT_PRIVATE_*`, and forbidden GitHub token keys while still prioritizing the candidate `PATH`.
- Changed files: `src/lib/coven-bin.ts` and `src/lib/coven-bin.test.ts`.

### Testing

- Ran `node --experimental-strip-types src/lib/coven-bin.test.ts`, which completed successfully.
- Ran `pnpm typecheck` (TypeScript `tsc --noEmit`), which completed successfully.
- Ran a workspace diff/check to ensure no whitespace or check failures remained, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a582789787483279bc1fe9825e7cc84)