### PR TITLE
fix(auth): use timing-safe compares for sidecar token checks

### DIFF
--- a/src/lib/server/local-origin.test.ts
+++ b/src/lib/server/local-origin.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
 import { isLocalOrigin } from "./local-origin.ts";
+
+const localOriginSource = readFileSync(fileURLToPath(new URL("./local-origin.ts", import.meta.url)), "utf8");
+assert.match(
+  localOriginSource,
+  /timingSafeEqualString\(req\.headers\.get\(TOKEN_HEADER\) \?\? "", sidecarToken\)/,
+  "packaged sidecar token check must be timing-safe",
+);
 
 const ORIGINAL_SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN;
 

--- a/src/lib/server/local-origin.ts
+++ b/src/lib/server/local-origin.ts
@@ -1,4 +1,8 @@
-import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
+import {
+  MOBILE_ACCESS_HEADER,
+  TOKEN_HEADER,
+  timingSafeEqualString,
+} from "../../proxy-helpers.ts";
 
 /**
  * True when a request is allowed to reach DESKTOP-ONLY local routes (codex
@@ -25,7 +29,12 @@ export function isLocalOrigin(req: Request): boolean {
   if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") return false;
 
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
-  if (sidecarToken && req.headers.get(TOKEN_HEADER) !== sidecarToken) return false;
+  if (
+    sidecarToken &&
+    !timingSafeEqualString(req.headers.get(TOKEN_HEADER) ?? "", sidecarToken)
+  ) {
+    return false;
+  }
 
   const host = req.headers.get("host") ?? "";
   const bare = host.startsWith("[") ? host.slice(1, host.indexOf("]")) : host.split(":")[0];

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -83,7 +83,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const sidecarTokenMatches = \(supplied: string \| null \| undefined\) =>\s*Boolean\(sidecarToken\) &&\s*Boolean\(supplied\) &&\s*timingSafeEqualString\(supplied as string, sidecarToken as string\)/,
+  /const sidecarTokenMatches = \(supplied: string \| null \| undefined\) => \{\s*if \(!sidecarToken \|\| !supplied\) return false;\s*return timingSafeEqualString\(supplied, sidecarToken\);\s*\}/,
   "sidecar auth must compare the supplied token with timingSafeEqualString",
 );
 assert.match(

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -78,8 +78,18 @@ assert.match(
 // (cookies auto-send cross-origin → CSRF).
 assert.match(
   source,
-  /const headerCsrfTrusted =\s*Boolean\(sidecarToken\) &&\s*req\.headers\.get\(TOKEN_HEADER\) === sidecarToken &&\s*isHeaderCsrfTrustedApiPath\(req\.nextUrl\.pathname\)/,
-  "origin/referer gate bypass must be keyed to the custom sidecar header token and mobile endpoint allowlist",
+  /const headerCsrfTrusted =\s*sidecarTokenMatches\(req\.headers\.get\(TOKEN_HEADER\)\) &&\s*isHeaderCsrfTrustedApiPath\(req\.nextUrl\.pathname\)/,
+  "origin/referer gate bypass must be keyed to the custom sidecar header token (timing-safe) and mobile endpoint allowlist",
+);
+assert.match(
+  source,
+  /const sidecarTokenMatches = \(supplied: string \| null \| undefined\) =>\s*Boolean\(sidecarToken\) &&\s*Boolean\(supplied\) &&\s*timingSafeEqualString\(supplied as string, sidecarToken as string\)/,
+  "sidecar auth must compare the supplied token with timingSafeEqualString",
+);
+assert.match(
+  source,
+  /const sidecarAuthenticated = sidecarTokenMatches\(suppliedToken\)/,
+  "sidecarAuthenticated must use the shared timing-safe matcher",
 );
 assert.match(
   source,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -247,10 +247,10 @@ export async function proxy(req: NextRequest) {
   // allowlisted mobile endpoints.
   // Match PTY auth: constant-time compare so token checks stay consistent across
   // the REST proxy and server.ts upgrade path.
-  const sidecarTokenMatches = (supplied: string | null | undefined) =>
-    Boolean(sidecarToken) &&
-    Boolean(supplied) &&
-    timingSafeEqualString(supplied as string, sidecarToken as string);
+  const sidecarTokenMatches = (supplied: string | null | undefined) => {
+    if (!sidecarToken || !supplied) return false;
+    return timingSafeEqualString(supplied, sidecarToken);
+  };
   const headerCsrfTrusted =
     sidecarTokenMatches(req.headers.get(TOKEN_HEADER)) &&
     isHeaderCsrfTrustedApiPath(req.nextUrl.pathname);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -245,9 +245,14 @@ export async function proxy(req: NextRequest) {
   // cross-origin → CSRF) and NOT the query/referer token paths. The token value
   // is still validated below; this only relaxes the CSRF source gate for the
   // allowlisted mobile endpoints.
-  const headerCsrfTrusted =
+  // Match PTY auth: constant-time compare so token checks stay consistent across
+  // the REST proxy and server.ts upgrade path.
+  const sidecarTokenMatches = (supplied: string | null | undefined) =>
     Boolean(sidecarToken) &&
-    req.headers.get(TOKEN_HEADER) === sidecarToken &&
+    Boolean(supplied) &&
+    timingSafeEqualString(supplied as string, sidecarToken as string);
+  const headerCsrfTrusted =
+    sidecarTokenMatches(req.headers.get(TOKEN_HEADER)) &&
     isHeaderCsrfTrustedApiPath(req.nextUrl.pathname);
 
   if (!headerCsrfTrusted) {
@@ -285,7 +290,7 @@ export async function proxy(req: NextRequest) {
     req.headers.get(TOKEN_HEADER) ??
     req.nextUrl.searchParams.get(TOKEN_PARAM) ??
     bearerFromRefererAny(req.headers.get("referer"), expectedOrigins);
-  const sidecarAuthenticated = Boolean(sidecarToken) && suppliedToken === sidecarToken;
+  const sidecarAuthenticated = sidecarTokenMatches(suppliedToken);
 
   if (!sidecarToken) {
     return process.env.COVEN_CAVE_BUNDLE === "1"


### PR DESCRIPTION
## Summary

Use `timingSafeEqualString` for `COVEN_CAVE_AUTH_TOKEN` checks in the REST proxy and `isLocalOrigin`, matching the PTY upgrade path's constant-time compares.

## Why

Sidecar token equality used plain `===` / `!==` while mobile and PTY auth already use timing-safe compares. This keeps auth checks consistent across surfaces and slightly harder to probe by timing.

## Changes

- `src/proxy.ts`: shared `sidecarTokenMatches` helper (early returns + `timingSafeEqualString`) for header CSRF trust and sidecar authentication
- `src/lib/server/local-origin.ts`: timing-safe packaged sidecar header check
- Tests updated in `middleware.test.ts` and `local-origin.test.ts`

## Verification

```bash
node --experimental-strip-types src/lib/server/local-origin.test.ts
node --experimental-strip-types src/middleware.test.ts
node --experimental-strip-types src/proxy-behavior.test.ts
```

Codex review on the fork PR: no major issues (`chatgpt-codex-connector[bot]` on `a35fa211fa`).

## Risk + rollout notes

Low risk, behavior-preserving. Token accept/reject outcomes are unchanged for correct and incorrect secrets. No migration or release-note requirement.
