### PR TITLE
fix(chat): recover stale transcript after stream drop

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -129,6 +129,7 @@ export const SUITES = {
     "src/lib/chat-session-prefs.test.ts",
     "src/lib/conversation-tree.test.ts",
     "src/lib/stream-text.test.ts",
+    "src/lib/chat-sse.test.ts",
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",
     "src/lib/chat-project-overrides.test.ts",

--- a/src/components/chat-view-chunk-coalescing.test.ts
+++ b/src/components/chat-view-chunk-coalescing.test.ts
@@ -36,8 +36,8 @@ assert.match(
 // ── 3. Stream end flushes ────────────────────────────────────────────────────
 assert.match(
   src,
-  /\n\s*\}\s*\n\s*chunkCoalescer\.flush\(\);\s*\n\s*\} catch \(err\) \{/,
-  "normal stream end must flush the tail of the buffer",
+  /if \(!sawDone && !controller\.signal\.aborted\) \{[\s\S]*?\/api\/chat\/stream[\s\S]*?\}\s*\n\s*chunkCoalescer\.flush\(\);/,
+  "a stream that ends before done must try recovery, then flush the tail of the buffer",
 );
 
 // ── 4. The error/abort path flushes before reading t.text ───────────────────

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -593,6 +593,11 @@ assert.match(
 );
 assert.match(
   source,
+  /ev\.kind === "progress" && ev\.id === "resume-gap"\)[\s\S]{0,100}?needsTranscriptResync = true/,
+  "An evicted replay gap must rehydrate the persisted transcript after the resumed stream settles",
+);
+assert.match(
+  source,
   /<LinkedContextRow\b/,
   "ChatView should render LinkedContextRow for task/GitHub chips",
 );

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -583,6 +583,16 @@ assert.match(
 );
 assert.match(
   source,
+  /const hasLiveGeneration = \(\) => \{[\s\S]*readLiveChatGeneration\(sessionId\)[\s\S]*isLiveSnapshotActive[\s\S]*if \(hasLiveGeneration\(\)\) \{[\s\S]*setHistoryState\("loaded"\)[\s\S]*return/,
+  "A stale successful history response must not overwrite an active live transcript",
+);
+assert.match(
+  source,
+  /consumeChatSse\(res\.body, applyStreamEvent\)[\s\S]*\/api\/chat\/stream\?runId=\$\{encodeURIComponent\(runId\)\}&cursor=\$\{cursor\}/,
+  "A chat stream that ends without done reattaches through the buffered stream endpoint",
+);
+assert.match(
+  source,
   /<LinkedContextRow\b/,
   "ChatView should render LinkedContextRow for task/GitHub chips",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4420,6 +4420,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       let cursor = 0;
       const applyStreamEvent = (ev: StreamEvent, eventCursor: number | null) => {
         if (eventCursor != null) cursor = eventCursor;
+        // The resume route emits this marker when the bounded event ring
+        // dropped output before our cursor. We can render the remaining tail,
+        // but must still rehydrate after settle to restore the missing middle.
+        if (ev.kind === "progress" && ev.id === "resume-gap") needsTranscriptResync = true;
         if (ev.kind === "assistant_chunk") {
           // Hot path: buffer instead of committing per token.
           chunkCoalescer.push(ev.text);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -160,6 +160,7 @@ import { ComposerGitChip } from "@/components/composer-git-chip";
 import { resolveActivePath, buildSiblingIndex, childLeaf } from "@/lib/conversation-tree";
 import { appendCollapsingNewlines } from "@/lib/stream-text";
 import { createChunkCoalescer } from "@/lib/chunk-coalescer";
+import { consumeChatSse } from "@/lib/chat-sse";
 import { stripStepMarkers } from "@/lib/workflow-step-progress";
 import {
   buildReflectTranscript,
@@ -3660,6 +3661,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       );
       setHistoryState("loaded");
     };
+    // A history request can start just before the user sends. By the time its
+    // successful response arrives, its transcript is already stale; applying
+    // it would erase the optimistic user/assistant pair from the screen. The
+    // live registry is the authority until that generation settles.
+    const hasLiveGeneration = () => {
+      const live = readLiveChatGeneration(sessionId);
+      return Boolean(live && isLiveSnapshotActive(live, Date.now()));
+    };
     // A prefetched (hover) or previously loaded transcript paints immediately
     // instead of blanking to the history skeleton. The fetch below still runs
     // as revalidation, so a stale cache entry is corrected as soon as the
@@ -3721,6 +3730,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         if (cancelled) return;
         setLinkedContext(json.context ?? null);
         if (json.ok && json.conversation) {
+          if (hasLiveGeneration()) {
+            setHistoryState("loaded");
+            return;
+          }
           storeConversation(sessionId, json);
           applyConversationPayload(json);
         } else if (json.ok && json.context) {
@@ -4278,6 +4291,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       apply: (text) => applyAssistantChunk(text, assistantId, liveGeneration),
     });
     const runId = crypto.randomUUID();
+    let needsTranscriptResync = false;
     abortRef.current = controller;
     stopKeysRef.current = { runId, sessionId: initialLiveSessionId ?? null };
     streamOwnerRef.current = true;
@@ -4402,37 +4416,50 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         label: "Connected to chat bridge",
         status: "done",
       }, liveGeneration.sessionId);
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        let idx;
-        while ((idx = buffer.indexOf("\n\n")) >= 0) {
-          const frame = buffer.slice(0, idx);
-          buffer = buffer.slice(idx + 2);
-          if (!frame.startsWith("data:")) continue;
-          const payload = frame.slice(5).trim();
-          if (!payload) continue;
-          try {
-            const ev = JSON.parse(payload) as StreamEvent;
-            if (ev.kind === "assistant_chunk") {
-              // Hot path: buffer instead of committing per token.
-              chunkCoalescer.push(ev.text);
-            } else {
-              // Ordering: buffered text must land before any progress /
-              // attachment / done record derived from later frames.
-              chunkCoalescer.flush();
-              handleEvent(ev, assistantId, request, liveGeneration);
-            }
-          } catch {
-            /* skip malformed */
+      let sawDone = false;
+      let cursor = 0;
+      const applyStreamEvent = (ev: StreamEvent, eventCursor: number | null) => {
+        if (eventCursor != null) cursor = eventCursor;
+        if (ev.kind === "assistant_chunk") {
+          // Hot path: buffer instead of committing per token.
+          chunkCoalescer.push(ev.text);
+        } else {
+          // Ordering: buffered text must land before any progress /
+          // attachment / done record derived from later frames.
+          chunkCoalescer.flush();
+          handleEvent(ev, assistantId, request, liveGeneration);
+        }
+      };
+      try {
+        const initial = await consumeChatSse(res.body, applyStreamEvent);
+        cursor = Math.max(cursor, initial.cursor);
+        sawDone = initial.sawDone;
+      } catch (error) {
+        // The bridge records every event in its run buffer. A dropped native
+        // WebView stream is recoverable; only rethrow an intentional Stop.
+        if (controller.signal.aborted) throw error;
+      }
+
+      if (!sawDone && !controller.signal.aborted) {
+        try {
+          const recovery = await fetch(
+            `/api/chat/stream?runId=${encodeURIComponent(runId)}&cursor=${cursor}`,
+            { cache: "no-store", signal: controller.signal },
+          );
+          if (recovery.ok && recovery.body) {
+            const resumed = await consumeChatSse(recovery.body, applyStreamEvent);
+            cursor = Math.max(cursor, resumed.cursor);
+            sawDone = resumed.sawDone;
           }
+        } catch (error) {
+          if (controller.signal.aborted) throw error;
         }
       }
       chunkCoalescer.flush();
+      // The buffer can have been reaped after the server persisted its reply
+      // (or the server may have restarted). Re-run history loading once this
+      // owner releases its live snapshot so the screen still catches up.
+      if (!sawDone && !controller.signal.aborted) needsTranscriptResync = true;
     } catch (err) {
       // Apply any buffered streamed text FIRST — the handlers below read
       // t.text (e.g. the cancelled fallback label) and must see all of it.
@@ -4470,6 +4497,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     } finally {
       // Always retire THIS generation's registry entry (keyed by session).
       clearLiveChatGeneration(liveGeneration.sessionId);
+      if (needsTranscriptResync && liveGeneration.sessionId === currentSessionRef.current) {
+        setHistoryRetryKey((k) => k + 1);
+      }
       // But only tear down the SHARED stream wiring if we still own it. After a
       // thread switch + a second send, a settling *background* stream must not
       // null the newer stream's abort controller / stop keys or re-enable the

--- a/src/lib/chat-sse.test.ts
+++ b/src/lib/chat-sse.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { consumeChatSse } from "./chat-sse.ts";
+
+function stream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+describe("consumeChatSse", () => {
+  it("returns the SSE cursor and accepts CRLF frames split across reads", async () => {
+    const seen: string[] = [];
+    const result = await consumeChatSse(
+      stream([
+        "id: 7\r\ndata: {\"kind\":\"assistant_chunk\",\"text\":\"hi\"}\r\n\r",
+        "\nid: 8\r\ndata: {\"kind\":\"done\"}\r\n\r\n",
+      ]),
+      (event) => seen.push(event.kind),
+    );
+
+    assert.deepEqual(seen, ["assistant_chunk", "done"]);
+    assert.equal(result.cursor, 8);
+    assert.equal(result.sawDone, true);
+  });
+
+  it("does not treat a transport end without done as a completed run", async () => {
+    const result = await consumeChatSse(
+      stream(['id: 3\ndata: {"kind":"progress","id":"start","label":"Starting","status":"running"}\n\n']),
+      () => {},
+    );
+
+    assert.equal(result.cursor, 3);
+    assert.equal(result.sawDone, false);
+  });
+});

--- a/src/lib/chat-sse.ts
+++ b/src/lib/chat-sse.ts
@@ -1,0 +1,71 @@
+import type { StreamEvent } from "@/lib/stream-events";
+
+export type ChatSseReadResult = {
+  /** Last server-issued event id observed while reading this response. */
+  cursor: number;
+  /** Whether the stream explicitly confirmed the run had settled. */
+  sawDone: boolean;
+};
+
+/**
+ * Consume Cave's chat SSE framing. `id:` is deliberately surfaced so a caller
+ * can reattach through `/api/chat/stream` after a WebView or network drop.
+ *
+ * The bridge currently emits LF frames, but accepting CRLF here matters for
+ * platform WebViews and intermediaries that normalize line endings.
+ */
+export async function consumeChatSse(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (event: StreamEvent, cursor: number | null) => void,
+): Promise<ChatSseReadResult> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let cursor = 0;
+  let sawDone = false;
+
+  const handleFrame = (frame: string) => {
+    let frameCursor: number | null = null;
+    const data: string[] = [];
+    for (const rawLine of frame.split(/\r?\n/)) {
+      if (rawLine.startsWith("id:")) {
+        const parsed = Number(rawLine.slice(3).trim());
+        if (Number.isSafeInteger(parsed) && parsed > 0) frameCursor = parsed;
+      } else if (rawLine.startsWith("data:")) {
+        data.push(rawLine.slice(5).trimStart());
+      }
+    }
+    if (frameCursor != null) cursor = frameCursor;
+    const payload = data.join("\n").trim();
+    if (!payload) return;
+    try {
+      const event = JSON.parse(payload) as StreamEvent;
+      if (!event || typeof event !== "object" || typeof event.kind !== "string") return;
+      if (event.kind === "done") sawDone = true;
+      onEvent(event, frameCursor);
+    } catch {
+      // A malformed frame must not discard the rest of a long-running reply.
+    }
+  };
+
+  const drain = () => {
+    while (true) {
+      const boundary = buffer.match(/\r?\n\r?\n/);
+      if (!boundary || boundary.index == null) return;
+      const end = boundary.index;
+      handleFrame(buffer.slice(0, end));
+      buffer = buffer.slice(end + boundary[0].length);
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    drain();
+  }
+  buffer += decoder.decode();
+  drain();
+  if (buffer.trim()) handleFrame(buffer);
+  return { cursor, sawDone };
+}


### PR DESCRIPTION
## Summary

- Keep an active optimistic transcript from being overwritten by a stale successful history response.
- Reattach a dropped send stream through the server event buffer, carrying forward the SSE cursor.
- Rehydrate persisted history if stream replay is no longer available, with parser and ChatView regression coverage.

## Root cause

A history request that began before sending could return after the optimistic user and assistant turns were on screen, then replace them with its older payload. Separately, the client read only the initial send SSE response and did not use the existing buffered replay route when a native WebView transport ended early.

## User impact

Fixes the stale-transcript behavior reported by Anakin Skywalker this morning: a sent message and persisted assistant reply could be absent from the screen until leaving and reopening the session.

## Validation

- Windows-native: pnpm typecheck
- node --experimental-strip-types --test src/lib/chat-sse.test.ts
- node --experimental-strip-types src/components/chat-view-polish.test.ts
- node --experimental-strip-types src/components/chat-view-chunk-coalescing.test.ts
- Native Tauri launch with daemon online on 127.0.0.1:3001
- pnpm test:app reached 116 files, then stopped on the pre-existing Windows path-separator assertion in scripts/sync-marketplace.test.mjs (tracked separately as cave-ki0).