### PR TITLE
test(server): hermetic COVEN_HOME for preferences/theme store suites

### DIFF
--- a/src/lib/server/preferences-store.test.ts
+++ b/src/lib/server/preferences-store.test.ts
@@ -12,6 +12,11 @@ const execFileAsync = promisify(execFile);
 const root = await mkdtemp(path.join(os.tmpdir(), "cave-preferences-store-"));
 const preferencesFile = path.join(root, "cave-preferences.json");
 const legacyThemeFile = path.join(root, "cave-theme.json");
+// Hermetic coven home: reconciliation walks <covenHome> for legacy entries, so
+// without this the test trips over the REAL ~/.coven compatibility symlinks
+// (their canonical targets != the temp override paths below) and fails on any
+// machine that has been migrated (threads-wro).
+process.env.COVEN_HOME = path.join(root, "coven-home");
 process.env.COVEN_PREFERENCES_PATH = preferencesFile;
 process.env.COVEN_THEME_PATH = legacyThemeFile;
 
@@ -197,6 +202,7 @@ try {
 
   console.log("preferences-store.test.ts: ok");
 } finally {
+  delete process.env.COVEN_HOME;
   delete process.env.COVEN_PREFERENCES_PATH;
   delete process.env.COVEN_THEME_PATH;
   await rm(root, { recursive: true, force: true });

--- a/src/lib/server/theme-store.test.ts
+++ b/src/lib/server/theme-store.test.ts
@@ -6,6 +6,9 @@ import path from "node:path";
 
 const root = await mkdtemp(path.join(os.tmpdir(), "cave-theme-adapter-"));
 const preferencesFile = path.join(root, "cave-preferences.json");
+// Hermetic coven home — keeps reconciliation off the REAL ~/.coven legacy
+// symlinks, whose canonical targets differ from the temp overrides (threads-wro).
+process.env.COVEN_HOME = path.join(root, "coven-home");
 process.env.COVEN_PREFERENCES_PATH = preferencesFile;
 process.env.COVEN_THEME_PATH = path.join(root, "missing-legacy-theme.json");
 
@@ -100,6 +103,7 @@ try {
 
   console.log("theme-store.test.ts: ok");
 } finally {
+  delete process.env.COVEN_HOME;
   delete process.env.COVEN_PREFERENCES_PATH;
   delete process.env.COVEN_THEME_PATH;
   await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
Fixes the local-only failures tracked as coven-threads bead threads-wro: reconciliation ran against the REAL ~/.coven legacy symlinks while canonical paths were temp overrides. Both suites now set a temp COVEN_HOME (and clean it up). Verified: both suites + backdrop/migration siblings green locally on a migrated machine; test:api reaches the known pre-existing tts flake (cave-k7i3) with everything else green.