### PR TITLE
fix(rituals): stretch Log/Agenda rows to the full pane width (cave-1p49)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -26,6 +26,7 @@
 
 ## Known render warns
 
+- Chart cards may screenshot as "No data yet" in validate's full sweep: @visx `useParentSize` applies measurements via `requestAnimationFrame`, and occluded/backgrounded headless pages get rAF throttled/starved — nondeterministic per page load; live/visible pages render in ~1 frame (the debounce has a leading-edge call, so `debounceTime` is irrelevant). Not a bundle defect. Mitigate in screenshot harnesses with `--disable-renderer-backgrounding --disable-backgrounding-occluded-windows --disable-background-timer-throttling`, or triage the warn against this note.
 - `[TOKENS_MISSING]` (~14 vars): `--toast-accent` (set at runtime via inline style by inbox-toast), `--x` (JS-set), `--accent-rose`, `--bg-sunken`, `--danger-bg/-border/-text`, `--accent-contrast` etc. — referenced by app surfaces (inbox-toast, craft-dossier, projects-view) but never defined in the repo either; pre-existing app quirk, not a bundle defect.
 - `[EXPORT_COLLISION] Icon` — false positive, see above.
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9134,6 +9134,14 @@ a.mobile-handoff__link:hover {
   cursor: pointer;
 }
 
+/* Buttons shrink-wrap even as flex containers — without an explicit width the
+   log row (and its hairline separator) ends at its content instead of
+   spanning the pane, and __spacer can't push the timestamp right. need-main
+   stays governed by flex:1 inside its flex-row parent. */
+.rituals-overview__row {
+  width: 100%;
+}
+
 .rituals-overview__need-main {
   padding: var(--space-2) var(--space-1);
 }


### PR DESCRIPTION
## Summary

In Automations → rituals overview, the Log rows and their hairline separators ended at content width (~600px on a wide pane) with timestamps stranded mid-row (screenshot report).

Root cause: `.rituals-overview__row` is a `<button>` — `display: flex` makes it a flex *container*, but buttons still shrink-wrap their content, and the rule's `flex: 1` is a no-op because the parent `.rituals-overview__log` is a plain block. The row markup already ships a `__spacer` meant to push trailing meta right — it only works once the button fills the pane.

Fix: `width: 100%` on `.rituals-overview__row`, scoped so `__need-main` (a genuine flex item in the needs rows) stays governed by its `flex: 1`.

Second commit records the corrected root cause of the chart "No data yet" captures in `.design-sync/NOTES.md` (rAF throttling in occluded headless pages — supersedes the mechanism described in #3474).

## Verification

Replica of the row markup rendered against the real stylesheet, before vs after: row width **291px → 1052px** (full pane), separators edge-to-edge, timestamps right-aligned.

Closes bead `cave-1p49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)