### PR TITLE
feat(growth): familiar dropdown replaces sidebar roster — scales to N familiars (cave-4d3n)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10588,72 +10588,80 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-color: color-mix(in oklch, var(--color-success) 34%, var(--border-hairline));
 }
 .growth-layout {
-  display: grid;
-  grid-template-columns: minmax(240px, 290px) minmax(0, 1fr);
-  gap: 14px;
-  align-items: start;
-}
-.growth-sidebar {
-  position: sticky;
-  top: 16px;
+  display: flex;
   min-width: 0;
-  padding: 14px;
+  flex-direction: column;
+  gap: 14px;
+}
+/* Familiar picker — a dropdown instead of a fixed sidebar roster, so the
+   surface scales to any number of familiars. Options group attention-first
+   (stalled → active), mirroring the triage chips above. */
+.growth-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px 14px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-raised) 84%, transparent);
 }
-.growth-sidebar ul {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.growth-familiar {
-  display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 10px;
-  gap: 10px;
-  align-items: center;
-  width: 100%;
-  min-height: 70px;
-  padding: 10px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--text-primary);
-  text-align: left;
-}
-.growth-familiar:hover,
-.growth-familiar.is-selected {
-  border-color: var(--border-hairline);
-  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
-}
-.growth-familiar__avatar { width: 34px; height: 34px; border-radius: 10px; object-fit: cover; }
-.growth-familiar__copy .pulse-bars { margin-top: 7px; }
-/* Per-row analytics deep link — quiet until hovered, aligned under the copy. */
-.growth-familiar__analytics {
+.growth-picker__label {
   display: inline-flex;
-  margin: 2px 0 0 54px;
-  color: var(--text-muted);
-  font-size: var(--text-2xs);
-  text-decoration: none;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
-.growth-familiar__analytics:hover { color: var(--accent-presence); }
-.growth-familiar__copy {
-  display: block;
+.growth-picker__select {
+  display: inline-flex;
   min-width: 0;
+  max-width: 100%;
+  height: 40px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+  color: var(--text-primary);
 }
-.growth-familiar__copy b,
-.growth-familiar__copy small {
-  display: block;
+.growth-picker__select:hover { background: var(--bg-hover); }
+.growth-picker__value {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+.growth-picker__value b {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 13px;
+  font-weight: 650;
 }
-.growth-familiar__copy b { font-size: 13px; font-weight: 650; }
-.growth-familiar__copy small { margin-top: 2px; color: var(--text-muted); font-size: 11px; }
+.growth-picker__avatar,
+.growth-picker__option-avatar {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  object-fit: cover;
+  font-size: 11px;
+}
+.growth-picker__count {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.growth-picker__popover { min-width: 300px; max-width: min(420px, 92vw); }
 .growth-dot {
   width: 9px;
   height: 9px;
@@ -10908,8 +10916,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 /* Pane-width responsiveness — mirrors the old viewport media rules but fires
    on the surface's own width. */
 @container growth (max-width: 920px) {
-  .growth-layout { grid-template-columns: 1fr; }
-  .growth-sidebar { position: static; }
   .growth-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .growth-signals { grid-template-columns: 1fr; }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10623,8 +10623,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   max-width: 100%;
   height: 40px;
   align-items: center;
-  gap: 8px;
-  padding: 0 12px;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-raised);
@@ -10635,14 +10635,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-flex;
   min-width: 0;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .growth-picker__value b {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-base);
   font-weight: 650;
 }
 .growth-picker__avatar,
@@ -10650,9 +10650,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   width: 22px;
   height: 22px;
   flex-shrink: 0;
-  border-radius: 7px;
+  border-radius: var(--radius-sm);
   object-fit: cover;
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 .growth-picker__count {
   margin-left: auto;

--- a/src/components/familiar-analytics-navigation.test.ts
+++ b/src/components/familiar-analytics-navigation.test.ts
@@ -20,12 +20,14 @@ describe("Familiar analytics navigation wiring", () => {
     assert.match(analyticsPage, /<FamiliarAnalyticsView familiarId=\{id\} \/>/);
   });
 
-  it("links growth roster rows to per-familiar analytics", () => {
+  it("links the selected growth familiar to its analytics page", () => {
     const source = readFileSync(new URL("./familiar-growth-view.tsx", import.meta.url), "utf8");
 
+    // The roster is a dropdown (cave-4d3n); analytics deep-links hang off the
+    // selected familiar's hero action instead of per-row links.
     assert.match(source, /import Link from "next\/link"/);
-    assert.match(source, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/);
-    assert.match(source, /Analytics →/);
+    assert.match(source, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(selected\.familiar\.id\)\}\/analytics`\}/);
+    assert.match(source, /Analytics/);
   });
 
   it("links familiar landing cards to per-familiar analytics", () => {

--- a/src/components/familiar-growth-view.test.ts
+++ b/src/components/familiar-growth-view.test.ts
@@ -21,8 +21,7 @@ describe("Familiar growth view", () => {
     assert.match(globals, /\.growth-triage__chip--active/);
   });
 
-  it("renders a 14-day pulse per roster row and in the report", () => {
-    assert.match(view, /<PulseBars pulse=\{pulse\} size="sm"/);
+  it("renders the 14-day session pulse in the report", () => {
     assert.match(report, /<PulseBars/);
     assert.match(report, /buildSessionPulse/);
   });
@@ -33,9 +32,25 @@ describe("Familiar growth view", () => {
     assert.match(report, /vs prior 7d/);
   });
 
-  it("keeps the roster analytics link on a proper class (no ad-hoc utility strings)", () => {
-    assert.match(view, /growth-familiar__analytics/);
-    assert.doesNotMatch(view, /ml-\[54px\]/);
+  it("selects familiars via a dropdown so the roster scales to any count (cave-4d3n)", () => {
+    assert.match(view, /import \{ StandardSelect, type StandardSelectGroup \} from "@\/components\/ui\/select"/);
+    assert.match(view, /label="Select familiar"/, "the dropdown carries an accessible label");
+    assert.match(view, /className="growth-picker__select focus-ring"/);
+    assert.doesNotMatch(view, /growth-sidebar/, "the fixed sidebar roster list is gone");
+    assert.match(globals, /\.growth-picker\s*\{/, "the picker bar has its own styles");
+  });
+
+  it("groups dropdown options by health, attention-first, and hides empty groups", () => {
+    assert.match(view, /HEALTH_KEYS\.map\(\(key\) => \(\{/, "groups follow the stalled → active order");
+    assert.match(view, /HEALTH_GROUP_LABELS\[key\]/);
+    assert.match(view, /\$\{triage\[key\]\}/, "each group heading carries its familiar count");
+    assert.match(view, /filter\(\(group\) => group\.options\.length > 0\)/);
+    assert.match(view, /reportSummary\(familiarStats, retro\)/, "options keep the per-familiar summary as detail text");
+  });
+
+  it("shows the selected familiar's health dot in the dropdown trigger", () => {
+    assert.match(view, /growth-picker__value/);
+    assert.match(view, /growth-dot growth-dot--\$\{selected\.report\.healthLabel\}/);
   });
 
   it("announces quiet refreshes to assistive tech", () => {
@@ -56,10 +71,6 @@ describe("Familiar growth view", () => {
     assert.match(view, /setUpdatedAt\(new Date\(\)\.toISOString\(\)\)/, "stamped on load settle, not render");
     assert.match(view, /Updated <RelativeTime iso=\{updatedAt\} \/>/, "renders as a semantic relative time");
     assert.match(globals, /\.growth-hero__updated/, "the stamp has its own class");
-  });
-
-  it("marks the selected roster row for assistive tech", () => {
-    assert.match(view, /aria-pressed=\{selectedItem\}/);
   });
 
   it("responds to pane width via container queries", () => {

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -317,10 +318,10 @@ export function FamiliarGrowthView({
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
           </button>
           {selected ? (
-            <a className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
+            <Link className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
               <Icon name="ph:chart-bar-bold" aria-hidden />
               Analytics
-            </a>
+            </Link>
           ) : null}
         </div>
       </header>

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PulseBars } from "@/components/ui/pulse-bars";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { StandardSelect, type StandardSelectGroup } from "@/components/ui/select";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { AuthedImage } from "@/components/ui/authed-image";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -16,7 +15,6 @@ import {
 } from "@/components/familiars-view-stats";
 import { FamiliarGrowthReport } from "@/components/familiar-growth-report";
 import { deriveGrowthReport, type FamiliarGrowthReport as GrowthReportModel } from "@/lib/familiar-growth-signals";
-import { buildSessionPulse, type PulseDay } from "@/lib/session-pulse";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { Icon } from "@/lib/icon";
 import type { RetroFamiliarState, RetroRunsSnapshot } from "@/lib/retro-runs";
@@ -77,12 +75,19 @@ const HEALTH_ORDER: Record<GrowthReportModel["healthLabel"], number> = {
 
 const HEALTH_KEYS = ["stalled", "quiet", "steady", "active"] as const;
 
+/** Dropdown group headings, in the same attention-first order. */
+const HEALTH_GROUP_LABELS: Record<GrowthReportModel["healthLabel"], string> = {
+  stalled: "Stalled",
+  quiet: "Quiet",
+  steady: "Steady",
+  active: "Active",
+};
+
 type RosterRow = {
   familiar: Familiar;
   stats: FamiliarCardStats;
   retro: RetroFamiliarState | null;
   report: GrowthReportModel;
-  pulse: PulseDay[];
 };
 
 function emptyStats(): FamiliarCardStats {
@@ -213,7 +218,6 @@ export function FamiliarGrowthView({
             stats: familiarStats,
             retro,
             report: deriveGrowthReport({ familiar, stats: familiarStats, retroState: retro, now }),
-            pulse: buildSessionPulse(data.sessions, familiar.id, now),
           };
         })
         .sort(
@@ -221,7 +225,7 @@ export function FamiliarGrowthView({
             HEALTH_ORDER[a.report.healthLabel] - HEALTH_ORDER[b.report.healthLabel] ||
             a.familiar.display_name.localeCompare(b.familiar.display_name),
         ),
-    [data.familiars, data.sessions, now, retroStates, stats],
+    [data.familiars, now, retroStates, stats],
   );
 
   const triage = useMemo(() => {
@@ -239,6 +243,35 @@ export function FamiliarGrowthView({
   }, [reports, selectedFamiliarId]);
 
   const selected = reports.find((item) => item.familiar.id === selectedFamiliarId) ?? reports[0] ?? null;
+
+  /** Health-grouped dropdown options — attention-first, so the familiars that
+      need nurturing surface at the top of an arbitrarily long roster. */
+  const familiarGroups = useMemo<StandardSelectGroup<string>[]>(
+    () =>
+      HEALTH_KEYS.map((key) => ({
+        label: `${HEALTH_GROUP_LABELS[key]} (${triage[key]})`,
+        options: reports
+          .filter((row) => row.report.healthLabel === key)
+          .map(({ familiar, stats: familiarStats, retro }) => ({
+            value: familiar.id,
+            label: familiar.display_name,
+            detail: `${familiar.role || familiar.harness || "familiar"} · ${reportSummary(familiarStats, retro)}`,
+            leading: (
+              <AuthedImage
+                className="retro-avatar growth-picker__option-avatar"
+                src={familiar.avatarUrl}
+                alt=""
+                fallback={
+                  <span className="retro-avatar growth-picker__option-avatar">
+                    {familiar.display_name.slice(0, 1).toUpperCase()}
+                  </span>
+                }
+              />
+            ),
+          })),
+      })).filter((group) => group.options.length > 0),
+    [reports, triage],
+  );
 
   const shellClass = `growth-surface${standalone ? " growth-surface--standalone" : ""}`;
 
@@ -300,62 +333,51 @@ export function FamiliarGrowthView({
       ) : null}
 
       <div className="growth-layout">
-        <aside className="growth-sidebar" aria-label="Familiar roster">
-          <div className="retro-panel-title">
+        <div className="growth-picker" role="group" aria-label="Familiar selection">
+          <span className="growth-picker__label">
             <Icon name="ph:users-three-bold" aria-hidden />
-            Familiar roster
-          </div>
-          {loading ? (
-            <SkeletonRows count={4} />
-          ) : reports.length === 0 ? (
-            <EmptyState
-              compact
-              icon="ph:users-three-bold"
-              headline="No familiars yet."
-              subtitle="Create a familiar to start tracking growth."
-            />
-          ) : (
-            <ul>
-              {reports.map(({ familiar, stats: familiarStats, retro, report, pulse }) => {
-                const selectedItem = selected?.familiar.id === familiar.id;
-                return (
-                  <li key={familiar.id}>
-                    <button
-                      type="button"
-                      className={`growth-familiar${selectedItem ? " is-selected" : ""}`}
-                      aria-pressed={selectedItem}
-                      onClick={() => setSelectedFamiliarId(familiar.id)}
-                    >
+            Familiar
+          </span>
+          {reports.length > 0 ? (
+            <>
+              <StandardSelect
+                label="Select familiar"
+                title="Select familiar"
+                value={selected?.familiar.id ?? ""}
+                onChange={setSelectedFamiliarId}
+                options={familiarGroups}
+                className="growth-picker__select focus-ring"
+                popoverClassName="growth-picker__popover"
+                renderValue={() =>
+                  selected ? (
+                    <span className="growth-picker__value">
                       <AuthedImage
-                        className="retro-avatar growth-familiar__avatar"
-                        src={familiar.avatarUrl}
+                        className="retro-avatar growth-picker__avatar"
+                        src={selected.familiar.avatarUrl}
                         alt=""
                         fallback={
-                          <span className="retro-avatar growth-familiar__avatar">
-                            {familiar.display_name.slice(0, 1).toUpperCase()}
+                          <span className="retro-avatar growth-picker__avatar">
+                            {selected.familiar.display_name.slice(0, 1).toUpperCase()}
                           </span>
                         }
                       />
-                      <span className="growth-familiar__copy">
-                        <b>{familiar.display_name}</b>
-                        <small>{familiar.role || familiar.harness || "familiar"}</small>
-                        <small>{reportSummary(familiarStats, retro)}</small>
-                        <PulseBars pulse={pulse} size="sm" />
-                      </span>
-                      <i className={`growth-dot growth-dot--${report.healthLabel}`} aria-label={report.healthLabel} />
-                    </button>
-                    <Link
-                      href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
-                      className="growth-familiar__analytics focus-ring"
-                    >
-                      Analytics →
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </aside>
+                      <b>{selected.familiar.display_name}</b>
+                      <i
+                        className={`growth-dot growth-dot--${selected.report.healthLabel}`}
+                        aria-label={selected.report.healthLabel}
+                      />
+                    </span>
+                  ) : (
+                    <span>Select familiar</span>
+                  )
+                }
+              />
+              <span className="growth-picker__count">
+                {reports.length === 1 ? "1 familiar" : `${reports.length} familiars`}
+              </span>
+            </>
+          ) : null}
+        </div>
 
         <div className="growth-main" aria-busy={loading || refreshing}>
           {loading ? (
@@ -372,8 +394,8 @@ export function FamiliarGrowthView({
             <EmptyState
               compact
               icon="ph:users-three-bold"
-              headline="No familiars available."
-              subtitle="Growth reports appear once a familiar exists."
+              headline="No familiars yet."
+              subtitle="Create a familiar to start tracking growth."
             />
           )}
         </div>


### PR DESCRIPTION
## What

The **Spot growth patterns** surface selected familiars via a sticky sidebar roster list, which doesn't scale past a handful of agents. This replaces it with the house `StandardSelect` dropdown so the surface supports N familiars.

- Picker bar above the report: **Familiar** label · dropdown · roster count
- Options group by health **attention-first** (stalled → quiet → steady → active), mirroring the triage chips; group headings carry counts; empty groups hidden
- Each option: avatar, name, role + `sessions · memories · retro runs` summary
- Trigger: selected familiar's avatar + name + health dot
- Layout goes single-column; dead sidebar CSS removed; container query kept for report grids

## Verification

- `familiar-growth-view.test.ts` (updated pins: dropdown, grouping, trigger dot), `familiar-growth-route-wiring.test.ts`, `globals.css.test.ts` — 17 pass / 0 fail
- `pnpm typecheck` clean

Bead: cave-4d3n