### PR TITLE
fix(charts): render BarChart category labels (cave-pn9v)

### DIFF
--- a/src/components/ui/charts/bar-chart.tsx
+++ b/src/components/ui/charts/bar-chart.tsx
@@ -43,7 +43,9 @@ function BarInner({
   data: BarDatum[];
   defaultColor: string;
 }) {
-  const margin = { top: 8, right: 4, bottom: 4, left: 4 };
+  // Bottom margin reserves a row for the category labels (.cave-chart__label
+  // is --text-2xs = 10px; 14px clears descenders).
+  const margin = { top: 8, right: 4, bottom: 14, left: 4 };
   const iw = Math.max(0, width - margin.left - margin.right);
   const ih = Math.max(0, height - margin.top - margin.bottom);
   if (data.length === 0 || width === 0) {
@@ -60,17 +62,27 @@ function BarInner({
         {data.map((d) => {
           const bw = xScale.bandwidth();
           const bh = ih - (yScale(d.value) ?? ih);
+          const x = xScale(d.label) ?? 0;
           return (
-            <Bar
-              key={d.label}
-              className="cave-chart__bar"
-              x={xScale(d.label) ?? 0}
-              y={yScale(d.value)}
-              width={bw}
-              height={Math.max(0, bh)}
-              rx={3}
-              fill={d.color ?? defaultColor}
-            />
+            <Group key={d.label}>
+              <Bar
+                className="cave-chart__bar"
+                x={x}
+                y={yScale(d.value)}
+                width={bw}
+                height={Math.max(0, bh)}
+                rx={3}
+                fill={d.color ?? defaultColor}
+              />
+              <text
+                className="cave-chart__label"
+                x={x + bw / 2}
+                y={ih + 10}
+                textAnchor="middle"
+              >
+                {d.label}
+              </text>
+            </Group>
           );
         })}
       </Group>


### PR DESCRIPTION
## Summary

`BarChart` drew only the bars — `BarDatum.label` was never rendered, so bars are unreadable without an external legend. Surfaced while composing a screen from the synced design system (the OpenCoven Claude Design import): the chart read as "missing/low-contrast labels".

`charts.css` already defines the intended idiom — `.cave-chart__label { fill: var(--text-muted); font-size: var(--text-2xs) }` — but no chart component used it (orphaned class). This PR:

- renders an x-axis `<text className="cave-chart__label">` centered under each band
- reserves 14px of bottom margin for the label row (10px type + descenders)

Token-correct across all 21 themes by construction (existing class, no literals). `BarChart` currently has no in-app consumers, so the change is purely additive.

## Verification

- `pnpm typecheck` clean in the worktree
- Rendered against the compiled token stylesheet on coven dark: labels legible under both default-lavender and per-datum colored bars (success/accent/danger)

Closes bead `cave-pn9v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)