### PR TITLE
fix(project-search): prevent user-controlled globs from widening ripgrep scope

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -949,6 +949,7 @@ export const SUITES = {
     "src/app/api/access-groups/route.test.ts",
     "src/app/api/project-permission-routes.test.ts",
     "src/app/api/project-local-human-read.test.ts",
+    "src/app/api/project-search-security.test.ts",
     "src/app/api/project-file/route.test.ts",
     "src/app/api/salem/pathfinder/feedback/route.test.ts",
     "src/app/api/feedback/message/route.test.ts",

--- a/src/app/api/project-search-security.test.ts
+++ b/src/app/api/project-search-security.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const route = await readFile(new URL("./project/search/route.ts", import.meta.url), "utf8");
+
+// Every glob handed to ripgrep must be a hardcoded exclusion literal. A
+// user-controlled or include glob can widen the search into hidden/ignored
+// files and expose secret-bearing lines in previews.
+const globPushes = [...route.matchAll(/"--glob",\s*([^),]+)/g)];
+for (const [, value] of globPushes) {
+  assert.match(
+    value.trim(),
+    /^"!/,
+    `ripgrep glob argument ${value.trim()} must be a hardcoded exclusion literal ("!...") — never user-controlled and never an include glob`,
+  );
+}
+assert.match(
+  route,
+  /"--glob",\s*"!\.env\*",\s*"--glob",\s*"!\*\*\/\.env\*"/,
+  "project search must keep the hardcoded .env-family exclusion globs that mirror /api/project-file's redaction boundary",
+);
+assert.match(
+  route,
+  /filterSearchResult\(parseRipgrepJson\(stdout\), glob\)/,
+  "project search should preserve the glob filter by applying it after ripgrep has already honored hidden and ignore defaults",
+);
+assert.match(
+  route,
+  /explicit include globs can widen the\s+\/\/ search to hidden or ignored files/,
+  "route should document why glob filtering cannot be delegated to ripgrep",
+);
+
+console.log("project-search-security.test.ts: ok");

--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -23,7 +23,9 @@ export const dynamic = "force-dynamic";
  * Spawns ripgrep (`rg --json`) under the requested root and parses its event
  * stream via the pure parser in @/lib/project-search. ripgrep respects
  * .gitignore and skips hidden/binary files by default, so results track the
- * same "git-visible working tree" surface as the @-mention file index.
+ * same "git-visible working tree" surface as the @-mention file index. The
+ * optional glob is applied after ripgrep returns so it cannot widen the search
+ * to hidden or ignored files.
  *
  * Security posture mirrors /api/changes: every spawn goes through execFile with
  * an argument array (no shell, no interpolation), the query is passed after
@@ -122,7 +124,6 @@ function buildRgArgs(params: {
   query: string;
   regex: boolean;
   caseMode: "smart" | "sensitive" | "insensitive";
-  glob: string | null;
 }): string[] {
   const args = ["--json", "--max-count", String(RG_MAX_COUNT), "--max-columns", "2000", "--no-messages",
     // One line of context on each side of a match, emitted as `context` events
@@ -132,9 +133,11 @@ function buildRgArgs(params: {
   if (params.caseMode === "insensitive") args.push("--ignore-case");
   else if (params.caseMode === "sensitive") args.push("--case-sensitive");
   else args.push("--smart-case");
-  if (params.glob) args.push("--glob", params.glob);
-  // Match /api/project-file's .env-family redaction boundary even when a
-  // caller-supplied glob explicitly includes hidden environment files.
+  // Do not pass user globs to ripgrep: explicit include globs can widen the
+  // search to hidden or ignored files. Filter the already git-visible result
+  // set in-process instead.
+  // Match /api/project-file's .env-family redaction boundary: exclude env
+  // files even when they are tracked and therefore git-visible.
   args.push("--glob", "!.env*", "--glob", "!**/.env*");
   // Pattern then an explicit search path. The path is REQUIRED: with no path
   // argument and a non-TTY stdin (which execFile gives the child), ripgrep
@@ -142,6 +145,45 @@ function buildRgArgs(params: {
   // until the timeout. "." searches the cwd we set on the spawn.
   args.push("--", params.query, ".");
   return args;
+}
+
+function globToRegExp(glob: string): RegExp {
+  let source = "^";
+  for (let i = 0; i < glob.length; i += 1) {
+    const char = glob[i];
+    const next = glob[i + 1];
+    if (char === "*") {
+      if (next === "*") {
+        source += ".*";
+        i += 1;
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[\^$+?.()|{}[\]]/g, "\\$&");
+    }
+  }
+  source += "$";
+  return new RegExp(source);
+}
+
+function globMatchesPath(glob: string, filePath: string): boolean {
+  const normalizedGlob = glob.replace(/\\/g, "/");
+  const normalizedPath = filePath.replace(/\\/g, "/");
+  const candidates = normalizedGlob.includes("/")
+    ? [normalizedPath]
+    : [normalizedPath, path.basename(normalizedPath)];
+  const re = globToRegExp(normalizedGlob);
+  return candidates.some((candidate) => re.test(candidate));
+}
+
+function filterSearchResult(result: SearchResult, glob: string | null): SearchResult {
+  if (!glob) return result;
+  const files = result.files.filter((file) => globMatchesPath(glob, file.path));
+  const totalMatches = files.reduce((count, file) => count + file.matches.length, 0);
+  return { ...result, files, totalMatches };
 }
 
 export async function GET(req: NextRequest) {
@@ -188,11 +230,11 @@ export async function GET(req: NextRequest) {
   const glob = sp.get("glob")?.trim() || null;
   const regex = sp.get("regex") === "1";
 
-  const args = buildRgArgs({ query, regex, caseMode, glob });
+  const args = buildRgArgs({ query, regex, caseMode });
 
   try {
     const { stdout } = await runRipgrep(resolved.root, args);
-    const result: SearchResult = parseRipgrepJson(stdout);
+    const result: SearchResult = filterSearchResult(parseRipgrepJson(stdout), glob);
     return NextResponse.json({ ok: true, repo: true, root: resolved.root, ...result });
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;

--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -162,7 +162,7 @@ function globToRegExp(glob: string): RegExp {
     } else if (char === "?") {
       source += "[^/]";
     } else {
-      source += char.replace(/[\^$+?.()|{}[\]]/g, "\\$&");
+      source += char.replace(/[\\^$+?.()|{}[\]]/g, "\\$&");
     }
   }
   source += "$";


### PR DESCRIPTION
### Motivation

- A user-controlled `glob` parameter was passed directly to ripgrep (`rg --glob`), which can explicitly include hidden or .gitignored files and expose secret-bearing lines in search previews.

### Description

- Remove passing user-controlled globs into ripgrep and stop delegating include globs to the `rg` process. 
- Add in-process glob filtering implemented by `globToRegExp`, `globMatchesPath`, and `filterSearchResult` that apply the glob to ripgrep's parsed, git-visible result set. 
- Update the route documentation to state the glob is applied after ripgrep returns so it cannot widen the search to hidden/ignored files. 
- Add a regression test `src/app/api/project-search-security.test.ts` asserting no `--glob` is pushed into ripgrep args and that the parsed result is filtered in-process, and wire this test into the API suite (`scripts/run-tests.mjs`).

### Testing

- Ran `pnpm test:api`, which executed the API test suite and passed (all API tests passed). 
- Ran `node --experimental-strip-types src/app/api/project-search-security.test.ts`, which passed and validated the new security assertions. 
- Ran `pnpm check:tests-wired`, which passed after wiring the new test into the API suite. 
- Ran `pnpm typecheck`, which failed due to unrelated existing `@milkdown/crepe` type/module resolution and implicit-any issues in `src/components/md-editor/md-editor-visual.tsx`, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c9e662bf483278629be9c0d524932)