### PR TITLE
fix(security): require sidecar token for Tailscale native app mode

### DIFF
--- a/docs/ios-native-rebuild.md
+++ b/docs/ios-native-rebuild.md
@@ -12,13 +12,14 @@
 >
 > **Owned / in-flight files (treat as a coordinated surface):**
 > - `apps/ios/CovenCave/**` — the native SwiftUI app (views, models, networking, project.yml).
-> - `scripts/mobile-tailscale.sh` — the `app` (tokenless) launch mode, incl. `COVEN_CAVE_TAILNET_TRUST=1`.
+> - `scripts/mobile-tailscale.sh` — the `app` launch mode, incl. `COVEN_CAVE_TAILNET_TRUST=1`
+>   plus the per-launch sidecar token required for `/api/`.
 > - `src/proxy.ts` — the `tailnetTrusted` host-gate branch (security-sensitive).
 > - Tests pinning the above: `src/middleware.test.ts`, `src/proxy-behavior.test.ts`,
 >   `scripts/mobile-tailscale.test.mjs`, `scripts/mobile-tailscale-native.test.mjs`.
 >
 > **Why (concrete history, 2026-06-20):**
-> - #1319 (scaffold + tokenless script) → #1329 (tailnet-trust fix + 18px rounded bubbles).
+> - #1319 (scaffold) → #1329 (tailnet-trust fix + 18px rounded bubbles).
 > - #1354 independently re-did the 18px bubbles; #1343 (a duplicate of the #1319/#1329 work,
 >   branched off an older `main`) then **reverted both #1354's bubbles and #1329's
 >   `COVEN_CAVE_TAILNET_TRUST=1` flag** — the latter silently breaking `pnpm mobile:tailscale:app`
@@ -28,7 +29,7 @@
 > **Rules of engagement:**
 > 1. Branch off the **latest** `origin/main`, not a stale base — most reverts came from old bases.
 > 2. Before changing a file above, confirm no open PR already does it; prefer extending the open PR.
-> 3. If you change the tokenless flow, update **both** the script and its tests in the same PR, and
+> 3. If you change the Tailscale app flow, update **both** the script and its tests in the same PR, and
 >    re-read `src/proxy.ts`'s gate — the `tailnetTrusted` flag is load-bearing for tailnet access.
 > 4. `tailscale serve` forwards the `<host>.ts.net` Host (NOT `127.0.0.1`); do not "simplify" the
 >    host gate back to loopback-only.
@@ -78,22 +79,24 @@ chat streaming all live there. The iOS app is a **first-class client**, not a re
 Rejected: Tauri iOS (still a webview → violates "not a preview"). Rejected: React Native (keeps a
 JS bridge, no real win over the existing web app; the point is native UIKit/SwiftUI feel).
 
-### Trust model — Tailscale-only, no token
+### Trust model — Tailscale plus app token
 
-Replace the per-launch `COVEN_CAVE_ACCESS_TOKEN` / `?covenCaveToken=` gate with **tailnet
-membership = trust**. Concretely, on the desktop server:
+Tailnet membership limits who can reach the desktop server, but it is not a Coven Cave app
+credential. Keep a per-launch `COVEN_CAVE_AUTH_TOKEN` for `/api/` requests so tailnet users cannot
+drive local control APIs unless the iOS app was paired with the printed token. Concretely, on the
+desktop server:
 
 1. **Bind the mobile listener to the Tailscale interface** (the host's `100.x.x.x` address /
    MagicDNS name), not a public `0.0.0.0`. Loopback stays open for the desktop webview.
 2. **Accept requests whose peer source IP is in the Tailscale CGNAT range** (`100.64.0.0/10`) or
-   loopback; reject others. No token in URL, header, or query.
+   loopback; reject others. `/api/` requests still carry the per-launch sidecar token.
 3. This holds across **all transports** — HTTP, SSE, WebSocket — since the prior token gate was
    enforced per-transport (see `feedback_access_gate_entry_points`). Each transport must apply the
    same source-IP check.
 
-Rationale: Tailscale is already a private, authenticated, encrypted mesh; being on the tailnet is
-itself the auth boundary the user wants. This removes the token-in-URL chunk-mangling failure mode
-entirely and makes "open the app, it just connects" possible.
+Rationale: Tailscale is a private, authenticated, encrypted mesh, but tailnet reachability alone is
+too broad for endpoints that can spawn local agent work. The app token is the Coven Cave-specific
+credential for those control APIs.
 
 > Security note to confirm in implementation: trusting source IP requires the server to not be
 > reachable off-tailnet on that listener. We bind to the Tailscale IP specifically; we do **not**
@@ -103,7 +106,7 @@ entirely and makes "open the app, it just connects" possible.
 ## API contract (confirmed — Phase 0 recon)
 
 The native networking layer (`CaveClient` in Swift) targets these. Base URL is the
-host's Tailscale address; no auth header (tailnet is the trust boundary).
+host's Tailscale address; `/api/` calls include the per-launch sidecar token.
 
 - **List familiars:** `GET /api/familiars` → `{ ok, familiars: [...] }`. Each familiar:
   `id`, `display_name`, `role`, `description`, `color`, `status`, `harness`, `model`,
@@ -123,20 +126,19 @@ host's Tailscale address; no auth header (tailnet is the trust boundary).
 
 A buildable, runnable SwiftUI app (iOS 17+, XcodeGen project) covering the Phase 1 UI + client:
 `CaveClient` (REST + `AsyncThrowingStream` SSE parser), `CaveConnection` (host normalisation,
-`.ts.net`→HTTPS / IP→HTTP:3000, no token), `AppModel` + `ChatThread` (single + group fan-out,
+`.ts.net`→HTTPS / IP→HTTP:3000), `AppModel` + `ChatThread` (single + group fan-out,
 on-disk thread persistence), and the views: connection, chats home (roster of threads),
 new-chat/group picker, chat thread (iMessage bubbles + per-familiar attribution + streaming),
 settings. **Verified on the iPhone 16 Pro simulator** against a mock implementing the contract
-above: native render (no webview), familiars loaded tokenlessly, group thread with attributed
+above: native render (no webview), familiars loaded through the paired server, group thread with attributed
 replies.
 
 ### Remaining for Phase 1 (next, separate PRs)
-- **Server: drop the token gate for tailnet traffic.** Relax `proxy.ts` `mobileAccessGate` /
-  sidecar-token enforcement so requests arriving over the Tailscale interface need no token,
-  and update `middleware.test.ts` accordingly. Security-sensitive + touches shared code → its
-  own focused PR (Phase 1b), not bundled with this additive scaffold.
+- **Server: pair native app requests with the printed sidecar token.** Keep `proxy.ts`
+  sidecar-token enforcement for `/api/` while allowing Tailscale Serve's forwarded host through
+  the host gate.
 - **Live streaming send** wired against a real desktop (the SSE client is built; needs the
-  server change above to connect tokenlessly).
+  server pairing above).
 - History load on thread open (client method exists; wire into `ChatView.onAppear`).
 
 ## Phased rollout
@@ -148,7 +150,7 @@ replies.
   does not enter the web CI checks — tracked/built separately).
 
 ### Phase 1 — MVP: seamless single + multi-familiar chat
-The "fully-functional MVP" bar. Native SwiftUI, no token, Tailscale connect.
+The "fully-functional MVP" bar. Native SwiftUI, paired token, Tailscale connect.
 1. **Connection:** discover/enter the host's MagicDNS name or Tailscale IP; persist it; health-check.
    No token. Graceful "can't reach host / not on tailnet" state.
 2. **Familiars list:** fetch + render familiars with avatars (Telegram-style roster).
@@ -159,7 +161,7 @@ The "fully-functional MVP" bar. Native SwiftUI, no token, Tailscale connect.
    prompt to each and shows replies attributed per-familiar (Telegram group feel).
 6. **Polish:** dark theme parity, haptics, pull-to-refresh, keyboard handling, empty/error states.
 
-**Phase 1 done =** install on a real iPhone over Tailscale, no token, chat with one familiar and
+**Phase 1 done =** install on a real iPhone over Tailscale, pair with the printed token, chat with one familiar and
 with a group, streamed replies, survives backgrounding. Verified on simulator + (if available) device.
 
 ### Phase 2 — Depth

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -78,8 +78,8 @@ assert.match(
 // (cookies auto-send cross-origin → CSRF).
 assert.match(
   source,
-  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) && req\.headers\.get\(TOKEN_HEADER\) === sidecarToken/,
-  "origin/referer gate bypass must be keyed to the custom sidecar header token",
+  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) &&\s*req\.headers\.get\(TOKEN_HEADER\) === sidecarToken &&\s*isHeaderCsrfTrustedApiPath\(req\.nextUrl\.pathname\)/,
+  "origin/referer gate bypass must be keyed to the custom sidecar header token and mobile endpoint allowlist",
 );
 assert.match(
   source,
@@ -90,6 +90,16 @@ assert.doesNotMatch(
   source,
   /csrfTrusted\s*=\s*mobileAccessAuthenticated/,
   "cookie-backed mobile-access must NOT bypass the CSRF origin gate",
+);
+assert.match(
+  source,
+  /HEADER_CSRF_TRUSTED_API_PATHS = new Set\(\["\/api\/mobile-handoff", "\/api\/mobile-token\/refresh"\]\)/,
+  "header-token CSRF relaxation must be limited to explicitly mobile-capable APIs",
+);
+assert.doesNotMatch(
+  source,
+  /HEADER_CSRF_TRUSTED_API_PATHS[\s\S]*codex-automations|HEADER_CSRF_TRUSTED_API_PATHS[\s\S]*\/api\/inbox/,
+  "local-only APIs must not be included in the header-token CSRF allowlist",
 );
 
 // Ordering guard: dev-mode token-bypass (NextResponse.next() when no token is set)

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -173,6 +173,16 @@ assert.match(
 assert.doesNotMatch(sidecarMonitorSource, /Boolean\(window\.__TAURI_INTERNALS__\)/, "mobile Tauri should not be treated as a sidecar host");
 assert.match(mobileScriptSource, /tailscale_cmd serve --bg "\$TAILSCALE_BACKEND"/, "mobile script should publish the exact loopback backend it started");
 assert.match(mobileScriptSource, /"authorization": `Bearer \$\{createMobileAccessToken\(accessToken\)\}`/, "mobile script should authenticate its local invite API request with a derived token");
+assert.match(
+  mobileScriptSource,
+  /CAVE_MOBILE_APP:-0[\s\S]*COVEN_CAVE_AUTH_TOKEN=.*SIDECAR_TOKEN_FILE/,
+  "native app Tailscale mode should start Next.js with a sidecar API token",
+);
+assert.doesNotMatch(
+  mobileScriptSource,
+  /Native iOS app is ready — no token required/,
+  "native app Tailscale mode must not advertise tokenless API access",
+);
 assert.match(nextConfigSource, /allowedDevOrigins:\s*\[[\s\S]*"\*\*\.ts\.net"/, "Next dev should allow Tailscale Serve origins for mobile browser access");
 assert.match(nextConfigSource, /devIndicators:\s*false/, "Next dev tools launcher should not intercept mobile bottom-tab taps");
 assert.match(mobileDocsSource, /signed (?:expiring )?invites?/, "mobile docs should describe the signed access token invite");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -141,6 +141,12 @@ function isLocalOnlyAutomationRun(pathname: string, method: string) {
   return method === "POST" && /^\/api\/codex-automations\/[^/]+\/run$/.test(pathname);
 }
 
+const HEADER_CSRF_TRUSTED_API_PATHS = new Set(["/api/mobile-handoff", "/api/mobile-token/refresh"]);
+
+function isHeaderCsrfTrustedApiPath(pathname: string) {
+  return HEADER_CSRF_TRUSTED_API_PATHS.has(pathname);
+}
+
 function isProductionWebhookGet(pathname: string, method: string) {
   return (
     method === "GET" &&
@@ -211,19 +217,20 @@ export async function proxy(req: NextRequest) {
 
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
   // A request bearing the sidecar token in the CUSTOM HEADER (x-coven-cave-token)
-  // is provably first-party: a browser cannot set a custom header on a
-  // cross-origin request (it forces a CORS preflight the server never approves),
-  // so such a request cannot be CSRF regardless of its Origin. Tailscale Serve
-  // terminates TLS and proxies to loopback, forwarding `Host: 127.0.0.1`, so a
-  // legitimately-authenticated WKWebView request keeps its real
-  // https://<machine>.ts.net identity only in the Origin header — which otherwise
-  // fails the same-origin gate and 403s every mutating request as "forbidden
-  // origin" (fixed in #618; #716 reverted it and re-broke mobile-over-Serve).
+  // can be sent by native/mobile clients over Tailscale Serve, where the proxy
+  // forwards `Host: 127.0.0.1` but preserves the real ts.net source in Origin.
+  // Only explicitly mobile-capable API routes may use that header to relax the
+  // Origin/Referer gate. Local-only routes such as automation and inbox APIs
+  // rely on their route-level loopback Host checks, so they must still fail
+  // closed when a remote Serve origin reaches the loopback backend.
   // Scope is deliberately the header ONLY: NOT the access cookie (auto-sent
   // cross-origin → CSRF) and NOT the query/referer token paths. The token value
-  // is still validated below; this only relaxes the CSRF source gate.
+  // is still validated below; this only relaxes the CSRF source gate for the
+  // allowlisted mobile endpoints.
   const headerCsrfTrusted =
-    Boolean(sidecarToken) && req.headers.get(TOKEN_HEADER) === sidecarToken;
+    Boolean(sidecarToken) &&
+    req.headers.get(TOKEN_HEADER) === sidecarToken &&
+    isHeaderCsrfTrustedApiPath(req.nextUrl.pathname);
 
   if (!headerCsrfTrusted) {
     const origin = req.headers.get("origin");


### PR DESCRIPTION
### Motivation
- A newly added Tailscale launcher could publish the local dev server to the tailnet without any Coven Cave token or verification, exposing privileged `/api/*` routes that can spawn local agent processes.  
- Reusing an already-listening port risked exposing unrelated services via `tailscale serve` if the port was occupied.  
- The change hardens the mobile app flow so tailnet reachability alone cannot drive local control APIs.

### Description
- Update `scripts/mobile-tailscale.sh` so app mode starts Next.js with a per-launch sidecar API token by exporting `COVEN_CAVE_AUTH_TOKEN` from the persisted `SIDECAR_TOKEN_FILE` for both `tmux` and `nohup` launch paths.  
- Ensure `start_next_server` will create/load the sidecar token in app mode, refuse to reuse recorded native-app servers that lack a persisted sidecar token, and avoid reusing ports that may belong to a different (token-gated) server.  
- Change the `app` invite output to print both the Serve address and the per-launch sidecar token (instead of advertising tokenless access).  
- Add source-level assertions in `src/middleware.test.ts` that the mobile script starts Next.js with the sidecar token and no longer advertises tokenless API access.  
- Update `docs/ios-native-rebuild.md` to document the revised trust model: Tailscale reachability plus a paired per-launch sidecar token for `/api/` requests.

### Testing
- Ran the app test suite with `pnpm test:app` and all app tests passed (561 test files).  
- Executed `node src/middleware.test.ts` to validate the updated source-level assertions and it completed successfully.  
- Ran `git diff --check` to verify no whitespace/format issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cfe8b10c08327b52660c0d1778c07)