### PR TITLE
fix(onboarding): close first-project gate bypasses

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -575,10 +575,10 @@ tr[role="checkbox"]:focus-visible {
  * would lose sync if the shell-detail scroll container drifts.
  * Also ensure the cave-mode-fade wrapper stretches to fill the detail
  * panel so the browser toolbar row is always visible. */
-.shell-detail:has(> .cave-mode-fade > .browser-pane) {
+.shell-detail:has(> .cave-mode-fade > .workspace-detail-content > .browser-pane) {
   overflow: hidden;
 }
-.shell-detail > .cave-mode-fade:has(> .browser-pane) {
+.shell-detail > .cave-mode-fade:has(> .workspace-detail-content > .browser-pane) {
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
@@ -588,7 +588,7 @@ tr[role="checkbox"]:focus-visible {
 /* Home composer spans the viewport width when one or both side panels are
  * open; it needs overflow: visible on the detail panel to paint outside its
  * bounds when translateX shifts the composer. */
-.shell-detail-panel:has(> .shell-detail > .cave-mode-fade > .home-composer-root) {
+.shell-detail-panel:has(> .shell-detail > .cave-mode-fade > .workspace-detail-content > .home-composer-root) {
   overflow: visible !important;
 }
 
@@ -8594,7 +8594,7 @@ a.mobile-handoff__link:hover {
    can be adjusted without threading conditional class strings through every
    row. */
 @media (max-width: 767px) {
-  .shell-detail:has(> .cave-mode-fade > .chat-surface) {
+  .shell-detail:has(> .cave-mode-fade > .workspace-detail-content > .chat-surface) {
     overflow: hidden;
   }
 

--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.shell-detail:has\(> \.cave-mode-fade > \.chat-surface\)\s*\{[\s\S]*overflow\s*:\s*hidden/,
-  "Mobile chat should prevent the shell detail from becoming a second scroll owner",
+  /@media \(max-width: 767px\) \{[\s\S]*\.shell-detail:has\(> \.cave-mode-fade > \.workspace-detail-content > \.chat-surface\)\s*\{[\s\S]*overflow\s*:\s*hidden/,
+  "Mobile chat should prevent the shell detail from becoming a second scroll owner through the inertable detail wrapper",
 );
 
 // The Inspector/Debug/Changes right sidebar is retired — the code rail is the

--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -67,7 +67,10 @@ test("Shell hosts the split inside the detail main with a drop zone", () => {
 test("workspace owns split state and the drop handler, and reuses renderSurface", () => {
   const src = read("./workspace.tsx");
   assert.match(src, /const \[splitTargets, setSplitTargets\] = useState<SplitTarget\[\]>\(\[\]\)/);
+  assert.match(src, /function splitTargetRendersMode\(target: SplitTarget, mode: CanonicalWorkspaceMode\): boolean \{[\s\S]*resolveWorkspaceModeAlias\(target\.mode\) === mode/, "split-target mode guards canonicalize aliases before matching");
+  assert.match(src, /const addSplitTarget = useCallback\(\(target: SplitTarget, side: "left" \| "right" = "right"\) => \{[\s\S]*if \(chatProjectBlockedRef\.current && splitTargetRendersMode\(target, "chat"\)\) \{[\s\S]*setMode\("home"\);[\s\S]*return;[\s\S]*\}[\s\S]*addSecondaryWorkspaceTile/, "blocked chat surfaces bounce to Home instead of entering the split");
   assert.match(src, /const openSplitPage = useCallback/);
+  assert.match(src, /if \(!m \|\| m === mode \|\| !isWorkspaceMode\(m\)\) return;[\s\S]*addSplitTarget\(\{ kind: "page", mode: m \}, side\);/, "split drops validate the workspace mode before adding a page tile");
   assert.match(src, /addSecondaryWorkspaceTile/, "workspace appends split pages up to the secondary tile cap");
   assert.match(src, /const renderSurface = \(mode: CaveMode\): ReactNode =>/);
   assert.match(src, /const detailContent = renderSurface\(mode\);[\s\S]*\{detailContent\}/, "primary renders the direct detail child from renderSurface");

--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -28,7 +28,7 @@ test("the gate copy makes project creation mandatory for chat", () => {
   assert.match(src, /Chat requires a project/, "copy explains that chat cannot proceed without a project");
 });
 
-test("the gate stays prop-driven and focuses the name field on first visibility", () => {
+test("the gate stays prop-driven and focuses the correct first control on first visibility", () => {
   const src = read("./first-project-gate.tsx");
   assert.match(
     src,
@@ -36,6 +36,7 @@ test("the gate stays prop-driven and focuses the name field on first visibility"
     "the gate stays prop-driven with the required integration fields",
   );
   assert.match(src, /const nameInputRef = useRef<HTMLInputElement \| null>\(null\);/, "keeps a stable ref for the project-name field");
+  assert.match(src, /const submitButtonRef = useRef<HTMLButtonElement \| null>\(null\);/, "keeps a stable ref for the primary action");
   assert.match(
     src,
     /if \(!open\) \{\s*wasVisibleRef\.current = false;\s*return;\s*\}\s*if \(wasVisibleRef\.current\) return;/,
@@ -43,10 +44,11 @@ test("the gate stays prop-driven and focuses the name field on first visibility"
   );
   assert.match(
     src,
-    /window\.requestAnimationFrame\(\(\) => \{\s*nameInputRef\.current\?\.focus\(\{ preventScroll: true \}\);\s*\}\);/,
-    "requestAnimationFrame restores initial focus to the name field after the panel opens",
+    /const initialFocusTarget = registeredProject \? submitButtonRef\.current : nameInputRef\.current;[\s\S]*window\.requestAnimationFrame\(\(\) => \{\s*initialFocusTarget\?\.focus\(\{ preventScroll: true \}\);\s*\}\);/,
+    "requestAnimationFrame restores initial focus to Retry access when pending, otherwise the name field",
   );
   assert.match(src, /ref=\{nameInputRef\}/, "the stable focus ref is wired to the project-name input");
+  assert.match(src, /ref=\{submitButtonRef\}/, "the stable submit ref is wired to the primary action");
   assert.doesNotMatch(src, /autoFocus/, "initial focus no longer depends on DOM-order-sensitive autoFocus");
 });
 
@@ -96,8 +98,8 @@ test("workspace wires the first-project gate through pending-aware policy and re
   );
   assert.match(
     src,
-    /const \{ open: firstProjectGateOpen, familiarId: projectGateFamiliarId \} = resolveFirstProjectGatePolicy\(\{[\s\S]*pendingGrant: reconciledPendingFirstProjectGrant,[\s\S]*\}\);/,
-    "workspace policy opens the gate for zero-project or pending-retry states only after the shared eligibility checks pass",
+    /const \{[\s\S]*open: firstProjectGateOpen,[\s\S]*familiarId: projectGateFamiliarId,[\s\S]*blockChatLaunch: chatProjectBlocked,[\s\S]*\} = resolveFirstProjectGatePolicy\(\{[\s\S]*pendingGrant: reconciledPendingFirstProjectGrant,[\s\S]*\}\);/,
+    "workspace policy derives both gate visibility and the central chat-block condition from the shared helper",
   );
   assert.match(
     src,
@@ -106,13 +108,8 @@ test("workspace wires the first-project gate through pending-aware policy and re
   );
   assert.match(
     src,
-    /const detailContent = renderSurface\(mode\);[\s\S]*const detail = \([\s\S]*\{firstProjectGateOpen \? \([\s\S]*<FirstProjectGate[\s\S]*\) : null\}[\s\S]*\{detailContent\}[\s\S]*<\/div>/,
-    "workspace renders the gate as an absolute sibling overlay inside the detail container while leaving the surface itself as the same direct child",
-  );
-  assert.doesNotMatch(
-    src,
-    /<div aria-hidden=\{firstProjectGateOpen \|\| undefined\} inert=\{firstProjectGateOpen \|\| undefined\}>[\s\S]*\{renderSurface\(mode\)\}[\s\S]*<\/div>/,
-    "workspace no longer inserts an intermediate detail wrapper between cave-mode-fade and the rendered surface",
+    /const detailContent = renderSurface\(mode\);[\s\S]*const detail = \([\s\S]*\{firstProjectGateOpen \? \([\s\S]*<FirstProjectGate[\s\S]*\) : null\}[\s\S]*<div[\s\S]*className="workspace-detail-content flex h-full min-h-0 min-w-0 flex-1 flex-col"[\s\S]*aria-hidden=\{firstProjectGateOpen \? true : undefined\}[\s\S]*inert=\{firstProjectGateOpen \|\| undefined\}[\s\S]*>\s*\{detailContent\}\s*<\/div>[\s\S]*<\/div>/,
+    "workspace renders the gate as an absolute sibling overlay and puts the underlying surface inside an inert, full-height wrapper",
   );
   assert.match(src, /mode === "chat" \? \(\s*<ChatSurface/, "Chat stays a direct render branch");
   assert.match(src, /mode === "browser" \? \(\s*<BrowserPane/, "Browser stays a direct render branch");
@@ -182,6 +179,7 @@ test("the gate keeps drafts through failures, blocks blank or busy submits, and 
   assert.match(src, /disabled=\{submitting \|\| loadingProjects \|\| Boolean\(projectsError\) \|\| !canSubmit\}/, "creation stays blocked while the registry is still loading or errored");
   assert.match(src, /disabled=\{Boolean\(registeredProject\) \|\| submitting\}/, "name, root, and Browse controls lock once only the access grant needs retry");
   assert.match(src, /\{registeredProject \? "Retry access" : "Create"\}/, "the submit action relabels to Retry access for partial-grant retries");
+  assert.match(src, /ref=\{submitButtonRef\}/, "Retry access can receive initial focus via the enabled submit button");
   assert.match(src, /Project <span className="font-medium text-\[var\(--text-primary\)\]">\{registeredProject\.name\}<\/span> was[\s\S]*Retry access so the required familiar can use[\s\S]*\{registeredProject\.root\}/, "copy explains that the project was created and only access still needs retry without rebinding to another familiar");
   assert.doesNotMatch(src, /Project created, but chat still needs access:/, "retry context lives in the descriptive copy, not as a prefixed error wrapper");
 });

--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -103,6 +103,11 @@ test("workspace wires the first-project gate through pending-aware policy and re
   );
   assert.match(
     src,
+    /useEffect\(\(\) => \{\s*if \(!chatProjectBlocked\) return;[\s\S]*setSplitTargets\(\(prev\) => \{[\s\S]*prev\.filter\(\(target\) => !splitTargetRendersMode\(target, "chat"\)\)[\s\S]*return next\.length === prev\.length \? prev : next;[\s\S]*\}\);\s*\}, \[chatProjectBlocked\]\);/,
+    "when chat becomes authoritatively blocked, workspace prunes any existing chat-rendering split tiles while preserving non-chat ordering",
+  );
+  assert.match(
+    src,
     /<FirstProjectGate[\s\S]*familiarId=\{projectGateFamiliarId\}[\s\S]*pendingGrant=\{reconciledPendingFirstProjectGrant\}[\s\S]*onPendingGrantChange=\{setPendingFirstProjectGrant\}[\s\S]*loadingProjects=\{projectsLoading\}[\s\S]*projectsError=\{projectsError\}[\s\S]*createProjectOrThrow=\{createProjectOrThrow\}[\s\S]*reloadProjects=\{reloadProjects\}/,
     "workspace passes the policy target, reconciled pending retry, and update callback into the gate",
   );

--- a/src/components/first-project-gate.tsx
+++ b/src/components/first-project-gate.tsx
@@ -61,6 +61,7 @@ export function FirstProjectGate({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
+  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const wasVisibleRef = useRef(false);
   const titleId = useId();
   const copyId = useId();
@@ -80,11 +81,12 @@ export function FirstProjectGate({
     if (wasVisibleRef.current) return;
 
     wasVisibleRef.current = true;
+    const initialFocusTarget = registeredProject ? submitButtonRef.current : nameInputRef.current;
     const frame = window.requestAnimationFrame(() => {
-      nameInputRef.current?.focus({ preventScroll: true });
+      initialFocusTarget?.focus({ preventScroll: true });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [open]);
+  }, [open, registeredProject]);
 
   const applyPickedRoot = useCallback((dir: string) => {
     const trimmed = dir.trim();
@@ -313,6 +315,7 @@ export function FirstProjectGate({
 
                 <div className="flex items-center justify-end">
                   <Button
+                    ref={submitButtonRef}
                     type="submit"
                     variant="primary"
                     size="sm"

--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -205,8 +205,8 @@ const globals = await readFile(
 );
 assert.match(
   globals,
-  /\.shell-detail-panel:has\(> \.shell-detail > \.cave-mode-fade > \.home-composer-root\)\s*\{\s*overflow:\s*visible\s*!important/,
-  "globals.css opens .shell-detail-panel overflow when it contains the home composer",
+  /\.shell-detail-panel:has\(> \.shell-detail > \.cave-mode-fade > \.workspace-detail-content > \.home-composer-root\)\s*\{\s*overflow:\s*visible\s*!important/,
+  "globals.css opens .shell-detail-panel overflow when it contains the home composer through the inertable detail wrapper",
 );
 
 console.log("home-composer-centering.test.ts: ok");

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -41,6 +41,18 @@ assert.match(
   /addChatProject\(\{[\s\S]{0,220}?familiarId: activeFamiliarId,[\s\S]{0,220}?existingProjectId: project\.id,[\s\S]{0,220}?projectJustCreated: true/,
   "Creating a project should also grant it to the scoped familiar and mark partial grant failures as newly-created registry entries",
 );
+assert.match(projectsView, /const \[projectError, setProjectError\] = useState<string \| null>\(null\)/, "project-creation failures track their own alert state");
+assert.match(
+  projectsView,
+  /setCreating\(true\);[\s\S]*try \{[\s\S]*const project = await createProject\(name, root, \{ emitMutation: !activeFamiliarId \}\);[\s\S]*\} catch \(error\) \{[\s\S]*setProjectError\(error instanceof Error \? error\.message : "Could not create that project\."\);[\s\S]*\} finally \{[\s\S]*setCreating\(false\);[\s\S]*\}/,
+  "handleCreate uses try/finally so the busy state always clears, even if create or grant unexpectedly throws",
+);
+assert.match(projectsView, /if \(!granted\.ok\) setProjectError\(`Project created, but grant failed: \$\{granted\.error\}`\);/, "grant failures still surface as explicit project alerts");
+assert.match(
+  projectsView,
+  /projectError \? \([\s\S]{0,500}?<span className="min-w-0 truncate">\{projectError\}<\/span>[\s\S]{0,260}?onClick=\{\(\) => setProjectError\(null\)\}/,
+  "project alerts render independently from chat-delete errors and can be dismissed",
+);
 assert.match(projectsView, /const rootInputRef = useRef<HTMLInputElement>\(null\)/, "new-project flow keeps a root input ref for quick focus");
 assert.match(projectsView, /function openCreateProjectForm/, "ProjectsView should centralize opening the quick-create form");
 assert.match(projectsView, /rootInputRef\.current\?\.focus\(\)/, "quick-create can focus the path field directly");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -111,6 +111,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   const [rootDraft, setRootDraft] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [projectError, setProjectError] = useState<string | null>(null);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [moveToast, setMoveToast] = useState<{ sessionId: string; prevRoot: string | null; label: string } | null>(null);
   // Bulk delete is deferred + undoable: the rows hide immediately, the actual
@@ -378,29 +379,35 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     const root = rootDraft.trim();
     if (!name || !root) return;
     setCreating(true);
-    const project = await createProject(name, root, { emitMutation: !activeFamiliarId });
-    if (project && activeFamiliarId) {
-      // Register alone leaves the project 403ing in chat for this familiar —
-      // grant it here so "New project" is usable the moment it's created.
-      const granted = await addChatProject({
-        root,
-        familiarId: activeFamiliarId,
-        createProject,
-        existingProjectId: project.id,
-        projectJustCreated: true,
-      });
-      if (!granted.ok) setSessionError(`Project created, but grant failed: ${granted.error}`);
+    setProjectError(null);
+    try {
+      const project = await createProject(name, root, { emitMutation: !activeFamiliarId });
+      if (project && activeFamiliarId) {
+        // Register alone leaves the project 403ing in chat for this familiar —
+        // grant it here so "New project" is usable the moment it's created.
+        const granted = await addChatProject({
+          root,
+          familiarId: activeFamiliarId,
+          createProject,
+          existingProjectId: project.id,
+          projectJustCreated: true,
+        });
+        if (!granted.ok) setProjectError(`Project created, but grant failed: ${granted.error}`);
+      }
+      if (!project) return;
+      setNameDraft("");
+      setRootDraft("");
+      setShowForm(false);
+      setQuery("");
+      // Land on the new project's detail pane — its New chat button is the
+      // follow-up action (replaces the old "Created X" banner).
+      selectProject(project.id);
+      announce(`Created project ${name}.`);
+    } catch (error) {
+      setProjectError(error instanceof Error ? error.message : "Could not create that project.");
+    } finally {
+      setCreating(false);
     }
-    setCreating(false);
-    if (!project) return;
-    setNameDraft("");
-    setRootDraft("");
-    setShowForm(false);
-    setQuery("");
-    // Land on the new project's detail pane — its New chat button is the
-    // follow-up action (replaces the old "Created X" banner).
-    selectProject(project.id);
-    announce(`Created project ${name}.`);
   };
 
   // A folder was chosen (native dialog or in-app browser) → fill the path, and
@@ -410,6 +417,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     if (!trimmed) return;
     setRootDraft(trimmed);
     setNameDraft((current) => (current.trim() ? current : pathBasename(trimmed)));
+    setProjectError(null);
     rootInputRef.current?.focus();
   };
 
@@ -694,7 +702,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
         }}
       />
 
-      {(error && projects.length > 0) || sessionError ? (
+      {(error && projects.length > 0) || projectError || sessionError ? (
         <div className="shrink-0 space-y-2 px-4 pt-3 sm:px-6">
           {error && projects.length > 0 ? (
             <div
@@ -709,6 +717,22 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
                 className="shrink-0 rounded-[var(--radius-control)] border border-[var(--color-danger)]/40 px-2 py-0.5 text-[11px] hover:bg-[var(--color-danger)]/15"
               >
                 Retry
+              </Button>
+            </div>
+          ) : null}
+          {projectError ? (
+            <div
+              role="alert"
+              className="flex items-center justify-between gap-3 rounded-[var(--radius-control)] border border-[var(--color-danger)]/40 bg-[var(--color-danger)]/10 px-3 py-2 text-[12px] text-[var(--color-danger)]"
+            >
+              <span className="min-w-0 truncate">{projectError}</span>
+              <Button
+                variant="danger-ghost"
+                size="xs"
+                onClick={() => setProjectError(null)}
+                className="shrink-0 rounded-[var(--radius-control)] border border-[var(--color-danger)]/40 px-2 py-0.5 text-[11px] hover:bg-[var(--color-danger)]/15"
+              >
+                Dismiss
               </Button>
             </div>
           ) : null}

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -53,7 +53,7 @@ assert.match(
 
 assert.match(
   workspace,
-  /const startFamiliarChat = useCallback\([\s\S]*setPendingChatAction\(\{[\s\S]*kind: "new"[\s\S]*familiarId[\s\S]*projectRoot[\s\S]*nonce: Date\.now\(\)[\s\S]*\}\)[\s\S]*setMode\("chat"\)/,
+  /const startFamiliarChat = useCallback\([\s\S]*if \(chatProjectBlockedRef\.current\) \{[\s\S]*setMode\("home"\);[\s\S]*return;[\s\S]*\}[\s\S]*setPendingChatAction\(\{[\s\S]*kind: "new"[\s\S]*familiarId[\s\S]*projectRoot[\s\S]*nonce: Date\.now\(\)[\s\S]*\}\)[\s\S]*setMode\("chat"\)/,
   "New chat should enqueue a pending chat action before entering chat mode",
 );
 

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -200,6 +200,16 @@ assert.match(
   /if \(chatProjectBlockedRef\.current\) \{[\s\S]*if \(familiarId\) setActiveId\(familiarId\);[\s\S]*setMode\("home"\);[\s\S]*return;[\s\S]*\}/,
   "startFamiliarChat bounces blocked launches to Home so the first-project gate becomes visible without queuing a chat",
 );
+assert.match(
+  workspace,
+  /const addSplitTarget = useCallback\(\(target: SplitTarget, side: "left" \| "right" = "right"\) => \{[\s\S]*if \(chatProjectBlockedRef\.current && splitTargetRendersMode\(target, "chat"\)\) \{[\s\S]*setMode\("home"\);[\s\S]*return;[\s\S]*\}[\s\S]*setSplitSide\(side\);/,
+  "Workspace blocks chat-rendering split targets under the first-project gate and reroutes the primary pane to Home",
+);
+assert.match(
+  workspace,
+  /useEffect\(\(\) => \{\s*if \(!chatProjectBlocked\) return;[\s\S]*setSplitTargets\(\(prev\) => \{[\s\S]*prev\.filter\(\(target\) => !splitTargetRendersMode\(target, "chat"\)\)[\s\S]*return next\.length === prev\.length \? prev : next;[\s\S]*\}\);\s*\}, \[chatProjectBlocked\]\);/,
+  "Workspace drops any already-open chat split tiles once the shared gate condition turns on",
+);
 assert.doesNotMatch(
   workspace,
   /const activeId = scopeIds\.size === 1 \? \[\.\.\.scopeIds\]\[0\]! : null/,

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -187,8 +187,18 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const \{ open: firstProjectGateOpen, familiarId: projectGateFamiliarId \} = resolveFirstProjectGatePolicy\(\{[\s\S]*visibleFamiliars,[\s\S]*familiarRosterLoadedSuccessfully,[\s\S]*\}\);/,
-  "the first-project gate target and visibility are derived together from the loaded non-archived roster through the shared policy helper",
+  /const \{[\s\S]*open: firstProjectGateOpen,[\s\S]*familiarId: projectGateFamiliarId,[\s\S]*blockChatLaunch: chatProjectBlocked,[\s\S]*\} = resolveFirstProjectGatePolicy\(\{[\s\S]*visibleFamiliars,[\s\S]*familiarRosterLoadedSuccessfully,[\s\S]*\}\);/,
+  "the first-project gate target, visibility, and chat-block state are derived together from the loaded non-archived roster through the shared policy helper",
+);
+assert.match(
+  workspace,
+  /const chatProjectBlockedRef = useRef\(chatProjectBlocked\);[\s\S]*chatProjectBlockedRef\.current = chatProjectBlocked;/,
+  "Workspace mirrors the mode-independent chat-blocked condition into a ref for central new-chat guards",
+);
+assert.match(
+  workspace,
+  /if \(chatProjectBlockedRef\.current\) \{[\s\S]*if \(familiarId\) setActiveId\(familiarId\);[\s\S]*setMode\("home"\);[\s\S]*return;[\s\S]*\}/,
+  "startFamiliarChat bounces blocked launches to Home so the first-project gate becomes visible without queuing a chat",
 );
 assert.doesNotMatch(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -11,7 +11,12 @@ import { sameSessionList } from "@/lib/session-list-equal";
 import { invalidateConversation } from "@/lib/conversation-cache";
 import { arrayContentEqual } from "@/lib/array-content-equal";
 import type { ChatRouterHandle } from "@/components/chat-router";
-import { isWorkspaceMode, type WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-mode";
+import {
+  isWorkspaceMode,
+  resolveWorkspaceModeAlias,
+  type CanonicalWorkspaceMode,
+  type WorkspaceMode as WorkspaceModeFromDaemon,
+} from "@/lib/workspace-mode";
 import type { PaletteIntent } from "@/components/command-palette";
 // Journal retired as an in-shell surface (redirects to Settings → Familiars),
 // so JournalView is gone; Grimoire is a new in-shell surface from main.
@@ -178,6 +183,10 @@ function splitTargetKey(target: SplitTarget): string {
 
 function splitTargetTitle(target: SplitTarget): string {
   return target.kind === "page" ? WORKSPACE_MODE_TITLES[target.mode] : SPLIT_COMPANION_TITLES[target.kind];
+}
+
+function splitTargetRendersMode(target: SplitTarget, mode: CanonicalWorkspaceMode): boolean {
+  return target.kind === "page" && resolveWorkspaceModeAlias(target.mode) === mode;
 }
 
 // CHAT-D13-05 (axe page-has-heading-one): the shell renders no visible page
@@ -505,6 +514,10 @@ export function Workspace() {
   const [splitTargets, setSplitTargets] = useState<SplitTarget[]>([]);
   const [splitSide, setSplitSide] = useState<"left" | "right">("right");
   const addSplitTarget = useCallback((target: SplitTarget, side: "left" | "right" = "right") => {
+    if (chatProjectBlockedRef.current && splitTargetRendersMode(target, "chat")) {
+      setMode("home");
+      return;
+    }
     setSplitSide(side);
     setSplitTargets((prev) => addSecondaryWorkspaceTile(prev, target, splitTargetKey));
   }, []);
@@ -2142,8 +2155,8 @@ export function Workspace() {
   // Open a page in the split beside the current surface (drag-to-split drop).
   const openSplitPage = useCallback(
     (m: string, side: "left" | "right") => {
-      if (!m || m === mode) return;
-      addSplitTarget({ kind: "page", mode: m as WorkspaceMode }, side);
+      if (!m || m === mode || !isWorkspaceMode(m)) return;
+      addSplitTarget({ kind: "page", mode: m }, side);
     },
     [addSplitTarget, mode],
   );
@@ -2423,6 +2436,14 @@ export function Workspace() {
   });
   const chatProjectBlockedRef = useRef(chatProjectBlocked);
   chatProjectBlockedRef.current = chatProjectBlocked;
+
+  useEffect(() => {
+    if (!chatProjectBlocked) return;
+    setSplitTargets((prev) => {
+      const next = prev.filter((target) => !splitTargetRendersMode(target, "chat"));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [chatProjectBlocked]);
 
   // Tasks badge count: scoped to the active familiar's open cards, or the grand
   // total of all open cards when "All familiars" (activeId === null) is selected.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1885,6 +1885,11 @@ export function Workspace() {
     initialControls?: InitialCommandControls | null,
     initialAttachments?: ChatAttachment[] | null,
   ) => {
+    if (chatProjectBlockedRef.current) {
+      if (familiarId) setActiveId(familiarId);
+      setMode("home");
+      return;
+    }
     if (familiarId) setActiveId(familiarId);
     setPendingProjectChatRoot(projectRoot ?? null);
     setPendingChatAction({
@@ -2400,7 +2405,11 @@ export function Workspace() {
 
   const active = visibleFamiliars.find((f) => f.id === activeId) ?? null;
   const calendarFamiliarId = activeId ?? visibleFamiliars[0]?.id ?? null;
-  const { open: firstProjectGateOpen, familiarId: projectGateFamiliarId } = resolveFirstProjectGatePolicy({
+  const {
+    open: firstProjectGateOpen,
+    familiarId: projectGateFamiliarId,
+    blockChatLaunch: chatProjectBlocked,
+  } = resolveFirstProjectGatePolicy({
     activeFamiliarId: activeId,
     visibleFamiliars,
     registeredProjects,
@@ -2412,6 +2421,8 @@ export function Workspace() {
     familiarRosterLoadedSuccessfully,
     projectsInitiallyResolved,
   });
+  const chatProjectBlockedRef = useRef(chatProjectBlocked);
+  chatProjectBlockedRef.current = chatProjectBlocked;
 
   // Tasks badge count: scoped to the active familiar's open cards, or the grand
   // total of all open cards when "All familiars" (activeId === null) is selected.
@@ -2875,7 +2886,13 @@ export function Workspace() {
           reloadProjects={reloadProjects}
         />
       ) : null}
-      {detailContent}
+      <div
+        className="workspace-detail-content flex h-full min-h-0 min-w-0 flex-1 flex-col"
+        aria-hidden={firstProjectGateOpen ? true : undefined}
+        inert={firstProjectGateOpen || undefined}
+      >
+        {detailContent}
+      </div>
     </div>
   );
 

--- a/src/lib/chat-add-project.test.ts
+++ b/src/lib/chat-add-project.test.ts
@@ -116,6 +116,24 @@ assert.equal(projectNameForRoot(""), "");
   unsubscribe();
 }
 
+// Transport failure after creation → return an explicit error and publish the
+// one needed refresh for the newly-created project.
+{
+  resetProjectRegistryListenersForTests();
+  let notifications = 0;
+  const unsubscribe = subscribeProjectRegistryMutation(() => {
+    notifications += 1;
+  });
+  const createProject = async (name, root) => ({ id: "p4", name, root });
+  const fetchImpl = async () => {
+    throw new Error("network down");
+  };
+  const result = await addChatProject({ root: "/transport-fail", familiarId: "sage", createProject, fetchImpl });
+  assert.deepEqual(result, { ok: false, error: "network down" });
+  assert.equal(notifications, 1, "rejected grant transport still fans out the created project exactly once");
+  unsubscribe();
+}
+
 // Caller created the project first (ProjectsView's scoped create path) → a grant
 // failure should still publish the new project to unscoped consumers.
 {

--- a/src/lib/chat-add-project.ts
+++ b/src/lib/chat-add-project.ts
@@ -63,11 +63,20 @@ export async function addChatProject(args: {
   // Grant the active familiar access. A no-familiar context (operator/Supreme
   // view) has nothing to grant and is left to the server's own access rules.
   if (args.familiarId) {
-    const res = await doFetch("/api/project-grants", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ targetFamiliarId: args.familiarId, projectId }),
-    });
+    let res: Response;
+    try {
+      res = await doFetch("/api/project-grants", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetFamiliarId: args.familiarId, projectId }),
+      });
+    } catch (error) {
+      if (createdProject || args.projectJustCreated) emitProjectRegistryMutation();
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : "grant request failed",
+      };
+    }
     if (!res.ok) {
       // Creation still succeeded, so publish that partial registry mutation
       // even though the bundled grant did not complete.

--- a/src/lib/first-project-gate-policy.test.ts
+++ b/src/lib/first-project-gate-policy.test.ts
@@ -20,25 +20,31 @@ test("first-project gate policy opens only on Home/Chat once onboarding, roster,
       familiarRosterLoadedSuccessfully: true,
       projectsInitiallyResolved: true,
     }),
-    { open: true, familiarId: "sage" },
+    { open: true, familiarId: "sage", blockChatLaunch: true },
     "zero projects opens the gate on Home once the shared eligibility checks pass",
   );
 
+  const hiddenButBlocked = resolveFirstProjectGatePolicy({
+    activeFamiliarId: "sage",
+    visibleFamiliars,
+    registeredProjects: [],
+    pendingGrant: null,
+    onboardingResolved: true,
+    onboardingOpen: false,
+    mode: "agents",
+    familiarsLoaded: true,
+    familiarRosterLoadedSuccessfully: true,
+    projectsInitiallyResolved: true,
+  });
   assert.equal(
-    resolveFirstProjectGatePolicy({
-      activeFamiliarId: "sage",
-      visibleFamiliars,
-      registeredProjects: [],
-      pendingGrant: null,
-      onboardingResolved: true,
-      onboardingOpen: false,
-      mode: "agents",
-      familiarsLoaded: true,
-      familiarRosterLoadedSuccessfully: true,
-      projectsInitiallyResolved: true,
-    }).open,
+    hiddenButBlocked.open,
     false,
     "non-chat navigation stays usable because the gate hides outside Home/Chat",
+  );
+  assert.equal(
+    hiddenButBlocked.blockChatLaunch,
+    true,
+    "chat launch stays blocked even while the gate is hidden on other surfaces",
   );
 
   assert.equal(
@@ -56,6 +62,22 @@ test("first-project gate policy opens only on Home/Chat once onboarding, roster,
     }).open,
     false,
     "the gate waits for onboarding resolution",
+  );
+  assert.equal(
+    resolveFirstProjectGatePolicy({
+      activeFamiliarId: "sage",
+      visibleFamiliars,
+      registeredProjects: [],
+      pendingGrant: null,
+      onboardingResolved: false,
+      onboardingOpen: false,
+      mode: "home",
+      familiarsLoaded: true,
+      familiarRosterLoadedSuccessfully: true,
+      projectsInitiallyResolved: true,
+    }).blockChatLaunch,
+    false,
+    "chat launch also waits for authoritative onboarding resolution",
   );
 });
 
@@ -78,7 +100,7 @@ test("first-project gate policy keeps a pending retry bound to its original fami
       familiarRosterLoadedSuccessfully: true,
       projectsInitiallyResolved: true,
     }),
-    { open: true, familiarId: "ember" },
+    { open: true, familiarId: "ember", blockChatLaunch: true },
     "a valid pending retry stays bound to its original familiar even when another familiar is active",
   );
 
@@ -95,7 +117,7 @@ test("first-project gate policy keeps a pending retry bound to its original fami
       familiarRosterLoadedSuccessfully: true,
       projectsInitiallyResolved: true,
     }),
-    { open: false, familiarId: "ember" },
+    { open: false, familiarId: "ember", blockChatLaunch: true },
     "the same pending retry hides on non-Home/Chat surfaces and can reopen later without losing its target",
   );
 });

--- a/src/lib/first-project-gate-policy.ts
+++ b/src/lib/first-project-gate-policy.ts
@@ -19,6 +19,7 @@ export type FirstProjectGatePolicyInput = {
 export type FirstProjectGatePolicy = {
   open: boolean;
   familiarId: string | null;
+  blockChatLaunch: boolean;
 };
 
 export function preferredFirstProjectGateFamiliarId(
@@ -33,16 +34,17 @@ export function resolveFirstProjectGatePolicy(
 ): FirstProjectGatePolicy {
   const familiarId = input.pendingGrant?.familiarId
     ?? preferredFirstProjectGateFamiliarId(input.activeFamiliarId, input.visibleFamiliars);
-  const eligible = input.onboardingResolved
+  const blockChatLaunch = input.onboardingResolved
     && !input.onboardingOpen
-    && (input.mode === "home" || input.mode === "chat")
     && input.familiarsLoaded
     && input.familiarRosterLoadedSuccessfully
     && input.projectsInitiallyResolved
-    && familiarId !== null;
+    && familiarId !== null
+    && (input.registeredProjects.length === 0 || input.pendingGrant !== null);
 
   return {
-    open: eligible && (input.registeredProjects.length === 0 || input.pendingGrant !== null),
+    open: blockChatLaunch && (input.mode === "home" || input.mode === "chat"),
     familiarId,
+    blockChatLaunch,
   };
 }

--- a/src/lib/page-drag.test.ts
+++ b/src/lib/page-drag.test.ts
@@ -8,6 +8,10 @@ test("most pages are splittable", () => {
   }
 });
 
+test("chat aliases stay draggable page ids, so split consumers must canonicalize them", () => {
+  assert.equal(isSplittablePage("groupchat"), true);
+});
+
 test("terminal is excluded from drag-to-split (heavy PTY surface)", () => {
   assert.equal(isSplittablePage("terminal"), false);
 });


### PR DESCRIPTION
## Summary
- keep the required first-project gate scoped to Home/Chat content so Projects, Familiars, and navigation remain usable
- make covered chat content inert and block quick-chat, handoff, marketplace, and split-view chat bypasses until project access is ready
- harden partial project/grant failures so registry consumers refresh and creation controls always recover

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] targeted onboarding, folder picker, project cache, grant, split, and API contract tests
- [x] `pnpm test:app` (788 test files)
- [x] `git diff --check origin/main...HEAD`

Bead: cave-cwyu