### PR TITLE
fix(projects): expand ~ before validating new project roots

### DIFF
--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -112,6 +112,17 @@ try {
     false,
     "late saved projects do not authorize more arbitrary project roots",
   );
+
+  assert.equal(
+    isAllowedNewProjectRoot("~"),
+    false,
+    "tilde project roots are checked after home-directory expansion",
+  );
+  assert.equal(
+    isAllowedNewProjectRoot("~/secret"),
+    false,
+    "tilde subpaths cannot masquerade as relative paths under the current working directory",
+  );
 } finally {
   restoreEnv();
   await rm(tmp, { recursive: true, force: true });

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -13,6 +13,19 @@ function realpathOrResolve(value: string): string {
   }
 }
 
+function expandHomeShortcut(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(homedir(), trimmed.slice(2));
+  }
+  return value;
+}
+
+function normalizeNewProjectRootCandidate(value: string): string {
+  return normalizeLegacyCovenWorkspacePath(expandHomeShortcut(value));
+}
+
 function normalizeLegacyCovenWorkspacePath(value: string): string {
   const resolved = path.resolve(value);
   const legacyRoot = path.resolve(path.join(covenHome(), "workspace"));
@@ -107,6 +120,6 @@ export function resolveAllowedProjectPath(value: string): string | null {
 }
 
 export function isAllowedNewProjectRoot(value: string): boolean {
-  const candidate = realpathOrResolve(normalizeLegacyCovenWorkspacePath(value));
+  const candidate = realpathOrResolve(normalizeNewProjectRootCandidate(value));
   return uniqueRoots(builtInProjectRoots()).some((root) => isWithinRoot(candidate, root));
 }


### PR DESCRIPTION
### Motivation
- Prevent a tilde-based allowlist bypass where a submitted root like `~` or `~/secret` passed `isAllowedNewProjectRoot()` (checked as a cwd-relative path) but was stored after expanding `~` to the user's home, thereby expanding the filesystem allowlist to sensitive home paths. 
- Make the validation path canonicalization match the persistence normalization so registration cannot be used to broaden trusted filesystem roots.

### Description
- Add an `expandHomeShortcut()` helper that expands leading `~` and `~/...` to `homedir()` and integrate it into a new `normalizeNewProjectRootCandidate()` helper. 
- Use `normalizeNewProjectRootCandidate()` inside `isAllowedNewProjectRoot()` so the allowlist check runs against the same home-expanded path that will be persisted. 
- Add regression assertions in `src/lib/server/project-paths.test.ts` to ensure `isAllowedNewProjectRoot("~")` and `isAllowedNewProjectRoot("~/secret")` are rejected and cannot masquerade as cwd-relative paths.

### Testing
- Ran the full app test suite with `pnpm test:app` and observed the test harness complete successfully with all app tests passing. 
- Ran TypeScript checks with `pnpm typecheck` and confirmed `tsc --noEmit` completed without errors. 
- Added targeted unit test assertions in `src/lib/server/project-paths.test.ts` that pass under the updated normalization logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a9623f3c8327b8ccc744b96bf37b)