### PR TITLE
feat(shell): home-first launch + cross-surface sidebar memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Changed
+- **Home-first launch + sidebar memory** — every fresh launch opens on the Home surface (chat stays one step away via ⌘2 / the composer; `?mode=` deep links and `#chat-…` hashes still land where they point), and the sidebar's open/collapsed state is now remembered across launches AND surfaces: one global preference (`cave:shell:nav-open`) replaces the per-panel-group layouts that let Home and Chat disagree about the nav (cave-igs4).
+
 ## [0.1.3] - 2026-07-18
 
 > 🧭 **A more capable, resilient Cave.** Coven conversations gain selectable dispatch modes and durable task handoffs, live chats reconnect cleanly across desktop and iOS, and a broad security and performance pass makes everyday work faster and safer.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -340,6 +340,7 @@ export const SUITES = {
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",
     "src/components/shell-left-panels-fit.test.ts",
+    "src/components/shell-nav-memory.test.ts",
     "src/components/workflows-view.test.ts",
     "src/components/projects-view.test.ts",
     "src/components/projects/projects-hub.test.ts",

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -24,11 +24,11 @@ assert.match(
   "workspace should provide exitChatMode so the sidebar back control returns to the prior surface",
 );
 
-// ── Chat-first IA (cave-hsa6): the app boots straight into the conversation. ──
+// ── Home-first boot: the app opens on Home; chat is one step away. ──
 assert.match(
   workspace,
-  /const \[mode, setModeRaw\] = useState<CaveMode>\("chat"\)/,
-  "workspace should boot into chat mode, not home",
+  /const \[mode, setModeRaw\] = useState<CaveMode>\("home"\)/,
+  "workspace should boot into home mode",
 );
 assert.match(
   workspace,

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+// Sidebar open-state memory: the nav panel's open/collapsed state is one
+// GLOBAL user preference (cave:shell:nav-open) applied on boot and on every
+// panel-group switch, so a fresh desktop launch restores the sidebar exactly
+// as the user left it — regardless of which surface (two-pane Home group vs
+// three-pane Chat group) last persisted its own panel-library layout.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
+
+assert.match(
+  shell,
+  /const NAV_OPEN_PREF_KEY = "cave:shell:nav-open";/,
+  "the sidebar preference persists under the cave:shell:nav-open key",
+);
+
+// Boot/group-switch application: after the group settles, a saved preference
+// wins over the group's own stale layout (and over the first-run rail).
+const applyEffect =
+  shell.match(/const navPrefArmedGroupRef[\s\S]*?\}, \[settled, isMobile, groupId\]\);/)?.[0] ?? "";
+assert.ok(applyEffect.length > 0, "the nav preference apply effect exists");
+assert.match(
+  applyEffect,
+  /const pref = readNavOpenPref\(\);/,
+  "boot reads the persisted sidebar preference",
+);
+assert.match(
+  applyEffect,
+  /if \(pref && panel\.isCollapsed\(\)\) \{\s*panel\.expand\(\);/,
+  "a saved open preference expands a collapsed nav on boot",
+);
+assert.match(
+  applyEffect,
+  /\} else if \(!pref && !panel\.isCollapsed\(\)\) \{\s*panel\.collapse\(\);/,
+  "a saved collapsed preference collapses an open nav on boot",
+);
+assert.match(
+  applyEffect,
+  /navPrefArmedGroupRef\.current = groupId;/,
+  "the effect arms preference writes for the settled group",
+);
+
+// Writes are user-driven only: the group must be armed (group-swap layout
+// churn is programmatic) and the code-rail auto-collapse must not be active.
+assert.match(
+  shell,
+  /navPrefArmedGroupRef\.current === groupId &&\s*\n\s*!railAutoCollapsedNavRef\.current\s*\n?\s*\) \{\s*\n\s*writeNavOpenPref\(open\);/,
+  "onResize persists the state only for user-driven changes on the armed group",
+);
+
+// The code-rail coupling raises its flag BEFORE collapsing, so the resulting
+// resize is recognized as programmatic and never overwrites the preference.
+assert.match(
+  shell,
+  /railAutoCollapsedNavRef\.current = true;\s*\n\s*userOverrodeNavRef\.current = false;\s*\n\s*navRef\.current\?\.collapse\(\);/,
+  "rail auto-collapse marks itself programmatic before the panel collapses",
+);
+
+// Storage access is guarded — strict privacy mode must not crash the shell.
+assert.match(
+  shell,
+  /function readNavOpenPref\(\): boolean \| null \{[\s\S]*?catch \{\s*\n?\s*return null;/,
+  "reading the preference tolerates unavailable storage",
+);
+
+console.log("shell-nav-memory: all assertions passed");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -118,6 +118,33 @@ function markShellMinimizeApplied(id: string): void {
   }
 }
 
+// Cross-surface, cross-launch sidebar memory: the nav's open/collapsed state
+// is ONE user preference, persisted globally. The panel library already
+// persists per-GROUP layouts, but the two-pane Home shell and the three-pane
+// Chat shell are separate groups whose layouts never see each other — so a
+// sidebar collapsed on one surface came back open when the next launch (or a
+// surface switch) landed on the other. Boot and group switches re-apply the
+// preference; only user-driven resizes write it (the code-rail auto
+// collapse/restore coupling and programmatic group-swap layout churn don't).
+const NAV_OPEN_PREF_KEY = "cave:shell:nav-open";
+function readNavOpenPref(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(NAV_OPEN_PREF_KEY);
+    return raw === "1" ? true : raw === "0" ? false : null;
+  } catch {
+    return null;
+  }
+}
+function writeNavOpenPref(open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(NAV_OPEN_PREF_KEY, open ? "1" : "0");
+  } catch {
+    /* ignore — strict privacy mode or quota */
+  }
+}
+
 // The left nav collapses to an icons-only rail (instead of vanishing) so the
 // destination icons stay reachable. Sizes at/below the rail read as "collapsed".
 const NAV_RAIL_PX = 56;
@@ -461,6 +488,30 @@ function ShellInner({
     group.setLayout({ ...cur, nav: railPct, detail: cur.detail + (nav - railPct) });
   }, [settled, isMobile, groupId]);
 
+  // Apply the remembered sidebar state on boot and on every panel-group switch
+  // (Home's two-pane shell and Chat's three-pane shell persist their layouts
+  // separately, so without this the OTHER group's stale width wins). Runs after
+  // the minimize-by-default effect above so a saved preference beats the
+  // first-run rail. onResize only writes the preference once this effect has
+  // armed the CURRENT group — the layout churn a group swap fires must never
+  // clobber the user's choice with the incoming group's stale width.
+  const navPrefArmedGroupRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!settled || isMobile) return;
+    const pref = readNavOpenPref();
+    const panel = navRef.current;
+    if (panel && pref !== null && !railAutoCollapsedNavRef.current) {
+      if (pref && panel.isCollapsed()) {
+        panel.expand();
+        setNavOpen(true);
+      } else if (!pref && !panel.isCollapsed()) {
+        panel.collapse();
+        setNavOpen(false);
+      }
+    }
+    navPrefArmedGroupRef.current = groupId;
+  }, [settled, isMobile, groupId]);
+
   useEffect(() => {
     onNavOpenChange?.(navOpen);
   }, [navOpen, onNavOpenChange]);
@@ -519,11 +570,13 @@ function ShellInner({
       if (isMobile) return;
       if (open) {
         // Rail became visible: collapse the nav only if it's currently open,
-        // and remember we did it so we can restore later.
+        // and remember we did it so we can restore later. The flag is raised
+        // BEFORE collapse() so the resulting onResize is recognized as
+        // programmatic and doesn't overwrite the persisted nav preference.
         if (navOpen) {
-          navRef.current?.collapse();
           railAutoCollapsedNavRef.current = true;
           userOverrodeNavRef.current = false;
+          navRef.current?.collapse();
         }
         return;
       }
@@ -605,7 +658,19 @@ function ShellInner({
         collapsedSize={isMobile ? 0 : NAV_RAIL_PX}
         panelRef={navRef}
         onResize={(size) => {
-          setNavOpen((size.inPixels ?? 0) > NAV_OPEN_THRESHOLD_PX);
+          const open = (size.inPixels ?? 0) > NAV_OPEN_THRESHOLD_PX;
+          setNavOpen(open);
+          // Persist user-driven changes only: the group must be armed (boot /
+          // group-swap layout churn is programmatic) and the code rail must
+          // not be mid-auto-collapse (its restore path clears the flag before
+          // expanding, so the restore correctly re-records "open").
+          if (
+            !isMobile &&
+            navPrefArmedGroupRef.current === groupId &&
+            !railAutoCollapsedNavRef.current
+          ) {
+            writeNavOpenPref(open);
+          }
         }}
       >
         {/* CHAT-D13-05: every complementary landmark carries a distinct

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -16,13 +16,12 @@ assert.match(
   "WorkspaceMode union keeps \"agents\" for internal familiar detail flows",
 );
 
-// Chat-first boot (cave-hsa6): the app opens on the conversation. Home remains
-// one step away — the chat Back control's lastNonChatMode still defaults to
-// "home", and ⌘1 / nav / deep links reach it as before.
+// Home-first boot: the app opens on the Home overview; Chat is one step away
+// and the chat Back control still returns to Home by default.
 assert.match(
   workspace,
-  /const \[mode, setModeRaw\] = useState<CaveMode>\("chat"\)/,
-  "Default workspace mode lands on Chat (chat-first boot, cave-hsa6)",
+  /const \[mode, setModeRaw\] = useState<CaveMode>\("home"\)/,
+  "Default workspace mode lands on Home (home-first boot)",
 );
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -321,12 +321,13 @@ export function Workspace() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  // Chat-first boot (cave-hsa6): the app opens on the conversation — the chat
-  // surface with the thread sidebar (a fresh session lands on the task-aware
-  // empty state). Home stays one step away (⌘1 / nav / the chat Back control,
-  // whose lastNonChatMode below still defaults to "home"). Deep links (?mode=,
-  // #chat-…) and cave:navigate-mode override this as before.
-  const [mode, setModeRaw] = useState<CaveMode>("chat");
+  // Home-first boot: every fresh launch (desktop app window or web tab)
+  // opens on the Home surface — the daily overview with the universal
+  // composer — per operator direction (this reverses cave-hsa6's chat-first
+  // boot). Chat stays one step away (⌘2 / nav / the composer submit), and
+  // deep links (?mode=, #chat-…) and cave:navigate-mode override this as
+  // before, so restored sessions and share links still land where they point.
+  const [mode, setModeRaw] = useState<CaveMode>("home");
   // Which tab the Grimoire surface shows. Lifted here so the Journal nav row can
   // route straight into Grimoire's Journal tab (see the setMode `journal` branch)
   // and so the choice persists across Grimoire remounts within a session.

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// Verifies the chat boot landing (cave-qvwu): booting into `/` paints the
+// Verifies the chat surface landing (cave-qvwu): opening chat (home-first
+// boot means via ?mode=chat) paints the
 // zero-turn compose view (ChatEmptyState + composer) without waiting for
 // /api/sessions/list — the fetch that used to gate the boot-compose effect
 // and left users on the ChatList skeleton wall for its full duration. Also
@@ -80,7 +81,7 @@ test.describe("chat boot landing", () => {
       await route.fulfill({ json: { ok: true, sessions: [SESSION_S1] } });
     });
 
-    await page.goto("/");
+    await page.goto("/?mode=chat");
     await expect(page.locator(".cave-chat-empty")).toBeVisible({ timeout: 45_000 });
     expect(sessionsFulfilled).toBe(false);
 
@@ -117,7 +118,7 @@ test.describe("chat boot landing", () => {
       route.fulfill({ json: { ok: true, sessions: [] } }),
     );
 
-    await page.goto("/");
+    await page.goto("/?mode=chat");
     const empty = page.locator(".cave-chat-empty");
     await expect(empty).toBeVisible({ timeout: 45_000 });
 

--- a/tests/chat-rename.spec.ts
+++ b/tests/chat-rename.spec.ts
@@ -59,7 +59,7 @@ async function setup(page: Page): Promise<{ patched: () => unknown }> {
       },
     }),
   );
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   await page.waitForTimeout(500);
   await page.keyboard.press("Meta+2");
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -43,7 +43,7 @@ async function gotoChat(page: Page) {
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions: SESSIONS } }),
   );
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   // Switch to the Chat surface (⌘2) — default landing is Home.
   await page.waitForTimeout(500);
   await page.keyboard.press("Meta+2");

--- a/tests/chat-split-panes.spec.ts
+++ b/tests/chat-split-panes.spec.ts
@@ -73,7 +73,7 @@ async function setup(page: Page) {
 }
 
 async function openChatSurface(page: Page) {
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   await page.waitForTimeout(500);
   await page.keyboard.press("Meta+2");
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });

--- a/tests/chat-task-chip-nav.spec.ts
+++ b/tests/chat-task-chip-nav.spec.ts
@@ -90,7 +90,7 @@ async function setup(page: Page) {
     }
     return route.continue();
   });
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   await page.waitForTimeout(500);
   await page.keyboard.press("Meta+2");
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -54,7 +54,7 @@ async function base(page: Page, sessions: unknown[]) {
       },
     }),
   );
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   await page.waitForTimeout(500);
   await page.keyboard.press("Meta+2");
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });

--- a/tests/composer-runtime-chip.spec.ts
+++ b/tests/composer-runtime-chip.spec.ts
@@ -92,7 +92,7 @@ async function seed(page: Page): Promise<Mutable> {
 test.describe("composer runtime chip", () => {
   test("always visible with the runtime + model, popover carries radio groups", async ({ page }) => {
     await seed(page);
-    await page.goto("/");
+    await page.goto("/?mode=chat");
     const chip = page.getByRole("button", { name: /Runtime: /, exact: false });
     await expect(chip).toBeVisible({ timeout: 45_000 });
     // toHaveAttribute retries — the label settles once model-state hydrates.
@@ -112,7 +112,7 @@ test.describe("composer runtime chip", () => {
 
   test("picking a runtime rebinds via /api/config, flips the chip, and refreshes the roster", async ({ page }) => {
     const state = await seed(page);
-    await page.goto("/");
+    await page.goto("/?mode=chat");
     const chip = page.getByRole("button", { name: /Runtime: /, exact: false });
     await expect(chip).toBeVisible({ timeout: 45_000 });
     await expect(chip).toHaveAttribute("aria-label", /Runtime: Codex/, { timeout: 15_000 });

--- a/tests/github-chat-cards.spec.ts
+++ b/tests/github-chat-cards.spec.ts
@@ -104,7 +104,7 @@ async function boot(page: Page, opts: { mergedRef: { merged: boolean }; mergeCal
     await route.fulfill({ json: { ok: true, merged: true, sha: "deadbee" } });
   });
 
-  await page.goto("/");
+  await page.goto("/?mode=chat");
   await page.waitForTimeout(400);
   await page.keyboard.press("Meta+2");
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });


### PR DESCRIPTION
Operator-requested launch behavior (bead **cave-igs4**):

## 1. Home-first launch

Every fresh launch (desktop window or web tab) opens on the **Home** surface instead of Chat — reverses cave-hsa6's chat-first boot per operator direction. Chat stays one step away (⌘2 / nav / submitting the home composer), and `?mode=` deep links, `#chat-…` hashes, and `cave:navigate-mode` override boot exactly as before.

## 2. Sidebar open-state memory (cross-launch AND cross-surface)

The nav's open/collapsed state becomes **one global persisted preference** (`cave:shell:nav-open`), applied after each panel group settles.

**Why the old persistence wasn't enough:** the panel library persists layouts *per group*, and Home's two-pane shell (`…v3.two-pane`) and Chat's three-pane shell (`…v3`) are separate groups that never see each other's state — collapsing the sidebar on one surface came back open whenever the next launch (or a surface switch) landed on the other group.

**Write discipline** (so programmatic moves can't clobber the user's choice):
- `onResize` persists only once the *current* group is armed — boot and group-swap layout churn never write
- the code-rail auto-collapse raises its programmatic flag **before** collapsing; its restore path still re-records "open"

**Verified end-to-end** (Playwright, dev server): boot → Home; expand → relaunch → still open; switch to Chat (other group) → still open; collapse there → relaunch onto Home → still collapsed.

## Test changes

- Boot pins updated: `workspace-familiars-landing`, `chat-sidebar-wiring` (home-first)
- New `shell-nav-memory.test.ts` pins the preference mechanics (registered in run-tests)
- 8 chat-surface e2e specs now reach chat explicitly via `/?mode=chat` (they were riding the chat-first boot)

## Validation

- `pnpm test:app` — **766/766**
- `pnpm typecheck` — clean
- Touched e2e specs pass locally (`--project desktop`): 11 passed; `chat-task-chip-nav` is flaky-on-retry **on untouched main too** (pre-existing); the `preferences-desktop` magnification spec fails only on this machine's legacy `~/.coven` symlink state (also fails on clean main locally; CI homes are clean)
