### PR TITLE
feat(chat): debug export hygiene — environment stamp, preview-stripped turn copies, event copy, tail-cap notice (cave-hxqk)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -48,6 +48,34 @@ assert.match(
   "Session model row prefers the daemon-recorded session model over the familiar's configured default",
 );
 
+// ── Export hygiene (chat-session-debugging S3) ───────────────────────────────
+
+assert.match(
+  source,
+  /environment: \{ appVersion: APP_VERSION, exportedAt: new Date\(\)\.toISOString\(\) \}/,
+  "Debug bundles must stamp the exporting build + timestamp for bug reports",
+);
+assert.match(
+  source,
+  /JSON\.stringify\(exportDebugTurn\(turn\), null, 2\)/,
+  "Copy turn and the expanded JSON must strip base64 attachment previews (multi-MB clipboard writes)",
+);
+assert.doesNotMatch(
+  source,
+  /getText=\{\(\) => JSON\.stringify\(turn, null, 2\)\}/,
+  "no raw-turn copy path may remain — every turn export goes through exportDebugTurn",
+);
+assert.match(
+  source,
+  /label="Copy event"/,
+  "Event rows should offer a copy affordance like turn rows do",
+);
+assert.match(
+  source,
+  /tailCapped[\s\S]*?Long event tail[\s\S]*?Load more/,
+  "Hitting the page-cap must surface a truncation notice with a Load more continuation, not truncate silently",
+);
+
 // ── Changes panel (CHAT-D8-01): working-tree review, now hosted by the code
 // rail (the inspector right panel that first carried it is retired) ──────────
 

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -6,15 +6,13 @@ import { useCopy } from "@/lib/use-copy";
 import { formatClock, formatTimestamp, useDateTimePrefs } from "@/lib/datetime-format";
 import { formatRuntime } from "@/lib/chat-response-metadata";
 import { usageBreakdown } from "@/lib/usage-format";
-import {
-  stripPreviewOnlyAttachmentFields,
-  type ChatAttachment,
-} from "@/lib/chat-attachments";
+import { APP_VERSION } from "@/lib/app-version";
 import { type ChatDebugSnapshot } from "@/lib/chat-debug-store";
 import {
   appendEvents,
   buildDebugBundle,
   debugFileName,
+  exportDebugTurn,
   formatEventPayload,
   nextAfterSeq,
   shouldPollEvents,
@@ -152,9 +150,11 @@ function TurnRow({ index, turn }: { index: number; turn: DebugTurn }) {
             <span className="min-w-0 truncate font-mono text-[10px] text-[var(--text-muted)]">
               {usageBreakdown(turn.usage, turn.costUsd) ?? ""}
             </span>
-            <CopyButton getText={() => JSON.stringify(turn, null, 2)} label="Copy turn" />
+            {/* Preview-stripped: a pasted screenshot's base64 must not land in
+                the clipboard or the JSON block below. */}
+            <CopyButton getText={() => JSON.stringify(exportDebugTurn(turn), null, 2)} label="Copy turn" />
           </div>
-          <JsonBlock text={JSON.stringify(turn, null, 2)} />
+          <JsonBlock text={JSON.stringify(exportDebugTurn(turn), null, 2)} />
         </div>
       ) : null}
     </div>
@@ -179,6 +179,9 @@ function EventRow({ event }: { event: CovenEvent }) {
       </button>
       {open ? (
         <div className="border-t border-[var(--border-hairline)] p-2">
+          <div className="mb-1 flex justify-end">
+            <CopyButton getText={() => JSON.stringify(event, null, 2)} label="Copy event" />
+          </div>
           <JsonBlock text={formatEventPayload(event.payload_json)} />
         </div>
       ) : null}
@@ -202,6 +205,9 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const fetchInFlightRef = useRef(false);
+  // True when a drain stopped at the page cap with a full final page — more
+  // events likely remain server-side and the list is silently incomplete.
+  const [tailCapped, setTailCapped] = useState(false);
 
   // Pages until the tail is drained (a full page means more may remain), so
   // finished sessions with >200 events aren't silently truncated. Capped as a
@@ -211,6 +217,7 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
     if (!sessionId || fetchInFlightRef.current) return;
     fetchInFlightRef.current = true;
     try {
+      let lastPageFull = false;
       for (let page = 0; page < 50; page++) {
         const res = await fetch(
           `/api/sessions/${encodeURIComponent(sessionId)}/events?afterSeq=${cursorRef.current}&limit=200`,
@@ -221,8 +228,10 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
         const incoming = json.events ?? [];
         setEvents((prev) => appendEvents(prev, incoming));
         cursorRef.current = Math.max(cursorRef.current, nextAfterSeq(incoming));
-        if (incoming.length < 200) break;
+        lastPageFull = incoming.length >= 200;
+        if (!lastPageFull) break;
       }
+      setTailCapped(lastPageFull);
       setEventsError(null);
     } catch (err) {
       setEventsError(err instanceof Error ? err.message : String(err));
@@ -276,15 +285,19 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   }, []);
 
   const bundleJson = useCallback(() => {
-    // Attachment previews carry base64 data-URLs; drop them from exports the
-    // same way sends do, so Copy all / Download stay reasonably sized.
-    const exportTurns = turns.map((turn) => {
-      const attachments = (turn as { attachments?: ChatAttachment[] }).attachments;
-      return attachments?.length
-        ? { ...turn, attachments: stripPreviewOnlyAttachmentFields(attachments) }
-        : turn;
-    });
-    return JSON.stringify(buildDebugBundle({ session, familiar, turns: exportTurns, events }), null, 2);
+    // buildDebugBundle strips attachment previews and stamps the environment
+    // block (which build exported this, when) for bug-report bundles.
+    return JSON.stringify(
+      buildDebugBundle({
+        session,
+        familiar,
+        turns,
+        events,
+        environment: { appVersion: APP_VERSION, exportedAt: new Date().toISOString() },
+      }),
+      null,
+      2,
+    );
   }, [session, familiar, turns, events]);
 
   const downloadBundle = useCallback(() => {
@@ -383,6 +396,18 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
               ))}
             </div>
           )}
+          {tailCapped ? (
+            <div className="mt-1 flex items-center justify-between gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1 text-[10px] text-[var(--text-muted)]">
+              <span>Long event tail — showing the first {events.length} events.</span>
+              <button
+                type="button"
+                className="focus-ring shrink-0 underline"
+                onClick={() => void fetchEvents()}
+              >
+                Load more
+              </button>
+            </div>
+          ) : null}
         </Section>
       </div>
 

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -58,22 +58,64 @@ assert.ok(
 );
 
 // buildDebugBundle: shape + familiar narrowed to {id, harness, model}
+const env = { appVersion: "0.1.2-test", exportedAt: "2026-07-17T12:00:00Z" };
 const bundle = buildDebugBundle({
   session: { id: "s1", status: "completed" },
   familiar: { id: "f1", display_name: "Nova", role: "dev", harness: "claude", model: "opus" },
   turns: [{ id: "t1", role: "user", text: "hi", createdAt: "2026-06-10T00:00:00Z" }],
   events: [ev(1)],
+  environment: env,
 });
 assert.equal(bundle.session.id, "s1");
 assert.deepEqual(bundle.familiar, { id: "f1", harness: "claude", model: "opus" });
 assert.equal(bundle.turns.length, 1);
 assert.equal(bundle.events.length, 1);
-assert.equal(buildDebugBundle({ session: null, familiar: null, turns: [], events: [] }).familiar, null);
+assert.deepEqual(bundle.environment, env, "bundle carries the repro environment block verbatim");
+assert.equal(
+  buildDebugBundle({ session: null, familiar: null, turns: [], events: [], environment: env }).familiar,
+  null,
+);
 const turnsRef = [{ id: "t1", role: "user", text: "hi", createdAt: "2026-06-10T00:00:00Z" }];
 assert.equal(
-  buildDebugBundle({ session: null, familiar: null, turns: turnsRef, events: [] }).turns,
+  buildDebugBundle({ session: null, familiar: null, turns: turnsRef, events: [], environment: env }).turns,
   turnsRef,
-  "turns are passed by reference, not cloned",
+  "attachment-free turns are passed by reference, not cloned",
+);
+
+// exportDebugTurn: preview-only attachment fields are stripped from exports
+import { exportDebugTurn } from "./session-debug.ts";
+
+const plainTurn = { id: "t1", role: "user", text: "hi", createdAt: "2026-06-10T00:00:00Z" };
+assert.equal(exportDebugTurn(plainTurn), plainTurn, "no attachments → same reference (no clone)");
+
+const attachedTurn = {
+  ...plainTurn,
+  attachments: [
+    { name: "shot.png", mimeType: "image/png", size: 12, dataUrl: "data:image/png;base64,AAAA" },
+  ],
+};
+const exported = exportDebugTurn(attachedTurn);
+assert.deepEqual(
+  exported.attachments,
+  [{ name: "shot.png", size: 12 }],
+  "preview-only fields (dataUrl, mimeType) are stripped; metadata survives",
+);
+assert.deepEqual(
+  attachedTurn.attachments[0].dataUrl,
+  "data:image/png;base64,AAAA",
+  "the live turn is not mutated by exporting",
+);
+const strippedBundle = buildDebugBundle({
+  session: null,
+  familiar: null,
+  turns: [attachedTurn],
+  events: [],
+  environment: env,
+});
+assert.equal(
+  strippedBundle.turns[0].attachments[0].dataUrl,
+  undefined,
+  "bundle turns go through exportDebugTurn — no base64 previews in Copy all / Download",
 );
 
 // debugFileName

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -1,6 +1,7 @@
 import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
 import { usageSummary, type TurnUsage } from "./usage-format.ts";
+import { stripPreviewOnlyAttachmentFields, type ChatAttachment } from "./chat-attachments.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -49,6 +50,7 @@ export type DebugTurn = {
   /** Structural subset of ChatResponseMetadata — enough to tell the model
    *  that actually served the turn from the familiar's configured one. */
   responseMetadata?: { model?: string; confirmedModel?: string };
+  attachments?: ChatAttachment[];
 };
 
 /** The model that actually served a turn, when the harness reported one —
@@ -77,6 +79,8 @@ export type DebugBundle = {
   familiar: { id: string; harness?: string; model?: string } | null;
   turns: DebugTurn[];
   events: CovenEvent[];
+  /** Repro context for bug-report bundles: which build exported this, when. */
+  environment: { appVersion: string; exportedAt: string };
 };
 
 /** Append a poll page onto the accumulated tail: dedupe by seq, keep ascending
@@ -124,23 +128,37 @@ export function formatEventPayload(payloadJson: string): string {
   }
 }
 
+/** Export/display form of a turn: attachment previews carry base64 data-URLs,
+ *  so they're stripped the same way sends do — a pasted screenshot must not
+ *  blow up a clipboard copy or the expanded JSON block. Reference-stable when
+ *  there is nothing to strip. */
+export function exportDebugTurn(turn: DebugTurn): DebugTurn {
+  return turn.attachments?.length
+    ? { ...turn, attachments: stripPreviewOnlyAttachmentFields(turn.attachments) }
+    : turn;
+}
+
 /** Typed constructor for the export bundle. Callers pass a full Familiar;
  *  the explicit field-pick strips everything but {id, harness, model} from
- *  the export. Arrays are passed by reference (snapshot at call time), not
- *  cloned. */
+ *  the export. Turns are preview-stripped via {@link exportDebugTurn}
+ *  (reference-stable when no turn has attachments); events are passed by
+ *  reference (snapshot at call time). */
 export function buildDebugBundle(args: {
   session: SessionRow | null;
   familiar: { id: string; harness?: string; model?: string } | null;
   turns: DebugTurn[];
   events: CovenEvent[];
+  environment: { appVersion: string; exportedAt: string };
 }): DebugBundle {
+  const anyAttachments = args.turns.some((turn) => turn.attachments?.length);
   return {
     session: args.session,
     familiar: args.familiar
       ? { id: args.familiar.id, harness: args.familiar.harness, model: args.familiar.model }
       : null,
-    turns: args.turns,
+    turns: anyAttachments ? args.turns.map(exportDebugTurn) : args.turns,
     events: args.events,
+    environment: args.environment,
   };
 }
 


### PR DESCRIPTION
## What

Slice S3 of the **chat-session-debugging** goal (Phase 1 audit gaps B3/C3/C4/C5). Builds on #3339 + #3352.

**Bundle repro context (B3).** `DebugBundle` gains `environment: { appVersion, exportedAt }` — bug-report bundles now say which build exported them and when. `buildDebugBundle` also owns the attachment-preview strip via the new pure `exportDebugTurn` (reference-stable when attachment-free, preserving the documented pass-by-reference behavior), replacing the pane's hand-rolled map.

**Preview-stripped turn copies (C3).** *Copy turn* and the expanded turn JSON serialized the raw turn — a pasted screenshot's base64 `dataUrl` became a multi-MB clipboard write. Both now go through `exportDebugTurn`, matching the bundle path (metadata survives; only `dataUrl`/`mimeType` drop, and the live turn is never mutated).

**Copy event (C4).** Event rows get the same copy affordance turn rows have (whole event JSON).

**Honest truncation (C5).** The 50-page drain cap used to stop silently. A full final page now sets `tailCapped` → "Long event tail — showing the first N events" + **Load more**, which continues paging from the cursor.

## Verification

- `pnpm test:app` — 754 test files pass (new behavioral tests: environment passthrough, strip + no-mutation + reference stability, bundle strips previews; pins: environment stamp, exportDebugTurn-only copies, Copy event, tail-cap notice)
- `pnpm typecheck` — clean

## Refs

- Bead: cave-hxqk (chat-session-debugging goal S3)
- Prior slices: #3339 (S1), #3352 (S2)
