### PR TITLE
feat(design): P3 token-drift codemod + drift gate — 1580 px literals → tokens

### DIFF
--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -294,7 +294,10 @@ stays reachable in ≤2 interactions.
 ## 9. Shipping checklist for a new surface
 
 1. Tokens only — no hardcoded colors, radii, or font sizes; verify in dark
-   *and* light, plus one non-default theme.
+   *and* light, plus one non-default theme. On-scale px literals are
+   auto-fixable: `node scripts/codemods/tokenize-css.mjs` (enforced, with
+   drift ratchets for the judgment cases, by
+   `src/lib/design-token-drift.test.ts`).
 2. Reuse the primitives (`src/components/ui/`: Button, EmptyState, Skeleton,
    Popover, Modal, ViewHeader, SearchInput…) before writing new ones.
 3. Chrome within budget (§8): ≤3 always-visible actions + one `OverflowMenu`;

--- a/scripts/codemods/tokenize-css.mjs
+++ b/scripts/codemods/tokenize-css.mjs
@@ -3,7 +3,8 @@
 // Rewrites exact on-scale px literals in src CSS to the sanctioned tokens
 // from `src/app/globals.css` (design-language checklist rule 1: tokens only):
 //
-//   font-size:      10/11/12/13/14/16/20/28px  -> var(--text-*)
+//   font-size:      10/11/12/13/14/20/28px     -> var(--text-*)
+//                   (16px stays literal — iOS anti-zoom floor, see below)
 //   padding/margin/gap family: 4px grid values -> var(--space-*)
 //   border-radius:  8/12/16/999px              -> var(--radius-*)
 //
@@ -183,7 +184,8 @@ export function cssFilesInScope() {
   const walk = (dir) => {
     for (const entry of readdirSync(dir)) {
       const full = path.join(dir, entry);
-      const rel = path.relative(repoRoot, full);
+      // POSIX-normalize so EXCLUDED_PATHS ("/"-separated) works on Windows.
+      const rel = path.relative(repoRoot, full).split(path.sep).join("/");
       if (EXCLUDED_PATHS.some((p) => (rel + "/").startsWith(p) || rel.startsWith(p))) continue;
       if (statSync(full).isDirectory()) walk(full);
       else if (entry.endsWith(".css")) out.push(rel);

--- a/scripts/codemods/tokenize-css.mjs
+++ b/scripts/codemods/tokenize-css.mjs
@@ -1,0 +1,227 @@
+// Design-token codemod — Cave UX P3 (Sage's 2026-07-03 audit, tier P3).
+//
+// Rewrites exact on-scale px literals in src CSS to the sanctioned tokens
+// from `src/app/globals.css` (design-language checklist rule 1: tokens only):
+//
+//   font-size:      10/11/12/13/14/16/20/28px  -> var(--text-*)
+//   padding/margin/gap family: 4px grid values -> var(--space-*)
+//   border-radius:  8/12/16/999px              -> var(--radius-*)
+//
+// Every mapping is value-preserving by construction: each token is *defined*
+// as that exact px value (pinned against the live globals.css definitions by
+// `src/lib/design-token-drift.test.ts`, which also asserts this codemod is a
+// no-op over the tree — the "no new on-scale literals" gate).
+//
+// What it deliberately leaves alone:
+//   - custom-property definition lines (`--foo: 12px;`) — token definitions
+//     are the sanctioned place for literals;
+//   - off-scale values (6px, 10.5px, …) — those need design judgment, and
+//     stay visible in the drift ratchet instead;
+//   - values inside calc()/max()/var() fallbacks, negative values, and
+//     multi-line or commented declarations;
+//   - `src/app/mockup/` (standalone mockup with its own token copy);
+//   - lines carrying a `tokens-exempt` marker comment.
+//
+// Usage:
+//   node scripts/codemods/tokenize-css.mjs            # rewrite in place
+//   node scripts/codemods/tokenize-css.mjs --check    # exit 1 if drift found
+//   node scripts/codemods/tokenize-css.mjs a.css b.css  # limit to files
+//
+// Idempotent: rerun any time drift accumulates.
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// px -> token name. Mirrors src/app/globals.css :root; the drift gate test
+// asserts this table matches the live definitions, so a token retune fails
+// loudly here instead of silently diverging.
+//
+// 16px (--text-lg) is deliberately NOT mapped: `font-size: 16px` on inputs is
+// the iOS Safari anti-zoom floor (see composer-zoom-smoke.test.ts and
+// ui/field.test.ts) — a behavior threshold, not a type-scale choice. It must
+// survive a token retune, so it stays a sanctioned literal.
+export const FONT_SIZE_TOKENS = new Map([
+  ["10px", "--text-2xs"],
+  ["11px", "--text-xs"],
+  ["12px", "--text-sm"],
+  ["13px", "--text-base"],
+  ["14px", "--text-md"],
+  ["20px", "--text-xl"],
+  ["28px", "--text-display"],
+]);
+
+// font-size literals the drift ratchet treats as sanctioned (not drift).
+export const SANCTIONED_FONT_SIZE_LITERALS = new Set(["16px"]);
+
+export const SPACE_TOKENS = new Map([
+  ["4px", "--space-1"],
+  ["8px", "--space-2"],
+  ["12px", "--space-3"],
+  ["16px", "--space-4"],
+  ["20px", "--space-5"],
+  ["24px", "--space-6"],
+  ["32px", "--space-8"],
+  ["40px", "--space-10"],
+]);
+
+export const RADIUS_TOKENS = new Map([
+  ["8px", "--radius-control"],
+  ["12px", "--radius-card"],
+  ["16px", "--radius-panel"],
+  ["999px", "--radius-pill"],
+]);
+
+export const FONT_SIZE_PROPS = new Set(["font-size"]);
+
+export const SPACING_PROPS = new Set([
+  "padding",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "padding-block",
+  "padding-inline",
+  "padding-block-start",
+  "padding-block-end",
+  "padding-inline-start",
+  "padding-inline-end",
+  "margin",
+  "margin-top",
+  "margin-right",
+  "margin-bottom",
+  "margin-left",
+  "margin-block",
+  "margin-inline",
+  "margin-block-start",
+  "margin-block-end",
+  "margin-inline-start",
+  "margin-inline-end",
+  "gap",
+  "row-gap",
+  "column-gap",
+]);
+
+export const RADIUS_PROPS = new Set(["border-radius"]);
+
+/** Repo-relative path prefixes the codemod (and the drift gate) never touch. */
+export const EXCLUDED_PATHS = ["src/app/mockup/"];
+
+export const EXEMPT_MARKER = "tokens-exempt";
+
+// One declaration on one line: indent, property, colon, value, `;` + rest.
+const DECL_RE = /^(\s*)([a-zA-Z-]+)(\s*:\s*)([^;]*)(;.*)$/;
+// A bare positive px length ("12px", "12.0px") — not calc()/var() parts,
+// which never split into a bare `<n>px` whitespace token.
+const PX_RE = /^([0-9]+(?:\.[0-9]+)?)px$/;
+
+function tableFor(prop) {
+  if (FONT_SIZE_PROPS.has(prop)) return FONT_SIZE_TOKENS;
+  if (SPACING_PROPS.has(prop)) return SPACE_TOKENS;
+  if (RADIUS_PROPS.has(prop)) return RADIUS_TOKENS;
+  return null;
+}
+
+function rewriteValue(value, table) {
+  // Split on whitespace runs, preserving them, and map each bare px piece.
+  return value
+    .split(/(\s+)/)
+    .map((piece) => {
+      const m = PX_RE.exec(piece);
+      if (!m) return piece;
+      const canonical = `${Number.parseFloat(m[1])}px`;
+      const token = table.get(canonical);
+      return token ? `var(${token})` : piece;
+    })
+    .join("");
+}
+
+/**
+ * Tokenize one CSS source. Pure and idempotent; returns the rewritten text.
+ */
+export function tokenizeCss(source) {
+  let inComment = false;
+  return source
+    .split("\n")
+    .map((line) => {
+      const startedInComment = inComment;
+      // Track block-comment state (no nesting in CSS).
+      let scan = line;
+      while (true) {
+        if (inComment) {
+          const end = scan.indexOf("*/");
+          if (end === -1) break;
+          inComment = false;
+          scan = scan.slice(end + 2);
+        } else {
+          const start = scan.indexOf("/*");
+          if (start === -1) break;
+          inComment = true;
+          scan = scan.slice(start + 2);
+        }
+      }
+      if (startedInComment) return line;
+      if (line.includes(EXEMPT_MARKER)) return line;
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("--")) return line; // token definitions stay literal
+      const m = DECL_RE.exec(line);
+      if (!m) return line;
+      const [, indent, prop, sep, value, tail] = m;
+      const table = tableFor(prop.toLowerCase());
+      if (!table) return line;
+      if (value.includes("/*")) return line; // comment inside value — hands off
+      return `${indent}${prop}${sep}${rewriteValue(value, table)}${tail}`;
+    })
+    .join("\n");
+}
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** All in-scope CSS files, repo-relative. Shared with the drift gate test. */
+export function cssFilesInScope() {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      const rel = path.relative(repoRoot, full);
+      if (EXCLUDED_PATHS.some((p) => (rel + "/").startsWith(p) || rel.startsWith(p))) continue;
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".css")) out.push(rel);
+    }
+  };
+  walk(path.join(repoRoot, "src"));
+  return out.sort();
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const check = args.includes("--check");
+  const files = args.filter((a) => a !== "--check");
+  const targets = files.length > 0 ? files : cssFilesInScope();
+
+  let changed = 0;
+  for (const rel of targets) {
+    const full = path.resolve(repoRoot, rel);
+    const before = readFileSync(full, "utf8");
+    const after = tokenizeCss(before);
+    if (after === before) continue;
+    changed += 1;
+    if (check) {
+      console.error(`[tokenize-css] drift: ${rel}`);
+    } else {
+      writeFileSync(full, after);
+      console.log(`[tokenize-css] rewrote ${rel}`);
+    }
+  }
+  if (check && changed > 0) {
+    console.error(
+      `[tokenize-css] ${changed} file(s) carry on-scale px literals — run: node scripts/codemods/tokenize-css.mjs`,
+    );
+    process.exit(1);
+  }
+  console.log(`[tokenize-css] ${check ? "checked" : "done"} — ${changed} file(s) ${check ? "with drift" : "rewritten"}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -618,6 +618,7 @@ export const SUITES = {
     "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",
+    "src/lib/design-token-drift.test.ts",
     "src/lib/cave-backdrop.test.ts",
     "src/components/backdrop-scrim.test.ts",
     "src/lib/url-safety.test.ts",

--- a/src/app/composer-zoom-smoke.test.ts
+++ b/src/app/composer-zoom-smoke.test.ts
@@ -47,6 +47,14 @@ assert.match(
 // selector. If a rule sets `font-size: <Npx>` where N < 16, fail.
 const PROBLEMATIC = /font-size\s*:\s*(\d+(?:\.\d+)?)px/g;
 
+// The token codemod (scripts/codemods/tokenize-css.mjs) rewrites on-scale px
+// to var(--text-*), so sub-16px sizes can also arrive as tokens. Resolve the
+// fixed-px type-scale tokens back to their px so they can't slip past the
+// bare-px scan above. Values pinned by design-token-drift.test.ts against
+// globals.css.
+const SUB16_TOKENS = /font-size\s*:\s*var\((--text-(?:2xs|xs|sm|base|md))\)/g;
+const TOKEN_PX = { "--text-2xs": 10, "--text-xs": 11, "--text-sm": 12, "--text-base": 13, "--text-md": 14 };
+
 // iOS Safari focus-zoom only affects touch (coarse-pointer) devices, so a
 // <16px size scoped to `@media (pointer: fine)` is desktop-only and safe.
 // Strip those blocks (brace-balanced) before scanning so legitimate desktop
@@ -96,6 +104,12 @@ for (const [label, url] of files) {
       assert.ok(
         px >= 16,
         `[${label}] selector \`${selector}\` sets font-size: ${px}px — iOS Safari will auto-zoom on focus (must be >= 16px). Use \`text-base\` Tailwind, the global max(16px, 1em) rule, or font-size: 16px.`,
+      );
+    }
+    SUB16_TOKENS.lastIndex = 0;
+    while ((m = SUB16_TOKENS.exec(body)) !== null) {
+      assert.fail(
+        `[${label}] selector \`${selector}\` sets font-size: var(${m[1]}) (${TOKEN_PX[m[1]]}px) — iOS Safari will auto-zoom on focus (must be >= 16px). Use the global max(16px, 1em) rule or font-size: 16px.`,
       );
     }
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -395,7 +395,7 @@ html {
 }
 ::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   /* Transparent border + padding-box clip insets the thumb so it reads as a
      slim pill with breathing room rather than a full-width bar. */
   border: 2px solid transparent;
@@ -506,13 +506,13 @@ select {
   top: 0;
   left: 0;
   z-index: 1000;
-  margin: 8px;
-  padding: 8px 14px;
-  border-radius: 8px;
+  margin: var(--space-2);
+  padding: var(--space-2) 14px;
+  border-radius: var(--radius-control);
   background: var(--bg-elevated, var(--background));
   color: var(--fg-base, var(--foreground));
   border: 1px solid var(--ring-focus);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   box-shadow: 0 4px 16px rgb(0 0 0 / 0.25);
   transform: translateY(-150%);
@@ -707,7 +707,7 @@ tr[role="checkbox"]:focus-visible {
   gap: 9px;
   width: 100%;
   height: 100%;
-  padding: 12px 0;
+  padding: var(--space-3) 0;
   border: 0;
   background: transparent;
   color: var(--text-muted);
@@ -720,7 +720,7 @@ tr[role="checkbox"]:focus-visible {
 }
 .code-sidebar__rail-label {
   writing-mode: vertical-rl;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -743,7 +743,7 @@ tr[role="checkbox"]:focus-visible {
   gap: 9px;
   width: 100%;
   height: 100%;
-  padding: 12px 0;
+  padding: var(--space-3) 0;
   border: 0;
   background: transparent;
   color: var(--text-muted);
@@ -756,7 +756,7 @@ tr[role="checkbox"]:focus-visible {
 }
 .chat-sidebar__rail-label {
   writing-mode: vertical-rl;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -783,7 +783,7 @@ tr[role="checkbox"]:focus-visible {
 
 /* Header */
 .cnav__title {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-primary);
@@ -793,11 +793,11 @@ tr[role="checkbox"]:focus-visible {
 .cnav__header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   /* Extra right padding so the trailing options (⋯) button isn't jammed against
      the panel edge; the left stays at --cnav-pad to align with the New-chat and
      search fields below. */
-  padding: 8px 15px 4px var(--cnav-pad);
+  padding: var(--space-2) 15px var(--space-1) var(--cnav-pad);
 }
 .cnav__back {
   display: grid;
@@ -838,7 +838,7 @@ tr[role="checkbox"]:focus-visible {
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 4px var(--cnav-pad) 8px;
+  padding: var(--space-1) var(--cnav-pad) var(--space-2);
 }
 .cnav__new {
   display: flex;
@@ -847,14 +847,14 @@ tr[role="checkbox"]:focus-visible {
   flex: 1 1 auto;
   min-width: 0;
   height: 34px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   border-radius: 10px;
   /* Brand accent (--accent-presence); var(--accent) is the shadcn surface
      token and rendered this button's chrome nearly invisible. */
   border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 560;
   text-align: left;
   transition: background var(--duration-fast) var(--ease-standard),
@@ -877,7 +877,7 @@ tr[role="checkbox"]:focus-visible {
 }
 .cnav__kbd {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-muted);
   padding: 1px 5px;
@@ -893,11 +893,11 @@ tr[role="checkbox"]:focus-visible {
   flex: 0 0 auto;
   height: 34px;
   min-width: 30px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   border-radius: 10px;
   border: 1px solid var(--border-hairline);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   transition: background var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard);
 }
@@ -920,7 +920,7 @@ tr[role="checkbox"]:focus-visible {
   padding: 0 3px;
   display: grid;
   place-items: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--bg-raised);
   background: color-mix(in oklch, var(--foreground) 12%, var(--bg-raised));
   font-size: 9px;
@@ -931,7 +931,7 @@ tr[role="checkbox"]:focus-visible {
 
 /* Search */
 .cnav__search-wrap {
-  padding: 2px var(--cnav-pad) 8px;
+  padding: 2px var(--cnav-pad) var(--space-2);
 }
 .cnav__search {
   display: flex;
@@ -991,7 +991,7 @@ tr[role="checkbox"]:focus-visible {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--foreground) 13%, transparent) transparent;
 }
@@ -1000,7 +1000,7 @@ tr[role="checkbox"]:focus-visible {
 }
 .cnav__scroll::-webkit-scrollbar-thumb {
   background: color-mix(in oklch, var(--foreground) 12%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 3px solid transparent;
   background-clip: padding-box;
 }
@@ -1012,7 +1012,7 @@ tr[role="checkbox"]:focus-visible {
 /* Section label (Pinned) */
 .cnav__label {
   padding: 10px var(--cnav-pad) 3px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -1029,7 +1029,7 @@ tr[role="checkbox"]:focus-visible {
   align-items: center;
   width: 100%;
   min-height: 40px;
-  padding: 4px 6px 4px 8px;
+  padding: var(--space-1) 6px var(--space-1) var(--space-2);
   background: color-mix(in oklch, var(--bg-raised) 96%, var(--foreground) 4%);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
@@ -1082,7 +1082,7 @@ tr[role="checkbox"]:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1.3;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
@@ -1139,11 +1139,11 @@ tr[role="checkbox"]:focus-visible {
 .cnav__thread-main {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 1;
   min-width: 0;
   min-height: 34px;
-  padding: 0 4px 0 var(--cnav-indent);
+  padding: 0 var(--space-1) 0 var(--cnav-indent);
   color: inherit;
   text-align: left;
 }
@@ -1197,7 +1197,7 @@ tr[role="checkbox"]:focus-visible {
 .cnav__dot {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   flex-shrink: 0;
   background: var(--text-muted);
 }
@@ -1263,12 +1263,12 @@ tr[role="checkbox"]:focus-visible {
   color: var(--color-success);
 }
 .cnav__thread--flat .cnav__pr-badge {
-  margin-left: 8px;
+  margin-left: var(--space-2);
 }
 .cnav__pr-badge + .cnav__thread-main,
 .cnav__thread--flat .cnav__pr-badge + .cnav__thread-main {
   /* The badge owns the gutter; keep only the row's internal 8px gap. */
-  padding-left: 8px;
+  padding-left: var(--space-2);
 }
 .cnav__pr-badge:hover {
   background: color-mix(in oklch, var(--foreground) 10%, transparent);
@@ -1317,9 +1317,9 @@ tr[role="checkbox"]:focus-visible {
 .cnav__confirm {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex-shrink: 0;
-  padding-right: 4px;
+  padding-right: var(--space-1);
 }
 .cnav__confirm-cancel {
   font-size: 10.5px;
@@ -1349,9 +1349,9 @@ tr[role="checkbox"]:focus-visible {
 .cnav__more {
   display: block;
   width: 100%;
-  padding: 7px 8px 7px var(--cnav-indent);
+  padding: 7px var(--space-2) 7px var(--cnav-indent);
   text-align: left;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   transition: color var(--duration-fast) var(--ease-standard);
 }
@@ -1365,8 +1365,8 @@ tr[role="checkbox"]:focus-visible {
   color: var(--text-muted);
 }
 .cnav__thread-empty {
-  padding: 4px 8px 6px var(--cnav-indent);
-  font-size: 11px;
+  padding: var(--space-1) var(--space-2) 6px var(--cnav-indent);
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -1376,11 +1376,11 @@ tr[role="checkbox"]:focus-visible {
   align-items: center;
   gap: 6px;
   margin: 0 var(--cnav-pad) 6px;
-  padding: 6px 8px;
-  border-radius: 8px;
+  padding: 6px var(--space-2);
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--color-danger) 12%, transparent);
   color: var(--color-danger);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .cnav__error-text {
   flex: 1;
@@ -1401,7 +1401,7 @@ tr[role="checkbox"]:focus-visible {
   border: none;
   color: inherit;
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   width: 100%;
   text-align: left;
@@ -1421,13 +1421,13 @@ tr[role="checkbox"]:focus-visible {
   border-radius: var(--radius-sm);
   background: var(--muted);
   color: var(--muted-foreground);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
 }
 
 .shell-nav-eyebrow {
   margin: var(--space-4) var(--space-2) var(--space-1);
-  font-size: 11px;
+  font-size: var(--text-xs);
   letter-spacing: 0.02em;
   color: var(--muted-foreground);
 }
@@ -1440,7 +1440,7 @@ tr[role="checkbox"]:focus-visible {
   border-radius: var(--radius-control);
   color: var(--muted-foreground);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   border: none;
   background: none;
@@ -1472,7 +1472,7 @@ tr[role="checkbox"]:focus-visible {
 .shell-nav-kbd,
 .shell-kbd {
   font-family: var(--font-mono), ui-monospace, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--muted-foreground);
   background: oklch(1 0 0 / 4%);
   padding: 2px 5px;
@@ -1496,7 +1496,7 @@ tr[role="checkbox"]:focus-visible {
   align-items: center;
   gap: var(--space-2);
   border-bottom: 1px solid var(--border-hairline);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--foreground);
 }
@@ -1517,7 +1517,7 @@ tr[role="checkbox"]:focus-visible {
   gap: var(--space-2);
   padding: var(--space-4) var(--space-6);
   border-bottom: 1px solid var(--border-hairline);
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 600;
 }
 
@@ -1526,7 +1526,7 @@ tr[role="checkbox"]:focus-visible {
   display: inline-block;
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   box-shadow: 0 0 0 2px oklch(0.605 0.12 295 / 18%);
 }
@@ -1549,7 +1549,7 @@ tr[role="checkbox"]:focus-visible {
   background: oklch(1 0 0 / 4%);
   padding: 1px 6px;
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--muted-foreground);
 }
 
@@ -1616,7 +1616,7 @@ tr[role="checkbox"]:focus-visible {
   gap: var(--space-3);
   padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--border-hairline);
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--muted-foreground);
 }
 
@@ -1680,7 +1680,7 @@ tr[role="checkbox"]:focus-visible {
 }
 .ui-confirm-body {
   margin-top: var(--space-2);
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -1719,7 +1719,7 @@ tr[role="checkbox"]:focus-visible {
 
 .required-inputs-copy {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -1744,7 +1744,7 @@ tr[role="checkbox"]:focus-visible {
 }
 
 .required-inputs-label {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--foreground);
 }
@@ -1753,12 +1753,12 @@ tr[role="checkbox"]:focus-visible {
   flex-shrink: 1;
   min-width: 0;
   max-width: 55%;
-  padding: 1px 8px;
-  border-radius: 999px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1766,9 +1766,9 @@ tr[role="checkbox"]:focus-visible {
 
 .required-inputs-control {
   width: 100%;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--foreground);
   background: var(--bg-base);
   border: 1px solid var(--border);
@@ -1811,7 +1811,7 @@ textarea.required-inputs-control {
 }
 
 .required-inputs-help {
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.4;
   color: var(--text-muted);
 }
@@ -1823,11 +1823,11 @@ textarea.required-inputs-control {
   gap: 6px;
   height: 26px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
   color: var(--muted-foreground);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-family: inherit;
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
@@ -1858,15 +1858,15 @@ textarea.required-inputs-control {
 .ui-initiator-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   height: 18px;
   max-width: 160px;
   padding: 0 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--text-secondary) 6%, transparent);
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 500;
   font-family: inherit;
   line-height: 1;
@@ -1921,7 +1921,7 @@ textarea.required-inputs-control {
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   line-height: 1;
@@ -1955,7 +1955,7 @@ textarea.required-inputs-control {
 }
 
 .ui-lifecycle-needs-human {
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   border-radius: 3px;
   background: color-mix(in oklch, var(--color-danger-soft) 18%, transparent);
   color: var(--color-danger-soft);
@@ -2018,13 +2018,13 @@ textarea.required-inputs-control {
 }
 
 .ui-template-card-title {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--foreground);
 }
 
 .ui-template-card-subtitle {
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--muted-foreground);
   line-height: 1.4;
 }
@@ -2068,7 +2068,7 @@ textarea.required-inputs-control {
   padding: 0 var(--space-3);
   height: 44px;
   border-bottom: 1px solid var(--border-hairline);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   flex-shrink: 0;
 }
@@ -2117,7 +2117,7 @@ textarea.required-inputs-control {
   justify-content: center;
   gap: var(--space-3);
   color: var(--muted-foreground);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .ui-dock-chat-body-title {
@@ -2144,7 +2144,7 @@ textarea.required-inputs-control {
   outline: none;
   color: var(--foreground);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .ui-dock-chat-input::placeholder {
@@ -2159,10 +2159,10 @@ textarea.required-inputs-control {
   gap: 6px;
   height: 26px;
   padding: 0 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-base);
   color: var(--muted-foreground);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-family: inherit;
   cursor: pointer;
   border: 1px solid var(--border-hairline);
@@ -2479,7 +2479,7 @@ textarea.required-inputs-control {
   gap: 10px;
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .workspace-deeplink-pending__spinner {
   width: 16px;
@@ -2561,7 +2561,7 @@ textarea.required-inputs-control {
   justify-content: center;
   width: 48px;
   height: 48px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   color: var(--accent-presence);
   margin-bottom: var(--space-1);
@@ -2591,14 +2591,14 @@ textarea.required-inputs-control {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 32px 24px;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-6);
   text-align: center;
   color: var(--text-secondary);
 }
 .ui-error-state--compact {
-  padding: 16px 12px;
-  gap: 4px;
+  padding: var(--space-4) var(--space-3);
+  gap: var(--space-1);
 }
 .ui-error-state-icon {
   display: inline-flex;
@@ -2621,9 +2621,9 @@ textarea.required-inputs-control {
   max-width: 36ch;
 }
 .ui-error-state-actions {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* ---- Skeleton ----------------------------------------------- */
@@ -2655,7 +2655,7 @@ textarea.required-inputs-control {
 .ui-skeleton--avatar {
   height: 28px;
   width: 28px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 .ui-skeleton-group {
   display: flex;
@@ -2799,7 +2799,7 @@ textarea.required-inputs-control {
   color: var(--text-primary);
   font-family: inherit;
   font-size: var(--text-sm);
-  padding: 0 4px;
+  padding: 0 var(--space-1);
 }
 .ui-search-input-field::placeholder {
   color: var(--text-muted);
@@ -2870,7 +2870,7 @@ textarea.required-inputs-control {
   padding: 1px 5px;
   border-radius: 4px;
   border: 1px solid var(--border-hairline);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }
 
 /* ---- Popover ------------------------------------------------ */
@@ -3044,7 +3044,7 @@ html[data-backdrop-on] .glass-overlay {
 .ui-popover-separator {
   height: 1px;
   background: var(--border-hairline);
-  margin: 4px 0;
+  margin: var(--space-1) 0;
 }
 .ui-popover-label {
   font-size: var(--text-2xs);
@@ -3063,7 +3063,7 @@ html[data-backdrop-on] .glass-overlay {
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--text-primary);
   font-size: var(--text-2xs);
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 5px;
   border: 1px solid var(--border-strong);
   box-shadow: 0 6px 16px oklch(0 0 0 / 50%);
@@ -3211,7 +3211,7 @@ html[data-backdrop-on] .glass-overlay {
 }
 /* Rendered-markdown previews read as docs, not chat bubbles. */
 .comux-md {
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.65;
 }
 /* Shared project identity tile (ProjectAvatar): uploaded image or a tinted
@@ -3304,7 +3304,7 @@ html[data-backdrop-on] .glass-overlay {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding-top: 12px;
+  padding-top: var(--space-3);
   width: 36px;
   flex-shrink: 0;
   height: 100%;
@@ -3352,7 +3352,7 @@ html[data-backdrop-on] .glass-overlay {
 .vault-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 14px;
   border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-raised);
@@ -3363,26 +3363,26 @@ html[data-backdrop-on] .glass-overlay {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 .vault-header-sub {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
 .vault-list {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .vault-filter {
-  padding: 8px 8px 0;
+  padding: var(--space-2) var(--space-2) 0;
 }
 .vault-row {
   position: relative;
@@ -3390,7 +3390,7 @@ html[data-backdrop-on] .glass-overlay {
   flex-direction: column;
   gap: 3px;
   padding: 9px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   transition: border-color 0.12s;
@@ -3405,13 +3405,13 @@ html[data-backdrop-on] .glass-overlay {
   padding-right: 52px; /* room for action buttons */
 }
 .vault-row-key {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-family: var(--font-mono, monospace);
   color: var(--text-primary);
   font-weight: 600;
 }
 .vault-row-ref {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: var(--font-mono, monospace);
   color: var(--text-muted);
   word-break: break-all;
@@ -3451,8 +3451,8 @@ html[data-backdrop-on] .glass-overlay {
 .vault-status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 10px;
+  gap: var(--space-1);
+  font-size: var(--text-2xs);
   font-weight: 500;
   padding: 1px 7px;
   border-radius: 20px;
@@ -3473,16 +3473,16 @@ html[data-backdrop-on] .glass-overlay {
 .vault-add-wrapper {
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklab, var(--bg-raised) 60%, var(--bg-base));
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
 }
 .vault-add-form { display: flex; flex-direction: column; gap: 10px; }
 .vault-add-row { display: flex; gap: 10px; }
 .vault-add-label {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   flex: 1;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -3491,7 +3491,7 @@ html[data-backdrop-on] .glass-overlay {
   border: 1px solid var(--border-strong);
   border-radius: 6px;
   color: var(--text-primary);
-  padding: 5px 8px;
+  padding: 5px var(--space-2);
   outline: none;
   width: 100%;
 }
@@ -3501,13 +3501,13 @@ html[data-backdrop-on] .glass-overlay {
 .vault-add-footer {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .vault-required-check {
   display: flex;
   align-items: center;
   gap: 5px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -3515,8 +3515,8 @@ html[data-backdrop-on] .glass-overlay {
 .vault-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11px;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
   font-weight: 500;
   padding: 5px 10px;
   border-radius: 6px;
@@ -3539,13 +3539,13 @@ html[data-backdrop-on] .glass-overlay {
 .vault-btn--primary:disabled { opacity: 0.5; cursor: default; }
 
 .vault-err {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-danger);
 }
 .vault-footer-note {
   flex-shrink: 0;
-  padding: 8px 14px;
-  font-size: 10px;
+  padding: var(--space-2) 14px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   border-top: 1px solid var(--border-hairline);
   line-height: 1.5;
@@ -4673,8 +4673,8 @@ button:active > .edge-rail-chip {
      the Tauri titlebar override below keeps the band slim next to the macOS
      traffic lights. */
   min-height: 34px;
-  gap: 8px;
-  padding-inline: 12px;
+  gap: var(--space-2);
+  padding-inline: var(--space-3);
   /* Seamless title bar: the strip shares the app canvas — no band color, no
      border seam. Structure below it reads as one continuous surface. */
   background: var(--bg-base);
@@ -4738,7 +4738,7 @@ button:active > .edge-rail-chip {
    flips to "hidden" only AFTER the native hide is confirmed), so the bar
    releases the room reserved for them and slides back to the window edge. */
 :root[data-tauri-titlebar][data-traffic-lights="hidden"] .shell-top {
-  padding-left: 12px;
+  padding-left: var(--space-3);
 }
 
 /* Subtle titlebar glass (native shell only — the browser tab keeps the fully
@@ -4779,7 +4779,7 @@ button:active > .edge-rail-chip {
 /* …but NOT when the analytics view is embedded inside the workspace shell
    (the inspector tab) — there the band sits mid-window, under shell chrome. */
 :root[data-tauri-titlebar] .shell-frame .fa-topbar {
-  padding-left: 24px;
+  padding-left: var(--space-6);
 }
 
 @media (min-width: 1024px) {
@@ -4890,7 +4890,7 @@ button:active > .edge-rail-chip {
    ──────────────────────────────────────────────── */
 
 .rail-empty {
-  padding: 20px;
+  padding: var(--space-5);
   text-align: center;
   color: var(--text-secondary);
   font-size: var(--text-sm);
@@ -4913,7 +4913,7 @@ button:active > .edge-rail-chip {
    (cave-kdkg). __open-full survives: inspector-pane's memory tab uses it. */
 .rail-memory__open-full {
   flex-shrink: 0;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border-top: 1px solid var(--border-hairline);
   border-left: 0;
   border-right: 0;
@@ -4931,14 +4931,14 @@ button:active > .edge-rail-chip {
 
 .inbox-view__tabs {
   display: flex;
-  gap: 4px;
-  padding: 8px 12px;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   background: var(--bg-panel);
 }
 
 .inbox-view__tab {
-  padding: 6px 12px;
+  padding: 6px var(--space-3);
   border-radius: var(--radius-control);
   background: transparent;
   border: 0;
@@ -4967,8 +4967,8 @@ button:active > .edge-rail-chip {
 .shell-banner {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
   font-size: var(--text-sm);
   border-bottom: 1px solid var(--border-hairline);
 }
@@ -5044,7 +5044,7 @@ button:active > .edge-rail-chip {
   z-index: 1200;
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: var(--space-6);
   background: color-mix(in oklch, black 54%, transparent);
   backdrop-filter: blur(8px);
 }
@@ -5067,8 +5067,8 @@ button:active > .edge-rail-chip {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 20px;
-  padding: 18px 20px;
+  gap: var(--space-5);
+  padding: 18px var(--space-5);
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -5089,7 +5089,7 @@ button:active > .edge-rail-chip {
   margin: 0;
   padding-left: 18px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.45;
 }
 
@@ -5113,11 +5113,11 @@ button:active > .edge-rail-chip {
 
 .cave-migration-review__files {
   overflow: auto;
-  padding: 12px 20px 20px;
+  padding: var(--space-3) var(--space-5) var(--space-5);
 }
 
 .cave-migration-file {
-  padding: 16px 0;
+  padding: var(--space-4) 0;
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -5126,13 +5126,13 @@ button:active > .edge-rail-chip {
 .cave-migration-review__footer > div {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
 .cave-migration-file__heading {
   justify-content: space-between;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .cave-migration-file__heading span {
@@ -5143,12 +5143,12 @@ button:active > .edge-rail-chip {
 .cave-migration-file dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-  margin: 12px 0;
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
 }
 
 .cave-migration-file dl > div {
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border-radius: var(--radius-control);
   background: var(--bg-subtle);
 }
@@ -5184,15 +5184,15 @@ button:active > .edge-rail-chip {
 
 @media (max-width: 767px) {
   .shell-banner {
-    gap: 8px;
-    padding: 8px 8px 8px 16px;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-2) var(--space-2) var(--space-4);
   }
 
   .shell-banner__cta {
     min-height: var(--touch-target);
     border-radius: 10px;
     padding-inline: 14px;
-    font-size: 13px;
+    font-size: var(--text-base);
     white-space: nowrap;
     -webkit-tap-highlight-color: transparent;
   }
@@ -5242,10 +5242,10 @@ button:active > .edge-rail-chip {
   position: relative;
   align-items: center;
   justify-content: flex-end;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
   width: 100%;
-  padding: 5px 12px;
+  padding: 5px var(--space-3);
   /* min-height (not a fixed height) so the bar grows with scaled-up content
      under screen magnification instead of clipping the search row. */
   min-height: 36px;
@@ -5265,7 +5265,7 @@ button:active > .edge-rail-chip {
 .menu-bar__group {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -5285,8 +5285,8 @@ button:active > .edge-rail-chip {
   width: min(480px, 42vw, calc(100% - 432px));
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
+  gap: var(--space-2);
+  padding: var(--space-1) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
@@ -5347,7 +5347,7 @@ button:active > .edge-rail-chip {
 .menu-bar__search kbd {
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1;
   color: var(--text-muted);
   padding: 2px 5px;
@@ -5391,7 +5391,7 @@ button:active > .edge-rail-chip {
    one box widen around it while the rest of the row stays square. */
 .menu-bar__task:has(.menu-bar__task-label--live) {
   width: auto;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
 }
 
 /* Ultra-minimal: the bar shows icons only. Labels stay in the DOM for the
@@ -5444,8 +5444,8 @@ button:active > .edge-rail-chip {
   min-width: 15px;
   height: 15px;
   padding: 0 5px;
-  border-radius: 8px;
-  font-size: 10px;
+  border-radius: var(--radius-control);
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1;
   color: var(--accent-presence-foreground);
@@ -5461,14 +5461,14 @@ button:active > .edge-rail-chip {
 .menu-bar__compose {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px;
 }
 
 .menu-bar__compose-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .menu-bar__compose-label {
@@ -5479,7 +5479,7 @@ button:active > .edge-rail-chip {
 .menu-bar__compose-select {
   flex: 1 1 auto;
   min-width: 0;
-  padding: 5px 8px;
+  padding: 5px var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -5491,7 +5491,7 @@ button:active > .edge-rail-chip {
   width: 100%;
   max-height: 160px;
   resize: none;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -5515,7 +5515,7 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 12px;
+  padding: 5px var(--space-3);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 26%, transparent);
@@ -5530,7 +5530,7 @@ button:active > .edge-rail-chip {
 }
 
 .menu-bar__compose-kbd {
-  font-size: 11px;
+  font-size: var(--text-xs);
   opacity: 0.7;
 }
 
@@ -5539,7 +5539,7 @@ button:active > .edge-rail-chip {
   width: 100%;
   grid-template-columns: 1fr minmax(auto, 560px) 1fr;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 0 14px;
   height: 40px;
   /* Seamless like the desktop .shell-top — no band, no border seam. */
@@ -5553,7 +5553,7 @@ button:active > .edge-rail-chip {
   justify-self: start;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .top-bar__search {
@@ -5563,8 +5563,8 @@ button:active > .edge-rail-chip {
   max-width: 560px;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 12px;
+  gap: var(--space-2);
+  padding: 5px var(--space-3);
   background: var(--bg-base);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
@@ -5611,7 +5611,7 @@ button:active > .edge-rail-chip {
 .top-bar__search kbd {
   margin-left: auto;
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1;
   color: var(--text-muted);
   padding: 2px 5px;
@@ -5624,7 +5624,7 @@ button:active > .edge-rail-chip {
   justify-self: end;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
 }
 
@@ -5656,7 +5656,7 @@ button:active > .edge-rail-chip {
   width: auto;
   min-width: 0;
   max-width: 180px;
-  padding: 0 8px 0 5px;
+  padding: 0 var(--space-2) 0 5px;
 }
 
 .familiar-switcher__trigger-label {
@@ -5750,14 +5750,14 @@ button:active > .edge-rail-chip {
   right: -1px;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--color-warning);
   box-shadow: 0 0 0 2px var(--bg-base);
 }
 
 .familiar-switcher__popover {
   padding: 0;
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   border: 1px solid var(--border-hairline);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -5775,7 +5775,7 @@ button:active > .edge-rail-chip {
 .familiar-switcher__header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px 10px 9px;
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--accent-presence) 5%, transparent);
@@ -5784,7 +5784,7 @@ button:active > .edge-rail-chip {
 .familiar-switcher__header-id {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   flex: 1;
 }
@@ -5797,7 +5797,7 @@ button:active > .edge-rail-chip {
 }
 
 .familiar-switcher__header-name {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 650;
   color: var(--text-primary);
   overflow: hidden;
@@ -5806,7 +5806,7 @@ button:active > .edge-rail-chip {
 }
 
 .familiar-switcher__header-role {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5816,14 +5816,14 @@ button:active > .edge-rail-chip {
 .familiar-switcher__edit {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex-shrink: 0;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 7px;
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-standard),
@@ -5843,7 +5843,7 @@ button:active > .edge-rail-chip {
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .familiar-switcher__list {
@@ -5858,9 +5858,9 @@ button:active > .edge-rail-chip {
 }
 
 .familiar-switcher__empty {
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -5875,8 +5875,8 @@ button:active > .edge-rail-chip {
   align-items: center;
   gap: 9px;
   width: 100%;
-  padding: 7px 8px;
-  border-radius: 8px;
+  padding: 7px var(--space-2);
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -5923,7 +5923,7 @@ button:active > .edge-rail-chip {
   bottom: -2px;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   box-shadow: 0 0 0 2px var(--bg-base);
 }
 
@@ -5933,7 +5933,7 @@ button:active > .edge-rail-chip {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
 }
 
@@ -5943,7 +5943,7 @@ button:active > .edge-rail-chip {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -5951,7 +5951,7 @@ button:active > .edge-rail-chip {
   flex-shrink: 0;
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--color-warning);
 }
 
@@ -6041,14 +6041,14 @@ button:active > .edge-rail-chip {
 
 .familiar-pin-order__hint {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
 .familiar-pin-order__list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -6058,7 +6058,7 @@ button:active > .edge-rail-chip {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .familiar-pin-order__row[data-dragging] {
@@ -6071,9 +6071,9 @@ button:active > .edge-rail-chip {
   align-items: center;
   gap: 9px;
   min-width: 0;
-  padding: 7px 8px;
+  padding: 7px var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-secondary);
   cursor: grab;
@@ -6101,7 +6101,7 @@ button:active > .edge-rail-chip {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -6112,7 +6112,7 @@ button:active > .edge-rail-chip {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -6123,7 +6123,7 @@ button:active > .edge-rail-chip {
   height: 30px;
   flex-shrink: 0;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--accent-presence);
   cursor: pointer;
@@ -6140,7 +6140,7 @@ button:active > .edge-rail-chip {
 }
 
 .familiar-pin-order__add-label {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -6160,12 +6160,12 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px 4px 5px;
+  padding: var(--space-1) var(--space-2) var(--space-1) 5px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-standard),
               border-color var(--duration-fast) var(--ease-standard),
@@ -6193,7 +6193,7 @@ button:active > .edge-rail-chip {
 .familiar-switcher__foot {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 6px;
   border-top: 1px solid var(--border-hairline);
 }
@@ -6206,12 +6206,12 @@ button:active > .edge-rail-chip {
   justify-content: center;
   gap: 6px;
   width: 100%;
-  padding: 8px 10px;
-  border-radius: 8px;
+  padding: var(--space-2) 10px;
+  border-radius: var(--radius-control);
   border: 1px dashed color-mix(in oklch, var(--accent-presence) 42%, transparent);
   background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
   color: var(--accent-presence);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-standard),
@@ -6224,20 +6224,20 @@ button:active > .edge-rail-chip {
 
 .familiar-switcher__foot-row {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .familiar-switcher__foot-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex: 1;
   padding: 6px 6px;
   border-radius: 7px;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   cursor: pointer;
   transition: color var(--duration-fast) var(--ease-standard),
@@ -6257,7 +6257,7 @@ button:active > .edge-rail-chip {
    control; give the trigger a touch of inset to match the action rows below. */
 .sidebar-familiar-slot {
   display: flex;
-  padding: 2px 2px 4px;
+  padding: 2px 2px var(--space-1);
 }
 
 /* One box family for the whole action row: every header control is the same
@@ -6337,9 +6337,9 @@ button:active > .edge-rail-chip {
   justify-content: center;
   min-width: 15px;
   height: 15px;
-  padding: 0 4px;
-  border-radius: 8px;
-  font-size: 10px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-control);
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1;
   color: var(--accent-presence-foreground);
@@ -6423,7 +6423,7 @@ button:active > .edge-rail-chip {
 
 .mobile-handoff__url {
   margin: 0;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -6453,7 +6453,7 @@ a.mobile-handoff__link:hover {
 
 .mobile-handoff__error {
   margin: 0;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border-hairline));
   border-radius: var(--radius-control);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
@@ -6466,7 +6466,7 @@ a.mobile-handoff__link:hover {
    (re)started. Caution treatment so it reads as advisory, not a hard failure. */
 .mobile-handoff__warning {
   margin: 0;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid color-mix(in srgb, var(--warning, #d9a441) 45%, var(--border-hairline));
   border-radius: var(--radius-control);
   background: color-mix(in srgb, var(--warning, #d9a441) 12%, transparent);
@@ -6533,7 +6533,7 @@ a.mobile-handoff__link:hover {
   align-items: flex-start;
   gap: 14px;
   margin-inline: -16px;
-  padding: 12px 18px 16px;
+  padding: var(--space-3) 18px var(--space-4);
   border-bottom: 1px solid var(--border-hairline);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -6570,7 +6570,7 @@ a.mobile-handoff__link:hover {
 .familiar-tab__grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 8px 20px;
+  gap: var(--space-2) var(--space-5);
 }
 
 @container (min-width: 900px) {
@@ -6605,7 +6605,7 @@ a.mobile-handoff__link:hover {
     padding-block: 10px;
   }
   .familiar-tab__cta {
-    padding-block: 8px;
+    padding-block: var(--space-2);
   }
 }
 
@@ -6617,29 +6617,29 @@ a.mobile-handoff__link:hover {
 .settings-familiars-panel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
+  gap: var(--space-3);
+  padding: var(--space-4);
 }
 
 .settings-familiars-panel__empty {
   color: var(--text-muted);
   font-size: var(--text-sm);
   text-align: center;
-  padding: 24px;
+  padding: var(--space-6);
 }
 
 .settings-familiars-panel__card {
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
-  padding: 14px 16px;
+  padding: 14px var(--space-4);
 }
 
 .settings-familiars-panel__card-head {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 .settings-familiars-panel__glyph {
@@ -6659,7 +6659,7 @@ a.mobile-handoff__link:hover {
 .settings-familiars-panel__harness-pill {
   border: 1px solid var(--border-hairline);
   background: var(--bg-elevated);
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   border-radius: 99px;
   font-size: 9px;
   text-transform: uppercase;
@@ -6670,7 +6670,7 @@ a.mobile-handoff__link:hover {
 .settings-familiars-panel__dl {
   display: grid;
   grid-template-columns: 80px 1fr;
-  gap: 6px 12px;
+  gap: 6px var(--space-3);
   font-size: var(--text-sm);
 }
 
@@ -6690,7 +6690,7 @@ a.mobile-handoff__link:hover {
 }
 
 .settings-familiars-panel__presence {
-  padding: 1px 8px;
+  padding: 1px var(--space-2);
   border-radius: 99px;
   font-size: 9px;
   text-transform: uppercase;
@@ -6702,8 +6702,8 @@ a.mobile-handoff__link:hover {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11px;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   background: transparent;
   border: 1px solid var(--border-hairline);
@@ -6721,7 +6721,7 @@ a.mobile-handoff__link:hover {
   .settings-back-button {
     min-height: var(--touch-target);
     border-radius: var(--radius-control);
-    padding-inline: 12px;
+    padding-inline: var(--space-3);
     -webkit-tap-highlight-color: transparent;
   }
 }
@@ -6759,8 +6759,8 @@ a.mobile-handoff__link:hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 12px 16px;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-hairline);
   flex-shrink: 0;
 }
@@ -6994,7 +6994,7 @@ a.mobile-handoff__link:hover {
   display: flex;
   align-items: center;
   gap: 7px;
-  margin: 8px 8px 4px;
+  margin: var(--space-2) var(--space-2) var(--space-1);
   padding: 0 9px;
   min-height: 36px;
   border: 1px solid var(--border-hairline);
@@ -7044,7 +7044,7 @@ a.mobile-handoff__link:hover {
   min-width: 0;
   min-height: 44px;
   gap: 9px;
-  padding: 5px 8px 5px 6px;
+  padding: 5px var(--space-2) 5px 6px;
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
@@ -7069,7 +7069,7 @@ a.mobile-handoff__link:hover {
   outline-offset: -2px;
 }
 .familiar-studio-picker__empty {
-  padding: 24px 12px;
+  padding: var(--space-6) var(--space-3);
   color: var(--text-muted);
   font-size: var(--text-sm);
   text-align: center;
@@ -7107,7 +7107,7 @@ a.mobile-handoff__link:hover {
 }
 .familiar-studio-picker__popover[data-compact] .familiar-studio-picker__results {
   gap: 1px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
 }
 .familiar-studio-picker__popover[data-compact] .familiar-studio-picker__footer {
   padding: 0 5px;
@@ -7129,7 +7129,7 @@ a.mobile-handoff__link:hover {
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   color: var(--text-primary);
   font-size: var(--text-base);
   font-family: inherit;
@@ -7214,7 +7214,7 @@ a.mobile-handoff__link:hover {
 .familiar-asana__connect-btn {
   flex: 0 0 auto;
   height: 32px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   border-radius: var(--radius-control);
   border: 1px solid var(--accent-presence);
   background: var(--accent-presence);
@@ -7232,7 +7232,7 @@ a.mobile-handoff__link:hover {
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   color: var(--text-primary);
   font-size: var(--text-base);
   font-family: inherit;
@@ -7259,20 +7259,20 @@ a.mobile-handoff__link:hover {
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-raised) 48%, transparent);
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
 }
 .familiar-studio-brain__capabilities[open] { padding-bottom: 10px; }
 .familiar-studio-brain__capabilities-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-secondary);
   list-style: none;
-  padding: 4px 0;
+  padding: var(--space-1) 0;
 }
 .familiar-studio-brain__capabilities-summary::-webkit-details-marker { display: none; }
 .familiar-studio-brain__capabilities-summary::before {
@@ -7294,12 +7294,12 @@ a.mobile-handoff__link:hover {
 .familiar-studio-brain__capabilities-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   padding-top: 6px;
 }
 .familiar-studio-brain__capabilities-line {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 .familiar-studio-brain__capabilities-line strong {
@@ -7309,7 +7309,7 @@ a.mobile-handoff__link:hover {
 .familiar-studio-brain__capabilities-line--warn { color: var(--color-warning); }
 .familiar-studio-brain__capabilities-empty {
   margin: 6px 0 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 @media (max-width: 860px) {
@@ -7509,7 +7509,7 @@ a.mobile-handoff__link:hover {
     padding: 0 calc(8px + var(--sai-right)) 0 calc(8px + var(--sai-left));
     padding-top: var(--sai-top);
     height: calc(52px + var(--sai-top));
-    gap: 8px;
+    gap: var(--space-2);
   }
   .top-bar__mobile-toggle {
     display: inline-flex;
@@ -7595,7 +7595,7 @@ a.mobile-handoff__link:hover {
      compact inside the phone action cluster. */
   .top-bar__actions .familiar-quickswitch {
     min-width: 0;
-    gap: 4px;
+    gap: var(--space-1);
   }
   .top-bar__actions .notification-bell {
     position: static;
@@ -7623,7 +7623,7 @@ a.mobile-handoff__link:hover {
   }
   .notification-bell__header {
     min-height: var(--touch-target);
-    padding: 0 8px 0 12px;
+    padding: 0 var(--space-2) 0 var(--space-3);
   }
   .notification-bell__settings-btn,
   .notification-bell__open-inbox {
@@ -7730,7 +7730,7 @@ a.mobile-handoff__link:hover {
   gap: 3px;
   min-width: 0;
   min-height: var(--touch-target);
-  padding: 7px 6px 8px;
+  padding: 7px 6px var(--space-2);
   background: transparent;
   border: 0;
   color: var(--text-muted);
@@ -7760,7 +7760,7 @@ a.mobile-handoff__link:hover {
   line-height: 0;
 }
 .mobile-bottom-tab__label {
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.1;
   font-weight: 500;
   letter-spacing: 0;
@@ -7781,7 +7781,7 @@ a.mobile-handoff__link:hover {
   right: 22%;
   bottom: calc(4px + max(0px, var(--sai-bottom)));
   height: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: currentColor;
   transform: scaleX(0);
   opacity: 0;
@@ -7867,7 +7867,7 @@ a.mobile-handoff__link:hover {
 /* Model chip → a clean, consistent pill. */
 .chat-list-row-model {
   border: 1px solid color-mix(in oklch, var(--border-hairline) 80%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
 }
 
@@ -7943,7 +7943,7 @@ a.mobile-handoff__link:hover {
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-sm);
   background: var(--bg-subtle);
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   min-height: 15px;
   font-family: var(--font-mono), ui-monospace, monospace;
   font-size: 9.5px;
@@ -7970,7 +7970,7 @@ a.mobile-handoff__link:hover {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 4px 10px;
+  padding: var(--space-2) var(--space-1) 10px;
   background: linear-gradient(
     to bottom,
     var(--bg-base) 62%,
@@ -8019,7 +8019,7 @@ a.mobile-handoff__link:hover {
   flex: 1;
 }
 .cal-agenda-daylabel-main {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 650;
   color: var(--text-primary);
   white-space: nowrap;
@@ -8030,7 +8030,7 @@ a.mobile-handoff__link:hover {
   color: var(--accent-presence);
 }
 .cal-agenda-daylabel-sub {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   margin-top: 1px;
 }
@@ -8042,10 +8042,10 @@ a.mobile-handoff__link:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: var(--text-secondary);
@@ -8062,9 +8062,9 @@ a.mobile-handoff__link:hover {
   display: grid;
   grid-template-columns: 62px 22px 1fr auto;
   align-items: center;
-  column-gap: 8px;
+  column-gap: var(--space-2);
   width: 100%;
-  padding: 5px 8px;
+  padding: 5px var(--space-2);
   border-radius: 9px;
   text-align: left;
   transition: background-color 120ms ease;
@@ -8074,7 +8074,7 @@ a.mobile-handoff__link:hover {
 }
 .cal-agenda-time {
   justify-self: end;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);
   white-space: nowrap;
@@ -8126,7 +8126,7 @@ a.mobile-handoff__link:hover {
   z-index: 1;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   outline: 3px solid var(--bg-base);
 }
 .cal-agenda-row:hover .cal-agenda-dot {
@@ -8135,10 +8135,10 @@ a.mobile-handoff__link:hover {
 .cal-agenda-dot-check {
   position: relative;
   z-index: 1;
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-muted);
   background: var(--bg-base);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 .cal-agenda-row:hover .cal-agenda-dot-check {
   background: var(--bg-raised);
@@ -8161,7 +8161,7 @@ a.mobile-handoff__link:hover {
 }
 .cal-agenda-platform {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .cal-agenda-title {
@@ -8170,7 +8170,7 @@ a.mobile-handoff__link:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-primary);
 }
 .cal-agenda-row.is-done .cal-agenda-title {
@@ -8198,7 +8198,7 @@ a.mobile-handoff__link:hover {
   align-items: center;
   height: 17px;
   padding: 0 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   color: var(--accent-presence-foreground);
   font-size: 9.5px;
@@ -8249,10 +8249,10 @@ a.mobile-handoff__link:hover {
 .cron-schedule-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   height: 20px;
-  padding: 0 8px;
-  border-radius: 999px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   font-size: 11.5px;
@@ -8307,8 +8307,8 @@ a.mobile-handoff__link:hover {
   }
 
   .calendar-toolbar {
-    gap: 8px;
-    padding: 8px 12px;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
   }
 
   .calendar-toolbar-icon,
@@ -8329,14 +8329,14 @@ a.mobile-handoff__link:hover {
   .calendar-empty-action {
     border-radius: 10px;
     padding-inline: 14px;
-    font-size: 13px;
+    font-size: var(--text-base);
   }
 
   .calendar-heading-button {
     display: inline-flex;
     align-items: center;
     border-radius: 10px;
-    padding-inline: 8px;
+    padding-inline: var(--space-2);
   }
 
   .browser-pane {
@@ -8371,7 +8371,7 @@ a.mobile-handoff__link:hover {
     order: 10;
     flex-basis: 100%;
     border-radius: 10px;
-    padding-inline: 12px;
+    padding-inline: var(--space-3);
   }
 
   .browser-address-input {
@@ -8457,7 +8457,7 @@ a.mobile-handoff__link:hover {
       "handle dot content"
       ". . actions";
     gap: 6px 10px;
-    padding: 14px 12px;
+    padding: 14px var(--space-3);
   }
 
   .chat-list-drag-handle {
@@ -8476,7 +8476,7 @@ a.mobile-handoff__link:hover {
   .chat-list-row-content {
     grid-area: content;
     min-width: 0;
-    gap: 4px;
+    gap: var(--space-1);
   }
 
   .chat-list-row-meta {
@@ -8491,7 +8491,7 @@ a.mobile-handoff__link:hover {
     max-width: 100%;
     flex-wrap: wrap;
     align-items: center;
-    row-gap: 4px;
+    row-gap: var(--space-1);
   }
 
   .chat-list-row-time {
@@ -8511,7 +8511,7 @@ a.mobile-handoff__link:hover {
     grid-area: actions;
     justify-content: flex-end;
     align-self: start;
-    gap: 8px;
+    gap: var(--space-2);
     min-width: 0;
   }
 
@@ -8538,7 +8538,7 @@ a.mobile-handoff__link:hover {
 
   .chat-list-row-confirm > button {
     min-height: 36px;
-    padding-inline: 12px;
+    padding-inline: var(--space-3);
   }
 
   .automation-create-chat-btn {
@@ -8549,7 +8549,7 @@ a.mobile-handoff__link:hover {
 
   .automation-list-row {
     min-height: var(--touch-target);
-    padding-block: 12px;
+    padding-block: var(--space-3);
     -webkit-tap-highlight-color: transparent;
   }
 
@@ -8559,13 +8559,13 @@ a.mobile-handoff__link:hover {
 
   /* ── Automation templates panel ─────────────────────────────────────────── */
   .automation-templates-panel {
-    padding-top: 4px;
+    padding-top: var(--space-1);
   }
 
   .automation-templates-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .automation-template-card {
@@ -8590,20 +8590,20 @@ a.mobile-handoff__link:hover {
   }
 
   .automation-template-card__emoji {
-    font-size: 20px;
+    font-size: var(--text-xl);
     line-height: 1;
     display: block;
   }
 
   .automation-template-card__title {
-    font-size: 12px;
+    font-size: var(--text-sm);
     line-height: 1.45;
     color: var(--text-primary);
     flex: 1;
   }
 
   .automation-template-card__schedule {
-    font-size: 11px;
+    font-size: var(--text-xs);
     color: var(--text-muted);
     margin-top: 2px;
   }
@@ -8624,15 +8624,15 @@ a.mobile-handoff__link:hover {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 40px;
-  padding: 5px 12px;
+  padding: 5px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
 }
 
 .surface-compact-title {
   margin-right: 2px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -8643,7 +8643,7 @@ a.mobile-handoff__link:hover {
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -8686,7 +8686,7 @@ a.mobile-handoff__link:hover {
   flex-direction: column;
   height: 100%;
   max-height: 100%;
-  padding: 18px 20px 0;
+  padding: 18px var(--space-5) 0;
   color: var(--text-primary);
 }
 
@@ -8695,9 +8695,9 @@ a.mobile-handoff__link:hover {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   margin: -18px -20px 2px;
-  padding: 18px 20px 14px;
+  padding: 18px var(--space-5) 14px;
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
   backdrop-filter: blur(16px) saturate(140%);
@@ -8715,9 +8715,9 @@ a.mobile-handoff__link:hover {
 }
 
 .workflow-eyebrow {
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-1);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.06em;
   line-height: 1.1;
@@ -8745,7 +8745,7 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog__section {
   display: grid;
   gap: 10px;
-  padding: 12px;
+  padding: var(--space-3);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 34%, transparent);
@@ -8762,7 +8762,7 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog__section-header h3 {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.04em;
   line-height: 1.1;
@@ -8780,7 +8780,7 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog__field > span {
   min-width: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 650;
   line-height: 1.2;
 }
@@ -8790,7 +8790,7 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog__runtime-grid,
 .automation-create-dialog__scope-grid {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 
@@ -8815,7 +8815,7 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog__schedule-card,
 .automation-create-dialog__schedule-body {
   display: grid;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -8839,7 +8839,7 @@ a.mobile-handoff__link:hover {
   margin: 0;
   overflow-wrap: anywhere;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1.35;
 }
 
@@ -8863,9 +8863,9 @@ a.mobile-handoff__link:hover {
   flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0 -20px;
-  padding: 12px 20px calc(12px + max(0px, var(--sai-bottom)));
+  padding: var(--space-3) var(--space-5) calc(12px + max(0px, var(--sai-bottom)));
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
   backdrop-filter: blur(16px) saturate(140%);
@@ -9007,9 +9007,9 @@ a.mobile-handoff__link:hover {
   border: none;
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1;
-  padding: 4px;
+  padding: var(--space-1);
   border-radius: var(--radius-sm);
   transition: color 0.14s, background 0.14s;
 }
@@ -9022,9 +9022,9 @@ a.mobile-handoff__link:hover {
 .salem-pf {
   width: 100%;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
-  padding: 12px;
+  padding: var(--space-3);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -9056,7 +9056,7 @@ a.mobile-handoff__link:hover {
 .salem-pf__cmd-text {
   flex: 1; min-width: 0; overflow-x: auto; white-space: pre;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px; color: var(--text-primary);
+  font-size: var(--text-xs); color: var(--text-primary);
 }
 .salem-pf__cmd-copy {
   flex-shrink: 0; background: none; border: none; cursor: pointer;
@@ -9070,7 +9070,7 @@ a.mobile-handoff__link:hover {
 .salem-pf__links { display: flex; flex-wrap: wrap; gap: 8px; }
 .salem-pf__link {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 11px; color: var(--accent-presence); text-decoration: none;
+  font-size: var(--text-xs); color: var(--accent-presence); text-decoration: none;
 }
 .salem-pf__link:hover { text-decoration: underline; }
 .salem-pf__actions { display: flex; flex-wrap: wrap; gap: 6px; padding-top: 2px; }
@@ -9114,7 +9114,7 @@ a.mobile-handoff__link:hover {
 .salem-pf-entry {
   display: flex; flex-direction: column; gap: 10px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-raised);
   padding: 10px;
 }
@@ -9138,7 +9138,7 @@ a.mobile-handoff__link:hover {
 .salem-panel__messages {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -9149,7 +9149,7 @@ a.mobile-handoff__link:hover {
 .salem-msg {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 100%;
 }
 .salem-msg__text {
@@ -9165,22 +9165,22 @@ a.mobile-handoff__link:hover {
 .salem-msg--user .salem-msg__text {
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 25%, var(--border-hairline));
-  border-radius: 12px 12px 4px 12px;
+  border-radius: var(--radius-card) var(--radius-card) 4px var(--radius-card);
   padding: 7px 11px;
   color: var(--text-primary);
 }
 .salem-msg--salem .salem-msg__text {
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 12%, var(--border-hairline));
-  border-radius: 4px 12px 12px 12px;
+  border-radius: 4px var(--radius-card) var(--radius-card) var(--radius-card);
   padding: 7px 11px;
 }
 
 .salem-msg__md {
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 12%, var(--border-hairline));
-  border-radius: 4px 12px 12px 12px;
-  padding: 8px 12px;
+  border-radius: 4px var(--radius-card) var(--radius-card) var(--radius-card);
+  padding: var(--space-2) var(--space-3);
   width: 100%;
 }
 .salem-msg__md .cave-md {
@@ -9204,7 +9204,7 @@ a.mobile-handoff__link:hover {
 .salem-msg__md .cave-md strong { color: var(--text-primary); font-weight: 600; }
 .salem-msg__md .cave-md em { color: var(--accent-presence); font-style: italic; }
 .salem-msg__md .cave-md code {
-  font-size: 11px;
+  font-size: var(--text-xs);
   background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 22%, var(--border-hairline));
   border-radius: 3px;
@@ -9251,8 +9251,8 @@ a.mobile-handoff__link:hover {
 .salem-panel__input-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-2);
+  padding: 10px var(--space-3);
   border-top: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-panel) 88%, var(--bg-base));
   flex-shrink: 0;
@@ -9386,7 +9386,7 @@ a.mobile-handoff__link:hover {
 }
 .cave-next-path {
   display: inline-flex; align-items: center; width: 100%; max-width: 100%;
-  padding: 7px 12px; border-radius: 8px;
+  padding: 7px var(--space-3); border-radius: 8px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-secondary); font-size: 12px; line-height: 1.2;
@@ -9424,8 +9424,8 @@ a.mobile-handoff__link:hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 12px clamp(20px, 5vw, 64px);
+  gap: var(--space-4);
+  padding: var(--space-3) clamp(20px, 5vw, 64px);
   /* Subtly more glass than the old near-opaque wash: content scrolling under
      the sticky band shows through as a saturated blur, macOS-chrome style. */
   background: color-mix(in oklch, var(--bg-base) 86%, transparent);
@@ -9437,7 +9437,7 @@ a.mobile-handoff__link:hover {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-secondary);
   text-decoration: none;
   transition: color 0.14s ease;
@@ -9460,8 +9460,8 @@ a.mobile-handoff__link:hover {
 .dr-eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 11px;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 650;
   text-transform: uppercase;
   letter-spacing: 0.18em;
@@ -9491,8 +9491,8 @@ a.mobile-handoff__link:hover {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px 16px;
-  margin-top: 16px;
+  gap: var(--space-2) var(--space-4);
+  margin-top: var(--space-4);
   font-size: 12.5px;
   color: var(--text-muted);
 }
@@ -9503,14 +9503,14 @@ a.mobile-handoff__link:hover {
 .dr-btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   height: 38px;
-  padding: 0 16px;
+  padding: 0 var(--space-4);
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 560;
   text-decoration: none;
   cursor: pointer;
@@ -9534,7 +9534,7 @@ a.mobile-handoff__link:hover {
   display: grid;
   /* Tighter min so more cards fit → the stats row uses the full width. */
   grid-template-columns: repeat(auto-fit, minmax(156px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 44px;
   /* Break the stats row out of the centered 1060px reading column so the cards
      span the full page width (side gutters match the shell's padding). .dr-page
@@ -9545,11 +9545,11 @@ a.mobile-handoff__link:hover {
 .dr-metric {
   position: relative;
   overflow: hidden;
-  padding: 20px;
+  padding: var(--space-5);
   /* Ultra low-profile, Apple-style grouped card: generous radius, a faint
      hairline over a barely-raised translucent fill — no accent bar, no shadow,
      no hover lift. All chrome earns its place. */
-  border-radius: 16px;
+  border-radius: var(--radius-panel);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 55%, transparent);
   background: color-mix(in oklch, var(--bg-raised) 45%, transparent);
   transition: background 0.18s ease, border-color 0.18s ease;
@@ -9579,7 +9579,7 @@ a.dr-metric--link { display: block; color: inherit; text-decoration: none; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
+  font-size: var(--text-md);
   color: var(--text-muted);
   opacity: 0;
   transform: translateX(-3px);
@@ -9628,8 +9628,8 @@ a.dr-metric--link:hover .dr-metric__go {
   min-width: 22px;
   height: 22px;
   padding: 0 7px;
-  border-radius: 999px;
-  font-size: 12px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
   background: var(--muted);
@@ -9675,7 +9675,7 @@ a.dr-row:active { transform: translateY(1px); }
 }
 .dr-row__body { min-width: 0; flex: 1; }
 .dr-row__title {
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 560;
   line-height: 1.35;
   color: var(--text-primary);
@@ -9701,9 +9701,9 @@ a.dr-row:active { transform: translateY(1px); }
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 11px;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
   font-weight: 560;
   color: var(--row-accent, var(--text-secondary));
   background: color-mix(in oklch, var(--row-accent, var(--accent-presence)) 12%, transparent);
@@ -9714,8 +9714,8 @@ a.dr-row:active { transform: translateY(1px); }
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 12px;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
   color: var(--text-muted);
   transition: color 0.14s ease, transform 0.14s ease;
 }
@@ -9725,19 +9725,19 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-empty {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 20px;
+  gap: var(--space-3);
+  padding: var(--space-5);
   border-radius: var(--radius-card);
   border: 1px dashed var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .dr-empty svg { font-size: 22px; color: var(--color-success, var(--accent-presence)); flex-shrink: 0; }
 
 /* Summary + generated card -------------------------------------------------- */
 .dr-panel {
-  padding: 20px 22px;
+  padding: var(--space-5) 22px;
   border-radius: var(--radius-panel);
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
@@ -9750,7 +9750,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 6px;
   margin: 10px 0 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 .dr-narrative-byline svg { color: var(--accent-presence); }
@@ -9769,7 +9769,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   background: var(--bg-raised);
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   display: grid;
   gap: 10px;
 }
@@ -9783,7 +9783,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 620;
   min-width: 0;
   overflow: hidden;
@@ -9793,8 +9793,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-group__label svg { color: var(--color-success); flex: none; }
 .dr-diffstat {
   display: inline-flex;
-  gap: 8px;
-  font-size: 12px;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
   font-variant-numeric: tabular-nums;
   flex: none;
 }
@@ -9807,7 +9807,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: none;
   align-self: center;
   padding: 3px 9px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-size: 0.75rem;
   text-decoration: none;
   color: var(--color-info);
@@ -9824,7 +9824,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-quicklinks {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 @media (min-width: 560px) {
   .dr-quicklinks { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -9832,7 +9832,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-quicklink {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 14px 15px;
   border-radius: var(--radius-card);
   border: 1px solid var(--border-hairline);
@@ -9862,8 +9862,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   justify-content: space-between;
   gap: 18px;
   flex-wrap: wrap;
-  padding: 22px 24px;
-  margin-bottom: 40px;
+  padding: 22px var(--space-6);
+  margin-bottom: var(--space-10);
   border-radius: var(--radius-panel);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
   background:
@@ -9890,10 +9890,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-mini-stat b { font-size: 13.5px; font-weight: 650; color: var(--text-secondary); }
 
 .dr-footer {
-  margin-top: 12px;
+  margin-top: var(--space-3);
   padding-top: 22px;
   border-top: 1px solid var(--border-hairline);
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -9926,10 +9926,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0 0 10px;
   color: var(--accent-presence);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -9944,13 +9944,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   margin: 10px 0 0;
   max-width: 66ch;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1.6;
 }
 .retro-hero__actions {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex-shrink: 0;
 }
 .retro-btn,
@@ -9964,11 +9964,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   transition: border-color 0.14s ease, background 0.14s ease, transform 0.06s ease;
 }
 .retro-btn {
-  gap: 8px;
+  gap: var(--space-2);
   height: 38px;
   padding: 0 14px;
   border-radius: var(--radius-control);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 620;
 }
 .retro-icon-btn {
@@ -10006,7 +10006,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-metric svg { color: var(--accent-presence); }
 .retro-metric span {
   display: block;
-  margin-top: 12px;
+  margin-top: var(--space-3);
   font-size: 26px;
   font-weight: 740;
   line-height: 1;
@@ -10015,7 +10015,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-metric p {
   margin: 6px 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .retro-controls {
   display: grid;
@@ -10027,10 +10027,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-search {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   height: 40px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-raised);
@@ -10053,20 +10053,20 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-radius: var(--radius-control);
   background: var(--bg-raised);
   color: var(--text-primary);
-  padding: 0 12px;
-  font-size: 13px;
+  padding: 0 var(--space-3);
+  font-size: var(--text-base);
 }
 .retro-callout {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 14px;
   padding: 11px 13px;
   border: 1px solid color-mix(in oklch, var(--color-warning) 35%, var(--border-hairline));
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--color-warning) 12%, transparent);
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .retro-callout-retry {
   margin-left: auto;
@@ -10089,9 +10089,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-panel-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-bottom: 10px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 700;
   color: var(--text-secondary);
   text-transform: uppercase;
@@ -10100,7 +10100,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-familiar-panel ul {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -10111,7 +10111,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   justify-content: space-between;
   gap: 10px;
   min-width: 0;
-  padding: 8px 0;
+  padding: var(--space-2) 0;
   border-top: 1px solid var(--border-hairline);
 }
 .retro-familiar-panel b,
@@ -10128,7 +10128,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   width: 8px;
   height: 8px;
   flex-shrink: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-muted);
 }
 .retro-familiar-panel i.is-running {
@@ -10159,7 +10159,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .retro-run-row__identity { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .retro-avatar {
@@ -10186,9 +10186,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-run-row__familiar { font-size: 14px; font-weight: 650; }
 .retro-run-row__meta { margin-top: 2px; color: var(--text-muted); font-size: 12px; }
 .retro-run-row__summary {
-  margin: 12px 0 0;
+  margin: var(--space-3) 0 0;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1.55;
 }
 .retro-run-row__stats {
@@ -10198,7 +10198,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   gap: 10px;
   margin-top: 10px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .retro-delta {
   font-weight: 700;
@@ -10209,13 +10209,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-run-row__notes {
   margin: 10px 0 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
 }
 .retro-run-row__raw {
   margin-top: 10px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .retro-run-row__raw summary {
   cursor: pointer;
@@ -10225,13 +10225,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-run-row__raw pre {
   max-height: 260px;
   overflow: auto;
-  margin: 8px 0 0;
-  padding: 12px;
+  margin: var(--space-2) 0 0;
+  padding: var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
@@ -10243,8 +10243,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-width: 76px;
   height: 24px;
   flex-shrink: 0;
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
   font-weight: 700;
 }
 .retro-pill--accept {
@@ -10282,7 +10282,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 /* Truthful freshness stamp beside the refresh action (fa-topbar__updated kin). */
 .growth-hero__updated {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   align-self: center;
@@ -10291,8 +10291,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-triage {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin: 12px 0 0;
+  gap: var(--space-2);
+  margin: var(--space-3) 0 0;
   padding: 0;
   list-style: none;
 }
@@ -10300,11 +10300,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  padding: 4px 10px;
+  padding: var(--space-1) 10px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 650;
 }
 .growth-triage__chip--stalled {
@@ -10345,7 +10345,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-sidebar ul {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -10376,7 +10376,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-flex;
   margin: 2px 0 0 54px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-decoration: none;
 }
 .growth-familiar__analytics:hover { color: var(--accent-presence); }
@@ -10397,7 +10397,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-dot {
   width: 9px;
   height: 9px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-muted);
 }
 .growth-dot--active { background: var(--color-success); box-shadow: 0 0 0 4px color-mix(in oklch, var(--color-success) 16%, transparent); }
@@ -10430,10 +10430,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   letter-spacing: 0;
 }
 .growth-report__header p:not(.retro-eyebrow) {
-  margin: 8px 0 0;
+  margin: var(--space-2) 0 0;
   max-width: 68ch;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.55;
 }
 .growth-health {
@@ -10442,8 +10442,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   justify-content: center;
   min-width: 82px;
   height: 28px;
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
   font-weight: 760;
   text-transform: uppercase;
 }
@@ -10479,13 +10479,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-summary__item p {
   margin: 5px 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .growth-summary__item small {
   display: block;
   margin-top: 6px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 /* Week-over-week movement chip — direction is the signal, tinted accordingly. */
 .growth-delta {
@@ -10493,10 +10493,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   width: max-content;
   margin-top: 6px;
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
-  font-size: 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-2xs);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
@@ -10513,7 +10513,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-delta--flat { color: var(--text-muted); }
 .growth-section {
   min-width: 0;
-  padding: 16px;
+  padding: var(--space-4);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
@@ -10522,26 +10522,26 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
 }
 .growth-section__head h4 {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 720;
 }
 .growth-section__head span {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Section-head drill-through — the count doubles as a door to the sessions
    list on the analytics page. */
 .growth-section__link {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-decoration: none;
 }
 .growth-section__link:hover { color: var(--text-primary); }
@@ -10549,38 +10549,38 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 .growth-track-card {
   min-width: 0;
-  padding: 12px;
+  padding: var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
 }
 .growth-track-card span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   text-transform: uppercase;
 }
 .growth-track-card b {
   display: block;
-  margin-top: 8px;
+  margin-top: var(--space-2);
   font-size: 24px;
   line-height: 1;
 }
 .growth-track-card p {
   margin: 6px 0 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Accept-rate meter — tone thresholds match GROWTH_THRESHOLDS (0.35 / 0.5). */
 .growth-track-meter {
   overflow: hidden;
   height: 6px;
-  margin-top: 8px;
-  border-radius: 999px;
+  margin-top: var(--space-2);
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--foreground) 7%, transparent);
 }
 .growth-track-meter i {
@@ -10608,7 +10608,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   grid-template-columns: 18px minmax(0, 1fr);
   gap: 10px;
   min-width: 0;
-  padding: 12px;
+  padding: var(--space-3);
   border: 1px solid var(--border-hairline);
   border-left-width: 3px;
   border-radius: var(--radius-control);
@@ -10622,19 +10622,19 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .growth-signal b { font-size: 13px; }
 .growth-signal small {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
 }
 /* Signal next step — every non-healthy signal carries the door to its fix. */
 .growth-signal__action {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   margin-top: 6px;
   color: var(--accent-presence);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-decoration: none;
 }
 .growth-signal__action:hover { text-decoration: underline; }
@@ -10674,7 +10674,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   overflow-y: auto;
   /* KPI drill-throughs glide to their section instead of teleporting. */
   scroll-behavior: smooth;
-  padding: 24px;
+  padding: var(--space-6);
   background: var(--bg-base);
   color: var(--text-primary);
   /* The same component renders full-page and inside the narrow inspector tab —
@@ -10692,12 +10692,12 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 34px;
   margin: -24px -24px 0;
-  padding: 10px 24px;
+  padding: 10px var(--space-6);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   background: color-mix(in oklch, var(--bg-base) 84%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -10714,7 +10714,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-topbar__updated {
   margin-left: auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
 }
 /* The stamp owns the right-push; the refresh button rides after it. (The
@@ -10733,7 +10733,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 20px;
+  gap: var(--space-5);
   padding: 18px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
@@ -10758,17 +10758,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-pulse__label {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 .fa-pulse__meta {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-header h1 {
-  margin: 4px 0 3px;
+  margin: var(--space-1) 0 3px;
   font-size: 26px;
   line-height: 1.1;
   letter-spacing: 0;
@@ -10776,7 +10776,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-header p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .fa-avatar {
   display: grid;
@@ -10841,9 +10841,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   color: var(--text-primary);
 }
 .fa-ring__label span {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: var(--fa-ring-color);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 800;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -10877,7 +10877,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 0 0 auto;
   margin-left: auto;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   text-decoration: none;
   border-radius: var(--radius-control);
@@ -10903,7 +10903,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   flex-direction: column;
   gap: 3px;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   border: 1px solid var(--border-hairline);
   border-left: 3px solid var(--border-hairline);
   border-radius: var(--radius-card);
@@ -10942,7 +10942,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 6px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
 }
 .fa-kpi__head svg { width: 14px; height: 14px; opacity: 0.85; }
@@ -10968,8 +10968,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
+  gap: var(--space-3);
+  padding: var(--space-4);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   background: var(--bg-surface);
@@ -10989,7 +10989,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 /* ── Recent sessions — the tracing spine of the analytics page. Rows open
    their thread (/#chat-<id>) or the daemon-event trace overlay; the hero
@@ -10997,7 +10997,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-sessions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .fa-session-list {
   display: flex;
@@ -11012,7 +11012,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 10px;
   min-width: 0;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -11021,7 +11021,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 0 0 auto;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 .fa-session__dot--run { background: var(--color-success); }
 .fa-session__dot--bad { background: var(--color-danger); }
@@ -11036,7 +11036,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-session__title {
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -11045,7 +11045,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-session__meta {
   overflow: hidden;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -11053,20 +11053,20 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-session__time {
   flex: 0 0 auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-trace-btn {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
+  gap: var(--space-1);
+  padding: 3px var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
 }
 .fa-trace-btn:hover {
@@ -11078,19 +11078,19 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 6px;
   align-self: flex-start;
-  padding: 4px 10px;
+  padding: var(--space-1) 10px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-primary);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
 }
 .fa-sessions__truncation {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-pulse__meta a {
   color: inherit;
@@ -11104,19 +11104,19 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .trace {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 .trace__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .trace__lede {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .trace-list {
   display: flex;
@@ -11131,7 +11131,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);
   gap: 10px;
-  padding: 8px 2px;
+  padding: var(--space-2) 2px;
 }
 .trace-item__marker {
   position: relative;
@@ -11139,7 +11139,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 8px;
   margin-top: 5px;
   justify-self: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--foreground) 30%, transparent);
 }
 /* The rail — each marker draws its own segment so the line never overshoots. */
@@ -11165,12 +11165,12 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .trace-kind {
   overflow: hidden;
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
   font-family: var(--font-mono, monospace);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -11189,29 +11189,29 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .trace-item__time {
   flex: 0 0 auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .trace-item__summary {
-  margin: 4px 0 0;
+  margin: var(--space-1) 0 0;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
 .trace-item__raw summary {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
 }
 .trace-item__raw pre {
   margin: 6px 0 0;
-  padding: 8px;
+  padding: var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   max-height: 220px;
   overflow: auto;
 }
@@ -11226,7 +11226,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-feedback-group__label {
   margin: 0 0 6px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -11244,7 +11244,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   grid-template-columns: minmax(90px, 1fr) minmax(60px, 1.2fr) auto;
   align-items: center;
   gap: 10px;
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .fa-feedback-row__name {
   overflow: hidden;
@@ -11252,12 +11252,12 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   white-space: nowrap;
   color: var(--text-primary);
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-feedback-row__bar {
   position: relative;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--color-danger) 28%, var(--bg-base));
   overflow: hidden;
 }
@@ -11272,7 +11272,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 10px;
   font-variant-numeric: tabular-nums;
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-feedback-row__up,
 .fa-feedback-row__down {
@@ -11285,17 +11285,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-feedback__unstamped {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Counts read as quiet pill chips, matching the app's chip language. */
 .fa-section__head > span {
   flex: 0 0 auto;
   padding: 2px 9px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -11303,7 +11303,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-section__title {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--text-md);
   letter-spacing: 0;
 }
 .fa-heal-list {
@@ -11315,7 +11315,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-analysis {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .fa-thread-analysis .fa-thread-score-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -11324,7 +11324,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-trend {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
@@ -11334,14 +11334,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 .fa-trend-verdict {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -11353,18 +11353,18 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-trend-verdict--insufficient { color: var(--text-muted); font-weight: 400; }
 .fa-trend__meta {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-trend__spark { margin: 0; }
 .fa-trend__spark figcaption {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }
 .fa-trend__empty {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 /* Per-metric delta against the previous trend bucket. */
 .fa-trend-chip {
@@ -11372,7 +11372,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 2px;
   margin-right: 6px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   vertical-align: middle;
@@ -11386,7 +11386,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 10px;
   /* Keeps bars visible inside the narrowest metric cells. */
   min-width: 44px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-raised);
 }
 .fa-factor-segment {
@@ -11422,8 +11422,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--space-3);
+  padding: var(--space-3);
   border: 1px solid var(--border-hairline);
   border-left-width: 3px;
   border-radius: var(--radius-control);
@@ -11434,18 +11434,18 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-heal-card--info { border-left-color: var(--color-info); }
 .fa-heal-card span {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
 }
 .fa-heal-card h3 {
   margin: 3px 0;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .fa-heal-card p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
 }
 .fa-heal-card > b {
@@ -11454,23 +11454,23 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
 }
 .fa-thread-signals {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .fa-response-confidence {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 /* Per-response confidence trend — the section's time axis. */
 .fa-response-trend {
   margin: 0;
-  padding: 12px 12px 8px;
+  padding: var(--space-3) var(--space-3) var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -11478,12 +11478,12 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-response-trend figcaption {
   margin-top: 6px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-response-factor-grid {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 .fa-response-factor {
   min-width: 0;
@@ -11495,7 +11495,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-response-factor span {
   display: block;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.25;
 }
 .fa-response-factor b {
@@ -11507,17 +11507,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-response-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .fa-response-tags > span {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-response-tags b {
   color: var(--text-primary);
@@ -11526,9 +11526,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 /* ── Recent responses — each confidence event links back to its thread, and
    can open the session trace. Score chip is tinted by the trend thresholds. */
 .fa-response-events h3 {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -11546,7 +11546,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 10px;
   min-width: 0;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -11555,8 +11555,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 0 0 auto;
   min-width: 34px;
   padding: 2px 6px;
-  border-radius: 999px;
-  font-size: 12px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
@@ -11582,7 +11582,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-response-event__body a {
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -11591,14 +11591,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-response-event__body small {
   overflow: hidden;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .fa-thread-empty { min-width: 0; }
 .fa-thread-review {
   min-width: 0;
-  padding: 12px;
+  padding: var(--space-3);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 36%, var(--border-hairline));
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 7%, var(--bg-base));
@@ -11607,34 +11607,34 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 10px;
   min-width: 0;
 }
 .fa-thread-review-head h3 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .fa-thread-review-head p {
   margin: 3px 0 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-thread-review-head > span {
   flex: 0 0 auto;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-thread-review-empty {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .fa-thread-review-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -11673,7 +11673,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-thread-review-chip {
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
 }
 .fa-thread-review-chip b {
@@ -11694,7 +11694,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-review-item {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   min-width: 0;
   height: auto;
@@ -11706,7 +11706,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: var(--bg-base);
   color: var(--text-secondary);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
   cursor: pointer;
   transition: border-color 120ms ease, background 120ms ease;
@@ -11761,7 +11761,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-score {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   padding: 10px;
   border: 1px solid var(--border-hairline);
@@ -11771,9 +11771,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-score > div:first-child {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .fa-thread-score b {
   color: var(--text-primary);
@@ -11782,17 +11782,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-contexts {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .fa-thread-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-transform: capitalize;
 }
 .fa-thread-pill--critical {
@@ -11807,7 +11807,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-table-shell {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 .fa-thread-table-toolbar {
@@ -11820,9 +11820,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-table__select-all {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 .fa-thread-table-wrap {
@@ -11849,7 +11849,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-width: 760px;
   border-collapse: collapse;
   table-layout: fixed;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .fa-thread-table__col-select { width: 34px; }
 .fa-thread-table__col-signal { width: 23%; }
@@ -11862,11 +11862,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   position: sticky;
   top: 0;
   z-index: 1;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border-bottom: 1px solid var(--border-strong);
   background: var(--bg-base);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   text-align: left;
   white-space: nowrap;
@@ -11886,12 +11886,12 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   vertical-align: middle;
 }
 .fa-thread-table__group td {
-  padding: 8px 10px 7px;
+  padding: var(--space-2) 10px 7px;
   border-top: 1px solid var(--border-strong);
   border-bottom: 1px solid var(--border-strong);
   background: color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 700;
   letter-spacing: .04em;
   text-transform: uppercase;
@@ -11908,17 +11908,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   margin-left: 6px;
   padding: 0 5px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 500;
   vertical-align: middle;
 }
 .fa-thread-table__signal-cell {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 .fa-thread-table__severity {
@@ -11938,7 +11938,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   max-width: 100%;
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   text-overflow: ellipsis;
   vertical-align: middle;
@@ -11947,16 +11947,16 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-table .board-table-muted,
 .fa-thread-table .board-table-cell-time {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .fa-thread-table__state {
   display: inline-flex;
   max-width: 100%;
   padding: 2px 7px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.35;
   text-transform: capitalize;
 }
@@ -11976,13 +11976,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: block;
   min-width: 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
 .fa-thread-table__empty td {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Sortable header buttons — quiet text that inherits the th typography. */
 .fa-thread-table thead th .fa-thread-table__sort {
@@ -11991,7 +11991,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 0;
   background: transparent;
   color: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 .fa-thread-table thead th .fa-thread-table__sort:hover {
@@ -12025,7 +12025,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   align-items: center;
   gap: 5px;
   color: var(--color-success, var(--accent-presence));
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .fa-contract-grid {
   display: grid;
@@ -12044,7 +12044,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   /* Top-align the badge with the label's first line — with centered
      alignment, two-line labels floated the icon into the seam between lines. */
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   padding: 9px 11px;
   border: 1px solid var(--border-hairline);
@@ -12053,7 +12053,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
      (.fa-thread-score) instead of a hollow outline. */
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .fa-contract-item svg {
   flex: 0 0 auto;
@@ -12099,7 +12099,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   /* Full-width stacked layout — trim the hero bars so they stay proportional. */
   .fa-header__pulse .pulse-bars--lg {
     height: 48px;
-    gap: 4px;
+    gap: var(--space-1);
   }
   .fa-ring {
     width: 86px;
@@ -12139,8 +12139,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin: 12px 0;
-  padding: 12px;
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, var(--border-hairline));
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 7%, var(--bg-surface));
@@ -12150,36 +12150,36 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 .tsc-title {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 700;
 }
 .tsc-meta {
   min-width: 0;
   overflow: hidden;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .tsc-scores {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 .tsc-score-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
-  padding: 8px;
+  padding: var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -12188,14 +12188,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-width: 0;
   overflow: hidden;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .tsc-score-item strong {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-variant-numeric: tabular-nums;
 }
 .tsc-score-item--ok strong { color: var(--color-success); }
@@ -12203,13 +12203,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .tsc-score-item--crit strong { color: var(--color-danger); }
 .tsc-blockers {
   color: var(--color-warning);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .tsc-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .tsc-actions button {
   display: inline-flex;
@@ -12221,7 +12221,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .tsc-actions button:hover {
   color: var(--text-primary);
@@ -12344,7 +12344,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   padding: 0.4rem 0.6rem;
   border-radius: 0.625rem;
   background: var(--bg-raised);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .cave-edit-card__summary {
   display: grid !important;
@@ -12406,7 +12406,7 @@ details[open] > .cave-edit-card__summary::before {
 .cave-edit-card__stat {
   flex: none;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .cave-edit-card__ins {
   color: var(--color-success);
@@ -12421,7 +12421,7 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: 0.5rem;
   background: transparent;
   color: var(--text-secondary, var(--text-primary));
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
 }
 .cave-edit-card__review:hover {
@@ -12441,7 +12441,7 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: 0.5rem;
   background: transparent;
   color: var(--text-secondary, var(--text-primary));
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
 }
 .cave-edit-card__undo:hover:not(:disabled) {
@@ -12462,7 +12462,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-edit-card__reverted {
   flex: none;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 .cave-edit-card__error {
@@ -12471,7 +12471,7 @@ details[open] > .cave-edit-card__summary::before {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-danger);
 }
 /* Review modal for edits the Changes panel can't show (file outside the
@@ -12479,7 +12479,7 @@ details[open] > .cave-edit-card__summary::before {
 .cave-review-modal {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 .cave-review-modal__path {
@@ -12488,7 +12488,7 @@ details[open] > .cave-edit-card__summary::before {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -12575,8 +12575,8 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-2);
+  padding: 10px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
 }
@@ -12586,7 +12586,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -12615,7 +12615,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 12px;
+  padding: var(--space-3);
   scrollbar-width: thin;
   scrollbar-color: var(--border-hairline) transparent;
 }
@@ -12624,13 +12624,13 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-thread::-webkit-scrollbar-thumb {
   background: var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 /* Turns — user right-aligned; familiar left with an avatar gutter. */
 .quick-chat-turn {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 100%;
 }
 .quick-chat-turn--user {
@@ -12647,8 +12647,8 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-bubble {
   min-width: 0;
   border-radius: var(--radius-panel, 14px);
-  padding: 8px 11px;
-  font-size: 13px;
+  padding: var(--space-2) 11px;
+  font-size: var(--text-base);
   line-height: 1.5;
 }
 .quick-chat-bubble--user {
@@ -12690,7 +12690,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-turn__error {
   margin-top: 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-danger, #e5484d);
 }
 
@@ -12710,13 +12710,13 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-typing {
   display: inline-flex;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 3px 0;
 }
 .quick-chat-typing i {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--fg-muted);
   animation: quick-chat-typing-bounce 1.1s ease-in-out infinite;
 }
@@ -12755,12 +12755,12 @@ details[open] > .cave-edit-card__summary::before {
   place-items: center;
   width: 40px;
   height: 40px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--accent-presence);
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
 .quick-chat-empty__title {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
 }
 .quick-chat-empty__hint {
@@ -12773,10 +12773,10 @@ details[open] > .cave-edit-card__summary::before {
   flex-wrap: wrap;
   justify-content: center;
   gap: 6px;
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 .quick-chat-chip {
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 /* Reply recommendation — a proposed next reply offered above the composer,
@@ -12784,8 +12784,8 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-reco {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px 6px 10px;
+  gap: var(--space-2);
+  padding: 6px var(--space-2) 6px 10px;
   border-radius: var(--radius-control);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
@@ -12793,7 +12793,7 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-reco__label {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex-shrink: 0;
   font-size: 10.5px;
   font-weight: 600;
@@ -12823,7 +12823,7 @@ details[open] > .cave-edit-card__summary::before {
   flex-shrink: 0;
 }
 .quick-chat-reco__kbd {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: var(--font-mono, ui-monospace, monospace);
   padding: 1px 5px;
   border-radius: 5px;
@@ -12867,7 +12867,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 .ui-btn.quick-chat-next-path {
   height: auto;
@@ -12894,8 +12894,8 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-overlay__composer {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-2);
+  padding: 10px var(--space-3);
   border-top: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 30%, transparent);
 }
@@ -12911,8 +12911,8 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
-  padding: 8px 10px;
-  font-size: 13px;
+  padding: var(--space-2) 10px;
+  font-size: var(--text-base);
   line-height: 1.45;
   outline: none;
   field-sizing: content;
@@ -12928,7 +12928,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .quick-chat-overlay__actions button:not(:disabled):hover {
   filter: brightness(1.06);
@@ -12940,17 +12940,17 @@ details[open] > .cave-edit-card__summary::before {
   display: inline-flex;
   min-width: 0;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   overflow: hidden;
 }
 .quick-chat-meta-chip {
   display: inline-flex;
   align-items: center;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-subtle);
   padding: 1px 7px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1.5;
   color: var(--text-secondary);
   white-space: nowrap;
@@ -12984,7 +12984,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--accent-presence);
   background: color-mix(in oklch, var(--bg-base) 78%, transparent);
@@ -12996,18 +12996,18 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-attachments {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .quick-chat-attachment-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   max-width: 100%;
-  padding: 2px 4px 2px 8px;
+  padding: 2px var(--space-1) 2px var(--space-2);
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 .quick-chat-attachment-chip__name {
@@ -13020,9 +13020,9 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-bubble__files {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   margin-top: 2px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--fg-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13033,14 +13033,14 @@ details[open] > .cave-edit-card__summary::before {
 .quick-chat-queued {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .quick-chat-queued__chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
-  padding: 2px 4px 2px 8px;
+  padding: 2px var(--space-1) 2px var(--space-2);
   border-radius: var(--radius-control);
   border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 6%, transparent);
@@ -13079,7 +13079,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .quick-chat-queued__count {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--fg-muted);
 }
 
@@ -13146,7 +13146,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
-  padding: 6px 8px 6px 12px;
+  padding: 6px var(--space-2) 6px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
   flex: 0 0 auto;
@@ -13156,7 +13156,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   gap: 6px;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0.01em;
   color: var(--text-muted);
@@ -13178,7 +13178,7 @@ details[open] > .cave-edit-card__summary::before {
   height: 22px;
   padding: 0 5px;
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1;
   color: var(--text-muted);
   background: transparent;
@@ -13239,7 +13239,7 @@ details[open] > .cave-edit-card__summary::before {
   transform: translate(-50%, -50%) scaleY(0.55);
   width: 4px;
   height: 36px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--text-muted) 60%, transparent);
   opacity: 0;
   pointer-events: none;
@@ -13290,9 +13290,9 @@ details[open] > .cave-edit-card__summary::before {
   top: 10px;
   left: 50%;
   transform: translateX(-50%);
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 11px;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
   font-weight: 700;
   line-height: 1.4;
   color: var(--accent-presence-foreground, #fff);
@@ -13337,10 +13337,10 @@ details[open] > .cave-edit-card__summary::before {
 .split-dropzone__hint {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border-radius: 999px;
-  font-size: 13px;
+  gap: var(--space-2);
+  padding: var(--space-2) 14px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-base);
   font-weight: 600;
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
   border: 1px solid var(--border-hairline);
@@ -13391,7 +13391,7 @@ details[open] > .cave-edit-card__summary::before {
 .chat-split__pane-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 0 0 auto;
   min-height: 32px;
   padding: 0 6px 0 10px;
@@ -13419,7 +13419,7 @@ details[open] > .cave-edit-card__summary::before {
   gap: 6px;
   min-width: 0;
   flex: 1;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
 }
@@ -13486,11 +13486,11 @@ details[open] > .cave-edit-card__summary::before {
 .chat-split__hint {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 80%;
-  padding: 8px 14px;
-  border-radius: 999px;
-  font-size: 13px;
+  padding: var(--space-2) 14px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
@@ -13514,7 +13514,7 @@ details[open] > .cave-edit-card__summary::before {
     flex: 0 0 auto;
     display: flex;
     gap: 6px;
-    padding: 6px 8px;
+    padding: 6px var(--space-2);
     overflow-x: auto;
     border-bottom: 1px solid var(--border-hairline);
     background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
@@ -13529,7 +13529,7 @@ details[open] > .cave-edit-card__summary::before {
     border-radius: var(--radius-sm);
     background: transparent;
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--text-sm);
     font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -13574,7 +13574,7 @@ details[open] > .cave-edit-card__summary::before {
   min-width: 0;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
 }
 .marketplace-category-stack {
   display: flex;
@@ -13592,7 +13592,7 @@ details[open] > .cave-edit-card__summary::before {
   min-height: 34px;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
   padding-bottom: 7px;
 }
@@ -13600,7 +13600,7 @@ details[open] > .cave-edit-card__summary::before {
   margin: 0;
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 700;
   line-height: 1.2;
   text-overflow: ellipsis;
@@ -13610,7 +13610,7 @@ details[open] > .cave-edit-card__summary::before {
   margin: 2px 0 0;
   overflow: hidden;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -13624,9 +13624,9 @@ details[open] > .cave-edit-card__summary::before {
   min-height: 178px;
   min-width: 0;
   border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-panel) 88%, transparent);
-  padding: 12px;
+  padding: var(--space-3);
 }
 .marketplace-card__decision {
   display: flex;
@@ -13637,20 +13637,20 @@ details[open] > .cave-edit-card__summary::before {
 .marketplace-card__decision-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   max-width: 100%;
   min-height: 22px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   border: 1px solid color-mix(in oklch, var(--border-hairline) 82%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-base) 84%, transparent);
   color: var(--text-secondary);
   font-size: 10.5px;
   font-weight: 650;
   line-height: 1;
-  padding: 4px 7px;
+  padding: var(--space-1) 7px;
 }
 .marketplace-card__meta {
   display: flex;
@@ -13666,7 +13666,7 @@ details[open] > .cave-edit-card__summary::before {
   min-height: 20px;
   max-width: 100%;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   overflow: hidden;
   border: 0;
   background: transparent;
@@ -13688,27 +13688,27 @@ details[open] > .cave-edit-card__summary::before {
 .marketplace-detail__decision-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 .marketplace-detail__decision-card {
   min-height: 112px;
   min-width: 0;
   border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-panel) 88%, transparent);
   padding: 10px;
 }
 .marketplace-detail__decision-card strong {
   display: block;
-  margin-top: 8px;
+  margin-top: var(--space-2);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.25;
 }
 .marketplace-detail__decision-card p {
   margin-top: 5px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.35;
 }
 .marketplace-detail__decision-label {
@@ -13717,7 +13717,7 @@ details[open] > .cave-edit-card__summary::before {
   gap: 5px;
   max-width: 100%;
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.06em;
   line-height: 1.1;
@@ -13726,7 +13726,7 @@ details[open] > .cave-edit-card__summary::before {
 @media (max-width: 520px) {
   .marketplace-browse-summary {
     flex-direction: column;
-    gap: 8px;
+    gap: var(--space-2);
   }
   .marketplace-detail__decision-grid {
     grid-template-columns: 1fr;
@@ -13740,8 +13740,8 @@ details[open] > .cave-edit-card__summary::before {
 .craft-loadout-intro {
   display: grid;
   grid-template-columns: minmax(220px, 0.8fr) minmax(420px, 1.6fr);
-  gap: 20px;
-  margin-bottom: 20px;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 88%, transparent);
   border-radius: 10px;
   background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
@@ -13757,13 +13757,13 @@ details[open] > .cave-edit-card__summary::before {
 .craft-loadout-intro p {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
 }
 .craft-loadout-intro__eyebrow,
 .craft-dossier__eyebrow {
   color: var(--text-secondary) !important;
-  font-size: 10px !important;
+  font-size: var(--text-2xs) !important;
   font-style: normal;
   font-weight: 750;
   letter-spacing: 0.13em;
@@ -13774,7 +13774,7 @@ details[open] > .cave-edit-card__summary::before {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   overflow: hidden;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
 }
 .craft-loadout-path > span {
@@ -13784,7 +13784,7 @@ details[open] > .cave-edit-card__summary::before {
   flex-direction: column;
   justify-content: center;
   gap: 2px;
-  padding: 12px 13px;
+  padding: var(--space-3) 13px;
 }
 .craft-loadout-path > span + span { border-left: 1px solid var(--border-hairline); }
 .craft-loadout-path small { color: var(--text-muted); font-size: 9px; font-variant-numeric: tabular-nums; }
@@ -13795,10 +13795,10 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Crafts grid lifecycle groups: local drafts above the published catalog. */
 .craft-grid-group { display: grid; gap: 10px; }
@@ -13807,7 +13807,7 @@ details[open] > .cave-edit-card__summary::before {
 .craft-grid-group__head h3 {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 750;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -13817,13 +13817,13 @@ details[open] > .cave-edit-card__summary::before {
 .craft-arrival-banner {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
   border: 1px dashed var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   padding: 9px 11px;
 }
 .craft-arrival-banner span { flex: 1; min-width: 0; }
@@ -13841,11 +13841,11 @@ details[open] > .cave-edit-card__summary::before {
 /* Draft plan verification chip (docs/craft-ux.md F1/F8). */
 .craft-draft-plan-status {
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   color: var(--text-muted);
-  font-size: 12px;
-  padding: 8px 10px;
+  font-size: var(--text-sm);
+  padding: var(--space-2) 10px;
 }
 .craft-draft-plan-status[data-state="ok"] span { display: inline-flex; align-items: center; gap: 6px; color: var(--text-secondary); }
 .craft-draft-plan-status summary { cursor: pointer; color: var(--text-secondary); font-weight: 600; }
@@ -13855,7 +13855,7 @@ details[open] > .cave-edit-card__summary::before {
   display: grid;
   gap: 6px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   padding: 9px 11px;
 }
@@ -13892,9 +13892,9 @@ details[open] > .cave-edit-card__summary::before {
 .craft-dossier__header {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
-  padding: 16px 18px;
+  padding: var(--space-4) 18px;
 }
 .craft-dossier__header h2 { margin: 2px 0 3px; color: var(--text-primary); font-size: 18px; font-weight: 730; letter-spacing: -0.02em; }
 .craft-dossier__header p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.45; }
@@ -13973,7 +13973,7 @@ details[open] > .cave-edit-card__summary::before {
   width: min(520px, 100vw);
   height: 100%;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-4);
   overflow-y: auto;
   border-left: 1px solid var(--border-hairline);
   background: var(--bg-base);
@@ -13984,13 +13984,13 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .craft-create-drawer__headline { min-width: 0; }
 .craft-create-drawer__eyebrow {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -14004,7 +14004,7 @@ details[open] > .cave-edit-card__summary::before {
 .craft-create-drawer__subtitle {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .craft-create-drawer__close {
@@ -14012,7 +14012,7 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: 6px;
   background: transparent;
   color: var(--text-muted);
-  padding: 4px;
+  padding: var(--space-1);
 }
 .craft-create-drawer__close:hover { color: var(--text-primary); }
 .craft-create-drawer__alert {
@@ -14021,14 +14021,14 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: 6px;
   background: var(--danger-bg);
   color: var(--danger-text);
-  font-size: 12px;
-  padding: 8px 10px;
+  font-size: var(--text-sm);
+  padding: var(--space-2) 10px;
 }
 .craft-create-drawer__field {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .craft-create-drawer__modes {
   align-self: flex-start;
@@ -14040,9 +14040,9 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: var(--radius-control, 8px);
   background: var(--bg-panel);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.5;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
 }
 .craft-create-drawer__goal::placeholder { color: var(--text-muted); }
 .craft-create-drawer__name {
@@ -14050,27 +14050,27 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: var(--radius-control, 8px);
   background: var(--bg-panel);
   color: var(--text-primary);
-  font-size: 13px;
-  padding: 8px 10px;
+  font-size: var(--text-base);
+  padding: var(--space-2) 10px;
 }
 .craft-create-drawer__name::placeholder { color: var(--text-muted); }
 .craft-create-drawer__hint {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-style: normal;
 }
 .craft-create-drawer__teach {
   display: grid;
   justify-items: start;
-  gap: 8px;
+  gap: var(--space-2);
   border: 1px dashed var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
 }
 .craft-create-drawer__teach p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.5; }
 .craft-create-drawer__retry {
-  margin-left: 8px;
+  margin-left: var(--space-2);
   border: 0;
   border-radius: 6px;
   background: transparent;
@@ -14085,7 +14085,7 @@ details[open] > .cave-edit-card__summary::before {
 .craft-create-drawer__how { display: grid; gap: 6px; }
 .craft-create-drawer__how h3 {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -14095,9 +14095,9 @@ details[open] > .cave-edit-card__summary::before {
   margin: 0;
   padding-left: 18px;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
 }
 .craft-create-drawer__how li::marker {
@@ -14107,13 +14107,13 @@ details[open] > .cave-edit-card__summary::before {
 .craft-create-drawer__awaiting {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   padding: 10px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .craft-create-drawer__awaiting-spin {
@@ -14124,29 +14124,29 @@ details[open] > .cave-edit-card__summary::before {
   flex-shrink: 0;
   border: 1px solid var(--border-hairline);
   border-radius: 6px;
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .craft-create-drawer__select {
   border: 1px solid var(--border-hairline);
   border-radius: 6px;
   background: var(--bg-panel);
   color: var(--text-primary);
-  font-size: 13px;
-  padding: 8px 10px;
+  font-size: var(--text-base);
+  padding: var(--space-2) 10px;
 }
 .craft-create-drawer__roles { display: grid; gap: 8px; }
 .craft-create-drawer__roles h3 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 650;
 }
 .craft-create-drawer__status {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .craft-create-drawer__role-list { display: grid; gap: 8px; }
 .craft-create-drawer__role {
@@ -14155,7 +14155,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: start;
   gap: 9px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   padding: 10px;
 }
@@ -14167,13 +14167,13 @@ details[open] > .cave-edit-card__summary::before {
 .craft-create-drawer__role strong {
   display: block;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .craft-create-drawer__role em {
   display: block;
   margin-top: 2px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-style: normal;
   line-height: 1.35;
 }
@@ -14181,10 +14181,10 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: auto;
   border-top: 1px solid var(--border-hairline);
-  padding-top: 12px;
+  padding-top: var(--space-3);
 }
 .craft-draft-ledger {
   display: grid;
@@ -14192,12 +14192,12 @@ details[open] > .cave-edit-card__summary::before {
   border: 1px solid var(--border-hairline);
   border-radius: 9px;
   background: var(--bg-panel);
-  padding: 12px;
+  padding: var(--space-3);
 }
 .craft-draft-ledger h3 {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 750;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -14212,7 +14212,7 @@ details[open] > .cave-edit-card__summary::before {
   background: var(--bg-base);
   color: var(--text-secondary);
   font-size: 10.5px;
-  padding: 4px 6px;
+  padding: var(--space-1) 6px;
 }
 .craft-draft-ledger__origin {
   color: var(--text-muted);
@@ -14230,7 +14230,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .craft-draft-ledger__stats strong {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 @media (max-width: 720px) {
   .craft-loadout-intro { grid-template-columns: 1fr; }
@@ -14259,7 +14259,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: 8px 18px;
+  gap: var(--space-2) 18px;
   padding: 10px 2px;
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
@@ -14316,7 +14316,7 @@ details[open] > .cave-edit-card__summary::before {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 14px 14px 18px;
   overflow-y: auto;
   border-right: 1px solid var(--border-hairline);
@@ -14325,7 +14325,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 2px 2px 12px;
+  padding: 2px 2px var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 .skill-browser__leaderboard-kicker {
@@ -14338,7 +14338,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .skill-browser__leaderboard-title {
   margin: 2px 0 0;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   letter-spacing: -0.01em;
@@ -14353,7 +14353,7 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__ecosystem-command {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
 }
 .skill-browser__ecosystem-command span {
@@ -14372,7 +14372,7 @@ details[open] > .cave-edit-card__summary::before {
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
   color: var(--text-secondary);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
   padding: 6px 9px;
 }
 /* Single summary line — the old chip strip overflowed sideways. */
@@ -14386,7 +14386,7 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__directory-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 2px 12px;
+  gap: 2px var(--space-3);
 }
 .skill-browser__directory-links a {
   flex: 0 0 auto;
@@ -14409,18 +14409,18 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__agents {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 /* Badge toggles ride inside the merged Filter group, set off from the
    category buttons by a hairline. */
 .skill-browser__rail-group .skill-browser__browse {
   margin-top: 6px;
-  padding-top: 8px;
+  padding-top: var(--space-2);
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 /* Rank lives in the leaderboard header now — a compact segmented control. */
 .skill-browser__leaderboard .skill-browser__modes {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   gap: 2px;
   padding: 2px;
   border-radius: var(--radius-pill, 999px);
@@ -14430,7 +14430,7 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__rail-group--inline {
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .skill-browser__rail-group--inline .skill-browser__rail-label {
   margin: 0;
@@ -14442,11 +14442,11 @@ details[open] > .cave-edit-card__summary::before {
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: transparent;
-  padding: 4px 8px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
 }
 .skill-browser__topics {
-  gap: 4px;
+  gap: var(--space-1);
 }
 .skill-browser__browse-btn,
 .skill-browser__topic,
@@ -14459,7 +14459,7 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: var(--radius-pill, 999px);
   background: transparent;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 550;
   line-height: 1;
   padding: 6px 9px;
@@ -14471,7 +14471,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .skill-browser__topic-count {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-variant-numeric: tabular-nums;
   opacity: 0.8;
 }
@@ -14504,7 +14504,7 @@ details[open] > .cave-edit-card__summary::before {
   width: 100%;
   min-height: 72px;
   text-align: left;
-  padding: 11px 12px;
+  padding: 11px var(--space-3);
   border-radius: var(--radius-card, 10px);
   border: 1px solid transparent;
   background: transparent;
@@ -14549,7 +14549,7 @@ details[open] > .cave-edit-card__summary::before {
   color: var(--text-muted);
 }
 .skill-browser__card-desc {
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-muted);
   display: -webkit-box;
@@ -14561,7 +14561,7 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__badge {
   flex: 0 0 auto;
   align-self: flex-start;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-secondary);
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
@@ -14592,7 +14592,7 @@ details[open] > .cave-edit-card__summary::before {
 .skill-browser__activity-bar {
   width: 3.5px;
   min-height: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--text-muted) 55%, transparent);
   transition: background 0.12s ease;
 }
@@ -14605,9 +14605,9 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -14615,7 +14615,7 @@ details[open] > .cave-edit-card__summary::before {
   display: block;
   max-width: 44px;
   height: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 
@@ -14626,7 +14626,7 @@ details[open] > .cave-edit-card__summary::before {
   width: 100%;
   max-width: 820px;
   margin-inline: auto;
-  padding: 26px 28px 16px;
+  padding: 26px 28px var(--space-4);
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 .skill-browser__detail-titlerow { display: flex; align-items: flex-start; gap: 12px; }
@@ -14637,9 +14637,9 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   gap: 6px;
   height: 30px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--surface-raised, transparent);
   color: var(--text-muted);
   cursor: pointer;
@@ -14667,9 +14667,9 @@ details[open] > .cave-edit-card__summary::before {
 }
 .skill-browser__decision-card strong {
   display: block;
-  margin-top: 4px;
+  margin-top: var(--space-1);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   line-height: 1.2;
   white-space: nowrap;
@@ -14693,7 +14693,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: 10px;
   min-width: 0;
 }
@@ -14707,9 +14707,9 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   overflow: hidden;
   height: 30px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-base);
   cursor: pointer;
   text-align: left;
@@ -14727,7 +14727,7 @@ details[open] > .cave-edit-card__summary::before {
   background: transparent;
   color: var(--text-primary);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 /* Green fill that sweeps left→right on copy. */
 .skill-browser__cli-fill {
@@ -14748,10 +14748,10 @@ details[open] > .cave-edit-card__summary::before {
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  padding-left: 8px;
+  padding-left: var(--space-2);
   background: linear-gradient(to right, transparent, var(--bg-base) 30%);
   color: var(--color-success);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 650;
   opacity: 0;
   transition: opacity 0.15s ease 0.1s;
@@ -14773,10 +14773,10 @@ details[open] > .cave-edit-card__summary::before {
   height: 30px;
   padding: 0 10px;
   border: 1px solid var(--accent-soft-border, var(--border-hairline));
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--accent-soft-bg, var(--surface-raised));
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 650;
   white-space: nowrap;
   cursor: pointer;
@@ -14814,18 +14814,18 @@ details[open] > .cave-edit-card__summary::before {
 }
 .skill-browser__detail-meta { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 12px; }
 .skill-browser__tag {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
   border: 0;
   border-radius: var(--radius-pill, 999px);
-  padding: 3px 8px;
+  padding: 3px var(--space-2);
 }
 .skill-browser__links {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 2px 12px;
+  gap: 2px var(--space-3);
   margin-top: 10px;
 }
 .skill-browser__links a,
@@ -14833,7 +14833,7 @@ details[open] > .cave-edit-card__summary::before {
   border: 0;
   background: transparent;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 550;
   padding: 0;
   text-decoration: none;
@@ -14852,9 +14852,9 @@ details[open] > .cave-edit-card__summary::before {
   gap: 6px;
   margin-top: 10px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-panel, var(--bg-base)) 74%, transparent);
-  padding: 8px;
+  padding: var(--space-2);
 }
 .skill-browser__source-group-head {
   display: flex;
@@ -14862,7 +14862,7 @@ details[open] > .cave-edit-card__summary::before {
   justify-content: space-between;
   gap: 10px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .skill-browser__source-group-head span:first-child {
   min-width: 0;
@@ -14886,14 +14886,14 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   border: 1px solid var(--border-hairline);
   border-radius: 7px;
   background: var(--bg-base);
   color: var(--text-secondary);
-  font-size: 11px;
-  padding: 6px 8px;
+  font-size: var(--text-xs);
+  padding: 6px var(--space-2);
   cursor: pointer;
 }
 .skill-browser__source-skill:hover {
@@ -14917,7 +14917,7 @@ details[open] > .cave-edit-card__summary::before {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 20px 28px 40px;
+  padding: var(--space-5) 28px var(--space-10);
 }
 /* The rendered SKILL.md shares the header's readable column. */
 .skill-browser__detail-body > * {
@@ -14931,21 +14931,21 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 32px 16px;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-4);
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 .skill-browser__empty svg { color: var(--accent-presence); opacity: 0.8; }
 .skill-browser__empty-action {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--accent-presence);
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
-  border-radius: 8px;
-  padding: 5px 12px;
+  border-radius: var(--radius-control);
+  padding: 5px var(--space-3);
   cursor: pointer;
 }
 .skill-browser__skeleton { display: flex; flex-direction: column; gap: 10px; }
@@ -15019,7 +15019,7 @@ details[open] > .cave-edit-card__summary::before {
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.2;
   cursor: pointer;
 }
@@ -15038,13 +15038,13 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-project-picker__filter {
   width: calc(100% - 12px);
-  margin: 6px 6px 4px;
-  padding: 5px 8px;
+  margin: 6px 6px var(--space-1);
+  padding: 5px var(--space-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .cave-project-picker__option {
   display: flex;
@@ -15072,12 +15072,12 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-project-picker__none {
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 .cave-project-picker__error {
   display: block;
-  margin-top: 4px;
+  margin-top: var(--space-1);
   font-size: 11.5px;
   color: var(--color-danger-soft);
 }
@@ -15091,7 +15091,7 @@ details[open] > .cave-edit-card__summary::before {
   z-index: 200;
   min-width: 280px;
   max-width: 420px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid var(--border-strong);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -15109,21 +15109,21 @@ details[open] > .cave-edit-card__summary::before {
 .ui-undo-toast__content {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-2);
+  padding: 10px var(--space-3);
 }
 
 .ui-undo-toast__icon {
   flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .ui-undo-toast__label {
   flex: 1;
   overflow: hidden;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -15144,7 +15144,7 @@ details[open] > .cave-edit-card__summary::before {
   background: none;
   color: var(--accent-presence);
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   transition: background 0.1s;
 }
@@ -15159,12 +15159,12 @@ details[open] > .cave-edit-card__summary::before {
 }
 
 .ui-undo-toast__kbd {
-  padding: 2px 4px;
+  padding: 2px var(--space-1);
   border-radius: 3px;
   background: color-mix(in oklch, var(--text-muted) 14%, transparent);
   color: var(--text-muted);
   font: inherit;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1;
 }
@@ -15180,7 +15180,7 @@ details[open] > .cave-edit-card__summary::before {
   background: none;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   transition: color 0.1s, background 0.1s;
 }
 
@@ -15217,8 +15217,8 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
+  gap: var(--space-3);
+  padding: 10px var(--space-4);
   border-bottom: 1px solid var(--border);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -15228,25 +15228,25 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-header-title {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   color: var(--text-primary);
 }
 
 .role-surface-header-title h2 {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   letter-spacing: 0.01em;
   white-space: nowrap;
 }
 
 .role-surface-header-role {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 1px 7px;
 }
 
@@ -15255,7 +15255,7 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   gap: 10px;
   margin-left: auto;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
@@ -15269,7 +15269,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-status-dot {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-muted);
 }
 
@@ -15287,10 +15287,10 @@ details[open] > .cave-edit-card__summary::before {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 3px 10px;
   background: transparent;
   cursor: pointer;
@@ -15324,7 +15324,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   min-width: 220px;
-  padding: 4px;
+  padding: var(--space-1);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--glass-elevated);
@@ -15337,9 +15337,9 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-primary);
   border-radius: var(--radius-sm);
   background: transparent;
@@ -15351,19 +15351,19 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-command:hover { background: var(--bg-hover); }
 
 .role-surface-command-hint {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
 .role-surface-notices {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px 16px 0;
+  gap: var(--space-1);
+  padding: 6px var(--space-4) 0;
 }
 
 .role-surface-notice {
-  font-size: 11px;
+  font-size: var(--text-xs);
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
@@ -15415,10 +15415,10 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-columns {
   display: grid;
   grid-template-columns: minmax(200px, 240px) minmax(0, 1fr) minmax(220px, 300px);
-  gap: 12px;
+  gap: var(--space-3);
   flex: 1;
   min-height: 0;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   overflow: hidden;
 }
 
@@ -15443,7 +15443,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-canvas-stack {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   min-height: 100%;
 }
 
@@ -15454,7 +15454,7 @@ details[open] > .cave-edit-card__summary::before {
   padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .role-surface-section-head {
@@ -15479,8 +15479,8 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 12px;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
   color: var(--text-primary);
 }
 
@@ -15488,8 +15488,8 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 4px 6px;
+  gap: var(--space-2);
+  padding: var(--space-1) 6px;
   border-radius: var(--radius-sm);
 }
 
@@ -15499,7 +15499,7 @@ details[open] > .cave-edit-card__summary::before {
   gap: 6px;
   width: 100%;
   padding: 5px 6px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   background: transparent;
   border: 0;
@@ -15560,7 +15560,7 @@ details[open] > .cave-edit-card__summary::before {
   background: color-mix(in oklch, var(--bg-base, var(--background)) 60%, transparent);
   border: 1px solid var(--input);
   border-radius: var(--radius-sm);
-  padding: 5px 8px;
+  padding: 5px var(--space-2);
 }
 
 /* Desktop-only compact sizes; on touch the global `max(16px, 1em)` input rule
@@ -15570,10 +15570,10 @@ details[open] > .cave-edit-card__summary::before {
   .role-surface-stack-form input,
   .role-surface-field input,
   .role-surface-field select {
-    font-size: 12px;
+    font-size: var(--text-sm);
   }
   .role-surface-notes {
-    font-size: 13px;
+    font-size: var(--text-base);
   }
 }
 
@@ -15589,7 +15589,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .role-surface-field--grow { flex: 1; }
@@ -15616,7 +15616,7 @@ details[open] > .cave-edit-card__summary::before {
   background: color-mix(in oklch, var(--bg-base, var(--background)) 55%, transparent);
   border: 1px solid var(--input);
   border-radius: var(--radius-md);
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
 }
 
 .role-surface-notes--short { min-height: 90px; }
@@ -15625,14 +15625,14 @@ details[open] > .cave-edit-card__summary::before {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
 .role-surface-check--done { color: var(--text-muted); text-decoration: line-through; }
 
 .role-surface-metric {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
@@ -15642,16 +15642,16 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   line-height: 1.5;
 }
 
 .role-surface-tag {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 1px 6px;
   white-space: nowrap;
 }
@@ -15667,11 +15667,11 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   gap: 5px;
-  padding: 8px;
+  padding: var(--space-2);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .role-surface-evidence-meta {
@@ -15696,14 +15696,14 @@ details[open] > .cave-edit-card__summary::before {
 }
 
 .role-surface-memory-path {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-family: var(--font-mono, ui-monospace, monospace);
   color: var(--text-primary);
   overflow-wrap: anywhere;
 }
 
 .role-surface-memory-excerpt {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -15714,7 +15714,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .role-surface-card {
@@ -15744,7 +15744,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-card-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .role-surface-clusters {
@@ -15757,10 +15757,10 @@ details[open] > .cave-edit-card__summary::before {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   border: 1px solid color-mix(in oklch, var(--room-accent) 35%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 3px 9px;
   background: color-mix(in oklch, var(--room-accent) 8%, transparent);
 }
@@ -15769,14 +15769,14 @@ details[open] > .cave-edit-card__summary::before {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 3px 10px;
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .role-surface-facts dt { color: var(--text-muted); }
 .role-surface-facts dd { color: var(--text-primary); overflow-wrap: anywhere; }
 
 .role-surface-content {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-family: var(--font-mono, ui-monospace, monospace);
   line-height: 1.5;
   color: var(--text-secondary);
@@ -15790,8 +15790,8 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
-  padding: 10px 8px;
+  gap: var(--space-1);
+  padding: 10px var(--space-2);
   color: var(--text-muted);
 }
 
@@ -15803,17 +15803,17 @@ details[open] > .cave-edit-card__summary::before {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 1;
   min-height: 0;
-  padding: 32px;
+  padding: var(--space-8);
   text-align: center;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .role-surface-unavailable-hint {
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -15831,8 +15831,8 @@ details[open] > .cave-edit-card__summary::before {
   align-items: center;
   gap: 7px;
   width: 100%;
-  padding: 7px 16px;
-  font-size: 11px;
+  padding: 7px var(--space-4);
+  font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-secondary);
@@ -15844,7 +15844,7 @@ details[open] > .cave-edit-card__summary::before {
 .role-surface-drawer-toggle:hover { color: var(--text-primary); }
 
 .role-surface-drawer-body {
-  padding: 0 16px 14px;
+  padding: 0 var(--space-4) 14px;
   max-height: 260px;
   overflow-y: auto;
 }
@@ -15898,7 +15898,7 @@ details[open] > .cave-edit-card__summary::before {
   display: grid;
   grid-template-columns: minmax(180px, 0.42fr) minmax(420px, 1fr);
   gap: 18px;
-  padding: 16px 18px;
+  padding: var(--space-4) 18px;
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
 }
@@ -15908,7 +15908,7 @@ details[open] > .cave-edit-card__summary::before {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 12px 18px;
+  padding: var(--space-3) 18px;
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklch, var(--bg-raised) 46%, transparent);
 }
@@ -15932,14 +15932,14 @@ details[open] > .cave-edit-card__summary::before {
 .research-links__hint { font-size: var(--text-2xs); color: var(--text-muted); }
 .research-links__composer {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: flex-end;
 }
 .research-links__input {
   flex: 1;
   min-width: 0;
   resize: vertical;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -15952,14 +15952,14 @@ details[open] > .cave-edit-card__summary::before {
 .research-links__groups {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 12px 18px;
+  gap: var(--space-3) 18px;
 }
 .research-links__group { min-width: 0; }
 .research-links__group-title {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-1);
   font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-secondary);
@@ -15975,10 +15975,10 @@ details[open] > .cave-edit-card__summary::before {
 .research-links__row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   border-radius: var(--radius-control);
-  padding: 2px 4px;
+  padding: 2px var(--space-1);
 }
 .research-links__row:hover { background: var(--bg-hover); }
 .research-links__open {
@@ -15988,7 +15988,7 @@ details[open] > .cave-edit-card__summary::before {
   flex-direction: column;
   align-items: flex-start;
   gap: 1px;
-  padding: 3px 4px;
+  padding: 3px var(--space-1);
   text-align: left;
   border-radius: var(--radius-control);
   cursor: pointer;
@@ -16058,7 +16058,7 @@ details[open] > .cave-edit-card__summary::before {
 .research-mission-composer {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px 12px;
+  gap: var(--space-2) var(--space-3);
   align-items: end;
 }
 
@@ -16081,7 +16081,7 @@ details[open] > .cave-edit-card__summary::before {
   width: 100%;
   min-height: 64px;
   resize: vertical;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   color: var(--text-primary);
   border: 1px solid var(--input);
   border-radius: var(--radius-md);
@@ -16099,7 +16099,7 @@ details[open] > .cave-edit-card__summary::before {
 .research-mission-composer__controls {
   display: flex;
   align-items: end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .research-mission-mode {
@@ -16115,7 +16115,7 @@ details[open] > .cave-edit-card__summary::before {
   border: 1px solid var(--input);
   border-radius: var(--radius-sm);
   background: var(--bg-raised);
-  padding: 4px 7px;
+  padding: var(--space-1) 7px;
   font-size: 16px;
 }
 
@@ -16131,7 +16131,7 @@ details[open] > .cave-edit-card__summary::before {
   font-size: 9.5px;
   color: var(--text-muted);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-raised) 65%, transparent);
 }
 
@@ -16171,8 +16171,8 @@ button.research-plan-chip:focus-visible {
 .research-bounds-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(90px, 1fr));
-  gap: 8px;
-  padding-top: 8px;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
 }
 
 .research-bounds-grid label { display: flex; flex-direction: column; gap: 3px; }
@@ -16201,7 +16201,7 @@ button.research-plan-chip:focus-visible {
   z-index: 2;
   display: flex;
   justify-content: space-between;
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   border-bottom: 1px solid var(--border);
   background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
   backdrop-filter: blur(12px);
@@ -16243,7 +16243,7 @@ button.research-plan-chip:focus-visible {
   width: 6px;
   height: 6px;
   margin-top: 5px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--text-muted);
 }
 .research-status-dot--busy { background: var(--research-accent); box-shadow: 0 0 0 4px var(--research-accent-soft); }
@@ -16260,7 +16260,7 @@ button.research-plan-chip:focus-visible {
   gap: 6px;
   padding: 22px 14px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .research-mission-nav__empty p { color: var(--text-secondary); }

--- a/src/components/chat-empty-state.test.ts
+++ b/src/components/chat-empty-state.test.ts
@@ -128,7 +128,7 @@ test("chat-first landing: time greeting eyebrow, calm first paint, disclosed con
 
   // The greeting eyebrow + context toggle stay on semantic tokens.
   assert.match(styles, /\.cave-chat-empty-greeting-dot \{[\s\S]*?background: var\(--accent-presence\)/, "greeting dot uses the presence accent token");
-  assert.match(styles, /\.cave-chat-empty-context-toggle \{[\s\S]*?border-radius: 999px/, "context toggle reads as a pill control");
+  assert.match(styles, /\.cave-chat-empty-context-toggle \{[\s\S]*?border-radius: var\(--radius-pill\)/, "context toggle reads as a pill control");
 });
 
 test("starter pills resume unassigned + own board work, marked as tasks (cave-qvwu)", () => {
@@ -170,7 +170,7 @@ test("starter pills resume unassigned + own board work, marked as tasks (cave-qv
 test("task-aware styles use semantic tokens and respect reduced motion", () => {
   assert.match(
     styles,
-    /\.cave-chat-empty-task-status \{[\s\S]*?border-radius: 999px/,
+    /\.cave-chat-empty-task-status \{[\s\S]*?border-radius: var\(--radius-pill\)/,
     "status chip is a pill",
   );
   assert.match(

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -312,7 +312,7 @@ assert.match(
 // Both pills must share one base rule so adjacent pills read as siblings.
 assert.match(
   globals,
-  /\.ui-origin-chip,\s*\.ui-initiator-chip\s*\{[\s\S]*?border-radius:\s*999px;[\s\S]*?\}/,
+  /\.ui-origin-chip,\s*\.ui-initiator-chip\s*\{[\s\S]*?border-radius:\s*var\(--radius-pill\);[\s\S]*?\}/,
   "Origin and initiator pills must share a single base chrome rule",
 );
 // The three row action buttons (pin/archive/delete) must be uniform squares.

--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -31,7 +31,7 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear-header\s*\{[\s\S]*position\s*:\s*sticky[\s\S]*top\s*:\s*0[\s\S]*padding\s*:\s*8px 12px 9px/,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-linear-header\s*\{[\s\S]*position\s*:\s*sticky[\s\S]*top\s*:\s*0[\s\S]*padding\s*:\s*var\(--space-2\) var\(--space-3\) 9px/,
   "Mobile chat header should stay compact under the shell-owned safe area",
 );
 

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -497,7 +497,7 @@ assert.match(
 
 assert.match(
   styles,
-  /\.cave-chat-linear-header\s*\{[\s\S]*padding:\s*4px 10px 5px;/,
+  /\.cave-chat-linear-header\s*\{[\s\S]*padding:\s*var\(--space-1\) 10px 5px;/,
   "Open chat header should be compressed for a streamlined session UI",
 );
 

--- a/src/components/familiar-chatout-codex/styles.module.css
+++ b/src/components/familiar-chatout-codex/styles.module.css
@@ -54,7 +54,7 @@
 .sidebarIconRow {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   height: 34px;
   color: var(--cv-text-3);
 }
@@ -70,9 +70,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 14px;
+  border-radius: var(--radius-control);
+  padding: var(--space-2) 10px;
+  font-size: var(--text-md);
   color: var(--cv-text-2);
 }
 
@@ -82,8 +82,8 @@
 }
 
 .sidebarSection {
-  margin: 24px 8px 8px;
-  font-size: 12px;
+  margin: var(--space-6) var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
   color: var(--cv-text-3);
 }
 
@@ -108,7 +108,7 @@
   border-bottom: 1px solid var(--cv-divider);
   padding: 0 18px;
   color: var(--cv-text-2);
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .topTitle {
@@ -124,14 +124,14 @@
 
 .topActions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--cv-text-3);
 }
 
 .transcriptViewport {
   min-height: 0;
   overflow-y: auto;
-  padding: 32px clamp(28px, 8vw, 144px) 28px;
+  padding: var(--space-8) clamp(28px, 8vw, 144px) 28px;
 }
 
 .transcript {
@@ -152,16 +152,16 @@
   border-radius: 18px;
   background: var(--cv-card);
   border: 1px solid var(--cv-border);
-  padding: 13px 16px;
+  padding: 13px var(--space-4);
   color: var(--cv-text);
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1.55;
 }
 
 .assistantRow {
   max-width: 820px;
   color: var(--cv-text-2);
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1.58;
 }
 
@@ -176,17 +176,17 @@
 .pillRow {
   display: flex;
   justify-content: center;
-  padding: 28px 0 20px;
+  padding: 28px 0 var(--space-5);
 }
 
 .centeredPill {
   max-width: min(720px, 92%);
   border: 1px solid var(--cv-divider);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--cv-pill-bg);
   color: var(--cv-text-2);
   padding: 10px 15px;
-  font-size: 14px;
+  font-size: var(--text-md);
   font-style: italic;
   line-height: 1.3;
 }
@@ -202,24 +202,24 @@
 .cardHeader {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 16px;
+  gap: var(--space-4);
   align-items: center;
   min-height: 72px;
-  padding: 14px 16px;
+  padding: 14px var(--space-4);
   border-bottom: 1px solid var(--cv-divider);
 }
 
 .cardTitleRow {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 
 .fileIcon {
   width: 34px;
   height: 34px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -234,40 +234,40 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--cv-text);
 }
 
 .cardMeta {
   margin-top: 3px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--cv-text-3);
 }
 
 .diffSummary {
   display: flex;
-  gap: 4px;
-  margin-top: 4px;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
   font-family: ui-monospace, "JetBrains Mono", SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .cardActions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .ghostButton,
 .disclosureButton {
   border: 1px solid var(--cv-border);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--cv-pill-bg);
   color: var(--cv-text-2);
   padding: 7px 10px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1;
 }
 
@@ -285,11 +285,11 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 42px;
-  padding: 0 16px;
+  padding: 0 var(--space-4);
   border-bottom: 1px solid var(--cv-divider);
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .filePath,
@@ -320,14 +320,14 @@
   border: 0;
   border-radius: 0;
   text-align: left;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   background: transparent;
 }
 
 .cardFooter {
   display: flex;
   justify-content: flex-end;
-  padding: 10px 16px;
+  padding: 10px var(--space-4);
 }
 
 .statusChip,
@@ -336,18 +336,18 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--cv-pill-bg);
   border: 1px solid var(--cv-divider);
   color: var(--cv-text-2);
   padding: 5px 9px;
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .runtimeRow {
   border-top: 1px solid var(--cv-divider);
   padding-top: 14px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .runTimeChip {
@@ -370,12 +370,12 @@
   color: var(--cv-text-2);
   padding: 10px 15px;
   font: inherit;
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .retryIcons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   color: var(--cv-text-3);
   opacity: 0.78;
 }
@@ -383,7 +383,7 @@
 .composerWrap {
   display: flex;
   align-items: center;
-  padding: 18px clamp(28px, 8vw, 144px) 24px;
+  padding: 18px clamp(28px, 8vw, 144px) var(--space-6);
 }
 
 .composer {
@@ -396,8 +396,8 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: end;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--space-3);
+  padding: var(--space-3);
 }
 
 .composerInput {
@@ -406,14 +406,14 @@
   align-items: flex-start;
   padding-top: 5px;
   color: var(--cv-text-disabled);
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .composerLeft,
 .composerRight {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .iconButton,
@@ -428,7 +428,7 @@
 .iconButton {
   width: 30px;
   height: 30px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--cv-text-3);
   background: transparent;
 }
@@ -436,7 +436,7 @@
 .sendButton {
   width: 36px;
   height: 36px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--cv-send);
   color: #061312;
   font-size: 18px;
@@ -444,12 +444,12 @@
 
 .controlPill {
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--cv-text-2);
   padding: 7px 9px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .inspector {
@@ -463,12 +463,12 @@
   background: var(--cv-inspector);
   border: 1px solid var(--cv-border);
   border-radius: 18px;
-  padding: 18px 18px 12px;
+  padding: 18px 18px var(--space-3);
 }
 
 .inspectorSection {
   border-bottom: 1px solid var(--cv-divider);
-  padding-bottom: 16px;
+  padding-bottom: var(--space-4);
   margin-bottom: 18px;
 }
 
@@ -482,7 +482,7 @@
   align-items: center;
   justify-content: space-between;
   color: var(--cv-text-3);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   margin-bottom: 9px;
 }
@@ -493,7 +493,7 @@
   align-items: center;
   min-height: 36px;
   color: var(--cv-text-2);
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .rowLabel {
@@ -508,17 +508,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--cv-pill-bg);
   color: var(--cv-text);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .commitDot,
 .statusDot {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--cv-accent);
 }
 
@@ -536,7 +536,7 @@
   gap: 10px;
   min-height: 28px;
   color: var(--cv-text-2);
-  font-size: 14px;
+  font-size: var(--text-md);
 }
 
 .avatar {
@@ -565,7 +565,7 @@
 
 .emptyState {
   color: var(--cv-text-3);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-style: italic;
 }
 
@@ -586,7 +586,7 @@
   }
 
   .leftSidebar {
-    padding: 12px 8px;
+    padding: var(--space-3) var(--space-2);
   }
 
   .leftSidebar span:not(.keepOnNarrow),

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -147,7 +147,9 @@ function ruleBlock(selector) {
 }
 
 // Every dark-chrome block that previously leaked theme ink must now use the
-// fixed properties — and none may still reference var(--text-*).
+// fixed properties — and none may still reference the theme ink tokens
+// (var(--text-primary/secondary/muted)). The --text-* SIZE tokens (--text-sm
+// and friends) are mode-independent px and are fine on fixed chrome.
 const darkChromeSelectors = [
   ".cave-code-wrap",
   ".cave-code-header",
@@ -166,8 +168,8 @@ const darkChromeSelectors = [
 for (const selector of darkChromeSelectors) {
   assert.doesNotMatch(
     ruleBlock(selector),
-    /var\(--text-/,
-    `${selector} is fixed dark chrome — it must not take theme ink (var(--text-*) flips dark in light mode)`,
+    /var\(--text-(?:primary|secondary|muted)\b/,
+    `${selector} is fixed dark chrome — it must not take theme ink (var(--text-primary/secondary/muted) flips dark in light mode)`,
   );
 }
 

--- a/src/components/quick-chat-polish.test.ts
+++ b/src/components/quick-chat-polish.test.ts
@@ -18,7 +18,7 @@ assert.match(
 // ── Meta chips ───────────────────────────────────────────────────────────────
 assert.match(
   globals,
-  /\.quick-chat-meta-chip \{[\s\S]{0,400}?border-radius: 999px;[\s\S]{0,200}?background: var\(--bg-subtle\);/,
+  /\.quick-chat-meta-chip \{[\s\S]{0,400}?border-radius: var\(--radius-pill\);[\s\S]{0,200}?background: var\(--bg-subtle\);/,
   "Meta chips are quiet token pills",
 );
 assert.doesNotMatch(

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -269,7 +269,7 @@ assert.doesNotMatch(
   );
   assert.match(
     css,
-    /:root\[data-tauri-titlebar\]\[data-traffic-lights="hidden"\] \.shell-top \{[\s\S]*?padding-left: 12px;/,
+    /:root\[data-tauri-titlebar\]\[data-traffic-lights="hidden"\] \.shell-top \{[\s\S]*?padding-left: var\(--space-3\);/,
     "hiding the lights releases the 78px title-bar inset",
   );
   assert.match(
@@ -332,7 +332,7 @@ assert.doesNotMatch(
   // sits mid-window and must NOT.
   assert.match(
     css,
-    /:root\[data-tauri-titlebar\] \.shell-frame \.fa-topbar \{\s*padding-left: 24px;/,
+    /:root\[data-tauri-titlebar\] \.shell-frame \.fa-topbar \{\s*padding-left: var\(--space-6\);/,
     "the inspector-embedded analytics breadcrumb keeps its own padding",
   );
   // Titlebar glass stays honest: blur is paired with the reduced-transparency

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -41,13 +41,13 @@ assert.doesNotMatch(
 
 assert.match(
   styles,
-  /\.sidebar-folder-row\s*\{[^}]*font-size:\s*13px/,
+  /\.sidebar-folder-row\s*\{[^}]*font-size:\s*var\(--text-base\)/,
   "Sidebar nav rows should keep compact side-panel text sizing",
 );
 
 assert.match(
   styles,
-  /\.sidebar-nav-scroll\s*\{[^}]*gap:\s*4px/,
+  /\.sidebar-nav-scroll\s*\{[^}]*gap:\s*var\(--space-1\)/,
   "Sidebar nav options should stay visually close together on desktop",
 );
 

--- a/src/components/sidepanel-badge-dots.test.ts
+++ b/src/components/sidepanel-badge-dots.test.ts
@@ -10,7 +10,7 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 // it into an accent dot so Board/Schedules/GitHub still signal at a glance.
 assert.match(
   sidebarCss,
-  /\.shell-nav--rail \.sidebar-badge \{[\s\S]*?position: absolute[\s\S]*?border-radius: 999px/,
+  /\.shell-nav--rail \.sidebar-badge \{[\s\S]*?position: absolute[\s\S]*?border-radius: var\(--radius-pill\)/,
   "collapsed rail shows the nav badge as a dot, not display:none",
 );
 assert.match(

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -1,0 +1,229 @@
+// Design-token drift gate — Cave UX P3 (Sage's 2026-07-03 audit).
+//
+// The design-language shipping checklist (docs/coven-design-language.md §9,
+// rule 1) is "tokens only — no hardcoded colors, radii, or font sizes". This
+// gate keeps that contract enforceable in two tiers:
+//
+//   1. ZERO TOLERANCE for on-scale literals: running the codemod
+//      (scripts/codemods/tokenize-css.mjs) over every in-scope CSS file must
+//      be a no-op. A `font-size: 12px` that should be `var(--text-sm)` fails
+//      here — fix by running:  node scripts/codemods/tokenize-css.mjs
+//
+//   2. RATCHETS for the judgment categories (off-scale px values, hex colors
+//      outside token definitions, inline TSX style objects). These can only
+//      go DOWN. If you add one deliberately (e.g. a genuinely dynamic inline
+//      style), lower-or-equal is enforced — raise the baseline in the same
+//      PR and say why. When you reduce drift, lower the baseline to bank it.
+//
+// The codemod's px→token tables are pinned against the live definitions in
+// src/app/globals.css, so a token retune fails loudly instead of letting the
+// codemod silently rewrite to stale values.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import {
+  tokenizeCss,
+  cssFilesInScope,
+  FONT_SIZE_TOKENS,
+  SPACE_TOKENS,
+  RADIUS_TOKENS,
+  FONT_SIZE_PROPS,
+  SPACING_PROPS,
+  RADIUS_PROPS,
+  SANCTIONED_FONT_SIZE_LITERALS,
+  EXEMPT_MARKER,
+} from "../../scripts/codemods/tokenize-css.mjs";
+
+// ── ratchet baselines ────────────────────────────────────────────────────────
+// Current counts as of the P3 codemod PR. Only lower these (banking progress)
+// or raise them with an explicit justification in your PR.
+const BASELINES = {
+  offScaleFontSizePx: 173, // 10.5px/11.5px/… — need per-case renormalization to the type scale
+  offScaleSpacingPx: 1351, // off-4px-grid pad/margin/gap components (2px/6px/10px/…)
+  offScaleRadiusPx: 213, // 4px/6px/10px/14px/… radii between the sanctioned steps
+  hexOutsideDefinitions: 157, // hex in render CSS (token definitions excluded)
+  inlineTsxStyles: 510, // style={{…}} in TSX; many are legit dynamic values
+};
+
+// ── unit sanity for the codemod transform ───────────────────────────────────
+
+{
+  // On-scale literals tokenize; result is idempotent.
+  const src = ".a {\n  font-size: 12px;\n  padding: 8px 12px;\n  border-radius: 999px;\n}\n";
+  const out = tokenizeCss(src);
+  assert.ok(out.includes("font-size: var(--text-sm);"));
+  assert.ok(out.includes("padding: var(--space-2) var(--space-3);"));
+  assert.ok(out.includes("border-radius: var(--radius-pill);"));
+  assert.equal(tokenizeCss(out), out, "codemod must be idempotent");
+
+  // Off-scale, zero, negative, calc/var-wrapped, and rem values are untouched.
+  // font-size: 16px is the sanctioned iOS anti-zoom floor (see the codemod's
+  // table comment) and stays literal too.
+  const keep = [
+    "  font-size: 10.5px;",
+    "  font-size: 16px;",
+    "  font-size: 0.875rem;",
+    "  padding: 0 11px;",
+    "  margin: -8px;",
+    "  gap: calc(8px + 1px);",
+    "  padding: var(--x, 12px);",
+    "  border-radius: 6px;",
+    "  line-height: 16px;", // not a tokenized property
+    "  width: 12px;", // not a tokenized property
+  ];
+  for (const line of keep) {
+    const block = `.a {\n${line}\n}\n`;
+    assert.equal(tokenizeCss(block), block, `must not rewrite: ${line.trim()}`);
+  }
+
+  // Token definitions stay literal — that's where px belongs.
+  const def = ":root {\n  --space-2: 8px;\n  --text-sm: 12px;\n}\n";
+  assert.equal(tokenizeCss(def), def);
+
+  // Comments (block and inline-before) are never rewritten.
+  const comment = "/*\n  padding: 8px;\n*/\n.a { /* gap: 4px */ color: red; }\n";
+  assert.equal(tokenizeCss(comment), comment);
+
+  // The exempt marker is an explicit opt-out.
+  const exempt = `.a {\n  font-size: 12px; /* ${EXEMPT_MARKER}: needs fixed px */\n}\n`;
+  assert.equal(tokenizeCss(exempt), exempt);
+}
+
+// ── pin: codemod tables mirror the live globals.css token definitions ──────
+
+{
+  const globals = readFileSync("src/app/globals.css", "utf8");
+  const defined = new Map<string, string>();
+  for (const m of globals.matchAll(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/gim)) {
+    if (!defined.has(m[1])) defined.set(m[1], m[2].trim()); // first (=:root dark) wins
+  }
+  for (const [table, name] of [
+    [FONT_SIZE_TOKENS, "font-size"],
+    [SPACE_TOKENS, "space"],
+    [RADIUS_TOKENS, "radius"],
+  ] as const) {
+    for (const [px, token] of table as Map<string, string>) {
+      assert.equal(
+        defined.get(token),
+        px,
+        `${name} table drift: codemod maps ${px} -> ${token}, but globals.css defines ${token}: ${defined.get(token) ?? "(missing)"} — update scripts/codemods/tokenize-css.mjs to match`,
+      );
+    }
+  }
+}
+
+// ── tier 1: the codemod is a no-op over the tree (no on-scale literals) ─────
+
+const files = cssFilesInScope();
+assert.ok(files.length > 10, "scanner should find the src CSS tree");
+
+for (const rel of files) {
+  const source = readFileSync(rel, "utf8");
+  assert.equal(
+    tokenizeCss(source),
+    source,
+    `${rel} has on-scale px literals that must use tokens — run: node scripts/codemods/tokenize-css.mjs`,
+  );
+}
+
+// ── tier 2: ratchets ────────────────────────────────────────────────────────
+
+/** Strip block comments so commented-out CSS never counts as drift. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "));
+}
+
+const DECL_RE = /^(\s*)([a-zA-Z-]+)(\s*:\s*)([^;]*);/;
+const PX_RE = /^([0-9]+(?:\.[0-9]+)?)px$/;
+
+function countOffScale(
+  source: string,
+  props: Set<string>,
+  table: Map<string, string>,
+  sanctioned: Set<string> = new Set(),
+): number {
+  let count = 0;
+  for (const line of stripComments(source).split("\n")) {
+    if (line.includes(EXEMPT_MARKER)) continue;
+    if (line.trimStart().startsWith("--")) continue;
+    const m = DECL_RE.exec(line);
+    if (!m || !props.has(m[2].toLowerCase())) continue;
+    for (const piece of m[4].split(/\s+/)) {
+      const px = PX_RE.exec(piece);
+      if (!px) continue;
+      const value = Number.parseFloat(px[1]);
+      if (value === 0) continue; // zero needs no token
+      if (sanctioned.has(`${value}px`)) continue;
+      if (!table.has(`${value}px`)) count += 1;
+    }
+  }
+  return count;
+}
+
+function countHexOutsideDefinitions(source: string): number {
+  let count = 0;
+  for (const line of stripComments(source).split("\n")) {
+    if (line.trimStart().startsWith("--")) continue; // token definitions are sanctioned
+    count += (line.match(/#[0-9a-fA-F]{3,8}\b/g) ?? []).length;
+  }
+  return count;
+}
+
+const totals = {
+  offScaleFontSizePx: 0,
+  offScaleSpacingPx: 0,
+  offScaleRadiusPx: 0,
+  hexOutsideDefinitions: 0,
+};
+for (const rel of files) {
+  const source = readFileSync(rel, "utf8");
+  totals.offScaleFontSizePx += countOffScale(
+    source,
+    FONT_SIZE_PROPS,
+    FONT_SIZE_TOKENS,
+    SANCTIONED_FONT_SIZE_LITERALS,
+  );
+  totals.offScaleSpacingPx += countOffScale(source, SPACING_PROPS, SPACE_TOKENS);
+  totals.offScaleRadiusPx += countOffScale(source, RADIUS_PROPS, RADIUS_TOKENS);
+  totals.hexOutsideDefinitions += countHexOutsideDefinitions(source);
+}
+
+function countInlineTsxStyles(dir: string): number {
+  let count = 0;
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) count += countInlineTsxStyles(full);
+    else if (entry.endsWith(".tsx"))
+      count += (readFileSync(full, "utf8").match(/style=\{\{/g) ?? []).length;
+  }
+  return count;
+}
+const inlineTsxStyles = countInlineTsxStyles("src");
+
+function ratchet(name: keyof typeof BASELINES, actual: number) {
+  assert.ok(
+    actual <= BASELINES[name],
+    `token-drift ratchet "${name}" went UP: ${actual} > baseline ${BASELINES[name]}. ` +
+      `New hardcoded values need tokens (docs/coven-design-language.md §9 rule 1); ` +
+      `if this one is genuinely dynamic/off-scale by design, raise the baseline in this PR and justify it.`,
+  );
+  if (actual < BASELINES[name]) {
+    console.log(
+      `[token-drift] ${name}: ${actual} < baseline ${BASELINES[name]} — lower the baseline to bank the progress`,
+    );
+  }
+}
+
+ratchet("offScaleFontSizePx", totals.offScaleFontSizePx);
+ratchet("offScaleSpacingPx", totals.offScaleSpacingPx);
+ratchet("offScaleRadiusPx", totals.offScaleRadiusPx);
+ratchet("hexOutsideDefinitions", totals.hexOutsideDefinitions);
+ratchet("inlineTsxStyles", inlineTsxStyles);
+
+console.log(
+  `design-token-drift: ok (codemod no-op over ${files.length} css files; ratchets ` +
+    `font=${totals.offScaleFontSizePx} space=${totals.offScaleSpacingPx} radius=${totals.offScaleRadiusPx} ` +
+    `hex=${totals.hexOutsideDefinitions} inline=${inlineTsxStyles})`,
+);

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -16,7 +16,7 @@
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  padding: 10px 0 12px;
+  padding: 10px 0 var(--space-3);
   border-right: 1px solid var(--border-hairline);
   background: var(--bg-elevated);
   /* Sticks to the viewport so the rail is always in reach as analytics scrolls. */
@@ -37,7 +37,7 @@
   height: 40px;
   border-radius: 10px;
   color: var(--accent-presence);
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
   flex-shrink: 0;
 }
 

--- a/src/styles/artifact-comments.css
+++ b/src/styles/artifact-comments.css
@@ -14,7 +14,7 @@
   color: #fff;
   background: var(--accent-presence);
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   box-shadow: 0 8px 22px -8px color-mix(in oklch, var(--accent-presence) 80%, transparent),
     0 2px 8px rgb(0 0 0 / 0.35);
   cursor: pointer;
@@ -29,18 +29,18 @@
 
 /* Collected comments panel under the turn. */
 .cave-artifact-comments {
-  margin-top: 12px;
-  padding: 10px 12px;
+  margin-top: var(--space-3);
+  padding: 10px var(--space-3);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, var(--border-hairline));
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--accent-presence) 5%, var(--bg-raised));
 }
 .cave-artifact-comments__head {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-bottom: 8px;
-  font-size: 11px;
+  margin-bottom: var(--space-2);
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -49,7 +49,7 @@
 .cave-artifact-comments__head svg { color: var(--accent-presence); }
 .cave-artifact-comments__hint {
   margin-left: auto;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;
@@ -61,10 +61,10 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .cave-artifact-comment {
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: 9px;
   background: var(--bg-base);
@@ -73,7 +73,7 @@
   margin: 0 0 6px;
   padding-left: 9px;
   border-left: 3px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-style: italic;
   line-height: 1.45;
   color: var(--text-secondary);
@@ -90,14 +90,14 @@
   min-height: 32px;
   max-height: 160px;
   resize: vertical;
-  padding: 6px 8px;
+  padding: 6px var(--space-2);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
   color: var(--text-primary);
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   outline: none;
   transition: border-color 0.12s ease;
 }
@@ -133,7 +133,7 @@
   align-items: center;
   gap: 6px;
   padding: 7px 13px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: #fff;
   background: var(--accent-presence);

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -71,7 +71,7 @@
     align-items: stretch;
     flex-wrap: wrap;
     gap: 10px;
-    padding: 18px 16px 16px;
+    padding: 18px var(--space-4) var(--space-4);
   }
 
   .board-header-title {
@@ -94,7 +94,7 @@
   .board-search-input {
     height: 44px;
     padding-inline: 44px 36px;
-    border-radius: 8px;
+    border-radius: var(--radius-control);
     font-size: 16px;
   }
 
@@ -109,7 +109,7 @@
     margin-left: 0;
     justify-content: flex-end;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .board-view-toggle {
@@ -119,9 +119,9 @@
   .board-toolbar-btn,
   .board-new-card-btn {
     min-height: var(--touch-target);
-    border-radius: 8px;
+    border-radius: var(--radius-control);
     padding-inline: 14px;
-    font-size: 13px;
+    font-size: var(--text-base);
   }
 
   /* The overflow '⋯' trigger is a tap-only control on phones — grow it to
@@ -326,11 +326,11 @@
   transform: translate(-50%, -120%);
   max-width: 220px;
   padding: 6px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
   background: var(--bg-elevated);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   line-height: 1.3;
   overflow: hidden;
@@ -581,7 +581,7 @@
   display:flex;
   align-items:center;
   gap:6px;
-  padding:5px 12px;
+  padding:5px var(--space-3);
 }
 .gh-compact-meta {
   display:flex;
@@ -596,16 +596,16 @@
   text-overflow:ellipsis;
   white-space:nowrap;
   color:var(--text-secondary);
-  font-size:11px;
+  font-size:var(--text-xs);
 }
 .gh-compact-auth {
   display:inline-flex;
   align-items:center;
   height:var(--gh-control-h);
   border:1px solid var(--border-hairline);
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   padding:0 7px;
-  font-size:10px;
+  font-size:var(--text-2xs);
   line-height:1;
   color:var(--text-muted);
 }
@@ -623,7 +623,7 @@
 }
 .gh-compact-rate {
   color:var(--text-muted);
-  font-size:10px;
+  font-size:var(--text-2xs);
   white-space:nowrap;
 }
 .gh-compact-tabs {
@@ -670,7 +670,7 @@
   border:1px solid var(--border-hairline);
   background:var(--bg-base);
   padding:0.5rem 0.75rem;
-  font-size:13px;
+  font-size:var(--text-base);
   color:var(--text-primary);
 }
 .gh-input::placeholder { color:var(--text-muted); }
@@ -718,7 +718,7 @@
   justify-content:center;
   padding-top:10px;
   border:1px solid color-mix(in oklab,var(--border-hairline) 70%,transparent);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:color-mix(in oklab,var(--bg-raised) 46%,transparent);
 }
 
@@ -742,7 +742,7 @@
   gap:6px;
   padding:7px 10px;
   border:1px dashed color-mix(in oklab,var(--border-hairline) 76%,transparent);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:transparent;
   color:var(--text-muted);
   font-size:11.5px;
@@ -758,7 +758,7 @@
   height:100%;
   overflow-x:auto;
   border:1px solid color-mix(in oklab,var(--border-hairline) 76%,transparent);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:color-mix(in oklab,var(--bg-raised) 62%,transparent);
   box-shadow:0 18px 60px rgba(0,0,0,.12);
   backdrop-filter:blur(16px) saturate(1.2);
@@ -848,7 +848,7 @@
   flex-direction:column;
   overflow:hidden;
   border:1px solid color-mix(in oklab,var(--border-hairline) 70%,transparent);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:
     linear-gradient(155deg,
       color-mix(in oklab,var(--bg-elevated) 74%,transparent),
@@ -863,10 +863,10 @@
   flex-direction:column;
   align-items:center;
   justify-content:center;
-  gap:8px;
+  gap:var(--space-2);
   color:var(--text-muted);
   text-align:center;
-  font-size:12px;
+  font-size:var(--text-sm);
 }
 .gh-glass-aura {
   position:absolute;
@@ -880,24 +880,24 @@
   position:relative;
   display:grid;
   grid-template-columns:repeat(3,minmax(0,1fr));
-  gap:8px;
+  gap:var(--space-2);
 }
 .gh-glass-stat {
   min-width:0;
   border:1px solid color-mix(in oklab,var(--border-hairline) 68%,transparent);
   border-radius:7px;
   background:color-mix(in oklab,var(--bg-base) 48%,transparent);
-  padding:8px;
+  padding:var(--space-2);
 }
 .gh-glass-stat span {
   display:block;
   color:var(--text-muted);
-  font-size:10px;
+  font-size:var(--text-2xs);
   line-height:1.1;
 }
 .gh-glass-stat strong {
   display:block;
-  margin-top:4px;
+  margin-top:var(--space-1);
   color:var(--text-primary);
   font-size:18px;
   line-height:1;
@@ -913,13 +913,13 @@
   align-items:center;
   gap:6px;
   margin-bottom:9px;
-  font-size:11px;
+  font-size:var(--text-xs);
   font-weight:650;
 }
 .gh-glass-hero h3 {
   margin:0;
   color:var(--text-primary);
-  font-size:20px;
+  font-size:var(--text-xl);
   line-height:1.18;
   font-weight:680;
   letter-spacing:0;
@@ -928,35 +928,35 @@
   display:flex;
   flex-wrap:wrap;
   gap:6px;
-  margin-top:12px;
+  margin-top:var(--space-3);
 }
 .gh-glass-meta span {
   display:inline-flex;
   align-items:center;
   max-width:100%;
   border:1px solid color-mix(in oklab,var(--border-hairline) 70%,transparent);
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   background:color-mix(in oklab,var(--bg-base) 54%,transparent);
-  padding:3px 8px;
+  padding:3px var(--space-2);
   color:var(--text-secondary);
   font-size:10.5px;
   line-height:1.2;
 }
 .gh-glass-section {
   border-top:1px solid color-mix(in oklab,var(--border-hairline) 68%,transparent);
-  padding:12px 0;
+  padding:var(--space-3) 0;
 }
 .gh-glass-section-title {
   margin-bottom:9px;
   color:var(--text-muted);
-  font-size:10px;
+  font-size:var(--text-2xs);
   font-weight:700;
   letter-spacing:.08em;
   text-transform:uppercase;
 }
 .gh-glass-facts {
   display:grid;
-  gap:8px;
+  gap:var(--space-2);
   margin:0;
 }
 .gh-glass-facts div {
@@ -1027,7 +1027,7 @@
   display:flex;
   align-items:center;
   flex-wrap:wrap;
-  gap:8px;
+  gap:var(--space-2);
   margin-top:11px;
 }
 .gh-issue-number {
@@ -1035,7 +1035,7 @@
   align-items:center;
   gap:3px;
   font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace);
-  font-size:13px;
+  font-size:var(--text-base);
   font-weight:650;
   color:var(--text-secondary);
 }
@@ -1058,9 +1058,9 @@
   display:inline-flex;
   align-items:center;
   gap:5px;
-  padding:3px 9px 3px 8px;
-  border-radius:999px;
-  font-size:11px;
+  padding:3px 9px 3px var(--space-2);
+  border-radius:var(--radius-pill);
+  font-size:var(--text-xs);
   font-weight:600;
   color:#fff;
 }
@@ -1085,15 +1085,15 @@
   display:flex;
   flex-wrap:wrap;
   align-items:center;
-  gap:8px;
-  margin-top:12px;
+  gap:var(--space-2);
+  margin-top:var(--space-3);
 }
 .gh-review-action-group { display:inline-flex; align-items:stretch; }
 .gh-review-action {
   display:inline-flex;
   align-items:center;
   gap:5px;
-  padding:4px 10px;
+  padding:var(--space-1) 10px;
   border:1px solid var(--border-hairline);
   border-radius:7px;
   background:var(--bg-raised);
@@ -1129,7 +1129,7 @@
   color:var(--text-primary);
   font:inherit;
   font-size:11.5px;
-  padding:0 8px;
+  padding:0 var(--space-2);
   max-width:130px;
   cursor:pointer;
 }
@@ -1173,21 +1173,21 @@
   display:flex;
   align-items:center;
   justify-content:space-between;
-  gap:8px;
+  gap:var(--space-2);
 }
 .gh-comments-count {
   margin-left:6px;
   padding:0 6px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   background:var(--bg-raised);
   color:var(--text-muted);
-  font-size:10px;
+  font-size:var(--text-2xs);
   font-weight:600;
 }
 .gh-comments-unresolved {
   display:inline-flex;
   align-items:center;
-  gap:4px;
+  gap:var(--space-1);
   color:var(--color-warning);
   font-size:10.5px;
   font-weight:600;
@@ -1198,25 +1198,25 @@
   border:1px solid var(--border-hairline);
   border-radius:10px;
   background:var(--bg-base);
-  padding:8px 10px;
+  padding:var(--space-2) 10px;
 }
 .gh-comment--inline {
   border:none;
   border-top:1px solid var(--border-hairline);
   border-radius:0;
   background:transparent;
-  padding:8px 0 0;
+  padding:var(--space-2) 0 0;
 }
 .gh-comment--inline:first-of-type { border-top:none; padding-top:0; }
 .gh-comment-head {
   display:flex;
   align-items:center;
   gap:6px;
-  margin-bottom:4px;
+  margin-bottom:var(--space-1);
 }
 .gh-comment-assoc {
   padding:0 5px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   border:1px solid var(--border-hairline);
   color:var(--text-muted);
   font-size:9px;
@@ -1244,9 +1244,9 @@
   align-self:flex-start;
   display:inline-flex;
   align-items:center;
-  gap:4px;
+  gap:var(--space-1);
   color:var(--text-muted);
-  font-size:11px;
+  font-size:var(--text-xs);
   background:none;
   border:none;
   cursor:pointer;
@@ -1258,7 +1258,7 @@
   border-left:2px solid var(--color-warning);
   border-radius:10px;
   background:var(--bg-base);
-  padding:8px 10px;
+  padding:var(--space-2) 10px;
 }
 .gh-thread.is-resolved {
   border-left-color:var(--color-success);
@@ -1274,15 +1274,15 @@
 .gh-thread-path {
   display:inline-flex;
   align-items:center;
-  gap:4px;
-  font-size:11px;
+  gap:var(--space-1);
+  font-size:var(--text-xs);
   font-weight:600;
   color:var(--text-secondary);
   font-family:var(--font-mono, ui-monospace, monospace);
 }
 .gh-thread-badge {
   padding:0 6px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   border:1px solid var(--border-hairline);
   color:var(--text-muted);
   font-size:9px;
@@ -1317,11 +1317,11 @@
 .gh-diff {
   margin:0 0 6px;
   border:1px solid var(--border-hairline);
-  border-radius:8px;
+  border-radius:var(--radius-control);
   background:var(--bg-raised);
   overflow:hidden;
   font-family:var(--font-mono, ui-monospace, monospace);
-  font-size:11px;
+  font-size:var(--text-xs);
   line-height:1.55;
 }
 .gh-diff--hunk.gh-thread-diff { margin:0 0 6px; }
@@ -1329,8 +1329,8 @@
   display:flex;
   align-items:center;
   justify-content:space-between;
-  gap:8px;
-  padding:3px 8px;
+  gap:var(--space-2);
+  padding:3px var(--space-2);
   border-bottom:1px solid var(--border-hairline);
   background:color-mix(in oklch, var(--bg-elevated) 60%, transparent);
 }
@@ -1380,7 +1380,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   border-radius:10px;
   background:var(--bg-base);
   color:var(--text-primary);
-  padding:8px 10px;
+  padding:var(--space-2) 10px;
   font-size:12.5px;
   line-height:1.5;
 }
@@ -1394,7 +1394,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   display:flex;
   align-items:center;
   justify-content:flex-end;
-  gap:8px;
+  gap:var(--space-2);
   margin-top:6px;
 }
 
@@ -1443,7 +1443,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  font-size:20px;
+  font-size:var(--text-xl);
   font-weight:700;
   color:var(--text-secondary);
   border:1px solid var(--border-hairline);
@@ -1454,12 +1454,12 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   display:inline-flex;
   align-items:center;
   gap:6px;
-  font-size:12px;
+  font-size:var(--text-sm);
   color:var(--text-muted);
 }
 .gh-profile-type {
   padding:0 5px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   border:1px solid var(--border-hairline);
   font-size:9px;
   font-weight:600;
@@ -1467,14 +1467,14 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   letter-spacing:0.04em;
 }
 .gh-profile-bio {
-  font-size:12px;
+  font-size:var(--text-sm);
   line-height:1.5;
   color:var(--text-secondary);
   word-break:break-word;
 }
 .gh-profile-stats {
   display:flex;
-  gap:12px;
+  gap:var(--space-3);
   font-size:11.5px;
   color:var(--text-muted);
   padding:2px 0;
@@ -1519,10 +1519,10 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   align-items:center;
   gap:3px;
   padding:1px 7px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   border:1px solid var(--border-hairline);
   background:var(--bg-base);
-  font-size:11px;
+  font-size:var(--text-xs);
   color:var(--text-secondary);
   line-height:1.5;
 }
@@ -1533,7 +1533,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   border-left:2px solid var(--text-muted);
   border-radius:10px;
   background:var(--bg-base);
-  padding:8px 10px;
+  padding:var(--space-2) 10px;
 }
 .gh-review-entry.is-approved { border-left-color:var(--color-success); }
 .gh-review-entry.is-changes { border-left-color:var(--color-danger); }
@@ -1569,7 +1569,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .gh-checks-toggle:hover { color:var(--text-primary); }
 .gh-checks-list {
   list-style:none;
-  margin:8px 0 0;
+  margin:var(--space-2) 0 0;
   padding:0;
   display:flex;
   flex-direction:column;
@@ -1578,16 +1578,16 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .gh-check-row {
   display:flex;
   align-items:center;
-  gap:8px;
+  gap:var(--space-2);
   padding:5px 6px;
-  border-radius:8px;
+  border-radius:var(--radius-control);
 }
 .gh-check-row:hover { background:var(--bg-raised); }
 .gh-check-icon { display:inline-flex; flex-shrink:0; }
 .gh-check-name {
   flex:1;
   min-width:0;
-  font-size:12px;
+  font-size:var(--text-sm);
   color:var(--text-secondary);
   overflow:hidden;
   text-overflow:ellipsis;
@@ -1595,10 +1595,10 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 }
 .gh-check-app {
   flex-shrink:0;
-  font-size:10px;
+  font-size:var(--text-2xs);
   color:var(--text-muted);
   padding:0 6px;
-  border-radius:999px;
+  border-radius:var(--radius-pill);
   background:var(--bg-base);
   border:1px solid var(--border-hairline);
 }
@@ -1649,7 +1649,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 12px clamp(12px, 4vw, 18px) calc(24px + var(--sai-bottom));
+  padding: var(--space-3) clamp(12px, 4vw, 18px) calc(24px + var(--sai-bottom));
   gap: 18px;
 }
 .board-card-stack__filters {
@@ -1661,7 +1661,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
-  margin: 0 calc(-1 * clamp(12px, 4vw, 18px)) 4px;
+  margin: 0 calc(-1 * clamp(12px, 4vw, 18px)) var(--space-1);
   padding: 5px clamp(12px, 4vw, 18px);
   position: sticky;
   top: 0;
@@ -1678,21 +1678,21 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .board-card-stack__section-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   padding: 6px 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%);
 }
 .board-card-stack__section-label {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-primary);
 }
 .board-card-stack__section-count {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -1716,15 +1716,15 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 }
 
 .board-card-stack__empty {
-  padding: 12px 2px;
-  font-size: 12px;
+  padding: var(--space-3) 2px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
 .board-card-stack__list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .board-card-stack__row {
@@ -1758,7 +1758,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   background: transparent;
   border: 0;
   color: inherit;
-  padding: 12px 14px;
+  padding: var(--space-3) 14px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -1772,7 +1772,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .board-card-stack__row-top {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .board-card-stack__priority-pill {
   font-size: 9px;
@@ -1797,13 +1797,13 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 [data-mode="light"] .board-card-stack__priority-pill--urgent { color: color-mix(in oklch, var(--color-danger) 76%, #000); }
 [data-mode="light"] .board-card-stack__priority-pill--high { color: color-mix(in oklch, var(--color-warning) 76%, #000); }
 .board-card-stack__row-title {
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text-primary);
   line-height: 1.35;
 }
 .board-card-stack__row-notes {
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
   line-height: 1.45;
   margin: 0;
@@ -1817,7 +1817,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   align-items: center;
   gap: 10px;
   margin-top: 2px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 .board-card-stack__row-familiar {
@@ -1844,7 +1844,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .board-card-stack__row-schedule {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-secondary);
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
@@ -1864,7 +1864,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   align-items: center;
   padding: 0 5px;
   border-radius: 5px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--color-warning);
   background: color-mix(in oklch, var(--color-warning) 12%, transparent);
   border: 1px solid color-mix(in oklch, var(--color-warning) 32%, var(--border-hairline));
@@ -1874,13 +1874,13 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   font-weight: 500;
   font-size: inherit;
   font-family: inherit;
   color: var(--text-secondary);
   white-space: nowrap;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border: 0;
   background: none;
   border-radius: 6px;
@@ -1925,7 +1925,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .board-gantt-unscheduled {
   margin-top: 10px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .board-card-stack__row-menu-trigger {
@@ -2000,7 +2000,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 }
 .cg-head .cg-left {
   z-index: 6; background: var(--bg-raised);
-  font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted);
+  font-size: var(--text-2xs); font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-muted);
 }
 /* stack the month band over the week ruler in the timeline side of the header */
 .cg-headstack { display: flex; flex-direction: column; flex: 0 0 auto; }
@@ -2008,14 +2008,14 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .cg-month {
   position: absolute; top: 0; bottom: 0;
   display: flex; align-items: center; padding-left: 7px;
-  font-size: 10px; font-weight: 700; color: var(--text-primary);
+  font-size: var(--text-2xs); font-weight: 700; color: var(--text-primary);
   border-left: 1px solid var(--border-strong); white-space: nowrap; overflow: hidden;
 }
 .cg-weeks { position: relative; height: 28px; flex: 0 0 auto; }
 .cg-week {
   position: absolute; top: 0; bottom: 0;
   display: flex; align-items: center; padding-left: 7px;
-  font-size: 10px; font-weight: 600; color: var(--text-secondary);
+  font-size: var(--text-2xs); font-weight: 600; color: var(--text-secondary);
   border-left: 1px solid var(--border-strong);
 }
 
@@ -2062,7 +2062,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   justify-self: end; margin-right: 8px; align-self: center;
   min-width: 16px; height: 15px; padding: 0 4px;
   display: inline-flex; align-items: center; justify-content: center;
-  font-size: 10px; color: var(--text-secondary);
+  font-size: var(--text-2xs); color: var(--text-secondary);
   background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
 }
 
@@ -2080,7 +2080,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   align-items: center;
   gap: 2px;
   margin-left: 6px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -2142,7 +2142,7 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .cg-drop-hint { position: absolute; top: 0; bottom: 0; z-index: 3; background: color-mix(in oklch, var(--accent-presence) 22%, transparent); border-left: 2px solid var(--accent-presence); border-right: 2px solid var(--accent-presence); pointer-events: none; }
 .cg-drag-label {
   position: absolute; top: -2px; transform: translateY(-100%);
-  font-size: 10px; font-weight: 600; color: var(--text-primary);
+  font-size: var(--text-2xs); font-weight: 600; color: var(--text-primary);
   background: var(--bg-raised); border: 1px solid var(--border-strong);
   padding: 1px 6px; border-radius: 4px; white-space: nowrap;
   z-index: 5; pointer-events: none; box-shadow: 0 1px 4px rgb(0 0 0 / 0.3);
@@ -2179,8 +2179,8 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .cg-legend {
   position: sticky; left: 0;
   display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
-  margin-top: 12px; padding: 10px 8px 2px;
-  font-size: 11px; color: var(--text-secondary);
+  margin-top: var(--space-3); padding: 10px 8px 2px;
+  font-size: var(--text-xs); color: var(--text-secondary);
 }
 .cg-leg { display: inline-flex; align-items: center; gap: 6px; }
 .cg-sw { width: 14px; height: 9px; border-radius: 2px; display: inline-block; }

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -41,7 +41,7 @@
    BASE PROSE
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 .cave-md {
-  font-size: 14px;
+  font-size: var(--text-md);
   /* Reading line-spacing + letter-spacing + alignment knobs (Settings →
      Appearance → Typography). Default to 1.7 / 0 / left when vars are unset. */
   line-height: var(--cave-reading-leading, 1.7);
@@ -256,7 +256,7 @@
    hover-revealed Expand chip that opens it full-size in a lightbox. */
 .cave-md .cave-table-block {
   position: relative;
-  margin: 8px 0 16px;
+  margin: var(--space-2) 0 var(--space-4);
 }
 .cave-md .cave-table-block > .cave-table-scroll {
   margin: 0;
@@ -269,15 +269,15 @@
   z-index: 2;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--bg-elevated) 88%, transparent);
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -297,7 +297,7 @@
   border-color: color-mix(in oklch, var(--accent-presence) 50%, transparent);
 }
 .cave-table-expand-glyph {
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1;
 }
 /* Touch devices have no hover — keep the affordance visible. */
@@ -328,7 +328,7 @@
   max-width: min(96vw, 1280px);
   max-height: 90vh;
   border: 1px solid var(--border-strong);
-  border-radius: 16px;
+  border-radius: var(--radius-panel);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -339,25 +339,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 9px 12px;
+  gap: var(--space-3);
+  padding: 9px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
 }
 .cave-table-lightbox__title {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
 .cave-table-lightbox__close {
-  padding: 4px 14px;
+  padding: var(--space-1) 14px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   cursor: pointer;
   transition:
@@ -373,7 +373,7 @@
 .cave-table-lightbox__body {
   min-height: 0;
   overflow: auto;
-  padding: 20px 24px;
+  padding: var(--space-5) var(--space-6);
 }
 .cave-table-lightbox__body table {
   font-size: 13.5px;
@@ -389,8 +389,8 @@
 .cave-md .cm-mermaid-diagram {
   display: flex;
   justify-content: center;
-  margin: 8px 0 16px;
-  padding: 20px 16px;
+  margin: var(--space-2) 0 var(--space-4);
+  padding: var(--space-5) var(--space-4);
   /* Diagram canvas: a faint dot grid on the panel layer, the same visual
      language as node editors — diagrams read as a drawing surface, not a
      quote box. Dots come from the hairline scale so all 19 themes hold. */
@@ -399,7 +399,7 @@
     color-mix(in oklch, var(--bg-panel) 72%, transparent);
   background-size: 18px 18px;
   border: 1px solid var(--border-hairline);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   overflow-x: auto;
 }
 .cave-md .cm-mermaid-diagram svg {
@@ -543,10 +543,10 @@
   right: 16px;
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px;
+  gap: var(--space-1);
+  padding: var(--space-1);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-panel) 78%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -560,7 +560,7 @@
   height: 30px;
   padding: 0;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -586,11 +586,11 @@
   bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
-  padding: 5px 12px;
-  border-radius: 999px;
+  padding: 5px var(--space-3);
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-panel) 88%, transparent);
   border: 1px solid var(--border-hairline);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   user-select: none;
   pointer-events: none;
@@ -600,13 +600,13 @@
 .cave-md .cm-mermaid {
   display: block;
   margin: 0;
-  padding: 12px;
+  padding: var(--space-3);
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   overflow-x: auto;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-secondary);
   white-space: pre;
@@ -701,7 +701,7 @@
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in oklch, var(--accent-presence) 20%, transparent) transparent;
-  font-size: 12px;
+  font-size: var(--text-sm);
   margin: 0.6em 0;
 }
 
@@ -755,7 +755,7 @@
 }
 
 .cave-code-lines {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--code-chrome-ink-faint);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -794,7 +794,7 @@
 .cave-code-lang {
   order: 0;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   /* No opacity dimmer: alpha-stacking is how the old 40% ink evaded
@@ -806,7 +806,7 @@
 .cave-code-filename {
   order: 2;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--code-chrome-ink-faint);
   flex: 1;
   overflow: hidden;
@@ -840,7 +840,7 @@
   border: none !important;
   padding: 0;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1; /* flex .cave-line rows set their own height; kill gap from \n text nodes */
 }
 
@@ -877,7 +877,7 @@
   /* AA at 10px on the code surface (was accent-28%/50%-alpha gray ≈ 2.2:1,
      the "ordinals" finding in CHAT-D13-02). */
   color: color-mix(in oklch, var(--code-chrome-accent) 30%, var(--code-chrome-ink-muted));
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-align: right;
   user-select: none;
   pointer-events: none;
@@ -924,7 +924,7 @@
 .cave-copy-btn {
   display: inline-flex;
   align-items: center;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   padding: 0.2em 0.6em;
   border-radius: var(--radius-sm);
@@ -981,7 +981,7 @@
 .cave-bubble-actions {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   margin-top: 5px;
   opacity: 0;
   transition: opacity var(--duration-fast, 120ms) var(--ease-standard, ease);
@@ -1012,8 +1012,8 @@
     position: static;
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
-    margin-top: 8px;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
   }
 
   .cave-bubble-actions .cave-copy-btn-bubble {
@@ -1035,7 +1035,7 @@
 .cave-chat-branch-nav { display: inline-flex; align-items: center; gap: 2px; }
 .cave-chat-branch-nav__btn {
   border: none; background: transparent; cursor: pointer;
-  padding: 0 4px; line-height: 1; font-size: 14px; opacity: 0.7;
+  padding: 0 var(--space-1); line-height: 1; font-size: 14px; opacity: 0.7;
 }
 .cave-chat-branch-nav__btn:hover:not(:disabled) { opacity: 1; }
 .cave-chat-branch-nav__btn:disabled { opacity: 0.3; cursor: default; }
@@ -1060,7 +1060,7 @@
 
 .cave-code-expand-btn {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.04em;
   padding: 0.2em 0.8em;
   border: none;
@@ -1107,7 +1107,7 @@
   width: 100%;
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-panel) 82%, transparent);
-  padding: 14px 18px 12px;
+  padding: 14px 18px var(--space-3);
   box-shadow: 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
 }
 
@@ -1117,7 +1117,7 @@
   width: 32px;
   height: 32px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
   color: var(--accent-presence);
   box-shadow: 0 1px 8px oklch(0 0 0 / 18%);
@@ -1133,7 +1133,7 @@
   background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
   padding: 0 10px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .cave-chat-transcript {
@@ -1165,7 +1165,7 @@
 .cave-chat-empty-shell {
   width: min(680px, 100%);
   display: grid;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 /* Chat-first landing eyebrow (cave-hsa6) — a quiet time-of-day greeting above
@@ -1180,7 +1180,7 @@
   margin: 0;
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1194,7 +1194,7 @@
   width: 5px;
   height: 5px;
   flex: 0 0 auto;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
 }
 
@@ -1204,19 +1204,19 @@
    working context; everything stays reachable. */
 .cave-chat-empty-context {
   display: grid;
-  gap: 12px;
+  gap: var(--space-3);
 }
 .cave-chat-empty-context-toggle {
   justify-self: center;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 12px;
+  padding: 5px var(--space-3);
   border: 1px solid var(--border-panel);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 550;
   cursor: pointer;
   transition: color 140ms ease, border-color 140ms ease, background 140ms ease;
@@ -1263,7 +1263,7 @@
   gap: 6px;
   margin: 5px 0 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.2;
 }
 
@@ -1289,7 +1289,7 @@
   border: 1px solid var(--border-panel);
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-elevated) 78%, transparent);
-  padding: 8px 11px;
+  padding: var(--space-2) 11px;
   color: var(--text-muted);
   /* Inline metadata card, not a floating modal — keep the lift subtle so it sits
    * in the page rather than hovering above it. */
@@ -1301,14 +1301,14 @@
 .cave-chat-empty-project-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
 .cave-chat-empty-project-label {
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -1322,7 +1322,7 @@
   background: transparent;
   color: var(--text-primary);
   font: inherit;
-  font-size: 14px;
+  font-size: var(--text-md);
   font-weight: 520;
   cursor: pointer;
   outline: none;
@@ -1340,7 +1340,7 @@
   overflow: hidden;
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1349,7 +1349,7 @@
 .cave-chat-empty-prompts {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* An odd chip count strands the last chip beside an empty cell; stretching it
@@ -1369,7 +1369,7 @@
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   padding: 0 11px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   text-align: left;
   transition:
@@ -1454,7 +1454,7 @@
 .cave-chat-empty-hint {
   margin: 0;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.4;
   text-align: center;
 }
@@ -1463,7 +1463,7 @@
 .cave-chat-empty-role {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.3;
 }
 
@@ -1482,7 +1482,7 @@
   gap: 6px;
   color: var(--text-muted);
   font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -1498,7 +1498,7 @@
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   padding: 0 11px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-align: left;
   transition:
     border-color 140ms ease,
@@ -1532,9 +1532,9 @@ button.cave-chat-empty-task:hover:not(:disabled) {
  * The word is always rendered — color never carries the meaning alone. */
 .cave-chat-empty-task-status {
   flex: 0 0 auto;
-  padding: 1px 8px;
+  padding: 1px var(--space-2);
   border: 1px solid color-mix(in oklch, var(--text-muted) 30%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--text-muted) 8%, transparent);
   color: var(--text-muted);
   font-size: 10.5px;
@@ -1591,9 +1591,9 @@ button.cave-chat-empty-task:hover:not(:disabled) {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 550;
 }
 
@@ -1604,7 +1604,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-chat-empty-work-more {
   padding-left: 2px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .cave-chat-empty-work-error {
@@ -1654,14 +1654,14 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-chat-empty-task-tile {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 38px;
   border: 1px dashed color-mix(in oklch, var(--accent-presence) 38%, var(--border-panel));
   border-radius: 7px;
   background: color-mix(in oklch, var(--accent-presence) 5%, transparent);
   padding: 0 11px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   text-align: left;
   transition:
@@ -1703,14 +1703,14 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-chat-empty-task-armed {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 38px;
   border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, var(--border-panel));
   border-radius: 7px;
   background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
   padding: 0 11px;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .cave-chat-empty-task-armed svg {
@@ -1757,7 +1757,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   background: transparent;
   padding: 0 9px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-align: left;
   transition:
     border-color 140ms ease,
@@ -1812,11 +1812,11 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 @media (max-width: 640px) {
   .cave-chat-empty {
     min-height: auto;
-    padding: 20px 14px 118px;
+    padding: var(--space-5) 14px 118px;
   }
 
   .cave-chat-empty-shell {
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .cave-chat-empty-meta {
@@ -1824,7 +1824,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   }
 
   .cave-chat-empty-project {
-    padding: 9px 12px;
+    padding: 9px var(--space-3);
   }
 
   .cave-chat-empty-project-label {
@@ -1837,7 +1837,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 
   .cave-chat-empty-prompts {
     grid-template-columns: 1fr;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .cave-chat-empty-prompt {
@@ -1883,10 +1883,10 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-user-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0 2px 5px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }
 
 .cave-turn-system .cave-turn-user-meta {
@@ -1949,7 +1949,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-assistant {
   display: grid;
   grid-template-columns: 38px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   width: 100%;
 }
 
@@ -1964,7 +1964,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-ordinal {
   color: var(--text-muted);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1;
 }
 
@@ -1974,7 +1974,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   width: 28px;
   height: 28px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 26%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
   color: var(--accent-presence);
 }
@@ -1998,7 +1998,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-raised));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 20%, transparent);
   flex-shrink: 0;
@@ -2024,7 +2024,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-card-header {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-3);
   min-height: 44px;
   border-bottom: 1px solid color-mix(in oklch, var(--foreground) 8%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 48%, transparent);
@@ -2040,7 +2040,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   align-items: center;
   border-radius: 5px;
   padding: 2px 6px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1.2;
 }
@@ -2079,12 +2079,12 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-retry {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   border-radius: var(--radius-sm);
   border: 1px solid color-mix(in oklch, var(--color-danger) 35%, transparent);
   background: transparent;
   padding: 1px 6px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1.2;
   color: var(--color-danger);
@@ -2103,12 +2103,12 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-turn-tools-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-hairline);
   background: transparent;
   padding: 1px 6px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1.2;
   color: var(--text-muted);
@@ -2131,20 +2131,20 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-progress-group,
 .cave-tool-group {
   border: 1px solid var(--border-hairline);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-panel) 36%, transparent);
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
 }
 
 .cave-tool-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   cursor: pointer;
   user-select: none;
   list-style: none;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -2185,10 +2185,10 @@ details[open] > .cave-tool-summary::before {
   border: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-elevated) 72%, transparent);
-  padding: 7px 8px;
+  padding: 7px var(--space-2);
   color: var(--text-secondary);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -2221,18 +2221,18 @@ details[open] > .cave-tool-summary::before {
   gap: 6px;
   margin-top: 9px;
   border-top: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
-  padding-top: 8px;
+  padding-top: var(--space-2);
 }
 
 .cave-progress-row {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 22px;
   border-radius: 6px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.4;
 }
 
@@ -2303,7 +2303,7 @@ details[open] > .cave-tool-summary::before {
 
 .cave-tool-io-label {
   margin-bottom: 5px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2327,18 +2327,18 @@ details[open] > .cave-tool-summary::before {
   display: grid;
   grid-template-columns: minmax(56px, 132px) minmax(0, 1fr);
   align-items: baseline;
-  gap: 4px 10px;
+  gap: var(--space-1) 10px;
   min-width: 0;
 }
 
 .cave-tool-field[data-multiline="true"] {
   grid-template-columns: minmax(0, 1fr);
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .cave-tool-field-label {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-muted);
   overflow-wrap: anywhere;
@@ -2347,7 +2347,7 @@ details[open] > .cave-tool-summary::before {
 .cave-tool-field-value {
   margin: 0;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -2373,14 +2373,14 @@ details[open] > .cave-tool-summary::before {
 .cave-tool-raw-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   margin-top: 7px;
   padding: 2px 7px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -2455,7 +2455,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 12px 12px;
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .cave-composer-control-row {
@@ -2466,7 +2466,7 @@ details[open] > .cave-tool-summary::before {
   grid-template-columns: minmax(0, 1fr) auto;
   min-height: 34px;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--text-muted);
 }
 
@@ -2475,7 +2475,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .cave-composer-submit-row {
@@ -2525,7 +2525,7 @@ details[open] > .cave-tool-summary::before {
   min-width: 0;
   max-width: 240px;
   padding: 0 11px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1;
   cursor: pointer;
   isolation: isolate;
@@ -2594,13 +2594,13 @@ details[open] > .cave-tool-summary::before {
   right: 3px;
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   box-shadow: 0 0 0 2px var(--bg-surface);
 }
 
 .composer-options__panel {
-  padding: 4px;
+  padding: var(--space-1);
 }
 
 /* Prompt-snippets action folded into the composer overflow (cave-xsq.4): a
@@ -2609,13 +2609,13 @@ details[open] > .cave-tool-summary::before {
 .composer-options__action {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 8px 6px;
+  padding: var(--space-2) 6px;
   border-radius: var(--radius-control);
   border-bottom: 1px solid var(--border-hairline);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .composer-options__action:hover {
   background: var(--bg-raised);
@@ -2626,7 +2626,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px 6px;
+  padding: var(--space-2) 6px;
 }
 
 .composer-options__section + .composer-options__section {
@@ -2634,7 +2634,7 @@ details[open] > .cave-tool-summary::before {
 }
 
 .composer-options__label {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.07em;
@@ -2651,12 +2651,12 @@ details[open] > .cave-tool-summary::before {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 4px 10px;
+  padding: var(--space-1) 10px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.2;
   white-space: nowrap;
   cursor: pointer;
@@ -2679,7 +2679,7 @@ details[open] > .cave-tool-summary::before {
 .cave-composer-input::-webkit-scrollbar-track { background: transparent; }
 .cave-composer-input::-webkit-scrollbar-thumb {
   background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .cave-composer-popover {
@@ -2690,13 +2690,13 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   min-height: 30px;
   border-bottom: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 40%, transparent);
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 /* Dense linear session view */
@@ -2732,12 +2732,12 @@ details[open] > .cave-tool-summary::before {
 .cave-drop-overlay-inner {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--bg-raised);
-  padding: 10px 16px;
-  font-size: 13px;
+  padding: 10px var(--space-4);
+  font-size: var(--text-base);
   color: var(--text-primary);
   box-shadow: 0 8px 24px color-mix(in oklch, var(--bg-base) 60%, transparent);
 }
@@ -2750,7 +2750,7 @@ details[open] > .cave-tool-summary::before {
   width: 100%;
   border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 74%, transparent);
-  padding: 4px 10px 5px;
+  padding: var(--space-1) 10px 5px;
 }
 
 .cave-mobile-header-identity,
@@ -2768,7 +2768,7 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 6px;
   min-height: 22px;
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .cave-chat-meta-line .cave-chat-title-input {
@@ -2829,7 +2829,7 @@ details[open] > .cave-tool-summary::before {
   width: 6px;
   height: 6px;
   flex-shrink: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: currentColor;
   box-shadow: 0 0 0 2px color-mix(in oklch, currentColor 14%, transparent);
 }
@@ -2864,7 +2864,7 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-meta-line__action {
   margin-left: 6px;
   border-radius: var(--radius-sm);
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   color: var(--text-primary);
   font-size: inherit;
   font-weight: 600;
@@ -2939,18 +2939,18 @@ details[open] > .cave-tool-summary::before {
   z-index: 80;
   width: min(320px, calc(100vw - 32px));
   border: 1px solid var(--border-strong);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   padding: 9px;
   box-shadow: 0 14px 34px color-mix(in oklch, var(--bg-base) 64%, transparent);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .cave-chat-model-popover__picker {
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .cave-chat-model-popover__heading {
@@ -2973,7 +2973,7 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-model-popover__option {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 4px 8px;
+  gap: var(--space-1) var(--space-2);
   align-items: center;
   width: 100%;
   padding: 5px 7px;
@@ -2981,7 +2981,7 @@ details[open] > .cave-tool-summary::before {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   text-align: left;
   cursor: pointer;
 }
@@ -3010,14 +3010,14 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-chat-model-popover__custom {
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-1);
 }
 
 .cave-chat-model-popover__custom-label {
   display: block;
   margin-bottom: 3px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }
 
 .cave-chat-model-popover__custom-row {
@@ -3168,7 +3168,7 @@ details[open] > .cave-tool-summary::before {
   z-index: 1200;
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: var(--space-6);
   background: color-mix(in oklch, var(--bg-base) 68%, transparent);
   backdrop-filter: blur(10px);
 }
@@ -3177,7 +3177,7 @@ details[open] > .cave-tool-summary::before {
   width: min(360px, calc(100vw - 32px));
   overflow: hidden;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -3189,21 +3189,21 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   border-bottom: 1px solid var(--border-hairline);
-  padding: 14px 16px;
+  padding: 14px var(--space-4);
 }
 
 .voice-call-overlay__heading {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .voice-call-overlay__heading strong {
   overflow: hidden;
-  font-size: 14px;
+  font-size: var(--text-md);
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3212,15 +3212,15 @@ details[open] > .cave-tool-summary::before {
 .voice-call-overlay__state,
 .voice-call-overlay__duration {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.3;
 }
 
 .voice-call-overlay__duration {
   flex: 0 0 auto;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
-  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  padding: 3px var(--space-2);
   font-variant-numeric: tabular-nums;
 }
 
@@ -3228,15 +3228,15 @@ details[open] > .cave-tool-summary::before {
   display: grid;
   min-height: 120px;
   place-items: center;
-  padding: 20px 16px;
+  padding: var(--space-5) var(--space-4);
 }
 
 /* How the call hears (cave-vpe1): honest engine label on live calls. */
 .voice-call-overlay__ears {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 2px 10px;
   letter-spacing: 0.02em;
 }
@@ -3246,14 +3246,14 @@ details[open] > .cave-tool-summary::before {
   justify-items: center;
   gap: 10px;
   color: var(--color-danger);
-  font-size: 13px;
+  font-size: var(--text-base);
   text-align: center;
 }
 
 .voice-call-overlay__hint {
   max-width: 280px;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.45;
 }
 
@@ -3263,7 +3263,7 @@ details[open] > .cave-tool-summary::before {
   justify-content: space-between;
   gap: 10px;
   border-top: 1px solid var(--border-hairline);
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
 }
 
 .voice-call-overlay__control,
@@ -3275,7 +3275,7 @@ details[open] > .cave-tool-summary::before {
   justify-content: center;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1;
   transition:
     background var(--duration-fast) var(--ease-standard),
@@ -3302,7 +3302,7 @@ details[open] > .cave-tool-summary::before {
 }
 
 .voice-call-overlay__retry {
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   background: var(--bg-base);
   color: var(--text-primary);
 }
@@ -3350,7 +3350,7 @@ details[open] > .cave-tool-summary::before {
   background: transparent;
   outline: none;
   color: var(--text-primary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 20px;
 }
 
@@ -3362,7 +3362,7 @@ details[open] > .cave-tool-summary::before {
   flex-shrink: 0;
   color: var(--text-muted);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -3412,7 +3412,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   min-height: 20px;
   overflow-x: auto;
   scrollbar-width: none;
@@ -3422,7 +3422,7 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-linked-chip {
   min-height: 20px;
   max-width: min(30vw, 300px);
-  gap: 4px;
+  gap: var(--space-1);
   padding: 0 6px;
   border-radius: 6px;
   font-size: 10.5px;
@@ -3453,7 +3453,7 @@ details[open] > .cave-tool-summary::before {
   width: 32px;
   height: 32px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-raised));
   color: var(--accent-presence);
   overflow: hidden;
@@ -3487,7 +3487,7 @@ details[open] > .cave-tool-summary::before {
 .cave-linear-turn {
   display: flex;
   flex-direction: column;
-  padding: 14px 0 12px;
+  padding: 14px 0 var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--foreground) 5%, transparent);
   /* CHAT-D3-07 render virtualization: let the browser skip layout + paint for
      turns scrolled out of view (the React side is already memoized, so this is
@@ -3550,7 +3550,7 @@ details[open] > .cave-tool-summary::before {
 .cave-linear-turn-content--with-avatar {
   display: grid;
   grid-template-columns: 52px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
 }
 
@@ -3631,7 +3631,7 @@ details[open] > .cave-tool-summary::before {
   min-height: 22px;
   margin-bottom: 5px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.4;
 }
 
@@ -3689,7 +3689,7 @@ details[open] > .cave-tool-summary::before {
   padding: 2px 7px;
   background: color-mix(in oklch, var(--bg-raised) 82%, var(--foreground));
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 650;
   line-height: 1.2;
 }
@@ -3702,12 +3702,12 @@ details[open] > .cave-tool-summary::before {
 
 .cave-linear-turn-recency {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
 }
 
 .cave-linear-turn-meta--identity {
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .cave-linear-turn-body {
@@ -3740,11 +3740,11 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-linear .cave-tool-group {
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-panel) 26%, transparent);
-  padding: 8px 9px;
+  padding: var(--space-2) 9px;
 }
 
 .cave-chat-linear .cave-composer-dock {
-  padding: 10px clamp(16px, 3vw, 34px) 16px;
+  padding: 10px clamp(16px, 3vw, 34px) var(--space-4);
 }
 
 .cave-composer-shell {
@@ -3775,7 +3775,7 @@ details[open] > .cave-tool-summary::before {
   min-height: var(--touch-target);
   place-items: center;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-panel) 48%, transparent);
   color: var(--text-secondary);
   list-style: none;
@@ -3794,7 +3794,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   max-height: 0;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   overflow: hidden;
   border: 1px solid var(--border-hairline);
   border-radius: 10px;
@@ -3817,22 +3817,22 @@ details[open] > .cave-tool-summary::before {
 .cave-mobile-context-card {
   min-width: 0;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 52%, transparent);
   padding: 10px;
 }
 
 .cave-mobile-context-kicker {
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   text-transform: uppercase;
 }
 
 .cave-mobile-context-title {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 650;
 }
 
@@ -3841,7 +3841,7 @@ details[open] > .cave-tool-summary::before {
   overflow: hidden;
   color: var(--text-muted);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -3861,11 +3861,11 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 6px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 42%, transparent);
   padding: 7px 9px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .cave-mobile-context-link {
@@ -3892,11 +3892,11 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 6px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 58%, transparent);
   padding: 0 10px;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
 }
 
@@ -3913,11 +3913,11 @@ details[open] > .cave-tool-summary::before {
 @media (max-width: 720px) {
   .cave-chat-workbench-header,
   .cave-chat-linear-header {
-    padding: 12px 14px 10px;
+    padding: var(--space-3) 14px 10px;
   }
 
   .cave-chat-transcript {
-    padding: 18px 12px 22px;
+    padding: 18px var(--space-3) 22px;
   }
 
   .cave-turn-assistant {
@@ -3930,7 +3930,7 @@ details[open] > .cave-tool-summary::before {
 
   .cave-linear-turn {
     grid-template-columns: 32px minmax(0, 1fr);
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .cave-turn-content,
@@ -3940,7 +3940,7 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-chat-linear .cave-composer-dock {
-    padding: 8px 12px 12px;
+    padding: var(--space-2) var(--space-3) var(--space-3);
   }
 }
 
@@ -3958,7 +3958,7 @@ details[open] > .cave-tool-summary::before {
     top: 0;
     z-index: 60;
     gap: 7px;
-    padding: 8px 12px 9px;
+    padding: var(--space-2) var(--space-3) 9px;
     background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
     backdrop-filter: blur(14px);
   }
@@ -3980,7 +3980,7 @@ details[open] > .cave-tool-summary::before {
     display: flex;
     min-width: 0;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .cave-mobile-header-familiar {
@@ -4004,9 +4004,9 @@ details[open] > .cave-tool-summary::before {
     flex: 0 0 auto;
     align-items: center;
     gap: 5px;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     padding: 0 9px;
-    font-size: 10px;
+    font-size: var(--text-2xs);
     font-weight: 650;
     white-space: nowrap;
   }
@@ -4014,7 +4014,7 @@ details[open] > .cave-tool-summary::before {
   .cave-mobile-daemon-pill > span {
     width: 6px;
     height: 6px;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background: currentColor;
   }
 
@@ -4041,7 +4041,7 @@ details[open] > .cave-tool-summary::before {
     border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
     background: color-mix(in oklch, var(--accent-presence) 11%, transparent);
     color: var(--text-secondary);
-    font-size: 11px;
+    font-size: var(--text-xs);
     text-align: left;
     -webkit-tap-highlight-color: transparent;
   }
@@ -4065,7 +4065,7 @@ details[open] > .cave-tool-summary::before {
     flex: 0 0 auto;
     text-transform: capitalize;
     color: var(--text-muted);
-    font-size: 10px;
+    font-size: var(--text-2xs);
   }
 
   .cave-mobile-header-task__open {
@@ -4083,7 +4083,7 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-chat-linear .cave-chat-transcript {
-    padding: 16px 12px 96px;
+    padding: var(--space-4) var(--space-3) 96px;
     padding-bottom: calc(324px + var(--sai-bottom));
     overscroll-behavior: contain;
     scroll-padding-top: calc(var(--sai-top) + 64px);
@@ -4092,17 +4092,17 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-chat-linear .cave-chat-thread {
-    gap: 4px;
+    gap: var(--space-1);
     min-width: 0;
   }
 
   .cave-chat-linear .cave-md {
-    font-size: 14px;
+    font-size: var(--text-md);
     line-height: 1.68;
   }
 
   .cave-linear-turn {
-    padding: 12px 0;
+    padding: var(--space-3) 0;
   }
 
   .cave-linear-turn--assistant .cave-linear-turn-content,
@@ -4144,7 +4144,7 @@ details[open] > .cave-tool-summary::before {
     bottom: calc(214px + var(--sai-bottom));
     width: var(--touch-target);
     height: var(--touch-target);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     -webkit-tap-highlight-color: transparent;
   }
 
@@ -4178,7 +4178,7 @@ details[open] > .cave-tool-summary::before {
     position: relative;
     display: flex;
     flex-direction: column;
-    border-radius: 16px;
+    border-radius: var(--radius-panel);
   }
 
   .cave-composer-popover {
@@ -4208,7 +4208,7 @@ details[open] > .cave-tool-summary::before {
     grid-template-columns: minmax(0, 1fr) auto;
     min-height: 48px;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .cave-composer-utility-row {
@@ -4229,7 +4229,7 @@ details[open] > .cave-tool-summary::before {
 
   .cave-mobile-action-chip {
     min-height: var(--touch-target);
-    padding-inline: 12px;
+    padding-inline: var(--space-3);
     -webkit-tap-highlight-color: transparent;
   }
 
@@ -4273,14 +4273,14 @@ details[open] > .cave-tool-summary::before {
 
 .cave-bubble-system-sigil {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: color-mix(in oklch, var(--code-chrome-accent) 70%, var(--code-chrome-ink-faint));
   flex-shrink: 0;
 }
 
 .cave-bubble-system-label {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.04em;
   color: var(--code-chrome-ink-muted);
   overflow: hidden;
@@ -4298,7 +4298,7 @@ details[open] > .cave-tool-summary::before {
   margin: 0;
   padding: 0.7em 1em;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.6;
   color: var(--code-chrome-ink-muted);
   white-space: pre-wrap;
@@ -4319,7 +4319,7 @@ details[open] > .cave-tool-summary::before {
 .cave-group-chat-turn {
   display: grid;
   grid-template-columns: 52px minmax(0, 1fr);
-  gap: 12px;
+  gap: var(--space-3);
   align-items: start;
   min-width: 0;
 }
@@ -4361,7 +4361,7 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 6px;
   min-height: 22px;
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
   line-height: 1.4;
 }
 
@@ -4389,7 +4389,7 @@ details[open] > .cave-tool-summary::before {
   padding: 2px 7px;
   background: color-mix(in oklch, var(--bg-raised) 82%, var(--foreground));
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 650;
   line-height: 1.2;
 }
@@ -4402,7 +4402,7 @@ details[open] > .cave-tool-summary::before {
 
 .cave-group-chat-recency {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
 }
 
@@ -4433,11 +4433,11 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-group-chat-name {
-    font-size: 14px;
+    font-size: var(--text-md);
   }
 
   .cave-group-chat-recency {
-    font-size: 12px;
+    font-size: var(--text-sm);
   }
 
   .cave-group-chat-badge {
@@ -4451,7 +4451,7 @@ details[open] > .cave-tool-summary::before {
 
 .cave-bubble-timestamp {
   margin-top: 3px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
   opacity: 0;
   max-height: 0;
@@ -4473,7 +4473,7 @@ details[open] > .cave-tool-summary::before {
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
 .cave-model-badge {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   padding: 2px 6px;
   border-radius: 5px;
@@ -4491,7 +4491,7 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-model-input {
-  font-size: 11px;
+  font-size: var(--text-xs);
   width: 160px;
   padding: 2px 6px;
   border-radius: 5px;
@@ -4636,9 +4636,9 @@ details[open] > .cave-tool-summary::before {
   left: 0;
   z-index: 40;
   width: min(320px, 78vw);
-  padding: 12px;
+  padding: var(--space-3);
   border: 1px solid var(--border-hairline, #2a2a2a);
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   background: var(--bg-elevated, #161616);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.28);
   display: flex;
@@ -4685,7 +4685,7 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__actions { display: flex; flex-wrap: wrap; gap: 6px; }
 .familiar-inline-card__actions button {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 12px; padding: 4px 8px;
+  font-size: var(--text-sm); padding: 4px 8px;
   border: 1px solid var(--border-hairline, #2a2a2a);
   border-radius: var(--radius-control); background: var(--bg-base, #111);
   color: var(--text-primary, #eee); cursor: pointer;
@@ -4717,7 +4717,7 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__memory-time { font-size: 10px; color: var(--text-secondary, #777); }
 .familiar-inline-card__memory-stale {
   margin-left: 6px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
-  padding: 1px 4px; border-radius: var(--radius-control);
+  padding: 1px var(--space-1); border-radius: var(--radius-control);
   color: var(--color-warning); border: 1px solid color-mix(in srgb, var(--color-warning) 45%, transparent);
 }
 
@@ -4725,7 +4725,7 @@ details[open] > .cave-tool-summary::before {
    Trust/health one-liner, activity meta, live workload and state-driven
    actions derived by familiar-card-insights from the analytics model. */
 .familiar-inline-card__insight {
-  font-size: 12px; line-height: 1.4; padding: 6px 8px;
+  font-size: var(--text-sm); line-height: 1.4; padding: 6px 8px;
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline, #2a2a2a);
   color: var(--text-primary, #ddd); background: var(--bg-base, #111);
@@ -4746,11 +4746,11 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__meta { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .familiar-inline-card__meta-item {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 11px; color: var(--text-secondary, #999);
+  font-size: var(--text-xs); color: var(--text-secondary, #999);
 }
 .familiar-inline-card__signal {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 11px; padding: 1px 6px; border-radius: var(--radius-pill, 999px);
+  font-size: var(--text-xs); padding: 1px 6px; border-radius: var(--radius-pill, 999px);
   color: var(--text-secondary, #999); border: 1px solid var(--border-hairline, #2a2a2a);
 }
 .familiar-inline-card__signal[data-severity="warn"] { color: var(--color-warning); border-color: color-mix(in srgb, var(--color-warning) 45%, transparent); }
@@ -4760,7 +4760,7 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__workload-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
 .familiar-inline-card__workload-item {
   display: flex; align-items: center; gap: 6px; width: 100%;
-  font-size: 12px; padding: 4px 6px; text-align: left;
+  font-size: var(--text-sm); padding: 4px 6px; text-align: left;
   border: 1px solid var(--border-hairline, #2a2a2a);
   border-radius: var(--radius-control); background: var(--bg-base, #111);
   color: var(--text-primary, #ddd); cursor: pointer;
@@ -4795,7 +4795,7 @@ details[open] > .cave-tool-summary::before {
 .cave-launch__hero { display: grid; justify-items: center; gap: 7px; text-align: center; }
 .cave-launch__mark {
   display: grid; place-items: center; width: 46px; height: 46px; margin-bottom: 3px;
-  border-radius: 12px; color: var(--accent-presence);
+  border-radius: var(--radius-card); color: var(--accent-presence);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 26%, transparent);
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
   box-shadow: 0 10px 28px oklch(0 0 0 / 22%), inset 0 1px 0 oklch(1 0 0 / 7%);
@@ -4813,7 +4813,7 @@ details[open] > .cave-tool-summary::before {
 }
 .cave-launch__card {
   display: flex; align-items: center; gap: 11px; text-align: left;
-  padding: 12px 13px; border-radius: 11px;
+  padding: var(--space-3) 13px; border-radius: 11px;
   border: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   cursor: pointer;
@@ -4826,11 +4826,11 @@ details[open] > .cave-tool-summary::before {
 }
 .cave-launch__card-copy { display: grid; gap: 2px; min-width: 0; flex: 1; }
 .cave-launch__card-name {
-  font-size: 13px; font-weight: 600; color: var(--text-primary);
+  font-size: var(--text-base); font-weight: 600; color: var(--text-primary);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .cave-launch__card-meta {
-  font-size: 11px; color: var(--text-muted);
+  font-size: var(--text-xs); color: var(--text-muted);
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
@@ -4847,7 +4847,7 @@ details[open] > .cave-tool-summary::before {
 .cave-launch__recent-icon { color: var(--text-muted); flex: 0 0 auto; }
 .cave-launch__recent-copy { display: grid; gap: 1px; min-width: 0; flex: 1; }
 .cave-launch__recent-title {
-  font-size: 13px; color: var(--text-primary);
+  font-size: var(--text-base); color: var(--text-primary);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .cave-launch__recent-meta { font-size: 11px; color: var(--text-muted); }
@@ -4948,7 +4948,7 @@ details[open] > .cave-tool-summary::before {
   width: 32px;
   height: 32px;
   flex: 0 0 auto;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-muted);
@@ -5002,10 +5002,10 @@ details[open] > .cave-tool-summary::before {
   right: -3px;
   min-width: 15px;
   height: 15px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   display: grid;
   place-items: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--composer-pill-gold, oklch(0.81 0.105 83));
   color: oklch(0.22 0.02 83);
   font-size: 9.5px;
@@ -5039,7 +5039,7 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 6px 0;
   border-right: 1px solid var(--border-hairline);
 }
@@ -5050,7 +5050,7 @@ details[open] > .cave-tool-summary::before {
   place-items: center;
   width: 30px;
   height: 30px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-muted);
@@ -5076,10 +5076,10 @@ details[open] > .cave-tool-summary::before {
   right: -3px;
   min-width: 15px;
   height: 15px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   display: grid;
   place-items: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--composer-pill-gold, oklch(0.81 0.105 83));
   color: oklch(0.22 0.02 83);
   font-size: 9.5px;
@@ -5127,12 +5127,12 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: var(--space-2);
+  padding: var(--space-2) 10px;
   border-bottom: 1px solid var(--border-hairline);
 }
 .workspace-rail__title {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -5173,9 +5173,9 @@ details[open] > .cave-tool-summary::before {
   display: grid;
   place-items: center;
   height: 100%;
-  padding: 24px;
+  padding: var(--space-6);
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -5196,9 +5196,9 @@ details[open] > .cave-tool-summary::before {
   display: grid;
   place-items: center;
   height: 100%;
-  padding: 24px;
+  padding: var(--space-6);
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -5215,7 +5215,7 @@ details[open] > .cave-tool-summary::before {
   flex: 0 0 45%;
   min-height: 0;
   overflow: auto;
-  padding: 6px 4px;
+  padding: 6px var(--space-1);
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -5250,7 +5250,7 @@ details[open] > .cave-tool-summary::before {
   flex: 1 1 auto;
   min-height: 0;
   height: 100%;
-  padding: 8px 6px;
+  padding: var(--space-2) 6px;
   border-right: 1px solid var(--border-hairline);
   border-bottom: 0;
   background: color-mix(in oklch, var(--bg-base) 92%, var(--foreground) 3%);
@@ -5288,11 +5288,11 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   height: 100%;
-  padding: 24px;
+  padding: var(--space-6);
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
 }
 
@@ -5301,14 +5301,14 @@ details[open] > .cave-tool-summary::before {
 .workspace-rail__empty-changes {
   width: min(100%, 380px);
   margin-top: 6px;
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   border: 1px dashed var(--border-hairline);
   border-radius: 10px;
   text-align: left;
 }
 .workspace-rail__empty-changes-title {
   margin: 0 0 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 .workspace-rail__empty-changes-list {
@@ -5324,7 +5324,7 @@ details[open] > .cave-tool-summary::before {
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 4px 6px;
+  padding: var(--space-1) 6px;
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
@@ -5359,7 +5359,7 @@ details[open] > .cave-tool-summary::before {
 .workspace-rail__empty-change-stat {
   flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -5379,7 +5379,7 @@ details[open] > .cave-tool-summary::before {
   border-bottom: 1px solid var(--border-hairline);
   color: var(--text-muted);
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .workspace-rail__preview-name {
@@ -5396,7 +5396,7 @@ details[open] > .cave-tool-summary::before {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex: 0 0 auto;
   font-family: var(--font-sans, inherit);
 }
@@ -5408,7 +5408,7 @@ details[open] > .cave-tool-summary::before {
   padding: 2px 7px;
   border-radius: 5px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   transition: color 120ms ease, background-color 120ms ease;
 }
 
@@ -5430,7 +5430,7 @@ details[open] > .cave-tool-summary::before {
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: var(--font-sans, inherit);
   color: var(--color-success, #34d399);
 }
@@ -5440,7 +5440,7 @@ details[open] > .cave-tool-summary::before {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: var(--font-sans, inherit);
   color: var(--color-danger, #f87171);
 }
@@ -5496,7 +5496,7 @@ details[open] > .cave-tool-summary::before {
 .workspace-rail__preview-skeleton {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .workspace-rail__preview-error {
@@ -5504,11 +5504,11 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-height: 160px;
-  padding: 16px;
+  padding: var(--space-4);
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 
@@ -5533,7 +5533,7 @@ details[open] > .cave-tool-summary::before {
 
 .workspace-rail__preview-meta {
   font-family: var(--font-mono, monospace);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -5552,7 +5552,7 @@ details[open] > .cave-tool-summary::before {
   flex: 0 0 44px;
   width: 44px;
   height: 100%;
-  padding: 12px 0;
+  padding: var(--space-3) 0;
   border: 0;
   border-left: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
@@ -5598,7 +5598,7 @@ details[open] > .cave-tool-summary::before {
 }
 .workspace-rail-reopen__label {
   writing-mode: vertical-rl;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -36,5 +36,5 @@
 }
 .cave-chart__label {
   fill: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -1,7 +1,7 @@
 /* In-chat artifact viewer — Canvas/Code tabs embedded in an assistant bubble.
    Same dots + segmented pill styling as the retired Canvas page's sketch node (see feature/journal-canvas-surface). */
 .chat-artifact {
-  margin: 8px 0;
+  margin: var(--space-2) 0;
   background: var(--bg-panel);
   border: 1px solid var(--border-hairline);
   border-radius: 10px;
@@ -63,7 +63,7 @@
 .chat-artifact__frame { width: 100%; height: 100%; border: 0; display: block; }
 .chat-artifact__code, .chat-artifact__code-edit {
   margin: 0; width: 100%; height: 360px; box-sizing: border-box;
-  padding: 12px 14px; overflow: auto;
+  padding: var(--space-3) 14px; overflow: auto;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px; line-height: 1.6;
   color: var(--text-primary); background: var(--bg-base); border: 0;
 }
@@ -80,7 +80,7 @@
 .chat-artifact__error {
   position: absolute; left: 10px; right: 10px; bottom: 10px;
   display: flex; align-items: center; gap: 8px;
-  padding: 8px 10px; font-size: var(--text-xs);
+  padding: var(--space-2) 10px; font-size: var(--text-xs);
   color: #fff; background: #b95050; border-radius: 8px;
 }
 .chat-artifact__error-msg { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
@@ -90,7 +90,7 @@
 /* Collapsed state: a calm full-width trigger that opens the refine space. */
 .chat-artifact__refine-trigger {
   display: flex; align-items: center; gap: 8px; width: 100%;
-  padding: 9px 12px; border: 0; border-top: 1px solid var(--border-hairline);
+  padding: 9px var(--space-3); border: 0; border-top: 1px solid var(--border-hairline);
   background: var(--bg-raised); color: var(--text-secondary);
   font-size: var(--text-xs); text-align: left; cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease;
@@ -101,7 +101,7 @@
 /* Expanded "dedicated space": textarea + suggestion rows + actions. */
 .chat-artifact__refine-panel {
   display: flex; flex-direction: column; gap: 10px;
-  padding: 10px 12px 12px; border-top: 1px solid var(--border-hairline); background: var(--bg-raised);
+  padding: 10px var(--space-3) var(--space-3); border-top: 1px solid var(--border-hairline); background: var(--bg-raised);
 }
 .chat-artifact__refine-head { display: flex; align-items: center; gap: 7px; }
 .chat-artifact__refine-title { font-size: var(--text-xs); font-weight: 600; color: var(--text-primary); }
@@ -116,7 +116,7 @@
 .chat-artifact__suggests { display: flex; flex-direction: column; gap: 6px; }
 .chat-artifact__suggests-label {
   display: flex; align-items: center; gap: 4px; margin: 2px 0 0;
-  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+  font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
   color: var(--text-muted);
 }
 .chat-artifact__chips { display: flex; flex-wrap: wrap; gap: 6px; }

--- a/src/styles/chat-canvas.css
+++ b/src/styles/chat-canvas.css
@@ -3,7 +3,7 @@
    show a non-interactive sandboxed thumbnail; opening a card mounts the full
    ChatArtifactViewer (chat-artifact.css) inside a Modal. */
 .chat-canvas-view {
-  padding: 16px;
+  padding: var(--space-4);
 }
 .chat-canvas-grid {
   display: grid;
@@ -49,8 +49,8 @@
 .chat-canvas-card__meta {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: var(--space-2);
+  padding: var(--space-2) 10px;
   min-width: 0;
 }
 .chat-canvas-card__title {

--- a/src/styles/color-picker.css
+++ b/src/styles/color-picker.css
@@ -2,15 +2,15 @@
 .cave-color-picker .react-colorful {
   width: 100%;
   height: 148px;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .cave-color-picker .react-colorful__saturation {
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border-bottom: none;
 }
 .cave-color-picker .react-colorful__hue {
   height: 14px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
 }
 .cave-color-picker .react-colorful__pointer {
   width: 16px;

--- a/src/styles/composer-git-chip.css
+++ b/src/styles/composer-git-chip.css
@@ -7,15 +7,15 @@
   display: inline-flex;
   flex: 0 1 auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   max-width: 240px;
   height: 30px;
   padding: 0 11px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
   cursor: pointer;
@@ -32,7 +32,7 @@
   display: inline-flex;
   min-width: 0;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 /* The branch segment is a real button — it opens the switch-branch menu
@@ -43,12 +43,12 @@
   align-items: center;
   gap: 3px;
   margin: 0;
-  padding: 2px 4px;
+  padding: 2px var(--space-1);
   font: inherit;
   line-height: 1;
   cursor: pointer;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: inherit;
 }
@@ -62,7 +62,7 @@
 .cave-composer-git-chip__menu-note,
 .cave-composer-git-chip__menu-error {
   padding: 6px 10px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 .cave-composer-git-chip__menu-error {
@@ -76,14 +76,14 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px 6px;
+  padding: var(--space-1) var(--space-2) 6px;
 }
 .cave-composer-git-chip__worktree-input {
   flex: 1 1 auto;
   min-width: 0;
   height: 26px;
-  padding: 0 8px;
-  font-size: 11px;
+  padding: 0 var(--space-2);
+  font-size: var(--text-xs);
   font-family: inherit;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-sm, 6px);
@@ -94,7 +94,7 @@
   flex: 0 0 auto;
   height: 26px;
   padding: 0 10px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   font-family: inherit;
   cursor: pointer;
@@ -142,12 +142,12 @@
   gap: 3px;
   margin: 0 -4px 0 0;
   padding: 2px 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-family: inherit;
   line-height: 1;
   cursor: pointer;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-primary);
   font-weight: 600;

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -13,7 +13,7 @@
   max-width: 260px;
   height: 30px;
   padding: 0 11px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-family: inherit;
   line-height: 1;
   cursor: pointer;
@@ -58,14 +58,14 @@
 .cave-host-choice {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 6px 8px;
-  border-radius: 8px;
+  padding: 6px var(--space-2);
+  border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-align: left;
   cursor: pointer;
   transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
@@ -91,12 +91,12 @@
   flex-shrink: 0;
   min-width: 22px;
   height: 22px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   border-radius: 6px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   cursor: pointer;
 }
 .cave-host-remove:hover { background: var(--bg-raised); color: var(--color-danger); }

--- a/src/styles/composer-runtime-chip.css
+++ b/src/styles/composer-runtime-chip.css
@@ -13,7 +13,7 @@
   max-width: 200px;
   height: 30px;
   padding: 0 11px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-family: inherit;
   line-height: 1;
   cursor: pointer;

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -7,7 +7,7 @@
 .dash-cta__row {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   min-width: 0;
 }
 .dash-cta__text { min-width: 0; }
@@ -23,8 +23,8 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 16px;
-  border-radius: 12px;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-card);
   font-size: 0.86rem;
   color: var(--color-success);
   background: color-mix(in srgb, var(--color-success) 9%, transparent);
@@ -50,7 +50,7 @@
 .dash-inbox__select-toggle { margin-left: auto; }
 .dash-inbox__bulkbar {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
-  margin: 4px 0 8px; padding: 6px 8px; border-radius: 8px;
+  margin: var(--space-1) 0 var(--space-2); padding: 6px 8px; border-radius: 8px;
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
 }
 .dash-inbox__bulkbar-left, .dash-inbox__bulkbar-right { display: flex; align-items: center; gap: 6px; }
@@ -72,7 +72,7 @@
 /* Open items beyond the visible cap drill through to the Rituals surface. */
 .dash-inbox__more {
   display: flex; align-items: center; gap: 6px;
-  margin-top: 8px; padding: 7px 10px; border-radius: 8px;
+  margin-top: var(--space-2); padding: 7px 10px; border-radius: 8px;
   font-size: 0.8rem; font-weight: 600; color: var(--text-muted);
   text-decoration: none; border: 1px dashed var(--border-hairline);
 }
@@ -82,9 +82,9 @@
 .dash-act {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   padding: 5px 11px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   font-size: 0.78rem;
   font-weight: 600;
   line-height: 1;
@@ -123,7 +123,7 @@
   display: flex;
   flex-direction: column;
   min-width: 150px;
-  padding: 4px;
+  padding: var(--space-1);
   border-radius: 10px;
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
@@ -238,7 +238,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 18px;
-  margin-bottom: 24px;
+  margin-bottom: var(--space-6);
   padding: 18px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
@@ -260,7 +260,7 @@
   width: 42px;
   height: 42px;
   flex-shrink: 0;
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   color: #111;
   box-shadow: inset 0 0 0 1px color-mix(in oklch, white 38%, transparent);
 }
@@ -268,7 +268,7 @@
 .settings-overview__kicker {
   margin: 0 0 1px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   line-height: 1.2;
   text-transform: uppercase;
@@ -284,9 +284,9 @@
 }
 
 .settings-overview__description {
-  margin: 4px 0 0;
+  margin: var(--space-1) 0 0;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.45;
 }
 
@@ -294,7 +294,7 @@
   display: flex;
   flex: 1 1 360px;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   margin-top: 0;
 }
@@ -305,12 +305,12 @@
   gap: 7px;
   min-width: 0;
   max-width: 190px;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-base) 68%, transparent);
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.25;
 }
 
@@ -418,7 +418,7 @@
   }
 
   .settings-shell__sidebar-head {
-    margin-bottom: 12px;
+    margin-bottom: var(--space-3);
   }
 
   .settings-overview {
@@ -443,7 +443,7 @@
 
   .settings-overview-strip {
     flex-direction: column;
-    margin-top: 16px;
+    margin-top: var(--space-4);
   }
 
   .settings-overview-strip__item span {
@@ -457,7 +457,7 @@
 .dash-today__grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 16px;
+  gap: var(--space-4);
   align-items: start;
 }
 @media (min-width: 720px) {
@@ -479,7 +479,7 @@
 .dash-today__sessions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding-top: 14px;
   border-top: 1px solid var(--border-hairline);
 }
@@ -497,8 +497,8 @@
 .dash-today__chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: var(--space-1) 10px;
+  border-radius: var(--radius-pill);
   font-size: 0.78rem;
   color: var(--text-secondary);
   background: var(--bg-base);
@@ -605,10 +605,10 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-agents { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
 .cockpit-agent { display: flex; }
 .cockpit-agent__link { display: flex; align-items: center; gap: 10px; padding: 6px 8px; flex: 1; min-width: 0;
-  border-radius: 8px; text-decoration: none; color: inherit; }
+  border-radius: var(--radius-control); text-decoration: none; color: inherit; }
 .cockpit-agent__link:hover { background: var(--bg-hover); }
 .cockpit-agent__avatar { position: relative; width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center;
-  font-size: 12px; font-weight: 700; color: #fff; flex: 0 0 auto; }
+  font-size: var(--text-sm); font-weight: 700; color: #fff; flex: 0 0 auto; }
 .cockpit-agent__on { position: absolute; right: -2px; bottom: -2px; width: 9px; height: 9px; border-radius: 50%;
   background: var(--color-success); border: 2px solid var(--bg-raised); }
 .cockpit-agent__body { display: flex; flex-direction: column; min-width: 0; flex: 1; }
@@ -627,7 +627,7 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 /* Empty-state bridge: shown only when the token probe proves GitHub is
    disconnected — deep-links to the GitHub surface, which owns the PAT flow. */
 .cockpit-connect { display: inline-flex; align-items: center; margin-left: 8px; padding: 2px 9px; border-radius: 999px;
-  font-size: 11px; font-weight: 600; text-decoration: none;
+  font-size: var(--text-xs); font-weight: 600; text-decoration: none;
   color: var(--accent-presence-foreground); background: var(--accent-presence); }
 .cockpit-connect:hover { filter: brightness(1.08); }
 
@@ -718,7 +718,7 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
 /* ── Shared status badge (confidence tier + activity health) ── */
 .cockpit-badge {
   display: inline-flex; align-items: center; padding: 1px 7px; border-radius: 999px;
-  font-size: 10px; font-weight: 700; letter-spacing: 0.01em; white-space: nowrap;
+  font-size: var(--text-2xs); font-weight: 700; letter-spacing: 0.01em; white-space: nowrap;
   border: 1px solid transparent;
 }
 .cockpit-badge--good { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 14%, transparent); border-color: color-mix(in oklch, var(--color-success) 34%, transparent); }
@@ -735,7 +735,7 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
   align-items: center; gap: 12px;
 }
 .cockpit-fam__head {
-  padding: 4px 10px 8px; border-bottom: 1px solid var(--border-hairline);
+  padding: var(--space-1) 10px var(--space-2); border-bottom: 1px solid var(--border-hairline);
   font-size: 9.5px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-muted);
 }
 .cockpit-fam__row {
@@ -749,7 +749,7 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
 .cockpit-fam__avatar {
   position: relative; width: 32px; height: 32px; flex: 0 0 auto; border-radius: 9px;
   display: grid; place-items: center; overflow: visible;
-  font-size: 14px; font-weight: 700; color: #fff;
+  font-size: var(--text-md); font-weight: 700; color: #fff;
 }
 .cockpit-fam__avatar img { width: 100%; height: 100%; object-fit: cover; border-radius: 9px; }
 .cockpit-fam__on {
@@ -825,7 +825,7 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
 .cockpit-fam__filter svg { width: 13px; height: 13px; flex: 0 0 auto; }
 .cockpit-fam__filter input {
   flex: 1; min-width: 0; border: 0; background: none; outline: none;
-  font-size: 12px; color: var(--text-primary);
+  font-size: var(--text-sm); color: var(--text-primary);
 }
 .cockpit-fam__filter input::placeholder { color: var(--text-muted); }
 .cockpit-fam__matchcount { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
@@ -840,11 +840,11 @@ a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-pr
   align-items: center; gap: 10px;
 }
 .cockpit-space__head {
-  padding: 2px 8px 7px; border-bottom: 1px solid var(--border-hairline);
+  padding: 2px var(--space-2) 7px; border-bottom: 1px solid var(--border-hairline);
   font-size: 9.5px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-muted);
 }
 .cockpit-space__row {
-  padding: 8px; border-radius: 9px; text-decoration: none; color: inherit;
+  padding: var(--space-2); border-radius: 9px; text-decoration: none; color: inherit;
   transition: background .12s;
 }
 .cockpit-space__row--link:hover { background: var(--bg-hover); }

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -20,7 +20,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  padding: 10px 20px;
+  padding: 10px var(--space-5);
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -29,11 +29,11 @@
   align-items: center;
   gap: 6px;
   padding: 3px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: transparent;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
   transition:
     background var(--duration-fast, 120ms) var(--ease-standard, ease),
@@ -67,7 +67,7 @@
 
 /* ── Attention strip (unlinked / stale PRs — repo hygiene) ───────────────── */
 .fwq-attention {
-  margin: 12px 20px 0;
+  margin: var(--space-3) var(--space-5) 0;
   border: 1px solid color-mix(in oklch, var(--color-warning) 34%, transparent);
   border-radius: var(--radius-panel, 12px);
   background: color-mix(in oklch, var(--color-warning) 7%, transparent);
@@ -78,8 +78,8 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 8px 12px;
-  font-size: 12px;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-warning);
   border-bottom: 1px solid color-mix(in oklch, var(--color-warning) 20%, transparent);
@@ -105,7 +105,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 12px;
+  padding: 7px var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--color-warning) 12%, transparent);
 }
 
@@ -122,7 +122,7 @@
 }
 
 .fwq-attention-name {
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -139,7 +139,7 @@
    connected. Presence-toned so it reads as informational, visually distinct
    from the warning-toned "needs attention" strip above it. */
 .fwq-asana {
-  margin: 12px 20px 0;
+  margin: var(--space-3) var(--space-5) 0;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
   border-radius: var(--radius-panel, 12px);
   background: color-mix(in oklch, var(--accent-presence) 6%, transparent);
@@ -150,8 +150,8 @@
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 8px 12px;
-  font-size: 12px;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--accent-presence);
   border-bottom: 1px solid color-mix(in oklch, var(--accent-presence) 18%, transparent);
@@ -177,7 +177,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 12px;
+  padding: 7px var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
 
@@ -194,7 +194,7 @@
 }
 
 .fwq-asana-name {
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -223,11 +223,11 @@
 .fwq-banner {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 12px 20px 0;
-  padding: 7px 12px;
+  gap: var(--space-2);
+  margin: var(--space-3) var(--space-5) 0;
+  padding: 7px var(--space-3);
   border-radius: var(--radius-panel, 12px);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .fwq-banner--danger {
@@ -252,7 +252,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 16px 20px 32px;
+  padding: var(--space-4) var(--space-5) var(--space-8);
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -269,10 +269,10 @@
 .fwq-lane-head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 9px 12px;
+  gap: var(--space-2);
+  padding: 9px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 
@@ -284,8 +284,8 @@
 .fwq-lane-count {
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);
-  padding: 1px 8px;
-  border-radius: 999px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
   background: var(--bg-hover);
 }
 
@@ -318,8 +318,8 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 10px 12px;
+  gap: var(--space-3);
+  padding: 10px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
 }
 
@@ -350,7 +350,7 @@
 }
 
 .fwq-card-name {
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -366,10 +366,10 @@
 
 /* Tag recipe (§ design language): 6–18% fill, 30–45% border, solid text. */
 .fwq-tag {
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.5;
   padding: 1px 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   color: var(--text-muted);
   white-space: nowrap;
@@ -416,7 +416,7 @@
 /* Quiet per-item age ("updated 2h ago" / "merged 1h ago") — plain muted text,
    not a pill, so it reads as metadata rather than a status. */
 .fwq-card-time {
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.5;
   color: var(--text-muted);
   white-space: nowrap;
@@ -435,7 +435,7 @@
 .fwq-card-hint {
   flex: 0 0 100%;
   margin: 2px 0 0;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -444,7 +444,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .fwq-note-input {
@@ -457,7 +457,7 @@
   background: var(--bg-base);
   color: var(--text-primary);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -18,8 +18,8 @@
   width: 100%;
   height: 100%;
   min-height: 0;
-  padding: 40px 32px 56px;
-  gap: 16px;
+  padding: var(--space-10) var(--space-8) 56px;
+  gap: var(--space-4);
   overflow-y: auto;
   box-sizing: border-box;
   /* The composer fills the width of the area it resides in (the detail panel),
@@ -49,8 +49,8 @@
 
 @media (max-width: 520px) {
   .home-composer-root {
-    padding: 20px 16px 28px;
-    gap: 12px;
+    padding: var(--space-5) var(--space-4) 28px;
+    gap: var(--space-3);
   }
 }
 
@@ -67,7 +67,7 @@
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-3);
   min-height: 15px;
   font-family: var(--font-mono);
   font-size: 10.5px;
@@ -87,7 +87,7 @@
 .home-composer-eyebrow-dot {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   box-shadow: 0 0 8px color-mix(in oklch, var(--accent-presence) 70%, transparent);
 }
@@ -126,7 +126,7 @@
 }
 
 .home-composer-sub {
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-muted);
   margin: 0;
   letter-spacing: -0.01em;
@@ -215,8 +215,8 @@
 .hc-drop-overlay-inner {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: var(--space-2);
+  font-size: var(--text-base);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -234,7 +234,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   padding: 6px 10px;
   border-top: 1px solid var(--border-hairline);
@@ -284,8 +284,8 @@
 .hc-attachments-wrap {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 8px 12px;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 .hc-attachments-head {
@@ -303,8 +303,8 @@
 .hc-attachments-clear {
   border: none;
   background: transparent;
-  padding: 2px 4px;
-  font-size: 11px;
+  padding: 2px var(--space-1);
+  font-size: var(--text-xs);
   color: var(--text-muted);
   cursor: pointer;
   border-radius: 5px;
@@ -325,7 +325,7 @@
   align-items: center;
   gap: 5px;
   max-width: 220px;
-  padding: 3px 6px 3px 8px;
+  padding: 3px 6px 3px var(--space-2);
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
   background: var(--bg-base);
@@ -372,8 +372,8 @@
   height: 30px;
   min-height: 30px;
   max-width: 200px;
-  padding: 0 11px 0 8px;
-  font-size: 11px;
+  padding: 0 11px 0 var(--space-2);
+  font-size: var(--text-xs);
   border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
@@ -413,11 +413,11 @@
   gap: 5px;
   min-height: 28px;
   box-sizing: border-box;
-  font-size: 12px;
+  font-size: var(--text-sm);
   /* Inactive tabs recede: lighter weight + faded label so the solid-accent
    * active tab is unmistakably the selected one. Hover/active brighten. */
   font-weight: 450;
-  padding: 4px 14px;
+  padding: var(--space-1) 14px;
   border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: transparent;
@@ -501,9 +501,9 @@
 
 .home-feed {
   display: block;
-  margin-top: 8px;
+  margin-top: var(--space-2);
   border: 1px solid var(--border-hairline);
-  border-radius: 16px;
+  border-radius: var(--radius-panel);
   background: color-mix(in oklch, var(--bg-raised) 55%, var(--bg-base));
   overflow: hidden;
   text-align: left;
@@ -554,7 +554,7 @@
   height: 28px;
   flex-shrink: 0;
   margin-left: auto;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-muted);
@@ -597,7 +597,7 @@
 .home-feed__rowtop { display: flex; align-items: center; gap: 6px; min-width: 0; }
 .home-feed__rowicon { color: var(--text-muted); flex-shrink: 0; }
 .home-feed__rowtitle {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 500;
   color: var(--text-primary);
   overflow: hidden;
@@ -605,7 +605,7 @@
   white-space: nowrap;
 }
 .home-feed__rowdesc {
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: 1.35;
   overflow: hidden;
@@ -624,20 +624,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 30px 16px;
+  gap: var(--space-2);
+  padding: 30px var(--space-4);
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
   text-align: center;
 }
 .home-feed__retry {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   color: var(--accent-presence);
   background: transparent;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
-  border-radius: 8px;
-  padding: 5px 12px;
+  border-radius: var(--radius-control);
+  padding: 5px var(--space-3);
   cursor: pointer;
   transition: background 0.12s ease;
 }
@@ -729,7 +729,7 @@
 .hc-slash-list {
   list-style: none;
   margin: 0;
-  padding: 4px 0;
+  padding: var(--space-1) 0;
   max-height: 260px;
   overflow-y: auto;
 }
@@ -738,7 +738,7 @@
   width: 100%;
   align-items: center;
   gap: 10px;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: 0;
   background: transparent;
   text-align: left;
@@ -753,14 +753,14 @@
 }
 .hc-slash-name {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-primary);
   min-width: 110px;
 }
 .hc-slash-desc {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -768,7 +768,7 @@
 }
 .hc-slash-arg {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   padding: 2px 6px;
   border-radius: 4px;
@@ -777,8 +777,8 @@
 }
 .hc-slash-footer {
   border-top: 1px solid var(--border-hairline);
-  padding: 6px 12px;
-  font-size: 10px;
+  padding: 6px var(--space-3);
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -790,10 +790,10 @@
 .home-columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-  gap: 24px;
+  gap: var(--space-6);
   width: 100%;
   max-width: 860px;
-  margin-top: 12px;
+  margin-top: var(--space-3);
 }
 
 @media (max-width: 720px) {
@@ -810,8 +810,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  margin: 0 0 8px;
-  font-size: 10px;
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -829,8 +829,8 @@
 
 .home-col__empty {
   margin: 0;
-  padding: 14px 16px;
-  font-size: 12px;
+  padding: 14px var(--space-4);
+  font-size: var(--text-sm);
   color: var(--text-muted);
   text-align: center;
   border: 1px dashed var(--border-hairline);
@@ -842,7 +842,7 @@
   align-items: center;
   gap: 9px;
   width: 100%;
-  padding: 9px 12px;
+  padding: 9px var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: transparent;
@@ -871,7 +871,7 @@
 .home-col-card__go {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex: none;
   margin-left: auto;
   font-size: 10.5px;
@@ -1067,7 +1067,7 @@
 .home-digest__live-dot {
   width: 7px;
   height: 7px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   flex-shrink: 0;
   animation: home-digest-live-pulse 2s var(--ease-standard, ease-out) infinite;

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -6,33 +6,33 @@
   width: 320px;
   flex: 0 0 320px;
   border-right: 1px solid var(--border-hairline);
-  padding: 12px;
+  padding: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   overflow-y: auto;
 }
 .journal-list__error {
-  padding: 8px 11px;
-  border-radius: 8px;
+  padding: var(--space-2) 11px;
+  border-radius: var(--radius-control);
   font-size: 11.5px;
   color: var(--color-danger);
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
 }
 .journal-list__cap {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-muted);
-  margin: 4px 2px 2px;
+  margin: var(--space-1) 2px 2px;
 }
 .journal-list__filter {
   width: 100%;
-  margin: 2px 0 8px;
+  margin: 2px 0 var(--space-2);
   padding: 6px 10px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
   font-size: 12.5px;
   color: var(--text-primary);
@@ -51,7 +51,7 @@
   gap: 6px;
   font-size: 12.5px;
   color: var(--text-muted);
-  padding: 16px 4px;
+  padding: var(--space-4) var(--space-1);
 }
 .journal-empty svg { flex: none; color: var(--accent-presence); opacity: 0.8; }
 
@@ -76,7 +76,7 @@
   gap: 6px;
   width: 100%;
   padding: 9px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 700;
   border-radius: 9px;
   border: 1px solid var(--accent-presence);
@@ -156,18 +156,18 @@
 }
 .journal-day__prev { font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .journal-entry__sec {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-muted);
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
 }
 /* Heading row with chronological prev/next entry controls on the right. */
 .journal-entry__sec--nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .journal-entry__daynav { display: inline-flex; gap: 4px; }
 .journal-entry__stats { display: flex; gap: 8px; margin-bottom: 18px; }
@@ -176,7 +176,7 @@
   background: var(--bg-panel, var(--bg-base));
   border: 1px solid var(--border-hairline);
   border-radius: 9px;
-  padding: 8px 10px;
+  padding: var(--space-2) 10px;
 }
 .journal-entry__stat b { font-size: 18px; display: block; line-height: 1; }
 .journal-entry__stat span { font-size: 10px; color: var(--text-muted); }
@@ -234,9 +234,9 @@
   border-radius: 10px;
   background: var(--bg-panel, var(--bg-base));
   color: var(--text-primary);
-  padding: 12px;
+  padding: var(--space-3);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.6;
 }
 /* Edit mode hosts the shared MdEditor (WYSIWYG/markdown) in place of the old
@@ -261,8 +261,8 @@
 .journal-entry__reflection { line-height: 1.6; color: var(--text-secondary); font-size: 13px; }
 /* Reflective "next-paths" prompts lifted out of the reflection markdown. */
 .journal-entry__next {
-  margin-top: 16px;
-  padding: 12px 14px;
+  margin-top: var(--space-4);
+  padding: var(--space-3) 14px;
   border: 1px solid var(--border-hairline);
   border-radius: 10px;
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
@@ -272,7 +272,7 @@
   align-items: center;
   gap: 5px;
   margin-bottom: 9px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -302,7 +302,7 @@
 .journal-next__chip {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   text-align: left;
   padding: 9px 11px;
@@ -376,7 +376,7 @@
   color: var(--text-secondary);
   background: var(--bg-raised);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   transition: background 0.13s ease, color 0.13s ease, border-color 0.13s ease,
     transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -419,14 +419,14 @@
   align-items: center;
   gap: 9px;
   max-width: min(92vw, 460px);
-  padding: 10px 12px 10px 13px;
+  padding: 10px var(--space-3) 10px 13px;
   font-size: 12.5px;
   color: var(--text-primary);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-strong));
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   box-shadow: 0 18px 50px -18px rgba(0, 0, 0, 0.6);
   animation: journal-notice-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
@@ -460,7 +460,7 @@
   color: var(--accent-presence);
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   transition: background 0.12s ease, transform 0.1s ease;
 }
@@ -483,8 +483,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 16px;
-  font-size: 11px;
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 .journal-entry__by b { color: var(--accent-presence); }

--- a/src/styles/md-editor.css
+++ b/src/styles/md-editor.css
@@ -68,8 +68,8 @@
 /* The ProseMirror page itself: comfortable document measure and the app's
  * reading rhythm instead of Crepe's defaults. */
 .md-editor-visual .milkdown .ProseMirror {
-  padding: 16px 20px 48px;
-  font-size: 13px;
+  padding: var(--space-4) var(--space-5) 48px;
+  font-size: var(--text-base);
   line-height: 1.65;
   color: var(--text-primary);
   caret-color: var(--accent-presence);
@@ -88,7 +88,7 @@
  * on disk. Green rows exist only in the local draft, red rows only on disk. */
 .md-editor__conflict-key {
   border-radius: 3px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
 }
 .md-editor__conflict-key--mine {
   background: color-mix(in oklch, var(--color-success, #3fb950) 18%, transparent);
@@ -100,8 +100,8 @@
 }
 .md-editor__conflict-line {
   display: flex;
-  gap: 8px;
-  padding: 0 8px;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--text-muted);
@@ -120,7 +120,7 @@
   color: var(--text-primary);
 }
 .md-editor__conflict-line--skip {
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   font-style: italic;
   opacity: 0.7;
 }

--- a/src/styles/notch-quick-chat.css
+++ b/src/styles/notch-quick-chat.css
@@ -37,7 +37,7 @@
   border-radius: 0 0 14px 14px;
   background: var(--bg-panel);
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: var(--text-xs);
   transition: border-radius 180ms ease;
 }
 

--- a/src/styles/profile-card.css
+++ b/src/styles/profile-card.css
@@ -26,7 +26,7 @@
   background: var(--pfc-bg);
   color: var(--pfc-text);
   font-family: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .pfc-loading {
@@ -38,7 +38,7 @@
   display: inline-flex;
   padding: 6px 14px;
   border: 1px solid var(--pfc-border, var(--border-hairline));
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: transparent;
   color: inherit;
   cursor: pointer;
@@ -53,7 +53,7 @@
 
 .pfc-topnav-link {
   color: var(--pfc-dim);
-  font-size: 12px;
+  font-size: var(--text-sm);
   text-decoration: none;
   border-radius: 6px;
   padding: 2px 6px;
@@ -65,15 +65,15 @@
 .pfc-callout {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 1200px;
   margin: 0 auto 10px;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid #4d3a1e;
   border-radius: 10px;
   background: #201a10;
   color: #d8b06a;
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 /* ── Card frame ─────────────────────────────────────────────────────── */
@@ -99,14 +99,14 @@
   grid-area: rail;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   padding: 18px;
   border-right: 1px solid var(--pfc-border-soft);
 }
 
 .pfc-wordmark {
   align-self: flex-start;
-  padding: 4px 12px 4px 2px;
+  padding: var(--space-1) var(--space-3) var(--space-1) 2px;
   font-size: clamp(24px, 2.6vw, 34px);
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -140,12 +140,12 @@
   color: rgba(255, 255, 255, 0.85);
 }
 .pfc-collab-tile .pfc-avatar-initial {
-  font-size: 20px;
+  font-size: var(--text-xl);
 }
 
 .pfc-nameplate {
   margin: 0;
-  padding: 6px 12px;
+  padding: 6px var(--space-3);
   font-size: clamp(20px, 2.2vw, 26px);
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -162,13 +162,13 @@
 .pfc-handle {
   margin: 0;
   color: var(--pfc-dim);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 
 .pfc-bio {
   margin: 0;
   color: var(--pfc-dim);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.6;
   overflow-wrap: anywhere;
 }
@@ -183,14 +183,14 @@
   flex: 1;
   align-self: center;
   color: var(--pfc-dim);
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.4;
 }
 .pfc-rail-chip-value {
   display: grid;
   place-items: center;
   min-width: 96px;
-  padding: 10px 16px;
+  padding: 10px var(--space-4);
   border: 1px solid var(--pfc-border);
   border-radius: 6px;
   background: var(--pfc-raised);
@@ -216,15 +216,15 @@
 .pfc-stat {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 16px 18px;
+  gap: var(--space-2);
+  padding: var(--space-4) 18px;
 }
 .pfc-stat + .pfc-stat {
   border-left: 1px solid var(--pfc-border-soft);
 }
 .pfc-stat-label {
   color: var(--pfc-dim);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .pfc-stat-value {
   font-size: clamp(24px, 2.6vw, 34px);
@@ -242,12 +242,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   margin-bottom: 10px;
 }
 .pfc-heatmap-head h2 {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   color: var(--pfc-dim);
 }
@@ -266,7 +266,7 @@
 
 .pfc-heatmap {
   overflow-x: auto;
-  padding-bottom: 4px;
+  padding-bottom: var(--space-1);
 }
 .pfc-heatmap-grid {
   display: flex;
@@ -317,8 +317,8 @@
 .pfc-panel {
   display: grid;
   grid-template-columns: 1.2fr 1fr;
-  gap: 12px;
-  padding: 16px 18px;
+  gap: var(--space-3);
+  padding: var(--space-4) 18px;
   min-width: 0;
 }
 .pfc-panel + .pfc-panel {
@@ -332,7 +332,7 @@
 }
 .pfc-panel-title {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 400;
   color: var(--pfc-dim);
 }
@@ -351,13 +351,13 @@
 .pfc-panel-right {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   padding-left: 14px;
   border-left: 1px solid var(--pfc-border-soft);
 }
 .pfc-panel-label {
   color: var(--pfc-dim);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .pfc-panel-mid {
   font-size: clamp(20px, 2.2vw, 28px);
@@ -366,11 +366,11 @@
 }
 .pfc-panel-sub {
   color: var(--pfc-faint);
-  font-size: 10px;
+  font-size: var(--text-2xs);
 }
 .pfc-panel-rule {
   width: 100%;
-  margin: 8px 0;
+  margin: var(--space-2) 0;
   border: none;
   border-top: 1px solid var(--pfc-border-soft);
 }
@@ -382,14 +382,14 @@
 }
 .pfc-collab h2 {
   margin: 0 0 10px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
   color: var(--pfc-dim);
 }
 .pfc-collab-empty {
   margin: 0;
   color: var(--pfc-faint);
-  font-size: 12px;
+  font-size: var(--text-sm);
 }
 .pfc-collab-row {
   display: flex;
@@ -427,7 +427,7 @@
   border-top: 1px solid var(--pfc-border);
   background: #0c0c0e;
   color: var(--pfc-dim);
-  font-size: 11px;
+  font-size: var(--text-xs);
   letter-spacing: 0.06em;
 }
 .pfc-foot-brand {

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -38,7 +38,7 @@
   gap: 1px;
   min-height: 0;
   overflow-y: auto;
-  padding: 8px;
+  padding: var(--space-2);
   border-right: 1px solid var(--border-hairline);
 }
 
@@ -49,9 +49,9 @@
 .projects-list-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 6px 8px;
+  padding: 6px var(--space-2);
   border: 1px solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
@@ -92,7 +92,7 @@
   height: 15px;
   padding: 0 5px;
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--foreground) 6%, transparent);
   color: var(--text-secondary);
   font-size: 9.5px;
@@ -107,7 +107,7 @@
 .projects-hub__detail {
   min-height: 0;
   overflow-y: auto;
-  padding: 16px 20px 24px;
+  padding: var(--space-4) var(--space-5) var(--space-6);
 }
 
 .projects-detail-head { display: flex; flex-direction: column; gap: 10px; }
@@ -126,8 +126,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 6px 12px;
-  font-size: 11px;
+  gap: 6px var(--space-3);
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -136,8 +136,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-bottom: 8px;
-  font-size: 10px;
+  margin-bottom: var(--space-2);
+  font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -147,7 +147,7 @@
 /* Dashed = invitation (design language §3): empty sections invite the next
    action instead of dead-ending. */
 .projects-detail-empty {
-  padding: 10px 12px;
+  padding: 10px var(--space-3);
   border: 1px dashed var(--border-hairline);
   border-radius: 10px;
   color: var(--text-muted);
@@ -164,7 +164,7 @@
   .projects-toolbar__row {
     align-items: flex-start;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: var(--space-2);
   }
   .projects-toolbar__controls {
     flex: 1 1 100%;

--- a/src/styles/pulse-bars.css
+++ b/src/styles/pulse-bars.css
@@ -22,7 +22,7 @@
   align-items: end;
   height: 100%;
   min-width: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--foreground) 5%, transparent);
 }
 .pulse-bars--lg .pulse-bars__day {

--- a/src/styles/quick-chat-glass.css
+++ b/src/styles/quick-chat-glass.css
@@ -68,7 +68,7 @@ html[data-glass] .tray-quick-chat__header {
   gap: 2px;
   padding: 2px;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   min-width: 0;
 }
 
@@ -88,7 +88,7 @@ html[data-glass] .quick-tab--active {
   gap: var(--space-1);
   min-width: 0;
   padding: 2px var(--space-1) 2px 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
 }
 
@@ -101,7 +101,7 @@ html[data-glass] .quick-tab--active {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 /* Inactive tabs shrink to just the avatar so several chats fit in 390px. */
@@ -121,7 +121,7 @@ html[data-glass] .quick-tab--active {
 .quick-tab__pulse {
   width: 6px;
   height: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   box-shadow: 0 0 6px color-mix(in oklch, var(--accent-presence) 60%, transparent);
   animation: quick-tab-pulse 1.4s ease-in-out infinite;

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -9,7 +9,7 @@
   height: 100%;
   overflow: hidden;
   padding: 10px 6px 10px;
-  font-size: 13px;
+  font-size: var(--text-base);
   color: var(--text-secondary);
   gap: 10px;
   background: linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 55%, transparent), transparent 42%),
@@ -27,9 +27,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
-  padding: 2px 4px 2px 7px;
+  padding: 2px var(--space-1) 2px 7px;
   flex-shrink: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-control);
@@ -87,7 +87,7 @@
   max-width: none;
   min-height: 34px;
   gap: 10px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   justify-content: flex-start;
   border-radius: var(--radius-control);
   border: 2px solid var(--accent-presence);
@@ -98,11 +98,11 @@
   border-color: var(--accent-presence);
 }
 .sidebar-familiar-switch .familiar-switcher__trigger-label {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
 }
 .sidebar-title {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-primary);
@@ -138,13 +138,13 @@
   align-items: center;
   width: 100%;
   gap: 10px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   min-height: 34px;
   border-radius: var(--radius-control);
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -200,11 +200,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .sidebar-action-kbd {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   color: var(--text-muted);
   flex-shrink: 0;
@@ -224,13 +224,13 @@
 
 .sidebar-familiar-filter {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
 }
 
 .sidebar-familiar-filter__label {
   padding: 0 2px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -274,9 +274,9 @@
   background: transparent;
   color: inherit;
   outline: none;
-  padding: 0 28px 0 32px;
+  padding: 0 28px 0 var(--space-8);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   cursor: pointer;
 }
 
@@ -306,14 +306,14 @@
   scrollbar-color: var(--border-hairline) transparent;
   /* Sections are separated by whitespace alone (no rules) for a calmer,
      Codex-style nav. */
-  gap: 4px;
+  gap: var(--space-1);
   padding: 2px 0 2px;
 }
 
 /* ── Bottom: Notifications + Settings ─────────────────────────────────────── */
 .sidebar-foot {
   flex-shrink: 0;
-  padding: 8px 6px 0;
+  padding: var(--space-2) 6px 0;
   /* Softer than a full hairline — the footer should read as a calm boundary,
      not a hard rule competing with the nav. */
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
@@ -323,7 +323,7 @@
      vertical stack below. */
   display: flex;
   flex-direction: row;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .sidebar-foot-bell,
@@ -336,12 +336,12 @@
   flex: 1;
   min-width: 0;
   gap: 10px;
-  padding: 0 8px;
-  border-radius: 8px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-control);
   border: 0;
   background: transparent;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
   cursor: pointer;
   text-align: left;
   transition: background 0.12s ease, color 0.12s ease;
@@ -356,7 +356,7 @@
   min-height: 34px;
   padding: 0;
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -367,7 +367,7 @@
    muted, unselectable; the footer above keeps its calm hairline boundary. */
 .sidebar-version {
   flex-shrink: 0;
-  padding: 3px 6px 4px;
+  padding: 3px 6px var(--space-1);
   font-size: 10.5px;
   line-height: 1;
   text-align: center;
@@ -400,7 +400,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
   min-width: 0;
   color: inherit;
 }
@@ -416,8 +416,8 @@
   place-items: center;
   min-width: 16px;
   height: 16px;
-  padding: 0 4px;
-  border-radius: 999px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-pill);
   background: var(--color-danger);
   color: var(--text-primary);
   font-size: 9.5px;
@@ -444,7 +444,7 @@
 }
 
 .sidebar-addins {
-  padding-top: 4px;
+  padding-top: var(--space-1);
 }
 
 /* Quiet eyebrow labels: muted uppercase text with a small accent tick, no
@@ -454,15 +454,15 @@
 .sidebar-section-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
-  margin: 12px 0 2px;
-  padding: 4px 10px;
+  margin: var(--space-3) 0 2px;
+  padding: var(--space-1) 10px;
   border-radius: 7px;
   background: transparent;
   border: 1px solid transparent;
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -505,7 +505,7 @@
   width: 2px;
   height: 11px;
   align-self: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   /* Brand accent — var(--accent) is the shadcn surface token and reads as
      background here, hiding the tick. */
   background: var(--accent-presence, currentColor);
@@ -516,7 +516,7 @@
 .sidebar-divider {
   height: 1px;
   background: var(--border-hairline);
-  margin: 4px 9px;
+  margin: var(--space-1) 9px;
   display: none;
 }
 
@@ -531,7 +531,7 @@
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 13px;
+  font-size: var(--text-base);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -596,9 +596,9 @@
 }
 
 .sidebar-badge {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   padding: 0.05em 0.45em;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
   color: var(--accent-presence);
   flex-shrink: 0;
@@ -607,12 +607,12 @@
 
 /* ── Recents header ──────────────────────────────────────────────────────── */
 .sidebar-recents-header {
-  margin: 4px 6px 3px;
-  padding: 4px 8px;
+  margin: var(--space-1) 6px 3px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 6px;
   background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -640,8 +640,8 @@
 }
 
 .sidebar-recents-empty {
-  padding: 6px 8px;
-  font-size: 11px;
+  padding: 6px var(--space-2);
+  font-size: var(--text-xs);
   color: var(--text-muted);
   font-style: italic;
 }
@@ -651,12 +651,12 @@
   align-items: baseline;
   width: 100%;
   gap: 6px;
-  padding: 4px 8px;
-  border-radius: 8px;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-control);
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -684,7 +684,7 @@
 
 .sidebar-recent-ts {
   flex-shrink: 0;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -695,13 +695,13 @@
   border-top: 0;
   padding: 0 0 10px;
   padding-top: 6px;
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
 }
 
 /* Footer rows slightly smaller/dimmer than header rows */
 .sidebar-actions--footer .sidebar-action-row {
-  font-size: 12px;
+  font-size: var(--text-sm);
   padding: 5px 10px;
   color: var(--text-muted);
 }
@@ -716,7 +716,7 @@
 
 .sidebar-bottom {
   flex-shrink: 0;
-  padding: 6px 7px 8px;
+  padding: 6px 7px var(--space-2);
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
 }
 
@@ -730,7 +730,7 @@
   border: none;
   background: transparent;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--text-base);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s ease, color 0.1s ease;
@@ -760,7 +760,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 10px 6px;
+  padding: var(--space-2) 10px 6px;
   border-bottom: 1px solid var(--border-hairline);
   flex-shrink: 0;
   overflow-x: auto;
@@ -799,11 +799,11 @@
 /* ── Familiars section (left nav) ────────────────────────────────────────── */
 .sidebar-familiar-section-label {
   margin: 5px 6px 2px;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 6px;
   background: color-mix(in oklch, var(--bg-base) 86%, var(--foreground) 14%);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 75%, transparent);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -815,7 +815,7 @@
 .sidebar-familiar-list {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 0 0;
+  padding: var(--space-1) 0 0;
   scrollbar-width: thin;
   scrollbar-color: var(--border-hairline) transparent;
 }
@@ -872,7 +872,7 @@
 
 .sidebar-familiar-row-name {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--text-sm);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -885,10 +885,10 @@
 }
 
 .sidebar-familiar-row-count {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   background: var(--bg-raised);
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   padding: 1px 5px;
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
@@ -939,7 +939,7 @@
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   padding: 0 11px;
-  font-size: 13px;
+  font-size: var(--text-base);
 }
 
 .sidebar-action-stack .sidebar-action-row:hover {
@@ -961,7 +961,7 @@
   gap: 6px;
   min-height: 30px;
   border-radius: var(--radius-control);
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   color: var(--text-secondary);
 }
 
@@ -997,11 +997,11 @@
 @media (max-height: 760px) {
   .sidebar-minimal {
     gap: 7px;
-    padding-top: 8px;
+    padding-top: var(--space-2);
   }
 
   .sidebar-nav-scroll {
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .sidebar-folder-row,
@@ -1134,7 +1134,7 @@
   padding: 0;
   font-size: 0;
   line-height: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--accent-presence);
   color: transparent;
 }

--- a/src/styles/skill-detail-preview.css
+++ b/src/styles/skill-detail-preview.css
@@ -7,8 +7,8 @@
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 12px 10px;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3) 10px;
   border-left: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
   overflow-y: auto;
@@ -28,7 +28,7 @@
 }
 .skill-preview__icon { color: var(--accent-presence); flex: 0 0 auto; }
 .skill-preview__name {
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   overflow-wrap: anywhere;
@@ -46,12 +46,12 @@
   color: color-mix(in oklch, var(--accent-presence) 80%, var(--text-secondary));
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 24%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 1px 7px;
 }
 .skill-preview__desc {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-secondary);
 }
@@ -59,10 +59,10 @@
 .skill-preview__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .skill-preview__tag {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   background: var(--bg-base);
   border: 1px solid var(--border-hairline);
@@ -71,7 +71,7 @@
 }
 .skill-preview__path {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -79,16 +79,16 @@
 }
 .skill-preview__hint {
   margin-top: auto;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 .skill-preview__hint kbd {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   background: var(--bg-base);
   border: 1px solid var(--border-hairline);
   border-radius: 4px;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
 }
 
 /* On narrow widths the side preview would crowd the list — hide it and let the

--- a/src/styles/summoning-circle.css
+++ b/src/styles/summoning-circle.css
@@ -149,15 +149,15 @@
   height: 22px;
   padding: 0 var(--space-1);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, var(--border-hairline));
-  border-radius: 999px;
-  font-size: 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-2xs);
   letter-spacing: 0.08em;
   color: var(--accent-presence);
 }
 
 .summoning-panel__hint {
   margin-top: 2px;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 
@@ -172,7 +172,7 @@
 
 /* Stepper */
 .summoning-progress {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-muted);
 }
 
@@ -194,8 +194,8 @@
   width: 100%;
   padding: var(--space-1) var(--space-3);
   border: 1px solid transparent;
-  border-radius: 999px;
-  font-size: 12px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   text-align: left;
 }
@@ -224,7 +224,7 @@
   place-items: center;
   min-width: 20px;
   height: 20px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   font-size: 9px;
   letter-spacing: 0.08em;
@@ -265,13 +265,13 @@
 }
 
 .summoning-vessel__title {
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .summoning-vessel__hint {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   line-height: 1.35;
   color: var(--text-muted);
 }
@@ -289,8 +289,8 @@
   gap: var(--space-1);
   padding: var(--space-1) var(--space-3);
   border: 1px solid var(--border-hairline);
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
@@ -341,8 +341,8 @@
   align-items: center;
   gap: var(--space-1);
   padding: 2px var(--space-2);
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
 }
 
 .summoning-check--ok {
@@ -392,7 +392,7 @@
 .summoning-aura {
   width: 22px;
   height: 22px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-strong);
 }
 
@@ -404,9 +404,9 @@
 
 .summoning-aura-reset {
   padding: 2px var(--space-2);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .summoning-incantation__row dt {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
@@ -450,7 +450,7 @@
 
 .summoning-incantation__row dd {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--text-primary);
   overflow-wrap: anywhere;
 }
@@ -462,7 +462,7 @@
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-control);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-warning);
   background: color-mix(in oklch, var(--color-warning) 10%, transparent);
   border: 1px solid color-mix(in oklch, var(--color-warning) 35%, var(--border-hairline));
@@ -474,7 +474,7 @@
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-control);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-danger);
   background: color-mix(in oklch, var(--color-danger) 10%, transparent);
   border: 1px solid color-mix(in oklch, var(--color-danger) 35%, var(--border-hairline));
@@ -520,7 +520,7 @@
 }
 
 .summoning-success__body {
-  font-size: 12px;
+  font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-secondary);
   max-width: 44ch;
@@ -547,7 +547,7 @@
 }
 
 .summoning-section__title {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-secondary);
@@ -582,13 +582,13 @@
 }
 
 .summoning-vitality__label {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .summoning-vitality__hint {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-muted);
 }
 
@@ -681,7 +681,7 @@
   width: 96px;
   height: 96px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--sc-accent) 12%, var(--bg-elevated));
   border: 1px solid color-mix(in oklch, var(--sc-accent) 35%, var(--border-hairline));
   color: var(--text-primary);


### PR DESCRIPTION
## What

Cave UX **P3** from Sage's 2026-07-03 heuristic audit (design-language §9 rule 1: **tokens only**). Bead `cave-6kgc`; follows P1.5 (#3152) and P1 (#3312).

### 1. The codemod — `scripts/codemods/tokenize-css.mjs`
Idempotent, **value-preserving by construction**: rewrites only px literals that exactly equal a sanctioned token's definition, across `src` CSS:

| Property family | Mapping |
|---|---|
| `font-size` | 10/11/12/13/14/20/28px → `var(--text-2xs…display)` |
| `padding`/`margin`/`gap` families | 4/8/12/16/20/24/32/40px → `var(--space-1…10)` |
| `border-radius` | 8/12/16/999px → `var(--radius-control/card/panel/pill)` |

**Deliberately untouched:** token-definition lines, comments, `calc()`/`var()` internals, negatives, off-scale values (stay visible as drift), `mockup.css`, `tokens-exempt`-marked lines, and **`font-size: 16px`** — that literal is the iOS anti-zoom floor (a behavior threshold guarded by `composer-zoom-smoke`/`field` tests, not a type-scale choice).

**Applied: 1580 substitutions across 26 CSS files.** Verified mechanically: every `-`/`+` diff pair resolves to byte-identical declarations when `var()` is expanded through the token table (0 mismatches).

### 2. The gate — `src/lib/design-token-drift.test.ts` (wired in `test:app`)
- **Pins the codemod tables to the live `globals.css` definitions** — a token retune fails loudly instead of the codemod rewriting to stale values.
- **Zero tolerance for new on-scale literals**: the codemod must be a no-op over the tree; failure message says to run it.
- **Down-only ratchets** for the judgment categories: off-scale font-size **173**, off-scale spacing **1351**, off-scale radius **213**, hex outside token definitions **157**, inline TSX `style={{` **510**. Raising any requires touching the baseline in-PR with justification.

### 3. Guard/pin adjustments
- `composer-zoom-smoke`: hardened — sub-16px **tokens** (`var(--text-2xs..md)`) on input selectors now fail like bare px (they'd otherwise slip through the px regex). Red-proofed.
- `message-bubble-code-header`: the fixed-chrome **theme-ink** pin (`var(--text-`) tightened to `--text-primary/secondary/muted` — the `--text-*` **size** tokens are mode-independent px and safe on dark chrome.
- 10 literal-value pins across 8 test files updated to tokenized forms.
- Design-language §9.1 now points at the codemod + gate.

## Verification
- 1580/1580 diff pairs value-identical (var-resolution check), 0 unpaired
- Gate red-proofed: pre-codemod CSS fails tier 1; injected hex fails the ratchet; injected sub-16 token on input fails zoom guard
- `test:app` **750 files green**, typecheck clean, tests-wired clean, codemod `--check` clean + idempotent

## Out of scope (follow-up beads)
Hex→semantic-token mapping (needs judgment), inline-style reduction, off-scale px normalization — all now ratcheted so they can only shrink.