### PR TITLE
fix(browser): reconcile programmatic workspace overlays

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -619,9 +619,11 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     // state rather than a body portal. The rAF runs after the DOM commit.
     const onInteraction = () => scheduleImmediateReconcile();
     const onShellLayout = () => startMotionWindow();
+    const onCoverChange = () => scheduleImmediateReconcile();
     window.addEventListener("resize", scheduleImmediateReconcile);
     window.addEventListener("scroll", scheduleImmediateReconcile, true);
     window.addEventListener("cave:native-webview-layout", onShellLayout);
+    window.addEventListener("cave:native-webview-cover-change", onCoverChange);
     window.addEventListener("cave:onboarding-open", onShellLayout);
     document.addEventListener("animationstart", onMotionStart, true);
     document.addEventListener("animationend", onMotionEnd, true);
@@ -644,6 +646,7 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
       window.removeEventListener("resize", scheduleImmediateReconcile);
       window.removeEventListener("scroll", scheduleImmediateReconcile, true);
       window.removeEventListener("cave:native-webview-layout", onShellLayout);
+      window.removeEventListener("cave:native-webview-cover-change", onCoverChange);
       window.removeEventListener("cave:onboarding-open", onShellLayout);
       document.removeEventListener("animationstart", onMotionStart, true);
       document.removeEventListener("animationend", onMotionEnd, true);

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -344,6 +344,8 @@ assert.match(pane, /new ResizeObserver\(scheduleImmediateReconcile\)/, "resizes 
 assert.match(pane, /portalObserver\.observe\(document\.body, \{\s*childList: true,\s*\}\)/, "only direct body portal mounts are mutation-observed");
 assert.match(pane, /animationstart[\s\S]{0,600}transitionend/, "CSS motion opens and closes a bounded reconcile window");
 assert.match(shell, /dispatchEvent\(new Event\("cave:native-webview-layout"\)\)[\s\S]{0,80}\[banners\]/, "shell banner layout changes explicitly schedule native bounds reconciliation");
+assert.match(workspace, /dispatchEvent\(new Event\("cave:native-webview-cover-change"\)\)[\s\S]{0,180}onboardingOpen/, "workspace overlays explicitly reconcile even when they open without a DOM interaction");
+assert.match(pane, /addEventListener\("cave:native-webview-cover-change", onCoverChange\)/, "programmatic workspace overlays schedule a coalesced visibility reconcile");
 assert.match(pane, /__CAVE_BROWSER_RECONCILE_METRICS__/, "reconciliation count and duration are exposed for native profiling");
 assert.match(pane, /visibilitychange[\s\S]{0,300}hideAll\(\)/, "backgrounding immediately hides native webviews");
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -493,6 +493,12 @@ export function Workspace() {
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
   const [mobileModeAutoRetryBlocked, setMobileModeAutoRetryBlocked] = useState(false);
+  // Workspace-owned overlays are siblings of Shell rather than body portals,
+  // so BrowserPane's narrow portal observer cannot see programmatic opens
+  // (notably first-run onboarding after its status request completes).
+  useEffect(() => {
+    window.dispatchEvent(new Event("cave:native-webview-cover-change"));
+  }, [paletteOpen, shortcutsOpen, onboardingOpen, reminderModalOpen, glyphPickerFor, mobileHandoffOpen]);
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
   // Deep-link target captured at mount, held until the async sessions fetch


### PR DESCRIPTION
## Summary

- dispatch an explicit native-webview cover lifecycle event whenever Workspace-owned overlay state changes
- coalesce that event into BrowserPane visibility reconciliation after the React DOM commit
- add regression guards for programmatic onboarding, palette, and modal opens

## Root cause

Follow-up acceptance review of #3376 found that Workspace-owned overlays are Shell siblings rather than direct `document.body` portals. Programmatic opens, especially first-run onboarding after an async status response, therefore have no click/key event or body portal mutation to wake the new event-driven BrowserPane reconciler. The native child webview could remain visible above the overlay.

## Validation

- `node --experimental-strip-types src/components/browser-polish.test.ts`
- `pnpm typecheck`
- `git diff --check`

## Tracking

Follow-up to #3268 and #3376.

Bead: `cave-9zx`