### PR TITLE
feat(home): ambient ritual-streak chip in the daily summary (cave-qvox)

### DIFF
--- a/src/lib/home-digest.test.ts
+++ b/src/lib/home-digest.test.ts
@@ -64,8 +64,10 @@ assert.ok(
     familiarNameById,
     nowMs: NOW,
   });
+  const chainedSummary = chained.find((card) => card.kind === "summary");
+  assert.ok(chainedSummary, "a streak contributes to the daily summary");
   assert.ok(
-    chained[0].lines.includes("2-day streak"),
+    chainedSummary.lines.includes("2-day streak"),
     "two consecutive active days surface as the ambient streak chip",
   );
 }

--- a/src/lib/home-digest.test.ts
+++ b/src/lib/home-digest.test.ts
@@ -48,6 +48,28 @@ assert.ok(summary.lines.includes("1 session"), "one non-archived session today")
 assert.ok(summary.lines.includes("1 reminder"), "one reminder fired today");
 assert.ok(summary.lines.includes("1 waiting"), "one response waiting today");
 
+// ── Ritual streak chip (cave-qvox): only a real chain earns the line ─────────
+assert.ok(
+  !summary.lines.some((l) => l.includes("streak")),
+  "a single active day is just 'today' — no streak line, no zero-shame",
+);
+{
+  const chained = buildDigestCards({
+    items,
+    sessions: [
+      ...sessions,
+      { id: "s4", title: "Yesterday's ritual", updated_at: hoursAgo(26), created_at: hoursAgo(26), familiarId: "f1" },
+    ],
+    rssItems,
+    familiarNameById,
+    nowMs: NOW,
+  });
+  assert.ok(
+    chained[0].lines.includes("2-day streak"),
+    "two consecutive active days surface as the ambient streak chip",
+  );
+}
+
 // ── Session cards: today only, archived + yesterday excluded ──────────────────
 const sessionCards = cards.filter((c) => c.kind === "session");
 assert.equal(sessionCards.length, 1, "only today's non-archived session");

--- a/src/lib/home-digest.ts
+++ b/src/lib/home-digest.ts
@@ -20,6 +20,7 @@
  */
 
 import type { InboxItem } from "@/lib/cave-inbox";
+import { covenStreak } from "@/lib/familiar-renown";
 import type { SessionRow } from "@/lib/types";
 import { hostFromUrl, relativeAge, type FeedItem } from "@/lib/rss";
 
@@ -288,6 +289,10 @@ export function buildDigestCards(input: BuildDigestInput): DigestCard[] {
 
   const summaryLines: string[] = [];
   if (todayTouchedCount) summaryLines.push(plural(todayTouchedCount, "session"));
+  // Ambient ritual-streak presence (cave-qvox): only once it's a real chain —
+  // a single active day is just "today", and absence never reads as shame.
+  const streakDays = covenStreak(sessions, nowMs);
+  if (streakDays >= 2) summaryLines.push(`${streakDays}-day streak`);
   if (remindersFired) summaryLines.push(plural(remindersFired, "reminder"));
   if (responsesWaiting) summaryLines.push(`${responsesWaiting} waiting`);
   if (familiarUpdates) summaryLines.push(plural(familiarUpdates, "familiar update"));


### PR DESCRIPTION
Follow-up bead `cave-qvox`: the coven ritual streak joins the home Daily-summary card's count chips — `3 sessions · 2-day streak · 1 reminder`. Ambient presence via the existing card; no new card kind, no layout change.

**Dignity rules**: the line appears only for a real chain (≥ 2 consecutive active days — one day is just "today"), and a broken streak is simply absent, never a shaming zero.

Unit-pinned both ways in `home-digest.test.ts`. Note: the live-home screenshot walk was blocked by the hero variant's collapsed recents section under the headless harness — the summary card itself is long-shipped and this addition is data-only through `covenStreak` (same lib as roster/cockpit, all surfaces agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)