### PR TITLE
feat(chat): comma-separated stop phrase options

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4679,7 +4679,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const text = (override ?? input).trim();
     if (!text && attachments.length === 0) return;
     if (attachments.length === 0 && intentFromSlash(text)) return;
-    // Global stop phrase (cave-uf2x): while a task is running, typing the
+    // Global stop phrases (cave-uf2x): while a task is running, typing any
     // configured phrase is a command — halt the turn (same path as the Stop
     // button) instead of leaving the draft stranded behind the busy bail.
     if (busy && matchesStopPhrase(text, readStopPhrase())) {

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -467,10 +467,10 @@ function CelebrationsToggle() {
   );
 }
 
-// The stop phrase is a safety valve: while a familiar is mid-task, typing
-// this exact phrase in any chat composer halts the run (the composer's busy
-// bail otherwise swallows plain sends). Commit on blur/Enter; clearing the
-// field disables interception.
+// Stop phrases are a safety valve: while a familiar is mid-task, typing any
+// one of these comma-separated phrases in a chat composer halts the run (the
+// composer's busy bail otherwise swallows plain sends). Commit on blur/Enter;
+// clearing the field disables interception.
 function StopPhraseField() {
   const saved = useStopPhrase();
   const [draft, setDraft] = useState<string | null>(null);
@@ -481,8 +481,8 @@ function StopPhraseField() {
   };
   return (
     <SettingsRow
-      label="Stop phrase"
-      description="Typing this in the composer while a task is running stops it. Leave empty to disable."
+      label="Stop phrases"
+      description="Typing any one of these in the composer while a task is running stops it. Separate options with commas; leave empty to disable."
     >
       <input
         value={value}
@@ -493,7 +493,7 @@ function StopPhraseField() {
         }}
         placeholder={DEFAULT_STOP_PHRASE}
         maxLength={STOP_PHRASE_MAX_LENGTH}
-        aria-label="Stop phrase"
+        aria-label="Stop phrases"
         className="focus-ring w-full max-w-sm rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-secondary)] outline-none"
       />
     </SettingsRow>

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -94,7 +94,10 @@ export type CavePreferences = {
   };
   general: {
     newsHeadlines: boolean;
-    /** Composer phrase that halts a running chat task; "" disables it. */
+    /**
+     * Comma-separated composer phrases, any of which halts a running chat
+     * task; "" disables the feature.
+     */
     stopPhrase: string;
     /**
      * Progression celebrations — milestone toasts and completion flourishes.
@@ -135,10 +138,13 @@ const DEFAULT_THEME: CaveThemePreferences = {
   updatedAt: "",
 };
 
-/** Default composer stop phrase; "" (after trim) turns the feature off. */
-export const DEFAULT_STOP_PHRASE = "stop";
-/** Longest phrase the preference stores; UI and matcher share this bound. */
-export const STOP_PHRASE_MAX_LENGTH = 64;
+/**
+ * Default composer stop phrases (comma-separated options); "" (after trim)
+ * turns the feature off.
+ */
+export const DEFAULT_STOP_PHRASE = "stop, cancel, halt, abort";
+/** Longest phrase list the preference stores; UI and matcher share this bound. */
+export const STOP_PHRASE_MAX_LENGTH = 160;
 
 function normalizeStopPhrase(value: unknown): string {
   if (typeof value !== "string") return DEFAULT_STOP_PHRASE;

--- a/src/lib/stop-phrase.test.ts
+++ b/src/lib/stop-phrase.test.ts
@@ -5,8 +5,10 @@ import { test } from "node:test";
 
 import {
   DEFAULT_STOP_PHRASE,
+  STOP_PHRASE_MAX_LENGTH,
   matchesStopPhrase,
   normalizeStopUtterance,
+  parseStopPhrases,
 } from "./stop-phrase.ts";
 import {
   applyPreferencesPatch,
@@ -33,16 +35,48 @@ test("matchesStopPhrase: containing the phrase is NOT a match — instructions p
   assert.equal(matchesStopPhrase("don't stop", "stop"), false);
 });
 
+test("matchesStopPhrase: comma-separated preference offers multiple options", () => {
+  const phrases = "stop, cancel , HALT,abort";
+  assert.equal(matchesStopPhrase("stop", phrases), true);
+  assert.equal(matchesStopPhrase("Cancel!", phrases), true);
+  assert.equal(matchesStopPhrase("halt", phrases), true);
+  assert.equal(matchesStopPhrase("  abort.  ", phrases), true);
+  assert.equal(matchesStopPhrase("continue", phrases), false);
+  // Still exact-match only, per option.
+  assert.equal(matchesStopPhrase("cancel the meeting", phrases), false);
+  assert.equal(matchesStopPhrase("stop, cancel", phrases), false);
+});
+
+test("parseStopPhrases: normalizes, dedupes, and drops empty segments", () => {
+  assert.deepEqual(parseStopPhrases("stop, cancel , HALT,abort"), [
+    "stop",
+    "cancel",
+    "halt",
+    "abort",
+  ]);
+  assert.deepEqual(parseStopPhrases("stop,,  ,Stop!,stop"), ["stop"]);
+  assert.deepEqual(parseStopPhrases(","), []);
+  assert.deepEqual(parseStopPhrases(""), []);
+});
+
+test("default stop phrase preference ships multiple comma-separated options", () => {
+  const options = parseStopPhrases(DEFAULT_STOP_PHRASE);
+  assert.ok(options.length > 1, "default offers more than one stop phrase");
+  assert.ok(options.includes("stop"));
+  for (const option of options) assert.equal(matchesStopPhrase(option, DEFAULT_STOP_PHRASE), true);
+});
+
 test("matchesStopPhrase: empty/blank phrase disables matching entirely", () => {
   assert.equal(matchesStopPhrase("stop", ""), false);
   assert.equal(matchesStopPhrase("", ""), false);
   assert.equal(matchesStopPhrase("stop", "   "), false);
+  assert.equal(matchesStopPhrase("stop", " , ,"), false);
   // Punctuation-only phrase normalizes to empty → off.
   assert.equal(matchesStopPhrase("!!!", "!!!"), false);
 });
 
 test("matchesStopPhrase: oversized composer text short-circuits without matching", () => {
-  const huge = `stop ${"x".repeat(500)}`;
+  const huge = `stop ${"x".repeat(STOP_PHRASE_MAX_LENGTH * 4)}`;
   assert.equal(matchesStopPhrase(huge, "stop"), false);
 });
 
@@ -71,9 +105,11 @@ test("preferences default stopPhrase and survive normalize/patch round-trips", (
 });
 
 test("validatePreferencesPatch validates stopPhrase as a trimmed bounded string", () => {
-  const parsed = validatePreferencesPatch({ general: { stopPhrase: `  halt${"x".repeat(200)}` } });
+  const parsed = validatePreferencesPatch({
+    general: { stopPhrase: `  halt${"x".repeat(STOP_PHRASE_MAX_LENGTH * 4)}` },
+  });
   const phrase = parsed.general?.stopPhrase ?? "";
-  assert.equal(phrase.length, 64);
+  assert.equal(phrase.length, STOP_PHRASE_MAX_LENGTH);
   assert.equal(phrase.startsWith("halt"), true);
   assert.throws(() => validatePreferencesPatch({ general: { stopPhrase: 7 } }));
 });
@@ -93,9 +129,9 @@ test("chat composer send() intercepts the stop phrase before the busy bail", () 
   assert.match(between, /cancelSend\(\)/);
 });
 
-test("Settings → General exposes the stop phrase field", () => {
+test("Settings → General exposes the stop phrases field", () => {
   const src = readFileSync(path.join(repoRoot, "src/components/settings-shell.tsx"), "utf8");
   assert.match(src, /<StopPhraseField \/>/);
   assert.match(src, /writeStopPhrase\(draft\)/);
-  assert.match(src, /aria-label="Stop phrase"/);
+  assert.match(src, /aria-label="Stop phrases"/);
 });

--- a/src/lib/stop-phrase.ts
+++ b/src/lib/stop-phrase.ts
@@ -1,15 +1,16 @@
 "use client";
 
 /**
- * Global stop phrase — a safety valve for running chat tasks.
+ * Global stop phrases — a safety valve for running chat tasks.
  *
  * While a familiar is mid-task the composer normally swallows plain sends
- * (CHAT-D5-01 keeps the draft intact instead of destroying it). Typing the
+ * (CHAT-D5-01 keeps the draft intact instead of destroying it). Typing a
  * configured stop phrase is the exception: it is treated as a command, not a
  * prompt — the running turn is cancelled exactly as if the Stop button were
- * pressed. The phrase lives in the synced preferences file
- * (`general.stopPhrase`, default "stop"); Settings → General owns the input.
- * Clearing the phrase disables the interception entirely.
+ * pressed. The preference is a comma-separated list of phrases living in the
+ * synced preferences file (`general.stopPhrase`, default
+ * "stop, cancel, halt, abort"); Settings → General owns the input. Clearing
+ * the field disables the interception entirely.
  *
  * Matching is deliberately exact (after normalization): "stop" halts the
  * task, but "stop using tabs" is an instruction for the model and must never
@@ -43,14 +44,31 @@ export function normalizeStopUtterance(raw: string): string {
 }
 
 /**
- * True when `text` IS the stop phrase (not merely contains it). An empty or
- * unset phrase never matches — that is the off switch.
+ * The preference stores one or more comma-separated phrases
+ * ("stop, cancel, halt"). Returns the normalized, de-duplicated candidates;
+ * an empty result means the feature is off.
+ */
+export function parseStopPhrases(phrase: string): string[] {
+  if (typeof phrase !== "string") return [];
+  const candidates = new Set<string>();
+  for (const part of phrase.split(",")) {
+    const normalized = normalizeStopUtterance(part);
+    if (normalized) candidates.add(normalized);
+  }
+  return [...candidates];
+}
+
+/**
+ * True when `text` IS one of the configured stop phrases (not merely contains
+ * one). An empty or unset phrase list never matches — that is the off switch.
  */
 export function matchesStopPhrase(text: string, phrase: string): boolean {
-  const normalizedPhrase = normalizeStopUtterance(phrase);
-  if (!normalizedPhrase) return false;
+  const candidates = parseStopPhrases(phrase);
+  if (candidates.length === 0) return false;
   if (typeof text !== "string" || text.length > STOP_PHRASE_MAX_LENGTH * 4) return false;
-  return normalizeStopUtterance(text) === normalizedPhrase;
+  const normalizedText = normalizeStopUtterance(text);
+  if (!normalizedText) return false;
+  return candidates.includes(normalizedText);
 }
 
 const listeners = new Set<() => void>();


### PR DESCRIPTION
## Summary
- The `general.stopPhrase` preference is now a comma-separated list: `parseStopPhrases()` splits, normalizes, dedupes; `matchesStopPhrase()` halts a running task when the composer text exactly matches ANY option (normalization unchanged: lowercase, collapsed whitespace, trailing punctuation stripped).
- Default becomes "stop, cancel, halt, abort"; max length 64 → 160; Preferences field relabeled "Stop phrases" with a comma-syntax hint.
- Empty / comma-only input still disables the feature.

## Test plan
- [x] `stop-phrase.test.ts` 12/12 (multi-option, dedupe, off-switch, length clamp)
- [x] preferences-schema + settings-shell-polish tests
- [x] `pnpm typecheck`