### PR TITLE
fix(board): reject invalid status and priority on create

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -870,6 +870,7 @@ export const SUITES = {
     "src/lib/harness-adapters.test.ts",
     "src/lib/copilot-stream.test.ts",
     "src/app/api/board/enrich-steps/route.test.ts",
+    "src/app/api/board/route.test.ts",
     "src/app/api/board/[id]/chat/route.test.ts",
     "src/app/api/sessions/route.test.ts",
     "src/app/api/chat/send/harness-routing.test.ts",

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -8,13 +8,13 @@ assert.match(source, /STATUSES/, "board create must import STATUSES for validati
 assert.match(source, /PRIORITIES/, "board create must import PRIORITIES for validation");
 assert.match(
   source,
-  /const STATUS_VALUES = new Set<string>\(STATUSES\)/,
-  "board create must build a status allowlist from STATUSES",
+  /const STATUS_VALUES = new Set<CardStatus>\(STATUSES\)/,
+  "board create must build a CardStatus allowlist from STATUSES",
 );
 assert.match(
   source,
-  /const PRIORITY_VALUES = new Set<string>\(PRIORITIES\)/,
-  "board create must build a priority allowlist from PRIORITIES",
+  /const PRIORITY_VALUES = new Set<CardPriority>\(PRIORITIES\)/,
+  "board create must build a CardPriority allowlist from PRIORITIES",
 );
 assert.match(
   source,

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const source = readFileSync(fileURLToPath(new URL("./route.ts", import.meta.url)), "utf8");
+
+assert.match(source, /STATUSES/, "board create must import STATUSES for validation");
+assert.match(source, /PRIORITIES/, "board create must import PRIORITIES for validation");
+assert.match(
+  source,
+  /const STATUS_VALUES = new Set<string>\(STATUSES\)/,
+  "board create must build a status allowlist from STATUSES",
+);
+assert.match(
+  source,
+  /const PRIORITY_VALUES = new Set<string>\(PRIORITIES\)/,
+  "board create must build a priority allowlist from PRIORITIES",
+);
+assert.match(
+  source,
+  /body\.status !== undefined && !STATUS_VALUES\.has\(body\.status\)/,
+  "POST must reject status values outside the board enum",
+);
+assert.match(
+  source,
+  /body\.priority !== undefined && !PRIORITY_VALUES\.has\(body\.priority\)/,
+  "POST must reject priority values outside the board enum",
+);
+assert.match(
+  source,
+  /error: "invalid status"/,
+  "invalid status responses must use a stable error string",
+);
+assert.match(
+  source,
+  /error: "invalid priority"/,
+  "invalid priority responses must use a stable error string",
+);
+
+console.log("board/route.test.ts: ok");

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import {
   createCard,
   loadBoard,
+  PRIORITIES,
+  STATUSES,
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
@@ -10,6 +12,9 @@ import type { ChatAttachment } from "@/lib/chat-attachments";
 import { trustedProjectCwd } from "@/lib/cave-projects";
 
 export const dynamic = "force-dynamic";
+
+const STATUS_VALUES = new Set<string>(STATUSES);
+const PRIORITY_VALUES = new Set<string>(PRIORITIES);
 
 export async function GET() {
   const board = await loadBoard();
@@ -43,6 +48,14 @@ export async function POST(req: Request) {
   }
   if (!body.title || !body.title.trim()) {
     return NextResponse.json({ ok: false, error: "title required" }, { status: 400 });
+  }
+  // Reject unknown column/priority values so hand-edited or agent payloads cannot
+  // plant strings that break Board filters and lifecycle inference.
+  if (body.status !== undefined && !STATUS_VALUES.has(body.status)) {
+    return NextResponse.json({ ok: false, error: "invalid status" }, { status: 400 });
+  }
+  if (body.priority !== undefined && !PRIORITY_VALUES.has(body.priority)) {
+    return NextResponse.json({ ok: false, error: "invalid priority" }, { status: 400 });
   }
   // A card assigned to a project derives its cwd from that project server-side —
   // never from the client body, which could contradict the project (cave-pw83).

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -13,8 +13,8 @@ import { trustedProjectCwd } from "@/lib/cave-projects";
 
 export const dynamic = "force-dynamic";
 
-const STATUS_VALUES = new Set<string>(STATUSES);
-const PRIORITY_VALUES = new Set<string>(PRIORITIES);
+const STATUS_VALUES = new Set<CardStatus>(STATUSES);
+const PRIORITY_VALUES = new Set<CardPriority>(PRIORITIES);
 
 export async function GET() {
   const board = await loadBoard();


### PR DESCRIPTION
## Summary

Validate `POST /api/board` `status` and `priority` against the board enums so unknown values cannot enter the store.

## Why

`createCard` previously accepted any status/priority string. Invalid values break Board columns/filters and lifecycle inference.

## Changes

- Allowlist `status` / `priority` with `STATUSES` / `PRIORITIES` (`Set<CardStatus>` / `Set<CardPriority>`)
- Return 400 with stable `invalid status` / `invalid priority` errors when present values are invalid; omitted fields still default in `createCard`
- Source-contract test in `src/app/api/board/route.test.ts`, wired into `scripts/run-tests.mjs` (app suite)

## Verification

```bash
node --experimental-strip-types src/app/api/board/route.test.ts
node scripts/check-tests-wired.mjs
```

Codex review on the fork PR: no major issues (`chatgpt-codex-connector[bot]` on `4ba42772b2`).

## Risk + rollout notes

Clients that already send only enum values are unaffected. Malformed agent/hand-edited payloads now get a clear 400 instead of a broken card. PATCH `/api/board/[id]` validation is out of scope for this PR.
