### PR TITLE
security(changes): disable repo `core.fsmonitor` during automatic status polling

### DIFF
--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -16,6 +16,18 @@ assert.doesNotMatch(
   "changes route should use gitDiff for every git diff invocation",
 );
 
+assert.match(
+  source,
+  /function gitStatus[\s\S]*\["-c", "core\.fsmonitor=false", "status", \.\.\.args\]/,
+  "git status calls must disable repository-configured fsmonitor commands",
+);
+
+assert.match(
+  source,
+  /gitStatus\(repoRoot, \["--porcelain=v1", "-z", "--untracked-files=all"\]\)/,
+  "change-list status polling must use the hardened gitStatus helper",
+);
+
 
 // The status GET carries the current branch (Projects hub Git section) — from
 // the existing currentBranch() helper, omitted on unborn repos.

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -59,6 +59,11 @@ function gitDiff(cwd: string, args: string[]): Promise<{ stdout: string; stderr:
   return git(cwd, ["diff", "--no-ext-diff", "--no-textconv", ...args]);
 }
 
+/** Run `git status` without repository-configured fsmonitor commands. */
+function gitStatus(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return git(cwd, ["-c", "core.fsmonitor=false", "status", ...args]);
+}
+
 /** Network git (push) and `gh` can take longer than the read-only 10s budget. */
 const NET_TIMEOUT_MS = 60_000;
 function gitLong(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
@@ -220,7 +225,7 @@ async function existsInHead(repoRoot: string, relPath: string): Promise<boolean>
 // ── GET: change list / single-file diff ───────────────────────────────────────
 
 async function listChanges(repoRoot: string): Promise<NextResponse> {
-  const { stdout } = await git(repoRoot, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  const { stdout } = await gitStatus(repoRoot, ["--porcelain=v1", "-z", "--untracked-files=all"]);
   const files = parsePorcelainZ(stdout);
 
   // Best-effort ins/del counts vs HEAD (covers staged + unstaged). Repos


### PR DESCRIPTION
### Motivation
- Prevent automatic client polling from triggering repository-configured `core.fsmonitor` commands when the UI queries the changes endpoint. 
- The changes-list path previously invoked `git status` under repo configuration, which can execute arbitrary commands via `core.fsmonitor` in a malicious working tree. 
- Harden the server-side status call so the diff-first client polling added earlier cannot lead to local command execution as the app user.

### Description
- Add a `gitStatus` helper that runs `git -c core.fsmonitor=false status ...` to explicitly disable repository-configured `core.fsmonitor` hooks during status calls. 
- Replace the direct `git(..., ["status", ...])` call in `listChanges` with the new `gitStatus` helper so the change-list path uses the hardened invocation. 
- Add assertions to `src/app/api/changes/route.test.ts` that validate the presence of `gitStatus` and that the change-list polling uses it, providing source-level regression coverage.

### Testing
- Ran `node src/app/api/changes/route.test.ts` and it succeeded. 
- Ran `node src/components/debug-pane.test.ts` and it succeeded. 
- Verified via a local repro that `git -c core.fsmonitor=false status --porcelain=...` does not invoke a repo-local `core.fsmonitor` script (manual shell check succeeded). 
- `pnpm typecheck` currently fails due to pre-existing unrelated TypeScript issues in `src/components/md-editor/md-editor-visual.tsx`, so full typecheck did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c99f5d4f08327891c908b8139ce05)