### PR TITLE
fix(chat): table lightbox traps Tab and restores focus on dismiss (CHAT-D11-02)

### DIFF
--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -102,3 +102,17 @@ test("bulk-select checkmark glyphs pair with the accent's semantic foreground", 
   );
   assert.doesNotMatch(dashboard, /\.dash-inbox__check\[data-checked="true"\]\s*\{[^}]*color:\s*#fff/);
 });
+
+test("table lightbox traps Tab and restores focus to its trigger (CHAT-D11-02)", async () => {
+  // openTableLightbox is imperative DOM — it can't mount useFocusTrap, so it
+  // must hand-mirror the hook's contract. Without this, Escape/Close drops
+  // keyboard focus to <body> and Tab walks the page behind the dialog.
+  const src = await read("./message-bubble.tsx");
+  const fn = src.slice(src.indexOf("function openTableLightbox"));
+  assert.match(fn, /const returnFocus = document\.activeElement instanceof HTMLElement \? document\.activeElement : null;/);
+  assert.match(fn, /returnFocus\?\.focus\(\);/, "dismiss must restore focus to the Expand trigger");
+  assert.match(fn, /event\.key === "Tab"/, "keydown handler must intercept Tab");
+  assert.match(fn, /querySelectorAll<HTMLElement>\(FOCUSABLE\)/, "trap must cycle the shared FOCUSABLE set");
+  assert.match(fn, /\(event\.shiftKey \? last : first\)\.focus\(\);/, "escaped focus must be recaptured into the dialog");
+  assert.match(src, /import \{ useFocusTrap, FOCUSABLE \} from "@\/lib\/use-focus-trap";/);
+});

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -35,7 +35,7 @@ import { Icon } from "@/lib/icon";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
-import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useFocusTrap, FOCUSABLE } from "@/lib/use-focus-trap";
 import { SHIKI_LANGS, resolveShikiLang, diffContentLang } from "@/lib/code-lang";
 import { parseFileRef, type FileRef } from "@/lib/file-ref";
 import { toggleCodeBlockCollapse } from "@/lib/code-block-collapse";
@@ -961,15 +961,49 @@ function openTableLightbox(scroll: HTMLElement) {
 
   const prevOverflow = document.body.style.overflow;
   document.body.style.overflow = "hidden";
+  // CHAT-D11-02: this dialog is imperative DOM (no React mount), so it can't
+  // use useFocusTrap — mirror its contract by hand: remember the trigger,
+  // trap Tab inside the overlay, and restore focus on dismiss. `.focus()` on
+  // a since-removed trigger is a harmless no-op.
+  const returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   const dismiss = () => {
     document.body.style.overflow = prevOverflow;
     document.removeEventListener("keydown", onKey);
     overlay.remove();
+    returnFocus?.focus();
   };
   const onKey = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       event.stopPropagation();
       dismiss();
+      return;
+    }
+    if (event.key === "Tab") {
+      // The cloned table can carry focusable links, so cycle everything in
+      // the overlay, not just the Close button. Same recapture rule as
+      // useFocusTrap: focus that escaped the dialog gets pulled back in.
+      const focusables = Array.from(overlay.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+        (el) => !el.hasAttribute("disabled"),
+      );
+      if (focusables.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (!activeEl || !overlay.contains(activeEl)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+      if (event.shiftKey && activeEl === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && activeEl === last) {
+        event.preventDefault();
+        first.focus();
+      }
     }
   };
   overlay.addEventListener("click", (event) => {


### PR DESCRIPTION
## What

The chat's expandable-table lightbox (`openTableLightbox`, message-bubble.tsx) is imperative DOM and missed the D11-02 focus-management pass its React siblings got. Before: **Escape/Close dropped focus to `<body>`** and **Tab walked the page behind the open dialog**.

Now it hand-mirrors the `useFocusTrap` contract:
- remembers the Expand trigger on open, restores focus to it on every dismiss path (Escape / Close / backdrop click)
- traps Tab/Shift+Tab across the overlay's `FOCUSABLE` set (shared selector imported from `use-focus-trap`), including the hook's escaped-focus recapture rule

## Why

Board card `953cfbab` — Cave UX P1 batch from Sage's 2026-07-03 heuristic audit. Audit of current main showed **6 of 7 P1 steps already landed** (CHAT-D6-01/02 edit+regenerate, D3-01 streaming markdown, D6-04 always-in-DOM actions, kanban drag announce, selection-survives-view-switch, D9-01 deep-links). This was the one remaining gap in the D11-02 class.

## Verification

- New pin in `a11y-audit-fixes.test.ts` — **fails against the old source** (verified via stash), passes now
- All 6 `message-bubble-*` test files: 0 failures; `glass-overlay-chrome` pin green
- `pnpm typecheck` clean
- Local `pnpm test:app` aborts at pre-existing non-hermetic `cave-inbox-bulk.test.ts` (fails identically on untouched main on this machine — real `~/.coven` legacy symlinks; filed **cave-spqh**). CI's clean runner is the full-suite authority here.

Bead: `cave-n3e2`