### PR TITLE
feat(memories): move doc search from the navigator rail into the header

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -24,7 +24,21 @@ assert.match(view, /export function GrimoireView\(/, "GrimoireView must be expor
 assert.match(view, /fetch\("\/api\/knowledge"/, "navigator lists the knowledge vault");
 assert.match(view, /fetch\("\/api\/memory"/, "navigator lists memory files");
 assert.match(view, /fetch\("\/api\/journal"/, "navigator lists journal days");
-assert.match(view, /aria-label="Search grimoire documents"/, "navigator search is labelled");
+assert.match(view, /aria-label="Search grimoire documents"/, "doc search is labelled");
+// cave-zqhr: the doc search moved OUT of the navigator rail into the compact
+// header beside the Knowledge/Journal/Relations tabs. It must be the shared
+// SearchInput in the actions cluster, and the rail must not grow a second
+// input back.
+assert.match(
+  view,
+  /surface-compact-actions[\s\S]{0,700}<SearchInput\s[\s\S]{0,300}containerClassName="surface-compact-search"/,
+  "the doc search is a shared SearchInput in the header actions cluster, not in the rail",
+);
+assert.doesNotMatch(
+  view,
+  /<aside[\s\S]*?type="search"/,
+  "the navigator rail carries no search input of its own (header owns it — cave-zqhr)",
+);
 assert.match(view, /New stitch/, "stitches can be sewn from pinned sources here");
 assert.match(view, /Blank entry/, "hand-written entries can still be created");
 assert.match(

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -36,6 +36,7 @@ import {
   type DateTimePrefs,
 } from "@/lib/datetime-format";
 import { GRIMOIRE_HASH_PREFIX } from "@/lib/grimoire-link";
+import { SearchInput } from "@/components/ui/search-input";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
@@ -1471,6 +1472,20 @@ export function GrimoireView({
           </button>
         </div>
         <div className="surface-compact-actions">
+          {/* Doc search lives up here beside the tabs (it used to sit inside
+              the navigator rail). Same query state — it still filters the
+              rail's Stitches/Memory/Journal sections. Hidden on Relations,
+              where nothing consumes the query. */}
+          {view !== "graph" ? (
+            <SearchInput
+              value={query}
+              onValueChange={setQuery}
+              onClear={() => setQuery("")}
+              placeholder="Search documents…"
+              aria-label="Search grimoire documents"
+              containerClassName="surface-compact-search"
+            />
+          ) : null}
           {view === "docs" ? (
             <>
               <button
@@ -1503,21 +1518,8 @@ export function GrimoireView({
           selection || view !== "docs" ? "hidden @min-[880px]/grimoire:flex" : ""
         }`}
       >
-        {/* Title + surface verbs moved to the compact band above; the rail
-            keeps only its list filter. */}
-        <div className="shrink-0 border-b border-[var(--border-hairline)] p-3">
-          <input
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape" && query) setQuery("");
-            }}
-            placeholder="Search documents…"
-            aria-label="Search grimoire documents"
-            className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-transparent px-2 py-1.5 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
-          />
-        </div>
+        {/* Title, surface verbs, and the doc search all live in the compact
+            band above — the rail is purely the grouped navigator now. */}
         <div ref={railListRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
           {loadError ? (
             <ErrorState compact headline="Couldn't load documents" subtitle={loadError} />


### PR DESCRIPTION
## What

On the Memories surface, the document search no longer lives inside the navigator sidepanel — it's now a top-level search bar in the compact header, right beside the Knowledge / Journal / Relations tabs.

## How

- The rail's inline `<input type="search">` block is removed; the rail is purely the grouped navigator (Stitches / Memory files / Journal) now.
- The header's actions cluster gains the shared `SearchInput` (magnifier icon, clear button, Escape-clears) in a `surface-compact-search` container — the same pattern the Marketplace header uses.
- Query state and filtering are unchanged: it still drives `visibleKnowledge`/`visibleMemory`/`visibleJournal` and auto-expands collapsed sections so matches stay reachable. The bar hides on the Relations tab, where nothing consumes the query.
- `grimoire-view.test.ts` pins the new contract: search must be a `SearchInput` in the header actions cluster, and the rail must not grow a second input back.

## Verification

Booted the branch and drove the Memories surface: tabs + search render side by side in the header, the rail has zero inputs, `aria-label="Search grimoire documents"` preserved. 790 test files pass; `tsc --noEmit` clean.

Closes cave-zqhr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)