### PR TITLE
feat(chat): route familiar task handoffs

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -73,6 +73,7 @@ test("completed familiar delegation trailers route bounded, attributable follow-
   assert.match(view, /delegationSourceReplyId: source\.id/, "records the stable source reply for persistence and idempotency");
   assert.match(view, /targetFamiliarIds: \[targetId\]/, "routes only to the explicitly delegated target");
   assert.match(view, /sessions\[targetId\] \?\? null/, "reuses the target familiar's latest pinned session");
+  assert.match(view, /const retryText = delegator \? `Delegated by @\$\{delegator\}:\\n\$\{userTurn\.text\}` : userTurn\.text/, "preserves delegation attribution when a failed target is retried");
   assert.match(view, /delegator \? "HANDOFF" : "OP"/, "renders familiar-issued work as an attributed handoff");
 });
 

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -31,8 +31,8 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   // lines (suggestions) so control markup never leaks and chips can render.
   assert.match(
     view,
-    /const \{ visible: visibleText, suggestions \} = extractNextPaths\(r\.text\)/,
-    "strips the next-paths block and parses suggestions from coven replies",
+    /const \{ visible: withoutNextPaths, suggestions \} = extractNextPaths\(r\.text\)[\s\S]*extractCovenDelegations\(withoutNextPaths\)/,
+    "strips next-path and delegation controls from coven replies",
   );
   // Parsed suggestions render as click-to-send chips that broadcast the line.
   assert.match(
@@ -59,6 +59,23 @@ test("@mentions target a subset of the coven", () => {
   assert.match(view, /applyMention\(draft, mention\.start, mention\.query/, "inserts the chosen familiar");
 });
 
+test("completed familiar delegation trailers route bounded, attributable follow-up work", () => {
+  assert.match(view, /extractCovenDelegations\(withoutNextPaths\)/, "parses only the tested structured trailer after removing next-path controls");
+  assert.match(view, /source\.status !== "done"/, "never routes a partial or failed familiar reply");
+  assert.match(view, /!group\.familiarIds\.includes\(targetId\)/, "rejects out-of-coven targets");
+  assert.match(view, /targetId === source\.familiarId/, "rejects self-delegation");
+  assert.match(view, /lineage\.has\(targetId\)/, "rejects delegation cycles");
+  assert.match(view, /delivered\.has\(dedupeKey\)/, "deduplicates source-to-target deliveries");
+  assert.match(view, /MAX_COVEN_DELEGATION_DEPTH/, "bounds delegation depth");
+  assert.match(view, /MAX_COVEN_DELEGATIONS_PER_TURN/, "bounds total delegated sends per human turn");
+  assert.match(view, /controller\.signal\.aborted/, "Stop prevents queued delegated sends from starting");
+  assert.match(view, /delegatedByFamiliarId: source\.familiarId/, "records who delegated the task");
+  assert.match(view, /delegationSourceReplyId: source\.id/, "records the stable source reply for persistence and idempotency");
+  assert.match(view, /targetFamiliarIds: \[targetId\]/, "routes only to the explicitly delegated target");
+  assert.match(view, /sessions\[targetId\] \?\? null/, "reuses the target familiar's latest pinned session");
+  assert.match(view, /delegator \? "HANDOFF" : "OP"/, "renders familiar-issued work as an attributed handoff");
+});
+
 test("Group chat transcript uses avatar author rows with recency", () => {
   assert.match(
     view,
@@ -70,11 +87,10 @@ test("Group chat transcript uses avatar author rows with recency", () => {
     /const dtPrefs = useDateTimePrefs\(\)/,
     "group chat reads date/time preferences for message recency",
   );
-  assert.match(
-    view,
-    /className="cave-group-chat-turn cave-group-chat-turn--user"[\s\S]*cave-group-chat-avatar cave-group-chat-avatar--human[\s\S]*cave-group-chat-name[\s\S]*operatorDisplayName[\s\S]*cave-group-chat-badge cave-group-chat-badge--op[\s\S]*formatChatRecency\(user\.createdAt, dtPrefs\)/,
-    "group user turns render a Discord-like avatar/profile-name/OP/recency header",
-  );
+  assert.match(view, /<UserChatAvatar className="cave-group-chat-avatar cave-group-chat-avatar--human"/, "human turns retain the user avatar");
+  assert.match(view, /delegator\?\.display_name \?\? operatorDisplayName/, "human turns retain the operator display name while handoffs show the familiar");
+  assert.match(view, /delegator \? "HANDOFF" : "OP"/, "human and familiar-authored turns have distinct badges");
+  assert.match(view, /formatChatRecency\(user\.createdAt, dtPrefs\)/, "group prompt turns retain recency");
   assert.match(
     view,
     /className="cave-group-chat-turn cave-group-chat-turn--assistant"[\s\S]*<FamiliarAvatar familiar=\{f\} size="xl"[\s\S]*cave-group-chat-name[\s\S]*f\?\.display_name[\s\S]*formatChatRecency\(r\.createdAt, dtPrefs\)/,

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -651,6 +651,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         error: undefined,
         activity: undefined,
       };
+      const delegator = userTurn.delegatedByFamiliarId
+        ? byId.get(userTurn.delegatedByFamiliarId)?.display_name ?? userTurn.delegatedByFamiliarId
+        : null;
+      const retryText = delegator ? `Delegated by @${delegator}:\n${userTurn.text}` : userTurn.text;
       updateReply(reply.id, () => fresh);
       setBusy(true);
       const controller = new AbortController();
@@ -661,7 +665,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         renderCovenRoundtablePrompt({
           participants: rosterParticipants,
           receivingFamiliarId: fresh.familiarId,
-          userText: userTurn.text,
+          userText: retryText,
           targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
         }),
         controller.signal,

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -41,6 +41,8 @@ import { formatChatRecency, useDateTimePrefs } from "@/lib/datetime-format";
 import { useUserProfile, userDisplayName } from "@/lib/user-profile";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
+  MAX_COVEN_DELEGATION_DEPTH,
+  MAX_COVEN_DELEGATIONS_PER_TURN,
   applyGroupEvent,
   parseSseBuffer,
   defaultGroupName,
@@ -50,6 +52,7 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
+  extractCovenDelegations,
   renderCovenRoundtablePrompt,
   findActiveMention,
   matchMentions,
@@ -514,6 +517,82 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
           ),
         ),
       );
+      // A familiar can perform an explicit human-requested handoff by emitting
+      // a validated delegation trailer. Plain assistant @mentions remain prose.
+      // Process the small delegation tree sequentially so Stop prevents queued
+      // work from starting and each target keeps its resumable familiar session.
+      const delivered = new Set(
+        transcriptRef.current
+          .filter((turn): turn is GroupUserTurn => turn.role === "user" && Boolean(turn.delegationSourceReplyId))
+          .map((turn) => `${turn.delegationSourceReplyId}:${turn.targetFamiliarIds?.[0] ?? ""}`),
+      );
+      let delegationCount = 0;
+      const runDelegations = async (
+        sourceReplies: GroupReply[],
+        depth: number,
+        lineage: Set<string>,
+      ): Promise<void> => {
+        if (depth >= MAX_COVEN_DELEGATION_DEPTH || controller.signal.aborted) return;
+        for (const source of sourceReplies) {
+          if (controller.signal.aborted || delegationCount >= MAX_COVEN_DELEGATIONS_PER_TURN) return;
+          if (source.status !== "done") continue;
+          const withoutNextPaths = extractNextPaths(source.text).visible;
+          const { delegations } = extractCovenDelegations(withoutNextPaths);
+          for (const delegation of delegations) {
+            if (controller.signal.aborted || delegationCount >= MAX_COVEN_DELEGATIONS_PER_TURN) return;
+            const targetId = delegation.targetFamiliarId;
+            const dedupeKey = `${source.id}:${targetId}`;
+            if (
+              targetId === source.familiarId ||
+              !group.familiarIds.includes(targetId) ||
+              lineage.has(targetId) ||
+              delivered.has(dedupeKey)
+            ) continue;
+            const target = byId.get(targetId);
+            if (!target) continue;
+            const at = nowIso();
+            const delegatedTurn: GroupUserTurn = {
+              id: newId(),
+              role: "user",
+              text: delegation.task,
+              targetFamiliarIds: [targetId],
+              delegatedByFamiliarId: source.familiarId,
+              delegationSourceReplyId: source.id,
+              delegationDepth: depth + 1,
+              createdAt: at,
+            };
+            const delegatedReply: GroupReply = {
+              id: newId(),
+              role: "assistant",
+              familiarId: targetId,
+              replyTo: delegatedTurn.id,
+              sessionId: groupsRef.current.find((item) => item.id === group.id)?.sessions[targetId] ?? null,
+              text: "",
+              status: "queued",
+              createdAt: at,
+            };
+            delivered.add(dedupeKey);
+            delegationCount += 1;
+            setTranscript((prev) => [...prev, delegatedTurn, delegatedReply]);
+            const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
+            const child = await streamOne(
+              group,
+              delegatedReply,
+              renderCovenRoundtablePrompt({
+                participants: rosterParticipants,
+                receivingFamiliarId: targetId,
+                userText: `Delegated by @${delegatedBy}:\n${delegation.task}`,
+                targeted: true,
+              }),
+              controller.signal,
+            );
+            await runDelegations([child], depth + 1, new Set([...lineage, targetId]));
+          }
+        }
+      };
+      for (const source of settled) {
+        await runDelegations([source], 0, new Set([source.familiarId]));
+      }
       // Only clear the shared abort/busy wiring if this broadcast still owns it.
       // A coven switch (or a newer broadcast) may have replaced abortRef while
       // this one was aborting; clearing unconditionally would kill the newer
@@ -898,6 +977,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     const targets = user.targetFamiliarIds
                       ?.map((id) => byId.get(id))
                       .filter((f): f is ResolvedFamiliar => Boolean(f));
+                    const delegator = user.delegatedByFamiliarId
+                      ? byId.get(user.delegatedByFamiliarId)
+                      : undefined;
                     return (
                     <div key={user.id} className="flex flex-col gap-2">
                       {targets && targets.length > 0 && (
@@ -909,16 +991,24 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                         </div>
                       )}
                       <div className="cave-group-chat-turn cave-group-chat-turn--user">
-                        <UserChatAvatar className="cave-group-chat-avatar cave-group-chat-avatar--human" />
+                        {delegator ? (
+                          <div className="cave-group-chat-avatar">
+                            <FamiliarAvatar familiar={delegator} size="xl" className="cave-group-chat-avatar__image" title={delegator.display_name} />
+                          </div>
+                        ) : (
+                          <UserChatAvatar className="cave-group-chat-avatar cave-group-chat-avatar--human" />
+                        )}
                         <div className="cave-group-chat-message">
                           <div className="cave-group-chat-meta">
-                            <span className="cave-group-chat-name">{operatorDisplayName}</span>
-                            <span className="cave-group-chat-badge cave-group-chat-badge--op">OP</span>
+                            <span className="cave-group-chat-name">{delegator?.display_name ?? operatorDisplayName}</span>
+                            <span className={`cave-group-chat-badge${delegator ? "" : " cave-group-chat-badge--op"}`}>
+                              {delegator ? "HANDOFF" : "OP"}
+                            </span>
                             <time className="cave-group-chat-recency" dateTime={user.createdAt}>
                               {formatChatRecency(user.createdAt, dtPrefs)}
                             </time>
                           </div>
-                          <MessageBubble role="user" content={user.text} timestamp={user.createdAt} showTimestamp={false} onOpenUrl={onOpenUrl} />
+                          <MessageBubble role={delegator ? "assistant" : "user"} content={user.text} timestamp={user.createdAt} showTimestamp={false} onOpenUrl={onOpenUrl} />
                         </div>
                       </div>
                       <div className="flex flex-col gap-3 pl-1">
@@ -929,7 +1019,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                           // reply, mirroring the single-chat surface; otherwise
                           // the raw control markup leaks into the coven bubble.
                           // The parsed lines render as click-to-send chips below.
-                          const { visible: visibleText, suggestions } = extractNextPaths(r.text);
+                          const { visible: withoutNextPaths, suggestions } = extractNextPaths(r.text);
+                          const { visible: visibleText } = extractCovenDelegations(withoutNextPaths);
                           return (
                             <div key={r.id} className="cave-group-chat-turn cave-group-chat-turn--assistant">
                               <div className="cave-group-chat-avatar">

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -10,6 +10,7 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
+  extractCovenDelegations,
   renderCovenRoster,
   renderCovenRoundtablePrompt,
   renderCovenContext,
@@ -193,6 +194,50 @@ test("parseMentions: punctuation after a name still matches", () => {
   assert.deepEqual(parseMentions("@Nova, thoughts?", ROSTER), ["nova"]);
 });
 
+test("extractCovenDelegations: strips a valid trailer and returns its routed task", () => {
+  const text =
+    '@Charm Review the design.\n\n<coven:delegation target="charm">@Charm Review the design.</coven:delegation>';
+  assert.deepEqual(extractCovenDelegations(text), {
+    visible: "@Charm Review the design.",
+    delegations: [{ targetFamiliarId: "charm", task: "@Charm Review the design." }],
+  });
+});
+
+test("extractCovenDelegations: a casual @mention never dispatches", () => {
+  assert.deepEqual(extractCovenDelegations("@Charm would know more about this."), {
+    visible: "@Charm would know more about this.",
+    delegations: [],
+  });
+});
+
+test("extractCovenDelegations: ignores quoted, inline-code, and fenced marker examples", () => {
+  const quoted = '> <coven:delegation target="charm">quoted</coven:delegation>';
+  const inline = '`<coven:delegation target="charm">inline</coven:delegation>`';
+  const fenced = '```xml\n<coven:delegation target="charm">fenced</coven:delegation>\n```';
+  for (const text of [quoted, inline, fenced]) {
+    assert.deepEqual(extractCovenDelegations(text), { visible: text, delegations: [] });
+  }
+});
+
+test("extractCovenDelegations: dedupes targets and rejects empty or malformed trailers", () => {
+  const text = [
+    '<coven:delegation target="charm">first</coven:delegation>',
+    '<coven:delegation target="charm">second</coven:delegation>',
+    '<coven:delegation target="sage"></coven:delegation>',
+    '<coven:delegation target="../bad">bad</coven:delegation>',
+  ].join("\n");
+  assert.deepEqual(extractCovenDelegations(text).delegations, [
+    { targetFamiliarId: "charm", task: "first" },
+  ]);
+});
+
+test("extractCovenDelegations: hides an incomplete trailing control while streaming", () => {
+  assert.deepEqual(
+    extractCovenDelegations('@Charm take this.\n<coven:delegation target="charm">partial'),
+    { visible: "@Charm take this.", delegations: [] },
+  );
+});
+
 test("findActiveMention: caret inside a fresh token returns start + query", () => {
   const text = "hey @Nov";
   assert.deepEqual(findActiveMention(text, text.length), { start: 4, query: "Nov" });
@@ -244,6 +289,7 @@ test("renderCovenRoster: names every participant with roles", () => {
   const out = renderCovenRoster(COVEN, "nova");
   assert.match(out, /- Nova — Lead orchestrator/);
   assert.match(out, /- Charm — Comms familiar/);
+  assert.match(out, /Charm — Comms familiar \[familiar-id: charm\]/);
   assert.match(out, /- You \(human\)/);
 });
 
@@ -285,6 +331,9 @@ test("renderCovenRoundtablePrompt: frames broadcast replies as independent first
   assert.match(out, /Other familiars receive the same human request in parallel/);
   assert.match(out, /Answer from your own identity, role, and judgment/);
   assert.match(out, /Do not summarize, predict, imitate, or speak for other familiars/);
+  assert.match(out, /Do not merely suggest that the human ask another familiar/);
+  assert.match(out, /address that familiar directly using their exact @display name/);
+  assert.match(out, /<coven:delegation target="familiar-id">/);
   assert.match(out, /What should we do\?$/);
   assert.doesNotMatch(out, /<coven_transcript>/);
 });

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -212,11 +212,20 @@ test("extractCovenDelegations: a casual @mention never dispatches", () => {
 
 test("extractCovenDelegations: ignores quoted, inline-code, and fenced marker examples", () => {
   const quoted = '> <coven:delegation target="charm">quoted</coven:delegation>';
+  const indentedQuote = '  > <coven:delegation target="charm">quoted</coven:delegation>';
   const inline = '`<coven:delegation target="charm">inline</coven:delegation>`';
+  const multiBacktickInline = '``<coven:delegation target="charm">inline</coven:delegation>``';
   const fenced = '```xml\n<coven:delegation target="charm">fenced</coven:delegation>\n```';
-  for (const text of [quoted, inline, fenced]) {
+  for (const text of [quoted, indentedQuote, inline, multiBacktickInline, fenced]) {
     assert.deepEqual(extractCovenDelegations(text), { visible: text, delegations: [] });
   }
+});
+
+test("extractCovenDelegations: preserves case-sensitive familiar ids", () => {
+  const text = '<coven:delegation target="Charm">review this</coven:delegation>';
+  assert.deepEqual(extractCovenDelegations(text).delegations, [
+    { targetFamiliarId: "Charm", task: "review this" },
+  ]);
 });
 
 test("extractCovenDelegations: dedupes targets and rejects empty or malformed trailers", () => {

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -216,7 +216,19 @@ test("extractCovenDelegations: ignores quoted, inline-code, and fenced marker ex
   const inline = '`<coven:delegation target="charm">inline</coven:delegation>`';
   const multiBacktickInline = '``<coven:delegation target="charm">inline</coven:delegation>``';
   const fenced = '```xml\n<coven:delegation target="charm">fenced</coven:delegation>\n```';
-  for (const text of [quoted, indentedQuote, inline, multiBacktickInline, fenced]) {
+  const tildeFenced = '~~~xml\n<coven:delegation target="charm">fenced</coven:delegation>\n~~~';
+  const indentedCode = '    <coven:delegation target="charm">indented</coven:delegation>';
+  const tabIndentedCode = '\t<coven:delegation target="charm">indented</coven:delegation>';
+  for (const text of [
+    quoted,
+    indentedQuote,
+    inline,
+    multiBacktickInline,
+    fenced,
+    tildeFenced,
+    indentedCode,
+    tabIndentedCode,
+  ]) {
     assert.deepEqual(extractCovenDelegations(text), { visible: text, delegations: [] });
   }
 });

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -20,6 +20,11 @@ const TRANSCRIPTS_KEY_PREFIX = "cave:group-chat:transcript:";
  *  nothing the model sees — it only bounds localStorage growth (and the cost
  *  of re-serializing the transcript on save). */
 export const TRANSCRIPT_CAP = 200;
+/** A human-originated Coven turn may trigger a small, bounded delegation tree.
+ *  Two hops supports A → B → C while preventing an open-ended agent loop. */
+export const MAX_COVEN_DELEGATION_DEPTH = 2;
+/** Independent cap for wide fan-out within one human turn. */
+export const MAX_COVEN_DELEGATIONS_PER_TURN = 4;
 
 /** A saved group of familiars chatted with together. */
 export type CovenGroup = {
@@ -43,6 +48,12 @@ export type GroupUserTurn = {
    * means it was broadcast to the whole coven.
    */
   targetFamiliarIds?: string[];
+  /** Present when this prompt was emitted by another familiar rather than the
+   *  human composer. These fields make the handoff attributable and idempotent
+   *  across transcript persistence and React re-renders. */
+  delegatedByFamiliarId?: string;
+  delegationSourceReplyId?: string;
+  delegationDepth?: number;
   createdAt: string;
 };
 
@@ -164,6 +175,66 @@ export function defaultGroupName(names: string[]): string {
 
 /** A coven member as seen by the mention parser/autocomplete. */
 export type MentionableFamiliar = { id: string; name: string };
+
+export type CovenDelegation = {
+  targetFamiliarId: string;
+  task: string;
+};
+
+export type ExtractedCovenDelegations = {
+  visible: string;
+  delegations: CovenDelegation[];
+};
+
+const DELEGATION_OPEN = "<coven:delegation";
+const COMPLETE_DELEGATION_RE =
+  /<coven:delegation\s+target="([a-z0-9][a-z0-9_-]*)">([\s\S]*?)<\/coven:delegation>/gi;
+
+/** Ranges where marker-shaped text is documentation, not an instruction. */
+function delegationIgnoredRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const re of [/```[\s\S]*?(?:```|$)/g, /`[^`\n]*`/g, /^>.*$/gm]) {
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text))) ranges.push([match.index, match.index + match[0].length]);
+  }
+  return ranges;
+}
+
+/**
+ * Extract explicit familiar-issued delegation controls while returning the
+ * human-readable reply without their hidden trailer. A plain `@Name` is never
+ * enough to dispatch work: only a complete, non-quoted control marker routes.
+ * The incomplete trailing marker is hidden during streaming so control markup
+ * does not flicker into the reply bubble.
+ */
+export function extractCovenDelegations(text: string): ExtractedCovenDelegations {
+  const ignored = delegationIgnoredRanges(text);
+  const isIgnored = (index: number) => ignored.some(([start, end]) => index >= start && index < end);
+  const delegations: CovenDelegation[] = [];
+  const remove: Array<[number, number]> = [];
+  const seenTargets = new Set<string>();
+  let match: RegExpExecArray | null;
+  COMPLETE_DELEGATION_RE.lastIndex = 0;
+  while ((match = COMPLETE_DELEGATION_RE.exec(text))) {
+    if (isIgnored(match.index)) continue;
+    remove.push([match.index, match.index + match[0].length]);
+    const targetFamiliarId = match[1].toLowerCase();
+    const task = match[2].trim();
+    if (!task || seenTargets.has(targetFamiliarId)) continue;
+    seenTargets.add(targetFamiliarId);
+    delegations.push({ targetFamiliarId, task });
+  }
+
+  let visible = text;
+  for (const [start, end] of remove.sort((a, b) => b[0] - a[0])) {
+    visible = visible.slice(0, start) + visible.slice(end);
+  }
+  const partial = visible.lastIndexOf(DELEGATION_OPEN);
+  if (partial >= 0 && !delegationIgnoredRanges(visible).some(([start, end]) => partial >= start && partial < end)) {
+    visible = visible.slice(0, partial);
+  }
+  return { visible: visible.trimEnd(), delegations };
+}
 
 /** True for a char that may not abut the end of a matched `@name` (a word char,
  *  so `@Alpha` does not greedily match a participant named `Al`). */
@@ -347,7 +418,7 @@ export function renderCovenRoster(
     if (p.kind === "human") return `- ${p.name} (human)`;
     const role = p.role.trim() ? ` — ${p.role.trim()}` : "";
     const you = p.id === receivingFamiliarId ? " (you)" : "";
-    return `- ${p.name}${role}${you}`;
+    return `- ${p.name}${role}${you} [familiar-id: ${p.id}]`;
   });
   return [
     "<coven_roster>",
@@ -384,7 +455,10 @@ export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): st
       : "This is an independent first-pass group reply. Other familiars receive the same human request in parallel.",
     "Answer from your own identity, role, and judgment.",
     "Do not summarize, predict, imitate, or speak for other familiars.",
-    "If useful, state what you would hand off to another familiar, but keep your answer yours.",
+    "Do not merely suggest that the human ask another familiar to do something.",
+    "When the human explicitly asks you to give, assign, delegate, or hand off a task to another familiar in this coven, address that familiar directly using their exact @display name and state the concrete task.",
+    'After the visible @mention task, append exactly one hidden routing trailer using the roster id: <coven:delegation target="familiar-id">the same concrete task</coven:delegation>.',
+    "Only emit that trailer for an explicit delegation request addressed to you; ordinary references to another familiar are not delegations.",
     "</coven_roundtable>",
   ].join("\n");
   return [roster, mode, args.userText.trim()].filter(Boolean).join("\n\n");

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -193,7 +193,11 @@ const COMPLETE_DELEGATION_RE =
 /** Ranges where marker-shaped text is documentation, not an instruction. */
 function delegationIgnoredRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  for (const re of [/```[\s\S]*?(?:```|$)/g, /`[^`\n]*`/g, /^>.*$/gm]) {
+  for (const re of [
+    /```[\s\S]*?(?:```|$)/g,
+    /(`+)[^\n]*?\1/g,
+    /^[ \t]{0,3}>.*$/gm,
+  ]) {
     let match: RegExpExecArray | null;
     while ((match = re.exec(text))) ranges.push([match.index, match.index + match[0].length]);
   }
@@ -218,7 +222,10 @@ export function extractCovenDelegations(text: string): ExtractedCovenDelegations
   while ((match = COMPLETE_DELEGATION_RE.exec(text))) {
     if (isIgnored(match.index)) continue;
     remove.push([match.index, match.index + match[0].length]);
-    const targetFamiliarId = match[1].toLowerCase();
+    // Familiar ids are validated case-insensitively but remain case-sensitive
+    // identifiers on Linux filesystems and throughout the roster. Preserve the
+    // exact roster id emitted in the control instead of silently changing it.
+    const targetFamiliarId = match[1];
     const task = match[2].trim();
     if (!task || seenTargets.has(targetFamiliarId)) continue;
     seenTargets.add(targetFamiliarId);

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -195,8 +195,10 @@ function delegationIgnoredRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   for (const re of [
     /```[\s\S]*?(?:```|$)/g,
+    /~~~[\s\S]*?(?:~~~|$)/g,
     /(`+)[^\n]*?\1/g,
     /^[ \t]{0,3}>.*$/gm,
+    /^(?: {4,}|\t).*$/gm,
   ]) {
     let match: RegExpExecArray | null;
     while ((match = re.exec(text))) ranges.push([match.index, match.index + match[0].length]);


### PR DESCRIPTION
## Summary

- replace hypothetical familiar handoff guidance with a visible `@Familiar` task plus a structured routing trailer
- validate and dispatch familiar-issued handoffs only to active Coven members while reusing the target's pinned session
- attribute handoff turns in the transcript and bound fan-out, depth, cycles, duplicates, and queued sends after Stop

## Acceptance criteria

- [x] An explicit request to Familiar A to give work to Familiar B produces a visible `@B` task
- [x] The handoff routes only to B through the existing chat send/session path
- [x] Casual mentions and quoted/code examples do not dispatch work
- [x] Handoffs are persisted and visibly attributed to the delegating familiar
- [x] Duplicate, self, cyclic, out-of-Coven, excessive-depth, and excessive-fan-out dispatches are rejected
- [x] Stop prevents queued delegated sends from starting

## Test plan

- [x] `node --experimental-strip-types --test src/lib/group-chat.test.ts src/components/group-chat-view.test.ts` (64 passed)
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm check:tests-wired` (1,038 test files wired; 1 allowlisted)
- [x] `corepack pnpm test:app` (764 test files passed)
- [x] `corepack pnpm test:api` (198 test files passed)
- [x] `corepack pnpm build` (bundle and standalone budgets passed)
- [x] Browser acceptance probe with mocked SSE: Human → Nova → `@Charm` → Charm required one human send, reused both pinned sessions, rendered HANDOFF attribution, hid routing controls, and a casual `@Charm` mention did not dispatch
- [x] `git diff --check`

Closes #3335

Bead: `cave-hlv.4`
