### PR TITLE
fix(analytics): contract compliance spans both grid columns

### DIFF
--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -478,6 +478,21 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(globals, /@container fa \(max-width: 880px\)/, "grid collapses by pane width, not viewport");
   });
 
+  it("gives contract compliance both columns after the sessions and self-heal row", () => {
+    assert.match(
+      source,
+      /id="fa-contract"\s+title="Contract compliance"\s+wide/,
+      "contract compliance opts into the full-width section layout",
+    );
+
+    const grid = source.slice(source.indexOf('<div className="fa-grid">'), source.indexOf("{traceTarget ?"));
+    const sessionsIndex = grid.indexOf('id="fa-sessions"');
+    const healIndex = grid.indexOf('id="fa-heal"');
+    const contractIndex = grid.indexOf("<ContractCompliance");
+    assert.ok(sessionsIndex >= 0 && sessionsIndex < healIndex, "recent sessions starts the paired row");
+    assert.ok(healIndex < contractIndex, "self-heal completes the row before the wide contract panel");
+  });
+
   it("makes .fa-page own its vertical scroll (html/body are overflow:hidden)", () => {
     const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
     const block = globals.match(/\.fa-page\s*\{[^}]*\}/);

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -608,6 +608,7 @@ const ContractCompliance = memo(function ContractCompliance({ report }: { report
     <FaSection
       id="fa-contract"
       title="Contract compliance"
+      wide
       count={report ? `${passCount}/${report.properties.length} · ${report.pass ? "passing" : "needs review"}` : "no report"}
     >
       {report ? (
@@ -994,10 +995,19 @@ export function FamiliarAnalyticsContent({
           />
         </FaSection>
 
-        {/* Contract compliance pairs with recent sessions on the first row —
-            the full-width thread-analysis panel below would otherwise leave an
-            empty cell beside the sessions list. The #fa-contract KPI
-            drill-through keeps working wherever the section lives. */}
+        {/* Self-heal requests pair with recent sessions on the first row —
+            contract compliance is full width now, so it would otherwise leave
+            an empty cell beside the sessions list. The #fa-heal and
+            #fa-contract KPI drill-throughs keep working wherever the sections
+            live. */}
+        <FaSection
+          id="fa-heal"
+          title="Self-heal requests"
+          count={`${healRequests.length} ${healRequests.length === 1 ? "request" : "requests"}`}
+        >
+          <SelfHealList requests={healRequests} />
+        </FaSection>
+
         <ContractCompliance report={model.contractReport} />
 
         <ThreadAnalysisSection
@@ -1006,14 +1016,6 @@ export function FamiliarAnalyticsContent({
           familiar={model.familiar}
           onSelfReportEnabled={onRefresh}
         />
-
-        <FaSection
-          id="fa-heal"
-          title="Self-heal requests"
-          count={`${healRequests.length} ${healRequests.length === 1 ? "request" : "requests"}`}
-        >
-          <SelfHealList requests={healRequests} />
-        </FaSection>
 
         <FaSection
           id="fa-thread-signals"


### PR DESCRIPTION
## Summary
- The contract property grid was cramped in a single `fa-grid` cell; the section is now `wide` (spans both columns).
- Self-heal requests move up beside Recent sessions so the full-width contract panel leaves no empty cell on row one (same DOM-order pairing rule as #3367).
- `#fa-contract` / `#fa-heal` KPI drill-throughs unaffected.

## Test plan
- [x] `familiar-analytics-view.test.ts` 28/28
- [x] `pnpm typecheck`