### PR TITLE
docs(nav): source-grounded navigation Mermaid maps (#3283 phase 6)

### DIFF
--- a/docs/diagrams/navigation/00-navigation-legend.mmd
+++ b/docs/diagrams/navigation/00-navigation-legend.mmd
@@ -1,0 +1,83 @@
+%% CovenCave navigation diagram legend
+%% Shared semantic palette for the navigation map set.
+%% Regenerated from main@bcf9f8bdbcb1 (2026-07-18) — final IA for issue #3283.
+%%{init: {
+  "theme": "base",
+  "flowchart": { "curve": "basis", "nodeSpacing": 36, "rankSpacing": 62, "padding": 16 },
+  "themeVariables": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "fontSize": "17px",
+    "primaryColor": "#241b31",
+    "primaryTextColor": "#f7f2ff",
+    "primaryBorderColor": "#b995e8",
+    "lineColor": "#927db1",
+    "clusterBkg": "#120f19",
+    "clusterBorder": "#5f4a78",
+    "edgeLabelBackground": "#120f19"
+  }
+}}%%
+flowchart TB
+  TITLE(["CovenCave navigation map legend"]):::entry
+
+  subgraph NODES["Node colors · what each destination represents"]
+    direction LR
+    ENTRY(["Entry point<br/>#a46bea"]):::entry
+    SURFACE["Primary surface / section<br/>#241b31"]:::surface
+    MENU["Menu / structural panel<br/>#382448"]:::menu
+    TAB["Selectable tab<br/>#17332d"]:::tab
+    ROUTE["Route or successful action<br/>#19312d"]:::route
+    VIEW["Rendered view / content pane<br/>#202a37"]:::view
+    PANEL["Inspector / detail panel<br/>#31233c"]:::panel
+    GROUP["Grouping / collection<br/>#292330"]:::group
+    LAUNCH["Launcher / decision<br/>#3b2e1c"]:::launcher
+    OVERLAY["Overlay / dialog / drawer<br/>#3c272f"]:::overlay
+    DANGER["Destructive action<br/>#3c2228"]:::danger
+    CONDITIONAL["Conditional / role-dependent<br/>#30253b"]:::conditional
+    ALIAS["Alias / compatibility mode<br/>#2a2630"]:::alias
+    HIDDEN["Hidden / retired destination<br/>#30232b"]:::hidden
+    DEV["Developer / review-only route<br/>#202329"]:::dev
+  end
+
+  subgraph SHAPES["Shapes and borders"]
+    direction LR
+    PILL(["Rounded pill<br/>application entry or launch point"]):::entry
+    RECT["Rectangle<br/>destination, view, menu, or action"]:::surface
+    DIAMOND{"Diamond<br/>choice or view switch"}:::launcher
+    THICK["Thick solid border<br/>primary navigable surface"]:::surface
+    DASHED["Dashed border<br/>transient, conditional, alias,<br/>hidden, or review-only"]:::overlay
+  end
+
+  subgraph LINES["Relationship lines"]
+    direction LR
+    DIRECTA["Current location"]:::surface -->|"solid arrow · direct navigation or containment"| DIRECTB["Destination"]:::tab
+    DIRECTA -. "dashed arrow · redirect, conditional path,<br/>deep-link remap, or overlay launch" .-> INDIRECT["Indirect destination"]:::conditional
+  end
+
+  subgraph READING["Reading guidance"]
+    direction LR
+    ORDER["Follow arrows from shell / route<br/>→ surface → tab → view"]:::view
+    CLUSTER["Large outlined boxes group<br/>related navigation regions"]:::group
+    LABEL["Edge labels explain non-obvious<br/>redirects and compatibility behavior"]:::launcher
+    TRANSPARENT["PNG background is transparent;<br/>dark canvas shown by the reviewer"]:::dev
+  end
+
+  TITLE --> NODES
+  TITLE --> SHAPES
+  TITLE --> LINES
+  TITLE --> READING
+
+  classDef entry fill:#a46bea,stroke:#e5d0ff,color:#160d22,stroke-width:3px;
+  classDef surface fill:#241b31,stroke:#bd96eb,color:#f8f3ff,stroke-width:3px;
+  classDef menu fill:#382448,stroke:#c6a1ed,color:#fbf7ff,stroke-width:2px;
+  classDef tab fill:#17332d,stroke:#69d6a6,color:#effff9,stroke-width:2px;
+  classDef route fill:#19312d,stroke:#66c7aa,color:#effff9,stroke-width:2px;
+  classDef view fill:#202a37,stroke:#7596bd,color:#eff6ff;
+  classDef panel fill:#31233c,stroke:#c490ec,color:#f8edff;
+  classDef group fill:#292330,stroke:#786789,color:#f0e9f8;
+  classDef launcher fill:#3b2e1c,stroke:#e3ba6a,color:#fff6df,stroke-width:2px;
+  classDef overlay fill:#3c272f,stroke:#e190ad,color:#fff0f5,stroke-dasharray:5 3;
+  classDef danger fill:#3c2228,stroke:#e06d88,color:#ffeef2,stroke-width:2px;
+  classDef conditional fill:#30253b,stroke:#db8fff,color:#f9edff,stroke-dasharray:5 4;
+  classDef alias fill:#2a2630,stroke:#9688a6,color:#eee8f4,stroke-dasharray:5 4;
+  classDef hidden fill:#30232b,stroke:#c77c9d,color:#ffeaf2,stroke-dasharray:5 4;
+  classDef dev fill:#202329,stroke:#687482,color:#dce4eb,stroke-dasharray:4 4;

--- a/docs/diagrams/navigation/01-global-navigation.mmd
+++ b/docs/diagrams/navigation/01-global-navigation.mmd
@@ -1,0 +1,138 @@
+%% CovenCave global navigation and route topology
+%% Sources: workspace.tsx, sidebar-minimal.tsx, sidebar-footer.tsx,
+%% mobile-bottom-tabs.tsx, top-bar.tsx, src/lib/workspace-mode.ts,
+%% src/app/route-inventory.test.ts, src/app/**/page.tsx
+%% Regenerated from main@bcf9f8bdbcb1 (2026-07-18) — final IA for issue #3283.
+%%{init: {
+  "theme": "base",
+  "flowchart": { "curve": "basis", "nodeSpacing": 30, "rankSpacing": 58, "padding": 14 },
+  "themeVariables": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "fontSize": "16px",
+    "primaryColor": "#241b31",
+    "primaryTextColor": "#f7f2ff",
+    "primaryBorderColor": "#b995e8",
+    "lineColor": "#927db1",
+    "secondaryColor": "#17332d",
+    "tertiaryColor": "#35233f",
+    "clusterBkg": "#120f19",
+    "clusterBorder": "#5f4a78",
+    "edgeLabelBackground": "#120f19"
+  }
+}}%%
+flowchart TB
+  ENTRY([Launch CovenCave]):::entry --> ROOT["/ · Workspace shell"]:::route
+
+  subgraph CHROME["Persistent shell chrome"]
+    direction LR
+    ROOT --> DESKTOP["Desktop ≥1024px"]:::platform
+    ROOT --> MOBILE["Mobile / tablet"]:::platform
+
+    DESKTOP --> DTOP["Top bar"]:::menu
+    DTOP --> HISTORY["Back · Forward"]:::utility
+    DTOP --> SEARCH["Search / Ask Salem · ⌘K"]:::launcher
+    DTOP --> QUICK["Quick chat · ⌘J"]:::launcher
+    DTOP --> DTASK["Enhance · Tasks · Rituals"]:::launcher
+
+    DESKTOP --> DSIDE["Left navigation"]:::menu
+    DSIDE --> SCOPE["Familiar scope switcher"]:::launcher
+    DSIDE --> NEWCHAT["New chat"]:::launcher
+    DSIDE --> DAILY["Daily"]:::group
+    DAILY --> HOME["Home · ⌘1"]:::surface
+    DAILY --> CHAT["Chat · ⌘2"]:::surface
+    DAILY --> TASKS["Tasks · ⌘3"]:::surface
+    DAILY --> RITUALS["Rituals · ⌘4"]:::surface
+    DSIDE --> QUIET["Quiet destinations"]:::group
+    QUIET --> MEMORIES["Memories"]:::surface
+    QUIET --> MARKET["Marketplace"]:::surface
+    QUIET --> GITHUB["GitHub"]:::surface
+    DSIDE --> ROOMS["Rooms · role-dependent"]:::conditional
+    DSIDE --> RECENT["Recent activity / sessions"]:::group
+    DSIDE --> FOOTER["Footer"]:::group
+    FOOTER --> DASH["Dashboard · /dashboard"]:::route
+    FOOTER --> SETTINGS["Settings · /settings"]:::route
+
+    MOBILE --> MTOP["Mobile top bar"]:::menu
+    MTOP --> DRAWER["Navigation drawer"]:::launcher
+    MTOP --> MSEARCH["Search / Ask Salem"]:::launcher
+    MTOP --> MSCOPE["Familiar switcher"]:::launcher
+    MTOP --> MCHAT["Quick chat"]:::launcher
+    MTOP --> MACTIONS["More actions<br/>Enhance · View tasks"]:::menu
+    MTOP --> PHONE["Open on phone"]:::launcher
+    MTOP --> BELL["Notifications"]:::menu
+    MTOP --> ACCOUNT["Account / Settings"]:::route
+    MOBILE --> MBOTTOM["Bottom tabs<br/>derived from sidebar FOLDER_MODES"]:::menu
+    MBOTTOM --> MHOME["Home"]:::surface
+    MBOTTOM --> MCHAT2["Chat"]:::surface
+    MBOTTOM --> MBOARD["Tasks"]:::surface
+    MBOTTOM --> MRITES["Rituals"]:::surface
+  end
+
+  subgraph HIDDEN["On-demand modes and typed aliases · MODE_ALIASES, workspace-mode.ts"]
+    direction TB
+    PALETTE["Command palette / deep link"]:::launcher --> BROWSER["Browser · ⌘5"]:::surface
+    PALETTE --> AGENTS["Familiars roster · mode: agents<br/>canonical, palette / deep link only"]:::surface
+    PALETTE --> JOURNAL["Journal"]:::alias
+    PALETTE --> CALENDAR["Calendar"]:::alias
+    PALETTE --> GROUPCHAT["Group Chat"]:::alias
+    PALETTE --> QUEUE["Familiar work queue<br/>mode: familiar-work-queue"]:::alias
+    PALETTE --> ROLES["Roles"]:::alias
+    PALETTE --> CAPS["Capabilities"]:::alias
+    PALETTE --> FLOW["Flow"]:::alias
+    PALETTE --> SUBMIT["Submissions"]:::hidden
+    JOURNAL -. "journal → grimoire · Journal tab" .-> MEMORIES
+    CALENDAR -. "calendar → inbox · Calendar tab" .-> RITUALS
+    GROUPCHAT -. "groupchat → chat · Group tab" .-> CHAT
+    QUEUE -. "familiar-work-queue → board · Queue tab" .-> TASKS
+    ROLES -. "roles → marketplace" .-> MARKET
+    CAPS -. "capabilities → marketplace" .-> MARKET
+    FLOW -. "flow → inbox · retired" .-> RITUALS
+  end
+
+  SEARCH -. "launcher" .-> PALETTE
+
+  subgraph ROUTES["Standalone production routes · pinned by route-inventory.test.ts"]
+    direction TB
+    DASH --> REPORT["Daily report · /daily-report/:date"]:::route
+    DASH --> DCOCKPIT["Cockpit panels<br/>Vitals · Familiars · Tasks · GitHub<br/>Up next · Inbox · Space"]:::group
+    DCOCKPIT --> DQUICK["Quick links<br/>Home · Tasks · Growth · Calendar · Settings"]:::launcher
+    DASH --> GROWTH["Familiar growth · /dashboard/familiars/growth"]:::route
+    DASH --> FANALYTICS["Familiar analytics<br/>/dashboard/familiars/:id/analytics"]:::route
+    DASH --> FPROFILE["Familiar profile<br/>/dashboard/familiars/:id/profile"]:::route
+    ROOT --> PROFILE["Human profile · /profile"]:::route
+    ROOT --> PROPOSALS["Proposals · /proposals"]:::route
+    ROOT --> WEAVES["Weaves · /weaves"]:::route
+    ROOT --> QCHAT["Tray / notch quick chat · /quick-chat"]:::route
+    REPORT --> REPORTBACK["Breadcrumb: Dashboard<br/>Actions: Dashboard · Home"]:::utility
+    FANALYTICS --> ANALYTICSRAIL["Analytics route rail<br/>Home · Chat · Tasks · Rituals · Journal<br/>Memories · Marketplace · GitHub · Dashboard"]:::menu
+    FPROFILE --> ANALYTICSRAIL
+    PROFILE --> ANALYTICSRAIL
+    PROPOSALS --> BACKHOME["Breadcrumb → CovenCave"]:::utility
+    WEAVES --> BACKHOME
+    ALIASA["/familiars/:id/analytics"]:::alias -. "redirect + query forward" .-> FANALYTICS
+    ALIASP["/familiars/:id/profile"]:::alias -. "redirect + query forward" .-> FPROFILE
+    OLDG["/familiars/growth · /retro<br/>/dashboard/retro"]:::alias -. "redirect" .-> GROWTH
+  end
+
+  subgraph DEV["Developer / design review routes · excluded from all nav hosts"]
+    direction TB
+    AESTHETIC["/aesthetic · token reference"]:::dev
+    MOCKUP["/mockup · aesthetic mockup"]:::dev
+    CHATOUT["/mockup/familiar-chatout-codex"]:::dev
+    FONTS["/preview/fonts · font review"]:::dev
+  end
+
+  ROOT -. "review-only routes" .-> DEV
+
+  classDef entry fill:#a46bea,stroke:#e5d0ff,color:#160d22,stroke-width:3px;
+  classDef platform fill:#203d37,stroke:#6bd1b1,color:#effff9,stroke-width:2px;
+  classDef menu fill:#382448,stroke:#c6a1ed,color:#fbf7ff,stroke-width:2px;
+  classDef group fill:#26202f,stroke:#766487,color:#eee5f8;
+  classDef surface fill:#241b31,stroke:#b995e8,color:#f7f2ff,stroke-width:2px;
+  classDef route fill:#19312d,stroke:#66c7aa,color:#effff9,stroke-width:2px;
+  classDef launcher fill:#3b2e1c,stroke:#e3ba6a,color:#fff6df;
+  classDef utility fill:#222734,stroke:#8293b7,color:#eef3ff;
+  classDef conditional fill:#30253b,stroke:#db8fff,color:#f9edff,stroke-dasharray:5 4;
+  classDef alias fill:#2a2630,stroke:#9688a6,color:#eee8f4,stroke-dasharray:5 4;
+  classDef hidden fill:#30232b,stroke:#c77c9d,color:#ffeaf2,stroke-dasharray:5 4;
+  classDef dev fill:#202329,stroke:#687482,color:#dce4eb,stroke-dasharray:4 4;

--- a/docs/diagrams/navigation/02-workspace-surfaces.mmd
+++ b/docs/diagrams/navigation/02-workspace-surfaces.mmd
@@ -1,0 +1,172 @@
+%% CovenCave workspace surfaces and nested navigation
+%% Sources: workspace.tsx, src/lib/workspace-mode.ts (canonical modes +
+%% MODE_ALIASES), and every surface component referenced by renderSurface
+%% Regenerated from main@bcf9f8bdbcb1 (2026-07-18) — final IA for issue #3283.
+%%{init: {
+  "theme": "base",
+  "flowchart": { "curve": "basis", "nodeSpacing": 28, "rankSpacing": 62, "padding": 12 },
+  "themeVariables": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "fontSize": "15px",
+    "primaryColor": "#241b31",
+    "primaryTextColor": "#f7f2ff",
+    "primaryBorderColor": "#b995e8",
+    "lineColor": "#8d78aa",
+    "clusterBkg": "#120f19",
+    "clusterBorder": "#5f4a78",
+    "edgeLabelBackground": "#120f19"
+  }
+}}%%
+flowchart TB
+  SHELL([Workspace shell]):::entry --> PRIMARY{Primary surface}:::decision
+
+  subgraph CORE["Conversation and work"]
+    direction LR
+    PRIMARY --> HOME["Home"]:::surface
+    HOME --> HOMECOMP["Composer<br/>Chat or Task destination"]:::view
+    HOME --> HOMEFEED["Daily summary · Needs you<br/>News · Recent sessions"]:::view
+    HOME --> HOMEACT["Open session · Open Rituals<br/>Open task board"]:::action
+
+    PRIMARY --> CHAT["Chat"]:::surface
+    CHAT --> CSESS["Sessions"]:::tab
+    CSESS --> THREADLIST["Project-grouped thread list"]:::view
+    CSESS --> THREAD["Conversation thread"]:::view
+    THREAD --> CODERAIL["Code rail"]:::panel
+    CODERAIL --> CHANGES["Changes"]:::tab
+    CODERAIL --> FILES["Files"]:::tab
+    CODERAIL --> TERMINAL["Terminal<br/>fullscreen rail only"]:::tab
+    CHAT --> CPROJECTS["Projects"]:::tab
+    CPROJECTS --> PLIST["Project list<br/>All / Active · A–Z / Recent"]:::view
+    CPROJECTS --> PDETAIL["Project detail"]:::view
+    PDETAIL --> PSESS["Sessions"]:::group
+    PDETAIL --> PGIT["Git"]:::group
+    PDETAIL --> PTASKS["Tasks"]:::group
+    PDETAIL --> PGRANTS["Grants"]:::group
+    CHAT --> CCANVAS["Canvas<br/>saved chat sketches"]:::tab
+    CHAT --> CFAMILIAR["Familiar<br/>identity · skills · tools"]:::tab
+    CHAT --> CSETTINGS["Settings<br/>chat archive policy"]:::tab
+    CHAT --> CGROUP["Group tab<br/>alias groupchat → chat"]:::tab
+
+    PRIMARY --> TASKS["Tasks"]:::surface
+    TASKS --> BTASKS["Tasks tab"]:::tab
+    TASKS --> BQUEUE["Queue tab<br/>alias familiar-work-queue → board"]:::tab
+    BTASKS --> BVIEWS{View}:::decision
+    BVIEWS --> KANBAN["Kanban"]:::view
+    BVIEWS --> TABLE["Table"]:::view
+    BVIEWS --> GANTT["Timeline / Gantt"]:::view
+    KANBAN --> BGRP["Group: Status · Familiar · Project"]:::group
+    TABLE --> BGRP
+    GANTT --> GGRP["Group: Project · Task · Familiar"]:::group
+    BTASKS --> BDETAIL["Task inspector / editor"]:::panel
+    BTASKS --> BNEW["New task dialog"]:::overlay
+  end
+
+  subgraph KNOWLEDGE["People and knowledge"]
+    direction LR
+    PRIMARY --> FAMILIARS["Familiars · mode: agents"]:::surface
+    FAMILIARS --> ROSTER["Roster"]:::view
+    ROSTER --> FDETAIL["Familiar detail"]:::view
+    FDETAIL --> FMEM["Memory"]:::tab
+    FDETAIL --> FNOTES["Daily Notes"]:::tab
+    FDETAIL --> FFILES["Files"]:::tab
+    FDETAIL --> FSESS["Sessions"]:::tab
+    FDETAIL --> FFEED["Feed"]:::tab
+    FDETAIL --> FTRACE["Session trace overlay"]:::overlay
+    FDETAIL --> FSTUDIO["Edit / Remove → Settings<br/>Familiar Studio"]:::route
+
+    PRIMARY --> MEMORIES["Memories"]:::surface
+    MEMORIES --> MDOCS["Docs"]:::tab
+    MEMORIES --> MJOURNAL["Journal"]:::tab
+    MEMORIES --> MGRAPH["Graph"]:::tab
+    MDOCS --> MNAV["Navigator"]:::panel
+    MNAV --> MSTITCH["Stitches"]:::group
+    MNAV --> MMEMORY["Memory files<br/>grouped by source root"]:::group
+    MNAV --> MJNAV["Journal days"]:::group
+    MDOCS --> OPENTABS["Open documents · max 8"]:::panel
+    OPENTABS --> EDITORS["Knowledge · Memory · Journal editors"]:::view
+    OPENTABS --> NEWSTITCH["New stitch"]:::overlay
+    OPENTABS --> BLANKENTRY["Blank entry"]:::overlay
+  end
+
+  subgraph OPERATIONS["Schedules, integrations, and tools"]
+    direction LR
+    PRIMARY --> RITUALS["Rituals"]:::surface
+    RITUALS --> RINBOX["Inbox"]:::tab
+    RITUALS --> RCALENDAR["Calendar"]:::tab
+    RITUALS --> RCRONS["Crons"]:::tab
+    RINBOX --> IGROUP["Group: Status · Familiar · Kind"]:::group
+    RINBOX --> IACTIONS["Select · bulk action<br/>Subscriptions"]:::action
+    RCALENDAR --> CVIEWS{Calendar view}:::decision
+    CVIEWS --> AGENDA["Agenda"]:::view
+    CVIEWS --> DAY["Day"]:::view
+    CVIEWS --> WEEK["Week"]:::view
+    CVIEWS --> MONTH["Month"]:::view
+    RCALENDAR --> DATEPICK["Jump-to-date mini month"]:::overlay
+    RCALENDAR --> EVENT["Event detail · Add / Edit reminder"]:::overlay
+    RCRONS --> CRONLIST["Active · Paused"]:::group
+    RCRONS --> CRONDETAIL["Cron detail / run history"]:::panel
+    RCRONS --> CRONCREATE["Create from blank or template"]:::overlay
+
+    PRIMARY --> MARKET["Marketplace"]:::surface
+    MARKET --> MBROWSE["Browse"]:::tab
+    MARKET --> MCRAFTS["Crafts"]:::tab
+    MARKET --> MSKILLS["Skills"]:::tab
+    MARKET --> MBUILD["Build"]:::tab
+    MBROWSE --> KINDS["All · APIs · MCP servers · Skills<br/>Prompts · Knowledge packs · Crafts"]:::group
+    MBROWSE --> CATEGORIES["Collections · Categories<br/>Recommended / Name / Installed"]:::group
+    MBROWSE --> PLUGINDETAIL["Plugin detail / Configure"]:::panel
+    MCRAFTS --> CRAFTGROUPS["Drafts · Published"]:::group
+    MCRAFTS --> CRAFTDRAWER["Create / edit Craft drawer"]:::overlay
+    MSKILLS --> SKILLDETAIL["Skill detail drawer"]:::overlay
+    MBUILD --> SKILLBUILDER["SKILL.md builder"]:::view
+
+    PRIMARY --> GITHUB["GitHub"]:::surface
+    GITHUB --> GHFILTER["All · PRs · Reviews · Issues"]:::tab
+    GITHUB --> GHORG["Organization / repository filters"]:::group
+    GITHUB --> GHITEM["Issue / PR detail"]:::panel
+    GHITEM --> GHCOMMENTS["Comments · Reviews"]:::group
+    GHITEM --> GHCHECKS["Checks · Linked work"]:::group
+    GITHUB --> GHAUTH["PAT setup / management"]:::overlay
+    GITHUB --> GHSUBS["Event subscriptions"]:::overlay
+
+    PRIMARY --> BROWSER["Browser"]:::surface
+    BROWSER --> BCONTROLS["Back · Forward · Reload · URL"]:::group
+    BROWSER --> WEBVIEW["Native webview / web fallback"]:::view
+  end
+
+  subgraph ROLESURFACES["Conditional Role rooms"]
+    direction LR
+    PRIMARY -. "active familiar role" .-> RROOMS["Rooms cluster"]:::conditional
+    RROOMS --> RESEARCH["Research Desk"]:::room
+    RROOMS --> COMMS["Comms Operations<br/>delivery queue drawer"]:::room
+    RROOMS --> WATCH["Watchtower<br/>Open · Snoozed · Closed · All"]:::room
+    RROOMS --> WRITING["Writing Desk<br/>published works drawer"]:::room
+    RROOMS --> CHART["Chart Room<br/>voyage log drawer"]:::room
+    RROOMS --> REVIEW["Review Deck<br/>checkpoints drawer"]:::room
+    RROOMS --> ARCHIVE["The Archive<br/>indexing activity drawer"]:::room
+    PRIMARY -. "hidden workspace mode" .-> SUBMISSIONS["OpenCoven Submissions"]:::hidden
+  end
+
+  subgraph SPLIT["Desktop split-pane navigation"]
+    direction LR
+    PRIMARY -. "drag splittable page" .-> SPLITPANE["Secondary tile"]:::conditional
+    SPLITPANE --> SPLITPAGE["Another workspace page"]:::panel
+    SPLITPANE --> SALEM["Salem chat"]:::panel
+    SPLITPANE --> MEMORYINSPECT["Memory inspector"]:::panel
+    SPLITPANE --> SPLITBROWSER["Browser companion"]:::panel
+    SPLITPANE --> PROMOTE["Promote · Close · Resize · Swap side"]:::action
+  end
+
+  classDef entry fill:#a46bea,stroke:#e5d0ff,color:#160d22,stroke-width:3px;
+  classDef decision fill:#3a2d1b,stroke:#e3ba6a,color:#fff4d6,stroke-width:2px;
+  classDef surface fill:#241b31,stroke:#bd96eb,color:#f8f3ff,stroke-width:3px;
+  classDef tab fill:#17332d,stroke:#69d6a6,color:#effff9,stroke-width:2px;
+  classDef view fill:#202a37,stroke:#7596bd,color:#eff6ff;
+  classDef group fill:#292330,stroke:#786789,color:#f0e9f8;
+  classDef panel fill:#31233c,stroke:#c490ec,color:#f8edff;
+  classDef overlay fill:#3c272f,stroke:#e190ad,color:#fff0f5,stroke-dasharray:5 3;
+  classDef action fill:#3b2e1c,stroke:#dfb25d,color:#fff6df;
+  classDef route fill:#19312d,stroke:#66c7aa,color:#effff9,stroke-dasharray:5 3;
+  classDef conditional fill:#30253b,stroke:#db8fff,color:#f9edff,stroke-dasharray:5 4;
+  classDef room fill:#2e2340,stroke:#d49cff,color:#fbf3ff,stroke-width:2px;
+  classDef hidden fill:#30232b,stroke:#c77c9d,color:#ffeaf2,stroke-dasharray:5 4;

--- a/docs/diagrams/navigation/03-settings-navigation.mmd
+++ b/docs/diagrams/navigation/03-settings-navigation.mmd
@@ -1,0 +1,94 @@
+%% CovenCave Settings information architecture
+%% Sources: src/components/settings-sections.ts, settings-shell.tsx,
+%% familiar-studio-inline.tsx
+%% Regenerated from main@bcf9f8bdbcb1 (2026-07-18) — final IA for issue #3283.
+%%{init: {
+  "theme": "base",
+  "flowchart": { "curve": "basis", "nodeSpacing": 30, "rankSpacing": 66, "padding": 14 },
+  "themeVariables": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "fontSize": "16px",
+    "primaryColor": "#241b31",
+    "primaryTextColor": "#f7f2ff",
+    "primaryBorderColor": "#b995e8",
+    "lineColor": "#927db1",
+    "clusterBkg": "#120f19",
+    "clusterBorder": "#5f4a78",
+    "edgeLabelBackground": "#120f19"
+  }
+}}%%
+flowchart LR
+  SETTINGS(["Settings · /settings"]):::entry --> SEARCH["Search settings<br/>jumps to section + group or Studio tab"]:::launcher
+  SETTINGS --> NAV{Section navigation}:::decision
+
+  NAV --> PROFILE["Profile"]:::section
+  PROFILE --> PIDENTITY["Identity<br/>display name · pronouns"]:::group
+  PROFILE --> PIMAGE["Image<br/>profile avatar"]:::group
+  PROFILE --> PDETAILS["Details<br/>bio · timezone"]:::group
+  PROFILE --> PLINKS["Links<br/>GitHub · socials · website"]:::group
+
+  NAV --> GENERAL["General"]:::section
+  GENERAL --> GWORK["Workspace<br/>workspace path"]:::group
+  GENERAL --> GHOME["Home<br/>news headlines"]:::group
+  GENERAL --> GCHAT["Chat<br/>stop phrase"]:::group
+  GENERAL --> GBACKUP["Backup<br/>encrypted export · restore"]:::group
+  GENERAL --> GSTART["Startup<br/>launch at login · open to"]:::group
+
+  NAV --> DAEMON["Daemon"]:::section
+  DAEMON --> DSTATUS["Status<br/>health · start / stop / restart"]:::group
+  DAEMON --> DCONN["Connection<br/>local / hub · executors · travel"]:::group
+  DAEMON --> DINFO["Info<br/>version · socket · PID · API"]:::group
+
+  NAV --> FAMILIARS["Familiars"]:::section
+  FAMILIARS --> ROSTER["Familiar roster / selector"]:::panel
+  ROSTER --> STUDIO{Familiar Studio tabs}:::decision
+  STUDIO --> SIDENTITY["Identity<br/>name · role · pronouns · description"]:::tab
+  STUDIO --> SLOOK["Look<br/>avatar · glyph · accent · backdrop"]:::tab
+  STUDIO --> SBRAIN["Brain<br/>runtime · model · voice<br/>prompt · capabilities"]:::tab
+  STUDIO --> SLIFE["Lifecycle<br/>archive · reorder · reset · remove"]:::tab
+  STUDIO --> SMEMORY["Memory<br/>memories · daily notes · recall"]:::tab
+  STUDIO --> SJOURNAL["Journal<br/>daily reflections · generation"]:::tab
+  STUDIO --> SPROJECTS["Projects<br/>access grants · allow / deny<br/>read / write policy"]:::tab
+  STUDIO --> SVAULT["Vault<br/>secrets · environment · credentials"]:::tab
+  FAMILIARS --> ACCESS["Access groups<br/>memberships · shared project grants"]:::group
+  FAMILIARS --> SUMMON["Summoning / enhancement circle"]:::overlay
+
+  NAV --> PHONE["Phone"]:::section
+  PHONE --> PSTEPS["Steps<br/>mobile mode · pair · QR · Tailscale"]:::group
+  PHONE --> PSECURITY["Why there is no password<br/>network trust model"]:::group
+  PHONE --> PAPP["Get the app<br/>native iOS · TestFlight"]:::group
+
+  NAV --> APPEAR["Appearance"]:::section
+  APPEAR --> ATABS{Appearance tabs}:::decision
+  ATABS --> ATHEME["Theme"]:::tab
+  ATHEME --> AMODE["Mode<br/>Dark · Light · System"]:::group
+  ATHEME --> APALETTE["Theme preset / custom theme"]:::group
+  ATHEME --> AIMPORT["Import from tweakcn"]:::group
+  ATHEME --> ABACKDROP["Backdrop"]:::group
+  ATABS --> ACOLORS["Colors"]:::tab
+  ACOLORS --> ATOKENS["Theme tokens<br/>custom picker · recent colors"]:::group
+  ATABS --> ATYPE["Typography"]:::tab
+  ATYPE --> AFONTS["Interface · code · terminal fonts"]:::group
+  ATYPE --> AREADING["Reading text<br/>family · size · leading · weight"]:::group
+  ATABS --> AINTERFACE["Interface"]:::tab
+  AINTERFACE --> ASWITCHER["Familiar switcher style"]:::group
+  AINTERFACE --> ACORNERS["Corner radius"]:::group
+  AINTERFACE --> ADATETIME["Date & time<br/>format · relative timestamps"]:::group
+
+  NAV --> ABOUT["About"]:::section
+  ABOUT --> ACAVE["CovenCave<br/>app version · build"]:::group
+  ABOUT --> ATOOLS["OpenCoven tools<br/>status · updates"]:::group
+  ABOUT --> ALINKS["Project links<br/>GitHub · Docs · X · Discord<br/>Grimoire · Podcast"]:::group
+
+  SETTINGS -. "mobile" .-> PICKER["Full-screen section picker<br/>section → content → Back"]:::conditional
+  SETTINGS -. "desktop" .-> SIDEBYSIDE["200px section rail + content<br/>↑↓ changes section · Esc back"]:::conditional
+
+  classDef entry fill:#a46bea,stroke:#e5d0ff,color:#160d22,stroke-width:3px;
+  classDef launcher fill:#3b2e1c,stroke:#e3ba6a,color:#fff6df,stroke-width:2px;
+  classDef decision fill:#3a2d1b,stroke:#e3ba6a,color:#fff4d6,stroke-width:2px;
+  classDef section fill:#241b31,stroke:#bd96eb,color:#f8f3ff,stroke-width:3px;
+  classDef group fill:#202a37,stroke:#7596bd,color:#eff6ff;
+  classDef tab fill:#17332d,stroke:#69d6a6,color:#effff9,stroke-width:2px;
+  classDef panel fill:#31233c,stroke:#c490ec,color:#f8edff;
+  classDef overlay fill:#3c272f,stroke:#e190ad,color:#fff0f5,stroke-dasharray:5 3;
+  classDef conditional fill:#30253b,stroke:#db8fff,color:#f9edff,stroke-dasharray:5 4;

--- a/docs/diagrams/navigation/04-menus-and-overlays.mmd
+++ b/docs/diagrams/navigation/04-menus-and-overlays.mmd
@@ -1,0 +1,120 @@
+%% CovenCave menus, launchers, contextual navigation, dialogs, and sheets
+%% Sources: workspace.tsx, command-palette.tsx, top-bar.tsx,
+%% sidebar-minimal.tsx, notification-bell.tsx, and surface overflow menus
+%% Regenerated from main@bcf9f8bdbcb1 (2026-07-18) — final IA for issue #3283.
+%%{init: {
+  "theme": "base",
+  "flowchart": { "curve": "basis", "nodeSpacing": 28, "rankSpacing": 62, "padding": 13 },
+  "themeVariables": {
+    "fontFamily": "Inter, ui-sans-serif, system-ui, sans-serif",
+    "fontSize": "15px",
+    "primaryColor": "#241b31",
+    "primaryTextColor": "#f7f2ff",
+    "primaryBorderColor": "#b995e8",
+    "lineColor": "#927db1",
+    "clusterBkg": "#120f19",
+    "clusterBorder": "#5f4a78",
+    "edgeLabelBackground": "#120f19"
+  }
+}}%%
+flowchart TB
+  UI([Any workspace surface]):::entry
+
+  subgraph GLOBAL["Global launchers and transient layers"]
+    direction LR
+    UI --> SEARCH["Search field · ⌘K"]:::launcher
+    SEARCH --> PALETTE["Command palette"]:::overlay
+    PALETTE --> PRECENT["Recent sessions"]:::group
+    PALETTE --> PSURF["Go to surface"]:::group
+    PALETTE --> PFAM["Switch familiar / New chat"]:::group
+    PALETTE --> PCARD["Tasks · Create task<br/>Kanban / Table / Gantt"]:::group
+    PALETTE --> PPROJECT["Open project"]:::group
+    PALETTE --> PMEM["Memory and file search"]:::group
+    PALETTE --> PSET["Settings search"]:::group
+    PALETTE --> PCMD["Slash commands"]:::group
+    PALETTE --> PSALEM["Ask Salem fallback"]:::group
+
+    UI --> FSWITCH["Familiar switcher"]:::menu
+    FSWITCH --> FALL["All familiars / multi-select scope"]:::group
+    FSWITCH --> FPRESENCE["Presence · sessions · reply badges"]:::group
+    FSWITCH --> FCREATE["Create / manage / reorder familiars"]:::route
+
+    UI --> NOTIFY["Notification bell"]:::menu
+    NOTIFY --> NROWS["Unread / active notification rows"]:::group
+    NOTIFY --> NACT["Mark read · Clear all · Open Rituals"]:::action
+    NOTIFY --> NPREF["Sound<br/>Quiet kinds<br/>Muted familiars"]:::submenu
+
+    UI --> QUICK["Quick chat · ⌘J"]:::overlay
+    UI --> SHORTCUTS["Keyboard shortcuts sheet · ⌘/"]:::overlay
+    UI --> ONBOARD["Onboarding overlay"]:::overlay
+    UI --> REMINDER["New / edit reminder modal"]:::overlay
+    UI --> PHONE["Mobile handoff modal"]:::overlay
+    UI --> GLYPH["Familiar glyph picker"]:::overlay
+    UI --> TOASTS["Inbox / undo / status toasts"]:::overlay
+  end
+
+  subgraph CHATMENUS["Chat navigation and menus"]
+    direction LR
+    UI --> CHATNAV["Chat sidebar"]:::menu
+    CHATNAV --> CORG["Organize sidebar"]:::submenu
+    CORG --> CRECENT["Recent chats"]:::group
+    CORG --> CPROJECT["By project"]:::group
+    CHATNAV --> CQUICK["New chat · Scheduled · Plugins"]:::action
+    CHATNAV --> CROW["Session context menu"]:::submenu
+    CROW --> COPEN["Open · Open in split"]:::action
+    CROW --> CTRANS["Rename · Move to project"]:::action
+    CROW --> CDEBUG["Inspect · Changes / Git"]:::action
+    CROW --> CDELETE["Delete"]:::danger
+    UI --> CODERAIL["Code rail sheet / panel"]:::panel
+    CODERAIL --> CRFULL["Pin · Fullscreen · Collapse"]:::action
+    CODERAIL --> CRTABS["Changes · Files · Terminal"]:::group
+  end
+
+  subgraph SURFACEMENUS["Surface-level progressive disclosure"]
+    direction LR
+    UI --> BOARDMENU["Tasks · More task actions"]:::submenu
+    BOARDMENU --> BMULTI["Select multiple"]:::action
+    BOARDMENU --> BCLEAR["Clear done → inline confirm"]:::danger
+    UI --> PROJECTMENU["Project options"]:::submenu
+    PROJECTMENU --> PEDIT["Rename · Edit folder"]:::action
+    PROJECTMENU --> PICON["Upload / generate / remove image"]:::action
+    PROJECTMENU --> PPATH["Copy path · Reveal folder · Browse files"]:::action
+    PROJECTMENU --> PCOLOR["Color submenu"]:::submenu
+    PROJECTMENU --> PDELETE["Delete project"]:::danger
+    UI --> FAMILIARMENU["Familiar options"]:::submenu
+    FAMILIARMENU --> FEDIT["Edit in Studio"]:::route
+    FAMILIARMENU --> FREMOVE["Remove → Lifecycle tab"]:::danger
+    UI --> GHMENU["GitHub · More options"]:::submenu
+    GHMENU --> GHGRP["No grouping · Group by org · Group by repo"]:::group
+    GHMENU --> GHPAT["Manage GitHub PAT"]:::overlay
+    UI --> CALMENU["Calendar +N more events"]:::submenu
+    CALMENU --> CALDAY["Open event / jump to day"]:::action
+    UI --> HOMECOMP["Composer options"]:::submenu
+    HOMECOMP --> HDEST["Destination · familiar · project"]:::group
+    HOMECOMP --> HSAVE["Save as template"]:::action
+    HOMECOMP --> HSLASH["Inline /command menus<br/>/model · /skill · /prompt"]:::submenu
+  end
+
+  subgraph DETAIL["Drawers, inspectors, and focused dialogs"]
+    direction LR
+    UI --> TASKINSPECT["Task inspector / editor"]:::panel
+    UI --> CRONINSPECT["Cron detail / run history"]:::panel
+    UI --> GHDETAIL["GitHub item detail"]:::panel
+    UI --> MARKETDETAIL["Marketplace plugin detail / configure"]:::panel
+    UI --> CRAFTDRAWER["Craft create / edit drawer"]:::overlay
+    UI --> SKILLDRAWER["Skill detail drawer"]:::overlay
+    UI --> STITCH["Stitch intake"]:::overlay
+    UI --> TRACE["Session trace overlay"]:::overlay
+    UI --> BROWSERSPLIT["Browser / Salem / Memory split companions"]:::panel
+  end
+
+  classDef entry fill:#a46bea,stroke:#e5d0ff,color:#160d22,stroke-width:3px;
+  classDef launcher fill:#3b2e1c,stroke:#e3ba6a,color:#fff6df,stroke-width:2px;
+  classDef menu fill:#382448,stroke:#c6a1ed,color:#fbf7ff,stroke-width:2px;
+  classDef submenu fill:#2f2539,stroke:#b792d9,color:#f7efff;
+  classDef overlay fill:#3c272f,stroke:#e190ad,color:#fff0f5,stroke-dasharray:5 3;
+  classDef panel fill:#202a37,stroke:#7596bd,color:#eff6ff;
+  classDef group fill:#292330,stroke:#786789,color:#f0e9f8;
+  classDef action fill:#19312d,stroke:#66c7aa,color:#effff9;
+  classDef route fill:#30253b,stroke:#db8fff,color:#f9edff,stroke-dasharray:5 4;
+  classDef danger fill:#3c2228,stroke:#e06d88,color:#ffeef2,stroke-width:2px;

--- a/docs/diagrams/navigation/README.md
+++ b/docs/diagrams/navigation/README.md
@@ -43,4 +43,4 @@ maps go stale:
 There is no generator; the maps are hand-maintained against the sources named
 in each file's header. When navigation structure changes: update the affected
 map, refresh its `%% Regenerated from` line with the new `main` short SHA, and
-keep the legend's class vocabulary (`00-navigation-legend.mmd`) authoritative.
+keep the legend's shared class vocabulary (`00-navigation-legend.mmd`) authoritative (add any new shared class there before using it across multiple maps).

--- a/docs/diagrams/navigation/README.md
+++ b/docs/diagrams/navigation/README.md
@@ -1,0 +1,46 @@
+# CovenCave navigation maps
+
+Source-grounded Mermaid diagrams of the app's navigation IA — the final state
+of the simplification tracked in issue
+[#3283](https://github.com/OpenCoven/coven-cave/issues/3283). Each `.mmd`
+header lists the source files it was read from and the `main` commit it was
+regenerated against.
+
+| Map | Covers |
+| --- | --- |
+| `00-navigation-legend.mmd` | Shared semantic palette (node classes/colors) used by the whole set |
+| `01-global-navigation.mmd` | Shell chrome (desktop sidebar + mobile drawer/tabs), route topology, aliases, redirects, dev-only routes |
+| `02-workspace-surfaces.mmd` | Every workspace surface `renderSurface` can show, with its internal tabs/panels |
+| `03-settings-navigation.mmd` | Settings IA (`settings-sections.ts` sections and nested editors) |
+| `04-menus-and-overlays.mmd` | Launchers (⌘K palette, switchers), contextual menus, drawers, dialogs |
+
+## Rendering
+
+Paste a file into <https://mermaid.live>, or render locally:
+
+```bash
+pnpm dlx @mermaid-js/mermaid-cli -i docs/diagrams/navigation/01-global-navigation.mmd -o /tmp/nav.svg
+```
+
+## Invariants that keep these maps honest
+
+The IA drawn here is pinned by tests, so structural drift fails CI before the
+maps go stale:
+
+- **One canonical name per surface** — `src/components/canonical-nav-names.test.ts`
+  (sidebar `FOLDER_MODES` is the vocabulary source; workspace titles must match;
+  mobile bottom tabs must *derive* from `FOLDER_MODES`, never hand-copy rows).
+- **Aliases never render as peer destinations** — `src/lib/workspace-mode.ts`
+  (`CANONICAL_WORKSPACE_MODES` + `MODE_ALIASES`) with behavior pinned by
+  `src/lib/workspace-mode.test.ts` and `src/components/workspace-alias-modes.test.ts`.
+- **Route classification** — `src/app/route-inventory.test.ts` classifies every
+  `page.tsx` (workspace / destination / redirect / window-host / dev-only),
+  enforces redirect targets, and keeps dev-only routes out of nav hosts.
+- **Palette vocabulary** — `src/components/palette-canonical-names.test.ts`.
+
+## Regenerating
+
+There is no generator; the maps are hand-maintained against the sources named
+in each file's header. When navigation structure changes: update the affected
+map, refresh its `%% Regenerated from` line with the new `main` short SHA, and
+keep the legend's class vocabulary (`00-navigation-legend.mmd`) authoritative.

--- a/docs/diagrams/navigation/README.md
+++ b/docs/diagrams/navigation/README.md
@@ -8,7 +8,7 @@ regenerated against.
 
 | Map | Covers |
 | --- | --- |
-| `00-navigation-legend.mmd` | Shared semantic palette (node classes/colors) used by the whole set |
+| `00-navigation-legend.mmd` | Core semantic palette (shared base node classes/colors); diagrams may define additional per-map classes as needed |
 | `01-global-navigation.mmd` | Shell chrome (desktop sidebar + mobile drawer/tabs), route topology, aliases, redirects, dev-only routes |
 | `02-workspace-surfaces.mmd` | Every workspace surface `renderSurface` can show, with its internal tabs/panels |
 | `03-settings-navigation.mmd` | Settings IA (`settings-sections.ts` sections and nested editors) |


### PR DESCRIPTION
Final phase (6/6) of #3283 (bead `cave-m4ih.7`): commit the source-grounded navigation Mermaid maps under `docs/diagrams/navigation/`, regenerated against `main@bcf9f8bd` to document the **final** IA after phases 1-5 landed.

## What changed vs the issue's originals

- **01-global-navigation**: mobile bottom tabs carry canonical labels (**Tasks**, **Rituals**) and are marked *derived from FOLDER_MODES* (#3429); alias cluster retitled to the typed `MODE_ALIASES` table (#3422) with per-edge `alias → canonical` annotations; `/familiars/:id/{analytics,profile}` drawn as query-forwarding redirect stubs (#3428); subgraph titles note the `route-inventory.test.ts` pin + dev-only nav exclusion.
- **02-workspace-surfaces**: Group/Queue tabs annotated with their alias mappings; sources header names `workspace-mode.ts`.
- **03/04**: source-path corrections (`src/components/settings-sections.ts`, `sidebar-minimal.tsx` — `workspace-sidebar.tsx` never existed); content verified current against sources.
- **README.md**: map index, rendering instructions, and the test invariants that keep the maps honest.
- Every file stamped `%% Regenerated from main@bcf9f8bdbcb1`.

## Verification

- All five diagrams parse with `mermaid.parse` (mermaid@11, headless).
- Docs-only diff — no runtime code touched.

Closes the phase plan in https://github.com/OpenCoven/coven-cave/issues/3283#issuecomment-5010763625.