### PR TITLE
fix(studio): a typed voice id always persists — per-field draft sync, unmount flush, Enter commit

### DIFF
--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -229,3 +229,63 @@ assert.match(
   /elevenCatalog\.status === "error" && elevenCatalog\.note/,
   "catalog failures surface an actionable hint while the raw-id inputs remain usable",
 );
+
+// ── Voice ids survive to disk (cave-32er) ────────────────────────────────────
+// The config round-trip is covered in cave-config.test.ts; what actually lost
+// a typed voice id was the CLIENT: a monolithic draft-reset effect keyed on
+// every familiar field (so the 4s roster poll landing one field's save wiped
+// another field's in-progress draft), plus blur-only commits that unmount
+// could skip. These pin the repaired shape.
+
+// 1. The full reset is keyed on the familiar id alone — never on field values.
+assert.match(
+  source,
+  /setToast\(null\);[\s\S]{0,1800}?\}, \[familiar\.id\]\)/,
+  "the full draft reset fires only when the familiar itself changes",
+);
+assert.doesNotMatch(
+  source,
+  /\}, \[\s*familiar\.id,\s*familiar\.harnessOverride,[\s\S]{0,300}familiar\.voiceName/,
+  "the all-fields reset dependency list is gone (it clobbered in-progress drafts)",
+);
+
+// 2. Per-field sync: each voice draft follows only its own backing value.
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*\n\s*setDraftVoiceName\(familiar\.voiceName \?\? ""\);\s*\n\s*\}, \[familiar\.voiceName\]\)/,
+  "the voice-id draft syncs on its own backing value only",
+);
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*\n\s*setDraftVoiceProvider\(familiar\.voiceProvider \?\? ""\);\s*\n\s*\}, \[familiar\.voiceProvider\]\)/,
+  "the voice-provider draft syncs on its own backing value only",
+);
+
+// 3. Dirty voice text flushes on unmount, so closing the Studio (or leaving
+//    the tab) without a blur still persists the typed id.
+assert.match(
+  source,
+  /const dirtyTextRef = useRef[\s\S]{0,600}?pendingVoiceName !== \(familiar\.voiceName \?\? ""\)/,
+  "unsaved voice text is tracked against the last saved values",
+);
+assert.match(
+  source,
+  /return \(\) => \{[\s\S]{0,700}?if \(pending\.familiarId !== familiar\.id\) return;[\s\S]{0,500}?familiars: \{ \[pending\.familiarId\]: pending\.patch \}/,
+  "the id-reset cleanup flushes dirty voice text for the SAME familiar (unmount), never cross-writing on a switch",
+);
+
+// 4. Enter commits the free-text voice inputs through their blur handlers.
+assert.match(
+  source,
+  /onBlur=\{\(\) => void save\(\{ voiceName: draftVoiceName\.trim\(\) \|\| null \}\)\}\s*\n\s*onKeyDown=\{\(e\) => \{[\s\S]{0,200}?if \(e\.key === "Enter"\) e\.currentTarget\.blur\(\);/,
+  "Enter commits a typed voice id instead of leaving it unsaved",
+);
+
+// 5. Successful saves catch the roster up immediately — every surface gating
+//    on familiar.voiceProvider (the chat kebab's Call item) sees the new
+//    voice without waiting for the next poll.
+assert.match(
+  source,
+  /reportDaemonSyncSuccess\(\);[\s\S]{0,400}?window\.dispatchEvent\(new Event\("cave:familiars-refresh"\)\);/,
+  "a successful config save dispatches cave:familiars-refresh (parity with the other /api/config writers)",
+);

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -84,6 +84,27 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
   // flight, so a stop click (or voice switch) can't be overtaken by late audio.
   const previewGenRef = useRef(0);
 
+  // Unsaved *text* drafts, diffed against the last-known saved values. The
+  // free-text voice fields commit on blur — but a tab/familiar switch or a
+  // Studio close can unmount the input before any blur fires, silently
+  // dropping a typed voice id (cave-32er). Recomputed every render so the
+  // id-reset cleanup below can flush what's still pending.
+  const dirtyTextRef = useRef<{ familiarId: string; patch: Record<string, unknown> }>({
+    familiarId: familiar.id,
+    patch: {},
+  });
+  {
+    const patch: Record<string, unknown> = {};
+    const pendingVoiceModel = draftVoiceModel.trim();
+    if (pendingVoiceModel !== (familiar.voiceModel ?? "")) patch.voiceModel = pendingVoiceModel || null;
+    const pendingVoiceName = draftVoiceName.trim();
+    if (pendingVoiceName !== (familiar.voiceName ?? "")) patch.voiceName = pendingVoiceName || null;
+    dirtyTextRef.current = { familiarId: familiar.id, patch };
+  }
+
+  // Full draft reset ONLY when the familiar itself changes; the cleanup
+  // flushes any still-dirty voice text first (it also runs on unmount, so
+  // closing the Studio mid-edit persists the typed id instead of eating it).
   useEffect(() => {
     setDraftHarness(familiar.harnessOverride ?? "");
     setDraftModel(familiar.model ?? "");
@@ -97,19 +118,63 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     setDraftVoiceName(familiar.voiceName ?? "");
     setDraftAutoSelfReport(Boolean(familiar.autoSelfReport));
     setToast(null);
-  }, [
-    familiar.id,
-    familiar.harnessOverride,
-    familiar.model,
-    familiar.note,
-    familiar.omnigent?.agentId,
-    familiar.omnigent?.hostId,
-    familiar.omnigent?.workspace,
-    familiar.voiceProvider,
-    familiar.voiceModel,
-    familiar.voiceName,
-    familiar.autoSelfReport,
-  ]);
+    return () => {
+      const pending = dirtyTextRef.current;
+      // On a familiar SWITCH the ref has already re-rendered for the next
+      // familiar (render precedes cleanup) — flushing would cross-write A's
+      // drafts onto B. Only flush when the pending patch belongs to the
+      // familiar this effect ran for (true on unmount, the blur-less case).
+      if (pending.familiarId !== familiar.id) return;
+      if (Object.keys(pending.patch).length === 0) return;
+      // Direct fetch (not save()) — this runs during unmount/switch, so no
+      // setState; a duplicate of an already-blurred commit is idempotent.
+      void fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ familiars: { [pending.familiarId]: pending.patch } }),
+      })
+        .then(() => window.dispatchEvent(new Event("cave:familiars-refresh")))
+        .catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [familiar.id]);
+
+  // Per-field draft sync (the identity tab's convention): each draft follows
+  // ITS OWN backing value only. The old single effect keyed on every field,
+  // so the 4s roster poll landing one field's save (say, voiceProvider)
+  // clobbered another field's in-progress draft — exactly how a typed voice
+  // id vanished before its blur-save could fire (cave-32er).
+  useEffect(() => {
+    setDraftHarness(familiar.harnessOverride ?? "");
+  }, [familiar.harnessOverride]);
+  useEffect(() => {
+    setDraftModel(familiar.model ?? "");
+    setModelCustomMode(false);
+  }, [familiar.model]);
+  useEffect(() => {
+    setDraftNote(familiar.note ?? "");
+  }, [familiar.note]);
+  useEffect(() => {
+    setDraftOmnigentAgentId(familiar.omnigent?.agentId ?? "");
+  }, [familiar.omnigent?.agentId]);
+  useEffect(() => {
+    setDraftOmnigentHostId(familiar.omnigent?.hostId ?? "");
+  }, [familiar.omnigent?.hostId]);
+  useEffect(() => {
+    setDraftOmnigentWorkspace(familiar.omnigent?.workspace ?? "");
+  }, [familiar.omnigent?.workspace]);
+  useEffect(() => {
+    setDraftVoiceProvider(familiar.voiceProvider ?? "");
+  }, [familiar.voiceProvider]);
+  useEffect(() => {
+    setDraftVoiceModel(familiar.voiceModel ?? "");
+  }, [familiar.voiceModel]);
+  useEffect(() => {
+    setDraftVoiceName(familiar.voiceName ?? "");
+  }, [familiar.voiceName]);
+  useEffect(() => {
+    setDraftAutoSelfReport(Boolean(familiar.autoSelfReport));
+  }, [familiar.autoSelfReport]);
 
   useEffect(() => {
     let cancelled = false;
@@ -209,6 +274,11 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
         if ("autoSelfReport" in patch) setDraftAutoSelfReport(Boolean(familiar.autoSelfReport));
       } else {
         reportDaemonSyncSuccess();
+        // Voice/harness edits gate visible affordances elsewhere (the chat
+        // kebab's Call item reads familiar.voiceProvider) — catch the roster
+        // up now instead of waiting for the next 4s poll, like every other
+        // /api/config writer (chat runtime chip, home model state).
+        window.dispatchEvent(new Event("cave:familiars-refresh"));
       }
     } catch (err) {
       setToast(`Couldn't save: ${(err as Error).message}`);
@@ -693,6 +763,11 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                       value={draftVoiceModel}
                       onChange={(e) => setDraftVoiceModel(e.target.value)}
                       onBlur={() => void save({ voiceModel: draftVoiceModel.trim() || null })}
+                      onKeyDown={(e) => {
+                        // Enter commits (via the blur handler) — typing an id
+                        // and pressing Enter must never leave it unsaved.
+                        if (e.key === "Enter") e.currentTarget.blur();
+                      }}
                       placeholder={
                         draftVoiceProvider === "local"
                           ? "llama3.2"
@@ -778,6 +853,10 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                         value={draftVoiceName}
                         onChange={(e) => setDraftVoiceName(e.target.value)}
                         onBlur={() => void save({ voiceName: draftVoiceName.trim() || null })}
+                        onKeyDown={(e) => {
+                          // Enter commits the typed voice id (blur → save).
+                          if (e.key === "Enter") e.currentTarget.blur();
+                        }}
                         placeholder={
                           draftVoiceProvider === "elevenlabs"
                             ? "ElevenLabs voice id (default: Rachel)"


### PR DESCRIPTION
## Problem

**Report:** the voice id provided for a familiar doesn't save / persist.

The config round-trip (`saveConfig` → `cave-config.json` → `bindingFor` → `/api/familiars`) was never the problem — `cave-config.test.ts` covers it. The **client** lost the id in `familiar-studio-brain-tab.tsx`, three ways:

1. **Draft-clobber race** — the draft-reset effect keyed on *every* familiar field, so the 4s roster poll landing one field's save (e.g. just having picked the ElevenLabs provider) wiped another field's in-progress draft: exactly how a typed voice id vanished before its blur-save could fire.
2. **Blur-only commit** — the free-text voice inputs saved only on blur; unmounting the panel (switching settings sections, closing the Studio) silently dropped a typed id.
3. **Stale roster** — `save()` never dispatched `cave:familiars-refresh`, so surfaces gating on `familiar.voiceProvider` (chat kebab's Call item) lagged a poll cycle.

## Fix

- Per-field draft sync (the identity tab's convention): full reset only on `familiar.id` change; each draft follows **its own** backing value.
- The id-reset cleanup flushes still-dirty voice text on unmount for the *same* familiar (guarded against cross-writing on a familiar switch); **Enter** commits explicitly through the blur handler.
- Successful saves dispatch `cave:familiars-refresh` — parity with the chat runtime chip and home model state.

Closes bead `cave-32er`.

## Verification

End-to-end against the **real config write path** (Playwright driving the production build at `/settings#familiars`, throwaway familiar id, real store backed up and diffed byte-identical after cleanup):

- ✅ type id → switch section **without blurring** → id lands in `cave-config.json` (the reported loss)
- ✅ saved id hydrates into the input after remount
- ✅ **Enter** commits
- ✅ an in-progress draft survives a roster refresh (clobber race gone)
- ✅ `pnpm typecheck`; `pnpm test:app` — **753 files** green (new source pins in `familiar-studio-brain-tab.test.ts`)