### PR TITLE
fix(palette): keep archived chats out of the browse-mode Recent chats list (cave-lzk2)

### DIFF
--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -65,6 +65,14 @@ assert.match(source, /recentSearches\.map/, "empty-query browse mode exposes rec
 assert.match(source, /Clear recent searches/, "recent search history is explicitly clearable");
 assert.match(source, /aria-label="Clear search query"/, "the palette offers a visible clear-query action");
 
+// (cave-lzk2) Archived chats never resurface in the browse-mode "Recent chats"
+// jump list; only an explicit typed query can find them.
+assert.match(
+  source,
+  /if \(!q && s\.archived_at\) return false;/,
+  "empty-query Recent chats excludes archived sessions",
+);
+
 assert.match(
   source,
   /kind:\s*"salem-answer"/,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -419,6 +419,10 @@ export function CommandPalette({
       (Date.parse(a.updated_at || a.created_at) || 0);
     const matchedSessions = sessions.filter((s) => {
       if (!s.familiarId) return false;
+      // Browse mode is the "Recent chats" jump list — archived chats never
+      // resurface there (the chat list's "Show archived" toggle is their
+      // home). A typed query still finds them, like any explicit search.
+      if (!q && s.archived_at) return false;
       if (scoped) {
         if (!scope!.has(s.familiarId)) return false;
         if (!q) return true;


### PR DESCRIPTION
## What

The ⌘K command palette's empty-query **Recent chats** group showed archived chats: `CommandPalette` gets the raw session roster and never filtered `archived_at`, unlike every other recents surface (sidebar recency view, chat empty-state, new-chat launch, home digest — all already filter).

Browse mode now drops archived rows. A **typed query still finds archived chats** — explicit search stays a way back to them, alongside the chat list's *Show archived* toggle.

## Verification

- `command-palette.test.ts` (+ new pin) passes; `pnpm typecheck` clean

Bead: cave-lzk2