### PR TITLE
Deep-link PR badges into GitHubView

### DIFF
--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -48,6 +48,16 @@ assert.match(
   /onOpenUrl=\{onOpenUrl\}\n\s+onOpen=/s,
   "the chat router hands its in-app URL opener to the chat list",
 );
+assert.match(
+  workspace,
+  /const openUrlInApp = useCallback\(\(url: string\) => \{\s*\n\s*if \(openGitHubTarget\(url\)\) \{/,
+  "workspace tries the native GitHubView target before falling back to the browser pane",
+);
+assert.match(
+  workspace,
+  /<ChatSurface[\s\S]*?onOpenUrl=\{openUrlInApp\}/,
+  "workspace passes the GitHub-aware app URL opener to chat-list badges",
+);
 
 // ── Badge styling: GitHub's state colors ─────────────────────────────────────
 for (const state of ["merged", "closed", "draft"]) {

--- a/src/components/workspace-sidebar-pr-badge.test.ts
+++ b/src/components/workspace-sidebar-pr-badge.test.ts
@@ -2,8 +2,8 @@
 // Source pins for the workspace-sidebar PR-status badge — the sidebar twin of
 // the chat list's badge (#2983): thread rows swap the status dot (and the
 // title-heuristic PR/branch glyph) for a clickable GitHub PR-state icon when
-// the session carries real PR context; clicking opens the PR in the in-app
-// browser (new-tab fallback) without opening the chat.
+// the session carries real PR context; clicking routes PR URLs through the
+// native GitHubView deep-linker (browser/new-tab fallback) without opening the chat.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -60,11 +60,16 @@ assert.match(
   "the badge has an accessible name naming the PR and its state",
 );
 
-// ── Wiring: workspace hands the sidebar its in-app URL opener ────────────────
+// ── Wiring: workspace hands the sidebar its app URL opener ──────────────────
 assert.match(
   workspace,
-  /<WorkspaceSidebar[\s\S]*?onOpenUrl=\{openUrlInAppBrowser\}/,
-  "workspace passes the in-app browser opener to the chat sidebar",
+  /const openUrlInApp = useCallback\(\(url: string\) => \{\s*\n\s*if \(openGitHubTarget\(url\)\) \{/,
+  "workspace wraps URL opens with the GitHub target interceptor first",
+);
+assert.match(
+  workspace,
+  /<WorkspaceSidebar[\s\S]*?onOpenUrl=\{openUrlInApp\}/,
+  "workspace passes the GitHub-aware app URL opener to the chat sidebar",
 );
 
 // ── Styling: GitHub's state colors + gutter alignment ────────────────────────

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1669,6 +1669,14 @@ export function Workspace() {
     return true;
   }, []);
 
+  const openUrlInApp = useCallback((url: string) => {
+    if (openGitHubTarget(url)) {
+      shellRef.current?.dismissNavMobile();
+      return;
+    }
+    openUrlInAppBrowser(url);
+  }, [openGitHubTarget, openUrlInAppBrowser]);
+
   const openReminderLink = useCallback((link: LinkRef) => {
     if (link.kind === "url") {
       if (!link.ref) return;
@@ -2433,7 +2441,7 @@ export function Workspace() {
         invalidateConversation(session.id);
         await loadSessions();
       }}
-      onOpenUrl={openUrlInAppBrowser}
+      onOpenUrl={openUrlInApp}
       scheduledCount={scheduleNeedsCount}
       onOpenSettings={() => {
         shellRef.current?.dismissNavMobile();
@@ -2506,7 +2514,7 @@ export function Workspace() {
         onOpenOnboarding={openOnboarding}
         onSessionsChanged={loadSessions}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-        onOpenUrl={openUrlInAppBrowser}
+        onOpenUrl={openUrlInApp}
       />
     ) : mode === "board" || mode === "familiar-work-queue" ? (
       // Tasks and the Work Queue are one surface (cave-oa1z, the Schedules


### PR DESCRIPTION
## Summary
- route PR badge URL opens through the existing GitHubView target parser before browser fallback
- wire both chat-list and workspace-sidebar badge entry points to the GitHub-aware opener
- update source-pin tests to lock the GitHubView routing contract

## Verification
- node --experimental-strip-types src/components/chat-list-pr-badge.test.ts
- node --experimental-strip-types src/components/workspace-sidebar-pr-badge.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app

Beads: cave-5xgk

Note: commit was created unsigned because the configured SSH signing agent was inaccessible in this non-interactive runtime (`ssh-keygen -Y sign` could not get an agent socket).
