### PR TITLE
fix(analytics): full-width panels, left-aligned review queue, defensive moodColor

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11821,6 +11821,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-thread-review-item {
   display: flex;
   align-items: flex-start;
+  /* .ui-btn centers its content; review items read as a left-aligned list. */
+  justify-content: flex-start;
   gap: var(--space-2);
   width: 100%;
   min-width: 0;
@@ -11846,16 +11848,27 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   outline: 2px solid var(--accent-presence);
   outline-offset: 1px;
 }
-.fa-thread-review-discuss {
+/* Trailing "discuss" icon slot — pinned to the right edge so the title/detail
+   stay left, revealed on hover/focus (always on coarse pointers). */
+.fa-thread-review-item > .ui-btn-icon-slot:last-child,
+.fa-thread-review-item > .ui-btn-icon-slot:last-child svg {
+  color: var(--accent-presence);
+}
+.fa-thread-review-item > .ui-btn-icon-slot:last-child {
   margin-left: auto;
   align-self: center;
-  color: var(--accent-presence) !important;
   opacity: 0;
   transition: opacity 120ms ease;
 }
-.fa-thread-review-item:hover .fa-thread-review-discuss,
-.fa-thread-review-item:focus-visible .fa-thread-review-discuss {
+.fa-thread-review-item:hover > .ui-btn-icon-slot:last-child,
+.fa-thread-review-item:focus-visible > .ui-btn-icon-slot:last-child {
   opacity: 1;
+}
+@media (pointer: coarse) {
+  .fa-thread-review-item > .ui-btn-icon-slot:last-child { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fa-thread-review-item > .ui-btn-icon-slot:last-child { transition: none; }
 }
 .fa-thread-review-list li.is-critical .fa-thread-review-item {
   border-color: color-mix(in oklch, var(--color-danger) 45%, var(--border-hairline));

--- a/src/components/code-editor-theme.ts
+++ b/src/components/code-editor-theme.ts
@@ -15,21 +15,29 @@ import { tags as t } from "@lezer/highlight";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 
 type MoodTheme = {
-  colors: Record<string, string>;
-  tokenColors: { scope: string[]; settings: { foreground?: string; fontStyle?: string } }[];
+  colors?: Record<string, string>;
+  // Per the VS Code theme spec, a tokenColors entry's scope may be a string,
+  // an array, or absent entirely (a global default entry).
+  tokenColors?: { scope?: string | string[]; settings?: { foreground?: string; fontStyle?: string } }[];
 };
 const mood = moodCTheme as MoodTheme;
 
+/** Look up a scope's foreground in the mood-c palette. Defensive on shape:
+ *  beyond the spec's `string | string[] | undefined` scope, Turbopack's dev
+ *  JSON modules have surfaced partial objects here — and this runs at module
+ *  evaluation, where a throw takes down every editor surface that imports it.
+ *  Each fallback mirrors the JSON value, so a miss renders identically. */
 function moodColor(scope: string, fallback: string): string {
-  for (const tc of mood.tokenColors) {
-    if (tc.scope.includes(scope) && tc.settings.foreground) return tc.settings.foreground;
+  for (const tc of mood.tokenColors ?? []) {
+    const scopes = Array.isArray(tc.scope) ? tc.scope : typeof tc.scope === "string" ? [tc.scope] : [];
+    if (scopes.includes(scope) && tc.settings?.foreground) return tc.settings.foreground;
   }
   return fallback;
 }
 
-export const moodInk = mood.colors["editor.foreground"] ?? "#c9c2dc";
-const gutterInk = mood.colors["editorLineNumber.foreground"] ?? "#4a4560";
-const gutterActiveInk = mood.colors["editorLineNumber.activeForeground"] ?? "#7a6fa0";
+export const moodInk = mood.colors?.["editor.foreground"] ?? "#c9c2dc";
+const gutterInk = mood.colors?.["editorLineNumber.foreground"] ?? "#4a4560";
+const gutterActiveInk = mood.colors?.["editorLineNumber.activeForeground"] ?? "#7a6fa0";
 
 const C = {
   comment: moodColor("comment", "#4a4560"),

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -331,6 +331,7 @@ const ThreadAnalysisSection = memo(function ThreadAnalysisSection({
     <FaSection
       id="fa-confidence"
       title="Confidence from thread analysis"
+      wide
       count={
         confidence.hasData
           ? `${confidence.reportCount} ${confidence.reportCount === 1 ? "report" : "reports"}`
@@ -948,18 +949,18 @@ export function FamiliarAnalyticsContent({
           />
         </FaSection>
 
+        {/* Contract compliance pairs with recent sessions on the first row —
+            the full-width thread-analysis panel below would otherwise leave an
+            empty cell beside the sessions list. The #fa-contract KPI
+            drill-through keeps working wherever the section lives. */}
+        <ContractCompliance report={model.contractReport} />
+
         <ThreadAnalysisSection
           confidence={model.confidence}
           trends={model.signalTrends}
           familiar={model.familiar}
           onSelfReportEnabled={onRefresh}
         />
-
-        {/* Contract compliance pairs with the thread-analysis panel — both read
-            on identity health — and sits above the fold instead of dangling
-            under the operational panels. The #fa-contract KPI drill-through
-            keeps working wherever the section lives. */}
-        <ContractCompliance report={model.contractReport} />
 
         <FaSection
           id="fa-heal"
@@ -987,6 +988,7 @@ export function FamiliarAnalyticsContent({
         <FaSection
           id="fa-model-performance"
           title="Model performance"
+          wide
           count={`${model.modelFeedback.total} ${model.modelFeedback.total === 1 ? "vote" : "votes"}`}
         >
           <ModelFeedbackSection rollup={model.modelFeedback} />


### PR DESCRIPTION
## What

**Familiar analytics dashboard layout**
- **Model performance** and **Confidence from thread analysis** sections now span both `fa-grid` columns (`wide`).
- **Contract compliance** moves up beside Recent sessions so the full-width confidence panel doesn't leave an empty grid cell.
- **Review queue** items are left-aligned: `.fa-thread-review-item` overrides `.ui-btn`'s `justify-content: center`, and the dead `.fa-thread-review-discuss` selector (Button renders trailing icons as `.ui-btn-icon-slot`) is repaired — discuss icon is right-pinned, hover/focus-revealed, always visible on coarse pointers, and keeps its accent color on critical rows.

**Editor theme crash fix**
- `moodColor` in `code-editor-theme.ts` ran at module evaluation assuming every `tokenColors` entry has an array `scope`; a Turbopack dev JSON-module partial shape threw `Cannot read properties of undefined (reading 'includes')` and took down every editor surface in the import chain (code editor → md-editor → memory reader → studio memory tab). Now spec-correct (`scope` may be `string | string[] | undefined`) and defensive on `settings`/`tokenColors`/`colors`. Fallbacks mirror the JSON values, so rendering is identical even on a total miss.

## Validation
- `familiar-analytics-view` + `thread-signals-section` + `code-editor` tests: 52/52 pass on this branch
- `pnpm typecheck` clean
- Smoke-tested `moodColor` against healthy JSON, string scopes, scopeless entries, and missing `tokenColors`