### PR TITLE
Redesign Memories with a Knowledge launcher screen

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -709,6 +709,8 @@ export const SUITES = {
     "src/lib/line-diff.test.ts",
     "src/components/md-editor/md-editor.test.ts",
     "src/components/grimoire-view.test.ts",
+    "src/components/grimoire-launcher.test.ts",
+    "src/lib/grimoire-launcher-data.test.ts",
     "src/components/grimoire-stub-links.test.ts",
     "src/lib/knowledge-flags.test.ts",
     "src/components/grimoire-graph-view.test.ts",

--- a/src/components/grimoire-helpers.ts
+++ b/src/components/grimoire-helpers.ts
@@ -10,6 +10,8 @@ export type GrimoireKnowledgeEntry = {
   enabled: boolean;
   body: string;
   extra?: Record<string, unknown>;
+  /** File mtime (ISO) from the list API — powers the launcher recency pool. */
+  modified?: string;
 };
 
 export type KnowledgeCollectionSummary = {

--- a/src/components/grimoire-launcher.test.ts
+++ b/src/components/grimoire-launcher.test.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Grimoire launcher ("Memories Prototype" redesign) — source pins for the
+// React wiring; the pure derivations behind the tiles are behaviorally
+// tested in src/lib/grimoire-launcher-data.test.ts.
+
+const launcher = await readFile(new URL("./grimoire-launcher.tsx", import.meta.url), "utf8");
+const view = await readFile(new URL("./grimoire-view.tsx", import.meta.url), "utf8");
+
+// ── The launcher replaces the old empty state ────────────────────────────────
+
+assert.match(
+  view,
+  /openTabs\.length === 0 \? \(\s*(?:\/\/[^\n]*\n\s*)*<GrimoireLauncher/,
+  "no open tabs shows the Knowledge launcher instead of a bare empty state",
+);
+assert.match(view, /onOpen=\{openDoc\}/, "launcher rows open documents through the shared tab model");
+assert.match(view, /onNewStitch=\{openStitchNew\}/, "launcher capture/templates route into the stitch intake");
+assert.match(
+  view,
+  /onShowJournal=\{\(\) => setView\("journal"\)\}[\s\S]{0,80}onShowGraph=\{\(\) => setView\("graph"\)\}/,
+  "the journal and graph tiles switch tabs",
+);
+assert.match(view, /graph=\{graph\}/, "the launcher sees the same scan-or-local graph as the canvas");
+
+// ── Header: centered segmented tabs + contextual dashed New stitch pill ─────
+
+assert.match(view, /className="focus-ring grimoire-tab"[\s\S]{0,60}>\s*Knowledge/, "the docs tab is labeled Knowledge");
+assert.match(view, /className="focus-ring grimoire-tab"[\s\S]{0,60}>\s*Relations/, "the graph tab is labeled Relations");
+assert.match(
+  view,
+  /\{view === "docs" \? \(\s*<>\s*<button[\s\S]{0,220}grimoire-newstitch/,
+  "the New stitch pill is contextual to the Knowledge tab",
+);
+
+// ── Stitch prefill: capture/template opens re-key the intake mount ──────────
+
+assert.match(
+  view,
+  /if \(opts\?\.patternId \|\| opts\?\.pinUrl\) \{\s*\n\s*setStitchPrefill/,
+  "only prefilled opens bump the prefill nonce (plain refocus keeps pinned sources)",
+);
+assert.match(
+  view,
+  /<StitchIntake\s*\n\s*key=\{`stitch-new-\$\{stitchPrefill\.nonce\}`\}\s*\n\s*initialRef=\{stitchPrefill\.pinUrl\}\s*\n\s*initialPatternId=\{stitchPrefill\.patternId \?\? null\}/,
+  "the intake mounts with the launcher's prefill",
+);
+
+// ── Launcher internals ───────────────────────────────────────────────────────
+
+assert.match(launcher, /buildLauncherItems\(\{ knowledge, memory, journal \}\)/, "the recency pool derives from the loaded corpora");
+assert.match(launcher, /detectLauncherCapture\(query\)/, "the search field doubles as a URL capture intake");
+assert.match(launcher, /onNewStitch\(\{ pinUrl: capture\.url \}\)/, "a detected URL pins into a new stitch");
+assert.match(launcher, /STITCH_PATTERNS\.map\(/, "the new-stitch row offers the shared stitch patterns");
+assert.match(launcher, /onNewStitch\(\{ patternId: p\.id \}\)/, "template tiles preselect their pattern");
+assert.match(launcher, /journalStreakDays\(journal\.map\(\(j\) => j\.date\)/, "the journal tile shows the reflection streak");
+assert.match(launcher, /launcherGraphCounts\(graph\)/, "the graph tiles count nodes/edges/detached from the doc graph");
+assert.match(launcher, /aria-label="Search all documents or paste a URL"/, "the big search is labelled");
+assert.match(launcher, /suppressHydrationWarning/, "the client-clock date line is hydration-safe");
+assert.ok(!/\bfetch\(/.test(launcher), "the launcher fetches nothing — it renders what the view loaded");
+
+console.log("grimoire-launcher.test: ok");

--- a/src/components/grimoire-launcher.tsx
+++ b/src/components/grimoire-launcher.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+/**
+ * Grimoire launcher — the Memories surface's Knowledge home screen
+ * ("Memories Prototype" redesign): an aurora banner, one big search that
+ * doubles as a URL intake, and a bento of live entry points into the corpus.
+ *
+ * Shown by grimoire-view when the Knowledge tab has no open tabs; all data
+ * (knowledge/memory/journal/graph) is what the view already loaded — this
+ * component fetches nothing. Pure derivations live in
+ * src/lib/grimoire-launcher-data.ts (unit-tested there).
+ */
+
+import { useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
+import { STITCH_PATTERNS } from "@/lib/stitch-patterns";
+import type { DocGraph } from "@/lib/grimoire-graph";
+import {
+  buildLauncherItems,
+  detectLauncherCapture,
+  journalStreakDays,
+  launcherGraphCounts,
+  launcherWeekStats,
+  searchLauncherItems,
+  topMemoryRoot,
+  type LauncherDocRef,
+  type LauncherItem,
+  type LauncherJournalInput,
+  type LauncherKnowledgeInput,
+  type LauncherMemoryInput,
+} from "@/lib/grimoire-launcher-data";
+
+/** One-line template hooks, after the prototype's new-stitch row. */
+const PATTERN_HOOKS: Record<string, string> = {
+  "decision-record": "Why we chose it",
+  "how-to": "Steps that work",
+  glossary: "Terms, pinned down",
+  "api-contract": "Inputs & promises",
+};
+
+function Marker({ marker }: { marker: LauncherItem["marker"] }) {
+  return <span aria-hidden className={`gl-marker gl-marker-${marker}`} />;
+}
+
+export function GrimoireLauncher({
+  knowledge,
+  memory,
+  journal,
+  graph,
+  journalTitle,
+  onOpen,
+  onNewStitch,
+  onBlankEntry,
+  onShowJournal,
+  onShowGraph,
+}: {
+  knowledge: LauncherKnowledgeInput[];
+  memory: LauncherMemoryInput[];
+  journal: LauncherJournalInput[];
+  graph: DocGraph | null;
+  /** Prefs-formatted journal day label (grimoire-view's journalDayLabel). */
+  journalTitle: (date: string) => string;
+  onOpen: (ref: LauncherDocRef) => void;
+  onNewStitch: (opts?: { patternId?: string; pinUrl?: string }) => void;
+  onBlankEntry: () => void;
+  onShowJournal: () => void;
+  onShowGraph: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  // One clock per mount: stable stats, no re-render drift.
+  const [nowMs] = useState(() => Date.now());
+
+  const items = useMemo(
+    () => buildLauncherItems({ knowledge, memory, journal }),
+    [knowledge, memory, journal],
+  );
+  const results = useMemo(() => searchLauncherItems(items, query), [items, query]);
+  const capture = useMemo(() => detectLauncherCapture(query), [query]);
+  const week = useMemo(
+    () => launcherWeekStats(items, journal, nowMs),
+    [items, journal, nowMs],
+  );
+  const streak = useMemo(() => {
+    const d = new Date(nowMs);
+    const todayIso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    return journalStreakDays(journal.map((j) => j.date), todayIso);
+  }, [journal, nowMs]);
+  const graphCounts = useMemo(() => launcherGraphCounts(graph), [graph]);
+  const topRoot = useMemo(() => topMemoryRoot(memory), [memory]);
+
+  const hero = items[0] ?? null;
+  const smallRecents = items.slice(1, 5);
+  const latestMemory = useMemo(
+    () => items.find((i) => i.ref.kind === "memory") ?? null,
+    [items],
+  );
+
+  const displayTitle = (item: LauncherItem) =>
+    item.ref.kind === "journal" ? `Journal — ${journalTitle(item.ref.date)}` : item.title;
+
+  const dateLine = useMemo(() => {
+    const d = new Date(nowMs);
+    const weekday = d.toLocaleDateString(undefined, { weekday: "long" });
+    const monthDay = d.toLocaleDateString(undefined, { month: "long", day: "numeric" });
+    return `${weekday} · ${monthDay}`;
+  }, [nowMs]);
+
+  const searching = query.trim().length > 0;
+
+  return (
+    <div className="gl-root">
+      <div className="gl-col">
+        <div className="gl-banner" aria-hidden>
+          <span className="gl-orb gl-orb-1" />
+          <span className="gl-orb gl-orb-2" />
+          <span className="gl-sheen" />
+        </div>
+
+        <section aria-label="Search and capture" className="gl-panel">
+          <span className="gl-chip">Continue where you left off</span>
+          <span className="gl-meta" suppressHydrationWarning>
+            {dateLine} · {items.length.toLocaleString()} {items.length === 1 ? "document" : "documents"}
+          </span>
+          <div className="gl-search">
+            <Icon name="ph:magnifying-glass" width={14} aria-hidden />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && query) setQuery("");
+                if (e.key === "Enter") {
+                  if (capture) onNewStitch({ pinUrl: capture.url });
+                  else if (results[0]) onOpen(results[0].ref);
+                }
+              }}
+              placeholder="Search all documents — or paste a URL to capture it…"
+              aria-label="Search all documents or paste a URL"
+            />
+          </div>
+
+          {searching ? (
+            <div className="gl-results" aria-label="Search results">
+              {capture ? (
+                <>
+                  <button type="button" className="gl-capture" onClick={() => onNewStitch({ pinUrl: capture.url })}>
+                    <Icon name="ph:push-pin" width={13} aria-hidden />
+                    <span className="gl-result-title">{capture.label}</span>
+                    <span className="gl-result-kind">
+                      {capture.flavor === "github" ? "GitHub" : capture.flavor === "llms" ? "llms.txt" : "Web page"}
+                    </span>
+                  </button>
+                  <button type="button" className="gl-result" onClick={() => onNewStitch()}>
+                    <Icon name="ph:plus" width={12} aria-hidden />
+                    <span className="gl-result-title">Start an empty stitch instead</span>
+                  </button>
+                </>
+              ) : results.length === 0 ? (
+                <p className="gl-empty-results">No documents match — press ⏎ after pasting a URL to capture it, or sew a new stitch.</p>
+              ) : (
+                results.map((item) => (
+                  <button key={item.key} type="button" className="gl-result" onClick={() => onOpen(item.ref)}>
+                    <Marker marker={item.marker} />
+                    <span className="gl-result-title">{displayTitle(item)}</span>
+                    <span className="gl-result-kind">
+                      {item.kindLabel}
+                      {item.modifiedMs !== null
+                        ? ` · ${relativeTime(new Date(item.modifiedMs).toISOString(), nowMs)}`
+                        : ""}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          ) : null}
+        </section>
+
+        {!searching ? (
+          <section aria-label="Knowledge overview" className="gl-bento">
+            {hero ? (
+              <button type="button" className="gl-card gl-hero" onClick={() => onOpen(hero.ref)}>
+                <span className="gl-kicker">Most recent</span>
+                <span className="gl-card-title">{displayTitle(hero)}</span>
+                <span className="gl-card-line">
+                  <Marker marker={hero.marker} />
+                  {hero.kindLabel}
+                  {hero.modifiedMs !== null
+                    ? ` · edited ${relativeTime(new Date(hero.modifiedMs).toISOString(), nowMs)}`
+                    : ""}
+                </span>
+                {hero.excerpt ? <span className="gl-hero-excerpt">{hero.excerpt}</span> : null}
+              </button>
+            ) : (
+              <button type="button" className="gl-card gl-hero" onClick={() => onNewStitch()}>
+                <span className="gl-kicker">Getting started</span>
+                <span className="gl-card-title">No documents yet</span>
+                <span className="gl-card-sub">Pin sources and sew your first stitch — it lands here.</span>
+              </button>
+            )}
+
+            <div className="gl-card gl-week">
+              <span className="gl-shine" aria-hidden />
+              <span className="gl-kicker">This week</span>
+              <span className="gl-week-row">
+                <span className="gl-stat">{week.filesTouched}</span>
+                <span>files touched</span>
+              </span>
+              <span className="gl-week-row">
+                <span className="gl-stat">{week.reflections}</span>
+                <span>reflections written</span>
+              </span>
+              <span className="gl-week-row">
+                <span className="gl-stat">{knowledge.length}</span>
+                <span>stitches total</span>
+              </span>
+            </div>
+
+            {smallRecents.map((item) => (
+              <button key={item.key} type="button" className="gl-card" onClick={() => onOpen(item.ref)}>
+                <span className="gl-card-line">
+                  <Marker marker={item.marker} />
+                  <span className="gl-line-title">{displayTitle(item)}</span>
+                </span>
+                <span className="gl-card-sub">
+                  {item.kindLabel}
+                  {item.modifiedMs !== null
+                    ? ` · ${relativeTime(new Date(item.modifiedMs).toISOString(), nowMs)}`
+                    : ""}
+                </span>
+              </button>
+            ))}
+
+            <button type="button" className="gl-card gl-detached" onClick={onShowGraph}>
+              <span className="gl-stat">{graphCounts.detached}</span>
+              <span className="gl-card-sub">detached docs with no links</span>
+              <span className="gl-arrow">weave them in →</span>
+            </button>
+
+            <button type="button" className="gl-card" onClick={onShowJournal}>
+              <span className="gl-stat">{streak > 0 ? `${streak}-day` : "No"}</span>
+              <span className="gl-card-sub">journal streak</span>
+              <span className="gl-arrow">
+                {week.reflections} reflection{week.reflections === 1 ? "" : "s"} this week →
+              </span>
+            </button>
+
+            <button type="button" className="gl-card" onClick={onShowGraph}>
+              <span className="gl-stat">{graphCounts.nodes.toLocaleString()}</span>
+              <span className="gl-card-sub">nodes in the graph</span>
+              <span className="gl-arrow">{graphCounts.edges.toLocaleString()} connections woven →</span>
+            </button>
+
+            <button
+              type="button"
+              className="gl-card"
+              onClick={() => (latestMemory ? onOpen(latestMemory.ref) : onNewStitch())}
+            >
+              <span className="gl-stat">{memory.length.toLocaleString()}</span>
+              <span className="gl-card-sub">memory files</span>
+              <span className="gl-arrow">
+                {topRoot ? `${topRoot.count.toLocaleString()} from ${topRoot.label} →` : "agents write these →"}
+              </span>
+            </button>
+
+            <div className="gl-card">
+              <span className="gl-kicker">Tip</span>
+              <span className="gl-card-sub">
+                Link docs with [[wiki-links]] — connected stitches surface each other here and in Relations.
+              </span>
+            </div>
+
+            <div className="gl-newrow">
+              <span className="gl-chip">New stitch</span>
+              <button
+                type="button"
+                className="gl-template gl-template-primary"
+                onClick={() => onNewStitch()}
+              >
+                <Icon name="ph:plus" width={12} aria-hidden />
+                <span className="gl-template-name">Blank stitch</span>
+              </button>
+              {STITCH_PATTERNS.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  className="gl-template"
+                  title={p.description}
+                  onClick={() => onNewStitch({ patternId: p.id })}
+                >
+                  <span className="gl-template-name">{p.name}</span>
+                  <span className="gl-template-sub">{PATTERN_HOOKS[p.id] ?? p.description}</span>
+                </button>
+              ))}
+              <button type="button" className="gl-template" onClick={onBlankEntry}>
+                <span className="gl-template-name">Blank entry</span>
+                <span className="gl-template-sub">Write by hand</span>
+              </button>
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -24,6 +24,8 @@ import { MdEditor, type MdEditorSaveResult } from "@/components/md-editor/md-edi
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
 import { JournalEntries } from "@/components/journal/journal-entries";
 import "@/styles/journal.css";
+import "@/styles/grimoire-launcher.css";
+import { GrimoireLauncher } from "@/components/grimoire-launcher";
 import type { Familiar } from "@/lib/types";
 import { serializeMdDocument } from "@/lib/md-frontmatter";
 import { relativeTime } from "@/lib/relative-time";
@@ -894,8 +896,30 @@ export function GrimoireView({
     });
   }, []);
 
-  const closeTab = useCallback((key: string) => {
-    setDirtyTabs((prev) => {
+  // Launcher-driven stitch prefill (URL capture / template row): bumping the
+  // nonce re-keys the StitchIntake mount so its mount-time initial state takes.
+  // Plain "New stitch" opens never bump it — refocusing the open intake must
+  // not blow away pinned sources.
+  const [stitchPrefill, setStitchPrefill] = useState<{
+    nonce: number;
+    patternId?: string;
+    pinUrl?: string;
+  }>({ nonce: 0 });
+  const openStitchNew = useCallback(
+    (opts?: { patternId?: string; pinUrl?: string }) => {
+      if (opts?.patternId || opts?.pinUrl) {
+        setStitchPrefill((prev) => ({
+          nonce: prev.nonce + 1,
+          ...(opts.patternId ? { patternId: opts.patternId } : {}),
+          ...(opts.pinUrl ? { pinUrl: opts.pinUrl } : {}),
+        }));
+      }
+      openDoc({ kind: "stitch-new" });
+    },
+    [openDoc],
+  );
+
+  const closeTab = useCallback((key: string) => {    setDirtyTabs((prev) => {
       if (!(key in prev)) return prev;
       const next = { ...prev };
       delete next[key];
@@ -1254,6 +1278,9 @@ export function GrimoireView({
     if (tab.kind === "stitch-new") {
       return (
         <StitchIntake
+          key={`stitch-new-${stitchPrefill.nonce}`}
+          initialRef={stitchPrefill.pinUrl}
+          initialPatternId={stitchPrefill.patternId ?? null}
           onSewn={(entryId) => {
             replaceTab(key, { kind: "knowledge", id: entryId });
             void load();
@@ -1299,13 +1326,21 @@ export function GrimoireView({
 
   const detail =
     openTabs.length === 0 ? (
-      <div className="grid h-full min-h-0 place-items-center p-8">
-        <EmptyState
-          icon="ph:book-open"
-          headline="Select a document"
-          subtitle="Pick a stitch, memory file, or journal day — or pin sources into a new stitch."
-        />
-      </div>
+      // No open tabs → the Knowledge launcher ("Memories Prototype"): aurora
+      // banner, one big search-or-capture field, and a bento of live entry
+      // points — all driven by the lists this view already loaded.
+      <GrimoireLauncher
+        knowledge={knowledge ?? []}
+        memory={memory ?? []}
+        journal={journal ?? []}
+        graph={graph}
+        journalTitle={(date) => journalDayLabel(date, dateTimePrefs)}
+        onOpen={openDoc}
+        onNewStitch={openStitchNew}
+        onBlankEntry={() => openDoc({ kind: "knowledge-new" })}
+        onShowJournal={() => setView("journal")}
+        onShowGraph={() => setView("graph")}
+      />
     ) : (
       <div className="flex h-full min-h-0 flex-col">
         <div
@@ -1398,73 +1433,58 @@ export function GrimoireView({
 
   return (
     <div className="grimoire-view flex h-full min-h-0 flex-col @container/grimoire">
-      {/* Compact header — the shared .surface-compact band (GitHub / Schedules /
-          Marketplace / Tasks): small title on the left, the surface verbs on the
-          right. The rail keeps its own search (it filters the rail list). */}
-      <header className="surface-compact-header">
+      {/* Compact band, launcher-era layout: title left, the Knowledge/Journal/
+          Relations segmented tabs centered, contextual verbs right (the dashed
+          "New stitch" pill only makes sense on the Knowledge tab). */}
+      <header className="surface-compact-header grimoire-header">
         <h1 className="surface-compact-title">Memories</h1>
+        <div role="group" aria-label="Memories view" className="grimoire-tabs">
+          <button
+            type="button"
+            aria-pressed={view === "docs"}
+            onClick={() => setView("docs")}
+            className="focus-ring grimoire-tab"
+          >
+            Knowledge
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === "journal"}
+            onClick={() => setView("journal")}
+            className="focus-ring grimoire-tab"
+          >
+            Journal
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === "graph"}
+            onClick={() => setView("graph")}
+            className="focus-ring grimoire-tab"
+          >
+            Relations
+          </button>
+        </div>
         <div className="surface-compact-actions">
-          <div
-            role="group"
-            aria-label="Memories view"
-            className="inline-flex h-[26px] items-center gap-0.5 rounded-md border border-[var(--border-hairline)] p-0.5"
-          >
-            <button
-              type="button"
-              aria-pressed={view === "docs"}
-              onClick={() => setView("docs")}
-              className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
-                view === "docs"
-                  ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
-                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-              }`}
-            >
-              <Icon name="ph:book-open" width={11} aria-hidden />
-              Docs
-            </button>
-            <button
-              type="button"
-              aria-pressed={view === "journal"}
-              onClick={() => setView("journal")}
-              className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
-                view === "journal"
-                  ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
-                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-              }`}
-            >
-              <Icon name="ph:calendar-blank" width={11} aria-hidden />
-              Journal
-            </button>
-            <button
-              type="button"
-              aria-pressed={view === "graph"}
-              onClick={() => setView("graph")}
-              className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
-                view === "graph"
-                  ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
-                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-              }`}
-            >
-              <Icon name="ph:graph" width={11} aria-hidden />
-              Graph
-            </button>
-          </div>
-          <button
-            type="button"
-            onClick={() => openDoc({ kind: "stitch-new" })}
-            className="focus-ring inline-flex h-[26px] items-center gap-1 rounded-md border border-[var(--accent-presence)]/40 bg-[var(--accent-presence)]/12 px-2 text-[11px] text-[var(--text-primary)] hover:bg-[var(--accent-presence)]/20"
-          >
-            <Icon name="ph:push-pin" width={11} aria-hidden />
-            New stitch
-          </button>
-          <button
-            type="button"
-            onClick={() => openDoc({ kind: "knowledge-new" })}
-            className="focus-ring inline-flex h-[26px] items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-          >
-            <Icon name="ph:plus" width={11} aria-hidden />
-            Blank entry
-          </button>
+          {view === "docs" ? (
+            <>
+              <button
+                type="button"
+                onClick={() => openStitchNew()}
+                className="focus-ring grimoire-newstitch"
+              >
+                <Icon name="ph:push-pin" width={11} aria-hidden />
+                New stitch
+              </button>
+              <button
+                type="button"
+                onClick={() => openDoc({ kind: "knowledge-new" })}
+                className="focus-ring inline-flex h-[26px] items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:plus" width={11} aria-hidden />
+                Blank entry
+              </button>
+            </>
+          ) : null}
         </div>
       </header>
       <div className="flex min-h-0 flex-1 gap-3 p-3">

--- a/src/components/stitch-intake.tsx
+++ b/src/components/stitch-intake.tsx
@@ -56,12 +56,22 @@ function defaultRefForKind(kind: PinKind): string {
 
 type SessionOption = { id: string; title: string };
 
-export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) {
+export function StitchIntake({
+  onSewn,
+  initialRef,
+  initialPatternId,
+}: {
+  onSewn: (entryId: string) => void;
+  /** Prefill the pin source field (launcher URL capture). Mount-time only. */
+  initialRef?: string;
+  /** Preselect a stitch pattern (launcher template row). Mount-time only. */
+  initialPatternId?: string | null;
+}) {
   const { announce } = useAnnouncer();
   const [thread, setThread] = useState<StitchThread | null>(null);
   const [title, setTitle] = useState("");
   const [kind, setKind] = useState<PinKind>("url");
-  const [ref, setRef] = useState("");
+  const [ref, setRef] = useState(initialRef ?? "");
   const [paste, setPaste] = useState("");
   const [sessionId, setSessionId] = useState("");
   const [sessions, setSessions] = useState<SessionOption[] | null>(null);
@@ -70,7 +80,7 @@ export function StitchIntake({ onSewn }: { onSewn: (entryId: string) => void }) 
   const [error, setError] = useState<string | null>(null);
   // Shape + destination (cave-kwx4): a pattern aims the sew at a body
   // scaffold; the collection files the entry beside its pack-seeded kin.
-  const [patternId, setPatternId] = useState<string | null>(null);
+  const [patternId, setPatternId] = useState<string | null>(initialPatternId ?? null);
   const [collection, setCollection] = useState("");
   const [collections, setCollections] = useState<{ id: string; name: string }[]>([]);
   useEffect(() => {

--- a/src/lib/grimoire-launcher-data.test.ts
+++ b/src/lib/grimoire-launcher-data.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildLauncherItems,
+  detectLauncherCapture,
+  journalStreakDays,
+  launcherExcerpt,
+  launcherGraphCounts,
+  launcherWeekStats,
+  memoryMarker,
+  searchLauncherItems,
+  topMemoryRoot,
+} from "./grimoire-launcher-data.ts";
+import type { DocGraph } from "./grimoire-graph.ts";
+
+const NOW = Date.parse("2026-07-18T12:00:00");
+const iso = (daysAgo: number) => new Date(NOW - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+
+function pool() {
+  return buildLauncherItems({
+    knowledge: [
+      { id: "release-checklist", title: "Release checklist", tags: ["release"], modified: iso(0.1) },
+      { id: "old-notes", title: "Old notes", tags: [] },
+    ],
+    memory: [
+      { relPath: "coven/MEMORY.md", fullPath: "/m/MEMORY.md", modified: iso(2), rootLabel: "Coven memory" },
+      { relPath: "runtime/2026-07-01.md", fullPath: "/m/r/2026-07-01.md", modified: iso(10), rootLabel: "OpenClaw runtime" },
+      { relPath: "runtime/2026-07-02.md", fullPath: "/m/r/2026-07-02.md", modified: iso(9), rootLabel: "OpenClaw runtime" },
+    ],
+    journal: [
+      { date: "2026-07-17", preview: "Shipped the launcher.", modified: iso(1) },
+      { date: "2026-06-01", preview: "Long ago.", modified: null },
+    ],
+  });
+}
+
+test("buildLauncherItems merges corpora newest-first, undated last", () => {
+  const items = pool();
+  assert.equal(items[0].title, "Release checklist");
+  assert.equal(items[0].kindLabel, "Stitch");
+  assert.equal(items[1].ref.kind, "journal");
+  // Undated knowledge sinks to the end.
+  assert.equal(items[items.length - 1].title, "Old notes");
+  assert.equal(items[items.length - 1].modifiedMs, null);
+});
+
+test("markers follow the prototype type language", () => {
+  const items = pool();
+  const byTitle = (t: string) => items.find((i) => i.title === t)!;
+  assert.equal(byTitle("Release checklist").marker, "ring-dashed");
+  assert.equal(byTitle("MEMORY.md").marker, "diamond");
+  assert.equal(byTitle("2026-07-01.md").marker, "dot");
+  assert.equal(byTitle("2026-07-17").marker, "ring-open");
+  assert.equal(memoryMarker("deep/dir/AGENTS.md"), "diamond");
+  assert.equal(memoryMarker("deep/dir/scratch.md"), "dot");
+});
+
+test("searchLauncherItems matches every token across title/tags/kind", () => {
+  const items = pool();
+  assert.equal(searchLauncherItems(items, "release check")[0].title, "Release checklist");
+  // Kind words match too.
+  assert.ok(searchLauncherItems(items, "journal").every((i) => i.kindLabel === "Journal"));
+  assert.equal(searchLauncherItems(items, "").length, 0);
+  assert.equal(searchLauncherItems(items, "zzz-nothing").length, 0);
+  assert.equal(searchLauncherItems(items, "m", 2).length, 2, "limit caps results");
+});
+
+test("launcherWeekStats counts trailing-7-day touches and reflections", () => {
+  const items = pool();
+  const stats = launcherWeekStats(
+    items,
+    [
+      { date: "2026-07-17", preview: "", modified: null },
+      { date: "2026-06-01", preview: "", modified: null },
+    ],
+    NOW,
+  );
+  // Release checklist (0.1d), MEMORY.md (2d), journal 2026-07-17 (1d) — the
+  // runtime files (9-10d) and June journal fall outside the window.
+  assert.equal(stats.filesTouched, 3);
+  assert.equal(stats.reflections, 1);
+});
+
+test("journalStreakDays counts back from today, tolerating an unwritten today", () => {
+  assert.equal(journalStreakDays(["2026-07-18", "2026-07-17", "2026-07-16"], "2026-07-18"), 3);
+  // Today not yet written — streak anchors on yesterday.
+  assert.equal(journalStreakDays(["2026-07-17", "2026-07-16"], "2026-07-18"), 2);
+  // A gap breaks the streak.
+  assert.equal(journalStreakDays(["2026-07-18", "2026-07-16"], "2026-07-18"), 1);
+  assert.equal(journalStreakDays(["2026-07-10"], "2026-07-18"), 0);
+  assert.equal(journalStreakDays([], "2026-07-18"), 0);
+});
+
+test("launcherGraphCounts counts doc nodes, edges, and detached docs (tags excluded)", () => {
+  const graph: DocGraph = {
+    nodes: [
+      { id: "a", ref: { kind: "knowledge", id: "a" }, kind: "knowledge", title: "A", degree: 1 },
+      { id: "b", ref: { kind: "knowledge", id: "b" }, kind: "knowledge", title: "B", degree: 0 },
+      { id: "t", ref: null, kind: "tag", title: "#t", degree: 1 },
+    ],
+    edges: [{ id: "e1", source: "a", target: "t", type: "tag" }],
+  };
+  assert.deepEqual(launcherGraphCounts(graph), { nodes: 2, edges: 1, detached: 1 });
+  assert.deepEqual(launcherGraphCounts(null), { nodes: 0, edges: 0, detached: 0 });
+});
+
+test("topMemoryRoot picks the largest root", () => {
+  assert.deepEqual(
+    topMemoryRoot([
+      { relPath: "a", fullPath: "a", modified: iso(1), rootLabel: "OpenClaw runtime" },
+      { relPath: "b", fullPath: "b", modified: iso(1), rootLabel: "OpenClaw runtime" },
+      { relPath: "c", fullPath: "c", modified: iso(1), rootLabel: "Coven memory" },
+    ]),
+    { label: "OpenClaw runtime", count: 2 },
+  );
+  assert.equal(topMemoryRoot([]), null);
+});
+
+test("detectLauncherCapture recognizes github repos, llms.txt, and plain pages", () => {
+  assert.equal(detectLauncherCapture("release notes"), null);
+  assert.equal(detectLauncherCapture("https://"), null);
+  assert.equal(detectLauncherCapture("http://localhost"), null, "hostname must be dotted");
+  const gh = detectLauncherCapture("https://github.com/OpenCoven/coven-cave");
+  assert.equal(gh?.flavor, "github");
+  assert.match(gh!.label, /repo/i);
+  // github.com root (no owner/repo) is just a page.
+  assert.equal(detectLauncherCapture("https://github.com")?.flavor, "page");
+  const llms = detectLauncherCapture("https://docs.example.com/llms.txt");
+  assert.equal(llms?.flavor, "llms");
+  const llmsFull = detectLauncherCapture("https://docs.example.com/llms-full.txt");
+  assert.equal(llmsFull?.flavor, "llms");
+  const page = detectLauncherCapture("www.example.com/blog/post");
+  assert.equal(page?.flavor, "page");
+  assert.equal(page?.url, "https://www.example.com/blog/post", "www.-prefixed input normalizes to https");
+  assert.equal(detectLauncherCapture("https://example.com/a b"), null, "spaces are not URLs");
+});
+
+test("launcherExcerpt strips markdown and clamps on a word edge", () => {
+  assert.equal(launcherExcerpt(undefined), undefined);
+  assert.equal(launcherExcerpt("   "), undefined);
+  assert.equal(
+    launcherExcerpt("## Heading\n\nCoven Cave is the *desktop* control room for [OpenCoven](https://x.y) familiars."),
+    "Coven Cave is the desktop control room for OpenCoven familiars.",
+  );
+  assert.equal(launcherExcerpt("```js\ncode only\n```"), undefined, "fenced code never leaks");
+  assert.equal(launcherExcerpt("See [[docs/setup|the setup guide]] first."), "See the setup guide first.");
+  const long = launcherExcerpt(`${"word ".repeat(60)}end`);
+  assert.ok(long!.length <= 201, "clamped");
+  assert.ok(long!.endsWith("…"), "ellipsis on clamp");
+  // knowledge bodies flow into hero items
+  const items = buildLauncherItems({
+    knowledge: [{ id: "a", title: "A", tags: [], body: "# T\n\nBody text here.", modified: iso(1) }],
+    memory: [],
+    journal: [],
+  });
+  assert.equal(items[0].excerpt, "Body text here.");
+});

--- a/src/lib/grimoire-launcher-data.ts
+++ b/src/lib/grimoire-launcher-data.ts
@@ -1,0 +1,273 @@
+/**
+ * Grimoire launcher data — pure logic behind the Memories launcher screen
+ * (the Knowledge tab's no-selection state; "Memories Prototype" redesign).
+ *
+ * Everything here is deterministic and side-effect free so the bento tiles,
+ * search, and capture detection can be unit-tested without React: merging the
+ * three corpora into one recency pool, week/streak stats, graph counts, and
+ * the URL-capture detection for the big search field.
+ */
+
+import type { DocGraph } from "@/lib/grimoire-graph";
+
+// ── Inputs (structural — mirrors what grimoire-view already loads) ──────────
+
+export type LauncherKnowledgeInput = {
+  id: string;
+  collection?: string;
+  title: string;
+  tags: string[];
+  /** Markdown body when the caller has it — feeds the hero excerpt. */
+  body?: string;
+  /** File mtime ISO string when the list API provides it. */
+  modified?: string;
+};
+
+export type LauncherMemoryInput = {
+  relPath: string;
+  fullPath: string;
+  modified: string;
+  rootLabel: string;
+};
+
+export type LauncherJournalInput = {
+  date: string;
+  preview: string;
+  modified: string | null;
+};
+
+// ── Pool items ───────────────────────────────────────────────────────────────
+
+export type LauncherDocRef =
+  | { kind: "knowledge"; id: string; collection?: string }
+  | { kind: "memory"; path: string }
+  | { kind: "journal"; date: string };
+
+/** Visual marker classes, after the prototype's type language:
+ *  diamond = canonical memory files, ring-dashed = stitches,
+ *  ring-open = journal reflections, dot = plain memory files. */
+export type LauncherMarker = "diamond" | "ring-dashed" | "ring-open" | "dot";
+
+export type LauncherItem = {
+  key: string;
+  ref: LauncherDocRef;
+  title: string;
+  kindLabel: "Stitch" | "Memory" | "Journal";
+  marker: LauncherMarker;
+  modifiedMs: number | null;
+  /** Plain-text snippet for the hero card, when the corpus provides a body. */
+  excerpt?: string;
+  /** Lowercased searchable text: title + tags + kind. */
+  haystack: string;
+};
+
+const CANONICAL_MEMORY_FILE = /^(memory|agents|claude|soul|readme)\.md$/i;
+
+export function memoryMarker(relPath: string): LauncherMarker {
+  const base = relPath.split("/").pop() ?? relPath;
+  return CANONICAL_MEMORY_FILE.test(base) ? "diamond" : "dot";
+}
+
+function toMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** First readable sentence-ish run of a markdown body: headings, link syntax,
+ *  emphasis, and code fences stripped, clamped to ~200 chars on a word edge. */
+export function launcherExcerpt(body: string | undefined, max = 200): string | undefined {
+  if (!body) return undefined;
+  const text = body
+    .replace(/```[\s\S]*?(```|$)/g, " ")
+    .replace(/^#{1,6}\s+.*$/gm, " ")
+    .replace(/^>\s?/gm, "")
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_, a, b) => b || a)
+    .replace(/[*_`~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return undefined;
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max);
+  const edge = cut.lastIndexOf(" ");
+  return `${cut.slice(0, edge > max * 0.6 ? edge : max)}…`;
+}
+
+/** Merge the three corpora into one pool sorted newest-first (undated last). */
+export function buildLauncherItems(input: {
+  knowledge: LauncherKnowledgeInput[];
+  memory: LauncherMemoryInput[];
+  journal: LauncherJournalInput[];
+}): LauncherItem[] {
+  const items: LauncherItem[] = [];
+  for (const k of input.knowledge) {
+    const excerpt = launcherExcerpt(k.body);
+    items.push({
+      key: `knowledge:${k.collection ? `${k.collection}/` : ""}${k.id}`,
+      ref: { kind: "knowledge", id: k.id, ...(k.collection ? { collection: k.collection } : {}) },
+      title: k.title || k.id,
+      kindLabel: "Stitch",
+      marker: "ring-dashed",
+      modifiedMs: toMs(k.modified),
+      ...(excerpt ? { excerpt } : {}),
+      haystack: `${k.title} ${k.id} ${k.tags.join(" ")} stitch`.toLowerCase(),
+    });
+  }
+  for (const m of input.memory) {
+    const base = m.relPath.split("/").pop() ?? m.relPath;
+    items.push({
+      key: `memory:${m.fullPath}`,
+      ref: { kind: "memory", path: m.fullPath },
+      title: base,
+      kindLabel: "Memory",
+      marker: memoryMarker(m.relPath),
+      modifiedMs: toMs(m.modified),
+      haystack: `${m.relPath} ${m.rootLabel} memory`.toLowerCase(),
+    });
+  }
+  for (const j of input.journal) {
+    const excerpt = launcherExcerpt(j.preview);
+    items.push({
+      key: `journal:${j.date}`,
+      ref: { kind: "journal", date: j.date },
+      title: j.date,
+      kindLabel: "Journal",
+      marker: "ring-open",
+      modifiedMs: toMs(j.modified) ?? toMs(`${j.date}T12:00:00`),
+      ...(excerpt ? { excerpt } : {}),
+      haystack: `${j.date} ${j.preview} journal reflection`.toLowerCase(),
+    });
+  }
+  return items.sort((a, b) => {
+    if (a.modifiedMs === null && b.modifiedMs === null) return a.title.localeCompare(b.title);
+    if (a.modifiedMs === null) return 1;
+    if (b.modifiedMs === null) return -1;
+    return b.modifiedMs - a.modifiedMs;
+  });
+}
+
+/** Every-token-must-match search over the pool. */
+export function searchLauncherItems(items: LauncherItem[], query: string, limit = 8): LauncherItem[] {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [];
+  const out: LauncherItem[] = [];
+  for (const item of items) {
+    if (tokens.every((t) => item.haystack.includes(t))) {
+      out.push(item);
+      if (out.length >= limit) break;
+    }
+  }
+  return out;
+}
+
+// ── Bento stats ──────────────────────────────────────────────────────────────
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type LauncherWeekStats = { filesTouched: number; reflections: number };
+
+/** Docs touched and reflections written in the trailing 7 days. */
+export function launcherWeekStats(
+  items: LauncherItem[],
+  journal: LauncherJournalInput[],
+  nowMs: number,
+): LauncherWeekStats {
+  const cutoff = nowMs - WEEK_MS;
+  let filesTouched = 0;
+  for (const item of items) {
+    if (item.modifiedMs !== null && item.modifiedMs >= cutoff && item.modifiedMs <= nowMs + WEEK_MS) {
+      filesTouched += 1;
+    }
+  }
+  let reflections = 0;
+  for (const day of journal) {
+    const ms = Date.parse(`${day.date}T12:00:00`);
+    if (Number.isFinite(ms) && ms >= cutoff) reflections += 1;
+  }
+  return { filesTouched, reflections };
+}
+
+/** Consecutive journal days ending today (or yesterday — an unfinished today
+ *  doesn't break the streak). Dates are local YYYY-MM-DD strings. */
+export function journalStreakDays(dates: string[], todayIso: string): number {
+  const have = new Set(dates);
+  const today = Date.parse(`${todayIso}T12:00:00`);
+  if (!Number.isFinite(today)) return 0;
+  const dayIso = (ms: number) => {
+    const d = new Date(ms);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  };
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  // Anchor on today when present, else yesterday; otherwise no live streak.
+  let cursor = today;
+  if (!have.has(dayIso(cursor))) {
+    cursor -= DAY_MS;
+    if (!have.has(dayIso(cursor))) return 0;
+  }
+  let streak = 0;
+  while (have.has(dayIso(cursor))) {
+    streak += 1;
+    cursor -= DAY_MS;
+  }
+  return streak;
+}
+
+export type LauncherGraphCounts = { nodes: number; edges: number; detached: number };
+
+/** Doc-node/edge counts plus detached docs (no edges at all) for the bento. */
+export function launcherGraphCounts(graph: DocGraph | null): LauncherGraphCounts {
+  if (!graph) return { nodes: 0, edges: 0, detached: 0 };
+  let nodes = 0;
+  let detached = 0;
+  for (const node of graph.nodes) {
+    if (node.kind === "tag") continue;
+    nodes += 1;
+    if (node.degree === 0) detached += 1;
+  }
+  return { nodes, edges: graph.edges.length, detached };
+}
+
+/** The memory root with the most files, for the "N from <root>" line. */
+export function topMemoryRoot(memory: LauncherMemoryInput[]): { label: string; count: number } | null {
+  const counts = new Map<string, number>();
+  for (const m of memory) counts.set(m.rootLabel, (counts.get(m.rootLabel) ?? 0) + 1);
+  let best: { label: string; count: number } | null = null;
+  for (const [label, count] of counts) {
+    if (!best || count > best.count) best = { label, count };
+  }
+  return best;
+}
+
+// ── URL capture detection (search field doubles as an intake) ────────────────
+
+export type LauncherCapture = {
+  url: string;
+  flavor: "github" | "llms" | "page";
+  /** Action label for the primary "pin into a new stitch" affordance. */
+  label: string;
+};
+
+export function detectLauncherCapture(rawQuery: string): LauncherCapture | null {
+  const raw = rawQuery.trim();
+  if (!/^(https?:\/\/|www\.)/i.test(raw) || /\s/.test(raw)) return null;
+  const normalized = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return null;
+  }
+  if (!url.hostname.includes(".")) return null;
+  const path = url.pathname;
+  if (/(^|\/)llms(-full)?\.txt$/i.test(path)) {
+    return { url: normalized, flavor: "llms", label: "Pin llms.txt into a new stitch" };
+  }
+  if (/(^|\.)github\.com$/i.test(url.hostname) && /^\/[^/]+\/[^/]+/.test(path)) {
+    return { url: normalized, flavor: "github", label: "Pin repo into a new stitch" };
+  }
+  return { url: normalized, flavor: "page", label: "Pin page into a new stitch" };
+}

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -84,6 +84,8 @@ export type KnowledgeEntry = {
   /** Stitch provenance: the pins this entry was sewn from (absent when the
    *  entry was written by hand). */
   pins?: StitchPinRef[];
+  /** File mtime (ISO) — list responses only; powers recency surfaces. */
+  modified?: string;
 };
 
 // ── Parse / serialize (pure) ─────────────────────────────────────────────────
@@ -324,7 +326,14 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
       if (!isValidKnowledgeId(id)) continue;
       try {
         const raw = await readFile(path.join(/* turbopackIgnore: true */ dir, name), "utf8");
-        entries.push(parseKnowledgeFile(id, raw, entryCollection));
+        const entry = parseKnowledgeFile(id, raw, entryCollection);
+        try {
+          const st = await stat(path.join(/* turbopackIgnore: true */ dir, name));
+          entry.modified = st.mtime.toISOString();
+        } catch {
+          // Recency is best-effort — a raced delete just omits it.
+        }
+        entries.push(entry);
       } catch {
         // Skip unreadable entries rather than failing the whole list.
       }
@@ -343,7 +352,14 @@ export async function listKnowledgeEntries(collection?: string): Promise<Knowled
       if (!isValidKnowledgeId(id)) continue;
       try {
         const raw = await readFile(/* turbopackIgnore: true */ full, "utf8");
-        entries.push(parseKnowledgeFile(id, raw));
+        const entry = parseKnowledgeFile(id, raw);
+        try {
+          const st = await stat(/* turbopackIgnore: true */ full);
+          entry.modified = st.mtime.toISOString();
+        } catch {
+          // Recency is best-effort — a raced delete just omits it.
+        }
+        entries.push(entry);
       } catch {
         // Skip unreadable entries rather than failing the whole list.
       }

--- a/src/styles/grimoire-launcher.css
+++ b/src/styles/grimoire-launcher.css
@@ -1,0 +1,575 @@
+/* Grimoire launcher + header — the "Memories Prototype" redesign.
+ *
+ * Translates the prototype's Nocturne styling onto the app's tokens
+ * (--accent-presence, --bg-*, --text-*, --border-hairline). Imported by
+ * grimoire-view.tsx alongside journal.css.
+ */
+
+/* ── Header: title left, centered segmented tabs, contextual verbs right ── */
+
+.grimoire-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+}
+
+.grimoire-header .surface-compact-actions {
+  justify-self: end;
+}
+
+.grimoire-tabs {
+  display: inline-flex;
+  justify-self: center;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+  background:
+    linear-gradient(120deg, color-mix(in oklch, var(--accent-presence) 12%, transparent), transparent 55%),
+    var(--bg-raised);
+}
+
+.grimoire-tab {
+  border: none;
+  border-radius: var(--radius-control);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.grimoire-tab:hover {
+  color: var(--text-primary);
+}
+
+.grimoire-tab[aria-pressed="true"] {
+  background: color-mix(in oklch, var(--accent-presence) 24%, transparent);
+  color: var(--text-primary);
+}
+
+/* The prototype's dashed "New stitch" pill — thread waiting to be sewn. */
+.grimoire-newstitch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 26px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1.5px dashed color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.grimoire-newstitch:hover {
+  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 80%, transparent);
+}
+
+/* ── Launcher shell ── */
+
+.gl-root {
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  container-type: inline-size;
+}
+
+.gl-col {
+  max-width: 1160px;
+  width: 96%;
+  margin: 0 auto;
+  padding: var(--space-4) 0 var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ── Banner: aurora field with drifting orbs and a slow sheen ── */
+
+.gl-banner {
+  position: relative;
+  height: 176px;
+  border-radius: var(--radius-panel);
+  overflow: hidden;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 26%, var(--border-hairline));
+  background:
+    radial-gradient(120% 160% at 12% 0%, color-mix(in oklch, var(--accent-presence) 34%, transparent), transparent 55%),
+    radial-gradient(90% 140% at 88% 12%, color-mix(in oklch, var(--accent-presence) 22%, oklch(0.29 0.06 245)) 0%, transparent 60%),
+    radial-gradient(120% 120% at 55% 110%, color-mix(in oklch, var(--accent-presence) 16%, transparent), transparent 55%),
+    var(--bg-raised);
+}
+
+.gl-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(40px);
+  pointer-events: none;
+}
+
+.gl-orb-1 {
+  width: 240px;
+  height: 240px;
+  left: 6%;
+  top: -40%;
+  background: color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  animation: glDrift1 9s ease-in-out infinite;
+}
+
+.gl-orb-2 {
+  width: 300px;
+  height: 300px;
+  right: 4%;
+  bottom: -60%;
+  background: color-mix(in oklch, var(--accent-presence) 26%, oklch(0.33 0.07 240));
+  animation: glDrift2 11s ease-in-out infinite;
+}
+
+.gl-sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 30%, rgba(255, 255, 255, 0.07) 46%, transparent 62%);
+  background-size: 220% 100%;
+  animation: glSheen 8s ease-in-out infinite;
+  pointer-events: none;
+}
+
+/* ── Glass panel: floating chip, date line, big search ── */
+
+.gl-panel {
+  position: relative;
+  margin: -64px auto 0;
+  width: min(920px, 94%);
+  border-radius: var(--radius-panel);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 9%, color-mix(in oklch, var(--bg-base) 55%, transparent));
+  backdrop-filter: blur(18px) saturate(1.35);
+  -webkit-backdrop-filter: blur(18px) saturate(1.35);
+  padding: var(--space-4) var(--space-4) var(--space-3);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
+}
+
+.gl-chip {
+  position: absolute;
+  top: -9px;
+  left: 16px;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  background: var(--bg-base);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--accent-presence) 70%, var(--text-primary));
+}
+
+.gl-meta {
+  position: absolute;
+  top: -7px;
+  right: 16px;
+  padding: 0 var(--space-2);
+  background: transparent;
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.gl-search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 78%, transparent);
+  padding: 0 var(--space-2);
+}
+
+.gl-search:focus-within {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline));
+}
+
+.gl-search input {
+  flex: 1;
+  min-width: 0;
+  height: 38px;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+
+.gl-search input::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Search results + capture actions ── */
+
+.gl-results {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.gl-result,
+.gl-capture {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-control);
+  background: transparent;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.gl-result:hover,
+.gl-capture:hover {
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+}
+
+.gl-result-title {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gl-result-kind {
+  flex-shrink: 0;
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.gl-capture {
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 7%, transparent);
+}
+
+.gl-empty-results {
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* ── Type markers (the prototype's document type language) ── */
+
+.gl-marker {
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.gl-marker-diamond {
+  width: 6px;
+  height: 6px;
+  background: var(--text-primary);
+  transform: rotate(45deg);
+}
+
+.gl-marker-ring-dashed {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 85%, var(--text-primary));
+}
+
+.gl-marker-ring-open {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1.2px solid color-mix(in oklch, var(--accent-presence) 60%, var(--text-primary));
+}
+
+.gl-marker-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+/* ── Bento grid ── */
+
+.gl-bento {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-rows: minmax(88px, auto);
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.gl-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--space-1);
+  min-width: 0;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
+  padding: var(--space-3) var(--space-3);
+  text-align: left;
+  overflow: hidden;
+  transition: border-color 130ms ease, transform 130ms ease;
+}
+
+button.gl-card {
+  cursor: pointer;
+}
+
+button.gl-card:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  transform: translateY(-1px);
+}
+
+.gl-hero {
+  grid-column: span 2;
+  grid-row: span 2;
+  justify-content: flex-start;
+  gap: var(--space-1);
+}
+
+.gl-hero-excerpt {
+  margin-top: var(--space-2);
+  font-size: var(--text-md);
+  line-height: 1.55;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.gl-week {
+  grid-row: span 2;
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 8%, color-mix(in oklch, var(--bg-raised) 60%, transparent));
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.gl-week .gl-shine {
+  position: absolute;
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  filter: blur(34px);
+  background: color-mix(in oklch, var(--accent-presence) 32%, transparent);
+  right: -40px;
+  top: -50px;
+  pointer-events: none;
+  animation: glShine 7s ease-in-out infinite;
+}
+
+.gl-kicker {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.gl-card-title {
+  font-size: var(--text-md);
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.gl-hero .gl-card-title {
+  font-size: var(--text-lg);
+}
+
+.gl-card-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  max-width: 100%;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.gl-card-line .gl-line-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.gl-card-sub {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.gl-stat {
+  font-size: var(--text-xl);
+  font-weight: 650;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.gl-week-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1);
+}
+
+.gl-week-row .gl-stat {
+  font-size: var(--text-lg);
+  min-width: 2ch;
+}
+
+.gl-week-row span:last-child {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.gl-arrow {
+  margin-top: auto;
+  font-size: var(--text-xs);
+  color: color-mix(in oklch, var(--accent-presence) 75%, var(--text-primary));
+}
+
+.gl-detached {
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+}
+
+/* ── New stitch row ── */
+
+.gl-newrow {
+  position: relative;
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-card);
+  border: 1.5px dashed color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 5%, transparent);
+  padding: var(--space-4) var(--space-3) var(--space-3);
+  margin-top: var(--space-1);
+}
+
+.gl-newrow .gl-chip {
+  top: -9px;
+}
+
+.gl-template {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 80%, transparent);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 130ms ease;
+}
+
+.gl-template:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+}
+
+.gl-template-name {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.gl-template-sub {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.gl-template-primary {
+  border: 1.5px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* ── Responsive: 4 → 2 → 1 columns, banner shrinks ── */
+
+@container (max-width: 899px) {
+  .gl-bento {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gl-banner {
+    height: 132px;
+  }
+
+  .gl-panel {
+    margin-top: -48px;
+  }
+}
+
+@container (max-width: 559px) {
+  .gl-bento {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gl-hero,
+  .gl-week {
+    grid-column: 1 / -1;
+    grid-row: auto;
+  }
+
+  .gl-meta {
+    display: none;
+  }
+}
+
+/* ── Motion ── */
+
+@keyframes glDrift1 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(36px, 14px); }
+}
+
+@keyframes glDrift2 {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(-42px, -10px); }
+}
+
+@keyframes glSheen {
+  0% { background-position: 130% 0; }
+  55%, 100% { background-position: -90% 0; }
+}
+
+@keyframes glShine {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gl-orb-1,
+  .gl-orb-2,
+  .gl-sheen,
+  .gl-week .gl-shine {
+    animation: none;
+  }
+}

--- a/tests/grimoire-autosave.spec.ts
+++ b/tests/grimoire-autosave.spec.ts
@@ -101,6 +101,13 @@ async function gotoGrimoire(page: Page) {
   await page.waitForSelector(".grimoire-view", { timeout: 30_000 });
 }
 
+/** The navigator rail. Row clicks scope here: with no open tabs the main pane
+ *  shows the Knowledge launcher, whose recents duplicate the rail rows'
+ *  accessible names (strict mode would reject the bare getByRole match). */
+function rail(page: Page) {
+  return page.locator(".grimoire-view aside");
+}
+
 // PUT bodies captured by the memory-file mock, reset per test (the negative
 // case asserts none arrive while typing).
 let memoryPuts: Array<Record<string, unknown>> = [];
@@ -124,7 +131,7 @@ test.describe("grimoire autosave (desktop)", () => {
     // The rail formats journal dates through datetime prefs ("Jul 1" /
     // "1 Jul", + year when not current) — match the row by its preview text,
     // which is stable across pref and clock-year changes.
-    await page.getByRole("button", { name: /Shipped the grimoire\./ }).click();
+    await rail(page).getByRole("button", { name: /Shipped the grimoire\./ }).click();
 
     const posted = page.waitForRequest(
       (req) => req.method() === "POST" && req.url().includes("/api/journal"),
@@ -140,7 +147,7 @@ test.describe("grimoire autosave (desktop)", () => {
 
   test("knowledge entries autosave after the debounce — no Save click", async ({ page }) => {
     await gotoGrimoire(page);
-    await page.getByRole("button", { name: /Release checklist/ }).click();
+    await rail(page).getByRole("button", { name: /Release checklist/ }).click();
 
     const posted = page.waitForRequest(
       (req) => req.method() === "POST" && req.url().includes("/api/knowledge"),
@@ -156,7 +163,7 @@ test.describe("grimoire autosave (desktop)", () => {
 
   test("memory files never autosave — typing leaves the draft unsaved", async ({ page }) => {
     await gotoGrimoire(page);
-    await page.getByRole("button", { name: /notes\.md/ }).click();
+    await rail(page).getByRole("button", { name: /notes\.md/ }).click();
 
     await typeInEditor(page, " A new fact.");
     // The editor tracks the draft as dirty (manual-save surface)…


### PR DESCRIPTION
Recreates the **"Memories Prototype"** Claude Design export (`Memories Prototype.dc.html`) as a redesign of the Memories (grimoire) surface. Bead: `cave-7tvn`.

## What changed

### Knowledge launcher (new default screen)
The Knowledge tab's no-selection state — previously a small empty-state card — is now a full launcher screen mirroring the prototype:

- **Aurora banner** with drifting orbs + sheen (design-token gradients, `prefers-reduced-motion` disables animation) and a floating **"Continue where you left off"** glass panel.
- **Search-or-capture field**: all-token search across stitches, memory files, and journal reflections (top 8, marker + kind + recency meta). Pasting a URL flips to **capture**: `github.com/<owner>/<repo>` → "Pin repo into a new stitch", `llms(-full).txt` → "Pin llms.txt", any other page → "Pin page" — plus "Start an empty stitch instead". Enter opens the top result or fires the capture.
- **Live bento grid**: most-recent hero (with markdown excerpt when the doc has a body), this-week stats (files touched / reflections written / stitches total), four recents, detached-docs → Relations, journal streak → Journal, graph nodes/edges → Relations, memory-file counts, and a wiki-links tip.
- **New-stitch template row**: Blank stitch + the four `STITCH_PATTERNS` templates (glossary, API contract, decision record, how-to) + Blank entry.

### Header
Centered **Knowledge / Journal / Relations** segmented tabs (same `aria-label="Memories view"` group and `aria-pressed` order), title left, contextual actions right: dashed **New stitch** pill + **Blank entry** (docs view only).

### Supporting changes
- `stitch-intake.tsx`: optional mount-time `initialRef` / `initialPatternId` props; grimoire-view re-keys the intake **only** when a prefill is present, so a plain "New stitch" refocus never remounts (pinned sources survive).
- `knowledge-vault.ts`: `listKnowledgeEntries` now attaches best-effort file mtime as `modified` (root scan **and** collection scan) so the launcher can rank stitches by recency. List-only; read/write round-trips untouched.
- `grimoire-autosave.spec.ts`: rail clicks scoped to `.grimoire-view aside` — launcher recents would otherwise create Playwright strict-mode duplicate matches.
- All launcher CSS uses design tokens; token-drift ratchets pass **without baseline changes**.

## Testing
- `src/lib/grimoire-launcher-data.test.ts` — 9 behavioral tests (pool merge/sort, search, week/streak/graph stats, markers, capture detection, excerpts).
- `src/components/grimoire-launcher.test.ts` — source pins (a11y labels, no fetches, one clock per mount).
- `pnpm typecheck` clean; `pnpm test:app` green (781 files); existing `grimoire-view.test.ts` pins pass unmodified.
- Visual verification against the prototype screenshots on a prod build with live data (2,017 docs): launcher, search results, URL capture, 760 px narrow, and 1280 px (zero horizontal overflow — the `fit-half-width` e2e width).

## Deferred (tracked in cave-7tvn)
Journal/reader/graph full-fidelity restyling; banner image persistence.
