### PR TITLE
fix(tokens): define the dangling danger/sunken vocabulary, migrate one-off vars (cave-309m)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,6 +82,10 @@
      by several components while undefined, which computed to transparent
      (cave-fdt5). */
   --bg-subtle: color-mix(in oklch, var(--bg-raised) 72%, transparent);
+  /* Recessed wells (sticky strips, modal inputs) — one visible step below
+     base. Referenced while undefined (cave-309m); derived from --bg-base so
+     every theme tracks. Light mode overrides below. */
+  --bg-sunken: color-mix(in oklch, var(--bg-base) 88%, black);
   --bg-elevated: oklch(0.20 0.028 293);     /* dropdowns / popovers */
   --bg-hover: oklch(0.24 0.030 293);        /* hover state */
   --border-hairline: var(--border);
@@ -185,6 +189,15 @@
   --color-danger: oklch(0.74 0.18 24);
   --color-danger-soft: oklch(0.82 0.08 24);
   --color-info: var(--accent-presence);
+  /* Inline danger-alert vocabulary (craft dossier, marketplace, skill
+     builder) — the design-language tint recipe applied to one solid token:
+     14% fill, 38% border, solid text. Referenced while undefined
+     (cave-309m), which computed to transparent fills and inherited text;
+     mixes derive from --color-danger so the light-mode override and all
+     themes track automatically. */
+  --danger-text: var(--color-danger);
+  --danger-bg: color-mix(in oklch, var(--color-danger) 14%, transparent);
+  --danger-border: color-mix(in oklch, var(--color-danger) 38%, transparent);
 
   /* ---- Icon sizes ----
      Replaces ad-hoc width={N} props. Consumers default to --icon-sm
@@ -301,6 +314,9 @@
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.93 0.016 293);
   --bg-hover: oklch(0.89 0.020 293);
+  /* Lighter mix step than dark mode — light surfaces need less push to
+     read as recessed. */
+  --bg-sunken: color-mix(in oklch, var(--bg-base) 96%, black);
 
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);

--- a/src/components/familiar-daily-notes.tsx
+++ b/src/components/familiar-daily-notes.tsx
@@ -195,7 +195,7 @@ export function FamiliarDailyNotes({ familiar }: Props) {
       {/* Editor */}
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
         {error ? (
-          <div className="rounded-md border border-[var(--accent-rose)]/40 bg-[var(--accent-rose)]/10 px-3 py-2 text-[11px] text-[var(--accent-rose)]">
+          <div className="rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[11px] text-[var(--danger-text)]">
             {error}
           </div>
         ) : null}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2605,7 +2605,7 @@ function MobileModeToggle() {
           disabled={busy}
           className={`settings-mobile-switch rounded-[var(--radius-control)] border px-3 py-1.5 text-[12px] transition-colors ${
             mobileModeEnabled
-              ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-contrast)]"
+              ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
               : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
           }`}
         >


### PR DESCRIPTION
## Summary

Six CSS custom properties were referenced but defined nowhere, silently computing to transparent fills / inherited text on every theme (found during the OpenCoven design-sync token audit, bead `cave-309m` — the sweep here found more call sites than the bead originally recorded).

**Defined** (theme-tracking mixes, same pattern as `--bg-subtle` / cave-fdt5):
- `--danger-bg` / `--danger-border` / `--danger-text` — a de-facto vocabulary already used across **three surfaces** (craft dossier, marketplace error banner, skill builder ×4). Defined next to the state colors via the design-language tint recipe (14% fill / 38% border / solid text) off `--color-danger`, so the light-mode override and all 21 themes track automatically.
- `--bg-sunken` — the missing recessed rung of the surface ladder (projects sticky strip, save-template inputs). Per-mode mix off `--bg-base` (88% dark / 96% light toward black).

**Migrated** (single call sites; no new vocabulary):
- `--accent-rose` → the danger vocabulary (it's an error banner; the palette has no rose accent)
- `--accent-contrast` → the existing AA-audited `--accent-presence-foreground`

## Verification

- `pnpm typecheck` clean
- `theme-contrast-audit.test.ts` passes (all theme × mode combos)
- `design-token-drift.test.ts` passes
- Zero remaining references to any of the six undefined names

Closes bead `cave-309m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)