### PR TITLE
fix(chat): suppress startup blocks before exec echo parsing

### DIFF
--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -39,6 +39,36 @@ assert.equal(
   "startup prompt blocks after the assistant marker should stay hidden",
 );
 
+
+assert.equal(
+  feed([
+    "codex",
+    "<INSTRUCTIONS>",
+    "exec",
+    "[click me](javascript:globalThis.__COVEN_POC=1)",
+    "</INSTRUCTIONS>",
+    "Visible reply",
+  ]),
+  "Visible reply\n",
+  "exec header bailout inside startup blocks should not leak hidden content",
+);
+
+assert.equal(
+  feed([
+    "codex",
+    "<INSTRUCTIONS>",
+    "exec",
+    "/bin/zsh -lc 'cat AGENTS.md' in /repo",
+    " exited 0 in 12ms:",
+    "",
+    "[click me](javascript:globalThis.__COVEN_POC=1)",
+    "</INSTRUCTIONS>",
+    "Visible reply",
+  ]),
+  "Visible reply\n",
+  "exec output resume inside startup blocks should not leak hidden content",
+);
+
 assert.equal(
   feed([
     "claude",

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -148,6 +148,27 @@ export class AssistantFilter {
     }
     if (this.phase !== "assistant") return "";
 
+    // Startup prompt echoes are always hidden before any other assistant-output
+    // heuristics run. In particular, an attacker-controlled startup block may
+    // contain lines that look like exec-echo state transitions; those must not
+    // be allowed to enter the exec parser and later bail out as visible prose.
+    if (this.suppressedStartupTag) {
+      const tag = startupBlockTag(trimmed);
+      if (tag?.closing && tag.tag === this.suppressedStartupTag) {
+        this.suppressedStartupTag = null;
+      }
+      return "";
+    }
+
+    const startupTag = startupBlockTag(trimmed);
+    if (startupTag && !startupTag.closing) {
+      this.suppressedStartupTag = startupTag.tag;
+      return "";
+    }
+    if (startupTag?.closing || isStartupNoiseLine(trimmed)) {
+      return "";
+    }
+
     // ── Exec-echo block detection ─────────────────────────────────────────
     // State machine: none → header → cmdline → output
     // We suppress the entire block from the saved assistant text.
@@ -238,23 +259,6 @@ export class AssistantFilter {
 
     if (isLeakedSkillDocBodyLine(trimmed)) {
       this.suppressLeakedSkillBody = true;
-      return "";
-    }
-
-    if (this.suppressedStartupTag) {
-      const tag = startupBlockTag(trimmed);
-      if (tag?.closing && tag.tag === this.suppressedStartupTag) {
-        this.suppressedStartupTag = null;
-      }
-      return "";
-    }
-
-    const tag = startupBlockTag(trimmed);
-    if (tag && !tag.closing) {
-      this.suppressedStartupTag = tag.tag;
-      return "";
-    }
-    if (tag?.closing || isStartupNoiseLine(trimmed)) {
       return "";
     }
 


### PR DESCRIPTION
### Motivation
- A newly added exec-echo state machine could parse lines from hidden startup blocks before those blocks were suppressed, allowing attacker-controlled startup content to be emitted through exec bailout/resume paths and reach trusted HTML rendering.
- Prevent leaking content from suppressed startup tags (e.g., `<INSTRUCTIONS>`) into assistant output and persisted conversation history.

### Description
- Move startup-block suppression to run before the exec-echo parser in `AssistantFilter` so suppressed startup lines are always dropped prior to any exec state transitions.
- Add two regression tests to `src/lib/chat-assistant-filter.test.ts` that assert `exec` header-bailout and exec-output-resume attempts inside a suppressed `<INSTRUCTIONS>` block do not leak visible assistant text.
- Modified files: `src/lib/chat-assistant-filter.ts` and `src/lib/chat-assistant-filter.test.ts`.

### Testing
- Ran the targeted test file with `node --experimental-strip-types src/lib/chat-assistant-filter.test.ts` and the new assertions passed.
- Ran the full app test suite with `pnpm test:app` (all test files passed) and `pnpm typecheck` which completed without errors.
- Ran `git diff --check` to validate formatting and whitespace issues and found no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0905bcb88327be85d6df07ead487)