### PR TITLE
Fail closed for missing chat project roots

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -368,7 +368,7 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /await resolveLocalRuntimeCwd\(body\.projectRoot \?\? resumeCwd\)/,
+  /await resolveLocalRuntimeCwd\(body\.projectRoot \?\? resumeCwd \?\? resolvedFamiliarWorkspace\)/,
   "Local Cave chat must fail closed on invalid project roots instead of downgrading to homedir",
 );
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -733,9 +733,25 @@ function openClawChatResponse(args: {
       pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", `${agentId} (${agentBinding.source})`);
       const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
       const spawnArgv = openClawSpawnArgs(argv);
-      const cwd = await resolveLocalRuntimeCwd(
-        args.body.projectRoot ?? (await conversationCwd(args.body.sessionId)),
-      );
+      let cwd: string;
+      try {
+        cwd = await resolveLocalRuntimeCwd(
+          args.body.projectRoot ?? (await conversationCwd(args.body.sessionId)),
+        );
+      } catch (error) {
+        if (error instanceof RuntimeScopeError) {
+          pushProgress("openclaw-start", "OpenClaw bridge not started", "error", error.message);
+          push({ kind: "error", code: error.code, message: error.message });
+          push({
+            kind: "done",
+            durationMs: Date.now() - startedAt,
+            isError: true,
+          });
+          close();
+          return;
+        }
+        throw error;
+      }
       const responseMetadata: ChatResponseMetadata = {
         familiarId: args.body.familiarId,
         harness: "openclaw",
@@ -1084,9 +1100,15 @@ export async function POST(req: Request) {
     !sshRuntime && !body.projectRoot && existingConversation?.runtime?.startsWith("local:")
       ? existingConversation.runtime.slice("local:".length).trim() || undefined
       : undefined;
+  const projects = sshRuntime ? [] : await loadProjects();
+  const resolvedFamiliarWorkspace = !sshRuntime
+    ? await resolveFamiliarWorkspace(body.familiarId)
+    : undefined;
   let cwd: string;
   try {
-    cwd = sshRuntime ? homedir() : await resolveLocalRuntimeCwd(body.projectRoot ?? resumeCwd);
+    cwd = sshRuntime
+      ? homedir()
+      : await resolveLocalRuntimeCwd(body.projectRoot ?? resumeCwd ?? resolvedFamiliarWorkspace);
   } catch (error) {
     if (error instanceof RuntimeScopeError) {
       return new Response(
@@ -1096,10 +1118,6 @@ export async function POST(req: Request) {
     }
     throw error;
   }
-  const projects = sshRuntime ? [] : await loadProjects();
-  const resolvedFamiliarWorkspace = !sshRuntime
-    ? await resolveFamiliarWorkspace(body.familiarId)
-    : undefined;
   const chatProjectId = sshRuntime
     ? null
     : chatProjectAccessId({

--- a/src/lib/chat-runtime-scope.test.ts
+++ b/src/lib/chat-runtime-scope.test.ts
@@ -21,10 +21,13 @@ await mkdir(outside, { recursive: true });
 const filePath = path.join(home, "not-a-dir.txt");
 await writeFile(filePath, "not a directory");
 
-assert.equal(
-  await resolveLocalRuntimeCwd(undefined, { homeDir: home }),
-  realpathSync(home),
-  "missing project root should default to the real home directory",
+await assert.rejects(
+  () => resolveLocalRuntimeCwd(undefined, { homeDir: home }),
+  (error) =>
+    error instanceof RuntimeScopeError &&
+    error.code === "project_root_required" &&
+    /refusing to start a homedir-scoped fallback session/.test(error.message),
+  "missing project roots should be refused instead of downgraded to home",
 );
 
 assert.equal(

--- a/src/lib/chat-runtime-scope.ts
+++ b/src/lib/chat-runtime-scope.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 type RuntimeScopeErrorCode =
+  | "project_root_required"
   | "project_root_outside_home"
   | "project_root_not_directory"
   | "project_root_unavailable";
@@ -56,7 +57,12 @@ export async function resolveLocalRuntimeCwd(
   const homePath = path.resolve(normalizePath(options.homeDir ?? homedir()));
   const homeRoot = await realpath(homePath);
   const trimmed = requested?.trim();
-  if (!trimmed) return homeRoot;
+  if (!trimmed) {
+    throw new RuntimeScopeError(
+      "project_root_required",
+      "projectRoot is required; refusing to start a homedir-scoped fallback session.",
+    );
+  }
 
   const candidate = path.resolve(normalizePath(trimmed));
   const relToHome = path.relative(homePath, candidate);


### PR DESCRIPTION
### Motivation
- The chat endpoint previously fell back to the user's home directory when `projectRoot` was missing or invalid, which allowed spawned familiars to run from `$HOME` and access sensitive user files.
- The intent is to minimize native agent filesystem scope by refusing uncontrolled homedir fallbacks and preferring an explicit familiar workspace when available.

### Description
- Change `resolveLocalRuntimeCwd` to fail when `projectRoot` is absent by adding a new `project_root_required` `RuntimeScopeError` instead of returning `homedir()` in `src/lib/chat-runtime-scope.ts`.
- Use the resolved familiar workspace as an explicit fallback for new local chats (`projectRoot ?? resumeCwd ?? resolvedFamiliarWorkspace`) so agents are not started in `$HOME` in `src/app/api/chat/send/route.ts`.
- Emit structured runtime-scope errors into the OpenClaw chat stream and return JSON errors instead of spawning a bridge when a scoped cwd cannot be resolved, preventing any child process from starting with an unsafe cwd in `src/app/api/chat/send/route.ts`.
- Update tests to assert the fail-closed behavior and to expect the familiar-workspace fallback in routing assertions (`src/lib/chat-runtime-scope.test.ts` and `src/app/api/chat/send/harness-routing.test.ts`).

### Testing
- Ran `node --experimental-strip-types src/lib/chat-runtime-scope.test.ts` and the test passed.
- Ran `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts` and the harness-routing tests passed.
- Ran `pnpm typecheck` and `git diff --check`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d2a89c3c88327b9a67a5f3cf1ae3f)