### PR TITLE
fix: prevent sidecar port desync

### DIFF
--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -363,9 +363,13 @@ ensure_tailscale() {
   fi
 }
 
+server_logged_ready() {
+  grep -F "> Ready on http://${HOST}:${PORT}" "$LOG_FILE" >/dev/null 2>&1
+}
+
 wait_for_server() {
   for _ in $(seq 1 80); do
-    if port_is_listening >/dev/null 2>&1; then
+    if recorded_server_is_running && port_is_listening >/dev/null 2>&1 && server_logged_ready; then
       return 0
     fi
     sleep 0.25

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -120,6 +120,12 @@ test("mobile tailscale invite command is chat-safe by default", () => {
   assert.doesNotMatch(script, /Open this URL on your phone:/);
 });
 
+test("mobile tailscale readiness requires this server's ready log", () => {
+  assert.match(script, /server_logged_ready\(\)/);
+  assert.match(script, /grep -F "> Ready on http:\/\/\$\{HOST\}:\$\{PORT\}" "\$LOG_FILE"/);
+  assert.match(script, /recorded_server_is_running && port_is_listening.*&& server_logged_ready/);
+});
+
 test("mobile tailscale runner syntax is shell-checkable by bash", () => {
   assert.match(script, /set -euo pipefail/);
 });

--- a/server.mjs
+++ b/server.mjs
@@ -419,27 +419,13 @@ server.on("upgrade", (req, socket, head) => {
 });
 server.keepAliveTimeout = 75e3;
 server.headersTimeout = 8e4;
-function startListening(attempt = 0) {
-  const currentPort = port + attempt;
-  const maxAttempts = 10;
-  server.listen(currentPort, hostname, () => {
-    console.log(`> Ready on http://${hostname}:${currentPort}`);
-    if (process.env.PORT !== String(currentPort)) {
-      process.env.PORT = String(currentPort);
-    }
-  });
-  server.once("error", (err) => {
-    if (err.code === "EADDRINUSE" && attempt < maxAttempts) {
-      console.warn(`Port ${currentPort} in use, trying ${currentPort + 1}...`);
-      server.removeAllListeners("error");
-      server.removeAllListeners("listening");
-      startListening(attempt + 1);
-    } else {
-      console.error(err);
-      process.exit(1);
-    }
-  });
-}
+server.listen(port, hostname, () => {
+  console.log(`> Ready on http://${hostname}:${port}`);
+});
+server.once("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});
 const HEAP_MONITOR_ENABLED = process.env.COVEN_CAVE_HEAP_MONITOR !== "0";
 const HEAP_MONITOR_INTERVAL_MS = (() => {
   const env = Number.parseInt(process.env.COVEN_CAVE_HEAP_MONITOR_INTERVAL_MS ?? "", 10);
@@ -498,4 +484,3 @@ function startHeapMonitor() {
   setInterval(tick, HEAP_MONITOR_INTERVAL_MS).unref();
 }
 startHeapMonitor();
-startListening();

--- a/server.ts
+++ b/server.ts
@@ -641,32 +641,14 @@ server.on("upgrade", (req, socket, head) => {
 server.keepAliveTimeout = 75_000;
 server.headersTimeout = 80_000;
 
-function startListening(attempt: number = 0): void {
-  const currentPort = port + attempt;
-  const maxAttempts = 10;
+server.listen(port, hostname, () => {
+  console.log(`> Ready on http://${hostname}:${port}`);
+});
 
-  server.listen(currentPort, hostname, () => {
-    console.log(`> Ready on http://${hostname}:${currentPort}`);
-    // Export the final port so wrapper scripts (dev-app.sh, etc.) can discover it.
-    if (process.env.PORT !== String(currentPort)) {
-      process.env.PORT = String(currentPort);
-    }
-  });
-
-  server.once("error", (err: NodeJS.ErrnoException) => {
-    if (err.code === "EADDRINUSE" && attempt < maxAttempts) {
-      console.warn(`Port ${currentPort} in use, trying ${currentPort + 1}...`);
-      server.removeAllListeners("error");
-      // listen() attached its callback via once('listening') before the failed
-      // bind — clear it too, or every stale callback fires on the winning port.
-      server.removeAllListeners("listening");
-      startListening(attempt + 1);
-    } else {
-      console.error(err);
-      process.exit(1);
-    }
-  });
-}
+server.once("error", (err: NodeJS.ErrnoException) => {
+  console.error(err);
+  process.exit(1);
+});
 
 // ── Heap telemetry (cave-ksjt) ────────────────────────────────────────────────
 // Long-lived servers (the packaged sidecar and dev runs alike) have died with
@@ -763,4 +745,3 @@ function startHeapMonitor(): void {
 }
 
 startHeapMonitor();
-startListening();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1527,15 +1527,26 @@ fn live_dev_server_url(app: &tauri::App) -> Option<tauri::Url> {
 }
 
 #[cfg(desktop)]
-fn wait_for_port(port: u16, timeout: Duration, should_cancel: impl Fn() -> bool) -> PortWaitResult {
+fn wait_for_sidecar_ready(
+    port: u16,
+    log_path: &Path,
+    timeout: Duration,
+    should_cancel: impl Fn() -> bool,
+) -> PortWaitResult {
     use std::net::{SocketAddr, TcpStream};
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    // Require the launched sidecar's own ready log line, not just a listening
+    // port — otherwise another process squatting the port would be trusted.
+    let ready_line = format!("> Ready on http://127.0.0.1:{}", port);
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         if should_cancel() {
             return PortWaitResult::Cancelled;
         }
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+        let logged_ready = std::fs::read_to_string(log_path)
+            .map(|log| log.lines().any(|line| line.trim() == ready_line))
+            .unwrap_or(false);
+        if logged_ready && TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
             return PortWaitResult::Ready;
         }
         thread::sleep(Duration::from_millis(150));
@@ -1773,7 +1784,7 @@ fn start_sidecar_runtime(
     } else {
         Duration::from_secs(20)
     };
-    match wait_for_port(port, sidecar_start_timeout, &should_cancel) {
+    match wait_for_sidecar_ready(port, &log_path, sidecar_start_timeout, &should_cancel) {
         PortWaitResult::Ready => {}
         PortWaitResult::Cancelled => return Err(SidecarStartError::Cancelled),
         PortWaitResult::TimedOut => {
@@ -2194,16 +2205,39 @@ mod tests {
     fn sidecar_port_wait_is_cancellable_and_detects_readiness() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind readiness fixture");
         let port = listener.local_addr().expect("fixture address").port();
+        let log_dir = std::env::temp_dir().join(format!(
+            "covencave-sidecar-ready-test-{}-{}",
+            std::process::id(),
+            port
+        ));
+        std::fs::create_dir_all(&log_dir).expect("create log fixture dir");
+        let log_path = log_dir.join("sidecar.log");
+
+        // A listening port without the sidecar's own ready log line must NOT
+        // be trusted — that's the port-squatting scenario this guards against.
+        std::fs::write(&log_path, "starting up\n").expect("write log fixture");
         assert!(matches!(
-            wait_for_port(port, Duration::from_secs(1), || false),
+            wait_for_sidecar_ready(port, &log_path, Duration::from_millis(600), || false),
+            PortWaitResult::TimedOut
+        ));
+
+        std::fs::write(
+            &log_path,
+            format!("starting up\n> Ready on http://127.0.0.1:{}\n", port),
+        )
+        .expect("write ready log fixture");
+        assert!(matches!(
+            wait_for_sidecar_ready(port, &log_path, Duration::from_secs(1), || false),
             PortWaitResult::Ready
         ));
         drop(listener);
 
         assert!(matches!(
-            wait_for_port(port, Duration::from_secs(1), || true),
+            wait_for_sidecar_ready(port, &log_path, Duration::from_secs(1), || true),
             PortWaitResult::Cancelled
         ));
+
+        let _ = std::fs::remove_dir_all(&log_dir);
     }
 
     #[cfg(target_os = "windows")]

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -179,3 +179,8 @@ assert.match(
   /\?covenCaveToken=\{auth_token\}&coven_access_token=\{mobile_access_token\}/,
   "Tauri app URL should bootstrap both named tokens into the webview",
 );
+assert.match(
+  tauriSource,
+  /wait_for_sidecar_ready\(port, &log_path, sidecar_start_timeout, &should_cancel\)/,
+  "Tauri sidecar should require the launched sidecar's ready log before trusting the URL",
+);

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -205,13 +205,11 @@ assert.equal(
   "normal same-origin browser dev mode remains allowed",
 );
 
-// ─── expectedRequestOrigins / port-fallback CSRF (cave-5sg) ────────────────
-// server.ts constructs Next with the CONFIGURED port, then startListening()
-// falls back to the next free port when it's taken. req.nextUrl.origin stays
-// pinned to the configured port, so the real browser Origin (the fallback
-// port, carried by Host) must also be accepted or every /api request 403s.
+// ─── expectedRequestOrigins / host-derived CSRF (cave-5sg) ────────────────
+// req.nextUrl.origin can stay pinned to the configured port while the real
+// browser Origin is carried by Host, so both origins remain accepted.
 {
-  // Fell back 3457 -> 3458: nextUrl still says :3457, Host says :3458.
+  // Host reports :3458 while nextUrl still says :3457.
   const origins = expectedRequestOrigins("http://127.0.0.1:3457", "http:", "127.0.0.1:3458");
   assert.deepEqual(
     origins,


### PR DESCRIPTION
### Motivation
- Prevent a local attacker from squatting the originally-requested loopback port and capturing token-bearing URLs when the Node sidecar falls back to an adjacent port. 
- Ensure the desktop/mobile launchers only trust the actual bound sidecar endpoint rather than a stale preselected port. 
- Preserve existing behavior for legitimate cases while removing the unsafe automatic adjacent-port bind fallback in the child process.

### Description
- Remove the server-side adjacent-port fallback in `server.ts` / `server.mjs` so the sidecar either binds the requested port or exits on bind failure. 
- Require explicit sidecar readiness by checking both TCP connectivity and the sidecar log `"> Ready on http://127.0.0.1:<port>"` line in the Tauri launcher by adding `wait_for_sidecar_ready(...)` in `src-tauri/src/lib.rs`. 
- Require the mobile runner to verify the tracked process, a listening port, and the exact ready log line by adding `server_logged_ready()` and tightening `wait_for_server()` in `scripts/mobile-tailscale.sh`. 
- Add/adjust regression assertions in `scripts/mobile-tailscale.test.mjs`, `src/middleware.test.ts`, and `src/proxy-behavior.test.ts` to cover the new readiness checks and update wording that referenced the removed port-fallback behavior.

### Testing
- `node scripts/mobile-tailscale.test.mjs` ran and passed. 
- `node --experimental-strip-types src/middleware.test.ts` and `node --experimental-strip-types src/proxy-behavior.test.ts` ran and passed. 
- `pnpm test:app`, `pnpm typecheck`, `pnpm build:server`, and `git diff --check` were executed and succeeded. 
- `bd prime && bd ready --json` was not run because the `bd` CLI is not installed in the environment, and `cd src-tauri && cargo check` was blocked by a missing system `glib-2.0.pc` (GLib development package).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c76afdd64832795523e2a2b786fa9)