### PR TITLE
ci(codeql): don't cancel in-flight PR runs (fix ruleset merge-gate deadlock)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,15 @@ on:
   workflow_dispatch:
 
 concurrency:
+  # Key on the full ref so each PR/branch has its own group. Do NOT cancel
+  # in-progress runs: the repo ruleset's code_scanning gate evaluates CodeQL
+  # against the PR merge commit, which regenerates whenever main moves. Cancelling
+  # in-flight PR runs (esp. the ~30min swift build) made the gate unsatisfiable
+  # under merge load — every main move murdered the run before it could report.
+  # Letting runs finish (and queueing the next) preserves full 5-language required
+  # coverage and dissolves that deadlock, at the cost of some extra runner minutes.
   group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: false
 
 permissions:
   actions: read


### PR DESCRIPTION
## Problem
The #3285 repo ruleset's `code_scanning` gate evaluates CodeQL against the PR **merge commit**, which regenerates whenever `main` moves. The CodeQL workflow had:
```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}  # true for PRs
```
So every time `main` moved, a PR's in-progress CodeQL run — including the ~30-min swift iOS build — got **cancelled and restarted**. Under merge load (multiple PRs landing per hour), swift never got an uninterrupted window to finish, making the merge gate **unsatisfiable**. #3388 sat blocked for hours cycling through cancelled runs.

## Fix
Set `cancel-in-progress: false` for the CodeQL workflow. In-flight runs finish; the next merge-commit change queues a fresh run instead of murdering the running one.

- ✅ Preserves full **5-language required coverage** (no ruleset change, swift stays a required gate)
- ✅ Dissolves the deadlock
- ⚖️ Costs some extra runner minutes under churn (acceptable — correctness > minutes for a required security gate)

## Why not the alternatives
- **Drop swift from required** — swift is our first-party iOS app code; least want to un-gate.
- **Head-commit eval** — would certify code never analyzed as-merged; defeats the gate.
- **Quiet-window merge** — band-aid, doesn't survive the next busy hour.

Reviewed with Cody; this is his #1-preferred structural fix (workflow, not ruleset).