### PR TITLE
perf(ios): cache ISO-8601 parsers instead of allocating per call

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -1,14 +1,26 @@
 import SwiftUI
 
+/// Cached ISO-8601 parsers. `ISO8601DateFormatter` is relatively expensive to
+/// allocate, and `caveParseISO` is called per-item inside sort/filter/map
+/// across the task, calendar, reminder and thread lists — so allocating a pair
+/// on every call showed up as list churn. Reuse two shared instances instead.
+/// `ISO8601DateFormatter` is thread-safe for reads.
+private let caveISOWithFractional: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+}()
+private let caveISOPlain: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+}()
+
 /// Parse an ISO-8601 timestamp (with or without fractional seconds).
 func caveParseISO(_ iso: String?) -> Date? {
     guard let iso, !iso.isEmpty else { return nil }
-    let withFrac = ISO8601DateFormatter()
-    withFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let d = withFrac.date(from: iso) { return d }
-    let plain = ISO8601DateFormatter()
-    plain.formatOptions = [.withInternetDateTime]
-    return plain.date(from: iso)
+    if let d = caveISOWithFractional.date(from: iso) { return d }
+    return caveISOPlain.date(from: iso)
 }
 
 struct TasksView: View {


### PR DESCRIPTION
## Summary
Fourth PR in the iOS performance pass. Cuts avoidable allocations in list scrolling/sorting.

## Root cause
`caveParseISO()` allocated up to **two `ISO8601DateFormatter` instances on every call**, and it's called per item inside `sorted`/`filter`/`map` across the tasks, calendar, reminders, and thread lists (e.g. `FamiliarThreadsView` sort comparator, `CalendarView` grouping). `ISO8601DateFormatter` is comparatively expensive to construct, so this was avoidable churn during scroll and re-sort.

## Fix
Hoist the two formatters (fractional + plain) to shared, lazily-initialized module-level instances and reuse them. `ISO8601DateFormatter` is thread-safe for reads; parsing behavior is identical (try fractional, then plain).

## Verification
- `xcodebuild build` (scheme `CovenCave`, iOS Simulator) → **BUILD SUCCEEDED**.

## Blast radius
Tiny — 1 file, pure internal caching. Same inputs/outputs.

## Notes
Part of the perf series (#3454 chat render, #3455 stream coalescing, #3456 persist debounce). CI does not build the Swift app; local `xcodebuild` is the iOS gate.
