### PR TITLE
fix(desktop): stop unhandled listeners[eventId].handlerId TypeError from focus-listener teardown (cave-ej6f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Fixed
+- **Desktop: unhandled `listeners[eventId].handlerId` TypeError on focus-listener teardown** — `useRefreshOnFocus` now subscribes to the raw `tauri://focus` event instead of `onFocusChanged`, whose composite unlisten discards its inner async deregistration promises; after an HMR or webview-navigation registry reset those surfaced as an uncatchable runtime error overlay.
+
 ### Changed
 - **Omnigent fleet is now per-user vault-gated** — Fleet surfaces (board Fleet button, `omnigent:…` host-chip options, per-familiar fleet defaults) appear if and only if the user has `OMNIGENT_TOKEN` set up in their Cave Vault; credentials that exist only in `~/.omnigent/auth_tokens.json` no longer surface Fleet UI on their own, and the token itself now resolves through the Vault chain (env → `.env.local` → encrypted store → `op://`/`dl://` reference).
 

--- a/src/lib/use-refresh-on-focus.test.ts
+++ b/src/lib/use-refresh-on-focus.test.ts
@@ -38,7 +38,16 @@ assert.doesNotThrow(
 const src = readFileSync(new URL("./use-refresh-on-focus.ts", import.meta.url), "utf8");
 assert.match(src, /window\.addEventListener\("focus", run\)/, "wires window focus");
 assert.match(src, /document\.addEventListener\("visibilitychange", onVisible\)/, "wires visibilitychange");
-assert.match(src, /getCurrentWindow\(\)\.onFocusChanged/, "wires the Tauri native focus event (the desktop fix)");
+assert.match(
+  src,
+  /getCurrentWindow\(\)\.listen\("tauri:\/\/focus"/,
+  "wires the Tauri native focus event (the desktop fix)",
+);
+assert.doesNotMatch(
+  src,
+  /\.onFocusChanged\(/,
+  "must not call onFocusChanged: its composite sync unlisten discards the inner async _unlisten rejections, which surface as an uncatchable 'listeners[eventId].handlerId' TypeError after an HMR/webview registry reset",
+);
 assert.match(src, /if \(isTauri\(\)\)/, "the Tauri path is guarded behind isTauri()");
 assert.match(src, /removeEventListener\("focus", run\)[\s\S]*?removeEventListener\("visibilitychange"/, "cleans up the web listeners");
 assert.match(src, /if \(disposed\) safeUnlisten\(un\);/, "late-resolving listen is torn down via the guard");

--- a/src/lib/use-refresh-on-focus.ts
+++ b/src/lib/use-refresh-on-focus.ts
@@ -44,7 +44,7 @@ export function safeUnlisten(un: (() => void) | undefined): void {
  * the installed desktop app:
  *   - `window` "focus" + `document` "visibilitychange" — browser tabs and most
  *     webviews.
- *   - Tauri `onFocusChanged` — the desktop window manager does NOT reliably emit
+ *   - Tauri `tauri://focus` — the desktop window manager does NOT reliably emit
  *     the web events when you switch between OS windows, so the native focus
  *     event is the dependable signal in the Tauri build. This is the actual fix
  *     for "stale data after an action in the installed app".
@@ -85,9 +85,16 @@ export function useRefreshOnFocus(
       void (async () => {
         try {
           const { getCurrentWindow } = await import("@tauri-apps/api/window");
-          const un = await getCurrentWindow().onFocusChanged((e: { payload: boolean }) => {
-            if (e.payload) run();
-          });
+          // Raw WINDOW_FOCUS event (fires only when focus is gained) instead
+          // of onFocusChanged: that helper registers TWO listeners (focus +
+          // blur) and returns a composite sync unlisten that fire-and-forgets
+          // both inner async _unlisten promises — when the injected registry
+          // is already reset (HMR / webview navigation) their rejections are
+          // discarded inside the composite where safeUnlisten cannot reach,
+          // and surface as an unhandled "listeners[eventId].handlerId"
+          // TypeError. Window.listen's unlisten is a plain async fn whose
+          // rejection safeUnlisten swallows.
+          const un = await getCurrentWindow().listen("tauri://focus", () => run());
           if (disposed) safeUnlisten(un);
           else unlisten = un;
         } catch {


### PR DESCRIPTION
## What

Fixes the runtime overlay error:

```
TypeError: undefined is not an object (evaluating 'listeners[eventId].handlerId')
  at unregisterListener (user-script)
  at safeUnlisten (src/lib/use-refresh-on-focus.ts:23)
```

## Why

`useRefreshOnFocus` used `getCurrentWindow().onFocusChanged(...)`. In @tauri-apps/api 2.11.1 that helper registers **two** listeners (WINDOW_FOCUS + WINDOW_BLUR) and returns a composite **sync** unlisten — `() => { unlistenFocus(); unlistenBlur(); }` — that fire-and-forgets both inner async `_unlisten` promises. When the injected event registry has been reset (HMR module reload / webview navigation), `unregisterListener` throws inside those discarded promises, where `safeUnlisten`'s sync try/catch **and** thenable `.catch` guard can't reach — so it surfaces as an unhandled rejection with the creation stack pointing at `safeUnlisten`.

## How

- Subscribe to the raw `tauri://focus` event via `Window.listen` — a single listener (the handler never acted on blur anyway), whose unlisten is a plain async fn; a stale-registry rejection lands in `safeUnlisten`'s existing `.catch`
- Test updates: pin the `tauri://focus` wiring, forbid `.onFocusChanged(` regressions
- CHANGELOG entry under Unreleased → Fixed

## Validation

- `node --experimental-strip-types --no-warnings --import ./scripts/test-alias-register.mjs --test src/lib/use-refresh-on-focus.test.ts` → pass (repo + worktree)
- `pnpm typecheck` clean

Closes cave-ej6f.