### PR TITLE
fix: fail closed for unsafe OpenClaw shim prompts

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -158,8 +158,13 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /import \{ openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv \} from "@\/lib\/openclaw-bin";/,
+  /import \{ openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv, openClawSupportsUntrustedArgs \} from "@\/lib\/openclaw-bin";/,
   "OpenClaw native chat should use the Windows-aware binary resolver instead of spawning a bare command",
+);
+assert.match(
+  chatRoute,
+  /if \(!openClawSupportsUntrustedArgs\(openclawCommand\)\)[\s\S]*openclaw_unsafe_shell/,
+  "OpenClaw chat should fail closed before passing untrusted prompts to shell-only Windows shims",
 );
 
 assert.match(
@@ -194,8 +199,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const spawnArgv = openClawSpawnArgs\(argv\);[\s\S]*spawn\(openClawBin\(\), spawnArgv,[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: openClawNeedsShell\(\)/,
-  "OpenClaw chat should shell-quote Windows npm .cmd shim argv before spawning",
+  /const openclawCommand = openClawBin\(\);[\s\S]*const spawnArgv = openClawSpawnArgs\(argv, openclawCommand\);[\s\S]*spawn\(openclawCommand, spawnArgv,[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: openClawNeedsShell\(openclawCommand\)/,
+  "OpenClaw chat should only spawn an OpenClaw command that can receive untrusted prompt argv safely",
 );
 
 // Session persistence contract (regression: chats forked into new sessions

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -60,7 +60,7 @@ import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects } from "@/lib/cave-projects";
 import { chatProjectAccessId } from "@/lib/chat-project-access";
-import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv } from "@/lib/openclaw-bin";
+import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv, openClawSupportsUntrustedArgs } from "@/lib/openclaw-bin";
 import {
   familiarWorkspacesRoot,
   readFamiliarWorkspaces,
@@ -828,7 +828,29 @@ function openClawChatResponse(args: {
       const agentId = agentBinding.openclawAgentId;
       pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", `${agentId} (${agentBinding.source})`);
       const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
-      const spawnArgv = openClawSpawnArgs(argv);
+      const openclawCommand = openClawBin();
+      if (!openClawSupportsUntrustedArgs(openclawCommand)) {
+        pushProgress(
+          "openclaw-start",
+          "OpenClaw bridge cannot start safely",
+          "error",
+          "The resolved OpenClaw Windows .cmd shim requires shell parsing, so Cave cannot pass chat prompts to it safely. Install or configure a native openclaw executable with OPENCLAW_BIN.",
+        );
+        push({
+          kind: "error",
+          code: "openclaw_unsafe_shell",
+          message:
+            "OpenClaw chat is unavailable because the resolved Windows .cmd shim requires unsafe shell parsing. Install or configure a native openclaw executable with OPENCLAW_BIN.",
+        });
+        push({
+          kind: "done",
+          durationMs: Date.now() - startedAt,
+          isError: true,
+        });
+        close();
+        return;
+      }
+      const spawnArgv = openClawSpawnArgs(argv, openclawCommand);
       let cwd: string;
       try {
         cwd = await resolveLocalRuntimeCwd(
@@ -865,11 +887,11 @@ function openClawChatResponse(args: {
         sessionKey: openClawSessionKey(conversationId),
       };
       pushProgress("openclaw-start", "Starting OpenClaw bridge", "running", cwd);
-      const child = spawn(openClawBin(), spawnArgv, {
+      const child = spawn(openclawCommand, spawnArgv, {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
         env: openClawSpawnEnv(),
-        shell: openClawNeedsShell(),
+        shell: openClawNeedsShell(openclawCommand),
       });
       pushProgress("openclaw-start", "OpenClaw bridge started", "done");
       pushProgress("openclaw-response", "Waiting for OpenClaw response", "running");

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -22,13 +22,18 @@ assert.match(
 );
 assert.match(
   src,
-  /export function openClawNeedsShell\(\): boolean[\s\S]*process\.platform === "win32"/,
-  "Windows OpenClaw npm shims should be spawned through shell mode",
+  /export function openClawNeedsShell\(bin = openClawBin\(\)\): boolean[\s\S]*process\.platform === "win32"[\s\S]*endsWith\("\.cmd"\)/,
+  "Only Windows OpenClaw .cmd npm shims should require shell mode",
 );
 assert.match(
   src,
-  /export function openClawSpawnArgs\(argv: string\[\]\): string\[\][\s\S]*openClawNeedsShell\(\)[\s\S]*quoteWindowsShellArg/,
+  /export function openClawSpawnArgs\(argv: string\[\], bin = openClawBin\(\)\): string\[\][\s\S]*openClawNeedsShell\(bin\)[\s\S]*quoteWindowsShellArg/,
   "Windows shell-mode OpenClaw spawn args should quote argv entries before Node joins them for cmd.exe",
+);
+assert.match(
+  src,
+  /export function openClawSupportsUntrustedArgs\(bin = openClawBin\(\)\): boolean[\s\S]*!openClawNeedsShell\(bin\)/,
+  "OpenClaw chat should be able to reject shell-only shims before passing untrusted prompts",
 );
 assert.match(
   src,

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -89,8 +89,12 @@ export function openClawBin(): string {
   return cachedBin;
 }
 
-export function openClawNeedsShell(): boolean {
-  return process.platform === "win32";
+export function openClawNeedsShell(bin = openClawBin()): boolean {
+  return process.platform === "win32" && bin.toLowerCase().endsWith(".cmd");
+}
+
+export function openClawSupportsUntrustedArgs(bin = openClawBin()): boolean {
+  return !openClawNeedsShell(bin);
 }
 
 const WINDOWS_SHELL_META_RE = /[\s"&|<>()^%!]/;
@@ -122,8 +126,8 @@ function quoteWindowsShellArg(arg: string): string {
   return `"${escaped}"`;
 }
 
-export function openClawSpawnArgs(argv: string[]): string[] {
-  return openClawNeedsShell() ? argv.map(quoteWindowsShellArg) : argv;
+export function openClawSpawnArgs(argv: string[], bin = openClawBin()): string[] {
+  return openClawNeedsShell(bin) ? argv.map(quoteWindowsShellArg) : argv;
 }
 
 export function openClawSpawnEnv(): NodeJS.ProcessEnv {


### PR DESCRIPTION
### Motivation
- A Windows-specific change allowed spawning OpenClaw with `shell:true` while passing attacker-controlled chat prompts as argv, which enables shell command injection through `.cmd` npm shims.
- The intent is to prevent prompt-driven command injection while preserving OpenClaw functionality on platforms and binaries that accept argv safely.

### Description
- Change `openClawNeedsShell()` to require both `process.platform === "win32"` and that the resolved `openclaw` binary ends with `.cmd`, and add `openClawSupportsUntrustedArgs()` to signal whether untrusted argv are safe to pass. (`src/lib/openclaw-bin.ts`)
- Thread the resolved OpenClaw command through spawn helpers by adding an optional `bin` parameter to `openClawSpawnArgs()` and using the resolved command when spawning. (`src/lib/openclaw-bin.ts`)
- Update the OpenClaw chat startup to resolve the command once, check `openClawSupportsUntrustedArgs()`, fail closed with a clear `openclaw_unsafe_shell` error stream if the resolved shim requires shell parsing, and only spawn when safe. (`src/app/api/chat/send/route.ts`)
- Add/adjust regression assertions to cover the new guard and the threaded `bin` usage in the OpenClaw unit tests and routing tests. (`src/lib/openclaw-bin.test.ts`, `src/app/api/chat/send/harness-routing.test.ts`)

### Testing
- Ran `node src/lib/openclaw-bin.test.ts`, which passed successfully. 
- Ran `node src/app/api/chat/send/harness-routing.test.ts`, which passed successfully. 
- Ran `pnpm typecheck` which failed due to an unrelated missing dependency/type (`@milkdown/crepe`) in the environment and not because of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c9f5308ec8327959efe1f8440a63b)