### PR TITLE
test(analytics): cover progression band derivation and placement

### DIFF
--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -214,6 +214,7 @@ export function buildFamiliarAnalyticsModel(
         familiars: [familiar],
         sessions: familiarSessions,
         covenEntries: data.covenEntries.filter((entry) => entry.familiar_id === familiar.id),
+        now,
       }).get(familiar.id) ?? emptyStats()
     : emptyStats();
   const growthReport = familiar

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -323,6 +323,21 @@ describe("FamiliarAnalyticsView", () => {
     assert.equal(model.confidence.reportCount, 1);
   });
 
+  it("derives progression from familiar stats and omits it for a missing familiar", async () => {
+    mockFetchFor("trusted");
+    const data = await loadFamiliarAnalyticsData("cody");
+    const model = buildFamiliarAnalyticsModel(data, Date.parse("2026-06-25T20:00:00.000Z"));
+
+    assert.equal(model.progression?.renown.score, 13, "ten sessions plus one memory earns 13 renown");
+    assert.equal(model.progression?.renown.tier.key, "adept");
+    assert.equal(model.progression?.renown.next?.remaining, 37);
+    assert.equal(model.progression?.renown.progress, 3 / 40);
+    assert.equal(model.progression?.streakDays, 1);
+
+    const missing = buildFamiliarAnalyticsModel({ ...data, familiars: [] });
+    assert.equal(missing.progression, null);
+  });
+
   it("derives signal trends from metric snapshots under a fixed clock", async () => {
     mockFetchFor("trusted");
     const data = await loadFamiliarAnalyticsData("cody");
@@ -402,6 +417,16 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(source, /<AnalyticsInsightBanner model=\{model\} healRequestCount=\{healRequests\.length\}/, "banner is rendered with the model");
     assert.match(source, /deriveAnalyticsInsight\(model, healRequestCount\)/, "banner derives the insight from the model");
     assert.match(source, /fa-insight--\$\{insight\.tone\}/, "banner is tinted by tone");
+  });
+
+  it("renders progression between the insight banner and KPI row with intentional copy", () => {
+    assert.match(
+      source,
+      /<AnalyticsInsightBanner[\s\S]*<ProgressionBand progression=\{model\.progression\} \/>[\s\S]*<FamiliarKpis/,
+      "progression is placed between the insight and KPI summary",
+    );
+    assert.match(source, /"Top of the ladder"/, "top-tier accessible copy remains explicit");
+    assert.match(source, /"a session today starts a streak"/, "zero streaks use invitational copy");
   });
 
   it("derives a 14-day session pulse and renders it in the hero", async () => {


### PR DESCRIPTION
Follow-up to #3391, which merged while its two Copilot review threads were still unresolved.\n\n## Changes\n- cover renown score, tier, next-rung remainder/progress, streak, and missing-familiar behavior\n- pin the progression band between the insight banner and KPI row, including top-tier and zero-streak copy\n- pass the analytics model's injected clock into familiar stat derivation so streak assertions and model output use one clock\n\n## Validation\n- focused familiar analytics test: 28/28\n- `pnpm typecheck`\n- `pnpm check:tests-wired` (1039 files)\n- `pnpm test:app` (765 files)\n- `git diff --check`\n\nTracks Bead `cave-wzp`.