### PR TITLE
fix(canvas): stop a corrupt store from destroying all sketches on next save; harden artifact sanitizer (cave-byr5)

### DIFF
--- a/src/app/api/canvas/route.ts
+++ b/src/app/api/canvas/route.ts
@@ -11,9 +11,21 @@ import type { CanvasPositions } from "@/lib/canvas-layout";
 
 export const dynamic = "force-dynamic";
 
+// loadCanvas throws (instead of reading as empty) when the store file exists
+// but can't be read — an empty read here would let the next save destroy real
+// sketches. Surface that as a structured 500; nothing was modified.
+function storeUnreadable(err: unknown) {
+  console.error("api/canvas: store unreadable", err);
+  return NextResponse.json({ ok: false, error: "canvas store unreadable" }, { status: 500 });
+}
+
 export async function GET() {
-  const file = await loadCanvas();
-  return NextResponse.json({ ok: true, positions: file.positions, artifacts: file.artifacts });
+  try {
+    const file = await loadCanvas();
+    return NextResponse.json({ ok: true, positions: file.positions, artifacts: file.artifacts });
+  } catch (err) {
+    return storeUnreadable(err);
+  }
 }
 
 export async function PUT(req: Request) {
@@ -26,8 +38,12 @@ export async function PUT(req: Request) {
   if (!body.positions || typeof body.positions !== "object") {
     return NextResponse.json({ ok: false, error: "positions required" }, { status: 400 });
   }
-  const file = await mergeCanvasPositions(body.positions);
-  return NextResponse.json({ ok: true, positions: file.positions });
+  try {
+    const file = await mergeCanvasPositions(body.positions);
+    return NextResponse.json({ ok: true, positions: file.positions });
+  } catch (err) {
+    return storeUnreadable(err);
+  }
 }
 
 export async function POST(req: Request) {
@@ -40,8 +56,12 @@ export async function POST(req: Request) {
   if (!body.artifact || typeof body.artifact !== "object") {
     return NextResponse.json({ ok: false, error: "artifact required" }, { status: 400 });
   }
-  const { file, savedId } = await upsertCanvasArtifact(body.artifact);
-  return NextResponse.json({ ok: true, artifacts: file.artifacts, savedId });
+  try {
+    const { file, savedId } = await upsertCanvasArtifact(body.artifact);
+    return NextResponse.json({ ok: true, artifacts: file.artifacts, savedId });
+  } catch (err) {
+    return storeUnreadable(err);
+  }
 }
 
 export async function DELETE(req: Request) {
@@ -54,6 +74,10 @@ export async function DELETE(req: Request) {
   if (!body.id || typeof body.id !== "string") {
     return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });
   }
-  const file = await deleteCanvasArtifact(body.id);
-  return NextResponse.json({ ok: true, artifacts: file.artifacts });
+  try {
+    const file = await deleteCanvasArtifact(body.id);
+    return NextResponse.json({ ok: true, artifacts: file.artifacts });
+  } catch (err) {
+    return storeUnreadable(err);
+  }
 }

--- a/src/lib/canvas-artifacts.test.ts
+++ b/src/lib/canvas-artifacts.test.ts
@@ -92,6 +92,49 @@ assert.equal(
   "a missing title is derived from the prompt",
 );
 
+// ── sanitizeArtifact hardening (cave-byr5) ──────────────────────────────────
+
+import { MAX_ARTIFACT_PROMPT_CHARS } from "./canvas-artifacts.ts";
+
+{
+  const [longPrompt] = sanitizeArtifacts([{ id: "p", prompt: "x".repeat(MAX_ARTIFACT_PROMPT_CHARS + 500) }]);
+  assert.equal(
+    longPrompt.prompt.length,
+    MAX_ARTIFACT_PROMPT_CHARS,
+    "an unbounded prompt is clamped — it rides every store read and card tooltip",
+  );
+
+  assert.equal(
+    sanitizeArtifacts([{ id: "i".repeat(300), prompt: "p" }]).length,
+    0,
+    "an absurdly long id is rejected outright (truncating could collide)",
+  );
+
+  const [badDates] = sanitizeArtifacts([
+    { id: "d", prompt: "p", createdAt: "not-a-date", updatedAt: "also-not" },
+  ]);
+  assert.equal(badDates.createdAt, "", "unparseable createdAt is coerced to empty");
+  assert.equal(
+    badDates.updatedAt,
+    "",
+    "unparseable updatedAt is coerced too — garbage sorted a sketch as newest forever",
+  );
+
+  const [fallback] = sanitizeArtifacts([
+    { id: "f", prompt: "p", createdAt: "2026-07-18T00:00:00Z", updatedAt: "garbage" },
+  ]);
+  assert.equal(
+    fallback.updatedAt,
+    "2026-07-18T00:00:00Z",
+    "a garbage updatedAt falls back to the valid createdAt",
+  );
+
+  const [kept] = sanitizeArtifacts([
+    { id: "k", prompt: "p", createdAt: "2026-07-18T00:00:00Z", updatedAt: "2026-07-18T01:00:00Z" },
+  ]);
+  assert.equal(kept.updatedAt, "2026-07-18T01:00:00Z", "valid timestamps pass through untouched");
+}
+
 // ── extractArtifact: classify React vs HTML ────────────────────────────────
 
 assert.deepEqual(

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -27,6 +27,12 @@ export type CanvasArtifact = {
 // can't bloat the canvas store. Generous enough for a real standalone page.
 export const MAX_ARTIFACT_CODE_CHARS = 200_000;
 const MAX_TITLE_CHARS = 60;
+// Prompts are short descriptions (the composer's ask or a refine request);
+// clamping keeps a runaway/buggy caller from bloating every store read.
+export const MAX_ARTIFACT_PROMPT_CHARS = 4_000;
+// Ids are client-minted (`art-<uuid>`, ghreview slugs); anything this long is
+// garbage and would pollute the positions map keyed by it.
+const MAX_ARTIFACT_ID_CHARS = 200;
 
 /**
  * Pull the HTML document out of a familiar's chat response.
@@ -242,13 +248,16 @@ export function sanitizeArtifact(value: unknown): CanvasArtifact | null {
   if (!value || typeof value !== "object") return null;
   const v = value as Record<string, unknown>;
   const id = typeof v.id === "string" ? v.id.trim() : "";
-  if (!id) return null;
-  const prompt = typeof v.prompt === "string" ? v.prompt : "";
+  if (!id || id.length > MAX_ARTIFACT_ID_CHARS) return null;
+  const prompt = (typeof v.prompt === "string" ? v.prompt : "").slice(0, MAX_ARTIFACT_PROMPT_CHARS);
   const code = clampArtifactCode(typeof v.code === "string" ? v.code : "");
   const title = typeof v.title === "string" && v.title.trim() ? v.title.trim().slice(0, MAX_TITLE_CHARS) : titleFromPrompt(prompt);
   const kind: ArtifactKind = v.kind === "react" ? "react" : "html";
-  const createdAt = typeof v.createdAt === "string" ? v.createdAt : "";
-  const updatedAt = typeof v.updatedAt === "string" ? v.updatedAt : createdAt;
+  // Timestamps feed the gallery's lexicographic recency sort and the card's
+  // date label — garbage strings sort a sketch as if newest forever. Coerce
+  // unparseable values to "" (renders dateless, sorts last).
+  const createdAt = typeof v.createdAt === "string" && Number.isFinite(Date.parse(v.createdAt)) ? v.createdAt : "";
+  const updatedAt = typeof v.updatedAt === "string" && Number.isFinite(Date.parse(v.updatedAt)) ? v.updatedAt : createdAt;
   return { id, title, prompt, code, kind, createdAt, updatedAt };
 }
 

--- a/src/lib/cave-canvas.test.ts
+++ b/src/lib/cave-canvas.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 // assignment and point every store call at the REAL ~/.coven store (which is
 // exactly how a test artifact once leaked into live data), so the module is
 // imported dynamically below.
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -122,6 +122,47 @@ const art = (id, code, extra = {}) => ({
 
   await deleteCanvasArtifact("art-react");
   assert.equal((await loadCanvas()).artifacts.length, 2, "delete by id still works");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Corrupt-store protection (cave-byr5). loadCanvas once read ANY failure as
+// an empty store — written when the file held only cosmetic positions. The
+// file now holds user sketches with no undo: reading a torn file as empty
+// meant the NEXT save destroyed every sketch. A provably-bad file must be
+// moved aside (bytes preserved) instead.
+// ═══════════════════════════════════════════════════════════════════════════
+
+{
+  const storePath = path.join(tmpHome, "canvas.json");
+  const corruptFiles = () => readdirSync(tmpHome).filter((f) => f.startsWith("canvas.json.corrupt-"));
+
+  // Torn JSON: moved aside, bytes preserved, store reads empty.
+  writeFileSync(storePath, "{{{ not json");
+  const afterCorrupt = await loadCanvas();
+  assert.equal(afterCorrupt.artifacts.length, 0, "a corrupt store reads as empty");
+  assert.equal(corruptFiles().length, 1, "the corrupt file is moved aside, not deleted");
+  assert.equal(
+    readFileSync(path.join(tmpHome, corruptFiles()[0]), "utf8"),
+    "{{{ not json",
+    "the original bytes survive for recovery",
+  );
+
+  // A save after the corruption starts a fresh store and leaves the preserved
+  // file alone — this exact sequence used to destroy every sketch.
+  const saved = await upsertCanvasArtifact(art("art-after-corrupt", "<!doctype html>x"));
+  assert.equal(saved.file.artifacts.length, 1, "saving after corruption starts a fresh store");
+  assert.equal(corruptFiles().length, 1, "the preserved corrupt file is untouched by the save");
+
+  // Valid-JSON-wrong-shape (an array) is just as unreadable — same treatment.
+  writeFileSync(storePath, "[1,2,3]");
+  await loadCanvas();
+  assert.equal(corruptFiles().length, 2, "shape-invalid JSON is also preserved aside");
+
+  // ENOENT is a genuine fresh start: no corrupt file is minted.
+  rmSync(storePath, { force: true });
+  const fresh = await loadCanvas();
+  assert.equal(fresh.artifacts.length, 0, "a missing file is an empty fresh start");
+  assert.equal(corruptFiles().length, 2, "a missing file mints no corrupt-aside");
 }
 
 rmSync(tmpHome, { recursive: true, force: true });

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -1,12 +1,10 @@
-// Persistence for Triage Canvas node positions.
-//
-// Positions live in their own file (`~/.coven/cave/canvas.json`) keyed by card
-// id, deliberately separate from the board file. The canvas is a *view* of
-// the board's cards — keeping layout out of the Card schema means the board
-// owner (and the many other sessions that mutate it) never has to know the
-// canvas exists, and a canvas write can never clobber card data.
+// Persistence for the Canvas store (`~/.coven/cave/canvas.json`): saved sketch
+// artifacts plus their (legacy standalone-canvas) node positions. Kept separate
+// from the board file so a canvas write can never clobber card data. Artifacts
+// are user content with no undo — the load path must never let a bad read turn
+// into an empty save that destroys them (see loadCanvas).
 
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdir, readFile, rename } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
@@ -59,15 +57,38 @@ async function ensureDir() {
 }
 
 export async function loadCanvas(): Promise<CanvasFile> {
+  let raw: string;
+  try {
+    raw = await readFile(CANVAS_PATH, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      // No store yet — a fresh start, nothing to protect.
+      return { ...EMPTY };
+    }
+    // The file exists but can't be read (permissions, IO). Treating that as
+    // empty would let the next save overwrite sketches we merely failed to
+    // read — surface the error instead; mutations abort, nothing is lost.
+    throw err;
+  }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(await readFile(CANVAS_PATH, "utf8"));
+    parsed = JSON.parse(raw);
   } catch {
-    // Missing file or torn/invalid JSON — start from an empty layout. Nothing
-    // is lost: positions are cosmetic and rebuild from the cards' statuses.
-    return { ...EMPTY };
+    parsed = null;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    // The file holds bytes that aren't a canvas store (torn write, foreign
+    // content). This store now carries user sketches with no undo — reading
+    // it as empty made the NEXT save silently destroy all of them. Move the
+    // bad file aside (bytes preserved for recovery) and start fresh.
+    const aside = `${CANVAS_PATH}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    try {
+      await rename(CANVAS_PATH, aside);
+      console.error(`cave-canvas: unreadable store moved aside to ${aside}`);
+    } catch {
+      // Rename raced another writer (who may have just replaced the file
+      // with a good one) or failed outright — leave the path alone either way.
+    }
     return { ...EMPTY };
   }
   const file = parsed as Partial<CanvasFile>;


### PR DESCRIPTION
## What

**Data-loss bug** (cave-byr5, P1): `loadCanvas` read **any** failure as an empty store — written back when `canvas.json` held only cosmetic node positions ("nothing is lost: positions are cosmetic"). The file now holds **user sketches with no undo**: a torn/corrupt `canvas.json` rendered an empty gallery, and the **next save overwrote the file, silently destroying every sketch**.

## Fix

`loadCanvas` now distinguishes three cases:

| case | behavior |
|---|---|
| `ENOENT` | fresh empty start (unchanged) |
| other read errors (perms/IO) | **throw** — all four `/api/canvas` methods answer a structured `{ ok:false, error:"canvas store unreadable" }` 500; no mutation writes over data we merely failed to read |
| provably-bad content (unparseable JSON / non-object shape) | moved aside to `canvas.json.corrupt-<timestamp>` — **bytes preserved for recovery** — then start fresh |

**Sanitizer hardening** (`sanitizeArtifact`, the disk + request-body trust boundary):
- `prompt` clamped to new `MAX_ARTIFACT_PROMPT_CHARS` (4k) — was unbounded and rides every store read/card tooltip
- absurd ids (>200 chars) rejected rather than truncated (truncation could collide)
- unparseable `createdAt`/`updatedAt` coerced to `""` — garbage strings fed the gallery's lexicographic recency sort and could pin a sketch as newest forever; `updatedAt` still falls back to a valid `createdAt`

## Verification

- New store tests (tmp `COVEN_CAVE_HOME`): corrupt → empty read + bytes-preserved aside; save-after-corruption starts fresh **without touching the preserved file** (the exact sequence that used to destroy sketches); shape-invalid JSON preserved too; ENOENT mints no aside. Sanitizer clamp/reject/coerce coverage.
- `pnpm test:app` — 768 test files pass; `pnpm typecheck` — clean

## Refs

- Bead: cave-byr5 · builds on #3392 (savedId/dedupe)
- Disjoint from open #3402 (creation-flow UI only)
