### PR TITLE
fix(chat): debug modal shows its own pane's session, not the global last-writer (cave-6nfq)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -435,6 +435,7 @@ export const SUITES = {
     "src/components/voice-call-overlay-state.test.ts",
     "src/components/voice-call-overlay.test.ts",
     "src/lib/session-debug.test.ts",
+    "src/lib/chat-debug-store.test.ts",
     "src/components/bottom-terminal-ws-bridge.test.ts",
     "src/components/bottom-terminal-startup-watchdog.test.ts",
     "src/components/familiars-memory-view-filter-paginate.test.ts",

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -327,8 +327,8 @@ assert.match(
 );
 assert.match(
   source,
-  /window\.dispatchEvent\(new CustomEvent\("cave:debug-open"\)\)/,
-  "Chat row Debug action should reuse the existing debug panel event bridge",
+  /requestDebugOpen\(\)/,
+  "Chat row Debug action should use the latched debug-open request (survives ChatView mounting after the dispatch)",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -10,6 +10,7 @@ import { useIsMobile, useIsCoarsePointer } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { sessionPrStatus } from "@/lib/session-pr-status";
+import { requestDebugOpen } from "@/lib/chat-debug-store";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -580,8 +581,11 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     e?.stopPropagation();
     setActiveId(session.id);
     onOpen(session.id, session.familiarId);
+    // Latched request: notifies a mounted ChatView via the window event and
+    // survives until one mounts — a bare rAF dispatch was lost whenever the
+    // open above had not rendered ChatView (and its listener) yet.
     window.requestAnimationFrame(() => {
-      window.dispatchEvent(new CustomEvent("cave:debug-open"));
+      requestDebugOpen();
     });
   };
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -81,7 +81,7 @@ import {
 } from "@/lib/slash-prompt";
 import { PromptSnippetsModal, promptIconName } from "@/components/prompt-snippets-modal";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
-import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
+import { clearChatDebugState, consumePendingDebugOpen, publishChatDebugState } from "@/lib/chat-debug-store";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 import { VoiceCallOverlay } from "./voice-call-overlay";
 import { ThreadSignalCard } from "@/components/thread-signal-card";
@@ -2349,10 +2349,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   }, []);
 
   // Other surfaces (chat-list row actions, the thread rail's Debug launcher)
-  // still reach debug through the cave:debug-open window-event bridge.
+  // still reach debug through the cave:debug-open window-event bridge; the
+  // latch catches a request dispatched before this listener mounted
+  // (chat-list opens the session, then asks for debug one rAF later).
   useEffect(() => {
     const onDebugOpen = () => setDebugModalOpen(true);
     window.addEventListener("cave:debug-open", onDebugOpen);
+    if (consumePendingDebugOpen()) setDebugModalOpen(true);
     return () => window.removeEventListener("cave:debug-open", onDebugOpen);
   }, []);
 
@@ -5987,7 +5990,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         ariaLabel="Session debug info"
       >
         <div className="h-[60vh] min-h-0">
-          <DebugPane />
+          {/* This instance's own state — not the global debug store, which a
+              sibling split-pane ChatView may have published over. */}
+          <DebugPane sessionId={sessionId} session={session ?? null} familiar={familiar} turns={turns} />
         </div>
       </Modal>
     </section>

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -8,7 +8,7 @@ import {
   stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
-import { useChatDebugSnapshot, type ChatDebugSnapshot } from "@/lib/chat-debug-store";
+import { type ChatDebugSnapshot } from "@/lib/chat-debug-store";
 import {
   appendEvents,
   buildDebugBundle,
@@ -379,8 +379,11 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   );
 }
 
-export function DebugPane() {
-  const snapshot = useChatDebugSnapshot();
+/** Session diagnostics for ONE chat instance. Props come from the owning
+ *  ChatView (which also hosts the modal this renders in), not from the global
+ *  chat-debug store — with split panes, several ChatViews publish there and a
+ *  last-writer read would show a different pane's session. */
+export function DebugPane(snapshot: ChatDebugSnapshot) {
   if (!snapshot.sessionId) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-center text-[11px] text-[var(--text-muted)]">

--- a/src/lib/chat-debug-store.test.ts
+++ b/src/lib/chat-debug-store.test.ts
@@ -1,0 +1,111 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  clearChatDebugState,
+  consumePendingDebugOpen,
+  getChatDebugSnapshot,
+  publishChatDebugState,
+  requestDebugOpen,
+} from "./chat-debug-store.ts";
+
+const snap = (sessionId, extra = {}) => ({
+  sessionId,
+  session: null,
+  familiar: null,
+  turns: [],
+  ...extra,
+});
+
+// ── Publish / read ───────────────────────────────────────────────────────────
+
+const empty = getChatDebugSnapshot();
+assert.equal(empty.sessionId, null, "store starts empty");
+assert.throws(
+  () => {
+    empty.turns.push({ id: "x" });
+  },
+  "the EMPTY sentinel's turns array is frozen — accidental mutation must throw",
+);
+
+const tokenA = Symbol("a");
+const tokenB = Symbol("b");
+
+publishChatDebugState(tokenA, snap("s-a"));
+assert.equal(getChatDebugSnapshot().sessionId, "s-a", "publish is readable");
+
+// ── Last writer wins (the reason DebugPane must NOT read this store) ─────────
+
+publishChatDebugState(tokenB, snap("s-b"));
+assert.equal(
+  getChatDebugSnapshot().sessionId,
+  "s-b",
+  "two live publishers race: the last writer wins, whatever pane it belongs to",
+);
+
+// ── Token-guarded clear ──────────────────────────────────────────────────────
+
+clearChatDebugState(tokenA);
+assert.equal(
+  getChatDebugSnapshot().sessionId,
+  "s-b",
+  "a stale publisher unmounting must not wipe state published after it",
+);
+
+clearChatDebugState(tokenB);
+assert.equal(getChatDebugSnapshot().sessionId, null, "the current publisher's clear empties the store");
+assert.equal(getChatDebugSnapshot(), empty, "clearing restores the shared EMPTY sentinel");
+
+clearChatDebugState(tokenB);
+assert.equal(getChatDebugSnapshot(), empty, "double-clear is a no-op");
+
+// ── Debug-open latch ─────────────────────────────────────────────────────────
+// chat-list opens a session, then asks for the debug modal one rAF later; when
+// ChatView (and its cave:debug-open listener) has not mounted yet, the window
+// event alone is lost. The latch survives until the next ChatView mount.
+
+assert.equal(consumePendingDebugOpen(), false, "no request pending initially");
+
+requestDebugOpen(1_000);
+assert.equal(consumePendingDebugOpen(1_500), true, "a fresh request is consumed");
+assert.equal(consumePendingDebugOpen(1_500), false, "consuming is one-shot");
+
+requestDebugOpen(1_000);
+assert.equal(
+  consumePendingDebugOpen(10_000),
+  false,
+  "a stale request (past the TTL) must not ghost-open the modal on a later mount",
+);
+assert.equal(consumePendingDebugOpen(10_000), false, "a stale request is discarded, not retried");
+
+// ── Wiring pins ──────────────────────────────────────────────────────────────
+
+const debugPane = readFileSync(new URL("../components/debug-pane.tsx", import.meta.url), "utf8");
+assert.doesNotMatch(
+  debugPane,
+  /useChatDebugSnapshot/,
+  "DebugPane must read its owning ChatView's props, not the global last-writer store — " +
+    "with split panes, the store may hold a different pane's session",
+);
+
+const chatView = readFileSync(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+assert.match(
+  chatView,
+  /<DebugPane sessionId=\{sessionId\} session=\{session \?\? null\} familiar=\{familiar\} turns=\{turns\} \/>/,
+  "ChatView hands its own live state to the DebugPane in its modal",
+);
+assert.match(
+  chatView,
+  /if \(consumePendingDebugOpen\(\)\) setDebugModalOpen\(true\);/,
+  "ChatView consumes a latched debug-open request on mount (rAF race fix)",
+);
+
+const chatList = readFileSync(new URL("../components/chat-list.tsx", import.meta.url), "utf8");
+assert.match(chatList, /requestDebugOpen\(\)/, "chat-list debug action goes through the latched request");
+assert.doesNotMatch(
+  chatList,
+  /new CustomEvent\("cave:debug-open"\)/,
+  "chat-list must not raw-dispatch cave:debug-open — the bare event loses the race with ChatView's mount",
+);
+
+console.log("chat-debug-store tests passed");

--- a/src/lib/chat-debug-store.ts
+++ b/src/lib/chat-debug-store.ts
@@ -1,10 +1,13 @@
 "use client";
 
 /**
- * Tiny in-memory store bridging ChatView's live chat state to the session
- * debug pane. Each ChatView instance publishes under its own token; DebugPane
- * (rendered in the right panel or a mobile modal — a different React subtree)
- * subscribes. Last publisher wins; clearing is token-guarded.
+ * Tiny in-memory store bridging ChatView's live chat state to surfaces in
+ * other React subtrees. Each ChatView instance publishes under its own token;
+ * the chat surface's code rail and its Changes tab subscribe for the active
+ * session's project root and running status. Last publisher wins; clearing is
+ * token-guarded. (The debug pane itself reads its owning ChatView's state via
+ * props — a global last-writer snapshot showed the wrong session when split
+ * panes mounted several ChatViews.)
  *
  * Not persisted. Cleared when the publishing ChatView unmounts.
  */
@@ -68,4 +71,37 @@ function getServerSnapshot() {
 
 export function useChatDebugSnapshot(): ChatDebugSnapshot {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/** Non-hook read for tests and imperative callers. */
+export function getChatDebugSnapshot(): ChatDebugSnapshot {
+  return state;
+}
+
+// ── Debug-open latch ──────────────────────────────────────────────────────────
+// Launchers outside ChatView (chat-list row action) open a session and then ask
+// for the debug modal. The window event alone races ChatView's mount: dispatched
+// one rAF after the open, it is lost if the listener isn't attached yet. The
+// latch records the request so ChatView can consume it on mount; the TTL keeps
+// a request that never found a ChatView (e.g. fired from a surface without one)
+// from ghost-opening the modal much later.
+
+const DEBUG_OPEN_TTL_MS = 3000;
+let pendingDebugOpenAt: number | null = null;
+
+/** Ask the active ChatView to open its debug modal: notifies a mounted listener
+ *  via "cave:debug-open" and latches the request for one about to mount. */
+export function requestDebugOpen(now: number = Date.now()): void {
+  pendingDebugOpenAt = now;
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("cave:debug-open"));
+  }
+}
+
+/** One-shot: true when a debug-open request is pending and fresh. Consuming
+ *  clears the latch either way so a stale request can't fire twice. */
+export function consumePendingDebugOpen(now: number = Date.now()): boolean {
+  const at = pendingDebugOpenAt;
+  pendingDebugOpenAt = null;
+  return at !== null && now - at <= DEBUG_OPEN_TTL_MS;
 }


### PR DESCRIPTION
## What

Slice S1 of the **chat-session-debugging** goal (Phase 1 audit finding A1/A4/E1).

**Wrong-session debug info in split panes (A1).** `chat-debug-store` is a module-global last-writer-wins snapshot, but the Debug modal mounts inside each ChatView (`chat-view.tsx:5983`). Split panes (`chat-router.tsx:706,759`) mount 2+ ChatViews that all publish — so pane A's Debug modal rendered whichever pane published last (a streaming sibling wins constantly). The per-instance Symbol token only guards *clears*, not publishes.
→ `DebugPane` now takes `{sessionId, session, familiar, turns}` as props from its **owning** ChatView. The global store stays for its intentional consumers (code rail + Changes tab, which want the active-session signal).

**Lost debug-open request (A4).** The chat-list row Debug action dispatched `cave:debug-open` one rAF after opening the session; when ChatView (and its listener) hadn't mounted yet, the event was silently lost.
→ `requestDebugOpen()` latches the request (3s TTL against ghost-opens) and still fires the window event; ChatView consumes the latch on mount.

**Zero store tests (E1).** Added the first behavioral tests for `chat-debug-store`: last-writer-wins, token-guarded clear, frozen EMPTY sentinel, latch one-shot + TTL — plus wiring pins that DebugPane must not read the global store.

## Verification

- `pnpm test:app` — 751 test files pass (updated the one pin that asserted the raw dispatch)
- `pnpm typecheck` — clean

## Refs

- Bead: cave-6nfq (chat-session-debugging goal S1)
- Audit trail: .copilot/goals.md chat-session-debugging