### PR TITLE
fix(mobile): reset stale Serve routes on disabled startup

### DIFF
--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -47,6 +47,17 @@ assert.match(settings, /reconcileMobileModeRequest/, "Settings should share the 
 assert.match(mobileModeReconcile, /json\.unavailable === true \|\| response\.status === 503/, "current clean unavailability and legacy 503 responses block automatic retries");
 assert.match(mobileModeReconcile, /options\?\.force/, "user Retry and toggle actions bypass the automatic circuit breaker");
 assert.match(workspace, /mobileModeHost/, "Workspace should keep the current native app host returned by the route");
+
+assert.match(
+  workspace,
+  /const didInitialMobileModeReconcileRef = useRef\(false\)[\s\S]*suppressError: isInitialReconcile && !mobileModeEnabled/,
+  "Workspace should silently send one boot-time app-stop when the persisted mobile-mode preference is disabled",
+);
+assert.doesNotMatch(
+  workspace,
+  /if \(!mobileModeEnabled && !mobileModeWasEnabledRef\.current\) return/,
+  "Workspace must not skip the initial disabled reconciliation because stale Tailscale Serve routes persist outside the UI process",
+);
 assert.match(workspace, /setMobileModeEnabled/, "Workspace should expose a way to toggle mobile mode from Settings");
 assert.match(modal, /\/api\/mobile-handoff/, "Modal should call the mobile handoff API");
 assert.match(modal, /dangerouslySetInnerHTML/, "Modal should render the QR SVG returned by the API");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -541,11 +541,16 @@ export function Workspace() {
     setMobileModeEnabledState(enabled);
   }, []);
 
-  const reconcileMobileMode = useCallback(async (enabled: boolean, options?: { force?: boolean }) => {
+  const reconcileMobileMode = useCallback(async (enabled: boolean, options?: { force?: boolean; suppressError?: boolean }) => {
     const result = await reconcileMobileModeRequest(enabled, options);
     setMobileModeAutoRetryBlocked(result.retryBlocked);
     if (!result.ok) {
-      setMobileModeError(result.stderr || result.error || "Mobile mode unavailable.");
+      // suppressError covers the one-time boot reconcile with the pref off:
+      // the shared reconciler reports transport failures as !ok too, so both
+      // the expected plain-web 503 and a fetch error stay silent there.
+      if (!options?.suppressError) {
+        setMobileModeError(result.stderr || result.error || "Mobile mode unavailable.");
+      }
       if (!enabled) setMobileModeHost(null);
       return;
     }
@@ -553,18 +558,23 @@ export function Workspace() {
     setMobileModeHost(enabled ? result.nativeHost ?? null : null);
   }, []);
 
-  // Reconcile only when mobile mode is (or just was) enabled. With the pref
-  // off there is nothing to stop — an unconditional boot-time POST meant
-  // every plain-web session hit /api/mobile-handoff, got the expected 503
-  // (the route needs the packaged app's signed token), and logged a console
-  // error + a misleading "Mobile mode unavailable" state for a feature the
-  // user never touched. Turning the toggle OFF still posts app-stop because
-  // the state change re-runs this effect while wasEnabledRef is set.
+  // Always reconcile once on boot, even when the persisted pref is off: Tailscale
+  // Serve routes outlive the web UI process, so a stale route from a crash or
+  // failed prior stop must be reset. Suppress only the boot-time disabled error
+  // so plain-web sessions do not show a misleading mobile-mode failure. After
+  // boot, disabled->disabled renders can skip, while enabled->disabled still
+  // posts app-stop.
   const mobileModeWasEnabledRef = useRef(false);
+  const didInitialMobileModeReconcileRef = useRef(false);
   useEffect(() => {
-    if (!mobileModeEnabled && !mobileModeWasEnabledRef.current) return;
+    const wasEnabled = mobileModeWasEnabledRef.current;
+    const isInitialReconcile = !didInitialMobileModeReconcileRef.current;
+    didInitialMobileModeReconcileRef.current = true;
     mobileModeWasEnabledRef.current = mobileModeEnabled;
-    void reconcileMobileMode(mobileModeEnabled);
+    if (!mobileModeEnabled && !wasEnabled && !isInitialReconcile) return;
+    void reconcileMobileMode(mobileModeEnabled, {
+      suppressError: isInitialReconcile && !mobileModeEnabled,
+    });
   }, [mobileModeEnabled, reconcileMobileMode]);
   // Recurring reconcile only while mobile mode is on; usePausablePoll pauses it
   // in a hidden tab and refreshes on return.


### PR DESCRIPTION
### Motivation
- A startup guard was suppressing the one-time `app-stop` reconciliation when the persisted mobile-mode preference was false, which can leave stale Tailscale Serve routes active and expose native APIs/PTY over a tailnet in tokenless mode.
- The change restores a safe automatic cleanup on cold boot while avoiding noisy errors for plain-web sessions.

### Description
- Change `reconcileMobileMode` in `src/components/workspace.tsx` to accept an `options?: { suppressError?: boolean }` parameter and conditionally suppress boot-time error reporting.
- Add `didInitialMobileModeReconcileRef` and update the `useEffect` so the workspace always performs a one-time reconcile on initial boot and only skips redundant reconciles after that; the initial disabled reconcile is run with `suppressError` to avoid noisy UI messages.
- Add source-level regression assertions in `src/components/mobile-handoff.test.ts` to ensure the initial disabled reconciliation behavior and the new suppression contract are present.

### Testing
- Ran `node --experimental-strip-types src/components/mobile-handoff.test.ts` which executed the modified smoke assertions and printed `mobile-handoff.test.ts OK` (success).
- Ran `pnpm exec tsc --noEmit` to typecheck the codebase and it completed without errors (success).
- Attempted `pnpm exec tsx src/components/mobile-handoff.test.ts` but the `tsx` runner was not present in the environment, so that invocation failed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bea984bec832790b9bfbffb0c2d2f)