### PR TITLE
fix(ci): fail the CodeQL job when SARIF processing never completes (cave-mq1f)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,10 +87,10 @@ jobs:
       # twice, merge deadlocked; cave-mq1f). Keep polling until the analysis
       # actually lands, and fail LOUDLY otherwise so a job re-run can heal it.
       - name: Require SARIF processing to complete
-        if: steps.analyze.outputs.sarif-id != ''
+        if: ${{ steps.analyze.outputs['sarif-id'] != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          SARIF_ID: ${{ steps.analyze.outputs.sarif-id }}
+          SARIF_ID: ${{ steps.analyze.outputs['sarif-id'] }}
         run: |
           set -euo pipefail
           for i in $(seq 1 32); do

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,12 +71,41 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL analysis
+        id: analyze
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           # Default setup rejects advanced SARIF uploads. Keep the migration
           # workflow green in analysis-only mode until an administrator
           # disables default setup and sets this repository variable to always.
           upload: ${{ vars.CODEQL_ADVANCED_UPLOAD || 'never' }}
+
+      # The analyze step waits ~2.5 min for server-side SARIF processing, then
+      # WARNS and continues on timeout — a processing failure therefore leaves
+      # this job green while the ruleset's code_scanning gate waits forever for
+      # the missing category and the PR sits BLOCKED with no red X anywhere
+      # (PR #3475: python uploaded "successfully", processing silently died
+      # twice, merge deadlocked; cave-mq1f). Keep polling until the analysis
+      # actually lands, and fail LOUDLY otherwise so a job re-run can heal it.
+      - name: Require SARIF processing to complete
+        if: steps.analyze.outputs.sarif-id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SARIF_ID: ${{ steps.analyze.outputs.sarif-id }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 32); do
+            status=$(gh api "repos/${GITHUB_REPOSITORY}/code-scanning/sarifs/${SARIF_ID}" --jq .processing_status || echo transient)
+            case "$status" in
+              complete) echo "SARIF processing complete."; exit 0 ;;
+              failed)
+                echo "::error::SARIF processing FAILED for ${{ matrix.language }}:"
+                gh api "repos/${GITHUB_REPOSITORY}/code-scanning/sarifs/${SARIF_ID}" --jq '.errors // empty' || true
+                exit 1 ;;
+            esac
+            sleep 15
+          done
+          echo "::error::SARIF for ${{ matrix.language }} still unprocessed after 8 minutes — the code_scanning merge gate will deadlock waiting for this category. Re-run this job."
+          exit 1
 
   # Out-of-band swift security audit: weekly + on demand. Scans the generated
   # iOS project on a macOS runner but NEVER uploads to code scanning, so the


### PR DESCRIPTION
## Summary

Root-causes and fixes the merge deadlock first hit on #3475. The framing in bead `cave-mq1f` ("docs-only PRs deadlock") turned out wrong once traced to ground truth:

- The `analyze` action **waits ~2.5 min** for server-side SARIF processing, then **warns and continues** on timeout — the job stays green regardless.
- On #3475, python's SARIF uploaded "successfully" but **never finished processing** (verified via the code-scanning analyses API an hour later: the merge ref had actions/js-ts/rust, no python — across two full CI cycles).
- The main-ruleset `code_scanning` rule then waits forever for the missing category: `mergeStateStatus: BLOCKED` with every visible check passing and **no red X anywhere to re-run**. (That PR was ultimately admin-merged with explicit authorization.)

## Fix

A post-analyze step polls `GET /code-scanning/sarifs/{id}` for up to 8 additional minutes and **fails the job** if processing reports `failed` or never completes. The silent unfixable deadlock becomes a visible per-language failure that `gh run rerun --failed` heals. No ruleset changes — the security gate keeps its teeth.

Skipped automatically when uploads are off (`sarif-id` empty) and for the no-upload swift audit job.

## Verification

- YAML parses clean; step uses only `github.token` with the job's existing `security-events: write` permission.
- This PR itself exercises the new step live on all four Analyze jobs (workflow files are `actions`-language, so the gate evaluates it end-to-end).

Closes bead `cave-mq1f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)