### PR TITLE
fix(rituals): add tabs and expand layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8993,8 +8993,8 @@ a.mobile-handoff__link:hover {
 
 .rituals-overview__events,
 .rituals-overview__lower {
-  width: min(920px, 100%);
-  margin-inline: auto;
+  width: 100%;
+  max-width: 100%;
 }
 
 .rituals-overview__section-toggle {
@@ -9076,8 +9076,9 @@ a.mobile-handoff__link:hover {
 
 .rituals-overview__needs {
   position: relative;
-  width: min(920px, 100%);
-  margin: var(--space-3) auto;
+  width: 100%;
+  max-width: 100%;
+  margin: var(--space-3) 0;
   padding: var(--space-3) var(--space-3) var(--space-2);
   border: 1px dashed color-mix(in oklch, var(--accent-presence) 54%, var(--border-hairline));
   border-radius: var(--radius-panel);
@@ -9308,8 +9309,9 @@ a.mobile-handoff__link:hover {
 }
 
 .rituals-overview__selection {
-  width: min(920px, 100%);
-  margin: var(--space-3) auto 0;
+  width: 100%;
+  max-width: 100%;
+  margin: var(--space-3) 0 0;
 }
 
 @container (max-width: 620px) {

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -273,7 +273,7 @@ assert.match(source, /announce\(`Run started for '\$\{auto\.name\}'\.`\)/, "run-
 assert.match(source, /announce\(`Created cron '\$\{input\.name\}'\.`\)/, "create announces");
 assert.match(source, /role="img" aria-label="Paused"/, "status dots carry accessible names");
 assert.match(source, /<section aria-labelledby=\{headingId\}/, "list sections are labelled landmarks with real headings");
-assert.match(source, /role="region"[\s\S]{0,220}aria-label=\{activeTab === "overview" \? "Rituals overview"/, "the content region names the active Rituals mode without relying on visible tabs");
+assert.match(source, /<div[\s\S]{0,120}role="tabpanel"[\s\S]{0,120}id=\{`automations-panel-\$\{activeTab\}`\}[\s\S]{0,120}aria-labelledby=\{`automations-tab-\$\{activeTab\}`\}[\s\S]{0,180}aria-label=\{activeTab === "overview" \? "Rituals overview" : activeTab === "calendar" \? "Rituals calendar" : "Rituals crons"\}/, "the active Rituals panel is a tabpanel with the destination-specific label");
 assert.match(source, /onClose=\{\(\) => \{ setCreateOpen\(false\); setTemplateInitialValues\(undefined\); \}\}/, "the create dialog closes through one reset path");
 assert.match(source, /window\.setTimeout\(\(\) => newBtnRef\.current\?\.focus\(\), 0\)/, "deletes hand focus somewhere stable instead of dropping it on <body>");
 

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -37,6 +37,7 @@ import { useConfirm } from "@/components/ui/confirm-dialog";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { SearchInput } from "@/components/ui/search-input";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
 import { useMultiSelect } from "@/lib/use-multi-select";
@@ -101,6 +102,12 @@ function linkLabel(link: LinkRef): string {
 // Calendar and Crons. The broader Automations/Flow experience lives on
 // feature/automations-flow.
 type AutomationTab = "overview" | "calendar" | "crons";
+
+const RITUAL_TABS = [
+  { id: "overview", label: "Overview" },
+  { id: "calendar", label: "Calendar" },
+  { id: "crons", label: "Crons" },
+] satisfies ReadonlyArray<TabItem<AutomationTab>>;
 
 // Fire a cross-surface navigation so "Open" on a flow jumps to its
 // dedicated editor surface (the Workspace owns setMode; see cave:navigate-mode).
@@ -2599,13 +2606,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
       {/* ── Main list ──────────────────────────────────────────────────────── */}
       <div className={`${detailOpen ? (cronDetailExpanded ? "hidden" : "hidden md:flex") : "flex"} flex-1 min-w-0 flex-col`}>
         <div className="surface-compact-header rituals-overview__header">
-          {activeTab !== "overview" ? (
-            <Button size="xs" variant="ghost" leadingIcon="ph:arrow-left" onClick={() => selectTab("overview")}>
-              Overview
-            </Button>
-          ) : (
-            <Icon name="ph:moon" width={15} className="rituals-overview__moon" aria-hidden />
-          )}
+          <Icon name="ph:moon" width={15} className="rituals-overview__moon" aria-hidden />
           <h1 className="surface-compact-title">Rituals</h1>
           {activeTab === "overview" ? (
             <p className="surface-compact-summary">{ritualWeekLabel(ritualWeek)}</p>
@@ -2704,14 +2705,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   ariaLabel="Rituals options"
                 >
                   <PopoverBody role="menu" ariaLabel="Rituals options">
-                    {calendarSlot ? (
-                      <PopoverItem icon="ph:calendar-check" onSelect={() => { setManageMenuOpen(false); selectTab("calendar"); }}>
-                        Open full calendar
-                      </PopoverItem>
-                    ) : null}
-                    <PopoverItem icon="ph:clock-countdown" onSelect={() => { setManageMenuOpen(false); selectTab("crons"); }}>
-                      Manage crons
-                    </PopoverItem>
                     <PopoverItem icon="ph:github-logo" onSelect={() => { setManageMenuOpen(false); void openSubscriptions(); }}>
                       Subscriptions
                     </PopoverItem>
@@ -2750,6 +2743,24 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             ) : null}
           </div>
         </div>
+        <Tabs
+          items={RITUAL_TABS}
+          value={activeTab}
+          onChange={selectTab}
+          ariaLabel="Rituals sections"
+          idPrefix="automations"
+          size="sm"
+          className="shrink-0 px-3"
+        />
+        {RITUAL_TABS.filter((tab) => tab.id !== activeTab).map((tab) => (
+          <div
+            key={tab.id}
+            role="tabpanel"
+            id={`automations-panel-${tab.id}`}
+            aria-labelledby={`automations-tab-${tab.id}`}
+            hidden
+          />
+        ))}
 
         {error && (
           <div
@@ -2770,8 +2781,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
         {/* List (or the Calendar surface when that tab is active) */}
         <div
-          role="region"
+          role="tabpanel"
           id={`automations-panel-${activeTab}`}
+          aria-labelledby={`automations-tab-${activeTab}`}
           aria-label={activeTab === "overview" ? "Rituals overview" : activeTab === "calendar" ? "Rituals calendar" : "Rituals crons"}
           className={activeTab === "calendar" ? "flex-1 min-h-0 overflow-hidden" : activeTab === "overview" ? "@container flex-1 overflow-y-auto rituals-overview" : "@container flex-1 overflow-y-auto px-4 pt-4 pb-8 @min-[640px]:px-8"}>
           {activeTab === "calendar" ? (

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -10,6 +10,7 @@ const menuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url)
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const calendar = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const notificationBell = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 const slashCommands = readFileSync(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
@@ -72,6 +73,36 @@ assert.match(
 );
 assert.match(
   automations,
+  /import\s+\{\s*Tabs,\s*type\s+TabItem\s*\}\s+from\s+"@\/components\/ui\/tabs";/,
+  "Rituals imports the shared Tabs primitive",
+);
+assert.match(
+  automations,
+  /const\s+RITUAL_TABS\s*=\s*\[[\s\S]{0,300}\{\s*id:\s*"overview",\s*label:\s*"Overview"\s*\}[\s\S]{0,160}\{\s*id:\s*"calendar",\s*label:\s*"Calendar"\s*\}[\s\S]{0,160}\{\s*id:\s*"crons",\s*label:\s*"Crons"\s*\}[\s\S]{0,240}satisfies\s+ReadonlyArray<TabItem<AutomationTab>>/,
+  "RITUAL_TABS should define Overview, Calendar, and Crons as typed shared tab items",
+);
+assert.match(
+  automations,
+  /<Tabs[\s\S]{0,200}items=\{RITUAL_TABS\}[\s\S]{0,120}value=\{activeTab\}[\s\S]{0,120}onChange=\{selectTab\}[\s\S]{0,120}ariaLabel="Rituals sections"[\s\S]{0,120}idPrefix="automations"/,
+  "Rituals tabs should be driven by the shared Tabs component with accessible wiring",
+);
+assert.match(
+  automations,
+  /role="tabpanel"[\s\S]{0,160}id=\{`automations-panel-\$\{activeTab\}`\}[\s\S]{0,160}aria-labelledby=\{`automations-tab-\$\{activeTab\}`\}/,
+  "Active tab content should use wired tabpanel semantics",
+);
+assert.match(
+  automations,
+  /RITUAL_TABS\.filter\(\(tab\) => tab\.id !== activeTab\)\.map\(\(tab\) => \([\s\S]{0,220}<div[\s\S]{0,220}id=\{`automations-panel-\$\{tab\.id\}`\}[\s\S]{0,120}aria-labelledby=\{`automations-tab-\$\{tab\.id\}`\}[\s\S]{0,120}hidden[\s\S]{0,40}\/>[\s\S]{0,40}\)\)/,
+  "Inactive tabs should render hidden tabpanel targets so shared tabs always point at real elements",
+);
+assert.doesNotMatch(
+  automations,
+  /Open full calendar|Manage crons/,
+  "The old overflow-only calendar/crons links should be removed",
+);
+assert.match(
+  automations,
   /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*initialTab === "crons" \? "crons" : "overview",?\s*\)/,
   "Surface defaults to the unified overview unless a deep link asks otherwise",
 );
@@ -96,13 +127,41 @@ assert.match(
   /initialTab=\{mode === "calendar" \? "calendar" : "overview"\}/,
   "Workspace lands on the overview unless the Calendar deep link asked for Calendar",
 );
-assert.match(automations, /setActiveTab\("calendar"\)|selectTab\("calendar"\)/, "the full Calendar remains reachable");
-assert.match(automations, /setActiveTab\("crons"\)|selectTab\("crons"\)/, "Cron management remains reachable");
 assert.match(automations, /sessionStorage\.setItem\("cave:calendar:pending-open-date", day\.key\)[\s\S]{0,100}selectTab\("calendar"\)/, "a ribbon day queues its date before Calendar mounts");
 assert.match(calendar, /sessionStorage\.getItem\("cave:calendar:pending-open-date"\)[\s\S]{0,180}openDateValue\(pendingDate\)/, "Calendar consumes a queued ribbon date on mount");
 assert.match(calendar, /addEventListener\("cave:calendar:open-date", openDate\)/, "Calendar accepts a day selected from the overview ribbon");
 assert.match(calendar, /setAnchor\(next\);[\s\S]{0,140}setViewMode\("day"\)/, "a ribbon day opens the matching single-day calendar");
 assert.match(calendar, /mobileRibbonDayOpen && viewMode === "day"/, "mobile preserves an explicitly selected ribbon day instead of forcing Agenda");
+assert.doesNotMatch(
+  globals,
+  /\.rituals-overview__events,\s*\.rituals-overview__lower\s*\{[^}]*width:\s*min\(920px,\s*100%\)/,
+  "events/lower should no longer cap width at 920px",
+);
+assert.doesNotMatch(
+  globals,
+  /\.rituals-overview__needs\s*\{[^}]*width:\s*min\(920px,\s*100%\)/,
+  "needs should no longer cap width at 920px",
+);
+assert.doesNotMatch(
+  globals,
+  /\.rituals-overview__selection\s*\{[^}]*width:\s*min\(920px,\s*100%\)/,
+  "selection should no longer cap width at 920px",
+);
+assert.match(
+  globals,
+  /\.rituals-overview__events,\s*\.rituals-overview__lower\s*\{[^}]*width:\s*100%/,
+  "events and lower should expand to full width",
+);
+assert.match(
+  globals,
+  /\.rituals-overview__needs\s*\{[^}]*width:\s*100%/,
+  "needs should expand to full width",
+);
+assert.match(
+  globals,
+  /\.rituals-overview__selection\s*\{[^}]*width:\s*100%/,
+  "selection should expand to full width",
+);
 assert.match(automations, /function useRitualNow\(\): Date \| null[\s\S]{0,560}setNow\(new Date\(\)\);[\s\S]{0,80}scheduleMidnight/, "the hydration-stable week clock starts in the browser and refreshes at local midnight");
 assert.match(automations, /ritualNow \? buildRitualWeek\(inboxVisible, ritualNow\) : \[\]/, "the week ribbon waits for the browser-local date before derivation");
 assert.doesNotMatch(sidebar, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");


### PR DESCRIPTION
## Summary
- add visible Overview, Calendar, and Crons tabs beneath the Rituals header
- preserve valid tab-to-panel ARIA relationships for active and inactive tabs
- expand the overview ribbon, Needs-you panel, Log/Agenda area, and selection controls to the available workspace width

## Test plan
- [x] focused Rituals and automations contract tests
- [x] `pnpm typecheck`
- [x] `pnpm test:app` (790 test files)
- [x] `git diff --check`

Bead: cave-8snu