### PR TITLE
feat(ios): re-attach to live chat runs mid-turn — resume cursor over the C2 ring (cave-h40l iOS half)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -369,10 +369,24 @@ struct CaveClient {
         var prompt: String
         var sessionId: String?
         var attachments: [ChatAttachment]?
+        /// Per-send client token (cave-h40l): the server keys its resumable
+        /// run buffer under this, so a NEW chat (no sessionId yet) is still
+        /// re-attachable after a transport drop.
+        var runId: String? = nil
     }
 
-    /// Open the SSE stream for a chat send. Yields decoded `StreamEvent`s.
-    func sendStream(_ body: SendBody) -> AsyncThrowingStream<StreamEvent, Error> {
+    /// One decoded SSE frame: the event plus the server's `id:` (the run
+    /// buffer seq). Consumers update their resume cursor AFTER applying the
+    /// event, so a drop can never skip or double a frame on resume.
+    struct StreamFrame {
+        let event: StreamEvent
+        /// Resume cursor as of this frame — nil until the server sends ids.
+        let id: Int?
+    }
+
+    /// Open the SSE stream for a chat send. Yields decoded frames — keep the
+    /// last applied frame's `id` to resume mid-turn via `resumeStream`.
+    func sendStream(_ body: SendBody) -> AsyncThrowingStream<StreamFrame, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
@@ -384,33 +398,56 @@ struct CaveClient {
                     let (bytes, resp) = try await Self.streamSession.bytes(for: req)
                     try Self.check(resp)
 
-                    var dataLines: [String] = []
+                    var parser = SSELineParser()
                     for try await line in bytes.lines {
-                        let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if trimmedLine.isEmpty {
-                            // Blank line = event boundary. Flush accumulated data.
-                            if !dataLines.isEmpty {
-                                let joined = dataLines.joined(separator: "\n")
-                                if let event = StreamEvent.decode(joined) {
-                                    continuation.yield(event)
-                                }
-                                dataLines.removeAll()
-                            }
-                            continue
+                        if let event = parser.consume(line) {
+                            continuation.yield(StreamFrame(event: event, id: parser.lastEventId))
                         }
-                        if trimmedLine.hasPrefix("data:") {
-                            let payload = String(trimmedLine.dropFirst(5)).trimmingCharacters(in: .whitespaces)
-                            if let event = StreamEvent.decode(payload) {
-                                continuation.yield(event)
-                                continue
-                            }
-                            dataLines.append(payload)
-                        }
-                        // ignore other SSE fields (event:, id:, :comment)
                     }
                     // Flush any trailing event with no terminating blank line.
-                    if !dataLines.isEmpty, let event = StreamEvent.decode(dataLines.joined(separator: "\n")) {
-                        continuation.yield(event)
+                    if let event = parser.flush() {
+                        continuation.yield(StreamFrame(event: event, id: parser.lastEventId))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Signals `GET /api/chat/stream` had no buffered run for the key — the
+    /// turn finished long ago or the server restarted. Callers fall back to
+    /// the post-hoc transcript resync.
+    struct NoResumableRun: Error {}
+
+    /// Re-attach to a LIVE chat run after a transport drop (cave-h40l).
+    /// Replays buffered events past `cursor` (the last applied frame id),
+    /// then tails the run live; the server disarms its detach-cap kill while
+    /// a tail is attached. Throws `NoResumableRun` on 404.
+    func resumeStream(runId: String, cursor: Int) -> AsyncThrowingStream<StreamFrame, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var req = try request("api/chat/stream?runId=\(urlQuery(runId))&cursor=\(cursor)")
+                    req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                    req.timeoutInterval = 600
+
+                    let (bytes, resp) = try await Self.streamSession.bytes(for: req)
+                    if (resp as? HTTPURLResponse)?.statusCode == 404 {
+                        throw NoResumableRun()
+                    }
+                    try Self.check(resp)
+
+                    var parser = SSELineParser()
+                    for try await line in bytes.lines {
+                        if let event = parser.consume(line) {
+                            continuation.yield(StreamFrame(event: event, id: parser.lastEventId))
+                        }
+                    }
+                    if let event = parser.flush() {
+                        continuation.yield(StreamFrame(event: event, id: parser.lastEventId))
                     }
                     continuation.finish()
                 } catch {

--- a/apps/ios/CovenCave/CovenCave/Networking/SSELineParser.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/SSELineParser.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Incremental parser for one SSE (`text/event-stream`) connection, shared by
+/// the original send stream and the mid-turn resume stream (cave-h40l).
+///
+/// Feed it lines; it returns a decoded `StreamEvent` whenever a frame
+/// completes, and tracks the last `id:` seen — the server puts the run
+/// buffer's seq there, so `lastEventId` is always a valid resume cursor for
+/// `GET /api/chat/stream?cursor=`.
+struct SSELineParser {
+    /// Last `id:` field seen — the resume cursor. Nil until the server sends one.
+    private(set) var lastEventId: Int?
+    private var dataLines: [String] = []
+
+    /// Consume one line. Returns a decoded event when the line completes a
+    /// frame (single-`data:` fast path or blank-line boundary), else nil.
+    mutating func consume(_ line: String) -> StreamEvent? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            // Blank line = frame boundary. Flush accumulated data.
+            return flush()
+        }
+        if trimmed.hasPrefix("id:") {
+            let value = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+            if let id = Int(value) { lastEventId = id }
+            return nil
+        }
+        if trimmed.hasPrefix("data:") {
+            let payload = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            // Fast path: most frames are one data line; decode immediately so
+            // a missing trailing blank line can't strand the final event.
+            if dataLines.isEmpty, let event = StreamEvent.decode(payload) {
+                return event
+            }
+            dataLines.append(payload)
+            return nil
+        }
+        // Other SSE fields (event:, retry:, ": comment" keep-alives) are ignored.
+        return nil
+    }
+
+    /// Flush any buffered multi-line frame — call at end of stream too, so a
+    /// trailing event with no terminating blank line still decodes.
+    mutating func flush() -> StreamEvent? {
+        guard !dataLines.isEmpty else { return nil }
+        let joined = dataLines.joined(separator: "\n")
+        dataLines.removeAll()
+        return StreamEvent.decode(joined)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -252,39 +252,42 @@ final class ChatThread: Identifiable, Hashable {
                         attachments: [CaveClient.ChatAttachment] = [], into messageId: String,
                         userMessageId: String? = nil,
                         client: CaveClient, onChange: @escaping () -> Void) async {
+        // Per-send token: the server keys its resumable run buffer under this
+        // (cave-h40l), so even a brand-new chat (no sessionId yet) can
+        // re-attach mid-turn after a transport drop.
+        let runId = UUID().uuidString
         let body = CaveClient.SendBody(familiarId: familiarId, prompt: prompt,
                                        sessionId: sessionIds[familiarId],
-                                       attachments: attachments.isEmpty ? nil : attachments)
+                                       attachments: attachments.isEmpty ? nil : attachments,
+                                       runId: runId)
         var receivedAnyEvent = false
+        // Resume cursor: the last applied frame's SSE id (run-buffer seq).
+        var cursor = 0
+        var sawDone = false
         do {
-            for try await event in client.sendStream(body) {
+            for try await frame in client.sendStream(body) {
                 receivedAnyEvent = true
-                switch event {
-                case .session(let sid):
-                    if !sid.isEmpty { sessionIds[familiarId] = sid }
-                case .assistantChunk(let chunk):
-                    mutate(messageId) { $0.text += chunk }
-                    onChange()
-                case .done(let isError, let sid):
-                    if let sid, !sid.isEmpty { sessionIds[familiarId] = sid }
-                    mutate(messageId) { $0.streaming = false; if isError { $0.isError = true } }
-                case .error(let message):
-                    mutate(messageId) {
-                        if $0.text.isEmpty { $0.text = message }
-                        $0.isError = true; $0.streaming = false
-                    }
-                default:
-                    break
-                }
+                apply(frame.event, into: messageId, familiarId: familiarId,
+                      sawDone: &sawDone, onChange: onChange)
+                if let id = frame.id { cursor = id }
             }
             mutate(messageId) { $0.streaming = false }
         } catch {
             // Transport interruption (network handoff, backgrounding, desktop
-            // blip). The server persists the turn — including a partial reply
-            // — even when the stream dies, so recover its copy before
-            // surfacing a raw connection error.
-            let recovered = await resyncInterruptedTurn(familiarId: familiarId, prompt: prompt,
+            // blip). The run is usually STILL LIVE server-side — re-attach to
+            // its buffered stream first and keep rendering in real time
+            // (cave-h40l). Only when no resumable run exists (finished long
+            // ago / server restarted) fall back to adopting the persisted
+            // transcript.
+            let resumed = await resumeInterruptedStream(runId: runId, cursor: cursor,
+                                                        into: messageId, familiarId: familiarId,
+                                                        sawDone: &sawDone,
+                                                        client: client, onChange: onChange)
+            var recovered = resumed
+            if !recovered {
+                recovered = await resyncInterruptedTurn(familiarId: familiarId, prompt: prompt,
                                                         into: messageId, client: client)
+            }
             if !recovered {
                 if let userMessageId, !receivedAnyEvent, Self.isOfflineTransportError(error) {
                     // The send never reached the server (no route, DNS failure,
@@ -305,6 +308,67 @@ final class ChatThread: Identifiable, Hashable {
         }
         updatedAt = Date()
         onChange()
+    }
+
+    /// Apply one stream event to the thread — shared by the original send
+    /// stream and the mid-turn resume stream so both render identically.
+    private func apply(_ event: StreamEvent, into messageId: String, familiarId: String,
+                       sawDone: inout Bool, onChange: @escaping () -> Void) {
+        switch event {
+        case .session(let sid):
+            if !sid.isEmpty { sessionIds[familiarId] = sid }
+        case .assistantChunk(let chunk):
+            mutate(messageId) { $0.text += chunk }
+            onChange()
+        case .done(let isError, let sid):
+            if let sid, !sid.isEmpty { sessionIds[familiarId] = sid }
+            mutate(messageId) { $0.streaming = false; if isError { $0.isError = true } }
+            sawDone = true
+        case .error(let message):
+            mutate(messageId) {
+                if $0.text.isEmpty { $0.text = message }
+                $0.isError = true; $0.streaming = false
+            }
+        default:
+            break
+        }
+    }
+
+    /// Re-attach to the still-live run after a transport drop: replay past
+    /// the cursor, then tail live until the turn ends. A few short-backoff
+    /// attempts ride out the network still settling (Wi-Fi handoff, tunnel
+    /// re-established). Returns true when the bubble finished live; false
+    /// falls back to the post-hoc transcript resync.
+    private func resumeInterruptedStream(runId: String, cursor: Int, into messageId: String,
+                                         familiarId: String, sawDone: inout Bool,
+                                         client: CaveClient, onChange: @escaping () -> Void) async -> Bool {
+        var nextCursor = cursor
+        for attempt in 0..<3 {
+            if attempt > 0 {
+                try? await Task.sleep(for: .milliseconds(600 * Int64(attempt)))
+            }
+            do {
+                for try await frame in client.resumeStream(runId: runId, cursor: nextCursor) {
+                    apply(frame.event, into: messageId, familiarId: familiarId,
+                          sawDone: &sawDone, onChange: onChange)
+                    if let id = frame.id { nextCursor = id }
+                }
+                // The resume stream closes when the run finishes. Without a
+                // done event the run may still be live (our tail dropped
+                // again) — retry from the advanced cursor.
+                if sawDone {
+                    mutate(messageId) { $0.streaming = false }
+                    return true
+                }
+            } catch is CaveClient.NoResumableRun {
+                // Nothing buffered under that run — turn ended long ago or
+                // the server restarted. Post-hoc resync owns recovery.
+                return false
+            } catch {
+                // Transport still flaky — back off and retry from the cursor.
+            }
+        }
+        return false
     }
 
     /// After a transport failure mid-stream, pull the persisted conversation

--- a/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
@@ -379,9 +379,9 @@ struct DiaryView: View {
                                        attachments: nil)
         streamTask = Task { @MainActor in
             do {
-                for try await event in client.sendStream(body) {
+                for try await frame in client.sendStream(body) {
                     if Task.isCancelled { return }
-                    switch event {
+                    switch frame.event {
                     case .session(let sid):
                         if !sid.isEmpty { sessionId = sid }
                     case .assistantChunk(let chunk):

--- a/apps/ios/CovenCave/CovenCaveTests/SSELineParserTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/SSELineParserTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import CovenCave
+
+/// SSELineParser is the shared frame decoder for the send stream AND the
+/// mid-turn resume stream (cave-h40l). Its `lastEventId` is the resume
+/// cursor, so exact-once semantics across a drop hang on these behaviors.
+final class SSELineParserTests: XCTestCase {
+    func testSingleDataLineDecodesImmediately() {
+        var parser = SSELineParser()
+        let event = parser.consume(#"data: {"kind":"assistant_chunk","text":"hi"}"#)
+        guard case .assistantChunk(let text)? = event else {
+            return XCTFail("expected assistant_chunk, got \(String(describing: event))")
+        }
+        XCTAssertEqual(text, "hi")
+    }
+
+    func testIdLineSetsResumeCursorBeforeItsEvent() {
+        var parser = SSELineParser()
+        XCTAssertNil(parser.consume("id: 7"))
+        XCTAssertEqual(parser.lastEventId, 7)
+        let event = parser.consume(#"data: {"kind":"assistant_chunk","text":"x"}"#)
+        XCTAssertNotNil(event)
+        // The frame's cursor is the id the server sent WITH it — a consumer
+        // that stores lastEventId after applying the event resumes exactly
+        // after this frame, never skipping or doubling it.
+        XCTAssertEqual(parser.lastEventId, 7)
+    }
+
+    func testEventsWithoutIdsLeaveCursorNil() {
+        var parser = SSELineParser()
+        _ = parser.consume(#"data: {"kind":"user","text":"hello"}"#)
+        XCTAssertNil(parser.lastEventId, "no id: line means no resume cursor — resume starts from 0")
+    }
+
+    func testKeepAliveCommentsAndUnknownFieldsAreIgnored() {
+        var parser = SSELineParser()
+        XCTAssertNil(parser.consume(": hb"))
+        XCTAssertNil(parser.consume("event: message"))
+        XCTAssertNil(parser.consume("retry: 500"))
+        XCTAssertNil(parser.consume(""))
+        XCTAssertNil(parser.lastEventId)
+    }
+
+    func testMalformedIdIsIgnoredNotAdopted() {
+        var parser = SSELineParser()
+        XCTAssertNil(parser.consume("id: not-a-number"))
+        XCTAssertNil(parser.lastEventId)
+        _ = parser.consume("id: 3")
+        XCTAssertEqual(parser.lastEventId, 3)
+    }
+
+    func testTrailingFrameWithoutBlankLineFlushes() {
+        var parser = SSELineParser()
+        // A first data line that fails immediate decode is buffered…
+        XCTAssertNil(parser.consume("data: {\"kind\":"))
+        // …joined by a continuation, and recovered by the end-of-stream flush.
+        XCTAssertNil(parser.consume(#"data: "done"}"#))
+        let event = parser.flush()
+        guard case .done? = event else {
+            return XCTFail("expected done from multi-line flush, got \(String(describing: event))")
+        }
+        XCTAssertNil(parser.flush(), "flush drains the buffer")
+    }
+
+    func testBlankLineBoundaryFlushesBufferedFrame() {
+        var parser = SSELineParser()
+        XCTAssertNil(parser.consume("data: {\"kind\":"))
+        XCTAssertNil(parser.consume(#"data: "error","message":"boom"}"#))
+        let event = parser.consume("")
+        guard case .error(let message)? = event else {
+            return XCTFail("expected error frame at boundary, got \(String(describing: event))")
+        }
+        XCTAssertEqual(message, "boom")
+    }
+
+    func testCursorAdvancesAcrossFrames() {
+        var parser = SSELineParser()
+        _ = parser.consume("id: 1")
+        _ = parser.consume(#"data: {"kind":"user","text":"q"}"#)
+        _ = parser.consume("id: 2")
+        let second = parser.consume(#"data: {"kind":"assistant_chunk","text":"a"}"#)
+        XCTAssertNotNil(second)
+        XCTAssertEqual(parser.lastEventId, 2)
+    }
+}

--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -96,15 +96,30 @@ assert.match(
 );
 
 const swiftCaveClient = read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+// The SSE frame decoding moved into the shared SSELineParser (cave-h40l) so
+// the send stream and the mid-turn resume stream parse identically — the
+// fast-path and boundary behaviors are pinned there (and unit-tested in
+// CovenCaveTests/SSELineParserTests.swift).
+const swiftSseParser = read("apps/ios/CovenCave/CovenCave/Networking/SSELineParser.swift");
 assert.match(
   swiftCaveClient,
-  /if let event = StreamEvent\.decode\(payload\) \{\s*\n\s*continuation\.yield\(event\)\s*\n\s*continue\s*\n\s*\}/,
+  /var parser = SSELineParser\(\)/,
+  "native SwiftUI streams should parse through the shared SSELineParser",
+);
+assert.match(
+  swiftSseParser,
+  /if dataLines\.isEmpty, let event = StreamEvent\.decode\(payload\) \{\s*\n\s*return event\s*\n\s*\}/,
   "native SwiftUI SSE parser should decode single data payloads immediately instead of depending on blank-frame boundaries",
 );
 assert.match(
-  swiftCaveClient,
-  /let trimmedLine = line\.trimmingCharacters\(in: \.whitespacesAndNewlines\)[\s\S]*?if trimmedLine\.isEmpty/,
+  swiftSseParser,
+  /let trimmed = line\.trimmingCharacters\(in: \.whitespacesAndNewlines\)[\s\S]*?if trimmed\.isEmpty/,
   "native SwiftUI SSE parser should treat whitespace-only separator lines as event boundaries",
+);
+assert.match(
+  swiftSseParser,
+  /if trimmed\.hasPrefix\("id:"\)/,
+  "native SwiftUI SSE parser should track id: lines — the mid-turn resume cursor (cave-h40l)",
 );
 
 const swiftCodeEditorView = read("apps/ios/CovenCave/CovenCave/Views/CodeEditorView.swift");

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -284,7 +284,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const push = \(e: StreamEvent\) => \{[\s\S]*?if \(closed \|\| req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(e\)\);[\s\S]*?catch/,
+  /const push = \(e: StreamEvent\) => \{[\s\S]*?if \(closed \|\| req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(e, seq\)\);[\s\S]*?catch/,
   "Native stream pushes should be ignored after close/abort so late child output cannot enqueue into a closed stream",
 );
 assert.match(
@@ -294,7 +294,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(event\)\);[\s\S]*?catch/,
+  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(event, seq\)\);[\s\S]*?catch/,
   "OpenClaw stream pushes should be ignored after close/abort so late child close/error output cannot enqueue into a cancelled stream",
 );
 assert.doesNotMatch(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -428,8 +428,11 @@ async function autoNameSessionFromFirstExchange(
   }
 }
 
-function sse(event: StreamEvent): Uint8Array {
-  return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
+function sse(event: StreamEvent, seq?: number): Uint8Array {
+  // `id:` carries the run buffer's seq (cave-h40l): a client that saw it can
+  // resume mid-turn via GET /api/chat/stream?cursor=<last id> after a drop.
+  const id = seq != null ? `id: ${seq}\n` : "";
+  return new TextEncoder().encode(`${id}data: ${JSON.stringify(event)}\n\n`);
 }
 
 // SSE comment frame + cadence keeping quiet streams alive: NATs, proxies, and
@@ -768,11 +771,12 @@ function openClawChatResponse(args: {
       const push = (event: StreamEvent) => {
         // Tee EVERY event through the per-run ring first (cave-h40l): the
         // buffer is what makes a dropped client resumable, so it must see
-        // events even after the original transport closed.
-        runBuffer?.record(event);
+        // events even after the original transport closed. The returned seq
+        // rides the SSE `id:` so live clients always hold a resume cursor.
+        const seq = runBuffer?.record(event);
         if (closed || args.req.signal.aborted) return;
         try {
-          controller.enqueue(sse(event));
+          controller.enqueue(sse(event, seq));
         } catch (error) {
           closed = true;
           if (!args.req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
@@ -1554,11 +1558,12 @@ export async function POST(req: Request) {
       const push = (e: StreamEvent) => {
         // Tee EVERY event through the per-run ring first (cave-h40l): the
         // buffer is what makes a dropped client resumable, so it must see
-        // events even after the original transport closed.
-        runBuffer?.record(e);
+        // events even after the original transport closed. The returned seq
+        // rides the SSE `id:` so live clients always hold a resume cursor.
+        const seq = runBuffer?.record(e);
         if (closed || req.signal.aborted) return;
         try {
-          controller.enqueue(sse(e));
+          controller.enqueue(sse(e, seq));
         } catch (error) {
           closed = true;
           if (!req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);

--- a/src/app/api/chat/stream/route.test.ts
+++ b/src/app/api/chat/stream/route.test.ts
@@ -76,8 +76,10 @@ test("a finished run drains its replay and closes immediately", async () => {
 const send = readFileSync(new URL("../send/route.ts", import.meta.url), "utf8");
 
 test("send route tees both harness stream paths through the run buffer", () => {
-  const tees = send.match(/runBuffer\?\.record\(e(?:vent)?\);\s*\n\s*if \(closed \|\| (?:args\.)?req\.signal\.aborted\) return;/g);
+  const tees = send.match(/const seq = runBuffer\?\.record\(e(?:vent)?\);\s*\n\s*if \(closed \|\| (?:args\.)?req\.signal\.aborted\) return;/g);
   assert.equal(tees?.length, 2, "both push() implementations record before the closed/aborted guard");
+  const seqEmits = send.match(/controller\.enqueue\(sse\(e(?:vent)?, seq\)\)/g);
+  assert.equal(seqEmits?.length, 2, "both paths emit the seq as the SSE id — live clients always hold a resume cursor");
   const opens = send.match(/openRunBuffer\(\[/g);
   assert.equal(opens?.length, 2, "both paths open a buffer under runId + conversation keys");
   const finishes = send.match(/runBuffer\?\.finish\(\)/g);

--- a/src/lib/server/chat-stream-buffer.ts
+++ b/src/lib/server/chat-stream-buffer.ts
@@ -50,7 +50,9 @@ const FINISHED_RETENTION_MS = 2 * 60_000;
 const buffers = new Map<string, RunBuffer>();
 
 export type RunBufferHandle = {
-  record: (event: StreamEvent) => void;
+  /** Records the event and returns its seq — the SSE `id:` the original
+   *  stream emits so any client holds a valid resume cursor. */
+  record: (event: StreamEvent) => number;
   finish: () => void;
 };
 
@@ -85,7 +87,7 @@ export function openRunBuffer(
 
   return {
     record: (event: StreamEvent) => {
-      if (buffer.done) return;
+      if (buffer.done) return buffer.nextSeq - 1;
       const entry: BufferedStreamEvent = {
         seq: buffer.nextSeq++,
         json: JSON.stringify(event),
@@ -97,6 +99,7 @@ export function openRunBuffer(
         if (dropped) buffer.bytes -= dropped.json.length;
       }
       for (const listener of buffer.tailListeners) listener(entry);
+      return entry.seq;
     },
     finish: () => {
       if (buffer.done) return;


### PR DESCRIPTION
## What

Completes **Connection C2** (cave-h40l): the iOS app re-attaches to a **still-live** chat run after a transport drop and keeps rendering in real time, instead of showing nothing until the turn ends and post-hoc resync adopts the transcript.

## Server (one small addition to #3331)

The original send stream now emits the run-buffer seq as the **SSE `id:`** on both harness paths (`record()` returns the seq, `sse()` carries it) — so any live client always holds a valid resume cursor, standard Last-Event-ID shape.

## iOS

- **`SSELineParser`** — shared incremental frame decoder for the send and resume streams; tracks `id:` as the resume cursor (the old inline loop discarded `id:` entirely). 8 unit tests: cursor pairing, malformed ids, multi-line frames, boundary + trailing flush, keep-alives.
- **`CaveClient`** — `SendBody.runId` (per-send token: a NEW chat with no sessionId is still resumable); `sendStream` yields `StreamFrame {event, id}`; new `resumeStream(runId:cursor:)` hits `GET /api/chat/stream`, 404 → typed `NoResumableRun`.
- **`ChatThread`** — mints a runId per stream, tracks the last applied frame's id, and on transport error tries `resumeInterruptedStream` first (≤3 short-backoff attempts; replay past cursor → live tail; `done` = fully recovered live). Falls back to the existing `resyncInterruptedTurn` only when no resumable run exists. Event handling extracted to `apply()` so both streams render identically. DiaryView updated to the frame shape.

## Verification

- Full iOS app **builds and all CovenCaveTests pass** on the iPhone 16 Pro simulator (Xcode 26.6), including the 8 new parser tests.
- Server: stream-route + buffer suites 10/10 (pins updated for the seq-emitting push shape); `pnpm typecheck` clean.
- Remaining manual step (tracked in the bead): a real-device network-drop pass — toggle airplane mode mid-reply, watch the bubble resume live.

Bead: cave-h40l (server half was #3331) · Queue: coven-cave-flagship-hardening (iOS program, C2)