### PR TITLE
fix(projects): validate saved project roots

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { deleteProject, patchProject } from "@/lib/cave-projects";
-import { isAllowedNewProjectRoot } from "@/lib/server/project-paths";
+import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -28,9 +28,15 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
       return NextResponse.json({ ok: false, error: "root cannot be empty" }, { status: 400 });
     }
     if (!isAllowedNewProjectRoot(trimmed)) {
+      // Containment first: out-of-workspace paths get a uniform 403 so the
+      // existence checks below cannot be used to probe arbitrary filesystem paths.
       return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
     }
-    patch.root = trimmed;
+    const validatedRoot = validateCaveProjectRoot(trimmed);
+    if (!validatedRoot.ok) {
+      return NextResponse.json({ ok: false, error: validatedRoot.error }, { status: 400 });
+    }
+    patch.root = validatedRoot.root;
   }
   if (typeof body.color === "string") {
     const trimmed = body.color.trim();

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -20,11 +20,13 @@ assert.match(listRoute, /export async function POST\(req: Request\)/, "projects 
 assert.match(listRoute, /name and root are required/, "POST /api/projects should validate required fields");
 assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects should validate roots before persisting them");
 assert.match(listRoute, /root must be inside an allowed workspace/, "POST /api/projects should reject unsafe roots");
+assert.match(listRoute, /validateCaveProjectRoot/, "POST /api/projects should require existing directory roots before persisting them");
 assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 when creating");
 
 assert.match(itemRoute, /export async function PUT/, "project item route should expose PUT");
 assert.match(itemRoute, /export async function DELETE/, "project item route should expose DELETE");
 assert.match(itemRoute, /isAllowedNewProjectRoot\(trimmed\)/, "PUT /api/projects/[id] should validate root patches before persisting them");
+assert.match(itemRoute, /validateCaveProjectRoot/, "PUT /api/projects/[id] should require existing directory roots before persisting them");
 assert.match(itemRoute, /nothing to update/, "PUT /api/projects/[id] should reject empty patches");
 assert.match(itemRoute, /not found/, "project item route should return not-found errors");
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
-import { isAllowedNewProjectRoot } from "@/lib/server/project-paths";
+import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -35,12 +35,18 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: "name and root are required" }, { status: 400 });
   }
   if (!isAllowedNewProjectRoot(root)) {
+    // Containment first: out-of-workspace paths get a uniform 403 so the
+    // existence checks below cannot be used to probe arbitrary filesystem paths.
     return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
+  }
+  const validatedRoot = validateCaveProjectRoot(root);
+  if (!validatedRoot.ok) {
+    return NextResponse.json({ ok: false, error: validatedRoot.error }, { status: 400 });
   }
 
   const project = await createProject({
     name,
-    root,
+    root: validatedRoot.root,
     color: typeof body.color === "string" ? body.color : undefined,
   });
   return NextResponse.json({ ok: true, project }, { status: 201 });

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -38,16 +38,21 @@ try {
   const canonical = path.join(process.env.COVEN_HOME, "workspaces", "familiars", "sage");
   const savedProjectRoot = path.join(tmp, "Documents", "GitHub", "OpenCoven", "coven-docs");
   await mkdir(canonical, { recursive: true });
+  const sensitiveFileRoot = path.join(tmp, "sensitive-config");
   await mkdir(path.join(savedProjectRoot, "docs"), { recursive: true });
+  await writeFile(sensitiveFileRoot, "SECRET\n");
   await writeFile(
     process.env.CAVE_PROJECTS_PATH_OVERRIDE,
     JSON.stringify({
       version: 1,
-      projects: [{ id: "docs", name: "Coven Docs", root: savedProjectRoot }],
+      projects: [
+        { id: "docs", name: "Coven Docs", root: savedProjectRoot },
+        { id: "sensitive", name: "Sensitive", root: sensitiveFileRoot },
+      ],
     }),
   );
 
-  const { isAllowedNewProjectRoot, resolveAllowedProjectPath } = await import("./project-paths.ts");
+  const { isAllowedNewProjectRoot, resolveAllowedProjectPath, validateCaveProjectRoot } = await import("./project-paths.ts");
   const legacy = path.join(process.env.COVEN_HOME, "workspace", "familiars", "sage");
 
   assert.equal(
@@ -122,6 +127,18 @@ try {
     isAllowedNewProjectRoot("~/secret"),
     false,
     "tilde subpaths cannot masquerade as relative paths under the current working directory",
+  );
+
+  assert.equal(
+    resolveAllowedProjectPath(sensitiveFileRoot),
+    null,
+    "saved Cave project roots that point at files are not promoted into the allowlist",
+  );
+
+  assert.deepEqual(
+    validateCaveProjectRoot(sensitiveFileRoot),
+    { ok: false, error: "root must be a directory" },
+    "project roots must be existing directories",
   );
 } finally {
   restoreEnv();

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -43,6 +43,24 @@ function caveProjectsFilePath(): string {
   return process.env.CAVE_PROJECTS_PATH_OVERRIDE ?? path.join(/* turbopackIgnore: true */ caveHome(), "projects.json");
 }
 
+export function validateCaveProjectRoot(value: string): { ok: true; root: string } | { ok: false; error: string } {
+  // Expand ~ first (matching isAllowedNewProjectRoot and cave-projects'
+  // normalizeRoot) so manually-typed ~/code/app roots stay accepted.
+  const root = expandHomeShortcut(value).trim();
+  if (!root) return { ok: false, error: "root is required" };
+  if (!path.isAbsolute(root)) return { ok: false, error: "root must be an absolute path" };
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(/* turbopackIgnore: true */ root);
+  } catch {
+    return { ok: false, error: "root does not exist" };
+  }
+  if (!stat.isDirectory()) return { ok: false, error: "root must be a directory" };
+
+  return { ok: true, root: realpathOrResolve(root) };
+}
+
 function savedCaveProjectRoots(): string[] {
   try {
     const parsed = JSON.parse(fs.readFileSync(/* turbopackIgnore: true */ caveProjectsFilePath(), "utf8")) as {
@@ -51,8 +69,10 @@ function savedCaveProjectRoots(): string[] {
     if (!Array.isArray(parsed.projects)) return [];
     return parsed.projects
       .map((project) => project.root)
-      .filter((root): root is string => typeof root === "string" && path.isAbsolute(root.trim()))
-      .map((root) => root.trim());
+      .filter((root): root is string => typeof root === "string")
+      .map((root) => validateCaveProjectRoot(root))
+      .filter((result): result is { ok: true; root: string } => result.ok)
+      .map((result) => result.root);
   } catch {
     return [];
   }


### PR DESCRIPTION
### Motivation
- Prevent saved Cave project roots from expanding the filesystem allowlist to arbitrary existing files (which allowed reading/overwriting sensitive files).
- Ensure project roots persisted via the API are canonicalized and are legitimate directories before they influence file-browsing or edit routes.

### Description
- Add `validateCaveProjectRoot(value)` in `src/lib/server/project-paths.ts` to require nonempty absolute paths that exist and are directories and return a canonicalized root via `realpathOrResolve` when valid.
- Filter `savedCaveProjectRoots()` through `validateCaveProjectRoot` so only validated directory roots are merged into `ALLOWED_ROOTS` in `project-paths.ts`.
- Harden the project creation `POST /api/projects` handler in `src/app/api/projects/route.ts` to validate roots before persisting and store the canonicalized root when valid.
- Harden the project update `PUT /api/projects/[id]` handler in `src/app/api/projects/[id]/route.ts` to validate replacement roots before persisting.
- Add regression coverage and route-contract assertions in `src/lib/server/project-paths.test.ts` and `src/app/api/projects/route.test.ts` to ensure file paths are rejected and validation is exercised.

### Testing
- Ran the full API test suite with `pnpm test:api` and observed all API tests pass (124 test files reported OK).
- Ran TypeScript checks with `pnpm typecheck` (`tsc --noEmit`) and observed no type errors.
- The modified route/unit tests `project-paths.test.ts` and `projects/route.test.ts` are included in the automated test run and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c95e7c9848327bc5217778c54c4e3)