### PR TITLE
fix(editor): stop Shiki mutating the shared mood-c theme singleton (cave-h1hi)

### DIFF
--- a/src/components/code-editor-theme.ts
+++ b/src/components/code-editor-theme.ts
@@ -17,7 +17,8 @@ import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 type MoodTheme = {
   colors?: Record<string, string>;
   // Per the VS Code theme spec, a tokenColors entry's scope may be a string,
-  // an array, or absent entirely (a global default entry).
+  // an array, or absent entirely (a global default entry). Shiki's in-place
+  // normalization (cave-h1hi) can also inject a scope-less global entry.
   tokenColors?: { scope?: string | string[]; settings?: { foreground?: string; fontStyle?: string } }[];
 };
 const mood = moodCTheme as MoodTheme;
@@ -29,6 +30,8 @@ const mood = moodCTheme as MoodTheme;
  *  Each fallback mirrors the JSON value, so a miss renders identically. */
 function moodColor(scope: string, fallback: string): string {
   for (const tc of mood.tokenColors ?? []) {
+    // Scope-less entries are valid TextMate global settings (and Shiki's
+    // in-place normalization can inject one — cave-h1hi); skip, don't crash.
     const scopes = Array.isArray(tc.scope) ? tc.scope : typeof tc.scope === "string" ? [tc.scope] : [];
     if (scopes.includes(scope) && tc.settings?.foreground) return tc.settings.foreground;
   }

--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -56,7 +56,7 @@ assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the editor installs
 // clone, never the module instance (cave-h1hi).
 assert.match(
   theme,
-  /Array\.isArray\(tc\.scope\) && tc\.scope\.includes\(scope\)/,
+  /const scopes = Array\.isArray\(tc\.scope\) \? tc\.scope : typeof tc\.scope === "string" \? \[tc\.scope\] : \[\]/,
   "moodColor guards scope-less tokenColors entries (valid TextMate globals; Shiki injects one)",
 );
 const bubbleSource = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");

--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -49,6 +49,22 @@ assert.match(
 assert.match(theme, /export const moodHighlight = HighlightStyle\.define\(/, "a HighlightStyle maps lezer tags to the mood-c palette");
 assert.match(theme, /syntaxHighlighting\(moodHighlight\)/, "the highlight style ships in the combined theme extension");
 assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the editor installs the shared highlight style");
+// The JSON import is a shared module singleton, and Shiki normalizes themes
+// IN PLACE (prepends a scope-less global tokenColors entry). moodColor must
+// skip scope-less entries instead of crashing every editor surface loaded
+// after a chat code block rendered, and message-bubble must hand Shiki a
+// clone, never the module instance (cave-h1hi).
+assert.match(
+  theme,
+  /Array\.isArray\(tc\.scope\) && tc\.scope\.includes\(scope\)/,
+  "moodColor guards scope-less tokenColors entries (valid TextMate globals; Shiki injects one)",
+);
+const bubbleSource = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+assert.match(
+  bubbleSource,
+  /themes: \[structuredClone\(moodCTheme\)/,
+  "Shiki receives a clone of the theme, never the shared JSON module instance",
+);
 // The code surface stays dark in EVERY app theme (light modes included), so
 // editor text/gutter inks must be fixed mood-c inks, not theme text tokens
 // (--text-primary is a dark ink in light themes → dark-on-dark).

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -85,7 +85,11 @@ function getHighlighter(): Promise<Highlighter> {
     highlighterPromise = (async () => {
       const { createHighlighter } = await import("shiki");
       return createHighlighter({
-        themes: [moodCTheme as Parameters<typeof createHighlighter>[0]["themes"][number]],
+        // Shiki normalizes themes IN PLACE (e.g. prepends a scope-less global
+        // tokenColors entry). The JSON import is a shared module singleton —
+        // code-editor-theme.ts reads the same object — so hand Shiki a clone,
+        // never the module instance (cave-h1hi).
+        themes: [structuredClone(moodCTheme) as Parameters<typeof createHighlighter>[0]["themes"][number]],
         langs: [...LANGS],
       });
     })();


### PR DESCRIPTION
## Bug

Every editor surface (rail file preview, code editor, MdEditor code blocks) crash-looped with `TypeError: Cannot read properties of undefined (reading 'includes')` after the first chat code block rendered — seen 700+ times in the 2026-07-17 dev log.

## Root cause

Shiki's `createHighlighter` **normalizes themes in place**: it prepends a scope-less global `tokenColors` entry to the theme object it receives. `message-bubble.tsx` passed the imported `mood-c-dark.json` **module object** directly, and `code-editor-theme.ts` imports the **same module singleton** — its module-eval `moodColor()` then hit `tc.scope.includes(...)` on the injected scope-less entry. Reproduced on node: `tokenColors` 17 → 18 with `{settings: {...}}` (no scope) prepended.

## Fix

- `message-bubble.tsx`: hand Shiki `structuredClone(moodCTheme)`, never the shared instance
- `code-editor-theme.ts`: `scope` is optional in TextMate themes — `moodColor` skips non-array scopes instead of crashing
- `code-editor.test.ts`: pins both sides (clone at the Shiki boundary + guard in moodColor)

## Validation

- node repro: module stays 17 tokenColors / 0 scope-less after highlighting with the clone
- `pnpm typecheck` clean
- `pnpm test:app` 758/758

Bead: cave-h1hi