### PR TITLE
fix(backdrop): keep the nav and chats panes solid over the backdrop image

### DIFF
--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -191,3 +191,16 @@ html[data-backdrop-on] .home-composer-root {
     -webkit-backdrop-filter: none;
   }
 }
+
+/* ── Side panes stay solid (the contract above, enforced) ────────────────────
+   A solid background is not enough: the backdrop is a fixed z-0 layer, and
+   panels that sit below it in paint order get the image composited over
+   their solid paint anyway (bit the chats rail after the icon-rail revamp).
+   Lift the nav + list panes one stacking step and ground them on the panel
+   color, so the image shows through the content area only. */
+html[data-backdrop-on] .shell-nav-panel,
+html[data-backdrop-on] .shell-list-panel {
+  position: relative;
+  z-index: 1;
+  background: var(--bg-panel);
+}


### PR DESCRIPTION
The backdrop image is a fixed z-0 layer. Panels whose paint order falls below it get the image composited over their solid backgrounds — after the icon-rail revamp (#3479) the chats rail fell below the layer, washing the session list with artwork (user-reported legibility issue).

Fix: one rule in backdrop.css — under `data-backdrop-on`, `.shell-nav-panel` and `.shell-list-panel` get `position: relative; z-index: 1; background: var(--bg-panel)`. This enforces the file's own documented contract ("the image shows through the content area only") and matches the design mock's solid sidebar.

Verified against a high-contrast test gradient at 0.6 intensity: side panes solid at desktop widths, mobile layout unaffected, content-area vibe intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)