### PR TITLE
fix(proxy): restrict host-derived CSRF origins to loopback

### DIFF
--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -250,6 +250,19 @@ assert.equal(
     ["https://cave.tailnet.example.ts.net"],
     "https scheme is preserved and deduped",
   );
+  assert.deepEqual(
+    expectedRequestOrigins("http://127.0.0.1:3000", "http:", "evil.example:8080"),
+    ["http://127.0.0.1:3000"],
+    "non-loopback Host headers must not become accepted CSRF origins in tokenless tailnet mode",
+  );
+  assert.equal(
+    isAllowedRequestSourceAny(
+      "http://evil.example:8080",
+      expectedRequestOrigins("http://127.0.0.1:3000", "http:", "evil.example:8080"),
+    ),
+    false,
+    "an Origin matching an arbitrary non-loopback Host is rejected",
+  );
   // Missing protocol defaults to http (loopback is never TLS on the socket).
   assert.deepEqual(
     expectedRequestOrigins("http://127.0.0.1:3457", null, "127.0.0.1:3458"),

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -89,14 +89,13 @@ export function isAllowedRequestSource(value: string | null, expectedOrigin: str
  * (the port it actually connected to, carried by the Host header) never equals
  * `nextUrl.origin` and every /api request 403s "forbidden origin" (cave-5sg).
  *
- * The request's own Host header carries the real authority. The host gate in
- * proxy() has already constrained it to loopback (or an authenticated /
- * tailnet-trusted remote), so a Host-derived origin is a safe second accepted
- * value: a cross-site browser attacker's Origin still won't match the Host
- * (the browser sets both and cannot forge either), and DNS-rebinding is caught
- * by the loopback host gate. `nextUrl.origin` is kept first so the
- * Tailscale-Serve / forwarded-host path (where Next trusts x-forwarded-host)
- * is entirely unchanged.
+ * The request's own Host header carries the real authority for local fallback,
+ * but only loopback Hosts may extend the accepted-origin set. Tokenless
+ * tailnet-trust mode deliberately relaxes the Host gate for Tailscale Serve
+ * forwarding, so adding arbitrary non-loopback Hosts here would let a
+ * browser-supplied Origin that matches that Host satisfy the CSRF check.
+ * `nextUrl.origin` is kept first so the Tailscale-Serve / forwarded-host path
+ * (where Next trusts x-forwarded-host) is entirely unchanged.
  */
 export function expectedRequestOrigins(
   nextUrlOrigin: string,
@@ -104,7 +103,7 @@ export function expectedRequestOrigins(
   host: string | null,
 ): string[] {
   const origins = [nextUrlOrigin];
-  if (host) {
+  if (isLoopbackHost(host)) {
     const scheme = protocol && protocol.length > 0 ? protocol : "http:";
     const derived = `${scheme}//${host}`;
     if (derived !== nextUrlOrigin) origins.push(derived);


### PR DESCRIPTION
### Motivation

- A recent change appended an origin derived from the request `Host` header to the accepted CSRF origins, which permitted an attacker-controlled non-loopback `Host`/`Origin` to pass CSRF checks when `COVEN_CAVE_TAILNET_TRUST=1` (tokenless tailnet mode). This change restores the intended safety boundary while preserving the port-fallback fix.

### Description

- Restrict `expectedRequestOrigins()` in `src/proxy-helpers.ts` to only append a Host-derived origin when `isLoopbackHost(host)` is true, so non-loopback `Host` headers do not become accepted CSRF origins.
- Update the helper's doc comment to explain the loopback-only policy and the reason for keeping `nextUrl.origin` first.
- Add regression coverage in `src/proxy-behavior.test.ts` that verifies a non-loopback Host such as `evil.example:8080` is not added and a matching attacker-controlled `Origin` is rejected.
- Preserve the original port-fallback behavior for loopback Hosts so the fallback-port Origin still passes.

### Testing

- Ran unit tests with `pnpm exec vitest run src/proxy-behavior.test.ts src/middleware.test.ts --reporter=verbose`, and the test run passed.
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`), and the typecheck passed.
- The repository uses Beads (`bd`) for task tracking but `bd` was not available in the container (`bd: command not found`), so Beads claim/update steps were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7bab22888327b0c11d4ca51e191b)