### PR TITLE
fix(ios): retain bubble updates for theme and familiar changes

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -465,15 +465,19 @@ struct SuggestionPills: View {
 // every bubble (each hosts a WKWebView) — the cause of slow typing on long
 // threads. Closures are excluded (they capture fresh state each render but
 // don't change what's drawn); optional-action closures are compared by presence
-// since that toggles which buttons appear.
+// since that toggles which buttons appear. Environment values and the complete
+// familiar model are included because they directly control colours, markdown
+// styling, and the familiar attribution row.
 extension MessageBubble: Equatable {
     static func == (lhs: MessageBubble, rhs: MessageBubble) -> Bool {
         lhs.message == rhs.message
             && lhs.isGroup == rhs.isGroup
-            && lhs.familiar?.id == rhs.familiar?.id
+            && lhs.familiar == rhs.familiar
             && lhs.isLast == rhs.isLast
             && lhs.operatorName == rhs.operatorName
             && lhs.operatorAvatarURL == rhs.operatorAvatarURL
+            && lhs.colorScheme == rhs.colorScheme
+            && lhs.chrome == rhs.chrome
             && (lhs.onRetry == nil) == (rhs.onRetry == nil)
             && (lhs.onReply == nil) == (rhs.onReply == nil)
             && (lhs.onOpenReader == nil) == (rhs.onOpenReader == nil)


### PR DESCRIPTION
Follow-up for #3454.

- compare the full `Familiar` value so refreshed names, avatars, and colours invalidate the bubble
- compare `colorScheme` and `chrome` so palette and markdown-theme changes remain visible

Validation: `git diff --check` passed. Native iOS/Xcode validation requires macOS; this WSL environment has neither `swift` nor `xcodebuild`.