### PR TITLE
fix(browser): replace perpetual webview reconciliation

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -631,7 +631,10 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     document.addEventListener("keydown", onInteraction, true);
     document.addEventListener("focusin", onInteraction, true);
     document.addEventListener("visibilitychange", onVisibilityChange);
-    scheduleImmediateReconcile();
+    // The pane's cave-mode-fade animation can begin before this effect's
+    // animationstart listener is attached. Sample the initial mount window
+    // explicitly so the native surface follows that 120ms transform too.
+    startMotionWindow();
 
     return () => {
       cancelAnimationFrame(raf);

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -213,9 +213,7 @@ function defaultPinnedTabs(): BrowserTab[] {
 //      live regions (toasts) are ignored so a corner toast doesn't blank the
 //      page.
 function surfaceIsCovered(surface: HTMLElement, rect: DOMRect): boolean {
-  const overlays = document.querySelectorAll(
-    '[role="dialog"], [aria-modal="true"], [role="menu"], [role="listbox"], [data-native-webview-cover="true"]',
-  );
+  const overlays = document.querySelectorAll(NATIVE_WEBVIEW_COVER_SELECTOR);
   for (const overlay of overlays) {
     if (overlay.getClientRects().length > 0) return true;
   }
@@ -234,6 +232,42 @@ function surfaceIsCovered(surface: HTMLElement, rect: DOMRect): boolean {
     return true;
   }
   return false;
+}
+
+const NATIVE_WEBVIEW_COVER_SELECTOR =
+  '[role="dialog"], [aria-modal="true"], [role="menu"], [role="listbox"], [data-native-webview-cover="true"]';
+const BROWSER_RECONCILE_INTERVAL_MS = 100;
+const BROWSER_MOTION_WINDOW_MS = 400;
+const BROWSER_RECONCILE_METRICS_KEY = "__CAVE_BROWSER_RECONCILE_METRICS__";
+
+type BrowserReconcileMetrics = {
+  count: number;
+  totalDurationMs: number;
+  lastDurationMs: number;
+  startedAt: number;
+};
+
+function recordBrowserReconcile(durationMs: number): void {
+  const metricsWindow = window as typeof window & {
+    [BROWSER_RECONCILE_METRICS_KEY]?: BrowserReconcileMetrics;
+  };
+  const metrics = metricsWindow[BROWSER_RECONCILE_METRICS_KEY] ?? {
+    count: 0,
+    totalDurationMs: 0,
+    lastDurationMs: 0,
+    startedAt: Date.now(),
+  };
+  metrics.count += 1;
+  metrics.totalDurationMs += durationMs;
+  metrics.lastDurationMs = durationMs;
+  metricsWindow[BROWSER_RECONCILE_METRICS_KEY] = metrics;
+}
+
+function nodeContainsNativeWebviewCover(node: Node): boolean {
+  return node instanceof Element && (
+    node.matches(NATIVE_WEBVIEW_COVER_SELECTOR) ||
+    node.querySelector(NATIVE_WEBVIEW_COVER_SELECTOR) !== null
+  );
 }
 
 // Mirrors OFFSCREEN_X/OFFSCREEN_Y in src-tauri/src/browser.rs — the "hidden"
@@ -461,8 +495,10 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
   // reacts to SIZE changes — a sibling reflow that MOVES the surface
   // without resizing it (e.g. a shell banner appearing/dismissing above
   // the pane, or the cave-mode-fade mount animation) leaves the overlay
-  // stale and overlapping the toolbar. Reconcile against the live rect
-  // every frame instead, issuing IPC only when the rounded bounds change.
+  // stale and overlapping the toolbar. Reconcile from layout/overlay events,
+  // with a short 10 Hz sampling window while CSS motion is actually running.
+  // This avoids a permanent display-rate callback while still following the
+  // 120-150ms shell and rail transitions that can move the surface.
   useEffect(() => {
     if (!active || !bridge || !nativeBrowserAvailable) {
       if (!active) invokeNativeBrowserDeactivateAll(bridge, label);
@@ -473,10 +509,10 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
 
     const tabIds = tabs.map((t) => t.id);
     let raf = 0;
+    let motionTimer = 0;
+    let motionUntil = 0;
     let hidden = false;
     let last = { x: 0, y: 0, w: 0, h: 0 };
-    let lastRun = 0;
-    let forceReconcilePending = false;
 
     const hideAll = () => {
       tabIds.forEach((id) => {
@@ -484,13 +520,9 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
       });
     };
 
-    const reconcile = (now: number, force = false) => {
-      // Throttle to ~10 Hz and idle while the tab is hidden. This loop
-      // otherwise runs a getBoundingClientRect + a full-document occlusion
-      // check (querySelectorAll + up to 5 elementFromPoint hit-tests)
-      // 60x/second continuously, even when nothing is moving.
-      if (document.visibilityState !== "visible" || (!force && now - lastRun < 100)) return;
-      lastRun = now;
+    const reconcile = () => {
+      if (document.visibilityState !== "visible") return;
+      const startedAt = performance.now();
       const rect = surface.getBoundingClientRect();
       // Hide every webview when the panel is collapsed, the toolbar is open,
       // OR a DOM overlay (onboarding, a modal, the palette…) renders above
@@ -528,27 +560,53 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
           });
         }
       }
+      recordBrowserReconcile(performance.now() - startedAt);
     };
-    const tick = (now: number) => {
-      raf = requestAnimationFrame(tick);
-      const force = forceReconcilePending;
-      forceReconcilePending = false;
-      reconcile(now, force);
-    };
-    raf = requestAnimationFrame(tick);
 
     const scheduleImmediateReconcile = () => {
-      forceReconcilePending = true;
+      if (raf || document.visibilityState !== "visible") return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        reconcile();
+      });
+    };
+    const sampleMotion = () => {
+      motionTimer = 0;
+      scheduleImmediateReconcile();
+      const remaining = motionUntil - performance.now();
+      if (remaining > 0) {
+        motionTimer = window.setTimeout(sampleMotion, Math.min(BROWSER_RECONCILE_INTERVAL_MS, remaining));
+      }
+    };
+    const startMotionWindow = () => {
+      motionUntil = Math.max(motionUntil, performance.now() + BROWSER_MOTION_WINDOW_MS);
+      if (!motionTimer) sampleMotion();
     };
     const resizeObserver = new ResizeObserver(scheduleImmediateReconcile);
     resizeObserver.observe(surface);
-    const mutationObserver = new MutationObserver(scheduleImmediateReconcile);
-    mutationObserver.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["role", "aria-modal", "hidden", "open", "class", "style"],
+    // Portaled dialogs are direct body children. Observe only that boundary,
+    // not the entire React tree: chat streaming and unrelated class/style
+    // updates must not wake BrowserPane reconciliation.
+    const portalObserver = new MutationObserver((records) => {
+      if (records.some((record) =>
+        [...record.addedNodes, ...record.removedNodes].some(nodeContainsNativeWebviewCover)
+      )) scheduleImmediateReconcile();
     });
+    portalObserver.observe(document.body, {
+      childList: true,
+    });
+    const motionAffectsSurface = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return false;
+      const detailRoot = surface.closest("#shell-main-content");
+      return target.contains(surface) || surface.contains(target) || (!!detailRoot && detailRoot.contains(target));
+    };
+    const onMotionStart = (event: Event) => {
+      if (motionAffectsSurface(event)) startMotionWindow();
+    };
+    const onMotionEnd = (event: Event) => {
+      if (motionAffectsSurface(event)) scheduleImmediateReconcile();
+    };
     const onVisibilityChange = () => {
       if (document.visibilityState !== "visible") {
         hidden = true;
@@ -557,16 +615,40 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
         scheduleImmediateReconcile();
       }
     };
+    // Click/key/focus cover inline overlays whose lifecycle is driven by React
+    // state rather than a body portal. The rAF runs after the DOM commit.
+    const onInteraction = () => scheduleImmediateReconcile();
+    const onShellLayout = () => startMotionWindow();
     window.addEventListener("resize", scheduleImmediateReconcile);
     window.addEventListener("scroll", scheduleImmediateReconcile, true);
+    window.addEventListener("cave:native-webview-layout", onShellLayout);
+    window.addEventListener("cave:onboarding-open", onShellLayout);
+    document.addEventListener("animationstart", onMotionStart, true);
+    document.addEventListener("animationend", onMotionEnd, true);
+    document.addEventListener("transitionrun", onMotionStart, true);
+    document.addEventListener("transitionend", onMotionEnd, true);
+    document.addEventListener("click", onInteraction, true);
+    document.addEventListener("keydown", onInteraction, true);
+    document.addEventListener("focusin", onInteraction, true);
     document.addEventListener("visibilitychange", onVisibilityChange);
+    scheduleImmediateReconcile();
 
     return () => {
       cancelAnimationFrame(raf);
+      clearTimeout(motionTimer);
       resizeObserver.disconnect();
-      mutationObserver.disconnect();
+      portalObserver.disconnect();
       window.removeEventListener("resize", scheduleImmediateReconcile);
       window.removeEventListener("scroll", scheduleImmediateReconcile, true);
+      window.removeEventListener("cave:native-webview-layout", onShellLayout);
+      window.removeEventListener("cave:onboarding-open", onShellLayout);
+      document.removeEventListener("animationstart", onMotionStart, true);
+      document.removeEventListener("animationend", onMotionEnd, true);
+      document.removeEventListener("transitionrun", onMotionStart, true);
+      document.removeEventListener("transitionend", onMotionEnd, true);
+      document.removeEventListener("click", onInteraction, true);
+      document.removeEventListener("keydown", onInteraction, true);
+      document.removeEventListener("focusin", onInteraction, true);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       hideAll();
     };

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const pane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const nativeLifecycle = await readFile(new URL("../lib/native-browser-lifecycle.ts", import.meta.url), "utf8");
@@ -115,7 +116,7 @@ assert.match(
 );
 assert.match(
   pane,
-  /querySelectorAll\([\s\S]{0,180}\[role="dialog"\][\s\S]{0,180}\[role="menu"\][\s\S]{0,180}\[role="listbox"\]/,
+  /NATIVE_WEBVIEW_COVER_SELECTOR\s*=\s*[\s\S]{0,180}\[role="dialog"\][\s\S]{0,180}\[role="menu"\][\s\S]{0,180}\[role="listbox"\]/,
   "visible dialogs, menus, and listboxes count as native-webview covers",
 );
 assert.match(
@@ -333,10 +334,16 @@ assert.match(pane, /if \(h\.stack\[h\.idx\] === evUrl\) \{/, "page-load history 
 
 // ───────── Correctness: listen() unlisten race + perf throttle ─────────
 assert.match(pane, /then\(\(fn\) => \{ if \(cancelled\) fn\(\); else unlisten/, "async listen() unlistens if the effect was already torn down");
-assert.match(pane, /if \(document\.visibilityState !== "visible" \|\| \(!force && now - lastRun < 100\)\) return;/, "the fallback bounds loop is throttled + idle-gated");
-assert.match(pane, /forceReconcilePending = true/, "urgent bounds changes are coalesced into the next animation frame");
+assert.doesNotMatch(pane, /requestAnimationFrame\(tick\)/, "stable browser idle has no perpetual display-rate callback");
+assert.doesNotMatch(pane, /subtree:\s*true/, "BrowserPane does not observe unrelated mutations across the React tree");
+assert.match(pane, /if \(raf \|\| document\.visibilityState !== "visible"\) return;/, "urgent bounds changes coalesce into one animation frame");
+assert.match(pane, /BROWSER_RECONCILE_INTERVAL_MS = 100/, "active CSS motion samples at the intended 10 Hz rate");
+assert.match(pane, /BROWSER_MOTION_WINDOW_MS = 400/, "motion sampling stops after a bounded stability window");
 assert.match(pane, /new ResizeObserver\(scheduleImmediateReconcile\)/, "resizes schedule a coalesced native bounds reconcile");
-assert.match(pane, /new MutationObserver\(scheduleImmediateReconcile\)/, "overlay DOM changes schedule a coalesced visibility reconcile");
+assert.match(pane, /portalObserver\.observe\(document\.body, \{\s*childList: true,\s*\}\)/, "only direct body portal mounts are mutation-observed");
+assert.match(pane, /animationstart[\s\S]{0,600}transitionend/, "CSS motion opens and closes a bounded reconcile window");
+assert.match(shell, /dispatchEvent\(new Event\("cave:native-webview-layout"\)\)[\s\S]{0,80}\[banners\]/, "shell banner layout changes explicitly schedule native bounds reconciliation");
+assert.match(pane, /__CAVE_BROWSER_RECONCILE_METRICS__/, "reconciliation count and duration are exposed for native profiling");
 assert.match(pane, /visibilitychange[\s\S]{0,300}hideAll\(\)/, "backgrounding immediately hides native webviews");
 
 // ───────── a11y: tab strip is a real tablist ─────────

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -339,6 +339,7 @@ assert.doesNotMatch(pane, /subtree:\s*true/, "BrowserPane does not observe unrel
 assert.match(pane, /if \(raf \|\| document\.visibilityState !== "visible"\) return;/, "urgent bounds changes coalesce into one animation frame");
 assert.match(pane, /BROWSER_RECONCILE_INTERVAL_MS = 100/, "active CSS motion samples at the intended 10 Hz rate");
 assert.match(pane, /BROWSER_MOTION_WINDOW_MS = 400/, "motion sampling stops after a bounded stability window");
+assert.match(pane, /animationstart listener is attached[\s\S]{0,160}startMotionWindow\(\);/, "initial pane animation opens a bounded reconcile window even when animationstart fires before effect setup");
 assert.match(pane, /new ResizeObserver\(scheduleImmediateReconcile\)/, "resizes schedule a coalesced native bounds reconcile");
 assert.match(pane, /portalObserver\.observe\(document\.body, \{\s*childList: true,\s*\}\)/, "only direct body portal mounts are mutation-observed");
 assert.match(pane, /animationstart[\s\S]{0,600}transitionend/, "CSS motion opens and closes a bounded reconcile window");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -783,6 +783,9 @@ export const Shell = forwardRef<ShellHandle, Parameters<typeof ShellInner>[0]>(S
 
 function ShellBannerStrip() {
   const { banners, dismissBanner } = useShellBanners();
+  useEffect(() => {
+    window.dispatchEvent(new Event("cave:native-webview-layout"));
+  }, [banners]);
   if (banners.length === 0) return null;
   return (
     <div className="shell-banner-strip">


### PR DESCRIPTION
## Summary

- replace BrowserPane's self-rescheduling `requestAnimationFrame` loop with event-coalesced reconciliation
- sample at 100 ms only during a bounded 400 ms CSS motion window, including the initial pane animation
- replace the document-wide subtree observer with direct-body portal detection and explicit shell-banner layout events
- expose `window.__CAVE_BROWSER_RECONCILE_METRICS__` with reconciliation count and duration for native profiling
- extend BrowserPane regression coverage for idle stability, overlays, animation windows, and banner movement

## Root cause

The previous effect scheduled a callback every display frame for the entire lifetime of an active BrowserPane. Although expensive bounds and occlusion reads were throttled to roughly 10 Hz, the renderer still woke at display rate and continued querying the document indefinitely. Its `MutationObserver` also watched the entire app subtree for common class and style changes, so unrelated streaming and animation activity forced more reconciliation.

## Impact

At 60 Hz, a stable five-minute Browser session previously scheduled about 18,000 frame callbacks and up to 3,000 expensive reconciliation passes. The new stable path performs its initial reconciliation and then sleeps until resize, scroll, visibility, interaction, overlay, banner, tab, or relevant CSS-motion events occur. Motion sampling stops after 400 ms.

The metrics object can be reset in native devtools before a five-minute capture:

```js
window.__CAVE_BROWSER_RECONCILE_METRICS__ = undefined
```

It then reports `count`, `totalDurationMs`, `lastDurationMs`, and `startedAt`.

## Validation

- `node --experimental-strip-types src/components/browser-polish.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired` (1,038 test files wired)
- `pnpm test:app` (764 app test files)
- `pnpm build` (Next production build, bundle budget, standalone budget)
- `git diff --check`

## Native five-minute profile

Captured on Windows from the native Tauri Browser route against exact pre-change `origin/main@369db97b` and the patched branch. Both runs stubbed only `browser_*` IPC so the main renderer reconciliation workload was isolated without launching the child page webview.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `requestAnimationFrame` callbacks | 35,998 | 416 | -98.84% |
| Browser surface reconciliations | 2,944 | 415 | -85.90% |
| `elementFromPoint` hit tests | 14,720 | 1,712 | -88.37% |
| Tauri process-tree CPU | 115.7031 s | 110.4062 s | -4.58% |
| Average process-tree CPU | 38.568% | 36.802% | -1.766 pp |

The live dev session had repeated unrelated server lock-error UI churn in both captures, so the event-driven path still reconciled 415 times; the absence of the prior perpetual loop is demonstrated by the 98.84% callback reduction and source/test guard.

Closes #3268

Bead: `cave-kgy`

