### PR TITLE
Fix stale recent chat deletes

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -23,6 +23,7 @@ export const SUITES = {
   app: [
     "src/lib/array-content-equal.test.ts",
     "src/lib/session-list-equal.test.ts",
+    "src/lib/session-list-deletes.test.ts",
     "src/lib/tool-edit-stat.test.ts",
     "src/lib/split-snap.test.ts",
     "src/lib/chat-split.test.ts",
@@ -155,6 +156,7 @@ export const SUITES = {
     "src/components/chat-split-host.test.ts",
     "src/components/chat-sidebar-wiring.test.ts",
     "src/components/workspace-sidebar-wiring.test.ts",
+    "src/components/workspace-session-delete.test.ts",
     "src/components/workspace-sidebar-pinned.test.ts",
     "src/components/workspace-sidebar-pr-badge.test.ts",
     "src/components/workspace-rail.test.ts",

--- a/src/components/workspace-session-delete.test.ts
+++ b/src/components/workspace-session-delete.test.ts
@@ -1,0 +1,56 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const workspaceSidebar = await readFile(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+
+assert.match(
+  workspace,
+  /const locallyDeletedSessionIdsRef = useRef<Set<string>>\(new Set\(\)\)/,
+  "Workspace should keep local delete tombstones beside shared session state",
+);
+
+assert.match(
+  workspace,
+  /const baseSessions = filterDeletedSessions\(\(json\.sessions \?\? \[\]\) as SessionRow\[\], locallyDeletedSessionIdsRef\.current\)/,
+  "Workspace should filter every sessions/list response before it reaches shared state",
+);
+
+assert.match(
+  workspace,
+  /const visibleBaseSessions = filterDeletedSessions\(baseSessions, locallyDeletedSessionIdsRef\.current\)[\s\S]*?attachGitHubTaskContext\(visibleBaseSessions, json\)/,
+  "GitHub task enrichment should not reintroduce locally deleted sessions",
+);
+
+assert.match(
+  workspace,
+  /if \(!res\.ok \|\| !json\.ok\) \{[\s\S]*?throw new Error\(json\.error \?\? "delete failed"\)/,
+  "Workspace delete should fail closed before hiding a row or invalidating cache",
+);
+
+assert.match(
+  workspace,
+  /locallyDeletedSessionIdsRef\.current\.add\(session\.id\)[\s\S]*?setSessions\(\(currentSessions\) => \{[\s\S]*?filterDeletedSessions\(currentSessions, locallyDeletedSessionIdsRef\.current\)/,
+  "Workspace should optimistically remove confirmed deletes from shared sessions",
+);
+
+assert.match(
+  workspace,
+  /invalidateConversation\(session\.id\);\s*void loadSessions\(\)/,
+  "Workspace should invalidate only after confirmed delete and then refresh in the background",
+);
+
+assert.match(
+  workspaceSidebar,
+  /const \[deleteError, setDeleteError\] = useState<string \| null>\(null\)/,
+  "WorkspaceSidebar should retain failed deletes as visible row errors",
+);
+
+assert.match(
+  workspaceSidebar,
+  /catch \(err\) \{[\s\S]*?setDeleteError\(err instanceof Error \? err\.message : "delete failed"\)/,
+  "WorkspaceSidebar should surface delete failures instead of clearing the row",
+);
+
+console.log("workspace-session-delete.test.ts passed");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -313,6 +313,7 @@ export function WorkspaceSidebar({
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null);
   const [registeringRoot, setRegisteringRoot] = useState<string | null>(null);
   const [registerError, setRegisterError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [view, setView] = useState<ChatSidebarView>("recent");
   const [menuOpen, setMenuOpen] = useState(false);
   const menuAnchorRef = useRef<HTMLButtonElement>(null);
@@ -415,9 +416,12 @@ export function WorkspaceSidebar({
 
   async function handleDeleteSession(session: SessionRow) {
     setDeletingSessionId(session.id);
+    setDeleteError(null);
     try {
       await onDeleteSession(session);
       setConfirmingSessionId(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "delete failed");
     } finally {
       setDeletingSessionId(null);
     }
@@ -572,6 +576,15 @@ export function WorkspaceSidebar({
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
             <span className="cnav__error-text">{registerError}</span>
             <button type="button" onClick={() => setRegisterError(null)} aria-label="Dismiss" className="shrink-0">
+              <Icon name="ph:x-bold" width={9} aria-hidden />
+            </button>
+          </div>
+        ) : null}
+        {deleteError ? (
+          <div role="alert" className="cnav__error">
+            <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
+            <span className="cnav__error-text">{deleteError}</span>
+            <button type="button" onClick={() => setDeleteError(null)} aria-label="Dismiss" className="shrink-0">
               <Icon name="ph:x-bold" width={9} aria-hidden />
             </button>
           </div>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -6,6 +6,7 @@ import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { stampFirstOpenOnce } from "@/lib/first-run-stamps";
 import { groupInboxFeed, unreadInboxCount } from "@/lib/inbox-feed";
 import { parseGitHubItemUrl, type GitHubItemTarget } from "@/lib/github-item-url";
+import { filterDeletedSessions } from "@/lib/session-list-deletes";
 import { sameSessionList } from "@/lib/session-list-equal";
 import { invalidateConversation } from "@/lib/conversation-cache";
 import { arrayContentEqual } from "@/lib/array-content-equal";
@@ -310,6 +311,7 @@ export function Workspace() {
   const loadGitHubTasksForceEpochRef = useRef(0);
   const loadGitHubTasksForceInFlightRef = useRef(0);
   const baseSessionsRef = useRef<SessionRow[]>([]);
+  const locallyDeletedSessionIdsRef = useRef<Set<string>>(new Set());
   const githubTasksRef = useRef<unknown>(null);
   const [daemonRunning, setDaemonRunning] = useState<boolean>(false);
   const { pushBanner, dismissBanner } = useShellBanners();
@@ -909,7 +911,8 @@ export function Workspace() {
         const baseSessions = baseSessionsRef.current.length > 0
           ? baseSessionsRef.current
           : currentSessions;
-        const enriched = attachGitHubTaskContext(baseSessions, json);
+        const visibleBaseSessions = filterDeletedSessions(baseSessions, locallyDeletedSessionIdsRef.current);
+        const enriched = attachGitHubTaskContext(visibleBaseSessions, json);
         return sameSessionList(currentSessions, enriched) ? currentSessions : enriched;
       });
     } catch {
@@ -952,7 +955,7 @@ export function Workspace() {
         }
 
         setSessionsError(false);
-        const baseSessions = (json.sessions ?? []) as SessionRow[];
+        const baseSessions = filterDeletedSessions((json.sessions ?? []) as SessionRow[], locallyDeletedSessionIdsRef.current);
         baseSessionsRef.current = baseSessions;
         const visibleSessions = githubTasksRef.current
           ? attachGitHubTaskContext(baseSessions, githubTasksRef.current)
@@ -2442,9 +2445,20 @@ export function Workspace() {
         shellRef.current?.dismissNavMobile();
       }}
       onDeleteSession={async (session) => {
-        await fetch(`/api/chat/conversation/${encodeURIComponent(session.id)}`, { method: "DELETE" });
+        const res = await fetch(`/api/chat/conversation/${encodeURIComponent(session.id)}`, { method: "DELETE" });
+        const json = await res.json().catch(() => ({ ok: false, error: "delete failed" }));
+        if (!res.ok || !json.ok) {
+          throw new Error(json.error ?? "delete failed");
+        }
+
+        locallyDeletedSessionIdsRef.current.add(session.id);
+        baseSessionsRef.current = filterDeletedSessions(baseSessionsRef.current, locallyDeletedSessionIdsRef.current);
+        setSessions((currentSessions) => {
+          const nextSessions = filterDeletedSessions(currentSessions, locallyDeletedSessionIdsRef.current);
+          return sameSessionList(currentSessions, nextSessions) ? currentSessions : nextSessions;
+        });
         invalidateConversation(session.id);
-        await loadSessions();
+        void loadSessions();
       }}
       onOpenUrl={openUrlInApp}
       scheduledCount={scheduleNeedsCount}

--- a/src/lib/session-list-deletes.test.ts
+++ b/src/lib/session-list-deletes.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { filterDeletedSessions } from "./session-list-deletes.ts";
+
+const rows = [
+  { id: "keep-1", updated_at: "2026-07-17T12:00:00.000Z" },
+  { id: "deleted", updated_at: "2026-07-17T12:01:00.000Z" },
+  { id: "keep-2", updated_at: "2026-07-17T12:02:00.000Z" },
+];
+
+assert.equal(
+  filterDeletedSessions(rows, new Set()),
+  rows,
+  "empty delete tombstones should keep the existing list reference",
+);
+
+assert.deepEqual(
+  filterDeletedSessions(rows, new Set(["deleted"])).map((row) => row.id),
+  ["keep-1", "keep-2"],
+  "deleted session ids should be removed without disturbing unrelated order",
+);
+
+assert.deepEqual(
+  filterDeletedSessions(rows, new Set(["missing"])).map((row) => row.id),
+  ["keep-1", "deleted", "keep-2"],
+  "unknown tombstones should not change visible rows",
+);
+
+console.log("session-list-deletes.test.ts passed");

--- a/src/lib/session-list-deletes.ts
+++ b/src/lib/session-list-deletes.ts
@@ -1,0 +1,9 @@
+import type { SessionRow } from "@/lib/types";
+
+export function filterDeletedSessions(
+  sessions: SessionRow[],
+  deletedIds: ReadonlySet<string>,
+): SessionRow[] {
+  if (deletedIds.size === 0) return sessions;
+  return sessions.filter((session) => !deletedIds.has(session.id));
+}


### PR DESCRIPTION
## Summary
- add local delete tombstones for workspace session rows so stale session-list cache responses cannot resurrect deleted chats
- filter GitHub-enriched session lists through the same tombstones
- surface delete failures in the workspace sidebar without hiding the row

Fixes #3338

## Verification
- node --experimental-strip-types src/lib/session-list-deletes.test.ts
- node --experimental-strip-types src/components/workspace-session-delete.test.ts
- pnpm check:tests-wired
- pnpm typecheck