### PR TITLE
feat(theme): OpenAI preset — Codex black monochrome palette

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -49,7 +49,7 @@ struct ThemeOption: Identifiable, Equatable {
 }
 
 enum ThemeRoster {
-    /// All 20 desktop presets, in the desktop's roster order.
+    /// All 21 desktop presets, in the desktop's roster order.
     static let all: [ThemeOption] = [
         .init("coven", "Coven", "Lavender-inked grimoire. The house default.",
               accentDark: "#9a8ecd", accentLight: "#6F62A8", bgDark: "#08060f", bgLight: "#f7f5fe"),
@@ -77,6 +77,8 @@ enum ThemeRoster {
               accentDark: "#818cf8", accentLight: "#5457e9", bgDark: "#1e1b18", bgLight: "#e7e5e4"),
         .init("claude", "Claude", "Warm parchment, muted ink, burnt-clay primary.",
               accentDark: "#d97757", accentLight: "#c96442", bgDark: "#262624", bgLight: "#faf9f5"),
+        .init("openai", "OpenAI", "Codex black. Void-dark monochrome.",
+              accentDark: "#ececec", accentLight: "#0d0d0d", bgDark: "#0d0d0d", bgLight: "#ffffff"),
         .init("pastel-dreams", "Pastel Dreams", "Soft violet pastels, lifted surfaces.",
               accentDark: "#c0aafd", accentLight: "#9377e6", bgDark: "#1c1917", bgLight: "#f7f3f9"),
         .init("meatseeks", "Meatseeks", "Supabase green over crisp utility surfaces.",

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -80,14 +80,14 @@ color.
   `:focus-visible` via the `.focus-ring` / `.focus-ring-inset` utilities.
 
 ### Theming
-`data-theme` (20 palettes: coven, tide, grove, ember, bloom, dusk, mist, hex,
-bane, slate, ghosty, claymorphism, claude, pastel-dreams, meatseeks, trucker,
-snow, contrast, beacon, solstice)
+`data-theme` (21 palettes: coven, tide, grove, ember, bloom, dusk, mist, hex,
+bane, slate, ghosty, claymorphism, claude, openai, pastel-dreams, meatseeks,
+trucker, snow, contrast, beacon, solstice)
 × `data-mode` (dark/light) are orthogonal attributes on `:root`, hydrated by
 `theme-script.tsx`. External shadcn themes import via tweakcn and are enriched
 with the Cave's derived semantic tokens (`settings-shell.tsx` →
 `enrichTweakcnTheme`). **Consequence: never hardcode a color; every surface
-must survive all 40 palette×mode combinations.**
+must survive all 42 palette×mode combinations.**
 
 ## 3. Signature idioms
 

--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -194,7 +194,7 @@
 
   try {
     var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
-    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","pastel-dreams","meatseeks","trucker","snow","contrast","beacon","solstice","custom"];
+    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","openai","pastel-dreams","meatseeks","trucker","snow","contrast","beacon","solstice","custom"];
     var theme = String(stored("coven-theme", themePrefs.id || "coven"));
     if (rename[theme]) theme = rename[theme];
     if (!isChoice(theme, valid)) theme = "coven";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4125,6 +4125,86 @@ html[data-backdrop-on] .glass-overlay {
   --chart-5: #b4552d;
 }
 
+/* ---- OpenAI — Codex black; void-dark monochrome with paper-white keys ----
+   Modeled on the Codex/ChatGPT surfaces: #0d0d0d canvas over a true-black
+   panel rail, grayscale elevation ladder, and a white filled accent (black
+   ink on it) like the composer send key. Light mode inverts to white paper
+   with black keys. Heritage teal survives only as a chart series. */
+[data-theme="openai"] {
+  --background: #0d0d0d;
+  --foreground: #ececec;
+  --card: #171717;
+  --card-foreground: #ececec;
+  --popover: #212121;
+  --popover-foreground: #ececec;
+  --primary: #ececec;
+  --primary-foreground: #0d0d0d;
+  --secondary: #212121;
+  --secondary-foreground: #ececec;
+  --muted: #212121;
+  --muted-foreground: #b4b4b4;
+  --accent: #2f2f2f;
+  --accent-foreground: #ececec;
+  --destructive: #dc2626;
+  --destructive-foreground: #ffffff;
+  --border: #2f2f2f;
+  --input: #424242;
+  --ring: #8f8f8f;
+  --accent-presence: #ececec;
+  --accent-presence-foreground: #0d0d0d;
+  --accent-presence-soft: color-mix(in oklch, #ececec 78%, transparent);
+  --accent-faint: color-mix(in oklch, #ececec 14%, transparent);
+  --bg-base: var(--background);
+  --bg-panel: #000000;
+  --bg-raised: var(--card);
+  --bg-elevated: #212121;
+  --bg-hover: #2f2f2f;
+  --border-strong: #6e6e6e;
+  --ring-focus: color-mix(in oklch, #ececec 55%, var(--foreground) 45%);
+  --chart-1: #ececec;
+  --chart-2: #10a37f;
+  --chart-3: #b4b4b4;
+  --chart-4: #8f8f8f;
+  --chart-5: #5d5d5d;
+}
+[data-theme="openai"][data-mode="light"] {
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --card: #f9f9f9;
+  --card-foreground: #0d0d0d;
+  --popover: #ffffff;
+  --popover-foreground: #0d0d0d;
+  --primary: #0d0d0d;
+  --primary-foreground: #ffffff;
+  --secondary: #ececec;
+  --secondary-foreground: #0d0d0d;
+  --muted: #f0f0f0;
+  --muted-foreground: #5d5d5d;
+  --accent: #ececec;
+  --accent-foreground: #0d0d0d;
+  --destructive: #b91c1c;
+  --destructive-foreground: #ffffff;
+  --border: #e3e3e3;
+  --input: #b4b4b4;
+  --ring: #5d5d5d;
+  --accent-presence: #0d0d0d;
+  --accent-presence-foreground: #ffffff;
+  --accent-presence-soft: color-mix(in oklch, #0d0d0d 78%, transparent);
+  --accent-faint: color-mix(in oklch, #0d0d0d 14%, transparent);
+  --bg-base: var(--background);
+  --bg-panel: #f9f9f9;
+  --bg-raised: var(--card);
+  --bg-elevated: #ececec;
+  --bg-hover: #e3e3e3;
+  --border-strong: #8f8f8f;
+  --ring-focus: color-mix(in oklch, #0d0d0d 55%, var(--foreground) 45%);
+  --chart-1: #0d0d0d;
+  --chart-2: #10a37f;
+  --chart-3: #5d5d5d;
+  --chart-4: #8f8f8f;
+  --chart-5: #b4b4b4;
+}
+
 /* ---- Pastel Dreams (tweakcn) - soft violet pastels with lifted white surfaces ---- */
 [data-theme="pastel-dreams"] {
   --font-sans: var(--font-open-sans), "Open Sans", ui-sans-serif, system-ui, sans-serif;

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -50,8 +50,8 @@ console.log("globals.css.test.ts (task 3) OK");
 // solstice), which the original loop of 9 never covered.
 const otherThemes = [
   "tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate",
-  "ghosty", "claymorphism", "claude", "pastel-dreams", "meatseeks", "trucker",
-  "snow", "contrast", "beacon", "solstice",
+  "ghosty", "claymorphism", "claude", "openai", "pastel-dreams", "meatseeks",
+  "trucker", "snow", "contrast", "beacon", "solstice",
 ];
 for (const id of otherThemes) {
   const darkRe = new RegExp(`\\[data-theme="${id}"\\]\\s*\\{`);

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -94,8 +94,9 @@ for (const legacy of ["mood-c", "sky", "orchid", "midnight"]) {
 }
 for (const id of [
   "coven", "tide", "grove", "ember", "bloom", "dusk", "mist", "hex",
-  "bane", "slate", "ghosty", "claymorphism", "claude", "pastel-dreams",
-  "meatseeks", "trucker", "snow", "contrast", "beacon", "solstice", "custom",
+  "bane", "slate", "ghosty", "claymorphism", "claude", "openai",
+  "pastel-dreams", "meatseeks", "trucker", "snow", "contrast", "beacon",
+  "solstice", "custom",
 ]) {
   assert.ok(bootScript.includes(`"${id}"`), `pre-paint theme allowlist contains ${id}`);
 }

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import { THEME_IDS, THEME_META, getSwatches } from "./theme-palettes.ts";
 import { LEGACY_THEME_RENAME, COVEN_THEME_KEY, COVEN_MODE_KEY } from "./theme-storage.ts";
 
-// 20 themes, coven is the default (first).
-assert.equal(THEME_IDS.length, 20);
+// 21 themes, coven is the default (first).
+assert.equal(THEME_IDS.length, 21);
 assert.equal(THEME_IDS[0], "coven");
 assert.deepEqual(
   [...THEME_IDS].sort(),
@@ -23,6 +23,7 @@ assert.deepEqual(
     "hex",
     "meatseeks",
     "mist",
+    "openai",
     "pastel-dreams",
     "slate",
     "snow",
@@ -71,6 +72,9 @@ assert.equal(THEME_META.ghosty.accentDark, "#a6a6a6");
 assert.equal(THEME_META.ghosty.accentLight, "#808080");
 assert.equal(THEME_META.claymorphism.name, "Claymorphism");
 assert.equal(THEME_META.claude.name, "Claude");
+assert.equal(THEME_META.openai.name, "OpenAI");
+assert.equal(THEME_META.openai.accentDark, "#ececec");
+assert.equal(THEME_META.openai.accentLight, "#0d0d0d");
 assert.equal(THEME_META["pastel-dreams"].name, "Pastel Dreams");
 assert.equal(THEME_META["pastel-dreams"].accentDark, "#c0aafd");
 assert.equal(THEME_META["pastel-dreams"].accentLight, "#9377e6");

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -1,5 +1,5 @@
 /**
- * 20-theme roster metadata + swatch lookup for the appearance settings UI.
+ * 21-theme roster metadata + swatch lookup for the appearance settings UI.
  * The actual palette CSS lives in `src/app/globals.css`; this module
  * mirrors the accent values and a representative background swatch
  * per (theme, mode) so the settings grid can preview each card.
@@ -25,6 +25,7 @@ export const THEME_IDS = [
   "ghosty",
   "claymorphism",
   "claude",
+  "openai",
   "pastel-dreams",
   "meatseeks",
   "trucker",
@@ -125,6 +126,12 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     description: "Warm parchment, muted ink, and a burnt-clay primary.",
     hue: 17, accentDark: "#d97757", accentLight: "#c96442",
     bgDark: "#262624", bgLight: "#faf9f5",
+  },
+  openai: {
+    name: "OpenAI",
+    description: "Codex black. Void-dark monochrome; the cursor blinks back.",
+    hue: 0, accentDark: "#ececec", accentLight: "#0d0d0d",
+    bgDark: "#0d0d0d", bgLight: "#ffffff",
   },
   "pastel-dreams": {
     name: "Pastel Dreams",


### PR DESCRIPTION
## What

Adds an **openai** theme to the 21-theme roster: Codex-black monochrome.

- **Dark**: void-dark `#0d0d0d` canvas over a true-black `#000` panel rail, grayscale elevation ladder (`#171717`/`#212121`/`#2f2f2f`), paper-white `#ececec` filled accent with dark ink on it (composer-send-key style).
- **Light**: white paper, `#f9f9f9` panels, black `#0d0d0d` keys.
- Heritage teal `#10a37f` survives only as a chart series.

## Registration points

- `THEME_IDS`/`THEME_META` (+ roster test pins, 20 → 21)
- `globals.css` dark + light palette blocks
- `theme-init.js` pre-paint allowlist (+ `theme-script.test.ts`)
- iOS `ThemeRoster.swift` mirror (order-checked by `ios-theme-override.test.ts`)
- `docs/coven-design-language.md` (21 palettes / 42 combos)

## Verification

- `theme-contrast-audit.test.ts`: **855 pairs across 21 themes × 2 modes, 0 failures** (WCAG AA text 4.5:1, non-text 3:1)
- theme-palettes / globals.css / theme-script / ios-theme-override tests all pass
- `pnpm typecheck` clean
- Visual: built + served the app, screenshotted home (dark = #0d0d0d, light = #ffffff) and the Settings → Appearance grid showing the new card