### PR TITLE
refactor(research): super-minimal desk intake — composer-hero, one plan pill, collapsed links (cave-i7y5)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15862,57 +15862,48 @@ details[open] > .cave-edit-card__summary::before {
   flex-direction: column;
   container-name: research-desk;
   container-type: inline-size;
-  background:
-    radial-gradient(80% 45% at 55% 0%, var(--research-accent-soft), transparent 68%),
-    var(--bg-base, var(--background));
+  background: var(--bg-base, var(--background));
 }
 
 .research-desk__intake {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.42fr) minmax(420px, 1fr);
-  gap: 18px;
-  padding: var(--space-4) 18px;
+  padding: var(--space-3) 18px;
   border-bottom: 1px solid var(--border);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
 }
 
-/* ── Links shelf (cave-avrt): the desk's auto-organized link drop-box ── */
+/* ── Links shelf (cave-avrt): the desk's auto-organized link drop-box.
+   Collapsed by default — one quiet summary row until you need it. ── */
 .research-links {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: var(--space-3) 18px;
+  gap: 8px;
+  padding: var(--space-2) 18px;
   border-bottom: 1px solid var(--border);
-  background: color-mix(in oklch, var(--bg-raised) 46%, transparent);
 }
-.research-links__header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 10px;
-}
-.research-links__title {
+.research-links__summary {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin: 0;
+  width: fit-content;
+  cursor: pointer;
+  list-style: none;
   font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
-.research-links__hint { font-size: var(--text-2xs); color: var(--text-muted); }
+.research-links__summary::-webkit-details-marker { display: none; }
+.research-links__summary:hover { color: var(--text-secondary); }
 .research-links__composer {
   display: flex;
   gap: var(--space-2);
-  align-items: flex-end;
+  align-items: center;
 }
 .research-links__input {
   flex: 1;
   min-width: 0;
-  resize: vertical;
-  padding: var(--space-2) 10px;
+  padding: var(--space-1) 10px;
+  min-height: 28px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -15974,14 +15965,6 @@ details[open] > .cave-edit-card__summary::before {
   font-size: var(--text-xs);
   color: var(--text-primary);
 }
-.research-links__url {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-}
 .research-links__meta { flex-shrink: 0; font-size: var(--text-2xs); color: var(--text-muted); }
 .research-links__remove {
   flex-shrink: 0;
@@ -15999,15 +15982,6 @@ details[open] > .cave-edit-card__summary::before {
 .research-links__remove:focus-visible { opacity: 1; }
 .research-links__remove:hover { color: var(--color-danger); }
 
-.research-desk__intake-copy {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 5px;
-  max-width: 300px;
-}
-
-.research-desk__intake-copy span,
 .research-mission-detail__eyebrow,
 .research-mission-nav__head,
 .research-evidence-trajectory__head,
@@ -16020,19 +15994,11 @@ details[open] > .cave-edit-card__summary::before {
   color: var(--text-muted);
 }
 
-.research-desk__intake-copy strong {
-  font-family: var(--font-serif, ui-serif, serif);
-  font-size: clamp(17px, 2vw, 23px);
-  font-weight: 500;
-  line-height: 1.15;
-  color: var(--text-primary);
-}
-
 .research-mission-composer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-2) var(--space-3);
-  align-items: end;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 .research-mission-composer__prompt {
@@ -16042,8 +16008,6 @@ details[open] > .cave-edit-card__summary::before {
   gap: 5px;
 }
 
-.research-mission-composer__prompt > label,
-.research-mission-mode > span,
 .research-bounds-grid span {
   font-size: 10.5px;
   font-weight: 600;
@@ -16071,17 +16035,12 @@ details[open] > .cave-edit-card__summary::before {
 
 .research-mission-composer__controls {
   display: flex;
-  align-items: end;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--space-2);
 }
 
-.research-mission-mode {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.research-mission-mode select,
+.research-mission-composer__controls select,
 .research-bounds-grid input {
   min-height: 30px;
   color: var(--text-primary);
@@ -16092,64 +16051,44 @@ details[open] > .cave-edit-card__summary::before {
   font-size: 16px;
 }
 
-.research-plan-review {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  grid-column: 1 / -1;
-}
-
-.research-plan-chip {
-  padding: 2px 7px;
-  font-size: 9.5px;
-  color: var(--text-muted);
+/* The whole plan in one quiet pill — mode, iterations, minutes, sources.
+   It is the bounds toggle, so it must read as pressable. */
+.research-plan-summary {
+  margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 3px 9px;
+  font-size: 10px;
+  color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-raised) 65%, transparent);
+  cursor: pointer;
 }
-
-/* Only the bound chips are interactive; they must look it. */
-button.research-plan-chip { cursor: pointer; color: var(--text-secondary); }
-button.research-plan-chip:hover {
+.research-plan-summary:hover {
   color: var(--research-accent);
   border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
 }
-button.research-plan-chip:focus-visible {
+.research-plan-summary:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: 1px;
 }
-
-/* The inference explanation is prose, not a control — keep it plain. */
-.research-plan-chip--note {
-  border-color: transparent;
-  background: transparent;
-  padding-left: 2px;
-  padding-right: 2px;
-}
-
-.research-plan-chip--mode {
+.research-plan-summary[aria-expanded="true"] {
   color: var(--research-accent);
   border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
   background: var(--research-accent-soft);
 }
 
-.research-bounds-disclosure {
-  grid-column: 1 / -1;
-  font-size: 10.5px;
-  color: var(--text-muted);
-}
-
-.research-bounds-disclosure summary { cursor: pointer; width: fit-content; }
-
 .research-bounds-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(90px, 1fr));
   gap: var(--space-2);
-  padding-top: var(--space-2);
 }
 
 .research-bounds-grid label { display: flex; flex-direction: column; gap: 3px; }
-.research-runtime-note, .research-mission-error { grid-column: 1 / -1; font-size: 10.5px; }
+.research-runtime-note, .research-mission-error { font-size: 10.5px; }
 .research-runtime-note { color: oklch(0.8 0.1 75); }
 .research-mission-error { color: var(--destructive, oklch(0.68 0.18 25)); }
 .research-intent-minimum { margin-top: 4px; font-size: 10.5px; color: var(--text-muted); }
@@ -16345,8 +16284,6 @@ button.research-plan-chip:focus-visible {
 .research-output-empty { padding: 5px 0; font-size: 10.5px; color: var(--text-muted); }
 
 @container research-desk (max-width: 900px) {
-  .research-desk__intake { grid-template-columns: 1fr; }
-  .research-desk__intake-copy { max-width: none; }
   .research-desk__workspace { grid-template-columns: 1fr; overflow-y: auto; }
   .research-mission-nav { min-height: auto; max-height: 190px; border-right: 0; border-bottom: 1px solid var(--border); }
   .research-mission-nav__list { display: grid; grid-auto-columns: minmax(190px, 44%); grid-auto-flow: column; overflow-x: auto; }
@@ -16360,8 +16297,6 @@ button.research-plan-chip:focus-visible {
 
 @container research-desk (max-width: 560px) {
   .research-desk__intake { padding: 12px; }
-  .research-mission-composer { grid-template-columns: 1fr; }
-  .research-mission-composer__controls { justify-content: space-between; }
   .research-bounds-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .research-mission-detail { padding-inline: 10px; }
   .research-mission-detail__header { flex-direction: column; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15875,7 +15875,7 @@ details[open] > .cave-edit-card__summary::before {
 .research-links {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   padding: var(--space-2) 18px;
   border-bottom: 1px solid var(--border);
 }
@@ -16060,7 +16060,7 @@ details[open] > .cave-edit-card__summary::before {
   text-overflow: ellipsis;
   white-space: nowrap;
   padding: 3px 9px;
-  font-size: 10px;
+  font-size: var(--text-2xs);
   color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);

--- a/src/components/role-surfaces/research-link-shelf.tsx
+++ b/src/components/role-surfaces/research-link-shelf.tsx
@@ -107,39 +107,36 @@ export function ResearchLinkShelf({ onOpenUrl }: Props) {
   const groups = groupSavedLinks(links);
 
   return (
-    <section className="research-links" aria-label="Saved links">
-      <header className="research-links__header">
-        <h3 className="research-links__title">
-          <Icon name="ph:link" width={14} height={14} aria-hidden /> Links
-        </h3>
-        <span className="research-links__hint">
-          Paste one or many — auto-organized. `/save` in chat lands here too.
-        </span>
-      </header>
+    <details className="research-links" aria-label="Saved links">
+      <summary className="research-links__summary focus-ring-inset">
+        <Icon name="ph:link" width={13} height={13} aria-hidden />
+        Links
+        {links.length > 0 ? <span className="research-links__count">{links.length}</span> : null}
+      </summary>
 
       <div className="research-links__composer">
-        <textarea
+        <input
+          type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            if (e.key === "Enter") {
               e.preventDefault();
               void saveDraft();
             }
           }}
-          rows={2}
-          placeholder="https://… (or paste any text — every link in it is saved)"
+          placeholder="Paste links — `/save` in chat lands here too"
           aria-label="Links to save"
           className="research-links__input focus-ring-inset"
           disabled={busy}
         />
         <Button
           size="xs"
-          variant="primary"
+          variant="ghost"
           onClick={() => void saveDraft()}
           disabled={busy || draftLinkCount === 0}
         >
-          {busy ? "Saving…" : draftLinkCount > 1 ? `Save ${draftLinkCount} links` : "Save"}
+          {busy ? "Saving…" : draftLinkCount > 1 ? `Save ${draftLinkCount}` : "Save"}
         </Button>
       </div>
 
@@ -154,7 +151,6 @@ export function ResearchLinkShelf({ onOpenUrl }: Props) {
           {groups.map((group) => (
             <div key={group.category} className="research-links__group">
               <h4 className="research-links__group-title">
-                <Icon name={group.icon} width={13} height={13} aria-hidden />
                 {group.label}
                 <span className="research-links__count">{group.links.length}</span>
               </h4>
@@ -168,7 +164,6 @@ export function ResearchLinkShelf({ onOpenUrl }: Props) {
                       title={link.url}
                     >
                       <span className="research-links__link-title">{link.title}</span>
-                      <span className="research-links__url">{link.url}</span>
                     </button>
                     <span className="research-links__meta">
                       <RelativeTime iso={link.addedAt} />
@@ -192,6 +187,6 @@ export function ResearchLinkShelf({ onOpenUrl }: Props) {
           Nothing saved yet. Paste links above, or type <code>/save &lt;url&gt;</code> in any chat.
         </p>
       )}
-    </section>
+    </details>
   );
 }

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -63,8 +63,8 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
     setBounds((current) => ({ ...current, [key]: value }));
   };
 
-  // A bound chip is a shortcut into the Review-bounds disclosure: open it,
-  // then focus the matching input once it is visible.
+  // The summary pill doubles as the bounds toggle: open the editor and focus
+  // its first input once visible; press again to collapse.
   const focusBound = (inputId: string) => {
     setBoundsOpen(true);
     requestAnimationFrame(() => document.getElementById(inputId)?.focus());
@@ -103,13 +103,13 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
   return (
     <form className="research-mission-composer" onSubmit={start}>
       <div className="research-mission-composer__prompt">
-        <label htmlFor="research-intent">What should we investigate?</label>
+        <label htmlFor="research-intent" className="sr-only">What should we investigate?</label>
         <textarea
           id="research-intent"
           value={intent}
           onChange={(event) => setIntent(event.target.value)}
-          placeholder="Compare approaches, map a field, draft a paper, or run bounded experiments…"
-          rows={3}
+          placeholder="What should we investigate?"
+          rows={2}
           aria-invalid={Boolean(error) || intentTooShort}
           aria-describedby={error
             ? "research-mission-error"
@@ -125,18 +125,28 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
       </div>
 
       <div className="research-mission-composer__controls">
-        <label className="research-mission-mode">
-          <span>Mode</span>
-          <select
-            value={mode}
-            onChange={(event) => setMode(event.target.value as "auto" | ResearchMissionMode)}
-          >
-            <option value="auto">Auto</option>
-            {RESEARCH_MISSION_MODES.map((value) => (
-              <option key={value} value={value}>{MODE_LABELS[value]}</option>
-            ))}
-          </select>
-        </label>
+        {/* The whole plan in one quiet pill: mode + bounds. Press to review/edit. */}
+        <button
+          type="button"
+          id="research-plan-review"
+          className="research-plan-summary"
+          title={mode === "auto" ? inferred.reason : "Selected manually"}
+          aria-expanded={boundsOpen}
+          aria-controls="research-bounds-editor"
+          onClick={() => (boundsOpen ? setBoundsOpen(false) : focusBound("research-bound-minutes"))}
+        >
+          {MODE_LABELS[effectiveMode]} · {bounds.maxIterations} iteration{bounds.maxIterations === 1 ? "" : "s"} · {bounds.wallClockMinutes} min · {bounds.sourceTarget} sources
+        </button>
+        <select
+          value={mode}
+          aria-label="Mode"
+          onChange={(event) => setMode(event.target.value as "auto" | ResearchMissionMode)}
+        >
+          <option value="auto">Auto</option>
+          {RESEARCH_MISSION_MODES.map((value) => (
+            <option key={value} value={value}>{MODE_LABELS[value]}</option>
+          ))}
+        </select>
         <Button
           type="submit"
           variant="primary"
@@ -149,45 +159,8 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
         </Button>
       </div>
 
-      <div id="research-plan-review" className="research-plan-review">
-        <span className="research-plan-chip research-plan-chip--mode">{MODE_LABELS[effectiveMode]}</span>
-        <span className="research-plan-chip research-plan-chip--note">
-          {mode === "auto" ? inferred.reason : "Selected manually"}
-        </span>
-        <span className="research-plan-chip">{plan.deliverables.join(" + ")}</span>
-        <button
-          type="button"
-          className="research-plan-chip"
-          title="Edit in Review bounds"
-          onClick={() => focusBound("research-bound-iterations")}
-        >
-          {bounds.maxIterations} iteration{bounds.maxIterations === 1 ? "" : "s"}
-        </button>
-        <button
-          type="button"
-          className="research-plan-chip"
-          title="Edit in Review bounds"
-          onClick={() => focusBound("research-bound-minutes")}
-        >
-          {bounds.wallClockMinutes} min
-        </button>
-        <button
-          type="button"
-          className="research-plan-chip"
-          title="Edit in Review bounds"
-          onClick={() => focusBound("research-bound-sources")}
-        >
-          {bounds.sourceTarget} sources
-        </button>
-      </div>
-
-      <details
-        className="research-bounds-disclosure"
-        open={boundsOpen}
-        onToggle={(event) => setBoundsOpen(event.currentTarget.open)}
-      >
-        <summary>Review bounds</summary>
-        <div className="research-bounds-grid">
+      {boundsOpen ? (
+        <div id="research-bounds-editor" className="research-bounds-grid">
           <label>
             <span>Minutes</span>
             <input
@@ -239,7 +212,7 @@ export function ResearchMissionComposer({ familiarId, daemonRunning, onStart }: 
             />
           </label>
         </div>
-      </details>
+      ) : null}
 
       {!daemonRunning ? (
         <p className="research-runtime-note">

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -19,6 +19,14 @@ test("surface is mission-first and no longer stores a pretend research desk", ()
   assert.doesNotMatch(surface, /RESEARCHER_INITIAL_STATE/);
 });
 
+test("intake is minimal — the composer is the hero, no marketing copy column", () => {
+  assert.doesNotMatch(surface, /research-desk__intake-copy/);
+  assert.doesNotMatch(surface, /From intent to evidence/);
+  // The intent question is asked exactly once: placeholder text, sr-only label.
+  assert.match(composer, /className="sr-only">What should we investigate\?/);
+  assert.match(composer, /placeholder="What should we investigate\?"/);
+});
+
 test("composer makes Auto routing and finite bounds reviewable", () => {
   assert.match(composer, /What should we investigate\?/);
   assert.match(composer, /Start research/);
@@ -42,23 +50,25 @@ test("composer enforces the shared minimum intent requirement", () => {
   assert.match(css, /\.research-intent-minimum/);
 });
 
-test("plan chips are honest about interactivity", () => {
-  // The three bound chips are buttons that open Review bounds and focus the
-  // matching input…
-  assert.match(composer, /const focusBound = \(inputId: string\) => \{/);
+test("the plan summary pill is the bounds toggle — honest, labeled, focusing", () => {
+  // One quiet pill states the whole plan (mode · iterations · minutes · sources)…
+  assert.match(composer, /className="research-plan-summary"/);
+  assert.match(composer, /\{MODE_LABELS\[effectiveMode\]\} · \{bounds\.maxIterations\}/);
+  // …explains Auto routing in its tooltip instead of a prose chip…
+  assert.match(composer, /title=\{mode === "auto" \? inferred\.reason : "Selected manually"\}/);
+  // …and toggles the bounds editor with real disclosure semantics, focusing
+  // the first input when opening.
+  assert.match(composer, /aria-expanded=\{boundsOpen\}/);
+  assert.match(composer, /aria-controls="research-bounds-editor"/);
+  assert.match(composer, /boundsOpen \? setBoundsOpen\(false\) : focusBound\("research-bound-minutes"\)/);
   assert.match(composer, /setBoundsOpen\(true\);\s*requestAnimationFrame\(\(\) => document\.getElementById\(inputId\)\?\.focus\(\)\)/);
   for (const id of ["research-bound-minutes", "research-bound-iterations", "research-bound-sources"]) {
-    assert.match(composer, new RegExp(`focusBound\\("${id}"\\)`));
     assert.match(composer, new RegExp(`id="${id}"`));
   }
-  // …the disclosure stays in sync when toggled natively…
-  assert.match(composer, /open=\{boundsOpen\}/);
-  assert.match(composer, /onToggle=\{\(event\) => setBoundsOpen\(event\.currentTarget\.open\)\}/);
-  // …and the inference explanation reads as prose, not a control.
-  assert.match(composer, /research-plan-chip--note/);
-  assert.match(css, /button\.research-plan-chip \{ cursor: pointer;/);
-  assert.match(css, /button\.research-plan-chip:focus-visible/);
-  assert.match(css, /\.research-plan-chip--note \{[^}]*border-color: transparent/);
+  // The toggle must look pressable and expose focus + expanded states.
+  assert.match(css, /\.research-plan-summary \{[^}]*cursor: pointer/);
+  assert.match(css, /\.research-plan-summary:focus-visible/);
+  assert.match(css, /\.research-plan-summary\[aria-expanded="true"\]/);
 });
 
 

--- a/src/components/role-surfaces/researcher-surface.tsx
+++ b/src/components/role-surfaces/researcher-surface.tsx
@@ -22,10 +22,6 @@ export function ResearcherSurface({ context }: { context: RoleSurfaceContext }) 
   return (
     <div className="research-desk">
       <section className="research-desk__intake" aria-label="Start research">
-        <div className="research-desk__intake-copy">
-          <span>Research familiar</span>
-          <strong>From intent to evidence to durable knowledge.</strong>
-        </div>
         <ResearchMissionComposer
           familiarId={context.activeFamiliar.id}
           daemonRunning={context.runtimeState.daemonRunning}

--- a/src/lib/link-organizer.test.ts
+++ b/src/lib/link-organizer.test.ts
@@ -142,4 +142,6 @@ test("the Research desk mounts the Links shelf over the same store", () => {
   assert.match(shelf, /extractLinks\(draft\)/, "the shelf accepts one or many pasted links");
   assert.match(shelf, /groupSavedLinks\(links\)/, "the shelf renders auto-organized groups");
   assert.match(shelf, /source: "desk"/, "desk saves are attributed");
+  assert.match(shelf, /<details className="research-links"/, "the shelf collapses to a quiet summary row");
+  assert.match(shelf, /research-links__summary/, "the summary row is the disclosure control");
 });


### PR DESCRIPTION
## Why

The Research Desk intake spent its space on chrome (screenshot review): a marketing copy column, the intent question stated twice, **six** meta chips plus a separate *Review bounds* line, a labeled Mode column, and an always-expanded Links band with header + hint + two-line rows. The missions started below the fold.

## Minimal version

- **Composer is the intake** — full-width textarea, question asked once (placeholder; label sr-only). Hero copy column deleted.
- **One plan pill** `Brief · 1 iteration · 20 min · 6 sources` replaces the chip row + disclosure; it's the bounds toggle (`aria-expanded`/`aria-controls`, opens and focuses the first input). Auto's inference reason lives in its tooltip.
- Bare **Mode** select + **Start research** inline.
- **Links** collapse to a `Links · N` summary row; expanded: single-line input + ghost Save, one-line rows (title · time · remove on hover), plain group labels. Full URL stays as row tooltip.
- Flat surfaces — radial accent wash and band tints removed. Net **−89 lines**.

## Verification

- `researcher-surface.test.ts` (new pins: minimal intake, plan-summary toggle) + `link-organizer.test.ts` (collapsed shelf pins) + `globals.css.test.ts` — 25 pass / 0 fail; `pnpm typecheck` clean
- Built + served; screenshotted the desk closed (composer-hero, links one-liner, missions above the fold) and expanded (bounds grid focused, one-line link rows) against real data

Bead: cave-i7y5