### PR TITLE
fix(charts): measure immediately on mount — kill the 300ms 'No data yet' flash (cave-ukx0)

### DIFF
--- a/src/components/ui/charts/bar-chart.tsx
+++ b/src/components/ui/charts/bar-chart.tsx
@@ -23,7 +23,7 @@ export function BarChart({
 }) {
   return (
     <div className="cave-chart cave-chart--bar" style={{ height }}>
-      <ParentSize>
+      <ParentSize debounceTime={0}>
         {({ width }) => (
           <BarInner width={width} height={height} data={data} defaultColor={defaultColor} />
         )}

--- a/src/components/ui/charts/donut-chart.tsx
+++ b/src/components/ui/charts/donut-chart.tsx
@@ -26,7 +26,7 @@ export function DonutChart({
 }) {
   return (
     <div className="cave-chart cave-chart--donut" style={{ height: size }}>
-      <ParentSize>
+      <ParentSize debounceTime={0}>
         {({ width }) => <DonutInner width={width} size={size} thickness={thickness} data={data} ariaLabel={ariaLabel} />}
       </ParentSize>
     </div>

--- a/src/components/ui/charts/heatmap.tsx
+++ b/src/components/ui/charts/heatmap.tsx
@@ -34,7 +34,7 @@ export function Heatmap({
 }) {
   return (
     <div className="cave-chart cave-chart--heatmap" style={{ height }}>
-      <ParentSize>
+      <ParentSize debounceTime={0}>
         {({ width }) => (
           <HeatInner width={width} height={height} rows={rows} cols={cols} cells={cells} colorFor={colorFor} ariaLabel={ariaLabel} cellTitle={cellTitle} />
         )}

--- a/src/components/ui/charts/trend-chart.tsx
+++ b/src/components/ui/charts/trend-chart.tsx
@@ -32,7 +32,7 @@ export function TrendChart({
 }) {
   return (
     <div className="cave-chart cave-chart--trend" style={{ height }}>
-      <ParentSize>
+      <ParentSize debounceTime={0}>
         {({ width }) => (
           <TrendInner width={width} height={height} series={series} threshold={threshold} fill={fill} ariaLabel={ariaLabel} />
         )}


### PR DESCRIPTION
## Summary

All four visx charts (`BarChart`, `DonutChart`, `Heatmap`, `TrendChart`) wrap themselves in a bare `<ParentSize>` — `@visx/responsive` defaults `debounceTime` to **300ms**, so the render-prop child gets `width=0` for the first ~300ms and each chart's `width === 0` guard shows the `.cave-chart__empty` "No data yet" state during that window.

Consequences: every chart mount **flashes the empty state in the app**, and any automated screenshot inside the window captures it (surfaced by the design-sync validate captures, which reliably photographed "No data yet" on chart cards).

Fix: `debounceTime={0}` on all four `ParentSize` usages — the first ResizeObserver callback applies immediately (~1 frame). Resize thrash isn't a concern at these chart sizes.

## Verification

- `pnpm typecheck` clean
- Timing probe: screenshot at **600ms post-mount** shows bars + category labels with no empty state — the pre-fix build reliably showed "No data yet" at the same timing

Closes bead `cave-ukx0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)