### PR TITLE
feat(chat): debug events filter — text query over kind + payload with honest counts (cave-8vfn)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -76,6 +76,29 @@ assert.match(
   "Hitting the page-cap must surface a truncation notice with a Load more continuation, not truncate silently",
 );
 
+// ── Events filter (chat-session-debugging S4) ────────────────────────────────
+
+assert.match(
+  source,
+  /filterEvents\(events, eventQuery\)/,
+  "The events list renders through the pure filter so behavior stays unit-tested",
+);
+assert.match(
+  source,
+  /aria-label="Filter events by kind or payload text"/,
+  "The filter input must be labelled for screen readers",
+);
+assert.match(
+  source,
+  /\{visibleEvents\.length\}\/\{events\.length\}/,
+  "An active filter shows an honest filtered/total count",
+);
+assert.match(
+  source,
+  /No events match/,
+  "A filter with zero hits says so instead of rendering an empty void",
+);
+
 // ── Changes panel (CHAT-D8-01): working-tree review, now hosted by the code
 // rail (the inspector right panel that first carried it is retired) ──────────
 

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
 import { formatClock, formatTimestamp, useDateTimePrefs } from "@/lib/datetime-format";
@@ -13,6 +13,7 @@ import {
   buildDebugBundle,
   debugFileName,
   exportDebugTurn,
+  filterEvents,
   formatEventPayload,
   nextAfterSeq,
   shouldPollEvents,
@@ -198,6 +199,8 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   const cwd = formatRuntime(session?.runtime);
   const [events, setEvents] = useState<CovenEvent[]>([]);
   const [eventsError, setEventsError] = useState<string | null>(null);
+  const [eventQuery, setEventQuery] = useState("");
+  const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
   // Tail-follow only makes sense while events are streaming in; opening a
   // finished session shouldn't jump past the Session section.
   const [follow, setFollow] = useState(status === "running");
@@ -387,11 +390,32 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
               </button>
             </div>
           ) : null}
+          {events.length > 0 ? (
+            <div className="mb-1.5 flex items-center gap-2">
+              <input
+                type="search"
+                value={eventQuery}
+                onChange={(e) => setEventQuery(e.target.value)}
+                placeholder="Filter events (kind or payload)"
+                aria-label="Filter events by kind or payload text"
+                className="focus-ring min-w-0 flex-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 py-1 text-[10px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+              />
+              {eventQuery.trim() ? (
+                <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
+                  {visibleEvents.length}/{events.length}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
           {events.length === 0 && !eventsError ? (
             <div className="py-2 text-[10px] text-[var(--text-muted)]">No events yet.</div>
+          ) : visibleEvents.length === 0 ? (
+            <div className="py-2 text-[10px] text-[var(--text-muted)]">
+              No events match “{eventQuery.trim()}”.
+            </div>
           ) : (
             <div className="flex flex-col gap-1">
-              {events.map((event) => (
+              {visibleEvents.map((event) => (
                 <EventRow key={event.seq} event={event} />
               ))}
             </div>

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -44,6 +44,29 @@ assert.equal(shouldPollEvents({ status: "running", visible: false }), false);
 assert.equal(shouldPollEvents({ status: "completed", visible: true }), false);
 assert.equal(shouldPollEvents({ status: null, visible: true }), false);
 
+// filterEvents: case-insensitive over kind + raw payload; reference-stable when blank
+import { filterEvents } from "./session-debug.ts";
+{
+  const tail = [
+    { ...ev(1, "tool_use"), payload_json: '{"name":"grep"}' },
+    { ...ev(2, "output"), payload_json: '{"data":"Error: ENOENT /tmp/x"}' },
+    { ...ev(3, "lifecycle"), payload_json: "{}" },
+  ];
+  assert.equal(filterEvents(tail, ""), tail, "blank query returns the same array (memo bail)");
+  assert.equal(filterEvents(tail, "   "), tail, "whitespace-only query is blank");
+  assert.deepEqual(
+    filterEvents(tail, "TOOL").map((e) => e.seq),
+    [1],
+    "kind matches are case-insensitive",
+  );
+  assert.deepEqual(
+    filterEvents(tail, "enoent").map((e) => e.seq),
+    [2],
+    "payload text matches without parsing the JSON",
+  );
+  assert.deepEqual(filterEvents(tail, "nope").map((e) => e.seq), [], "no match → empty");
+}
+
 // formatEventPayload: pretty-prints JSON, passes through non-JSON untouched
 assert.equal(formatEventPayload('{"a":1}'), '{\n  "a": 1\n}');
 assert.equal(formatEventPayload("not json"), "not json");

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -103,6 +103,17 @@ export function shouldPollEvents(args: { status: string | null; visible: boolean
   return args.status === "running" && args.visible;
 }
 
+/** Case-insensitive substring filter over the event tail: matches kind or the
+ *  raw payload JSON (so ids, paths, and error text inside payloads hit without
+ *  a parse). Reference-stable on a blank query so React memos can bail. */
+export function filterEvents(events: CovenEvent[], query: string): CovenEvent[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return events;
+  return events.filter(
+    (e) => e.kind.toLowerCase().includes(q) || e.payload_json.toLowerCase().includes(q),
+  );
+}
+
 export function formatEventPayload(payloadJson: string): string {
   try {
     const parsed = JSON.parse(payloadJson);


### PR DESCRIPTION
## What

Slice S4 of the **chat-session-debugging** goal (Phase 1 audit gap C1, C2-lite). Builds on #3339 / #3352 / #3357.

**Events filter.** Debugging a long session meant scanning the whole event tail by eye. New pure `filterEvents` in `session-debug.ts`: case-insensitive substring match over `kind` **and the raw `payload_json`** — ids, paths, and error text inside payloads hit without parsing; reference-stable on a blank query (memo bail).

The Events section gains a labelled `type="search"` input; an active query renders an honest `filtered/total` count, and zero hits say *"No events match …"* instead of an empty void.

**C2 note:** no virtualization primitive exists in the repo — filtering practically bounds the rendered DOM for long tails; virtualization itself stays deferred (recorded in the goal).

## Verification

- `pnpm test:app` — 758 test files pass (behavioral tests: case-insensitivity, payload match, blank-query reference stability; pins: pure-filter wiring, labelled input, count, zero-hit copy)
- `pnpm typecheck` — clean

## Refs

- Bead: cave-8vfn (chat-session-debugging goal S4)
- Prior slices: #3339, #3352, #3357
