### PR TITLE
Address Copilot review on the Memories launcher (#3445)

### DIFF
--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -913,13 +913,19 @@ export function GrimoireView({
           ...(opts.patternId ? { patternId: opts.patternId } : {}),
           ...(opts.pinUrl ? { pinUrl: opts.pinUrl } : {}),
         }));
+      } else {
+        // Plain opens keep the nonce (an already-open intake must not remount
+        // and lose pinned sources) but drop any stale prefill so the next
+        // fresh mount starts blank instead of replaying an old capture.
+        setStitchPrefill((prev) => (prev.patternId || prev.pinUrl ? { nonce: prev.nonce } : prev));
       }
       openDoc({ kind: "stitch-new" });
     },
     [openDoc],
   );
 
-  const closeTab = useCallback((key: string) => {    setDirtyTabs((prev) => {
+  const closeTab = useCallback((key: string) => {
+    setDirtyTabs((prev) => {
       if (!(key in prev)) return prev;
       const next = { ...prev };
       delete next[key];

--- a/src/lib/grimoire-launcher-data.test.ts
+++ b/src/lib/grimoire-launcher-data.test.ts
@@ -81,6 +81,28 @@ test("launcherWeekStats counts trailing-7-day touches and reflections", () => {
   assert.equal(stats.reflections, 1);
 });
 
+test("launcherWeekStats caps the window at end-of-today (no future inflation)", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const futureItem = buildLauncherItems({
+    knowledge: [
+      { id: "skewed", title: "Skewed clock", tags: [], modified: new Date(NOW + 2 * dayMs).toISOString() },
+      { id: "fresh", title: "Fresh", tags: [], modified: new Date(NOW - dayMs).toISOString() },
+    ],
+    memory: [],
+    journal: [],
+  });
+  const stats = launcherWeekStats(
+    futureItem,
+    [
+      { date: "2026-07-18", preview: "", modified: null }, // today, noon anchor — counts even in the morning
+      { date: "2026-07-19", preview: "", modified: null }, // tomorrow — never counts
+    ],
+    Date.parse("2026-07-18T09:00:00"),
+  );
+  assert.equal(stats.filesTouched, 1, "future mtimes (clock skew) are excluded");
+  assert.equal(stats.reflections, 1, "today counts, future-dated entries do not");
+});
+
 test("journalStreakDays counts back from today, tolerating an unwritten today", () => {
   assert.equal(journalStreakDays(["2026-07-18", "2026-07-17", "2026-07-16"], "2026-07-18"), 3);
   // Today not yet written — streak anchors on yesterday.

--- a/src/lib/grimoire-launcher-data.ts
+++ b/src/lib/grimoire-launcher-data.ts
@@ -167,6 +167,16 @@ const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type LauncherWeekStats = { filesTouched: number; reflections: number };
 
+/** End of the local day containing `ms` — the inclusive upper bound for
+ *  "this week". Today's noon-anchored journal dates count even in the
+ *  morning; genuinely future mtimes (clock skew, future-dated entries)
+ *  don't inflate the tiles. */
+function endOfDayMs(ms: number): number {
+  const d = new Date(ms);
+  d.setHours(23, 59, 59, 999);
+  return d.getTime();
+}
+
 /** Docs touched and reflections written in the trailing 7 days. */
 export function launcherWeekStats(
   items: LauncherItem[],
@@ -174,16 +184,17 @@ export function launcherWeekStats(
   nowMs: number,
 ): LauncherWeekStats {
   const cutoff = nowMs - WEEK_MS;
+  const horizon = endOfDayMs(nowMs);
   let filesTouched = 0;
   for (const item of items) {
-    if (item.modifiedMs !== null && item.modifiedMs >= cutoff && item.modifiedMs <= nowMs + WEEK_MS) {
+    if (item.modifiedMs !== null && item.modifiedMs >= cutoff && item.modifiedMs <= horizon) {
       filesTouched += 1;
     }
   }
   let reflections = 0;
   for (const day of journal) {
     const ms = Date.parse(`${day.date}T12:00:00`);
-    if (Number.isFinite(ms) && ms >= cutoff) reflections += 1;
+    if (Number.isFinite(ms) && ms >= cutoff && ms <= horizon) reflections += 1;
   }
   return { filesTouched, reflections };
 }


### PR DESCRIPTION
Follow-up for the four [Copilot review comments on #3445](https://github.com/OpenCoven/coven-cave/pull/3445) that landed after it merged:

- **launcherWeekStats bounds** ([comment](https://github.com/OpenCoven/coven-cave/pull/3445#discussion_r3608945523), [comment](https://github.com/OpenCoven/coven-cave/pull/3445#discussion_r3608945528)): the trailing-7-day window is now capped at end-of-today. Future mtimes (clock skew) no longer inflate *files touched*; future-dated journal entries no longer count as *reflections written*; today's noon-anchored date still counts in the morning. New unit test pins both bounds.
- **Stale stitch prefill** ([comment](https://github.com/OpenCoven/coven-cave/pull/3445#discussion_r3608945512)): plain "New stitch" opens clear any leftover `patternId`/`pinUrl` (nonce kept, so an already-open intake never remounts and pinned sources survive) — a later fresh mount starts blank instead of replaying an old capture/template.
- **closeTab formatting** ([comment](https://github.com/OpenCoven/coven-cave/pull/3445#discussion_r3608945501)): un-inlined the callback body.

Verified: `pnpm typecheck` clean; grimoire-launcher-data (10 tests incl. the new bounds case), grimoire-view pins, and launcher pins all pass.