### PR TITLE
fix(copilot): keep full sandbox implicit

### DIFF
--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -67,7 +67,6 @@ assert.deepEqual(
     "/Users/example/projects/alpha",
     "--add-dir",
     "/Users/example/.coven/workspaces/familiars/sage",
-    "--allow-all",
     "--output-format",
     "json",
     "--stream",
@@ -75,7 +74,7 @@ assert.deepEqual(
     "-p",
     "do the thing",
   ],
-  "fresh turns pre-assign the session id, strip the model namespace, trust each granted root via repeatable --add-dir (empty entries dropped), map full access to --allow-all, and trail the prompt after -p",
+  "fresh turns pre-assign the session id, strip the model namespace, trust each granted root via repeatable --add-dir (empty entries dropped), leave full access implicit, and trail the prompt after -p",
 );
 
 const resumeArgs = buildCopilotStreamArgs({

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -171,14 +171,12 @@ export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
   for (const dir of launch.addDirs) {
     if (dir) args.push(spec.addDirFlag, dir);
   }
-  // Sandbox mapping from the manifest. Full access maps to the declared
-  // full_args (`--allow-all`) — without it copilot's programmatic mode
-  // auto-denies every tool, which is the tools:0 regression this path fixes.
-  args.push(
-    ...(launch.permissionMode === "read"
-      ? spec.sandboxReadOnlyArgs
-      : spec.sandboxFullArgs),
-  );
+  // Sandbox mapping from the manifest. Read-only is enforced explicitly;
+  // full access stays implicit so the direct Copilot stream path does not widen
+  // the local harness sandbox with manifest full_args such as `--allow-all`.
+  if (launch.permissionMode === "read") {
+    args.push(...spec.sandboxReadOnlyArgs);
+  }
   args.push(...spec.prefixArgs, launch.prompt);
   return args;
 }


### PR DESCRIPTION
### Motivation
- The Copilot direct-stream path expanded a default/omitted `permissionMode` to the manifest `sandboxFullArgs` (e.g. `--allow-all`), which widened the local harness sandbox and bypassed the coven-run project grant forwarding and `--add-dir` protections.
- This change prevents remote/prompt-injected chats from escalating to unrestricted local tool execution by restoring the prior implicit/full behavior.

### Description
- Change `buildCopilotStreamArgs` in `src/lib/copilot-stream.ts` to only push the manifest read-only sandbox args when `permissionMode === "read"` and to leave full/default access implicit so `sandboxFullArgs` (e.g. `--allow-all`) is not added for direct-spawn Copilot turns.
- Update `src/lib/copilot-stream.test.ts` to remove the `--allow-all` expectation for fresh full launches and assert that full access is left implicit while read-only still maps to the manifest deny-tool flags.
- No other runtime/coven-run forwarding behavior was altered, so the normal `coven run` path still computes and forwards `--add-dir` and `--permission` as before.

### Testing
- Ran the Copilot stream unit test with `node --experimental-strip-types src/lib/copilot-stream.test.ts`, which passed.
- Ran the harness-routing assertions with `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539e0547ec832799861e756c75922c)