### PR TITLE
fix(desktop): recover orphan migration takeovers

### DIFF
--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -77,6 +77,34 @@ try {
   assert.deepEqual(orphanResult.errors, []);
   assert.ok(Date.now() - orphanStartedAt < 2_000, "same-process takeover orphan is reclaimed immediately");
   assert.deepEqual(JSON.parse(await readFile(path.join(orphanCave, "config.json"), "utf8")), { windows: true });
+
+  // A crashed claimant's PID may be reused by another Windows process. Bound
+  // apparently live claims by age so that reuse cannot recreate the hang.
+  const reusedPidHome = path.join(root, "reused-pid-takeover", ".coven");
+  process.env.COVEN_HOME = reusedPidHome;
+  const reusedPidCave = path.join(reusedPidHome, "cave");
+  const reusedPidLock = path.join(reusedPidCave, ".migration.lock");
+  await mkdir(reusedPidLock, { recursive: true });
+  await writeFile(path.join(reusedPidLock, "owner.json"), JSON.stringify({
+    pid: process.pid,
+    token: "released-owner",
+    releasedAt: new Date().toISOString(),
+  }));
+  const reusedPidTakeover = path.join(reusedPidLock, ".takeover");
+  await writeFile(reusedPidTakeover, JSON.stringify({
+    pid: process.ppid,
+    takeoverToken: "crashed-claim-with-reused-pid",
+    ownerToken: "released-owner",
+  }));
+  const stale = new Date(Date.now() - 10 * 60_000);
+  await utimes(reusedPidTakeover, stale, stale);
+  await writeFile(path.join(reusedPidHome, "cave-config.json"), '{"windows":true}', "utf8");
+
+  const reusedPidStartedAt = Date.now();
+  const reusedPidResult = await migrateCaveHome();
+  assert.deepEqual(reusedPidResult.errors, []);
+  assert.ok(Date.now() - reusedPidStartedAt < 2_000, "aged claim is reclaimed despite PID reuse");
+  assert.deepEqual(JSON.parse(await readFile(path.join(reusedPidCave, "config.json"), "utf8")), { windows: true });
   console.log("cave-home-migration-windows.test.ts: ok");
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -49,6 +49,34 @@ try {
   const [ownerResult, contenderResult] = await Promise.all([owner, contender]);
   assert.deepEqual(ownerResult.errors, []);
   assert.deepEqual(contenderResult.errors, []);
+
+  // A failed reclaim rename can leave a recent takeover marker owned by this
+  // still-live sidecar. It is orphaned when its token is not actively tracked,
+  // and later storage operations must recover it without waiting five minutes.
+  const orphanHome = path.join(root, "same-process-orphan-takeover", ".coven");
+  process.env.COVEN_HOME = orphanHome;
+  const orphanCave = path.join(orphanHome, "cave");
+  const orphanLock = path.join(orphanCave, ".migration.lock");
+  await mkdir(orphanLock, { recursive: true });
+  await writeFile(path.join(orphanLock, "owner.json"), JSON.stringify({
+    pid: process.pid,
+    token: "released-same-process-owner",
+    startedAt: new Date().toISOString(),
+    releasedAt: new Date().toISOString(),
+  }));
+  await writeFile(path.join(orphanLock, ".takeover"), JSON.stringify({
+    pid: process.pid,
+    takeoverToken: "abandoned-same-process-takeover",
+    ownerToken: "released-same-process-owner",
+    startedAt: new Date().toISOString(),
+  }));
+  await writeFile(path.join(orphanHome, "cave-config.json"), '{"windows":true}', "utf8");
+
+  const orphanStartedAt = Date.now();
+  const orphanResult = await migrateCaveHome();
+  assert.deepEqual(orphanResult.errors, []);
+  assert.ok(Date.now() - orphanStartedAt < 2_000, "same-process takeover orphan is reclaimed immediately");
+  assert.deepEqual(JSON.parse(await readFile(path.join(orphanCave, "config.json"), "utf8")), { windows: true });
   console.log("cave-home-migration-windows.test.ts: ok");
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -857,31 +857,127 @@ try {
     ]);
     assert.deepEqual(first.errors, []);
     assert.deepEqual(second.errors, []);
-    assert.equal(staleObservers, 2);
+    assert.ok(staleObservers >= 2, "both stale-lock contenders observed reclamation");
     assert.equal(maxActive, 1);
     assert.equal(active, 0);
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
   // A contender can crash after publishing its takeover claim but before it
-  // renames the stale lock. Legacy claims did not record a PID, so reclaim an
-  // aged marker instead of retrying EEXIST forever and blocking every store.
+  // renames the stale lock. Competing observers fence that immutable claim to
+  // one deterministic retained path, so a delayed observer cannot rename a
+  // successor lock after the first observer wins.
   {
     const { coven, cave } = await home("orphan-takeover-claim");
     await mkdir(cave, { recursive: true });
     const lock = path.join(cave, ".migration.lock");
     await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" }));
     const takeover = path.join(lock, ".takeover");
-    await writeFile(takeover, JSON.stringify({ takeoverToken: "abandoned", ownerToken: null }));
+    await writeFile(takeover, JSON.stringify({ takeoverToken: "abandoned", ownerToken: "dead-owner" }));
     const stale = new Date(Date.now() - 10 * 60_000);
     await utimes(lock, stale, stale);
+    await utimes(takeover, stale, stale);
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    let observers = 0;
+    let releaseObservers!: () => void;
+    const bothObserved = new Promise<void>((resolve) => { releaseObservers = resolve; });
+    let active = 0;
+    let maxActive = 0;
+    const options = {
+      createSymlink: denySymlink,
+      takeoverRemovalProbe: async () => {
+        observers += 1;
+        if (observers === 2) releaseObservers();
+        await bothObserved;
+      },
+      lockProbe: async (event: "stale-observed" | "acquired" | "released") => {
+        if (event === "acquired") {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        } else if (event === "released") {
+          active -= 1;
+        }
+      },
+    };
+    const startedAt = Date.now();
+    const [first, second] = await Promise.all([migrateCaveHome(options), migrateCaveHome(options)]);
+    assert.deepEqual(first.errors, []);
+    assert.deepEqual(second.errors, []);
+    assert.ok(Date.now() - startedAt < 2_000, "an orphan takeover claim is reclaimed without hanging");
+    assert.ok(observers >= 2, "both orphan observers reached the immutable claim");
+    assert.equal(maxActive, 1);
+    assert.equal(active, 0);
+    const fences = (await readdir(cave)).filter((entry) => entry.startsWith(".migration.lock.reclaimed-"));
+    assert.equal(fences.length, 1, "all orphan observers target one retained generation fence");
+    assert.equal((await json(path.join(cave, fences[0], ".takeover"))).takeoverToken, "abandoned");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
+  // A crashed claimant's PID can be reused by an unrelated process. Even when
+  // that PID appears live, an aged claim must not block migration forever.
+  {
+    const { coven, cave } = await home("reused-pid-takeover-claim");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      token: "released-owner",
+      releasedAt: new Date().toISOString(),
+    }));
+    const takeover = path.join(lock, ".takeover");
+    await writeFile(takeover, JSON.stringify({
+      pid: process.ppid,
+      takeoverToken: "crashed-claim-with-reused-pid",
+      ownerToken: "released-owner",
+    }));
+    const stale = new Date(Date.now() - 10 * 60_000);
     await utimes(takeover, stale, stale);
     await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
 
     const startedAt = Date.now();
     const result = await migrateCaveHome({ createSymlink: denySymlink });
     assert.deepEqual(result.errors, []);
-    assert.ok(Date.now() - startedAt < 2_000, "an orphan takeover claim is reclaimed without hanging");
+    assert.ok(Date.now() - startedAt < 2_000, "an aged claim is reclaimed despite PID reuse");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
+  // Registration must precede publication. Pause the first same-process
+  // contender after writeFile and prove a second contender leaves its active
+  // marker intact while waiting for the takeover to finish.
+  {
+    const { coven, cave } = await home("takeover-register-before-publish");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" }));
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    let markPublished!: (token: string) => void;
+    const published = new Promise<string>((resolve) => { markPublished = resolve; });
+    let releasePublisher!: () => void;
+    const publisherMayContinue = new Promise<void>((resolve) => { releasePublisher = resolve; });
+    let paused = false;
+    const first = migrateCaveHome({
+      createSymlink: denySymlink,
+      takeoverPublishProbe: async (token) => {
+        if (paused) return;
+        paused = true;
+        markPublished(token);
+        await publisherMayContinue;
+      },
+    });
+    const publishedToken = await published;
+    const second = migrateCaveHome({ createSymlink: denySymlink });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal((await json(path.join(lock, ".takeover"))).takeoverToken, publishedToken);
+    releasePublisher();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    assert.deepEqual(firstResult.errors, []);
+    assert.deepEqual(secondResult.errors, []);
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -908,6 +908,35 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
+  // A failed Windows reclaim rename can also leave a takeover claim from this
+  // still-live process. Only an actively tracked token represents an in-flight
+  // contender; an untracked same-process marker must not block later stores.
+  {
+    const { coven, cave } = await home("same-process-orphan-takeover");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    await writeFile(path.join(lock, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      token: "released-same-process-owner",
+      startedAt: new Date().toISOString(),
+      releasedAt: new Date().toISOString(),
+    }));
+    await writeFile(path.join(lock, ".takeover"), JSON.stringify({
+      pid: process.pid,
+      takeoverToken: "abandoned-same-process-takeover",
+      ownerToken: "released-same-process-owner",
+      startedAt: new Date().toISOString(),
+    }));
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    const startedAt = Date.now();
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(Date.now() - startedAt < 2_000, "a same-process orphan takeover is reclaimed without hanging");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
   // Publishing release intent must not let a waiter reclaim the lock before
   // its owner finishes the unlock rename. Otherwise the old release path can
   // rename a newly acquired successor lock and break mutual exclusion.

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -863,6 +863,28 @@ try {
     assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
   }
 
+  // A contender can crash after publishing its takeover claim but before it
+  // renames the stale lock. Legacy claims did not record a PID, so reclaim an
+  // aged marker instead of retrying EEXIST forever and blocking every store.
+  {
+    const { coven, cave } = await home("orphan-takeover-claim");
+    await mkdir(cave, { recursive: true });
+    const lock = path.join(cave, ".migration.lock");
+    await mkdir(lock);
+    const takeover = path.join(lock, ".takeover");
+    await writeFile(takeover, JSON.stringify({ takeoverToken: "abandoned", ownerToken: null }));
+    const stale = new Date(Date.now() - 10 * 60_000);
+    await utimes(lock, stale, stale);
+    await utimes(takeover, stale, stale);
+    await writeFile(path.join(coven, "cave-config.json"), '{"safe":true}');
+
+    const startedAt = Date.now();
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(Date.now() - startedAt < 2_000, "an orphan takeover claim is reclaimed without hanging");
+    assert.deepEqual(await json(path.join(cave, "config.json")), { safe: true });
+  }
+
   // A failed Windows unlock rename can leave a lock owned by this still-live
   // process on disk. Process liveness alone cannot distinguish that orphan
   // from an active critical section, so the process-wide active-token set is

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -6,6 +6,7 @@ import {
   link,
   lstat,
   mkdir,
+  open,
   readFile,
   readlink,
   readdir,
@@ -115,6 +116,10 @@ export type ReconciliationOptions = {
   lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
   /** Test-only unlock rename override. */
   lockReleaseRename?: typeof rename;
+  /** Test-only hook after an exclusive takeover claim is published. */
+  takeoverPublishProbe?: (takeoverToken: string) => void | Promise<void>;
+  /** Test-only hook before a reclaimable takeover claim is advanced. */
+  takeoverRemovalProbe?: (takeover: string, takeoverToken: string | null) => void | Promise<void>;
   /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
   compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
   /** Test-only hook after managed-mirror canonical validation. */
@@ -283,44 +288,132 @@ async function readLockOwner(lock: string): Promise<LockOwner> {
   };
 }
 
-async function removeOrphanTakeover(takeover: string): Promise<boolean> {
-  const [claim, info] = await Promise.all([
-    readFile(takeover, "utf8")
-      .then((value) => JSON.parse(value) as { pid?: unknown; takeoverToken?: unknown })
-      .catch(() => null),
-    stat(takeover).catch((error) => {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-      throw error;
-    }),
-  ]);
-  if (!info) return true;
+type TakeoverClaim = {
+  pid?: unknown;
+  takeoverToken?: unknown;
+  ownerToken?: unknown;
+  startedAt?: unknown;
+  abandonedAt?: unknown;
+};
 
-  const pid = typeof claim?.pid === "number" && Number.isSafeInteger(claim.pid)
-    ? claim.pid
+type TakeoverSnapshot = {
+  claim: TakeoverClaim | null;
+  identity: string;
+  mtimeMs: number;
+};
+
+async function readTakeoverClaim(takeover: string): Promise<TakeoverSnapshot | null> {
+  let handle;
+  try {
+    handle = await open(takeover, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const [raw, info] = await Promise.all([handle.readFile("utf8"), handle.stat()]);
+    let claim: TakeoverClaim | null = null;
+    try {
+      claim = JSON.parse(raw) as TakeoverClaim;
+    } catch {
+      // Legacy or partially published claims are handled by their age.
+    }
+    const token = typeof claim?.takeoverToken === "string" ? claim.takeoverToken : null;
+    return {
+      claim,
+      identity: token ?? `legacy-${createHash("sha256").update(raw).digest("hex")}`,
+      mtimeMs: info.mtimeMs,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function takeoverClaimIsReclaimable(snapshot: TakeoverSnapshot): boolean {
+  if (typeof snapshot.claim?.abandonedAt === "string") return true;
+  const pid = typeof snapshot.claim?.pid === "number" && Number.isSafeInteger(snapshot.claim.pid)
+    ? snapshot.claim.pid
     : null;
-  const takeoverToken = typeof claim?.takeoverToken === "string"
-    ? claim.takeoverToken
+  const takeoverToken = typeof snapshot.claim?.takeoverToken === "string"
+    ? snapshot.claim.takeoverToken
     : null;
+  const ageMs = Date.now() - snapshot.mtimeMs;
   const sameProcessOrphan = pid === process.pid &&
     (!takeoverToken || !activeTakeoverTokens().has(takeoverToken));
-  if (sameProcessOrphan) {
-    // The claimant is still alive, but this token is not part of an active
-    // takeover in this process. Reclaim it without applying the age window.
-  } else if (pid) {
+  if (sameProcessOrphan) return true;
+  if (pid) {
     try {
       process.kill(pid, 0);
-      return false;
+      return ageMs > LOCK_STALE_MS;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EPERM") return false;
+      return (error as NodeJS.ErrnoException).code !== "EPERM" || ageMs > LOCK_STALE_MS;
     }
-  } else if (Date.now() - info.mtimeMs <= LOCK_STALE_MS) {
-    // Older releases did not record the claimant PID. Give a live legacy
-    // takeover the same stale window as an unreadable lock owner.
-    return false;
   }
+  return ageMs > LOCK_STALE_MS;
+}
 
-  await rm(takeover, { force: true });
-  return true;
+async function publishTakeoverClaim(
+  lock: string,
+  ownerToken: string | null,
+  takeoverToken: string,
+): Promise<boolean> {
+  const candidate = path.join(lock, `.takeover-candidate-${takeoverToken}`);
+  const claimPath = path.join(lock, ".takeover");
+  await writeFile(candidate, JSON.stringify({
+    pid: process.pid,
+    takeoverToken,
+    ownerToken,
+    startedAt: nowIso(),
+  }), { flag: "wx" });
+  try {
+    const currentOwner = await readLockOwner(lock);
+    if (currentOwner.token !== ownerToken) return false;
+    await link(candidate, claimPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+    throw error;
+  } finally {
+    await rm(candidate, { force: true });
+  }
+}
+
+function takeoverFencePath(
+  lock: string,
+  snapshot: TakeoverSnapshot,
+  owner: LockOwner,
+  lockBirthtimeMs: number,
+): string {
+  const generation = JSON.stringify({
+    claim: snapshot.identity,
+    ownerPid: owner.pid,
+    ownerToken: owner.token,
+    ownerStartedAt: owner.startedAt,
+    lockBirthtimeMs,
+  });
+  const digest = createHash("sha256").update(generation).digest("hex").slice(0, 32);
+  return `${lock}.reclaimed-${digest}`;
+}
+
+async function renameLockToFence(lock: string, fence: string): Promise<boolean> {
+  try {
+    await rename(lock, fence);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? "";
+    if (["EEXIST", "ENOTEMPTY", "ENOENT"].includes(code)) return false;
+    if (["EACCES", "EPERM"].includes(code)) {
+      const fenceExists = await stat(fence).then(
+        () => true,
+        (statError) => {
+          if ((statError as NodeJS.ErrnoException).code === "ENOENT") return false;
+          throw statError;
+        },
+      );
+      if (fenceExists) return false;
+    }
+    throw error;
+  }
 }
 
 async function renameLockCandidate(candidate: string, lock: string): Promise<void> {
@@ -442,38 +535,53 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
           await options.lockProbe?.("stale-observed");
           const takeover = path.join(lock, ".takeover");
           const takeoverToken = randomBytes(16).toString("hex");
+          // Register before writeFile can publish the claim. Another
+          // same-process contender must never mistake this token for an
+          // abandoned marker during the await boundary.
+          activeTakeoverTokens().add(takeoverToken);
           try {
-            await writeFile(
-              takeover,
-              JSON.stringify({
-                pid: process.pid,
-                takeoverToken,
-                ownerToken: owner.token,
-                startedAt: nowIso(),
-              }),
-              { flag: "wx" },
-            );
-            activeTakeoverTokens().add(takeoverToken);
-            try {
-              const currentOwner = await readLockOwner(lock);
-              if (currentOwner.token !== owner.token) {
-                await rm(takeover, { force: true });
-              } else {
-                const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
-                await rename(lock, reclaimed);
-                await rm(reclaimed, { recursive: true, force: true });
-                continue;
-              }
-            } finally {
-              activeTakeoverTokens().delete(takeoverToken);
-              // A failed Windows rename must not leave a same-process claim
-              // that every later store mistakes for an active contender.
-              await rm(takeover, { force: true }).catch(() => {});
+            const ownerBeforePublish = await readLockOwner(lock);
+            if (ownerBeforePublish.token !== owner.token) continue;
+            const published = await publishTakeoverClaim(lock, owner.token, takeoverToken);
+            const inspected = await readTakeoverClaim(takeover);
+            if (!inspected) continue;
+            if (published) {
+              await options.takeoverPublishProbe?.(takeoverToken);
+            } else {
+              const inspectedToken = typeof inspected.claim?.takeoverToken === "string"
+                ? inspected.claim.takeoverToken
+                : null;
+              if (!takeoverClaimIsReclaimable(inspected)) continue;
+              await options.takeoverRemovalProbe?.(takeover, inspectedToken);
             }
+
+            // Claims are immutable. Re-read both the claim identity and lock
+            // generation immediately before fencing the whole directory.
+            const generationBefore = await stat(lock);
+            const [currentClaim, currentOwner] = await Promise.all([
+              readTakeoverClaim(takeover),
+              readLockOwner(lock),
+            ]);
+            const generationAfter = await stat(lock);
+            if (
+              generationBefore.birthtimeMs !== generationAfter.birthtimeMs ||
+              currentClaim?.identity !== inspected.identity ||
+              currentOwner.token !== owner.token
+            ) continue;
+
+            // Every observer of this claim targets the same retained,
+            // non-empty fence. A delayed contender therefore cannot rename a
+            // newly acquired successor lock after another observer wins.
+            if (
+              await renameLockToFence(
+                lock,
+                takeoverFencePath(lock, inspected, currentOwner, generationAfter.birthtimeMs),
+              )
+            ) continue;
           } catch (takeoverError) {
-            const code = (takeoverError as NodeJS.ErrnoException).code ?? "";
-            if (code === "EEXIST" && await removeOrphanTakeover(takeover)) continue;
-            if (!["EEXIST", "ENOENT"].includes(code)) throw takeoverError;
+            if ((takeoverError as NodeJS.ErrnoException).code !== "ENOENT") throw takeoverError;
+          } finally {
+            activeTakeoverTokens().delete(takeoverToken);
           }
         }
       } catch (lockError) {

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -142,10 +142,17 @@ const LOCK_STALE_MS = 5 * 60_000;
 declare global {
   // eslint-disable-next-line no-var
   var __caveHomeReconciliationLockTokens: Set<string> | undefined;
+  // eslint-disable-next-line no-var
+  var __caveHomeReconciliationTakeoverTokens: Set<string> | undefined;
 }
 
 function activeLockTokens(): Set<string> {
   return globalThis.__caveHomeReconciliationLockTokens ??=
+    new Set<string>();
+}
+
+function activeTakeoverTokens(): Set<string> {
+  return globalThis.__caveHomeReconciliationTakeoverTokens ??=
     new Set<string>();
 }
 
@@ -279,7 +286,7 @@ async function readLockOwner(lock: string): Promise<LockOwner> {
 async function removeOrphanTakeover(takeover: string): Promise<boolean> {
   const [claim, info] = await Promise.all([
     readFile(takeover, "utf8")
-      .then((value) => JSON.parse(value) as { pid?: unknown })
+      .then((value) => JSON.parse(value) as { pid?: unknown; takeoverToken?: unknown })
       .catch(() => null),
     stat(takeover).catch((error) => {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -291,7 +298,15 @@ async function removeOrphanTakeover(takeover: string): Promise<boolean> {
   const pid = typeof claim?.pid === "number" && Number.isSafeInteger(claim.pid)
     ? claim.pid
     : null;
-  if (pid) {
+  const takeoverToken = typeof claim?.takeoverToken === "string"
+    ? claim.takeoverToken
+    : null;
+  const sameProcessOrphan = pid === process.pid &&
+    (!takeoverToken || !activeTakeoverTokens().has(takeoverToken));
+  if (sameProcessOrphan) {
+    // The claimant is still alive, but this token is not part of an active
+    // takeover in this process. Reclaim it without applying the age window.
+  } else if (pid) {
     try {
       process.kill(pid, 0);
       return false;
@@ -438,14 +453,22 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
               }),
               { flag: "wx" },
             );
-            const currentOwner = await readLockOwner(lock);
-            if (currentOwner.token !== owner.token) {
-              await rm(takeover, { force: true });
-            } else {
-              const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
-              await rename(lock, reclaimed);
-              await rm(reclaimed, { recursive: true, force: true });
-              continue;
+            activeTakeoverTokens().add(takeoverToken);
+            try {
+              const currentOwner = await readLockOwner(lock);
+              if (currentOwner.token !== owner.token) {
+                await rm(takeover, { force: true });
+              } else {
+                const reclaimed = `${lock}.reclaimed-${takeoverToken}`;
+                await rename(lock, reclaimed);
+                await rm(reclaimed, { recursive: true, force: true });
+                continue;
+              }
+            } finally {
+              activeTakeoverTokens().delete(takeoverToken);
+              // A failed Windows rename must not leave a same-process claim
+              // that every later store mistakes for an active contender.
+              await rm(takeover, { force: true }).catch(() => {});
             }
           } catch (takeoverError) {
             const code = (takeoverError as NodeJS.ErrnoException).code ?? "";

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -276,6 +276,38 @@ async function readLockOwner(lock: string): Promise<LockOwner> {
   };
 }
 
+async function removeOrphanTakeover(takeover: string): Promise<boolean> {
+  const [claim, info] = await Promise.all([
+    readFile(takeover, "utf8")
+      .then((value) => JSON.parse(value) as { pid?: unknown })
+      .catch(() => null),
+    stat(takeover).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }),
+  ]);
+  if (!info) return true;
+
+  const pid = typeof claim?.pid === "number" && Number.isSafeInteger(claim.pid)
+    ? claim.pid
+    : null;
+  if (pid) {
+    try {
+      process.kill(pid, 0);
+      return false;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EPERM") return false;
+    }
+  } else if (Date.now() - info.mtimeMs <= LOCK_STALE_MS) {
+    // Older releases did not record the claimant PID. Give a live legacy
+    // takeover the same stale window as an unreadable lock owner.
+    return false;
+  }
+
+  await rm(takeover, { force: true });
+  return true;
+}
+
 async function renameLockCandidate(candidate: string, lock: string): Promise<void> {
   try {
     await rename(candidate, lock);
@@ -396,7 +428,16 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
           const takeover = path.join(lock, ".takeover");
           const takeoverToken = randomBytes(16).toString("hex");
           try {
-            await writeFile(takeover, JSON.stringify({ takeoverToken, ownerToken: owner.token }), { flag: "wx" });
+            await writeFile(
+              takeover,
+              JSON.stringify({
+                pid: process.pid,
+                takeoverToken,
+                ownerToken: owner.token,
+                startedAt: nowIso(),
+              }),
+              { flag: "wx" },
+            );
             const currentOwner = await readLockOwner(lock);
             if (currentOwner.token !== owner.token) {
               await rm(takeover, { force: true });
@@ -407,7 +448,9 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
               continue;
             }
           } catch (takeoverError) {
-            if (!["EEXIST", "ENOENT"].includes((takeoverError as NodeJS.ErrnoException).code ?? "")) throw takeoverError;
+            const code = (takeoverError as NodeJS.ErrnoException).code ?? "";
+            if (code === "EEXIST" && await removeOrphanTakeover(takeover)) continue;
+            if (!["EEXIST", "ENOENT"].includes(code)) throw takeoverError;
           }
         }
       } catch (lockError) {


### PR DESCRIPTION
## Summary
- record takeover claimant PID and start time in migration lock markers
- reclaim dead claimant markers and aged legacy markers so startup cannot retry EEXIST forever
- add regression coverage for the orphan legacy takeover state reproduced on Windows

## Root cause
A crashed contender left .coven/cave/.migration.lock/.takeover behind. The next packaged launch repeatedly hit EEXIST while trying to claim the stale migration lock, so the server health endpoint reported ready but workspace initialization never completed and the native startup window remained visible.

## Verification
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/cave-home-migration.test.ts
- pnpm typecheck
- node scripts/check-tests-wired.mjs
- pnpm build (pre-PR packaged candidate validation)
- Windows packaged StartupProbeOnly harness: workspace ready in 6836 ms from rebuilt MSI candidate

## Tracking
- Bead: cave-wq3
- Related to #3269