### PR TITLE
fix(flows): trust the familiar's workspace in direct copilot flow spawns

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,13 @@ improvements.
 
 ## Community Contributors
 
+### Val Alexander ([@BunsDev](https://github.com/BunsDev))
+
+Val contributed the direct copilot flow workspace trust grant, including the
+familiar workspace validation and regression coverage that let non-interactive
+flow runs access their own workspace safely.
+(proposed in [#3411](https://github.com/OpenCoven/coven-cave/pull/3411))
+
 ### Jiachen LIU ([@AmberLJC](https://github.com/AmberLJC))
 
 Jiachen authored the two MIT-licensed research-ideation skills adapted for the

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -79,18 +79,24 @@ test("spawns with the prompt as one argv element and persists the transcript", a
 test("addDirs ride as repeatable --add-dir trust flags ahead of the prompt", async () => {
   const runRoot = mkdtempSync(join(TMP, "adddir-run-"));
   const workspace = join(TMP, "familiar-workspace");
+  const secondWorkspace = join(TMP, "second-familiar-workspace");
   const { done } = startCopilotFlowRun({
     spec: SPEC,
     prompt: "hello",
     projectRoot: runRoot,
     familiarId: "sage",
-    addDirs: [workspace],
+    addDirs: [` ${workspace} `, "", runRoot, workspace, secondWorkspace],
   });
   await done;
   const argv = JSON.parse(readFileSync(join(runRoot, "argv.json"), "utf8"));
-  const flagIndex = argv.indexOf("--add-dir");
+  const flagIndexes = argv.flatMap((arg, index) => arg === "--add-dir" ? [index] : []);
+  const flagIndex = flagIndexes[0];
   assert.ok(flagIndex >= 0, "add-dir trust flag present");
-  assert.equal(argv[flagIndex + 1], workspace);
+  assert.deepEqual(
+    flagIndexes.map((index) => argv[index + 1]),
+    [workspace, secondWorkspace],
+    "trust grants are trimmed and deduped, with blanks and the spawn cwd excluded",
+  );
   assert.ok(flagIndex < argv.indexOf("-p"), "trust flags ride ahead of the prompt flag");
 });
 

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -35,6 +35,7 @@ const SPEC = {
   sessionIdFlag: "--session-id",
   resumeFlag: "--resume",
   modelFlag: "--model",
+  addDirFlag: "--add-dir",
   sandboxFullArgs: ["--allow-all"],
   sandboxReadOnlyArgs: [],
 };
@@ -62,6 +63,7 @@ test("spawns with the prompt as one argv element and persists the transcript", a
   assert.match(argv[promptIndex], /\[Identity: You are Sage, a Researcher\./);
   assert.equal(argv.length, promptIndex + 1, "nothing trails the prompt argument");
   assert.ok(argv.includes("--session-id"), "fresh session id is pre-assigned");
+  assert.ok(!argv.includes("--add-dir"), "no trust flags when addDirs is omitted");
 
   // The finished transcript is a Cave conversation under the session id, with
   // the assistant's final content (trailing control markers intact).
@@ -72,6 +74,24 @@ test("spawns with the prompt as one argv element and persists the transcript", a
   assert.match(conv.turns[1].text, /@@research-control/);
   assert.match(conv.turns[1].text, /"decision":"complete"/);
   assert.ok(!conv.turns[1].isError, "successful run is not an error turn");
+});
+
+test("addDirs ride as repeatable --add-dir trust flags ahead of the prompt", async () => {
+  const runRoot = mkdtempSync(join(TMP, "adddir-run-"));
+  const workspace = join(TMP, "familiar-workspace");
+  const { done } = startCopilotFlowRun({
+    spec: SPEC,
+    prompt: "hello",
+    projectRoot: runRoot,
+    familiarId: "sage",
+    addDirs: [workspace],
+  });
+  await done;
+  const argv = JSON.parse(readFileSync(join(runRoot, "argv.json"), "utf8"));
+  const flagIndex = argv.indexOf("--add-dir");
+  assert.ok(flagIndex >= 0, "add-dir trust flag present");
+  assert.equal(argv[flagIndex + 1], workspace);
+  assert.ok(flagIndex < argv.indexOf("-p"), "trust flags ride ahead of the prompt flag");
 });
 
 test("a failed spawn persists an error turn instead of dropping the run", async () => {

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -35,6 +35,15 @@ export type CopilotFlowLaunch = {
   familiarId: string | null;
   familiarName?: string;
   familiarRole?: string;
+  /**
+   * Directories to trust at the harness level (repeatable `--add-dir`) —
+   * typically the familiar's own workspace, which flow prompts direct memory
+   * and self-report writes into. Without this the one-shot CLI cannot prompt
+   * for permission and every shell/tool access outside the spawn cwd
+   * hard-fails. The spawn cwd (projectRoot) is already trusted and must not
+   * be listed (cave-n1yc contract).
+   */
+  addDirs?: string[];
 };
 
 export type CopilotFlowStart = {
@@ -72,9 +81,7 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     newSessionId: sessionId,
     model: null,
     permissionMode: "full",
-    // Flow runs have no granted-roots concept; the spawn cwd (projectRoot)
-    // is already trusted and must not be listed (cave-n1yc contract).
-    addDirs: [],
+    addDirs: launch.addDirs ?? [],
   });
 
   const child = spawn(launch.spec.executable, args, {

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -74,6 +74,13 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     ? copilotIdentityPreamble(launch.familiarId, launch.familiarName, launch.familiarRole)
     : "";
   const prompt = identity ? `${identity}\n\n${launch.prompt}` : launch.prompt;
+  const addDirs = Array.from(
+    new Set(
+      (launch.addDirs ?? [])
+        .map((root) => root.trim())
+        .filter((root) => root && root !== launch.projectRoot),
+    ),
+  );
   const args = buildCopilotStreamArgs({
     spec: launch.spec,
     prompt,
@@ -81,7 +88,7 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     newSessionId: sessionId,
     model: null,
     permissionMode: "full",
-    addDirs: launch.addDirs ?? [],
+    addDirs,
   });
 
   const child = spawn(launch.spec.executable, args, {

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -42,4 +42,19 @@ assert.match(
   "direct copilot flow spawn must not bypass configured hub authority",
 );
 
+// Flow prompts direct familiars to write memory/self-reports into their own
+// workspace, but the spawn cwd is the project root and a non-interactive run
+// can't prompt for permission — the workspace must ride as a harness-level
+// trust grant or every such write hard-fails.
+assert.match(
+  source,
+  /startCopilotFlowRun\(\{[\s\S]*?addDirs: await flowFamiliarAddDirs\(familiarId, projectRoot\),[\s\S]*?\}\);/,
+  "direct copilot flow spawn must trust the familiar's own workspace via addDirs",
+);
+assert.match(
+  source,
+  /function flowFamiliarAddDirs[\s\S]*?isValidFamiliarId\(familiarId\)[\s\S]*?realpath\(await familiarWorkspace\(familiarId\)\)/,
+  "the workspace grant must be slug-validated and canonicalized before trusting",
+);
+
 console.log("flow-executor.test.ts: ok");

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -21,6 +21,9 @@ import {
   type FlowTriggerInput,
 } from "@/lib/flow/flow-compile";
 import { flowMissingRequiredInputs } from "@/lib/required-inputs";
+import { realpath, stat } from "node:fs/promises";
+import { familiarWorkspace } from "@/lib/coven-paths";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import type { FlowRunRecord, FlowRunStepStatus } from "@/lib/flows";
 import { recordFlowRun } from "@/lib/server/flow-store";
@@ -49,6 +52,35 @@ function flowFamiliar(flow: FlowDoc): string | null {
     if (typeof familiar === "string" && familiar.trim()) return familiar.trim();
   }
   return null;
+}
+
+/**
+ * The familiar's own workspace as a harness-level trust grant for the direct
+ * copilot flow spawn. Flow prompts direct familiars to write memory and
+ * self-reports into their workspace, but the spawn cwd is the project root —
+ * and a non-interactive run can't prompt for permission, so every access to
+ * an untrusted workspace hard-fails (the recurring "filesystem access to own
+ * workspace" familiar self-report). Resolved conservatively: strict slug id,
+ * an existing real directory, and never the spawn cwd itself (cave-n1yc).
+ */
+async function flowFamiliarAddDirs(
+  familiarId: string | null,
+  projectRoot: string,
+): Promise<string[]> {
+  if (!familiarId || !isValidFamiliarId(familiarId)) return [];
+  try {
+    const workspace = await realpath(await familiarWorkspace(familiarId));
+    if (!(await stat(workspace)).isDirectory()) return [];
+    let root = projectRoot;
+    try {
+      root = await realpath(projectRoot);
+    } catch {
+      /* keep the normalized form for comparison */
+    }
+    return workspace === root ? [] : [workspace];
+  } catch {
+    return [];
+  }
 }
 
 function initialFlowRunStepStatus(
@@ -205,6 +237,7 @@ export async function startFlowSession(
         familiarId,
         familiarName: "display_name" in binding ? binding.display_name : undefined,
         familiarRole: "role" in binding ? binding.role : undefined,
+        addDirs: await flowFamiliarAddDirs(familiarId, projectRoot),
       });
       return finishStart(sessionId);
     }


### PR DESCRIPTION
## What

Direct copilot flow spawns (cave-lhc0) hardcoded `addDirs: []`, so the familiar's own workspace was never trusted at the harness level. With cwd at the project root and non-interactive mode unable to prompt for permission, every workspace access (memory, self-reports, drafts) hard-failed.

This is the recurring **"filesystem access to own workspace"** familiar self-report signal (sage, 2026-07-12 + follow-ups): chat spawns were fixed by cave-n1yc (`addDirs: grantDirs`, ungated), but flow runs — research missions included — kept the gap.

## How

- `CopilotFlowLaunch` gains optional `addDirs`, forwarded to `buildCopilotStreamArgs` (default `[]`, backward compatible).
- `flow-executor` resolves the familiar's workspace via `flowFamiliarAddDirs`: strict slug id (`isValidFamiliarId`), `familiarWorkspace(id)` realpath'd and stat-checked as an existing directory, and excluded when it equals the spawn cwd (cave-n1yc contract).
- Hub-authority and SSH paths are untouched — the grant only applies to the local direct spawn.

## Readiness

- [x] Targeted tests: `node --test src/lib/server/flow-copilot-session.test.ts src/lib/server/flow-executor.test.ts` — 5/5 pass (new argv assertion for `--add-dir` placement + no-addDirs regression guard + executor wiring/source assertions)
- [x] `tsc --noEmit` clean
- [x] No secrets in diff; placeholders only in tests