### PR TITLE
Fix local-only automation run ingress

### DIFF
--- a/src/lib/server/local-origin.test.ts
+++ b/src/lib/server/local-origin.test.ts
@@ -1,13 +1,21 @@
 import assert from "node:assert/strict";
+import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
 import { isLocalOrigin } from "./local-origin.ts";
 
-const withHost = (host?: string) =>
-  new Request("http://x/", { headers: host === undefined ? {} : { host } });
+const withHost = (host?: string, extraHeaders: Record<string, string> = {}) =>
+  new Request("http://x/", {
+    headers: host === undefined ? extraHeaders : { host, ...extraHeaders },
+  });
 
 // Loopback hosts (with or without a port) are accepted.
 assert.equal(isLocalOrigin(withHost("127.0.0.1:3000")), true, "127.0.0.1 accepted");
 assert.equal(isLocalOrigin(withHost("localhost:8443")), true, "localhost accepted");
 assert.equal(isLocalOrigin(withHost("localhost")), true, "bare localhost accepted");
+assert.equal(
+  isLocalOrigin(withHost("127.0.0.1:3000", { [MOBILE_ACCESS_HEADER]: "1" })),
+  false,
+  "verified mobile/tailnet-forwarded requests cannot satisfy the desktop-only local-origin guard",
+);
 
 // Non-loopback hosts are rejected — including the tailnet host the phone uses
 // (a 100.64.0.0/10 CGNAT address, or the equivalent magic-DNS name), which is

--- a/src/lib/server/local-origin.ts
+++ b/src/lib/server/local-origin.ts
@@ -1,3 +1,5 @@
+import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
+
 /**
  * True when the request's Host header is loopback (127.0.0.1 / localhost / [::1]).
  *
@@ -13,6 +15,8 @@
  * check has a single, test-covered source of truth.
  */
 export function isLocalOrigin(req: Request): boolean {
+  if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") return false;
+
   const host = req.headers.get("host") ?? "";
   const bare = host.split(":")[0];
   return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -26,6 +26,8 @@ assert.match(source, /isAllowedRequestSource\(origin, expectedOrigin\)/, "API or
 assert.match(source, /isAllowedRequestSource\(referer, expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
 assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless-tailnet CSRF guard");
+assert.match(source, /isLocalOnlyAutomationRun\(req\.nextUrl\.pathname, req\.method\)/, "run-now automation execution should have a dedicated local-only proxy guard");
+assert.match(source, /mobileAccessAuthenticated \|\| tailnetTrusted \|\| !isLoopbackHost\(requestHost\)/, "run-now automation execution must deny mobile, tailnet, and non-loopback proxy ingress");
 assert.match(source, /missing request source/, "tokenless tailnet GET webhooks should reject absent Origin and Referer headers");
 
 // Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -118,6 +118,10 @@ function hasSafeContentType(req: NextRequest) {
   return SAFE_CONTENT_TYPES.includes(mediaType);
 }
 
+function isLocalOnlyAutomationRun(pathname: string, method: string) {
+  return method === "POST" && /^\/api\/codex-automations\/[^/]+\/run$/.test(pathname);
+}
+
 function isProductionWebhookGet(pathname: string, method: string) {
   return (
     method === "GET" &&
@@ -166,6 +170,17 @@ export async function proxy(req: NextRequest) {
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
   if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)) {
     return jsonError(403, "forbidden host");
+  }
+
+  // Running a Codex automation launches the local `codex` binary with the
+  // user's repository/filesystem authority. Keep that execution surface off
+  // the mobile and tailnet ingress paths even when those paths are otherwise
+  // authenticated: their forwarded Host value is client/forwarder-controlled
+  // and cannot prove that the original peer was loopback.
+  if (isLocalOnlyAutomationRun(req.nextUrl.pathname, req.method)) {
+    if (mobileAccessAuthenticated || tailnetTrusted || !isLoopbackHost(requestHost)) {
+      return jsonError(403, "forbidden local-only endpoint");
+    }
   }
 
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;


### PR DESCRIPTION
### Motivation
- Close a privilege-escalation gap where the `POST /api/codex-automations/[id]/run` endpoint relied on a spoofable `Host` header and could spawn a local `codex exec` from non-local ingress. 
- Ensure the local-only execution surface is unreachable via mobile/tailnet/forwarded requests that can supply loopback-looking `Host` values.

### Description
- Add a proxy-level guard that detects `POST /api/codex-automations/[id]/run` and rejects requests coming via mobile-authenticated, tailnet-trusted, or non-loopback ingress before they reach route handlers by returning a 403. 
- Harden the shared `isLocalOrigin` helper to treat requests marked by the proxy as verified mobile access (`MOBILE_ACCESS_HEADER`) as non-local so they cannot satisfy the desktop-only guard. 
- Add regression assertions to the middleware and local-origin tests to cover the new proxy guard and the mobile-marker rejection in `isLocalOrigin`. 

### Testing
- Ran TypeScript checks with `pnpm exec tsc --noEmit --pretty false` and they succeeded. 
- Ran targeted test commands `node --experimental-strip-types src/lib/server/local-origin.test.ts` and `node --experimental-strip-types src/middleware.test.ts` and both passed. 
- Executed the full API test suite with `pnpm test:api` and all API tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9fef8c0c8327b659148af394f5d3)