### PR TITLE
feat(weaves): the weave map — threads and their memory surfaces as a verified graph (cave-kgts)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -470,6 +470,7 @@ export const SUITES = {
     "src/lib/thread-self-report.test.ts",
     "src/lib/threads-read.test.ts",
     "src/lib/threads-adapters.test.ts",
+    "src/lib/weave-map.test.ts",
     "src/lib/weave-rail.test.ts",
     "src/lib/strand-inspect.test.ts",
     "src/lib/proposal-flow.test.ts",
@@ -1169,6 +1170,7 @@ const ALIAS_LOADER = new Set([
   // familiars-view-stats now imports ritualStreak from "@/lib/familiar-renown".
   "src/components/familiars-view-stats.test.ts",
   "src/lib/session-pulse.test.ts",
+  "src/lib/weave-map.test.ts",
   "src/components/familiar-analytics-view.test.ts",
   "src/lib/thread-confidence.test.ts",
   "src/lib/signal-trends.test.ts",

--- a/src/components/weave-map.tsx
+++ b/src/components/weave-map.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+// The weave map canvas (cave-kgts) — threads and the memory surfaces they
+// verifiably touch, laid out by the grimoire's zero-dep force engine. Every
+// edge is evidence: solid strong = authority contract, solid faint = audited
+// touches (count-weighted), dashed = staged proposal (the invitation).
+// Threads wear their tension tone; unknown/stale wear blocked — fail-closed
+// is a rendering rule here, same as everywhere in Phase 4.
+
+import { useEffect, useMemo, useRef } from "react";
+import {
+  createForceSim,
+  settleForceSim,
+  tickForceSim,
+  ALPHA_MIN,
+  type ForceSim,
+} from "@/lib/grimoire-force";
+import { buildWeaveMap, type WeaveMap, type WeaveMapTone } from "@/lib/weave-map";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+import type { AuditEntryView, ProposalView, ThreadView } from "@/lib/threads-read";
+
+const TONE_TOKEN: Record<WeaveMapTone, string> = {
+  holds: "--color-success",
+  frayed: "--color-warning",
+  snapped: "--color-danger",
+  blocked: "--text-muted",
+};
+
+const THREAD_RADIUS = 9;
+const SURFACE_RADIUS = 6;
+const HEIGHT = 260;
+
+type Props = {
+  threads: ThreadView[];
+  audit: AuditEntryView[];
+  proposals: ProposalView[];
+  selectedThreadId: string | null;
+  onSelectThread: (threadId: string) => void;
+};
+
+export function WeaveMapCanvas({ threads, audit, proposals, selectedThreadId, onSelectThread }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = usePrefersReducedMotion();
+
+  const map: WeaveMap = useMemo(
+    () => buildWeaveMap({ threads, audit, proposals }),
+    [threads, audit, proposals],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || map.nodes.length === 0) return;
+    const parent = canvas.parentElement;
+    const width = parent ? parent.clientWidth : 480;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.floor(width * dpr);
+    canvas.height = Math.floor(HEIGHT * dpr);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${HEIGHT}px`;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const cs = getComputedStyle(canvas);
+    const token = (t: string) => cs.getPropertyValue(t).trim() || "#888";
+    const toneColor: Record<WeaveMapTone, string> = {
+      holds: token(TONE_TOKEN.holds),
+      frayed: token(TONE_TOKEN.frayed),
+      snapped: token(TONE_TOKEN.snapped),
+      blocked: token(TONE_TOKEN.blocked),
+    };
+    const edgeColor = token("--border-strong");
+    const surfaceFill = token("--accent-presence");
+    const labelColor = token("--text-secondary");
+    const labelStrong = token("--text-primary");
+    const halo = token("--bg-raised");
+
+    const sim: ForceSim = createForceSim(
+      map.nodes.map((n) => ({ id: n.id, radius: n.kind === "thread" ? THREAD_RADIUS : SURFACE_RADIUS })),
+      map.edges.map((e) => ({
+        source: e.from,
+        target: e.to,
+        strength: e.style === "authority" ? 1 : e.style === "touched" ? 0.6 : 0.45,
+        distanceScale: e.style === "authority" ? 0.8 : 1.15,
+      })),
+    );
+    const index = new Map(sim.ids.map((id, i) => [id, i]));
+
+    const draw = () => {
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, HEIGHT);
+      ctx.save();
+      ctx.translate(width / 2, HEIGHT / 2);
+
+      for (const edge of map.edges) {
+        const a = index.get(edge.from);
+        const b = index.get(edge.to);
+        if (a === undefined || b === undefined) continue;
+        ctx.beginPath();
+        ctx.moveTo(sim.x[a], sim.y[a]);
+        ctx.lineTo(sim.x[b], sim.y[b]);
+        ctx.strokeStyle = edgeColor;
+        ctx.globalAlpha = edge.style === "authority" ? 0.9 : 0.45;
+        ctx.lineWidth = edge.style === "touched" ? Math.min(1 + edge.count * 0.5, 3.5) : 1.2;
+        ctx.setLineDash(edge.style === "pending" ? [4, 3] : []);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1;
+      }
+
+      for (const node of map.nodes) {
+        const i = index.get(node.id);
+        if (i === undefined) continue;
+        const x = sim.x[i];
+        const y = sim.y[i];
+        if (node.kind === "thread") {
+          const selected = node.threadId === selectedThreadId;
+          ctx.beginPath();
+          ctx.arc(x, y, THREAD_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = halo;
+          ctx.fill();
+          ctx.lineWidth = selected ? 3 : 2;
+          ctx.strokeStyle = toneColor[node.tone];
+          ctx.stroke();
+        } else {
+          ctx.beginPath();
+          ctx.arc(x, y, SURFACE_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = surfaceFill;
+          ctx.globalAlpha = 0.85;
+          ctx.fill();
+          ctx.globalAlpha = 1;
+        }
+        ctx.font = "10px ui-monospace, monospace";
+        ctx.textAlign = "center";
+        ctx.fillStyle = node.kind === "thread" ? labelStrong : labelColor;
+        ctx.fillText(node.label, x, y + (node.kind === "thread" ? THREAD_RADIUS : SURFACE_RADIUS) + 11);
+      }
+      ctx.restore();
+    };
+
+    let raf = 0;
+    if (reducedMotion) {
+      // Synchronous settle, one static paint — same treatment as the grimoire.
+      settleForceSim(sim);
+      draw();
+    } else {
+      const step = () => {
+        const alpha = tickForceSim(sim);
+        draw();
+        if (alpha > ALPHA_MIN) raf = requestAnimationFrame(step);
+      };
+      raf = requestAnimationFrame(step);
+    }
+
+    const onClick = (event: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const px = event.clientX - rect.left - width / 2;
+      const py = event.clientY - rect.top - HEIGHT / 2;
+      for (const node of map.nodes) {
+        if (node.kind !== "thread") continue;
+        const i = index.get(node.id);
+        if (i === undefined) continue;
+        const dx = px - sim.x[i];
+        const dy = py - sim.y[i];
+        if (dx * dx + dy * dy <= (THREAD_RADIUS + 4) ** 2) {
+          onSelectThread(node.threadId);
+          return;
+        }
+      }
+    };
+    canvas.addEventListener("click", onClick);
+    return () => {
+      cancelAnimationFrame(raf);
+      canvas.removeEventListener("click", onClick);
+    };
+  }, [map, reducedMotion, selectedThreadId, onSelectThread]);
+
+  if (map.nodes.length === 0) return null;
+
+  const touchedCount = map.edges.filter((e) => e.style === "touched").length;
+  const pendingCount = map.edges.filter((e) => e.style === "pending").length;
+
+  return (
+    <section aria-label="Weave map" className="rounded-[var(--radius-card)] border border-[var(--border-hairline)] bg-[var(--bg-raised)]">
+      <header className="flex items-baseline justify-between gap-2 border-b border-[var(--border-hairline)] px-3 py-2">
+        <h3 className="text-xs font-medium text-[var(--text-primary)]">Weave map</h3>
+        <p className="text-[10px] text-[var(--text-muted)]">
+          solid = authority · weighted = audited touches · dashed = staged
+        </p>
+      </header>
+      <canvas ref={canvasRef} role="img" aria-label={`Weave map: ${threads.length} threads, ${touchedCount} audited touch edges, ${pendingCount} staged`} />
+      <footer className="border-t border-[var(--border-hairline)] px-3 py-1.5">
+        <p className="text-[10px] text-[var(--text-muted)]">
+          Memory reads aren&rsquo;t audited yet — the map shows verified writes and contracts only.
+        </p>
+      </footer>
+    </section>
+  );
+}

--- a/src/components/weaves-view.tsx
+++ b/src/components/weaves-view.tsx
@@ -8,8 +8,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { StrandInspector } from "@/components/strand-inspector";
 import { ThreadPane } from "@/components/thread-pane";
+import { WeaveMapCanvas } from "@/components/weave-map";
 import { WeaveRail } from "@/components/weave-rail";
-import type { ProposalView, ThreadView, WeaveDetail, WeaveSummary } from "@/lib/threads-read";
+import type { AuditEntryView, ProposalView, ThreadView, WeaveDetail, WeaveSummary } from "@/lib/threads-read";
 import {
   blockedMessage,
   railModel,
@@ -150,6 +151,30 @@ export function WeavesView() {
     };
   }, [selectedWeaveId]);
 
+  // Audit rows for the weave map's "touched" edges — one lazy fetch per
+  // thread of the open weave. A blocked read contributes nothing (the map
+  // simply shows fewer edges), never an invented edge.
+  const [weaveAudit, setWeaveAudit] = useState<AuditEntryView[]>([]);
+  useEffect(() => {
+    if (paneState?.kind !== "ready") {
+      setWeaveAudit([]);
+      return;
+    }
+    let cancelled = false;
+    void Promise.all(
+      paneState.data.threads.map((thread) =>
+        fetchSurface<AuditEntryView[]>(`/api/threads/${encodeURIComponent(thread.id)}/audit`).then(
+          (state) => (state.kind === "ready" ? state.data : []),
+        ),
+      ),
+    ).then((batches) => {
+      if (!cancelled) setWeaveAudit(batches.flat());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [paneState]);
+
   const onTraceWeave = useCallback(
     (weave: WeaveSummary) => {
       if (railState.kind === "ready") setTrace(traceForWeave(weave, railState.meta));
@@ -201,6 +226,13 @@ export function WeavesView() {
             <BlockedSurface state={paneState} />
           ) : (
             <div className="flex flex-col gap-4">
+              <WeaveMapCanvas
+                threads={paneState.data.threads}
+                audit={weaveAudit}
+                proposals={proposalsState.kind === "ready" ? proposalsState.data : []}
+                selectedThreadId={selectedThreadId}
+                onSelectThread={(id) => setSelectedThreadId(id === selectedThreadId ? null : id)}
+              />
               <ThreadPane
                 weave={paneState.data}
                 meta={paneState.meta}

--- a/src/lib/weave-map.test.ts
+++ b/src/lib/weave-map.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildWeaveMap, surfaceNodeId, threadNodeId, toneForTension } from "./weave-map.ts";
+import type { AuditEntryView, ProposalView, ThreadView } from "./threads-read.ts";
+
+function thread(id: string, surface: string, writer = "familiar:sage", state: "holds" | "frayed" | "snapped" | "unknown" = "holds"): ThreadView {
+  const tension =
+    state === "holds"
+      ? { state: "holds" as const }
+      : state === "frayed"
+        ? { state: "frayed" as const, strand: null, channel: null, reason: { kind: "other" as const }, detectedAt: null }
+        : state === "snapped"
+          ? { state: "snapped" as const, channel: null, reason: { kind: "other" as const }, at: null }
+          : { state: "unknown" as const, why: "daemon-unreachable" as const };
+  return {
+    id,
+    weaveId: "w1",
+    surface,
+    writer,
+    tension,
+    holdsUnder: [],
+    requiredStrands: {},
+    strandCount: 0,
+    createdAt: null,
+  };
+}
+
+function auditRow(threadId: string | null, filesTouched: string[], id = 1): AuditEntryView {
+  return {
+    id,
+    eventType: "proposal_approved",
+    proposalId: null,
+    familiarId: "sage",
+    wardVersion: null,
+    wardHash: "00",
+    tier: null,
+    decision: "permit",
+    approver: null,
+    diffHash: null,
+    filesTouched,
+    channel: "mutation",
+    threadId,
+    submittedAt: "2026-07-15T08:00:00Z",
+    decidedAt: "2026-07-15T08:00:01Z",
+    recordedAt: "2026-07-15T08:00:02Z",
+  };
+}
+
+function proposal(threadId: string, surfaces: string[], parse: "ok" | "corrupt" = "ok"): ProposalView {
+  return {
+    file: "p.json",
+    parse,
+    payload:
+      parse === "ok"
+        ? {
+            id: "p1",
+            familiarId: "sage",
+            writer: "familiar:sage",
+            channel: "mutation",
+            threadId,
+            fray: { state: "holds" },
+            edits: surfaces.map((surface) => ({ surface, contents: { encoding: "utf8" as const, data: "x" } })),
+            stagedAt: null,
+          }
+        : null,
+  };
+}
+
+describe("toneForTension", () => {
+  it("maps the three crate states and fails closed on the UI-only ones", () => {
+    assert.equal(toneForTension({ state: "holds" }), "holds");
+    assert.equal(toneForTension({ state: "unknown", why: "daemon-unreachable" }), "blocked");
+    assert.equal(toneForTension({ state: "stale", lastKnown: null, observedAt: "2026-07-15T08:00:00Z" }), "blocked");
+  });
+});
+
+describe("buildWeaveMap", () => {
+  it("builds authority edges from the thread contract", () => {
+    const map = buildWeaveMap({ threads: [thread("t1", "SOUL.md")], audit: [], proposals: [] });
+    assert.equal(map.nodes.length, 2);
+    const threadNode = map.nodes.find((n) => n.kind === "thread");
+    assert.equal(threadNode?.label, "sage", "familiar: prefix stripped for display");
+    assert.deepEqual(
+      map.edges.map((e) => [e.from, e.to, e.style, e.count]),
+      [[threadNodeId("t1"), surfaceNodeId("SOUL.md"), "authority", 1]],
+    );
+  });
+
+  it("aggregates audited touches per (thread, file) with counts", () => {
+    const map = buildWeaveMap({
+      threads: [thread("t1", "SOUL.md")],
+      audit: [auditRow("t1", ["MEMORY.md"], 1), auditRow("t1", ["MEMORY.md", "SOUL.md"], 2)],
+      proposals: [],
+    });
+    const touched = map.edges.filter((e) => e.style === "touched");
+    const memoryEdge = touched.find((e) => e.to === surfaceNodeId("MEMORY.md"));
+    assert.equal(memoryEdge?.count, 2);
+    assert.match(memoryEdge?.detail ?? "", /2 audited decisions/);
+    assert.ok(map.nodes.some((n) => n.kind === "surface" && n.surface === "MEMORY.md"));
+  });
+
+  it("skips unattributable audit rows — no thread id, no edge", () => {
+    const map = buildWeaveMap({
+      threads: [thread("t1", "SOUL.md")],
+      audit: [auditRow(null, ["MEMORY.md"]), auditRow("t-foreign", ["MEMORY.md"])],
+      proposals: [],
+    });
+    assert.equal(map.edges.filter((e) => e.style === "touched").length, 0);
+    assert.ok(!map.nodes.some((n) => n.kind === "surface" && n.surface === "MEMORY.md"));
+  });
+
+  it("staged proposals ride as pending edges; corrupt proposals are ignored", () => {
+    const map = buildWeaveMap({
+      threads: [thread("t1", "SOUL.md")],
+      audit: [],
+      proposals: [proposal("t1", ["IDENTITY.md", "IDENTITY.md"]), proposal("t1", ["x"], "corrupt")],
+    });
+    const pending = map.edges.filter((e) => e.style === "pending");
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].count, 2);
+    assert.match(pending[0].detail, /2 staged edits/);
+  });
+
+  it("thread tone follows tension, failing closed", () => {
+    const map = buildWeaveMap({
+      threads: [thread("t1", "a", "familiar:sage", "frayed"), thread("t2", "b", "familiar:echo", "unknown")],
+      audit: [],
+      proposals: [],
+    });
+    const tones = new Map(map.nodes.filter((n) => n.kind === "thread").map((n) => [n.threadId, n.tone]));
+    assert.equal(tones.get("t1"), "frayed");
+    assert.equal(tones.get("t2"), "blocked");
+  });
+});

--- a/src/lib/weave-map.ts
+++ b/src/lib/weave-map.ts
@@ -1,0 +1,149 @@
+// The weave map — coven-threads memory made visible (cave-kgts).
+//
+// Pure builder: authority threads + their memory surfaces as a small graph,
+// every edge a VERIFIED fact. Three edge styles, three provenances:
+//
+//   authority — the thread's own contract (ThreadView.surface): this writer
+//               may propose writes to this surface. Always present.
+//   touched   — ward_audit rows: files a decision actually touched, keyed by
+//               thread_id. Aggregated per (thread, file) with a count.
+//   pending   — staged proposals awaiting decision: dashed, the invitation.
+//
+// Fail-closed (Phase-4 §4): audit rows without a thread_id can't be
+// attributed and are skipped, never guessed; unknown/stale tension renders
+// as the blocked tone. Memory READS are not audited yet (Phase 5) — this map
+// deliberately shows no "recalled" edges, because none can be verified.
+
+import type {
+  AuditEntryView,
+  ProposalView,
+  TensionView,
+  ThreadView,
+} from "./threads-read.ts";
+
+export type WeaveMapTone = "holds" | "frayed" | "snapped" | "blocked";
+
+export type WeaveMapNode =
+  | {
+      id: string;
+      kind: "thread";
+      threadId: string;
+      /** Writer identity with the `familiar:` prefix stripped for display. */
+      label: string;
+      tone: WeaveMapTone;
+    }
+  | {
+      id: string;
+      kind: "surface";
+      surface: string;
+      label: string;
+    };
+
+export type WeaveMapEdgeStyle = "authority" | "touched" | "pending";
+
+export type WeaveMapEdge = {
+  from: string;
+  to: string;
+  style: WeaveMapEdgeStyle;
+  /** Aggregated evidence count (audit rows / staged edits behind the edge). */
+  count: number;
+  /** One-line evidence copy for the hover/selection detail. */
+  detail: string;
+};
+
+export type WeaveMap = {
+  nodes: WeaveMapNode[];
+  edges: WeaveMapEdge[];
+};
+
+/** §2.1 tension → node tone; the two UI-only states fail closed to blocked. */
+export function toneForTension(tension: TensionView): WeaveMapTone {
+  switch (tension.state) {
+    case "holds":
+      return "holds";
+    case "frayed":
+      return "frayed";
+    case "snapped":
+      return "snapped";
+    default:
+      return "blocked";
+  }
+}
+
+export function threadNodeId(threadId: string): string {
+  return `thread:${threadId}`;
+}
+
+export function surfaceNodeId(surface: string): string {
+  return `surface:${surface}`;
+}
+
+function writerLabel(writer: string): string {
+  return writer.startsWith("familiar:") ? writer.slice("familiar:".length) : writer;
+}
+
+export function buildWeaveMap(args: {
+  threads: ThreadView[];
+  audit: AuditEntryView[];
+  proposals: ProposalView[];
+}): WeaveMap {
+  const threadIds = new Set(args.threads.map((t) => t.id));
+  const nodes = new Map<string, WeaveMapNode>();
+  const edgeAgg = new Map<string, WeaveMapEdge>();
+
+  const ensureSurface = (surface: string) => {
+    const id = surfaceNodeId(surface);
+    if (!nodes.has(id)) nodes.set(id, { id, kind: "surface", surface, label: surface });
+    return id;
+  };
+  const addEdge = (from: string, to: string, style: WeaveMapEdgeStyle) => {
+    const key = `${style}|${from}|${to}`;
+    const existing = edgeAgg.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      edgeAgg.set(key, { from, to, style, count: 1, detail: "" });
+    }
+  };
+
+  for (const thread of args.threads) {
+    const id = threadNodeId(thread.id);
+    nodes.set(id, {
+      id,
+      kind: "thread",
+      threadId: thread.id,
+      label: writerLabel(thread.writer),
+      tone: toneForTension(thread.tension),
+    });
+    addEdge(id, ensureSurface(thread.surface), "authority");
+  }
+
+  for (const entry of args.audit) {
+    // No thread id → no attribution; skipping is the honest treatment.
+    if (!entry.threadId || !threadIds.has(entry.threadId)) continue;
+    for (const file of entry.filesTouched) {
+      addEdge(threadNodeId(entry.threadId), ensureSurface(file), "touched");
+    }
+  }
+
+  for (const proposal of args.proposals) {
+    const payload = proposal.payload;
+    if (proposal.parse !== "ok" || !payload) continue;
+    if (!threadIds.has(payload.threadId)) continue;
+    for (const edit of payload.edits) {
+      addEdge(threadNodeId(payload.threadId), ensureSurface(edit.surface), "pending");
+    }
+  }
+
+  const edges = [...edgeAgg.values()].map((edge) => ({
+    ...edge,
+    detail:
+      edge.style === "authority"
+        ? "authority contract — this writer may propose writes here"
+        : edge.style === "touched"
+          ? `${edge.count} audited decision${edge.count === 1 ? "" : "s"} touched this file`
+          : `${edge.count} staged edit${edge.count === 1 ? "" : "s"} awaiting decision`,
+  }));
+
+  return { nodes: [...nodes.values()], edges };
+}


### PR DESCRIPTION
Bead `cave-kgts` — the answer to "how do we show coven-threads memory visually": make the product's own metaphor literal. A force-laid map above the thread pane where **every edge is a verified fact**, in the Phase-4 fail-closed spirit.

- **Thread nodes** wear their tension tone (holds/frayed/snapped rings; unknown + stale fail closed to the blocked tone).
- **Edges are evidence, three provenances**: solid strong = the thread's **authority contract**; weighted solid = **audited touches** (`ward_audit.filesTouched` keyed by `thread_id`, count-aggregated into stroke weight); dashed = **staged proposals** (the invitation, straight from the design language).
- **What it refuses to draw**: recalled-memory edges. Reads aren't audited yet (Phase 5), so the footer says exactly that — *"Memory reads aren't audited yet — the map shows verified writes and contracts only."* Unattributable audit rows (no thread id) are skipped, never guessed; a blocked audit read yields fewer edges, never invented ones.
- **Implementation**: pure builder (`weave-map.ts`, fully tested) + a compact canvas on the grimoire's zero-dep force engine — synchronous settle under reduced motion, palette resolved from CSS custom properties at draw time (all 40 theme×mode combos), click-to-select threads, counts in the canvas `aria-label`.

## Verified

- `weave-map.test.ts`: tone fail-closed mapping, authority/touched/pending aggregation + counts, unattributable-row skip, corrupt-proposal skip — wired into `run-tests.mjs` (`check-tests-wired` green, 1032 files).
- Built app on the phase-4 fixtures (daemon-less): 2 sage threads render holds-green, `SOUL.md`/`MEMORY.md` surface nodes, audited-touch edge drawn, aria reports "2 threads, 1 audited touch edges, 0 staged". Screenshot on the bead trail. tsc clean, bundle budgets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)