### PR TITLE
fix(changes): gate single-file diff and revert to git-status entries

### DIFF
--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -133,4 +133,25 @@ assert.match(
   "tool-internal dunder refs (beads' __dolt_remote_info__) stay out of the menu",
 );
 
+assert.match(
+  source,
+  /function isChangedFile[\s\S]*?changedFilePaths[\s\S]*?parsePorcelainZ/,
+  "direct diff/revert requests must be authorized against git status, not guessed ignored files",
+);
+assert.match(
+  source,
+  /function changedFilePaths[\s\S]*?gitStatus\(repoRoot, \["--porcelain=v1", "-z", "--untracked-files=all"\]\)/,
+  "the diff/revert authorization set must come from the hardened gitStatus helper (fsmonitor disabled)",
+);
+assert.match(
+  source,
+  /if \(!\(await isChangedFile\(root\.repoRoot, filePath\)\)\) return pathNotAllowed\(\);/,
+  "single-file diff requests should only serve paths present in git status",
+);
+assert.match(
+  source,
+  /if \(!\(await isChangedFile\(root\.repoRoot, body\.path\)\)\) return pathNotAllowed\(\);/,
+  "revert requests should only operate on paths present in git status",
+);
+
 console.log("changes route.test.ts: ok");

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -300,6 +300,15 @@ async function existsInHead(repoRoot: string, relPath: string): Promise<boolean>
   }
 }
 
+async function changedFilePaths(repoRoot: string): Promise<Set<string>> {
+  const { stdout } = await gitStatus(repoRoot, ["--porcelain=v1", "-z", "--untracked-files=all"]);
+  return new Set(parsePorcelainZ(stdout).map((file) => file.path));
+}
+
+async function isChangedFile(repoRoot: string, relPath: string): Promise<boolean> {
+  return (await changedFilePaths(repoRoot)).has(relPath);
+}
+
 // ── GET: change list / single-file diff ───────────────────────────────────────
 
 async function listChanges(repoRoot: string): Promise<NextResponse> {
@@ -451,6 +460,7 @@ export async function GET(req: NextRequest) {
     if (filePath === null) return await listChanges(root.repoRoot);
     const abs = resolveContainedFile(root.repoRoot, filePath);
     if (!abs) return pathNotAllowed();
+    if (!(await isChangedFile(root.repoRoot, filePath))) return pathNotAllowed();
     return await diffFile(root.repoRoot, filePath, abs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -762,6 +772,7 @@ export async function POST(req: NextRequest) {
   }
   const abs = resolveContainedFile(root.repoRoot, body.path);
   if (!abs) return pathNotAllowed();
+  if (!(await isChangedFile(root.repoRoot, body.path))) return pathNotAllowed();
 
   try {
     // Decide how to revert based on whether the file exists at HEAD. Reverting


### PR DESCRIPTION
### Motivation
- The `/api/changes` handlers allowed client-supplied repo roots and served diffs for any repo-relative path (including ignored/untracked secrets) and could run `git checkout`/`git clean` against any accessible repo, creating an information-disclosure and integrity risk. 
- The intent is to limit single-file diff and destructive revert actions to the same set of files shown by the changes list (the `git status` output) so callers cannot guess ignored files or operate outside the review surface.

### Description
- Add `changedFilePaths` and `isChangedFile` helpers that compute the `git status --porcelain=v1 -z --untracked-files=all` membership set (repo-relative paths) and expose a simple membership predicate. 
- Require `isChangedFile(root.repoRoot, path)` before serving a single-file diff in the GET handler, returning the standard 403 `path not allowed` when the path is not present in `git status`. 
- Require the same `isChangedFile` check before allowing a POST revert operation to proceed, preventing revert/clean/checkout from affecting files not present in the reported changes. 
- Add assertions to `src/app/api/changes/route.test.ts` that pin the new security behavior so the route source must include the status-based guard.

### Testing
- Ran `node --experimental-strip-types src/app/api/changes/route.test.ts` and it passed. 
- Ran `node --experimental-strip-types src/components/debug-pane.test.ts` and it passed. 
- Ran `git diff --check` which produced no issues. 
- Ran `pnpm exec tsc --noEmit` which surfaced unrelated TypeScript resolution/implicit-any issues in `src/components/md-editor/md-editor-visual.tsx` (pre-existing and unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd4ee18088327b5092c88833fad12)