### PR TITLE
feat(familiar-card): recent-memory peek rows are clickable Grimoire cards (cave-00w0)

### DIFF
--- a/src/components/familiar-inline-card.test.ts
+++ b/src/components/familiar-inline-card.test.ts
@@ -38,6 +38,22 @@ assert.match(src, /useFamiliarMemory/, "uses memory hook");
 assert.match(src, /openFamiliarStudio\(\s*familiar\.id\s*,\s*"memory"\s*\)/, "View all → memory tab");
 assert.match(src, /__memory-stale/, "stale memory entries carry a badge");
 
+// Memory peek rows are clickable cards (cave-00w0): each row is a button that
+// deep-links to the doc in the Grimoire (same path the command palette takes)
+// and closes the popover via act().
+assert.match(
+  src,
+  /className="familiar-inline-card__memory-item focus-ring-inset"/,
+  "memory rows render as focusable button cards",
+);
+assert.match(
+  src,
+  /onClick=\{\(\) => act\(\(\) => openGrimoireDoc\("memory", m\.fullPath\)\)\}/,
+  "clicking a memory card opens that doc in the Grimoire and closes the card",
+);
+assert.match(src, /title=\{`Open in Grimoire — \$\{m\.relPath\}`\}/, "cards say where they go");
+assert.match(src, /familiar-inline-card__memory-open/, "cards carry an open-affordance arrow");
+
 // ── Insight layer (cave-ck70) ───────────────────────────────────────────────
 // Trust/health one-liner, activity meta, live workload, contextual actions —
 // derived by familiar-card-insights from the shared analytics model.
@@ -93,6 +109,16 @@ assert.match(
   css,
   /\.cave-linear-turn-avatar\.is-selected \{[^}]*z-index/,
   "open card stacks above the following turns",
+);
+assert.match(
+  css,
+  /\.familiar-inline-card__memory-item \{[^}]*cursor: pointer;/s,
+  "memory cards look pressable",
+);
+assert.match(
+  css,
+  /\.familiar-inline-card__memory-item:hover \.familiar-inline-card__memory-open,\s*\.familiar-inline-card__memory-item:focus-visible \.familiar-inline-card__memory-open \{ opacity: 1; \}/,
+  "the open arrow reveals on hover AND keyboard focus",
 );
 
 console.log("familiar-inline-card.test.ts: ok");

--- a/src/components/familiar-inline-card.tsx
+++ b/src/components/familiar-inline-card.tsx
@@ -12,6 +12,7 @@ import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { openGrimoireDoc } from "@/lib/grimoire-link";
 import type { Familiar } from "@/lib/types";
 import {
   loadFamiliarAnalyticsData,
@@ -380,13 +381,25 @@ export function FamiliarInlineCard({
         ) : (
           <ul className="familiar-inline-card__memory-list">
             {entries.map((m) => (
-              <li key={m.fullPath} className="familiar-inline-card__memory-item">
-                <span className="familiar-inline-card__memory-title">
-                  {m.title}
-                  {m.stale ? <span className="familiar-inline-card__memory-stale">stale</span> : null}
-                </span>
-                {m.excerpt ? <span className="familiar-inline-card__memory-excerpt">{m.excerpt}</span> : null}
-                <span className="familiar-inline-card__memory-time">{formatRelTime(m.modified)}</span>
+              <li key={m.fullPath}>
+                {/* Each peek row is a card that lands on the doc itself in the
+                    Grimoire editor — same deep link the command palette uses. */}
+                <button
+                  type="button"
+                  className="familiar-inline-card__memory-item focus-ring-inset"
+                  title={`Open in Grimoire — ${m.relPath}`}
+                  onClick={() => act(() => openGrimoireDoc("memory", m.fullPath))}
+                >
+                  <span className="familiar-inline-card__memory-title">
+                    {m.title}
+                    {m.stale ? <span className="familiar-inline-card__memory-stale">stale</span> : null}
+                  </span>
+                  {m.excerpt ? <span className="familiar-inline-card__memory-excerpt">{m.excerpt}</span> : null}
+                  <span className="familiar-inline-card__memory-time">
+                    {formatRelTime(m.modified)}
+                    <Icon name="ph:arrow-bend-up-right" width={10} className="familiar-inline-card__memory-open" aria-hidden />
+                  </span>
+                </button>
               </li>
             ))}
           </ul>

--- a/src/lib/familiar-card-data.test.ts
+++ b/src/lib/familiar-card-data.test.ts
@@ -15,6 +15,11 @@ assert.equal(picked[0].title, "b.md", "newest first, basename title");
 assert.equal(picked[0].excerpt, "bravo");
 assert.equal(picked[1].title, "d.md", "second newest");
 assert.ok(picked.every((p) => p.fullPath.startsWith("/x/")), "keeps fullPath");
+assert.deepEqual(
+  picked.map((p) => p.relPath),
+  ["memory/b.md", "memory/d.md"],
+  "keeps relPath for the card's open-in-Grimoire tooltip (cave-00w0)",
+);
 
 // missing excerpt → empty string, never undefined
 const noExcerpt = pickFamiliarMemory([{ familiarId: "cody", relPath: "m/e.md", modified: "2026-06-12T00:00:00.000Z", fullPath: "/x/e.md" }], "cody", 3);

--- a/src/lib/familiar-card-data.ts
+++ b/src/lib/familiar-card-data.ts
@@ -21,6 +21,8 @@ export type MemoryPeekEntry = {
   excerpt: string;
   modified: string;
   fullPath: string;
+  /** Source-relative path — tooltip context for the card's open action. */
+  relPath: string;
   /** Older than GROWTH_THRESHOLDS.staleMemoryDays — badge as stale. */
   stale: boolean;
 };
@@ -94,6 +96,7 @@ export function pickFamiliarMemory(
         excerpt,
         modified: e.modified,
         fullPath: e.fullPath,
+        relPath: e.relPath,
         stale: Number.isFinite(modifiedMs) && now - modifiedMs > STALE_MEMORY_MS,
       };
     });

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2997,7 +2997,30 @@ details[open] > .cave-tool-summary::before {
 .familiar-inline-card__view-all:focus-visible { outline: var(--ring-width, 2px) solid var(--ring-focus, #7c93ff); outline-offset: var(--ring-offset, 2px); }
 .familiar-inline-card__memory-muted { font-size: 12px; color: var(--text-secondary, #888); }
 .familiar-inline-card__memory-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
-.familiar-inline-card__memory-item { display: flex; flex-direction: column; gap: 1px; }
+/* Peek rows are cards: the whole row is a button that opens the doc in the
+   Grimoire. Quiet at rest; hairline + wash raise on hover/focus. */
+.familiar-inline-card__memory-item {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 1px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.familiar-inline-card__memory-item:hover {
+  background: var(--bg-hover);
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+}
+.familiar-inline-card__memory-time { display: inline-flex; align-items: center; gap: var(--space-1); }
+.familiar-inline-card__memory-open { opacity: 0; color: var(--text-muted); transition: opacity 120ms ease; }
+.familiar-inline-card__memory-item:hover .familiar-inline-card__memory-open,
+.familiar-inline-card__memory-item:focus-visible .familiar-inline-card__memory-open { opacity: 1; }
 .familiar-inline-card__memory-title { font-size: 12px; font-weight: 500; color: var(--text-primary, #ddd); }
 .familiar-inline-card__memory-excerpt { font-size: 11px; color: var(--text-secondary, #999); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .familiar-inline-card__memory-time { font-size: 10px; color: var(--text-secondary, #777); }


### PR DESCRIPTION
## What

The familiar profile (inline) card's **Recent memory** items were static `<li>`s. They're now clickable card components:

- Whole row = a `<button>` card → `openGrimoireDoc("memory", fullPath)` (the exact deep-link the ⌘K palette uses) and the popover closes
- Pressable treatment: hairline border + raised wash on hover; open-arrow affordance reveals on hover **and** `:focus-visible`; `focus-ring-inset`
- Tooltip names the destination (`Open in Grimoire — <relPath>`); `relPath` added to `MemoryPeekEntry`
- Tokens only (drift gate clean); icon from the existing `ICON_NAMES` roster

## Verification

- `familiar-inline-card.test.ts` (+5 pins), `familiar-card-data.test.ts` (+relPath behavioral assert), `design-token-drift.test.ts` — 3 pass / 0 fail
- `pnpm typecheck` clean

Bead: cave-00w0