### PR TITLE
feat(nav): left side-panel on every destination page

### DIFF
--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -1,5 +1,6 @@
 import { loadInbox } from "@/lib/cave-inbox";
 import { Icon } from "@/lib/icon";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { EmptyState, ItemRow, MetricCard, QuickLink, SectionHead } from "@/components/daily-report-ui";
 import {
   breakdownForDay,
@@ -27,7 +28,9 @@ export default async function DailyReportPage({ params }: Props) {
 
   if (!item) {
     return (
-      <main className="dr-page">
+      <AnalyticsPageShell>
+      {/* div, not main: the shell's aps-main is the page's main landmark. */}
+      <div className="dr-page">
         <div className="dr-topbar" data-tauri-drag-region="deep">
           <a className="dr-back" href="/dashboard">
             <Icon name="ph:arrow-left" aria-hidden />
@@ -58,7 +61,8 @@ export default async function DailyReportPage({ params }: Props) {
             </div>
           </section>
         </div>
-      </main>
+      </div>
+      </AnalyticsPageShell>
     );
   }
 
@@ -101,7 +105,9 @@ export default async function DailyReportPage({ params }: Props) {
     : 0;
 
   return (
-    <main className="dr-page">
+    <AnalyticsPageShell>
+    {/* div, not main: the shell's aps-main is the page's main landmark. */}
+    <div className="dr-page">
       <div className="dr-topbar" data-tauri-drag-region="deep">
         <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
           <a className="dr-back" href="/dashboard">
@@ -460,6 +466,7 @@ export default async function DailyReportPage({ params }: Props) {
           stays live.
         </footer>
       </div>
-    </main>
+    </div>
+    </AnalyticsPageShell>
   );
 }

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -18,6 +18,8 @@ assert.match(page, /buildDashboardModel/, "dashboard builds the first-paint view
 assert.match(page, /BentoDashboard/, "dashboard renders the bento surface");
 assert.match(page, /dr-page dr-page--bento/, "page opts into the flex shell so the frame fills the viewport");
 assert.match(page, /dr-topbar/, "the sticky breadcrumb topbar stays");
+assert.match(page, /AnalyticsPageShell/, "dashboard mounts the standalone left side-panel (cave-4i6u)");
+assert.doesNotMatch(page, /<main /, "the shell's aps-main is the page's main landmark — no nested <main>");
 
 // ── Component wiring ──────────────────────────────────────────────────────────
 

--- a/src/app/dashboard/familiars/growth/page.tsx
+++ b/src/app/dashboard/familiars/growth/page.tsx
@@ -1,28 +1,32 @@
 import { FamiliarGrowthView } from "@/components/familiar-growth-view";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { Icon } from "@/lib/icon";
 
 export const dynamic = "force-dynamic";
 
 export default function FamiliarGrowthDashboardPage() {
   return (
-    <main className="dr-page">
-      <div className="dr-topbar" data-tauri-drag-region="deep">
-        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-          <a className="dr-back" href="/dashboard">
-            <Icon name="ph:arrow-left" aria-hidden />
-            Dashboard
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          {/* ?mode= is the SPA's deep-link param; a bare #familiars hash has
-              no consumer and landed on the boot surface (cave-aka2). */}
-          <a className="dr-back" href="/?mode=agents">
-            Familiars
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          <span className="dr-crumb-current">Growth</span>
-        </nav>
+    <AnalyticsPageShell>
+      {/* div, not main: the shell's aps-main is the page's main landmark. */}
+      <div className="dr-page">
+        <div className="dr-topbar" data-tauri-drag-region="deep">
+          <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+            <a className="dr-back" href="/dashboard">
+              <Icon name="ph:arrow-left" aria-hidden />
+              Dashboard
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            {/* ?mode= is the SPA's deep-link param; a bare #familiars hash has
+                no consumer and landed on the boot surface (cave-aka2). */}
+            <a className="dr-back" href="/?mode=agents">
+              Familiars
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            <span className="dr-crumb-current">Growth</span>
+          </nav>
+        </div>
+        <FamiliarGrowthView standalone />
       </div>
-      <FamiliarGrowthView standalone />
-    </main>
+    </AnalyticsPageShell>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { loadInbox } from "@/lib/cave-inbox";
 import { Icon } from "@/lib/icon";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { BentoDashboard } from "@/components/dashboard/bento-dashboard";
 import { buildDashboardModel } from "@/lib/dashboard-model";
 
@@ -10,19 +11,22 @@ export default async function DashboardPage() {
   const model = buildDashboardModel(inbox.items, new Date());
 
   return (
-    <main className="dr-page dr-page--bento">
-      <div className="dr-topbar" data-tauri-drag-region="deep">
-        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-          <a className="dr-back" href="/">
-            <Icon name="ph:arrow-left" aria-hidden />
-            CovenCave
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          <span className="dr-crumb-current">Dashboard</span>
-        </nav>
-      </div>
+    <AnalyticsPageShell>
+      {/* div, not main: the shell's aps-main is the page's main landmark. */}
+      <div className="dr-page dr-page--bento">
+        <div className="dr-topbar" data-tauri-drag-region="deep">
+          <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+            <a className="dr-back" href="/">
+              <Icon name="ph:arrow-left" aria-hidden />
+              CovenCave
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            <span className="dr-crumb-current">Dashboard</span>
+          </nav>
+        </div>
 
-      <BentoDashboard model={model} />
-    </main>
+        <BentoDashboard model={model} />
+      </div>
+    </AnalyticsPageShell>
   );
 }

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/lib/icon";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { ProposalApproval } from "@/components/proposal-approval";
 
 export const dynamic = "force-dynamic";
@@ -9,26 +10,29 @@ export const metadata = {
 
 export default function ProposalsPage() {
   return (
-    <main className="dr-page">
-      <div className="dr-topbar" data-tauri-drag-region="deep">
-        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-          <a className="dr-back" href="/">
-            <Icon name="ph:arrow-left" aria-hidden />
-            CovenCave
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          <span className="dr-crumb-current">Proposals</span>
-        </nav>
+    <AnalyticsPageShell>
+      {/* div, not main: the shell's aps-main is the page's main landmark. */}
+      <div className="dr-page">
+        <div className="dr-topbar" data-tauri-drag-region="deep">
+          <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+            <a className="dr-back" href="/">
+              <Icon name="ph:arrow-left" aria-hidden />
+              CovenCave
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            <span className="dr-crumb-current">Proposals</span>
+          </nav>
+        </div>
+        <div className="px-4 pb-6">
+          <p className="mb-3 max-w-2xl text-xs text-[var(--text-muted)]">
+            Staged writes from ~/.coven/pending/ — each one degraded to a proposal by a frayed thread.
+            A proposal is data, not authority: approving forwards your decision to the daemon, which
+            re-validates before anything touches a protected surface. This page never applies edits
+            itself.
+          </p>
+          <ProposalApproval />
+        </div>
       </div>
-      <div className="px-4 pb-6">
-        <p className="mb-3 max-w-2xl text-xs text-[var(--text-muted)]">
-          Staged writes from ~/.coven/pending/ — each one degraded to a proposal by a frayed thread.
-          A proposal is data, not authority: approving forwards your decision to the daemon, which
-          re-validates before anything touches a protected surface. This page never applies edits
-          itself.
-        </p>
-        <ProposalApproval />
-      </div>
-    </main>
+    </AnalyticsPageShell>
   );
 }

--- a/src/app/route-inventory.test.ts
+++ b/src/app/route-inventory.test.ts
@@ -103,6 +103,22 @@ for (const [route, spec] of Object.entries(ROUTE_INVENTORY)) {
   assert.doesNotMatch(source, /return \(|return </, `${route} is a pure stub — it must not render JSX of its own`);
 }
 
+// ── Destination pages carry the standalone left side-panel ───────────────────
+// Destination routes render outside the SPA workspace (which owns
+// SidebarMinimal), so without a shell they'd have no nav at all — the exact
+// "dashboard has no sidepanel" gap (cave-4i6u). Every destination page must
+// mount AnalyticsPageShell, the standalone rail with ?mode= deep links back
+// into the SPA. Window-hosts (overlay windows) and dev-only pages stay bare.
+for (const [route, spec] of Object.entries(ROUTE_INVENTORY)) {
+  if (spec.kind !== "destination") continue;
+  const file = path.join(appDir, route.replace(/^\//, ""), "page.tsx");
+  const source = readFileSync(file, "utf8");
+  assert.ok(
+    source.includes("AnalyticsPageShell"),
+    `${route} is a destination route — it must mount AnalyticsPageShell so the left side-panel is present on every page (cave-4i6u)`,
+  );
+}
+
 // ── Dev-only pages stay out of every navigation host ─────────────────────────
 const componentsDir = new URL("../components/", import.meta.url);
 const navHosts = [

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -5,8 +5,13 @@ export const metadata: Metadata = {
 };
 
 export default function SettingsPage() {
-  return <SettingsShell />;
+  return (
+    <AnalyticsPageShell>
+      <SettingsShell />
+    </AnalyticsPageShell>
+  );
 }
 
-// Client shell lives below — keeps page.tsx a server component for metadata
+// Client shells live below — keeps page.tsx a server component for metadata
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { SettingsShell } from "@/components/settings-shell";

--- a/src/app/weaves/page.tsx
+++ b/src/app/weaves/page.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/lib/icon";
+import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { WeavesView } from "@/components/weaves-view";
 
 export const dynamic = "force-dynamic";
@@ -9,25 +10,28 @@ export const metadata = {
 
 export default function WeavesPage() {
   return (
-    <main className="dr-page">
-      <div className="dr-topbar" data-tauri-drag-region="deep">
-        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-          <a className="dr-back" href="/">
-            <Icon name="ph:arrow-left" aria-hidden />
-            CovenCave
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          <span className="dr-crumb-current">Weaves</span>
-        </nav>
+    <AnalyticsPageShell>
+      {/* div, not main: the shell's aps-main is the page's main landmark. */}
+      <div className="dr-page">
+        <div className="dr-topbar" data-tauri-drag-region="deep">
+          <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
+            <a className="dr-back" href="/">
+              <Icon name="ph:arrow-left" aria-hidden />
+              CovenCave
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            <span className="dr-crumb-current">Weaves</span>
+          </nav>
+        </div>
+        <div className="px-4 pb-6">
+          <p className="mb-3 max-w-2xl text-xs text-[var(--text-muted)]">
+            Each weave is a familiar&apos;s enforced pattern of threads over its protected memory; each
+            thread binds one surface to one writer. Status here traces to predicate results — anything
+            unverifiable renders blocked, never healthy.
+          </p>
+          <WeavesView />
+        </div>
       </div>
-      <div className="px-4 pb-6">
-        <p className="mb-3 max-w-2xl text-xs text-[var(--text-muted)]">
-          Each weave is a familiar&apos;s enforced pattern of threads over its protected memory; each
-          thread binds one surface to one writer. Status here traces to predicate results — anything
-          unverifiable renders blocked, never healthy.
-        </p>
-        <WeavesView />
-      </div>
-    </main>
+    </AnalyticsPageShell>
   );
 }

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
 import "@/styles/analytics-page-shell.css";
 
@@ -24,14 +25,20 @@ const PRIMARY: RailDest[] = [
 const NAV_ICON = CAVE_ICON_SIZE.sidePanelNav;
 
 /**
- * Standalone-route left side-panel. The familiar-analytics route renders OUTSIDE
- * the SPA workspace (which owns SidebarMinimal), so on its own it has no nav. This
- * shell gives it the app's left rail at EVERY screen size (goal: the left
- * sidepanel on analytics, all screens): a compact, always-visible icon column of
- * the primary destinations (deep-linking back into the SPA) plus Dashboard — so
- * you can navigate away from analytics without a browser Back.
+ * Standalone-route left side-panel. Destination routes (/dashboard, /weaves,
+ * /proposals, /settings, /profile, /daily-report, familiar analytics) render
+ * OUTSIDE the SPA workspace (which owns SidebarMinimal), so on their own they
+ * have no nav. This shell gives every one of them the app's left rail at EVERY
+ * screen size: a compact, always-visible icon column of the primary
+ * destinations (deep-linking back into the SPA) plus Dashboard — so you can
+ * navigate away without a browser Back. route-inventory.test.ts enforces that
+ * every destination page mounts it.
  */
 export function AnalyticsPageShell({ children }: { children: ReactNode }) {
+  // Only the Dashboard foot link can be "current" — the PRIMARY rows deep-link
+  // into the SPA at `/`, which this shell never wraps.
+  const pathname = usePathname();
+  const onDashboard = pathname === "/dashboard";
   return (
     <div className="aps">
       <nav className="aps-rail" aria-label="Primary">
@@ -47,7 +54,13 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
             </li>
           ))}
         </ul>
-        <a className="aps-rail-link aps-rail-foot" href="/dashboard" aria-label="Dashboard" title="Dashboard">
+        <a
+          className="aps-rail-link aps-rail-foot"
+          href="/dashboard"
+          aria-label="Dashboard"
+          title="Dashboard"
+          aria-current={onDashboard ? "page" : undefined}
+        >
           <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
         </a>
       </nav>

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -72,6 +72,13 @@
   border-color: color-mix(in oklch, var(--border-strong) 60%, transparent);
 }
 
+/* The destination you are on (accent = presence, per the design language). */
+.aps-rail-link[aria-current="page"] {
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+}
+
 .aps-rail-foot {
   margin-top: auto;
   flex-shrink: 0;


### PR DESCRIPTION
## What

The left side-panel is now present on **every** page — especially the dashboard pages, which previously had none.

## Why

Destination routes render outside the SPA workspace (which owns `SidebarMinimal`), so `/dashboard`, `/dashboard/familiars/growth`, `/weaves`, `/proposals`, `/settings`, and `/daily-report/[date]` had no side panel at all — landing there stranded you with only a breadcrumb. `AnalyticsPageShell` (the standalone icon rail with `?mode=` deep links back into the SPA) already existed for exactly this purpose but was applied to only 3 of the 9 destination pages.

## How

- Wrap all remaining destination pages in `AnalyticsPageShell`, converting each page's root `<main class="dr-page">` to a `<div>` (the shell's `aps-main` is the page's main landmark — no nested landmarks).
- The rail's Dashboard foot link gets `aria-current="page"` + an accent-presence tint (12% fill / 35% border per the tint recipe) when on `/dashboard`.
- **New rule in `route-inventory.test.ts`:** every `destination`-kind route must mount `AnalyticsPageShell`, so a future destination page can't ship without the side panel. Window-hosts (`/quick-chat`) and dev-only pages stay bare by design.

## Verification

Booted the branch and screenshotted: rail present on `/dashboard` (with active tint on the foot link), `/dashboard/familiars/growth`, `/weaves`, and `/settings`; no console errors on the changed pages (compared against main's server). 790 test files pass; `tsc --noEmit` clean.

Closes cave-4i6u.

🤖 Generated with [Claude Code](https://claude.com/claude-code)