### PR TITLE
fix(security): harden local-origin route guard

### DIFF
--- a/src/lib/server/local-origin.test.ts
+++ b/src/lib/server/local-origin.test.ts
@@ -1,28 +1,70 @@
 import assert from "node:assert/strict";
-import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
+import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
 import { isLocalOrigin } from "./local-origin.ts";
 
-const withHost = (host?: string, extraHeaders: Record<string, string> = {}) =>
-  new Request("http://x/", {
-    headers: host === undefined ? extraHeaders : { host, ...extraHeaders },
-  });
+const ORIGINAL_SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN;
 
-// Loopback hosts (with or without a port) are accepted.
-assert.equal(isLocalOrigin(withHost("127.0.0.1:3000")), true, "127.0.0.1 accepted");
-assert.equal(isLocalOrigin(withHost("localhost:8443")), true, "localhost accepted");
-assert.equal(isLocalOrigin(withHost("localhost")), true, "bare localhost accepted");
-assert.equal(
-  isLocalOrigin(withHost("127.0.0.1:3000", { [MOBILE_ACCESS_HEADER]: "1" })),
-  false,
-  "verified mobile/tailnet-forwarded requests cannot satisfy the desktop-only local-origin guard",
-);
+function restoreEnv() {
+  if (ORIGINAL_SIDECAR_TOKEN === undefined) delete process.env.COVEN_CAVE_AUTH_TOKEN;
+  else process.env.COVEN_CAVE_AUTH_TOKEN = ORIGINAL_SIDECAR_TOKEN;
+}
 
-// Non-loopback hosts are rejected — including the tailnet host the phone uses
-// (a 100.64.0.0/10 CGNAT address, or the equivalent magic-DNS name), which is
-// the whole point: these routes are desktop-only, not phone-reachable.
-assert.equal(isLocalOrigin(withHost("100.101.102.103:8443")), false, "tailnet host rejected (desktop-only)");
-assert.equal(isLocalOrigin(withHost("192.168.1.5:8443")), false, "LAN host rejected");
-assert.equal(isLocalOrigin(withHost("evil.example.com")), false, "remote host rejected");
-assert.equal(isLocalOrigin(withHost(undefined)), false, "missing Host rejected");
+const withHeaders = (headers: HeadersInit = {}) => new Request("http://x/", { headers });
+const withHost = (host?: string) => withHeaders(host === undefined ? {} : { host });
+
+try {
+  delete process.env.COVEN_CAVE_AUTH_TOKEN;
+
+  // Loopback hosts (with or without a port) are accepted in tokenless local dev.
+  assert.equal(isLocalOrigin(withHost("127.0.0.1:3000")), true, "127.0.0.1 accepted");
+  assert.equal(isLocalOrigin(withHost("localhost:8443")), true, "localhost accepted");
+  assert.equal(isLocalOrigin(withHost("localhost")), true, "bare localhost accepted");
+  assert.equal(isLocalOrigin(withHost("[::1]:3000")), true, "IPv6 loopback accepted");
+  assert.equal(isLocalOrigin(withHost("[::1]")), true, "bare IPv6 loopback accepted");
+
+  // Non-loopback hosts are rejected — including the tailnet host the phone uses
+  // (a 100.64.0.0/10 CGNAT address, or the equivalent magic-DNS name), which is
+  // the whole point: these routes are desktop-only, not phone-reachable.
+  assert.equal(isLocalOrigin(withHost("100.101.102.103:8443")), false, "tailnet host rejected (desktop-only)");
+  assert.equal(isLocalOrigin(withHost("192.168.1.5:8443")), false, "LAN host rejected");
+  assert.equal(isLocalOrigin(withHost("evil.example.com")), false, "remote host rejected");
+  assert.equal(isLocalOrigin(withHost(undefined)), false, "missing Host rejected");
+
+  assert.equal(
+    isLocalOrigin(withHeaders({ host: "127.0.0.1:3000", [MOBILE_ACCESS_HEADER]: "1" })),
+    false,
+    "verified mobile/tailnet-forwarded requests cannot satisfy the desktop-only local-origin guard",
+  );
+
+  process.env.COVEN_CAVE_AUTH_TOKEN = "sidecar-secret";
+  assert.equal(
+    isLocalOrigin(withHeaders({ host: "127.0.0.1:3000" })),
+    false,
+    "packaged sidecars require the first-party sidecar token header",
+  );
+  assert.equal(
+    isLocalOrigin(withHeaders({ host: "127.0.0.1:3000", [TOKEN_HEADER]: "wrong" })),
+    false,
+    "wrong sidecar token rejected",
+  );
+  assert.equal(
+    isLocalOrigin(withHeaders({ host: "127.0.0.1:3000", [TOKEN_HEADER]: "sidecar-secret" })),
+    true,
+    "matching sidecar token accepted on loopback Host",
+  );
+  assert.equal(
+    isLocalOrigin(
+      withHeaders({
+        host: "127.0.0.1:3000",
+        [TOKEN_HEADER]: "sidecar-secret",
+        [MOBILE_ACCESS_HEADER]: "1",
+      }),
+    ),
+    false,
+    "mobile marker still rejects even if the sidecar token is present",
+  );
+} finally {
+  restoreEnv();
+}
 
 console.log("local-origin.test.ts: ok");

--- a/src/lib/server/local-origin.ts
+++ b/src/lib/server/local-origin.ts
@@ -1,23 +1,33 @@
-import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
+import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
 
 /**
- * True when the request's Host header is loopback (127.0.0.1 / localhost / [::1]).
+ * True when a request is allowed to reach DESKTOP-ONLY local routes (codex
+ * exec, automation create/delete/run, inbox writes).
  *
- * Defense-in-depth gate for DESKTOP-ONLY routes (codex exec, automation
- * create/delete/run, inbox writes). The server already authenticates every
- * request (access token + same-origin — see server.ts); this adds the
- * requirement that the Host be loopback, so these routes are NOT reachable
- * from the phone / tailnet. Over `tailscale serve` the Host is
- * `<name>.ts.net`, which this rejects BY DESIGN — do not add this guard to
- * routes the iOS app legitimately needs (board, chat, inbox read).
+ * The Host header is client-controlled, so a loopback-looking Host
+ * (127.0.0.1 / localhost / [::1]) is only a compatibility hint for tokenless
+ * local dev; it is not accepted for mobile-authenticated requests, and
+ * packaged sidecars that configure COVEN_CAVE_AUTH_TOKEN must also present
+ * the first-party x-coven-cave-token header that the SidecarAuthBridge
+ * injects.
  *
- * Previously copy-pasted verbatim into each such route; centralized here so the
- * check has a single, test-covered source of truth.
+ * The proxy strips any client-supplied x-coven-cave-mobile-access header and
+ * re-adds it only after validating a mobile credential, which lets this guard
+ * reject phone/tailnet requests even when their Host is spoofed to loopback.
+ * Over `tailscale serve` the Host is `<name>.ts.net`, which this rejects BY
+ * DESIGN — do not add this guard to routes the iOS app legitimately needs
+ * (board, chat, inbox read).
+ *
+ * Previously copy-pasted verbatim into each such route; centralized here so
+ * the check has a single, test-covered source of truth.
  */
 export function isLocalOrigin(req: Request): boolean {
   if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") return false;
 
+  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
+  if (sidecarToken && req.headers.get(TOKEN_HEADER) !== sidecarToken) return false;
+
   const host = req.headers.get("host") ?? "";
-  const bare = host.split(":")[0];
-  return bare === "127.0.0.1" || bare === "localhost" || bare === "[::1]";
+  const bare = host.startsWith("[") ? host.slice(1, host.indexOf("]")) : host.split(":")[0];
+  return bare === "127.0.0.1" || bare === "localhost" || bare === "::1";
 }


### PR DESCRIPTION
### Motivation
- The existing desktop-only route guard relied solely on the client-controlled `Host` header, which can be spoofed (e.g. via Tailscale Serve), exposing privileged automation create/delete/activate operations to remote callers. 
- The change hardens the local-origin decision so loopback-only operations cannot be reached by requests that are mobile/tailnet-authenticated or otherwise spoof the `Host` header.

### Description
- Reject requests that carry the proxy-added mobile marker header `x-coven-cave-mobile-access: 1` so validated mobile/tailnet requests cannot be treated as local-origin. 
- When `COVEN_CAVE_AUTH_TOKEN` is set, require the first-party `x-coven-cave-token` header to match that token before allowing local-origin access. 
- Normalize IPv6 bracketed host parsing (handle `[::1]`) while preserving tokenless loopback behavior for local development. 
- Extend `src/lib/server/local-origin.test.ts` to cover spoofed mobile marker cases and packaged-sidecar token enforcement.

### Testing
- Ran the updated unit test directly with `node --experimental-strip-types src/lib/server/local-origin.test.ts`, which passed. 
- Ran the API test suite with `pnpm test:api`, which executed 115 test files and all passed. 
- Ran TypeScript checks with `pnpm typecheck` (`tsc --noEmit`), which passed with no errors. 
- Note: attempted Beads workflow commands (`bd prime` / `bd ready`) but `bd` was not available in the container, so no durable Beads claim was made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aa9c5baa88327825701a4c257d8c0)