### PR TITLE
feat(dashboard): coven ritual streak KPI on the cockpit (cave-eg4g)

### DIFF
--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -18,6 +18,7 @@ import {
   spaceUsageRows, formatBytes,
 } from "@/lib/dashboard-analytics";
 import type { SpaceUsageArea } from "@/lib/server/space-usage";
+import { covenStreak } from "@/lib/familiar-renown";
 import {
   deriveCovenVitals, deriveCovenInsight, covenSessionsSeries,
   type FamiliarInsightRow, type CovenVitals,
@@ -278,6 +279,9 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
     [vitals, insightRows, ready],
   );
   const covenSeries = useMemo(() => covenSessionsSeries(data.sessions, nowMs, 14), [data.sessions, nowMs]);
+  // Coven ritual streak — consecutive active days across the whole coven
+  // (familiar-renown's bucketing, so it agrees with the roster streak tiles).
+  const streakDays = useMemo(() => covenStreak(data.sessions, nowMs), [data.sessions, nowMs]);
 
   // ── Vitals KPI specs. Every tile is a live analytics figure with a 7-day
   //    trend; each carries the direction that reads as "good" so the delta is
@@ -290,6 +294,8 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
     { icon: "ph:seal-check", value: vitals.avgConfidence, label: "Coven confidence", sub: contractFetchPartial ? scoredCoverageSub : vitals.confidenceTier ?? "fills in after thread reflections", accent: "teal", metric: "confidence", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:sparkle", value: vitals.activeFamiliars, label: "Active familiars", sub: `${vitals.familiarCount} in coven`, accent: "green", metric: "active", good: "up", src: "familiars", href: "/?mode=agents" },
     { icon: "ph:heartbeat", value: vitals.sessions7d, label: "Sessions · 7d", sub: wowSub(vitals.sessionsWowDelta), accent: "lavender", metric: "sessions", good: "up", src: "sessions", href: "/?mode=agents" },
+    // Dignity rule: a broken streak reads as an invitation, never a reprimand.
+    { icon: "ph:flame", value: streakDays, suffix: "d", label: "Ritual streak", sub: streakDays > 0 ? "consecutive active days" : "a session today starts one", accent: "green", metric: "streak", good: "up", src: "sessions", href: "/?mode=agents" },
     { icon: "ph:flag-checkered", value: acceptPct, suffix: "%", label: "Retro accept rate", sub: retroSub(vitals), accent: "blue", metric: "accept", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:list-checks-bold", value: contractPct, suffix: "%", label: "Contract health", sub: contractFetchPartial ? contractCoverageSub : contractSub(vitals), accent: "amber", metric: "contract", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:warning-circle", value: liveOpen ?? model.openCount, label: "Needs you", sub: (liveOpen ?? model.openCount) === 0 ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down", href: "/?mode=inbox" },
@@ -311,6 +317,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       accept: acceptPct ?? 0,
       contract: contractPct ?? 0,
       needs: model.openCount,
+      streak: streakDays,
     };
     setTrends((prev) => {
       const store: TrendStore = { ...prev, [dayKey(now)]: snap };
@@ -320,7 +327,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       return store;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount]);
+  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount, streakDays]);
 
   // ── Draggable secondary layout ──
   const sensors = useSensors(

--- a/src/lib/dashboard-cockpit-format.test.ts
+++ b/src/lib/dashboard-cockpit-format.test.ts
@@ -46,6 +46,15 @@ test("seriesFor yields 7 points oldest→newest with nulls for missing days", ()
   assert.equal(series[0].value, null); // missing day is a gap, not a fake zero
 });
 
+test("streak is a first-class trend key — old snapshots read as gaps", () => {
+  const now = new Date(2026, 6, 14, 12, 0, 0);
+  // Yesterday's snapshot predates the streak metric; today's carries it.
+  const store = { [dayKey(now)]: { streak: 6 }, "2026-07-13": { sessions: 3 } };
+  const series = seriesFor(store, "streak", now);
+  assert.equal(series.at(-1).value, 6);
+  assert.equal(series.at(-2).value, null, "pre-streak snapshot is a gap, never a fake zero");
+});
+
 test("KPI sub-lines teach instead of shrugging", () => {
   assert.equal(retroSub({ retroAccepted: 0, retroReverted: 0 }), "fills in after the first retro run");
   assert.equal(retroSub({ retroAccepted: 3, retroReverted: 1 }), "3/4 accepted");

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -48,7 +48,7 @@ export function reconcileLayout(stored: Partial<Layout>): Layout {
 // ─── 7-day vitals trends (persisted client-side, keyed by day) ────────────────
 
 export const TREND_DAYS = 7;
-export type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contract" | "needs";
+export type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contract" | "needs" | "streak";
 // Persisted JSON can legitimately miss keys for a day (older snapshots predate
 // newer metrics) — seriesFor already reads missing values as gaps.
 export type DaySnap = Partial<Record<TrendKey, number>>;


### PR DESCRIPTION
Follow-up bead `cave-eg4g` from the progression arc (#3350/#3359): the coven-wide ritual streak joins the cockpit vitals.

- Flame `KpiTile` valued by `covenStreak(sessions)` — the same `familiar-renown` bucketing as the roster streak tiles, so the two surfaces always agree.
- `TrendKey` gains `"streak"`; the daily snapshot records it, so the tile accrues a real 7-day sparkline. Pre-streak snapshots read as **gaps, never fake zeros** (pinned).
- Dignity rule: zero-streak sub-line is *"a session today starts one"*.

Verified on the built app (tile renders with the dignity sub-line in a daemon-less state); cockpit format tests 8/8, tsc clean, budgets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)