### PR TITLE
Prevent familiarId 'supreme' bearer bypass and require local-human gates for grant mutations

### DIFF
--- a/src/app/api/grant-proposals/[id]/route.ts
+++ b/src/app/api/grant-proposals/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { isLocalOrigin } from "@/lib/server/local-origin";
+
 import {
   ProjectAccessDeniedError,
   resolveGrantProposal,
@@ -26,6 +28,12 @@ export async function PATCH(
   req: Request,
   { params: rawParams }: { params: Promise<{ id: string }> },
 ) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json(
+      { ok: false, error: "proposal decisions must be confirmed from the local desktop" },
+      { status: 403 },
+    );
+  }
   const params = await rawParams;
   let payload: Record<string, unknown>;
   try {

--- a/src/app/api/grant-proposals/route.ts
+++ b/src/app/api/grant-proposals/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { isLocalOrigin } from "@/lib/server/local-origin";
+
 import {
   ProjectAccessDeniedError,
   createGrantProposal,
@@ -13,6 +15,12 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json(
+      { ok: false, error: "grant proposals must be created from the local desktop" },
+      { status: 403 },
+    );
+  }
   let payload: Record<string, unknown>;
   try {
     payload = (await req.json()) as Record<string, unknown>;

--- a/src/app/api/project-grants/route.test.ts
+++ b/src/app/api/project-grants/route.test.ts
@@ -38,6 +38,11 @@ assert.match(grantsRoute, /export async function POST\(/, "project grants route 
 assert.match(grantsRoute, /export async function DELETE\(/, "project grants route should revoke human grants");
 assert.match(
   grantsRoute,
+  /requireLocalHumanGrantMutation\(req\)/,
+  "direct grant mutations should require a local human request",
+);
+assert.match(
+  grantsRoute,
   /rejectRelayedApproval\(payload\)/,
   "direct grant mutations should reject actor/relayed-human fields instead of trusting familiar claims",
 );
@@ -76,11 +81,21 @@ assert.match(proposalsRoute, /export async function GET\(/, "grant proposals rou
 assert.match(proposalsRoute, /export async function POST\(/, "grant proposals route should create proposals");
 assert.match(
   proposalsRoute,
+  /isLocalOrigin\(req\)/,
+  "proposal creation should require a local human request",
+);
+assert.match(
+  proposalsRoute,
   /createGrantProposal\(\{[\s\S]*proposedBy:[\s\S]*targetFamiliarId:[\s\S]*projectId:[\s\S]*claimedHumanApproval:/,
   "proposal route should pass Supreme proposal claims to the guarded core primitive",
 );
 
 assert.match(proposalItemRoute, /export async function PATCH\(/, "proposal item route should resolve proposals");
+assert.match(
+  proposalItemRoute,
+  /isLocalOrigin\(req\)/,
+  "proposal resolution should require a local human request",
+);
 assert.match(
   proposalItemRoute,
   /rejectRelayedApproval\(payload\)/,

--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { isLocalOrigin } from "@/lib/server/local-origin";
+
 import {
   grantProjectToFamiliar,
   listAccessGroups,
@@ -31,6 +33,14 @@ async function readPayload(req: Request): Promise<Record<string, unknown> | Resp
   } catch {
     return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
   }
+}
+
+function requireLocalHumanGrantMutation(req: Request): Response | null {
+  if (isLocalOrigin(req)) return null;
+  return NextResponse.json(
+    { ok: false, error: "grant changes must be confirmed from the local desktop" },
+    { status: 403 },
+  );
 }
 
 function grantInput(payload: Record<string, unknown>) {
@@ -70,6 +80,8 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const blocked = requireLocalHumanGrantMutation(req);
+  if (blocked) return blocked;
   const payload = await readPayload(req);
   if (payload instanceof Response) return payload;
   const rejected = rejectRelayedApproval(payload);
@@ -93,6 +105,8 @@ export async function POST(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const blocked = requireLocalHumanGrantMutation(req);
+  if (blocked) return blocked;
   const payload = await readPayload(req);
   if (payload instanceof Response) return payload;
   const rejected = rejectRelayedApproval(payload);

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -7,11 +7,13 @@ import path from "node:path";
 const tmp = await mkdtemp(path.join(tmpdir(), "project-permissions-test-"));
 process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
 process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(tmp, "permission-config.json");
+process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "projects.json");
 process.env.CAVE_SUPREME_FAMILIAR_ID = "supreme";
 
 try {
   const {
     assertProjectAccess,
+    assertProjectRootAccess,
     bootstrapSupremeProjectGrants,
     canAccessProject,
     createAccessGroup,
@@ -34,6 +36,11 @@ try {
     { id: "cave", name: "Cave", root: "/tmp/cave", createdAt: "now", updatedAt: "now" },
     { id: "docs", name: "Docs", root: "/tmp/docs", createdAt: "now", updatedAt: "now" },
   ];
+  await writeFile(
+    process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+    JSON.stringify({ version: 1, projects }),
+    "utf8",
+  );
 
   assert.equal(
     canAccessProject({ projectGrants: [] }, { familiarId: "nova" }, "cave", "supreme"),
@@ -70,9 +77,18 @@ try {
     (err) => err instanceof ProjectAccessDeniedError && err.status === 403,
     "missing grants fail closed with a 403 error",
   );
+  await assert.rejects(
+    () => assertProjectRootAccess({ familiarId: "nova" }, "/tmp/cave/subdir", "chat"),
+    (err) => err instanceof ProjectAccessDeniedError && err.status === 403,
+    "unregistered roots, including subdirectories of registered projects, fail closed",
+  );
+  await assertProjectRootAccess({ familiarId: "nova" }, "/tmp/cave/subdir", "chat", {
+    allowUnregisteredRoot: true,
+  });
   const audited = await loadProjectPermissions();
-  assert.equal(audited.permissionAudit.at(-2)?.decision, "allow", "allowed decisions are audited");
-  assert.equal(audited.permissionAudit.at(-1)?.decision, "deny", "denied decisions are audited");
+  assert.equal(audited.permissionAudit.at(-3)?.decision, "allow", "allowed decisions are audited");
+  assert.equal(audited.permissionAudit.at(-2)?.decision, "deny", "denied decisions are audited");
+  assert.equal(audited.permissionAudit.at(-1)?.projectId, "unregistered:/tmp/cave/subdir", "unregistered root denials are audited");
 
   const proposal = await createGrantProposal({
     proposedBy: "supreme",
@@ -328,6 +344,7 @@ try {
 } finally {
   delete process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE;
   delete process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE;
+  delete process.env.CAVE_PROJECTS_PATH_OVERRIDE;
   delete process.env.CAVE_SUPREME_FAMILIAR_ID;
   await rm(tmp, { recursive: true, force: true });
 }

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -43,20 +43,20 @@ try {
   );
 
   assert.equal(
-    canAccessProject({ projectGrants: [] }, { familiarId: "nova" }, "cave", "supreme"),
+    canAccessProject({ projectGrants: [] }, { familiarId: "nova" }, "cave"),
     false,
     "familiars start without project access",
   );
   assert.equal(
-    canAccessProject({ projectGrants: [] }, { familiarId: "supreme" }, "cave", "supreme"),
-    true,
-    "Supreme has implicit access to every project",
+    canAccessProject({ projectGrants: [] }, { familiarId: "supreme" }, "cave"),
+    false,
+    "the Supreme familiar id is not an implicit bearer token for project access",
   );
 
   await grantProjectToFamiliar({ familiarId: "nova", projectId: "cave", source: "human" });
   const permissions = await loadProjectPermissions();
   assert.equal(
-    canAccessProject(permissions, { familiarId: "nova" }, "cave", "supreme"),
+    canAccessProject(permissions, { familiarId: "nova" }, "cave"),
     true,
     "a human-created grant allows the target project",
   );
@@ -67,8 +67,8 @@ try {
   );
   assert.deepEqual(
     (await filterProjectsForFamiliar(projects, "supreme")).map((project) => project.id),
-    ["cave", "docs"],
-    "Supreme sees all projects",
+    [],
+    "the Supreme familiar id only sees explicitly granted projects",
   );
 
   await assertProjectAccess({ familiarId: "nova" }, "cave", "chat");
@@ -133,6 +133,11 @@ try {
       .map((grant) => [grant.projectId, grant.source]),
     [["cave", "bootstrap"], ["docs", "bootstrap"]],
     "bootstrap records Supreme grants for all existing projects",
+  );
+  assert.deepEqual(
+    (await filterProjectsForFamiliar(projects, "supreme")).map((project) => project.id),
+    ["cave", "docs"],
+    "bootstrapped Supreme project access is backed by explicit grants",
   );
   assert.deepEqual(
     bootstrapped.projectGrants
@@ -239,7 +244,7 @@ try {
     "group-only access resolves with its sources",
   );
   assert.equal(
-    canAccessProject(await loadProjectPermissions(), { familiarId: "wren" }, "cave", "supreme", "write"),
+    canAccessProject(await loadProjectPermissions(), { familiarId: "wren" }, "cave", "write"),
     true,
     "canAccessProject honours group grants and required level",
   );
@@ -294,7 +299,7 @@ try {
   const windowMs = Date.parse(accepting.finalizesAt) - Date.parse(accepting.acceptedAt);
   assert.equal(windowMs, GRANT_ACCEPT_UNDO_WINDOW_MS, "window spans GRANT_ACCEPT_UNDO_WINDOW_MS");
   assert.equal(
-    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs", "supreme"),
+    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs"),
     false,
     "no grant materializes while the undo window is open",
   );
@@ -308,7 +313,7 @@ try {
   assert.equal(undone.status, "pending", "undo returns the proposal to the human's queue");
   assert.equal(undone.finalizesAt, undefined, "undo clears the window deadline");
   assert.equal(
-    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs", "supreme"),
+    canAccessProject(await loadProjectPermissions(), { familiarId: "ember" }, "docs"),
     false,
     "undone acceptance leaves no grant behind",
   );
@@ -330,7 +335,7 @@ try {
   const finalizedProposal = finalized.grantProposals.find((p) => p.id === undoable.id);
   assert.equal(finalizedProposal.status, "accepted", "an elapsed window finalizes on load");
   assert.equal(
-    canAccessProject(finalized, { familiarId: "ember" }, "docs", "supreme"),
+    canAccessProject(finalized, { familiarId: "ember" }, "docs"),
     true,
     "the grant materializes once the window elapses",
   );

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -433,15 +433,13 @@ export async function assertProjectRootAccess(
   ctx: ProjectAccessContext,
   projectRoot: string | null | undefined,
   surface: ProjectPermissionSurface,
+  options: { allowUnregisteredRoot?: boolean } = {},
 ): Promise<CaveProject | null> {
   if (!projectRoot?.trim()) return null;
   const project = projectForRoot(projectRoot, await loadProjects());
   if (!project) {
-    // The root does not correspond to any registered project, so there is no
-    // grant surface to enforce (e.g. an offline travel replay whose queued
-    // local runtime cwd was never registered). There is nothing to authorize
-    // — and nothing an attacker could bypass — so allow it through rather than
-    // hard-failing legitimate replays for unregistered local roots.
+    if (options.allowUnregisteredRoot) return null;
+    await assertProjectAccess(ctx, `unregistered:${projectRoot}`, surface);
     return null;
   }
   await assertProjectAccess(ctx, project.id, surface);

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -343,12 +343,10 @@ export function canAccessProject(
     Partial<Pick<ProjectPermissionsFile, "accessGroups">>,
   ctx: ProjectAccessContext,
   projectId: string,
-  supremeFamiliarId: string,
   required: ProjectAccessLevel = "read",
 ): boolean {
   const familiarId = ctx.familiarId?.trim();
   if (!familiarId) return false;
-  if (familiarId === supremeFamiliarId) return true;
   const effective = effectiveProjectAccess(
     { projectGrants: file.projectGrants, accessGroups: file.accessGroups ?? [] },
     familiarId,
@@ -362,13 +360,7 @@ export async function listAccessibleProjects(
   projects: CaveProject[],
   familiarId: string,
 ): Promise<{ project: CaveProject; access: ProjectAccessLevel }[]> {
-  const [permissions, config] = await Promise.all([
-    loadProjectPermissions(),
-    loadHumanPermissionConfig(),
-  ]);
-  if (familiarId === config.supremeFamiliarId) {
-    return projects.map((project) => ({ project, access: "write" as const }));
-  }
+  const permissions = await loadProjectPermissions();
   const accessible: { project: CaveProject; access: ProjectAccessLevel }[] = [];
   for (const project of projects) {
     const { level } = effectiveProjectAccess(permissions, familiarId, project.id);
@@ -399,20 +391,16 @@ export async function assertProjectAccess(
   surface: ProjectPermissionSurface,
 ): Promise<void> {
   const familiarId = ctx.familiarId?.trim();
-  const [permissions, config] = await Promise.all([
-    loadProjectPermissions(),
-    loadHumanPermissionConfig(),
-  ]);
+  const permissions = await loadProjectPermissions();
   const required = requiredAccessLevel(surface);
-  const isSupreme = !!familiarId && familiarId === config.supremeFamiliarId;
-  const effective = familiarId && !isSupreme
+  const effective = familiarId
     ? effectiveProjectAccess(permissions, familiarId, projectId)
     : null;
-  const allowed = isSupreme || accessLevelSatisfies(effective?.level, required);
+  const allowed = accessLevelSatisfies(effective?.level, required);
 
   let reason: PermissionAuditReason;
   if (allowed) {
-    reason = isSupreme ? "supreme" : effective?.direct ? "grant" : "group";
+    reason = effective?.direct ? "grant" : "group";
   } else {
     reason = effective?.level ? "insufficient-access" : "missing-grant";
   }

--- a/src/lib/travel-offline-replay.test.ts
+++ b/src/lib/travel-offline-replay.test.ts
@@ -86,13 +86,13 @@ assert.match(
 
 assert.match(
   replay,
-  /const projectRoot = stringValue\(payload\.projectRoot\) \?\? runtimeCwd \?\? process\.cwd\(\)/,
+  /const payloadProjectRoot = stringValue\(payload\.projectRoot\)[\s\S]*const projectRoot = payloadProjectRoot \?\? runtimeCwd \?\? process\.cwd\(\)/,
   "chat replay should derive projectRoot from queued local runtime when payload omits it",
 );
 
 assert.match(
   replay,
-  /await assertProjectRootAccess\(\{ familiarId \}, projectRoot, "chat"\)/,
+  /const allowLocalRuntimeCwd = normalizeProjectRoot\(projectRoot\) === normalizeProjectRoot\(process\.cwd\(\)\)[\s\S]*await assertProjectRootAccess\(\{ familiarId \}, projectRoot, "chat", \{[\s\S]*allowUnregisteredRoot: allowLocalRuntimeCwd/,
   "chat replay should revalidate the current familiar project grant before spawning a hub session",
 );
 

--- a/src/lib/travel-offline-replay.ts
+++ b/src/lib/travel-offline-replay.ts
@@ -114,8 +114,12 @@ async function replayChat(item: CaveTravelQueueItem, config: CaveConfig): Promis
     throw new Error("queued SSH-runtime chat cannot be replayed as a local hub session");
   }
   const runtimeCwd = runtime?.startsWith("local:") ? stringValue(runtime.slice("local:".length)) : null;
-  const projectRoot = stringValue(payload.projectRoot) ?? runtimeCwd ?? process.cwd();
-  await assertProjectRootAccess({ familiarId }, projectRoot, "chat");
+  const payloadProjectRoot = stringValue(payload.projectRoot);
+  const projectRoot = payloadProjectRoot ?? runtimeCwd ?? process.cwd();
+  const allowLocalRuntimeCwd = normalizeProjectRoot(projectRoot) === normalizeProjectRoot(process.cwd());
+  await assertProjectRootAccess({ familiarId }, projectRoot, "chat", {
+    allowUnregisteredRoot: allowLocalRuntimeCwd,
+  });
 
   const binding = bindingFor(config, familiarId);
   const attachments = objectArray<ChatAttachment>(payload.attachments);


### PR DESCRIPTION
### Motivation
- Fix an authorization flaw where routes trusted a caller-supplied `familiarId` and treated the configured `supreme` ID as a bearer token, allowing remote callers to bypass project grants. 
- Prevent remote/mobile callers from creating or revoking human-managed grants or resolving proposals by posting actor-controlled IDs.

### Description
- Remove implicit all-project access based on a request-supplied Supreme familiar string by stopping special-case checks for `supreme` inside `canAccessProject`, `filterProjectsForFamiliar`, and `assertProjectAccess` so access requires explicit grants and bootstrapped grants are used to give Supreme projects access. 
- Add a local-desktop gate (`isLocalOrigin`) and `requireLocalHumanGrantMutation` checks to the project grants route so `POST`/`DELETE` require a loopback/local request. 
- Enforce local origin for grant proposals by checking `isLocalOrigin` in the grant-proposals `POST` and the proposal item `PATCH` routes. 
- Update tests to assert the new behavior: remove bearer-style Supreme expectations and add assertions that routes require local-human requests for grant mutations.

### Testing
- Ran the updated unit tests `src/lib/project-permissions.test.ts` and `src/app/api/project-grants/route.test.ts`, both passed. 
- Ran the full API test suite with `pnpm test:api` (115 test files) and all tests passed. 
- Ran static type checks with `pnpm typecheck` (TypeScript `--noEmit`) and `git diff --check`; both succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9cfd00c0832799b8f361b627923b)