### PR TITLE
fix(ios): avoid bearer token leak during discovery

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -800,17 +800,23 @@ final class AppModel {
         case none
     }
 
-    /// Probe every candidate base URL concurrently, then adjudicate strictly
-    /// in candidate order so the semantics match a sequential walk: the first
-    /// `.ok` in order wins, and a 401/403 earlier in the order is TERMINAL —
-    /// it's a live Cave token gate talking, and the fix is pairing. Adopting
-    /// a later candidate past it could silently connect to a different
-    /// instance on a sibling port (e.g. a dev server on :3000) — the user
-    /// thinks they're talking to the desktop they paired with, but they
-    /// aren't. Concurrency only changes the wall clock: one probe's timeout
-    /// (~6s) instead of the sum across candidates (30s+ on a cold launch).
+    /// Probe candidate base URLs and adjudicate strictly in candidate order: the
+    /// first `.ok` in order wins, and a 401/403 earlier in the order is
+    /// TERMINAL — it's a live Cave token gate talking, and the fix is pairing.
+    /// Adopting a later candidate past it could silently connect to a different
+    /// instance on a sibling port (e.g. a dev server on :3000) — the user thinks
+    /// they're talking to the desktop they paired with, but they aren't.
+    ///
+    /// When a paired credential exists, probe sequentially so we never spray a
+    /// Bearer token at speculative sibling ports after an earlier candidate has
+    /// already succeeded or rejected it. Unpaired probes carry no secret, so they
+    /// may still run concurrently for the cold-launch wall-clock win.
     static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
         guard !candidates.isEmpty else { return .none }
+        if CaveConnection.accessToken != nil {
+            return await discoverBaseURLSequentially(candidates)
+        }
+
         let results = await withTaskGroup(of: (Int, ProbeResult).self) { group in
             for (index, base) in candidates.enumerated() {
                 group.addTask { (index, await Self.probe(base)) }
@@ -819,6 +825,21 @@ final class AppModel {
             for await (index, result) in group { collected[index] = result }
             return collected
         }
+        return adjudicateDiscoveryResults(results, candidates: candidates)
+    }
+
+    private static func discoverBaseURLSequentially(_ candidates: [URL]) async -> DiscoveryOutcome {
+        for base in candidates {
+            switch await Self.probe(base) {
+            case .ok: return .found(base)
+            case .unauthorized: return .unauthorized
+            case .failed: continue
+            }
+        }
+        return .none
+    }
+
+    private static func adjudicateDiscoveryResults(_ results: [ProbeResult?], candidates: [URL]) -> DiscoveryOutcome {
         for (index, result) in results.enumerated() {
             switch result {
             case .ok: return .found(candidates[index])

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -69,15 +69,20 @@ assert.match(
   "dev-tab requests must send the Bearer token — without it the Developer tab 401s on a paired desktop",
 );
 
-// --- Discovery: concurrent probes, ordered adjudication, 401 stays terminal -
+// --- Discovery: credential-safe probes, ordered adjudication, 401 terminal -
 assert.match(
   model,
-  /static func discoverBaseURL[\s\S]*?withTaskGroup/,
-  "candidates should be probed concurrently (wall-clock = one probe, not the sum)",
+  /if CaveConnection\.accessToken != nil \{\s*\n\s*return await discoverBaseURLSequentially\(candidates\)/,
+  "paired discovery must probe sequentially so Bearer tokens are not sent to speculative sibling ports",
 );
 assert.match(
   model,
-  /for \(index, result\) in results\.enumerated\(\)[\s\S]*?case \.ok: return \.found\(candidates\[index\]\)[\s\S]*?case \.unauthorized: return \.unauthorized/,
+  /let results = await withTaskGroup/,
+  "unpaired discovery can still probe concurrently (wall-clock = one probe, not the sum)",
+);
+assert.match(
+  model,
+  /private static func adjudicateDiscoveryResults[\s\S]*?for \(index, result\) in results\.enumerated\(\)[\s\S]*?case \.ok: return \.found\(candidates\[index\]\)[\s\S]*?case \.unauthorized: return \.unauthorized/,
   "results must be adjudicated in candidate order with 401/403 still terminal (sibling-port safety)",
 );
 


### PR DESCRIPTION
### Motivation
- Concurrent discovery probes were sending the stored mobile `Bearer` token to every candidate endpoint, which could leak the paired credential to sibling ports or unrelated services before ordered adjudication selected the correct endpoint. 
- The intent is to preserve the faster cold-launch behavior of concurrent probes when no credential exists while preventing credential disclosure when a paired token is present.

### Description
- Change `discoverBaseURL(_:)` to run a sequential candidate walk when `CaveConnection.accessToken` is present and to keep the existing concurrent `withTaskGroup` path when no token exists.
- Add `discoverBaseURLSequentially(_:)` to probe candidates one-by-one and stop on the first `.ok` or terminal `.unauthorized` result. 
- Factor adjudication into `adjudicateDiscoveryResults(_:, candidates:)` for the concurrent path so ordered semantics (`.ok` wins, 401/403 terminal) are preserved. 
- Update the contract test `scripts/ios-connection-stability.test.mjs` to require credential-safe (sequential) paired discovery, to allow concurrent unpaired discovery, and to keep ordered adjudication pinned.

### Testing
- Ran `node scripts/ios-connection-stability.test.mjs` which passed (`ios-connection-stability: OK`).
- Ran `npm run test:mobile`, which executed 70 mobile test files and all passed. 
- Ran `npm run typecheck` which failed due to unrelated local type declaration issues (`@codemirror/language` and `@lezer/highlight` missing type declarations) and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c03d1408c8327b1363c338baae4cb)