### PR TITLE
feat(queue): tame N-bead lanes — triage sort, age stamps, collapsible lanes, visible cap (cave-19jy)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -115,6 +115,7 @@ export const SUITES = {
     "src/lib/beads-pr-management.test.ts",
     "src/lib/beads-pr-patrol.test.ts",
     "src/lib/beads-work-queue.test.ts",
+    "src/components/familiar-work-queue-view.test.ts",
     "src/components/gh-review-actions.test.ts",
     "src/lib/gfm-autolink.test.ts",
     "src/lib/gh-diff.test.ts",

--- a/src/components/familiar-work-queue-view.test.ts
+++ b/src/components/familiar-work-queue-view.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+// Familiar Work Queue view (cave-19jy) — source pins for the triage-at-scale
+// affordances: collapsible lanes with persisted state, the visible cap with a
+// Show-all toggle, bead-row age stamps, and priority-tinted chips. The pure
+// lane model is behaviorally tested in src/lib/beads-work-queue.test.ts.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const view = readFileSync(new URL("./familiar-work-queue-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/familiar-work-queue.css", import.meta.url), "utf8");
+
+// Lane headers are real disclosure controls, not decorative rows.
+assert.match(view, /className="fwq-lane-toggle focus-ring-inset"/, "the whole lane head toggles");
+assert.match(view, /aria-expanded=\{!collapsed\}/, "disclosure state is exposed to AT");
+assert.match(view, /onClick=\{\(\) => toggleLane\(lane\.key\)\}/);
+assert.match(css, /\.fwq-lane-caret\.is-open \{ transform: rotate\(90deg\); \}/, "caret signals open state");
+
+// Collapse persists per lane; `waiting` starts collapsed; hydration is
+// post-mount so SSR and the first client render agree.
+assert.match(view, /const COLLAPSED_LANES_KEY = "cave:fwq:collapsed:v1"/);
+assert.match(view, /DEFAULT_COLLAPSED: readonly WorkQueueLaneKey\[\] = \["waiting"\]/);
+assert.match(view, /setCollapsedLanes\(readCollapsedLanes\(\)\);\s*\}, \[\]\)/, "storage hydrates after mount");
+assert.match(view, /writeCollapsedLanes\(next\)/, "toggles persist");
+
+// Long lanes mount a capped card list until asked — the N-bead perf fix.
+assert.match(view, /const LANE_VISIBLE_CAP = 8/);
+assert.match(view, /lane\.items\.slice\(0, LANE_VISIBLE_CAP\)/);
+assert.match(view, /`Show all \$\{lane\.items\.length\}`/, "cap toggle names the hidden count");
+assert.match(view, /`Show top \$\{LANE_VISIBLE_CAP\}`/, "and collapses back");
+assert.match(view, /aria-expanded=\{showAll\}/, "cap toggle is a disclosure for AT");
+assert.match(css, /\.fwq-lane-more \{/, "the foot row has real styles");
+
+// Bead-only rows carry a truthful age stamp (PR rows already had one).
+assert.match(
+  view,
+  /\{!item\.pr && !item\.merged && item\.bead\?\.updated_at \? \(\s*<span className="fwq-card-time"/,
+  "bead rows show updated-relative time",
+);
+
+// P0/P1 read at a glance in a mixed lane.
+assert.match(view, /fwq-tag--p\$\{Math\.min\(item\.bead\.priority, 3\)\}/);
+assert.match(css, /\.fwq-tag--p0,\s*\.fwq-tag--p1 \{/, "warm tint for high priorities");
+
+console.log("familiar-work-queue-view.test.ts: ok");

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -57,6 +57,39 @@ const LANE_TONE: Record<WorkQueueLaneKey, "urgent" | "ready" | "neutral" | "quie
   "post-merge-cleanup": "ready",
 };
 
+/** Long lanes mount this many cards until the operator asks for the rest —
+ *  the triage view stays scannable (and cheap) at N-many beads (cave-19jy). */
+const LANE_VISIBLE_CAP = 8;
+
+const COLLAPSED_LANES_KEY = "cave:fwq:collapsed:v1";
+
+/** Lanes collapsed on first run — `waiting` is explicitly non-actionable. */
+const DEFAULT_COLLAPSED: readonly WorkQueueLaneKey[] = ["waiting"];
+
+function readCollapsedLanes(): Set<WorkQueueLaneKey> {
+  if (typeof window === "undefined") return new Set(DEFAULT_COLLAPSED);
+  try {
+    const raw = window.localStorage.getItem(COLLAPSED_LANES_KEY);
+    if (!raw) return new Set(DEFAULT_COLLAPSED);
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set(DEFAULT_COLLAPSED);
+    return new Set(parsed.filter((k): k is WorkQueueLaneKey => typeof k === "string" && k in LANE_TITLES_GUARD));
+  } catch {
+    return new Set(DEFAULT_COLLAPSED);
+  }
+}
+
+function writeCollapsedLanes(keys: Set<WorkQueueLaneKey>): void {
+  try {
+    window.localStorage.setItem(COLLAPSED_LANES_KEY, JSON.stringify([...keys]));
+  } catch {
+    /* storage unavailable — collapse state stays session-local */
+  }
+}
+
+// Key-guard for the storage parse above (LANE_ICON covers every lane key).
+const LANE_TITLES_GUARD = LANE_ICON;
+
 type FetchedQueue = {
   queue: WorkQueue;
   /** False when the beads adapter failed and the queue is PRs-only. */
@@ -127,6 +160,10 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [familiarFilter, setFamiliarFilter] = useState<string | null>(null);
+  // Per-lane disclosure + show-all state. Collapse persists across sessions;
+  // "show all" is per-visit intent and resets on reload (cave-19jy).
+  const [collapsedLanes, setCollapsedLanes] = useState<Set<WorkQueueLaneKey>>(() => new Set(DEFAULT_COLLAPSED));
+  const [expandedLanes, setExpandedLanes] = useState<Set<WorkQueueLaneKey>>(() => new Set());
   // Beads that got a handoff note THIS session — Close unlocks immediately
   // without waiting for the poll to re-read comment_count (cave-hlv.2).
   const [evidenceAdded, setEvidenceAdded] = useState<Set<string>>(() => new Set());
@@ -140,6 +177,22 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
   // truthful between polls (the equality guard below keeps queue state stable,
   // so nothing else would tick them).
   useMinuteTick();
+
+  // Collapse state hydrates after mount so SSR and the first client render
+  // agree (same idiom as the chat sidebar's organize view).
+  useEffect(() => {
+    setCollapsedLanes(readCollapsedLanes());
+  }, []);
+
+  const toggleLane = useCallback((key: WorkQueueLaneKey) => {
+    setCollapsedLanes((cur) => {
+      const next = new Set(cur);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      writeCollapsedLanes(next);
+      return next;
+    });
+  }, []);
 
   const load = useCallback(async () => {
     const seq = ++loadSeq.current;
@@ -406,33 +459,75 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
             }
           />
         ) : (
-          visibleLanes.map((lane) => (
-            <section key={lane.key} className={`fwq-lane fwq-lane--${LANE_TONE[lane.key]}`} aria-label={lane.title}>
-              <header className="fwq-lane-head">
-                <Icon name={LANE_ICON[lane.key]} width={15} aria-hidden />
-                <span className="fwq-lane-title">{lane.title}</span>
-                <span className="fwq-lane-count">{lane.items.length}</span>
-              </header>
-              <ul className="fwq-cards">
-                {lane.items.map((item) => (
-                  <WorkQueueCard
-                    key={item.key}
-                    item={item}
-                    familiarLabel={familiarName(item.familiar)}
-                    busy={busyId === item.key}
-                    hasEvidence={
-                      !!item.bead &&
-                      (hasVerificationEvidence(item.bead) || evidenceAdded.has(item.bead.id.toLowerCase()))
-                    }
-                    onOpenUrl={onOpenUrl}
-                    onClaim={() => void runAction(item, "claim")}
-                    onClose={() => void runAction(item, "close")}
-                    onComment={(text) => runComment(item, text)}
-                  />
-                ))}
-              </ul>
-            </section>
-          ))
+          visibleLanes.map((lane) => {
+            const collapsed = collapsedLanes.has(lane.key);
+            const showAll = expandedLanes.has(lane.key);
+            const capped = !showAll && lane.items.length > LANE_VISIBLE_CAP;
+            const visibleItems = capped ? lane.items.slice(0, LANE_VISIBLE_CAP) : lane.items;
+            return (
+              <section key={lane.key} className={`fwq-lane fwq-lane--${LANE_TONE[lane.key]}`} aria-label={lane.title}>
+                <header className="fwq-lane-head">
+                  <button
+                    type="button"
+                    className="fwq-lane-toggle focus-ring-inset"
+                    aria-expanded={!collapsed}
+                    onClick={() => toggleLane(lane.key)}
+                  >
+                    <Icon
+                      name="ph:caret-right-bold"
+                      width={11}
+                      className={`fwq-lane-caret${collapsed ? "" : " is-open"}`}
+                      aria-hidden
+                    />
+                    <Icon name={LANE_ICON[lane.key]} width={15} aria-hidden />
+                    <span className="fwq-lane-title">{lane.title}</span>
+                    <span className="fwq-lane-count">{lane.items.length}</span>
+                  </button>
+                </header>
+                {collapsed ? null : (
+                  <>
+                    <ul className="fwq-cards">
+                      {visibleItems.map((item) => (
+                        <WorkQueueCard
+                          key={item.key}
+                          item={item}
+                          familiarLabel={familiarName(item.familiar)}
+                          busy={busyId === item.key}
+                          hasEvidence={
+                            !!item.bead &&
+                            (hasVerificationEvidence(item.bead) || evidenceAdded.has(item.bead.id.toLowerCase()))
+                          }
+                          onOpenUrl={onOpenUrl}
+                          onClaim={() => void runAction(item, "claim")}
+                          onClose={() => void runAction(item, "close")}
+                          onComment={(text) => runComment(item, text)}
+                        />
+                      ))}
+                    </ul>
+                    {lane.items.length > LANE_VISIBLE_CAP ? (
+                      <button
+                        type="button"
+                        className="fwq-lane-more focus-ring-inset"
+                        aria-expanded={showAll}
+                        onClick={() =>
+                          setExpandedLanes((cur) => {
+                            const next = new Set(cur);
+                            if (next.has(lane.key)) next.delete(lane.key);
+                            else next.add(lane.key);
+                            return next;
+                          })
+                        }
+                      >
+                        {showAll
+                          ? `Show top ${LANE_VISIBLE_CAP}`
+                          : `Show all ${lane.items.length}`}
+                      </button>
+                    ) : null}
+                  </>
+                )}
+              </section>
+            );
+          })
         )}
       </div>
     </div>
@@ -562,7 +657,7 @@ function WorkQueueCard({
           {item.surface ? <span className="fwq-tag">{item.surface}</span> : null}
           {beadId ? <span className="fwq-tag fwq-tag--bead">{beadId}</span> : null}
           {item.bead && !item.pr && !item.merged ? (
-            <span className="fwq-tag">P{item.bead.priority}</span>
+            <span className={`fwq-tag fwq-tag--p${Math.min(item.bead.priority, 3)}`}>P{item.bead.priority}</span>
           ) : null}
           {item.pr ? (
             <>
@@ -584,6 +679,11 @@ function WorkQueueCard({
           {item.merged?.mergedAt ? (
             <span className="fwq-card-time" title={new Date(item.merged.mergedAt).toLocaleString()}>
               merged {relativeTime(item.merged.mergedAt)}
+            </span>
+          ) : null}
+          {!item.pr && !item.merged && item.bead?.updated_at ? (
+            <span className="fwq-card-time" title={new Date(item.bead.updated_at).toLocaleString()}>
+              updated {relativeTime(item.bead.updated_at)}
             </span>
           ) : null}
         </div>

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -260,3 +260,22 @@ assert.equal(
 }
 
 console.log("beads-work-queue.test.ts: ok");
+
+// ── no-open-PR triage order: priority asc, then oldest update first (cave-19jy)
+{
+  const at = (h) => new Date(NOW - h * HOURS).toISOString();
+  const beads = [
+    { ...bead("cave-fresh-p1", { priority: 1 }), updated_at: at(2) },
+    { ...bead("cave-old-p1", { priority: 1 }), updated_at: at(90) },
+    { ...bead("cave-old-p0", { priority: 0 }), updated_at: at(50) },
+    { ...bead("cave-any-p2", { priority: 2 }), updated_at: at(200) },
+    { ...bead("cave-undated-p1", { priority: 1 }), updated_at: null },
+  ];
+  const q = buildWorkQueue(beads, [], [], { nowMs: NOW });
+  const lane = q.lanes.find((l) => l.key === "no-open-PR");
+  assert.deepEqual(
+    lane.items.map((i) => i.bead.id),
+    ["cave-old-p0", "cave-old-p1", "cave-fresh-p1", "cave-undated-p1", "cave-any-p2"],
+    "P0 first; within a priority the stalest update leads; undated beads sort after dated peers",
+  );
+}

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -263,7 +263,10 @@ export function buildWorkQueue(
 function itemSortKey(item: WorkQueueItem): string {
   if (item.pr) return `0:${String(item.pr.number).padStart(8, "0")}`;
   if (item.merged) return `0:${String(item.merged.number).padStart(8, "0")}`;
-  if (item.bead) return `1:${item.bead.priority}:${item.bead.id}`;
+  // Beads triage priority-first, then OLDEST update first so long-waiting
+  // work surfaces above fresh arrivals (cave-19jy). An undated bead can't
+  // prove its age, so it sorts after dated peers of the same priority.
+  if (item.bead) return `1:${item.bead.priority}:${item.bead.updated_at || "9999"}:${item.bead.id}`;
   return `2:${item.key}`;
 }
 

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -269,11 +269,59 @@
 .fwq-lane-head {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  padding: 9px var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
   font-size: var(--text-sm);
   font-weight: 600;
+}
+
+/* The whole head row is the disclosure control (cave-19jy). */
+.fwq-lane-toggle {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 9px var(--space-3);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+}
+.fwq-lane-toggle:hover .fwq-lane-title { color: var(--text-primary); }
+.fwq-lane-caret {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform var(--duration-fast, 120ms) ease;
+}
+.fwq-lane-caret.is-open { transform: rotate(90deg); }
+
+/* Show all N / Show top N — quiet full-width foot row on capped lanes. */
+.fwq-lane-more {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+  background: transparent;
+}
+.fwq-lane-more:hover { color: var(--accent-presence); background: var(--bg-hover); }
+
+/* Priority tint — P0/P1 must pop in a mixed lane; P2+ stays quiet. */
+.fwq-tag--p0,
+.fwq-tag--p1 {
+  color: var(--color-warning);
+  border-color: color-mix(in oklch, var(--color-warning) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--color-warning) 10%, transparent);
+}
+.fwq-tag--p0 {
+  color: var(--color-danger);
+  border-color: color-mix(in oklch, var(--color-danger) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--color-danger) 10%, transparent);
 }
 
 .fwq-lane-title {


### PR DESCRIPTION
## What (PR 1/3 of the queue-at-scale plan)

The Tasks → Queue tab collapsed under 60+ beads: one flat lane, join order, no ages.

- **Triage sort** in `buildWorkQueue`: priority asc → oldest `updated_at` first (undated last within priority); PR lanes keep number order
- **Age stamps** on bead rows (`updated Xd ago`, absolute in tooltip)
- **Collapsible lanes** — headers are real disclosure buttons, persisted per lane (`cave:fwq:collapsed:v1`), `waiting` collapsed by default
- **Visible cap** — long lanes mount top 8 + `Show all N` / `Show top 8` toggle (also the perf fix)
- **Priority tints** — P0 danger / P1 warning chips

## Verification

- `beads-work-queue.test.ts` new behavioral sort case; new `familiar-work-queue-view.test.ts` (10 pins) registered in SUITES; `check-tests-wired` green
- `design-token-drift` + `pnpm typecheck` clean
- Built + served with a mocked 60-bead queue: verified capped (8 P0s oldest-first), Show-all (59 rows, P0→P1), and collapsed states via screenshots

Bead: cave-19jy · Plan: session plan.md (approved)