### PR TITLE
feat(chat): debug pane diagnostic depth — served model + usage/cost per turn, pref-aware timestamps, work branch/cwd (cave-308c)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -20,6 +20,34 @@ assert.doesNotMatch(
   "Debug payload blocks should not force unreadable break-all wrapping",
 );
 
+// ── Diagnostic depth (chat-session-debugging S2) ─────────────────────────────
+
+assert.match(
+  source,
+  /turnMetaSummary\(turn\)/,
+  "Turn rows should surface the served model + usage/cost meta, not bury it in raw JSON",
+);
+assert.match(
+  source,
+  /title=\{usageBreakdown\(turn\.usage, turn\.costUsd\) \?\? undefined\}/,
+  "The compact turn meta should carry the full usage breakdown as its tooltip",
+);
+assert.match(
+  source,
+  /formatTimestamp\(session\.created_at, dtPrefs\)/,
+  "Session created/updated must honor the user's datetime prefs (raw ISO stays on the title attr)",
+);
+assert.match(
+  source,
+  /<KVRow k="work branch"/,
+  "Session section should expose the per-session work branch attribution row",
+);
+assert.match(
+  source,
+  /session\?\.model \?\? familiar\?\.model/,
+  "Session model row prefers the daemon-recorded session model over the familiar's configured default",
+);
+
 // ── Changes panel (CHAT-D8-01): working-tree review, now hosted by the code
 // rail (the inspector right panel that first carried it is retired) ──────────
 

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -3,7 +3,9 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
-import { formatClock } from "@/lib/datetime-format";
+import { formatClock, formatTimestamp, useDateTimePrefs } from "@/lib/datetime-format";
+import { formatRuntime } from "@/lib/chat-response-metadata";
+import { usageBreakdown } from "@/lib/usage-format";
 import {
   stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
@@ -16,6 +18,7 @@ import {
   formatEventPayload,
   nextAfterSeq,
   shouldPollEvents,
+  turnMetaSummary,
   type CovenEvent,
   type DebugTurn,
 } from "@/lib/session-debug";
@@ -114,6 +117,8 @@ function JsonBlock({ text }: { text: string }) {
 function TurnRow({ index, turn }: { index: number; turn: DebugTurn }) {
   const [open, setOpen] = useState(false);
   const lifecycle = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "pending" : "complete");
+  // Served model + token/cost meta — otherwise only visible in the raw JSON.
+  const meta = turnMetaSummary(turn);
   return (
     <div className="rounded-md border border-[var(--border-hairline)]">
       <button
@@ -131,11 +136,22 @@ function TurnRow({ index, turn }: { index: number; turn: DebugTurn }) {
           {turn.tools?.length ? `${turn.tools.length} tool${turn.tools.length === 1 ? "" : "s"}` : ""}
           {turn.progress?.length ? `${turn.tools?.length ? " · " : ""}${turn.progress.length} progress` : ""}
         </span>
+        {meta ? (
+          <span
+            className="max-w-40 shrink-0 truncate font-mono text-[var(--text-muted)]"
+            title={usageBreakdown(turn.usage, turn.costUsd) ?? undefined}
+          >
+            {meta}
+          </span>
+        ) : null}
         <span className="shrink-0 font-mono text-[var(--text-muted)]">{fmtMs(turn.durationMs)}</span>
       </button>
       {open ? (
         <div className="border-t border-[var(--border-hairline)] p-2">
-          <div className="mb-1 flex justify-end">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className="min-w-0 truncate font-mono text-[10px] text-[var(--text-muted)]">
+              {usageBreakdown(turn.usage, turn.costUsd) ?? ""}
+            </span>
             <CopyButton getText={() => JSON.stringify(turn, null, 2)} label="Copy turn" />
           </div>
           <JsonBlock text={JSON.stringify(turn, null, 2)} />
@@ -175,6 +191,8 @@ function EventRow({ event }: { event: CovenEvent }) {
 function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   const { sessionId, session, familiar, turns } = snapshot;
   const status = session?.status ?? null;
+  const dtPrefs = useDateTimePrefs();
+  const cwd = formatRuntime(session?.runtime);
   const [events, setEvents] = useState<CovenEvent[]>([]);
   const [eventsError, setEventsError] = useState<string | null>(null);
   // Tail-follow only makes sense while events are streaming in; opening a
@@ -304,15 +322,29 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
             </span>
           </KVRow>
           <KVRow k="harness">{session?.harness ?? familiar?.harness ?? "—"}</KVRow>
-          <KVRow k="model">{familiar?.model ?? "—"}</KVRow>
+          {/* The session's own model (daemon-recorded) over the familiar's
+              configured default; per-turn served models live on turn rows. */}
+          <KVRow k="model">{session?.model ?? familiar?.model ?? "—"}</KVRow>
           <KVRow k="familiar">{familiar?.display_name ?? "—"}</KVRow>
           <KVRow k="origin">{session?.origin ?? "—"}</KVRow>
           <KVRow k="exit code">{session?.exit_code ?? "—"}</KVRow>
           <KVRow k="project root" title={session?.project_root}>
             {session?.project_root ?? "—"}
           </KVRow>
-          <KVRow k="created">{session?.created_at ?? "—"}</KVRow>
-          <KVRow k="updated">{session?.updated_at ?? "—"}</KVRow>
+          {cwd ? (
+            <KVRow k="cwd" title={cwd.title}>
+              {cwd.label}
+            </KVRow>
+          ) : null}
+          <KVRow k="work branch" title={session?.workBranch ?? undefined}>
+            {session?.workBranch ?? "—"}
+          </KVRow>
+          <KVRow k="created" title={session?.created_at}>
+            {session?.created_at ? formatTimestamp(session.created_at, dtPrefs) || session.created_at : "—"}
+          </KVRow>
+          <KVRow k="updated" title={session?.updated_at}>
+            {session?.updated_at ? formatTimestamp(session.updated_at, dtPrefs) || session.updated_at : "—"}
+          </KVRow>
         </Section>
 
         <Section title="Turns" count={turns.length}>

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -80,6 +80,55 @@ assert.equal(
 assert.equal(debugFileName("s1"), "debug-s1.json");
 assert.equal(debugFileName(null), "debug-session.json");
 
+// ── turnActualModel / turnMetaSummary: served-model + usage meta (S2) ───────
+import { turnActualModel, turnMetaSummary } from "./session-debug.ts";
+
+const baseTurn = { id: "t1", role: "assistant", text: "hi", createdAt: "2026-07-17T00:00:00Z" };
+
+assert.equal(turnActualModel(baseTurn), null, "no responseMetadata → no served model");
+assert.equal(
+  turnActualModel({ ...baseTurn, responseMetadata: { model: "opus-4" } }),
+  "opus-4",
+  "requested model reported when no confirmation exists",
+);
+assert.equal(
+  turnActualModel({ ...baseTurn, responseMetadata: { model: "opus-4", confirmedModel: "sonnet-4.6" } }),
+  "sonnet-4.6",
+  "confirmedModel (post-application truth) wins over the requested model",
+);
+assert.equal(
+  turnActualModel({ ...baseTurn, responseMetadata: { model: "  " } }),
+  null,
+  "whitespace-only model is not a model",
+);
+
+assert.equal(turnMetaSummary(baseTurn), null, "no model, no usage → null (row shows nothing)");
+assert.equal(
+  turnMetaSummary({ ...baseTurn, responseMetadata: { model: "opus-4" } }),
+  "opus-4",
+  "model-only meta",
+);
+assert.equal(
+  turnMetaSummary({ ...baseTurn, usage: { inputTokens: 1000, outputTokens: 234 }, costUsd: 0.08 }),
+  "1.2k tok · $0.08",
+  "usage-only meta reuses the shared usageSummary formatter",
+);
+assert.equal(
+  turnMetaSummary({
+    ...baseTurn,
+    responseMetadata: { confirmedModel: "sonnet-4.6" },
+    usage: { inputTokens: 1000, outputTokens: 234 },
+    costUsd: 0.08,
+  }),
+  "sonnet-4.6 · 1.2k tok · $0.08",
+  "combined meta: served model first, then tokens/cost",
+);
+assert.equal(
+  turnMetaSummary({ ...baseTurn, usage: { inputTokens: 0, outputTokens: 0 } }),
+  null,
+  "zero-token usage with no cost reports nothing, not '0 tok'",
+);
+
 console.log("session-debug core assertions passed");
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -1,5 +1,6 @@
 import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
+import { usageSummary, type TurnUsage } from "./usage-format.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -41,7 +42,35 @@ export type DebugTurn = {
   lifecycle?: "queued" | "connecting" | "streaming" | "tooling" | "cancelled" | "failed" | "complete";
   durationMs?: number;
   origin?: "chat" | "voice";
+  /** Token usage / cost from the harness result event; absent when the
+   *  harness emitted none. */
+  usage?: TurnUsage;
+  costUsd?: number;
+  /** Structural subset of ChatResponseMetadata — enough to tell the model
+   *  that actually served the turn from the familiar's configured one. */
+  responseMetadata?: { model?: string; confirmedModel?: string };
 };
+
+/** The model that actually served a turn, when the harness reported one —
+ *  `confirmedModel` (post-application truth) over the requested `model`.
+ *  Distinct from the familiar's configured model shown in the Session
+ *  section: harness routing and model application can diverge from it. */
+export function turnActualModel(turn: DebugTurn): string | null {
+  const meta = turn.responseMetadata;
+  const model = meta?.confirmedModel || meta?.model;
+  return model?.trim() ? model : null;
+}
+
+/** One-line diagnostic meta for a turn row: "opus-4 · 12.4k tok · $0.08".
+ *  Null when the turn carries neither a served model nor usage/cost. */
+export function turnMetaSummary(turn: DebugTurn): string | null {
+  const parts: string[] = [];
+  const model = turnActualModel(turn);
+  if (model) parts.push(model);
+  const usage = usageSummary(turn.usage, turn.costUsd);
+  if (usage) parts.push(usage);
+  return parts.length ? parts.join(" · ") : null;
+}
 
 export type DebugBundle = {
   session: SessionRow | null;


### PR DESCRIPTION
## What

Slice S2 of the **chat-session-debugging** goal (Phase 1 audit gaps B1/B4/B5). Builds on #3339 (per-pane truthful snapshot).

**Per-turn diagnostics surfaced (B1).** Turn rows showed only role/lifecycle/tool+progress counts/duration — usage, cost, and the model that *actually served* the turn were visible only by expanding raw JSON. `DebugTurn` gains `usage/costUsd/responseMetadata` (structural subsets; the data already flowed through from ChatView's `Turn`). New pure helpers in `session-debug.ts`:
- `turnActualModel` — `confirmedModel` (post-application truth) over the requested `model`
- `turnMetaSummary` — `"sonnet-4.6 · 1.2k tok · $0.08"` via the shared `usageSummary` formatter (same one MetaLine uses)

Compact meta renders on the row with the full `usageBreakdown` tooltip; the expanded block repeats the breakdown beside **Copy turn**.

**Truthful Session section (B4/B5).**
- `created`/`updated`: raw ISO → `formatTimestamp` with the user's datetime prefs (raw ISO preserved on `title`; unparseable falls back to raw) — same gap class as cave-0rx0
- `model`: prefers the daemon-recorded `session.model` over the familiar's configured default (per-turn served models live on turn rows)
- new `work branch` row — per-session attribution, never the shared checkout's current branch
- new `cwd` row via `formatRuntime`

## Verification

- `pnpm test:app` — 753 test files pass (new behavioral tests for `turnActualModel`/`turnMetaSummary`; pins for prefs timestamps, work-branch row, model precedence)
- `pnpm typecheck` — clean

## Refs

- Bead: cave-308c (chat-session-debugging goal S2)
- Prior slice: #3339 (cave-6nfq)