### PR TITLE
feat(threads): daemon adapter default + verbatim decision refusals (threads-v3g)

### DIFF
--- a/src/app/api/proposals-flow-e2e.test.ts
+++ b/src/app/api/proposals-flow-e2e.test.ts
@@ -66,8 +66,8 @@ describe("route-source pins: handlers are exactly the composition under test", (
 });
 
 describe("GET flow — real checked-in staged writes through the env-selected adapter", () => {
-  it("serves the pending fixtures with the freshness envelope (fixtures default)", async () => {
-    delete process.env.COVEN_THREADS_ADAPTER;
+  it("serves the pending fixtures with the freshness envelope (explicit fixtures mode)", async () => {
+    process.env.COVEN_THREADS_ADAPTER = "fixtures";
     delete process.env.COVEN_THREADS_FIXTURE_SCENARIO;
     const envelope = await activeThreadsAdapter().proposals();
     assert.equal(httpStatusForEnvelope(envelope, "GET"), 200);
@@ -86,7 +86,7 @@ describe("GET flow — real checked-in staged writes through the env-selected ad
   });
 
   it("daemon-timeout scenario blocks the list (R3), never an empty-healthy answer", async () => {
-    delete process.env.COVEN_THREADS_ADAPTER;
+    process.env.COVEN_THREADS_ADAPTER = "fixtures";
     process.env.COVEN_THREADS_FIXTURE_SCENARIO = "daemon-timeout";
     const envelope = await activeThreadsAdapter().proposals();
     assert.equal(envelope.blocked, true);
@@ -98,7 +98,7 @@ describe("GET flow — real checked-in staged writes through the env-selected ad
 
 describe("decision flow — forward-only, fail-closed, staged files untouched", () => {
   it("R5: fixtures mode (no daemon) answers 503 and the checked-in files never change", async () => {
-    delete process.env.COVEN_THREADS_ADAPTER;
+    process.env.COVEN_THREADS_ADAPTER = "fixtures";
     delete process.env.COVEN_THREADS_FIXTURE_SCENARIO;
     const pendingDir = path.join(process.cwd(), "fixtures", "phase-4", "pending");
     const before = readdirSync(pendingDir).sort();
@@ -110,7 +110,7 @@ describe("decision flow — forward-only, fail-closed, staged files untouched", 
   });
 
   it("reject path fails closed identically without a daemon", async () => {
-    delete process.env.COVEN_THREADS_ADAPTER;
+    process.env.COVEN_THREADS_ADAPTER = "fixtures";
     const envelope = await activeThreadsAdapter().reject(PROPOSAL_OK);
     assert.equal(envelope.why, "daemon-unavailable");
     assert.equal(httpStatusForEnvelope(envelope, "POST"), 503);

--- a/src/lib/proposal-flow.ts
+++ b/src/lib/proposal-flow.ts
@@ -77,6 +77,7 @@ const REFUSAL_MESSAGES: Record<string, string> = {
   "daemon-endpoint-missing": "The daemon does not accept decisions yet — nothing was applied.",
   "daemon-timeout": "The daemon timed out — nothing was applied; the proposal stays pending.",
   "proposal-corrupt": "The staged file is corrupt — the daemon was never asked.",
+  "proposal-refused": "The daemon re-validated and refused the decision — nothing was applied.",
   "not-found": "No staged proposal by that id — it may already be decided.",
   "invalid-id": "That proposal id is not valid.",
 };

--- a/src/lib/threads-adapters.test.ts
+++ b/src/lib/threads-adapters.test.ts
@@ -430,6 +430,53 @@ describe("daemon adapter — proposals and decisions", () => {
     assert.equal(httpStatusForEnvelope(res, "POST"), 503);
   });
 
+  it("§3.7: a daemon revalidation refusal surfaces verbatim as proposal-refused (409), not transport", async () => {
+    const { home } = homeWithPending();
+    const adapter = new DaemonThreadsAdapter({
+      call: async <T>() => ({
+        ok: false,
+        status: 409,
+        data: { blocked: true, why: "proposal-revalidation-failed", verdict: { DegradeToProposal: {} } } as unknown as T,
+      }),
+      covenHomeDir: home,
+    });
+    const res = await adapter.approve(PROPOSAL_OK, "reviewed");
+    assert.equal(res.blocked, true);
+    assert.equal(res.why, "proposal-refused");
+    assert.equal(httpStatusForEnvelope(res, "POST"), 409);
+  });
+
+  it("§3.7: the daemon's own proposal-not-found and proposal-corrupt map to their semantic whys", async () => {
+    const { home } = homeWithPending();
+    const notFound = new DaemonThreadsAdapter({
+      call: async <T>() => ({ ok: false, status: 404, data: { blocked: true, why: "proposal-not-found" } as unknown as T }),
+      covenHomeDir: home,
+    });
+    const nf = await notFound.approve(PROPOSAL_OK);
+    assert.equal(nf.why, "not-found");
+    assert.equal(httpStatusForEnvelope(nf, "POST"), 404);
+
+    const corrupt = new DaemonThreadsAdapter({
+      call: async <T>() => ({ ok: false, status: 409, data: { blocked: true, why: "proposal-corrupt" } as unknown as T }),
+      covenHomeDir: home,
+    });
+    const co = await corrupt.reject(PROPOSAL_OK);
+    assert.equal(co.why, "proposal-corrupt");
+    assert.equal(httpStatusForEnvelope(co, "POST"), 409);
+  });
+
+  it("a bodyless daemon 404 still reads as daemon-endpoint-missing (pre-#408 daemon)", async () => {
+    const { home } = homeWithPending();
+    const adapter = new DaemonThreadsAdapter({
+      call: async () => ({ ok: false, status: 404, data: null }),
+      covenHomeDir: home,
+    });
+    const res = await adapter.approve(PROPOSAL_OK);
+    assert.equal(res.blocked, true);
+    assert.equal(res.why, "daemon-endpoint-missing");
+    assert.equal(httpStatusForEnvelope(res, "POST"), 503);
+  });
+
   it("R6: a corrupt staged proposal answers proposal-corrupt (409), decision never forwarded", async () => {
     const home = tempDir("phase4-corrupt-home-");
     mkdirSync(path.join(home, "pending"));
@@ -477,17 +524,18 @@ describe("daemon adapter — proposals and decisions", () => {
   });
 });
 
-describe("adapter selection (fixtures-first until threads-986.19 merges)", () => {
-  it("defaults to fixtures; env flips to daemon; timeout scenario honored", () => {
+describe("adapter selection (daemon default since PR #382 + coven#408; fixtures by override)", () => {
+  it("defaults to daemon; env flips to fixtures; timeout scenario honored in fixtures mode", () => {
     const prevAdapter = process.env.COVEN_THREADS_ADAPTER;
     const prevScenario = process.env.COVEN_THREADS_FIXTURE_SCENARIO;
     try {
       delete process.env.COVEN_THREADS_ADAPTER;
       delete process.env.COVEN_THREADS_FIXTURE_SCENARIO;
-      assert.equal(activeThreadsAdapter().kind, "fixtures");
+      assert.equal(activeThreadsAdapter().kind, "daemon");
       process.env.COVEN_THREADS_ADAPTER = "daemon";
       assert.equal(activeThreadsAdapter().kind, "daemon");
-      delete process.env.COVEN_THREADS_ADAPTER;
+      process.env.COVEN_THREADS_ADAPTER = "fixtures";
+      assert.equal(activeThreadsAdapter().kind, "fixtures");
       process.env.COVEN_THREADS_FIXTURE_SCENARIO = "daemon-timeout";
       assert.equal(activeThreadsAdapter().kind, "fixtures");
     } finally {

--- a/src/lib/threads-adapters.ts
+++ b/src/lib/threads-adapters.ts
@@ -464,8 +464,26 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
       body: note === undefined ? {} : { note },
       timeoutMs: this.timeoutMs,
     });
-    if (!res.ok) return this.blockedFromDaemon(res);
+    if (!res.ok) return this.blockedFromDecision(res);
     return okEnvelope(res.data, this.meta(pendingDirCursor(pendingDir), true));
+  }
+
+  /**
+   * §3.7: the daemon "applies or refuses" and the route returns its outcome —
+   * a semantic refusal (blocked body with a why) must surface as that refusal,
+   * not be flattened into a transport-shaped `daemon-unavailable` (which the
+   * UI copy reads as "the proposal stays pending" — false for a daemon-side
+   * revalidation refusal, which consumes the staged file).
+   */
+  private blockedFromDecision(res: DaemonResponse<unknown>): ThreadsEnvelope<unknown> {
+    const body = res.data;
+    if (typeof body === "object" && body !== null && (body as { blocked?: unknown }).blocked === true) {
+      const why = (body as { why?: unknown }).why;
+      if (why === "proposal-not-found") return blockedEnvelope("not-found", this.meta("none", false));
+      if (why === "proposal-corrupt") return blockedEnvelope("proposal-corrupt", this.meta("none", false));
+      return blockedEnvelope("proposal-refused", this.meta("none", false));
+    }
+    return this.blockedFromDaemon(res);
   }
 
   async approve(proposalId: string, note?: string): Promise<ThreadsEnvelope<unknown>> {
@@ -478,12 +496,18 @@ export class DaemonThreadsAdapter implements ThreadsReadAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// Adapter selection: fixtures-first until threads-986.19 merges (spec §1).
+// Adapter selection: daemon-present is the default since threads-986.19
+// merged PR #382 (2026-07-15) and the daemon grew the read/decision endpoints
+// (coven#408, threads-v3g) — spec §1's fixtures-first condition has lapsed.
+// COVEN_THREADS_ADAPTER=fixtures keeps the daemon-absent adapter for demos,
+// tests, and the fixture scenarios.
 
 export function activeThreadsAdapter(): ThreadsReadAdapter {
-  if (process.env.COVEN_THREADS_ADAPTER === "daemon") return new DaemonThreadsAdapter();
-  const scenario = process.env.COVEN_THREADS_FIXTURE_SCENARIO === "daemon-timeout" ? "daemon-timeout" : "default";
-  return new FixturesThreadsAdapter({ scenario });
+  if (process.env.COVEN_THREADS_ADAPTER === "fixtures") {
+    const scenario = process.env.COVEN_THREADS_FIXTURE_SCENARIO === "daemon-timeout" ? "daemon-timeout" : "default";
+    return new FixturesThreadsAdapter({ scenario });
+  }
+  return new DaemonThreadsAdapter();
 }
 
 /** Map a blocked envelope's `why` to the HTTP status the route answers (§3.7, §4). */
@@ -496,6 +520,8 @@ export function httpStatusForEnvelope(envelope: ThreadsEnvelope<unknown>, method
       return 400;
     case "proposal-corrupt":
       return 409; // R6
+    case "proposal-refused":
+      return 409; // §3.7: daemon re-validated and refused — semantic, not transport
     case "daemon-unavailable":
     case "daemon-unreachable":
     case "daemon-endpoint-missing":

--- a/src/lib/threads-read.ts
+++ b/src/lib/threads-read.ts
@@ -41,6 +41,7 @@ export type BlockedWhy =
   | "meta-missing"
   | "not-found"
   | "proposal-corrupt"
+  | "proposal-refused"
   | "invalid-id";
 
 export const THREADS_STALE_TTL_MS = 30_000;


### PR DESCRIPTION
Cave side of bead threads-v3g, contract specs/PHASE-4-CAVE-SURFACES.md (coven-threads).

- §1 flip: fixtures-first condition lapsed (PR #382 merged; endpoints live via OpenCoven/coven#408) → daemon adapter is the default; `COVEN_THREADS_ADAPTER=fixtures` opts back into daemon-absent mode (E2E updated to select it explicitly).
- §3.7 verbatim outcomes: daemon semantic refusals map to `not-found` / `proposal-corrupt` / new `proposal-refused` (409) instead of transport-shaped `daemon-unavailable` (503) with misleading stays-pending copy; bodyless 404 still reads `daemon-endpoint-missing` (pre-#408 daemon).
- Live-verified against a hermetic real daemon over the socket (reads + staging + drift refusal + approve apply). Found daemon-side P1 during verification: ward_manifest baseline never advances post-apply → bead threads-eql (fix in flight).

Validation: test:app 754/754, targeted suites green, typecheck clean.