### PR TITLE
Validate GitHub username and harden .env.local upserts to prevent injection

### DIFF
--- a/src/app/api/github/pat/route.ts
+++ b/src/app/api/github/pat/route.ts
@@ -24,6 +24,16 @@ export const runtime = "nodejs";
 
 const PAT_KEY = "GITHUB_PAT";
 const LOGIN_KEY = "GITHUB_USERNAME";
+const GITHUB_USERNAME_PATTERN = /^[A-Za-z0-9-]{1,39}$/;
+
+function isValidGitHubUsername(username: string): boolean {
+  return (
+    GITHUB_USERNAME_PATTERN.test(username) &&
+    !username.startsWith("-") &&
+    !username.endsWith("-") &&
+    !username.includes("--")
+  );
+}
 
 /** Apply key updates to .env.local in place. `null` deletes a key. Comments,
  *  blank lines, key ordering, and unrelated values are preserved (the old
@@ -84,6 +94,9 @@ export async function POST(req: NextRequest) {
 
   if (!pat && !username) {
     return NextResponse.json({ ok: false, error: "pat or username is required" }, { status: 400 });
+  }
+  if (username && !isValidGitHubUsername(username)) {
+    return NextResponse.json({ ok: false, error: "username must be a valid GitHub username" }, { status: 400 });
   }
 
   let login: string | null = username || null;

--- a/src/lib/env-file.test.ts
+++ b/src/lib/env-file.test.ts
@@ -58,4 +58,13 @@ const { upsertEnvContent } = await import("./env-file.ts");
   assert.equal(upsertEnvContent("ONLY=x\n", { ONLY: null }), "");
 }
 
+// Reject values containing newlines so caller-supplied values cannot inject
+// additional KEY=value entries into .env.local.
+{
+  assert.throws(
+    () => upsertEnvContent("", { GITHUB_USERNAME: "alice\nWORKSPACE_ROOT=/" }),
+    /must not contain newlines/,
+  );
+}
+
 console.log("env-file.test.ts: all assertions passed");

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -97,6 +97,15 @@ export function readEnvLocalValue(key: string): string | undefined {
  * appended, a `null` value deletes its key, and every other line is preserved
  * byte-for-byte.
  */
+function assertEnvAssignmentSafe(key: string, value: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    throw new Error(`invalid env key: ${key}`);
+  }
+  if (/[\r\n]/.test(value)) {
+    throw new Error(`env value for ${key} must not contain newlines`);
+  }
+}
+
 export function upsertEnvContent(existing: string, updates: Record<string, string | null>): string {
   const lines = existing === "" ? [] : existing.split("\n");
   // Drop a single trailing empty line (from a trailing newline) so appended
@@ -122,12 +131,14 @@ export function upsertEnvContent(existing: string, updates: Record<string, strin
     const val = remaining.get(key)!;
     remaining.delete(key);
     if (val === null) continue; // delete: drop this line
+    assertEnvAssignmentSafe(key, val);
     out.push(`${key}=${val}`);
   }
 
   // Append keys that weren't already present (skip deletes for absent keys).
   for (const [key, val] of remaining) {
     if (val === null) continue;
+    assertEnvAssignmentSafe(key, val);
     out.push(`${key}=${val}`);
   }
 


### PR DESCRIPTION
### Motivation
- The username-only GitHub setup flow allowed unvalidated `username.trim()` values to be written into `.env.local`, which enabled newline-based env injection (e.g. `alice\nWORKSPACE_ROOT=/`) and expansion of trusted roots. 
- Prevent persistent environment-variable injection while preserving the existing username-only convenience for valid GitHub usernames.

### Description
- Add GitHub username syntax validation via `isValidGitHubUsername` and reject invalid usernames in `src/app/api/github/pat/route.ts` before persisting them. 
- Add `assertEnvAssignmentSafe` in `src/lib/env-file.ts` that rejects invalid env keys and values containing newlines, and invoke it for both in-place replacements and appended keys. 
- Add a regression assertion in `src/lib/env-file.test.ts` that verifies newline-containing values (e.g. `alice\nWORKSPACE_ROOT=/`) are rejected instead of being serialized into `.env.local`.

### Testing
- Ran TypeScript checks with `pnpm exec tsc --noEmit --pretty false` which succeeded. 
- Ran the env-file unit assertions with `node --experimental-strip-types src/lib/env-file.test.ts` which printed success. 
- `bd` (Beads) CLI could not be executed in this environment, so `bd prime`/`bd ready` were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d0e2fc76c8327b558c7afd040079f)