### PR TITLE
feat(familiars): terminal-futurist roster cards in the profile-card language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ breaking config changes; patch releases stay additive.
 ## [Unreleased]
 
 ### Changed
+- **Familiars roster speaks the profile-card language** — roster cards restyled as terminal stat tiles matching the profile share card: monospace lowercase labels, hairline-divided sessions / this-week / memories band with glowing numerals, a 14-day activity strip bucketed like the profile heatmap, framed square avatars, and the checkerboard `familiars` wordmark on the surface header (cave-uw7c).
 - **Omnigent fleet is now per-user vault-gated** — Fleet surfaces (board Fleet button, `omnigent:…` host-chip options, per-familiar fleet defaults) appear if and only if the user has `OMNIGENT_TOKEN` set up in their Cave Vault; credentials that exist only in `~/.omnigent/auth_tokens.json` no longer surface Fleet UI on their own, and the token itself now resolves through the Vault chain (env → `.env.local` → encrypted store → `op://`/`dl://` reference).
 
 ## [0.1.2] - 2026-07-16

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,12 @@
      radius appearance setting: `sharp` overrides it to a squared value. */
   --radius-pill: 999px;
 
+  /* ---- Terminal-numeral glow (cave-uw7c) ----
+     The profile share card's glowing-stat treatment, generalized for themed
+     surfaces (roster stat tiles, dashboards). currentColor-based so it works
+     on any ink; light mode zeroes it — bloom on paper reads as blur. */
+  --glow-numeral: 0 0 12px color-mix(in srgb, currentColor 38%, transparent);
+
   /* ---- Spacing ---- */
   --space-1: 4px;
   --space-2: 8px;
@@ -267,6 +273,8 @@
    ============================================================ */
 :root[data-mode="light"] {
   color-scheme: light;
+  /* No numeral bloom on light surfaces — glow reads as blur on paper. */
+  --glow-numeral: none;
   --background: oklch(0.975 0.012 293);
   --foreground: oklch(0.18 0.020 293);
   --card: oklch(0.95 0.014 293);
@@ -6476,10 +6484,13 @@ a.mobile-handoff__link:hover {
 }
 
 /* ────────────────────────────────────────────────
-   Familiars roster cards (cave-g2r6)
-   De-boxed: a wash + inset soft hairline instead of a hard border, with a
-   quiet hover lift. The wrapper owns the visual card so the open button and
-   the footer analytics link live inside it as siblings.
+   Familiars roster cards (cave-g2r6 · cave-uw7c)
+   De-boxed terminal stat tile: a wash + inset soft hairline instead of a
+   hard border, with a quiet hover lift. The wrapper owns the visual card so
+   the open button and the footer profile/analytics links live inside it as
+   siblings. Typography follows the profile share card (profile-card.css):
+   monospace lowercase micro-labels, hairline-divided stat band, glowing
+   numerals, and a mini activity strip bucketed like the pfc heatmap.
    ──────────────────────────────────────────────── */
 
 .familiars-view__card {
@@ -6502,6 +6513,173 @@ a.mobile-handoff__link:hover {
   .familiars-view__card,
   .familiars-view__card:hover {
     transform: none;
+  }
+}
+
+/* Square framed avatar, as on the share card's identity rail. */
+.familiars-view__avatar-tile {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  flex: none;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--bg-raised) 80%, transparent);
+  overflow: hidden;
+}
+.familiars-view__avatar-tile img {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+  object-fit: cover;
+}
+
+/* Lowercase monospace micro-label — the share card's label voice. */
+.familiars-view__microlabel {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--text-muted);
+}
+
+.familiars-view__tagline {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  color: var(--text-muted);
+}
+
+/* Page heading as the share card's checkerboard wordmark. */
+.familiars-view__wordmark {
+  display: inline-block;
+  padding: var(--space-1) var(--space-3) var(--space-1) var(--space-1);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xl);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--text-primary);
+  text-shadow: var(--glow-numeral);
+  background:
+    repeating-conic-gradient(
+      color-mix(in srgb, var(--foreground) 6%, transparent) 0% 25%,
+      transparent 0% 50%
+    )
+    0 0 / 12px 12px;
+}
+
+/* Detail-panel nameplate — the share card's halftone strip, theme-aware. */
+.familiars-view__nameplate {
+  padding: var(--space-1) var(--space-3) var(--space-1) var(--space-2);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-md);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--text-primary);
+  text-shadow: var(--glow-numeral);
+  background:
+    radial-gradient(color-mix(in srgb, var(--foreground) 12%, transparent) 1px, transparent 1px)
+    0 0 / 6px 6px,
+    color-mix(in oklch, var(--bg-raised) 70%, transparent);
+}
+
+/* Hairline-divided tri-stat band. */
+.familiars-view__statband {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+}
+.familiars-view__stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+}
+.familiars-view__stat + .familiars-view__stat {
+  border-left: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+}
+.familiars-view__stat-label {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+.familiars-view__stat-value {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xl);
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text-primary);
+  text-shadow: var(--glow-numeral);
+  font-variant-numeric: tabular-nums;
+}
+
+/* 14-day activity strip — accent-tinted level ramp, same 1..4 bucketing as
+   the profile-card heatmap. Cells are decorative (aria-hidden); the count
+   lives in the title tooltip. */
+.familiars-view__strip {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3) 0;
+}
+.familiars-view__strip i {
+  display: block;
+  height: 14px;
+  /* Square cells on purpose — the share card's heatmap voice. */
+  background: color-mix(in oklch, var(--border-hairline) 45%, transparent);
+}
+.familiars-view__strip i[data-level="1"] {
+  background: color-mix(in oklch, var(--accent-presence) 30%, var(--bg-raised));
+}
+.familiars-view__strip i[data-level="2"] {
+  background: color-mix(in oklch, var(--accent-presence) 55%, var(--bg-raised));
+}
+.familiars-view__strip i[data-level="3"] {
+  background: color-mix(in oklch, var(--accent-presence) 80%, var(--bg-raised));
+}
+.familiars-view__strip i[data-level="4"] {
+  background: var(--accent-presence);
+}
+
+/* Status chips (active session / response needed) in the label voice. */
+.familiars-view__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-1);
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  /* Squared chip corners on purpose — terminal voice. */
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  line-height: 1.7;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+.familiars-view__chip--warning {
+  color: var(--color-warning);
+}
+
+/* Live-presence dot pulses gently; static under reduced motion. */
+.familiars-view__status-dot--live {
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent-presence) 70%, transparent);
+  animation: familiars-status-pulse 2.4s ease-in-out infinite;
+}
+@keyframes familiars-status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .familiars-view__status-dot--live {
+    animation: none;
   }
 }
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/coven-analytics";
 import { deriveConfidenceScore, type ConfidenceScore } from "@/lib/familiar-confidence";
 import { deriveGrowthReport } from "@/lib/familiar-growth-signals";
-import { buildFamiliarCardStats, type FamiliarCardStats, type CovenMemoryEntry } from "@/components/familiars-view-stats";
+import { ACTIVITY_DAYS, buildFamiliarCardStats, type FamiliarCardStats, type CovenMemoryEntry } from "@/components/familiars-view-stats";
 import { useFamiliarContracts } from "@/lib/use-familiar-contracts";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useMinuteTick } from "@/lib/use-minute-tick";
@@ -61,7 +61,7 @@ type CockpitData = {
 
 const EMPTY: CockpitData = { cards: [], familiars: [], github: [], inbox: [], sessions: [], memory: [], space: [] };
 
-const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsLast7d: 0, hasActiveSession: false };
+const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsTotal: 0, sessionsLast7d: 0, hasActiveSession: false, activity: new Array<number>(ACTIVITY_DAYS).fill(0) };
 
 // A KPI tile's visual props plus the data plumbing the root owns: which trend
 // metric feeds its sparkline and which fetch source gates its loading state.

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -1,4 +1,5 @@
 import {
+  ACTIVITY_DAYS,
   buildFamiliarCardStats,
   type CovenMemoryEntry,
   type FamiliarCardStats,
@@ -120,8 +121,10 @@ function emptyStats(): FamiliarCardStats {
     memoryCount: 0,
     latestMemory: null,
     lastSessionAt: null,
+    sessionsTotal: 0,
     sessionsLast7d: 0,
     hasActiveSession: false,
+    activity: new Array<number>(ACTIVITY_DAYS).fill(0),
   };
 }
 

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -9,6 +9,7 @@ import { useAnnouncer } from "@/components/ui/live-region";
 import { AuthedImage } from "@/components/ui/authed-image";
 import { RelativeTime } from "@/components/ui/relative-time";
 import {
+  ACTIVITY_DAYS,
   buildFamiliarCardStats,
   type CovenMemoryEntry,
   type FamiliarCardStats,
@@ -89,8 +90,10 @@ function emptyStats(): FamiliarCardStats {
     memoryCount: 0,
     latestMemory: null,
     lastSessionAt: null,
+    sessionsTotal: 0,
     sessionsLast7d: 0,
     hasActiveSession: false,
+    activity: new Array<number>(ACTIVITY_DAYS).fill(0),
   };
 }
 

--- a/src/components/familiar-roster-card.test.ts
+++ b/src/components/familiar-roster-card.test.ts
@@ -11,8 +11,8 @@ assert.match(card, /aria-label=\{`Open \$\{familiar\.display_name\}`\}/, "Card h
 
 assert.match(
   card,
-  /<FamiliarAvatar familiar=\{familiar\} size="sm" \/>/,
-  "Card renders the shared FamiliarAvatar so uploaded images win over glyph fallback",
+  /<FamiliarAvatar familiar=\{familiar\} size="lg" \/>/,
+  "Card renders the shared FamiliarAvatar (framed square tile) so uploaded images win over glyph fallback",
 );
 
 assert.match(card, /familiar\.display_name/, "Card shows display name");

--- a/src/components/familiars-view-stats.test.ts
+++ b/src/components/familiars-view-stats.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildFamiliarCardStats } from "./familiars-view-stats.ts";
+import { ACTIVITY_DAYS, buildFamiliarCardStats } from "./familiars-view-stats.ts";
 
 const NOW = Date.parse("2026-06-08T12:00:00.000Z");
 const minutesAgo = (m: number) => new Date(NOW - m * 60_000).toISOString();
@@ -36,6 +36,17 @@ assert.equal(f1?.latestMemory?.title, "Latest f1 memory", "f1 latest memory is t
 assert.equal(f1?.lastSessionAt, sessions[0].created_at, "f1 last session uses the newest non-archived session start");
 assert.equal(f1?.sessionsLast7d, 2, "f1 has 2 sessions in the last 7d (s1 and s2; s3 is excluded at 8d)");
 assert.equal(f1?.hasActiveSession, false, "f1 has no session start in the active window");
+assert.equal(f1?.sessionsTotal, 4, "f1 counts every non-archived session (s6 archived is excluded)");
+assert.equal(f1?.activity.length, ACTIVITY_DAYS, "activity strip covers ACTIVITY_DAYS UTC days");
+assert.equal(f1?.activity[ACTIVITY_DAYS - 1], 1, "today's cell counts s1 (started 10 minutes ago)");
+assert.equal(f1?.activity[ACTIVITY_DAYS - 2], 1, "yesterday's cell counts s2");
+assert.equal(f1?.activity[ACTIVITY_DAYS - 9], 1, "8-days-ago cell counts s3 (inside the strip even though outside 7d)");
+assert.equal(f1?.activity[ACTIVITY_DAYS - 10], 1, "9-days-ago cell counts s5's created_at start");
+assert.equal(
+  f1?.activity.reduce((sum, n) => sum + n, 0),
+  4,
+  "strip counts every non-archived session start inside the window (UTC day bucketing)",
+);
 
 // f2
 const f2 = stats.get("f2");
@@ -51,6 +62,8 @@ assert.equal(f3?.latestMemory, null);
 assert.equal(f3?.lastSessionAt, null);
 assert.equal(f3?.sessionsLast7d, 0);
 assert.equal(f3?.hasActiveSession, false);
+assert.equal(f3?.sessionsTotal, 0);
+assert.ok(f3?.activity.every((n) => n === 0), "zero-session familiar has an all-zero activity strip");
 
 // 7d window edge: session at exactly 7d should be EXCLUDED (strict less-than)
 const edge7d = buildFamiliarCardStats({

--- a/src/components/familiars-view-stats.ts
+++ b/src/components/familiars-view-stats.ts
@@ -16,12 +16,23 @@ export type FamiliarCardStats = {
   memoryCount: number;
   latestMemory: { title: string; updatedAt: string } | null;
   lastSessionAt: string | null;
+  /** Every non-archived session attributed to the familiar. */
+  sessionsTotal: number;
   sessionsLast7d: number;
   hasActiveSession: boolean;
+  /**
+   * Sessions per UTC day for the roster card's mini activity strip —
+   * ACTIVITY_DAYS entries, oldest first, today last. Same UTC day bucketing
+   * as the profile-card heatmap so both surfaces agree.
+   */
+  activity: number[];
 };
 
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60_000;
+const DAY_MS = 24 * 60 * 60_000;
+const SEVEN_DAYS_MS = 7 * DAY_MS;
 const FIVE_MINUTES_MS = 5 * 60_000;
+/** Days shown by the roster card activity strip. */
+export const ACTIVITY_DAYS = 14;
 
 function sessionStartAt(session: SessionRow): string | null {
   return session.created_at ?? session.updated_at ?? null;
@@ -36,6 +47,7 @@ export function buildFamiliarCardStats(args: {
   const now = args.now ?? Date.now();
   const sevenCutoff = now - SEVEN_DAYS_MS;
   const activeCutoff = now - FIVE_MINUTES_MS;
+  const todayIndex = Math.floor(now / DAY_MS);
 
   const sessionsByFamiliar = new Map<string, SessionRow[]>();
   for (const session of args.sessions) {
@@ -63,6 +75,7 @@ export function buildFamiliarCardStats(args: {
     let lastSessionMs = -Infinity;
     let sessionsLast7d = 0;
     let hasActiveSession = false;
+    const activity = new Array<number>(ACTIVITY_DAYS).fill(0);
     for (const session of sessions) {
       const startedAt = sessionStartAt(session);
       if (!startedAt) continue;
@@ -74,6 +87,10 @@ export function buildFamiliarCardStats(args: {
       }
       if (ms > sevenCutoff) sessionsLast7d += 1;
       if (ms > activeCutoff) hasActiveSession = true;
+      const daysAgo = todayIndex - Math.floor(ms / DAY_MS);
+      if (daysAgo >= 0 && daysAgo < ACTIVITY_DAYS) {
+        activity[ACTIVITY_DAYS - 1 - daysAgo] += 1;
+      }
     }
 
     let latestMemory: FamiliarCardStats["latestMemory"] = null;
@@ -91,8 +108,10 @@ export function buildFamiliarCardStats(args: {
       memoryCount: memories.length,
       latestMemory,
       lastSessionAt,
+      sessionsTotal: sessions.length,
       sessionsLast7d,
       hasActiveSession,
+      activity,
     });
   }
   return result;

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -14,8 +14,8 @@ assert.match(
 
 assert.match(
   source,
-  /<FamiliarAvatar familiar=\{familiar\} size="sm" \/>/,
-  "FamiliarsView detail header/card should render FamiliarAvatar instead of raw daemon icons",
+  /<FamiliarAvatar familiar=\{familiar\} size="lg" \/>/,
+  "FamiliarsView roster card should render FamiliarAvatar instead of raw daemon icons",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -24,10 +24,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { FamiliarSummoningCircle } from "@/components/familiar-summoning-circle";
 import {
+  ACTIVITY_DAYS,
   buildFamiliarCardStats,
   type FamiliarCardStats,
   type CovenMemoryEntry,
 } from "@/components/familiars-view-stats";
+import { compactCount } from "@/lib/profile-card";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { SUMMON_FAMILIAR_EVENT, consumeSummonPending } from "@/lib/summon-events";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
@@ -244,11 +246,8 @@ export function FamiliarsView({
       <header className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-3">
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
-            <div className="flex items-center gap-2">
-              <Icon name="ph:users-three" width={16} className="text-[var(--accent-presence)]" />
-              <h1 className="text-[14px] font-semibold text-[var(--text-primary)]">Familiars</h1>
-            </div>
-            <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            <h1 className="familiars-view__wordmark">Familiars</h1>
+            <p className="familiars-view__tagline mt-1.5">
               Roster of every familiar — identity, status, recent activity, memory at a glance.
             </p>
           </div>
@@ -302,7 +301,7 @@ export function FamiliarsView({
                 }
               }}
               placeholder="Search familiars…"
-              className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-7 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
+              className="focus-ring h-8 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 pl-7 pr-7 font-mono text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
             />
             {!query && (
               <kbd
@@ -457,8 +456,10 @@ function emptyStats(): FamiliarCardStats {
     memoryCount: 0,
     latestMemory: null,
     lastSessionAt: null,
+    sessionsTotal: 0,
     sessionsLast7d: 0,
     hasActiveSession: false,
+    activity: new Array<number>(ACTIVITY_DAYS).fill(0),
   };
 }
 
@@ -509,60 +510,93 @@ function FamiliarRosterCard({
   onSelect,
 }: AgentRosterCardProps) {
   const lastSessionLabel = stats.lastSessionAt
-    ? `Last session ${age(stats.lastSessionAt)}`
+    ? `last session ${age(stats.lastSessionAt)}`
     : "No sessions yet";
-  const sessionsLabel =
-    stats.sessionsLast7d > 0 ? ` · ${stats.sessionsLast7d} this week` : "";
+  const stripTotal = stats.activity.reduce((sum, n) => sum + n, 0);
   return (
-    // De-boxed card (cave-g2r6): the wrapper carries the wash + soft hairline
-    // so the open button and the analytics link can sit inside one visual card
-    // as sibling interactive elements (no nested controls).
+    // De-boxed card (cave-g2r6) restyled as a terminal stat tile (cave-uw7c):
+    // the wrapper carries the wash + soft hairline so the open button and the
+    // profile/analytics links can sit inside one visual card as sibling
+    // interactive elements (no nested controls). Typography and the stat band
+    // follow the profile share card (src/styles/profile-card.css) — monospace
+    // lowercase labels, hairline-divided tiles, glowing numerals.
     <div className="familiars-view__card group relative flex h-full flex-col">
       <button
         type="button"
         onClick={onSelect}
-        className="focus-ring flex flex-1 flex-col items-stretch gap-2 rounded-[inherit] p-3 pb-2 text-left"
+        className="focus-ring flex flex-1 flex-col items-stretch rounded-[inherit] text-left"
         aria-label={`Open ${familiar.display_name}`}
       >
-        <div className="flex items-center gap-2">
-          <FamiliarAvatar familiar={familiar} size="sm" />
+        <span className="flex items-center gap-2.5 px-3 pt-3">
+          <span className="familiars-view__avatar-tile" aria-hidden="true">
+            <FamiliarAvatar familiar={familiar} size="lg" />
+          </span>
           <span className="min-w-0 flex-1">
-            <span className="block truncate text-[13px] font-semibold text-[var(--text-primary)]">
+            <span className="block truncate font-mono text-[13px] font-semibold tracking-wide text-[var(--text-primary)]">
               {familiar.display_name}
             </span>
-            <span className="block truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+            <span className="familiars-view__microlabel mt-1 block truncate">
               {familiar.role || familiar.harness || familiar.id}
             </span>
           </span>
-        </div>
+          <span className="familiars-view__microlabel inline-flex shrink-0 items-center gap-1.5 self-start">
+            <span
+              className={`inline-flex h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-[var(--accent-presence)] familiars-view__status-dot--live" : "bg-[var(--text-muted)]"}`}
+              aria-hidden="true"
+            />
+            {daemonRunning ? "online" : "offline"}
+          </span>
+        </span>
 
-        <div className="flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
-          <span
-            className={`inline-flex h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-[var(--accent-presence)]" : "bg-[var(--text-muted)]"}`}
-            aria-hidden="true"
-          />
-          <span>{daemonRunning ? "online" : "offline"}</span>
-          {stats.hasActiveSession ? (
-            <span className="rounded bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[9px] text-[var(--accent-presence)]">
-              active session
-            </span>
-          ) : null}
-          {responseNeeded ? (
-            <span className="rounded bg-[var(--color-warning)]/15 px-1.5 py-0.5 text-[9px] text-[var(--color-warning)]">
-              response needed
-            </span>
-          ) : null}
-        </div>
+        {stats.hasActiveSession || responseNeeded ? (
+          <span className="flex flex-wrap items-center gap-1.5 px-3 pt-2">
+            {stats.hasActiveSession ? (
+              <span className="familiars-view__chip text-[var(--accent-presence)]">
+                active session
+              </span>
+            ) : null}
+            {responseNeeded ? (
+              <span className="familiars-view__chip familiars-view__chip--warning">
+                response needed
+              </span>
+            ) : null}
+          </span>
+        ) : null}
 
-        <p className="mt-auto text-[11px] text-[var(--text-secondary)]">
-          {lastSessionLabel}{sessionsLabel}
-        </p>
+        <span className="familiars-view__statband mt-3">
+          <span className="familiars-view__stat">
+            <span className="familiars-view__stat-label">sessions</span>
+            <span className="familiars-view__stat-value">{compactCount(stats.sessionsTotal)}</span>
+          </span>
+          <span className="familiars-view__stat">
+            <span className="familiars-view__stat-label">this week</span>
+            <span className="familiars-view__stat-value">{compactCount(stats.sessionsLast7d)}</span>
+          </span>
+          <span className="familiars-view__stat">
+            <span className="familiars-view__stat-label">memories</span>
+            <span className="familiars-view__stat-value">{compactCount(stats.memoryCount)}</span>
+          </span>
+        </span>
+
+        <span
+          className="familiars-view__strip"
+          aria-hidden="true"
+          title={`${stripTotal} session${stripTotal === 1 ? "" : "s"} in the last ${ACTIVITY_DAYS} days`}
+        >
+          {stats.activity.map((count, index) => (
+            <i key={index} data-level={activityLevel(count, stats.activity)} />
+          ))}
+        </span>
+
+        <span className="familiars-view__microlabel mt-auto block truncate px-3 pb-2.5 pt-2">
+          {lastSessionLabel}
+        </span>
       </button>
 
-      {/* Card footer — memory snapshot as a quiet one-liner + the analytics
-          link folded inside the card (it used to float orphaned below the
-          border). Hairline divider, no second box. */}
-      <div className="familiars-view__card-footer flex items-center justify-between gap-2 border-t border-[var(--border-hairline)]/60 px-3 py-2 text-[11px]">
+      {/* Card footer — memory snapshot as a quiet one-liner + the profile and
+          analytics links folded inside the card (they used to float orphaned
+          below the border). Hairline divider, no second box. */}
+      <div className="familiars-view__card-footer flex items-center justify-between gap-2 border-t border-[var(--border-hairline)]/60 px-3 py-2 font-mono text-[10px]">
         <span className="min-w-0 flex-1 truncate text-[var(--text-muted)]" title={stats.latestMemory?.title}>
           {memoryStatus === "loading" ? (
             // Shimmer instead of a "Loading memory…" string — one loading
@@ -585,20 +619,30 @@ function FamiliarRosterCard({
         <Link
           href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
           aria-label={`Open profile for ${familiar.display_name}`}
-          className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+          className="focus-ring shrink-0 rounded-[var(--radius-sm)] lowercase text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
         >
           Profile →
         </Link>
         <Link
           href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
           aria-label={`Open analytics for ${familiar.display_name}`}
-          className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+          className="focus-ring shrink-0 rounded-[var(--radius-sm)] lowercase text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
         >
           Analytics →
         </Link>
       </div>
     </div>
   );
+}
+
+/**
+ * Bucket a day's count against the strip max — same 1..4 ramp as the profile
+ * card heatmap (src/lib/profile-card.ts levelFor) so both surfaces agree.
+ */
+function activityLevel(count: number, activity: number[]): 0 | 1 | 2 | 3 | 4 {
+  const max = Math.max(0, ...activity);
+  if (count <= 0 || max <= 0) return 0;
+  return Math.min(4, Math.max(1, Math.ceil((count / max) * 4))) as 1 | 2 | 3 | 4;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -689,7 +733,7 @@ function FamiliarDetailRail({ familiars, selectedId, onSelect, onPreview, onBack
                   onSelect(f.id);
                   onPreview(f);
                 }}
-                className={`focus-ring familiars-view__rail-avatar inline-flex h-9 w-9 items-center justify-center rounded-full border ${
+                className={`focus-ring familiars-view__rail-avatar inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-md border ${
                   active
                     ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/15 text-[var(--accent-presence)]"
                     : "border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
@@ -846,10 +890,10 @@ function FamiliarDetailPanel({
             <FamiliarAvatar familiar={familiar} size="xl" />
           </button>
           <div className="min-w-0">
-            <h2 className="truncate text-[14px] font-semibold text-[var(--text-primary)]">
+            <h2 className="familiars-view__nameplate truncate">
               {familiar.display_name}
             </h2>
-            <p className="truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+            <p className="familiars-view__microlabel mt-1 truncate">
               {familiar.role || familiar.harness || familiar.id}
             </p>
           </div>
@@ -1029,7 +1073,7 @@ function FamiliarAvatarPreviewOverlay({ familiar, onClose }: FamiliarAvatarPrevi
           <div className="truncate text-[14px] font-semibold text-[var(--text-primary)]">
             {familiar.display_name}
           </div>
-          <div className="mt-0.5 truncate text-[11px] uppercase tracking-widest text-[var(--text-secondary)]">
+          <div className="familiars-view__microlabel mt-1 truncate">
             {familiar.role || familiar.harness || familiar.id}
           </div>
         </div>

--- a/src/lib/familiar-growth-signals.test.ts
+++ b/src/lib/familiar-growth-signals.test.ts
@@ -26,8 +26,10 @@ function stats(overrides: Partial<FamiliarCardStats> = {}): FamiliarCardStats {
     memoryCount: 3,
     latestMemory: { title: "Recent memory", updatedAt: daysAgo(1) },
     lastSessionAt: daysAgo(1),
+    sessionsTotal: 4,
     sessionsLast7d: 4,
     hasActiveSession: true,
+    activity: new Array(14).fill(0),
     ...overrides,
   };
 }


### PR DESCRIPTION
## What

Propagates the profile share card's terminal-futurist aesthetic (the `pfc-*` card the operator screenshotted as the target vibe) to the familiars roster and its surface chrome — bead **cave-uw7c**.

### Roster cards → terminal stat tiles
- Monospace lowercase micro-labels (the share card's label voice)
- Hairline-divided tri-stat band: **sessions / this week / memories** with glowing numerals (`--glow-numeral`, zeroed under `data-mode="light"`)
- **14-day activity strip** per familiar, bucketed 1..4 against the window max exactly like the pfc heatmap (`levelFor` semantics), accent-presence level ramp
- Framed square avatar tiles, squared status chips, pulsing presence dot (static under `prefers-reduced-motion`)
- Footer unchanged in behavior: memory one-liner + Profile → / Analytics → links

### Surface chrome
- `familiars` wordmark with the share card's checkerboard treatment + mono tagline
- Detail-panel nameplate takes the halftone strip; detail rail avatars squared

### Data
- `buildFamiliarCardStats` grows `sessionsTotal` + `activity[]` (per-UTC-day counts, `ACTIVITY_DAYS` window; same UTC bucketing as `session-pulse`), unit-tested; `emptyStats` callers (cockpit, analytics data, growth view) updated

## Validation

- `pnpm test:app` — **750/750 pass** (incl. updated source-pin tests + design-token-drift gate)
- `pnpm typecheck` — clean
- New CSS fully tokenized (no ratchet regressions; off-scale literals renormalized to the type/space scale)
- Playwright screenshots of roster (dark + forced light) and detail panel against the built app with the live roster — light mode drops the glow and tracks theme tokens
