### PR TITLE
test: isolate COVEN_HOME in cave-inbox-bulk + knowledge-packs tests (hermeticity)

### DIFF
--- a/src/lib/cave-inbox-bulk.test.ts
+++ b/src/lib/cave-inbox-bulk.test.ts
@@ -9,7 +9,13 @@ import os from "node:os";
 import path from "node:path";
 
 const tmpHome = mkdtempSync(path.join(os.tmpdir(), "cave-inbox-bulk-"));
-process.env.COVEN_CAVE_HOME = tmpHome;
+// COVEN_HOME must move too: the store gate (withCaveHomeReconciledStore)
+// scans `covenHome()` for legacy cave-*.json entries, so pointing only
+// COVEN_CAVE_HOME at a temp dir still reads the developer's real ~/.coven —
+// and fails outright when its compatibility symlinks target the real
+// canonical dir instead of the temp one (cave-spqh).
+process.env.COVEN_HOME = path.join(tmpHome, ".coven");
+process.env.COVEN_CAVE_HOME = path.join(tmpHome, "cave");
 
 // Import AFTER the env override — INBOX_PATH is computed at module load.
 const { applyBulkAction, createItem, loadInbox } = await import("./cave-inbox.ts");

--- a/src/lib/server/knowledge-packs.test.ts
+++ b/src/lib/server/knowledge-packs.test.ts
@@ -11,10 +11,15 @@ const prevPlugins = process.env.COVEN_MARKETPLACE_PLUGINS_DIR;
 const prevVault = process.env.COVEN_KNOWLEDGE_DIR;
 const prevProjects = process.env.CAVE_PROJECTS_PATH_OVERRIDE;
 const prevCaveHome = process.env.COVEN_CAVE_HOME;
+const prevCovenHome = process.env.COVEN_HOME;
 process.env.COVEN_MARKETPLACE_PLUGINS_DIR = path.join(scratchRoot, "plugins");
 process.env.COVEN_KNOWLEDGE_DIR = path.join(scratchRoot, "vault");
 process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(scratchRoot, "projects.json");
 process.env.COVEN_CAVE_HOME = path.join(scratchRoot, "cave-home");
+// The projects store's reconciliation gate scans `covenHome()` for legacy
+// entries; leave that at the real ~/.coven and the test reads (and can fail
+// on) the developer's live state (cave-spqh).
+process.env.COVEN_HOME = path.join(scratchRoot, ".coven");
 
 try {
   const packDir = path.join(process.env.COVEN_MARKETPLACE_PLUGINS_DIR, "worldbuilding");
@@ -140,6 +145,7 @@ try {
   if (prevVault === undefined) delete process.env.COVEN_KNOWLEDGE_DIR; else process.env.COVEN_KNOWLEDGE_DIR = prevVault;
   if (prevProjects === undefined) delete process.env.CAVE_PROJECTS_PATH_OVERRIDE; else process.env.CAVE_PROJECTS_PATH_OVERRIDE = prevProjects;
   if (prevCaveHome === undefined) delete process.env.COVEN_CAVE_HOME; else process.env.COVEN_CAVE_HOME = prevCaveHome;
+  if (prevCovenHome === undefined) delete process.env.COVEN_HOME; else process.env.COVEN_HOME = prevCovenHome;
   await rm(scratchRoot, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
## What

`cave-inbox-bulk.test.ts` and `knowledge-packs.test.ts` isolated `COVEN_CAVE_HOME` into a temp dir but left `COVEN_HOME` pointing at the real `~/.coven`. The store gate (`withCaveHomeReconciledStore`) scans `covenHome()` for legacy `cave-*.json` entries — so on any dev machine whose live `~/.coven` carries compatibility symlinks, the reconciliation preflight throws `legacy symlink does not target canonical storage` and **`pnpm test:app` aborts at file 72** before the rest of the suite runs. CI never sees it (clean runner homes), which is why this hid.

Fix: point `COVEN_HOME` at the scratch root too (same convention as `cave-home-migration.test.ts`), and restore it in knowledge-packs' env cleanup.

## Audit

Checked every test that sets `COVEN_CAVE_HOME` without `COVEN_HOME`:
- `cave-inbox-bulk.test.ts` — fixed
- `knowledge-packs.test.ts` — fixed (same failure signature confirmed)
- `server-heap-monitor.test.ts` — unaffected (spawns child with explicit env allowlist)

## Verification

On the machine that reproduced the failure:
- both tests: **fail on old source → pass with fix** (exact env, same invocation)
- full `pnpm test:app`: **749/749 files pass** (previously aborted at 72)
- `pnpm typecheck` clean

Bead: `cave-spqh` (discovered during cave-n3e2 / PR #3312)