### PR TITLE
fix(chat): friendly zero-session empty state in the session rail

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -158,6 +158,7 @@ export const SUITES = {
     "src/lib/home-greeting.test.ts",
     "src/lib/secret-validators.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
+    "src/components/chat-project-sidebar-empty.test.ts",
     "src/lib/session-pr-status.test.ts",
     "src/lib/merged-chat-auto-archive.test.ts",
     "src/lib/branch-pr-context.test.ts",

--- a/src/components/chat-project-sidebar-empty.test.ts
+++ b/src/components/chat-project-sidebar-empty.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+// Source pins for the session rail's zero-session state. When a familiar is
+// selected but no sessions exist yet, the rail must render a friendly
+// invitation with a real affordance — not a blank nav (board card:
+// "Chat empty state — no affordance when no sessions exist").
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const src = await readFile(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
+
+// The empty state renders only when there is genuinely nothing to show:
+// no search in flight and zero project groups.
+assert.match(
+  src,
+  /\{!hasSearch && groups\.length === 0 \? \(/,
+  "zero-session empty state is gated on no-search + no-groups",
+);
+
+// It reuses the shared EmptyState primitive, not bespoke markup.
+assert.match(
+  src,
+  /import \{ EmptyState \} from "@\/components\/ui\/empty-state"/,
+  "the rail uses the shared EmptyState primitive",
+);
+assert.match(
+  src,
+  /icon="ph:chat-circle-dots"/,
+  "the empty state carries a chat glyph as the visual cue",
+);
+
+// The affordance is real: a primary button that opens a fresh compose view
+// through the same onNewChat path as the folder "+" buttons.
+assert.match(
+  src,
+  /<Button size="sm" variant="primary" leadingIcon="ph:plus" onClick=\{\(\) => onNewChat\(null\)\}>/,
+  "the empty state's Start-a-chat button routes through onNewChat(null)",
+);
+
+console.log("chat-project-sidebar-empty.test.ts: ok");

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -24,6 +24,8 @@ import {
   writeSessionOrder,
 } from "@/lib/chat-session-order";
 import { Icon, type IconName } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import {
   CHAT_SESSION_DRAG_MIME,
@@ -612,6 +614,28 @@ export function ChatProjectSidebar({
               </SortableContext>
             </DndContext>
           )
+        ) : null}
+
+        {/* ── Zero sessions — a friendly invitation instead of a blank rail.
+              Without this, a familiar with no sessions yet rendered an empty
+              nav and the rail read as broken. onNewChat(null) opens a fresh
+              compose view (no project scope) — the same path as the folder
+              "+" buttons. */}
+        {!hasSearch && groups.length === 0 ? (
+          <div className="px-3 pt-4">
+            <EmptyState
+              compact
+              className="rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/35"
+              icon="ph:chat-circle-dots"
+              headline="No conversations yet"
+              subtitle="Start a chat and your sessions will appear here."
+              actions={
+                <Button size="sm" variant="primary" leadingIcon="ph:plus" onClick={() => onNewChat(null)}>
+                  Start a chat
+                </Button>
+              }
+            />
+          </div>
         ) : null}
 
         {/* ── Projects — scope the list to one working directory ── */}


### PR DESCRIPTION
## Problem

**Board card: Chat empty state — no affordance when no sessions exist** (labels: ux, chat — high priority)

When a familiar is selected but no sessions exist, the session rail (`ChatProjectSidebar`) rendered an empty `<nav>`: the search-results block only renders while searching, and the projects tree only renders when `groups.length > 0`. The user saw a blank area with no cue that a conversation could be started.

## Fix

- Render the shared `EmptyState` primitive in the rail when `!hasSearch && groups.length === 0`: chat-circle glyph, "No conversations yet" headline, and a primary **Start a chat** button.
- The button routes through the existing `onNewChat(null)` path (same as the per-folder "+" buttons), opening a fresh compose view.
- Dashed-border invitation treatment consistent with the app's other invitation tiles.

## Tests

- New source-pin test `src/components/chat-project-sidebar-empty.test.ts` (gate, shared primitive, glyph, affordance), wired into the app suite in `scripts/run-tests.mjs`.
- `pnpm check:tests-wired` ✓ · `pnpm typecheck` ✓ · related pins (`chat-project-sidebar-dnd`, `chat-router-switching`) ✓