### PR TITLE
fix(chat): prevent deleted sessions from reappearing

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -24,6 +24,7 @@ export const SUITES = {
     "src/lib/array-content-equal.test.ts",
     "src/lib/session-list-equal.test.ts",
     "src/lib/session-list-deletes.test.ts",
+    "src/lib/use-undo-delete-deferred.test.ts",
     "src/lib/tool-edit-stat.test.ts",
     "src/lib/split-snap.test.ts",
     "src/lib/chat-split.test.ts",

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -108,8 +108,8 @@ assert.doesNotMatch(
 
 // In-chat delete lives ONLY in the session overflow (kebab) menu now — the
 // danger "Delete chat…" item swaps the menu body to a confirm view, the
-// explicit Delete commits via deleteChat, and success refreshes the session
-// list and navigates back. No standalone header trash button remains.
+// explicit Delete commits via deleteChat, and success reports the confirmed id
+// to Workspace and navigates back. No standalone header trash button remains.
 assert.match(
   source,
   /const deleteChat = async[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(sessionId\)\}`, \{ method: "DELETE" \}\)/,
@@ -117,8 +117,8 @@ assert.match(
 );
 assert.match(
   source,
-  /onSessionsChanged\?\.\(\);\s*\n\s*onBack\?\.\(\);/,
-  "Successful delete refreshes sessions and navigates back to the list",
+  /onSessionsDeleted\(\[sessionId\]\);\s*\n\s*onBack\?\.\(\);/,
+  "Successful delete reaches the shared boundary and navigates back to the list",
 );
 
 // The kebab's delete is a two-step guard: the danger item arms a confirm view

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -30,8 +30,8 @@ assert.match(
 
 assert.match(
   source,
-  /onSessionsChanged\?\.\(\)/,
-  "ChatList should ask the shell to refresh sessions after deleting a chat",
+  /onSessionsDeleted\(\[sessionId\]\)/,
+  "ChatList should report a confirmed single delete to the Workspace boundary",
 );
 
 assert.match(
@@ -356,6 +356,8 @@ assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} set
 assert.match(source, /const bulkDelete = \(\) =>/, "bulk delete handler exists (deferred/undoable)");
 assert.match(source, /const bulkArchive = async \(archived: boolean\)/, "bulk archive/unarchive handler exists");
 assert.match(source, /Promise\.all\([\s\S]{0,80}fetch\(`\/api\/chat\/conversation\//, "bulk delete runs the per-chat deletes in parallel");
+assert.match(source, /successfulSessionIds\(removed\.map\(\(session\) => session\.id\), results\)/, "bulk delete selects only confirmed ids");
+assert.match(source, /if \(deletedIds\.length > 0\) onSessionsDeleted\(deletedIds\)/, "bulk delete reports confirmed ids once");
 // Bulk delete is deferred + undoable via the shared undo toast.
 assert.match(source, /useUndoDelete<SessionRow\[\]>\(\)/, "bulk delete routes through useUndoDelete");
 assert.match(source, /scheduleBulkDelete\(\s*removed,/, "bulk delete schedules the batch through the undo window");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -19,7 +19,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { OverflowMenu } from "@/components/ui/overflow-menu";
 import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { useUndoDelete } from "@/lib/use-undo-delete";
-import { cancelHoverPrefetch, hoverPrefetchConversation, invalidateConversation } from "@/lib/conversation-cache";
+import { cancelHoverPrefetch, hoverPrefetchConversation } from "@/lib/conversation-cache";
+import { successfulSessionIds } from "@/lib/session-list-deletes";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
@@ -80,6 +81,7 @@ type Props = {
   onOpen: (sessionId: string, familiarId?: string | null, findQuery?: string) => void;
   onNewChat: (projectRoot?: string, familiarId?: string | null) => void;
   onSessionsChanged?: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   /** Open a URL in the in-app browser (the PR-status badge's click-through).
    *  Falls back to a new tab when absent. */
   onOpenUrl?: (url: string) => void;
@@ -246,7 +248,7 @@ function ChatListSection({
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, onOpenUrl, sessionsLoaded = true, sessionsError = false, compact = false }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, onSessionsDeleted, onOpenUrl, sessionsLoaded = true, sessionsError = false, compact = false }: Props) {
   useMinuteTick(); // keep the "Xm ago" timestamps current without a data refresh
   // Scope the project rail to what the active familiar is granted; with no
   // active familiar (all-familiars view) this loads every project as before.
@@ -606,8 +608,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       }
       setConfirmDeleteId(null);
       setActiveId((current) => (current === sessionId ? null : current));
-      invalidateConversation(sessionId);
-      onSessionsChanged?.();
+      onSessionsDeleted([sessionId]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "delete failed");
     } finally {
@@ -701,7 +702,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const selectedVisibleCount = visibleIds.filter((id) => selectedIds.has(id)).length;
 
   // Deferred + undoable: hide the selected chats now, fire the DELETEs only
-  // after the undo window, refetch once. Undo restores the whole batch.
+  // after the undo window, then report confirmed ids. Undo restores the batch.
   const bulkDelete = () => {
     // Only delete rows that are both selected AND currently visible — a section
     // collapsed after selecting must protect its now-hidden chats from deletion.
@@ -718,15 +719,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         const results = await Promise.all(
           removed.map((s) =>
             fetch(`/api/chat/conversation/${encodeURIComponent(s.id)}`, { method: "DELETE" })
-              .then((r) => r.json().catch(() => ({ ok: false })))
-              .then((j) => {
-                if (j.ok) invalidateConversation(s.id);
-                return !!j.ok;
+              .then(async (response) => {
+                const json = await response.json().catch(() => ({ ok: false }));
+                return response.ok && Boolean(json.ok);
               })
               .catch(() => false),
           ),
         );
-        if (results.some(Boolean)) onSessionsChanged?.();
+        const deletedIds = successfulSessionIds(removed.map((session) => session.id), results);
+        if (deletedIds.length > 0) onSessionsDeleted(deletedIds);
         if (results.some((ok) => !ok)) setError("Some chats couldn't be deleted.");
       },
     );

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -69,6 +69,7 @@ type Props = {
   onSetActiveFamiliar?: (id: string) => void;
   onSessionStarted?: () => void;
   onSessionsChanged?: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   sessionsLoaded?: boolean;
   /** Last session-list load failed — forwarded to ChatList (cave-x6k5). */
   sessionsError?: boolean;
@@ -135,6 +136,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onSetActiveFamiliar,
     onSessionStarted,
     onSessionsChanged,
+    onSessionsDeleted,
     sessionsLoaded,
     sessionsError,
     familiarsLoaded,
@@ -661,6 +663,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         sessionsError={sessionsError}
         compact={compact}
         onSessionsChanged={onSessionsChanged}
+        onSessionsDeleted={onSessionsDeleted}
         onOpenUrl={onOpenUrl}
         onOpen={(sessionId, familiarId, findQuery) => {
           const next = selectFamiliarForChat(familiarId);
@@ -722,6 +725,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       daemonRunning={daemonRunning}
       sessions={sessions}
       onSessionsChanged={onSessionsChanged}
+      onSessionsDeleted={onSessionsDeleted}
       onBack={() => setView({ kind: "list" })}
       onSessionStarted={(sid) => {
         // Only promote the sessionId in the view state when the current chat
@@ -767,6 +771,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
               daemonRunning={daemonRunning}
               sessions={sessions}
               onSessionsChanged={onSessionsChanged}
+              onSessionsDeleted={onSessionsDeleted}
               onOpenTask={onOpenTask}
               onOpenUrl={onOpenUrl}
             />

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -92,6 +92,7 @@ type Props = {
   onSlashFromChat: (command: string, args: string) => boolean;
   onOpenOnboarding: () => void;
   onSessionsChanged?: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   /** Forwarded to ChatRouter → ChatView so the Task chip in the chat header
    *  routes back to the board with the linked card focused. */
   onOpenTask?: (cardId: string) => void;
@@ -127,6 +128,7 @@ export function ChatSurface({
   onSlashFromChat,
   onOpenOnboarding,
   onSessionsChanged,
+  onSessionsDeleted,
   onOpenTask,
   onOpenUrl,
   hideThreadRail = false,
@@ -585,7 +587,7 @@ export function ChatSurface({
         </div>
 
         {scope === "projects" ? (
-          <ProjectsView sessions={sessions} familiars={familiars} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
+          <ProjectsView sessions={sessions} familiars={familiars} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} onSessionsDeleted={onSessionsDeleted} activeFamiliarId={activeFamiliarId} />
         ) : scope === "canvas" ? (
           // Saved-sketch gallery: everything "Save to Canvas" persisted from
           // inline chat artifacts, browsable/reopenable/deletable in place.
@@ -643,6 +645,7 @@ export function ChatSurface({
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}
                   onSessionsChanged={onSessionsChanged}
+                  onSessionsDeleted={onSessionsDeleted}
                   onSlashFromChat={onSlashFromChat}
                   onOpenOnboarding={onOpenOnboarding}
                   pendingProjectRoot={pendingProjectRoot}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -355,6 +355,7 @@ type Props = {
   sessions?: SessionRow[];
   onSessionStarted?: (sessionId: string) => void;
   onSessionsChanged?: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   onBack?: () => void;
   onSlashCommand?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
@@ -2314,7 +2315,7 @@ async function chatBridgeFailureMessage(res: Response): Promise<string> {
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, daemonRunning, sessions, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, daemonRunning, sessions, onSessionStarted, onSessionsChanged, onSessionsDeleted, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -5143,8 +5144,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         setError(json.error ?? "delete failed");
         return;
       }
-      invalidateConversation(sessionId);
-      onSessionsChanged?.();
+      onSessionsDeleted([sessionId]);
       onBack?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "delete failed");

--- a/src/components/familiar-panel.tsx
+++ b/src/components/familiar-panel.tsx
@@ -9,6 +9,7 @@ type Props = {
   sessions: SessionRow[];
   daemonRunning: boolean;
   onSessionStarted: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   onSlashFromChat: (command: string, args: string) => boolean;
   onOpenOnboarding: () => void;
 };
@@ -23,6 +24,7 @@ export const FamiliarPanel = forwardRef<ChatRouterHandle, Props>(function Famili
     sessions,
     daemonRunning,
     onSessionStarted,
+    onSessionsDeleted,
     onSlashFromChat,
   } = props;
 
@@ -48,6 +50,7 @@ export const FamiliarPanel = forwardRef<ChatRouterHandle, Props>(function Famili
             sessions={sessions}
             daemonRunning={daemonRunning}
             onSessionStarted={onSessionStarted}
+            onSessionsDeleted={onSessionsDeleted}
             onSlashFromChat={onSlashFromChat}
             onOpenOnboarding={onOpenOnboarding}
             compact

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -157,7 +157,8 @@ assert.match(
   /Promise\.all\(removed\.map\(\(s\) => deleteOneSession\(s\.id\)\)\)/,
   "bulk delete runs the per-chat deletes in parallel",
 );
-assert.match(projectsView, /results\.some\(Boolean\)\) onSessionsChanged/, "bulk delete refetches once if any chat was deleted");
+assert.match(projectsView, /successfulSessionIds\(removed\.map\(\(session\) => session\.id\), results\)/, "bulk delete selects only confirmed ids");
+assert.match(projectsView, /if \(deletedIds\.length > 0\) onSessionsDeleted\(deletedIds\)/, "bulk delete reports confirmed ids once");
 // Bulk delete is deferred + undoable (shared useUndoDelete + UndoToast).
 assert.match(projectsView, /useUndoDelete<SessionRow\[\]>\(\)/, "bulk delete routes through useUndoDelete");
 assert.match(projectsView, /scheduleSessionDelete\(\s*removed,/, "the batch is scheduled through the undo window");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEven
 import "@/styles/projects.css";
 import { Icon } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
-import { invalidateConversation } from "@/lib/conversation-cache";
+import { successfulSessionIds } from "@/lib/session-list-deletes";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { normalizeProjectRoot, sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
 import { deriveProjectStatus } from "@/lib/project-status";
@@ -59,11 +59,12 @@ type ProjectsViewProps = {
   familiars?: Familiar[];
   onNewChat?: (projectRoot: string) => void;
   onSessionsChanged?: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
   /** When set, only projects this familiar has been granted are shown. */
   activeFamiliarId?: string | null;
 };
 
-export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessionsChanged, activeFamiliarId = null }: ProjectsViewProps) {
+export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessionsChanged, onSessionsDeleted, activeFamiliarId = null }: ProjectsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const minuteTick = useMinuteTick(); // keep "last active" relative times + the active filter current
   // Mutations that only show visually (create, undo) get announced here; move
@@ -427,7 +428,8 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   };
 
   // Delete one chat, mirroring the Chats list delete (DELETE
-  // /api/chat/conversation/:id). Returns whether it succeeded; callers refetch.
+  // /api/chat/conversation/:id). Returns whether it succeeded; callers report
+  // confirmed ids to the Workspace-owned deletion boundary.
   const deleteOneSession = async (sessionId: string): Promise<boolean> => {
     try {
       const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
@@ -436,7 +438,6 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
         setSessionError(json.error ?? "delete failed");
         return false;
       }
-      invalidateConversation(sessionId);
       return true;
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "delete failed");
@@ -444,15 +445,15 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     }
   };
 
-  // Delete a single chat from the detail pane, then ask the parent to refetch
-  // sessions so the row disappears everywhere.
+  // Delete a single chat from the detail pane, then report it so Workspace
+  // removes the row from every shared-session surface before reloading.
   const handleDeleteSession = async (sessionId: string) => {
     setSessionError(null);
-    if (await deleteOneSession(sessionId)) onSessionsChanged?.();
+    if (await deleteOneSession(sessionId)) onSessionsDeleted([sessionId]);
   };
 
   // Bulk-delete the chats selected in the detail pane — deferred + undoable:
-  // hide them now, fire the DELETEs only after the undo window, refetch once.
+  // hide them now, then report only confirmed ids after the undo window.
   const handleDeleteSessions = async (sessionIds: string[]) => {
     setSessionError(null);
     if (sessionIds.length === 0) return;
@@ -465,7 +466,8 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
       `${removed.length} chat${removed.length === 1 ? "" : "s"}`,
       async () => {
         const results = await Promise.all(removed.map((s) => deleteOneSession(s.id)));
-        if (results.some(Boolean)) onSessionsChanged?.();
+        const deletedIds = successfulSessionIds(removed.map((session) => session.id), results);
+        if (deletedIds.length > 0) onSessionsDeleted(deletedIds);
       },
     );
   };

--- a/src/components/workspace-session-delete.test.ts
+++ b/src/components/workspace-session-delete.test.ts
@@ -4,6 +4,11 @@ import { readFile } from "node:fs/promises";
 
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const workspaceSidebar = await readFile(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const chatRouter = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const chatList = await readFile(new URL("./chat-list.tsx", import.meta.url), "utf8");
+const projectsView = await readFile(new URL("./projects-view.tsx", import.meta.url), "utf8");
 
 assert.match(
   workspace,
@@ -31,15 +36,54 @@ assert.match(
 
 assert.match(
   workspace,
-  /locallyDeletedSessionIdsRef\.current\.add\(session\.id\)[\s\S]*?setSessions\(\(currentSessions\) => \{[\s\S]*?filterDeletedSessions\(currentSessions, locallyDeletedSessionIdsRef\.current\)/,
-  "Workspace should optimistically remove confirmed deletes from shared sessions",
+  /const handleSessionsDeleted = useCallback\(\(sessionIds: readonly string\[\]\) => \{[\s\S]*?recordDeletedSessionIds\(locallyDeletedSessionIdsRef\.current, sessionIds\)[\s\S]*?setSessions\(\(currentSessions\) => \{[\s\S]*?filterDeletedSessions\(/,
+  "Workspace should own the confirmed-delete transition and remove ids from shared sessions",
 );
 
 assert.match(
   workspace,
-  /invalidateConversation\(session\.id\);\s*void loadSessions\(\)/,
-  "Workspace should invalidate only after confirmed delete and then refresh in the background",
+  /for \(const sessionId of confirmedIds\) invalidateConversation\(sessionId\);\s*void loadSessions\(\)/,
+  "Workspace should invalidate confirmed ids and then refresh once in the background",
 );
+
+assert.match(workspace, /handleSessionsDeleted\(\[session\.id\]\)/, "sidebar deletion uses the shared boundary");
+assert.match(workspace, /onSessionsDeleted=\{handleSessionsDeleted\}/, "nested chat surfaces receive the shared boundary");
+
+assert.equal(
+  chatSurface.match(/onSessionsDeleted=\{onSessionsDeleted\}/g)?.length,
+  2,
+  "ChatSurface threads the boundary to both Projects and ChatRouter",
+);
+assert.equal(
+  chatRouter.match(/onSessionsDeleted=\{onSessionsDeleted\}/g)?.length,
+  3,
+  "ChatRouter threads the boundary to the list, primary chat, and split-pane chats",
+);
+
+for (const [name, source] of [
+  ["ChatView", chatView],
+  ["ChatList", chatList],
+  ["ProjectsView", projectsView],
+]) {
+  assert.match(
+    source,
+    /onSessionsDeleted: \(sessionIds: readonly string\[\]\) => void/,
+    `${name} requires the shared delete boundary so a new caller cannot silently omit it`,
+  );
+}
+
+const chatViewDelete = chatView.match(/const deleteChat = async \(\) => \{[\s\S]*?\n  \};/)?.[0] ?? "";
+assert.match(chatViewDelete, /if \(!res\.ok \|\| !json\.ok\) \{[\s\S]*?return;[\s\S]*?onSessionsDeleted\(\[sessionId\]\)/);
+assert.doesNotMatch(chatViewDelete, /invalidateConversation|onSessionsChanged/, "header delete delegates reconciliation only after success");
+
+const chatListDelete = chatList.match(/const deleteSession = async[\s\S]*?\n  \};/)?.[0] ?? "";
+assert.match(chatListDelete, /if \(!res\.ok \|\| !json\.ok\) \{[\s\S]*?return;[\s\S]*?onSessionsDeleted\(\[sessionId\]\)/);
+assert.doesNotMatch(chatListDelete, /invalidateConversation|onSessionsChanged/, "list delete delegates reconciliation only after success");
+
+assert.match(projectsView, /if \(await deleteOneSession\(sessionId\)\) onSessionsDeleted\(\[sessionId\]\)/);
+assert.doesNotMatch(projectsView, /invalidateConversation/, "Projects delegates cache invalidation to Workspace");
+assert.match(projectsView, /successfulSessionIds\([\s\S]*?if \(deletedIds\.length > 0\) onSessionsDeleted\(deletedIds\)/);
+assert.match(chatList, /successfulSessionIds\([\s\S]*?if \(deletedIds\.length > 0\) onSessionsDeleted\(deletedIds\)/);
 
 assert.match(
   workspaceSidebar,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -6,7 +6,7 @@ import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { stampFirstOpenOnce } from "@/lib/first-run-stamps";
 import { groupInboxFeed, unreadInboxCount } from "@/lib/inbox-feed";
 import { parseGitHubItemUrl, type GitHubItemTarget } from "@/lib/github-item-url";
-import { filterDeletedSessions } from "@/lib/session-list-deletes";
+import { filterDeletedSessions, recordDeletedSessionIds } from "@/lib/session-list-deletes";
 import { sameSessionList } from "@/lib/session-list-equal";
 import { invalidateConversation } from "@/lib/conversation-cache";
 import { arrayContentEqual } from "@/lib/array-content-equal";
@@ -1008,6 +1008,25 @@ export function Workspace() {
       }
     })();
   }, [activeId]);
+
+  const handleSessionsDeleted = useCallback((sessionIds: readonly string[]) => {
+    const confirmedIds = recordDeletedSessionIds(locallyDeletedSessionIdsRef.current, sessionIds);
+    if (confirmedIds.length === 0) return;
+
+    baseSessionsRef.current = filterDeletedSessions(
+      baseSessionsRef.current,
+      locallyDeletedSessionIdsRef.current,
+    );
+    setSessions((currentSessions) => {
+      const nextSessions = filterDeletedSessions(
+        currentSessions,
+        locallyDeletedSessionIdsRef.current,
+      );
+      return sameSessionList(currentSessions, nextSessions) ? currentSessions : nextSessions;
+    });
+    for (const sessionId of confirmedIds) invalidateConversation(sessionId);
+    void loadSessions();
+  }, [loadSessions]);
 
   useEffect(() => {
     loadFamiliars();
@@ -2489,14 +2508,7 @@ export function Workspace() {
           throw new Error(json.error ?? "delete failed");
         }
 
-        locallyDeletedSessionIdsRef.current.add(session.id);
-        baseSessionsRef.current = filterDeletedSessions(baseSessionsRef.current, locallyDeletedSessionIdsRef.current);
-        setSessions((currentSessions) => {
-          const nextSessions = filterDeletedSessions(currentSessions, locallyDeletedSessionIdsRef.current);
-          return sameSessionList(currentSessions, nextSessions) ? currentSessions : nextSessions;
-        });
-        invalidateConversation(session.id);
-        void loadSessions();
+        handleSessionsDeleted([session.id]);
       }}
       onOpenUrl={openUrlInApp}
       scheduledCount={scheduleNeedsCount}
@@ -2570,6 +2582,7 @@ export function Workspace() {
         onSlashFromChat={handleSlashIntent}
         onOpenOnboarding={openOnboarding}
         onSessionsChanged={loadSessions}
+        onSessionsDeleted={handleSessionsDeleted}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
         onOpenUrl={openUrlInApp}
       />

--- a/src/lib/conversation-cache.test.ts
+++ b/src/lib/conversation-cache.test.ts
@@ -138,11 +138,12 @@ test("hovering another row re-arms the singleton timer onto the new session", as
 const chatList = await readFile(new URL("../components/chat-list.tsx", import.meta.url), "utf8");
 const chatRail = await readFile(new URL("../components/chat-project-sidebar.tsx", import.meta.url), "utf8");
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("../components/workspace.tsx", import.meta.url), "utf8");
 
-test("chat-list rows arm hover prefetch and invalidate on delete", () => {
+test("chat-list rows arm hover prefetch and report confirmed deletes", () => {
   assert.match(chatList, /onMouseEnter=\{\(\) => \{ if \(!selectMode\) hoverPrefetchConversation\(s\.id\); \}\}/);
   assert.match(chatList, /onMouseLeave=\{cancelHoverPrefetch\}/);
-  assert.match(chatList, /invalidateConversation\(sessionId\)/);
+  assert.match(chatList, /onSessionsDeleted\(\[sessionId\]\)/);
 });
 
 test("thread-rail rows arm hover prefetch", () => {
@@ -150,7 +151,7 @@ test("thread-rail rows arm hover prefetch", () => {
   assert.match(chatRail, /onMouseLeave=\{cancelHoverPrefetch\}/);
 });
 
-test("chat-view paints cached payloads, revalidates, and invalidates on send/delete", () => {
+test("chat-view paints cached payloads and mutations invalidate at their shared owner", () => {
   // Cached paint goes through the same apply path as a fresh fetch…
   assert.match(chatView, /readCachedConversation\(sessionId\)/);
   assert.match(chatView, /applyConversationPayload\(cachedConversation\)/);
@@ -159,4 +160,7 @@ test("chat-view paints cached payloads, revalidates, and invalidates on send/del
   // …and mutations drop the entry so stale history can't be painted.
   assert.match(chatView, /invalidateConversation\(liveGeneration\.sessionId\)/);
   assert.match(chatView, /invalidateConversation\(sessionId\)/);
+  // Confirmed deletion invalidation is centralized so list, project, header,
+  // sidebar, and split-pane deletes cannot drift apart.
+  assert.match(workspace, /for \(const sessionId of confirmedIds\) invalidateConversation\(sessionId\)/);
 });

--- a/src/lib/session-list-deletes.test.ts
+++ b/src/lib/session-list-deletes.test.ts
@@ -1,6 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { filterDeletedSessions } from "./session-list-deletes.ts";
+import { deriveChatProjectGroups, filterVisibleChatSessions } from "./chat-projects.ts";
+import { sortPinnedFirst } from "./chat-session-prefs.ts";
+import {
+  filterDeletedSessions,
+  recordDeletedSessionIds,
+  successfulSessionIds,
+} from "./session-list-deletes.ts";
 
 const rows = [
   { id: "keep-1", updated_at: "2026-07-17T12:00:00.000Z" },
@@ -24,6 +30,66 @@ assert.deepEqual(
   filterDeletedSessions(rows, new Set(["missing"])).map((row) => row.id),
   ["keep-1", "deleted", "keep-2"],
   "unknown tombstones should not change visible rows",
+);
+
+const enrichedRows = [
+  {
+    id: "keep",
+    title: "Keep",
+    familiarId: "familiar-1",
+    project_root: "/repo",
+    status: "active",
+    created_at: "2026-07-17T12:00:00.000Z",
+    updated_at: "2026-07-17T12:00:00.000Z",
+    githubTask: { number: 1 },
+  },
+  {
+    id: "deleted-enriched",
+    title: "Deleted",
+    familiarId: "familiar-1",
+    project_root: "/repo",
+    status: "active",
+    created_at: "2026-07-17T12:01:00.000Z",
+    updated_at: "2026-07-17T12:01:00.000Z",
+    githubTask: { number: 2 },
+  },
+];
+
+const tombstones = new Set<string>();
+assert.deepEqual(
+  recordDeletedSessionIds(tombstones, ["deleted-enriched", "deleted-enriched", ""]),
+  ["deleted-enriched"],
+  "confirmed ids are recorded once before a reload",
+);
+assert.deepEqual(
+  recordDeletedSessionIds(tombstones, ["deleted-enriched"]),
+  [],
+  "a duplicate confirmation does not schedule redundant reconciliation",
+);
+
+// Simulate both a cached payload and an older request resolving after the
+// confirmed delete. The Workspace-owned tombstone filters either response.
+const cachedBeforeDelete = enrichedRows;
+const olderInFlight = Promise.resolve(enrichedRows);
+const cachedVisible = filterDeletedSessions(cachedBeforeDelete, tombstones);
+const inFlightVisible = filterDeletedSessions(await olderInFlight, tombstones);
+assert.deepEqual(cachedVisible.map((row) => row.id), ["keep"]);
+assert.deepEqual(inFlightVisible.map((row) => row.id), ["keep"]);
+
+// Downstream chat/search, project, pinned, and GitHub-enriched consumers all
+// derive from the same filtered shared rows, so none can retain the tombstone.
+const chatVisible = filterVisibleChatSessions(inFlightVisible, null);
+const projectGroups = sortPinnedFirst(
+  deriveChatProjectGroups(chatVisible, []),
+  ["deleted-enriched", "keep"],
+);
+assert.deepEqual(projectGroups.flatMap((group) => group.sessions.map((row) => row.id)), ["keep"]);
+assert.deepEqual(chatVisible[0]?.githubTask, { number: 1 }, "unrelated enriched rows remain intact");
+
+assert.deepEqual(
+  successfulSessionIds(["ok-1", "failed", "ok-2"], [true, false, true]),
+  ["ok-1", "ok-2"],
+  "partial bulk deletion reports only server-confirmed ids",
 );
 
 console.log("session-list-deletes.test.ts passed");

--- a/src/lib/session-list-deletes.ts
+++ b/src/lib/session-list-deletes.ts
@@ -7,3 +7,30 @@ export function filterDeletedSessions(
   if (deletedIds.size === 0) return sessions;
   return sessions.filter((session) => !deletedIds.has(session.id));
 }
+
+/**
+ * Record the ids a DELETE request confirmed before any follow-up list response
+ * can be applied. Returns the unique, non-empty ids recorded by this call.
+ */
+export function recordDeletedSessionIds(
+  deletedIds: Set<string>,
+  sessionIds: readonly string[],
+): string[] {
+  const recorded: string[] = [];
+  const seen = new Set<string>();
+  for (const sessionId of sessionIds) {
+    if (!sessionId || seen.has(sessionId) || deletedIds.has(sessionId)) continue;
+    seen.add(sessionId);
+    deletedIds.add(sessionId);
+    recorded.push(sessionId);
+  }
+  return recorded;
+}
+
+/** Pair bulk mutation results back to their input ids without hiding failures. */
+export function successfulSessionIds(
+  sessionIds: readonly string[],
+  succeeded: readonly boolean[],
+): string[] {
+  return sessionIds.filter((sessionId, index) => Boolean(sessionId) && succeeded[index] === true);
+}

--- a/src/lib/use-undo-delete-deferred.test.ts
+++ b/src/lib/use-undo-delete-deferred.test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { scheduleDeferredDelete } from "./use-undo-delete.ts";
+
+let deletes = 0;
+const cancelled = scheduleDeferredDelete(async () => {
+  deletes += 1;
+}, 10);
+clearTimeout(cancelled); // the same cancellation used by Undo
+await new Promise((resolve) => setTimeout(resolve, 25));
+assert.equal(deletes, 0, "undo before commit sends no DELETE request");
+
+scheduleDeferredDelete(async () => {
+  deletes += 1;
+}, 5);
+await new Promise((resolve) => setTimeout(resolve, 20));
+assert.equal(deletes, 1, "an un-cancelled deferred delete commits exactly once");
+
+console.log("use-undo-delete-deferred.test.ts passed");

--- a/src/lib/use-undo-delete.ts
+++ b/src/lib/use-undo-delete.ts
@@ -4,6 +4,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const UNDO_WINDOW_MS = 4_000;
 
+export function scheduleDeferredDelete(
+  deleteFn: () => Promise<void>,
+  delayMs = UNDO_WINDOW_MS,
+): ReturnType<typeof setTimeout> {
+  return setTimeout(() => {
+    void deleteFn();
+  }, delayMs);
+}
+
 export type UndoEntry<T> = {
   id: string;       // unique key for this pending deletion
   item: T;          // the item being deleted, for potential restore
@@ -41,10 +50,10 @@ export function useUndoDelete<T>() {
       }
 
       const id = `undo-${Date.now()}`;
-      const timeoutId = setTimeout(() => {
+      const timeoutId = scheduleDeferredDelete(async () => {
         setPending(null);
-        void deleteFn();
-      }, UNDO_WINDOW_MS);
+        await deleteFn();
+      });
 
       const entry: UndoEntry<T> = { id, item, label, deleteFn, timeoutId };
       setPending(entry);


### PR DESCRIPTION
## Summary

- centralize successful chat-deletion reconciliation in Workspace and require every delete surface to report confirmed session IDs
- synchronously tombstone confirmed IDs before any cached, in-flight, or enriched session-list response can reapply them
- preserve undo semantics and partial-bulk failures: cancelled deletes never reach the server, successful IDs disappear, and failed IDs remain visible
- cover sidebar, chat header, chat list, Projects, primary/split panes, cached/enriched responses, pinned/project/search derivations, and deferred undo behavior

## Root cause

PR #3369 protected the sidebar path, but non-sidebar delete owners still invalidated/refetched independently. That left Workspace unaware of successful IDs, so stale SWR data, an older in-flight list response, or GitHub enrichment could restore a deleted row.

Workspace now owns the only confirmed-delete boundary. It records the tombstone synchronously, filters both base and rendered state, invalidates conversation data, and starts one reconciliation load.

## Verification

- `pnpm typecheck`
- `pnpm check:tests-wired` — 1040 test files wired
- `pnpm test:app` — 766/766 files passed
- `pnpm test:api` — 198/198 files passed
- `pnpm test:conformance` — 3/3 files passed (documented platform skips)
- `pnpm build` — production build, bundle budget, and standalone budget passed
- `git diff --check`

Fixes #3385
Bead: cave-8ll