### PR TITLE
Distinguish daemon offline from status failures

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -61,6 +61,7 @@ export const SUITES = {
     "src/lib/authed-image-cache.test.ts",
     "src/lib/app-update.test.ts",
     "src/lib/about-status.test.ts",
+    "src/lib/daemon-status-classification.test.ts",
     "src/lib/about-diagnostics.test.ts",
     "src/lib/browser-navigation-queue.test.ts",
     "src/lib/open-external.test.ts",

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -18,6 +18,12 @@ assert.match(
 
 assert.match(
   source,
+  /callDaemonTarget<Health>\(target,/,
+  "the health request and status metadata should use the same resolved daemon target",
+);
+
+assert.match(
+  source,
   /target: targetSummary\(target\)/,
   "daemon status response should include the current target summary",
 );
@@ -92,6 +98,18 @@ assert.match(
   source,
   /res\.status === 401 \|\| res\.status === 403[\s\S]*hub unauthorized/,
   "hub auth failures should be labelled separately instead of treated as offline",
+);
+
+assert.match(
+  source,
+  /availability: failureAvailability\(target, res\)/,
+  "daemon failures should expose a machine-readable availability classification",
+);
+
+assert.match(
+  source,
+  /running: true,[\s\S]{0,80}availability: "online"/,
+  "a healthy daemon should expose online availability",
 );
 
 console.log("daemon status route.test.ts: ok");

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { loadConfig, loadState, recordLocalSubdaemonWakeRequest, recordTravelHubReachability } from "@/lib/cave-config";
 import {
-  callDaemon,
+  callDaemonTarget,
   daemonTargetForConfig,
   extractDaemonError,
   type DaemonResponse,
@@ -9,6 +9,7 @@ import {
 } from "@/lib/coven-daemon";
 import { covenWorkspaceRoot } from "@/lib/coven-paths";
 import { displayCovenVersion, installedCovenVersion } from "@/lib/coven-version";
+import { classifyDaemonFailureAvailability } from "@/lib/daemon-status-classification";
 import { startLocalDaemon } from "@/lib/daemon-start";
 import { executorStatusesForConfig } from "@/lib/executor-status";
 import { deriveTravelClientStatus } from "@/lib/travel-client-state";
@@ -46,6 +47,14 @@ function failureReason(target: DaemonTarget, res: DaemonResponse<unknown>) {
   return `hub unreachable: ${detail}`;
 }
 
+function failureAvailability(target: DaemonTarget, res: DaemonResponse<unknown>) {
+  return classifyDaemonFailureAvailability({
+    targetMode: target.mode,
+    responseStatus: res.status,
+    reason: extractDaemonError(res),
+  });
+}
+
 export async function GET() {
   const config = await loadConfig();
   const target = daemonTargetForConfig(config);
@@ -61,6 +70,7 @@ export async function GET() {
     });
     return NextResponse.json({
       running: false,
+      availability: "misconfigured",
       reason: target.error,
       target: targetSummary(target),
       executors: executorStatuses,
@@ -70,7 +80,11 @@ export async function GET() {
     });
   }
 
-  const res = await callDaemon<Health>({ path: "/api/v1/health", timeoutMs: 1500 });
+  // Use the same resolved target for the health request, response metadata,
+  // and failure classification. Reloading config inside callDaemon() created
+  // a race where a connection-mode change could query one target while the
+  // response claimed (and classified) another.
+  const res = await callDaemonTarget<Health>(target, { path: "/api/v1/health", timeoutMs: 1500 });
   let travelReplay: TravelOfflineReplayResult | null = null;
   if (target.mode === "hub") {
     hubReachable = hubAnswered(res);
@@ -100,6 +114,7 @@ export async function GET() {
   if (!res.ok || !res.data) {
     return NextResponse.json({
       running: false,
+      availability: failureAvailability(target, res),
       reason: failureReason(target, res),
       target: targetSummary(target),
       executors: executorStatuses,
@@ -115,6 +130,7 @@ export async function GET() {
       : null;
   return NextResponse.json({
     running: true,
+    availability: "online",
     apiVersion: res.data.apiVersion,
     covenVersion: displayCovenVersion({
       daemonVersion: res.data.covenVersion,

--- a/src/components/workspace-sessions-navigation.test.ts
+++ b/src/components/workspace-sessions-navigation.test.ts
@@ -37,3 +37,21 @@ assert.match(
   /else if \(daemonStatusResolved\)/,
   "daemon-offline banner is gated on a resolved status, not the initial unknown state",
 );
+
+assert.match(
+  workspace,
+  /classifyDaemonStatusPoll\(/,
+  "daemon status polling should distinguish definitive offline from unavailable checks",
+);
+
+assert.match(
+  workspace,
+  /requestId !== daemonStatusRequestRef\.current/,
+  "an older status poll must not overwrite a newer post-start result",
+);
+
+assert.match(
+  workspace,
+  /id: "daemon-status-unavailable"[\s\S]{0,300}label: "Retry"/,
+  "inconclusive daemon checks should be retryable without offering Start daemon",
+);

--- a/src/components/workspace-sessions-navigation.test.ts
+++ b/src/components/workspace-sessions-navigation.test.ts
@@ -55,3 +55,12 @@ assert.match(
   /id: "daemon-status-unavailable"[\s\S]{0,300}label: "Retry"/,
   "inconclusive daemon checks should be retryable without offering Start daemon",
 );
+
+const unavailableBranch = workspace.match(
+  /if \(result\.kind === "unavailable"\) \{([\s\S]*?)\n    \}/,
+)?.[1] ?? "";
+assert.doesNotMatch(
+  unavailableBranch,
+  /setDaemonOffline\(false\)/,
+  "an inconclusive check must not clear a previously confirmed sticky offline state",
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -630,7 +630,6 @@ export function Workspace() {
     }
     if (result.kind === "unavailable") {
       daemonHealthyStreakRef.current = 0;
-      setDaemonOffline(false);
       setDaemonStatusUnavailable(result.reason);
       return;
     }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -44,6 +44,7 @@ import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
 import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { useMilestoneWatch } from "@/lib/use-milestone-watch";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { classifyDaemonStatusPoll } from "@/lib/daemon-status-classification";
 import type { BrowserPaneHandle } from "@/components/browser-pane";
 // Heavy, mode-gated surfaces are code-split via @/components/lazy-surfaces so
 // their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
@@ -379,14 +380,16 @@ export function Workspace() {
   // Sticky offline signal for the banner. A crash-looping / codesigning-zombie
   // daemon flaps: it briefly answers health (running:true) then dies again. The
   // banner keys off this instead of the raw per-poll status so a single transient
-  // "running" doesn't flicker it away — it shows on the first failed poll and
-  // only clears after the daemon is *consistently* healthy (see the streak ref).
+  // "running" doesn't flicker it away — it shows on the first definitive local-
+  // offline poll and only clears after the daemon is *consistently* healthy.
   const [daemonOffline, setDaemonOffline] = useState(false);
   // The access-token gate rejected our credential (401 on the status poll).
   // Distinct from daemonOffline: the daemon may be fine — WE can't see it, and
   // the fix is re-auth (reload to the gate page), not "Start daemon" (cave-wkp5).
   const [authExpired, setAuthExpired] = useState(false);
+  const [daemonStatusUnavailable, setDaemonStatusUnavailable] = useState<string | null>(null);
   const daemonHealthyStreakRef = useRef(0);
+  const daemonStatusRequestRef = useRef(0);
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
   const browserNavigationIdRef = useRef(Date.now() * 1024);
   const [browserNavigationQueue, setBrowserNavigationQueue] = useState<BrowserNavigationRequest[]>([]);
@@ -591,52 +594,63 @@ export function Workspace() {
   useMilestoneWatch();
 
   const refreshDaemonStatus = useCallback(async (opts?: { trusted?: boolean }) => {
-    let running = false;
-    let authRejected = false;
+    const requestId = ++daemonStatusRequestRef.current;
+    let result: ReturnType<typeof classifyDaemonStatusPoll>;
+    let credentialAccepted = false;
     try {
       const res = await fetch("/api/daemon/status", { cache: "no-store" });
-      if (res.status === 401) {
-        // The access-token gate rejected US — the daemon may be perfectly
-        // healthy; we just can't see it. Attributing this to the daemon put
-        // users in front of a "Daemon offline" banner whose "Start daemon"
-        // CTA also 401s (cave-wkp5). Surface re-auth instead, and leave the
-        // daemon state untouched.
-        authRejected = true;
-      } else {
-        const json = (await res.json()) as { running?: boolean };
-        running = json.running === true;
-        setDaemonRunning(running);
-        // A real (non-401) answer proves the credential is accepted again.
-        setAuthExpired(false);
-      }
+      const payload = await res.json().catch(() => null);
+      result = classifyDaemonStatusPoll({
+        responseStatus: res.status,
+        responseOk: res.ok,
+        payload,
+      });
+      // A real non-401 response proves the Cave credential is accepted again.
+      credentialAccepted = res.status !== 401;
     } catch {
-      if (!authRejected) setDaemonRunning(false);
-    } finally {
-      if (authRejected) {
-        setAuthExpired(true);
-        setDaemonStatusResolved(true);
-      } else {
-        // Drive the sticky offline signal: any failed poll marks the daemon
-        // offline immediately, but a background poll takes two *consecutive*
-        // healthy polls to clear — otherwise a flapping zombie daemon keeps
-        // dismissing the banner.
-        if (running) {
-          daemonHealthyStreakRef.current += 1;
-          // A `trusted` refresh follows an explicit user-initiated start, so a
-          // healthy answer is enough to clear the banner immediately — without it
-          // the "Start daemon" banner lingered for a poll cycle (~5s) after the
-          // daemon was already up.
-          if (opts?.trusted) daemonHealthyStreakRef.current = 2;
-          if (daemonHealthyStreakRef.current >= 2) setDaemonOffline(false);
-        } else {
-          daemonHealthyStreakRef.current = 0;
-          setDaemonOffline(true);
-        }
-        // The first poll has now produced a real answer — only after this may the
-        // offline banner appear, so a fresh load doesn't flash it before we know.
-        setDaemonStatusResolved(true);
-      }
+      result = classifyDaemonStatusPoll({
+        responseStatus: 0,
+        responseOk: false,
+        payload: null,
+        error: "status request failed",
+      });
     }
+
+    // An explicit refresh after Start can overtake an older background poll.
+    // Only the newest request may publish state, or that stale offline result
+    // can put the banner back after the daemon is already healthy.
+    if (requestId !== daemonStatusRequestRef.current) return;
+    if (credentialAccepted) setAuthExpired(false);
+
+    setDaemonStatusResolved(true);
+    if (result.kind === "auth-expired") {
+      setAuthExpired(true);
+      setDaemonStatusUnavailable(null);
+      return;
+    }
+    if (result.kind === "unavailable") {
+      daemonHealthyStreakRef.current = 0;
+      setDaemonOffline(false);
+      setDaemonStatusUnavailable(result.reason);
+      return;
+    }
+
+    setDaemonStatusUnavailable(null);
+    if (result.kind === "offline") {
+      daemonHealthyStreakRef.current = 0;
+      setDaemonRunning(false);
+      setDaemonOffline(true);
+      return;
+    }
+
+    setDaemonRunning(true);
+    daemonHealthyStreakRef.current += 1;
+    // A `trusted` refresh follows an explicit user-initiated start, so a
+    // healthy answer is enough to clear the banner immediately — without it
+    // the "Start daemon" banner lingered for a poll cycle (~5s) after the
+    // daemon was already up.
+    if (opts?.trusted) daemonHealthyStreakRef.current = 2;
+    if (daemonHealthyStreakRef.current >= 2) setDaemonOffline(false);
   }, []);
 
   const startDaemon = useCallback(async () => {
@@ -789,8 +803,8 @@ export function Workspace() {
       dismissBanner("daemon-offline");
       dismissBanner("daemon-start-error");
     } else if (daemonStatusResolved) {
-      // Only show the offline banner once the status has actually resolved to
-      // "not running" — never during the initial unknown window.
+      // Only show the offline banner once status has resolved to a definitive
+      // local-offline result — never during the initial unknown window.
       pushBanner({
         id: "daemon-offline",
         severity: "warning",
@@ -804,6 +818,27 @@ export function Workspace() {
       });
     }
   }, [daemonOffline, daemonStatusResolved, authExpired, pushBanner, dismissBanner, startDaemon]);
+
+  // A status-service failure, timeout, malformed response, or non-local target
+  // problem does not prove the local daemon is stopped. Keep that uncertainty
+  // accurate and retryable instead of offering the misleading Start daemon CTA.
+  useEffect(() => {
+    if (!daemonStatusUnavailable || authExpired || daemonOffline) {
+      dismissBanner("daemon-status-unavailable");
+      return;
+    }
+    pushBanner({
+      id: "daemon-status-unavailable",
+      severity: "warning",
+      title: `Daemon status unavailable — ${daemonStatusUnavailable}`,
+      cta: {
+        label: "Retry",
+        onClick: () => {
+          void refreshDaemonStatus();
+        },
+      },
+    });
+  }, [daemonStatusUnavailable, authExpired, daemonOffline, pushBanner, dismissBanner, refreshDaemonStatus]);
 
   // Re-auth banner: the access-token gate is rejecting every request, so all
   // surfaces are degrading at once. A reload lands on the gate page, which

--- a/src/lib/daemon-status-classification.test.ts
+++ b/src/lib/daemon-status-classification.test.ts
@@ -1,0 +1,146 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  classifyDaemonFailureAvailability,
+  classifyDaemonStatusPoll,
+} from "./daemon-status-classification.ts";
+
+assert.equal(
+  classifyDaemonFailureAvailability({
+    targetMode: "local",
+    responseStatus: 0,
+    reason: "daemon offline",
+  }),
+  "offline",
+  "a refused or absent local socket is definitively offline",
+);
+
+for (const [name, input, expected] of [
+  [
+    "local timeout",
+    { targetMode: "local", responseStatus: 0, reason: "daemon timeout" },
+    "unreachable",
+  ],
+  [
+    "local permission failure",
+    { targetMode: "local", responseStatus: 0, reason: "socket exists but not readable" },
+    "unreachable",
+  ],
+  [
+    "local health error",
+    { targetMode: "local", responseStatus: 503, reason: "not ready" },
+    "unhealthy",
+  ],
+  [
+    "hub timeout",
+    { targetMode: "hub", responseStatus: 0, reason: "hub unreachable: daemon timeout" },
+    "unreachable",
+  ],
+  [
+    "hub auth",
+    { targetMode: "hub", responseStatus: 401, reason: "hub unauthorized" },
+    "unauthorized",
+  ],
+  [
+    "hub health error",
+    { targetMode: "hub", responseStatus: 503, reason: "hub unhealthy" },
+    "unhealthy",
+  ],
+  [
+    "missing hub config",
+    { targetMode: "unconfigured-hub", responseStatus: 0, reason: "missing URL" },
+    "misconfigured",
+  ],
+]) {
+  assert.equal(classifyDaemonFailureAvailability(input), expected, name);
+}
+
+assert.deepEqual(
+  classifyDaemonStatusPoll({
+    responseStatus: 200,
+    responseOk: true,
+    payload: {
+      running: false,
+      availability: "offline",
+      reason: "daemon offline",
+      target: { mode: "local" },
+    },
+  }),
+  { kind: "offline" },
+  "the explicit local-offline classification keeps the Start daemon path",
+);
+
+assert.deepEqual(
+  classifyDaemonStatusPoll({
+    responseStatus: 200,
+    responseOk: true,
+    payload: { running: false, reason: "daemon offline", target: { mode: "local" } },
+  }),
+  { kind: "offline" },
+  "an older status route's exact local-offline payload remains compatible",
+);
+
+for (const [name, input] of [
+  ["route HTTP failure", { responseStatus: 500, responseOk: false, payload: null }],
+  ["malformed payload", { responseStatus: 200, responseOk: true, payload: { nope: true } }],
+  [
+    "local timeout",
+    {
+      responseStatus: 200,
+      responseOk: true,
+      payload: {
+        running: false,
+        availability: "unreachable",
+        reason: "daemon timeout",
+        target: { mode: "local" },
+      },
+    },
+  ],
+  [
+    "hub unauthorized",
+    {
+      responseStatus: 200,
+      responseOk: true,
+      payload: {
+        running: false,
+        availability: "unauthorized",
+        reason: "hub unauthorized",
+        target: { mode: "hub" },
+      },
+    },
+  ],
+  [
+    "unconfigured hub",
+    {
+      responseStatus: 200,
+      responseOk: true,
+      payload: {
+        running: false,
+        availability: "misconfigured",
+        reason: "server hub URL is not configured",
+        target: { mode: "unconfigured-hub" },
+      },
+    },
+  ],
+]) {
+  assert.equal(classifyDaemonStatusPoll(input).kind, "unavailable", name);
+}
+
+assert.deepEqual(
+  classifyDaemonStatusPoll({
+    responseStatus: 0,
+    responseOk: false,
+    payload: null,
+    error: "status request failed",
+  }),
+  { kind: "unavailable", reason: "status request failed" },
+  "a failed browser request is unknown, not offline",
+);
+
+assert.deepEqual(
+  classifyDaemonStatusPoll({ responseStatus: 401, responseOk: false, payload: null }),
+  { kind: "auth-expired" },
+  "the Cave access-token gate remains distinct from daemon availability",
+);
+
+console.log("daemon-status-classification.test.ts: ok");

--- a/src/lib/daemon-status-classification.ts
+++ b/src/lib/daemon-status-classification.ts
@@ -1,0 +1,106 @@
+export type DaemonAvailability =
+  | "online"
+  | "offline"
+  | "unreachable"
+  | "unhealthy"
+  | "unauthorized"
+  | "misconfigured";
+
+export type DaemonTargetMode = "local" | "hub" | "unconfigured-hub";
+
+const AVAILABILITY_VALUES = new Set<DaemonAvailability>([
+  "online",
+  "offline",
+  "unreachable",
+  "unhealthy",
+  "unauthorized",
+  "misconfigured",
+]);
+
+export function classifyDaemonFailureAvailability(input: {
+  targetMode: DaemonTargetMode;
+  responseStatus: number;
+  reason: string | null;
+}): Exclude<DaemonAvailability, "online"> {
+  const { targetMode, responseStatus, reason } = input;
+  if (targetMode === "unconfigured-hub") return "misconfigured";
+  if (targetMode === "hub" && (responseStatus === 401 || responseStatus === 403)) {
+    return "unauthorized";
+  }
+  if (responseStatus > 0) return "unhealthy";
+  if (targetMode === "local" && reason?.trim().toLowerCase() === "daemon offline") {
+    return "offline";
+  }
+  return "unreachable";
+}
+
+type DaemonStatusPayload = {
+  running?: unknown;
+  availability?: unknown;
+  reason?: unknown;
+  target?: { mode?: unknown };
+};
+
+export type DaemonStatusPollResult =
+  | { kind: "running" }
+  | { kind: "offline" }
+  | { kind: "auth-expired" }
+  | { kind: "unavailable"; reason: string };
+
+function statusPayload(value: unknown): DaemonStatusPayload | null {
+  if (!value || typeof value !== "object") return null;
+  return value as DaemonStatusPayload;
+}
+
+function payloadReason(payload: DaemonStatusPayload): string | null {
+  return typeof payload.reason === "string" && payload.reason.trim()
+    ? payload.reason.trim()
+    : null;
+}
+
+function payloadAvailability(payload: DaemonStatusPayload): DaemonAvailability | null {
+  return typeof payload.availability === "string" &&
+    AVAILABILITY_VALUES.has(payload.availability as DaemonAvailability)
+    ? payload.availability as DaemonAvailability
+    : null;
+}
+
+/**
+ * Classify the shell's status poll without converting "could not check" into
+ * "the local daemon is stopped". The legacy fallback keeps rolling upgrades
+ * honest when an older status route returns the exact local-offline response.
+ */
+export function classifyDaemonStatusPoll(input: {
+  responseStatus: number;
+  responseOk: boolean;
+  payload: unknown;
+  error?: string;
+}): DaemonStatusPollResult {
+  const { responseStatus, responseOk, error } = input;
+  if (responseStatus === 401) return { kind: "auth-expired" };
+  if (error) return { kind: "unavailable", reason: error };
+  if (!responseOk) {
+    return { kind: "unavailable", reason: `status service returned http ${responseStatus}` };
+  }
+
+  const payload = statusPayload(input.payload);
+  if (!payload || typeof payload.running !== "boolean") {
+    return { kind: "unavailable", reason: "status service returned an invalid response" };
+  }
+  if (payload.running) return { kind: "running" };
+
+  const reason = payloadReason(payload);
+  const availability = payloadAvailability(payload);
+  const legacyLocalOffline =
+    availability === null &&
+    payload.target?.mode === "local" &&
+    reason?.toLowerCase() === "daemon offline";
+  const explicitLocalOffline =
+    availability === "offline" && payload.target?.mode === "local";
+  if (explicitLocalOffline || legacyLocalOffline) return { kind: "offline" };
+
+  return {
+    kind: "unavailable",
+    reason: reason ?? "daemon status could not be confirmed",
+  };
+}


### PR DESCRIPTION
## Summary

- expose explicit daemon availability (`online`, `offline`, `unreachable`, `unhealthy`, `unauthorized`, or `misconfigured`) from the status route
- reserve the global **Daemon offline** / **Start daemon** banner for a definitively absent or refused local daemon socket
- show a separate retryable **Daemon status unavailable** banner for status-service, timeout, malformed-response, hub-auth, hub-health, and hub-configuration failures
- prevent stale background polls from overwriting a newer post-start result, and query the same resolved daemon target that the route reports

## Root cause

`Workspace.refreshDaemonStatus` reduced every non-401 failure to `running = false`, then set the sticky `daemonOffline` flag. The status route also returned `running: false` for every daemon or hub failure without a machine-readable distinction. Together, those paths falsely presented **Start daemon** when Cave had only failed to check status or when the configured target was a remote hub.

The photographed instance itself was a genuine local-daemon stop: the live status response reported the local named pipe as offline, its recorded PID was dead, and no Coven process or named pipe existed. This PR preserves that result while removing the false-positive paths around it.

Bead: `cave-0xw`

## Validation

- `node --experimental-strip-types src/lib/daemon-status-classification.test.ts`
- focused daemon route, workspace navigation, and Start-daemon tests
- `pnpm check:tests-wired` (1039 test files wired)
- `pnpm typecheck`
- `pnpm test:app` (765 test files passed)
- `pnpm test:api` (198 test files passed)
- `pnpm build` (Next build, bundle budget, and standalone budget passed)
- `git diff --check`
