### PR TITLE
fix(chat): target suggestion chips to their author

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -24,7 +24,7 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   // Injects the coven roster into each send so a familiar knows who else is present.
   assert.match(view, /renderCovenRoundtablePrompt\(\{/, "builds the per-familiar roundtable prompt");
   assert.match(view, /receivingFamiliarId: r\.familiarId/, "marks the receiving familiar in prompt context");
-  assert.match(view, /targeted: mentioned\.length > 0/, "tells the prompt whether the user targeted this reply");
+  assert.match(view, /targeted,/, "tells the prompt whether the user targeted this reply");
   assert.doesNotMatch(view, /renderCovenContext\(contextTurns, r\.familiarId/, "default group chat does not relay peer replies");
   assert.doesNotMatch(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "full-coven broadcasts no longer switch to sequential relay");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
@@ -34,24 +34,43 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
     /const \{ visible: visibleText, suggestions \} = extractNextPaths\(r\.text\)/,
     "strips the next-paths block and parses suggestions from coven replies",
   );
-  // Parsed suggestions render as click-to-send chips that broadcast the line.
+  // Parsed suggestions render as click-to-send chips targeted to their author.
   assert.match(
     view,
     /className="cave-next-paths mt-1\.5" data-count=\{suggestions\.length\}/,
     "renders the next-paths chip row, stamping its count for the uniform-rows layout",
   );
-  assert.match(view, /onClick=\{\(\) => void broadcast\(s\)\}/, "clicking a chip broadcasts the suggestion");
+  assert.match(
+    view,
+    /sendSuggestion\(s, r\.familiarId, f\?\.display_name \?\? r\.familiarId\)/,
+    "clicking a chip targets the familiar who authored it",
+  );
+  assert.match(
+    view,
+    /broadcast\(mentionSuggestionAuthor\(suggestion, displayName\), \[familiarId\]\)/,
+    "suggestion sends visibly mention the author while routing by familiar id",
+  );
+  assert.match(
+    view,
+    /sessionId: group\.sessions\[fid\] \?\? null/,
+    "the targeted reply reuses its familiar's existing coven session",
+  );
+  assert.match(
+    view,
+    /if \(targetIds\.length === 0\) \{[\s\S]*?return;/,
+    "suggestions from removed familiars cannot fall back to a coven broadcast",
+  );
 });
 
 test("@mentions target a subset of the coven", () => {
   // Send routes to mentioned familiars only, falling back to the full roster.
-  assert.match(view, /const mentioned = parseMentions\(text, mentionable\)/, "parses @mentions on send");
+  assert.match(view, /resolveGroupMessageTargets\(/, "resolves composer mentions and explicit targets through the pure routing helper");
   assert.match(
     view,
-    /mentioned\.length > 0 \? group\.familiarIds\.filter/,
-    "targets only mentioned familiars, else broadcasts to all",
+    /text,\s*\n\s*group\.familiarIds,\s*\n\s*mentionable,\s*\n\s*explicitTargetFamiliarIds/,
+    "passes visible text, the current roster, and any authoritative target to routing",
   );
-  assert.match(view, /targetFamiliarIds: mentioned\.length > 0/, "records the targeted ids on the user turn");
+  assert.match(view, /targetFamiliarIds: targeted \? targetIds : undefined/, "records targeted ids on the user turn");
   assert.match(view, /replies: GroupReply\[\] = targetIds\.map/, "only the targets reply");
   // Composer autocomplete reuses the tested pure helpers.
   assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -49,7 +49,8 @@ import {
   removeGroup,
   setGroupSession,
   setGroupParticipants,
-  parseMentions,
+  resolveGroupMessageTargets,
+  mentionSuggestionAuthor,
   renderCovenRoundtablePrompt,
   findActiveMention,
   matchMentions,
@@ -448,18 +449,30 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   );
 
   const broadcast = useCallback(
-    async (rawText: string) => {
+    async (rawText: string, explicitTargetFamiliarIds?: string[]) => {
       const group = activeGroupRef.current;
       const text = rawText.trim();
       if (!group || group.familiarIds.length === 0 || !text || busy || abortRef.current) return;
-      // Tagging a subset of familiars with `@mentions` targets the message at just
-      // those participants; with no mention it broadcasts to the whole coven.
+      // Suggestion chips carry their author's id explicitly. Visible mentions in
+      // generated suggestion text must not widen that authoritative destination.
+      // Composer messages still target their @mentions or the full coven.
       const mentionable: MentionableFamiliar[] = group.familiarIds.map((id) => ({
         id,
         name: byId.get(id)?.display_name ?? "",
       }));
-      const mentioned = parseMentions(text, mentionable);
-      const targetIds = mentioned.length > 0 ? group.familiarIds.filter((id) => mentioned.includes(id)) : group.familiarIds;
+      const { targetIds, targeted } = resolveGroupMessageTargets(
+        text,
+        group.familiarIds,
+        mentionable,
+        explicitTargetFamiliarIds,
+      );
+      // Historical replies remain in the transcript after roster edits. If their
+      // author has left this coven, do not create a stranded user turn or unlock a
+      // fallback broadcast by mistake.
+      if (targetIds.length === 0) {
+        announce("That familiar is no longer in this coven.", "assertive");
+        return;
+      }
       // Roster reflects the FULL coven (not just @mention targets) — a familiar
       // should know who else is in the room even when addressed alone. Composed
       // per-familiar so each sees itself marked "(you)".
@@ -477,7 +490,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         id: newId(),
         role: "user",
         text,
-        targetFamiliarIds: mentioned.length > 0 ? targetIds : undefined,
+        targetFamiliarIds: targeted ? targetIds : undefined,
         createdAt: at,
       };
       const replies: GroupReply[] = targetIds.map((fid) => ({
@@ -508,7 +521,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
               participants: rosterParticipants,
               receivingFamiliarId: r.familiarId,
               userText: text,
-              targeted: mentioned.length > 0,
+              targeted,
             }),
             controller.signal,
           ),
@@ -536,9 +549,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     [busy, streamOne, byId, announce, operatorDisplayName],
   );
 
-  // The composer and "click a next-path suggestion to send" chips both go
-  // through broadcast — a clicked suggestion is just a one-tap next prompt.
+  // Composer sends and suggestion chips share the stream path, but a suggestion
+  // is an explicitly targeted follow-up to the familiar that authored it.
   const send = useCallback(() => broadcast(draft), [broadcast, draft]);
+  const sendSuggestion = useCallback(
+    (suggestion: string, familiarId: string, displayName: string) =>
+      broadcast(mentionSuggestionAuthor(suggestion, displayName), [familiarId]),
+    [broadcast],
+  );
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
@@ -1001,7 +1019,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                           key={i}
                                           type="button"
                                           className={`cave-next-path${recommended ? " cave-next-path--recommended" : ""}`}
-                                          onClick={() => void broadcast(s)}
+                                          onClick={() => void sendSuggestion(s, r.familiarId, f?.display_name ?? r.familiarId)}
                                           disabled={busy}
                                           aria-label={recommended ? `Recommended: ${s}` : undefined}
                                           title={recommended ? "Recommended next step" : undefined}

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -10,6 +10,8 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
+  resolveGroupMessageTargets,
+  mentionSuggestionAuthor,
   renderCovenRoster,
   renderCovenRoundtablePrompt,
   renderCovenContext,
@@ -191,6 +193,36 @@ test("parseMentions: @ mid-word (email) is not a mention", () => {
 
 test("parseMentions: punctuation after a name still matches", () => {
   assert.deepEqual(parseMentions("@Nova, thoughts?", ROSTER), ["nova"]);
+});
+
+test("resolveGroupMessageTargets: no mention broadcasts in roster order", () => {
+  assert.deepEqual(
+    resolveGroupMessageTargets("What does everyone think?", ["nova", "sage"], ROSTER),
+    { targetIds: ["nova", "sage"], targeted: false },
+  );
+});
+
+test("resolveGroupMessageTargets: composer mentions target their parsed subset", () => {
+  assert.deepEqual(
+    resolveGroupMessageTargets("@Sage please check this", ["nova", "sage"], ROSTER),
+    { targetIds: ["sage"], targeted: true },
+  );
+});
+
+test("resolveGroupMessageTargets: explicit suggestion author cannot be widened by inner mentions", () => {
+  const text = mentionSuggestionAuthor("Ask @Sage to review it", "Nova Star");
+  assert.equal(text, "@Nova Star Ask @Sage to review it");
+  assert.deepEqual(
+    resolveGroupMessageTargets(text, ["nova-star", "sage"], ROSTER, ["nova-star"]),
+    { targetIds: ["nova-star"], targeted: true },
+  );
+});
+
+test("resolveGroupMessageTargets: removed explicit targets never fall back to broadcast", () => {
+  assert.deepEqual(
+    resolveGroupMessageTargets("@Nova Continue", ["sage"], ROSTER, ["nova"]),
+    { targetIds: [], targeted: true },
+  );
 });
 
 test("findActiveMention: caret inside a fresh token returns start + query", () => {

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -208,6 +208,37 @@ export function parseMentions(text: string, participants: MentionableFamiliar[])
 }
 
 /**
+ * Resolve the authoritative recipients for one coven message.
+ *
+ * Composer messages derive their targets from visible `@mentions`, falling
+ * back to the full coven when none are present. One-tap UI actions such as a
+ * familiar's next-path suggestion may instead provide explicit ids. In that
+ * case visible mentions are deliberately ignored so generated suggestion text
+ * cannot widen the destination set.
+ */
+export function resolveGroupMessageTargets(
+  text: string,
+  groupFamiliarIds: string[],
+  participants: MentionableFamiliar[],
+  explicitTargetFamiliarIds?: string[],
+): { targetIds: string[]; targeted: boolean } {
+  const mentioned = explicitTargetFamiliarIds === undefined ? parseMentions(text, participants) : [];
+  const requested = explicitTargetFamiliarIds ?? mentioned;
+  const targeted = explicitTargetFamiliarIds !== undefined || mentioned.length > 0;
+  return {
+    targetIds: targeted
+      ? groupFamiliarIds.filter((id) => requested.includes(id))
+      : [...groupFamiliarIds],
+    targeted,
+  };
+}
+
+/** Prefix a suggestion with the author mention shown in the user transcript. */
+export function mentionSuggestionAuthor(suggestion: string, displayName: string): string {
+  return `@${displayName.trim()} ${suggestion.trim()}`.trim();
+}
+
+/**
  * Locate the `@mention` token the caret is currently editing, for autocomplete.
  * Returns the `@`'s index and the partial query typed after it, or `null` when
  * the caret is not inside a mention. The token starts at an `@` preceded by


### PR DESCRIPTION
## Summary

- route each group-chat next-path suggestion only to the familiar that authored it
- show the targeted follow-up as a visible `@Display Name` user message
- keep the originating `familiarId` authoritative even when suggestion text contains other mentions
- preserve normal full-coven broadcasts and manually entered mention routing
- prevent suggestions on historical replies from removed familiars from falling back to a broadcast

Fixes #3336.
Supersedes the closed, unmerged #3346.

## Root cause

Suggestion chips called `broadcast(s)` without carrying the surrounding reply's `familiarId`. Since generated suggestion text normally has no mention, the existing no-mention fallback routed the message to every familiar in the coven.

## Implementation

The group-chat send path now resolves recipients through a pure routing helper. Composer sends still parse visible mentions, while suggestion clicks provide an explicit author id that cannot be widened by generated text. The visible transcript text is separately prefixed with the author's display-name mention.

Targeted replies continue to use the familiar's existing per-coven session id. If the author of a historical reply is no longer in the coven, the send stops with an accessible announcement rather than creating a stranded turn or broadcasting.

## Validation

- `node --experimental-strip-types --test src/lib/group-chat.test.ts src/components/group-chat-view.test.ts` — 57 passed
- `pnpm typecheck` — passed
- `pnpm check:tests-wired` — all 1,038 test files wired
- `pnpm test:app` — all 764 app test files passed
- `git diff --check` — passed

Coverage includes:

- normal unmentioned full-coven broadcasts
- manual single-familiar mention routing
- multi-word author display names
- suggestion text containing another familiar mention
- removed historical targets never falling back to broadcast
- existing session reuse and targeted transcript metadata

## Environment note

`pnpm install --frozen-lockfile` linked the locked dependencies, then its optional `node-pty` native build exited because `make` is unavailable in this WSL environment. The TypeScript and complete app test gates above executed successfully with the linked dependencies.