### PR TITLE
fix(ios): flush coalesced chunks on transport errors

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -281,6 +281,7 @@ final class ChatThread: Identifiable, Hashable {
             // (cave-h40l). Only when no resumable run exists (finished long
             // ago / server restarted) fall back to adopting the persisted
             // transcript.
+            flush(coalescer, into: messageId, onChange: onChange)
             let resumed = await resumeInterruptedStream(runId: runId, cursor: cursor,
                                                         into: messageId, familiarId: familiarId,
                                                         sawDone: &sawDone, coalescer: coalescer,
@@ -386,10 +387,12 @@ final class ChatThread: Identifiable, Hashable {
                     return true
                 }
             } catch is CaveClient.NoResumableRun {
+                flush(coalescer, into: messageId, onChange: onChange)
                 // Nothing buffered under that run — turn ended long ago or
                 // the server restarted. Post-hoc resync owns recovery.
                 return false
             } catch {
+                flush(coalescer, into: messageId, onChange: onChange)
                 // Transport still flaky — back off and retry from the cursor.
             }
         }

--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -57,8 +57,18 @@ assert.match(
 );
 assert.match(
   swiftChatThread,
-  /case \.assistantChunk\(let chunk\):\s*\n\s*mutate\(messageId\) \{ \$0\.text \+= chunk \}\s*\n\s*onChange\(\)/,
-  "native SwiftUI chat should notify/persist after assistant chunks so responses render while streaming",
+  /case \.assistantChunk\(let chunk\):[\s\S]*?coalescer\.append\(chunk\)[\s\S]*?if coalescer\.shouldFlush\(\) \{\s*\n\s*flush\(coalescer, into: messageId, onChange: onChange\)/,
+  "native SwiftUI chat should buffer assistant chunks and periodically notify/persist while streaming",
+);
+assert.match(
+  swiftChatThread,
+  /catch \{[\s\S]*?flush\(coalescer, into: messageId, onChange: onChange\)\s*\n\s*let resumed = await resumeInterruptedStream/,
+  "native SwiftUI chat should flush buffered assistant text before recovering a dropped send stream",
+);
+assert.match(
+  swiftChatThread,
+  /} catch is CaveClient\.NoResumableRun \{\s*\n\s*flush\(coalescer, into: messageId, onChange: onChange\)[\s\S]*?} catch \{\s*\n\s*flush\(coalescer, into: messageId, onChange: onChange\)/,
+  "native SwiftUI chat should retain buffered text when a resumed stream cannot continue",
 );
 assert.match(
   swiftChatThread,


### PR DESCRIPTION
Follow-up for #3455.

Flushes the shared `StreamCoalescer` before recovering a failed send stream and on each failed/no-resumable resume path, so chunks received during the final coalescing interval are not lost. Updates the mobile native source-contract assertions accordingly.

Validation:
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:mobile` (81 files)

The original head branch is owned by `OpenCoven` and does not permit maintainer edits, so this must merge into `cody/perf-stream-coalesce` before #3455 can pass its mobile check.