### PR TITLE
fix(search): redact .env-family files from project search

### DIFF
--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -133,6 +133,9 @@ function buildRgArgs(params: {
   else if (params.caseMode === "sensitive") args.push("--case-sensitive");
   else args.push("--smart-case");
   if (params.glob) args.push("--glob", params.glob);
+  // Match /api/project-file's .env-family redaction boundary even when a
+  // caller-supplied glob explicitly includes hidden environment files.
+  args.push("--glob", "!.env*", "--glob", "!**/.env*");
   // Pattern then an explicit search path. The path is REQUIRED: with no path
   // argument and a non-TTY stdin (which execFile gives the child), ripgrep
   // blocks reading stdin instead of walking the directory — so it would hang

--- a/src/lib/project-search.test.ts
+++ b/src/lib/project-search.test.ts
@@ -150,4 +150,21 @@ function contextLine(path, lineNumber, text) {
   assert.deepEqual(result.files, []);
 }
 
+// ── .env-family files are redacted from project search results ──────────────
+{
+  const stdout = [
+    matchLine(".env", 1, "PUBLIC_SENTINEL=ok\n", 0),
+    contextLine(".env", 2, "SECRET_API_KEY=super-secret-token\n"),
+    matchLine("packages/app/.env.local", 1, "PUBLIC_SENTINEL=ok\n", 0),
+    contextLine("packages/app/.env.local", 2, "SECRET_API_KEY=super-secret-token\n"),
+    matchLine("src/env-example.ts", 1, "PUBLIC_SENTINEL=ok\n", 0),
+    contextLine("src/env-example.ts", 2, "not secret context\n"),
+  ].join("\n");
+  const result = parseRipgrepJson(stdout);
+  assert.equal(result.totalMatches, 1, ".env-family matches are dropped");
+  assert.equal(result.files.length, 1);
+  assert.equal(result.files[0].path, "src/env-example.ts");
+  assert.equal(result.files[0].matches[0].after, "not secret context");
+}
+
 console.log("project-search.test.ts: all assertions passed");

--- a/src/lib/project-search.ts
+++ b/src/lib/project-search.ts
@@ -56,6 +56,10 @@ const DEFAULT_MAX_MATCHES = 500;
 const DEFAULT_MAX_PER_FILE = 50;
 const DEFAULT_MAX_PREVIEW = 240;
 
+function isEnvFamilyPath(filePath: string): boolean {
+  return filePath.split(/[\\/]+/).some((part) => part.startsWith(".env"));
+}
+
 type RgText = { text?: string; bytes?: string };
 
 type RgMatchData = {
@@ -117,7 +121,7 @@ export function parseRipgrepJson(stdout: string, options: ParseOptions = {}): Se
     // arrive prefixed with "./" — strip it so the path is clean for display and
     // for rejoining to the project root.
     const path = textOf(data.path).replace(/^\.\//, "");
-    if (!path) continue;
+    if (!path || isEnvFamilyPath(path)) continue;
     const lineNumber = typeof data.line_number === "number" ? data.line_number : 0;
     if (lineNumber <= 0) continue;
     const text = clip(textOf(data.lines).replace(/\r?\n$/, ""));


### PR DESCRIPTION
### Motivation

- Project search began returning ripgrep `context` lines as `before`/`after` fields and also accepted caller-controlled `--glob`, allowing a client to include hidden `.env*` files and leak adjacent secret lines. 
- The repository already redacts `.env` contents in the project-file API, so search should maintain the same protection boundary to avoid inconsistent information disclosure. 
- The change aims to close this information-leak by preventing `.env`-family files from being searched or parsed into returned context fields.

### Description

- Append ripgrep exclusion globs to the search invocation so caller-provided globs cannot re-include `.env`-family files by adding `--glob '!.env*'` and `--glob '!**/.env*'` to the args in `buildRgArgs` in `src/app/api/project/search/route.ts`.
- Add a parser-level defense-in-depth in `src/lib/project-search.ts` by introducing `isEnvFamilyPath` and skipping any `match` or `context` events whose path contains a segment starting with `.env` so no preview or `before`/`after` is produced for these files.
- Add a regression test in `src/lib/project-search.test.ts` that simulates `.env` and nested `.env.local` events and verifies they are dropped while non-`.env` files still preserve context.

### Testing

- Ran the parser unit tests with `node --experimental-strip-types src/lib/project-search.test.ts`, which completed successfully with all assertions passing.
- Ran TypeScript check with `pnpm typecheck`, which returned without errors.
- Verified test wiring with `pnpm check:tests-wired`, which reported all tests wired and passed.
- Ran `git diff --check` (whitespace/checks) which showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c95ec5f3483278a8851b3776c859f)