### PR TITLE
fix(security): narrow project path allowlist

### DIFF
--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -33,14 +33,15 @@ try {
   delete process.env.COVEN_WORKSPACE_ROOT;
   delete process.env.WORKSPACE_ROOT;
   delete process.env.NEXT_PUBLIC_WORKSPACE_ROOT;
-  delete process.env.OPENCLAW_WORKSPACE_ROOT;
-
   const canonical = path.join(process.env.COVEN_HOME, "workspaces", "familiars", "sage");
   const savedProjectRoot = path.join(tmp, "Documents", "GitHub", "OpenCoven", "coven-docs");
+  const openclawWorkspaceRoot = path.join(tmp, ".openclaw", "workspace");
+  process.env.OPENCLAW_WORKSPACE_ROOT = openclawWorkspaceRoot;
   await mkdir(canonical, { recursive: true });
   const sensitiveFileRoot = path.join(tmp, "sensitive-config");
   await mkdir(path.join(savedProjectRoot, "docs"), { recursive: true });
   await writeFile(sensitiveFileRoot, "SECRET\n");
+  await mkdir(path.join(openclawWorkspaceRoot, "agent-other", "private"), { recursive: true });
   await writeFile(
     process.env.CAVE_PROJECTS_PATH_OVERRIDE,
     JSON.stringify({
@@ -139,6 +140,12 @@ try {
     validateCaveProjectRoot(sensitiveFileRoot),
     { ok: false, error: "root must be a directory" },
     "project roots must be existing directories",
+  );
+
+  assert.equal(
+    resolveAllowedProjectPath(path.join(openclawWorkspaceRoot, "agent-other", "private", "secrets.json")),
+    null,
+    "OpenClaw workspace roots are not globally allowed for generic project file/tree APIs",
   );
 } finally {
   restoreEnv();

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -87,9 +87,6 @@ function builtInProjectRoots(): string[] {
     process.env.WORKSPACE_ROOT,
     process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
     covenWorkspaceRoot(),
-    // Allow openclaw workspace roots so workspace readers can load familiar research dirs.
-    process.env.OPENCLAW_WORKSPACE_ROOT,
-    path.join(/* turbopackIgnore: true */ homedir(), ".openclaw", "workspace"),
     process.cwd(),
     // Research mission workspaces host bounded research sessions and live
     // under cave state rather than a registered project root.


### PR DESCRIPTION
### Motivation

- A previous change added `OPENCLAW_WORKSPACE_ROOT` and `~/.openclaw/workspace` to the global project path allowlist used by `resolveAllowedProjectPath`, which unintentionally allowed generic project file/tree APIs to enumerate and read files under the OpenClaw workspace.

### Description

- Remove `process.env.OPENCLAW_WORKSPACE_ROOT` and `path.join(homedir(), ".openclaw", "workspace")` from the shared `ALLOWED_ROOTS` in `src/lib/server/project-paths.ts` so OpenClaw roots are not globally trusted by generic project APIs.
- Add a regression assertion to `src/lib/server/project-paths.test.ts` that sets `OPENCLAW_WORKSPACE_ROOT`, creates a temp OpenClaw workspace, and asserts `resolveAllowedProjectPath` returns `null` for a file under that OpenClaw path while preserved Cave project roots remain allowed.
- Affected files: `src/lib/server/project-paths.ts` and `src/lib/server/project-paths.test.ts`.

### Testing

- Ran the full API test suite with `pnpm test:api`, and the test run completed successfully with all API tests passing (126 test files).
- The added regression is exercised by the updated `project-paths.test.ts` and is included in the test run above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d087d95f083278233283881ced3de)