### PR TITLE
fix(mobile): require mobile access token for Tailscale app mode

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -2,9 +2,8 @@ import Foundation
 
 /// REST + streaming client for the Coven Cave desktop API.
 /// When the desktop is token-gated (COVEN_CAVE_ACCESS_TOKEN), every request —
-/// REST and SSE alike — carries the paired credential as a Bearer header; in
-/// tokenless tailnet-trust mode no header is sent and the tailnet boundary is
-/// the trust anchor, as before.
+/// REST and SSE alike — carries the paired credential as a Bearer header. This
+/// is required for the Tailscale app path because it exposes the full API.
 struct CaveClient {
     var connection: CaveConnection
 
@@ -111,8 +110,8 @@ struct CaveClient {
     }
 
     /// Rolling renewal: exchange the current credential for a fresh 30-day
-    /// token. Returns the new token, or nil when the desktop runs tokenless
-    /// (503) or the credential can't refresh — callers treat nil as "keep
+    /// token. Returns the new token, or nil when the desktop has no refresh
+    /// endpoint (503) or the credential can't refresh — callers treat nil as "keep
     /// using what we have".
     func refreshAccessToken() async -> String? {
         guard let req = try? request("api/mobile-token/refresh", method: "POST") else { return nil }

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// Describes how to reach the desktop host over Tailscale.
-///
-/// There is **no token**. Trust is established by being on the same Tailscale
-/// tailnet as the host: the desktop serves the mobile API only over its Tailscale
-/// interface (via `tailscale serve`), so any request that reaches it is already
-/// tailnet-authenticated. The app only needs the host's address.
+/// Describes the Tailscale host and optional mobile access credential. The
+/// desktop may publish the full API through `tailscale serve`, so tailnet
+/// reachability is paired with a Cave access token for authorization.
 struct CaveConnection: Codable, Equatable {
     /// A MagicDNS name (e.g. `my-mac.tailnet-name.ts.net`) or a raw Tailscale IP
     /// (e.g. `100.101.102.103`). May include a scheme and/or port; we normalise.

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
@@ -6,7 +6,7 @@ import Foundation
 ///   (tap on device, or scan its QR)
 /// - any http(s) invite URL carrying `coven_access_token`/`covenCaveToken` —
 ///   the browser-invite QR payload, pasted or scanned
-/// - a bare host / host:port / full URL, with no credential (tokenless mode)
+/// - a bare host / host:port / full URL, with no credential (local/dev mode)
 struct CaveInvite: Equatable {
     var host: String
     var token: String?

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -638,7 +638,7 @@ final class AppModel {
             CaveConnection.saveAccessToken(token)
         } else if !isSameEndpoint {
             // Tokens are stored globally, so never carry an old desktop's
-            // credential to a newly configured host from a tokenless invite.
+            // credential to a newly configured host from an uncredentialed input.
             CaveConnection.saveAccessToken(nil)
         }
         if !isSameEndpoint {

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -100,7 +100,7 @@ struct SettingsView: View {
             .padding(.vertical, 6)
             .listRowBackground(chrome.bgRaised.opacity(0.6))
         } footer: {
-            Text("Connected over your Tailscale network — no token or password to manage.")
+            Text("Connected over your Tailscale network with a paired Cave access token.")
         }
     }
 

--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -384,17 +384,11 @@ start_with_tmux() {
   fi
 
   if [ "${CAVE_MOBILE_APP:-0}" = "1" ]; then
-    # Native SwiftUI app over Tailscale: NO token at all. Tailscale Serve is the
-    # only ingress to loopback:${PORT} and the proxy's CSRF Origin/Referer gate
-    # still blocks any drive-by browser request (those always carry an Origin);
-    # a native client sends none, so it passes the gate, and with neither
-    # COVEN_CAVE_ACCESS_TOKEN nor COVEN_CAVE_AUTH_TOKEN set (and not bundled) the
-    # /api/ proxy falls through to NextResponse.next(). COVEN_CAVE_TAILNET_TRUST=1
-    # relaxes the loopback host gate because Tailscale Serve forwards the
-    # <host>.ts.net Host (not 127.0.0.1). Tailnet membership is the trust
-    # boundary — see docs/ios-native-rebuild.md.
+    # Native SwiftUI app over Tailscale: protect the full API surface with the
+    # same mobile access token used by invite mode. Tailscale membership is not
+    # sufficient authorization because Serve exposes every /api route.
     tmux new-session -d -s "$TMUX_SESSION" -c "$PWD" \
-      "bash -lc 'unset COVEN_CAVE_ACCESS_TOKEN COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE; export COVEN_CAVE_TAILNET_TRUST=1 HOSTNAME=\"$HOST\" PORT=\"$PORT\"; exec pnpm dev >>\"$LOG_FILE\" 2>&1'"
+      "bash -lc 'unset COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE COVEN_CAVE_TAILNET_TRUST; export COVEN_CAVE_ACCESS_TOKEN=\"\$(cat \"$TOKEN_FILE\")\" HOSTNAME=\"$HOST\" PORT=\"$PORT\"; exec pnpm dev >>\"$LOG_FILE\" 2>&1'"
     tmux display-message -p -t "$TMUX_SESSION" '#{pane_pid}' >"$PID_FILE"
     return 0
   fi
@@ -417,9 +411,9 @@ start_with_tmux() {
 
 start_with_nohup() {
   if [ "${CAVE_MOBILE_APP:-0}" = "1" ]; then
-    # Tokenless native-app server. See start_with_tmux for the trust rationale.
-    nohup env -u COVEN_CAVE_ACCESS_TOKEN -u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE \
-      COVEN_CAVE_TAILNET_TRUST=1 \
+    # Token-gated native-app server. See start_with_tmux for the trust rationale.
+    nohup env -u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE -u COVEN_CAVE_TAILNET_TRUST \
+      COVEN_CAVE_ACCESS_TOKEN="$ACCESS_TOKEN" \
       HOSTNAME="$HOST" \
       PORT="$PORT" \
       pnpm dev >"$LOG_FILE" 2>&1 </dev/null &
@@ -445,13 +439,13 @@ start_next_server() {
     ensure_state_dir
     if [ "${CAVE_MOBILE_APP:-0}" = "1" ]; then
       if recorded_server_is_running && recorded_server_mode_is app; then
-        clear_mobile_tokens
+        load_or_create_token
         echo "CovenCave native-app server is already listening on ${HOST}:${PORT}."
         return 0
       fi
-      # Refuse to reuse a token-gated or untracked server under tokenless app mode.
-      if [ -n "${COVEN_CAVE_ACCESS_TOKEN:-}" ] || [ -s "$TOKEN_FILE" ] || [ -s "$SIDECAR_TOKEN_FILE" ]; then
-        echo "Error: port ${PORT} is already in use by a token-gated server. Run 'pnpm mobile:tailscale:stop' first." >&2
+      # Refuse to reuse a sidecar-gated or untracked server under app mode.
+      if [ -s "$SIDECAR_TOKEN_FILE" ]; then
+        echo "Error: port ${PORT} is already in use by a native sidecar server. Run 'pnpm mobile:tailscale:stop' first." >&2
         exit 1
       fi
       require_recorded_server
@@ -477,9 +471,10 @@ start_next_server() {
   fi
 
   if [ "${CAVE_MOBILE_APP:-0}" = "1" ]; then
-    # tokenless app mode: do not mint or load any token, and clear stale tokens
-    # from invite/native runs so future app-mode reuse is judged by server.mode.
-    clear_mobile_tokens
+    # App mode serves the full API surface through Tailscale, so mint/load the
+    # mobile access token and clear only stale sidecar tokens from native runs.
+    rm -f "$SIDECAR_TOKEN_FILE"
+    load_or_create_token
   elif [ "${CAVE_MOBILE_NATIVE:-0}" != "1" ]; then
     load_or_create_token
   else
@@ -781,10 +776,9 @@ try {
 NODE
 }
 
-# Tokenless native SwiftUI app over Tailscale Serve. Starts a loopback Next
-# server with NO access/sidecar token, publishes it via `tailscale serve`, and
-# prints the host to type into the iOS app. There is no invite/token to copy —
-# tailnet membership is the trust boundary. See docs/ios-native-rebuild.md.
+# Native SwiftUI app over Tailscale Serve. Starts a loopback Next server with a
+# mobile access token, publishes it via `tailscale serve`, and prints/scans a
+# pairing URL so tailnet peers still need the Cave credential for the full API.
 app_command() {
   ensure_tailscale
   CAVE_MOBILE_APP=1 start_next_server
@@ -801,15 +795,15 @@ app_command() {
     APP_URL="http://${APP_IP_HOST}:${PORT}/"
   fi
 
-  APP_HOST="$(node -e "process.stdout.write(new URL(process.argv[1]).host)" "$APP_URL")"
+  APP_PAIRING_URL="$(node -e "const url = new URL(process.argv[1]); url.searchParams.set('coven_access_token', process.argv[2]); process.stdout.write(url.toString())" "$APP_URL" "$ACCESS_TOKEN")"
 
   echo
-  echo "Native iOS app is ready — no token required."
-  echo "In the Coven Cave app, enter this address:"
+  echo "Native iOS app is ready."
+  echo "In the Coven Cave app, scan or paste this pairing URL:"
   echo
-  echo "    ${APP_HOST}"
+  echo "    ${APP_PAIRING_URL}"
   echo
-  print_terminal_qr "$APP_URL"
+  print_terminal_qr "$APP_PAIRING_URL"
   echo
   echo "Stop with: pnpm mobile:tailscale:stop"
   echo

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -23,22 +23,16 @@ test("mobile tailscale runner exposes operator commands", () => {
   assert.match(packageJson.scripts["mobile:tailscale:stop"], /mobile-tailscale\.sh stop/);
 });
 
-test("mobile tailscale app mode serves the native client with no token", () => {
-  // The tokenless native-app path must mint/load NO access or sidecar token and
-  // unset both (plus COVEN_CAVE_BUNDLE) when starting the server.
+test("mobile tailscale app mode serves the native client with an access token", () => {
+  // The native-app path exposes the full API through Tailscale Serve, so it must
+  // mint/load a mobile access token and only clear sidecar/bundle trust.
   assert.match(script, /CAVE_MOBILE_APP/);
   assert.match(script, /app\) resolve_active_port; maybe_fallback_port; app_command ;;/);
-  assert.match(
-    script,
-    /unset COVEN_CAVE_ACCESS_TOKEN COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE/,
-  );
-  assert.match(script, /-u COVEN_CAVE_ACCESS_TOKEN -u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE/);
-  assert.match(script, /tokenless app mode: do not mint or load any token/);
-  // Tailscale Serve forwards the <host>.ts.net Host (verified against a real
-  // tailnet), so the tokenless server MUST set COVEN_CAVE_TAILNET_TRUST=1 to
-  // relax proxy.ts's loopback host gate — otherwise every request 403s.
-  assert.match(script, /export COVEN_CAVE_TAILNET_TRUST=1/);
-  assert.match(script, /COVEN_CAVE_TAILNET_TRUST=1/);
+  assert.match(script, /load_or_create_token/);
+  assert.match(script, /COVEN_CAVE_ACCESS_TOKEN="\$ACCESS_TOKEN"/);
+  assert.match(script, /unset COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE COVEN_CAVE_TAILNET_TRUST/);
+  assert.match(script, /-u COVEN_CAVE_AUTH_TOKEN -u COVEN_CAVE_BUNDLE -u COVEN_CAVE_TAILNET_TRUST/);
+  assert.match(script, /coven_access_token/);
   assert.match(script, /HOSTNAME="\$HOST"/);
   assert.match(script, /PORT="\$PORT"/);
 });
@@ -60,13 +54,11 @@ test("mobile tailscale app mode falls back to Tailscale IP HTTP when MagicDNS is
   assert.match(script, /APP_URL="http:\/\/\$\{APP_IP_HOST\}:\$\{PORT\}\/"/);
 });
 
-test("mobile tailscale app mode records tokenless ownership separately from invite tokens", () => {
+test("mobile tailscale app mode records ownership separately from sidecar tokens", () => {
   assert.match(script, /MODE_FILE=/);
   assert.match(script, /write_server_mode app/);
   assert.match(script, /recorded_server_mode_is app/);
-  assert.match(script, /clear_mobile_tokens/);
-  assert.match(script, /rm -f "\$TOKEN_FILE" "\$SIDECAR_TOKEN_FILE"/);
-  assert.match(script, /rm -f "\$INVITE_FILE" "\$EXPIRES_FILE"/);
+  assert.match(script, /rm -f "\$SIDECAR_TOKEN_FILE"/);
 });
 
 test("mobile tailscale app mode takes over an untracked same-checkout dev server", () => {

--- a/server.mjs
+++ b/server.mjs
@@ -111,11 +111,10 @@ function sameOrigin(value, expectedOrigin) {
 function isAllowedUpgradeSource(req, tokenAuthenticated = false) {
   const host = req.headers.host;
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
-  const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
   if (!isLoopbackHost(host)) {
     if (!host) return false;
     if (tokenAuthenticated) return sameOrigin(req.headers.origin, `http://${host}`);
-    return tailnetTrusted && !req.headers.origin;
+    return false;
   }
   return sameOrigin(req.headers.origin, `http://${host}`);
 }

--- a/server.ts
+++ b/server.ts
@@ -185,29 +185,22 @@ function isAllowedUpgradeSource(req: IncomingMessage, tokenAuthenticated = false
   // forwards to 127.0.0.1, so a legitimate tailnet client still arrives over
   // loopback. A non-loopback peer is a direct LAN/WAN connection — never trust.
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
-  const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
   if (!isLoopbackHost(host)) {
     // A meaningful same-origin/host gate needs a Host header; fail closed on
     // malformed upgrade requests instead of letting them ride a relaxation.
     if (!host) return false;
-    // Two ways a non-loopback Host is legitimate — both arrive via `tailscale
-    // serve`, which forwards the request's `<host>.ts.net` Host, NOT 127.0.0.1:
-    //   1. A token-authenticated upgrade (paired iOS app / handoff browser
-    //      holding a signed access token): the credential proves the caller,
-    //      exactly like proxy.ts's isAllowedApiHost(mobileAccessAuthenticated)
-    //      relaxation on REST. Without this, a paired phone's terminal 403s at
-    //      the host gate while every REST call works (the "terminal tab never
-    //      connects" bug). The sameOrigin gate below still blocks cross-site
-    //      browser upgrades.
-    //   2. Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
-    //      `pnpm mobile:tailscale:app`): tailnet membership is the ingress
-    //      boundary. Only native clients that omit Origin may use this
-    //      relaxation; browser WebSockets always carry Origin and can make
-    //      Host and Origin match after DNS rebinding, so an Origin-bearing
-    //      upgrade must not ride the trust flag.
-    // By default (no flag, no credential) upgrades remain loopback-host only.
+    // The only way a non-loopback Host is legitimate is a token-authenticated
+    // upgrade (paired iOS app / handoff browser holding a signed access token)
+    // arriving via `tailscale serve`, which forwards the request's
+    // `<host>.ts.net` Host, NOT 127.0.0.1: the credential proves the caller,
+    // exactly like proxy.ts's isAllowedApiHost(mobileAccessAuthenticated)
+    // relaxation on REST. Without this, a paired phone's terminal 403s at the
+    // host gate while every REST call works (the "terminal tab never
+    // connects" bug). The sameOrigin gate below still blocks cross-site
+    // browser upgrades. Tailnet membership alone is NOT authorization:
+    // credential-less upgrades remain loopback-host only.
     if (tokenAuthenticated) return sameOrigin(req.headers.origin, `http://${host}`);
-    return tailnetTrusted && !req.headers.origin;
+    return false;
   }
   return sameOrigin(req.headers.origin, `http://${host}`);
 }

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -134,12 +134,13 @@ function nativeAppBackendUrl(req: Request) {
   const configured = normalizeLoopbackBackend(process.env.COVEN_CAVE_NATIVE_APP_BACKEND_URL);
   if (configured) return configured;
 
-  // Tokenless native-app mode (`pnpm mobile:tailscale:app` sets
-  // COVEN_CAVE_TAILNET_TRUST=1): tailnet membership is the trust boundary, so
-  // the server publishes itself bare. In every token-gated mode — the packaged
-  // bundle above all — app-start publishes THIS server and mints signed
-  // invites instead (see ensureNativeAppServe), so there is no separate
-  // backend to point at.
+  // The packaged desktop app runs an authenticated sidecar on a random loopback
+  // port. In bundled mode, reconcile the native route against the app server
+  // started by `pnpm mobile:tailscale:app` instead of the packaged sidecar.
+  if (process.env.COVEN_CAVE_BUNDLE === "1") {
+    return "http://127.0.0.1:3000";
+  }
+
   return backendUrl();
 }
 
@@ -164,7 +165,7 @@ async function verifyNativeAppBackend(req: Request, backend: string) {
     if (res.ok) return { ok: true as const };
     const authHint =
       res.status === 401 || res.status === 403
-        ? " The backend is still token-gated; start the tokenless native app server with `pnpm mobile:tailscale:app`."
+        ? " The backend is not paired; start the native app server with `pnpm mobile:tailscale:app` and scan its pairing URL."
         : "";
     return {
       ok: false as const,

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -134,13 +134,12 @@ function nativeAppBackendUrl(req: Request) {
   const configured = normalizeLoopbackBackend(process.env.COVEN_CAVE_NATIVE_APP_BACKEND_URL);
   if (configured) return configured;
 
-  // The packaged desktop app runs an authenticated sidecar on a random loopback
-  // port. In bundled mode, reconcile the native route against the app server
-  // started by `pnpm mobile:tailscale:app` instead of the packaged sidecar.
-  if (process.env.COVEN_CAVE_BUNDLE === "1") {
-    return "http://127.0.0.1:3000";
-  }
-
+  // App mode is token-gated (`pnpm mobile:tailscale:app` mints the mobile
+  // access token), so app-start publishes THIS server and mints signed invites
+  // (see ensureNativeAppServe). The packaged bundle above all must not
+  // hard-depend on a dev checkout's server (cave-gzje); pointing at a
+  // different local server requires the explicit
+  // COVEN_CAVE_NATIVE_APP_BACKEND_URL override above.
   return backendUrl();
 }
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -19,17 +19,13 @@ assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing side
 assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject unsafe origins");
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
-assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated, tailnetTrusted\)/, "valid mobile access and narrow tailnet-trust should feed the API host gate separately");
-assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless app mode (COVEN_CAVE_TAILNET_TRUST) should relax the host gate for tailnet-forwarded requests");
+assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
+assert.doesNotMatch(source, /isAllowedApiHost\([^)]*tailnetTrusted[^)]*\)/, "tailnet membership alone must not relax the API host gate");
+assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "the tailnet-trust flag should survive only as a taint marker that further restricts automation ingress");
 assert.match(
   source,
-  /const mobileAccessMarker =\s*mobileAccessAuthenticated \|\| \(tailnetTrusted && isTailscaleServeHost\(requestHost\)\)/,
-  "tokenless tailnet-trust mode should still stamp the mobile-access marker for ts.net hosts",
-);
-assert.match(
-  source,
-  /nextWithMobileAccessMarker\(req, mobileAccessMarker\)/,
-  "proxy should forward the derived mobile marker into downstream request headers",
+  /nextWithMobileAccessMarker\(req, mobileAccessAuthenticated\)/,
+  "proxy should forward the verified mobile-access state into downstream request headers",
 );
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
 assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");
@@ -55,10 +51,10 @@ assert.doesNotMatch(
   /image\/svg\+xml/,
   "the API content-type gate must not admit active SVG backdrop payloads",
 );
-assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless-tailnet CSRF guard");
+assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless CSRF guard");
 assert.match(source, /isLocalOnlyAutomationRun\(req\.nextUrl\.pathname, req\.method\)/, "run-now automation execution should have a dedicated local-only proxy guard");
 assert.match(source, /mobileAccessAuthenticated \|\| tailnetTrusted \|\| !isLoopbackHost\(requestHost\)/, "run-now automation execution must deny mobile, tailnet, and non-loopback proxy ingress");
-assert.match(source, /missing request source/, "tokenless tailnet GET webhooks should reject absent Origin and Referer headers");
+assert.match(source, /missing request source/, "tokenless GET webhooks should reject absent Origin and Referer headers");
 // cave-gzje: a verified signed mobile invite is the paired phone's credential.
 // The final sidecar gate must admit it (the phone can never learn the
 // webview's per-launch token), and the webhook-GET missing-source guard must
@@ -70,8 +66,8 @@ assert.match(
 );
 assert.match(
   source,
-  /\(\(tailnetTrusted && !sidecarToken\) \|\| mobileAccessAuthenticated\) &&\s*isProductionWebhookGet/,
-  "the webhook-GET missing-source guard must also cover mobile-cookie-authenticated requests",
+  /\(!sidecarToken \|\| mobileAccessAuthenticated\) &&\s*isProductionWebhookGet/,
+  "the webhook-GET missing-source guard must cover tokenless servers and mobile-cookie-authenticated requests",
 );
 
 // Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the
@@ -101,7 +97,7 @@ assert.doesNotMatch(
 // the bypass ran first and silently let non-loopback callers through during
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
-  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated, tailnetTrusted)");
+  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated)");
   const originIdx = source.indexOf("isAllowedRequestSourceAny(origin, expectedOrigins)");
   const refererIdx = source.indexOf("isAllowedRequestSourceAny(referer, expectedOrigins)");
   const contentTypeIdx = source.indexOf("unsupported content-type");

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -315,29 +315,30 @@ assert.equal(
   );
 }
 
-// ─── Native iOS app (tokenless, over Tailscale Serve) contract ─────────────
+// ─── Native iOS app (Tailscale Serve + mobile access token) contract ──────
 // The native SwiftUI client (pnpm mobile:tailscale:app) is NOT a browser: it
-// sends no Origin and no Referer, and Tailscale Serve forwards Host: 127.0.0.1
-// to the loopback server. With neither COVEN_CAVE_ACCESS_TOKEN nor
-// COVEN_CAVE_AUTH_TOKEN configured (and not bundled), proxy() falls through to
-// NextResponse.next() AFTER these source gates pass. These assertions pin the
-// gate-level behavior that flow depends on; the proxy() body ordering is pinned
-// by middleware.test.ts. A malicious same-machine BROWSER page is still blocked
-// because it always carries a cross-origin Origin (rejected just above).
+// sends no Origin and no Referer. Those absent source headers can pass the CSRF
+// helper, so the API Host gate must require the paired mobile access credential
+// before accepting a remote-looking Tailscale Serve Host.
 assert.equal(
-  isAllowedApiHost("127.0.0.1:3000", false),
+  isAllowedApiHost("cave.tailnet.example.ts.net", false),
+  false,
+  "native app: tailnet Host without mobile access auth is forbidden",
+);
+assert.equal(
+  isAllowedApiHost("cave.tailnet.example.ts.net", true),
   true,
-  "tokenless app: Tailscale Serve forwards loopback Host, which is allowed",
+  "native app: paired mobile access auth permits the Tailscale Serve Host",
 );
 assert.equal(
   isAllowedRequestSource(null, expected),
   true,
-  "tokenless app: native client sends no Origin → source gate passes",
+  "native app: absent Origin still passes the source helper",
 );
 assert.equal(
   isAllowedRequestSource(null, "http://127.0.0.1:3000"),
   true,
-  "tokenless app: absent Referer at the loopback Serve backend passes",
+  "native app: absent Referer still passes the source helper",
 );
 
 // ─── shouldRequireMobileAccessCredential ──────────────────────────────────

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,6 @@ import {
   timingSafeEqualString,
   isLoopbackHost,
   isAllowedApiHost,
-  isTailscaleServeHost,
   sameOrigin,
   isAllowedRequestSource,
   isAllowedRequestSourceAny,
@@ -188,17 +187,16 @@ export async function proxy(req: NextRequest) {
   const mobileAccessAuthenticated = mobileAccessToken
     ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
     : false;
-  // Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
-  // `pnpm mobile:tailscale:app`): Tailscale Serve forwards the request's
-  // tailnet Host instead of loopback. Keep the DNS-rebinding host gate strict:
-  // mobile-access credentials may authenticate any Host, but tokenless tailnet
-  // trust only admits Tailscale Serve names/IPs, not arbitrary rebinding hosts.
+  // Tailscale app mode (`pnpm mobile:tailscale:app`) now always provisions the
+  // mobile access credential, so a remote-looking (Tailscale Serve) Host is
+  // accepted only when that credential verifies. COVEN_CAVE_TAILNET_TRUST no
+  // longer relaxes this gate — tailnet membership alone is not authorization —
+  // but the flag still marks tailnet ingress below so local-only automation
+  // runs stay off that path.
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
-  if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated, tailnetTrusted)) {
+  if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated)) {
     return jsonError(403, "forbidden host");
   }
-  const mobileAccessMarker =
-    mobileAccessAuthenticated || (tailnetTrusted && isTailscaleServeHost(requestHost));
 
   // Running a Codex automation launches the local `codex` binary with the
   // user's repository/filesystem authority. Keep that execution surface off
@@ -237,8 +235,8 @@ export async function proxy(req: NextRequest) {
       return jsonError(403, "forbidden referer");
     }
     // Production GET webhooks are intentionally state-changing: a matching
-    // request starts an agent-backed flow. In tokenless Tailscale mode there is
-    // no sidecar secret to prove the caller is first-party, and browsers can
+    // request starts an agent-backed flow. When no sidecar secret is configured
+    // there is nothing to prove the caller is first-party, and browsers can
     // issue cross-site GET navigations/subresources with both Origin and
     // Referer omitted (for example via Referrer-Policy: no-referrer). The same
     // applies to a request authenticated only by the mobile-access cookie
@@ -246,7 +244,7 @@ export async function proxy(req: NextRequest) {
     // same-origin source header for that narrow state-changing GET surface so
     // absent headers cannot bypass the CSRF gate.
     if (
-      ((tailnetTrusted && !sidecarToken) || mobileAccessAuthenticated) &&
+      (!sidecarToken || mobileAccessAuthenticated) &&
       isProductionWebhookGet(req.nextUrl.pathname, req.method) &&
       !origin &&
       !referer
@@ -267,7 +265,7 @@ export async function proxy(req: NextRequest) {
   if (!sidecarToken) {
     return process.env.COVEN_CAVE_BUNDLE === "1"
       ? jsonError(500, "missing sidecar auth token")
-      : nextWithMobileAccessMarker(req, mobileAccessMarker);
+      : nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
   }
 
   if (!sidecarAuthenticated && !mobileAccessAuthenticated) {
@@ -281,7 +279,7 @@ export async function proxy(req: NextRequest) {
     return jsonError(401, "unauthorized");
   }
 
-  return nextWithMobileAccessMarker(req, mobileAccessMarker);
+  return nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
 }
 
 export const config = {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -177,12 +177,16 @@ assert.match(src, /if \(!isLoopbackHost\(host\)\)/, "server only relaxes the loo
 // tailscale serve forwards from 127.0.0.1, so a non-loopback peer is a direct
 // LAN/WAN connection that must never be trusted.
 assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "server verifies the WebSocket peer address, not only the Host header");
-// Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1) relaxes ONLY the
-// loopback *host* gate for native clients that omit Origin, so the iOS terminal
-// reaches /api/pty-ws over the tailnet (tailscale serve forwards the <host>.ts.net
-// Host) without trusting browser-controlled Host+Origin pairs after DNS rebinding.
-assert.match(src, /process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless tailnet app mode has an explicit WebSocket host-gate relaxation");
-assert.match(src, /return tailnetTrusted && !req\.headers\.origin/, "tailnet host relaxation only accepts Origin-less native WebSocket upgrades");
+// Tailscale Serve forwards the <host>.ts.net Host. The iOS terminal may use
+// that host only after the mobile access token authenticates the upgrade;
+// tailnet membership alone must not relax the host gate.
+assert.match(src, /const tokenAuthenticated = isPtyAuthRequired\(\) \? isAuthorized\(req, query\) : false/, "the upgrade credential is verified before the host gate");
+assert.match(
+  src,
+  /if \(tokenAuthenticated\) return sameOrigin\(req\.headers\.origin, `http:\/\/\$\{host\}`\);\s*\n\s*return false;/,
+  "credential-less remote-looking WebSocket upgrades are rejected outright",
+);
+assert.doesNotMatch(src, /COVEN_CAVE_TAILNET_TRUST/, "tailnet trust must not bypass WebSocket host auth");
 assert.match(packageJson.scripts.postinstall ?? "", /fix-node-pty-spawn-helper\.mjs/, "postinstall repairs node-pty spawn-helper mode");
 assert.equal(
   existsSync(new URL("../scripts/fix-node-pty-spawn-helper.mjs", import.meta.url)),


### PR DESCRIPTION
### Motivation
- A tokenless `pnpm mobile:tailscale:app` flow published the full loopback Next.js backend via Tailscale Serve while unsetting `COVEN_CAVE_ACCESS_TOKEN`/`COVEN_CAVE_AUTH_TOKEN`/`COVEN_CAVE_BUNDLE`, allowing remote tailnet peers to reach privileged local-only mutating APIs that start agent sessions and run workflows.
- The local-only guards relied on `Host`/`Origin` values forwarded by Serve and thus could be bypassed; the change restores an explicit credential requirement for remote-looking Tailscale hosts to prevent unauthorized remote actions.

### Description
- Require the mobile access credential for the Tailscale app path by changing the app server startup to mint/load the mobile access token and clear only sidecar state, and emit a pairing URL that carries `coven_access_token` for the native client to persist; changes live in `scripts/mobile-tailscale.sh` (app/startup/pairing URL).
- Remove the tailnet-trust bypass from the API middleware by requiring `mobileAccessAuthenticated` for the API host gate in `src/proxy.ts` so remote-looking Tailscale hosts are accepted only when the mobile access credential verifies.
- Tighten the PTY WebSocket upgrade host gate in `server.ts` so a non-loopback (Tailscale Serve) `Host` is accepted only when the mobile access token has authenticated the upgrade; retain loopback-only behavior for unauthenticated peers.
- Update client-side copy/comments and pairing semantics in the iOS code (`apps/ios/CovenCave/**`) and adjust tests that pin the prior contract (`scripts/mobile-tailscale.test.mjs`, `src/middleware.test.ts`, `src/proxy-behavior.test.ts`, `src/server-pty-ws.test.ts`, and related tests) to assert the new token-gated Tailscale app flow.

### Testing
- Ran `node scripts/mobile-tailscale.test.mjs` and the suite passed (12/12 tests OK).
- Ran middleware and behavior tests with `node src/middleware.test.ts`, `node src/server-pty-ws.test.ts`, `node src/proxy-behavior.test.ts`, and `node src/components/mobile-handoff.test.ts`; all tests passed.
- Performed a shell syntax check `bash -n scripts/mobile-tailscale.sh` and it returned no syntax errors.
- All automated checks listed above completed successfully (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7e74d6608327b0ff64527a35533a)