### PR TITLE
fix(studio): ignore IME Enter in voice fields

### DIFF
--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -280,6 +280,15 @@ assert.match(
   /onBlur=\{\(\) => void save\(\{ voiceName: draftVoiceName\.trim\(\) \|\| null \}\)\}\s*\n\s*onKeyDown=\{\(e\) => \{[\s\S]{0,200}?if \(e\.key === "Enter"\) e\.currentTarget\.blur\(\);/,
   "Enter commits a typed voice id instead of leaving it unsaved",
 );
+const imeSafeVoiceEnterHandlers =
+  source.match(
+    /onKeyDown=\{\(e\) => \{\s*if \(e\.nativeEvent\.isComposing\) return;[\s\S]{0,200}?if \(e\.key === "Enter"\) e\.currentTarget\.blur\(\);/g,
+  ) ?? [];
+assert.equal(
+  imeSafeVoiceEnterHandlers.length,
+  2,
+  "both free-text voice inputs ignore Enter while an IME composition is active",
+);
 
 // 5. Successful saves catch the roster up immediately — every surface gating
 //    on familiar.voiceProvider (the chat kebab's Call item) sees the new

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -764,6 +764,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                       onChange={(e) => setDraftVoiceModel(e.target.value)}
                       onBlur={() => void save({ voiceModel: draftVoiceModel.trim() || null })}
                       onKeyDown={(e) => {
+                        if (e.nativeEvent.isComposing) return;
                         // Enter commits (via the blur handler) — typing an id
                         // and pressing Enter must never leave it unsaved.
                         if (e.key === "Enter") e.currentTarget.blur();
@@ -854,6 +855,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                         onChange={(e) => setDraftVoiceName(e.target.value)}
                         onBlur={() => void save({ voiceName: draftVoiceName.trim() || null })}
                         onKeyDown={(e) => {
+                          if (e.nativeEvent.isComposing) return;
                           // Enter commits the typed voice id (blur → save).
                           if (e.key === "Enter") e.currentTarget.blur();
                         }}


### PR DESCRIPTION
## Summary

- ignore Enter while either free-text voice field is in active IME composition
- preserve ordinary Enter → blur → save behavior
- pin both handlers so one cannot regress independently

Follow-up to #3354 and review comments 3603947034 / 3603947069.
Bead: `cave-w8i3`

## Verification

- `node --experimental-strip-types src/components/familiar-studio-brain-tab.test.ts`
- `pnpm typecheck`
- `git diff --check`