### PR TITLE
Add selectable Broadcast and Round robin Coven modes

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -9,24 +9,29 @@ const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 
-test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () => {
+test("GroupChatView schedules Broadcast and Round robin replies through /api/chat/send", () => {
   assert.match(view, /export function GroupChatView/, "exports GroupChatView");
-  // Fan-out: one /api/chat/send per participant carrying the per-familiar id.
+  // Both schedules use one /api/chat/send per participant carrying the
+  // per-familiar id. The pure scheduler owns concurrent vs sequential timing.
   assert.match(view, /fetch\("\/api\/chat\/send"/, "sends through the chat bridge");
   assert.match(view, /familiarId: reply\.familiarId/, "each stream targets one familiar");
-  assert.match(view, /Promise\.all\(\s*replies\.map/, "fans out to every participant in parallel");
+  assert.match(view, /runCovenReplySchedule\(\{/, "delegates reply timing to the tested scheduler");
+  assert.match(view, /mode: group\.responseMode/, "uses the active Coven's configured response mode");
   // Reuses the tested pure reducers rather than re-parsing inline.
   assert.match(view, /applyGroupEvent|parseSseBuffer/, "uses the pure stream reducers");
   // Per-familiar session pinning so each thread resumes.
   assert.match(view, /recordSession\(group\.id, reply\.familiarId/, "pins each familiar's session id");
   // A Stop control aborts the in-flight broadcast.
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
-  // Injects the coven roster into each send so a familiar knows who else is present.
+  // Broadcast injects the roster but remains an independent first pass.
   assert.match(view, /renderCovenRoundtablePrompt\(\{/, "builds the per-familiar roundtable prompt");
-  assert.match(view, /receivingFamiliarId: r\.familiarId/, "marks the receiving familiar in prompt context");
+  assert.match(view, /receivingFamiliarId: reply\.familiarId/, "marks the receiving familiar in prompt context");
   assert.match(view, /targeted,/, "tells the prompt whether the user targeted this reply");
-  assert.doesNotMatch(view, /renderCovenContext\(contextTurns, r\.familiarId/, "default group chat does not relay peer replies");
-  assert.doesNotMatch(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "full-coven broadcasts no longer switch to sequential relay");
+  // Round robin passes settled replies into a relay-aware prompt. The default
+  // remains Broadcast, so this branch is selected only by explicit config.
+  assert.match(view, /group\.responseMode === "round-robin"[\s\S]*renderCovenRoundRobinPrompt\(\{/, "round robin uses the relay-aware prompt");
+  assert.match(view, /transcript: \[\.\.\.priorTurns, userTurn, \.\.\.settledBefore\]/, "later speakers receive settled earlier replies");
+  assert.match(view, /extractNextPaths\(turn\.text\)\.visible/, "relay strips internal next-path controls");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
   // lines (suggestions) so control markup never leaks and chips can render.
   assert.match(
@@ -71,7 +76,7 @@ test("@mentions target a subset of the coven", () => {
     "passes visible text, the current roster, and any authoritative target to routing",
   );
   assert.match(view, /targetFamiliarIds: targeted \? targetIds : undefined/, "records targeted ids on the user turn");
-  assert.match(view, /replies: GroupReply\[\] = targetIds\.map/, "only the targets reply");
+  assert.match(view, /replies: GroupReply\[\] = orderedTargetIds\.map/, "only the targets reply, in the selected mode's order");
   // Composer autocomplete reuses the tested pure helpers.
   assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");
   assert.match(view, /matchMentions\(mention\.query, mentionable\)/, "filters the roster by the query");
@@ -96,6 +101,16 @@ test("completed familiar delegation trailers route bounded, attributable follow-
   assert.match(view, /sessions\[targetId\] \?\? null/, "reuses the target familiar's latest pinned session");
   assert.match(view, /const retryText = delegator \? `Delegated by @\$\{delegator\}:\\n\$\{userTurn\.text\}` : userTurn\.text/, "preserves delegation attribution when a failed target is retried");
   assert.match(view, /delegator \? "HANDOFF" : "OP"/, "renders familiar-issued work as an attributed handoff");
+});
+
+test("response mode is configured per Coven and locked while a turn is running", () => {
+  assert.match(view, /options=\{COVEN_RESPONSE_MODES\}/, "offers the two canonical response modes");
+  assert.match(view, /ariaLabel="Coven response mode"/, "labels the mode selector for assistive technology");
+  assert.match(view, /<fieldset disabled=\{busy\}/, "prevents mid-turn mode changes");
+  assert.match(view, /setGroupResponseMode\(group, responseMode, nowIso\(\)\)/, "persists the setting on the active Coven");
+  assert.match(view, /responseMode: group\.responseMode/, "snapshots mode on each user turn for stable retries");
+  assert.match(view, /nextRoundRobinLeadId\(current\.familiarIds, leadId\)/, "rotates the next round-robin lead");
+  assert.match(view, /leads next/, "shows who will lead the next round");
 });
 
 test("Group chat transcript uses avatar author rows with recency", () => {

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -7,12 +7,11 @@ import "@/styles/cave-composer.css";
 /**
  * GroupChatView — the "coven" group-chat surface.
  *
- * A coven is a saved set of familiars you talk to together. A prompt is
- * broadcast to every participant in parallel; each familiar answers in its own
- * resumable `/api/chat/send` session and its reply is attributed inline. This
- * mirrors the daemon/coven-CLI model — there is no server-side "group session",
- * so the group lives client-side and simply pins one session id per familiar
- * (the same fan-out the iOS app uses).
+ * A coven is a saved set of familiars you talk to together. Broadcast mode fans
+ * a prompt out in parallel; Round robin mode rotates the lead and relays settled
+ * peer replies before the next familiar takes its turn. Each familiar still has
+ * its own resumable `/api/chat/send` session because there is no server-side
+ * group-session primitive.
  */
 
 import {
@@ -37,6 +36,7 @@ import { MessageBubble } from "@/components/message-bubble";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { UserChatAvatar } from "@/components/user-chat-avatar";
+import { Segmented } from "@/components/ui/settings-controls";
 import { formatChatRecency, useDateTimePrefs } from "@/lib/datetime-format";
 import { useUserProfile, userDisplayName } from "@/lib/user-profile";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -55,7 +55,13 @@ import {
   extractCovenDelegations,
   resolveGroupMessageTargets,
   mentionSuggestionAuthor,
+  setGroupResponseMode,
+  orderRoundRobinFamiliarIds,
+  nextRoundRobinLeadId,
   renderCovenRoundtablePrompt,
+  renderCovenRoundRobinPrompt,
+  runCovenReplySchedule,
+  COVEN_RESPONSE_MODES,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -69,6 +75,7 @@ import {
   type GroupReply,
   type MentionableFamiliar,
   type RosterParticipant,
+  type CovenResponseMode,
 } from "@/lib/group-chat";
 
 type Props = {
@@ -394,7 +401,39 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     [persistGroups],
   );
 
-  // --- broadcast send ------------------------------------------------------
+  const changeResponseMode = useCallback(
+    (responseMode: CovenResponseMode) => {
+      const group = activeGroupRef.current;
+      if (!group || busy || group.responseMode === responseMode) return;
+      persistGroups(
+        upsertGroup(groupsRef.current, setGroupResponseMode(group, responseMode, nowIso())),
+      );
+      announce(
+        responseMode === "broadcast"
+          ? "Broadcast mode. Familiars will respond at the same time."
+          : "Round robin mode. Familiars will respond in turn and see earlier replies.",
+      );
+    },
+    [announce, busy, persistGroups],
+  );
+
+  const advanceRoundRobinLead = useCallback((groupId: string, leadId: string) => {
+    setGroups((prev) => {
+      const current = prev.find((group) => group.id === groupId);
+      if (!current) return prev;
+      const nextLead = nextRoundRobinLeadId(current.familiarIds, leadId);
+      if (current.nextRoundRobinLeadId === nextLead) return prev;
+      const next = upsertGroup(prev, {
+        ...current,
+        nextRoundRobinLeadId: nextLead,
+        updatedAt: nowIso(),
+      });
+      saveGroups(next);
+      return next;
+    });
+  }, []);
+
+  // --- mode-aware group send ----------------------------------------------
   const streamOne = useCallback(
     async (group: CovenGroup, reply: GroupReply, prompt: string, signal: AbortSignal): Promise<GroupReply> => {
       // `settled` mirrors the live React state so callers can await the final
@@ -477,6 +516,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         announce("That familiar is no longer in this coven.", "assertive");
         return;
       }
+      const orderedTargetIds = group.responseMode === "round-robin"
+        ? orderRoundRobinFamiliarIds(group.familiarIds, targetIds, group.nextRoundRobinLeadId)
+        : targetIds;
       // Roster reflects the FULL coven (not just @mention targets) — a familiar
       // should know who else is in the room even when addressed alone. Composed
       // per-familiar so each sees itself marked "(you)".
@@ -495,9 +537,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         role: "user",
         text,
         targetFamiliarIds: targeted ? targetIds : undefined,
+        responseMode: group.responseMode,
         createdAt: at,
       };
-      const replies: GroupReply[] = targetIds.map((fid) => ({
+      const replies: GroupReply[] = orderedTargetIds.map((fid, index) => ({
         id: newId(),
         role: "assistant",
         familiarId: fid,
@@ -505,8 +548,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         sessionId: group.sessions[fid] ?? null,
         text: "",
         status: "queued",
+        activity:
+          group.responseMode === "round-robin" && index > 0
+            ? `Waiting for ${byId.get(orderedTargetIds[index - 1])?.display_name ?? orderedTargetIds[index - 1]}…`
+            : undefined,
         createdAt: at,
       }));
+      const priorTurns = transcriptRef.current;
       // The user just sent — snap them to the bottom regardless of prior scroll.
       stickToBottomRef.current = true;
       setShowJump(false);
@@ -516,21 +564,37 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
-      const settled = await Promise.all(
-        replies.map((r) =>
-          streamOne(
-            group,
-            r,
-            renderCovenRoundtablePrompt({
-              participants: rosterParticipants,
-              receivingFamiliarId: r.familiarId,
-              userText: text,
-              targeted,
-            }),
-            controller.signal,
-          ),
-        ),
-      );
+      if (group.responseMode === "round-robin" && replies.length > 1) {
+        advanceRoundRobinLead(group.id, replies[0].familiarId);
+      }
+      const settled = await runCovenReplySchedule({
+        mode: group.responseMode,
+        replies,
+        signal: controller.signal,
+        onCancelled: (cancelled) => updateReply(cancelled.id, () => cancelled),
+        runReply: (reply, settledBefore) => {
+          const prompt = group.responseMode === "round-robin"
+            ? renderCovenRoundRobinPrompt({
+                participants: rosterParticipants,
+                receivingFamiliarId: reply.familiarId,
+                userText: text,
+                targeted,
+                familiarNames: mentionable,
+                transcript: [...priorTurns, userTurn, ...settledBefore].map((turn) =>
+                  turn.role === "assistant"
+                    ? { ...turn, text: extractNextPaths(turn.text).visible }
+                    : turn,
+                ),
+              })
+            : renderCovenRoundtablePrompt({
+                participants: rosterParticipants,
+                receivingFamiliarId: reply.familiarId,
+                userText: text,
+                targeted,
+              });
+          return streamOne(group, reply, prompt, controller.signal);
+        },
+      });
       // A familiar can perform an explicit human-requested handoff by emitting
       // a validated delegation trailer. Plain assistant @mentions remain prose.
       // Process the small delegation tree sequentially so Stop prevents queued
@@ -629,7 +693,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         announce(`${total - failed} of ${total} familiars replied; ${failed} failed.`, "assertive");
       }
     },
-    [busy, streamOne, byId, announce, operatorDisplayName],
+    [advanceRoundRobinLead, busy, streamOne, byId, announce, operatorDisplayName, updateReply],
   );
 
   // Composer sends and suggestion chips share the stream path, but a suggestion
@@ -684,12 +748,28 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       const settled = await streamOne(
         group,
         fresh,
-        renderCovenRoundtablePrompt({
-          participants: rosterParticipants,
-          receivingFamiliarId: fresh.familiarId,
-          userText: retryText,
-          targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
-        }),
+        (userTurn.responseMode ?? "broadcast") === "round-robin"
+          ? renderCovenRoundRobinPrompt({
+              participants: rosterParticipants,
+              receivingFamiliarId: fresh.familiarId,
+              userText: retryText,
+              targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
+              familiarNames: group.familiarIds.map((id) => ({
+                id,
+                name: byId.get(id)?.display_name ?? id,
+              })),
+              transcript: transcriptRef.current
+                .filter((turn) => turn.id !== reply.id)
+                .map((turn) => turn.role === "assistant"
+                  ? { ...turn, text: extractNextPaths(turn.text).visible }
+                  : turn),
+            })
+          : renderCovenRoundtablePrompt({
+              participants: rosterParticipants,
+              receivingFamiliarId: fresh.familiarId,
+              userText: retryText,
+              targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
+            }),
         controller.signal,
       );
       // Ownership-guarded (see broadcast): don't clobber a newer stream's wiring.
@@ -788,6 +868,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const participants = activeGroup
     ? activeGroup.familiarIds.map((id) => byId.get(id)).filter(Boolean as unknown as (f: ResolvedFamiliar | undefined) => f is ResolvedFamiliar)
     : [];
+  const nextRoundRobinLead = activeGroup?.nextRoundRobinLeadId
+    ? byId.get(activeGroup.nextRoundRobinLeadId) ?? null
+    : participants[0] ?? null;
 
   // --- render --------------------------------------------------------------
   return (
@@ -805,7 +888,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
           {groups.length === 0 ? (
             <p className="px-2 py-3 text-[12px] leading-relaxed" style={{ color: "var(--text-muted)" }}>
-              A coven is a group of familiars you talk to together. Create one to broadcast a prompt to all of them at once.
+              A coven is a group of familiars you talk to together. Create one to choose how they take turns responding.
             </p>
           ) : (
             <ul className="flex flex-col gap-0.5">
@@ -924,6 +1007,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   )}
                 </div>
               </div>
+              <div className="flex flex-col items-end gap-1">
+                <fieldset disabled={busy} className="disabled:opacity-60">
+                  <Segmented
+                    options={COVEN_RESPONSE_MODES}
+                    value={activeGroup.responseMode}
+                    onChange={changeResponseMode}
+                    getLabel={(mode) => mode === "broadcast" ? "Broadcast" : "Round robin"}
+                    ariaLabel="Coven response mode"
+                  />
+                </fieldset>
+                <span className="text-[10px]" style={{ color: "var(--text-muted)" }}>
+                  {activeGroup.responseMode === "broadcast"
+                    ? "Everyone responds at once"
+                    : `${nextRoundRobinLead?.display_name ?? "First familiar"} leads next`}
+                </span>
+              </div>
               <Button
                 ref={addBtnRef}
                 size="sm"
@@ -988,11 +1087,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                 <div className="grid h-full place-items-center">
                   <EmptyState
                     icon="ph:chats-circle"
-                    headline={participants.length === 0 ? "Add familiars to begin" : "Broadcast your first message"}
+                      headline={participants.length === 0 ? "Add familiars to begin" : "Start the conversation"}
                     subtitle={
                       participants.length === 0
                         ? "Use Add to pick the familiars in this coven."
-                        : "Your prompt goes to every familiar in the coven. Each replies in its own thread."
+                        : activeGroup.responseMode === "broadcast"
+                          ? "Every familiar responds at once in its own thread."
+                          : "Familiars respond in turn and see earlier replies."
                     }
                     compact
                   />

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -9,13 +9,19 @@ import {
   removeGroup,
   setGroupSession,
   setGroupParticipants,
+  setGroupResponseMode,
+  orderRoundRobinFamiliarIds,
+  nextRoundRobinLeadId,
   parseMentions,
   extractCovenDelegations,
   resolveGroupMessageTargets,
   mentionSuggestionAuthor,
   renderCovenRoster,
   renderCovenRoundtablePrompt,
+  renderCovenRoundRobinPrompt,
   renderCovenContext,
+  runCovenReplySchedule,
+  loadGroups,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -123,6 +129,8 @@ test("makeGroup: dedupes participants and defaults the name", () => {
   assert.deepEqual(g.familiarIds, ["a", "b"]);
   assert.equal(g.name, "New coven");
   assert.deepEqual(g.sessions, {});
+  assert.equal(g.responseMode, "broadcast");
+  assert.equal(g.nextRoundRobinLeadId, "a");
 });
 
 test("upsertGroup: replaces by id and sorts newest-first", () => {
@@ -160,6 +168,55 @@ test("setGroupParticipants: drops session pins for removed familiars", () => {
   assert.deepEqual(g.familiarIds, ["a", "c"]);
   assert.equal(g.sessions.a, "sess-a");
   assert.equal(g.sessions.b, undefined);
+  assert.equal(g.nextRoundRobinLeadId, "a");
+});
+
+test("setGroupParticipants: repairs a removed round-robin lead", () => {
+  let g = makeGroup("X", ["a", "b"], "2026-06-24T00:00:00.000Z", "g1");
+  g = { ...g, nextRoundRobinLeadId: "b" };
+  g = setGroupParticipants(g, ["a", "c"], "2026-06-24T01:00:00.000Z");
+  assert.equal(g.nextRoundRobinLeadId, "a");
+});
+
+test("setGroupResponseMode: preserves sessions and initializes the lead", () => {
+  let g = makeGroup("X", ["a", "b"], "2026-06-24T00:00:00.000Z", "g1");
+  g = setGroupSession(g, "a", "sess-a", "2026-06-24T00:30:00.000Z");
+  g = setGroupResponseMode({ ...g, nextRoundRobinLeadId: undefined }, "round-robin", "2026-06-24T01:00:00.000Z");
+  assert.equal(g.responseMode, "round-robin");
+  assert.equal(g.nextRoundRobinLeadId, "a");
+  assert.equal(g.sessions.a, "sess-a");
+});
+
+test("round-robin ordering rotates the lead and filters to mentioned targets", () => {
+  assert.deepEqual(orderRoundRobinFamiliarIds(["a", "b", "c"], ["a", "b", "c"], "b"), ["b", "c", "a"]);
+  assert.deepEqual(orderRoundRobinFamiliarIds(["a", "b", "c"], ["a", "c"], "b"), ["c", "a"]);
+  assert.equal(nextRoundRobinLeadId(["a", "b", "c"], "a"), "b");
+  assert.equal(nextRoundRobinLeadId(["a", "b", "c"], "c"), "a");
+});
+
+test("loadGroups: legacy groups default to broadcast without losing session pins", () => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const legacy = {
+    id: "legacy",
+    name: "Legacy coven",
+    familiarIds: ["a", "b"],
+    sessions: { a: "sess-a" },
+    createdAt: "t1",
+    updatedAt: "t2",
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: { getItem: () => JSON.stringify([legacy]) },
+  });
+  try {
+    const [loaded] = loadGroups();
+    assert.equal(loaded.responseMode, "broadcast");
+    assert.equal(loaded.nextRoundRobinLeadId, "a");
+    assert.equal(loaded.sessions.a, "sess-a");
+  } finally {
+    if (previous) Object.defineProperty(globalThis, "localStorage", previous);
+    else delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
 });
 
 // --- @mentions -------------------------------------------------------------
@@ -423,6 +480,99 @@ function roundTranscript(): GroupTurn[] {
     reply("r2", "charm", "u1", "Agreed — three of us."),
   ];
 }
+
+test("renderCovenRoundRobinPrompt: later recipients see settled peers and stay themselves", () => {
+  const out = renderCovenRoundRobinPrompt({
+    participants: COVEN,
+    receivingFamiliarId: "charm",
+    userText: "What should we do?",
+    targeted: false,
+    familiarNames: NAMES,
+    transcript: [
+      user("u1", "What should we do?"),
+      reply("r1", "nova", "u1", "Stabilize recovery first."),
+    ],
+  });
+  assert.match(out, /<coven_round_robin>/);
+  assert.match(out, /Nova said:[\s\S]*Stabilize recovery first/);
+  assert.match(out, /answer as yourself/i);
+  assert.doesNotMatch(out, /Charm said:/);
+  assert.doesNotMatch(out, /independent first-pass/);
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+test("runCovenReplySchedule: broadcast starts every familiar concurrently", async () => {
+  const controller = new AbortController();
+  const a = baseReply({ id: "a", familiarId: "a" });
+  const b = baseReply({ id: "b", familiarId: "b" });
+  const waits = new Map([["a", deferred<GroupReply>()], ["b", deferred<GroupReply>()]]);
+  const started: string[] = [];
+  const running = runCovenReplySchedule({
+    mode: "broadcast",
+    replies: [a, b],
+    signal: controller.signal,
+    runReply: (candidate) => {
+      started.push(candidate.familiarId);
+      return waits.get(candidate.familiarId)!.promise;
+    },
+  });
+  await Promise.resolve();
+  assert.deepEqual(started, ["a", "b"]);
+  waits.get("a")!.resolve({ ...a, status: "done", text: "A" });
+  waits.get("b")!.resolve({ ...b, status: "done", text: "B" });
+  assert.equal((await running).length, 2);
+});
+
+test("runCovenReplySchedule: round robin waits and passes settled replies forward", async () => {
+  const controller = new AbortController();
+  const a = baseReply({ id: "a", familiarId: "a" });
+  const b = baseReply({ id: "b", familiarId: "b" });
+  const first = deferred<GroupReply>();
+  const started: string[] = [];
+  const settledSeen: string[][] = [];
+  const running = runCovenReplySchedule({
+    mode: "round-robin",
+    replies: [a, b],
+    signal: controller.signal,
+    runReply: async (candidate, settledBefore) => {
+      started.push(candidate.familiarId);
+      settledSeen.push(settledBefore.map((item) => item.familiarId));
+      if (candidate.familiarId === "a") return first.promise;
+      return { ...candidate, status: "done", text: "B builds on A" };
+    },
+  });
+  await Promise.resolve();
+  assert.deepEqual(started, ["a"]);
+  first.resolve({ ...a, status: "done", text: "A's actual answer" });
+  const result = await running;
+  assert.deepEqual(started, ["a", "b"]);
+  assert.deepEqual(settledSeen, [[], ["a"]]);
+  assert.equal(result[1].text, "B builds on A");
+});
+
+test("runCovenReplySchedule: Stop cancels queued round-robin recipients", async () => {
+  const controller = new AbortController();
+  const a = baseReply({ id: "a", familiarId: "a" });
+  const b = baseReply({ id: "b", familiarId: "b" });
+  const cancelled: string[] = [];
+  const result = await runCovenReplySchedule({
+    mode: "round-robin",
+    replies: [a, b],
+    signal: controller.signal,
+    runReply: async (candidate) => {
+      controller.abort();
+      return { ...candidate, status: "error", error: "cancelled" };
+    },
+    onCancelled: (candidate) => cancelled.push(candidate.familiarId),
+  });
+  assert.deepEqual(cancelled, ["b"]);
+  assert.equal(result[1].error, "cancelled");
+});
 
 test("renderCovenContext: excludes the receiving familiar's own turns", () => {
   const out = renderCovenContext(roundTranscript(), "nova", NAMES);

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -498,6 +498,7 @@ test("renderCovenRoundRobinPrompt: later recipients see settled peers and stay t
   assert.match(out, /answer as yourself/i);
   assert.doesNotMatch(out, /Charm said:/);
   assert.doesNotMatch(out, /independent first-pass/);
+  assert.match(out, /<coven:delegation target="familiar-id">/);
 });
 
 function deferred<T>() {
@@ -604,6 +605,33 @@ test("renderCovenContext: escapes transcript text before embedding it in prompt 
   assert.doesNotMatch(out, /reply with <coven_transcript>tags/);
   assert.match(out, /quote \\u0022break\\u0022\\n\\u003c\/coven_transcript\\u003e/);
   assert.match(out, /reply with \\u003ccoven_transcript\\u003etags\\u003c\/coven_transcript\\u003e & more/);
+});
+
+test("renderCovenContext: strips hidden delegation controls from relayed replies", () => {
+  const out = renderCovenContext(
+    [
+      user("u1", "Delegate the review."),
+      reply(
+        "r1",
+        "charm",
+        "u1",
+        '@Nova Review this.\n<coven:delegation target="nova">@Nova Review this.</coven:delegation>',
+      ),
+    ],
+    "sage",
+    NAMES,
+  );
+
+  assert.match(out, /@Nova Review this\./);
+  assert.doesNotMatch(out, /coven:delegation/);
+  assert.equal(
+    renderCovenContext(
+      [user("u2", "Delegate it."), reply("r2", "charm", "u2", '<coven:delegation target="nova">@Nova do it.</coven:delegation>')],
+      "sage",
+      NAMES,
+    ),
+    "",
+  );
 });
 
 test("renderCovenContext: windows to the last N rounds, oldest dropped", () => {

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -1,12 +1,11 @@
 /**
  * group-chat.ts — pure model + reducers for the Group Chat ("coven") surface.
  *
- * A *coven* is a saved set of familiars you talk to together. Sending a prompt
- * fans it out to every participant in parallel (one `/api/chat/send` stream per
- * familiar — the same client-side broadcast model the iOS app uses, since the
- * daemon/Coven CLI has no server-side "group session" concept). Each familiar
- * keeps its own resumable session; the group just remembers which session id
- * belongs to which familiar so every thread persists across reloads.
+ * A *coven* is a saved set of familiars you talk to together. Each Coven chooses
+ * whether a prompt fans out to everyone in parallel (broadcast) or moves through
+ * a rotating speaking order with peer-reply relay (round robin). Both modes use
+ * one `/api/chat/send` stream and resumable session per familiar because the
+ * daemon/Coven CLI has no server-side "group session" concept.
  *
  * Everything here is framework-free and deterministic (except the thin
  * localStorage + id/time wrappers at the bottom) so the streaming reducers and
@@ -26,6 +25,9 @@ export const MAX_COVEN_DELEGATION_DEPTH = 2;
 /** Independent cap for wide fan-out within one human turn. */
 export const MAX_COVEN_DELEGATIONS_PER_TURN = 4;
 
+export const COVEN_RESPONSE_MODES = ["broadcast", "round-robin"] as const;
+export type CovenResponseMode = (typeof COVEN_RESPONSE_MODES)[number];
+
 /** A saved group of familiars chatted with together. */
 export type CovenGroup = {
   id: string;
@@ -33,6 +35,10 @@ export type CovenGroup = {
   familiarIds: string[];
   /** Per-familiar resumed session ids so each thread survives reloads. */
   sessions: Record<string, string>;
+  /** How a multi-recipient human turn is dispatched. */
+  responseMode: CovenResponseMode;
+  /** Familiar that should lead the next multi-recipient round-robin turn. */
+  nextRoundRobinLeadId?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -54,6 +60,8 @@ export type GroupUserTurn = {
   delegatedByFamiliarId?: string;
   delegationSourceReplyId?: string;
   delegationDepth?: number;
+  /** Snapshot at send time so retries keep the original turn semantics. */
+  responseMode?: CovenResponseMode;
   createdAt: string;
 };
 
@@ -374,6 +382,8 @@ export function makeGroup(
     name: name.trim() || "New coven",
     familiarIds: dedupe(familiarIds),
     sessions: {},
+    responseMode: "broadcast",
+    nextRoundRobinLeadId: dedupe(familiarIds)[0],
     createdAt: now,
     updatedAt: now,
   };
@@ -413,7 +423,48 @@ export function setGroupParticipants(
   for (const id of ids) {
     if (group.sessions[id]) sessions[id] = group.sessions[id];
   }
-  return { ...group, familiarIds: ids, sessions, updatedAt: now };
+  const nextRoundRobinLeadId = ids.includes(group.nextRoundRobinLeadId ?? "")
+    ? group.nextRoundRobinLeadId
+    : ids[0];
+  return { ...group, familiarIds: ids, sessions, nextRoundRobinLeadId, updatedAt: now };
+}
+
+export function setGroupResponseMode(
+  group: CovenGroup,
+  responseMode: CovenResponseMode,
+  now: string,
+): CovenGroup {
+  return {
+    ...group,
+    responseMode,
+    nextRoundRobinLeadId:
+      group.nextRoundRobinLeadId && group.familiarIds.includes(group.nextRoundRobinLeadId)
+        ? group.nextRoundRobinLeadId
+        : group.familiarIds[0],
+    updatedAt: now,
+  };
+}
+
+/** Rotate selected recipients around the persisted Coven lead. */
+export function orderRoundRobinFamiliarIds(
+  familiarIds: string[],
+  targetIds: string[],
+  nextLeadId?: string,
+): string[] {
+  const roster = dedupe(familiarIds);
+  const targets = new Set(dedupe(targetIds));
+  if (roster.length === 0 || targets.size === 0) return [];
+  const start = Math.max(0, nextLeadId ? roster.indexOf(nextLeadId) : 0);
+  const rotated = [...roster.slice(start), ...roster.slice(0, start)];
+  return rotated.filter((id) => targets.has(id));
+}
+
+/** Advance the persisted lead one roster slot after the familiar that led. */
+export function nextRoundRobinLeadId(familiarIds: string[], leadId: string): string | undefined {
+  const roster = dedupe(familiarIds);
+  if (roster.length === 0) return undefined;
+  const leadIndex = roster.indexOf(leadId);
+  return roster[(leadIndex < 0 ? 0 : leadIndex + 1) % roster.length];
 }
 
 function dedupe(ids: string[]): string[] {
@@ -502,6 +553,63 @@ export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): st
     "</coven_roundtable>",
   ].join("\n");
   return [roster, mode, args.userText.trim()].filter(Boolean).join("\n\n");
+}
+
+export type CovenRoundRobinPromptArgs = CovenRoundtablePromptArgs & {
+  transcript: GroupTurn[];
+  familiarNames: MentionableFamiliar[];
+};
+
+/** Build one sequential reply prompt with settled peer context. */
+export function renderCovenRoundRobinPrompt(args: CovenRoundRobinPromptArgs): string {
+  const roster = renderCovenRoster(args.participants, args.receivingFamiliarId);
+  const context = renderCovenContext(args.transcript, args.receivingFamiliarId, args.familiarNames);
+  const mode = [
+    "<coven_round_robin>",
+    args.targeted
+      ? "You were directly mentioned in this coven's round-robin conversation."
+      : "You are taking your turn in this coven's round-robin conversation.",
+    "Read the other participants' completed replies provided below, then answer as yourself.",
+    "Use your own identity, role, and judgment. You may agree, disagree, extend, or redirect the discussion.",
+    "Do not imitate another familiar or present their words as your own.",
+    "</coven_round_robin>",
+  ].join("\n");
+  return [roster, mode, context, args.userText.trim()].filter(Boolean).join("\n\n");
+}
+
+export type CovenReplyRunner = (
+  reply: GroupReply,
+  settledBefore: GroupReply[],
+) => Promise<GroupReply>;
+
+/**
+ * Dispatch one Coven turn. Broadcast starts every reply together. Round robin
+ * waits for each reply before starting the next and exposes the settled prefix
+ * to the prompt builder. Aborted queued replies are settled as cancelled without
+ * invoking the runner, so Stop cannot leak another request after cancellation.
+ */
+export async function runCovenReplySchedule(args: {
+  mode: CovenResponseMode;
+  replies: GroupReply[];
+  signal: AbortSignal;
+  runReply: CovenReplyRunner;
+  onCancelled?: (reply: GroupReply) => void;
+}): Promise<GroupReply[]> {
+  if (args.mode === "broadcast") {
+    return Promise.all(args.replies.map((reply) => args.runReply(reply, [])));
+  }
+
+  const settled: GroupReply[] = [];
+  for (const reply of args.replies) {
+    if (args.signal.aborted) {
+      const cancelled = { ...reply, status: "error" as const, error: "cancelled", activity: undefined };
+      settled.push(cancelled);
+      args.onCancelled?.(cancelled);
+      continue;
+    }
+    settled.push(await args.runReply(reply, [...settled]));
+  }
+  return settled;
 }
 
 // ---------------------------------------------------------------------------
@@ -599,7 +707,7 @@ export function loadGroups(): CovenGroup[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isCovenGroup);
+    return parsed.filter(isCovenGroup).map(normalizeCovenGroup);
   } catch {
     return [];
   }
@@ -668,4 +776,17 @@ function isCovenGroup(value: unknown): value is CovenGroup {
     typeof g.sessions === "object" &&
     g.sessions !== null
   );
+}
+
+function normalizeCovenGroup(group: CovenGroup): CovenGroup {
+  const responseMode: CovenResponseMode = COVEN_RESPONSE_MODES.includes(group.responseMode)
+    ? group.responseMode
+    : "broadcast";
+  const nextLead = group.nextRoundRobinLeadId;
+  return {
+    ...group,
+    responseMode,
+    nextRoundRobinLeadId:
+      nextLead && group.familiarIds.includes(nextLead) ? nextLead : group.familiarIds[0],
+  };
 }

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -527,6 +527,13 @@ export type CovenRoundtablePromptArgs = {
   targeted: boolean;
 };
 
+const COVEN_DELEGATION_PROMPT_LINES = [
+  "Do not merely suggest that the human ask another familiar to do something.",
+  "When the human explicitly asks you to give, assign, delegate, or hand off a task to another familiar in this coven, address that familiar directly using their exact @display name and state the concrete task.",
+  'After the visible @mention task, append exactly one hidden routing trailer using the roster id: <coven:delegation target="familiar-id">the same concrete task</coven:delegation>.',
+  "Only emit that trailer for an explicit delegation request addressed to you; ordinary references to another familiar are not delegations.",
+] as const;
+
 /**
  * Build the default group-chat prompt for one familiar.
  *
@@ -546,10 +553,7 @@ export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): st
       : "This is an independent first-pass group reply. Other familiars receive the same human request in parallel.",
     "Answer from your own identity, role, and judgment.",
     "Do not summarize, predict, imitate, or speak for other familiars.",
-    "Do not merely suggest that the human ask another familiar to do something.",
-    "When the human explicitly asks you to give, assign, delegate, or hand off a task to another familiar in this coven, address that familiar directly using their exact @display name and state the concrete task.",
-    'After the visible @mention task, append exactly one hidden routing trailer using the roster id: <coven:delegation target="familiar-id">the same concrete task</coven:delegation>.',
-    "Only emit that trailer for an explicit delegation request addressed to you; ordinary references to another familiar are not delegations.",
+    ...COVEN_DELEGATION_PROMPT_LINES,
     "</coven_roundtable>",
   ].join("\n");
   return [roster, mode, args.userText.trim()].filter(Boolean).join("\n\n");
@@ -572,6 +576,7 @@ export function renderCovenRoundRobinPrompt(args: CovenRoundRobinPromptArgs): st
     "Read the other participants' completed replies provided below, then answer as yourself.",
     "Use your own identity, role, and judgment. You may agree, disagree, extend, or redirect the discussion.",
     "Do not imitate another familiar or present their words as your own.",
+    ...COVEN_DELEGATION_PROMPT_LINES,
     "</coven_round_robin>",
   ].join("\n");
   return [roster, mode, context, args.userText.trim()].filter(Boolean).join("\n\n");
@@ -639,8 +644,9 @@ function escapeCovenPromptText(text: string): string {
  * Third-person, named, with an explicit stay-yourself guard (Coven canon).
  * Excludes the receiving familiar's own turns (already in its resumed session),
  * keeps only settled non-empty replies, and windows to the last N rounds. The
- * caller passes already-cleaned reply text (next-paths block stripped) so this
- * stays dependency-free. Returns "" when there is nothing to relay.
+ * The caller strips next-path controls; this helper strips delegation controls
+ * itself so hidden routing markup can never enter another familiar's prompt.
+ * Returns "" when there is nothing to relay.
  */
 export function renderCovenContext(
   transcript: GroupTurn[],
@@ -669,12 +675,14 @@ export function renderCovenContext(
   const kept = rounds
     .map((r) => ({
       user: r.user,
-      replies: r.replies.filter(
-        (rep) =>
-          rep.status === "done" &&
-          rep.text.trim() !== "" &&
-          rep.familiarId !== receivingFamiliarId,
-      ),
+      replies: r.replies
+        .map((rep) => ({ ...rep, text: extractCovenDelegations(rep.text).visible.trim() }))
+        .filter(
+          (rep) =>
+            rep.status === "done" &&
+            rep.text !== "" &&
+            rep.familiarId !== receivingFamiliarId,
+        ),
     }))
     .filter((r) => r.replies.length > 0);
 
@@ -688,7 +696,7 @@ export function renderCovenContext(
     const lines: string[] = [`(human) asked: "${escapeCovenPromptText(r.user.text.trim())}"`];
     for (const rep of r.replies) {
       lines.push(`${escapeCovenPromptText(nameOf(rep.familiarId))} said:`);
-      lines.push(escapeCovenPromptText(rep.text.trim()));
+      lines.push(escapeCovenPromptText(rep.text));
     }
     return lines.join("\n");
   });


### PR DESCRIPTION
## Summary

Adds a per-Coven response mode configuration so a group conversation can run in either:

- **Broadcast** — the current/default behavior; all selected familiars receive the user turn concurrently and answer independently.
- **Round robin** — familiars answer sequentially; each later familiar receives the settled peer replies from earlier in that round.

Closes #3337.
Bead: `cave-92l`

## Changes

- Persists `responseMode` and the next rotating Round robin lead on each Coven.
- Normalizes legacy saved Covens to `broadcast` without losing participants, sessions, or transcripts.
- Adds an accessible Broadcast / Round robin selector in the active Coven header.
- Disables the selector during an active turn so one turn cannot change semantics mid-flight.
- Keeps Broadcast fan-out concurrent.
- Adds true rotating Round robin order, including `@mention` subset filtering.
- Relays only settled, visible peer reply text to later speakers.
- Preserves the originating mode on a user turn so retries keep the same prompt semantics.
- Makes Stop cancel the active stream and mark queued Round robin speakers cancelled.

## Acceptance criteria

- [x] Response mode is configured per Coven.
- [x] Existing and newly created Covens default to Broadcast.
- [x] Broadcast retains concurrent fan-out behavior.
- [x] Round robin executes one familiar at a time.
- [x] Later Round robin speakers see earlier settled replies.
- [x] The lead rotates between rounds and remains valid when participants change.
- [x] Targeted `@mentions` retain the mode's scheduling semantics.
- [x] Mode changes preserve existing session pins and transcripts.
- [x] The selector is accessible, visible at narrow widths, and locked while busy.
- [x] Stop/error paths do not leave queued speakers running.

## Verification

- `node --experimental-strip-types --test src/lib/group-chat.test.ts src/components/group-chat-view.test.ts` — 62/62 passed.
- `pnpm typecheck` — passed.
- `pnpm check:tests-wired` — all 1,038 test files wired into CI.
- `pnpm test:app` — all 764 app test files passed.
- `pnpm build` — passed.
- Bundle budget — passed (1,781 KB initial JS / 2,800 KB budget; 801 KB initial CSS / 870 KB budget).
- Standalone budget — passed (6,433 files / 7,000; 349,331,020 bytes / 419,430,400).
- Browser acceptance at 1440×900 and 800×900:
  - Broadcast rendered selected by default.
  - Round robin selection persisted to the Coven.
  - Next-lead cue rendered.
  - Selector remained fully inside the 800 px viewport.

## Risk and rollout

The new persisted fields are client-side and backward compatible. Broadcast remains the default, so existing Covens retain current behavior unless a user explicitly selects Round robin.