### PR TITLE
feat(fleet): gate Omnigent fleet UI on OMNIGENT_TOKEN in the Cave Vault (cave-s1pb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Changed
+- **Omnigent fleet is now per-user vault-gated** — Fleet surfaces (board Fleet button, `omnigent:…` host-chip options, per-familiar fleet defaults) appear if and only if the user has `OMNIGENT_TOKEN` set up in their Cave Vault; credentials that exist only in `~/.omnigent/auth_tokens.json` no longer surface Fleet UI on their own, and the token itself now resolves through the Vault chain (env → `.env.local` → encrypted store → `op://`/`dl://` reference).
+
 ## [0.1.2] - 2026-07-16
 
 > 🛡️ **A safer, leaner Cave.** Windows home migration becomes lossless and contention-safe, the familiar glyph catalogue leaves the startup bundle, encrypted backup/restore arrives, and daily chat, dashboard, updater, and multi-host workflows get a broad reliability pass.

--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -6,6 +6,7 @@ import { chatHostOptions, sshHostRegistry, type ChatHostOption } from "@/lib/cha
 import { isSshRuntime, normalizeFamiliarRuntime } from "@/lib/familiar-runtime";
 import { OmnigentClient } from "@/lib/omnigent/client";
 import { omnigentHostOptionId } from "@/lib/omnigent/ids";
+import { isOmnigentEnvConfigured } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -38,10 +39,12 @@ async function omnigentHostOptions(
   config: Awaited<ReturnType<typeof loadConfig>>,
 ): Promise<ChatHostOption[]> {
   if (!config.omnigent.baseUrl || !config.omnigent.exposeHostsInComposer) return [];
+  // Fleet gate: omnigent:<host_id> options appear if and ONLY if the user has
+  // OMNIGENT_TOKEN set up in their Cave Vault, and the client resolved real
+  // credential material. Mirrors isFleetTokenPresent in @/lib/omnigent/fleet-gate.
+  if (!isOmnigentEnvConfigured()) return [];
   try {
     const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
-    // Fleet gate: no auth token (tokenless local mode) → no omnigent options
-    // in the chip. Mirrors isFleetTokenPresent in @/lib/omnigent/fleet-gate.
     if (!client.authenticated || client.authMode === "none") return [];
     const hosts = await client.listHosts();
     return hosts.map((h) => {

--- a/src/app/api/omnigent/status/route.ts
+++ b/src/app/api/omnigent/status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/cave-config";
 import { OmnigentClient, OmnigentError } from "@/lib/omnigent/client";
+import { isOmnigentEnvConfigured } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +14,9 @@ export async function GET(req: Request) {
 
   const config = await loadConfig();
   const baseUrl = config.omnigent.baseUrl;
+  // Per-user fleet opt-in: OMNIGENT_TOKEN set up in the Cave Vault. The
+  // client gate (isFleetTokenPresent) hides all Fleet UI without it.
+  const envInVault = isOmnigentEnvConfigured();
   if (!baseUrl) {
     return NextResponse.json({
       ok: true,
@@ -21,6 +25,7 @@ export async function GET(req: Request) {
       hasToken: false,
       authenticated: false,
       authMode: "none",
+      envInVault,
       online: false,
       error: "Set omnigent.baseUrl in Cave config (Settings → Omnigent fleet).",
     });
@@ -36,6 +41,7 @@ export async function GET(req: Request) {
       hasToken: client.hasToken,
       authenticated: client.authenticated || client.authMode === "none",
       authMode: client.authMode,
+      envInVault,
       online: true,
       health,
       defaults: config.omnigent,
@@ -57,6 +63,7 @@ export async function GET(req: Request) {
         hasToken: client.hasToken,
         authenticated: client.authenticated,
         authMode: client.authMode,
+        envInVault,
         online: false,
         error: message,
         defaults: config.omnigent,
@@ -69,6 +76,7 @@ export async function GET(req: Request) {
         hasToken: false,
         authenticated: false,
         authMode: "none",
+        envInVault,
         online: false,
         error: message,
         defaults: config.omnigent,

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1316,7 +1316,7 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
   // when you actually need to dispatch/cancel or read the timestamps.
   const [lifecycleOpen, setLifecycleOpen] = useState(false);
   const [newLabel, setNewLabel] = useState("");
-  // Fleet buttons stay hidden without an Omnigent auth token (cave-cfvv).
+  // Fleet buttons stay hidden unless OMNIGENT_TOKEN is set up in the user's Vault (cave-cfvv).
   const fleetEnabled = useFleetTokenEnabled();
 
   const session = sessions.find((s) => s.id === card.sessionId) ?? null;

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -45,7 +45,7 @@ function runtimeLabel(runtimeId: string | null | undefined, harnesses: HarnessRe
 
 export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
-  // Fleet defaults card stays hidden without an Omnigent auth token (cave-cfvv).
+  // Fleet defaults card stays hidden unless OMNIGENT_TOKEN is set up in the user's Vault (cave-cfvv).
   const fleetEnabled = useFleetTokenEnabled();
   const [draftHarness, setDraftHarness] = useState(familiar.harnessOverride ?? "");
   const [draftModel, setDraftModel] = useState(familiar.model ?? "");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -739,7 +739,7 @@ function OmnigentSettingsGroup() {
     <SettingsGroup label="Omnigent fleet">
       <SettingControlRow
         label="Server URL"
-        hint="HTTPS URL of your Omnigent server (e.g. Tailscale). Token is read from ~/.omnigent/auth_tokens.json — never stored in Cave config."
+        hint="HTTPS URL of your Omnigent server (e.g. Tailscale). Fleet UI unlocks per user: add OMNIGENT_TOKEN to your Vault. Tokens are never stored in Cave config."
       >
         <input
           value={baseUrl}
@@ -779,7 +779,7 @@ function OmnigentSettingsGroup() {
       </SettingControlRow>
       <SettingControlRow
         label="Show fleet in Host chip"
-        hint="When on — and an Omnigent auth token is present — Chat and Home Host pickers list Omnigent hosts (omnigent:…) so a send can start a fleet session. Without a token, no Fleet buttons appear anywhere."
+        hint="When on — and OMNIGENT_TOKEN is set up in your Vault — Chat and Home Host pickers list Omnigent hosts (omnigent:…) so a send can start a fleet session. Without the Vault env, no Fleet buttons appear anywhere."
       >
         <label className="flex items-center gap-2 text-[12px]">
           <input

--- a/src/lib/omnigent/client.test.ts
+++ b/src/lib/omnigent/client.test.ts
@@ -1,11 +1,24 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { mkdtempSync } from "node:fs";
 import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pickDefaultAgentId, pickDefaultHostId } from "./client.ts";
-import { normalizeOmnigentBaseUrl, resolveOmnigentAuth } from "./token.ts";
+import { isOmnigentEnvConfigured, normalizeOmnigentBaseUrl, resolveOmnigentAuth } from "./token.ts";
+
+// Sandbox the Cave Vault: OMNIGENT_TOKEN resolves through it (process env →
+// .env.local → encrypted store → op/dl ref), so point every vault path at a
+// fresh tmp dir and clear any real token so developer/CI machine state can't
+// leak into auth-resolution assertions.
+const vaultSandbox = mkdtempSync(path.join(os.tmpdir(), "omnigent-vault-sandbox-"));
+process.env.COVEN_CAVE_HOME = path.join(vaultSandbox, "cave");
+process.env.COVEN_VAULT_FILE = path.join(vaultSandbox, "vault.yaml");
+process.env.COVEN_CAVE_ENV_FILE = path.join(vaultSandbox, ".env.local");
+process.env.COVEN_CAVE_LOCAL_VAULT_FILE = path.join(vaultSandbox, "local-vault.enc.json");
+process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE = path.join(vaultSandbox, "local-vault.key");
+delete process.env.OMNIGENT_TOKEN;
 
 test("normalizeOmnigentBaseUrl strips path and trailing slash", () => {
   assert.equal(
@@ -197,5 +210,33 @@ test("resolveOmnigentAuth allows unauthenticated local mode", async () => {
     process.env.HOME = prevHome;
     if (prevTok === undefined) delete process.env.OMNIGENT_TOKEN;
     else process.env.OMNIGENT_TOKEN = prevTok;
+  }
+});
+
+test("resolveOmnigentAuth resolves OMNIGENT_TOKEN through the Cave Vault", async () => {
+  const prevHome = process.env.HOME;
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "omnigent-vault-"));
+  process.env.HOME = tmp; // no ~/.omnigent/auth_tokens.json
+  delete process.env.OMNIGENT_TOKEN;
+  try {
+    // Nothing in the sandboxed vault yet → env not configured, fleet stays hidden.
+    assert.equal(isOmnigentEnvConfigured(), false);
+
+    const { setLocalEncryptedSecret, deleteLocalEncryptedSecret } = await import(
+      "../local-encrypted-vault.ts"
+    );
+    setLocalEncryptedSecret("OMNIGENT_TOKEN", "vault-token");
+    try {
+      assert.equal(isOmnigentEnvConfigured(), true);
+      const auth = await resolveOmnigentAuth("https://omni.example.com");
+      assert.equal(auth.mode, "env");
+      assert.equal(auth.token, "vault-token");
+      assert.equal(auth.authenticated, true);
+    } finally {
+      deleteLocalEncryptedSecret("OMNIGENT_TOKEN");
+    }
+  } finally {
+    delete process.env.OMNIGENT_TOKEN; // resolveSecret caches into process.env
+    process.env.HOME = prevHome;
   }
 });

--- a/src/lib/omnigent/fleet-gate.test.ts
+++ b/src/lib/omnigent/fleet-gate.test.ts
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { isFleetTokenPresent } from "./fleet-gate.ts";
 
 test("hidden when Omnigent is not configured", () => {
-  assert.equal(isFleetTokenPresent({ configured: false, authenticated: true, authMode: "jwt" }), false);
+  assert.equal(
+    isFleetTokenPresent({ configured: false, authenticated: true, authMode: "jwt", envInVault: true }),
+    false,
+  );
   assert.equal(isFleetTokenPresent({}), false);
 });
 
@@ -12,19 +15,42 @@ test("hidden for null/undefined status payloads", () => {
   assert.equal(isFleetTokenPresent(undefined), false);
 });
 
+test("hidden unless the Omnigent env is set up in the user's vault", () => {
+  // Credentials from ~/.omnigent/auth_tokens.json alone (JWT/Databricks) must
+  // not surface Fleet UI — the vault env is the per-user opt-in.
+  for (const authMode of ["jwt", "databricks"]) {
+    assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode }), false);
+    assert.equal(
+      isFleetTokenPresent({ configured: true, authenticated: true, authMode, envInVault: false }),
+      false,
+    );
+  }
+  // Fail closed on status payloads that predate the envInVault field.
+  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode: "env" }), false);
+});
+
 test("hidden for tokenless local mode even when status reports authenticated", () => {
   // /api/omnigent/status reports authenticated=true for authMode "none" when
   // the server is online — the gate must still hide Fleet UI without a token.
-  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode: "none" }), false);
-  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true }), false);
+  assert.equal(
+    isFleetTokenPresent({ configured: true, authenticated: true, authMode: "none", envInVault: true }),
+    false,
+  );
+  assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, envInVault: true }), false);
 });
 
 test("hidden when configured but no credential material resolved", () => {
-  assert.equal(isFleetTokenPresent({ configured: true, authenticated: false, authMode: "jwt" }), false);
+  assert.equal(
+    isFleetTokenPresent({ configured: true, authenticated: false, authMode: "jwt", envInVault: true }),
+    false,
+  );
 });
 
-test("shown for jwt, env, and databricks credential material", () => {
+test("shown for jwt, env, and databricks credential material when env is in the vault", () => {
   for (const authMode of ["jwt", "env", "databricks"]) {
-    assert.equal(isFleetTokenPresent({ configured: true, authenticated: true, authMode }), true);
+    assert.equal(
+      isFleetTokenPresent({ configured: true, authenticated: true, authMode, envInVault: true }),
+      true,
+    );
   }
 });

--- a/src/lib/omnigent/fleet-gate.ts
+++ b/src/lib/omnigent/fleet-gate.ts
@@ -2,22 +2,28 @@
  * Fleet visibility gate.
  *
  * Fleet-launching UI — the board "Fleet" button, `omnigent:<host_id>` host-chip
- * options, and the per-familiar fleet defaults card — must stay hidden unless
- * the configured Omnigent server resolved real credential material (JWT, env
- * token, or a Databricks pointer). Tokenless local mode (authMode "none")
- * keeps the /api/omnigent/* proxies usable for API callers but surfaces no
- * Fleet buttons anywhere.
+ * options, and the per-familiar fleet defaults card — is shown if and ONLY if
+ * the current user has the Omnigent env (`OMNIGENT_TOKEN`) set up in their
+ * Cave Vault (`envInVault`) AND the configured server resolved real credential
+ * material. Credentials that exist only in `~/.omnigent/auth_tokens.json`
+ * (JWT / Databricks pointer) do NOT surface Fleet UI on their own, and
+ * tokenless local mode (authMode "none") keeps the /api/omnigent/* proxies
+ * usable for API callers but surfaces no Fleet buttons anywhere.
  */
 
 export type FleetGateStatus = {
   configured?: boolean;
   authenticated?: boolean;
   authMode?: string;
+  /** True when OMNIGENT_TOKEN is set up in the user's Cave Vault. */
+  envInVault?: boolean;
 };
 
-/** True only when Omnigent is configured AND an auth token is present. */
+/** True only when the user's vault has the Omnigent env set up AND the
+ *  configured server resolved an auth token. Fails closed on absent fields. */
 export function isFleetTokenPresent(status: FleetGateStatus | null | undefined): boolean {
   if (!status?.configured) return false;
+  if (status.envInVault !== true) return false;
   if ((status.authMode ?? "none") === "none") return false;
   return status.authenticated === true;
 }

--- a/src/lib/omnigent/token.ts
+++ b/src/lib/omnigent/token.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { hasConfiguredSecretMetadata, resolveSecret } from "../vault.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -31,6 +32,36 @@ export function normalizeOmnigentBaseUrl(url: string): string {
     return `${parsed.protocol}//${parsed.host}`;
   } catch {
     return trimmed;
+  }
+}
+
+/** The Cave Vault env key that opts a user into the Omnigent fleet. */
+export const OMNIGENT_TOKEN_ENV = "OMNIGENT_TOKEN";
+
+/**
+ * True when `OMNIGENT_TOKEN` is set up in this user's Cave Vault (process env,
+ * writable .env.local, local encrypted secret, or an op://‑style reference).
+ * Fleet UI visibility is gated on exactly this: a user without the env in
+ * their vault sees no Fleet surfaces, regardless of any
+ * `~/.omnigent/auth_tokens.json` credentials. Metadata-only — never resolves
+ * or caches the secret value.
+ */
+export function isOmnigentEnvConfigured(): boolean {
+  try {
+    return hasConfiguredSecretMetadata(OMNIGENT_TOKEN_ENV);
+  } catch {
+    return Boolean(process.env[OMNIGENT_TOKEN_ENV]?.trim());
+  }
+}
+
+/** Resolve the env token through the Cave Vault chain (process env →
+ *  .env.local → local encrypted store → op/dl reference). Falls back to bare
+ *  process.env if the vault module itself fails. */
+function resolveEnvToken(): string | null {
+  try {
+    return resolveSecret(OMNIGENT_TOKEN_ENV)?.trim() || null;
+  } catch {
+    return process.env[OMNIGENT_TOKEN_ENV]?.trim() || null;
   }
 }
 
@@ -92,20 +123,25 @@ async function mintDatabricksToken(workspaceHost: string): Promise<string | null
  *
  * Handles:
  * - Session JWT records (`token` + optional `expires_at`)
- * - `OMNIGENT_TOKEN` env fallback
+ * - `OMNIGENT_TOKEN` fallback, resolved through the Cave Vault chain
+ *   (process env → .env.local → encrypted store → op/dl reference)
  * - Databricks pointer records (`auth_type: "databricks"`, no token) by
  *   minting a fresh bearer via `databricks auth token --host <workspace>`
  * - No credential (local/single-user Omnigent) → mode `none`, still usable
  */
 export async function resolveOmnigentAuth(baseUrl: string): Promise<OmnigentAuthResolution> {
-  const envToken = process.env.OMNIGENT_TOKEN?.trim() || null;
+  // Lazy + memoized: the vault chain may shell out to `op`/`dcli`, so only pay
+  // for it when the env tier is actually consulted (JWT hits return earlier).
+  let envTokenMemo: string | null | undefined;
+  const envToken = (): string | null =>
+    envTokenMemo !== undefined ? envTokenMemo : (envTokenMemo = resolveEnvToken());
   const key = normalizeOmnigentBaseUrl(baseUrl);
   if (!key) {
     return {
-      token: envToken,
-      mode: envToken ? "env" : "none",
+      token: envToken(),
+      mode: envToken() ? "env" : "none",
       extraHeaders: {},
-      authenticated: Boolean(envToken),
+      authenticated: Boolean(envToken()),
     };
   }
 
@@ -151,10 +187,10 @@ export async function resolveOmnigentAuth(baseUrl: string): Promise<OmnigentAuth
         }
         // Pointer present but mint failed — still "authenticated" for UI, token null
         return {
-          token: envToken,
-          mode: envToken ? "env" : "databricks",
+          token: envToken(),
+          mode: envToken() ? "env" : "databricks",
           extraHeaders,
-          authenticated: Boolean(envToken) || Boolean(workspaceHost),
+          authenticated: Boolean(envToken()) || Boolean(workspaceHost),
         };
       }
 
@@ -178,8 +214,8 @@ export async function resolveOmnigentAuth(baseUrl: string): Promise<OmnigentAuth
     // missing file / parse error → env / none
   }
 
-  if (envToken) {
-    return { token: envToken, mode: "env", extraHeaders: {}, authenticated: true };
+  if (envToken()) {
+    return { token: envToken(), mode: "env", extraHeaders: {}, authenticated: true };
   }
   // Local / single-user Omnigent: no bearer required
   return { token: null, mode: "none", extraHeaders: {}, authenticated: false };

--- a/src/lib/omnigent/use-fleet-gate.ts
+++ b/src/lib/omnigent/use-fleet-gate.ts
@@ -14,8 +14,9 @@ function probeFleetToken(): Promise<boolean> {
 }
 
 /**
- * True only when Omnigent is configured with an auth token — the condition
- * for showing any Fleet button. Defaults to false (hidden) until proven.
+ * True only when the user has the Omnigent env set up in their Cave Vault and
+ * the server resolved an auth token — the condition for showing any Fleet
+ * button. Defaults to false (hidden) until proven.
  */
 export function useFleetTokenEnabled(): boolean {
   const [enabled, setEnabled] = useState(false);


### PR DESCRIPTION
## What

Fleet surfaces — the board **Fleet** button, `omnigent:<host_id>` host-chip options in Chat/Home pickers, and the per-familiar fleet defaults card — now appear **if and only if** the current user has `OMNIGENT_TOKEN` set up in their Cave Vault.

## Why

Fleet visibility was gated on any credential material (`~/.omnigent/auth_tokens.json` JWT, Databricks pointer, or bare `process.env`). That surfaces fleet UI for users who never opted in through the Cave. The Vault is the per-user env surface, so it becomes the single opt-in switch.

## How

- `isFleetTokenPresent` (fleet-gate) requires a new `envInVault` field — fail-closed for null/legacy payloads
- `GET /api/omnigent/status` reports `envInVault` via new `isOmnigentEnvConfigured()` (metadata-only — never resolves/caches the secret)
- `GET /api/hosts` skips `omnigent:` options unless the vault env is configured
- `resolveOmnigentAuth` resolves `OMNIGENT_TOKEN` through the Vault chain (process env → `.env.local` → local encrypted store → `op://`/`dl://` ref), lazily + memoized so JWT hits never pay for an `op read`
- `/api/omnigent/*` proxies remain usable for API callers (unchanged, documented behavior)
- Settings hints + gate comments updated; CHANGELOG entry under Unreleased

## Validation

- `node --test src/lib/omnigent/fleet-gate.test.ts src/lib/omnigent/client.test.ts` → 19/19 pass (new coverage: vault-chain resolution, per-user opt-in gating, fail-closed legacy payloads; client tests now sandbox all vault paths + `OMNIGENT_TOKEN`)
- `pnpm typecheck` clean
- api-contracts / vault / settings-search suites pass

Closes cave-s1pb.