### PR TITLE
feat(analytics): progression band — renown tier, next-rung meter, ritual streak (cave-p5d0)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11151,6 +11151,59 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-insight__action:hover { color: var(--text-primary); background: var(--bg-hover); }
 .fa-insight__action svg { width: 12px; height: 12px; color: currentColor; }
 
+/* Progression band — tier chip + renown meter + streak, one quiet row
+   between the insight banner and the KPI tiles. Tint recipe on the tier
+   (accent = presence: earned standing, not a CTA). */
+.fa-progression {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-raised);
+}
+.fa-progression__tier {
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+}
+.fa-progression__score {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.fa-progression__meter {
+  flex: 1 1 120px;
+  min-width: 80px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--border-hairline) 60%, transparent);
+  overflow: hidden;
+}
+.fa-progression__meter i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--accent-presence) 70%, transparent);
+}
+.fa-progression__next,
+.fa-progression__streak {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.fa-progression__streak { display: inline-flex; align-items: center; gap: 4px; }
+.fa-progression__streak svg { width: 12px; height: 12px; color: var(--color-warning); }
+
 .fa-kpis {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -4,6 +4,7 @@ import {
   type CovenMemoryEntry,
   type FamiliarCardStats,
 } from "@/components/familiars-view-stats";
+import { deriveRenown, type FamiliarRenown } from "@/lib/familiar-renown";
 import { deriveThreadConfidence, type ThreadConfidence } from "@/lib/thread-confidence";
 import { deriveSignalTrends, type SignalTrends, type ThreadMetricSnapshot } from "@/lib/signal-trends";
 import type { ContractReport } from "@/lib/familiar-contract";
@@ -80,6 +81,12 @@ export type FamiliarAnalyticsModel = {
   threadReports: ThreadSelfReport[];
   /** Thumbs-vote aggregates by model/runtime (message-feedback-rollup). */
   modelFeedback: MessageFeedbackRollup;
+  /**
+   * Renown + ritual streak — the progression system's read of this familiar
+   * (same derivation as the roster cards, so the surfaces always agree).
+   * Null when the familiar itself couldn't be resolved.
+   */
+  progression: { renown: FamiliarRenown; streakDays: number } | null;
   /** Per-day session counts for the trailing 14 days (oldest first). */
   sessionPulse: PulseDay[];
   /** This familiar's sessions, newest first, capped for the drill-through list. */
@@ -235,6 +242,12 @@ export function buildFamiliarAnalyticsModel(
     healRequests,
     threadReports: data.threadReports,
     modelFeedback: data.modelFeedback,
+    progression: familiar
+      ? {
+          renown: deriveRenown({ sessionsTotal: stats.sessionsTotal, memoryCount: stats.memoryCount }),
+          streakDays: stats.streakDays,
+        }
+      : null,
     sessionPulse: buildSessionPulse(familiarSessions, data.familiarId, now),
     recentSessions: [...familiarSessions]
       .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -779,6 +779,49 @@ const AnalyticsInsightBanner = memo(function AnalyticsInsightBanner({
   );
 });
 
+/**
+ * Progression band — the renown system's read of this familiar (same
+ * derivation as the roster card, so the two surfaces always agree): tier,
+ * score, progress toward the next rung, and the ritual streak. A broken
+ * streak reads as an invitation, never a reprimand.
+ */
+const ProgressionBand = memo(function ProgressionBand({
+  progression,
+}: {
+  progression: FamiliarAnalyticsModel["progression"];
+}) {
+  if (!progression) return null;
+  const { renown, streakDays } = progression;
+  const pct = Math.round(renown.progress * 100);
+  return (
+    <section className="fa-progression" aria-label="Progression">
+      <span className="fa-progression__tier">{renown.tier.label}</span>
+      <span className="fa-progression__score">{renown.score} renown</span>
+      <div
+        className="fa-progression__meter"
+        role="img"
+        aria-label={
+          renown.next
+            ? `${renown.next.remaining} renown to ${renown.next.tier.label}`
+            : "Top of the ladder"
+        }
+        title={renown.next ? `${renown.next.remaining} to ${renown.next.tier.label}` : "Top of the ladder"}
+      >
+        <i style={{ width: `${pct}%` }} />
+      </div>
+      <span className="fa-progression__next">
+        {renown.next ? `${renown.next.remaining} to ${renown.next.tier.label}` : "top of the ladder"}
+      </span>
+      <span className="fa-progression__streak">
+        <Icon name="ph:flame" aria-hidden />
+        {streakDays > 0
+          ? `${streakDays}-day streak`
+          : "a session today starts a streak"}
+      </span>
+    </section>
+  );
+});
+
 /** Scannable KPI row — each tile drills through to the section it summarizes. */
 const FamiliarKpis = memo(function FamiliarKpis({
   model,
@@ -930,6 +973,8 @@ export function FamiliarAnalyticsContent({
       </header>
 
       <AnalyticsInsightBanner model={model} healRequestCount={healRequests.length} />
+
+      <ProgressionBand progression={model.progression} />
 
       <FamiliarKpis model={model} healRequestCount={healRequests.length} />
 


### PR DESCRIPTION
Follow-up bead `cave-p5d0` from the progression arc: the familiar analytics page gains a one-row **Progression band** between the insight banner and the KPI tiles.

- `FamiliarAnalyticsModel.progression` — `deriveRenown` over the stats the model builder already computes, plus `streakDays`; identical derivation to the roster card, so the surfaces always agree.
- Tier pill in the tint recipe on `--accent-presence` (earned standing, not a CTA), mono score, **progress meter to the next rung** (accessible label carries "N renown to <tier>"; "top of the ladder" at luminary), flame streak with the dignity rule (zero = *"a session today starts a streak"*).
- Tokens only; static meter — nothing animates, nothing to reduce.

Verified live: Nova renders **magus · 141 renown · 9 to archon · 2-day streak**, meter ~90%. tsc clean, view pins + token-drift 27/27, budgets green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)