### PR TITLE
feat(rituals): unify minimalist overview

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -697,6 +697,7 @@ export const SUITES = {
     "src/lib/reading-hyphens.test.ts",
     "src/lib/datetime-format.test.ts",
     "src/lib/relative-time.test.ts",
+    "src/lib/rituals-overview.test.ts",
     "src/lib/model-label.test.ts",
     "src/lib/composer-history.test.ts",
     "src/lib/appearance-corner-radius.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -930,7 +930,7 @@ tr[role="checkbox"]:focus-visible {
   border-radius: var(--radius-pill);
   border: 1px solid var(--bg-raised);
   background: color-mix(in oklch, var(--foreground) 12%, var(--bg-raised));
-  font-size: 9px;
+  font-size: var(--text-2xs);
   font-weight: 650;
   color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
@@ -8970,6 +8970,355 @@ a.mobile-handoff__link:hover {
 .surface-compact-search {
   flex: 0 1 220px;
   min-width: 140px;
+}
+
+/* Rituals overview — option 3a from the minimalist design handoff. The week
+   ribbon stays quiet; the Needs-you queue is the only raised, glowing surface. */
+.rituals-overview {
+  padding: var(--space-3) clamp(var(--space-3), 4vw, var(--space-6)) var(--space-6);
+  color: var(--text-primary);
+  background:
+    radial-gradient(circle at 76% 8%, color-mix(in oklch, var(--accent-presence) 8%, transparent), transparent 32%),
+    var(--bg-base);
+}
+
+.rituals-overview__header {
+  background: color-mix(in oklch, var(--bg-base) 92%, transparent);
+}
+
+.rituals-overview__moon {
+  color: var(--accent-presence);
+  filter: drop-shadow(0 0 7px color-mix(in oklch, var(--accent-presence) 55%, transparent));
+}
+
+.rituals-overview__events,
+.rituals-overview__lower {
+  width: min(920px, 100%);
+  margin-inline: auto;
+}
+
+.rituals-overview__section-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) 0 var(--space-2);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  font-weight: 650;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.rituals-overview__fade-rule {
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, var(--border-hairline), transparent);
+}
+
+.rituals-overview__week {
+  display: flex;
+  gap: var(--space-2);
+  overflow-x: auto;
+  padding: var(--space-1) 0 var(--space-3);
+  scrollbar-width: none;
+}
+
+.rituals-overview__week::-webkit-scrollbar {
+  display: none;
+}
+
+.rituals-overview__day {
+  position: relative;
+  display: grid;
+  flex: 1 0 64px;
+  min-width: 54px;
+  place-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-1);
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+
+.rituals-overview__day strong {
+  color: inherit;
+  font-size: var(--text-sm);
+  font-weight: 560;
+}
+
+.rituals-overview__day:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+
+.rituals-overview__day--today {
+  border-color: var(--accent-presence);
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 7%, transparent);
+}
+
+.rituals-overview__day i {
+  position: absolute;
+  bottom: 3px;
+  width: 4px;
+  height: 4px;
+  border: 1px solid color-mix(in oklch, var(--text-muted) 75%, transparent);
+  border-radius: var(--radius-pill);
+}
+
+.rituals-overview__needs {
+  position: relative;
+  width: min(920px, 100%);
+  margin: var(--space-3) auto;
+  padding: var(--space-3) var(--space-3) var(--space-2);
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 54%, var(--border-hairline));
+  border-radius: var(--radius-panel);
+  background:
+    radial-gradient(circle at 88% 30%, color-mix(in oklch, var(--accent-presence) 13%, transparent), transparent 38%),
+    color-mix(in oklch, var(--bg-raised) 80%, var(--bg-base));
+  box-shadow: 0 0 30px color-mix(in oklch, var(--accent-presence) 11%, transparent);
+}
+
+.rituals-overview__needs h2 {
+  position: absolute;
+  top: -9px;
+  left: 12px;
+  margin: 0;
+  padding: 0 var(--space-2);
+  background: var(--bg-base);
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  font-weight: 650;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.rituals-overview__needs ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.rituals-overview__need-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-1);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 68%, transparent);
+}
+
+.rituals-overview__need-row:last-child {
+  border-bottom: 0;
+}
+
+.rituals-overview__need-main,
+.rituals-overview__row {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.rituals-overview__need-main {
+  padding: var(--space-2) var(--space-1);
+}
+
+.rituals-overview__need-main:hover,
+.rituals-overview__row:hover {
+  background: color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+
+.rituals-overview__live-dot {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--accent-presence) 80%, transparent);
+}
+
+.rituals-overview__row {
+  padding: var(--space-2) var(--space-1);
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 58%, transparent);
+  font-size: var(--text-sm);
+}
+
+.rituals-overview__row--quiet {
+  border-bottom: 0;
+  padding-block: var(--space-1);
+}
+
+.rituals-overview__row-title {
+  min-width: 0;
+  overflow: hidden;
+  flex: 0 1 auto;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 520;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rituals-overview__kind {
+  flex: none;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  font-size: 9px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.rituals-overview__meta {
+  flex: none;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.rituals-overview__spacer {
+  flex: 1;
+}
+
+.rituals-overview__pane-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 0 var(--space-1);
+}
+
+.rituals-overview__pane-nav > span {
+  flex: 1;
+}
+
+.rituals-overview__pane-nav button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: var(--space-1) var(--space-2);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.rituals-overview__pane-nav button[aria-pressed="true"] {
+  color: var(--accent-presence);
+}
+
+.rituals-overview__pane-nav button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.rituals-overview__pane {
+  min-height: 180px;
+  touch-action: pan-y;
+}
+
+.rituals-overview__log {
+  max-height: min(42vh, 360px);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.rituals-overview__thread {
+  display: flex;
+  max-height: min(42vh, 360px);
+  flex-direction: column;
+  gap: var(--space-1);
+  overflow-y: auto;
+}
+
+.rituals-overview__thread-group,
+.rituals-overview__now {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  gap: var(--space-3);
+}
+
+.rituals-overview__thread-date {
+  padding-top: var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  text-align: right;
+}
+
+.rituals-overview__thread-line {
+  min-width: 0;
+  padding-left: var(--space-3);
+  border-left: 1px solid color-mix(in oklch, var(--border-strong) 72%, transparent);
+}
+
+.rituals-overview__now {
+  align-items: center;
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  text-align: right;
+}
+
+.rituals-overview__now-line {
+  position: relative;
+  height: 1px;
+  background: linear-gradient(90deg, var(--accent-presence), transparent);
+}
+
+.rituals-overview__now-line > span {
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+  box-shadow: 0 0 9px color-mix(in oklch, var(--accent-presence) 75%, transparent);
+}
+
+.rituals-overview__empty {
+  padding: var(--space-4);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  text-align: center;
+}
+
+.rituals-overview__selection {
+  width: min(920px, 100%);
+  margin: var(--space-3) auto 0;
+}
+
+@container (max-width: 620px) {
+  .rituals-overview__need-row {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-block: var(--space-1);
+  }
+
+  .rituals-overview__need-row > span {
+    align-self: flex-end;
+  }
+
+  .rituals-overview__kind,
+  .rituals-overview__row > .rituals-overview__meta:first-of-type {
+    display: none;
+  }
 }
 
 .workflow-dialog-backdrop {

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -148,12 +148,18 @@ assert.doesNotMatch(
   "detail panel actions should use radius tokens instead of hard-coded radii",
 );
 
-// The active Rituals surface is Inbox + Calendar + Crons. Bulk selection now
-// belongs to the INBOX feed (group-by + select-by-group/search, cave-fcy8);
-// the older per-reminder bulk machinery is gone for good.
-assert.match(source, /type AutomationTab = "inbox" \| "calendar" \| "crons"/, "Rituals exposes Inbox, Calendar and Crons tabs");
+// The active Rituals surface defaults to the handoff's unified overview. Full
+// Calendar and Crons remain secondary destinations; bulk selection belongs to
+// the overview's management mode.
+assert.match(source, /type AutomationTab = "overview" \| "calendar" \| "crons"/, "Rituals exposes Overview, Calendar and Crons modes");
 assert.doesNotMatch(source, /bulkPatchReminders|bulkDeleteReminders|ReminderTaskList|reminderSelect/, "the orphaned reminder bulk-select machinery stays deleted");
-assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : initialTab === "crons" \? "crons" : "inbox"/, "Inbox is the default landing tab; calendar/crons deep links still win");
+assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : initialTab === "crons" \? "crons" : "overview"/, "Overview is the default landing mode; calendar/crons deep links still win");
+assert.match(source, /aria-label="Toggle events ribbon"/, "the overview includes a collapsible week ribbon");
+assert.match(source, /Needs you · \{inboxFeed\.needsYou\.length\}/, "the only raised work queue is the Needs-you tier");
+assert.match(source, /aria-label="Show ritual log"/, "the overview exposes the activity log");
+assert.match(source, /aria-label="Show agenda thread"/, "the overview exposes the agenda thread");
+assert.match(source, /overviewSwipeStartRef/, "Log and Agenda support a manual swipe gesture");
+assert.doesNotMatch(source, /setInterval\([\s\S]{0,100}setOverviewPane/, "the overview never auto-rotates between Log and Agenda");
 
 // ── Inbox grouping + collective actions (cave-fcy8) ─────────────────────────
 // Group-by control re-shapes the feed; selection acts on the visible
@@ -161,9 +167,8 @@ assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : 
 // actions ride ONE POST /api/inbox/bulk; delete keeps the undo window.
 assert.match(source, /buildInboxGroups\(inboxVisible, inboxGroupBy, familiarLabel\)/, "groups derive from the pure lib over the filtered feed");
 assert.match(source, /INBOX_GROUP_BY_OPTIONS/, "the group-by control offers the lib's dimensions");
-// The group-by is three visible segmented tabs (marketplace kind-filter
-// precedent), never a dropdown — the active dimension reads at a glance.
-assert.match(source, /ariaLabel="Group inbox by"[\s\S]{0,220}INBOX_GROUP_BY_OPTIONS\.map\(\(option\) => \(\{ id: option\.value, label: option\.label \}\)\)/, "group-by renders as a named segmented Tabs control");
+// Grouping is deliberately behind the overflow menu in the minimalist shell.
+assert.match(source, /INBOX_GROUP_BY_OPTIONS\.map\(\(option\) => \([\s\S]{0,420}Group selection by \{option\.label\.toLowerCase\(\)\}/, "group-by remains reachable from the overview options menu");
 assert.doesNotMatch(source, /<StandardSelect[\s\S]{0,120}label="Group inbox by"/, "the group-by dropdown is gone");
 assert.match(source, /cave:inbox:group-by/, "the group-by choice persists per install");
 assert.match(source, /const inboxSelect = useMultiSelect\(inboxVisible, \(it\) => it\.id\)/, "selection universe = the visible matches");
@@ -268,8 +273,7 @@ assert.match(source, /announce\(`Run started for '\$\{auto\.name\}'\.`\)/, "run-
 assert.match(source, /announce\(`Created cron '\$\{input\.name\}'\.`\)/, "create announces");
 assert.match(source, /role="img" aria-label="Paused"/, "status dots carry accessible names");
 assert.match(source, /<section aria-labelledby=\{headingId\}/, "list sections are labelled landmarks with real headings");
-assert.match(source, /idPrefix="automations"/, "tabs get ids so the panel can reference them");
-assert.match(source, /role="tabpanel"[\s\S]{0,120}aria-labelledby=\{`automations-tab-\$\{activeTab\}`\}/, "the content region is a labelled tabpanel");
+assert.match(source, /role="region"[\s\S]{0,220}aria-label=\{activeTab === "overview" \? "Rituals overview"/, "the content region names the active Rituals mode without relying on visible tabs");
 assert.match(source, /onClose=\{\(\) => \{ setCreateOpen\(false\); setTemplateInitialValues\(undefined\); \}\}/, "the create dialog closes through one reset path");
 assert.match(source, /window\.setTimeout\(\(\) => newBtnRef\.current\?\.focus\(\), 0\)/, "deletes hand focus somewhere stable instead of dropping it on <body>");
 

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -38,7 +38,6 @@ import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { SearchInput } from "@/components/ui/search-input";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
-import { Tabs } from "@/components/ui/tabs";
 import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { CwdPickerField } from "@/components/cwd-picker-field";

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -38,7 +38,8 @@ import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { SearchInput } from "@/components/ui/search-input";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
-import { Tabs, type TabItem } from "@/components/ui/tabs";
+import { Tabs } from "@/components/ui/tabs";
+import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { CwdPickerField } from "@/components/cwd-picker-field";
 import { FamiliarMultiSelect } from "@/components/automation-familiar-select";
@@ -46,6 +47,7 @@ import { SkillSelect } from "@/components/automation-skill-select";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { automationMatchesFilter } from "@/lib/familiar-multiselect";
+import { buildRitualWeek, ritualAgendaItems, ritualLogItems, type RitualDay } from "@/lib/rituals-overview";
 import { AutomationCreateDialog, type AutomationCreateInput, type AutomationCreateInitialValues } from "@/components/automation-create-dialog";
 import { AUTOMATION_TEMPLATES, TEMPLATE_CATEGORIES, type AutomationTemplate } from "@/lib/automation-templates";
 import type { FlowDoc } from "@/lib/flows";
@@ -99,7 +101,7 @@ function linkLabel(link: LinkRef): string {
 // The active Rituals surface: Inbox (the full feed, mostly reminders) plus
 // Calendar and Crons. The broader Automations/Flow experience lives on
 // feature/automations-flow.
-type AutomationTab = "inbox" | "calendar" | "crons";
+type AutomationTab = "overview" | "calendar" | "crons";
 
 // Fire a cross-surface navigation so "Open" on a flow jumps to its
 // dedicated editor surface (the Workspace owns setMode; see cave:navigate-mode).
@@ -1778,9 +1780,167 @@ function TemplatesPanel({
   );
 }
 
+type RitualOverviewPane = "log" | "agenda";
+
+function ritualItemDate(item: InboxItem): Date | null {
+  const iso = item.fireAt ?? item.firedAt ?? item.updatedAt;
+  if (!iso) return null;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function ritualWeekLabel(days: RitualDay[]): string {
+  const first = days[0]?.date;
+  const last = days.at(-1)?.date;
+  if (!first || !last) return "";
+  const month = new Intl.DateTimeFormat(undefined, { month: "short" });
+  if (first.getMonth() === last.getMonth()) {
+    return `${month.format(first)} ${first.getDate()}–${last.getDate()}`;
+  }
+  return `${month.format(first)} ${first.getDate()} – ${month.format(last)} ${last.getDate()}`;
+}
+
+function useRitualNow(): Date | null {
+  const [now, setNow] = useState<Date | null>(null);
+  useEffect(() => {
+    let timer: number | null = null;
+    const scheduleMidnight = () => {
+      const current = new Date();
+      const next = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 1);
+      timer = window.setTimeout(() => {
+        setNow(new Date());
+        scheduleMidnight();
+      }, Math.max(1_000, next.getTime() - current.getTime() + 250));
+    };
+    setNow(new Date());
+    scheduleMidnight();
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, []);
+  return now;
+}
+
+function RitualItemRow({
+  item,
+  familiarLabel,
+  onSelect,
+  quiet = false,
+}: {
+  item: InboxItem;
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+  quiet?: boolean;
+}) {
+  const familiar = familiarLabel(item.familiarId);
+  const date = ritualItemDate(item);
+  return (
+    <button
+      type="button"
+      className={`rituals-overview__row focus-ring-inset${quiet ? " rituals-overview__row--quiet" : ""}`}
+      onClick={() => onSelect(item)}
+    >
+      <StatusIcon item={item} />
+      <span className="rituals-overview__row-title">{item.title}</span>
+      <span className="rituals-overview__kind">{inboxKindLabel(item.kind)}</span>
+      {familiar ? <span className="rituals-overview__meta">{familiar}</span> : null}
+      <span className="rituals-overview__spacer" />
+      <span className="rituals-overview__meta">{date ? relTime(date.toISOString()) : relTime(item.updatedAt)}</span>
+    </button>
+  );
+}
+
+function RitualNeedsRow({
+  item,
+  familiarLabel,
+  onSelect,
+  onDone,
+  onSnooze,
+  onDismiss,
+  onUnwatch,
+}: {
+  item: InboxItem;
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+  onDone: (item: InboxItem) => void;
+  onSnooze: (item: InboxItem) => void;
+  onDismiss: (item: InboxItem) => void;
+  onUnwatch?: (item: InboxItem, repo: string) => void;
+}) {
+  const familiar = familiarLabel(item.familiarId);
+  const watchedRepo = repoFromGithubSubTag(item.auto);
+  return (
+    <li className="rituals-overview__need-row">
+      <button type="button" className="rituals-overview__need-main focus-ring-inset" onClick={() => onSelect(item)}>
+        <span aria-hidden className="rituals-overview__live-dot" />
+        <span className="rituals-overview__row-title">{item.title}</span>
+        {familiar ? <span className="rituals-overview__meta">{familiar}</span> : null}
+        <span className="rituals-overview__meta">{item.firedAt ? relTime(item.firedAt) : relTime(item.updatedAt)}</span>
+      </button>
+      <RowActions>
+        <RowActionButton icon="ph:check-bold" label={`Mark ${item.title} done`} text="Done" onClick={() => onDone(item)} />
+        {item.status === "fired" ? (
+          <RowActionButton icon="ph:clock-countdown" label={`Snooze ${item.title} for 1 hour`} text="Snooze" onClick={() => onSnooze(item)} />
+        ) : null}
+        {onUnwatch && watchedRepo ? (
+          <RowActionButton
+            icon="ph:bell-slash"
+            label={`Unwatch ${watchedRepo} — stop GitHub notifications from it`}
+            text="Unwatch"
+            onClick={() => onUnwatch(item, watchedRepo)}
+          />
+        ) : null}
+        <RowActionButton icon="ph:x" label={`Dismiss ${item.title}`} text="Dismiss" onClick={() => onDismiss(item)} />
+      </RowActions>
+    </li>
+  );
+}
+
+function RitualAgendaThread({
+  items,
+  familiarLabel,
+  onSelect,
+}: {
+  items: InboxItem[];
+  familiarLabel: (fid?: string | null) => string | null;
+  onSelect: (item: InboxItem) => void;
+}) {
+  const now = Date.now();
+  const upcoming = items.filter((item) => (ritualItemDate(item)?.getTime() ?? 0) >= now).slice(0, 8).reverse();
+  const past = [...items].reverse().filter((item) => (ritualItemDate(item)?.getTime() ?? 0) < now).slice(0, 8);
+  const renderThreadItem = (item: InboxItem) => {
+    const date = ritualItemDate(item);
+    const label = date
+      ? new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date)
+      : "—";
+    return (
+      <div className="rituals-overview__thread-group" key={item.id}>
+        <span className="rituals-overview__thread-date">{label}</span>
+        <div className="rituals-overview__thread-line">
+          <RitualItemRow item={item} familiarLabel={familiarLabel} onSelect={onSelect} quiet />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="rituals-overview__thread">
+      {upcoming.length > 0 ? upcoming.map(renderThreadItem) : (
+        <p className="rituals-overview__empty">Nothing scheduled ahead.</p>
+      )}
+      <div className="rituals-overview__now">
+        <span>now</span>
+        <span className="rituals-overview__now-line"><span /></span>
+      </div>
+      {past.map(renderThreadItem)}
+    </div>
+  );
+}
+
 // ── Root ──────────────────────────────────────────────────────────────────────
 export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink, calendarSlot, initialTab }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  const ritualNow = useRitualNow();
   const confirm = useConfirm(); // still used by "Run now" (a non-delete action)
   // Deferred + undoable deletes (reminders, automations, bulk): rows hide at
   // once, the DELETEs fire only after the undo window, and Undo restores them.
@@ -1798,10 +1958,16 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // Focus lands here after a delete unmounts the detail panel that held it —
   // otherwise it falls to <body> and keyboard users lose their place.
   const newBtnRef = useRef<HTMLButtonElement | null>(null);
+  const manageBtnRef = useRef<HTMLButtonElement | null>(null);
+  const overviewSwipeStartRef = useRef<number | null>(null);
   const [activeTab, setActiveTab] = useState<AutomationTab>(
-    initialTab === "calendar" && calendarSlot ? "calendar" : initialTab === "crons" ? "crons" : "inbox",
+    initialTab === "calendar" && calendarSlot ? "calendar" : initialTab === "crons" ? "crons" : "overview",
   );
   const [newMenuOpen, setNewMenuOpen] = useState(false);
+  const [manageMenuOpen, setManageMenuOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [eventsOpen, setEventsOpen] = useState(true);
+  const [overviewPane, setOverviewPane] = useState<RitualOverviewPane>("log");
   // Selected item is either an InboxItem or a CodexAutomation — track by kind
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [selectedCodex, setSelectedCodex] = useState<CodexAutomation | null>(null);
@@ -2293,6 +2459,16 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     [items, hiddenIds, q],
   );
   const inboxFeed = useMemo(() => groupInboxFeed(inboxVisible), [inboxVisible]);
+  const ritualWeek = useMemo(
+    () => ritualNow ? buildRitualWeek(inboxVisible, ritualNow) : [],
+    [inboxVisible, ritualNow],
+  );
+  const ritualAgenda = useMemo(() => ritualAgendaItems(inboxVisible), [inboxVisible]);
+  const needsYouIds = useMemo(() => new Set(inboxFeed.needsYou.map((item) => item.id)), [inboxFeed.needsYou]);
+  const ritualLog = useMemo(
+    () => ritualLogItems(inboxVisible).filter((item) => !needsYouIds.has(item.id)),
+    [inboxVisible, needsYouIds],
+  );
   const [inboxGroupBy, setInboxGroupBy] = useState<InboxGroupBy>(() => {
     if (typeof window === "undefined") return "attention";
     const raw = window.localStorage.getItem("cave:inbox:group-by");
@@ -2392,10 +2568,25 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const selectTab = (tab: AutomationTab) => {
     setActiveTab(tab);
     setQuery(""); // the filter is scoped to one tab at a time
+    setSearchOpen(false);
     inboxSelect.exit(); // selection is an inbox-tab mode, never carried across
     // Clear any open detail on switch — the new tab may not host that type.
     setSelectedItem(null);
     setSelectedCodex(null);
+  };
+
+  const openCalendarDay = (day: RitualDay) => {
+    window.sessionStorage.setItem("cave:calendar:pending-open-date", day.key);
+    selectTab("calendar");
+  };
+
+  const finishOverviewSwipe = (clientX: number) => {
+    const start = overviewSwipeStartRef.current;
+    overviewSwipeStartRef.current = null;
+    if (start === null) return;
+    const distance = clientX - start;
+    if (distance <= -40) setOverviewPane("agenda");
+    if (distance >= 40) setOverviewPane("log");
   };
 
   return (
@@ -2408,26 +2599,19 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     <section className="flex h-full" style={{ background: "var(--bg-base)" }}>
       {/* ── Main list ──────────────────────────────────────────────────────── */}
       <div className={`${detailOpen ? (cronDetailExpanded ? "hidden" : "hidden md:flex") : "flex"} flex-1 min-w-0 flex-col`}>
-        {/* Compact header: title, tabs, live summary, filter, and actions in
-            ONE slim topmost band — mirrors the GitHub surface's
-            gh-compact-header so operational surfaces share the same
-            minimalist chrome. */}
-        <div className="surface-compact-header">
+        <div className="surface-compact-header rituals-overview__header">
+          {activeTab !== "overview" ? (
+            <Button size="xs" variant="ghost" leadingIcon="ph:arrow-left" onClick={() => selectTab("overview")}>
+              Overview
+            </Button>
+          ) : (
+            <Icon name="ph:moon" width={15} className="rituals-overview__moon" aria-hidden />
+          )}
           <h1 className="surface-compact-title">Rituals</h1>
-          <Tabs
-            className="surface-compact-tabs"
-            variant="segment"
-            size="sm"
-            ariaLabel="Rituals tabs"
-            idPrefix="automations"
-            value={activeTab}
-            onChange={selectTab}
-            items={[
-              { id: "inbox" as const, label: "Inbox", count: inboxFeed.needsYou.length },
-              ...(calendarSlot ? [{ id: "calendar" as const, label: "Calendar" }] : []),
-              { id: "crons", label: "Crons", count: codexAutos.length },
-            ] satisfies TabItem<AutomationTab>[]}
-          />
+          {activeTab === "overview" ? (
+            <p className="surface-compact-summary">{ritualWeekLabel(ritualWeek)}</p>
+          ) : null}
+          {activeTab === "calendar" ? <p className="surface-compact-summary">Calendar</p> : null}
           {activeTab === "crons" && initialLoadDone && summary.active + summary.paused > 0 && (
             <p className="surface-compact-summary">
               <span className="inline-flex items-center gap-1.5">
@@ -2440,76 +2624,128 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               )}
             </p>
           )}
-          {activeTab === "inbox" && initialLoadDone && inboxFeed.needsYou.length + inboxFeed.active.length > 0 && (
-            <p className="surface-compact-summary">
-              {inboxFeed.needsYou.length > 0 && (
-                <span className="inline-flex items-center gap-1.5">
-                  <span aria-hidden className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--color-warning)" }} />
-                  {inboxFeed.needsYou.length} need{inboxFeed.needsYou.length === 1 ? "s" : ""} you
-                </span>
-              )}
-              {inboxFeed.active.length > 0 && <span>{inboxFeed.needsYou.length > 0 ? "· " : ""}{inboxFeed.active.length} active</span>}
-            </p>
-          )}
           <div className="surface-compact-actions">
-            {/* Text filter, scoped per tab. Gated on the UNfiltered presence
-                of rows so filtering to zero never hides the box (you can still
-                clear) — and it stays up in inbox select mode, so "search →
-                select all matches → act" is one flow. */}
-            {activeTab !== "calendar" && initialLoadDone &&
-              (activeTab === "inbox" ? items.length > 0 : codexAutos.length > 0) ? (
+            {activeTab === "overview" && searchOpen && initialLoadDone && items.length > 0 ? (
+              <div className="surface-compact-search">
+                <SearchInput
+                  value={query}
+                  onValueChange={setQuery}
+                  onClear={() => { setQuery(""); setSearchOpen(false); }}
+                  placeholder="Filter rituals…"
+                  aria-label="Filter rituals"
+                />
+              </div>
+            ) : null}
+            {activeTab === "overview" && !searchOpen ? (
+              <Button
+                aria-label="Search rituals"
+                size="sm"
+                variant="ghost"
+                leadingIcon="ph:magnifying-glass"
+                onClick={() => setSearchOpen(true)}
+              />
+            ) : null}
+            {activeTab === "crons" && initialLoadDone && codexAutos.length > 0 ? (
               <div className="surface-compact-search">
                 <SearchInput
                   value={query}
                   onValueChange={setQuery}
                   onClear={() => setQuery("")}
-                  placeholder={activeTab === "inbox" ? "Filter inbox…" : "Filter crons…"}
-                  aria-label={activeTab === "inbox" ? "Filter inbox" : "Filter crons"}
+                  placeholder="Filter crons…"
+                  aria-label="Filter crons"
                 />
               </div>
             ) : null}
-            {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 ? (
-              // Group-by reads as three visible choices (marketplace kind-filter
-              // precedent), not a dropdown — one glance shows the active dimension.
-              <Tabs
-                variant="segment"
-                size="sm"
-                bordered={false}
-                ariaLabel="Group inbox by"
-                value={inboxGroupBy}
-                onChange={updateInboxGroupBy}
-                items={INBOX_GROUP_BY_OPTIONS.map((option) => ({ id: option.value, label: option.label }))}
-              />
+            {activeTab === "overview" ? (
+              <>
+                <Button
+                  ref={newBtnRef}
+                  size="sm"
+                  className="automation-create-chat-btn"
+                  leadingIcon="ph:plus"
+                  aria-expanded={newMenuOpen}
+                  aria-haspopup="menu"
+                  onClick={() => setNewMenuOpen((open) => !open)}
+                >
+                  New
+                </Button>
+                <Popover
+                  open={newMenuOpen}
+                  onOpenChange={setNewMenuOpen}
+                  anchorRef={newBtnRef}
+                  placement="bottom-end"
+                  minWidth={190}
+                  ariaLabel="Create ritual"
+                >
+                  <PopoverBody role="menu" ariaLabel="Create ritual">
+                    <PopoverItem icon="ph:bell" disabled={!onNewReminder} onSelect={() => { setNewMenuOpen(false); onNewReminder?.(); }}>
+                      New reminder
+                    </PopoverItem>
+                    <PopoverItem icon="ph:clock-countdown" onSelect={() => { setNewMenuOpen(false); setCreateOpen(true); }}>
+                      New cron
+                    </PopoverItem>
+                  </PopoverBody>
+                </Popover>
+                <Button
+                  ref={manageBtnRef}
+                  size="sm"
+                  variant="ghost"
+                  aria-label="More Rituals options"
+                  aria-expanded={manageMenuOpen}
+                  aria-haspopup="menu"
+                  leadingIcon="ph:dots-three"
+                  onClick={() => setManageMenuOpen((open) => !open)}
+                />
+                <Popover
+                  open={manageMenuOpen}
+                  onOpenChange={setManageMenuOpen}
+                  anchorRef={manageBtnRef}
+                  placement="bottom-end"
+                  minWidth={220}
+                  ariaLabel="Rituals options"
+                >
+                  <PopoverBody role="menu" ariaLabel="Rituals options">
+                    {calendarSlot ? (
+                      <PopoverItem icon="ph:calendar-check" onSelect={() => { setManageMenuOpen(false); selectTab("calendar"); }}>
+                        Open full calendar
+                      </PopoverItem>
+                    ) : null}
+                    <PopoverItem icon="ph:clock-countdown" onSelect={() => { setManageMenuOpen(false); selectTab("crons"); }}>
+                      Manage crons
+                    </PopoverItem>
+                    <PopoverItem icon="ph:github-logo" onSelect={() => { setManageMenuOpen(false); void openSubscriptions(); }}>
+                      Subscriptions
+                    </PopoverItem>
+                    {inboxVisible.length > 0 ? (
+                      <PopoverItem icon="ph:check-square" onSelect={() => { setManageMenuOpen(false); inboxSelect.setSelectMode(true); }}>
+                        Select ritual items
+                      </PopoverItem>
+                    ) : null}
+                    {INBOX_GROUP_BY_OPTIONS.map((option) => (
+                      <PopoverItem
+                        key={option.value}
+                        checked={inboxGroupBy === option.value}
+                        onSelect={() => { setManageMenuOpen(false); updateInboxGroupBy(option.value); }}
+                      >
+                        Group selection by {option.label.toLowerCase()}
+                      </PopoverItem>
+                    ))}
+                  </PopoverBody>
+                </Popover>
+              </>
             ) : null}
-            {activeTab === "inbox" && initialLoadDone && inboxVisible.length > 0 && !inboxSelect.selectMode ? (
+            {activeTab === "calendar" && onNewReminder ? (
               <Button
                 size="sm"
-                variant="secondary"
-                leadingIcon="ph:check-square"
-                onClick={() => inboxSelect.setSelectMode(true)}
-                title="Pick inbox items (or whole groups) for a collective action"
+                className="automation-create-chat-btn"
+                leadingIcon="ph:plus"
+                onClick={onNewReminder}
               >
-                Select
-              </Button>
-            ) : null}
-            {activeTab === "inbox" && !inboxSelect.selectMode ? (
-              <Button
-                size="sm"
-                variant="secondary"
-                leadingIcon="ph:github-logo"
-                onClick={() => void openSubscriptions()}
-                title="Choose which GitHub repos and events land in this Inbox"
-              >
-                Subscriptions
-              </Button>
-            ) : null}
-            {activeTab === "inbox" && onNewReminder ? (
-              <Button size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={onNewReminder}>
                 New reminder
               </Button>
             ) : null}
             {activeTab === "crons" ? (
-              <Button ref={newBtnRef} size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={() => setCreateOpen(true)}>
+              <Button size="sm" className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={() => setCreateOpen(true)}>
                 New cron
               </Button>
             ) : null}
@@ -2535,10 +2771,10 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
         {/* List (or the Calendar surface when that tab is active) */}
         <div
-          role="tabpanel"
+          role="region"
           id={`automations-panel-${activeTab}`}
-          aria-labelledby={`automations-tab-${activeTab}`}
-          className={activeTab === "calendar" ? "flex-1 min-h-0 overflow-hidden" : "@container flex-1 overflow-y-auto px-4 pt-4 pb-8 @min-[640px]:px-8"}>
+          aria-label={activeTab === "overview" ? "Rituals overview" : activeTab === "calendar" ? "Rituals calendar" : "Rituals crons"}
+          className={activeTab === "calendar" ? "flex-1 min-h-0 overflow-hidden" : activeTab === "overview" ? "@container flex-1 overflow-y-auto rituals-overview" : "@container flex-1 overflow-y-auto px-4 pt-4 pb-8 @min-[640px]:px-8"}>
           {activeTab === "calendar" ? (
             calendarSlot
           ) : !initialLoadDone ? (
@@ -2551,7 +2787,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 />
               ))}
             </div>
-          ) : activeTab === "inbox" ? (
+          ) : activeTab === "overview" ? (
             inboxFeed.needsYou.length + inboxFeed.active.length + inboxFeed.resolved.length === 0 ? (
               q ? (
                 <EmptyState
@@ -2561,13 +2797,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   subtitle="Try a different search term."
                 />
               ) : (
-                <EmptyState
-                  className="mt-12"
-                  icon="ph:tray"
-                  headline="Inbox zero"
-                  subtitle="Reminders and notifications land here as they fire — enjoy the quiet."
-                  actions={onNewReminder ? <Button leadingIcon="ph:plus" onClick={onNewReminder}>New reminder</Button> : undefined}
-                />
+                <EmptyState className="mt-12" icon="ph:moon" headline="All quiet"
+                  subtitle="Reminders, events, and familiar activity will gather here."
+                  actions={onNewReminder ? <Button leadingIcon="ph:plus" onClick={onNewReminder}>New reminder</Button> : undefined} />
               )
             ) : (
               <>
@@ -2601,21 +2833,119 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                     </Button>
                   </SelectionToolbar>
                 ) : null}
-                <InboxFeedList
-                  groups={inboxGroups}
-                  selectedId={selectedItem?.id ?? null}
-                  selectMode={inboxSelect.selectMode}
-                  isSelected={inboxSelect.isSelected}
-                  groupSelected={(group) => inboxSelect.allSelected(group.items)}
-                  onToggleGroup={(group) => inboxSelect.toggleSelectAll(group.items)}
-                  onToggle={inboxSelect.toggle}
-                  familiarLabel={familiarLabel}
-                  onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
-                  onDone={(item) => void completeInboxItem(item)}
-                  onSnooze={(item) => void snoozeInboxItem(item)}
-                  onDismiss={(item) => void dismissInboxItem(item)}
-                  onUnwatch={(item, repo) => void unwatchRepo(item, repo)}
-                />
+                {inboxSelect.selectMode ? (
+                  <div className="rituals-overview__selection">
+                    <InboxFeedList
+                      groups={inboxGroups}
+                      selectedId={selectedItem?.id ?? null}
+                      selectMode
+                      isSelected={inboxSelect.isSelected}
+                      groupSelected={(group) => inboxSelect.allSelected(group.items)}
+                      onToggleGroup={(group) => inboxSelect.toggleSelectAll(group.items)}
+                      onToggle={inboxSelect.toggle}
+                      familiarLabel={familiarLabel}
+                      onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
+                      onDone={(item) => void completeInboxItem(item)}
+                      onSnooze={(item) => void snoozeInboxItem(item)}
+                      onDismiss={(item) => void dismissInboxItem(item)}
+                      onUnwatch={(item, repo) => void unwatchRepo(item, repo)}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <section className="rituals-overview__events" aria-labelledby="rituals-events-heading">
+                      <button
+                        type="button"
+                        className="rituals-overview__section-toggle focus-ring"
+                        aria-label="Toggle events ribbon"
+                        aria-expanded={eventsOpen}
+                        onClick={() => setEventsOpen((open) => !open)}
+                      >
+                        <span id="rituals-events-heading">Events</span>
+                        <Icon name={eventsOpen ? "ph:caret-down" : "ph:caret-right"} width={11} aria-hidden />
+                        <span aria-hidden className="rituals-overview__fade-rule" />
+                      </button>
+                      {eventsOpen && ritualWeek.length > 0 ? (
+                        <div className="rituals-overview__week" aria-label={ritualWeekLabel(ritualWeek)}>
+                          {ritualWeek.map((day) => (
+                            <button
+                              type="button"
+                              key={day.key}
+                              className={`rituals-overview__day focus-ring${day.isToday ? " rituals-overview__day--today" : ""}`}
+                              aria-label={`Open ${new Intl.DateTimeFormat(undefined, { weekday: "long", month: "long", day: "numeric" }).format(day.date)} in calendar`}
+                              aria-current={day.isToday ? "date" : undefined}
+                              onClick={() => openCalendarDay(day)}
+                            >
+                              <span>{day.weekday}</span>
+                              <strong>{day.day}</strong>
+                              {day.hasItems ? <i aria-hidden /> : null}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </section>
+
+                    {inboxFeed.needsYou.length > 0 ? (
+                      <section className="rituals-overview__needs" aria-labelledby="rituals-needs-heading">
+                        <h2 id="rituals-needs-heading">Needs you · {inboxFeed.needsYou.length}</h2>
+                        <ul>
+                          {inboxFeed.needsYou.map((item) => (
+                            <RitualNeedsRow
+                              key={item.id}
+                              item={item}
+                              familiarLabel={familiarLabel}
+                              onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }}
+                              onDone={(next) => void completeInboxItem(next)}
+                              onSnooze={(next) => void snoozeInboxItem(next)}
+                              onDismiss={(next) => void dismissInboxItem(next)}
+                              onUnwatch={(next, repo) => void unwatchRepo(next, repo)}
+                            />
+                          ))}
+                        </ul>
+                      </section>
+                    ) : null}
+
+                    <section className="rituals-overview__lower" aria-label="Ritual activity">
+                      <div className="rituals-overview__pane-nav">
+                        <button type="button" className="focus-ring" aria-label="Show ritual log"
+                          aria-pressed={overviewPane === "log"} onClick={() => setOverviewPane("log")}>
+                          Log · {ritualLog.length}
+                        </button>
+                        <button type="button" className="focus-ring" aria-label="Show agenda thread"
+                          aria-pressed={overviewPane === "agenda"} onClick={() => setOverviewPane("agenda")}>
+                          Agenda thread
+                        </button>
+                        <span />
+                        <button type="button" className="focus-ring" aria-label="Show previous ritual pane"
+                          onClick={() => setOverviewPane("log")} disabled={overviewPane === "log"}>
+                          <Icon name="ph:caret-left" width={13} aria-hidden />
+                        </button>
+                        <button type="button" className="focus-ring" aria-label="Show next ritual pane"
+                          onClick={() => setOverviewPane("agenda")} disabled={overviewPane === "agenda"}>
+                          <Icon name="ph:caret-right" width={13} aria-hidden />
+                        </button>
+                      </div>
+                      <div
+                        className="rituals-overview__pane"
+                        onPointerDown={(event) => { overviewSwipeStartRef.current = event.clientX; }}
+                        onPointerUp={(event) => finishOverviewSwipe(event.clientX)}
+                        onPointerCancel={() => { overviewSwipeStartRef.current = null; }}
+                      >
+                        {overviewPane === "log" ? (
+                          <div className="rituals-overview__log">
+                            {ritualLog.length > 0 ? ritualLog.map((item) => (
+                              <RitualItemRow key={item.id} item={item} familiarLabel={familiarLabel}
+                                onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }} />
+                            )) : <p className="rituals-overview__empty">No quiet activity yet.</p>}
+                          </div>
+                        ) : (
+                          <RitualAgendaThread items={ritualAgenda} familiarLabel={familiarLabel}
+                            onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }} />
+                        )}
+                      </div>
+                    </section>
+                  </>
+                )}
               </>
             )
           ) : q && codexActive.length + codexPaused.length === 0 ? (

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1720,9 +1720,30 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   // viewport actually matches mobile. Keeps server/client markup in sync.
   const [viewMode, setViewMode] = useState<ViewMode>("week");
   const [anchor, setAnchor] = useState<Date>(new Date());
+  const [mobileRibbonDayOpen, setMobileRibbonDayOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const openDateValue = (date?: string | null) => {
+      if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
+      const next = new Date(`${date}T12:00:00`);
+      if (Number.isNaN(next.getTime())) return;
+      setAnchor(next);
+      setMobileRibbonDayOpen(true);
+      setViewMode("day");
+    };
+    const openDate = (event: Event) => {
+      openDateValue((event as CustomEvent<{ date?: string }>).detail?.date);
+    };
+    const pendingDate = window.sessionStorage.getItem("cave:calendar:pending-open-date");
+    if (pendingDate) {
+      window.sessionStorage.removeItem("cave:calendar:pending-open-date");
+      openDateValue(pendingDate);
+    }
+    window.addEventListener("cave:calendar:open-date", openDate);
+    return () => window.removeEventListener("cave:calendar:open-date", openDate);
+  }, []);
   // Week view needs ~7 usable columns; inside a narrow split tile (~360px)
   // they floor at ~40px each. Below 560px of CONTAINER width, week renders
   // with the day presentation instead — the user's stored week choice is
@@ -1760,8 +1781,14 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   // have a `min-w-[560px]` floor, which would overflow a 360px screen.
   // Lets the user swap back to a grid once they're on a tablet+.
   useEffect(() => {
-    if (isMobile && viewMode !== "agenda") setViewMode("agenda");
-  }, [isMobile, viewMode]);
+    if (isMobile && viewMode !== "agenda" && !(mobileRibbonDayOpen && viewMode === "day")) {
+      setMobileRibbonDayOpen(false);
+      setViewMode("agenda");
+    }
+  }, [isMobile, mobileRibbonDayOpen, viewMode]);
+  useEffect(() => {
+    if (viewMode !== "day" && mobileRibbonDayOpen) setMobileRibbonDayOpen(false);
+  }, [mobileRibbonDayOpen, viewMode]);
 
   // Hard-scope: filter every downstream view (agenda/day/week/month) to the
   // active familiar. Defensive null escape: bypass the filter entirely.

--- a/src/components/github-subscribe-ux.test.ts
+++ b/src/components/github-subscribe-ux.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // cave-hlxn: subscribing/unsubscribing to GitHub events is one click away
-// everywhere the events surface — the Rituals Inbox (manager + per-row
+// everywhere the events surface — the Rituals overview (manager + per-row
 // unwatch) and the GitHub surface (watch chip for the repo you're viewing).
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -8,11 +8,11 @@ import { readFileSync } from "node:fs";
 const automations = readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8");
 const githubView = readFileSync(new URL("./github-view.tsx", import.meta.url), "utf8");
 
-// ── Rituals Inbox: the Subscriptions manager is one click from the feed ──────
+// ── Rituals: the Subscriptions manager stays in the overview options menu ────
 assert.match(
   automations,
-  /leadingIcon="ph:github-logo"[\s\S]{0,200}Subscriptions/,
-  "the Inbox tab header offers a Subscriptions button",
+  /<PopoverItem icon="ph:github-logo"[\s\S]{0,200}Subscriptions/,
+  "the overview options menu offers Subscriptions",
 );
 assert.match(
   automations,
@@ -53,8 +53,8 @@ assert.match(
 );
 assert.match(
   automations,
-  /onUnwatch=\{\(item, repo\) => void unwatchRepo\(item, repo\)\}/,
-  "the feed wires the unwatch handler through to rows",
+  /<RitualNeedsRow[\s\S]{0,700}onUnwatch=\{\(next, repo\) => void unwatchRepo\(next, repo\)\}/,
+  "the visible Needs-you queue wires the unwatch handler through to GitHub rows",
 );
 
 // ── GitHub surface: watch the repo you're viewing ────────────────────────────

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -18,7 +18,7 @@ type Props = {
   /** Calendar surface rendered as the leading tab (merged schedule page). */
   calendarSlot?: ReactNode;
   /** Tab to open on mount — "calendar" deep-links the Calendar nav button. */
-  initialTab?: "inbox" | "calendar" | "crons";
+  initialTab?: "overview" | "calendar" | "crons";
 };
 
 export function InboxEscalationsView({

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -1,8 +1,7 @@
 // @ts-nocheck
 // The Rituals surface (nav id `inbox`, formerly "Schedules") is the
-// slimmed-down schedule home: Calendar plus Crons only. Full Automations/Flow
-// work lives on the feature branch and must not be surfaced from the main
-// navigation.
+// unified schedule home: a week ribbon, Needs-you queue, and manual Log/Agenda
+// switch. Full Calendar and Crons remain secondary operational destinations.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -10,6 +9,7 @@ const automations = readFileSync(new URL("./automations-view.tsx", import.meta.u
 const menuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const calendar = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const notificationBell = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 const slashCommands = readFileSync(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
@@ -64,53 +64,47 @@ assert.match(
   "/rituals plus legacy /schedules, /automations and /inbox aliases route to the inbox mode",
 );
 
-// ── Slim typed tab model ────────────────────────────────────────────────────
+// ── Unified overview model ──────────────────────────────────────────────────
 assert.match(
   automations,
-  /type AutomationTab = "inbox" \| "calendar" \| "crons"/,
-  "Surface exposes Inbox, Calendar, and Crons tabs",
+  /type AutomationTab = "overview" \| "calendar" \| "crons"/,
+  "Surface exposes Overview, Calendar, and Crons modes",
 );
 assert.match(
   automations,
-  // Inbox is the default landing tab; explicit deep links (Calendar nav,
-  // legacy crons links) may override on mount.
-  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*initialTab === "crons" \? "crons" : "inbox",?\s*\)/,
-  "Surface defaults to the Inbox tab unless a deep link asks otherwise",
+  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*initialTab === "crons" \? "crons" : "overview",?\s*\)/,
+  "Surface defaults to the unified overview unless a deep link asks otherwise",
 );
 assert.match(automations, /<h1[\s\S]*?>\s*Rituals\s*<\/h1>/, "Surface header reads Rituals");
-assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Tabs use the shared segment Tabs");
-
-// Tabs present, in order: Inbox first (the landing tab), then Calendar, Crons.
-assert.match(automations, /\{ id: "inbox" as const, label: "Inbox", count: inboxFeed\.needsYou\.length \}/, "Inbox tab with the needs-you count");
-assert.match(automations, /\{ id: "calendar" as const, label: "Calendar" \}/, "Calendar tab");
-assert.match(automations, /\{ id: "crons", label: "Crons", count: codexAutos\.length \}/, "Crons tab");
-assert.doesNotMatch(automations, /\{ id: "all", label: "All"/, "All tab moved out with Automations");
-assert.doesNotMatch(automations, /\{ id: "reminders", label: "Reminders"/, "Reminders tab moved out with Automations");
-assert.doesNotMatch(automations, /\{ id: "flows", label: "Flows"/, "Flows tab moved to the feature branch");
-assert.doesNotMatch(automations, /\{ id: "activity", label: "Activity"/, "Activity tab moved out with Automations");
-assert.doesNotMatch(automations, /\{ id: "templates", label: "Templates"/, "Templates tab moved out with Automations");
 assert.match(
   automations,
-  /id: "inbox"[\s\S]*id: "calendar"[\s\S]*id: "crons"/,
-  "tabs ordered Inbox, Calendar, Crons",
-);
-// The Inbox tab renders the full grouped feed and lands there by default from
-// the workspace (Calendar deep links still open Calendar).
-assert.match(
-  automations,
-  /activeTab === "inbox" \?[\s\S]*?<InboxFeedList/,
-  "the Inbox tab renders the grouped inbox feed",
+  /aria-label="Toggle events ribbon"[\s\S]*Needs you · \{inboxFeed\.needsYou\.length\}[\s\S]*aria-label="Show ritual log"[\s\S]*aria-label="Show agenda thread"/,
+  "overview follows the handoff hierarchy: week ribbon, Needs-you queue, then Log/Agenda",
 );
 assert.match(
   automations,
-  /<InboxFeedList[\s\S]*?onDone=\{\(item\) => void completeInboxItem\(item\)\}[\s\S]*?onSnooze=\{\(item\) => void snoozeInboxItem\(item\)\}[\s\S]*?onDismiss=\{\(item\) => void dismissInboxItem\(item\)\}/,
-  "feed rows wire Done / Snooze / Dismiss to the inbox action endpoints",
+  /onPointerDown=\{\(event\) => \{ overviewSwipeStartRef\.current = event\.clientX; \}\}[\s\S]*onPointerUp=\{\(event\) => finishOverviewSwipe\(event\.clientX\)\}/,
+  "Log and Agenda switch only through explicit controls or a manual swipe",
+);
+assert.match(
+  automations,
+  /<RitualNeedsRow[\s\S]*?onDone=\{\(next\) => void completeInboxItem\(next\)\}[\s\S]*?onSnooze=\{\(next\) => void snoozeInboxItem\(next\)\}[\s\S]*?onDismiss=\{\(next\) => void dismissInboxItem\(next\)\}/,
+  "Needs-you rows wire Done / Snooze / Dismiss to the inbox action endpoints",
 );
 assert.match(
   workspace,
-  /initialTab=\{mode === "calendar" \? "calendar" : "inbox"\}/,
-  "Workspace lands the surface on Inbox unless the Calendar deep link asked for Calendar",
+  /initialTab=\{mode === "calendar" \? "calendar" : "overview"\}/,
+  "Workspace lands on the overview unless the Calendar deep link asked for Calendar",
 );
+assert.match(automations, /setActiveTab\("calendar"\)|selectTab\("calendar"\)/, "the full Calendar remains reachable");
+assert.match(automations, /setActiveTab\("crons"\)|selectTab\("crons"\)/, "Cron management remains reachable");
+assert.match(automations, /sessionStorage\.setItem\("cave:calendar:pending-open-date", day\.key\)[\s\S]{0,100}selectTab\("calendar"\)/, "a ribbon day queues its date before Calendar mounts");
+assert.match(calendar, /sessionStorage\.getItem\("cave:calendar:pending-open-date"\)[\s\S]{0,180}openDateValue\(pendingDate\)/, "Calendar consumes a queued ribbon date on mount");
+assert.match(calendar, /addEventListener\("cave:calendar:open-date", openDate\)/, "Calendar accepts a day selected from the overview ribbon");
+assert.match(calendar, /setAnchor\(next\);[\s\S]{0,140}setViewMode\("day"\)/, "a ribbon day opens the matching single-day calendar");
+assert.match(calendar, /mobileRibbonDayOpen && viewMode === "day"/, "mobile preserves an explicitly selected ribbon day instead of forcing Agenda");
+assert.match(automations, /function useRitualNow\(\): Date \| null[\s\S]{0,560}setNow\(new Date\(\)\);[\s\S]{0,80}scheduleMidnight/, "the hydration-stable week clock starts in the browser and refreshes at local midnight");
+assert.match(automations, /ritualNow \? buildRitualWeek\(inboxVisible, ritualNow\) : \[\]/, "the week ribbon waits for the browser-local date before derivation");
 assert.doesNotMatch(sidebar, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");
 
 assert.doesNotMatch(automations, /listFlows\(\)/, "Rituals does not load flow docs");

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -14,8 +14,9 @@ assert.match(vault, /No secrets match/, "vault shows a no-matches message");
 
 const auto = read("./automations-view.tsx");
 assert.match(auto, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "automations imports SearchInput");
-assert.match(auto, /<SearchInput[\s\S]*?aria-label=\{activeTab === "inbox" \? "Filter inbox" : "Filter crons"\}/, "automations renders a tab-scoped filter (inbox/crons)");
-// The text filter applies to both tabs' source derivations (the inbox feed is
+assert.match(auto, /placeholder="Filter rituals…"[\s\S]*?aria-label="Filter rituals"/, "the Rituals overview exposes its compact search on demand");
+assert.match(auto, /placeholder="Filter crons…"[\s\S]*?aria-label="Filter crons"/, "Cron management retains a scoped text filter");
+// The text filter applies to both modes' source derivations (the overview is
 // the selection universe, so a live search term = "every match").
 assert.match(auto, /items\.filter\(\(it\) => !hiddenIds\.has\(it\.id\) && \(!q \|\| \(it\.title \?\? ""\)\.toLowerCase\(\)\.includes\(q\)\)\)/, "the inbox feed honors the text filter");
 assert.match(auto, /a\.name\.toLowerCase\(\)\.includes\(q\)/, "automations honor the text filter");

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -44,7 +44,7 @@ assert.match(
 assert.equal(MODE_ALIASES.calendar, "inbox");
 assert.match(
   workspace,
-  /mode === "inbox" \|\| mode === "calendar"[\s\S]{0,400}?key=\{mode\}\s+initialTab=\{mode === "calendar" \? "calendar" : "inbox"\}/,
+  /mode === "inbox" \|\| mode === "calendar"[\s\S]{0,400}?key=\{mode\}\s+initialTab=\{mode === "calendar" \? "calendar" : "overview"\}/,
   "the calendar alias renders the Rituals surface on its Calendar tab (keyed remount)",
 );
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2750,7 +2750,7 @@ export function Workspace() {
       // remounts so the deep link lands on it.
       <InboxEscalationsView
         key={mode}
-        initialTab={mode === "calendar" ? "calendar" : "inbox"}
+        initialTab={mode === "calendar" ? "calendar" : "overview"}
         onOpenSource={(item) => {
           if (item.sourceSessionKey) {
             openFamiliarSession(item.sourceSessionKey);

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -44,7 +44,7 @@ const BASELINES = {
   offScaleSpacingPx: 1349, // off-4px-grid pad/margin/gap components (2px/6px/10px/…) — +4: the chat composer footer band copies the home hc-footer-band metrics verbatim (6px 10px pad, 6px gap, 11px chip pad) for cross-composer parity
   offScaleRadiusPx: 212, // 4px/6px/10px/14px/… radii between the sanctioned steps
   hexOutsideDefinitions: 155, // hex in render CSS (token definitions excluded)
-  inlineTsxStyles: 501, // style={{…}} in TSX; many are legit dynamic values
+  inlineTsxStyles: 500, // style={{…}} in TSX; many are legit dynamic values
 };
 
 // ── unit sanity for the codemod transform ───────────────────────────────────

--- a/src/lib/rituals-overview.test.ts
+++ b/src/lib/rituals-overview.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { InboxItem } from "./cave-inbox.ts";
+import { buildRitualWeek, ritualAgendaItems, ritualLogItems } from "./rituals-overview.ts";
+
+function item(id: string, overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id,
+    kind: "reminder",
+    title: id,
+    status: "pending",
+    createdAt: "2026-07-01T12:00:00.000Z",
+    updatedAt: "2026-07-01T12:00:00.000Z",
+    recurrence: { type: "none" },
+    source: "user",
+    ...overrides,
+  };
+}
+
+describe("buildRitualWeek", () => {
+  it("returns the Sunday-starting week and marks scheduled days", () => {
+    const week = buildRitualWeek(
+      [item("friday", { fireAt: "2026-07-17T14:00:00.000Z" })],
+      new Date("2026-07-17T16:00:00.000Z"),
+    );
+
+    assert.deepEqual(week.map((day) => day.key), [
+      "2026-07-12",
+      "2026-07-13",
+      "2026-07-14",
+      "2026-07-15",
+      "2026-07-16",
+      "2026-07-17",
+      "2026-07-18",
+    ]);
+    assert.equal(week[5]?.isToday, true);
+    assert.equal(week[5]?.hasItems, true);
+  });
+
+  it("moves to the next week at Sunday midnight", () => {
+    const saturday = buildRitualWeek([], new Date("2026-07-18T16:00:00.000Z"));
+    const sunday = buildRitualWeek([], new Date("2026-07-19T16:00:00.000Z"));
+
+    assert.equal(saturday[0]?.key, "2026-07-12");
+    assert.equal(sunday[0]?.key, "2026-07-19");
+    assert.equal(sunday[0]?.isToday, true);
+  });
+});
+
+describe("ritual item ordering", () => {
+  const items = [
+    item("later", { fireAt: "2026-07-20T12:00:00.000Z", updatedAt: "2026-07-03T12:00:00.000Z" }),
+    item("sooner", { fireAt: "2026-07-19T12:00:00.000Z", updatedAt: "2026-07-04T12:00:00.000Z" }),
+    item("dismissed", { status: "dismissed", fireAt: "2026-07-18T12:00:00.000Z" }),
+  ];
+
+  it("sorts the agenda forward and excludes dismissed items", () => {
+    assert.deepEqual(ritualAgendaItems(items).map(({ id }) => id), ["sooner", "later"]);
+  });
+
+  it("sorts the activity log newest first and excludes dismissed items", () => {
+    assert.deepEqual(ritualLogItems(items).map(({ id }) => id), ["sooner", "later"]);
+  });
+});

--- a/src/lib/rituals-overview.test.ts
+++ b/src/lib/rituals-overview.test.ts
@@ -19,9 +19,10 @@ function item(id: string, overrides: Partial<InboxItem> = {}): InboxItem {
 
 describe("buildRitualWeek", () => {
   it("returns the Sunday-starting week and marks scheduled days", () => {
+    const friday = new Date(2026, 6, 17, 14);
     const week = buildRitualWeek(
-      [item("friday", { fireAt: "2026-07-17T14:00:00.000Z" })],
-      new Date("2026-07-17T16:00:00.000Z"),
+      [item("friday", { fireAt: friday.toISOString() })],
+      new Date(2026, 6, 17, 16),
     );
 
     assert.deepEqual(week.map((day) => day.key), [
@@ -38,8 +39,8 @@ describe("buildRitualWeek", () => {
   });
 
   it("moves to the next week at Sunday midnight", () => {
-    const saturday = buildRitualWeek([], new Date("2026-07-18T16:00:00.000Z"));
-    const sunday = buildRitualWeek([], new Date("2026-07-19T16:00:00.000Z"));
+    const saturday = buildRitualWeek([], new Date(2026, 6, 18, 16));
+    const sunday = buildRitualWeek([], new Date(2026, 6, 19, 16));
 
     assert.equal(saturday[0]?.key, "2026-07-12");
     assert.equal(sunday[0]?.key, "2026-07-19");

--- a/src/lib/rituals-overview.ts
+++ b/src/lib/rituals-overview.ts
@@ -1,0 +1,74 @@
+import type { InboxItem } from "@/lib/cave-inbox";
+
+export type RitualDay = {
+  date: Date;
+  key: string;
+  weekday: string;
+  day: number;
+  isToday: boolean;
+  hasItems: boolean;
+};
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function dateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function itemTime(item: InboxItem, mode: "agenda" | "log"): number {
+  const iso =
+    mode === "agenda"
+      ? item.fireAt ?? item.firedAt ?? item.updatedAt
+      : item.firedAt ?? item.updatedAt ?? item.createdAt;
+  const parsed = Date.parse(iso);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function visibleItems(items: InboxItem[]): InboxItem[] {
+  return items.filter((item) => item.status !== "dismissed");
+}
+
+export function buildRitualWeek(items: InboxItem[], now = new Date()): RitualDay[] {
+  const today = startOfDay(now);
+  const sunday = new Date(today);
+  sunday.setDate(today.getDate() - today.getDay());
+  const scheduledDays = new Set(
+    visibleItems(items)
+      .map((item) => item.fireAt ?? item.firedAt)
+      .filter((iso): iso is string => Boolean(iso))
+      .map((iso) => {
+        const date = new Date(iso);
+        return Number.isNaN(date.getTime()) ? "" : dateKey(date);
+      })
+      .filter(Boolean),
+  );
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(sunday);
+    date.setDate(sunday.getDate() + index);
+    const key = dateKey(date);
+    return {
+      date,
+      key,
+      weekday: new Intl.DateTimeFormat(undefined, { weekday: "narrow" }).format(date),
+      day: date.getDate(),
+      isToday: date.getTime() === today.getTime(),
+      hasItems: scheduledDays.has(key),
+    };
+  });
+}
+
+export function ritualAgendaItems(items: InboxItem[]): InboxItem[] {
+  return visibleItems(items)
+    .filter((item) => Boolean(item.fireAt ?? item.firedAt))
+    .sort((a, b) => itemTime(a, "agenda") - itemTime(b, "agenda"));
+}
+
+export function ritualLogItems(items: InboxItem[]): InboxItem[] {
+  return visibleItems(items).sort((a, b) => itemTime(b, "log") - itemTime(a, "log"));
+}


### PR DESCRIPTION
## Summary
- replace visible Rituals tabs with the approved minimalist overview: collapsible week ribbon, Needs-you queue, and manual Log/Agenda panes
- preserve Calendar, Crons, subscriptions, selection, reminder actions, and GitHub Unwatch flows behind the unified surface
- add hydration-safe local-midnight rollover and reliable mobile ribbon-to-Day navigation

## Test plan
- [x] `pnpm test:app` (789 test files)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] 390x844 Playwright interaction: ribbon-selected date remains in Calendar Day view
- [x] final code review: no significant issues

Bead: `cave-xwiu`