### PR TITLE
fix(ios): restrict zoom WebView base URLs

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ContentZoom.swift
@@ -34,6 +34,10 @@ extension Notification.Name {
 /// markdown WebView's message handler) can request a full-screen zoom without
 /// threading a closure all the way up the view tree.
 enum ContentZoom {
+    /// Prevent generated zoom documents from resolving relative URLs against
+    /// local files or an attacker-controlled origin.
+    static let safeHTMLBaseURL = URL(string: "about:blank")!
+
     static func present(_ target: ZoomTarget) {
         NotificationCenter.default.post(name: .caveZoomContent, object: target)
     }
@@ -159,7 +163,10 @@ private struct ZoomableHTMLView: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         // Pinch-zoom comes from the user-scalable viewport in the document below.
-        webView.loadHTMLString(Self.document(for: html), baseURL: nil)
+        webView.loadHTMLString(
+            Self.document(for: html),
+            baseURL: ContentZoom.safeHTMLBaseURL
+        )
         return webView
     }
 
@@ -205,7 +212,10 @@ private struct ZoomableCodeView: UIViewRepresentable {
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
         webView.scrollView.indicatorStyle = .white
-        webView.loadHTMLString(Self.document(for: html), baseURL: nil)
+        webView.loadHTMLString(
+            Self.document(for: html),
+            baseURL: ContentZoom.safeHTMLBaseURL
+        )
         return webView
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/ContentZoomTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ContentZoomTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import CovenCave
+
+final class ContentZoomTests: XCTestCase {
+    func testGeneratedHTMLUsesRestrictedBaseURL() {
+        XCTAssertEqual(ContentZoom.safeHTMLBaseURL.absoluteString, "about:blank")
+    }
+}


### PR DESCRIPTION
## Summary

- load generated HTML and code zoom documents against a controlled `about:blank` base URL
- cover the shared safe base URL with a focused iOS unit test
- eliminate both unrestricted `loadHTMLString` calls in `ContentZoom.swift`

## Root cause

The zoom WebViews rendered HTML fragments originating in chat content with `baseURL: nil`. WebKit could therefore resolve relative URLs without a controlled origin, which CodeQL reports as `swift/unsafe-webview-fetch` in [code-scanning alert 130](https://github.com/OpenCoven/coven-cave/security/code-scanning/130).

## Impact

Generated zoom documents can no longer use their base URL to resolve local-file or attacker-controlled relative resources. Existing inline styling, pinch zoom, and rendering behavior remain unchanged.

## Validation

- `git diff --check`
- source audit confirms both `ContentZoom` WebViews use `ContentZoom.safeHTMLBaseURL`
- added `ContentZoomTests.testGeneratedHTMLUsesRestrictedBaseURL`
- macOS iOS build and CodeQL analysis delegated to required PR checks because Xcode is unavailable on this WSL host

Bead: `cave-jke`
