### PR TITLE
feat(nav): derive mobile bottom tabs from the sidebar's primary cluster (#3283 phase 4)

### DIFF
--- a/src/components/canonical-nav-names.test.ts
+++ b/src/components/canonical-nav-names.test.ts
@@ -40,11 +40,23 @@ assert.match(
   /import \{ FOLDER_MODES \} from "@\/components\/sidebar-minimal";/,
   "mobile tabs must import the sidebar's FOLDER_MODES source of truth",
 );
+const tabsDeclaration = mobileTabs.match(
+  /const\s+TABS\s*=\s*FOLDER_MODES[\s\S]*?;(?=\s*\n)/,
+)?.[0];
+assert.ok(tabsDeclaration, "mobile tabs must derive TABS directly from FOLDER_MODES");
 assert.match(
-  mobileTabs,
-  /FOLDER_MODES\.filter\(\(fm\) => !fm\.quiet && !fm\.navHidden\)\.map\(\s*\(fm\) => \(\{ id: fm\.id, label: fm\.label, ariaLabel: fm\.label, iconName: fm\.iconName \}\),?\s*\)/,
+  tabsDeclaration,
+  /\.filter\(\s*\(?\s*fm\s*\)?\s*=>\s*!fm\.quiet\s*&&\s*!fm\.navHidden\s*\)/,
   "mobile tabs must be derived from the sidebar's primary (non-quiet, non-hidden) cluster",
 );
+for (const field of ["id", "label", "ariaLabel", "iconName"]) {
+  const sourceField = field === "ariaLabel" ? "label" : field;
+  assert.match(
+    tabsDeclaration,
+    new RegExp(`\\b${field}\\s*:\\s*fm\\.${sourceField}\\b`),
+    `mobile tabs must derive ${field} from the canonical FOLDER_MODES row`,
+  );
+}
 assert.doesNotMatch(
   mobileTabs,
   /\{ id: "[a-z-]+", label: "/,
@@ -55,8 +67,12 @@ assert.doesNotMatch(
 // the drawer keeps the rest reachable: quiet rows exist in FOLDER_MODES.
 const primaryIds = [];
 const folderBlock = sidebar.match(/const FOLDER_MODES[\s\S]*?\n\];/)[0];
-for (const row of folderBlock.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"[^\n]*/g)) {
-  if (!/quiet: true/.test(row[0]) && !/navHidden: true/.test(row[0])) primaryIds.push(row[1]);
+for (const row of folderBlock.matchAll(/\{[\s\S]*?\}/g)) {
+  const id = row[0].match(/\bid\s*:\s*"([a-z-]+)"/)?.[1];
+  if (!id) continue;
+  if (!/\bquiet\s*:\s*true\b/.test(row[0]) && !/\bnavHidden\s*:\s*true\b/.test(row[0])) {
+    primaryIds.push(id);
+  }
 }
 assert.deepEqual(
   primaryIds,

--- a/src/components/canonical-nav-names.test.ts
+++ b/src/components/canonical-nav-names.test.ts
@@ -29,25 +29,40 @@ const sidebarLabels = extractLabels(
   "FOLDER_MODES",
   /const FOLDER_MODES[\s\S]*?\n\];/,
 );
-const mobileLabels = extractLabels(
+
+// ── Mobile bottom tabs DERIVE from the sidebar's primary cluster ─────────────
+// Parity by construction (issue #3283 acceptance: "Desktop and mobile present
+// the same conceptual hierarchy"): the tab strip maps FOLDER_MODES rows that
+// are neither quiet nor navHidden, reusing the canonical label as both the
+// visible label and the accessible name. No hand-copied row list may return.
+assert.match(
   mobileTabs,
-  "TABS",
-  /const TABS[\s\S]*?\n\];/,
+  /import \{ FOLDER_MODES \} from "@\/components\/sidebar-minimal";/,
+  "mobile tabs must import the sidebar's FOLDER_MODES source of truth",
+);
+assert.match(
+  mobileTabs,
+  /FOLDER_MODES\.filter\(\(fm\) => !fm\.quiet && !fm\.navHidden\)\.map\(\s*\(fm\) => \(\{ id: fm\.id, label: fm\.label, ariaLabel: fm\.label, iconName: fm\.iconName \}\),?\s*\)/,
+  "mobile tabs must be derived from the sidebar's primary (non-quiet, non-hidden) cluster",
+);
+assert.doesNotMatch(
+  mobileTabs,
+  /\{ id: "[a-z-]+", label: "/,
+  "mobile tabs must not hand-copy id/label rows — derive them from FOLDER_MODES",
 );
 
-// ── Mobile bottom tabs use the sidebar's canonical labels ────────────────────
-let sharedTabs = 0;
-for (const [id, label] of mobileLabels) {
-  const canonical = sidebarLabels.get(id);
-  if (canonical === undefined) continue;
-  sharedTabs += 1;
-  assert.equal(
-    label,
-    canonical,
-    `mobile tab "${id}" must use the canonical sidebar label "${canonical}", got "${label}"`,
-  );
+// The primary cluster the tabs mirror stays the four daily destinations, and
+// the drawer keeps the rest reachable: quiet rows exist in FOLDER_MODES.
+const primaryIds = [];
+const folderBlock = sidebar.match(/const FOLDER_MODES[\s\S]*?\n\];/)[0];
+for (const row of folderBlock.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"[^\n]*/g)) {
+  if (!/quiet: true/.test(row[0]) && !/navHidden: true/.test(row[0])) primaryIds.push(row[1]);
 }
-assert.ok(sharedTabs >= 3, "mobile tabs should share several destinations with the sidebar");
+assert.deepEqual(
+  primaryIds,
+  ["home", "chat", "board", "inbox"],
+  "sidebar primary cluster (→ mobile tabs) should be the four daily destinations",
+);
 
 // ── The sr-only h1 / split-tile title map agrees for sidebar destinations ────
 const titlesBlock = workspace.match(

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -2,33 +2,27 @@
 
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
- * viewports. Surfaces the most-used destinations (Home, Chat, Tasks, Rituals)
- * as a tablist with icon + label and an active highlight. Labels use the
- * canonical surface names shared with the desktop sidebar (issue #3283 —
- * one surface, one name).
+ * viewports. Surfaces the desktop sidebar's primary cluster (the non-quiet,
+ * non-hidden FOLDER_MODES rows — Home, Chat, Tasks, Rituals) as a tablist
+ * with icon + label and an active highlight. Tabs are DERIVED from
+ * FOLDER_MODES rather than hand-copied so desktop and mobile present the
+ * same conceptual hierarchy by construction (issue #3283 — one surface, one
+ * name; the quiet cluster and footer stay reachable via the nav drawer,
+ * which hosts the full sidebar).
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
  * responsible for that conditional render — this component itself doesn't
  * check viewport.
  */
 
-import { Icon, type IconName } from "@/lib/icon";
+import { Icon } from "@/lib/icon";
+import { FOLDER_MODES } from "@/components/sidebar-minimal";
 
-type TabId = "home" | "chat" | "board" | "inbox";
-
-type TabDef = {
-  id: TabId;
-  label: string;
-  ariaLabel: string;
-  iconName: IconName;
-};
-
-const TABS: TabDef[] = [
-  { id: "home", label: "Home", ariaLabel: "Home", iconName: "ph:house-bold" },
-  { id: "chat", label: "Chat", ariaLabel: "Chat", iconName: "ph:chats" },
-  { id: "board", label: "Tasks", ariaLabel: "Tasks", iconName: "ph:kanban" },
-  { id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" },
-];
+// Primary daily destinations: exactly the rows the desktop sidebar promotes
+// (quiet rows live in the drawer's full sidebar; navHidden are on-demand).
+const TABS = FOLDER_MODES.filter((fm) => !fm.quiet && !fm.navHidden).map(
+  (fm) => ({ id: fm.id, label: fm.label, ariaLabel: fm.label, iconName: fm.iconName }),
+);
 
 export type MobileBottomTabsProps = {
   mode: string;

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -32,8 +32,8 @@ assert.match(
 
 assert.match(
   mobileTabs,
-  /{ id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" }/,
-  "Mobile bottom tabs should use the canonical Rituals name for both the visible label and the accessible name",
+  /FOLDER_MODES\.filter\(\(fm\) => !fm\.quiet && !fm\.navHidden\)/,
+  "Mobile bottom tabs should derive from the desktop sidebar's primary cluster, inheriting canonical names (Rituals included) by construction",
 );
 
 assert.match(

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -27,8 +27,8 @@ assert.match(
 );
 assert.match(
   mobileTabs,
-  /\{ id: "inbox", label: "Rituals", ariaLabel: "Rituals", iconName: "ph:calendar-check" \}/,
-  "Mobile bottom tab uses the canonical Rituals label (one surface, one name — issue #3283)",
+  /import \{ FOLDER_MODES \} from "@\/components\/sidebar-minimal";/,
+  "Mobile bottom tabs derive rows from the sidebar's FOLDER_MODES, so the inbox tab inherits the canonical Rituals label (one surface, one name — issue #3283)",
 );
 assert.match(
   notificationBell,

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -27,8 +27,8 @@ assert.match(
 );
 assert.match(
   mobileTabs,
-  /import \{ FOLDER_MODES \} from "@\/components\/sidebar-minimal";/,
-  "Mobile bottom tabs derive rows from the sidebar's FOLDER_MODES, so the inbox tab inherits the canonical Rituals label (one surface, one name — issue #3283)",
+  /const\s+TABS\s*=\s*FOLDER_MODES[\s\S]*?\.filter\([\s\S]*?!fm\.quiet\s*&&\s*!fm\.navHidden[\s\S]*?\.map\([\s\S]*?label\s*:\s*fm\.label[\s\S]*?ariaLabel\s*:\s*fm\.label/,
+  "Mobile bottom tabs derive visible and accessible labels from the canonical FOLDER_MODES rows (one surface, one name — issue #3283)",
 );
 assert.match(
   notificationBell,


### PR DESCRIPTION
Phase 4 of #3283 (nav IA simplification, bead `cave-m4ih.4`): desktop/mobile **hierarchy parity by construction**.

## Audit result

- The mobile nav drawer already hosts the **full sidebar** (quiet cluster Memories/Marketplace/GitHub + footer Dashboard/Settings), so every desktop destination is reachable on mobile — no new surface needed.
- The actual gap: `mobile-bottom-tabs.tsx` hand-copied its 4 rows (id/label/icon). That copy is exactly how the earlier drift shipped (desktop **Tasks** vs mobile **Board**, **Rituals** vs **Rites**).

## Change

- `TABS` now **derives** from `FOLDER_MODES` (`!quiet && !navHidden`) — the same source of truth the desktop sidebar renders and the ⌘K palette imports. Canonical label doubles as the accessible name.
- `canonical-nav-names.test.ts`: mobile check upgraded from label-equality to structural pins (must import FOLDER_MODES, must derive, must NOT hand-copy rows) + pins the primary cluster to `home/chat/board/inbox`.
- `mobile-shell-smoke.test.ts` / `rituals-tabs.test.ts`: literal TABS-row pins repointed to the derivation.

No new test file → no `run-tests.mjs` change (no conflict with #3428).

## Verification

- `pnpm typecheck` ✓
- `pnpm test:app` — 778 files ✓

Part of the phase plan in https://github.com/OpenCoven/coven-cave/issues/3283#issuecomment-5010763625.