### PR TITLE
fix(release): tie manual release checkouts to tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,6 @@ on:
         description: "Tag to attach builds to (e.g. v0.0.16). Must already exist on origin."
         required: true
         type: string
-      source_ref:
-        description: "Git ref to build from for manual release-infra retries. Defaults to tag."
-        required: false
-        type: string
       platform:
         description: "Platform to build when manually re-running a release."
         required: false
@@ -101,9 +97,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Manual retries may need newer release infrastructure while still
-          # attaching artifacts to an existing tag.
-          ref: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref }}
+          # Build the exact tag whose release receives the artifacts. Keeping
+          # checkout provenance tied to RELEASE_TAG prevents manual retries from
+          # signing and publishing assets from an unrelated ref.
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set release metadata
         shell: bash
@@ -456,9 +453,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Manual retries may need newer release infrastructure while still
-          # attaching artifacts to an existing tag.
-          ref: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref }}
+          # Run release helper scripts from the same tag whose release metadata
+          # is being updated, rather than from an operator-supplied ref.
+          ref: ${{ github.event.inputs.tag || github.ref }}
           # release-notes.sh resolves the previous tag for the compare link
           # via `git tag --sort=-version:refname`, so the checksums job needs
           # the full tag history (shallow defaults would only have HEAD).

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -111,15 +111,13 @@ test("Linux AppImage strips bundled GLib so host GLib is used at runtime", () =>
   );
 });
 
-test("manual release retries can build from a source ref while attaching to the tag", () => {
-  assert.match(releaseWorkflow, /source_ref:/);
+test("manual release retries build from the release tag before publishing", () => {
+  assert.doesNotMatch(releaseWorkflow, /source_ref:/);
+  assert.doesNotMatch(releaseWorkflow, /github\.event\.inputs\.source_ref/);
   assert.match(
     releaseWorkflow,
-    /description: "Git ref to build from for manual release-infra retries\. Defaults to tag\."/,
-  );
-  assert.match(
-    releaseWorkflow,
-    /ref: \$\{\{ github\.event\.inputs\.source_ref \|\| github\.event\.inputs\.tag \|\| github\.ref \}\}/,
+    /ref: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref \}\}/,
+    "release checkouts must use the same tag/ref whose release receives assets",
   );
   assert.match(
     releaseWorkflow,


### PR DESCRIPTION
### Motivation
- Prevent manual `workflow_dispatch` runners from building, signing, or notarizing artifacts from an arbitrary ref while attaching them to an existing release tag, which could let an operator-p with dispatch permission publish malicious signed artifacts to an official release.
- Keep build and release-helper script provenance tied to the reviewed/tagged source whose release metadata and uploads are being modified.

### Description
- Remove the `source_ref` `workflow_dispatch` input from `.github/workflows/release.yml` so operators cannot supply an alternate build ref when dispatching the release workflow.
- Change `actions/checkout` in the `build` and `checksums` jobs to use `ref: ${{ github.event.inputs.tag || github.ref }}` so checkouts are always the tag/ref receiving the uploads.
- Update `scripts/release-macos-signing.test.mjs` to assert `source_ref` is no longer present and to verify checkouts are tag-bound.
- Commit message used: `fix(release): tie manual release checkouts to tag`.

### Testing
- Ran `node --test scripts/release-macos-signing.test.mjs` and all tests passed (`9 passed`, `0 failed`).
- Parsed the modified workflow with a YAML parser via `node` to ensure the workflow is valid and the YAML loads successfully (`release.yml parsed`).
- Ran `git diff --check` to validate there are no whitespace/patch errors and it reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cad34732c83278dc137721e360354)