### PR TITLE
feat(chat): debug pane live-region announcements (cave-v8lm)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -99,6 +99,29 @@ assert.match(
   "A filter with zero hits says so instead of rendering an empty void",
 );
 
+// ── Live-region announcements (chat-session-debugging S5) ────────────────────
+
+assert.match(
+  source,
+  /if \(copied\) announce\(/,
+  "Copy success must be announced — the check-icon swap is visual-only",
+);
+assert.match(
+  source,
+  /announce\(`Events failed to load: \$\{eventsError\}`, "assertive"\)/,
+  "Events load failures must reach screen readers assertively, not appear as a silent banner",
+);
+assert.match(
+  source,
+  /if \(tailCapped\) announce\(/,
+  "The tail-cap notice must be announced when it appears",
+);
+assert.match(
+  source,
+  /announce\("Following live events"\)/,
+  "Resuming follow announces; scroll-driven pauses stay silent by design (announcement spam)",
+);
+
 // ── Changes panel (CHAT-D8-01): working-tree review, now hosted by the code
 // rail (the inspector right panel that first carried it is retired) ──────────
 

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -8,6 +8,7 @@ import { formatRuntime } from "@/lib/chat-response-metadata";
 import { usageBreakdown } from "@/lib/usage-format";
 import { APP_VERSION } from "@/lib/app-version";
 import { type ChatDebugSnapshot } from "@/lib/chat-debug-store";
+import { useAnnouncer } from "@/components/ui/live-region";
 import {
   appendEvents,
   buildDebugBundle,
@@ -42,6 +43,11 @@ function statusColor(status: string | undefined): string {
 
 function CopyButton({ getText, label }: { getText: () => string; label?: string }) {
   const { copied, copy } = useCopy();
+  const { announce } = useAnnouncer();
+  // The check-icon swap is visual-only; mirror it for screen readers.
+  useEffect(() => {
+    if (copied) announce(label ? `${label} — copied to clipboard` : "Copied to clipboard");
+  }, [copied, announce, label]);
   return (
     <button
       type="button"
@@ -201,6 +207,7 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [eventQuery, setEventQuery] = useState("");
   const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
+  const { announce } = useAnnouncer();
   // Tail-follow only makes sense while events are streaming in; opening a
   // finished session shouldn't jump past the Session section.
   const [follow, setFollow] = useState(status === "running");
@@ -211,6 +218,15 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
   // True when a drain stopped at the page cap with a full final page — more
   // events likely remain server-side and the list is silently incomplete.
   const [tailCapped, setTailCapped] = useState(false);
+
+  // The error banner and tail-cap notice appear silently for sighted users to
+  // scan; mirror them into the live region so SR users hear state changes.
+  useEffect(() => {
+    if (eventsError) announce(`Events failed to load: ${eventsError}`, "assertive");
+  }, [eventsError, announce]);
+  useEffect(() => {
+    if (tailCapped) announce("Long event tail — more events available to load");
+  }, [tailCapped, announce]);
 
   // Pages until the tail is drained (a full page means more may remain), so
   // finished sessions with >200 events aren't silently truncated. Capped as a
@@ -283,9 +299,10 @@ function DebugPaneInner({ snapshot }: { snapshot: ChatDebugSnapshot }) {
 
   const resumeFollow = useCallback(() => {
     setFollow(true);
+    announce("Following live events");
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, []);
+  }, [announce]);
 
   const bundleJson = useCallback(() => {
     // buildDebugBundle strips attachment previews and stamps the environment


### PR DESCRIPTION
## What

Slice S5 of the **chat-session-debugging** goal (Phase 1 audit gaps D1/D2). Builds on #3339 / #3352 / #3357 / #3361.

The debug pane had **zero aria-live output**: copy success was a visual icon swap, the events error banner and tail-cap notice appeared silently, and follow-resume gave no feedback. This wires the app-wide `useAnnouncer` (LiveRegionProvider already wraps the app in `layout.tsx`):

- `CopyButton` announces on the `copied` flip (label-aware: *"Copy turn — copied to clipboard"*)
- events load failures announce **assertively** with the error text
- the tail-cap notice announces politely when it appears
- `resumeFollow` announces *"Following live events"*; scroll-driven pauses stay silent by design — announcing every scroll position change is spam

## Verification

- `pnpm test:app` — 758 test files pass (pins for each announcement path; one unrelated `opencoven-tools-resolve` suite flake passed standalone and on rerun)
- `pnpm typecheck` — clean

## Refs

- Bead: cave-v8lm (chat-session-debugging goal S5)
- Prior slices: #3339, #3352, #3357, #3361
