### PR TITLE
feat(mobile): phone pairing self-provisions in dev — one click, no pnpm incantation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -993,6 +993,7 @@ export const SUITES = {
     "src/lib/server/skill-build.test.ts",
     "src/lib/server/prompt-scan.test.ts",
     "src/lib/server/adapter-conflict-heal.test.ts",
+    "src/lib/server/mobile-access-provision.test.ts",
   ],
   mobile: [
     "src/lib/mobile-access-token.test.ts",

--- a/server.mjs
+++ b/server.mjs
@@ -20,7 +20,25 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   } catch {
   }
 }
-const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
+function persistedMobileAccessSecretFile() {
+  const port2 = (process.env.PORT || "3000").trim() || "3000";
+  const stateRoot = process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() || join(
+    process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"),
+    "coven-cave"
+  );
+  const stateDir = process.env.COVEN_CAVE_MOBILE_STATE_DIR?.trim() || join(stateRoot, `mobile-tailscale-${port2}`);
+  return join(stateDir, "access-token");
+}
+if (process.env.COVEN_CAVE_BUNDLE !== "1" && process.env.COVEN_CAVE_E2E !== "1" && !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()) {
+  try {
+    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
+    if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
+  } catch {
+  }
+}
+function accessToken() {
+  return process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
+}
 const SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN ?? "";
 const ACCESS_COOKIE = "coven_cave_access";
 const LEGACY_ACCESS_COOKIE = "coven_access_token";
@@ -62,9 +80,10 @@ function timingSafeEqualString(a, b) {
   return diff === 0;
 }
 function isExpectedAccessToken(value) {
-  if (!ACCESS_TOKEN || !value) return false;
-  if (timingSafeEqualString(value, ACCESS_TOKEN)) return true;
-  return isValidSignedAccessToken(value, ACCESS_TOKEN);
+  const secret = accessToken();
+  if (!secret || !value) return false;
+  if (timingSafeEqualString(value, secret)) return true;
+  return isValidSignedAccessToken(value, secret);
 }
 function isExpectedSidecarToken(value) {
   return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
@@ -160,7 +179,7 @@ function parseUpgradeTarget(rawUrl) {
   return { pathname, query };
 }
 function isPtyAuthRequired() {
-  return Boolean(ACCESS_TOKEN || SIDECAR_TOKEN);
+  return Boolean(accessToken() || SIDECAR_TOKEN);
 }
 function isAuthorized(req, query) {
   if (!isPtyAuthRequired()) return false;

--- a/server.ts
+++ b/server.ts
@@ -30,7 +30,46 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   }
 }
 
-const ACCESS_TOKEN = process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
+// Boot re-arm (cave-os73): a tokenless dev boot outside the packaged bundle
+// re-arms COVEN_CAVE_ACCESS_TOKEN from the pairing secret that Settings ·
+// Phone (or scripts/mobile-tailscale.sh — same state file) provisioned, so
+// paired phones survive dev-server restarts and a still-configured Tailscale
+// Serve route stays token-gated. Mirrors src/lib/server/mobile-access-
+// provision.ts, inlined because the standalone server.mjs cannot import from
+// src/.
+function persistedMobileAccessSecretFile(): string {
+  const port = (process.env.PORT || "3000").trim() || "3000";
+  const stateRoot =
+    process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() ||
+    join(
+      process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"),
+      "coven-cave",
+    );
+  const stateDir =
+    process.env.COVEN_CAVE_MOBILE_STATE_DIR?.trim() ||
+    join(stateRoot, `mobile-tailscale-${port}`);
+  return join(stateDir, "access-token");
+}
+
+if (
+  process.env.COVEN_CAVE_BUNDLE !== "1" &&
+  process.env.COVEN_CAVE_E2E !== "1" &&
+  !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()
+) {
+  try {
+    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
+    if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
+  } catch {
+    // No provisioned secret — stay tokenless, exactly as before.
+  }
+}
+
+// Read lazily, not snapshotted: Settings · Phone can provision and arm the
+// pairing secret mid-session (cave-os73), and the PTY upgrade gate must honor
+// tokens signed with it without a server restart.
+function accessToken(): string {
+  return process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
+}
 const SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN ?? "";
 const ACCESS_COOKIE = "coven_cave_access";
 const LEGACY_ACCESS_COOKIE = "coven_access_token";
@@ -106,9 +145,10 @@ function timingSafeEqualString(a: string, b: string): boolean {
 }
 
 function isExpectedAccessToken(value: string | undefined | null): boolean {
-  if (!ACCESS_TOKEN || !value) return false;
-  if (timingSafeEqualString(value, ACCESS_TOKEN)) return true;
-  return isValidSignedAccessToken(value, ACCESS_TOKEN);
+  const secret = accessToken();
+  if (!secret || !value) return false;
+  if (timingSafeEqualString(value, secret)) return true;
+  return isValidSignedAccessToken(value, secret);
 }
 
 function isExpectedSidecarToken(value: string | undefined | null): boolean {
@@ -273,7 +313,7 @@ function parseUpgradeTarget(rawUrl: string): { pathname: string; query: UpgradeQ
 }
 
 function isPtyAuthRequired(): boolean {
-  return Boolean(ACCESS_TOKEN || SIDECAR_TOKEN);
+  return Boolean(accessToken() || SIDECAR_TOKEN);
 }
 
 function isAuthorized(req: IncomingMessage, query: Record<string, string | string[] | undefined>): boolean {

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -4,6 +4,14 @@ import QRCode from "qrcode";
 import { stripAnsi } from "@/lib/ansi";
 import { readMobileLastSeen } from "@/lib/server/mobile-paired";
 import {
+  armMobileAccessSecret,
+  provisionMobileAccessSecret,
+  retireMobileAccessSecret,
+} from "@/lib/server/mobile-access-provision";
+import { signMobileAccessToken } from "@/lib/mobile-access-token";
+import { appTokenTtlMs } from "@/lib/mobile-token-refresh";
+import { ACCESS_TOKEN_COOKIE } from "@/proxy-helpers";
+import {
   buildPairingSteps,
   classifyTailscaleSelf,
   createMobileInvite,
@@ -203,28 +211,80 @@ function mobileUnavailableResponse(
 }
 
 function mobileAccessUnavailableResponse() {
-  // Plain `next dev` never sets COVEN_CAVE_ACCESS_TOKEN, so neither signed
-  // invites nor persistent native-app Serve routes are safe to create. Give
-  // devs the exact next step instead of an opaque string; keep the terse
-  // message in packaged builds, where a missing token is a real
-  // misconfiguration rather than the dev default.
+  // With self-provisioning (cave-os73) this is reached only when minting or
+  // persisting the pairing secret failed in dev, or when a packaged build is
+  // missing its Tauri-supplied token — a real misconfiguration, kept terse.
   const error =
     process.env.NODE_ENV !== "production"
-      ? "Mobile handoff isn't available in plain `pnpm dev` — it needs the signed access token that the packaged app and `pnpm mobile:tailscale` set up. Run `pnpm mobile:tailscale` (or open the packaged app), then use Open on phone from that session."
+      ? "Couldn't set up phone pairing automatically (the pairing secret could not be provisioned). Retry, or run `pnpm mobile:tailscale` and pair from that session."
       : "mobile access token unavailable";
   return mobileUnavailableResponse(error, {
     steps: buildPairingSteps({ access: { ok: false, detail: error } }),
   });
 }
 
+/**
+ * Resolve the pairing secret, provisioning one on the fly for a tokenless
+ * dev server (cave-os73). Arms the in-process gate immediately so the
+ * Tailscale Serve route this request is about to publish is token-gated from
+ * the moment it exists. Returns the secret plus whether THIS request
+ * provisioned it — the response then hands the requesting browser a signed
+ * cookie so the freshly armed gate never locks out the session that turned
+ * pairing on.
+ */
+function resolveMobileAccessSecret(): { secret: string; provisioned: boolean } | null {
+  const existing = mobileAccessSecret();
+  if (existing) return { secret: existing, provisioned: false };
+  const provisioned = provisionMobileAccessSecret();
+  if (!provisioned) return null;
+  armMobileAccessSecret(provisioned);
+  return { secret: provisioned, provisioned: true };
+}
+
+/** Install the freshly provisioned session credential on whatever response
+ *  goes out — success or failure — so the dev browser that just armed the
+ *  gate keeps working without a reload or manual token entry. */
+async function withBrowserAccessCookie(
+  res: NextResponse,
+  req: Request,
+  secret: string,
+): Promise<NextResponse> {
+  const expiresAt = Date.now() + appTokenTtlMs();
+  const token = await signMobileAccessToken({ secret, expiresAt });
+  let secure = false;
+  try {
+    secure = new URL(req.url).protocol === "https:";
+  } catch {
+    // Loopback dev is http; default stays false.
+  }
+  res.cookies.set(ACCESS_TOKEN_COOKIE, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure,
+    path: "/",
+    maxAge: Math.max(1, Math.floor(appTokenTtlMs() / 1000)),
+  });
+  return res;
+}
+
 async function ensureNativeAppServe(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
-  if (!mobileAccessSecret()) {
+  const access = resolveMobileAccessSecret();
+  if (!access) {
     return mobileAccessUnavailableResponse();
   }
 
+  const res = await ensureNativeAppServeReady(req, chatId, access.secret);
+  return access.provisioned ? withBrowserAccessCookie(res, req, access.secret) : res;
+}
+
+async function ensureNativeAppServeReady(
+  req: Request,
+  chatId: string | null | undefined,
+  accessSecret: string,
+) {
   const backend = nativeAppBackendUrl(req);
   const backendReady = await verifyNativeAppBackend(req, backend);
   if (!backendReady.ok) {
@@ -338,7 +398,7 @@ async function ensureNativeAppServe(req: Request, chatId?: string | null) {
   if (!nativeTokenlessMode()) {
     const invite = await createMobileInvite({
       baseUrl: discovery.serveUrl,
-      accessSecret: mobileAccessSecret(),
+      accessSecret,
       sidecarToken: process.env.COVEN_CAVE_AUTH_TOKEN,
       ttlMs: MOBILE_INVITE_TTL_MS,
     });
@@ -390,11 +450,20 @@ async function mobileHandoff(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
-  const accessSecret = mobileAccessSecret();
-  if (!accessSecret) {
+  const access = resolveMobileAccessSecret();
+  if (!access) {
     return mobileAccessUnavailableResponse();
   }
 
+  const res = await mobileHandoffReady(req, access.secret, chatId);
+  return access.provisioned ? withBrowserAccessCookie(res, req, access.secret) : res;
+}
+
+async function mobileHandoffReady(
+  req: Request,
+  accessSecret: string,
+  chatId?: string | null,
+) {
   // `--json` doubles as the connectivity check (exit 0 == connected) and the
   // source for the MagicDNS fallback host below.
   const self = await runTailscale(["status", "--self", "--json"]);
@@ -512,6 +581,10 @@ export async function POST(req: Request) {
 
   if (action === "app-stop") {
     const reset = await runTailscale(["serve", "reset"]);
+    // Mobile mode Off retires the self-provisioned pairing secret (cave-os73):
+    // disarm the in-process gate and drop the persisted file so the next dev
+    // boot stays tokenless. No-op in the packaged bundle.
+    retireMobileAccessSecret();
     return NextResponse.json({
       ok: reset.ok,
       error: reset.ok ? undefined : "failed to stop mobile mode",

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -95,7 +95,7 @@ assert.doesNotMatch(
 assert.match(handoffRoute, /function nativeTokenlessMode\(\)/, "the tokenless/invite trust decision should be a single named predicate");
 assert.match(
   handoffRoute,
-  /if \(!nativeTokenlessMode\(\)\) \{[\s\S]*?createMobileInvite\(\{[\s\S]*?accessSecret: mobileAccessSecret\(\),[\s\S]*?sidecarToken: process\.env\.COVEN_CAVE_AUTH_TOKEN/,
+  /if \(!nativeTokenlessMode\(\)\) \{[\s\S]*?createMobileInvite\(\{[\s\S]*?accessSecret,[\s\S]*?sidecarToken: process\.env\.COVEN_CAVE_AUTH_TOKEN/,
   "token-gated app-start mints the signed invite the packaged phone pairs with",
 );
 assert.match(
@@ -134,8 +134,8 @@ assert.doesNotMatch(
 assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
 assert.match(
   handoffRoute,
-  /async function ensureNativeAppServe[\s\S]*if \(!mobileAccessSecret\(\)\)[\s\S]*return mobileAccessUnavailableResponse\(\)/,
-  "native app mobile-mode start must require the mobile access token before starting Tailscale Serve",
+  /async function ensureNativeAppServe[\s\S]*?const access = resolveMobileAccessSecret\(\);[\s\S]*?if \(!access\) \{[\s\S]*?return mobileAccessUnavailableResponse\(\)/,
+  "native app mobile-mode start must resolve (or self-provision) the mobile access secret before starting Tailscale Serve",
 );
 assert.match(settings, /MobileModeToggle/, "Settings should render a mobile mode toggle component");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");
@@ -148,8 +148,8 @@ assert.doesNotMatch(settings, /CopyValue value="pnpm mobile:tailscale:app"/, "Se
 assert.match(settings, /describeMobileHandoffError/, "Settings translates handoff failures into plain language");
 assert.match(
   settings,
-  /Pairing runs in the packaged Cave app/,
-  "the plain-dev failure tells users to open the packaged app instead of quoting pnpm incantations",
+  /Pairing secret unavailable/,
+  "the access-rung failure explains the self-provisioned pairing secret instead of quoting pnpm incantations",
 );
 assert.match(settings, /Technical details/, "the raw handoff error stays available behind a disclosure");
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2331,10 +2331,10 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
  *  behind a disclosure; the headline tells a person what to actually do. */
 function describeMobileHandoffError(raw: string): { headline: string; hint: string } {
   const text = raw.toLowerCase();
-  if (text.includes("pnpm dev") || text.includes("access token")) {
+  if (text.includes("pnpm dev") || text.includes("access token") || text.includes("pairing secret")) {
     return {
-      headline: "Pairing runs in the packaged Cave app",
-      hint: "This dev server can’t mint pairing codes — open CovenCave from Applications and pair from there.",
+      headline: "Pairing secret unavailable",
+      hint: "Cave provisions the pairing secret automatically — retry below. If this persists, restart Cave (or the dev server) and check the app data folder’s permissions.",
     };
   }
   if (text.includes("tailscale") && (text.includes("not installed") || text.includes("cli not found"))) {

--- a/src/lib/server/mobile-access-provision.test.ts
+++ b/src/lib/server/mobile-access-provision.test.ts
@@ -1,0 +1,139 @@
+// Tests for mobile-access-provision (cave-os73): Settings · Phone self-
+// provisions the pairing secret in dev instead of dead-ending on
+// "run `pnpm mobile:tailscale`".
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, statSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import {
+  armMobileAccessSecret,
+  loadPersistedMobileAccessSecret,
+  mobileAccessSecretFile,
+  provisionMobileAccessSecret,
+  rearmPersistedMobileAccessSecret,
+  retireMobileAccessSecret,
+} from "./mobile-access-provision.ts";
+
+function devEnv(overrides: Record<string, string | undefined> = {}): Record<string, string | undefined> {
+  return {
+    COVEN_CAVE_MOBILE_STATE_ROOT: mkdtempSync(path.join(tmpdir(), "cave-mobile-")),
+    PORT: "3000",
+    ...overrides,
+  };
+}
+
+test("state file mirrors scripts/mobile-tailscale.sh layout (root/port scoped)", () => {
+  const file = mobileAccessSecretFile({
+    COVEN_CAVE_MOBILE_STATE_ROOT: "/tmp/state-root",
+    PORT: "3007",
+  });
+  assert.equal(file, "/tmp/state-root/mobile-tailscale-3007/access-token");
+
+  const explicitDir = mobileAccessSecretFile({
+    COVEN_CAVE_MOBILE_STATE_DIR: "/tmp/custom-dir",
+  });
+  assert.equal(explicitDir, "/tmp/custom-dir/access-token");
+
+  const xdg = mobileAccessSecretFile({ XDG_STATE_HOME: "/tmp/xdg-state" });
+  assert.equal(xdg, "/tmp/xdg-state/coven-cave/mobile-tailscale-3000/access-token");
+});
+
+test("provision mints, persists (0600), and is idempotent", () => {
+  const env = devEnv();
+  const first = provisionMobileAccessSecret(env);
+  assert.ok(first && first.length >= 32, "mints a strong secret");
+
+  const file = mobileAccessSecretFile(env);
+  assert.equal(readFileSync(file, "utf8").trim(), first);
+  assert.equal(statSync(file).mode & 0o777, 0o600, "secret file is 0600");
+  assert.equal(statSync(path.dirname(file)).mode & 0o777, 0o700, "state dir is 0700");
+
+  assert.equal(provisionMobileAccessSecret(env), first, "reuses the persisted secret");
+  assert.equal(loadPersistedMobileAccessSecret(env), first);
+});
+
+test("provision reuses a secret the mobile:tailscale script already persisted", () => {
+  const env = devEnv();
+  const file = mobileAccessSecretFile(env);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, "script-minted-secret\n", "utf8");
+  assert.equal(provisionMobileAccessSecret(env), "script-minted-secret");
+});
+
+test("provision refuses the packaged bundle and e2e runs", () => {
+  assert.equal(provisionMobileAccessSecret(devEnv({ COVEN_CAVE_BUNDLE: "1" })), null);
+  assert.equal(provisionMobileAccessSecret(devEnv({ COVEN_CAVE_E2E: "1" })), null);
+});
+
+test("arm sets the request-time gate env", () => {
+  const env = devEnv();
+  armMobileAccessSecret("s3cret", env);
+  assert.equal(env.COVEN_CAVE_ACCESS_TOKEN, "s3cret");
+});
+
+test("rearm arms from disk only when tokenless outside the bundle", () => {
+  const env = devEnv();
+  const secret = provisionMobileAccessSecret(env);
+  assert.ok(secret);
+
+  assert.equal(rearmPersistedMobileAccessSecret(env), secret, "boot re-arm loads the persisted secret");
+  assert.equal(env.COVEN_CAVE_ACCESS_TOKEN, secret);
+
+  const alreadyArmed = devEnv({ COVEN_CAVE_ACCESS_TOKEN: "existing" });
+  assert.equal(rearmPersistedMobileAccessSecret(alreadyArmed), null, "existing token wins");
+  assert.equal(alreadyArmed.COVEN_CAVE_ACCESS_TOKEN, "existing");
+
+  assert.equal(rearmPersistedMobileAccessSecret(devEnv()), null, "nothing persisted → stays tokenless");
+
+  const bundle = devEnv({ COVEN_CAVE_BUNDLE: "1" });
+  assert.equal(rearmPersistedMobileAccessSecret(bundle), null, "bundle never re-arms from dev state");
+});
+
+test("retire disarms and removes the persisted secret", () => {
+  const env = devEnv();
+  const secret = provisionMobileAccessSecret(env);
+  assert.ok(secret);
+  armMobileAccessSecret(secret, env);
+
+  retireMobileAccessSecret(env);
+  assert.equal(env.COVEN_CAVE_ACCESS_TOKEN, undefined);
+  assert.equal(existsSync(mobileAccessSecretFile(env)), false);
+  assert.equal(rearmPersistedMobileAccessSecret(env), null, "next boot stays tokenless");
+});
+
+// ── Wiring pins ──────────────────────────────────────────────────────────────
+// Behavioral seams live above; these pin the route and server wiring so the
+// self-provisioning path can't silently detach (repo convention).
+
+test("mobile-handoff route provisions, arms, cookies the session, and retires on stop", () => {
+  const route = readFileSync(
+    path.join(process.cwd(), "src/app/api/mobile-handoff/route.ts"),
+    "utf8",
+  );
+  assert.match(route, /provisionMobileAccessSecret\(\)/, "route provisions when tokenless");
+  assert.match(route, /armMobileAccessSecret\(provisioned\)/, "route arms the gate before the serve route goes live");
+  assert.match(route, /withBrowserAccessCookie\(res, req, access\.secret\)/, "provisioning responses carry the signed browser cookie");
+  assert.match(route, /ACCESS_TOKEN_COOKIE/, "cookie uses the canonical access-cookie name");
+  assert.match(
+    route,
+    /app-stop[\s\S]{0,400}retireMobileAccessSecret\(\)/,
+    "Mobile mode Off retires the self-provisioned secret",
+  );
+});
+
+test("custom server re-arms at boot and reads the token lazily", () => {
+  const server = readFileSync(path.join(process.cwd(), "server.ts"), "utf8");
+  assert.match(server, /persistedMobileAccessSecretFile/, "boot re-arm reads the persisted state file");
+  assert.match(
+    server,
+    /COVEN_CAVE_BUNDLE !== "1"[\s\S]{0,200}COVEN_CAVE_E2E !== "1"/,
+    "re-arm is guarded off in the packaged bundle and e2e",
+  );
+  assert.match(server, /function accessToken\(\)/, "PTY gate reads the access token lazily");
+  assert.doesNotMatch(
+    server,
+    /const ACCESS_TOKEN = process\.env\.COVEN_CAVE_ACCESS_TOKEN/,
+    "no boot-time snapshot — mid-session arming must reach the PTY gate",
+  );
+});

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -1,0 +1,129 @@
+// mobile-access-provision: self-provision the phone-pairing secret in dev.
+//
+// The mobile access secret (COVEN_CAVE_ACCESS_TOKEN) is what signed pairing
+// invites are minted from and what the request gate verifies against. The
+// packaged app mints and persists its own (src-tauri load_or_create_mobile_
+// access_token), and `pnpm mobile:tailscale` restarts the dev server with one
+// — but plain `pnpm dev` had neither, so Settings · Phone dead-ended with
+// "run pnpm mobile:tailscale". Pairing should just work: when Mobile mode
+// starts in a tokenless dev server, provision the secret here, persist it to
+// THE SAME state file the script uses (so both flows share one pairing
+// identity), and arm it in-process. server.ts re-arms from the persisted
+// secret at boot so a restarted dev server keeps the phone paired — and keeps
+// the still-live Tailscale Serve route token-gated (cave-os73).
+//
+// Never provisions in the packaged bundle (COVEN_CAVE_BUNDLE=1): there a
+// missing token is a real misconfiguration the Tauri shell must fix, and
+// minting a second secret would fork the pairing identity.
+
+import { randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** Mirrors scripts/mobile-tailscale.sh STATE_ROOT/STATE_DIR/TOKEN_FILE. */
+export function mobileAccessSecretFile(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const port = (env.PORT || "3000").trim() || "3000";
+  const stateRoot =
+    env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() ||
+    path.join(
+      env.XDG_STATE_HOME?.trim() || path.join(homedir(), ".local", "state"),
+      "coven-cave",
+    );
+  const stateDir =
+    env.COVEN_CAVE_MOBILE_STATE_DIR?.trim() ||
+    path.join(stateRoot, `mobile-tailscale-${port}`);
+  return path.join(stateDir, "access-token");
+}
+
+function provisioningAllowed(env: Record<string, string | undefined>): boolean {
+  // The packaged bundle owns its secret; e2e runs must stay tokenless so
+  // daemon-less specs keep driving the API without credentials.
+  return env.COVEN_CAVE_BUNDLE !== "1" && env.COVEN_CAVE_E2E !== "1";
+}
+
+/** The persisted pairing secret, or null when none has been provisioned. */
+export function loadPersistedMobileAccessSecret(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  try {
+    const secret = readFileSync(mobileAccessSecretFile(env), "utf8").trim();
+    return secret.length > 0 ? secret : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the persisted pairing secret, minting and persisting a fresh one when
+ * missing. Returns null when provisioning is not allowed here (packaged
+ * bundle, e2e) or persistence fails — callers fall back to the existing
+ * "unavailable" response. Does NOT arm the process env; callers arm
+ * explicitly (armMobileAccessSecret) right before the serve route goes live
+ * so the gate and the exposure switch on together.
+ */
+export function provisionMobileAccessSecret(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  if (!provisioningAllowed(env)) return null;
+  const existing = loadPersistedMobileAccessSecret(env);
+  if (existing) return existing;
+  const file = mobileAccessSecretFile(env);
+  try {
+    mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    const secret = randomBytes(32).toString("base64url");
+    writeFileSync(file, secret, { encoding: "utf8", mode: 0o600 });
+    chmodSync(file, 0o600);
+    return secret;
+  } catch {
+    return null;
+  }
+}
+
+/** Arm the in-process gate: every credential path reads this env at request
+ *  time (src/proxy.ts, mobile-token/refresh, mobile-handoff). */
+export function armMobileAccessSecret(
+  secret: string,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  env.COVEN_CAVE_ACCESS_TOKEN = secret;
+}
+
+/**
+ * Boot-time re-arm: when the server starts tokenless outside the packaged
+ * bundle but a provisioned secret exists on disk, arm it. Keeps paired
+ * phones working across dev-server restarts and keeps a still-configured
+ * Tailscale Serve route token-gated instead of silently open. Returns the
+ * armed secret, or null when nothing was armed.
+ */
+export function rearmPersistedMobileAccessSecret(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  if (!provisioningAllowed(env)) return null;
+  if (env.COVEN_CAVE_ACCESS_TOKEN?.trim()) return null;
+  const secret = loadPersistedMobileAccessSecret(env);
+  if (!secret) return null;
+  armMobileAccessSecret(secret, env);
+  return secret;
+}
+
+/**
+ * Turn Mobile mode off: disarm the in-process gate and remove the persisted
+ * secret so the next boot stays tokenless. Only removes the secret this
+ * module (or the mobile:tailscale script) persisted — never touches the
+ * packaged bundle's env-supplied token file.
+ */
+export function retireMobileAccessSecret(
+  env: Record<string, string | undefined> = process.env,
+): void {
+  if (!provisioningAllowed(env)) return;
+  delete env.COVEN_CAVE_ACCESS_TOKEN;
+  const file = mobileAccessSecretFile(env);
+  try {
+    if (existsSync(file)) rmSync(file);
+  } catch {
+    // Best-effort — a stale file only means the next boot re-arms.
+  }
+}

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -46,13 +46,17 @@ assert.match(
 assert.match(src, /COVEN_CAVE_ACCESS_TOKEN/, "server checks sidecar access token");
 assert.match(src, /ACCESS_COOKIE = "coven_cave_access"/, "server accepts the same access cookie as REST middleware");
 assert.match(src, /ACCESS_QUERY_PARAM = "coven_access_token"/, "server accepts the mobile access token query param for WebSocket auth");
-assert.match(src, /if \(!ACCESS_TOKEN \|\| !value\) return false/, "PTY WebSocket access-token auth fails closed when no access token is configured");
+assert.match(
+  src,
+  /const secret = accessToken\(\);\s*if \(!secret \|\| !value\) return false/,
+  "PTY WebSocket access-token auth fails closed when no access token is configured, reading the token lazily so mid-session arming (cave-os73) reaches the gate",
+);
 // The 401 applies when a remote/mobile credential is configured. With neither
 // token (the local desktop app / dev server) the loopback host+origin gate is
 // the protection, preserving credential-less local connections — #714 dropped
 // that guard and 401'd every local terminal. Native mobile mode configures
 // only COVEN_CAVE_AUTH_TOKEN, so it must also trigger auth.
-assert.match(src, /function isPtyAuthRequired\(\): boolean \{\s*return Boolean\(ACCESS_TOKEN \|\| SIDECAR_TOKEN\);\s*\}/, "PTY auth is required when either the mobile access token or sidecar token is configured");
+assert.match(src, /function isPtyAuthRequired\(\): boolean \{\s*return Boolean\(accessToken\(\) \|\| SIDECAR_TOKEN\);\s*\}/, "PTY auth is required when either the mobile access token or sidecar token is configured");
 assert.match(src, /if \(isPtyAuthRequired\(\) && !tokenAuthenticated\)/, "PTY upgrade 401s on missing credentials when any PTY auth token is configured (credential-less loopback is the local app)");
 assert.match(src, /SIDECAR_QUERY_PARAM = "covenCaveToken"/, "PTY WebSocket auth accepts the sidecar token query param used by native WebSockets");
 // Credentials are verified BEFORE the source gate: a paired device over
@@ -101,7 +105,7 @@ assert.match(
 );
 assert.match(
   src,
-  /if \(timingSafeEqualString\(value, ACCESS_TOKEN\)\) return true;\s*\n\s*return isValidSignedAccessToken\(value, ACCESS_TOKEN\);/,
+  /if \(timingSafeEqualString\(value, secret\)\) return true;\s*\n\s*return isValidSignedAccessToken\(value, secret\);/,
   "isExpectedAccessToken accepts the raw secret OR a valid signed token",
 );
 assert.match(


### PR DESCRIPTION
## Problem (bead cave-os73)

Settings · Phone in plain `pnpm dev` dead-ends at **Pairing service ready**:

> Mobile handoff isn't available in plain `pnpm dev` — it needs the signed access token that the packaged app and `pnpm mobile:tailscale` set up…

The pairing secret (`COVEN_CAVE_ACCESS_TOKEN`) only existed when the packaged app or the script exported it at boot. The phone should just connect.

## Fix

- **`src/lib/server/mobile-access-provision.ts`** (new): mint/persist the pairing secret in the **same state file** `scripts/mobile-tailscale.sh` uses (XDG state, port-scoped, dir 0700 / file 0600 — one shared pairing identity), arm it in-process, retire it on Mobile mode Off. Never provisions under `COVEN_CAVE_BUNDLE=1` (Tauri owns its secret) or `COVEN_CAVE_E2E=1` (daemon-less specs stay tokenless).
- **mobile-handoff route**: a tokenless dev server now provisions + arms **before** the Tailscale Serve route goes live — the gate and the exposure switch on together. Every provisioning response (success *or* failure) carries a signed `coven_cave_access` cookie, so the browser that turned pairing on is never locked out. `app-stop` retires the secret → tokenless dev again.
- **server.ts / server.mjs**: access token read **lazily** (mid-session arming reaches the PTY WebSocket gate without a restart) + **boot re-arm** from the persisted secret — paired phones survive dev restarts, and a still-configured Serve route stays token-gated instead of silently open.
- **settings-shell**: access-rung failure copy updated ("Pairing secret unavailable") — the old "Pairing runs in the packaged Cave app" dead end is gone.

## Verification

Hermetic e2e against a stubbed `tailscale` (status/serve/reset), fresh state root:

| step | result |
|---|---|
| pair click on tokenless dev | `ok:true`, ladder all green, QR svg, `covencave://` link, `Set-Cookie` |
| secret file | created 0600 in `mobile-tailscale-<port>/access-token` |
| credential-less request after arm | **401** |
| browser cookie / phone bearer token | **200 / 200** |
| Safari invite URL exchange | **307** cookie exchange |
| server restart | re-armed: 401 / 200 / 200 |
| Mobile mode Off | secret retired, credential-less **200** again |

Tests: new module 9/9; updated pins in `mobile-handoff.test.ts`, `server-pty-ws.test.ts`; `pnpm test:mobile` 81/81; `pnpm typecheck` clean; `check-tests-wired` green; `server.mjs` regenerated via `pnpm build:server`.