### PR TITLE
fix(dashboard): keep unloaded session trends as gaps

### DIFF
--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -45,7 +45,7 @@ import {
   SpaceUsagePanel, UsagePanel, type ConfidenceRow, type KpiTileProps,
 } from "@/components/dashboard/cockpit-panels";
 import {
-  DEFAULT_LAYOUT, STATUS_ORDER, coverageSub, contractSub, dayKey, longDate, panelTitle,
+  DEFAULT_LAYOUT, STATUS_ORDER, buildTrendSnapshot, coverageSub, contractSub, dayKey, longDate, panelTitle,
   reconcileLayout, retroSub, seriesFor, wowSub,
   type DaySnap, type Layout, type TrendKey, type TrendStore,
 } from "@/lib/dashboard-cockpit-format";
@@ -308,9 +308,10 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
     try { const raw = localStorage.getItem(TRENDS_KEY); if (raw) setTrends(JSON.parse(raw) as TrendStore); } catch { /* ignore */ }
   }, []);
   const vitalsReady = ready.has("cards") && ready.has("familiars") && (confidenceRaw !== null || data.familiars.length === 0);
+  const sessionsReady = ready.has("sessions");
   useEffect(() => {
     if (!vitalsReady) return;
-    const snap: DaySnap = {
+    const snap: DaySnap = buildTrendSnapshot({
       confidence: vitals.avgConfidence ?? 0,
       active: vitals.activeFamiliars,
       sessions: vitals.sessions7d,
@@ -318,7 +319,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       contract: contractPct ?? 0,
       needs: model.openCount,
       streak: streakDays,
-    };
+    }, sessionsReady);
     setTrends((prev) => {
       const store: TrendStore = { ...prev, [dayKey(now)]: snap };
       const days = Object.keys(store).sort();
@@ -327,7 +328,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       return store;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [vitalsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount, streakDays]);
+  }, [vitalsReady, sessionsReady, vitals.avgConfidence, vitals.activeFamiliars, vitals.sessions7d, acceptPct, contractPct, model.openCount, streakDays]);
 
   // ── Draggable secondary layout ──
   const sensors = useSensors(

--- a/src/lib/dashboard-cockpit-format.test.ts
+++ b/src/lib/dashboard-cockpit-format.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   DEFAULT_LAYOUT,
   PANEL_TITLES,
+  buildTrendSnapshot,
   confidenceColor,
   contractSub,
   coverageSub,
@@ -53,6 +54,18 @@ test("streak is a first-class trend key — old snapshots read as gaps", () => {
   const series = seriesFor(store, "streak", now);
   assert.equal(series.at(-1).value, 6);
   assert.equal(series.at(-2).value, null, "pre-streak snapshot is a gap, never a fake zero");
+});
+
+test("session-backed trends stay gaps until sessions finish loading", () => {
+  const values = {
+    confidence: 0, active: 0, sessions: 0, accept: 0,
+    contract: 0, needs: 0, streak: 0,
+  };
+  assert.deepEqual(buildTrendSnapshot(values, false), {
+    confidence: 0, active: 0, accept: 0, contract: 0, needs: 0,
+  });
+  assert.deepEqual(buildTrendSnapshot(values, true), values,
+    "an empty but loaded session list records honest zeros");
 });
 
 test("KPI sub-lines teach instead of shrugging", () => {

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -54,6 +54,26 @@ export type TrendKey = "confidence" | "active" | "sessions" | "accept" | "contra
 export type DaySnap = Partial<Record<TrendKey, number>>;
 export type TrendStore = Record<string, DaySnap>; // "YYYY-MM-DD" -> snapshot
 
+/** Build today's persisted snapshot without fabricating session-backed zeros
+ * while the session list is still loading. */
+export function buildTrendSnapshot(
+  values: Record<TrendKey, number>,
+  sessionsReady: boolean,
+): DaySnap {
+  const snap: DaySnap = {
+    confidence: values.confidence,
+    active: values.active,
+    accept: values.accept,
+    contract: values.contract,
+    needs: values.needs,
+  };
+  if (sessionsReady) {
+    snap.sessions = values.sessions;
+    snap.streak = values.streak;
+  }
+  return snap;
+}
+
 export function dayKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }


### PR DESCRIPTION
## Summary
- follow up the unresolved review finding on #3390
- omit session-backed `sessions` and `streak` trend values until `/api/sessions/list` has completed loading
- rerun persistence when sessions become ready, so an empty loaded list records honest zero values
- add focused regression coverage for both loading and loaded-empty states

## Acceptance criteria
- [x] Unloaded session data cannot persist fake zero trend points
- [x] Missing session-backed data remains a gap
- [x] An empty but loaded session list records real zero values
- [x] Session readiness participates in the persistence effect dependencies

## Verification
- `node --experimental-strip-types --test src/lib/dashboard-cockpit-format.test.ts` (9/9)
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app` (765/765 files)
- `pnpm build` (including bundle and standalone budgets)

Tracks `cave-0dh`.
