### PR TITLE
feat(chat): recommended next-path ghost-fills the empty composer — ⇥/← to accept (cave-h62k)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -488,6 +488,7 @@ export const SUITES = {
     "src/components/thread-signals-section.test.ts",
     "src/lib/thread-signal-dismissals.test.ts",
     "src/components/chat-view.test.ts",
+    "src/components/chat-composer-rec-autofill.test.ts",
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",
     "src/lib/cron-prompt.test.ts",

--- a/src/components/chat-composer-rec-autofill.test.ts
+++ b/src/components/chat-composer-rec-autofill.test.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+// Pins for the recommended-next-path composer ghost fill (cave-h62k): the
+// empty composer mirrors the last settled turn's top suggestion as its
+// placeholder, and ⇥ / ← accept it as an editable draft — fill, never send.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// The recommendation derives from the ACTIVE branch path's last settled
+// assistant turn — same suggestion the pills flag as "Recommended".
+assert.match(
+  source,
+  /const recommendedNextPath = useMemo\(\(\) => \{[\s\S]*?extractNextPaths\(last\.text\)\.suggestions\[0\] \?\? null;[\s\S]*?\}, \[activePath\]\);/,
+  "recommendedNextPath memo reads the active path's last settled assistant turn",
+);
+assert.match(
+  source,
+  /\.find\(\(t\) => t\.role === "assistant" && !t\.pending && !t\.error\)/,
+  "pending and errored turns never feed the recommendation",
+);
+
+// Key handling: empty-draft-only, not while busy, Shift+Tab untouched, and
+// ordered AFTER the menu/token handlers so they keep owning Tab while open.
+const keyBranch = source.match(
+  /\(\(e\.key === "Tab" && !e\.shiftKey\) \|\| e\.key === "ArrowLeft"\) &&\n\s*input === "" &&\n\s*!busy &&\n\s*recommendedNextPath/,
+);
+assert.ok(keyBranch, "⇥/← fill is gated on empty draft, not-busy, and a live recommendation");
+const menuKeyIdx = source.indexOf("if (handleMenuKey(e)) return;");
+const fillIdx = source.indexOf('e.key === "ArrowLeft"');
+assert.ok(menuKeyIdx !== -1 && fillIdx > menuKeyIdx, "menus keep owning Tab — fill branch comes after handleMenuKey");
+assert.match(
+  source,
+  /setInput\(recommendedNextPath\);\n\s*return;/,
+  "accepting fills the draft (never sends)",
+);
+
+// Placeholder: the recommendation replaces the idle hint; streaming keeps
+// its own placeholder.
+assert.match(
+  source,
+  /: recommendedNextPath\n\s*\? `\$\{recommendedNextPath\}  ⇥ to fill`/,
+  "empty composer shows the recommendation as its placeholder with the ⇥ hint",
+);
+
+console.log("chat-composer-rec-autofill: all pins hold");

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -299,10 +299,18 @@ assert.doesNotMatch(
   "Composer dock model pill should be removed — header meta line carries the model",
 );
 
+// The steady-state hint survives behind the recommended-next-path ghost fill
+// (cave-h62k): with a recommendation the placeholder mirrors it (`⇥ to fill`),
+// without one the classic `Message <familiar>…  ↵ to send` remains.
 assert.match(
   source,
-  /placeholder=\{busy \? "Streaming… \(esc to cancel\)" : `Message \$\{familiar\.display_name\}…  ↵ to send`\}/,
+  /: `Message \$\{familiar\.display_name\}…  ↵ to send`/,
   "Composer placeholder should include ↵ to send hint in steady state",
+);
+assert.match(
+  source,
+  /busy\s*\? "Streaming… \(esc to cancel\)"/,
+  "Streaming keeps its own placeholder ahead of the recommendation branch",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3390,6 +3390,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return resolveActivePath(turns, activeLeafId) as Turn[];
   }, [turns, activeLeafId]);
 
+  // The last settled assistant turn's top next-path — the pills flag that one
+  // as "Recommended", and the empty composer mirrors it as its placeholder so
+  // ⇥ / ← can accept it without reaching for the pills.
+  const recommendedNextPath = useMemo(() => {
+    const last = [...activePath]
+      .reverse()
+      .find((t) => t.role === "assistant" && !t.pending && !t.error);
+    if (!last?.text) return null;
+    return extractNextPaths(last.text).suggestions[0] ?? null;
+  }, [activePath]);
+
   // Branch-nav siblings for EVERY turn, built once per `turns` change instead
   // of scanning the whole array per rendered row (which ran on every stream
   // chunk). Lookups are O(1).
@@ -5005,6 +5016,22 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (handlePlaceholderTab(e, inputRef.current, setInput)) return;
     // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer
     if (handleArrowKey(e, input, setInput)) return;
+    // Recommended-next-path ghost fill: an EMPTY composer showing the
+    // recommendation as its placeholder accepts it with ⇥ or ← (both inert
+    // in an empty textarea, so no editing behaviour is lost). Ordered after
+    // the menus and token branches — they keep owning Tab while open — and
+    // gated on the empty draft so native Tab focus-move survives the moment
+    // there's real text (a11y). Fill, never send: the draft stays editable.
+    if (
+      ((e.key === "Tab" && !e.shiftKey) || e.key === "ArrowLeft") &&
+      input === "" &&
+      !busy &&
+      recommendedNextPath
+    ) {
+      e.preventDefault();
+      setInput(recommendedNextPath);
+      return;
+    }
     // `isComposing` is true for the Enter that confirms an IME candidate
     // (CJK/pinyin/kana). Treating that Enter as "send" fires a half-composed,
     // garbled message and destroys the candidate selection, so let the IME keep it.
@@ -5798,7 +5825,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               onClick={syncComposerCaret}
               onSelect={syncComposerCaret}
               onPaste={handlePaste}
-              placeholder={busy ? "Streaming… (esc to cancel)" : `Message ${familiar.display_name}…  ↵ to send`}
+              placeholder={
+                busy
+                  ? "Streaming… (esc to cancel)"
+                  : recommendedNextPath
+                    ? `${recommendedNextPath}  ⇥ to fill`
+                    : `Message ${familiar.display_name}…  ↵ to send`
+              }
               rows={1}
               inputMode="text"
               enterKeyHint="send"


### PR DESCRIPTION
Bead `cave-h62k`. The suggestion pills already flag the last settled turn's top next-path as **Recommended** (green pulse). This makes that recommendation one keystroke away:

- **Empty composer mirrors it as the placeholder** — `<suggestion>  ⇥ to fill` (streaming keeps its own placeholder; no recommendation → unchanged default).
- **⇥ or ← accepts it into the draft** — editable, never auto-sent. Both keys are inert in an empty textarea so no editing behaviour is lost.
- **A11y-ordered**: the fill branch sits after the mention/slash-menu and `{{token}}` handlers (they keep owning Tab while open) and gates on the empty draft, so native Tab focus-move survives the moment there's real text. Shift+Tab untouched.
- `recommendedNextPath` derives from the active branch path's last settled assistant turn via `extractNextPaths` — pending/errored turns never feed it.

## Verified

- New pin suite `chat-composer-rec-autofill.test.ts` (ordering after `handleMenuKey`, empty-draft gate, fill-never-send, placeholder wiring), wired into `run-tests.mjs`; all 12 existing chat-view source-slicing suites still green; tsc clean.
- Built app, seeded conversation: placeholder mirrors the suggestion, ⇥ fills, ← fills, non-empty draft leaves Tab native (screenshot on the bead trail; seed cleaned up after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)