### PR TITLE
fix(canvas): preserve explicit artifact updates after dedupe

### DIFF
--- a/src/components/canvas-add-tile.tsx
+++ b/src/components/canvas-add-tile.tsx
@@ -189,7 +189,7 @@ export function CanvasAddTile({ familiarId, hero = false, onSaved }: {
         body: JSON.stringify({ artifact }),
       });
       if (!res.ok) throw new Error(String(res.status));
-      const data = (await res.json()) as { artifacts?: CanvasArtifact[]; savedId?: string };
+      const data = (await res.json()) as { artifacts?: CanvasArtifact[]; savedId?: string | null };
       announce(`Saved '${artifact.title}' to Canvas.`);
       dispatch({ type: "saved" });
       setRefineText("");

--- a/src/lib/cave-canvas.test.ts
+++ b/src/lib/cave-canvas.test.ts
@@ -104,6 +104,17 @@ const art = (id, code, extra = {}) => ({
   assert.equal(replaced.savedId, "art-three", "same-id update replaces in place");
   assert.equal(replaced.file.artifacts.length, 3, "same-id update does not grow the store");
 
+  // Same-id replacement remains authoritative even if the replacement now
+  // matches another artifact's content. It must not delete the edited record
+  // and settle under the other id.
+  const matchingReplace = await upsertCanvasArtifact(art("art-three", "<!doctype html>same"));
+  assert.equal(matchingReplace.savedId, "art-three", "same-id update does not settle under a twin");
+  assert.equal(matchingReplace.file.artifacts.length, 3, "same-id update does not collapse distinct records");
+  assert.equal(
+    matchingReplace.file.artifacts.find((artifact) => artifact.id === "art-three")?.code,
+    "<!doctype html>same",
+  );
+
   // Unusable payload leaves the store untouched and reports no saved id.
   const junk = await upsertCanvasArtifact({ nope: true });
   assert.equal(junk.savedId, null, "an unusable payload settles nowhere");

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -141,8 +141,14 @@ export async function upsertCanvasArtifact(
   }
   return withLock(async () => {
     const current = await loadCanvas();
+    const incumbent = current.artifacts.find((a) => a.id === clean.id);
     const without = current.artifacts.filter((a) => a.id !== clean.id);
-    const twin = without.find((a) => a.kind === clean.kind && a.code === clean.code);
+    // An explicit update to an existing id is authoritative, even when its new
+    // content happens to match another artifact. Content dedupe is only for
+    // saves that arrive under a newly minted id.
+    const twin = incumbent
+      ? undefined
+      : without.find((a) => a.kind === clean.kind && a.code === clean.code);
     const settled = twin
       ? { ...twin, title: clean.title, prompt: clean.prompt, updatedAt: clean.updatedAt }
       : clean;


### PR DESCRIPTION
## What

Follow-up to #3392, which merged while its final review pass was in progress.

- matches the Canvas POST response type to the actual nullable `savedId` contract requested in the unresolved review thread
- keeps same-id replacement authoritative when an edit changes an artifact to content that already exists under another id; content dedupe now applies only to newly minted ids
- adds regression coverage for that same-id/twin collision

## Verification

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/cave-canvas.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired` — 1,039 test files wired
- `pnpm test:app` — 765 test files passed
- `git diff --check`

## Tracking

- Original PR: #3392
- Bead: cave-kam
