### PR TITLE
fix(proxy): limit header CSRF bypass to mobile APIs

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -78,8 +78,8 @@ assert.match(
 // (cookies auto-send cross-origin → CSRF).
 assert.match(
   source,
-  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) && req\.headers\.get\(TOKEN_HEADER\) === sidecarToken/,
-  "origin/referer gate bypass must be keyed to the custom sidecar header token",
+  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) &&\s*req\.headers\.get\(TOKEN_HEADER\) === sidecarToken &&\s*isHeaderCsrfTrustedApiPath\(req\.nextUrl\.pathname\)/,
+  "origin/referer gate bypass must be keyed to the custom sidecar header token and mobile endpoint allowlist",
 );
 assert.match(
   source,
@@ -90,6 +90,16 @@ assert.doesNotMatch(
   source,
   /csrfTrusted\s*=\s*mobileAccessAuthenticated/,
   "cookie-backed mobile-access must NOT bypass the CSRF origin gate",
+);
+assert.match(
+  source,
+  /HEADER_CSRF_TRUSTED_API_PATHS = new Set\(\["\/api\/mobile-handoff", "\/api\/mobile-token\/refresh"\]\)/,
+  "header-token CSRF relaxation must be limited to explicitly mobile-capable APIs",
+);
+assert.doesNotMatch(
+  source,
+  /HEADER_CSRF_TRUSTED_API_PATHS[\s\S]*codex-automations|HEADER_CSRF_TRUSTED_API_PATHS[\s\S]*\/api\/inbox/,
+  "local-only APIs must not be included in the header-token CSRF allowlist",
 );
 
 // Ordering guard: dev-mode token-bypass (NextResponse.next() when no token is set)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -141,6 +141,12 @@ function isLocalOnlyAutomationRun(pathname: string, method: string) {
   return method === "POST" && /^\/api\/codex-automations\/[^/]+\/run$/.test(pathname);
 }
 
+const HEADER_CSRF_TRUSTED_API_PATHS = new Set(["/api/mobile-handoff", "/api/mobile-token/refresh"]);
+
+function isHeaderCsrfTrustedApiPath(pathname: string) {
+  return HEADER_CSRF_TRUSTED_API_PATHS.has(pathname);
+}
+
 function isProductionWebhookGet(pathname: string, method: string) {
   return (
     method === "GET" &&
@@ -211,19 +217,20 @@ export async function proxy(req: NextRequest) {
 
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
   // A request bearing the sidecar token in the CUSTOM HEADER (x-coven-cave-token)
-  // is provably first-party: a browser cannot set a custom header on a
-  // cross-origin request (it forces a CORS preflight the server never approves),
-  // so such a request cannot be CSRF regardless of its Origin. Tailscale Serve
-  // terminates TLS and proxies to loopback, forwarding `Host: 127.0.0.1`, so a
-  // legitimately-authenticated WKWebView request keeps its real
-  // https://<machine>.ts.net identity only in the Origin header — which otherwise
-  // fails the same-origin gate and 403s every mutating request as "forbidden
-  // origin" (fixed in #618; #716 reverted it and re-broke mobile-over-Serve).
+  // can be sent by native/mobile clients over Tailscale Serve, where the proxy
+  // forwards `Host: 127.0.0.1` but preserves the real ts.net source in Origin.
+  // Only explicitly mobile-capable API routes may use that header to relax the
+  // Origin/Referer gate. Local-only routes such as automation and inbox APIs
+  // rely on their route-level loopback Host checks, so they must still fail
+  // closed when a remote Serve origin reaches the loopback backend.
   // Scope is deliberately the header ONLY: NOT the access cookie (auto-sent
   // cross-origin → CSRF) and NOT the query/referer token paths. The token value
-  // is still validated below; this only relaxes the CSRF source gate.
+  // is still validated below; this only relaxes the CSRF source gate for the
+  // allowlisted mobile endpoints.
   const headerCsrfTrusted =
-    Boolean(sidecarToken) && req.headers.get(TOKEN_HEADER) === sidecarToken;
+    Boolean(sidecarToken) &&
+    req.headers.get(TOKEN_HEADER) === sidecarToken &&
+    isHeaderCsrfTrustedApiPath(req.nextUrl.pathname);
 
   if (!headerCsrfTrusted) {
     const origin = req.headers.get("origin");


### PR DESCRIPTION
### Motivation
- A global `x-coven-cave-token` CSRF/source bypass allowed authenticated remote/mobile requests (over Tailscale Serve) to reach local-only endpoints that rely only on a forwarded loopback `Host`, creating a high-severity authorization/origin-gate bypass. 
- The fix scopes the header-based relaxation to only explicitly mobile-capable API surfaces so local-only automation/inbox routes continue to fail closed for remote origins.

### Description
- Add an allowlist `HEADER_CSRF_TRUSTED_API_PATHS` and helper `isHeaderCsrfTrustedApiPath` in `src/proxy.ts` to enumerate mobile-capable endpoints. 
- Change the header-CSRF-trust predicate so `headerCsrfTrusted` requires the sidecar header _and_ that the request path is allowlisted. 
- Update the proxy comments to document the scoped trust rationale for Tailscale Serve and local-only routes. 
- Strengthen `src/middleware.test.ts` to assert the presence of the allowlist and to ensure local-only endpoints (e.g., Codex automations and inbox) are not included in it.

### Testing
- Ran `node src/middleware.test.ts`, which passed. 
- Ran `node src/proxy-behavior.test.ts`, which passed. 
- Ran `git diff --check`, which reported no whitespace/format issues. 
- Ran `pnpm typecheck`, which failed due to pre-existing unrelated type/module issues in `src/components/md-editor/md-editor-visual.tsx` (missing `@milkdown/crepe` types and implicit `any` parameters); these are unrelated to the proxy change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb17183008327880284f225c11295)