### PR TITLE
fix(canvas): stop Save to Canvas duplicating byte-identical sketches (cave-spq7)

### DIFF
--- a/src/app/api/canvas/route.ts
+++ b/src/app/api/canvas/route.ts
@@ -40,8 +40,8 @@ export async function POST(req: Request) {
   if (!body.artifact || typeof body.artifact !== "object") {
     return NextResponse.json({ ok: false, error: "artifact required" }, { status: 400 });
   }
-  const file = await upsertCanvasArtifact(body.artifact);
-  return NextResponse.json({ ok: true, artifacts: file.artifacts });
+  const { file, savedId } = await upsertCanvasArtifact(body.artifact);
+  return NextResponse.json({ ok: true, artifacts: file.artifacts, savedId });
 }
 
 export async function DELETE(req: Request) {

--- a/src/components/canvas-add-tile.tsx
+++ b/src/components/canvas-add-tile.tsx
@@ -189,11 +189,13 @@ export function CanvasAddTile({ familiarId, hero = false, onSaved }: {
         body: JSON.stringify({ artifact }),
       });
       if (!res.ok) throw new Error(String(res.status));
-      const data = (await res.json()) as { artifacts?: CanvasArtifact[] };
+      const data = (await res.json()) as { artifacts?: CanvasArtifact[]; savedId?: string };
       announce(`Saved '${artifact.title}' to Canvas.`);
       dispatch({ type: "saved" });
       setRefineText("");
-      onSaved(data.artifacts ?? [], artifact.id);
+      // The store content-dedupes: re-keeping an unchanged sketch settles into
+      // the existing record's id, so highlight where the save actually landed.
+      onSaved(data.artifacts ?? [], data.savedId ?? artifact.id);
     } catch {
       setSaveError("Couldn't save to the Canvas — try again.");
     } finally {

--- a/src/lib/cave-canvas.test.ts
+++ b/src/lib/cave-canvas.test.ts
@@ -1,7 +1,21 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 
-import { sanitizePositions } from "./cave-canvas.ts";
+// COVEN_CAVE_HOME must be set BEFORE cave-canvas.ts is evaluated — the module
+// computes CANVAS_PATH at load. A static import would hoist above this
+// assignment and point every store call at the REAL ~/.coven store (which is
+// exactly how a test artifact once leaked into live data), so the module is
+// imported dynamically below.
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpHome = mkdtempSync(path.join(os.tmpdir(), "cave-canvas-test-"));
+process.env.COVEN_CAVE_HOME = tmpHome;
+
+const { sanitizePositions, upsertCanvasArtifact, deleteCanvasArtifact, loadCanvas } = await import(
+  "./cave-canvas.ts"
+);
 
 // sanitizePositions is the trust boundary for everything that reaches disk or
 // arrives over the PUT body — it must drop anything that isn't a finite point.
@@ -40,3 +54,81 @@ assert.deepEqual(
 );
 
 console.log("cave-canvas.test.ts ✓");
+
+// ═══════════════════════════════════════════════════════════════════════════
+// upsertCanvasArtifact — content dedupe (cave-spq7). "Save to Canvas" mints a
+// fresh id per click; id-only dedupe let byte-identical re-saves pile up as
+// twin tiles (two dup pairs observed in a real store). Runs against the temp
+// store established by COVEN_CAVE_HOME above.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const art = (id, code, extra = {}) => ({
+  id,
+  title: `t-${id}`,
+  prompt: `p-${id}`,
+  code,
+  kind: "html",
+  createdAt: "2026-07-17T00:00:00Z",
+  updatedAt: "2026-07-17T00:00:00Z",
+  ...extra,
+});
+
+{
+  const first = await upsertCanvasArtifact(art("art-one", "<!doctype html>same"));
+  assert.equal(first.savedId, "art-one", "a fresh save settles under its own id");
+  assert.equal(first.file.artifacts.length, 1);
+
+  // Byte-identical re-save under a NEW id must update the incumbent, not twin it.
+  const resave = await upsertCanvasArtifact(
+    art("art-two", "<!doctype html>same", { title: "renamed", updatedAt: "2026-07-17T01:00:00Z" }),
+  );
+  assert.equal(resave.file.artifacts.length, 1, "unchanged content must not mint a twin tile");
+  assert.equal(resave.savedId, "art-one", "the save settles into the incumbent's id");
+  const settled = resave.file.artifacts[0];
+  assert.equal(settled.id, "art-one", "incumbent id survives (saved position stays keyed to it)");
+  assert.equal(settled.createdAt, "2026-07-17T00:00:00Z", "incumbent createdAt survives");
+  assert.equal(settled.updatedAt, "2026-07-17T01:00:00Z", "caller's updatedAt is taken");
+  assert.equal(settled.title, "renamed", "caller's title is taken");
+
+  // Same code but a DIFFERENT kind is a different artifact — no dedupe.
+  const otherKind = await upsertCanvasArtifact(art("art-react", "<!doctype html>same", { kind: "react" }));
+  assert.equal(otherKind.file.artifacts.length, 2, "same code under another kind stays separate");
+  assert.equal(otherKind.savedId, "art-react");
+
+  // Different content is a plain insert.
+  const different = await upsertCanvasArtifact(art("art-three", "<!doctype html>other"));
+  assert.equal(different.file.artifacts.length, 3, "distinct content inserts normally");
+
+  // Same-id replace (the refine/update path) still wins over content dedupe.
+  const replaced = await upsertCanvasArtifact(art("art-three", "<!doctype html>edited"));
+  assert.equal(replaced.savedId, "art-three", "same-id update replaces in place");
+  assert.equal(replaced.file.artifacts.length, 3, "same-id update does not grow the store");
+
+  // Unusable payload leaves the store untouched and reports no saved id.
+  const junk = await upsertCanvasArtifact({ nope: true });
+  assert.equal(junk.savedId, null, "an unusable payload settles nowhere");
+  assert.equal(junk.file.artifacts.length, 3);
+
+  await deleteCanvasArtifact("art-react");
+  assert.equal((await loadCanvas()).artifacts.length, 2, "delete by id still works");
+}
+
+rmSync(tmpHome, { recursive: true, force: true });
+
+// ── Wiring pins ──────────────────────────────────────────────────────────────
+
+const routeSource = readFileSync(new URL("../app/api/canvas/route.ts", import.meta.url), "utf8");
+assert.match(
+  routeSource,
+  /artifacts: file\.artifacts, savedId/,
+  "POST /api/canvas reports the id the save settled under (dedupe may land on the incumbent)",
+);
+
+const addTileSource = readFileSync(new URL("../components/canvas-add-tile.tsx", import.meta.url), "utf8");
+assert.match(
+  addTileSource,
+  /onSaved\(data\.artifacts \?\? \[\], data\.savedId \?\? artifact\.id\)/,
+  "the add tile highlights the settled tile, not the client-minted id a dedupe discarded",
+);
+
+console.log("cave-canvas upsert dedupe tests ✓");

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -121,22 +121,35 @@ export async function mergeCanvasPositions(
 }
 
 /**
- * Insert or replace an artifact by id, returning the updated file. The caller's
- * record is normalized through sanitizeArtifacts so a bad body can't corrupt
- * the store. `updatedAt` is the caller's responsibility (it has the clock).
+ * Insert or replace an artifact, returning the updated file plus the id the
+ * record settled under. Callers replace by id; when the id is new but the
+ * content is byte-identical to an existing sketch (same kind + code), the
+ * existing record is updated in place instead — "Save to Canvas" mints a
+ * fresh id per click, so id-only dedupe let unchanged re-saves pile up as
+ * twin tiles. Keeping the incumbent's id also keeps its createdAt and saved
+ * position. The caller's record is normalized through sanitizeArtifacts so a
+ * bad body can't corrupt the store. `updatedAt` is the caller's
+ * responsibility (it has the clock).
  */
-export async function upsertCanvasArtifact(artifact: CanvasArtifact): Promise<CanvasFile> {
+export async function upsertCanvasArtifact(
+  artifact: CanvasArtifact,
+): Promise<{ file: CanvasFile; savedId: string | null }> {
   const [clean] = sanitizeArtifacts([artifact]);
   if (!clean) {
     // Nothing usable in the payload — return the current file unchanged.
-    return withLock(loadCanvas);
+    return withLock(async () => ({ file: await loadCanvas(), savedId: null }));
   }
   return withLock(async () => {
     const current = await loadCanvas();
     const without = current.artifacts.filter((a) => a.id !== clean.id);
-    const next: CanvasFile = { ...current, artifacts: [...without, clean] };
+    const twin = without.find((a) => a.kind === clean.kind && a.code === clean.code);
+    const settled = twin
+      ? { ...twin, title: clean.title, prompt: clean.prompt, updatedAt: clean.updatedAt }
+      : clean;
+    const rest = twin ? without.filter((a) => a.id !== twin.id) : without;
+    const next: CanvasFile = { ...current, artifacts: [...rest, settled] };
     await saveCanvas(next);
-    return next;
+    return { file: next, savedId: settled.id };
   });
 }
 


### PR DESCRIPTION
## What

**Bug** (cave-spq7, found by driving the running app): every *Save to Canvas* mints a fresh `art-${uuid}`, and `upsertCanvasArtifact` deduped **by id only** — so re-saving an unchanged sketch (re-save from a gallery-opened viewer, a double save from chat, an add-tile re-keep) appended a byte-identical twin tile. The live store on this machine had two such dup pairs (identical `code`, ids minutes apart), visible as twin cards in the Canvas tab.

## Fix

`upsertCanvasArtifact` content-dedupes at the single choke point (all saves flow through `POST /api/canvas` → here):

- after the id filter, a record with the **same `kind` + `code`** is updated in place — the incumbent keeps its **id** (and with it `createdAt` and its saved canvas position); the caller's `title`/`prompt`/`updatedAt` are taken
- same-**id** replaces (the refine path) still win over content dedupe
- same code under a **different kind** stays a separate artifact
- the function returns the id the save **settled under**; the route reports it as `savedId`, and `CanvasAddTile` highlights that tile instead of the client-minted id a dedupe discarded

## Verification

- Behavioral tests against a `COVEN_CAVE_HOME` temp store (dedupe, id/createdAt survival, kind separation, same-id replace, junk payload, delete) + wiring pins for `savedId`. **Test-hygiene note:** the env var is now set *before* a dynamic import of `cave-canvas.ts` — a hoisted static import evaluated `CANVAS_PATH` against the real store, and an earlier draft's first run leaked one record into live data (removed immediately, backup kept).
- `pnpm test:app` — 765 test files pass; `pnpm typecheck` — clean
- Canvas surface verified in the running app (v0.1.3 build): gallery, viewer modal (Canvas/Code tabs), add-tile composer all healthy; zero console/page errors

## Refs

- Bead: cave-spq7
