### PR TITLE
fix(chat): target group suggestion chips

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -24,7 +24,7 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   // Injects the coven roster into each send so a familiar knows who else is present.
   assert.match(view, /renderCovenRoundtablePrompt\(\{/, "builds the per-familiar roundtable prompt");
   assert.match(view, /receivingFamiliarId: r\.familiarId/, "marks the receiving familiar in prompt context");
-  assert.match(view, /targeted: mentioned\.length > 0/, "tells the prompt whether the user targeted this reply");
+  assert.match(view, /targeted,/, "tells the prompt whether the user targeted this reply");
   assert.doesNotMatch(view, /renderCovenContext\(contextTurns, r\.familiarId/, "default group chat does not relay peer replies");
   assert.doesNotMatch(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "full-coven broadcasts no longer switch to sequential relay");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
@@ -34,24 +34,39 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
     /const \{ visible: visibleText, suggestions \} = extractNextPaths\(r\.text\)/,
     "strips the next-paths block and parses suggestions from coven replies",
   );
-  // Parsed suggestions render as click-to-send chips that broadcast the line.
+  // Parsed suggestions render as click-to-send chips targeted to their author.
   assert.match(
     view,
     /className="cave-next-paths mt-1\.5" data-count=\{suggestions\.length\}/,
     "renders the next-paths chip row, stamping its count for the uniform-rows layout",
   );
-  assert.match(view, /onClick=\{\(\) => void broadcast\(s\)\}/, "clicking a chip broadcasts the suggestion");
+  assert.match(
+    view,
+    /sendSuggestion\(s, r\.familiarId, f\?\.display_name \?\? r\.familiarId\)/,
+    "clicking a chip targets the familiar who authored it",
+  );
+  assert.match(
+    view,
+    /broadcast\(`@\$\{displayName\} \$\{suggestion\}`, \[familiarId\]\)/,
+    "suggestion sends prefix the author's display name and route by their id",
+  );
+  assert.match(
+    view,
+    /const mentioned = explicitTargetFamiliarIds \? \[\] : parseMentions\(text, mentionable\)/,
+    "mentions inside a suggestion cannot expand its explicit target",
+  );
+  assert.match(view, /disabled=\{busy\}/, "chips are disabled while a send is active");
 });
 
 test("@mentions target a subset of the coven", () => {
   // Send routes to mentioned familiars only, falling back to the full roster.
-  assert.match(view, /const mentioned = parseMentions\(text, mentionable\)/, "parses @mentions on send");
+  assert.match(view, /explicitTargetFamiliarIds \? \[\] : parseMentions\(text, mentionable\)/, "parses @mentions on untargeted sends");
   assert.match(
     view,
-    /mentioned\.length > 0 \? group\.familiarIds\.filter/,
+    /mentioned\.length > 0\s*\? group\.familiarIds\.filter/,
     "targets only mentioned familiars, else broadcasts to all",
   );
-  assert.match(view, /targetFamiliarIds: mentioned\.length > 0/, "records the targeted ids on the user turn");
+  assert.match(view, /targetFamiliarIds: targeted/, "records the targeted ids on the user turn");
   assert.match(view, /replies: GroupReply\[\] = targetIds\.map/, "only the targets reply");
   // Composer autocomplete reuses the tested pure helpers.
   assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -444,18 +444,24 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   );
 
   const broadcast = useCallback(
-    async (rawText: string) => {
+    async (rawText: string, explicitTargetFamiliarIds?: string[]) => {
       const group = activeGroupRef.current;
       const text = rawText.trim();
       if (!group || group.familiarIds.length === 0 || !text || busy || abortRef.current) return;
-      // Tagging a subset of familiars with `@mentions` targets the message at just
-      // those participants; with no mention it broadcasts to the whole coven.
+      // A suggestion chip carries its author's id explicitly. Its display text may
+      // contain @mentions, but those must not expand the authoritative target.
+      // Composer messages continue to target @mentions or the whole coven.
       const mentionable: MentionableFamiliar[] = group.familiarIds.map((id) => ({
         id,
         name: byId.get(id)?.display_name ?? "",
       }));
-      const mentioned = parseMentions(text, mentionable);
-      const targetIds = mentioned.length > 0 ? group.familiarIds.filter((id) => mentioned.includes(id)) : group.familiarIds;
+      const mentioned = explicitTargetFamiliarIds ? [] : parseMentions(text, mentionable);
+      const targetIds = explicitTargetFamiliarIds
+        ? group.familiarIds.filter((id) => explicitTargetFamiliarIds.includes(id))
+        : mentioned.length > 0
+          ? group.familiarIds.filter((id) => mentioned.includes(id))
+          : group.familiarIds;
+      const targeted = explicitTargetFamiliarIds !== undefined || mentioned.length > 0;
       // Roster reflects the FULL coven (not just @mention targets) — a familiar
       // should know who else is in the room even when addressed alone. Composed
       // per-familiar so each sees itself marked "(you)".
@@ -473,7 +479,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         id: newId(),
         role: "user",
         text,
-        targetFamiliarIds: mentioned.length > 0 ? targetIds : undefined,
+        targetFamiliarIds: targeted ? targetIds : undefined,
         createdAt: at,
       };
       const replies: GroupReply[] = targetIds.map((fid) => ({
@@ -504,7 +510,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
               participants: rosterParticipants,
               receivingFamiliarId: r.familiarId,
               userText: text,
-              targeted: mentioned.length > 0,
+              targeted,
             }),
             controller.signal,
           ),
@@ -533,8 +539,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   );
 
   // The composer and "click a next-path suggestion to send" chips both go
-  // through broadcast — a clicked suggestion is just a one-tap next prompt.
+  // through broadcast. A suggestion is a one-tap targeted follow-up to its author.
   const send = useCallback(() => broadcast(draft), [broadcast, draft]);
+  const sendSuggestion = useCallback(
+    (suggestion: string, familiarId: string, displayName: string) =>
+      broadcast(`@${displayName} ${suggestion}`, [familiarId]),
+    [broadcast],
+  );
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
@@ -997,7 +1008,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                           key={i}
                                           type="button"
                                           className={`cave-next-path${recommended ? " cave-next-path--recommended" : ""}`}
-                                          onClick={() => void broadcast(s)}
+                                          onClick={() => void sendSuggestion(s, r.familiarId, f?.display_name ?? r.familiarId)}
                                           disabled={busy}
                                           aria-label={recommended ? `Recommended: ${s}` : undefined}
                                           title={recommended ? "Recommended next step" : undefined}


### PR DESCRIPTION
# fix(chat): target group suggestion chips

## Summary

Group-chat next-path suggestion chips previously rebroadcast their text to every familiar. This change sends each suggestion only to the familiar that authored it, while displaying the author-directed `@DisplayName` text in the transcript.

Fixes #3336

## Changes

- Added an explicit-target send path that keeps a suggestion author’s familiar ID authoritative, even if the suggestion text contains other mentions.
- Routed suggestion chips through that path and preserved the existing busy-state disabling.
- Updated component-source assertions for targeted suggestion behavior.

## Testing

- Passed: `sandbox-run "node --experimental-strip-types --test src/components/group-chat-view.test.ts"`
- Attempted: `sandbox-run "pnpm typecheck"` (sandbox command wrapper attempted to change to a nonexistent `repo` directory before running the project command, so the typecheck did not execute.)

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
