### PR TITLE
Dedupe client polling: shared /api/changes gate, useProjects microcache, gentler migration poll

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -684,6 +684,7 @@ export const SUITES = {
     "src/lib/composer-history.test.ts",
     "src/lib/appearance-corner-radius.test.ts",
     "src/lib/use-changes-summary.test.ts",
+    "src/lib/changes-summary-fetch.test.ts",
     "src/lib/use-familiar-contracts.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
     "src/components/composer-density.test.ts",

--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -23,7 +23,7 @@ assert.match(src, /Recover legacy/, "review offers legacy recovery");
 assert.match(src, /Open backup folder/, "review exposes verified recovery bundles");
 assert.match(src, /return "Defer"/, "review lets users defer ambiguous decisions");
 assert.match(src, /shell_open_path/, "desktop opens the absolute backup directory through the validated command");
-assert.match(src, /usePausablePoll\(\(\) => void refresh\(\), 30_000/, "managed mirrors are rechecked for stale legacy writes while Cave remains open");
+assert.match(src, /usePausablePoll\(\(\) => void refresh\(\), 5 \* 60_000/, "managed mirrors are rechecked for stale legacy writes while Cave remains open — at a gentle 5min cadence (the endpoint rescans the legacy home per hit; cave-v8hh)");
 assert.match(src, /JSON\.stringify\(\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry");
 assert.match(src, /review-dismissed:/, "dismissal is keyed by the exact review set");
 assert.match(src, /detail\.legacyHash \?\? "missing"/, "a changed legacy mirror re-surfaces after an earlier dismissal");

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -129,8 +129,10 @@ export function CaveHomeMigrationBannerTrigger() {
 
   // Ordinary Windows mirrors can be changed by an older tool after Cave has
   // started. Re-check while the shell is visible so those writes are surfaced
-  // without requiring an app restart.
-  usePausablePoll(() => void refresh(), 30_000, { pauseWhileInputActive: true });
+  // without requiring an app restart. 5 minutes: the endpoint scans the legacy
+  // home on every hit and the drift it watches for is rare and non-urgent, so
+  // a tighter cadence is pure overhead (cave-v8hh).
+  usePausablePoll(() => void refresh(), 5 * 60_000, { pauseWhileInputActive: true });
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -312,7 +312,7 @@ assert.match(
 // the count resets on a real root change.
 assert.match(
   chatSurface,
-  /let inFlight = false;[\s\S]*?const load = async \(\) => \{\s*\n\s*if \(inFlight\) return;/,
+  /let inFlight = false;[\s\S]*?const load = async \(opts\?: \{ force\?: boolean \}\) => \{\s*\n\s*if \(inFlight\) return;/,
   "change-count fetch dedupe is scoped per effect-run, not a cross-run ref",
 );
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/lazy-surfaces";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending, consumeProjectsTabPending } from "@/lib/chat-tab-events";
 import { useCodeRail } from "@/lib/use-code-rail";
+import { fetchChangesSummary } from "@/lib/changes-summary-fetch";
 import { useStageChecksBadge } from "@/lib/use-stage-checks-badge";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
@@ -209,17 +210,21 @@ export function ChatSurface({
     // root only. A previous cross-run ref wrongly blocked the new root's first
     // load when the old root's fetch was still in flight, leaving a stale count.
     let inFlight = false;
-    const load = async () => {
+    // The fetch goes through the shared changes-summary gate (cave-v8hh) so
+    // this badge, the composer git chip, the stage header, and the Changes
+    // panel — all polling the same root — cost one request per 5s window, not
+    // four. The refresh signal forces so a just-made edit can't reuse a
+    // pre-mutation response.
+    const load = async (opts?: { force?: boolean }) => {
       if (inFlight) return;
       inFlight = true;
       try {
-        const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(root)}`, { cache: "no-store" });
-        const json = (await res.json().catch(() => ({}))) as { ok?: boolean; files?: unknown[] };
+        const { httpOk, json } = await fetchChangesSummary(root, opts);
         if (cancelled) return;
         // Failures stay `null` (unknown), never a fake zero — a transient
         // error followed by a successful load must not read as a fresh 0→N
         // edit batch and pop the closed-by-default rail open (cave-xsq.7).
-        setChangeCount(res.ok && json.ok ? (json.files?.length ?? 0) : null);
+        setChangeCount(httpOk && json.ok ? (json.files?.length ?? 0) : null);
       } catch {
         if (!cancelled) setChangeCount(null);
       } finally {
@@ -227,7 +232,7 @@ export function ChatSurface({
       }
     };
     void load();
-    const onRefresh = () => { void load(); };
+    const onRefresh = () => { void load({ force: true }); };
     window.addEventListener("cave:changes-refresh", onRefresh);
     let intervalId: number | undefined;
     if (sessionRunning) {

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { arrayContentEqual } from "@/lib/array-content-equal";
+import { fetchChangesSummary } from "@/lib/changes-summary-fetch";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -450,16 +451,22 @@ export function SessionChangesInner({
   const [creatingPr, setCreatingPr] = useState(false);
   const [prUrl, setPrUrl] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
+  // Default is a FORCED fetch through the shared changes-summary gate
+  // (cave-v8hh): the mount/visibility/`cave:changes-refresh`/post-mutation
+  // callers all follow a state change and must not reuse a cached response.
+  // Only the 5s running poll passes shared:true — that's the call that piles
+  // up with the chip/header/badge pollers on the same root, and one real
+  // request per window is exactly what it needs.
+  const load = useCallback(async (opts?: { shared?: boolean }) => {
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     setRefreshing(true);
     try {
-      const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`, {
-        cache: "no-store",
+      const { httpOk, status, json: raw } = await fetchChangesSummary(projectRoot, {
+        force: !opts?.shared,
       });
-      const json = (await res.json()) as ChangesResponse;
-      if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+      const json = raw as ChangesResponse;
+      if (!httpOk || !json.ok) throw new Error(json.error ?? `http ${status}`);
       setNotARepo(json.repo === false);
       setRepoRoot(json.repoRoot ?? null);
       // Content-guard: an unchanged 5s poll keeps the previous reference so the
@@ -509,7 +516,7 @@ export function SessionChangesInner({
   useEffect(() => {
     if (!running) return;
     const id = window.setInterval(() => {
-      if (document.visibilityState === "visible") void load();
+      if (document.visibilityState === "visible") void load({ shared: true });
     }, POLL_MS);
     return () => window.clearInterval(id);
   }, [load, running]);

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -64,8 +64,14 @@ assert.match(
 
 assert.match(
   source,
+  /fetchChangesSummary\(root/,
+  "chat-surface loads /api/changes for the active root through the shared changes-summary gate (cave-v8hh)",
+);
+
+assert.doesNotMatch(
+  source,
   /fetch\(`\/api\/changes\?projectRoot=\$\{encodeURIComponent\(/,
-  "chat-surface fetches /api/changes for the active session's project root",
+  "no private /api/changes summary fetch remains — the gate owns the request",
 );
 
 assert.match(

--- a/src/lib/changes-summary-fetch.test.ts
+++ b/src/lib/changes-summary-fetch.test.ts
@@ -1,0 +1,139 @@
+// @ts-nocheck
+/**
+ * Tests for src/lib/changes-summary-fetch.ts (cave-v8hh): the shared, deduped
+ * gate in front of the bare `/api/changes?projectRoot=` summary GET.
+ *
+ * Several chat-surface subscribers poll the same root's summary on a 5s
+ * cadence (composer git chip, stage header, code-rail badge, Changes panel);
+ * this gate collapses each window onto one real request. Covers:
+ *  1. concurrent callers for one root share a single fetch
+ *  2. within the 4s TTL a later caller reuses the cached response (no fetch)
+ *  3. past the TTL the next caller fetches fresh
+ *  4. force:true bypasses the cached response
+ *  5. roots are cached independently
+ *  6. a rejected fetch is not cached — the next call retries
+ *  7. the request shape: bare summary URL + cache:no-store, result carries
+ *     httpOk/status/json through
+ */
+
+import assert from "node:assert/strict";
+import {
+  fetchChangesSummary,
+  resetChangesSummaryCacheForTests,
+} from "./changes-summary-fetch.ts";
+
+const calls = [];
+let responder = null;
+
+function stubFetch() {
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    if (responder) return responder(url);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, repo: true, files: [], branch: "main", worktree: null }),
+    };
+  };
+}
+
+function reset() {
+  calls.length = 0;
+  responder = null;
+  resetChangesSummaryCacheForTests();
+}
+
+const realFetch = globalThis.fetch;
+stubFetch();
+
+try {
+  // ── 1. concurrent callers share one fetch ─────────────────────────────────
+  {
+    reset();
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    responder = async () => {
+      await gate;
+      return { ok: true, status: 200, json: async () => ({ ok: true, files: [1, 2] }) };
+    };
+    const a = fetchChangesSummary("/repo");
+    const b = fetchChangesSummary("/repo");
+    release();
+    const [ra, rb] = await Promise.all([a, b]);
+    assert.equal(calls.length, 1, "concurrent subscribers must share one request");
+    assert.deepEqual(ra.json.files, [1, 2]);
+    assert.deepEqual(rb.json.files, [1, 2]);
+  }
+
+  // ── 2. within the TTL a later caller reuses the response ──────────────────
+  {
+    reset();
+    await fetchChangesSummary("/repo");
+    const again = await fetchChangesSummary("/repo");
+    assert.equal(calls.length, 1, "a caller inside the TTL must not refetch");
+    assert.equal(again.httpOk, true);
+  }
+
+  // ── 3. past the TTL the next caller fetches fresh ──────────────────────────
+  {
+    reset();
+    await fetchChangesSummary("/repo");
+    await new Promise((r) => setTimeout(r, 4100));
+    await fetchChangesSummary("/repo");
+    assert.equal(calls.length, 2, "past the 4s TTL the summary must be refetched");
+  }
+
+  // ── 4. force bypasses the cached response ───────────────────────────────────
+  {
+    reset();
+    const first = await fetchChangesSummary("/repo");
+    assert.equal(first.httpOk, true);
+    await fetchChangesSummary("/repo", { force: true });
+    assert.equal(calls.length, 2, "force must drop the cached entry and refetch");
+  }
+
+  // ── 5. roots are cached independently ───────────────────────────────────────
+  {
+    reset();
+    await fetchChangesSummary("/repo-a");
+    await fetchChangesSummary("/repo-b");
+    assert.equal(calls.length, 2, "different roots must not share cache entries");
+    assert.match(calls[0].url, /projectRoot=%2Frepo-a/);
+    assert.match(calls[1].url, /projectRoot=%2Frepo-b/);
+  }
+
+  // ── 6. a rejected fetch is not cached ───────────────────────────────────────
+  {
+    reset();
+    responder = async () => { throw new Error("network down"); };
+    await assert.rejects(fetchChangesSummary("/repo"), /network down/);
+    responder = null;
+    const recovered = await fetchChangesSummary("/repo");
+    assert.equal(calls.length, 2, "a failure must not be cached — the next call retries");
+    assert.equal(recovered.httpOk, true);
+  }
+
+  // ── 7. request shape + result passthrough ───────────────────────────────────
+  {
+    reset();
+    responder = async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ ok: false, error: "boom" }),
+    });
+    const result = await fetchChangesSummary("/some root/with spaces");
+    assert.equal(
+      calls[0].url,
+      `/api/changes?projectRoot=${encodeURIComponent("/some root/with spaces")}`,
+      "the gate must hit the bare summary URL (no branches/checkpoints/path params)",
+    );
+    assert.equal(calls[0].init?.cache, "no-store");
+    assert.equal(result.httpOk, false);
+    assert.equal(result.status, 500);
+    assert.equal(result.json.error, "boom");
+  }
+
+  console.log("changes-summary-fetch.test.ts: all assertions passed");
+} finally {
+  globalThis.fetch = realFetch;
+}

--- a/src/lib/changes-summary-fetch.ts
+++ b/src/lib/changes-summary-fetch.ts
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Shared, deduped fetch for the bare `/api/changes?projectRoot=` summary
+ * (cave-v8hh).
+ *
+ * On the chat surface three subscribers poll the SAME root's summary every 5s
+ * — the composer git chip and the stage header (both via useChangesSummary)
+ * plus the code-rail badge in chat-surface — and the Changes panel adds a
+ * fourth while a session runs. Each hand-rolled its own fetch, so one 5s tick
+ * cost 2-4 identical requests (each a `git status` on the server). This module
+ * gives them one gate: concurrent callers share a single in-flight request,
+ * and callers within the microcache window reuse the last response.
+ *
+ * TTL: 4s — just under the 5s poll cadence, so each poll window still performs
+ * exactly one real fetch, staggered subscribers coalesce onto it, and no
+ * subscriber ever sees data older than one poll interval. A resolved error
+ * payload can be served for at most one TTL; the next tick recomputes it.
+ *
+ * `force: true` (post-mutation refreshes: revert, commit, checkpoint restore,
+ * branch switch, the `cave:changes-refresh` signal) drops the cached entry
+ * first so the caller never reuses a pre-mutation response. If another
+ * subscriber's request is mid-flight it is shared instead — it started after
+ * the previous cached response, so it is as fresh as a new request would be.
+ *
+ * Network failures reject through to every awaiting caller and are never
+ * cached (swr-cache only stores resolutions), so each caller's own catch
+ * semantics ("keep last known summary") are unchanged.
+ */
+
+import { createSwrCache } from "./swr-cache.ts";
+
+export type ChangesSummaryResponse = {
+  ok?: boolean;
+  error?: string;
+  repo?: boolean;
+  repoRoot?: string | null;
+  files?: unknown[];
+  branch?: string | null;
+  worktree?: string | null;
+};
+
+export type ChangesSummaryResult = {
+  /** HTTP-level `res.ok` — callers branch on this exactly as they did on the Response. */
+  httpOk: boolean;
+  status: number;
+  json: ChangesSummaryResponse;
+};
+
+const TTL_MS = 4000;
+
+// staleServeMs === ttlMs disables the serve-stale window: within the TTL the
+// cached response is shared, past it the next caller blocks on a fresh fetch.
+const cache = createSwrCache<ChangesSummaryResult>({ ttlMs: TTL_MS, staleServeMs: TTL_MS });
+
+async function requestSummary(projectRoot: string): Promise<ChangesSummaryResult> {
+  const res = await fetch(
+    `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`,
+    { cache: "no-store" },
+  );
+  const json = (await res.json()) as ChangesSummaryResponse;
+  return { httpOk: res.ok, status: res.status, json };
+}
+
+export function fetchChangesSummary(
+  projectRoot: string,
+  opts?: { force?: boolean },
+): Promise<ChangesSummaryResult> {
+  if (opts?.force) cache.invalidate(projectRoot);
+  return cache.get(projectRoot, () => requestSummary(projectRoot));
+}
+
+/** Test-only: drop all cached summaries so cases don't leak into each other. */
+export function resetChangesSummaryCacheForTests(): void {
+  cache.clear();
+}

--- a/src/lib/swr-cache.test.ts
+++ b/src/lib/swr-cache.test.ts
@@ -15,6 +15,9 @@
  *  7. background revalidation failure keeps serving the stale value
  *  8. keys are independent
  *  9. clear() drops entries
+ * 10. invalidate(key) drops that key only — next get recomputes
+ * 11. invalidate during an in-flight compute shares that compute (it is as
+ *     fresh as a new request) instead of stacking another
  */
 
 import assert from "node:assert/strict";
@@ -149,6 +152,39 @@ const STALE = 30_000;
   cache.clear();
   assert.equal(await cache.get("k", compute.fn), "v2");
   assert.equal(compute.count(), 2);
+}
+
+// ── 10. invalidate(key) drops that key only ──────────────────────────────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  const computeA = makeCompute(["a1", "a2"]);
+  const computeB = makeCompute(["b1", "b2"]);
+  await cache.get("a", computeA.fn);
+  await cache.get("b", computeB.fn);
+  cache.invalidate("a");
+  assert.equal(await cache.get("a", computeA.fn), "a2", "invalidated key recomputes while fresh");
+  assert.equal(await cache.get("b", computeB.fn), "b1", "other keys keep their fresh entries");
+  assert.equal(computeA.count(), 2);
+  assert.equal(computeB.count(), 1);
+}
+
+// ── 11. invalidate during an in-flight compute shares that compute ───────────
+{
+  const clock = makeClock();
+  const cache = createSwrCache({ ttlMs: TTL, staleServeMs: STALE, now: clock.now });
+  await cache.get("k", async () => "v1");
+  let calls = 0;
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const compute = async () => { calls += 1; await gate; return "v2"; };
+  cache.invalidate("k");
+  const first = cache.get("k", compute); // starts the fresh compute
+  cache.invalidate("k"); // a second force while that compute is mid-flight…
+  const second = cache.get("k", compute);
+  release();
+  assert.deepEqual(await Promise.all([first, second]), ["v2", "v2"]);
+  assert.equal(calls, 1, "a force during an in-flight compute must piggyback, not stack requests");
 }
 
 console.log("swr-cache.test.ts: all assertions passed");

--- a/src/lib/swr-cache.ts
+++ b/src/lib/swr-cache.ts
@@ -21,6 +21,13 @@
 
 export type SwrCache<T> = {
   get(key: string, compute: () => Promise<T>): Promise<T>;
+  /**
+   * Drop one key's cached entry so the next `get` recomputes. An in-flight
+   * compute for the key is left to finish and is shared by that next `get` —
+   * it started after the caller's mutation-triggering read, so it is as fresh
+   * as a brand-new request would be.
+   */
+  invalidate(key: string): void;
   /** Drop every cached entry (state resets in tests / config changes). */
   clear(): void;
 };
@@ -69,6 +76,9 @@ export function createSwrCache<T>(options: {
         return entry.value;
       }
       return revalidate(key, compute);
+    },
+    invalidate(key) {
+      entries.delete(key);
     },
     clear() {
       entries.clear();

--- a/src/lib/use-changes-summary.test.ts
+++ b/src/lib/use-changes-summary.test.ts
@@ -14,8 +14,19 @@ assert.match(
 );
 assert.match(src, /document\.visibilityState !== "visible"/, "skips work while the document is hidden");
 assert.match(src, /inFlight\.current/, "single-flight guard prevents overlapping requests");
-assert.match(src, /`\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}`/, "hits /api/changes for the root");
-assert.doesNotMatch(src, /&path=/, "summary request omits a file path — it only needs the count");
+// cave-v8hh: the request goes through the shared changes-summary gate so the
+// chip + header + rail badge + panel cost one request per root per 5s window.
+assert.match(
+  src,
+  /fetchChangesSummary\(projectRoot, opts\)/,
+  "fetches through the shared changes-summary gate (no private fetch)",
+);
+assert.doesNotMatch(src, /fetch\(`\/api\/changes/, "no direct /api/changes fetch remains");
+assert.match(
+  src,
+  /void load\(\{ force: true \}\)/,
+  "reload() forces through the gate so a post-mutation refresh never reuses a cached response",
+);
 // cave-e794: the recurring poll + on-return refresh go through the shared
 // usePausablePoll hook instead of a hand-rolled interval + visibility trio.
 assert.match(

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchChangesSummary } from "@/lib/changes-summary-fetch";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 
 /**
@@ -14,6 +15,11 @@ import { usePausablePoll } from "@/lib/use-pausable-poll";
  * same 5s interval, document-visibility gating, and a single-flight guard. It is
  * `active`-gated so it pauses (no redundant polling) once the full panel is
  * shown and takes over polling itself.
+ *
+ * The fetch itself goes through the shared changes-summary gate (cave-v8hh):
+ * several subscribers poll the same root at once (composer git chip, stage
+ * header, code-rail badge, Changes panel), and the gate collapses each 5s
+ * window onto one real request instead of 2-4 identical ones.
  */
 const POLL_MS = 5000;
 
@@ -29,16 +35,9 @@ type ChangesSummary = {
   /** Linked-worktree name (checkout dir basename) — null in the primary checkout. */
   worktree: string | null;
   /** Immediate refetch — for callers that just mutated git state (e.g. the
-   *  composer's branch switch) and shouldn't wait out the 5s poll. */
+   *  composer's branch switch) and shouldn't wait out the 5s poll. Forces
+   *  through the shared gate so it never reuses a pre-mutation response. */
   reload: () => void;
-};
-
-type ChangesResponse = {
-  ok?: boolean;
-  repo?: boolean;
-  files?: unknown[];
-  branch?: string | null;
-  worktree?: string | null;
 };
 
 export function useChangesSummary(
@@ -56,20 +55,16 @@ export function useChangesSummary(
   // into the new root's state.
   const generation = useRef(0);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (opts?: { force?: boolean }) => {
     if (!active || !projectRoot) return;
     if (inFlight.current) return;
     if (document.visibilityState !== "visible") return;
     const gen = generation.current;
     inFlight.current = true;
     try {
-      const res = await fetch(
-        `/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`,
-        { cache: "no-store" },
-      );
-      const json = (await res.json()) as ChangesResponse;
+      const { httpOk, json } = await fetchChangesSummary(projectRoot, opts);
       if (generation.current !== gen) return;
-      if (res.ok && json.ok) {
+      if (httpOk && json.ok) {
         setNotARepo(json.repo === false);
         setCount(Array.isArray(json.files) ? json.files.length : 0);
         setBranch(typeof json.branch === "string" ? json.branch : null);
@@ -96,7 +91,7 @@ export function useChangesSummary(
   usePausablePoll(() => void load(), POLL_MS, { enabled: active && Boolean(projectRoot) });
 
   const reload = useCallback(() => {
-    void load();
+    void load({ force: true });
   }, [load]);
 
   return { count, loaded, notARepo, branch, worktree, reload };

--- a/src/lib/use-projects.test.ts
+++ b/src/lib/use-projects.test.ts
@@ -24,4 +24,29 @@ assert.doesNotMatch(
   "the reset lives in the effect, not in load(), so in-place reload() never blanks the list",
 );
 
+// cave-v8hh: GET /api/projects is deduped through a module-level microcache —
+// the hook's 8+ consumers used to fire one identical request each on a surface
+// mount. Mutations must drop the cache (every scope) so no consumer can be
+// served a pre-mutation list, and reload() must bypass it.
+assert.match(
+  source,
+  /projectsCache\.get\(key, \(\) => requestProjects\(familiarId\)\)/,
+  "loads go through the shared projects microcache",
+);
+assert.match(
+  source,
+  /if \(opts\?\.force\) projectsCache\.invalidate\(key\);/,
+  "force drops the cached scope before refetching",
+);
+assert.match(
+  source,
+  /void load\(\{ force: true \}\);/,
+  "reload() bypasses the microcache",
+);
+assert.equal(
+  (source.match(/invalidateProjectsCache\(\);/g) ?? []).length,
+  5,
+  "all five mutations (create/rename/updateRoot/updateColor/delete) invalidate the cache",
+);
+
 console.log("use-projects.test.ts: ok");

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -3,6 +3,58 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
+import { createSwrCache } from "./swr-cache.ts";
+
+type ProjectsPayload = { ok?: boolean; projects?: CaveProject[]; error?: string };
+
+/**
+ * Module-level dedupe for GET /api/projects (cave-v8hh). The hook has 8+
+ * consumers (sidebar, chat views, board, composer, palette, modals) and no
+ * shared store, so a surface mount fired the same request once per consumer —
+ * traces showed 6 back-to-back copies. A short hard-TTL microcache collapses
+ * a mount burst (plus dev StrictMode's double effects) onto one request per
+ * scope. There is no steady poll on this endpoint, so the 2.5s window only
+ * ever spans a burst; mutations clear it, and reload() bypasses it.
+ */
+const CACHE_TTL_MS = 2500;
+
+// staleServeMs === ttlMs disables the serve-stale window (hard TTL).
+const projectsCache = createSwrCache<ProjectsPayload>({
+  ttlMs: CACHE_TTL_MS,
+  staleServeMs: CACHE_TTL_MS,
+});
+
+async function requestProjects(familiarId: string | null): Promise<ProjectsPayload> {
+  const url = familiarId
+    ? `/api/projects?familiarId=${encodeURIComponent(familiarId)}`
+    : "/api/projects";
+  const res = await fetch(url);
+  // Thrown (not returned) so HTTP failures are never cached — swr-cache only
+  // stores resolutions — and every coalesced caller sees the same error.
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as ProjectsPayload;
+}
+
+function fetchProjects(
+  familiarId: string | null,
+  opts?: { force?: boolean },
+): Promise<ProjectsPayload> {
+  const key = familiarId ?? "";
+  if (opts?.force) projectsCache.invalidate(key);
+  return projectsCache.get(key, () => requestProjects(familiarId));
+}
+
+// A mutation on any project invalidates EVERY scope: creates/renames/deletes
+// change the unscoped list and any familiar-scoped list that includes (or
+// gains) the project, and per-scope bookkeeping isn't worth it at this TTL.
+function invalidateProjectsCache(): void {
+  projectsCache.clear();
+}
+
+/** Test-only: drop the module-level cache between cases. */
+export function resetProjectsCacheForTests(): void {
+  projectsCache.clear();
+}
 
 export type ProjectsState = {
   projects: CaveProject[];
@@ -31,42 +83,38 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
   const [projects, setProjects] = useState<CaveProject[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
+  // Generation guard: bumped on every load() call, scope change, and disable,
+  // so a stale response can't write into newer state. (Replaces the previous
+  // per-instance AbortController — the shared, coalesced request can't be
+  // aborted by one of its subscribers, so late results are discarded instead.)
+  const generationRef = useRef(0);
 
-  const load = useCallback(async () => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
+  const load = useCallback(async (opts?: { force?: boolean }) => {
+    generationRef.current += 1;
+    const gen = generationRef.current;
     setLoading(true);
     setError(null);
 
     try {
-      const url = familiarId
-        ? `/api/projects?familiarId=${encodeURIComponent(familiarId)}`
-        : "/api/projects";
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as { ok?: boolean; projects?: CaveProject[]; error?: string };
-      if (!controller.signal.aborted) {
-        if (data.ok === false) {
-          setError(data.error ?? "Failed to load projects");
-        } else {
-          setProjects(sortProjectsAlphabetically(Array.isArray(data.projects) ? data.projects : []));
-        }
+      const data = await fetchProjects(familiarId, opts);
+      if (generationRef.current !== gen) return;
+      if (data.ok === false) {
+        setError(data.error ?? "Failed to load projects");
+      } else {
+        setProjects(sortProjectsAlphabetically(Array.isArray(data.projects) ? data.projects : []));
       }
     } catch (err) {
-      if (!controller.signal.aborted) {
+      if (generationRef.current === gen) {
         setError(err instanceof Error ? err.message : "Failed to load projects");
       }
     } finally {
-      if (!controller.signal.aborted) setLoading(false);
+      if (generationRef.current === gen) setLoading(false);
     }
   }, [familiarId]);
 
   useEffect(() => {
     if (!enabled) {
-      abortRef.current?.abort();
-      abortRef.current = null;
+      generationRef.current += 1;
       setLoading(false);
       return;
     }
@@ -79,8 +127,16 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     // unaffected, so an in-place refresh never blanks the list.
     setProjects([]);
     load();
-    return () => abortRef.current?.abort();
+    return () => {
+      generationRef.current += 1;
+    };
   }, [enabled, load]);
+
+  // Post-mutation refresh: bypass the microcache so callers always see the
+  // just-mutated list.
+  const reload = useCallback(() => {
+    void load({ force: true });
+  }, [load]);
 
   const createProject = useCallback(async (name: string, root: string): Promise<CaveProject | null> => {
     const res = await fetch("/api/projects", {
@@ -90,6 +146,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
+      invalidateProjectsCache();
       setProjects((prev) => sortProjectsAlphabetically([...prev, data.project as CaveProject]));
       return data.project as CaveProject;
     }
@@ -104,6 +161,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
+      invalidateProjectsCache();
       setProjects((prev) =>
         sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
       );
@@ -120,6 +178,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
+      invalidateProjectsCache();
       setProjects((prev) =>
         sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
       );
@@ -136,6 +195,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
+      invalidateProjectsCache();
       setProjects((prev) =>
         sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
       );
@@ -148,6 +208,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
     const data = await res.json();
     if (data.ok) {
+      invalidateProjectsCache();
       setProjects((prev) => prev.filter((project) => project.id !== id));
       return true;
     }
@@ -158,7 +219,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     projects,
     loading,
     error,
-    reload: load,
+    reload,
     createProject,
     renameProject,
     updateRoot,


### PR DESCRIPTION
## Why

A mobile network trace (313 requests over a few minutes) showed three client-side redundancies:

1. **`/api/changes` (22×)** — up to four independent 5s pollers on the *same* project root: composer git chip + stage header (both via `useChangesSummary`), the code-rail badge in `chat-surface`, and the Changes panel while a session runs. Each tick cost 2–4 identical requests; each is a `git status` server-side.
2. **`/api/projects` (10×, incl. a ×6 back-to-back mount burst)** — `useProjects` has 8+ consumers and no shared store, so a surface mount fired one identical GET per consumer (dev StrictMode doubles it).
3. **`/api/cave-home-migration` (6×)** — the banner rescanned the legacy home every 30s forever, for rare/non-urgent drift.

## What

- **`swr-cache`**: add per-key `invalidate()`. A force during an in-flight compute piggybacks on it — that request started after the mutation-triggering read, so it's as fresh as a new one.
- **New `changes-summary-fetch` module**: one shared gate for the bare `/api/changes?projectRoot=` summary (4s hard TTL, just under the 5s cadence → exactly **one real request per poll window per root**, shared by all subscribers). Post-mutation refreshes (`cave:changes-refresh`, panel mount/visibility loads, `reload()`) **force** through the gate so they never reuse a pre-mutation response; only steady-state polls ride the cache.
- **`useProjects`**: module-level 2.5s hard-TTL microcache per scope collapses mount bursts; all five mutations invalidate every scope; `reload()` bypasses; a generation guard replaces the per-instance `AbortController` (a shared request can't be aborted by one subscriber).
- **Migration banner**: 30s → 5min.

**Unchanged by design:** sessions/list 4s, daemon/status 5s, theme 10s polls (intentional cadences); `usePausablePoll` discipline; all pinned wiring structures (generation guards, single-flight refs, effect-scoped resets). Pins updated only where the fetch literal moved behind the gate.

## Verification

- New behavioral tests: `changes-summary-fetch.test.ts` (7 cases: concurrent share, TTL reuse/expiry, force bypass, per-root keys, failure-not-cached, request shape), `swr-cache.test.ts` cases 10–11 (invalidate scope, in-flight piggyback).
- `pnpm test:app`: **769/769 files pass** (incl. `pausable-poll-discipline`, `workspace-rail-wiring`, `chat-surface`, `use-projects`, `composer-git-chip`, `projects-hub` pins).
- `pnpm typecheck`: clean. `check-tests-wired`: all 1044 wired.
- `test:api`: one pre-existing env-dependent failure (`voice/elevenlabs/tts` expects no resolvable key; my local vault has one) — fails identically on clean `origin/main`, passes in CI's clean env. No server code touched here.

Closes bead `cave-v8hh`.