### PR TITLE
feat(server): heap telemetry — high-watermark warnings + one pre-OOM snapshot per episode (cave-ksjt)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -910,6 +910,7 @@ export const SUITES = {
     "src/app/api/voice/elevenlabs/catalog/route.test.ts",
     "src/app/api/voice/transcript/route.test.ts",
     "src/server-pty-ws.test.ts",
+    "src/server-heap-monitor.test.ts",
     "src/lib/pty-ws-bridge.test.ts",
     "scripts/release-macos-signing.test.mjs",
     "scripts/generate-latest-json.test.mjs",

--- a/server.mjs
+++ b/server.mjs
@@ -1,7 +1,10 @@
 import { createHmac } from "node:crypto";
-import { readFileSync, statSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getHeapStatistics, writeHeapSnapshot } from "node:v8";
 import next from "next";
 import { WebSocket, WebSocketServer } from "ws";
 const require2 = createRequire(import.meta.url);
@@ -437,4 +440,62 @@ function startListening(attempt = 0) {
     }
   });
 }
+const HEAP_MONITOR_ENABLED = process.env.COVEN_CAVE_HEAP_MONITOR !== "0";
+const HEAP_MONITOR_INTERVAL_MS = (() => {
+  const env = Number.parseInt(process.env.COVEN_CAVE_HEAP_MONITOR_INTERVAL_MS ?? "", 10);
+  return Number.isFinite(env) && env > 0 ? env : 3e5;
+})();
+const HEAP_WARN_RATIO = 0.85;
+const HEAP_SNAPSHOT_RATIO = 0.95;
+const HEAP_SNAPSHOT_KEEP = 2;
+let heapSnapshotSeq = 0;
+function heapDiagnosticsDir() {
+  const covenHome = process.env.COVEN_HOME || join(homedir(), ".coven");
+  const caveHome = process.env.COVEN_CAVE_HOME || join(covenHome, "cave");
+  return join(caveHome, "diagnostics");
+}
+const mb = (bytes) => `${Math.round(bytes / (1024 * 1024))}MB`;
+function pruneHeapSnapshots(dir) {
+  const snapshots = readdirSync(dir).filter((name) => name.startsWith("cave-heap-") && name.endsWith(".heapsnapshot")).sort();
+  while (snapshots.length > HEAP_SNAPSHOT_KEEP) {
+    const oldest = snapshots.shift();
+    try {
+      unlinkSync(join(dir, oldest));
+    } catch {
+    }
+  }
+}
+function startHeapMonitor() {
+  if (!HEAP_MONITOR_ENABLED) return;
+  let snapshotWritten = false;
+  const tick = () => {
+    const heap = getHeapStatistics();
+    const ratio = heap.used_heap_size / heap.heap_size_limit;
+    if (ratio < HEAP_WARN_RATIO) {
+      snapshotWritten = false;
+      return;
+    }
+    const usage = process.memoryUsage();
+    console.warn(
+      `[heap-monitor] heapUsed=${mb(heap.used_heap_size)} heapLimit=${mb(heap.heap_size_limit)} (${Math.round(ratio * 100)}%) rss=${mb(usage.rss)} external=${mb(usage.external)} ptySessions=${sessions.size} uptimeMin=${Math.round(process.uptime() / 60)}`
+    );
+    if (ratio < HEAP_SNAPSHOT_RATIO || snapshotWritten) return;
+    try {
+      const dir = heapDiagnosticsDir();
+      mkdirSync(dir, { recursive: true });
+      const stamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-");
+      const seq = String(heapSnapshotSeq += 1).padStart(3, "0");
+      const file = join(dir, `cave-heap-${stamp}-pid${process.pid}-${seq}.heapsnapshot`);
+      writeHeapSnapshot(file);
+      snapshotWritten = true;
+      pruneHeapSnapshots(dir);
+      console.warn(`[heap-monitor] wrote heap snapshot ${file}`);
+    } catch (err) {
+      snapshotWritten = true;
+      console.warn(`[heap-monitor] failed to write heap snapshot`, err);
+    }
+  };
+  setInterval(tick, HEAP_MONITOR_INTERVAL_MS).unref();
+}
+startHeapMonitor();
 startListening();

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,10 @@
 import { createHmac } from "node:crypto";
-import { readFileSync, statSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getHeapStatistics, writeHeapSnapshot } from "node:v8";
 
 import next from "next";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -665,4 +668,99 @@ function startListening(attempt: number = 0): void {
   });
 }
 
+// ── Heap telemetry (cave-ksjt) ────────────────────────────────────────────────
+// Long-lived servers (the packaged sidecar and dev runs alike) have died with
+// "Ineffective mark-compacts near heap limit" after hours of uptime, leaving
+// no evidence of WHAT filled the heap. This monitor makes the next episode
+// diagnosable: it logs a structured warning once heap usage crosses a high
+// watermark, and writes ONE heap snapshot per episode as the process
+// approaches the limit — before the OOM kill destroys the evidence.
+//
+// Mirrors src/lib/coven-paths.ts covenHome()/caveHome() for the snapshot
+// destination (server.ts is transpiled standalone and cannot import src/).
+
+const HEAP_MONITOR_ENABLED = process.env.COVEN_CAVE_HEAP_MONITOR !== "0";
+const HEAP_MONITOR_INTERVAL_MS = (() => {
+  const env = Number.parseInt(process.env.COVEN_CAVE_HEAP_MONITOR_INTERVAL_MS ?? "", 10);
+  return Number.isFinite(env) && env > 0 ? env : 300_000; // 5 minutes
+})();
+/** Log a structured warning at ≥85% of the V8 heap limit. */
+const HEAP_WARN_RATIO = 0.85;
+/** Write the per-episode heap snapshot at ≥95% — about to OOM, capture now. */
+const HEAP_SNAPSHOT_RATIO = 0.95;
+/** Snapshots kept in the diagnostics dir (oldest pruned first). */
+const HEAP_SNAPSHOT_KEEP = 2;
+/** Disambiguates snapshots written within the same millisecond. */
+let heapSnapshotSeq = 0;
+
+function heapDiagnosticsDir(): string {
+  const covenHome = process.env.COVEN_HOME || join(homedir(), ".coven");
+  const caveHome = process.env.COVEN_CAVE_HOME || join(covenHome, "cave");
+  return join(caveHome, "diagnostics");
+}
+
+const mb = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))}MB`;
+
+/** Prune oldest heap snapshots so the diagnostics dir never grows unbounded. */
+function pruneHeapSnapshots(dir: string): void {
+  const snapshots = readdirSync(dir)
+    .filter((name) => name.startsWith("cave-heap-") && name.endsWith(".heapsnapshot"))
+    .sort(); // names embed an ISO-like timestamp, so lexical order = age order
+  while (snapshots.length > HEAP_SNAPSHOT_KEEP) {
+    const oldest = snapshots.shift()!;
+    try {
+      unlinkSync(join(dir, oldest));
+    } catch {
+      // Already gone — fine.
+    }
+  }
+}
+
+function startHeapMonitor(): void {
+  if (!HEAP_MONITOR_ENABLED) return;
+  // Latches once per high-heap episode; re-arms after usage recovers below
+  // the warn watermark so a later, separate episode captures its own snapshot.
+  let snapshotWritten = false;
+
+  const tick = (): void => {
+    const heap = getHeapStatistics();
+    const ratio = heap.used_heap_size / heap.heap_size_limit;
+    if (ratio < HEAP_WARN_RATIO) {
+      snapshotWritten = false;
+      return;
+    }
+
+    const usage = process.memoryUsage();
+    console.warn(
+      `[heap-monitor] heapUsed=${mb(heap.used_heap_size)} heapLimit=${mb(heap.heap_size_limit)} ` +
+        `(${Math.round(ratio * 100)}%) rss=${mb(usage.rss)} external=${mb(usage.external)} ` +
+        `ptySessions=${sessions.size} uptimeMin=${Math.round(process.uptime() / 60)}`,
+    );
+
+    if (ratio < HEAP_SNAPSHOT_RATIO || snapshotWritten) return;
+    // writeHeapSnapshot is synchronous and stop-the-world (seconds at GB
+    // scale) — acceptable exactly once, when the alternative is dying with
+    // no evidence minutes later.
+    try {
+      const dir = heapDiagnosticsDir();
+      mkdirSync(dir, { recursive: true });
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const seq = String((heapSnapshotSeq += 1)).padStart(3, "0");
+      const file = join(dir, `cave-heap-${stamp}-pid${process.pid}-${seq}.heapsnapshot`);
+      writeHeapSnapshot(file);
+      snapshotWritten = true;
+      pruneHeapSnapshots(dir);
+      console.warn(`[heap-monitor] wrote heap snapshot ${file}`);
+    } catch (err) {
+      // Diagnostics must never take the server down with it.
+      snapshotWritten = true; // don't retry a failing write every tick
+      console.warn(`[heap-monitor] failed to write heap snapshot`, err);
+    }
+  };
+
+  // unref: telemetry must never keep the process alive on shutdown.
+  setInterval(tick, HEAP_MONITOR_INTERVAL_MS).unref();
+}
+
+startHeapMonitor();
 startListening();

--- a/src/server-heap-monitor.test.ts
+++ b/src/server-heap-monitor.test.ts
@@ -1,0 +1,138 @@
+// @ts-nocheck
+// Behavioral test for the server.ts heap monitor (cave-ksjt).
+//
+// server.ts is transpiled standalone (it cannot import src/), so the monitor
+// lives inline. To test its BEHAVIOR — warn watermark, one-snapshot-per-
+// episode latch, re-arm on recovery, bounded snapshot retention — this test
+// slices the monitor section out of server.ts and evaluates it with injected
+// fakes for V8 heap statistics, the snapshot writer, and the timer.
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { transformSync } from "esbuild";
+
+const src = readFileSync(new URL("../server.ts", import.meta.url), "utf8");
+
+const START = "// ── Heap telemetry (cave-ksjt)";
+const END = "\nstartHeapMonitor();";
+const startIdx = src.indexOf(START);
+const endIdx = src.indexOf(END, startIdx);
+assert.ok(startIdx !== -1, "server.ts contains the heap telemetry section");
+assert.ok(endIdx !== -1, "the telemetry section ends by starting the monitor");
+// Strip types the same way build:server does, so the harness evaluates the
+// exact logic that ships in server.mjs.
+const section = transformSync(src.slice(startIdx, endIdx), { loader: "ts", format: "esm" }).code;
+
+/** Evaluate the monitor section with fakes; returns handles to drive it. */
+function harness({ env = {} } = {}) {
+  const state = {
+    warns: [],
+    snapshots: [],
+    tick: null,
+    intervalMs: null,
+    unrefd: false,
+    heap: { used_heap_size: 0, heap_size_limit: 1000 },
+    dir: mkdtempSync(join(tmpdir(), "ksjt-heap-monitor-")),
+  };
+  const fakeProcess = {
+    env: { COVEN_CAVE_HOME: state.dir, ...env },
+    memoryUsage: () => ({ rss: 500 * 1024 * 1024, external: 10 * 1024 * 1024 }),
+    uptime: () => 3600,
+    pid: 4242,
+  };
+  const fakeConsole = {
+    warn: (...args) => state.warns.push(args.join(" ")),
+  };
+  const fakeSetInterval = (fn, ms) => {
+    state.tick = fn;
+    state.intervalMs = ms;
+    return { unref: () => { state.unrefd = true; } };
+  };
+  const fakeWriteHeapSnapshot = (file) => {
+    writeFileSync(file, "{}");
+    state.snapshots.push(file);
+  };
+  // The section references `sessions` (PTY session map) for log context.
+  const sessions = new Map();
+
+  const factory = new Function(
+    "process", "console", "setInterval",
+    "getHeapStatistics", "writeHeapSnapshot",
+    "mkdirSync", "readdirSync", "unlinkSync", "join", "homedir", "sessions",
+    `${section}\nstartHeapMonitor();`,
+  );
+  factory(
+    fakeProcess, fakeConsole, fakeSetInterval,
+    () => state.heap, fakeWriteHeapSnapshot,
+    (dir, opts) => mkdirSync(dir, opts),
+    (dir) => readdirSync(dir),
+    (file) => rmSync(file),
+    join,
+    () => state.dir,
+    sessions,
+  );
+  return state;
+}
+
+// ── Disabled by env kill-switch: no timer is ever registered ─────────────────
+{
+  const h = harness({ env: { COVEN_CAVE_HEAP_MONITOR: "0" } });
+  assert.equal(h.tick, null, "COVEN_CAVE_HEAP_MONITOR=0 disables the monitor");
+  rmSync(h.dir, { recursive: true, force: true });
+}
+
+// ── Quiet under the watermark; warns above it; snapshots near the limit ──────
+{
+  const h = harness();
+  assert.ok(h.tick, "monitor registers its interval tick");
+  assert.equal(h.intervalMs, 300_000, "default interval is 5 minutes");
+  assert.equal(h.unrefd, true, "the timer is unref'd");
+
+  h.heap = { used_heap_size: 500, heap_size_limit: 1000 }; // 50%
+  h.tick();
+  assert.equal(h.warns.length, 0, "healthy heap logs nothing");
+
+  h.heap = { used_heap_size: 900, heap_size_limit: 1000 }; // 90%
+  h.tick();
+  assert.equal(h.warns.length, 1, "crossing 85% logs a structured warning");
+  assert.match(h.warns[0], /\[heap-monitor\] heapUsed=/, "warning is namespaced + structured");
+  assert.match(h.warns[0], /ptySessions=0/, "warning carries PTY session count context");
+  assert.equal(h.snapshots.length, 0, "85-95% warns without snapshotting");
+
+  h.heap = { used_heap_size: 960, heap_size_limit: 1000 }; // 96%
+  h.tick();
+  assert.equal(h.snapshots.length, 1, "crossing 95% writes the episode's heap snapshot");
+  assert.match(h.snapshots[0], /cave-heap-.*-pid4242-\d{3}\.heapsnapshot$/, "snapshot name carries timestamp + pid + seq");
+
+  h.tick(); // still at 96%
+  assert.equal(h.snapshots.length, 1, "one snapshot per high-heap episode (latched)");
+
+  h.heap = { used_heap_size: 400, heap_size_limit: 1000 }; // recovered
+  h.tick();
+  h.heap = { used_heap_size: 970, heap_size_limit: 1000 }; // second episode
+  h.tick();
+  assert.equal(h.snapshots.length, 2, "recovery below the watermark re-arms the snapshot latch");
+
+  rmSync(h.dir, { recursive: true, force: true });
+}
+
+// ── Snapshot retention stays bounded ─────────────────────────────────────────
+{
+  const h = harness({ env: { COVEN_CAVE_HEAP_MONITOR_INTERVAL_MS: "1234" } });
+  assert.equal(h.intervalMs, 1234, "interval is env-tunable");
+
+  for (let episode = 0; episode < 4; episode++) {
+    h.heap = { used_heap_size: 100, heap_size_limit: 1000 };
+    h.tick(); // re-arm
+    h.heap = { used_heap_size: 990, heap_size_limit: 1000 };
+    h.tick(); // snapshot
+  }
+  assert.equal(h.snapshots.length, 4, "four episodes wrote four snapshots");
+  const kept = readdirSync(join(h.dir, "diagnostics")).filter((f) => f.endsWith(".heapsnapshot"));
+  assert.equal(kept.length, 2, "diagnostics dir keeps only the newest snapshots");
+
+  rmSync(h.dir, { recursive: true, force: true });
+}
+
+console.log("server-heap-monitor.test.ts: ok");

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -392,4 +392,39 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
   );
 }
 
+// ── Heap telemetry (cave-ksjt) ────────────────────────────────────────────────
+// Long-lived servers died with "Ineffective mark-compacts near heap limit"
+// after hours, leaving no evidence. The monitor logs a structured warning at a
+// high watermark and captures one heap snapshot per episode near the limit.
+assert.match(src, /const HEAP_WARN_RATIO = 0\.85/, "heap monitor warns at 85% of the V8 heap limit");
+assert.match(src, /const HEAP_SNAPSHOT_RATIO = 0\.95/, "heap monitor snapshots at 95% of the V8 heap limit");
+assert.match(
+  src,
+  /process\.env\.COVEN_CAVE_HEAP_MONITOR !== "0"/,
+  "heap monitor has an env kill-switch (COVEN_CAVE_HEAP_MONITOR=0)",
+);
+assert.match(
+  src,
+  /setInterval\(tick, HEAP_MONITOR_INTERVAL_MS\)\.unref\(\)/,
+  "heap monitor timer is unref'd so it never keeps the process alive",
+);
+assert.match(src, /writeHeapSnapshot\(file\)/, "approaching the limit captures a V8 heap snapshot");
+assert.match(
+  src,
+  /if \(ratio < HEAP_SNAPSHOT_RATIO \|\| snapshotWritten\) return/,
+  "at most one snapshot per high-heap episode",
+);
+assert.match(
+  src,
+  /if \(ratio < HEAP_WARN_RATIO\) \{\s*\n\s*snapshotWritten = false;/,
+  "the snapshot latch re-arms after heap usage recovers",
+);
+assert.match(src, /while \(snapshots\.length > HEAP_SNAPSHOT_KEEP\)/, "old snapshots are pruned (bounded diagnostics dir)");
+assert.match(
+  src,
+  /ptySessions=\$\{sessions\.size\}/,
+  "the warning line carries server-owned state context (PTY session count)",
+);
+assert.match(src, /startHeapMonitor\(\);/, "the heap monitor starts with the server");
+
 console.log("server-pty-ws.test.ts OK");


### PR DESCRIPTION
## Context — two OOM crashes, no evidence

server.ts died twice (2026-07-14/15, 9.1h and 5.75h uptime) with `FATAL ERROR: Ineffective mark-compacts near heap limit` (~3.9GB heap, GC mu ~0.27) under ordinary steady UI polling. The packaged sidecar runs the same server.ts, so long desktop sessions are on the same clock. Nothing recorded what filled the heap.

## Investigation (this session, negative results worth keeping)

Load-probed a prod build (`server.mjs`, isolated `COVEN_HOME`) with the exact crash-workload route set (changes/project-files/theme/projects/familiars/board/sessions-list/daemon-status/inbox/chat model-state+usage+conversation):

- **Prod: flat.** 12,360 requests / 815MB response bytes → RSS oscillates ~207MB, heap snapshots 39→42MB. No growth.
- **SSE is abort-safe.** 50 hard-aborted `/api/inbox/stream` connections + 200 broadcasts → heap snapshot shows **1** live `ReadableStreamDefaultController`. `cancel()` runs; subscribers/heartbeats don't leak.
- **Dev: bounded.** Same 1000-round workload → ~500MB oscillating; +60 HMR recompiles → flattens ~670MB.
- server-owned state audited: PTY scrollback ring bounded (256KB), sessions reaped on detach, files-route cache keyed by realpathed root, sessions-list SWR cache bounded.

The leak evidently needs hours-scale ingredients that can't be compressed into a probe (live agent chat streams, git watcher accumulation, real HMR-under-agent-edit churn). So: **stop guessing — instrument.**

## Change

Inline heap monitor in server.ts (transpiled standalone — can't import `src/`), sampling V8 heap stats every 5 min:

- **≥85% of heap limit** → structured `[heap-monitor]` warn line (heapUsed/heapLimit/%, rss, external, ptySessions, uptimeMin)
- **≥95%** → writes **one heap snapshot per episode** to `<caveHome>/diagnostics/` before the OOM kill destroys the evidence; latch re-arms when usage recovers below 85%; newest 2 kept (bounded)
- `COVEN_CAVE_HEAP_MONITOR=0` kill-switch; `COVEN_CAVE_HEAP_MONITOR_INTERVAL_MS` tunable; timer `unref()`d; snapshot failures caught and latched (diagnostics can never take the server down)

## Verification

- `src/server-heap-monitor.test.ts` (new, wired into run-tests SUITES): extracts the monitor section from server.ts, esbuild-transforms it exactly like `build:server`, and drives scripted heap ratios — verifies quiet-under-watermark, warn format + context fields, snapshot at 95%, one-per-episode latch, re-arm on recovery, bounded retention, kill-switch, env interval
- Source pins added to `src/server-pty-ws.test.ts`; `server.mjs` regenerated (regen pin passes)
- `check-tests-wired` ✓, `pnpm typecheck` ✓, prod boot smoke on the built server ✓ (Ready + routes 200, no monitor noise at healthy heap)

Bead: cave-ksjt