### PR TITLE
perf: stop reparsing unchanged conversation transcripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "next build && pnpm build:server",
     "postbuild": "node scripts/bundle-budget.mjs && node scripts/standalone-budget.mjs",
     "test:bundle": "node scripts/bundle-budget.mjs",
+    "bench:conversation-list": "node --experimental-strip-types scripts/conversation-list-benchmark.mjs",
     "analyze:bundle": "next experimental-analyze --output",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",

--- a/scripts/conversation-list-benchmark.mjs
+++ b/scripts/conversation-list-benchmark.mjs
@@ -1,0 +1,94 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+const fileCount = Number(process.env.CAVE_BENCH_CONVERSATIONS ?? 100);
+const transcriptBytes = Number(process.env.CAVE_BENCH_TRANSCRIPT_BYTES ?? 256 * 1024);
+const iterations = Number(process.env.CAVE_BENCH_ITERATIONS ?? 20);
+const benchHome = await mkdtemp(path.join(tmpdir(), "cave-conversation-list-bench-"));
+const previousHome = process.env.HOME;
+process.env.HOME = benchHome;
+
+function percentile(values, percent) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * percent))];
+}
+
+function summarize(label, durations, bytesRead) {
+  return {
+    label,
+    p50Ms: Number(percentile(durations, 0.5).toFixed(2)),
+    p95Ms: Number(percentile(durations, 0.95).toFixed(2)),
+    bytesReadPerScan: bytesRead,
+  };
+}
+
+try {
+  const {
+    clearConversationListMetadataCache,
+    CONV_DIR,
+    getConversationListMetrics,
+    listConversations,
+  } = await import("../src/lib/cave-conversations.ts");
+  await mkdir(CONV_DIR, { recursive: true });
+  const payload = "x".repeat(transcriptBytes);
+  for (let index = 0; index < fileCount; index += 1) {
+    const sessionId = `benchmark-${String(index).padStart(4, "0")}`;
+    await writeFile(
+      path.join(CONV_DIR, `${sessionId}.json`),
+      JSON.stringify({
+        sessionId,
+        familiarId: "charm",
+        harness: "codex",
+        title: `Benchmark ${index}`,
+        createdAt: "2026-07-17T00:00:00.000Z",
+        updatedAt: "2026-07-17T00:00:00.000Z",
+        turns: [{ id: "turn", role: "assistant", text: payload, createdAt: "2026-07-17T00:00:00.000Z" }],
+      }),
+      "utf8",
+    );
+  }
+
+  const legacyDurations = [];
+  let legacyBytes = 0;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = performance.now();
+    let bytes = 0;
+    for (const name of await readdir(CONV_DIR)) {
+      if (!name.endsWith(".json")) continue;
+      const raw = await readFile(path.join(CONV_DIR, name), "utf8");
+      bytes += Buffer.byteLength(raw);
+      JSON.parse(raw);
+    }
+    legacyDurations.push(performance.now() - startedAt);
+    legacyBytes = bytes;
+  }
+
+  clearConversationListMetadataCache();
+  await listConversations();
+  const cachedDurations = [];
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = performance.now();
+    await listConversations();
+    cachedDurations.push(performance.now() - startedAt);
+  }
+  const cachedMetrics = getConversationListMetrics();
+
+  console.log(
+    JSON.stringify(
+      {
+        fixture: { fileCount, transcriptBytes, iterations },
+        before: summarize("full transcript parse", legacyDurations, legacyBytes),
+        after: summarize("warm metadata cache", cachedDurations, cachedMetrics.bytesRead),
+        cacheHitRate: cachedMetrics.cacheHitRate,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  await rm(benchHome, { recursive: true, force: true });
+}

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -193,6 +193,120 @@ assert.equal(failedSummary?.exitCode, 1, "failed conversation summaries expose e
 assert.equal(await deleteConversation("summary-ok"), true);
 assert.equal(await deleteConversation("summary-failed"), true);
 
+// Issue #3266: metadata scans read each large transcript once, then use the
+// stat-keyed summary cache until that specific file changes.
+{
+  const {
+    clearConversationListMetadataCache,
+    CONV_DIR,
+    getConversationListMetrics,
+  } = await import("./cave-conversations.ts");
+  const { mkdir, writeFile, utimes } = await import("node:fs/promises");
+  await mkdir(CONV_DIR, { recursive: true });
+  const fixtureIds = Array.from({ length: 12 }, (_, index) => `metadata-perf-${index}`);
+  const largeText = "x".repeat(128 * 1024);
+
+  for (const [index, sessionId] of fixtureIds.entries()) {
+    await writeFile(
+      path.join(CONV_DIR, `${sessionId}.json`),
+      JSON.stringify({
+        sessionId,
+        familiarId: "charm",
+        harness: "codex",
+        title: `Cached ${index}`,
+        branch: "main",
+        createdAt: "2026-06-12T00:00:00.000Z",
+        updatedAt: `2026-06-12T00:00:${String(index).padStart(2, "0")}.000Z`,
+        turns: [
+          {
+            id: `${sessionId}-assistant`,
+            role: "assistant",
+            text: largeText,
+            createdAt: "2026-06-12T00:00:00.000Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+  }
+
+  clearConversationListMetadataCache();
+  const coldRows = await listConversations();
+  const cold = getConversationListMetrics();
+  assert.equal(coldRows.length, fixtureIds.length);
+  assert.equal(cold.cacheMisses, fixtureIds.length);
+  assert.ok(cold.bytesRead >= fixtureIds.length * largeText.length);
+  assert.ok(cold.peakReadConcurrency <= 8, "cache misses stay under the read concurrency cap");
+
+  const warmRows = await listConversations();
+  const warm = getConversationListMetrics();
+  assert.deepEqual(warmRows, coldRows, "warm metadata rows remain identical");
+  assert.equal(warm.cacheHits, fixtureIds.length);
+  assert.equal(warm.cacheMisses, 0);
+  assert.equal(warm.cacheHitRate, 1);
+  assert.equal(warm.bytesRead, 0, "unchanged scans do not reread transcript bodies");
+
+  const externallyChanged = fixtureIds[0];
+  const externalFile = path.join(CONV_DIR, `${externallyChanged}.json`);
+  await writeFile(
+    externalFile,
+    JSON.stringify({
+      sessionId: externallyChanged,
+      familiarId: "charm",
+      harness: "codex",
+      title: "Changed outside Cave",
+      branch: "agent/external-change",
+      createdAt: "2026-06-12T00:00:00.000Z",
+      updatedAt: "2026-06-13T00:00:00.000Z",
+      activeLeafId: "external-assistant",
+      turns: [
+        {
+          id: "external-assistant",
+          role: "assistant",
+          text: "failed externally",
+          isError: true,
+          createdAt: "2026-06-13T00:00:00.000Z",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  const future = new Date(Date.now() + 60_000);
+  await utimes(externalFile, future, future);
+  const changedRows = await listConversations();
+  const changed = changedRows.find((row) => row.sessionId === externallyChanged);
+  const changedMetrics = getConversationListMetrics();
+  assert.equal(changed?.title, "Changed outside Cave");
+  assert.equal(changed?.branch, "agent/external-change");
+  assert.equal(changed?.status, "failed");
+  assert.equal(changedMetrics.cacheMisses, 1, "only the externally changed file is reread");
+  assert.equal(changedMetrics.cacheHits, fixtureIds.length - 1);
+
+  const saved = await loadConversation(fixtureIds[1]);
+  assert.ok(saved);
+  saved.title = "Changed through saveConversation";
+  saved.branch = "agent/saved-change";
+  await saveConversation(saved);
+  const savedRows = await listConversations();
+  assert.equal(
+    savedRows.find((row) => row.sessionId === fixtureIds[1])?.title,
+    "Changed through saveConversation",
+  );
+  assert.equal(getConversationListMetrics().cacheMisses, 1, "save invalidates one summary");
+
+  for (const sessionId of fixtureIds) assert.equal(await deleteConversation(sessionId), true);
+  assert.deepEqual(await listConversations(), []);
+  assert.equal(getConversationListMetrics().cacheEntries, 0, "deleted entries are pruned");
+
+  await writeFile(path.join(CONV_DIR, "metadata-corrupt.json"), "{ not json", "utf8");
+  const corruptRows = await listConversations();
+  assert.equal(corruptRows[0]?.sessionId, "metadata-corrupt");
+  assert.equal(corruptRows[0]?.familiarId, "");
+  await listConversations();
+  assert.equal(getConversationListMetrics().bytesRead, 0, "corrupt fallback rows are cached too");
+  assert.equal(await deleteConversation("metadata-corrupt"), true);
+}
+
 // ── CHAT-D9-02: conversation content search ──────────────────────────────────
 // Appended section — searchConversations over fixture transcripts written
 // directly into CONV_DIR (still pointing at the temp HOME from above).

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -204,7 +204,7 @@ assert.equal(await deleteConversation("summary-failed"), true);
     CONV_DIR,
     getConversationListMetrics,
   } = await import("./cave-conversations.ts");
-  const { mkdir, writeFile, utimes } = await import("node:fs/promises");
+  const { mkdir, rm, writeFile, utimes } = await import("node:fs/promises");
   await mkdir(CONV_DIR, { recursive: true });
   const fixtureIds = Array.from({ length: 12 }, (_, index) => `metadata-perf-${index}`);
   const largeText = "x".repeat(128 * 1024);
@@ -295,6 +295,10 @@ assert.equal(await deleteConversation("summary-failed"), true);
     savedRows.find((row) => row.sessionId === fixtureIds[1])?.title,
     "Changed through saveConversation",
   );
+  assert.equal(
+    savedRows.find((row) => row.sessionId === fixtureIds[1])?.branch,
+    "agent/saved-change",
+  );
   assert.equal(getConversationListMetrics().cacheMisses, 1, "save invalidates one summary");
 
   for (const sessionId of fixtureIds) assert.equal(await deleteConversation(sessionId), true);
@@ -320,6 +324,15 @@ assert.equal(await deleteConversation("summary-failed"), true);
     "valid JSON with an invalid conversation shape keeps the cached fallback row",
   );
   assert.equal(await deleteConversation("metadata-invalid-shape"), true);
+
+  const unreadablePath = path.join(CONV_DIR, "metadata-unreadable.json");
+  await mkdir(unreadablePath);
+  const unreadableRows = await listConversations();
+  assert.equal(unreadableRows[0]?.sessionId, "metadata-unreadable");
+  await listConversations();
+  assert.equal(getConversationListMetrics().cacheMisses, 1, "read failures are retried");
+  assert.equal(getConversationListMetrics().cacheHits, 0, "read failures are not cached");
+  await rm(unreadablePath, { recursive: true });
 }
 
 // ── CHAT-D9-02: conversation content search ──────────────────────────────────

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -78,6 +78,9 @@ const cancelledTurn = cancelledConv?.turns.find((turn) => turn.id === "turn-assi
 assert.equal(cancelledTurn?.cancelled, true, "cancelled flag must round-trip through the store");
 assert.equal(cancelledTurn?.isError, false, "a user cancel is not an error");
 assert.equal(cancelledTurn?.text, "Roses are red, violets", "partial streamed text must survive the save");
+const cancelledSummary = (await listConversations()).find((row) => row.sessionId === "cancelled-turn");
+assert.equal(cancelledSummary?.status, "completed", "cancelled conversations remain non-failures");
+assert.equal(cancelledSummary?.exitCode, 0, "cancelled conversations retain a successful exit code");
 assert.equal(await deleteConversation("cancelled-turn"), true);
 
 // CHAT-D12-02: per-turn token usage and cost round-trip through the store —
@@ -305,6 +308,18 @@ assert.equal(await deleteConversation("summary-failed"), true);
   await listConversations();
   assert.equal(getConversationListMetrics().bytesRead, 0, "corrupt fallback rows are cached too");
   assert.equal(await deleteConversation("metadata-corrupt"), true);
+
+  await writeFile(path.join(CONV_DIR, "metadata-invalid-shape.json"), "{}", "utf8");
+  const invalidShapeRows = await listConversations();
+  assert.equal(invalidShapeRows[0]?.sessionId, "metadata-invalid-shape");
+  assert.equal(invalidShapeRows[0]?.familiarId, "");
+  await listConversations();
+  assert.equal(
+    getConversationListMetrics().bytesRead,
+    0,
+    "valid JSON with an invalid conversation shape keeps the cached fallback row",
+  );
+  assert.equal(await deleteConversation("metadata-invalid-shape"), true);
 }
 
 // ── CHAT-D9-02: conversation content search ──────────────────────────────────

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -242,12 +242,18 @@ async function readConversationSummary(
   fallbackSessionId: string,
   mtimeMs: number,
   fileSize: number,
-): Promise<{ summary: ConversationSummary | null; bytesRead: number }> {
+): Promise<{ summary: ConversationSummary | null; bytesRead: number; cacheable: boolean }> {
   let raw: string;
   try {
     raw = await readFile(file, "utf8");
   } catch {
-    return { summary: fallbackConversationSummary(fallbackSessionId, mtimeMs), bytesRead: 0 };
+    // A sharing violation or other transient read failure must be retried on
+    // the next scan even when the file's stat key did not change.
+    return {
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      bytesRead: 0,
+      cacheable: false,
+    };
   }
 
   let conv: ConversationFile;
@@ -257,6 +263,7 @@ async function readConversationSummary(
     return {
       summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
       bytesRead: fileSize,
+      cacheable: true,
     };
   }
 
@@ -285,6 +292,7 @@ async function readConversationSummary(
         updatedAt: conv.updatedAt,
       },
       bytesRead: fileSize,
+      cacheable: true,
     };
   } catch {
     // loadConversation() treats any invalid conversation shape like a parse
@@ -292,6 +300,7 @@ async function readConversationSummary(
     return {
       summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
       bytesRead: fileSize,
+      cacheable: true,
     };
   }
 }
@@ -370,12 +379,16 @@ export async function listConversations(): Promise<ConversationSummary[]> {
           activeReads -= 1;
         }
         bytesRead += loaded.bytesRead;
-        conversationSummaryCache.set(file, {
-          mtimeMs: info.mtimeMs,
-          ctimeMs: info.ctimeMs,
-          size: info.size,
-          summary: loaded.summary,
-        });
+        if (loaded.cacheable) {
+          conversationSummaryCache.set(file, {
+            mtimeMs: info.mtimeMs,
+            ctimeMs: info.ctimeMs,
+            size: info.size,
+            summary: loaded.summary,
+          });
+        } else {
+          conversationSummaryCache.delete(file);
+        }
         results[index] = loaded.summary;
       } catch {
         conversationSummaryCache.delete(file);

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -287,9 +287,12 @@ async function readConversationSummary(
       bytesRead: fileSize,
     };
   } catch {
-    // Preserve the prior behavior for valid JSON with an invalid conversation
-    // shape: skip it rather than exposing a partial row.
-    return { summary: null, bytesRead: fileSize };
+    // loadConversation() treats any invalid conversation shape like a parse
+    // failure, so preserve listConversations()'s filename/mtime fallback row.
+    return {
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      bytesRead: fileSize,
+    };
   }
 }
 

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, appendFile, readdir, stat, unlink } from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
@@ -102,6 +103,65 @@ function conversationTerminalStatus(conv: ConversationFile): { status: string; e
   return { status: "completed", exitCode: 0 };
 }
 
+export type ConversationSummary = {
+  sessionId: string;
+  familiarId: string;
+  harness?: string;
+  model?: string;
+  runtime?: string;
+  title?: string;
+  origin?: SessionOrigin;
+  branch?: string;
+  status?: string;
+  exitCode?: number | null;
+  createdAt?: string;
+  updatedAt: string;
+};
+
+export type ConversationListMetrics = {
+  scanCount: number;
+  filesSeen: number;
+  cacheHits: number;
+  cacheMisses: number;
+  cacheHitRate: number;
+  bytesRead: number;
+  durationMs: number;
+  peakReadConcurrency: number;
+  cacheEntries: number;
+};
+
+const CONVERSATION_LIST_READ_CONCURRENCY = 8;
+// The list route only needs this compact projection. Stat keys detect both
+// ordinary edits (mtime/size) and atomic replacements (ctime), while keeping
+// unchanged transcript bodies out of the four-second polling path.
+type ConversationSummaryCacheEntry = {
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+  summary: ConversationSummary | null;
+};
+const conversationSummaryCache = new Map<string, ConversationSummaryCacheEntry>();
+let conversationListScanCount = 0;
+let conversationListMetrics: ConversationListMetrics = {
+  scanCount: 0,
+  filesSeen: 0,
+  cacheHits: 0,
+  cacheMisses: 0,
+  cacheHitRate: 0,
+  bytesRead: 0,
+  durationMs: 0,
+  peakReadConcurrency: 0,
+  cacheEntries: 0,
+};
+
+export function getConversationListMetrics(): ConversationListMetrics {
+  return { ...conversationListMetrics };
+}
+
+export function clearConversationListMetadataCache(): void {
+  conversationSummaryCache.clear();
+}
+
 async function ensureDir() {
   await mkdir(CONV_DIR, { recursive: true });
 }
@@ -152,6 +212,7 @@ export async function saveConversation(conv: ConversationFile): Promise<void> {
   // a crash mid-write must leave the previous transcript intact, never a
   // torn half-JSON that loadConversation silently drops.
   await writeJsonAtomic(pathFor(conv.sessionId), conv);
+  conversationSummaryCache.delete(pathFor(conv.sessionId));
 }
 
 export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<void> {
@@ -163,85 +224,186 @@ export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<voi
 
 export async function deleteConversation(sessionId: string): Promise<boolean> {
   try {
-    await unlink(pathFor(sessionId));
+    const file = pathFor(sessionId);
+    await unlink(file);
+    conversationSummaryCache.delete(file);
     return true;
   } catch {
     return false;
   }
 }
 
-export async function listConversations(): Promise<
-  Array<{
-    sessionId: string;
-    familiarId: string;
-    harness?: string;
-    model?: string;
-    runtime?: string;
-    title?: string;
-    origin?: SessionOrigin;
-    branch?: string;
-    status?: string;
-    exitCode?: number | null;
-    createdAt?: string;
-    updatedAt: string;
-  }>
-> {
+function fallbackConversationSummary(sessionId: string, mtimeMs: number): ConversationSummary {
+  return { sessionId, familiarId: "", updatedAt: new Date(mtimeMs).toISOString() };
+}
+
+async function readConversationSummary(
+  file: string,
+  fallbackSessionId: string,
+  mtimeMs: number,
+  fileSize: number,
+): Promise<{ summary: ConversationSummary | null; bytesRead: number }> {
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf8");
+  } catch {
+    return { summary: fallbackConversationSummary(fallbackSessionId, mtimeMs), bytesRead: 0 };
+  }
+
+  let conv: ConversationFile;
+  try {
+    conv = JSON.parse(raw) as ConversationFile;
+  } catch {
+    return {
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      bytesRead: fileSize,
+    };
+  }
+
+  try {
+    // Match loadConversation's lazy legacy normalization before deriving the
+    // active-path terminal status, without writing the migrated body here.
+    if (!conv.activeLeafId && conv.turns.length > 0) {
+      const linearized = linearizeLegacy(conv.turns);
+      conv.turns = linearized.turns;
+      conv.activeLeafId = linearized.activeLeafId;
+    }
+    const terminal = conversationTerminalStatus(conv);
+    return {
+      summary: {
+        sessionId: conv.sessionId,
+        familiarId: conv.familiarId,
+        harness: conv.harness,
+        model: conv.model,
+        runtime: conv.runtime,
+        title: conv.title,
+        origin: conv.origin,
+        ...(conv.branch ? { branch: conv.branch } : {}),
+        status: terminal.status,
+        exitCode: terminal.exitCode,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+      },
+      bytesRead: fileSize,
+    };
+  } catch {
+    // Preserve the prior behavior for valid JSON with an invalid conversation
+    // shape: skip it rather than exposing a partial row.
+    return { summary: null, bytesRead: fileSize };
+  }
+}
+
+export async function listConversations(): Promise<ConversationSummary[]> {
+  const startedAt = performance.now();
+  const scanCount = ++conversationListScanCount;
   await ensureDir();
-  let entries;
+  let entries: string[];
   try {
     entries = await readdir(CONV_DIR);
   } catch {
+    if (scanCount >= conversationListMetrics.scanCount) {
+      conversationListMetrics = {
+        scanCount,
+        filesSeen: 0,
+        cacheHits: 0,
+        cacheMisses: 0,
+        cacheHitRate: 0,
+        bytesRead: 0,
+        durationMs: performance.now() - startedAt,
+        peakReadConcurrency: 0,
+        cacheEntries: conversationSummaryCache.size,
+      };
+    }
     return [];
   }
-  const results: Array<{
-    sessionId: string;
-    familiarId: string;
-    harness?: string;
-    model?: string;
-    runtime?: string;
-    title?: string;
-    origin?: SessionOrigin;
-    branch?: string;
-    status?: string;
-    exitCode?: number | null;
-    createdAt?: string;
-    updatedAt: string;
-  }> = [];
-  for (const name of entries) {
-    if (!name.endsWith(".json")) continue;
-    try {
-      const sessionId = name.replace(/\.json$/, "");
-      const conv = await loadConversation(sessionId);
-      if (conv) {
-        const terminal = conversationTerminalStatus(conv);
-        results.push({
-          sessionId: conv.sessionId,
-          familiarId: conv.familiarId,
-          harness: conv.harness,
-          model: conv.model,
-          runtime: conv.runtime,
-          title: conv.title,
-          origin: conv.origin,
-          ...(conv.branch ? { branch: conv.branch } : {}),
-          status: terminal.status,
-          exitCode: terminal.exitCode,
-          createdAt: conv.createdAt,
-          updatedAt: conv.updatedAt,
-        });
-      } else {
-        const s = await stat(path.join(CONV_DIR, name));
-        results.push({
-          sessionId,
-          familiarId: "",
-          updatedAt: s.mtime.toISOString(),
-        });
-      }
-    } catch {
-      /* skip */
-    }
+
+  const names = entries.filter((name) => name.endsWith(".json"));
+  const files = names.map((name) => path.join(CONV_DIR, name));
+  const liveFiles = new Set(files);
+  for (const file of conversationSummaryCache.keys()) {
+    if (!liveFiles.has(file)) conversationSummaryCache.delete(file);
   }
-  results.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
-  return results;
+
+  const results: Array<ConversationSummary | null | undefined> = new Array(names.length);
+  let nextIndex = 0;
+  let cacheHits = 0;
+  let cacheMisses = 0;
+  let bytesRead = 0;
+  let activeReads = 0;
+  let peakReadConcurrency = 0;
+
+  const worker = async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= names.length) return;
+      const name = names[index];
+      const file = files[index];
+      try {
+        const info = await stat(file);
+        const cached = conversationSummaryCache.get(file);
+        if (
+          cached &&
+          cached.mtimeMs === info.mtimeMs &&
+          cached.ctimeMs === info.ctimeMs &&
+          cached.size === info.size
+        ) {
+          cacheHits += 1;
+          results[index] = cached.summary;
+          continue;
+        }
+
+        cacheMisses += 1;
+        activeReads += 1;
+        peakReadConcurrency = Math.max(peakReadConcurrency, activeReads);
+        let loaded: Awaited<ReturnType<typeof readConversationSummary>>;
+        try {
+          loaded = await readConversationSummary(
+            file,
+            name.replace(/\.json$/, ""),
+            info.mtimeMs,
+            info.size,
+          );
+        } finally {
+          activeReads -= 1;
+        }
+        bytesRead += loaded.bytesRead;
+        conversationSummaryCache.set(file, {
+          mtimeMs: info.mtimeMs,
+          ctimeMs: info.ctimeMs,
+          size: info.size,
+          summary: loaded.summary,
+        });
+        results[index] = loaded.summary;
+      } catch {
+        conversationSummaryCache.delete(file);
+        results[index] = null;
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(CONVERSATION_LIST_READ_CONCURRENCY, names.length) },
+      worker,
+    ),
+  );
+
+  const summaries = results.filter((summary): summary is ConversationSummary => Boolean(summary));
+  summaries.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  if (scanCount >= conversationListMetrics.scanCount) {
+    conversationListMetrics = {
+      scanCount,
+      filesSeen: names.length,
+      cacheHits,
+      cacheMisses,
+      cacheHitRate: names.length === 0 ? 0 : cacheHits / names.length,
+      bytesRead,
+      durationMs: performance.now() - startedAt,
+      peakReadConcurrency,
+      cacheEntries: conversationSummaryCache.size,
+    };
+  }
+  return summaries;
 }
 
 // ── Content search (CHAT-D9-02) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- cache compact conversation-list metadata by file mtime, ctime, and size
- refresh cache misses with bounded concurrency and prune deleted entries
- invalidate summaries after Cave-owned saves and deletes while detecting external edits
- expose scan, cache-hit, bytes-read, duration, and concurrency metrics
- add large-transcript regression fixtures and a reproducible benchmark

## Root cause

`listConversations()` called `loadConversation()` sequentially for every JSON file on every cache recomputation. That made the four-second session poll repeatedly read and parse every full transcript even though the route only needs a small metadata projection.

## Performance

`pnpm bench:conversation-list` with 100 conversations, 256 KiB transcripts, and 20 iterations:

| Path | p50 | p95 | Transcript bytes per scan |
| --- | ---: | ---: | ---: |
| Prior full parse | 131.56 ms | 407.66 ms | 26,240,590 |
| Warm metadata cache | 4.91 ms | 10.09 ms | 0 |

Warm cache hit rate was 100%. The benchmark is intended for before/after comparison on the same host; absolute timings vary with filesystem conditions.

## Correctness

The regression coverage verifies unchanged warm scans, one-file external edits, Cave-owned saves, branch/status changes, deletion pruning, corrupt-file fallback behavior, and an eight-reader upper bound. Legacy transcripts retain the same lazy path normalization used by `loadConversation()` before terminal status is derived.

## Validation

- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app` (764 test files)
- `pnpm test:api` (198 test files)
- `node --experimental-strip-types src/lib/cave-conversations.test.ts`
- `pnpm bench:conversation-list`
- `git diff --check`

Closes #3266

Bead: `cave-a9d`
