### PR TITLE
fix(projects): allow creating projects anywhere under $HOME

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 
 import { deleteProject, patchProject } from "@/lib/cave-projects";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
 export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
   const { id } = await params;
   let body: Record<string, unknown> = {};
   try {
@@ -56,7 +59,9 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
   return NextResponse.json({ ok: true, project });
 }
 
-export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
   const { id } = await params;
   const deleted = await deleteProject(id);
   if (!deleted) return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -22,6 +22,12 @@ assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects s
 assert.match(listRoute, /root must be inside an allowed workspace/, "POST /api/projects should reject unsafe roots");
 assert.match(listRoute, /validateCaveProjectRoot/, "POST /api/projects should require existing directory roots before persisting them");
 assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 when creating");
+assert.match(listRoute, /rejectNonLocalRequest\(req\)/, "projects route must reject non-loopback requests before touching project state");
+assert.match(
+  listRoute,
+  /rejectNonLocalRequest[\s\S]*export async function POST/,
+  "POST /api/projects must enforce loopback before registering $HOME-scoped roots",
+);
 
 assert.match(itemRoute, /export async function PUT/, "project item route should expose PUT");
 assert.match(itemRoute, /export async function DELETE/, "project item route should expose DELETE");
@@ -29,6 +35,7 @@ assert.match(itemRoute, /isAllowedNewProjectRoot\(trimmed\)/, "PUT /api/projects
 assert.match(itemRoute, /validateCaveProjectRoot/, "PUT /api/projects/[id] should require existing directory roots before persisting them");
 assert.match(itemRoute, /nothing to update/, "PUT /api/projects/[id] should reject empty patches");
 assert.match(itemRoute, /not found/, "project item route should return not-found errors");
+assert.match(itemRoute, /rejectNonLocalRequest/, "project item route must enforce loopback before mutating project roots");
 
 assert.match(seedRoute, /seedDefaultProjectsIfEmpty/, "seed route should invoke default seeding");
 assert.match(seedRoute, /export async function POST\(\)/, "seed route should expose POST only");

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -22,11 +22,15 @@ assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects s
 assert.match(listRoute, /root must be inside an allowed workspace/, "POST /api/projects should reject unsafe roots");
 assert.match(listRoute, /validateCaveProjectRoot/, "POST /api/projects should require existing directory roots before persisting them");
 assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 when creating");
-assert.match(listRoute, /rejectNonLocalRequest\(req\)/, "projects route must reject non-loopback requests before touching project state");
 assert.match(
   listRoute,
-  /rejectNonLocalRequest[\s\S]*export async function POST/,
-  "POST /api/projects must enforce loopback before registering $HOME-scoped roots",
+  /export async function POST\(req: Request\)\s*\{\s*const denied = rejectNonLocalRequest\(req\);/,
+  "POST /api/projects must enforce loopback before registering \$HOME-scoped roots",
+);
+assert.doesNotMatch(
+  listRoute,
+  /export async function GET\(req: Request\)\s*\{\s*const denied = rejectNonLocalRequest/,
+  "GET /api/projects stays reachable over the tailnet like its read-only siblings (familiars/board/sessions)",
 );
 
 assert.match(itemRoute, /export async function PUT/, "project item route should expose PUT");

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -2,12 +2,15 @@ import { NextResponse } from "next/server";
 
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
   await seedDefaultProjectsIfEmpty();
   const projects = await loadProjects();
   const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || null;
@@ -22,6 +25,8 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
   let body: Record<string, unknown> = {};
   try {
     body = (await req.json()) as Record<string, unknown>;

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -9,8 +9,6 @@ import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/p
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const denied = rejectNonLocalRequest(req);
-  if (denied) return denied;
   await seedDefaultProjectsIfEmpty();
   const projects = await loadProjects();
   const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || null;

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
 const originalEnv = {

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -122,12 +122,34 @@ try {
   assert.equal(
     isAllowedNewProjectRoot("~"),
     false,
-    "tilde project roots are checked after home-directory expansion",
+    "tilde project roots are checked after home-directory expansion; $HOME itself is never a project root",
   );
   assert.equal(
     isAllowedNewProjectRoot("~/secret"),
+    true,
+    "home-directory descendants are allowed as new project roots (matches the fs-browse folder picker boundary)",
+  );
+
+  // A real directory nested under $HOME is an allowed new-project root, since
+  // the loopback-only folder picker can navigate there. Symlink-safe: the
+  // check realpaths the candidate before containment.
+  const homeChildProject = await mkdtemp(path.join(await realpath(homedir()), "coven-newproj-"));
+  try {
+    assert.equal(
+      isAllowedNewProjectRoot(homeChildProject),
+      true,
+      "an existing directory under $HOME is an allowed new project root",
+    );
+  } finally {
+    await rm(homeChildProject, { recursive: true, force: true });
+  }
+
+  // Paths outside $HOME (e.g. a sibling of the OS tmp home) stay rejected so
+  // registration can't reach arbitrary filesystem locations.
+  assert.equal(
+    isAllowedNewProjectRoot(path.join(tmp, "outside-home")),
     false,
-    "tilde subpaths cannot masquerade as relative paths under the current working directory",
+    "roots outside both the built-in workspace roots and $HOME are rejected",
   );
 
   assert.equal(

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -141,5 +141,18 @@ export function resolveAllowedProjectPath(value: string): string | null {
 
 export function isAllowedNewProjectRoot(value: string): boolean {
   const candidate = realpathOrResolve(normalizeNewProjectRootCandidate(value));
-  return uniqueRoots(builtInProjectRoots()).some((root) => isWithinRoot(candidate, root));
+  if (uniqueRoots(builtInProjectRoots()).some((root) => isWithinRoot(candidate, root))) {
+    return true;
+  }
+  // The "New project" folder picker (fs-browse) lets the user navigate
+  // anywhere under $HOME, so registration must accept the same boundary or
+  // the picker offers folders creation then rejects with a 403. This widening
+  // is safe only because the projects POST route is loopback-only (see
+  // rejectNonLocalRequest there): a phone on the tailnet cannot register
+  // arbitrary home paths. Containment is realpath-based, so symlink escapes
+  // out of $HOME are still rejected. $HOME itself is excluded — registering
+  // the entire home directory as one project is never intended and would be
+  // an unbounded root — so only strict descendants qualify.
+  const home = realpathOrResolve(homedir());
+  return candidate !== home && isWithinRoot(candidate, home);
 }


### PR DESCRIPTION
## Problem

The `New project` folder picker (`fs-browse`) lets the user navigate the entire home directory, but `isAllowedNewProjectRoot` only accepted roots under the Coven workspace / cwd / research missions. Selecting a valid folder like `~/Documents/GitHub/model-distillation-lab` then failed with:

```
POST /api/projects → 403 "root must be inside an allowed workspace"
```

The picker invited a choice that creation would refuse.

## Fix

- **Align registration with the picker's boundary:** accept any real directory that is a **strict descendant of $HOME** ($HOME itself stays excluded), with realpath-based containment so symlink escapes out of $HOME are still rejected.
- **Security (required by the widening):** the projects POST route had **no loopback guard**. Added `rejectNonLocalRequest` to `POST /api/projects` and `PUT/DELETE /api/projects/[id]`, matching `fs-browse` — a phone on the tailnet must not register or repoint arbitrary home paths.

## Verification

- `project-paths.test.ts` + `projects route.test.ts` → **ok** (updated 2 now-obsolete assertions; added home-descendant, outside-home, and loopback coverage)
- Full **api** test suite → exited 0
- `tsc --noEmit` → clean

## Blast radius

+56 / −4 across 5 files; server-side only. No UI changes needed — the failing case is under $HOME and now succeeds.