### PR TITLE
Fix research mission detail loopback guard

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -746,6 +746,7 @@ export const SUITES = {
     "src/app/api/workflows/run/route.test.ts",
     "src/app/api/flows/run/route.test.ts",
     "src/app/api/research/missions/route.test.ts",
+    "src/app/api/research/missions/[id]/route.test.ts",
     "src/app/api/research/missions/[id]/actions/route.test.ts",
     "src/app/api/research/missions/[id]/schedule/route.test.ts",
     "src/app/api/flows/webhook/route.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -156,7 +156,7 @@ const contracts: RouteContract[] = [
   { route: "/roles/workflows", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/research/missions/[id]/actions", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
   { route: "/research/missions/[id]/schedule", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
-  { route: "/research/missions/[id]", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/research/missions/[id]", methods: ["GET"], kind: "json", localOriginGuard: true, pathGuard: true },
   { route: "/research/missions", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
   { route: "/retro-runs", methods: ["GET"], kind: "json" },
   { route: "/rss", methods: ["GET"], kind: "json" },

--- a/src/app/api/research/missions/[id]/route.test.ts
+++ b/src/app/api/research/missions/[id]/route.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+test("mission detail is local-only, path guarded, and reconciles before returning", () => {
+  assert.match(source, /rejectNonLocalRequest\(req\)/);
+  assert.match(source, /isValidResearchMissionId/);
+  assert.match(source, /path not allowed/);
+  assert.match(source, /status: 403/);
+  assert.match(source, /runner\.reconcile/);
+  assert.match(source, /runner\.reconcileAutomation/);
+});

--- a/src/app/api/research/missions/[id]/route.ts
+++ b/src/app/api/research/missions/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { makeProductionResearchMissionRunner } from "@/lib/server/research-mission-runner";
 import {
   isValidResearchMissionId,
@@ -9,9 +10,11 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(
-  _req: Request,
+  req: Request,
   context: { params: Promise<{ id: string }> },
 ) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
   const { id } = await context.params;
   if (!isValidResearchMissionId(id)) {
     return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });


### PR DESCRIPTION
### Motivation
- The `GET /api/research/missions/[id]` route omitted the shared local-only guard and therefore exposed full mission metadata and could trigger reconciliation for remote callers, violating the design that `src/app/api/research/missions/**` is loopback-gated. 
- Sibling mission routes (`list`, `create`, `actions`, `schedule`) already enforced the guard, so the omission was an accidental regression that raises a confidentiality risk. 

### Description
- Add `rejectNonLocalRequest(req)` to the `GET` handler in `src/app/api/research/missions/[id]/route.ts` and return early when forbidden. 
- Update the API contract entry in `src/app/api/api-contracts.test.ts` to mark `/research/missions/[id]` with `localOriginGuard: true`. 
- Add a focused route contract test `src/app/api/research/missions/[id]/route.test.ts` that asserts the detail route is local-only, path-guarded, and performs reconciliation before returning. 
- Wire the new test into the test runner list in `scripts/run-tests.mjs`. 

### Testing
- Ran `node --experimental-strip-types src/app/api/research/missions/[id]/route.test.ts`, which passed. 
- Ran `node --experimental-strip-types src/app/api/api-contracts.test.ts`, which passed and reported the route contracts as expected. 
- Ran `pnpm check:tests-wired`, which passed (all tests wired into CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5440cdb7f88327b913dd48745c6c0e)