### PR TITLE
fix(chat): self-heal built-in-shadowed adapter manifests that brick every coven run

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -984,6 +984,7 @@ export const SUITES = {
     "src/lib/server/skill-scan.test.ts",
     "src/lib/server/skill-build.test.ts",
     "src/lib/server/prompt-scan.test.ts",
+    "src/lib/server/adapter-conflict-heal.test.ts",
   ],
   mobile: [
     "src/lib/mobile-access-token.test.ts",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -38,6 +38,11 @@ import { covenLaunchCommand } from "@/lib/coven-bin";
 import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { sweepStuckCreatedSessions } from "@/lib/server/stuck-created-sweep";
 import {
+  detectBuiltinAdapterConflict,
+  healBuiltinShadowedManifest,
+  type BuiltinAdapterConflict,
+} from "@/lib/server/adapter-conflict-heal";
+import {
   buildCopilotStreamArgs,
   copilotIdentityPreamble,
   copilotStreamSpec,
@@ -1646,6 +1651,12 @@ export async function POST(req: Request) {
       // miss). Triggers a single transparent retry without --continue.
       let resumeFailed = false;
 
+      // Fatal registry conflict from a stale scaffolded manifest whose id a
+      // CLI upgrade promoted to built-in (copilot, coven-code). Kills every
+      // `coven run` at startup, so the turn ends with no assistant text.
+      // Detected from stderr; healed (manifest quarantined) and retried below.
+      let adapterConflict: BuiltinAdapterConflict | null = null;
+
       // Model parity: the harness echoes its resolved model on the init/system
       // stream event. Capturing it lets the application state render honestly as
       // `applied` instead of staying `pending`. Null until the init event with a
@@ -2018,6 +2029,9 @@ export async function POST(req: Request) {
           child.stderr.on("data", (data: Buffer) => {
             const text = stripAnsi(data.toString("utf8"));
             if (RESUME_ERR_RE.test(text)) resumeFailed = true;
+            if (!adapterConflict) {
+              adapterConflict = detectBuiltinAdapterConflict(text);
+            }
             for (const line of text.split(/\r?\n/)) {
               const trimmed = line.trim();
               if (!trimmed) continue;
@@ -2075,6 +2089,41 @@ export async function POST(req: Request) {
       // First attempt — uses --continue if body.sessionId was set.
       const turnSpawnStartMs = Date.now();
       await runAttempt(args);
+
+      // Self-heal (cave-1c05): a stale scaffolded manifest whose id the
+      // installed CLI now ships as a built-in harness makes the registry load
+      // fatal, killing the run before any assistant output. Quarantine the
+      // manifest the CLI named (rename off the scanned `.json` extension) and
+      // retry the same turn. Bounded: several stale manifests can conflict,
+      // but each pass must have healed a new one to continue. Local runs
+      // only — an SSH runtime's error names a remote path.
+      for (
+        let heals = 0;
+        heals < 3 && adapterConflict && !sshRuntime && !runHandle.stopRequested;
+        heals++
+      ) {
+        const conflict: BuiltinAdapterConflict = adapterConflict;
+        const healed = await healBuiltinShadowedManifest(conflict);
+        if (!healed) break;
+        pushProgress(
+          "adapter-heal",
+          `Quarantined stale ${conflict.id} adapter manifest; retrying`,
+          "running",
+          conflict.manifestPath,
+        );
+        assistantFilter = new AssistantFilter({ passthrough: rawStdoutHarness });
+        assistantText = "";
+        jsonBuf = "";
+        result = {};
+        toolTracker = new ToolCallTracker();
+        copilotText.reset();
+        stderrTail.length = 0;
+        stdoutErrTail.length = 0;
+        resumeFailed = false;
+        adapterConflict = null;
+        await runAttempt(args);
+        pushProgress("adapter-heal", "Retry after manifest quarantine finished", "done");
+      }
 
       // Transparent retry: if codex reported its rollout-resume failed and
       // we had been resuming, start a fresh thread (no --continue) so the

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { NextRequest, NextResponse } from "next/server";
 import { loadConfig, saveConfig } from "@/lib/cave-config";
 import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
+import { isManifestShadowedByBuiltin } from "@/lib/server/adapter-conflict-heal";
 
 const ALLOWED_TOP_LEVEL_KEYS = new Set([
   "addons",
@@ -65,6 +66,10 @@ async function scaffoldAdapterManifestsFromPatch(body: ConfigPatchBody): Promise
       ensuredAdaptersDir = true;
     }
     const manifestPath = path.join(adaptersDir, scaffold.filename);
+    // A quarantined manifest means the installed CLI ships this id as a
+    // built-in harness and fatally rejects the external copy — never
+    // resurrect it (cave-1c05).
+    if (await isManifestShadowedByBuiltin(manifestPath)) continue;
     if (!(await pathExists(manifestPath))) {
       await writeFile(manifestPath, scaffold.contents, "utf8");
     }

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -20,6 +20,7 @@ import {
   isTrustedOnboardingHarness,
 } from "@/lib/harness-adapters";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
+import { isManifestShadowedByBuiltin } from "@/lib/server/adapter-conflict-heal";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -90,7 +91,13 @@ export async function POST(req: Request) {
   const adapterManifest = adapterManifestScaffoldForHarness(harness);
   if (adapterManifest) {
     const manifestPath = path.join(adaptersDir, adapterManifest.filename);
-    if (!(await pathExists(manifestPath))) {
+    // A quarantined manifest means the installed CLI ships this id as a
+    // built-in harness and fatally rejects the external copy — never
+    // resurrect it (cave-1c05).
+    if (
+      !(await isManifestShadowedByBuiltin(manifestPath)) &&
+      !(await pathExists(manifestPath))
+    ) {
       await writeFile(manifestPath, adapterManifest.contents, "utf8");
       wrote.push(`adapters/${adapterManifest.filename}`);
     }

--- a/src/lib/server/adapter-conflict-heal.test.ts
+++ b/src/lib/server/adapter-conflict-heal.test.ts
@@ -1,0 +1,131 @@
+// Tests for adapter-conflict-heal (cave-1c05): recovery from the Coven CLI's
+// fatal "external harness adapter `x` … conflicts with a built-in harness"
+// registry error, which bricked every `coven run` (chat surfaced it as codex
+// turns ending "No assistant text returned").
+import assert from "node:assert/strict";
+import { mkdtemp, readFile as readFileFs, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  detectBuiltinAdapterConflict,
+  healBuiltinShadowedManifest,
+  isManifestShadowedByBuiltin,
+  shadowedMarkerPath,
+  SHADOWED_MANIFEST_SUFFIX,
+} from "./adapter-conflict-heal.ts";
+
+const CLI_ERROR =
+  "Error: external harness adapter `copilot` in /Users/buns/.coven/adapters/copilot.json conflicts with a built-in harness";
+
+test("detectBuiltinAdapterConflict parses the released CLI error line", () => {
+  const conflict = detectBuiltinAdapterConflict(CLI_ERROR);
+  assert.deepEqual(conflict, {
+    id: "copilot",
+    manifestPath: "/Users/buns/.coven/adapters/copilot.json",
+  });
+});
+
+test("detectBuiltinAdapterConflict returns null for unrelated stderr", () => {
+  assert.equal(detectBuiltinAdapterConflict("ERROR: token refresh failed"), null);
+  assert.equal(detectBuiltinAdapterConflict(""), null);
+});
+
+test("heal renames a manifest inside the adapters root and marks it shadowed", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "adapters-"));
+  const manifest = path.join(root, "copilot.json");
+  await writeFile(manifest, "{}", "utf8");
+
+  const healed = await healBuiltinShadowedManifest(
+    { id: "copilot", manifestPath: manifest },
+    root,
+  );
+  assert.equal(healed, true);
+  await assert.rejects(stat(manifest), "original manifest must be gone");
+  const marker = shadowedMarkerPath(manifest);
+  assert.equal((await stat(marker)).isFile(), true);
+  assert.equal(await readFileFs(marker, "utf8"), "{}");
+  assert.equal(await isManifestShadowedByBuiltin(manifest), true);
+});
+
+test("heal refuses paths outside the adapters root (prefix-bypass included)", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "adapters-"));
+  const evilSibling = `${root}-evasion`;
+  const outside = path.join(evilSibling, "copilot.json");
+  assert.equal(
+    await healBuiltinShadowedManifest({ id: "copilot", manifestPath: outside }, root),
+    false,
+    "root-prefix sibling dir must not pass containment",
+  );
+  assert.equal(
+    await healBuiltinShadowedManifest(
+      { id: "copilot", manifestPath: "/etc/passwd" },
+      root,
+    ),
+    false,
+  );
+  assert.equal(
+    await healBuiltinShadowedManifest({ id: "copilot", manifestPath: root }, root),
+    false,
+    "the root itself is not a manifest",
+  );
+});
+
+test("heal refuses non-.json paths and missing files", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "adapters-"));
+  await writeFile(path.join(root, "notes.txt"), "x", "utf8");
+  assert.equal(
+    await healBuiltinShadowedManifest(
+      { id: "notes", manifestPath: path.join(root, "notes.txt") },
+      root,
+    ),
+    false,
+  );
+  assert.equal(
+    await healBuiltinShadowedManifest(
+      { id: "gone", manifestPath: path.join(root, "gone.json") },
+      root,
+    ),
+    false,
+  );
+});
+
+test("isManifestShadowedByBuiltin is false without the marker", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "adapters-"));
+  const manifest = path.join(root, "copilot.json");
+  await writeFile(manifest, "{}", "utf8");
+  assert.equal(await isManifestShadowedByBuiltin(manifest), false);
+});
+
+test("marker suffix keeps quarantined files off the CLI's .json dir scan", () => {
+  assert.ok(!shadowedMarkerPath("/x/copilot.json").endsWith(".json"));
+  assert.ok(SHADOWED_MANIFEST_SUFFIX.startsWith("."));
+});
+
+// Wiring pins: the chat send route must detect the conflict from harness
+// stderr and heal+retry; both scaffold sites must refuse to resurrect a
+// quarantined manifest.
+test("chat send route wires conflict detection and heal-retry", async () => {
+  const source = await readFileFs(
+    path.join(process.cwd(), "src/app/api/chat/send/route.ts"),
+    "utf8",
+  );
+  assert.match(source, /detectBuiltinAdapterConflict\(text\)/);
+  assert.match(source, /healBuiltinShadowedManifest\(conflict\)/);
+  assert.match(source, /adapterConflict && !sshRuntime/);
+  assert.match(source, /pushProgress\(\s*"adapter-heal"/);
+});
+
+test("scaffold sites refuse to resurrect quarantined manifests", async () => {
+  for (const file of [
+    "src/app/api/config/route.ts",
+    "src/app/api/onboarding/setup/route.ts",
+  ]) {
+    const source = await readFileFs(path.join(process.cwd(), file), "utf8");
+    assert.match(
+      source,
+      /isManifestShadowedByBuiltin\(manifestPath\)/,
+      `${file} must check the shadowed marker before scaffolding`,
+    );
+  }
+});

--- a/src/lib/server/adapter-conflict-heal.ts
+++ b/src/lib/server/adapter-conflict-heal.ts
@@ -1,0 +1,100 @@
+// adapter-conflict-heal: recover from Coven CLI built-in/manifest id clashes.
+//
+// Cave scaffolds registry adapter manifests into $COVEN_HOME/adapters, and
+// every coven spawn points COVEN_HARNESS_ADAPTER_DIRS there. When a CLI
+// upgrade later promotes one of those adapters to a *built-in* harness
+// (copilot in coven v0.1.2, coven-code before it), released CLIs treat the
+// now-shadowed manifest as a FATAL registry error:
+//
+//   Error: external harness adapter `copilot` in ~/.coven/adapters/copilot.json
+//   conflicts with a built-in harness
+//
+// …which bricks every `coven run` — including harnesses the manifest never
+// mentioned. Chat surfaced that as codex turns ending "No assistant text
+// returned". The runtime-side fix (skip + warn) is OpenCoven/coven#412; this
+// module is Cave's self-heal for the CLIs already in the field: detect the
+// conflict in harness stderr, quarantine the stale manifest by renaming it
+// off the `.json` extension the CLI scans, and let the caller retry the turn.
+
+import { rename, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export type BuiltinAdapterConflict = {
+  /** Adapter id the CLI reported (e.g. "copilot"). */
+  id: string;
+  /** Manifest path exactly as the CLI printed it. */
+  manifestPath: string;
+};
+
+// Matches the released CLI's fatal error line. The id charset mirrors the
+// CLI's own `valid_adapter_id` (lowercase alnum plus `.`/`_`/`-`); the path
+// is whatever the CLI printed between "in " and " conflicts".
+const BUILTIN_CONFLICT_RE =
+  /external harness adapter `([a-z0-9._-]+)` in (.+?) conflicts with a built-in harness/;
+
+/** Suffix that quarantines a manifest: the CLI's dir scan only reads `.json`. */
+export const SHADOWED_MANIFEST_SUFFIX = ".shadowed-by-builtin";
+
+/**
+ * Parse a harness stderr chunk for the fatal built-in conflict error.
+ * Returns the first conflict found, or null.
+ */
+export function detectBuiltinAdapterConflict(
+  text: string,
+): BuiltinAdapterConflict | null {
+  const match = BUILTIN_CONFLICT_RE.exec(text);
+  if (!match) return null;
+  return { id: match[1], manifestPath: match[2].trim() };
+}
+
+/** The adapters directory Cave scaffolds into (honors COVEN_HOME). */
+export function covenAdaptersDir(): string {
+  const home = process.env.COVEN_HOME?.trim() || path.join(homedir(), ".coven");
+  return path.join(home, "adapters");
+}
+
+export function shadowedMarkerPath(manifestPath: string): string {
+  return `${manifestPath}${SHADOWED_MANIFEST_SUFFIX}`;
+}
+
+/**
+ * True when a previous heal quarantined this manifest — the scaffold sites
+ * check this so a config save can't resurrect a manifest the installed CLI
+ * chokes on.
+ */
+export async function isManifestShadowedByBuiltin(
+  manifestPath: string,
+): Promise<boolean> {
+  try {
+    return (await stat(shadowedMarkerPath(manifestPath))).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Quarantine the conflicting manifest by renaming it to the marker path.
+ * Only paths inside the adapters root are touched (prefix-safe containment:
+ * `resolved === root || resolved.startsWith(root + path.sep)`), so a crafted
+ * or remote error line can't rename arbitrary files. Returns true when the
+ * rename happened.
+ */
+export async function healBuiltinShadowedManifest(
+  conflict: BuiltinAdapterConflict,
+  adaptersRoot: string = covenAdaptersDir(),
+): Promise<boolean> {
+  const root = path.resolve(adaptersRoot);
+  const resolved = path.resolve(conflict.manifestPath);
+  const contained =
+    resolved === root || resolved.startsWith(root + path.sep);
+  if (!contained || resolved === root) return false;
+  if (!resolved.endsWith(".json")) return false;
+  try {
+    if (!(await stat(resolved)).isFile()) return false;
+    await rename(resolved, shadowedMarkerPath(resolved));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem (bead cave-1c05)

Installed Coven CLIs treat a `COVEN_HOME/adapters` manifest whose id a CLI upgrade promoted to **built-in** (`copilot` in coven v0.1.2, `coven-code` earlier) as a **fatal** registry error:

```
Error: external harness adapter `copilot` in ~/.coven/adapters/copilot.json conflicts with a built-in harness
```

Cave points `COVEN_HARNESS_ADAPTER_DIRS` at that dir on every spawn — and Cave itself scaffolded those manifests — so one stale file killed **every** `coven run`, any harness. In chat this surfaced as codex turns ending **“No assistant text returned”** (observed today on two conversations; reproduced locally on coven v0.1.1 and v0.1.2).

## Fix

- **`src/lib/server/adapter-conflict-heal.ts`** (new): parse the CLI's conflict error from harness stderr; quarantine the named manifest by renaming it to `<name>.json.shadowed-by-builtin` (the CLI's dir scan only reads `.json`). Containment-checked against the adapters root with the prefix-bypass-safe form (`resolved === root || resolved.startsWith(root + path.sep)`), `.json`-only, missing-file tolerant.
- **Chat send route**: when a turn dies on the conflict, heal and transparently retry the same turn (bounded to 3 heals — several stale manifests can conflict serially; each pass must have healed a new one). Local runs only; SSH runtimes name remote paths. Progress steps: `adapter-heal`.
- **Scaffold guards**: config PATCH and onboarding setup skip manifests carrying the shadowed marker, so a config save can't resurrect a manifest the installed CLI chokes on.

Runtime-side fix (skip + warn instead of fatal): OpenCoven/coven#412.

## Tests

`src/lib/server/adapter-conflict-heal.test.ts` (registered in the `api` suite): error-line parsing, rename+marker behavior, containment (incl. `${root}-evasion` prefix bypass), non-`.json`/missing-file refusal, plus wiring pins for the send route heal-retry and both scaffold guards.

Verified: `pnpm typecheck` ✓ · new tests 9/9 ✓ · config/onboarding/send-route sibling tests ✓ · end-to-end `coven run codex --stream-json` answers with marker files present ✓ (the `preferences-store.test.ts` failure in `test:api` reproduces identically on `main` in this env — pre-existing, unrelated)