### PR TITLE
Gate Omnigent fleet settings on OMNIGENT_SERVER_URL in the Cave Vault

### DIFF
--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -6,7 +6,7 @@ import { chatHostOptions, sshHostRegistry, type ChatHostOption } from "@/lib/cha
 import { isSshRuntime, normalizeFamiliarRuntime } from "@/lib/familiar-runtime";
 import { OmnigentClient } from "@/lib/omnigent/client";
 import { omnigentHostOptionId } from "@/lib/omnigent/ids";
-import { isOmnigentEnvConfigured } from "@/lib/omnigent/token";
+import { isOmnigentEnvConfigured, resolveOmnigentBaseUrl } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -38,13 +38,14 @@ function registryFromConfig(config: Awaited<ReturnType<typeof loadConfig>>) {
 async function omnigentHostOptions(
   config: Awaited<ReturnType<typeof loadConfig>>,
 ): Promise<ChatHostOption[]> {
-  if (!config.omnigent.baseUrl || !config.omnigent.exposeHostsInComposer) return [];
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
+  if (!baseUrl || !config.omnigent.exposeHostsInComposer) return [];
   // Fleet gate: omnigent:<host_id> options appear if and ONLY if the user has
   // OMNIGENT_TOKEN set up in their Cave Vault, and the client resolved real
   // credential material. Mirrors isFleetTokenPresent in @/lib/omnigent/fleet-gate.
   if (!isOmnigentEnvConfigured()) return [];
   try {
-    const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
+    const client = await OmnigentClient.fromBaseUrl(baseUrl);
     if (!client.authenticated || client.authMode === "none") return [];
     const hosts = await client.listHosts();
     return hosts.map((h) => {

--- a/src/app/api/omnigent/agents/route.ts
+++ b/src/app/api/omnigent/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/cave-config";
 import { OmnigentClient, OmnigentError } from "@/lib/omnigent/client";
+import { resolveOmnigentBaseUrl } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -12,15 +13,16 @@ export async function GET(req: Request) {
   if (forbidden) return forbidden;
 
   const config = await loadConfig();
-  if (!config.omnigent.baseUrl) {
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
+  if (!baseUrl) {
     return NextResponse.json(
-      { ok: false, error: "omnigent.baseUrl is not configured" },
+      { ok: false, error: "Omnigent server URL is not configured (OMNIGENT_SERVER_URL)" },
       { status: 400 },
     );
   }
 
   try {
-    const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
+    const client = await OmnigentClient.fromBaseUrl(baseUrl);
     const agents = await client.listAgents();
     return NextResponse.json({
       ok: true,

--- a/src/app/api/omnigent/hosts/route.ts
+++ b/src/app/api/omnigent/hosts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/cave-config";
 import { OmnigentClient, OmnigentError } from "@/lib/omnigent/client";
+import { resolveOmnigentBaseUrl } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -12,9 +13,10 @@ export async function GET(req: Request) {
   if (forbidden) return forbidden;
 
   const config = await loadConfig();
-  if (!config.omnigent.baseUrl) {
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
+  if (!baseUrl) {
     return NextResponse.json(
-      { ok: false, error: "omnigent.baseUrl is not configured" },
+      { ok: false, error: "Omnigent server URL is not configured (OMNIGENT_SERVER_URL)" },
       { status: 400 },
     );
   }
@@ -22,7 +24,7 @@ export async function GET(req: Request) {
   try {
     // Do not require a local token: single-user Omnigent accepts unauthenticated
     // calls; multi-user servers return 401 from Omnigent itself.
-    const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
+    const client = await OmnigentClient.fromBaseUrl(baseUrl);
     const hosts = await client.listHosts();
     return NextResponse.json({
       ok: true,

--- a/src/app/api/omnigent/sessions/route.ts
+++ b/src/app/api/omnigent/sessions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/cave-config";
 import { OmnigentClient, OmnigentError } from "@/lib/omnigent/client";
 import { createOmnigentRun, WardPreflightError } from "@/lib/omnigent/run";
+import { resolveOmnigentBaseUrl } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest, readJsonBody } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -13,15 +14,16 @@ export async function GET(req: Request) {
   if (forbidden) return forbidden;
 
   const config = await loadConfig();
-  if (!config.omnigent.baseUrl) {
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
+  if (!baseUrl) {
     return NextResponse.json(
-      { ok: false, error: "omnigent.baseUrl is not configured" },
+      { ok: false, error: "Omnigent server URL is not configured (OMNIGENT_SERVER_URL)" },
       { status: 400 },
     );
   }
 
   try {
-    const client = await OmnigentClient.fromBaseUrl(config.omnigent.baseUrl);
+    const client = await OmnigentClient.fromBaseUrl(baseUrl);
     const sessions = await client.listSessions(40);
     return NextResponse.json({
       ok: true,

--- a/src/app/api/omnigent/status/route.ts
+++ b/src/app/api/omnigent/status/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { loadConfig } from "@/lib/cave-config";
 import { OmnigentClient, OmnigentError } from "@/lib/omnigent/client";
-import { isOmnigentEnvConfigured } from "@/lib/omnigent/token";
+import {
+  isOmnigentEnvConfigured,
+  isOmnigentServerUrlConfigured,
+  resolveOmnigentBaseUrl,
+} from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 
 export const dynamic = "force-dynamic";
@@ -13,10 +17,14 @@ export async function GET(req: Request) {
   if (forbidden) return forbidden;
 
   const config = await loadConfig();
-  const baseUrl = config.omnigent.baseUrl;
   // Per-user fleet opt-in: OMNIGENT_TOKEN set up in the Cave Vault. The
   // client gate (isFleetTokenPresent) hides all Fleet UI without it.
   const envInVault = isOmnigentEnvConfigured();
+  // Settings-surface gate: the Omnigent group in Settings → Daemon renders
+  // only when OMNIGENT_SERVER_URL is set up in the Cave Vault (metadata-only).
+  const serverUrlInVault = isOmnigentServerUrlConfigured();
+  // Vault URL wins over Cave config; config stays a fallback.
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
   if (!baseUrl) {
     return NextResponse.json({
       ok: true,
@@ -26,8 +34,9 @@ export async function GET(req: Request) {
       authenticated: false,
       authMode: "none",
       envInVault,
+      serverUrlInVault,
       online: false,
-      error: "Set omnigent.baseUrl in Cave config (Settings → Omnigent fleet).",
+      error: "Add OMNIGENT_SERVER_URL to your Cave Vault (Settings → Vault).",
     });
   }
 
@@ -42,6 +51,7 @@ export async function GET(req: Request) {
       authenticated: client.authenticated || client.authMode === "none",
       authMode: client.authMode,
       envInVault,
+      serverUrlInVault,
       online: true,
       health,
       defaults: config.omnigent,
@@ -64,6 +74,7 @@ export async function GET(req: Request) {
         authenticated: client.authenticated,
         authMode: client.authMode,
         envInVault,
+        serverUrlInVault,
         online: false,
         error: message,
         defaults: config.omnigent,
@@ -77,6 +88,7 @@ export async function GET(req: Request) {
         authenticated: false,
         authMode: "none",
         envInVault,
+        serverUrlInVault,
         online: false,
         error: message,
         defaults: config.omnigent,

--- a/src/components/settings-daemon-multihost.test.ts
+++ b/src/components/settings-daemon-multihost.test.ts
@@ -98,4 +98,44 @@ assert.match(shell, /fetch\("\/api\/daemon\/status", \{ cache: "no-store", signa
 assert.match(shell, /fetch\("\/api\/config", \{ cache: "no-store", signal: ctl\.signal \}\)/, "the multi-host config load carries an abort signal");
 assert.doesNotMatch(shell, /getItem\("coven-custom-theme"\)/, "the custom-theme key goes through COVEN_CUSTOM_THEME_KEY, never a string literal");
 
+// ── Omnigent vault-URL gate ──────────────────────────────────────────────────
+// The whole "Omnigent fleet" group is invisible in the Daemon tab unless
+// OMNIGENT_SERVER_URL is set up in the user's Cave Vault; the Vault value is
+// also the active server URL (it wins over Cave config), so the group never
+// offers an editable URL nor persists one.
+const statusRoute = readFileSync(
+  new URL("../app/api/omnigent/status/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  shell,
+  /if \(serverUrlInVault !== true\) return null;/,
+  "Omnigent group renders nothing unless the status probe proves OMNIGENT_SERVER_URL is in the Vault (fail closed while loading)",
+);
+assert.match(
+  shell,
+  /setServerUrlInVault\(j\.serverUrlInVault === true\)/,
+  "Omnigent group derives its visibility from /api/omnigent/status serverUrlInVault",
+);
+assert.match(
+  shell,
+  /\.catch\(\(\) => \{\s*if \(!ctl\.signal\.aborted\) setServerUrlInVault\(false\);\s*\}\)/,
+  "a failed status probe hides the Omnigent group instead of leaving it in limbo",
+);
+assert.doesNotMatch(
+  shell,
+  /omnigent: \{[^}]*baseUrl/,
+  "the Omnigent save payload must not write baseUrl — the Vault env supplies the server URL",
+);
+assert.match(
+  statusRoute,
+  /const serverUrlInVault = isOmnigentServerUrlConfigured\(\);/,
+  "/api/omnigent/status must report whether OMNIGENT_SERVER_URL exists in the Vault",
+);
+assert.match(
+  statusRoute,
+  /resolveOmnigentBaseUrl\(config\.omnigent\.baseUrl\)/,
+  "the status probe resolves the base URL Vault-first",
+);
+
 console.log("settings-daemon-multihost.test.ts: ok");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -673,10 +673,17 @@ function formatHostWorkspaceText(map: Record<string, string> | undefined): strin
     .join("\n");
 }
 
-/** Omnigent fleet connection — the config surface for the host chip and remote runs. */
+/** Omnigent fleet connection — the config surface for the host chip and remote runs.
+ *  Renders NOTHING unless OMNIGENT_SERVER_URL is set up in the user's Cave
+ *  Vault: without the Vault env the group is absent from the Daemon tab
+ *  entirely (fail closed while the probe is in flight). The Vault URL is also
+ *  the active server URL — it overrides the Cave-config value. */
 function OmnigentSettingsGroup() {
   const { announce } = useAnnouncer();
-  const [baseUrl, setBaseUrl] = useState("");
+  // null = probe in flight → hidden; the group only appears once the status
+  // endpoint proves the Vault env exists.
+  const [serverUrlInVault, setServerUrlInVault] = useState<boolean | null>(null);
+  const [activeBaseUrl, setActiveBaseUrl] = useState("");
   const [workspace, setWorkspace] = useState("");
   const [hostWorkspaceText, setHostWorkspaceText] = useState("");
   const [exposeHosts, setExposeHosts] = useState(true);
@@ -692,7 +699,6 @@ function OmnigentSettingsGroup() {
         ok?: boolean;
         config?: {
           omnigent?: {
-            baseUrl?: string;
             defaultWorkspace?: string;
             hostWorkspaceMap?: Record<string, string>;
             exposeHostsInComposer?: boolean;
@@ -701,7 +707,6 @@ function OmnigentSettingsGroup() {
       }) => {
         if (ctl.signal.aborted || !j.ok) return;
         const o = j.config?.omnigent;
-        setBaseUrl(o?.baseUrl ?? "");
         setWorkspace(o?.defaultWorkspace ?? "");
         setHostWorkspaceText(formatHostWorkspaceText(o?.hostWorkspaceMap));
         setExposeHosts(o?.exposeHostsInComposer !== false);
@@ -714,9 +719,13 @@ function OmnigentSettingsGroup() {
         hasToken?: boolean;
         authMode?: string;
         configured?: boolean;
+        serverUrlInVault?: boolean;
+        baseUrl?: string;
         error?: string;
       }) => {
         if (ctl.signal.aborted) return;
+        setServerUrlInVault(j.serverUrlInVault === true);
+        setActiveBaseUrl(typeof j.baseUrl === "string" ? j.baseUrl : "");
         if (!j.configured) setStatusLine("Not configured");
         else if (j.online) {
           const mode = j.authMode || (j.hasToken ? "jwt" : "none");
@@ -727,7 +736,9 @@ function OmnigentSettingsGroup() {
           );
         } else setStatusLine(j.error ? `Offline · ${j.error}` : "Offline");
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!ctl.signal.aborted) setServerUrlInVault(false);
+      });
     return () => ctl.abort();
   }, []);
 
@@ -739,8 +750,9 @@ function OmnigentSettingsGroup() {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
+          // baseUrl deliberately omitted: the Vault env supplies the server
+          // URL; the shallow omnigent merge keeps any config fallback as is.
           omnigent: {
-            baseUrl: baseUrl.trim(),
             defaultWorkspace: workspace.trim(),
             hostWorkspaceMap: parseHostWorkspaceText(hostWorkspaceText),
             exposeHostsInComposer: exposeHosts,
@@ -766,20 +778,23 @@ function OmnigentSettingsGroup() {
     }
   };
 
+  // Vault-gated: no OMNIGENT_SERVER_URL in the Cave Vault (or probe still in
+  // flight / failed) → the Daemon tab shows no Omnigent surface whatsoever.
+  if (serverUrlInVault !== true) return null;
+
   return (
     <SettingsGroup label="Omnigent fleet">
       <SettingControlRow
         label="Server URL"
-        hint="HTTPS URL of your Omnigent server (e.g. Tailscale). Fleet UI unlocks per user: add OMNIGENT_TOKEN to your Vault. Tokens are never stored in Cave config."
+        hint="Supplied by OMNIGENT_SERVER_URL in your Cave Vault (it overrides Cave config). Fleet UI unlocks per user: add OMNIGENT_TOKEN to your Vault. Tokens are never stored in Cave config."
       >
-        <input
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-          aria-label="Omnigent server URL"
-          placeholder="https://omnigent.example.ts.net"
-          className="w-full min-w-[260px] max-w-md rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none"
-          spellCheck={false}
-        />
+        <span
+          className="w-full min-w-[260px] max-w-md truncate rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-secondary)]"
+          aria-label="Omnigent server URL (from Vault)"
+          title={activeBaseUrl || undefined}
+        >
+          {activeBaseUrl || "—"}
+        </span>
       </SettingControlRow>
       <SettingControlRow
         label="Default workspace"

--- a/src/lib/omnigent/client.test.ts
+++ b/src/lib/omnigent/client.test.ts
@@ -6,7 +6,13 @@ import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pickDefaultAgentId, pickDefaultHostId } from "./client.ts";
-import { isOmnigentEnvConfigured, normalizeOmnigentBaseUrl, resolveOmnigentAuth } from "./token.ts";
+import {
+  isOmnigentEnvConfigured,
+  isOmnigentServerUrlConfigured,
+  normalizeOmnigentBaseUrl,
+  resolveOmnigentAuth,
+  resolveOmnigentBaseUrl,
+} from "./token.ts";
 
 // Sandbox the Cave Vault: OMNIGENT_TOKEN resolves through it (process env →
 // .env.local → encrypted store → op/dl ref), so point every vault path at a
@@ -19,6 +25,7 @@ process.env.COVEN_CAVE_ENV_FILE = path.join(vaultSandbox, ".env.local");
 process.env.COVEN_CAVE_LOCAL_VAULT_FILE = path.join(vaultSandbox, "local-vault.enc.json");
 process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE = path.join(vaultSandbox, "local-vault.key");
 delete process.env.OMNIGENT_TOKEN;
+delete process.env.OMNIGENT_SERVER_URL;
 
 test("normalizeOmnigentBaseUrl strips path and trailing slash", () => {
   assert.equal(
@@ -239,4 +246,59 @@ test("resolveOmnigentAuth resolves OMNIGENT_TOKEN through the Cave Vault", async
     delete process.env.OMNIGENT_TOKEN; // resolveSecret caches into process.env
     process.env.HOME = prevHome;
   }
+});
+
+test("isOmnigentServerUrlConfigured reflects vault state", async () => {
+  delete process.env.OMNIGENT_SERVER_URL;
+  // Sandboxed vault is empty → not configured, Daemon-tab group stays hidden.
+  assert.equal(isOmnigentServerUrlConfigured(), false);
+
+  const { setLocalEncryptedSecret, deleteLocalEncryptedSecret } = await import(
+    "../local-encrypted-vault.ts"
+  );
+  setLocalEncryptedSecret("OMNIGENT_SERVER_URL", "https://omni.example.com");
+  try {
+    assert.equal(isOmnigentServerUrlConfigured(), true);
+  } finally {
+    deleteLocalEncryptedSecret("OMNIGENT_SERVER_URL");
+    delete process.env.OMNIGENT_SERVER_URL;
+  }
+  assert.equal(isOmnigentServerUrlConfigured(), false);
+});
+
+test("isOmnigentServerUrlConfigured sees process env", async () => {
+  process.env.OMNIGENT_SERVER_URL = "https://env.example.com";
+  try {
+    assert.equal(isOmnigentServerUrlConfigured(), true);
+  } finally {
+    delete process.env.OMNIGENT_SERVER_URL;
+  }
+});
+
+test("resolveOmnigentBaseUrl prefers the vault URL over Cave config", async () => {
+  delete process.env.OMNIGENT_SERVER_URL;
+  const { setLocalEncryptedSecret, deleteLocalEncryptedSecret } = await import(
+    "../local-encrypted-vault.ts"
+  );
+  setLocalEncryptedSecret("OMNIGENT_SERVER_URL", "omni.example.com/api/");
+  try {
+    // Vault value wins over the config fallback and is normalized.
+    assert.equal(
+      resolveOmnigentBaseUrl("https://config.example.com"),
+      "https://omni.example.com",
+    );
+  } finally {
+    deleteLocalEncryptedSecret("OMNIGENT_SERVER_URL");
+    delete process.env.OMNIGENT_SERVER_URL; // resolveSecret caches into process.env
+  }
+});
+
+test("resolveOmnigentBaseUrl falls back to config when vault is empty", async () => {
+  delete process.env.OMNIGENT_SERVER_URL;
+  assert.equal(
+    resolveOmnigentBaseUrl("  https://config.example.com  "),
+    "https://config.example.com",
+  );
+  assert.equal(resolveOmnigentBaseUrl(undefined), "");
+  assert.equal(resolveOmnigentBaseUrl(""), "");
 });

--- a/src/lib/omnigent/run.ts
+++ b/src/lib/omnigent/run.ts
@@ -18,6 +18,7 @@ import {
   WardPreflightError,
 } from "./ward-preflight.ts";
 import { resolveWorkspaceForHost } from "./workspace-resolve.ts";
+import { resolveOmnigentBaseUrl } from "./token.ts";
 
 export { WardPreflightError };
 export { resolveWorkspaceForHost } from "./workspace-resolve.ts";
@@ -85,9 +86,9 @@ export async function createOmnigentRun(
   config: CaveConfig,
   request: OmnigentRunRequest,
 ): Promise<OmnigentRunResult> {
-  const baseUrl = config.omnigent.baseUrl;
+  const baseUrl = resolveOmnigentBaseUrl(config.omnigent.baseUrl);
   if (!baseUrl) {
-    throw new Error("omnigent.baseUrl is not configured — set the server URL in Settings → Omnigent fleet");
+    throw new Error("Omnigent server URL is not configured — add OMNIGENT_SERVER_URL to your Cave Vault");
   }
 
   const prompt = request.prompt.trim();

--- a/src/lib/omnigent/token.ts
+++ b/src/lib/omnigent/token.ts
@@ -38,6 +38,40 @@ export function normalizeOmnigentBaseUrl(url: string): string {
 /** The Cave Vault env key that opts a user into the Omnigent fleet. */
 export const OMNIGENT_TOKEN_ENV = "OMNIGENT_TOKEN";
 
+/** The Cave Vault env key that supplies — and gates — the Omnigent server URL. */
+export const OMNIGENT_SERVER_URL_ENV = "OMNIGENT_SERVER_URL";
+
+/**
+ * True when `OMNIGENT_SERVER_URL` is set up in this user's Cave Vault (process
+ * env, writable .env.local, local encrypted secret, or an op://-style
+ * reference). The entire Omnigent fleet group in Settings → Daemon is gated on
+ * exactly this: without the Vault env the group does not render at all.
+ * Metadata-only — never resolves or caches the secret value.
+ */
+export function isOmnigentServerUrlConfigured(): boolean {
+  try {
+    return hasConfiguredSecretMetadata(OMNIGENT_SERVER_URL_ENV);
+  } catch {
+    return Boolean(process.env[OMNIGENT_SERVER_URL_ENV]?.trim());
+  }
+}
+
+/**
+ * The effective Omnigent base URL: `OMNIGENT_SERVER_URL` from the Cave Vault
+ * wins over the Cave-config value (which remains a fallback for a configured
+ * ref that fails to resolve). Returns "" when neither source has a URL.
+ */
+export function resolveOmnigentBaseUrl(configBaseUrl?: string | null): string {
+  let vaultUrl: string | null;
+  try {
+    vaultUrl = resolveSecret(OMNIGENT_SERVER_URL_ENV)?.trim() || null;
+  } catch {
+    vaultUrl = process.env[OMNIGENT_SERVER_URL_ENV]?.trim() || null;
+  }
+  if (vaultUrl) return normalizeOmnigentBaseUrl(vaultUrl);
+  return (configBaseUrl ?? "").trim();
+}
+
 /**
  * True when `OMNIGENT_TOKEN` is set up in this user's Cave Vault (process env,
  * writable .env.local, local encrypted secret, or an op://‑style reference).


### PR DESCRIPTION
## What

The **Omnigent fleet** group in Settings → Daemon is now completely invisible unless `OMNIGENT_SERVER_URL` is set up in the user's Cave Vault — no group, no header, nothing. Fail-closed: hidden while the status probe is in flight or if it errors.

The Vault env is also the **source of truth for the server URL**:

- `resolveOmnigentBaseUrl()` (new, `src/lib/omnigent/token.ts`) resolves Vault-first (normalized via `normalizeOmnigentBaseUrl`), falling back to the Cave-config value only when the Vault has nothing.
- All server-side consumers go through it: `/api/omnigent/{status,hosts,sessions,agents}`, the `/api/hosts` picker, and `createOmnigentRun`.
- `/api/omnigent/status` now reports `serverUrlInVault`; the settings group derives its visibility from exactly that.
- The Server URL row in settings is read-only (shows the active resolved URL); the save payload no longer writes `omnigent.baseUrl` (the shallow config merge preserves any stored fallback).
- `isOmnigentServerUrlConfigured()` is metadata-only (never resolves/caches the secret).

The existing `OMNIGENT_TOKEN` fleet gate (Fleet buttons elsewhere) is unchanged.

## Verification

- `pnpm typecheck` clean.
- Behavioral tests in `src/lib/omnigent/client.test.ts` (17 pass): vault-wins-over-config + normalization, config fallback, empty → "", metadata check via env and encrypted store.
- Wiring pins in `settings-daemon-multihost.test.ts`: gate returns null, visibility derives from `serverUrlInVault`, failed probe hides, save omits `baseUrl`, status route resolves Vault-first.
- **Live Playwright against a prod build**: without the env the Daemon tab shows no Omnigent surface; with `OMNIGENT_SERVER_URL=omni.example.com/api/` the group renders and shows the normalized `https://omni.example.com`.

Note: `pnpm test:api` locally trips two pre-existing voice tests that leak this machine's real vault state (`elevenlabs/tts`, `hydrate-instructions`) — both files untouched by this diff; CI's clean env is authoritative.