### PR TITLE
fix(queue): anchor the ref-join description fallback — no more casual-mention bead capture (cave-opld)

### DIFF
--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -333,6 +333,40 @@ assert.equal(
   );
 }
 
+{
+  // cave-opld (review of #3426): the description fallback is anchored to the
+  // File-bead signature + the PR's own URL. A bead that merely MENTIONS a PR
+  // ("Follow-up to PR #88") or carries a FOREIGN repo's /pull/88 URL must not
+  // be consumed as PR 88's link — that silently dropped real work out of the
+  // no-open-PR lane and suppressed the unlinked flag.
+  const mentionBead = {
+    ...bead("cave-mention", { labels: ["familiar:kitty"] }),
+    description: "Follow-up to PR #88 — tighten the join later",
+  };
+  const foreignBead = {
+    ...bead("cave-foreign"),
+    description: "Port the upstream fix https://github.com/vercel/next.js/pull/88",
+  };
+  const q = buildWorkQueue([mentionBead, foreignBead], [pr(88, "needs-review", { beads: [] })], [], {
+    nowMs: NOW,
+  });
+  assert.deepEqual(q.unlinked, [88], "casual mentions and foreign URLs leave the PR unlinked");
+  assert.deepEqual(
+    q.lanes.find((l) => l.key === "no-open-PR").items.map((i) => i.bead.id).sort(),
+    ["cave-foreign", "cave-mention"],
+    "both beads keep waiting as their own work items",
+  );
+
+  // The File-bead signature alone (URL elided) still links — it is what the
+  // queue's own flow writes.
+  const signatureBead = {
+    ...bead("cave-signed"),
+    description: "Filed from unlinked PR #88 — see the PR for context",
+  };
+  const q2 = buildWorkQueue([signatureBead], [pr(88, "needs-review", { beads: [] })], [], { nowMs: NOW });
+  assert.deepEqual(q2.unlinked, [], "the File-bead signature is an anchor on its own");
+}
+
 // ── beadRefMatchesPr: the pure ref shapes ────────────────────────────────────
 assert.equal(beadRefMatchesPr("gh-123", 123), true, "gh-<n>");
 assert.equal(beadRefMatchesPr("#123", 123), true, "#<n>");

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -47,21 +47,28 @@ export function beadRefMatchesPr(ref: string | null | undefined, prNumber: numbe
   return new RegExp(`/pull/${n}/?$`).test(trimmed);
 }
 
-// Description fallback for the ref join: the exact `pull/<n>` URL segment or a
-// `PR #<n>` token — both written by the queue's File-bead flow. Boundary-guarded
-// so PR 123 never matches `/pull/1234` or `PR #1234`.
-function beadDescriptionMatchesPr(description: string | null | undefined, prNumber: number): boolean {
+// Description fallback for the ref join, anchored to what the queue's
+// File-bead flow actually writes: the PR's own URL (repo-qualified), or the
+// `Filed from unlinked PR #<n>` signature. A casual mention — "Follow-up to
+// PR #88", a foreign repo's /pull/88 URL — must NOT consume the bead as PR
+// 88's link (cave-opld; review of #3426). Digit-boundary-guarded so PR 123
+// never matches PR 1234's URL or token.
+function beadDescriptionMatchesPr(
+  description: string | null | undefined,
+  pr: Pick<PullRequestSummary, "number" | "url">,
+): boolean {
   if (!description) return false;
-  const n = String(prNumber);
+  const url = pr.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return (
-    new RegExp(`/pull/${n}(?!\\d)`).test(description) || new RegExp(`\\bPR #${n}(?!\\d)`).test(description)
+    new RegExp(`${url}(?!\\d)`).test(description) ||
+    new RegExp(`\\bFiled from unlinked PR #${pr.number}(?!\\d)`).test(description)
   );
 }
 
 // Prefer the explicit external_ref when it names the PR; otherwise fall back
-// to the description URL/token (ready output carries no external_ref).
-function beadMatchesPr(bead: ReadyBead, prNumber: number): boolean {
-  return beadRefMatchesPr(bead.external_ref, prNumber) || beadDescriptionMatchesPr(bead.description, prNumber);
+// to the File-bead description signature (ready output carries no external_ref).
+function beadMatchesPr(bead: ReadyBead, pr: Pick<PullRequestSummary, "number" | "url">): boolean {
+  return beadRefMatchesPr(bead.external_ref, pr.number) || beadDescriptionMatchesPr(bead.description, pr);
 }
 
 /**
@@ -223,7 +230,7 @@ export function buildWorkQueue(
     // (cave-p63a). That ref-join links the PR — familiar/surface/bead chip and
     // all — instead of leaving it flagged unlinked.
     if (pr.beadIds.length === 0 && !bead) {
-      bead = readyBeads.find((b) => beadMatchesPr(b, pr.number));
+      bead = readyBeads.find((b) => beadMatchesPr(b, pr));
     }
     const isUnlinked = pr.beadIds.length === 0 && !bead;
     if (isUnlinked) unlinked.push(pr.number);


### PR DESCRIPTION
## What

Follow-up to #3426 from its code review (medium): `beadDescriptionMatchesPr` matched **any** `PR #<n>` / `/pull/<n>` text, so a bead that merely *mentioned* a PR ("Follow-up to PR #88") — or carried a **foreign repo's** pull URL — was consumed as that PR's linked bead: it vanished from the no-open-PR lane and suppressed the PR's `unlinked` attention flag.

The fallback is now anchored to what the File-bead flow actually writes: the `Filed from unlinked PR #<n>` signature (digit-bounded) or the PR's **own repo-qualified URL** (regex-escaped, digit-bounded), passed as `pr.url` into the join. Explicit `external_ref` matching is unchanged.

## Verification

- New regression cases: casual mention + foreign-repo URL stay unlinked (both beads keep their no-open-PR rows); signature-only still links; all existing join/near-miss cases pass
- `beads-work-queue.test.ts` + `familiar-work-queue-view.test.ts` green; `pnpm typecheck` clean

Bead: cave-opld · Review finding: pr3426-review agent