### PR TITLE
Avoid exposing Apple notarization password

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -44,6 +44,10 @@ test("Apple ID notarization avoids putting the app password in process arguments
   assert.match(releaseScript, /security delete-keychain "\$NOTARY_KEYCHAIN_PATH"/);
   assert.match(releaseScript, /rm -rf "\$NOTARY_KEYCHAIN_DIR"/);
 
+  const cleanupFunction = releaseScript.slice(
+    releaseScript.indexOf("cleanup_release_artifacts()"),
+    releaseScript.indexOf("trap cleanup_release_artifacts EXIT"),
+  );
   const setupFunctions = releaseScript.slice(
     releaseScript.indexOf("store_notary_credentials()"),
     releaseScript.indexOf("print_notary_log()"),
@@ -57,6 +61,15 @@ test("Apple ID notarization avoids putting the app password in process arguments
     releaseScript.indexOf("cleanup_dmg_artifacts()"),
   );
 
+  assert.match(cleanupFunction, /local exit_status=\$\?/);
+  assert.match(cleanupFunction, /rm -rf "\$NOTARY_KEYCHAIN_DIR" \|\| true/);
+  assert.match(cleanupFunction, /rm -rf "\$DMG_STAGE" \|\| true/);
+  assert.match(cleanupFunction, /return "\$exit_status"/);
+  assert(
+    cleanupFunction.indexOf('security delete-keychain "$NOTARY_KEYCHAIN_PATH"') <
+      cleanupFunction.indexOf('rm -rf "$DMG_STAGE"'),
+    "credential cleanup must run before best-effort DMG cleanup",
+  );
   assert.doesNotMatch(setupFunctions, /--password/);
   assert.doesNotMatch(logFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);
   assert.doesNotMatch(submitFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -35,6 +35,33 @@ test("sidecar bundle restores executable mode for node-pty spawn-helper", () => 
   assert.match(sidecarScript, /fix_node_pty_spawn_helpers "\$DEST\/node_modules"/);
 });
 
+test("Apple ID notarization avoids putting the app password in process arguments", () => {
+  assert.match(releaseScript, /setup_notary_keychain_profile\(\)/);
+  assert.match(releaseScript, /printf '%s\\n' "\$NOTARY_APPLE_PASSWORD" \| xcrun notarytool store-credentials/);
+  assert.match(releaseScript, /retry 3 10 store_notary_credentials/);
+  assert.match(releaseScript, /NOTARY_KEYCHAIN_DIR="\$\(mktemp -d -t covencave-notary-keychain\)"/);
+  assert.match(releaseScript, /--keychain-profile "\$NOTARY_KEYCHAIN_PROFILE"/);
+  assert.match(releaseScript, /security delete-keychain "\$NOTARY_KEYCHAIN_PATH"/);
+  assert.match(releaseScript, /rm -rf "\$NOTARY_KEYCHAIN_DIR"/);
+
+  const setupFunctions = releaseScript.slice(
+    releaseScript.indexOf("store_notary_credentials()"),
+    releaseScript.indexOf("print_notary_log()"),
+  );
+  const logFunction = releaseScript.slice(
+    releaseScript.indexOf("print_notary_log()"),
+    releaseScript.indexOf("run_notary_submit()"),
+  );
+  const submitFunction = releaseScript.slice(
+    releaseScript.indexOf("run_notary_submit()"),
+    releaseScript.indexOf("cleanup_dmg_artifacts()"),
+  );
+
+  assert.doesNotMatch(setupFunctions, /--password/);
+  assert.doesNotMatch(logFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);
+  assert.doesNotMatch(submitFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);
+});
+
 test("notary rejection stops before stapling and prints the Apple log", () => {
   assert.match(releaseScript, /print_notary_log\(\)/);
   assert.match(releaseScript, /Submission in terminal status: Invalid/);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,15 +53,18 @@ retry() {
 }
 
 cleanup_release_artifacts() {
-  if [ -n "${DMG_STAGE:-}" ]; then
-    rm -rf "$DMG_STAGE"
-  fi
+  local exit_status=$?
+
   if [ -n "${NOTARY_KEYCHAIN_PATH:-}" ]; then
     security delete-keychain "$NOTARY_KEYCHAIN_PATH" >/dev/null 2>&1 || true
   fi
   if [ -n "${NOTARY_KEYCHAIN_DIR:-}" ]; then
-    rm -rf "$NOTARY_KEYCHAIN_DIR"
+    rm -rf "$NOTARY_KEYCHAIN_DIR" || true
   fi
+  if [ -n "${DMG_STAGE:-}" ]; then
+    rm -rf "$DMG_STAGE" || true
+  fi
+  return "$exit_status"
 }
 trap cleanup_release_artifacts EXIT
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,6 +17,10 @@ NOTARY_ISSUER="${NOTARY_ISSUER:-${APPLE_API_ISSUER:-}}"
 NOTARY_APPLE_ID="${NOTARY_APPLE_ID:-${APPLE_ID:-}}"
 NOTARY_APPLE_PASSWORD="${NOTARY_APPLE_PASSWORD:-${APPLE_PASSWORD:-}}"
 NOTARY_TEAM_ID="${NOTARY_TEAM_ID:-${APPLE_TEAM_ID:-}}"
+NOTARY_KEYCHAIN_PROFILE=""
+NOTARY_KEYCHAIN_DIR=""
+NOTARY_KEYCHAIN_PATH=""
+DMG_STAGE=""
 NODE_ENTITLEMENTS="src-tauri/entitlements/node.plist"
 
 require_tool() {
@@ -47,6 +51,46 @@ retry() {
     n=$((n + 1))
   done
 }
+
+cleanup_release_artifacts() {
+  if [ -n "${DMG_STAGE:-}" ]; then
+    rm -rf "$DMG_STAGE"
+  fi
+  if [ -n "${NOTARY_KEYCHAIN_PATH:-}" ]; then
+    security delete-keychain "$NOTARY_KEYCHAIN_PATH" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${NOTARY_KEYCHAIN_DIR:-}" ]; then
+    rm -rf "$NOTARY_KEYCHAIN_DIR"
+  fi
+}
+trap cleanup_release_artifacts EXIT
+
+store_notary_credentials() {
+  # Refill stdin on every retry without ever exposing the password in argv.
+  printf '%s\n' "$NOTARY_APPLE_PASSWORD" | xcrun notarytool store-credentials "$NOTARY_KEYCHAIN_PROFILE" \
+    --apple-id "$NOTARY_APPLE_ID" \
+    --team-id "$NOTARY_TEAM_ID" \
+    --keychain "$NOTARY_KEYCHAIN_PATH"
+}
+
+setup_notary_keychain_profile() {
+  local keychain_password
+
+  NOTARY_KEYCHAIN_PROFILE="covencave-notary-$$"
+  NOTARY_KEYCHAIN_DIR="$(mktemp -d -t covencave-notary-keychain)"
+  NOTARY_KEYCHAIN_PATH="$NOTARY_KEYCHAIN_DIR/notary.keychain-db"
+  keychain_password="$(openssl rand -hex 24)"
+
+  echo "==> Creating temporary notarytool keychain profile"
+  security create-keychain -p "$keychain_password" "$NOTARY_KEYCHAIN_PATH"
+  security set-keychain-settings -lut 21600 "$NOTARY_KEYCHAIN_PATH"
+  security unlock-keychain -p "$keychain_password" "$NOTARY_KEYCHAIN_PATH"
+
+  # Feed the app-specific password on stdin so it never appears in process
+  # arguments. Submit/log commands reference only this temporary keychain
+  # profile, which the EXIT trap deletes after the release run.
+  retry 3 10 store_notary_credentials
+}
 print_notary_log() {
   local submission_id="$1"
 
@@ -59,9 +103,8 @@ print_notary_log() {
   set +e
   if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
     xcrun notarytool log "$submission_id" \
-      --apple-id "$NOTARY_APPLE_ID" \
-      --password "$NOTARY_APPLE_PASSWORD" \
-      --team-id "$NOTARY_TEAM_ID"
+      --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" \
+      --keychain "$NOTARY_KEYCHAIN_PATH"
   else
     xcrun notarytool log "$submission_id" \
       --key "$NOTARY_KEY_FILE" \
@@ -84,9 +127,8 @@ run_notary_submit() {
   set +e
   if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
     xcrun notarytool submit "$DMG_PATH" \
-      --apple-id "$NOTARY_APPLE_ID" \
-      --password "$NOTARY_APPLE_PASSWORD" \
-      --team-id "$NOTARY_TEAM_ID" \
+      --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" \
+      --keychain "$NOTARY_KEYCHAIN_PATH" \
       --no-s3-acceleration \
       --verbose \
       --wait 2>&1 | tee "$output"
@@ -269,7 +311,10 @@ else
   exit 1
 fi
 
-if [ "$NOTARY_AUTH_MODE" = "api-key" ]; then
+if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
+  require_tool security
+  setup_notary_keychain_profile
+elif [ "$NOTARY_AUTH_MODE" = "api-key" ]; then
   require_file "$NOTARY_KEY_FILE"
   echo "==> Validating App Store Connect API key"
   openssl pkey -in "$NOTARY_KEY_FILE" -noout -check >/dev/null
@@ -362,7 +407,6 @@ echo "==> Packaging DMG with Applications shortcut"
 # tend to double-click the .app inside the mounted DMG, which causes macOS to
 # AppTranslocate the bundle into a sandbox path.
 DMG_STAGE=$(mktemp -d -t covencave-dmg)
-trap 'rm -rf "$DMG_STAGE"' EXIT
 cp -R "$APP_PATH" "$DMG_STAGE/"
 ln -s /Applications "$DMG_STAGE/Applications"
 mkdir -p "$DMG_STAGE/.background"


### PR DESCRIPTION
### Motivation

- The Apple app-specific password was previously passed to `xcrun notarytool` via `--password`, which exposes it in process arguments and risks local credential disclosure on CI or developer machines.

### Description

- Introduce `NOTARY_KEYCHAIN_PROFILE` and `NOTARY_KEYCHAIN_PATH` and add `setup_notary_keychain_profile()` to create a temporary keychain profile and feed the app-specific password to `xcrun notarytool store-credentials` on stdin so the password never appears in argv. 
- Update `run_notary_submit()` and `print_notary_log()` to use `--keychain-profile` and `--keychain` for Apple ID auth instead of `--apple-id/--password/--team-id`. 
- Add `cleanup_release_artifacts()` and an `EXIT` trap to remove the temporary keychain and DMG staging directory after the release run. 
- Add a regression test in `scripts/release-macos-signing.test.mjs` to assert the new keychain-based flow is present and that `--password` is no longer used in the Apple ID notarization code paths.

### Testing

- Ran a shell syntax check with `bash -n scripts/release.sh`, which succeeded.
- Ran the macOS release signing tests with `node scripts/release-macos-signing.test.mjs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d1504c1cc83279dc0e2da71ef88bd)