### PR TITLE
Fix offline replay project-root authorization fail-open

### DIFF
--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -7,11 +7,13 @@ import path from "node:path";
 const tmp = await mkdtemp(path.join(tmpdir(), "project-permissions-test-"));
 process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
 process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(tmp, "permission-config.json");
+process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "projects.json");
 process.env.CAVE_SUPREME_FAMILIAR_ID = "supreme";
 
 try {
   const {
     assertProjectAccess,
+    assertProjectRootAccess,
     bootstrapSupremeProjectGrants,
     canAccessProject,
     createAccessGroup,
@@ -34,6 +36,11 @@ try {
     { id: "cave", name: "Cave", root: "/tmp/cave", createdAt: "now", updatedAt: "now" },
     { id: "docs", name: "Docs", root: "/tmp/docs", createdAt: "now", updatedAt: "now" },
   ];
+  await writeFile(
+    process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+    JSON.stringify({ version: 1, projects }),
+    "utf8",
+  );
 
   assert.equal(
     canAccessProject({ projectGrants: [] }, { familiarId: "nova" }, "cave", "supreme"),
@@ -70,9 +77,18 @@ try {
     (err) => err instanceof ProjectAccessDeniedError && err.status === 403,
     "missing grants fail closed with a 403 error",
   );
+  await assert.rejects(
+    () => assertProjectRootAccess({ familiarId: "nova" }, "/tmp/cave/subdir", "chat"),
+    (err) => err instanceof ProjectAccessDeniedError && err.status === 403,
+    "unregistered roots, including subdirectories of registered projects, fail closed",
+  );
+  await assertProjectRootAccess({ familiarId: "nova" }, "/tmp/cave/subdir", "chat", {
+    allowUnregisteredRoot: true,
+  });
   const audited = await loadProjectPermissions();
-  assert.equal(audited.permissionAudit.at(-2)?.decision, "allow", "allowed decisions are audited");
-  assert.equal(audited.permissionAudit.at(-1)?.decision, "deny", "denied decisions are audited");
+  assert.equal(audited.permissionAudit.at(-3)?.decision, "allow", "allowed decisions are audited");
+  assert.equal(audited.permissionAudit.at(-2)?.decision, "deny", "denied decisions are audited");
+  assert.equal(audited.permissionAudit.at(-1)?.projectId, "unregistered:/tmp/cave/subdir", "unregistered root denials are audited");
 
   const proposal = await createGrantProposal({
     proposedBy: "supreme",
@@ -328,6 +344,7 @@ try {
 } finally {
   delete process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE;
   delete process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE;
+  delete process.env.CAVE_PROJECTS_PATH_OVERRIDE;
   delete process.env.CAVE_SUPREME_FAMILIAR_ID;
   await rm(tmp, { recursive: true, force: true });
 }

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -433,15 +433,13 @@ export async function assertProjectRootAccess(
   ctx: ProjectAccessContext,
   projectRoot: string | null | undefined,
   surface: ProjectPermissionSurface,
+  options: { allowUnregisteredRoot?: boolean } = {},
 ): Promise<CaveProject | null> {
   if (!projectRoot?.trim()) return null;
   const project = projectForRoot(projectRoot, await loadProjects());
   if (!project) {
-    // The root does not correspond to any registered project, so there is no
-    // grant surface to enforce (e.g. an offline travel replay whose queued
-    // local runtime cwd was never registered). There is nothing to authorize
-    // — and nothing an attacker could bypass — so allow it through rather than
-    // hard-failing legitimate replays for unregistered local roots.
+    if (options.allowUnregisteredRoot) return null;
+    await assertProjectAccess(ctx, `unregistered:${projectRoot}`, surface);
     return null;
   }
   await assertProjectAccess(ctx, project.id, surface);

--- a/src/lib/travel-offline-replay.test.ts
+++ b/src/lib/travel-offline-replay.test.ts
@@ -86,13 +86,13 @@ assert.match(
 
 assert.match(
   replay,
-  /const projectRoot = stringValue\(payload\.projectRoot\) \?\? runtimeCwd \?\? process\.cwd\(\)/,
+  /const payloadProjectRoot = stringValue\(payload\.projectRoot\)[\s\S]*const projectRoot = payloadProjectRoot \?\? runtimeCwd \?\? process\.cwd\(\)/,
   "chat replay should derive projectRoot from queued local runtime when payload omits it",
 );
 
 assert.match(
   replay,
-  /await assertProjectRootAccess\(\{ familiarId \}, projectRoot, "chat"\)/,
+  /const allowLocalRuntimeCwd = normalizeProjectRoot\(projectRoot\) === normalizeProjectRoot\(process\.cwd\(\)\)[\s\S]*await assertProjectRootAccess\(\{ familiarId \}, projectRoot, "chat", \{[\s\S]*allowUnregisteredRoot: allowLocalRuntimeCwd/,
   "chat replay should revalidate the current familiar project grant before spawning a hub session",
 );
 

--- a/src/lib/travel-offline-replay.ts
+++ b/src/lib/travel-offline-replay.ts
@@ -114,8 +114,12 @@ async function replayChat(item: CaveTravelQueueItem, config: CaveConfig): Promis
     throw new Error("queued SSH-runtime chat cannot be replayed as a local hub session");
   }
   const runtimeCwd = runtime?.startsWith("local:") ? stringValue(runtime.slice("local:".length)) : null;
-  const projectRoot = stringValue(payload.projectRoot) ?? runtimeCwd ?? process.cwd();
-  await assertProjectRootAccess({ familiarId }, projectRoot, "chat");
+  const payloadProjectRoot = stringValue(payload.projectRoot);
+  const projectRoot = payloadProjectRoot ?? runtimeCwd ?? process.cwd();
+  const allowLocalRuntimeCwd = normalizeProjectRoot(projectRoot) === normalizeProjectRoot(process.cwd());
+  await assertProjectRootAccess({ familiarId }, projectRoot, "chat", {
+    allowUnregisteredRoot: allowLocalRuntimeCwd,
+  });
 
   const binding = bindingFor(config, familiarId);
   const attachments = objectArray<ChatAttachment>(payload.attachments);


### PR DESCRIPTION
### Motivation
- Close a fail-open authorization gap where offline replay allowed unknown or non-exact queued `projectRoot` values to bypass project grant checks and spawn local sessions. 
- Preserve legitimate offline replay that originates from the runtime's own cwd while keeping all other unknown roots subject to normal permission checks.

### Description
- Change `assertProjectRootAccess` to accept `options: { allowUnregisteredRoot?: boolean }` and, by default, route unknown roots through the standard permission chokepoint as `unregistered:<root>` so they fail closed unless explicitly allowed. 
- Update the replay path in `replayChat` to separate `payloadProjectRoot`, compute `allowLocalRuntimeCwd = normalizeProjectRoot(projectRoot) === normalizeProjectRoot(process.cwd())`, and call `assertProjectRootAccess(..., { allowUnregisteredRoot: allowLocalRuntimeCwd })` so only the local runtime cwd is exempt. 
- Add and update tests: write a temporary `projects.json` in `project-permissions.test.ts` and assert that unregistered subpaths fail closed and are audited as `unregistered:<root>`, and update `travel-offline-replay.test.ts` assertions to match the new guard and option. 
- Preserve existing semantics for registered projects so `assertProjectAccess` continues enforcing grants for known project ids.

### Testing
- Ran the targeted tests with `node --experimental-strip-types src/lib/project-permissions.test.ts` and `node --experimental-strip-types src/lib/travel-offline-replay.test.ts`, which both succeeded. 
- Ran the full app test suite with `pnpm test:app` and all 517 test files passed. 
- Ran `pnpm typecheck` which completed without errors. 
- Note: repository uses Beads (`bd`) for task tracking, but `bd` was not installed in the execution environment so `bd prime` / `bd ready` were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1b4539d083279b8cc821992c5221)