### PR TITLE
chore(release): stamp v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,34 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
-### Fixed
-- **Desktop: unhandled `listeners[eventId].handlerId` TypeError on focus-listener teardown** — `useRefreshOnFocus` now subscribes to the raw `tauri://focus` event instead of `onFocusChanged`, whose composite unlisten discards its inner async deregistration promises; after an HMR or webview-navigation registry reset those surfaced as an uncatchable runtime error overlay.
+## [0.1.3] - 2026-07-18
+
+> 🧭 **A more capable, resilient Cave.** Coven conversations gain selectable dispatch modes and durable task handoffs, live chats reconnect cleanly across desktop and iOS, and a broad security and performance pass makes everyday work faster and safer.
+
+### Added
+- **Selectable Coven dispatch modes** — choose Broadcast to send a prompt to every familiar at once or Round robin to advance through the roster one familiar at a time (#3377).
+- **Richer chat continuity** — familiar task handoffs route back into chat, next-path suggestions can fill the composer, and reconnectable stream cursors let desktop and iOS re-attach to live turns without restarting them (#3374, #3358, #3331, #3351).
+- **Weaves, progression, and creation surfaces** — a verified weave graph connects threads to memory, renown tiers and ritual streaks add milestone feedback, and Canvas gains an in-grid add flow for described, pasted, or blank sketches (#3363, #3350, #3359, #3342).
+- **Deeper diagnostics and setup guidance** — chat debug tools gain filtering, safer exports, served-model and usage details; daemon status distinguishes offline from failed checks; mobile pairing now explains its probe ladder and recovery steps (#3361, #3357, #3352, #3378, #3305, #3257).
+- **New appearance and model choices** — the OpenAI monochrome theme joins the palette, familiar selection scales through a dropdown, and GPT-5.6 variants are available in the Copilot catalog (#3355, #3360, #3345).
 
 ### Changed
-- **Root stylesheet split by surface (#3264)** — the 868 KiB global CSS every route downloaded is now route-scoped: chat/composer/markdown-reader/dashboard/editor/xterm sheets load with their surfaces, the retired XYFlow import is gone, and `cave-chat.css` is split into shared `cave-md` / `cave-composer` / `chat-list` / `calendar` layers. Root-layout CSS drops 886 → 630 KiB (−29%); `/settings`, reports, and error routes no longer parse conversation or terminal styles. New root + home CSS budgets in the postbuild bundle gate hold the win.
-- **Dashboard confidence now reads from real thread self-reports** — the cockpit's Coven-confidence vital, Familiar-insights column, and Performance matrix score with the same thread-confidence metric the familiar analytics page uses (reflection-derived confidence, tool reliability, memory recall, file-finding) instead of the retired synthetic weighted-factor score; familiars without reflections read "—" until their first thread report lands.
-- **Familiars roster speaks the profile-card language** — roster cards restyled as terminal stat tiles matching the profile share card: monospace lowercase labels, hairline-divided sessions / this-week / memories band with glowing numerals, a 14-day activity strip bucketed like the profile heatmap, framed square avatars, and the checkerboard `familiars` wordmark on the surface header (cave-uw7c).
-- **Omnigent fleet is now per-user vault-gated** — Fleet surfaces (board Fleet button, `omnigent:…` host-chip options, per-familiar fleet defaults) appear if and only if the user has `OMNIGENT_TOKEN` set up in their Cave Vault; credentials that exist only in `~/.omnigent/auth_tokens.json` no longer surface Fleet UI on their own, and the token itself now resolves through the Vault chain (env → `.env.local` → encrypted store → `op://`/`dl://` reference).
+- **Faster rendering and transcript loading** — unchanged conversation transcripts are no longer reparsed, and route-scoped styles cut the root stylesheet from 886 KiB to 630 KiB while keeping new bundle budgets around the improvement (#3375, #3364).
+- **Clearer work surfaces** — research intake is reduced to a focused composer, Familiar analytics use full-width panels, the composer footer owns project/runtime/git/task context, and Skills adopts the Marketplace side-panel grammar (#3365, #3367, #3347, #3343).
+- **Thread-backed truth** — daemon adapters become the default for Threads, decision refusals surface verbatim, dashboard confidence reads from thread self-reports, and the retired synthetic response-confidence path is removed (#3362, #3349, #3332).
+- **Vault-gated fleet access** — Omnigent Fleet surfaces now appear only when `OMNIGENT_TOKEN` resolves through the user's Cave Vault rather than from ambient machine credentials (#3333).
+
+### Fixed
+- **Browser, editor, and iOS stability** — browser panes replace perpetual reconciliation with bounded event-driven recovery, Shiki can no longer mutate the shared theme singleton, and iOS WebView zoom only accepts trusted base URLs (#3376, #3366, #3379).
+- **Chat and session correctness** — suggestion chips target their author, stale recent-chat deletes stay deleted, debug modals bind to the right session, startup blocks no longer leak into exec parsing, and desktop focus-listener teardown no longer throws an unhandled runtime error (#3373, #3369, #3339, #3326, #3334).
+- **Self-healing local runtime state** — built-in-shadowed adapter manifests repair themselves, orphaned home-migration takeovers recover, sidecar ports stay synchronized, and disabled mobile serving clears stale state (#3372, #3356, #3301, #3303).
+- **Studio input reliability** — typed voice IDs persist across field changes and unmounts, while IME composition no longer commits voice fields early (#3354, #3368).
+- **Release provenance** — manual release rebuilds check out the exact tag receiving their artifacts, and Apple notarization credentials no longer appear in process arguments (#3318, #3328).
+
+### Security
+- Project roots, saved workspaces, project search, file actions, and offline replay now validate or constrain user-controlled paths before reading or executing (#3295, #3321, #3323, #3304, #3314, #3325).
+- Local-origin, proxy, mobile, hosted-context, and automation routes now fail closed when tokens, trusted hosts, or loopback guarantees are absent (#3296, #3299, #3302, #3307, #3308, #3309, #3310, #3317, #3319, #3320, #3322).
+- Child-process and prompt boundaries scrub toolchain secrets, fence untrusted daily-report facts, validate GitHub identities, and require local-human authorization for grant mutations (#3294, #3300, #3306, #3327).
 
 ## [0.1.2] - 2026-07-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "block2",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.2"
+version = "0.1.3"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## CovenCave v0.1.3

A more capable, resilient Cave: selectable Broadcast and Round robin Coven modes, durable chat handoffs and reconnectable live turns, richer progression and Weave surfaces, and a broad security, reliability, and performance pass.

### What changed

- stamp all six application version locations from `0.1.2` to `0.1.3`
- curate the `0.1.3` CHANGELOG section from the 80 commits since `v0.1.2`
- prepare from current `origin/main` after #3377, #3375, #3376, #3379, and #3366 merged
- track the release workflow in Bead `cave-9j0`

### Validation

- [x] `node scripts/stamp-release.test.mjs`
- [x] `node scripts/release-notes.test.mjs`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired` — 1,039 test files wired
- [x] `pnpm test:mobile` — 81 test files
- [x] `pnpm build`
- [x] bundle and standalone budgets
- [x] `cargo +1.95.0 check --manifest-path src-tauri/Cargo.toml --locked`
- [ ] `pnpm test:app` — Windows-only path-separator assertion in `scripts/sync-marketplace.test.mjs`, tracked as `cave-ki0`; release diff does not touch that test
- [ ] `pnpm test:api` — host Node reports `C:\Program Files\nodejs\node.exe` as `process.execPath`, but child-process respawn returns `ENOENT`

### Release checklist

- [x] Stamp all six version locations
- [x] Curate CHANGELOG release notes
- [x] Sign the release-prep commit
- [x] Pass the full CI and CodeQL rollup
- [x] Mark ready for review
- [x] Squash merge to `main`
- [x] Create and push signed tag `v0.1.3`
- [x] Verify release artifacts, updater manifest, signatures, checksums, and Homebrew dispatch

