### PR TITLE
Start the local daemon on native desktop launch

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -62,6 +62,7 @@ export const SUITES = {
     "src/lib/app-update.test.ts",
     "src/lib/about-status.test.ts",
     "src/lib/daemon-status-classification.test.ts",
+    "src/lib/daemon-desktop-auto-start.test.ts",
     "src/lib/about-diagnostics.test.ts",
     "src/lib/browser-navigation-queue.test.ts",
     "src/lib/open-external.test.ts",

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -41,7 +41,7 @@ assert.doesNotMatch(
 
 assert.match(
   workspace,
-  /fetch\("\/api\/daemon\/start", \{ method: "POST" \}\)/,
+  /runWorkspaceDaemonStart\(\{[\s\S]*fetchImpl: fetch/,
   "Workspace should make the offline daemon state actionable via the shared banner channel",
 );
 

--- a/src/components/daemon-start-button.test.ts
+++ b/src/components/daemon-start-button.test.ts
@@ -25,8 +25,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /const startDaemon = useCallback\([\s\S]*await fetch\("\/api\/daemon\/start", \{ method: "POST" \}\)[\s\S]*await refreshDaemonStatus\(\)/,
-  "Workspace banner start action should refresh daemon status immediately after starting",
+  /const startDaemon = useCallback\([\s\S]*runWorkspaceDaemonStart\(\{[\s\S]*fetchImpl: fetch[\s\S]*refreshStatus: refreshDaemonStatus/,
+  "Workspace automatic and manual starts should share the behaviorally tested start flow",
 );
 
 assert.match(

--- a/src/components/workspace-sessions-navigation.test.ts
+++ b/src/components/workspace-sessions-navigation.test.ts
@@ -46,7 +46,7 @@ assert.match(
 
 assert.match(
   workspace,
-  /requestId !== daemonStatusRequestRef\.current/,
+  /!requestGate\.isLatest\(requestId\)/,
   "an older status poll must not overwrite a newer post-start result",
 );
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -45,6 +45,12 @@ import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { useMilestoneWatch } from "@/lib/use-milestone-watch";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { classifyDaemonStatusPoll } from "@/lib/daemon-status-classification";
+import {
+  createDaemonDesktopAutoStartCoordinator,
+  createDaemonStatusRequestGate,
+  runWorkspaceDaemonStart,
+} from "@/lib/daemon-desktop-auto-start";
+import { useTauriPlatform } from "@/lib/tauri-platform";
 import type { BrowserPaneHandle } from "@/components/browser-pane";
 // Heavy, mode-gated surfaces are code-split via @/components/lazy-surfaces so
 // their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
@@ -273,6 +279,7 @@ function attachGitHubTaskContext(sessions: SessionRow[], data: unknown): Session
 
 export function Workspace() {
   const nextRouter = useRouter();
+  const tauriPlatform = useTauriPlatform();
   const routerRef = useRef<ChatRouterHandle | null>(null);
   const shellRef = useRef<ShellHandle | null>(null);
   // ⌘J quick-chat launcher (cave-xsq.6): a ref so the global keydown effect
@@ -389,7 +396,17 @@ export function Workspace() {
   const [authExpired, setAuthExpired] = useState(false);
   const [daemonStatusUnavailable, setDaemonStatusUnavailable] = useState<string | null>(null);
   const daemonHealthyStreakRef = useRef(0);
-  const daemonStatusRequestRef = useRef(0);
+  const daemonStatusRequestGateRef = useRef<ReturnType<typeof createDaemonStatusRequestGate> | null>(null);
+  if (daemonStatusRequestGateRef.current === null) {
+    daemonStatusRequestGateRef.current = createDaemonStatusRequestGate();
+  }
+  const startDaemonRef = useRef<() => Promise<void>>(async () => {});
+  const daemonAutoStartCoordinatorRef = useRef<ReturnType<typeof createDaemonDesktopAutoStartCoordinator> | null>(null);
+  if (daemonAutoStartCoordinatorRef.current === null) {
+    daemonAutoStartCoordinatorRef.current = createDaemonDesktopAutoStartCoordinator(() => {
+      void startDaemonRef.current();
+    });
+  }
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
   const browserNavigationIdRef = useRef(Date.now() * 1024);
   const [browserNavigationQueue, setBrowserNavigationQueue] = useState<BrowserNavigationRequest[]>([]);
@@ -594,7 +611,8 @@ export function Workspace() {
   useMilestoneWatch();
 
   const refreshDaemonStatus = useCallback(async (opts?: { trusted?: boolean }) => {
-    const requestId = ++daemonStatusRequestRef.current;
+    const requestGate = daemonStatusRequestGateRef.current!;
+    const requestId = requestGate.begin();
     let result: ReturnType<typeof classifyDaemonStatusPoll>;
     let credentialAccepted = false;
     try {
@@ -619,7 +637,10 @@ export function Workspace() {
     // An explicit refresh after Start can overtake an older background poll.
     // Only the newest request may publish state, or that stale offline result
     // can put the banner back after the daemon is already healthy.
-    if (requestId !== daemonStatusRequestRef.current) return;
+    if (!requestGate.isLatest(requestId)) return;
+    // The coordinator pins this first accepted decision. Later polls may update
+    // live UI state, but can never turn into a delayed automatic restart.
+    daemonAutoStartCoordinatorRef.current!.observeStatus(result);
     if (credentialAccepted) setAuthExpired(false);
 
     setDaemonStatusResolved(true);
@@ -653,26 +674,22 @@ export function Workspace() {
   }, []);
 
   const startDaemon = useCallback(async () => {
-    try {
-      const res = await fetch("/api/daemon/start", { method: "POST" });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || json?.ok === false) {
-        throw new Error(json?.error || json?.stderr || "daemon did not start");
-      }
-      dismissBanner("daemon-start-error");
-      // Trusted: the user just started it and the API reported success, so a
-      // single healthy status poll is enough to dismiss the offline banner now.
-      await refreshDaemonStatus({ trusted: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "daemon did not start";
-      pushBanner({
+    await runWorkspaceDaemonStart({
+      fetchImpl: fetch,
+      dismissError: () => dismissBanner("daemon-start-error"),
+      reportError: (message) => pushBanner({
         id: "daemon-start-error",
         severity: "error",
         title: `Daemon start failed — ${message}`,
-      });
-      await refreshDaemonStatus();
-    }
+      }),
+      refreshStatus: refreshDaemonStatus,
+    });
   }, [dismissBanner, pushBanner, refreshDaemonStatus]);
+  startDaemonRef.current = startDaemon;
+
+  useEffect(() => {
+    daemonAutoStartCoordinatorRef.current!.observePlatform(tauriPlatform);
+  }, [tauriPlatform]);
 
   // One-shot legacy localStorage key sweep: runs once per browser profile,
   // then marks itself done so it never re-runs.

--- a/src/lib/daemon-desktop-auto-start.test.ts
+++ b/src/lib/daemon-desktop-auto-start.test.ts
@@ -1,0 +1,137 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  createDaemonDesktopAutoStartCoordinator,
+  createDaemonStatusRequestGate,
+  daemonDesktopAutoStartDecision,
+  runWorkspaceDaemonStart,
+} from "./daemon-desktop-auto-start.ts";
+
+const localOffline = { kind: "offline", targetMode: "local" };
+const running = { kind: "running" };
+const authExpired = { kind: "auth-expired" };
+const unavailable = { kind: "unavailable", reason: "daemon timeout" };
+
+for (const [name, platform, status, expected] of [
+  ["desktop local offline", "desktop", localOffline, "start"],
+  ["platform still resolving", "unknown", localOffline, "wait"],
+  ["status still resolving", "desktop", null, "wait"],
+  ["healthy desktop", "desktop", running, "skip"],
+  ["desktop auth failure", "desktop", authExpired, "skip"],
+  ["desktop unavailable", "desktop", unavailable, "skip"],
+  ["plain browser", "browser", localOffline, "skip"],
+  ["native iOS", "ios", localOffline, "skip"],
+  ["native Android", "android", localOffline, "skip"],
+  ["defensive non-local offline", "desktop", { kind: "offline", targetMode: "hub" }, "skip"],
+]) {
+  assert.equal(
+    daemonDesktopAutoStartDecision({ platform, firstStatus: status }),
+    expected,
+    name,
+  );
+}
+
+{
+  let starts = 0;
+  const coordinator = createDaemonDesktopAutoStartCoordinator(() => { starts += 1; });
+  coordinator.observeStatus(localOffline);
+  assert.equal(starts, 0, "offline status waits for asynchronous platform detection");
+  coordinator.observePlatform("desktop");
+  coordinator.observeStatus(localOffline);
+  coordinator.observePlatform("desktop");
+  assert.equal(starts, 1, "re-renders and later polls cannot duplicate the automatic start");
+}
+
+{
+  let starts = 0;
+  let coordinator;
+  coordinator = createDaemonDesktopAutoStartCoordinator(() => {
+    starts += 1;
+    coordinator.observeStatus(localOffline);
+    coordinator.observePlatform("desktop");
+  });
+  coordinator.observePlatform("desktop");
+  coordinator.observeStatus(localOffline);
+  assert.equal(starts, 1, "the latch is consumed before the start callback can re-enter");
+}
+
+{
+  let starts = 0;
+  const coordinator = createDaemonDesktopAutoStartCoordinator(() => { starts += 1; });
+  coordinator.observeStatus(running);
+  coordinator.observeStatus(localOffline);
+  coordinator.observePlatform("desktop");
+  coordinator.observeStatus(localOffline);
+  assert.equal(starts, 0, "a healthy first decision prevents auto-restart after a later crash");
+}
+
+for (const [name, platform, status] of [
+  ["browser", "browser", localOffline],
+  ["iOS", "ios", localOffline],
+  ["Android", "android", localOffline],
+  ["auth", "desktop", authExpired],
+  ["unavailable", "desktop", unavailable],
+]) {
+  let starts = 0;
+  const coordinator = createDaemonDesktopAutoStartCoordinator(() => { starts += 1; });
+  coordinator.observePlatform(platform);
+  coordinator.observeStatus(status);
+  coordinator.observeStatus(localOffline);
+  assert.equal(starts, 0, `${name} consumes the launch decision without starting later`);
+}
+
+{
+  const gate = createDaemonStatusRequestGate();
+  const background = gate.begin();
+  const trustedPostStart = gate.begin();
+  assert.equal(gate.isLatest(background), false, "an older background result cannot publish after Start");
+  assert.equal(gate.isLatest(trustedPostStart), true, "the trusted post-start result remains authoritative");
+}
+
+function response(ok, payload) {
+  return { ok, json: async () => payload };
+}
+
+{
+  const requests = [];
+  const refreshes = [];
+  let dismissed = 0;
+  const errors = [];
+  const ok = await runWorkspaceDaemonStart({
+    fetchImpl: async function (...args) {
+      assert.equal(this, undefined, "WebView fetch must not receive the dependency object as its receiver");
+      requests.push(args);
+      return response(true, { ok: true });
+    },
+    dismissError: () => { dismissed += 1; },
+    reportError: (message) => errors.push(message),
+    refreshStatus: async (opts) => { refreshes.push(opts); },
+  });
+  assert.equal(ok, true);
+  assert.deepEqual(requests, [["/api/daemon/start", { method: "POST" }]], "automatic start never sends restart mode");
+  assert.equal(dismissed, 1);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(refreshes, [{ trusted: true }], "success performs the trusted refresh");
+}
+
+{
+  const refreshes = [];
+  const errors = [];
+  let requests = 0;
+  const deps = {
+    fetchImpl: async () => {
+      requests += 1;
+      return response(false, { ok: false, error: "Coven CLI missing" });
+    },
+    dismissError: () => assert.fail("failure must not dismiss its diagnostic"),
+    reportError: (message) => errors.push(message),
+    refreshStatus: async (opts) => { refreshes.push(opts); },
+  };
+  assert.equal(await runWorkspaceDaemonStart(deps), false);
+  assert.equal(await runWorkspaceDaemonStart(deps), false, "manual retry remains available after failure");
+  assert.equal(requests, 2);
+  assert.deepEqual(errors, ["Coven CLI missing", "Coven CLI missing"]);
+  assert.deepEqual(refreshes, [undefined, undefined], "failure keeps ordinary status authoritative");
+}
+
+console.log("daemon-desktop-auto-start.test.ts: ok");

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -1,0 +1,115 @@
+import type { DaemonStatusPollResult } from "@/lib/daemon-status-classification";
+import type { TauriPlatform } from "@/lib/tauri-platform";
+
+export type DaemonDesktopAutoStartDecision = "wait" | "start" | "skip";
+
+/**
+ * Decide only after both independent boot facts are known. Tauri platform
+ * detection is asynchronous, so the first accepted daemon result must remain
+ * pinned while the native shell resolves desktop versus mobile.
+ */
+export function daemonDesktopAutoStartDecision(input: {
+  platform: TauriPlatform;
+  firstStatus: DaemonStatusPollResult | null;
+}): DaemonDesktopAutoStartDecision {
+  if (input.platform === "unknown" || input.firstStatus === null) return "wait";
+  return input.platform === "desktop" &&
+    input.firstStatus.kind === "offline" &&
+    input.firstStatus.targetMode === "local"
+    ? "start"
+    : "skip";
+}
+
+export type DaemonDesktopAutoStartCoordinator = {
+  observePlatform(platform: TauriPlatform): void;
+  observeStatus(status: DaemonStatusPollResult): void;
+};
+
+/**
+ * Rendezvous the first accepted status decision with the resolved platform.
+ * The decision is consumed synchronously before `start` is called, so even a
+ * re-entrant status observation cannot issue a duplicate request.
+ */
+export function createDaemonDesktopAutoStartCoordinator(
+  start: () => void,
+): DaemonDesktopAutoStartCoordinator {
+  let platform: TauriPlatform = "unknown";
+  let firstStatus: DaemonStatusPollResult | null = null;
+  let consumed = false;
+
+  const reconcile = () => {
+    if (consumed) return;
+    const decision = daemonDesktopAutoStartDecision({ platform, firstStatus });
+    if (decision === "wait") return;
+    consumed = true;
+    if (decision === "start") start();
+  };
+
+  return {
+    observePlatform(nextPlatform) {
+      platform = nextPlatform;
+      reconcile();
+    },
+    observeStatus(status) {
+      if (firstStatus === null) firstStatus = status;
+      reconcile();
+    },
+  };
+}
+
+/** Monotonic guard shared by background and trusted post-start status reads. */
+export function createDaemonStatusRequestGate() {
+  let latestRequestId = 0;
+  return {
+    begin() {
+      latestRequestId += 1;
+      return latestRequestId;
+    },
+    isLatest(requestId: number) {
+      return requestId === latestRequestId;
+    },
+  };
+}
+
+type DaemonStartPayload = {
+  ok?: unknown;
+  error?: unknown;
+  stderr?: unknown;
+};
+
+function daemonStartPayload(value: unknown): DaemonStartPayload {
+  return value && typeof value === "object" ? value as DaemonStartPayload : {};
+}
+
+/** Shared automatic/manual Workspace start behavior with injectable effects. */
+export async function runWorkspaceDaemonStart(input: {
+  fetchImpl: typeof fetch;
+  dismissError(): void;
+  reportError(message: string): void;
+  refreshStatus(opts?: { trusted?: boolean }): Promise<void>;
+}): Promise<boolean> {
+  try {
+    // Keep the injected function unbound. Calling `input.fetchImpl(...)`
+    // supplies `input` as the receiver, which WebView2's native fetch rejects
+    // with "Illegal invocation".
+    const { fetchImpl } = input;
+    const response = await fetchImpl("/api/daemon/start", { method: "POST" });
+    const payload = daemonStartPayload(await response.json().catch(() => ({})));
+    if (!response.ok || payload.ok === false) {
+      const message =
+        typeof payload.error === "string" && payload.error.trim()
+          ? payload.error
+          : typeof payload.stderr === "string" && payload.stderr.trim()
+            ? payload.stderr
+            : "daemon did not start";
+      throw new Error(message);
+    }
+    input.dismissError();
+    await input.refreshStatus({ trusted: true });
+    return true;
+  } catch (error) {
+    input.reportError(error instanceof Error ? error.message : "daemon did not start");
+    await input.refreshStatus();
+    return false;
+  }
+}

--- a/src/lib/daemon-status-classification.test.ts
+++ b/src/lib/daemon-status-classification.test.ts
@@ -66,7 +66,7 @@ assert.deepEqual(
       target: { mode: "local" },
     },
   }),
-  { kind: "offline" },
+  { kind: "offline", targetMode: "local" },
   "the explicit local-offline classification keeps the Start daemon path",
 );
 
@@ -76,7 +76,7 @@ assert.deepEqual(
     responseOk: true,
     payload: { running: false, reason: "daemon offline", target: { mode: "local" } },
   }),
-  { kind: "offline" },
+  { kind: "offline", targetMode: "local" },
   "an older status route's exact local-offline payload remains compatible",
 );
 

--- a/src/lib/daemon-status-classification.ts
+++ b/src/lib/daemon-status-classification.ts
@@ -43,7 +43,7 @@ type DaemonStatusPayload = {
 
 export type DaemonStatusPollResult =
   | { kind: "running" }
-  | { kind: "offline" }
+  | { kind: "offline"; targetMode: "local" }
   | { kind: "auth-expired" }
   | { kind: "unavailable"; reason: string };
 
@@ -97,7 +97,9 @@ export function classifyDaemonStatusPoll(input: {
     reason?.toLowerCase() === "daemon offline";
   const explicitLocalOffline =
     availability === "offline" && payload.target?.mode === "local";
-  if (explicitLocalOffline || legacyLocalOffline) return { kind: "offline" };
+  if (explicitLocalOffline || legacyLocalOffline) {
+    return { kind: "offline", targetMode: "local" };
+  }
 
   return {
     kind: "unavailable",


### PR DESCRIPTION
## Summary

- make the native desktop shell attempt one local-daemon start after its first accepted definitive local-offline status
- consume the launch decision before asynchronous work so re-renders, overlapping polls, and later daemon failures cannot create a restart loop
- share the existing manual POST path, trusted refresh, and failure diagnostics between automatic and manual starts
- preserve fail-closed behavior for browser, native mobile, hub/non-local, auth, unavailable, unhealthy, and malformed status states

## Safety

- automatic startup sends only `POST /api/daemon/start` and never `restart=true`
- healthy launch remains a no-op
- later daemon failure remains manual recovery
- status request ordering prevents a stale background response from overwriting the trusted post-start refresh

## Verification

- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:app` (766 app test files)
- native Windows Tauri/WebView2 smoke:
  - stopped local daemon produced exactly one automatic POST and reached running state
  - a healthy relaunch preserved daemon PID 60368
  - stopping the daemon later surfaced the offline/Start daemon UI without auto-restarting
  - the smoke exposed and the tests now guard WebView2's receiver-sensitive native `fetch` behavior

Closes #3389
Beads: cave-tpr