### PR TITLE
feat(chat): composer footer band — project · runtime/model · git · tasks move out of the input box

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -301,6 +301,7 @@ export const SUITES = {
     "src/components/message-bubble-jump-to-line.test.ts",
     "src/components/message-bubble-file-links.test.ts",
     "src/components/chat-view-polish.test.ts",
+    "src/components/chat-composer-footer-band.test.ts",
     "src/components/composer-runtime-chip.test.ts",
     "src/components/composer-git-chip.test.ts",
     "src/components/chat-siderail-hide-archived.test.ts",

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -1,0 +1,99 @@
+// @ts-nocheck
+// Source pins for the chat composer footer band (cave-8eo2): the session's
+// metadata — project · runtime/model · git context · linked tasks — rides a
+// darker band attached to the composer panel's underside (the home composer's
+// hc-footer-band grammar), moved OUT of the input's control row and the chat
+// header so the write surface above stays a minimal box: textarea + attach /
+// voice / Options on the left, enhance / send on the right.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+
+// ── The band is the panel's last section, after the control row ─────────────
+assert.match(
+  source,
+  /className="cave-composer-controls"[\s\S]*?className="cave-composer-footer-band"/,
+  "the footer band renders after the composer controls, inside the panel",
+);
+
+// ── Band contents: project · runtime · git on the left, tasks on the right ──
+assert.match(
+  source,
+  /className="cave-composer-footer-band">\s*<div className="cave-composer-footer-band__context">\s*<ProjectPicker/,
+  "the band's context cluster leads with the project picker",
+);
+assert.match(
+  source,
+  /<ProjectPicker\s*\n\s*projects=\{projects\}\s*\n\s*value=\{resolvedProjectId\}\s*\n\s*onChange=\{setProjectIdDraft\}\s*\n\s*allowNoProject/,
+  "the project chip shows the RESOLVED selection (draft → task project → session cwd) and writes the draft",
+);
+assert.match(
+  source,
+  /createProject=\{createProject\}[\s\S]{0,200}?className="cave-chat-project-selector"/,
+  "the project chip folds in the add-project flow (register + grant) like the home band",
+);
+assert.match(
+  source,
+  /className="cave-composer-footer-band__context">[\s\S]{0,900}?<ComposerRuntimeChip[\s\S]{0,900}?<ComposerGitChip projectRoot=\{activeProjectRoot\} onOpenUrl=\{onOpenUrl\} \/>/,
+  "runtime/model and git context sit beside the project chip in the band",
+);
+assert.match(
+  source,
+  /className="cave-composer-footer-band">[\s\S]*?\{linkedContextRow\}\s*\n\s*<\/div>/,
+  "the linked-context strip (tasks · GitHub · link/create) trails the band",
+);
+
+// ── The input box is minimal: no metadata chips in the utility row ───────────
+const utilityRow = source.match(
+  /className="cave-composer-utility-row">[\s\S]*?<\/div>\s*<div className="cave-composer-submit-row">/,
+)?.[0] ?? "";
+assert.ok(utilityRow, "chat composer utility row is present");
+assert.doesNotMatch(
+  utilityRow,
+  /ComposerRuntimeChip|ComposerGitChip/,
+  "the utility row carries no runtime/git metadata — attach · voice · Options only",
+);
+
+// ── The header no longer hosts the linked-context strip ─────────────────────
+const header = source.match(/<header className="cave-chat-linear-header[\s\S]*?<\/header>/)?.[0] ?? "";
+assert.ok(header, "chat header is present");
+assert.doesNotMatch(
+  header,
+  /linkedContextRow/,
+  "the header renders MetaLine only — the linked-context strip moved to the band",
+);
+
+// ── Band chrome: attached underside strip, one tone deeper ──────────────────
+assert.match(
+  css,
+  /\.cave-composer-footer-band \{[\s\S]*?border-top: 1px solid var\(--border-hairline\);[\s\S]*?background: color-mix\(in oklch, var\(--bg-base\) 62%, transparent\);/,
+  "the band is the darker hairline-topped strip clipped into the panel's bottom corners",
+);
+assert.match(
+  css,
+  /\.cave-composer-footer-band .cave-project-picker__trigger\.cave-chat-project-selector \{[\s\S]*?height: 30px;[\s\S]*?border-radius: var\(--radius-pill\);/,
+  "the project chip matches the 30px pill family of the chips beside it",
+);
+
+// ── Reveal + mobile behavior ─────────────────────────────────────────────────
+assert.match(
+  css,
+  /\.cave-composer-footer-band:hover \.cave-chat-linked-context \.cave-chat-linked-chip--link-task/,
+  "the bare link-a-task affordance reveals on band hover (was header hover)",
+);
+assert.match(
+  css,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-footer-band,\s*\.cave-composer-footer-band__context \{\s*flex-wrap: wrap;/,
+  "phone widths wrap the band's chips instead of crushing them",
+);
+// On phones the linked-context cluster stays hidden (class-wide rule) — the
+// header's MobileHeaderTask chip carries the affiliation there.
+assert.match(
+  css,
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-chat-meta-line,\s*\.cave-chat-linked-context \{\s*display: none;/,
+  "mobile hides the band's linked-context cluster in favor of MobileHeaderTask",
+);
+
+console.log("chat-composer-footer-band.test.ts: ok");

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -571,20 +571,20 @@ assert.match(
 assert.match(
   source,
   /<LinkedContextRow\b/,
-  "ChatView header should render LinkedContextRow for task/GitHub chips",
+  "ChatView should render LinkedContextRow for task/GitHub chips",
 );
-// Slim header: the linked-context strip only earns its own header row when
-// there are actual chips; the bare "link a task" affordance rides inline with
-// the session actions so an unlinked session's header stays one row.
+// Footer band (cave-8eo2): the linked-context strip rides the composer footer
+// band — beside the project, runtime, and git chips — not the header, so the
+// header stays one row and the metadata reads where the message is written.
 assert.match(
   source,
-  /const hasLinkedChips =[\s\S]*?Boolean\(linkedContext\?\.task\)/,
-  "ChatView derives hasLinkedChips from the linked context",
+  /className="cave-composer-footer-band">[\s\S]*?\{linkedContextRow\}/,
+  "The linked-context row rides the composer footer band",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /\{!hasLinkedChips \? linkedContextRow : null\}[\s\S]*?<\/MetaLine>[\s\S]*?\{hasLinkedChips \? linkedContextRow : null\}/,
-  "The linked-context row renders inline with session actions when chip-less, and as its own header row only with chips",
+  /hasLinkedChips/,
+  "The header no longer hosts the linked-context row (no chip-count gating)",
 );
 
 assert.doesNotMatch(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -133,7 +133,7 @@ import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
 import { SaveTemplateModal } from "@/components/save-template-modal";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
-import { ProjectPickerPopover, useAddProjectFlow } from "@/components/project-picker";
+import { ProjectPicker, ProjectPickerPopover, useAddProjectFlow } from "@/components/project-picker";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolVisual } from "@/lib/tool-visual";
 import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
@@ -5177,14 +5177,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
-  // Slim header: the linked-context strip only earns its own header row when
-  // there are actual task/GitHub chips to show. A bare "link a task" affordance
-  // rides inline with the session actions instead, so an unlinked session's
-  // header is one row (title + meta), not title + a mostly-empty second band.
-  const hasLinkedChips =
-    Boolean(linkedContext?.task) ||
-    (linkedContext?.tasks?.length ?? 0) > 0 ||
-    (linkedContext?.github?.length ?? 0) > 0;
+  // The linked-context strip (task/GitHub chips + link/create affordances)
+  // rides the composer footer band — beside the project, runtime, and git
+  // context — so the header stays one row (title + meta) and the chat's
+  // metadata reads where the message is written, not as chrome above it.
   const linkedContextRow = (
     <LinkedContextRow
       linkedContext={linkedContext}
@@ -5304,10 +5300,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               />
             )}
             {overflowAddProject.addProjectModal}
-            {!hasLinkedChips ? linkedContextRow : null}
           </div>
         </MetaLine>
-        {hasLinkedChips ? linkedContextRow : null}
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       {/* Stage header keys on the SESSION's root — the same source the rail
@@ -5912,17 +5906,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       } satisfies ComposerOptionSection,
                     ]}
                   />
-                  <ComposerRuntimeChip
-                    runtime={modelHarness}
-                    modelValue={composerModelValue}
-                    modelOptions={composerModelOptions}
-                    onPickRuntime={handleSelectRuntime}
-                    onPickModel={handleSelectModel}
-                    disabled={busy}
-                  />
-                  {/* Git context — branch · dirty count · worktree · PR — for
-                      chats rooted in a git repo (hidden otherwise). */}
-                  <ComposerGitChip projectRoot={activeProjectRoot} onOpenUrl={onOpenUrl} />
                 </div>
                 <div className="cave-composer-submit-row">
                   <EnhanceControl
@@ -5955,6 +5938,37 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   )}
                 </div>
               </div>
+            </div>
+            {/* Footer band — the darker strip attached to the panel's underside
+                (home-composer parity): where the message runs (project ·
+                runtime/model · git) plus the work it's tied to (linked tasks).
+                Session metadata lives here, OUT of the input's control row, so
+                the box above stays a minimal write surface. */}
+            <div className="cave-composer-footer-band">
+              <div className="cave-composer-footer-band__context">
+                <ProjectPicker
+                  projects={projects}
+                  value={resolvedProjectId}
+                  onChange={setProjectIdDraft}
+                  allowNoProject
+                  familiarId={familiar.id ?? null}
+                  createProject={createProject}
+                  ariaLabel="Project for this chat"
+                  className="cave-chat-project-selector"
+                />
+                <ComposerRuntimeChip
+                  runtime={modelHarness}
+                  modelValue={composerModelValue}
+                  modelOptions={composerModelOptions}
+                  onPickRuntime={handleSelectRuntime}
+                  onPickModel={handleSelectModel}
+                  disabled={busy}
+                />
+                {/* Git context — branch · dirty count · worktree · PR — for
+                    chats rooted in a git repo (hidden otherwise). */}
+                <ComposerGitChip projectRoot={activeProjectRoot} onOpenUrl={onOpenUrl} />
+              </div>
+              {linkedContextRow}
             </div>
           </div>
         </div>

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -50,8 +50,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /<ComposerOptionsMenu[\s\S]*?\/>\s*\n\s*<ComposerRuntimeChip/,
-  "the chip sits in the utility row after the Options menu — always visible, session or not",
+  /className="cave-composer-footer-band__context"[\s\S]{0,700}?<ComposerRuntimeChip/,
+  "the chip sits in the composer footer band's context cluster — always visible, session or not",
 );
 
 // ── Runtime switching is real: familiar-level config, optimistic + refetch ──

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -41,7 +41,7 @@ import {
 // or raise them with an explicit justification in your PR.
 const BASELINES = {
   offScaleFontSizePx: 173, // 10.5px/11.5px/… — need per-case renormalization to the type scale
-  offScaleSpacingPx: 1351, // off-4px-grid pad/margin/gap components (2px/6px/10px/…)
+  offScaleSpacingPx: 1355, // off-4px-grid pad/margin/gap components (2px/6px/10px/…) — +4: the chat composer footer band copies the home hc-footer-band metrics verbatim (6px 10px pad, 6px gap, 11px chip pad) for cross-composer parity
   offScaleRadiusPx: 213, // 4px/6px/10px/14px/… radii between the sanctioned steps
   hexOutsideDefinitions: 157, // hex in render CSS (token definitions excluded)
   inlineTsxStyles: 510, // style={{…}} in TSX; many are legit dynamic values

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2482,6 +2482,60 @@ details[open] > .cave-tool-summary::before {
   justify-content: flex-end;
 }
 
+/* ── Footer band ─────────────────────────────────────────────────────────────
+ * The darker strip attached to the panel's underside (home composer's
+ * hc-footer-band, same grammar): the chat's session metadata — project ·
+ * runtime/model · git context on the left, linked tasks/GitHub on the right —
+ * moved OUT of the input's control row so the write surface above stays
+ * minimal. Last child of .cave-composer-panel, so the panel's overflow clips
+ * it into the rounded bottom corners; it reads as the card, one tone deeper. */
+.cave-composer-footer-band {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: 6px 10px;
+  border-top: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+}
+
+.cave-composer-footer-band__context {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* The linked-task cluster hugs the trailing edge; its own overflow-x keeps a
+   long chip run scrolling internally instead of widening the band. */
+.cave-composer-footer-band > .cave-chat-linked-context {
+  flex: 0 1 auto;
+}
+
+/* Project chip — same 30px pill family as the runtime chip beside it (the
+   home band's treatment, scoped to the chat selector class). */
+.cave-composer-footer-band .cave-project-picker__trigger.cave-chat-project-selector {
+  height: 30px;
+  min-height: 30px;
+  max-width: 200px;
+  padding: 0 11px 0 var(--space-2);
+  font-size: var(--text-xs);
+  border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
+}
+
+.cave-composer-footer-band .cave-project-picker__trigger.cave-chat-project-selector:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 36%, transparent);
+}
+
+.cave-composer-footer-band .cave-project-picker__trigger.cave-chat-project-selector .cave-project-picker__trigger-label {
+  max-width: 132px;
+}
+
 .cave-composer-icon-button {
   border-color: color-mix(in oklch, var(--foreground) 10%, transparent);
   background: color-mix(in oklch, var(--bg-surface) 52%, transparent);
@@ -3128,10 +3182,11 @@ details[open] > .cave-tool-summary::before {
 }
 
 /* Ultra-minimal header (pointer devices): at rest only the ⋮ kebab and the
- * find affordance show; the lone "link a task" chip reveals on header hover or
- * keyboard focus, keeping its layout slot (no reflow on reveal). Touch devices
- * — which have no hover — skip this and show everything. The kebab holds every
- * secondary action, so nothing becomes hover-only. */
+ * find affordance show — they reveal on header hover or keyboard focus,
+ * keeping their layout slots (no reflow on reveal). The composer footer
+ * band's lone "link a task" chip follows the same rhythm against the band.
+ * Touch devices — which have no hover — skip this and show everything. The
+ * kebab holds every secondary action, so nothing becomes hover-only. */
 @media (hover: hover) and (pointer: fine) {
   .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find),
   .cave-chat-linked-context .cave-chat-linked-chip--link-task {
@@ -3146,7 +3201,7 @@ details[open] > .cave-tool-summary::before {
   .cave-chat-linear-header:hover .cave-chat-session-actions > .focus-ring,
   .cave-chat-session-actions:focus-within > .focus-ring,
   .cave-chat-session-actions:has([aria-expanded="true"]) > .focus-ring,
-  .cave-chat-linear-header:hover .cave-chat-linked-context .cave-chat-linked-chip--link-task,
+  .cave-composer-footer-band:hover .cave-chat-linked-context .cave-chat-linked-chip--link-task,
   .cave-chat-linked-context:focus-within .cave-chat-linked-chip--link-task {
     opacity: 1;
     transform: none;
@@ -3968,8 +4023,10 @@ details[open] > .cave-tool-summary::before {
     overflow: hidden;
   }
 
-  /* Mobile keeps its own identity rail + context menu; the desktop meta
-     line and linked-context chips would double-report there. */
+  /* Mobile keeps its own identity rail + context menu; the desktop meta line
+     would double-report there, and the footer band's linked-context cluster
+     yields to the header's MobileHeaderTask chip (the band keeps project ·
+     runtime · git, which have no mobile twin). */
   .cave-chat-meta-line,
   .cave-chat-linked-context {
     display: none;
@@ -4212,6 +4269,13 @@ details[open] > .cave-tool-summary::before {
   }
 
   .cave-composer-utility-row {
+    flex-wrap: wrap;
+  }
+
+  /* Phone width: the band's context chips wrap instead of crushing each
+     other (home band's rhythm). */
+  .cave-composer-footer-band,
+  .cave-composer-footer-band__context {
     flex-wrap: wrap;
   }
 


### PR DESCRIPTION
## What

The chat input box carried its session metadata inline — runtime/model + git chips in the utility row, project behind the kebab, linked-task strip on its own header row. This adopts the **home composer's footer-band grammar** for the chat composer (`hc-footer-band` → `cave-composer-footer-band`):

- **Footer band** attached to the composer panel's underside now shows: **project** (shared `ProjectPicker` wired to the resolved selection `resolvedProjectId` → `setProjectIdDraft`, add-project flow included) · **runtime/model** (`ComposerRuntimeChip`) · **git context** (`ComposerGitChip`) · **linked tasks/GitHub** (`LinkedContextRow`, trailing).
- **Input box is now minimal**: textarea + attach/voice/Options left, enhance/send right.
- **Header stays one row** (title + meta) — the linked-context strip no longer claims a header row.
- Mobile: band chips wrap; the linked-context cluster stays hidden <768px in favor of the existing `MobileHeaderTask`; link-a-task hover reveal retargets from header hover to band hover.

Closes bead `cave-8eo2`.

## Screenshot

Clean input box with the metadata band attached beneath (project · runtime/model; git chip appears for repo-rooted chats, task chips when linked):

_(verified via Playwright against the production build — band is the panel's last child, clipped into the rounded corners; utility row carries no metadata chips; header carries no linked-context)_

## Tests

- New source pins: `src/components/chat-composer-footer-band.test.ts` (registered in `test:app`).
- Updated pins: `composer-runtime-chip.test.ts` (chip placement → band), `chat-view-polish.test.ts` (linked-row placement → band, `hasLinkedChips` gone).
- `design-token-drift.test.ts`: `offScaleSpacingPx` baseline +4 — the band copies the home `hc-footer-band` metrics verbatim (6px 10px pad, 6px gap, 11px chip pad) for cross-composer parity.

## Verification

- `pnpm typecheck` ✓
- `pnpm test:app` — 751 test files ✓
- e2e `composer-runtime-chip` (desktop) ✓ — locates the chip by accessible name, placement-agnostic
- e2e `chat-task-chip-nav` is flaky **on clean origin/main too** (3/3 identical failures on a baseline worktree, env-local `~/.coven` reconciliation + cold-compile) — pre-existing, not introduced here
- Playwright screenshot of the built app confirms band structure + minimal input box