### PR TITLE
Make Canvas creation describe-first and preview-first

### DIFF
--- a/src/components/canvas-add-tile.tsx
+++ b/src/components/canvas-add-tile.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import {
+  buildArtifactRepairPrompt,
   buildPreviewSrcDoc,
   buildRefinePrompt,
   buildSketchPrompt,
@@ -15,57 +16,82 @@ import {
   INITIAL_ADD_TILE_STATE,
   addTileReducer,
   buildAddArtifact,
+  buildArtifactRevision,
   derivePastedTitle,
   detectPastedKind,
+  focusTargetForState,
+  generationStatusText,
+  type ArtifactIdentity,
   type AddTileMode,
 } from "@/lib/canvas-add";
+import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
+import { Tabs } from "@/components/ui/tabs";
 
-// The Canvas gallery's in-grid composer (cave-fema): a ghost tile that
-// expands in place. Describe streams a sketch from a familiar (same client
-// chat bridge as the inline viewer); Paste/Blank take code directly. Saving
-// is always explicit — nothing hits /api/canvas until Keep / Add to Canvas.
+const CREATE_SUGGESTIONS = [
+  "A pricing page with three plans",
+  "A mobile dashboard for tracking habits",
+  "A settings panel with dark mode",
+] as const;
 
-const MODES: { id: AddTileMode; label: string }[] = [
-  { id: "describe", label: "Describe" },
-  { id: "paste", label: "Paste code" },
-  { id: "blank", label: "Blank" },
-];
+type ResultTab = "canvas" | "code";
 
-export function CanvasAddTile({ familiarId, hero = false, onSaved }: {
+export function CanvasAddTile({
+  familiarId,
+  hero = false,
+  onArtifactsChanged,
+  onActiveArtifactChange,
+}: {
   familiarId: string | null;
-  /** Hero form fills the empty gallery; grid form is the first tile. */
   hero?: boolean;
-  onSaved: (artifacts: CanvasArtifact[], savedId: string) => void;
+  onArtifactsChanged: (artifacts: CanvasArtifact[], changedId: string) => void;
+  onActiveArtifactChange: (id: string | null) => void;
 }) {
   const [state, dispatch] = useReducer(addTileReducer, INITIAL_ADD_TILE_STATE);
   const [chosenFamiliar, setChosenFamiliar] = useState<string | null>(null);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [streamChars, setStreamChars] = useState(0);
   const [refineText, setRefineText] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const [resultTab, setResultTab] = useState<ResultTab>("canvas");
+  const [codeMenuOpen, setCodeMenuOpen] = useState(false);
+  const [codeSaving, setCodeSaving] = useState(false);
+  const [codeSaveError, setCodeSaveError] = useState<string | null>(null);
+  const [runtimeError, setRuntimeError] = useState<string | null>(null);
+  const [discarding, setDiscarding] = useState(false);
   const { announce } = useAnnouncer();
 
   const abortRef = useRef<AbortController | null>(null);
+  const currentRunRef = useRef<string | null>(null);
+  const mountedRef = useRef(true);
   const ghostRef = useRef<HTMLButtonElement | null>(null);
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
   const editorRef = useRef<HTMLTextAreaElement | null>(null);
   const cancelRef = useRef<HTMLButtonElement | null>(null);
-  const refineInputRef = useRef<HTMLInputElement | null>(null);
+  const refineInputRef = useRef<HTMLTextAreaElement | null>(null);
   const retryRef = useRef<HTMLButtonElement | null>(null);
-  // What Retry re-runs: the last generation request, verbatim.
-  const lastRunRef = useRef<{ prompt: string } | null>(null);
+  const codeMenuRef = useRef<HTMLButtonElement | null>(null);
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
 
   const activeFamiliar = chosenFamiliar ?? familiarId;
   const expanded = state.phase !== "collapsed";
 
-  // Abort any in-flight generation on unmount.
-  useEffect(() => () => abortRef.current?.abort(), []);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+    };
+  }, []);
 
-  // Lazy familiar roster for the switcher — one attempt per mount (a failed
-  // or empty roster must not re-fetch on every expand; the switcher then
-  // simply shows the active familiar).
+  // The artifact being actively created is rendered by this tile. Hide its
+  // gallery card until the flow closes so autosave never creates a duplicate.
+  useEffect(() => {
+    const activeId = expanded && state.result ? state.identity?.id ?? null : null;
+    onActiveArtifactChange(activeId);
+    return () => onActiveArtifactChange(null);
+  }, [expanded, state.identity?.id, state.result, onActiveArtifactChange]);
+
   const rosterFetchedRef = useRef(false);
   useEffect(() => {
     if (!expanded || rosterFetchedRef.current) return;
@@ -77,136 +103,278 @@ export function CanvasAddTile({ familiarId, hero = false, onSaved }: {
         if (data?.familiars) setFamiliars(data.familiars);
       })
       .catch(() => {
-        // An abort (quick expand -> collapse) must not consume the single
-        // attempt — the next expand should try again. Real failures keep the
-        // latch; the switcher then just shows the active familiar.
         if (ctrl.signal.aborted) rosterFetchedRef.current = false;
-      })
+      });
     return () => ctrl.abort();
-  }, [expanded, familiars.length]);
+  }, [expanded]);
 
-  // Focus follows phase TRANSITIONS: expand -> input; a real collapse -> back
-  // to the ghost; generating/result/error -> their primary control (the
-  // previous element unmounts, and focus must not fall to document.body).
-  // Keyed off the previous phase so the initial mount never steals focus.
   const prevPhaseRef = useRef(state.phase);
   useEffect(() => {
     const prev = prevPhaseRef.current;
     prevPhaseRef.current = state.phase;
-    if (prev === state.phase) return; // mount, or a non-phase re-render
-    switch (state.phase) {
-      case "composing":
-        (state.mode === "describe" ? promptRef.current : editorRef.current)?.focus();
-        break;
-      case "collapsed":
-        ghostRef.current?.focus();
-        break;
-      case "generating":
-        cancelRef.current?.focus();
-        break;
-      case "result":
-        refineInputRef.current?.focus();
-        break;
-      case "error":
-        retryRef.current?.focus();
-        break;
-    }
+    const target = focusTargetForState(state, prev);
+    if (target === "prompt") promptRef.current?.focus();
+    if (target === "editor") editorRef.current?.focus();
+    if (target === "ghost") ghostRef.current?.focus();
+    if (target === "cancel") cancelRef.current?.focus();
+    if (target === "refine") refineInputRef.current?.focus();
+    if (target === "retry") retryRef.current?.focus();
   }, [state.phase, state.mode]);
 
-  // Switching modes while composing swaps the input element — follow it.
   useEffect(() => {
     if (state.phase !== "composing") return;
     (state.mode === "describe" ? promptRef.current : editorRef.current)?.focus();
   }, [state.mode, state.phase]);
 
-  const collapse = useCallback(() => {
-    abortRef.current?.abort();
-    setStreamChars(0);
-    setSaveError(null);
-    dispatch({ type: "collapse" });
-  }, []);
+  const previewSrc = useMemo(() => {
+    if (!state.result) return "";
+    return state.result.kind === "react"
+      ? buildReactSrcDoc(state.result.code)
+      : buildPreviewSrcDoc(state.result.code);
+  }, [state.result]);
 
-  const runGeneration = useCallback(async (prompt: string) => {
-    if (!activeFamiliar) return;
-    lastRunRef.current = { prompt };
-    const ctrl = new AbortController();
-    abortRef.current = ctrl;
-    setStreamChars(0);
-    const result = await generateArtifactCode({
-      prompt,
-      familiarId: activeFamiliar,
-      signal: ctrl.signal,
-      onText: (t) => setStreamChars(t.length),
-    });
-    if (ctrl.signal.aborted) return; // collapse/discard already handled state
-    if (result.code && result.kind && !result.error) {
-      dispatch({ type: "generated", code: result.code, kind: result.kind });
-      announce("Sketch ready — Keep, Refine, or Discard.");
-    } else {
-      dispatch({ type: "generation-failed", message: result.error ?? "Generation failed." });
-      announce("Sketch generation failed.");
+  useEffect(() => {
+    setRuntimeError(null);
+    function onMessage(event: MessageEvent) {
+      if (event.source !== frameRef.current?.contentWindow) return;
+      if (event.data?.type === "sandbox-error" && typeof event.data.message === "string") {
+        setRuntimeError(event.data.message);
+      }
     }
-  }, [activeFamiliar, announce]);
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [previewSrc]);
 
-  const conjure = useCallback(() => {
-    if (state.phase !== "composing" || !state.prompt.trim() || !activeFamiliar) return;
-    dispatch({ type: "generate" });
-    void runGeneration(buildSketchPrompt(state.prompt));
-  }, [state.phase, state.prompt, activeFamiliar, runGeneration]);
-
-  const refine = useCallback(() => {
-    const ask = refineText.trim();
-    // Guard BEFORE dispatching: entering "generating" with no familiar to run
-    // would wedge the spinner with no terminal event (mirrors conjure).
-    if (state.phase !== "result" || !state.result || !ask || !activeFamiliar) return;
-    dispatch({ type: "refine" });
-    setRefineText("");
-    void runGeneration(buildRefinePrompt(state.result.code, ask, state.result.kind));
-  }, [state.phase, state.result, refineText, activeFamiliar, runGeneration]);
-
-  const retry = useCallback(() => {
-    if (state.phase !== "error" || !lastRunRef.current || !activeFamiliar) return;
-    dispatch({ type: "retry" });
-    void runGeneration(lastRunRef.current.prompt);
-  }, [state.phase, activeFamiliar, runGeneration]);
-
-  const save = useCallback(async (code: string, kind: "html" | "react") => {
-    const artifact = buildAddArtifact({
-      id: `art-${crypto.randomUUID()}`,
-      now: new Date().toISOString(),
-      mode: state.mode,
-      prompt: state.prompt,
-      pastedTitle: state.pastedTitle,
-      code,
-      kind,
-    });
-    setSaving(true);
-    setSaveError(null);
+  const persistArtifact = useCallback(async (artifact: CanvasArtifact, revision: number) => {
+    dispatch({ type: "save-started", revision });
     try {
-      const res = await fetch("/api/canvas", {
+      const response = await fetch("/api/canvas", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ artifact }),
       });
-      if (!res.ok) throw new Error(String(res.status));
-      const data = (await res.json()) as { artifacts?: CanvasArtifact[]; savedId?: string | null };
+      if (!response.ok) throw new Error(String(response.status));
+      const data = (await response.json()) as { artifacts?: CanvasArtifact[]; savedId?: string | null };
+      if (!mountedRef.current) return;
+      const savedId = data.savedId ?? artifact.id;
+      const savedCreatedAt = data.artifacts?.find((entry) => entry.id === savedId)?.createdAt;
+      dispatch({ type: "save-succeeded", revision, savedId, savedCreatedAt });
+      // Content dedupe may settle an unchanged sketch into an incumbent record.
+      // Adopt that id so refine/discard continue operating on the saved record.
+      onArtifactsChanged(data.artifacts ?? [], savedId);
       announce(`Saved '${artifact.title}' to Canvas.`);
-      dispatch({ type: "saved" });
-      setRefineText("");
-      // The store content-dedupes: re-keeping an unchanged sketch settles into
-      // the existing record's id, so highlight where the save actually landed.
-      onSaved(data.artifacts ?? [], data.savedId ?? artifact.id);
     } catch {
-      setSaveError("Couldn't save to the Canvas — try again.");
-    } finally {
-      setSaving(false);
+      if (!mountedRef.current) return;
+      dispatch({ type: "save-failed", revision });
+      announce("Preview not saved. Retry is available.", "assertive");
     }
-  }, [state.mode, state.prompt, state.pastedTitle, announce, onSaved]);
+  }, [announce, onArtifactsChanged]);
 
-  // ── Collapsed: the ghost tile ──────────────────────────────────────────────
-  // Both tile forms live inside the gallery's role="list" grid — wrap them in
-  // a listitem (display: contents keeps the grid track on the tile itself) so
-  // list semantics stay valid for AT alongside the sketch cards.
+  const runGeneration = useCallback(async (opts: {
+    runId: string;
+    identity: ArtifactIdentity;
+    revision: number;
+    prompt: string;
+    originalIntent: string;
+    expectedKind?: "html" | "react";
+    sessionId?: string | null;
+    purpose: "create" | "refine";
+  }) => {
+    if (!activeFamiliar) return;
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    currentRunRef.current = opts.runId;
+    setStreamChars(0);
+
+    const current = () => currentRunRef.current === opts.runId && !ctrl.signal.aborted;
+    let result = await generateArtifactCode({
+      prompt: opts.prompt,
+      familiarId: activeFamiliar,
+      sessionId: opts.sessionId,
+      signal: ctrl.signal,
+      onText: (text) => { if (current()) setStreamChars(text.length); },
+    });
+
+    if (current() && result.failure === "format") {
+      dispatch({ type: "begin-repair", runId: opts.runId });
+      announce("The preview needs a quick repair. Still working.");
+      result = await generateArtifactCode({
+        prompt: buildArtifactRepairPrompt(opts.originalIntent, opts.expectedKind),
+        familiarId: activeFamiliar,
+        sessionId: result.sessionId,
+        signal: ctrl.signal,
+        onText: (text) => { if (current()) setStreamChars(text.length); },
+      });
+    }
+
+    if (!current()) return;
+    if (!result.code || !result.kind || result.failure) {
+      const format = result.failure === "format";
+      const message = format
+        ? "We couldn’t turn that response into a preview."
+        : opts.purpose === "refine"
+          ? "We couldn’t apply that change. Your last preview is still here."
+          : "We couldn’t create that preview. Try again.";
+      dispatch({
+        type: "generation-failed",
+        runId: opts.runId,
+        message,
+        kind: format ? "format" : "generation",
+      });
+      announce(message, "assertive");
+      return;
+    }
+
+    const artifact = buildArtifactRevision({
+      identity: opts.identity,
+      prompt: state.prompt,
+      code: result.code,
+      kind: result.kind,
+      updatedAt: new Date().toISOString(),
+    });
+    dispatch({
+      type: "generated",
+      runId: opts.runId,
+      code: artifact.code,
+      kind: result.kind,
+      sessionId: result.sessionId,
+      revision: opts.revision,
+    });
+    setResultTab("canvas");
+    setRefineText("");
+    announce(opts.purpose === "refine" ? "Preview updated. Saving." : "Preview ready. Saving to Canvas.");
+    void persistArtifact(artifact, opts.revision);
+  }, [activeFamiliar, announce, persistArtifact, state.prompt]);
+
+  const createPreview = useCallback(() => {
+    if (!state.prompt.trim() || !activeFamiliar) return;
+    const runId = crypto.randomUUID();
+    const identity = state.identity ?? {
+      id: `art-${crypto.randomUUID()}`,
+      createdAt: new Date().toISOString(),
+    };
+    const revision = state.revision + 1;
+    dispatch({ type: "begin-generation", runId, identity });
+    void runGeneration({
+      runId,
+      identity,
+      revision,
+      prompt: buildSketchPrompt(state.prompt),
+      originalIntent: state.prompt,
+      purpose: "create",
+    });
+  }, [activeFamiliar, runGeneration, state.identity, state.prompt, state.revision]);
+
+  const refine = useCallback(() => {
+    const ask = refineText.trim();
+    if (!ask || !activeFamiliar || !state.result || !state.identity || state.phase !== "result") return;
+    const runId = crypto.randomUUID();
+    const revision = state.revision + 1;
+    dispatch({ type: "begin-refine", runId });
+    void runGeneration({
+      runId,
+      identity: state.identity,
+      revision,
+      prompt: buildRefinePrompt(state.result.code, ask, state.result.kind),
+      originalIntent: ask,
+      expectedKind: state.result.kind,
+      sessionId: state.result.sessionId,
+      purpose: "refine",
+    });
+  }, [activeFamiliar, refineText, runGeneration, state.identity, state.phase, state.result, state.revision]);
+
+  const cancel = useCallback(() => {
+    currentRunRef.current = null;
+    abortRef.current?.abort();
+    setStreamChars(0);
+    announce("Preview creation cancelled.");
+    dispatch({ type: "collapse" });
+  }, [announce]);
+
+  const collapse = useCallback(() => {
+    currentRunRef.current = null;
+    abortRef.current?.abort();
+    setStreamChars(0);
+    setCodeMenuOpen(false);
+    dispatch({ type: "collapse" });
+  }, []);
+
+  const retrySave = useCallback(() => {
+    if (!state.identity || !state.result) return;
+    const artifact = buildArtifactRevision({
+      identity: state.identity,
+      prompt: state.prompt,
+      code: state.result.code,
+      kind: state.result.kind,
+      updatedAt: new Date().toISOString(),
+    });
+    void persistArtifact(artifact, state.revision);
+  }, [persistArtifact, state.identity, state.prompt, state.result, state.revision]);
+
+  const discard = useCallback(async () => {
+    if (!state.identity || !state.result) return;
+    // Every valid generated result starts an autosave. Even when the client
+    // observed a failure, the server may have committed before the response
+    // was lost, so DELETE the stable id idempotently instead of assuming the
+    // record never reached disk.
+    setDiscarding(true);
+    try {
+      const response = await fetch("/api/canvas", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: state.identity.id }),
+      });
+      if (!response.ok) throw new Error(String(response.status));
+      const data = (await response.json()) as { artifacts?: CanvasArtifact[] };
+      onArtifactsChanged(data.artifacts ?? [], state.identity.id);
+      dispatch({ type: "discard-local" });
+      announce("Preview discarded from Canvas.");
+    } catch {
+      dispatch({ type: "discard-failed", message: "Couldn’t discard this preview. Try again." });
+      announce("Couldn’t discard this preview.", "assertive");
+    } finally {
+      setDiscarding(false);
+    }
+  }, [announce, onArtifactsChanged, state.identity, state.result]);
+
+  const saveCode = useCallback(async () => {
+    if (!state.pastedCode.trim() || codeSaving) return;
+    const kind = detectPastedKind(state.pastedCode);
+    const artifact = buildAddArtifact({
+      id: `art-${crypto.randomUUID()}`,
+      now: new Date().toISOString(),
+      mode: state.mode,
+      prompt: "",
+      pastedTitle: state.pastedTitle,
+      code: state.pastedCode,
+      kind,
+    });
+    setCodeSaving(true);
+    setCodeSaveError(null);
+    try {
+      const response = await fetch("/api/canvas", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ artifact }),
+      });
+      if (!response.ok) throw new Error(String(response.status));
+      const data = (await response.json()) as { artifacts?: CanvasArtifact[] };
+      onArtifactsChanged(data.artifacts ?? [], artifact.id);
+      dispatch({ type: "code-saved" });
+      announce(`Saved '${artifact.title}' to Canvas.`);
+    } catch {
+      setCodeSaveError("Couldn’t save this code to Canvas. Try again.");
+      announce("Couldn’t save this code to Canvas.", "assertive");
+    } finally {
+      setCodeSaving(false);
+    }
+  }, [announce, codeSaving, onArtifactsChanged, state.mode, state.pastedCode, state.pastedTitle]);
+
+  const chooseCodeMode = useCallback((mode: AddTileMode) => {
+    setCodeMenuOpen(false);
+    dispatch({ type: "set-mode", mode });
+  }, []);
+
   if (!expanded) {
     return (
       <div role="listitem" className="chat-canvas-add__li">
@@ -225,208 +393,270 @@ export function CanvasAddTile({ familiarId, hero = false, onSaved }: {
   }
 
   const pastedKind = detectPastedKind(state.pastedCode);
-  const previewSrc = state.result
-    ? state.result.kind === "react"
-      ? buildReactSrcDoc(state.result.code)
-      : buildPreviewSrcDoc(state.result.code)
-    : null;
+  const refineSuggestions = state.result
+    ? [...DEFAULT_REFINE_SUGGESTIONS.slice(0, 2), ...generateRefineSuggestions(state.result.code, state.result.kind, 2)]
+    : [];
+  const busy = state.phase === "generating" || state.phase === "repairing";
 
   return (
     <div role="listitem" className="chat-canvas-add__li">
-    <section
-      className={`chat-canvas-add chat-canvas-add--expanded${hero ? " chat-canvas-add--hero" : ""}`}
-      aria-label="New sketch"
-      onKeyDown={(e) => {
-        if (e.key === "Escape") { e.preventDefault(); collapse(); }
-      }}
-    >
-      <div className="chat-canvas-add__head">
-        <div className="chat-canvas-add__modes" role="group" aria-label="How to add">
-          {MODES.map((m) => (
-            <button
-              key={m.id}
-              type="button"
-              className="chat-canvas-add__mode focus-ring"
-              aria-pressed={state.mode === m.id}
-              disabled={state.phase === "generating"}
-              onClick={() => dispatch({ type: "set-mode", mode: m.id })}
-            >
-              {m.label}
-            </button>
-          ))}
+      <section
+        className={`chat-canvas-add chat-canvas-add--expanded${hero ? " chat-canvas-add--hero" : ""}`}
+        aria-label="New sketch"
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && !codeMenuOpen) {
+            event.preventDefault();
+            busy ? cancel() : collapse();
+          }
+        }}
+      >
+        <div className="chat-canvas-add__head">
+          <div>
+            <h2 className="chat-canvas-add__heading">
+              {state.phase === "result" ? "Your preview" : "What would you like to create?"}
+            </h2>
+            {state.phase === "composing" && state.mode === "describe" ? (
+              <p className="chat-canvas-add__subheading">Describe a screen, component, or interaction.</p>
+            ) : null}
+          </div>
+          <span className="chat-canvas-add__spacer" />
+          <button type="button" className="chat-canvas-add__close focus-ring" aria-label="Close composer" onClick={collapse}>
+            <Icon name="ph:x" aria-hidden />
+          </button>
         </div>
-        <button
-          type="button"
-          className="chat-canvas-add__close focus-ring"
-          aria-label="Close composer"
-          onClick={collapse}
-        >
-          <Icon name="ph:x" aria-hidden />
-        </button>
-      </div>
 
-      {state.phase === "generating" ? (
-        <>
-          <div className="chat-canvas-add__skeleton" aria-hidden />
-          {/* The stable sentence is the live region; the fast-ticking char
-              count is visual-only so SRs don't re-announce every chunk. */}
-          <div className="chat-canvas-add__status">
-            <Icon name="ph:sparkle" aria-hidden />
-            <span role="status">
-              {familiars.find((f) => f.id === activeFamiliar)?.display_name ?? "Familiar"} is sketching…
-            </span>
-            <span aria-hidden>{streamChars > 0 ? ` ${(streamChars / 1000).toFixed(1)}k chars` : ""}</span>
-          </div>
-          <div className="chat-canvas-add__row">
-            <span className="chat-canvas-add__spacer" />
-            <button ref={cancelRef} type="button" className="chat-canvas-add__ghost-btn focus-ring" onClick={collapse}>
-              Cancel
-            </button>
-          </div>
-        </>
-      ) : state.phase === "error" ? (
-        <>
-          <div className="chat-canvas-add__error" role="alert">{state.error}</div>
-          <div className="chat-canvas-add__row">
-            <span className="chat-canvas-add__spacer" />
-            <button type="button" className="chat-canvas-add__ghost-btn focus-ring" onClick={() => dispatch({ type: "discard-result" })}>
-              Back
-            </button>
-            <button type="button" className="chat-canvas-add__go focus-ring" ref={retryRef} onClick={retry}>
-              Retry
-            </button>
-          </div>
-        </>
-      ) : state.phase === "result" && state.result ? (
-        <>
-          <div className="chat-canvas-add__preview">
-            <iframe
-              title="Generated sketch preview"
-              sandbox="allow-scripts"
-              srcDoc={previewSrc ?? ""}
-              tabIndex={-1}
-            />
-          </div>
-          <input
-            ref={refineInputRef}
-            className="chat-canvas-add__refine-input focus-ring"
-            aria-label="Refine the sketch"
-            placeholder="Refine it — e.g. make the header sticky…"
-            value={refineText}
-            onChange={(e) => setRefineText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && refineText.trim() && !saving) { e.preventDefault(); refine(); }
-            }}
-          />
-          {saveError ? <div className="chat-canvas-add__error" role="alert">{saveError}</div> : null}
-          <div className="chat-canvas-add__row">
-            <button type="button" className="chat-canvas-add__ghost-btn focus-ring" disabled={saving} onClick={() => dispatch({ type: "discard-result" })}>
-              Discard
-            </button>
-            <span className="chat-canvas-add__spacer" />
-            <button
-              type="button"
-              className="chat-canvas-add__ghost-btn focus-ring"
-              disabled={!refineText.trim() || saving}
-              onClick={refine}
-            >
-              Refine
-            </button>
-            <button
-              type="button"
-              className="chat-canvas-add__go focus-ring"
-              disabled={saving}
-              onClick={() => void save(state.result!.code, state.result!.kind)}
-            >
-              <Icon name="ph:check-bold" aria-hidden />
-              Keep
-            </button>
-          </div>
-        </>
-      ) : state.mode === "describe" ? (
-        <>
-          <textarea
-            ref={promptRef}
-            className="chat-canvas-add__prompt focus-ring"
-            aria-label="Describe the sketch to generate"
-            placeholder="Describe a sketch — e.g. a pricing page with three tiers, dark theme…"
-            value={state.prompt}
-            onChange={(e) => dispatch({ type: "set-prompt", prompt: e.target.value })}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); conjure(); }
-            }}
-          />
-          <div className="chat-canvas-add__row">
-            <select
-              className="chat-canvas-add__familiar focus-ring"
-              aria-label="Familiar to generate with"
-              value={activeFamiliar ?? ""}
-              onChange={(e) => setChosenFamiliar(e.target.value || null)}
-            >
-              {activeFamiliar && !familiars.some((f) => f.id === activeFamiliar) ? (
-                <option value={activeFamiliar}>{activeFamiliar}</option>
-              ) : null}
-              {familiars.map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.emoji ? `${f.emoji} ` : ""}{f.display_name}
-                </option>
-              ))}
-            </select>
-            <span className="chat-canvas-add__spacer" />
-            <button
-              type="button"
-              className="chat-canvas-add__go focus-ring"
-              disabled={!state.prompt.trim() || !activeFamiliar}
-              title={activeFamiliar ? "Generate (⌘↵)" : "Pick a familiar first"}
-              onClick={conjure}
-            >
+        {busy ? (
+          <>
+            <div className="chat-canvas-add__skeleton" aria-hidden />
+            <div className="chat-canvas-add__status">
               <Icon name="ph:sparkle" aria-hidden />
-              Conjure
-            </button>
-          </div>
-        </>
-      ) : (
-        <>
-          <textarea
-            ref={editorRef}
-            className="chat-canvas-add__editor focus-ring"
-            aria-label="Sketch code"
-            spellCheck={false}
-            placeholder="Paste a self-contained HTML document or a React component…"
-            value={state.pastedCode}
-            onChange={(e) => dispatch({ type: "set-pasted-code", code: e.target.value })}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && state.pastedCode.trim() && !saving) {
-                e.preventDefault();
-                void save(state.pastedCode, pastedKind);
-              }
-            }}
-          />
-          {saveError ? <div className="chat-canvas-add__error" role="alert">{saveError}</div> : null}
-          <div className="chat-canvas-add__row">
-            <input
-              className="chat-canvas-add__title focus-ring"
-              aria-label="Sketch title"
-              placeholder={derivePastedTitle(state.pastedCode)}
-              value={state.pastedTitle}
-              onChange={(e) => dispatch({ type: "set-pasted-title", title: e.target.value })}
+              <span role="status">
+                {generationStatusText(
+                  state.phase === "repairing" ? "repairing" : "generating",
+                  familiars.find((f) => f.id === activeFamiliar)?.display_name ?? "Familiar",
+                )}
+              </span>
+              <span aria-hidden>{streamChars > 0 ? ` ${(streamChars / 1000).toFixed(1)}k chars` : ""}</span>
+            </div>
+            <div className="chat-canvas-add__row">
+              <span className="chat-canvas-add__spacer" />
+              <button ref={cancelRef} type="button" className="chat-canvas-add__ghost-btn focus-ring" onClick={cancel}>Cancel</button>
+            </div>
+          </>
+        ) : state.phase === "error" ? (
+          <>
+            <div className="chat-canvas-add__error" role="alert">{state.error}</div>
+            <div className="chat-canvas-add__row">
+              <button type="button" className="chat-canvas-add__ghost-btn focus-ring" onClick={() => dispatch({ type: "edit-description" })}>
+                Edit description
+              </button>
+              <span className="chat-canvas-add__spacer" />
+              <button ref={retryRef} type="button" className="chat-canvas-add__go focus-ring" disabled={!activeFamiliar} onClick={createPreview}>
+                Try again
+              </button>
+            </div>
+          </>
+        ) : state.phase === "result" && state.result ? (
+          <>
+            <div className="chat-canvas-add__result-head">
+              <Tabs<ResultTab>
+                variant="segment"
+                size="sm"
+                ariaLabel="Preview result"
+                value={resultTab}
+                onChange={setResultTab}
+                items={[
+                  { id: "canvas", label: "Preview", icon: "ph:squares-four" },
+                  { id: "code", label: "Code", icon: "ph:code" },
+                ]}
+              />
+              <span className={`chat-canvas-add__save-state chat-canvas-add__save-state--${state.saveState}`} aria-live="polite">
+                {state.saveState === "saving" ? "Saving…" : state.saveState === "saved" ? "Saved" : "Not saved"}
+              </span>
+              {state.saveState === "error" ? (
+                <button type="button" className="chat-canvas-add__retry-save focus-ring" onClick={retrySave}>Retry save</button>
+              ) : null}
+            </div>
+            {resultTab === "canvas" ? (
+              <div className="chat-canvas-add__preview">
+                <iframe
+                  ref={frameRef}
+                  title="Generated sketch preview"
+                  sandbox="allow-scripts"
+                  srcDoc={previewSrc}
+                />
+                {runtimeError ? <div className="chat-canvas-add__runtime-error" role="alert">{runtimeError}</div> : null}
+              </div>
+            ) : (
+              <pre className="chat-canvas-add__code"><code>{state.result.code}</code></pre>
+            )}
+            {state.error ? <div className="chat-canvas-add__error" role="alert">{state.error}</div> : null}
+            <label className="chat-canvas-add__refine-label" htmlFor="canvas-add-refine">Describe a change</label>
+            <textarea
+              id="canvas-add-refine"
+              ref={refineInputRef}
+              className="chat-canvas-add__refine-input focus-ring"
+              placeholder="Make it mobile-friendly, add an empty state…"
+              value={refineText}
+              onChange={(event) => setRefineText(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  refine();
+                }
+              }}
             />
-            <span className="chat-canvas-add__kind" title="Detected from the code">
-              {pastedKind === "react" ? "React" : "HTML"}
-            </span>
-            <button
-              type="button"
-              className="chat-canvas-add__go focus-ring"
-              disabled={!state.pastedCode.trim() || saving}
-              onClick={() => void save(state.pastedCode, pastedKind)}
-            >
-              <Icon name="ph:check-bold" aria-hidden />
-              Add to Canvas
-            </button>
-          </div>
-        </>
-      )}
-    </section>
+            {codeSaveError ? <div className="chat-canvas-add__error" role="alert">{codeSaveError}</div> : null}
+            <div className="chat-canvas-add__suggestions" aria-label="Suggested changes">
+              {refineSuggestions.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  className="chat-canvas-add__suggestion focus-ring"
+                  aria-label={`Use suggested change: ${suggestion}`}
+                  onClick={() => {
+                    setRefineText(suggestion);
+                    announce(`Suggested change added: ${suggestion}`);
+                    requestAnimationFrame(() => refineInputRef.current?.focus());
+                  }}
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
+            <div className="chat-canvas-add__row">
+              <button type="button" className="chat-canvas-add__ghost-btn focus-ring" disabled={discarding || state.saveState === "saving"} onClick={() => void discard()}>
+                {discarding ? "Discarding…" : "Discard"}
+              </button>
+              <span className="chat-canvas-add__spacer" />
+              <button
+                type="button"
+                className="chat-canvas-add__go focus-ring"
+                disabled={!refineText.trim() || !activeFamiliar || state.saveState === "saving"}
+                title={activeFamiliar ? "Refine preview (⌘↵)" : "Choose a familiar first"}
+                onClick={refine}
+              >
+                <Icon name="ph:sparkle" aria-hidden /> Refine preview
+              </button>
+            </div>
+          </>
+        ) : state.mode === "describe" ? (
+          <>
+            <textarea
+              ref={promptRef}
+              className="chat-canvas-add__prompt focus-ring"
+              aria-label="What would you like to create?"
+              placeholder="Describe a screen, component, or interaction…"
+              value={state.prompt}
+              onChange={(event) => dispatch({ type: "set-prompt", prompt: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  createPreview();
+                }
+              }}
+            />
+            {hero ? (
+              <div className="chat-canvas-add__suggestions" aria-label="Starting suggestions">
+                {CREATE_SUGGESTIONS.map((suggestion) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    className="chat-canvas-add__suggestion focus-ring"
+                    aria-label={`Use starting suggestion: ${suggestion}`}
+                    onClick={() => {
+                      dispatch({ type: "set-prompt", prompt: suggestion });
+                      announce(`Description added: ${suggestion}`);
+                      requestAnimationFrame(() => promptRef.current?.focus());
+                    }}
+                  >
+                    {suggestion}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            <div className="chat-canvas-add__row">
+              <select
+                className="chat-canvas-add__familiar focus-ring"
+                aria-label="Familiar to create with"
+                value={activeFamiliar ?? ""}
+                onChange={(event) => setChosenFamiliar(event.target.value || null)}
+              >
+                {!activeFamiliar ? <option value="">Choose a familiar</option> : null}
+                {activeFamiliar && !familiars.some((f) => f.id === activeFamiliar) ? <option value={activeFamiliar}>{activeFamiliar}</option> : null}
+                {familiars.map((familiar) => (
+                  <option key={familiar.id} value={familiar.id}>{familiar.emoji ? `${familiar.emoji} ` : ""}{familiar.display_name}</option>
+                ))}
+              </select>
+              <button
+                ref={codeMenuRef}
+                type="button"
+                className="chat-canvas-add__start-code focus-ring"
+                aria-haspopup="menu"
+                aria-expanded={codeMenuOpen}
+                onClick={() => setCodeMenuOpen((open) => !open)}
+              >
+                Start from code <Icon name="ph:caret-down" aria-hidden />
+              </button>
+              <Popover open={codeMenuOpen} onOpenChange={setCodeMenuOpen} anchorRef={codeMenuRef} placement="bottom-start" minWidth={210} ariaLabel="Start from code">
+                <PopoverBody role="menu" ariaLabel="Start from code">
+                  <PopoverItem onSelect={() => chooseCodeMode("paste")}>Paste code</PopoverItem>
+                  <PopoverItem onSelect={() => chooseCodeMode("blank-html")}>Blank HTML</PopoverItem>
+                  <PopoverItem onSelect={() => chooseCodeMode("blank-react")}>Blank React component</PopoverItem>
+                </PopoverBody>
+              </Popover>
+              <span className="chat-canvas-add__spacer" />
+              <button
+                type="button"
+                className="chat-canvas-add__go focus-ring"
+                disabled={!state.prompt.trim() || !activeFamiliar}
+                title={activeFamiliar ? "Create preview (⌘↵)" : "Choose a familiar first"}
+                onClick={createPreview}
+              >
+                <Icon name="ph:sparkle" aria-hidden /> Create preview
+              </button>
+            </div>
+            {!activeFamiliar ? <p className="chat-canvas-add__no-familiar" role="status">Choose a familiar to create a preview.</p> : null}
+          </>
+        ) : (
+          <>
+            <div className="chat-canvas-add__code-head">
+              <button type="button" className="chat-canvas-add__start-code focus-ring" onClick={() => dispatch({ type: "set-mode", mode: "describe" })}>
+                <Icon name="ph:arrow-left" aria-hidden /> Back to description
+              </button>
+              <span className="chat-canvas-add__kind">{pastedKind === "react" ? "React" : "HTML"}</span>
+            </div>
+            <textarea
+              ref={editorRef}
+              className="chat-canvas-add__editor focus-ring"
+              aria-label={state.mode === "paste" ? "Paste sketch code" : state.mode === "blank-react" ? "Blank React component" : "Blank HTML document"}
+              spellCheck={false}
+              placeholder="Paste a self-contained HTML document or React component…"
+              value={state.pastedCode}
+              onChange={(event) => dispatch({ type: "set-pasted-code", code: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  void saveCode();
+                }
+              }}
+            />
+            <div className="chat-canvas-add__row">
+              <input
+                className="chat-canvas-add__title focus-ring"
+                aria-label="Sketch title"
+                placeholder={derivePastedTitle(state.pastedCode)}
+                value={state.pastedTitle}
+                onChange={(event) => dispatch({ type: "set-pasted-title", title: event.target.value })}
+              />
+              <span className="chat-canvas-add__spacer" />
+              <button type="button" className="chat-canvas-add__go focus-ring" disabled={!state.pastedCode.trim() || codeSaving} onClick={() => void saveCode()}>
+                <Icon name="ph:check-bold" aria-hidden /> {codeSaving ? "Saving…" : "Add to Canvas"}
+              </button>
+            </div>
+          </>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/chat-canvas-tab.test.ts
+++ b/src/components/chat-canvas-tab.test.ts
@@ -76,13 +76,12 @@ assert.notEqual(formatArtifactWhen("2026-07-12T00:00:00Z"), "", "real timestamps
 
 // ── Add tile (cave-fema): in-grid sketch creation ────────────────────────────
 // The gallery owns its add affordance: a ghost tile leads the grid (and IS
-// the empty state), expanding in-place into the Describe/Paste/Blank
-// composer. Save is explicit; nothing hits /api/canvas mid-stream.
+// the empty state), expanding in-place into the describe-first composer.
 const addTile = readFileSync(new URL("./canvas-add-tile.tsx", import.meta.url), "utf8");
 
 assert.match(
   view,
-  /<CanvasAddTile hero=\{artifacts\.length === 0\} familiarId=\{familiarId\} onSaved=\{handleSaved\} \/>/,
+  /<CanvasAddTile[\s\S]{0,300}?hero=\{galleryArtifacts\.length === 0\}[\s\S]{0,300}?onArtifactsChanged=\{handleSaved\}/,
   "ONE stable tile mount leads the grid — hero-styled when empty, so crossing zero never remounts the composer",
 );
 assert.doesNotMatch(view, /<CanvasAddTile hero familiarId/, "no second, remount-prone hero mount remains");
@@ -91,17 +90,27 @@ assert.match(view, /chat-canvas-card--new/, "a kept sketch settles in with a one
 
 assert.match(addTile, /aria-expanded=\{false\}/, "the ghost tile reports its expansion state");
 assert.match(addTile, /generateArtifactCode\(\{/, "describe streams through the existing chat bridge");
+assert.match(addTile, /What would you like to create\?/, "default path asks for intent, not an implementation mode");
+assert.match(addTile, /Create preview/, "primary action creates a preview");
 assert.match(addTile, /buildSketchPrompt\(state\.prompt\)/, "prompts are wrapped with the shared sketch contract");
 assert.match(addTile, /buildRefinePrompt\(state\.result\.code, ask, state\.result\.kind\)/, "refine reuses the shared refine contract");
+assert.match(addTile, /buildArtifactRepairPrompt/, "format recovery uses the bounded repair prompt");
+assert.match(addTile, /sessionId: result\.sessionId/, "repair resumes the same hidden Canvas session");
 assert.match(addTile, /abortRef\.current\?\.abort\(\)/, "collapse/unmount aborts an in-flight generation");
 assert.match(addTile, /sandbox="allow-scripts"/, "the in-tile preview keeps the opaque-origin sandbox");
+assert.doesNotMatch(addTile, /allow-same-origin/, "preview remains opaque-origin");
 assert.match(addTile, /detectPastedKind\(state\.pastedCode\)/, "pasted code kind is detected, not asked");
 assert.match(addTile, /useAnnouncer/, "completion and saves are announced to AT");
+assert.match(addTile, /aria-haspopup="menu"/, "Start from code is an accessible secondary menu");
+assert.match(addTile, /Blank HTML/, "explicit blank HTML remains available");
+assert.match(addTile, /Blank React component/, "explicit blank React remains available");
+assert.doesNotMatch(addTile, /const MODES/, "equal-weight implementation mode switcher is removed");
 assert.match(
   addTile,
   /method: "POST",[\s\S]{0,200}?body: JSON\.stringify\(\{ artifact \}\)/,
-  "saving posts one artifact to the existing canvas store route",
+  "autosave posts one artifact to the existing canvas store route",
 );
-assert.doesNotMatch(addTile, /fetch\("\/api\/canvas"[\s\S]{0,80}?onText/, "no save happens mid-stream — explicit Keep only");
+assert.doesNotMatch(addTile, />\s*Keep\s*</, "generated previews no longer require an ambiguous Keep action");
+assert.match(view, /artifact\.id !== activeComposerId/, "the active autosaved artifact is hidden from gallery cards to prevent duplicates");
 
 console.log("chat canvas tab wiring: ok");

--- a/src/components/chat-canvas-view.tsx
+++ b/src/components/chat-canvas-view.tsx
@@ -30,6 +30,7 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
   const [state, setState] = useState<LoadState>("loading");
   const [openId, setOpenId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [activeComposerId, setActiveComposerId] = useState<string | null>(null);
   const confirm = useConfirm();
 
   // The id a just-kept sketch settles in with — drives a one-shot highlight.
@@ -98,6 +99,11 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
     [openId, artifacts],
   );
 
+  const galleryArtifacts = useMemo(
+    () => activeComposerId ? artifacts.filter((artifact) => artifact.id !== activeComposerId) : artifacts,
+    [activeComposerId, artifacts],
+  );
+
   if (state === "error") {
     return (
       <div className="chat-canvas-view flex min-h-0 min-w-0 flex-1 items-center justify-center">
@@ -129,8 +135,13 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
             never remounts the composer (which would wipe typed input and
             abort an in-flight generation). Empty gallery = hero-styled tile:
             the add tile IS the empty state. */}
-        <CanvasAddTile hero={artifacts.length === 0} familiarId={familiarId} onSaved={handleSaved} />
-        {artifacts.map((artifact) => {
+        <CanvasAddTile
+          hero={galleryArtifacts.length === 0}
+          familiarId={familiarId}
+          onArtifactsChanged={handleSaved}
+          onActiveArtifactChange={setActiveComposerId}
+        />
+        {galleryArtifacts.map((artifact) => {
           const srcDoc =
             artifact.kind === "react" ? buildReactSrcDoc(artifact.code) : buildPreviewSrcDoc(artifact.code);
           return (

--- a/src/lib/canvas-add.test.ts
+++ b/src/lib/canvas-add.test.ts
@@ -1,282 +1,172 @@
 // @ts-nocheck
-// Canvas add tile (cave-fema): the pure composer state machine behind the
-// in-grid "New sketch" tile. Phases: collapsed -> composing -> generating ->
-// result | error. Retention rules matter: a collapse or failure must never
-// eat the user's prompt or pasted code; only a successful save resets.
 import assert from "node:assert/strict";
 import {
   INITIAL_ADD_TILE_STATE,
   addTileReducer,
   buildAddArtifact,
+  buildArtifactRevision,
   derivePastedTitle,
   detectPastedKind,
+  focusTargetForState,
+  generationStatusText,
 } from "./canvas-add.ts";
-import { STARTER_ARTIFACT_HTML, MAX_ARTIFACT_CODE_CHARS } from "./canvas-artifacts.ts";
+import {
+  MAX_ARTIFACT_CODE_CHARS,
+  STARTER_ARTIFACT_HTML,
+  STARTER_ARTIFACT_REACT,
+} from "./canvas-artifacts.ts";
 
-const s0 = INITIAL_ADD_TILE_STATE;
+const reduce = (state, ...events) => events.reduce(addTileReducer, state);
+const identity = { id: "art-stable", createdAt: "2026-07-18T00:00:00.000Z" };
 
-// ── expand / collapse ────────────────────────────────────────────────────────
-{
-  const open = addTileReducer(s0, { type: "expand" });
-  assert.equal(open.phase, "composing", "expand opens the composer");
-  assert.equal(open.mode, "describe", "describe is the default mode");
+// Describe-first expand and prompt retention.
+const open = addTileReducer(INITIAL_ADD_TILE_STATE, { type: "expand" });
+assert.equal(open.phase, "composing");
+assert.equal(open.mode, "describe");
+const prompted = addTileReducer(open, { type: "set-prompt", prompt: "a pricing page" });
+assert.equal(addTileReducer(prompted, { type: "collapse" }).prompt, "a pricing page");
 
-  const closed = addTileReducer(
-    { ...open, prompt: "a pricing page" },
-    { type: "collapse" },
-  );
-  assert.equal(closed.phase, "collapsed", "collapse closes the tile");
-  assert.equal(closed.prompt, "a pricing page", "collapse retains the prompt");
-  assert.equal(closed.result, null, "collapse discards an unsaved result");
-  assert.equal(closed.error, null, "collapse clears errors");
+// Advanced paths are explicit and use the requested implementation starter.
+const html = addTileReducer(open, { type: "set-mode", mode: "blank-html" });
+assert.equal(html.pastedCode, STARTER_ARTIFACT_HTML);
+const react = addTileReducer(open, { type: "set-mode", mode: "blank-react" });
+assert.equal(react.pastedCode, STARTER_ARTIFACT_REACT);
+assert.equal(detectPastedKind(react.pastedCode), "react");
+assert.equal(addTileReducer(open, { type: "set-mode", mode: "paste" }).pastedCode, "");
 
-  const closedWithCode = addTileReducer(
-    { ...open, pastedCode: "<p>keep me</p>" },
-    { type: "collapse" },
-  );
-  assert.equal(closedWithCode.pastedCode, "<p>keep me</p>", "collapse retains pasted code");
-}
+// Focus and live-region behavior are derived from state, not timing or stream
+// chunk count, so keyboard/SR outcomes remain stable across rerenders.
+assert.equal(focusTargetForState(open, "collapsed"), "prompt");
+assert.equal(focusTargetForState(react, "collapsed"), "editor");
+assert.equal(focusTargetForState({ ...open, phase: "generating" }, "composing"), "cancel");
+assert.equal(focusTargetForState({ ...open, phase: "repairing" }, "generating"), "cancel");
+assert.equal(focusTargetForState({ ...open, phase: "result" }, "generating"), "refine");
+assert.equal(focusTargetForState({ ...open, phase: "error" }, "repairing"), "retry");
+assert.equal(generationStatusText("generating", "Nova"), "Nova is creating your preview…");
+assert.equal(generationStatusText("repairing", "Nova"), "Still preparing your preview…");
 
-// ── mode switching ───────────────────────────────────────────────────────────
-{
-  const open = addTileReducer(s0, { type: "expand" });
-  const blank = addTileReducer(open, { type: "set-mode", mode: "blank" });
-  assert.equal(blank.mode, "blank");
-  assert.equal(blank.pastedCode, STARTER_ARTIFACT_HTML, "blank seeds the starter template");
+// One identity survives initial generation, format repair, save, and refines.
+const creating = reduce(
+  prompted,
+  { type: "begin-generation", runId: "run-1", identity },
+  { type: "begin-repair", runId: "run-1" },
+);
+assert.equal(creating.phase, "repairing");
+assert.deepEqual(creating.identity, identity);
+const generated = addTileReducer(creating, {
+  type: "generated",
+  runId: "run-1",
+  code: "<html>v1</html>",
+  kind: "html",
+  sessionId: "canvas-session",
+  revision: 1,
+});
+assert.equal(generated.phase, "result");
+assert.equal(generated.saveState, "saving");
+const saved = addTileReducer(generated, { type: "save-succeeded", revision: 1 });
+assert.equal(saved.saveState, "saved");
+assert.equal(saved.result.sessionId, "canvas-session");
+const deduped = addTileReducer(generated, {
+  type: "save-succeeded",
+  revision: 1,
+  savedId: "art-incumbent",
+  savedCreatedAt: "incumbent-created-at",
+});
+assert.equal(deduped.identity.id, "art-incumbent", "content-deduped saves adopt the settled id");
+assert.equal(deduped.identity.createdAt, "incumbent-created-at", "dedupe adopts the incumbent creation time");
+assert.deepEqual(saved.persistedResult, saved.result);
+const refining = addTileReducer(saved, { type: "begin-refine", runId: "run-2" });
+assert.equal(refining.generationPurpose, "refine");
+assert.deepEqual(refining.identity, identity);
+const refined = addTileReducer(refining, {
+  type: "generated",
+  runId: "run-2",
+  code: "<html>v2</html>",
+  kind: "html",
+  sessionId: "canvas-session",
+  revision: 2,
+});
+assert.equal(refined.result.code, "<html>v2</html>");
+assert.equal(refined.result.sessionId, "canvas-session");
+assert.equal(refined.saveState, "saving");
 
-  // Switching to blank must never clobber code the user already pasted.
-  const pasted = addTileReducer(
-    { ...open, mode: "paste", pastedCode: "<h1>mine</h1>" },
-    { type: "set-mode", mode: "blank" },
-  );
-  assert.equal(pasted.pastedCode, "<h1>mine</h1>", "blank never overwrites non-empty code");
+// Persistence failure keeps the valid preview and retry is revision-idempotent.
+const notSaved = addTileReducer(refined, { type: "save-failed", revision: 2 });
+assert.equal(notSaved.phase, "result");
+assert.equal(notSaved.result.code, "<html>v2</html>");
+assert.equal(notSaved.persistedResult.code, "<html>v1</html>");
+assert.equal(notSaved.saveState, "error");
+assert.equal(addTileReducer(notSaved, { type: "save-started", revision: 1 }).saveState, "error", "stale retry ignored");
+assert.equal(addTileReducer(notSaved, { type: "save-started", revision: 2 }).saveState, "saving");
 
-  const back = addTileReducer(blank, { type: "set-mode", mode: "describe" });
-  assert.equal(back.pastedCode, STARTER_ARTIFACT_HTML, "mode switches retain editor contents");
+// Failed refine preserves the last valid preview and saved revision.
+const refineFailed = addTileReducer(refining, {
+  type: "generation-failed",
+  runId: "run-2",
+  message: "could not refine",
+  kind: "generation",
+});
+assert.equal(refineFailed.phase, "result");
+assert.deepEqual(refineFailed.result, saved.result);
+assert.deepEqual(refineFailed.persistedResult, saved.persistedResult);
 
-  const midGen = { ...open, phase: "generating" };
-  assert.equal(
-    addTileReducer(midGen, { type: "set-mode", mode: "paste" }).mode,
-    "describe",
-    "set-mode is a no-op outside composing",
-  );
-
-  const whitespace = addTileReducer(
-    { ...open, mode: "paste", pastedCode: "   \n  " },
-    { type: "set-mode", mode: "blank" },
-  );
-  assert.equal(whitespace.pastedCode, STARTER_ARTIFACT_HTML, "whitespace-only code still seeds the starter");
-}
-
-// ── generate lifecycle ───────────────────────────────────────────────────────
-{
-  const open = addTileReducer(s0, { type: "expand" });
-  assert.equal(
-    addTileReducer(open, { type: "generate" }).phase,
-    "composing",
-    "generate is a no-op with an empty prompt",
-  );
-
-  const composed = { ...open, prompt: "a kanban board" };
-  const generating = addTileReducer(composed, { type: "generate" });
-  assert.equal(generating.phase, "generating");
-
-  const done = addTileReducer(generating, {
-    type: "generated",
-    code: "<!doctype html><html><body>x</body></html>",
-    kind: "html",
-  });
-  assert.equal(done.phase, "result");
-  assert.equal(done.result.kind, "html");
-
-  const failed = addTileReducer(generating, {
-    type: "generation-failed",
-    message: "the familiar reported an error",
-  });
-  assert.equal(failed.phase, "error");
-  assert.equal(failed.error, "the familiar reported an error");
-  assert.equal(failed.prompt, "a kanban board", "failure retains the prompt");
-
-  const retried = addTileReducer(failed, { type: "retry" });
-  assert.equal(retried.phase, "generating", "retry re-enters generating");
-  assert.equal(retried.error, null);
-
-  assert.equal(addTileReducer(composed, { type: "retry" }).phase, "composing", "retry is a no-op outside error");
-
-  assert.equal(
-    addTileReducer({ ...composed, phase: "generating" }, { type: "generate" }).phase,
-    "generating",
-    "generate is a no-op outside composing",
-  );
-  assert.equal(
-    addTileReducer({ ...composed, mode: "paste" }, { type: "generate" }).phase,
-    "composing",
-    "generate is a no-op outside describe mode",
-  );
-}
-
-// ── refine keeps the prior result until replaced ─────────────────────────────
-{
-  const result = {
-    ...s0,
-    phase: "result",
-    prompt: "a form",
-    result: { code: "<p>v1</p>", kind: "html" },
-  };
-  const refining = addTileReducer(result, { type: "refine" });
-  assert.equal(refining.phase, "generating");
-  assert.deepEqual(refining.result, result.result, "refine retains the prior sketch mid-flight");
-
-  const refineFailed = addTileReducer(refining, {
-    type: "generation-failed",
-    message: "cancelled",
-  });
-  assert.deepEqual(refineFailed.result, result.result, "a failed refine keeps the prior sketch");
-
-  const noResult = addTileReducer(s0, { type: "expand" });
-  assert.equal(addTileReducer(noResult, { type: "refine" }).phase, "composing", "refine is a no-op without a result");
-}
-
-// ── late async events never resurrect a collapsed/discarded tile ────────────
-{
-  const open = addTileReducer(s0, { type: "expand" });
-  const generating = addTileReducer({ ...open, prompt: "x" }, { type: "generate" });
-  const collapsed = addTileReducer(generating, { type: "collapse" });
-  assert.equal(
-   addTileReducer(collapsed, { type: "generated", code: "<p>late</p>", kind: "html" }).phase,
-   "collapsed",
-   "a late generated event never reopens a collapsed tile",
-  );
-  assert.equal(
-   addTileReducer(collapsed, { type: "generation-failed", message: "aborted" }).phase,
-   "collapsed",
-   "a late failure never reopens a collapsed tile",
-  );
-
-  const discarded = addTileReducer(
-   { ...s0, phase: "result", result: { code: "<p>v1</p>", kind: "html" } },
-   { type: "discard-result" },
-  );
-  const lateAfterDiscard = addTileReducer(discarded, { type: "generated", code: "<p>v1</p>", kind: "html" });
-  assert.equal(lateAfterDiscard.result, null, "a late generated event never revives a discarded sketch");
-}
-
-// ── discard and saved ────────────────────────────────────────────────────────
-{
-  const result = {
-    ...s0,
-    phase: "result",
-    prompt: "a form",
-    result: { code: "<p>v1</p>", kind: "html" },
-  };
-  const discarded = addTileReducer(result, { type: "discard-result" });
-  assert.equal(discarded.phase, "composing");
-  assert.equal(discarded.result, null);
-  assert.equal(discarded.prompt, "a form", "discard keeps the prompt for another go");
-
-  const saved = addTileReducer(result, { type: "saved" });
-  assert.deepEqual(saved, INITIAL_ADD_TILE_STATE, "save resets the whole composer");
-}
-
-// ── field edits ──────────────────────────────────────────────────────────────
-{
-  const open = addTileReducer(s0, { type: "expand" });
-  assert.equal(addTileReducer(open, { type: "set-prompt", prompt: "x" }).prompt, "x");
-  const code = addTileReducer(open, { type: "set-pasted-code", code: "<div/>" });
-  assert.equal(code.pastedCode, "<div/>");
-  const titled = addTileReducer(open, { type: "set-pasted-title", title: "My sketch" });
-  assert.equal(titled.pastedTitle, "My sketch");
-}
-
-// ── derivePastedTitle ────────────────────────────────────────────────────────
+// Format repair is one explicit phase and late/wrong-run events are rejected.
 assert.equal(
-  derivePastedTitle("<!doctype html><html><head><title>Neat Page</title></head></html>"),
-  "Neat Page",
-  "prefers the document title",
+  addTileReducer({ ...creating, phase: "generating" }, { type: "begin-repair", runId: "wrong" }).phase,
+  "generating",
+);
+const collapsed = addTileReducer(creating, { type: "collapse" });
+assert.equal(collapsed.phase, "collapsed");
+assert.equal(
+  addTileReducer(collapsed, { type: "generated", runId: "run-1", code: "late", kind: "html", sessionId: "late", revision: 1 }).result,
+  null,
+  "late generation cannot resurrect a cancelled run",
 );
 assert.equal(
-  derivePastedTitle("<body><h1>Big <em>Header</em></h1></body>"),
-  "Big Header",
-  "falls back to h1 text, tags stripped",
-);
-assert.equal(derivePastedTitle("<p>no headings</p>"), "Pasted sketch", "defaults when untitled");
-assert.equal(
-  derivePastedTitle(`<h1>${"long ".repeat(40)}</h1>`).length <= 60,
-  true,
-  "titles are clamped like every other artifact title",
-);
-assert.equal(
-  derivePastedTitle("<html><head><title></title></head><body><h1>Real Heading</h1></body></html>"),
-  "Real Heading",
-  "an empty <title> falls back to the h1",
+  addTileReducer(creating, { type: "generated", runId: "other", code: "late", kind: "html", sessionId: "late", revision: 1 }).result,
+  null,
+  "a previous run cannot overwrite the active run",
 );
 
-// ── detectPastedKind ─────────────────────────────────────────────────────────
-assert.equal(detectPastedKind("<!doctype html><html></html>"), "html");
-assert.equal(detectPastedKind("export default function App() { return <p/>; }"), "react");
+// Closing an unsaved preview retains it; closing a saved preview completes it.
+assert.equal(addTileReducer(generated, { type: "collapse" }).result.code, "<html>v1</html>");
+assert.deepEqual(addTileReducer(saved, { type: "collapse" }), INITIAL_ADD_TILE_STATE);
+const savingClosed = addTileReducer(generated, { type: "collapse" });
+assert.deepEqual(
+  addTileReducer(savingClosed, { type: "save-succeeded", revision: 1 }),
+  INITIAL_ADD_TILE_STATE,
+  "a late successful autosave joins the gallery without reopening the draft",
+);
 
-// ── buildAddArtifact ─────────────────────────────────────────────────────────
-{
-  const art = buildAddArtifact({
-    id: "art-1",
-    now: "2026-07-17T00:00:00.000Z",
-    mode: "describe",
-    prompt: "a pricing page with three tiers",
-    pastedTitle: "",
-    code: "<!doctype html><html></html>",
-    kind: "html",
-  });
-  assert.equal(art.title, "a pricing page with three tiers", "describe titles from the prompt");
-  assert.equal(art.prompt, "a pricing page with three tiers");
-  assert.equal(art.createdAt, art.updatedAt);
+// A saved draft discards only after the component's DELETE succeeds; a local
+// unsaved draft can clear immediately while keeping the description editable.
+const discarded = addTileReducer(notSaved, { type: "discard-local" });
+assert.equal(discarded.phase, "composing");
+assert.equal(discarded.result, null);
+assert.equal(discarded.prompt, "a pricing page");
 
-  const pasted = buildAddArtifact({
-    id: "art-2",
-    now: "2026-07-17T00:00:00.000Z",
-    mode: "paste",
-    prompt: "",
-    pastedTitle: "",
-    code: "<html><head><title>Hand-made</title></head></html>",
-    kind: "html",
-  });
-  assert.equal(pasted.title, "Hand-made", "paste derives its title from the code");
-  assert.equal(pasted.prompt, "", "pasted sketches carry no generation prompt");
+// Payload helpers keep identity and createdAt stable while updatedAt advances.
+const v1 = buildArtifactRevision({ identity, prompt: "a dashboard", code: "one", kind: "html", updatedAt: "t1" });
+const v2 = buildArtifactRevision({ identity, prompt: "a dashboard", code: "two", kind: "react", updatedAt: "t2" });
+assert.equal(v1.id, v2.id);
+assert.equal(v1.createdAt, v2.createdAt);
+assert.equal(v2.updatedAt, "t2");
+assert.equal(v2.code, "two");
 
-  const named = buildAddArtifact({
-    id: "art-3",
-    now: "2026-07-17T00:00:00.000Z",
-    mode: "paste",
-    prompt: "",
-    pastedTitle: "Explicit name",
-    code: "<p>x</p>",
-    kind: "html",
-  });
-  assert.equal(named.title, "Explicit name", "an explicit title wins");
+assert.equal(derivePastedTitle("<title>Neat Page</title>"), "Neat Page");
+assert.equal(derivePastedTitle("<h1>Big <em>Header</em></h1>"), "Big Header");
+assert.equal(derivePastedTitle("<p>none</p>"), "Pasted sketch");
+assert.equal(detectPastedKind("export default function App(){return <p/>}"), "react");
 
-  const clamped = buildAddArtifact({
-    id: "art-4",
-    now: "2026-07-17T00:00:00.000Z",
-    mode: "paste",
-    prompt: "",
-    pastedTitle: "Big",
-    code: "x".repeat(MAX_ARTIFACT_CODE_CHARS + 500),
-    kind: "html",
-  });
-  assert.equal(clamped.code.length, MAX_ARTIFACT_CODE_CHARS, "code is clamped to the storage cap");
-  assert.equal(clamped.id, "art-4");
-  assert.equal(clamped.kind, "html");
-  assert.equal(clamped.createdAt, "2026-07-17T00:00:00.000Z", "createdAt is the injected now");
-
-  const describeNamed = buildAddArtifact({
-    id: "art-5",
-    now: "2026-07-17T00:00:00.000Z",
-    mode: "describe",
-    prompt: "a dashboard",
-    pastedTitle: "Named anyway",
-    code: "<p>x</p>",
-    kind: "html",
-  });
-  assert.equal(describeNamed.title, "Named anyway", "an explicit title wins in describe mode too");
-}
+const clamped = buildAddArtifact({
+  id: "art-code",
+  now: "now",
+  mode: "paste",
+  prompt: "",
+  pastedTitle: "Code",
+  code: "x".repeat(MAX_ARTIFACT_CODE_CHARS + 10),
+  kind: "html",
+});
+assert.equal(clamped.code.length, MAX_ARTIFACT_CODE_CHARS);
 
 console.log("canvas-add.test.ts: ok");

--- a/src/lib/canvas-add.ts
+++ b/src/lib/canvas-add.ts
@@ -1,11 +1,10 @@
-// Pure logic for the Canvas "New sketch" tile (cave-fema): the composer state
-// machine, pasted-code helpers, and the save-payload builder. Framework-free —
-// the component owns fetches/aborts/announcements; everything here is
-// deterministic and unit-tested. Spec:
-// docs/superpowers/specs/2026-07-17-canvas-add-tile-design.md (local).
+// Pure state and payload helpers for Canvas's describe-first New sketch flow.
+// The component owns effects; this reducer owns lifecycle/race invariants so
+// late async events cannot revive or overwrite a cancelled/newer run.
 
 import {
   STARTER_ARTIFACT_HTML,
+  STARTER_ARTIFACT_REACT,
   clampArtifactCode,
   looksLikeReact,
   titleFromPrompt,
@@ -13,21 +12,35 @@ import {
   type CanvasArtifact,
 } from "@/lib/canvas-artifacts";
 
-export type AddTileMode = "describe" | "paste" | "blank";
-export type AddTilePhase = "collapsed" | "composing" | "generating" | "result" | "error";
+export type AddTileMode = "describe" | "paste" | "blank-html" | "blank-react";
+export type AddTilePhase =
+  | "collapsed"
+  | "composing"
+  | "generating"
+  | "repairing"
+  | "result"
+  | "error";
+export type AddTileSaveState = "idle" | "saving" | "saved" | "error";
+
+export type ArtifactIdentity = { id: string; createdAt: string };
+export type AddTileResult = { code: string; kind: ArtifactKind; sessionId: string | null };
 
 export type AddTileState = {
   phase: AddTilePhase;
   mode: AddTileMode;
-  /** Describe-mode prompt. Survives collapse/failure; only save resets it. */
   prompt: string;
-  /** Paste/Blank editor contents. Same retention rules as the prompt. */
   pastedCode: string;
-  /** Explicit user-entered title for pasted code ("" = derive from code). */
   pastedTitle: string;
-  /** The generated sketch awaiting Keep/Refine/Discard. */
-  result: { code: string; kind: ArtifactKind } | null;
+  result: AddTileResult | null;
+  /** Last revision confirmed in the store; refine failures never replace it. */
+  persistedResult: AddTileResult | null;
+  identity: ArtifactIdentity | null;
+  revision: number;
+  saveState: AddTileSaveState;
+  activeRunId: string | null;
+  generationPurpose: "create" | "refine" | null;
   error: string | null;
+  errorKind: "format" | "generation" | "discard" | null;
 };
 
 export type AddTileEvent =
@@ -37,13 +50,18 @@ export type AddTileEvent =
   | { type: "set-prompt"; prompt: string }
   | { type: "set-pasted-code"; code: string }
   | { type: "set-pasted-title"; title: string }
-  | { type: "generate" }
-  | { type: "generated"; code: string; kind: ArtifactKind }
-  | { type: "generation-failed"; message: string }
-  | { type: "refine" }
-  | { type: "retry" }
-  | { type: "discard-result" }
-  | { type: "saved" };
+  | { type: "begin-generation"; runId: string; identity: ArtifactIdentity }
+  | { type: "begin-refine"; runId: string }
+  | { type: "begin-repair"; runId: string }
+  | { type: "generated"; runId: string; code: string; kind: ArtifactKind; sessionId: string | null; revision: number }
+  | { type: "generation-failed"; runId: string; message: string; kind: "format" | "generation" }
+  | { type: "save-started"; revision: number }
+  | { type: "save-succeeded"; revision: number; savedId?: string; savedCreatedAt?: string }
+  | { type: "save-failed"; revision: number }
+  | { type: "edit-description" }
+  | { type: "discard-local" }
+  | { type: "discard-failed"; message: string }
+  | { type: "code-saved" };
 
 export const INITIAL_ADD_TILE_STATE: AddTileState = {
   phase: "collapsed",
@@ -52,57 +70,169 @@ export const INITIAL_ADD_TILE_STATE: AddTileState = {
   pastedCode: "",
   pastedTitle: "",
   result: null,
+  persistedResult: null,
+  identity: null,
+  revision: 0,
+  saveState: "idle",
+  activeRunId: null,
+  generationPurpose: null,
   error: null,
+  errorKind: null,
 };
 
-/**
- * The composer state machine. Retention is the contract: collapse, failure,
- * and discard keep what the user typed; only `saved` resets everything. An
- * unsaved `result` never survives a collapse (nothing was persisted).
- */
+export type AddTileFocusTarget = "ghost" | "prompt" | "editor" | "cancel" | "refine" | "retry" | null;
+
+/** Pure accessibility view-model for predictable focus after phase changes. */
+export function focusTargetForState(
+  state: Pick<AddTileState, "phase" | "mode">,
+  previousPhase: AddTilePhase,
+): AddTileFocusTarget {
+  if (state.phase === previousPhase) return null;
+  switch (state.phase) {
+    case "collapsed": return "ghost";
+    case "composing": return state.mode === "describe" ? "prompt" : "editor";
+    case "generating":
+    case "repairing": return "cancel";
+    case "result": return "refine";
+    case "error": return "retry";
+  }
+}
+
+/** One stable live-region sentence per generation phase. */
+export function generationStatusText(
+  phase: "generating" | "repairing",
+  familiarName: string,
+): string {
+  return phase === "repairing"
+    ? "Still preparing your preview…"
+    : `${familiarName || "Familiar"} is creating your preview…`;
+}
+
 export function addTileReducer(state: AddTileState, event: AddTileEvent): AddTileState {
   switch (event.type) {
     case "expand":
-      return state.phase === "collapsed" ? { ...state, phase: "composing" } : state;
+      if (state.phase !== "collapsed") return state;
+      return { ...state, phase: state.result ? "result" : "composing" };
     case "collapse":
-      return { ...state, phase: "collapsed", result: null, error: null };
+      // A confirmed artifact has joined the gallery, so closing completes this
+      // creation and the next New sketch starts fresh. An unsaved valid preview
+      // remains in reducer state and reopens instead of being silently lost.
+      if (state.result && state.saveState === "saved") return INITIAL_ADD_TILE_STATE;
+      return { ...state, phase: "collapsed", activeRunId: null, generationPurpose: null };
     case "set-mode": {
       if (state.phase !== "composing") return state;
-      const next = { ...state, mode: event.mode };
-      // Blank = Paste pre-seeded with the starter — but never clobber code
-      // the user already has in the editor.
-      if (event.mode === "blank" && !state.pastedCode.trim()) {
-        next.pastedCode = STARTER_ARTIFACT_HTML;
-      }
-      return next;
+      let pastedCode = state.pastedCode;
+      if (event.mode === "blank-html") pastedCode = STARTER_ARTIFACT_HTML;
+      if (event.mode === "blank-react") pastedCode = STARTER_ARTIFACT_REACT;
+      return { ...state, mode: event.mode, pastedCode, error: null, errorKind: null };
     }
     case "set-prompt":
-      return { ...state, prompt: event.prompt };
+      return state.phase === "composing" ? { ...state, prompt: event.prompt } : state;
     case "set-pasted-code":
-      return { ...state, pastedCode: event.code };
+      return state.phase === "composing" ? { ...state, pastedCode: event.code } : state;
     case "set-pasted-title":
-      return { ...state, pastedTitle: event.title };
-    case "generate":
-      if (state.phase !== "composing" || state.mode !== "describe" || !state.prompt.trim()) {
-        return state;
-      }
-      return { ...state, phase: "generating", error: null };
-    case "refine":
-      return state.phase === "result" ? { ...state, phase: "generating", error: null } : state;
-    case "retry":
-      return state.phase === "error" ? { ...state, phase: "generating", error: null } : state;
+      return state.phase === "composing" ? { ...state, pastedTitle: event.title } : state;
+    case "begin-generation":
+      if ((state.phase !== "composing" && state.phase !== "error") || !state.prompt.trim()) return state;
+      return {
+        ...state,
+        phase: "generating",
+        mode: "describe",
+        identity: state.identity ?? event.identity,
+        activeRunId: event.runId,
+        generationPurpose: "create",
+        error: null,
+        errorKind: null,
+      };
+    case "begin-refine":
+      if (state.phase !== "result" || !state.result || !state.identity) return state;
+      return {
+        ...state,
+        phase: "generating",
+        activeRunId: event.runId,
+        generationPurpose: "refine",
+        error: null,
+        errorKind: null,
+      };
+    case "begin-repair":
+      return state.phase === "generating" && state.activeRunId === event.runId
+        ? { ...state, phase: "repairing" }
+        : state;
     case "generated":
-      // Async terminal events only apply to an in-flight generation — a late
-      // arrival after collapse/discard must not resurrect the tile.
-      if (state.phase !== "generating") return state;
-      return { ...state, phase: "result", result: { code: event.code, kind: event.kind }, error: null };
+      if (
+        (state.phase !== "generating" && state.phase !== "repairing") ||
+        state.activeRunId !== event.runId ||
+        event.revision <= state.revision
+      ) return state;
+      return {
+        ...state,
+        phase: "result",
+        result: { code: event.code, kind: event.kind, sessionId: event.sessionId },
+        revision: event.revision,
+        saveState: "saving",
+        error: null,
+        errorKind: null,
+      };
     case "generation-failed":
-      if (state.phase !== "generating") return state;
-      // A failed refine keeps the prior sketch recoverable (result retained).
-      return { ...state, phase: "error", error: event.message };
-    case "discard-result":
-      return { ...state, phase: "composing", result: null, error: null };
-    case "saved":
+      if (
+        (state.phase !== "generating" && state.phase !== "repairing") ||
+        state.activeRunId !== event.runId
+      ) return state;
+      return {
+        ...state,
+        phase: state.result ? "result" : "error",
+        activeRunId: null,
+        generationPurpose: null,
+        error: event.message,
+        errorKind: event.kind,
+      };
+    case "save-started":
+      return event.revision === state.revision && state.result
+        ? { ...state, saveState: "saving", error: null, errorKind: null }
+        : state;
+    case "save-succeeded":
+      if (event.revision !== state.revision || !state.result) return state;
+      // If the user closed while the autosave was in flight, the successful
+      // artifact now belongs to the gallery; clear the retained draft so the
+      // next New sketch really is new.
+      if (state.phase === "collapsed") return INITIAL_ADD_TILE_STATE;
+      return {
+            ...state,
+            identity: event.savedId && state.identity
+              ? {
+                  id: event.savedId,
+                  createdAt: event.savedCreatedAt ?? state.identity.createdAt,
+                }
+              : state.identity,
+            saveState: "saved",
+            persistedResult: state.result,
+            activeRunId: null,
+            generationPurpose: null,
+          };
+    case "save-failed":
+      return event.revision === state.revision && state.result
+        ? {
+            ...state,
+            saveState: "error",
+            activeRunId: null,
+            generationPurpose: null,
+            error: "Couldn’t save this preview.",
+            errorKind: "generation",
+          }
+        : state;
+    case "edit-description":
+      return state.phase === "error"
+        ? { ...state, phase: "composing", error: null, errorKind: null, activeRunId: null }
+        : state;
+    case "discard-local":
+      return {
+        ...INITIAL_ADD_TILE_STATE,
+        phase: "composing",
+        prompt: state.prompt,
+      };
+    case "discard-failed":
+      return { ...state, error: event.message, errorKind: "discard" };
+    case "code-saved":
       return INITIAL_ADD_TILE_STATE;
     default:
       return state;
@@ -111,26 +241,20 @@ export function addTileReducer(state: AddTileState, event: AddTileEvent): AddTil
 
 const strip = (html: string): string => html.replace(/<[^>]*>/g, " ");
 
-/** Title for pasted code: `<title>` text, else first `<h1>` text, else a
- *  default — collapsed and clamped with the same rules as prompt titles. */
 export function derivePastedTitle(code: string): string {
   const src = typeof code === "string" ? code : "";
   const title = src.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1];
   const h1 = src.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)?.[1];
-  // First non-empty candidate wins — a present-but-empty <title></title> must
-  // not suppress the <h1> fallback.
   const raw = [title, h1]
     .map((s) => strip(s ?? "").replace(/\s+/g, " ").trim())
     .find(Boolean) ?? "";
   return raw ? titleFromPrompt(raw) : "Pasted sketch";
 }
 
-/** Kind of pasted code, via the same heuristic generation extraction uses. */
 export function detectPastedKind(code: string): ArtifactKind {
   return looksLikeReact(code) ? "react" : "html";
 }
 
-/** The artifact a Keep/Add action persists. `id`/`now` injected for purity. */
 export function buildAddArtifact(opts: {
   id: string;
   now: string;
@@ -151,5 +275,24 @@ export function buildAddArtifact(opts: {
     kind: opts.kind,
     createdAt: opts.now,
     updatedAt: opts.now,
+  };
+}
+
+/** Build an id-stable generated/refined revision without changing createdAt. */
+export function buildArtifactRevision(opts: {
+  identity: ArtifactIdentity;
+  prompt: string;
+  code: string;
+  kind: ArtifactKind;
+  updatedAt: string;
+}): CanvasArtifact {
+  return {
+    id: opts.identity.id,
+    title: titleFromPrompt(opts.prompt),
+    prompt: opts.prompt,
+    code: clampArtifactCode(opts.code),
+    kind: opts.kind,
+    createdAt: opts.identity.createdAt,
+    updatedAt: opts.updatedAt,
   };
 }

--- a/src/lib/canvas-artifacts.test.ts
+++ b/src/lib/canvas-artifacts.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   buildPreviewSrcDoc,
+  buildArtifactRepairPrompt,
   buildRefinePrompt,
   buildSketchPrompt,
   clampArtifactCode,
@@ -12,6 +13,7 @@ import {
   MAX_ARTIFACT_CODE_CHARS,
   sanitizeArtifacts,
   STARTER_ARTIFACT_HTML,
+  STARTER_ARTIFACT_REACT,
   titleFromPrompt,
 } from "./canvas-artifacts.ts";
 
@@ -74,6 +76,13 @@ assert.match(refine, /<!doctype html><html><\/html>/, "refine prompt embeds the 
 assert.match(refine, /FULL updated document/, "refine asks for the full document, not a diff");
 
 assert.match(STARTER_ARTIFACT_HTML, /^<!doctype html>/i, "starter template is a full document");
+assert.match(STARTER_ARTIFACT_REACT, /export default function App/, "React starter is a complete default-exported component");
+
+const repair = buildArtifactRepairPrompt("a responsive dashboard");
+assert.match(repair, /a responsive dashboard/, "repair carries the original intent");
+assert.match(repair, /one complete `html` or `tsx` fenced artifact/, "repair requests exactly one supported artifact");
+assert.doesNotMatch(repair, /previous response[\s\S]*```/, "repair does not echo an arbitrarily large malformed response");
+assert.match(buildArtifactRepairPrompt("add a button", "react"), /one complete `tsx` fenced artifact/);
 
 // ── sanitizeArtifacts: trust boundary for disk + request bodies ────────────
 

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -223,6 +223,32 @@ export function buildRefinePrompt(
   ].join("\n");
 }
 
+/**
+ * One-shot recovery prompt for a Canvas-origin response that streamed
+ * successfully but could not be rendered. Keeping this separate from the
+ * normal sketch prompt lets callers retry only the format failure, and pass
+ * the first run's session id so the repair remains in the same hidden Canvas
+ * conversation.
+ */
+export function buildArtifactRepairPrompt(
+  originalIntent: string,
+  kind?: ArtifactKind,
+): string {
+  const intent = (originalIntent ?? "").trim() || "the requested UI";
+  const form = kind === "react"
+    ? "one complete `tsx` fenced artifact"
+    : kind === "html"
+      ? "one complete `html` fenced artifact"
+      : "one complete `html` or `tsx` fenced artifact";
+  return [
+    "Repair the previous response so the Canvas can preview it.",
+    `Return only ${form}, with no prose before or after.`,
+    "The artifact must be complete, self-contained, and require no network access.",
+    "Original user intent:",
+    intent,
+  ].join("\n");
+}
+
 /** A minimal starter document for hand-written / pasted artifacts. */
 export const STARTER_ARTIFACT_HTML = [
   "<!doctype html>",
@@ -241,6 +267,24 @@ export const STARTER_ARTIFACT_HTML = [
   '  <div class="card"><h1>Hello, canvas</h1><p>Edit this HTML to sketch a UI.</p></div>',
   "</body>",
   "</html>",
+].join("\n");
+
+/** A minimal interactive starter for the explicit Blank React path. */
+export const STARTER_ARTIFACT_REACT = [
+  "export default function App() {",
+  "  const [count, setCount] = React.useState(0);",
+  "  return (",
+  '    <main className="min-h-screen bg-slate-950 text-slate-100 grid place-items-center p-6">',
+  '      <section className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-xl">',
+  '        <h1 className="text-2xl font-semibold">Hello, canvas</h1>',
+  '        <p className="mt-2 text-slate-400">Edit this React component to sketch an interaction.</p>',
+  '        <button className="mt-5 rounded-lg bg-violet-500 px-4 py-2 font-medium hover:bg-violet-400" onClick={() => setCount((value) => value + 1)}>',
+  "          Clicked {count} times",
+  "        </button>",
+  "      </section>",
+  "    </main>",
+  "  );",
+  "}",
 ].join("\n");
 
 /** Validate/normalize a raw artifact record from disk or a request body. */

--- a/src/lib/canvas-generate.test.ts
+++ b/src/lib/canvas-generate.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 
-import { parseSseFrame } from "./canvas-generate.ts";
+import { generateArtifactCode, parseSseFrame } from "./canvas-generate.ts";
 
 // parseSseFrame is the pure half of the streaming generator — it must tolerate
 // the exact frame shape /api/chat/send emits ("data: {json}") and shrug off
@@ -23,5 +23,56 @@ assert.equal(parseSseFrame(": keep-alive comment"), null, "SSE comments are igno
 assert.equal(parseSseFrame("event: ping"), null, "non-data lines are ignored");
 assert.equal(parseSseFrame("data: "), null, "empty data payload yields null");
 assert.equal(parseSseFrame("data: {not json"), null, "malformed JSON yields null, not a throw");
+
+const originalFetch = globalThis.fetch;
+const encoder = new TextEncoder();
+const responseFor = (frames) => new Response(
+  new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+      controller.close();
+    },
+  }),
+  { status: 200 },
+);
+
+try {
+  let sentBody = null;
+  globalThis.fetch = async (_url, init) => {
+    sentBody = JSON.parse(init.body);
+    return responseFor([
+      { kind: "session", sessionId: "canvas-session" },
+      { kind: "assistant_chunk", text: "```html\n<!doctype html><html></html>\n```" },
+      { kind: "done", sessionId: "canvas-session" },
+    ]);
+  };
+  const valid = await generateArtifactCode({ familiarId: "nova", prompt: "build" });
+  assert.equal(valid.failure, null);
+  assert.equal(valid.kind, "html");
+  assert.equal(valid.sessionId, "canvas-session");
+  assert.equal(sentBody.origin, "canvas");
+
+  globalThis.fetch = async (_url, init) => {
+    sentBody = JSON.parse(init.body);
+    return responseFor([
+      { kind: "assistant_chunk", text: "Here is some prose without a complete preview." },
+      { kind: "done" },
+    ]);
+  };
+  const malformed = await generateArtifactCode({
+    familiarId: "nova",
+    prompt: "repair",
+    sessionId: "canvas-session",
+  });
+  assert.equal(malformed.failure, "format", "successful stream + no artifact is a structured format failure");
+  assert.equal(malformed.sessionId, "canvas-session", "repair keeps the original hidden session when no new session event arrives");
+  assert.equal(sentBody.sessionId, "canvas-session", "repair resumes the original Canvas-origin run");
+
+  globalThis.fetch = async () => new Response("offline", { status: 503 });
+  const transport = await generateArtifactCode({ familiarId: "nova", prompt: "build" });
+  assert.equal(transport.failure, "transport", "HTTP/runtime failures are never classified as repairable format failures");
+} finally {
+  globalThis.fetch = originalFetch;
+}
 
 console.log("canvas-generate.test.ts ✓");

--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -31,6 +31,9 @@ export type GenerateResult = {
   text: string;
   sessionId: string | null;
   error: string | null;
+  /** Structured cause so Canvas can repair format failures without retrying
+   * transport/auth/runtime failures or parsing user-facing copy. */
+  failure: "transport" | "format" | null;
 };
 
 /**
@@ -43,6 +46,8 @@ export async function generateArtifactCode(opts: {
   prompt: string;
   familiarId: string;
   projectRoot?: string | null;
+  /** Resume the hidden Canvas-origin conversation (used by one-shot repair). */
+  sessionId?: string | null;
   signal?: AbortSignal;
   onText?: (fullText: string) => void;
 }): Promise<GenerateResult> {
@@ -54,6 +59,7 @@ export async function generateArtifactCode(opts: {
       body: JSON.stringify({
         familiarId: opts.familiarId,
         prompt: opts.prompt,
+        sessionId: opts.sessionId ?? undefined,
         projectRoot: opts.projectRoot ?? undefined,
         // Provenance: these sends belong to the Canvas/artifact surface, so
         // the chat lists can keep them out of the conversation rail.
@@ -62,17 +68,31 @@ export async function generateArtifactCode(opts: {
       signal: opts.signal,
     });
   } catch (err) {
-    return { code: null, kind: null, text: "", sessionId: null, error: (err as Error)?.message ?? "request failed" };
+    return {
+      code: null,
+      kind: null,
+      text: "",
+      sessionId: opts.sessionId ?? null,
+      error: opts.signal?.aborted ? "cancelled" : (err as Error)?.message ?? "request failed",
+      failure: "transport",
+    };
   }
   if (!res.ok || !res.body) {
-    return { code: null, kind: null, text: "", sessionId: null, error: `chat bridge ${res.status}` };
+    return {
+      code: null,
+      kind: null,
+      text: "",
+      sessionId: opts.sessionId ?? null,
+      error: `chat bridge ${res.status}`,
+      failure: "transport",
+    };
   }
 
   const reader = res.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   let text = "";
-  let sessionId: string | null = null;
+  let sessionId: string | null = opts.sessionId ?? null;
   let error: string | null = null;
 
   // A mid-stream network drop (or an abort) makes reader.read() REJECT — an
@@ -115,14 +135,13 @@ export async function generateArtifactCode(opts: {
   }
 
   const extracted = extractArtifact(text);
-  if (!extracted && !error) {
-    error = "The familiar didn't return a renderable UI. Try rephrasing.";
-  }
+  const failure = error ? "transport" : extracted ? null : "format";
   return {
     code: extracted?.code ?? null,
     kind: extracted?.kind ?? null,
     text,
     sessionId,
-    error,
+    error: error ?? (failure === "format" ? "response format could not be previewed" : null),
+    failure,
   };
 }

--- a/src/lib/cave-canvas.test.ts
+++ b/src/lib/cave-canvas.test.ts
@@ -179,7 +179,7 @@ assert.match(
 const addTileSource = readFileSync(new URL("../components/canvas-add-tile.tsx", import.meta.url), "utf8");
 assert.match(
   addTileSource,
-  /onSaved\(data\.artifacts \?\? \[\], data\.savedId \?\? artifact\.id\)/,
+  /onArtifactsChanged\(data\.artifacts \?\? \[\], savedId\)/,
   "the add tile highlights the settled tile, not the client-minted id a dedupe discarded",
 );
 

--- a/src/styles/chat-canvas.css
+++ b/src/styles/chat-canvas.css
@@ -170,6 +170,17 @@
   align-items: center;
   gap: var(--space-2);
 }
+.chat-canvas-add__heading {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: 650;
+  color: var(--text-primary);
+}
+.chat-canvas-add__subheading {
+  margin: 2px 0 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
 .chat-canvas-add__modes { display: flex; gap: var(--space-1); flex: 1; }
 .chat-canvas-add__mode {
   font-size: var(--text-xs);
@@ -212,6 +223,7 @@
   padding: var(--space-2) var(--space-3);
 }
 .chat-canvas-add__prompt { min-height: 72px; resize: vertical; }
+.chat-canvas-add__refine-input { min-height: 64px; resize: vertical; }
 .chat-canvas-add__editor {
   min-height: 160px;
   resize: vertical;
@@ -234,6 +246,27 @@
   border-radius: var(--radius-pill);
   padding: var(--space-1) var(--space-2);
   max-width: 180px;
+}
+.chat-canvas-add__start-code,
+.chat-canvas-add__retry-save {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-control);
+}
+.chat-canvas-add__start-code:hover,
+.chat-canvas-add__retry-save:hover { color: var(--text-primary); background: var(--bg-raised); }
+.chat-canvas-add__start-code svg { width: 12px; height: 12px; }
+.chat-canvas-add__no-familiar {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-warning, var(--text-muted));
 }
 .chat-canvas-add__kind {
   flex-shrink: 0;
@@ -298,6 +331,53 @@
   border-radius: var(--radius-control);
   padding: var(--space-2) var(--space-3);
 }
+.chat-canvas-add__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.chat-canvas-add__suggestion {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+.chat-canvas-add__suggestion:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.chat-canvas-add__result-head,
+.chat-canvas-add__code-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.chat-canvas-add__result-head .chat-canvas-add__save-state { margin-left: auto; }
+.chat-canvas-add__save-state {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.chat-canvas-add__save-state--saved { color: var(--color-success); }
+.chat-canvas-add__save-state--error { color: var(--color-danger); }
+.chat-canvas-add__refine-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.chat-canvas-add__code {
+  min-height: 200px;
+  max-height: 320px;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  padding: var(--space-3);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-xs);
+  white-space: pre;
+}
 /* Result preview inside the tile — same sandboxed-thumbnail treatment as
    cards (thumb precedent: sketches expect a white page behind them). */
 .chat-canvas-add__preview {
@@ -316,6 +396,16 @@
   transform: scale(0.5);
   transform-origin: top left;
   pointer-events: none;
+}
+.chat-canvas-add__runtime-error {
+  position: absolute;
+  inset: auto var(--space-2) var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--bg-panel);
+  color: var(--color-danger);
+  font-size: var(--text-xs);
+  padding: var(--space-2);
 }
 /* A kept sketch settles into the grid with a one-shot highlight. */
 .chat-canvas-card--new {


### PR DESCRIPTION
## Summary

- make New sketch open directly into a describe-first composer, with prompt suggestions and an accessible familiar switcher
- move Paste code, Blank HTML, and Blank React behind a secondary Start from code menu
- autosave valid previews under one creation identity, refine the settled record in place, and keep valid previews recoverable when persistence fails
- add one abortable, same-session format-repair attempt with plain-language recovery after a second format failure
- keep Preview primary and Code secondary, expose refinement continuously, and prevent an active autosaved preview from rendering as a duplicate gallery card
- preserve current-main byte-identical content dedupe by adopting the server-settled artifact id and creation time

## Why

Canvas previously framed creation as an implementation-mode choice and required an ambiguous Keep action after generation. A valid preview could remain transient, malformed familiar output surfaced technical extraction failures, and refinement did not read as the natural continuation of creation.

This changes the user model to intent → preview → refine while retaining code-first paths as explicit advanced options.

## Verification

- `pnpm typecheck`
- `pnpm check:tests-wired` — all 1043 test files wired
- `pnpm test:app` — 768 test files passed
- `pnpm build` — Next build, server build, bundle budget, and standalone budget passed
- `git diff --check`
- focused Canvas state, generation, artifact, persistence, and wiring tests after rebasing onto current main
- exact-head CI: 768 app, 199 API, and 81 mobile test files; E2E, Rust, CodeQL, and cross-environment jobs all passed
- isolated production-browser lifecycle run covering keyboard focus, reduced motion, code entry modes, same-session repair/refinement, stable upsert identity, persistence failure and retry, duplicate suppression, discard, cancellation, and no transport retry

The repository Tauri wrapper reached Cargo against the verified build, but this execution environment has no C linker (`cc`, `gcc`, or `clang`) and no Windows interop, so it could not link and launch the native shell here.

Closes #3387

Bead: `cave-9hd`