### PR TITLE
fix(ui): abort stale mobile-handoff modal fetches

### DIFF
--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -99,6 +99,7 @@ export function MobileHandoffModal({
         body: JSON.stringify(chatId ? { action: "app-start", chatId } : { action: "app-start" }),
         signal: controller.signal,
       });
+      if (controller.signal.aborted) return;
       const json = (await res.json()) as HandoffResponse;
       if (controller.signal.aborted) return;
       if (!json.ok) {
@@ -108,11 +109,12 @@ export function MobileHandoffModal({
       }
       setHandoff(json);
       if (copyRequest > 0 && copyRequest !== lastAutoCopyRequestRef.current) {
-        lastAutoCopyRequestRef.current = copyRequest;
         await copyHandoffUrl(json);
+        if (controller.signal.aborted) return;
+        lastAutoCopyRequestRef.current = copyRequest;
       }
     } catch (err) {
-      if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) {
+      if (controller.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
         return;
       }
       setHandoff(null);
@@ -172,7 +174,7 @@ export function MobileHandoffModal({
       if (!json.ok) setError(json.stderr || json.error || "Tailscale Serve reset failed.");
       setHandoff(null);
     } catch (err) {
-      if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) {
+      if (controller.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
         return;
       }
       setError(err instanceof Error ? err.message : "Tailscale Serve reset failed.");

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -68,6 +68,8 @@ export function MobileHandoffModal({
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState<"host" | "invite" | null>(null);
   const lastAutoCopyRequestRef = useRef(0);
+  /** Aborts an in-flight start when the modal closes, remounts, or Refresh races. */
+  const startAbortRef = useRef<AbortController | null>(null);
 
   const copyHandoffUrl = useCallback(async (nextHandoff: HandoffReady) => {
     const url = nextHandoff.inviteUrl || nextHandoff.url || nextHandoff.nativeUrl;
@@ -82,6 +84,10 @@ export function MobileHandoffModal({
   }, []);
 
   const start = useCallback(async (copyRequest = 0) => {
+    startAbortRef.current?.abort();
+    const controller = new AbortController();
+    startAbortRef.current = controller;
+
     setLoading(true);
     setError(null);
     setCopied(null);
@@ -91,8 +97,10 @@ export function MobileHandoffModal({
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(chatId ? { action: "app-start", chatId } : { action: "app-start" }),
+        signal: controller.signal,
       });
       const json = (await res.json()) as HandoffResponse;
+      if (controller.signal.aborted) return;
       if (!json.ok) {
         setHandoff(null);
         setError(json.stderr || json.error || "Mobile handoff failed.");
@@ -104,15 +112,29 @@ export function MobileHandoffModal({
         await copyHandoffUrl(json);
       }
     } catch (err) {
+      if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) {
+        return;
+      }
       setHandoff(null);
       setError(err instanceof Error ? err.message : "Mobile handoff failed.");
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) setLoading(false);
+      if (startAbortRef.current === controller) startAbortRef.current = null;
     }
   }, [chatId, copyHandoffUrl]);
 
   useEffect(() => {
-    if (open) void start(autoCopyRequest);
+    if (!open) {
+      startAbortRef.current?.abort();
+      startAbortRef.current = null;
+      setLoading(false);
+      return;
+    }
+    void start(autoCopyRequest);
+    return () => {
+      startAbortRef.current?.abort();
+      startAbortRef.current = null;
+    };
   }, [autoCopyRequest, open, start]);
 
   const copyUrl = useCallback(async () => {
@@ -131,6 +153,10 @@ export function MobileHandoffModal({
   }, [handoff]);
 
   const resetServe = useCallback(async () => {
+    startAbortRef.current?.abort();
+    const controller = new AbortController();
+    startAbortRef.current = controller;
+
     setLoading(true);
     setError(null);
     try {
@@ -138,14 +164,21 @@ export function MobileHandoffModal({
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ action: "reset" }),
+        signal: controller.signal,
       });
+      if (controller.signal.aborted) return;
       const json = (await res.json()) as HandoffResponse;
+      if (controller.signal.aborted) return;
       if (!json.ok) setError(json.stderr || json.error || "Tailscale Serve reset failed.");
       setHandoff(null);
     } catch (err) {
+      if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) {
+        return;
+      }
       setError(err instanceof Error ? err.message : "Tailscale Serve reset failed.");
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) setLoading(false);
+      if (startAbortRef.current === controller) startAbortRef.current = null;
     }
   }, []);
 

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -60,6 +60,14 @@ assert.doesNotMatch(
 );
 assert.match(workspace, /setMobileModeEnabled/, "Workspace should expose a way to toggle mobile mode from Settings");
 assert.match(modal, /\/api\/mobile-handoff/, "Modal should call the mobile handoff API");
+assert.match(modal, /startAbortRef/, "Modal should keep an AbortController ref for in-flight start/reset");
+assert.match(modal, /new AbortController\(\)/, "Modal should abort stale handoff fetches on refresh/close");
+assert.match(modal, /signal: controller\.signal/, "Modal handoff fetch must pass AbortSignal");
+assert.match(
+  modal,
+  /controller\.signal\.aborted \|\| \(err instanceof DOMException && err\.name === "AbortError"\)/,
+  "Modal must ignore AbortError instead of clobbering state with a failure",
+);
 assert.match(modal, /dangerouslySetInnerHTML/, "Modal should render the QR SVG returned by the API");
 assert.match(modal, /expiresAtIso/, "Modal should display the invite expiry");
 assert.match(modal, /copyText\(/, "Modal should support copying the authenticated URL");

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -65,7 +65,7 @@ assert.match(modal, /new AbortController\(\)/, "Modal should abort stale handoff
 assert.match(modal, /signal: controller\.signal/, "Modal handoff fetch must pass AbortSignal");
 assert.match(
   modal,
-  /controller\.signal\.aborted \|\| \(err instanceof DOMException && err\.name === "AbortError"\)/,
+  /controller\.signal\.aborted \|\| \(err instanceof Error && err\.name === "AbortError"\)/,
   "Modal must ignore AbortError instead of clobbering state with a failure",
 );
 assert.match(modal, /dangerouslySetInnerHTML/, "Modal should render the QR SVG returned by the API");


### PR DESCRIPTION
## Summary

Abort in-flight mobile handoff `app-start` / `reset` requests when the modal closes or Refresh races, so older responses cannot overwrite a newer QR or error state.

## Why

Rapid open/close/Refresh could apply a stale handoff response after a newer request had already started.

## Changes

- `AbortController` mutex for start/reset fetches in `mobile-handoff-modal.tsx`
- Ignore aborted requests / `AbortError`; clear loading on close
- Abort checks before JSON parse and after auto-copy; only advance auto-copy id after success
- Source-contract asserts in `mobile-handoff.test.ts`

## Verification

```bash
node --experimental-strip-types src/components/mobile-handoff.test.ts
```

Codex review on the fork PR: no major issues (`chatgpt-codex-connector[bot]` on `f2e59aa54f`).

## Risk + rollout notes

UI-only. Successful handoff flow unchanged; aborted requests no longer surface as failures. No migration.
