### PR TITLE
feat(github): PR-merge reward flare on the chat GitHub card (cave-hshy)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -457,6 +457,7 @@ export const SUITES = {
     "src/app/accent-token-usage.test.ts",
     "src/app/globals-reveal-on-hover.test.ts",
     "src/components/board-reward-flare.test.ts",
+    "src/components/github-card-reward.test.ts",
     "src/components/familiar-roster-card.test.ts",
     "src/components/workspace-milestone-quiet.test.ts",
     "src/lib/familiar-growth-signals.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11204,6 +11204,25 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-progression__streak { display: inline-flex; align-items: center; gap: 4px; }
 .fa-progression__streak svg { width: 12px; height: 12px; color: var(--color-warning); }
 
+/* One-shot PR-merge flare (cave-hshy) — the board's card-done bloom retold
+   on the chat GitHub card. Border/shadow only (no layout shift), announce()
+   is the AT channel, reduced motion collapses it entirely. */
+.cave-gh-card--reward { animation: cave-gh-reward-flare 700ms var(--ease-decelerate) forwards; }
+@keyframes cave-gh-reward-flare {
+  0% {
+    border-color: color-mix(in oklch, var(--color-success) 70%, var(--border-hairline));
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--color-success) 45%, transparent),
+      0 0 18px color-mix(in oklch, var(--color-success) 40%, transparent);
+  }
+  100% {
+    border-color: var(--border-hairline);
+    box-shadow: 0 0 0 10px transparent, 0 0 34px transparent;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-gh-card--reward { animation: none; }
+}
+
 .fa-kpis {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));

--- a/src/components/github-card-reward.test.ts
+++ b/src/components/github-card-reward.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+// Pins for the PR-merge reward flare (cave-hshy) — same contracts as the
+// board's card-done flare: celebrations-pref gated, announce() stays the AT
+// channel, one-shot with a self-clearing timer, reduced-motion collapse.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./github-card.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /if \(pending\.kind === "merge"\) \{\n\s*announce\(`Merged \$\{descriptor\.repo\}#\$\{descriptor\.number\}\.`\);\n\s*onMerged\?\.\(\);/,
+  "merge success announces for AT and signals the parent — the flare is visual-only on top",
+);
+assert.match(
+  source,
+  /onMerged=\{\(\) => \{ if \(readCelebrationsEnabled\(\)\) setJustMerged\(true\); \}\}/,
+  "the flare fires only when celebrations are enabled",
+);
+assert.match(
+  source,
+  /setTimeout\(\(\) => setJustMerged\(false\), 900\)/,
+  "reward state self-clears so re-renders can't replay the flare",
+);
+assert.match(
+  source,
+  /justMerged \? " cave-gh-card--reward" : ""/,
+  "the card root wears the reward class",
+);
+
+assert.match(
+  css,
+  /cave-gh-reward-flare 700ms var\(--ease-decelerate\) forwards/,
+  "700ms decelerate one-shot (summoning-flare vocabulary)",
+);
+assert.match(
+  css,
+  /@media \(prefers-reduced-motion: reduce\) \{\n\s*\.cave-gh-card--reward \{ animation: none; \}/,
+  "reduced motion collapses the flare entirely",
+);
+
+console.log("github-card-reward: all pins hold");

--- a/src/components/github-card.tsx
+++ b/src/components/github-card.tsx
@@ -9,8 +9,10 @@
  */
 
 import { useEffect, useState } from "react";
+import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { Icon, type IconName } from "@/lib/icon";
 import { relativeTime } from "@/lib/relative-time";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { countChecks, isFailConclusion, type CheckCounts, type CheckSummary } from "@/lib/github-checks";
 import { descriptorUrl, type GitHubBlockDescriptor } from "@/lib/github-blocks";
@@ -233,11 +235,15 @@ function CardActions({
   descriptor,
   item,
   onMutated,
+  onMerged,
 }: {
   descriptor: GitHubBlockDescriptor;
   item: ItemDetail;
   onMutated: () => void;
+  /** Fired once on a confirmed merge — the parent card plays the reward flare. */
+  onMerged?: () => void;
 }) {
+  const { announce } = useAnnouncer();
   const [composing, setComposing] = useState(false);
   const [draft, setDraft] = useState("");
   const [phase, setPhase] = useState<ActionPhase>("idle");
@@ -318,6 +324,11 @@ function CardActions({
             }),
           );
     if (ok) {
+      // The flare is visual-only on top of this announcement (AT channel).
+      if (pending.kind === "merge") {
+        announce(`Merged ${descriptor.repo}#${descriptor.number}.`);
+        onMerged?.();
+      }
       setPending(null);
       setReviewBody("");
       onMutated();
@@ -643,9 +654,19 @@ export function GitHubCard({
     else window.open(url, "_blank", "noopener,noreferrer");
   };
 
+  // One-shot merge flare (cave-hshy) — the board's card-done bloom retold on
+  // the PR card. Celebrations-pref gated; self-clears so re-renders can't
+  // replay it; reduced-motion collapses the animation in CSS.
+  const [justMerged, setJustMerged] = useState(false);
+  useEffect(() => {
+    if (!justMerged) return;
+    const t = setTimeout(() => setJustMerged(false), 900);
+    return () => clearTimeout(t);
+  }, [justMerged]);
+
   return (
     <div
-      className="cave-gh-card flex items-start gap-2.5 rounded-md border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-2"
+      className={`cave-gh-card flex items-start gap-2.5 rounded-md border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-2${justMerged ? " cave-gh-card--reward" : ""}`}
       data-gh-kind={descriptor.kind}
     >
       <span aria-hidden className="mt-[2px] inline-flex shrink-0" style={{ color: glyph.color }}>
@@ -701,7 +722,7 @@ export function GitHubCard({
             <ReviewThreadBody descriptor={descriptor} onOpenUrl={onOpenUrl} />
           </div>
         ) : null}
-        {item ? <CardActions descriptor={descriptor} item={item} onMutated={state.refresh} /> : null}
+        {item ? <CardActions descriptor={descriptor} item={item} onMutated={state.refresh} onMerged={() => { if (readCelebrationsEnabled()) setJustMerged(true); }} /> : null}
         {expanded && checks.phase === "ready" ? (
           <div className="mt-2 border-t border-[var(--border-hairline)] pt-2">
             <CheckRunList runs={checks.data.runs} onOpenUrl={onOpenUrl} />


### PR DESCRIPTION
Final slice of the progression arc's completion-moment work (bead `cave-hshy`): merging a PR from the chat GitHub card's tier-2 flow now plays the **one-shot success bloom** — the exact vocabulary shipped on the board's card-done flare (#3359): 700ms decelerate, border/shadow only, celebrations-pref gated, self-clearing, reduced-motion collapses it.

Also fixes a silent-success gap: the merge previously refreshed with no announcement — `announce("Merged repo#N.")` now lands as the AT channel, with the flare visual-only on top.

**Deliberately deferred** (kept on the bead): session-settle and memory-save flares — high-frequency moments that need a cooldown design before they earn motion.

Pinned by `github-card-reward.test.ts` (pref gate · announce · self-clear · reduced-motion); tsc clean; `check-tests-wired` green (1040 files); token-drift green.