### PR TITLE
style(theme): repaint default Coven palette toward neutral graphite

### DIFF
--- a/src/app/globals-background.test.ts
+++ b/src/app/globals-background.test.ts
@@ -6,8 +6,8 @@ const globals = await readFile(new URL("./globals.css", import.meta.url), "utf8"
 
 assert.match(
   globals,
-  /:root \{[\s\S]*?--background:\s*oklch\(0\.13 0\.022 293\);/,
-  "Default Coven Cave background should stay on the dark lavender-inked oklch foundation",
+  /:root \{[\s\S]*?--background:\s*oklch\(0\.24 0\.006 291\);/,
+  "Default Coven Cave background should stay on the dark neutral-inked oklch foundation",
 );
 
 assert.match(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,7 +21,7 @@
      - Issue #14 names: --bg-base, --bg-raised, --border-hairline, --text-*…
    Both resolve to the same colours so they stay in sync.
 
-   Brand: OpenCoven lavender (#9A8ECD) lives at --accent-presence.
+   Brand: OpenCoven lavender (#9386D0) lives at --accent-presence.
    Reserved for familiar presence dots and the health strip — not
    for primary CTAs.
 
@@ -33,21 +33,27 @@
 
 :root {
   /* ---- Palette (oklch — same colour science as shadcn) ----
-     Coven dark: lavender-inked grimoire. The chroma is real,
-     not a hint — surfaces should read violet, not gray. */
-  --background: oklch(0.13 0.022 293);
+     Coven dark v1.3: charcoal-graphite surfaces (chroma pared back to a
+     whisper) with the violet reserved for the brand accent — reads as
+     ink-and-graphite, not a tinted gray, matching the reference "New
+     automation" mock (cave: default-theme-repaint). */
+  --background: oklch(0.24 0.006 291);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.165 0.025 293);
+  --card: oklch(0.26 0.007 291);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.165 0.025 293);
+  --popover: oklch(0.26 0.007 291);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 293);
-  --primary-foreground: oklch(0.165 0.025 293);
-  --secondary: oklch(0.20 0.028 293);
+  --primary: oklch(0.92 0.004 291);
+  /* Dark ink, not tied to --card — --primary-foreground also paints text on
+     --brand/--accent-presence (a mid-tone violet), which needs a genuinely
+     dark ink for 4.5:1, not whatever lightness the raised surface happens
+     to be (theme-contrast-audit.test.ts). */
+  --primary-foreground: oklch(0.16 0.008 291);
+  --secondary: oklch(0.29 0.008 291);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.20 0.028 293);
-  --muted-foreground: oklch(0.66 0.018 293);
-  --accent: oklch(0.20 0.028 293);
+  --muted: oklch(0.29 0.008 291);
+  --muted-foreground: oklch(0.66 0.010 291);
+  --accent: oklch(0.29 0.008 291);
   --accent-foreground: oklch(0.985 0 0);
   --border: color-mix(in oklch, var(--foreground) 12%, transparent);
   /* WCAG 1.4.11: --border-strong marks interactive boundaries (inputs,
@@ -55,14 +61,14 @@
      22% composited under 2:1 on every theme. Hairline stays decorative. */
   --border-strong: color-mix(in oklch, var(--foreground) 48%, transparent);
   --input: color-mix(in oklch, var(--foreground) 18%, transparent);
-  --ring: oklch(0.55 0.08 293);
+  --ring: oklch(0.55 0.075 291);
 
   /* ---- Coven brand ----
      Lavender presence accent. Use sparingly — familiar dots,
      status strip, the gradient AI toggle in #22. */
-  --accent-presence: #9a8ecd;
+  --accent-presence: #9386d0;
   --accent-presence-foreground: var(--primary-foreground);
-  --accent-presence-soft: oklch(0.72 0.08 295);
+  --accent-presence-soft: oklch(0.70 0.10 293);
   --brand: var(--accent-presence);
   /* Follows the per-theme ink choice — hardcoded white failed AA on every
      palette whose accent is light (22 of 32 theme×mode combos). */
@@ -75,7 +81,7 @@
   /* Fixed near-opaque dark "ink" for code surfaces — read code blocks AND the
      file editor share it so the Code page's read↔edit toggle keeps one bg. */
   --code-surface: oklch(0.12 0.012 280 / 92%);
-  --bg-panel: oklch(0.10 0.020 293);        /* deepest — app shell / sidebar floor */
+  --bg-panel: oklch(0.22 0.006 291);        /* deepest — app shell / sidebar floor */
   --bg-raised: var(--card);
   /* Subtle inline fill (chips, keycaps, recent-search pills). Derived from
      the raised surface so it tracks every theme — this token was referenced
@@ -86,8 +92,8 @@
      base. Referenced while undefined (cave-309m); derived from --bg-base so
      every theme tracks. Light mode overrides below. */
   --bg-sunken: color-mix(in oklch, var(--bg-base) 88%, black);
-  --bg-elevated: oklch(0.20 0.028 293);     /* dropdowns / popovers */
-  --bg-hover: oklch(0.24 0.030 293);        /* hover state */
+  --bg-elevated: oklch(0.29 0.008 291);     /* dropdowns / popovers */
+  --bg-hover: oklch(0.32 0.009 291);        /* hover state */
   --border-hairline: var(--border);
   --fg-base: var(--text-primary);
   --fg-muted: var(--text-secondary);
@@ -289,31 +295,31 @@
   color-scheme: light;
   /* No numeral bloom on light surfaces — glow reads as blur on paper. */
   --glow-numeral: none;
-  --background: oklch(0.975 0.012 293);
-  --foreground: oklch(0.18 0.020 293);
-  --card: oklch(0.95 0.014 293);
-  --card-foreground: oklch(0.18 0.020 293);
-  --popover: oklch(0.97 0.014 293);
-  --popover-foreground: oklch(0.18 0.020 293);
-  --primary: oklch(0.20 0.022 293);
-  --primary-foreground: oklch(0.975 0.012 293);
-  --secondary: oklch(0.92 0.018 293);
-  --secondary-foreground: oklch(0.18 0.020 293);
-  --muted: oklch(0.92 0.018 293);
-  --muted-foreground: oklch(0.42 0.024 293);
-  --accent: oklch(0.92 0.018 293);
-  --accent-foreground: oklch(0.18 0.020 293);
-  --ring: oklch(0.55 0.10 293);
+  --background: oklch(0.975 0.004 291);
+  --foreground: oklch(0.18 0.008 291);
+  --card: oklch(0.95 0.005 291);
+  --card-foreground: oklch(0.18 0.008 291);
+  --popover: oklch(0.97 0.005 291);
+  --popover-foreground: oklch(0.18 0.008 291);
+  --primary: oklch(0.20 0.008 291);
+  --primary-foreground: oklch(0.975 0.004 291);
+  --secondary: oklch(0.92 0.007 291);
+  --secondary-foreground: oklch(0.18 0.008 291);
+  --muted: oklch(0.92 0.007 291);
+  --muted-foreground: oklch(0.42 0.009 291);
+  --accent: oklch(0.92 0.007 291);
+  --accent-foreground: oklch(0.18 0.008 291);
+  --ring: oklch(0.55 0.09 291);
 
-  --accent-presence: #6F62A8;
+  --accent-presence: #6859ac;
   --accent-presence-foreground: var(--primary-foreground);
-  --accent-presence-soft: oklch(0.55 0.08 295);
+  --accent-presence-soft: oklch(0.53 0.10 291);
 
   --bg-base: var(--background);
-  --bg-panel: oklch(0.99 0.010 293);
+  --bg-panel: oklch(0.99 0.004 291);
   --bg-raised: var(--card);
-  --bg-elevated: oklch(0.93 0.016 293);
-  --bg-hover: oklch(0.89 0.020 293);
+  --bg-elevated: oklch(0.93 0.006 291);
+  --bg-hover: oklch(0.89 0.008 291);
   /* Lighter mix step than dark mode — light surfaces need less push to
      read as recessed. */
   --bg-sunken: color-mix(in oklch, var(--bg-base) 96%, black);

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -36,7 +36,7 @@ assert.doesNotMatch(
 //    Anchored to the first :root { … } block (no attribute selector) so the
 //    assertion can't drift into another theme's background.
 const covenRootBlock = css.match(/:root\s*\{([\s\S]*?)\n\}/)?.[1] ?? "";
-assert.match(covenRootBlock, /--background\s*:\s*oklch\(0\.13 0\.022 293\)/, "coven dark background");
+assert.match(covenRootBlock, /--background\s*:\s*oklch\(0\.24 0\.006 291\)/, "coven dark background");
 assert.match(
   covenRootBlock,
   /--accent-presence-foreground\s*:\s*var\(--primary-foreground\)/,

--- a/src/app/preview/fonts/page.tsx
+++ b/src/app/preview/fonts/page.tsx
@@ -118,7 +118,7 @@ function CandidateCard({ candidate }: { candidate: Candidate }) {
         <span
           style={{
             fontSize: 13,
-            color: "var(--text-muted, #9a8ecd)",
+            color: "var(--text-muted, #9386d0)",
             fontFamily: "var(--font-sans), system-ui, sans-serif",
           }}
         >
@@ -200,7 +200,7 @@ function CandidateCard({ candidate }: { candidate: Candidate }) {
           lineHeight: 1.4,
           margin: "0 0 1.5rem",
           padding: "0.5rem 0 0.5rem 1.25rem",
-          borderLeft: "2px solid var(--oc-purple-primary, #9a8ecd)",
+          borderLeft: "2px solid var(--oc-purple-primary, #9386d0)",
           color: "var(--text-primary, #f4f1fa)",
           maxWidth: "48ch",
         }}
@@ -231,7 +231,7 @@ function CandidateCard({ candidate }: { candidate: Candidate }) {
           style={{
             fontFamily: "var(--font-mono), ui-monospace, monospace",
             fontSize: 12,
-            color: "var(--text-muted, #9a8ecd)",
+            color: "var(--text-muted, #9386d0)",
             letterSpacing: "0.06em",
             textTransform: "uppercase",
           }}
@@ -261,7 +261,7 @@ export default function FontPreviewPage() {
               fontSize: 12,
               letterSpacing: "0.16em",
               textTransform: "uppercase",
-              color: "var(--oc-purple-primary, #9a8ecd)",
+              color: "var(--oc-purple-primary, #9386d0)",
               margin: "0 0 0.75rem",
             }}
           >
@@ -310,7 +310,7 @@ export default function FontPreviewPage() {
             borderTop: "1px solid var(--border-subtle, rgba(154, 142, 205, 0.18))",
             fontFamily: "var(--font-mono), ui-monospace, monospace",
             fontSize: 12,
-            color: "var(--text-muted, #9a8ecd)",
+            color: "var(--text-muted, #9386d0)",
             letterSpacing: "0.04em",
           }}
         >

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -164,10 +164,10 @@ async function createXterm(
     // Required for the search addon's match decorations (highlights + count).
     allowProposedApi: true,
     theme: {
-      background: "oklch(0.11 0.022 293)",
+      background: "oklch(0.22 0.006 291)",
       foreground: "#e6e6f0",
-      cursor: "#9a8ecd",
-      selectionBackground: "rgba(154,142,205,0.35)",
+      cursor: "#9386d0",
+      selectionBackground: "rgba(147,134,208,0.35)",
     },
   });
   const fit = new FitAddon();

--- a/src/components/familiar-studio-look-tab.tsx
+++ b/src/components/familiar-studio-look-tab.tsx
@@ -37,7 +37,7 @@ const COLOR_PRESETS: ColorPreset[] = [
   {
     label: "Theme",
     color: "color-mix(in oklch, var(--accent-presence) 72%, white 28%)",
-    inputFallback: "#9a8ecd",
+    inputFallback: "#9386d0",
   },
   {
     label: "Lilac",

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -596,12 +596,12 @@ async function getMermaidPlugin(): Promise<PreviewPlugin | null> {
         // overrides the plugin's default "loose" so diagrams from untrusted
         // chat content can't smuggle scripts/click handlers (postProcess
         // output bypasses our sanitizer).
-        const accent = themeToken("--accent-presence", "#9a8ecd");
-        const raised = themeToken("--bg-raised", "#1c1a24");
-        const panel = themeToken("--bg-panel", "#14121b");
+        const accent = themeToken("--accent-presence", "#9386d0");
+        const raised = themeToken("--bg-raised", "#242327");
+        const panel = themeToken("--bg-panel", "#1a1a1d");
         const textPrimary = themeToken("--text-primary", "#e6e6f0");
-        const textSecondary = themeToken("--text-secondary", "#a5a1b6");
-        const hairline = themeToken("--border-strong", "#3a3648");
+        const textSecondary = themeToken("--text-secondary", "#929198");
+        const hairline = themeToken("--border-strong", "#807f80");
         const plugin = mermaidPlugin({
           // "base" is the only mermaid theme that honors themeVariables;
           // darkMode below keeps its derived shades on the dark ramp.

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -27,7 +27,7 @@ export type SettingsIndexEntry = {
 
 export const SECTIONS: SectionMeta[] = [
   { id: "profile", label: "Profile", icon: "ph:user-circle", description: "Your name, image, and details familiars know you by.", accent: "#f0c987" },
-  { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9a8ecd" },
+  { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9386d0" },
   { id: "daemon", label: "Daemon", icon: "ph:terminal-window", description: "Local runtime status and process controls.", accent: "#69d6a6" },
   { id: "familiars", label: "Familiars", icon: "ph:users-three", description: "Roster, identity, permissions, and pin order.", accent: "#d8a9ff" },
   { id: "mobile", label: "Phone", icon: "ph:device-mobile", description: "Native iOS handoff over your Tailscale network.", accent: "#73d9d0" },

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -52,8 +52,8 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
   coven: {
     name: "Coven",
     description: "Lavender-inked grimoire. The house default; mind the runes.",
-    hue: 293, accentDark: "#9a8ecd", accentLight: "#6F62A8",
-    bgDark: "oklch(0.13 0.022 293)", bgLight: "oklch(0.975 0.012 293)",
+    hue: 291, accentDark: "#9386d0", accentLight: "#6859ac",
+    bgDark: "oklch(0.24 0.006 291)", bgLight: "oklch(0.975 0.004 291)",
   },
   tide: {
     name: "Tide",

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -226,54 +226,54 @@ export function accessGatePage({ invalidToken = false }: { invalidToken?: boolea
     display: grid;
     place-items: center;
     min-height: 100vh;
-    background: oklch(0.13 0.022 293);
-    color: oklch(0.93 0.01 293);
+    background: oklch(0.24 0.006 291);
+    color: oklch(0.93 0.004 291);
     font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
   }
   main {
     width: min(360px, calc(100vw - 48px));
     padding: 28px;
-    border: 1px solid oklch(0.93 0.01 293 / 12%);
+    border: 1px solid oklch(0.93 0.004 291 / 12%);
     border-radius: 16px;
-    background: oklch(0.165 0.025 293);
+    background: oklch(0.26 0.007 291);
   }
   .dot {
     width: 8px;
     height: 8px;
     border-radius: 999px;
-    background: #9a8ecd;
-    box-shadow: 0 0 0 4px oklch(0.62 0.08 293 / 16%);
+    background: #9386d0;
+    box-shadow: 0 0 0 4px oklch(0.62 0.09 291 / 16%);
     margin-bottom: 16px;
   }
   h1 { margin: 0 0 6px; font-size: 16px; font-weight: 650; }
-  p { margin: 0 0 16px; color: oklch(0.66 0.018 293); font-size: 13px; }
+  p { margin: 0 0 16px; color: oklch(0.66 0.010 291); font-size: 13px; }
   .note { color: oklch(0.72 0.14 78); }
   form { display: flex; gap: 8px; }
   input {
     flex: 1;
     min-width: 0;
     padding: 8px 12px;
-    border: 1px solid oklch(0.93 0.01 293 / 22%);
+    border: 1px solid oklch(0.93 0.004 291 / 22%);
     border-radius: 999px;
-    background: oklch(0.13 0.022 293);
+    background: oklch(0.22 0.006 291);
     color: inherit;
     font: inherit;
   }
   input:focus-visible, button:focus-visible {
-    outline: 2px solid oklch(0.62 0.08 293 / 55%);
+    outline: 2px solid oklch(0.62 0.09 291 / 55%);
     outline-offset: 1px;
   }
   button {
     padding: 8px 16px;
-    border: 1px solid oklch(0.93 0.01 293 / 22%);
+    border: 1px solid oklch(0.93 0.004 291 / 22%);
     border-radius: 999px;
-    background: oklch(0.20 0.028 293);
+    background: oklch(0.29 0.008 291);
     color: inherit;
     font: inherit;
     font-weight: 600;
     cursor: pointer;
   }
-  button:hover { background: oklch(0.24 0.030 293); }
+  button:hover { background: oklch(0.32 0.009 291); }
 </style>
 </head>
 <body>

--- a/src/styles/cave-md.css
+++ b/src/styles/cave-md.css
@@ -25,7 +25,7 @@
      chrome labels must clear AA 4.5:1 on the code surface — 40% composited
      to ~3.7:1. Pinned by theme-contrast-audit.test.ts (chrome section). */
   --code-chrome-ink-faint: oklch(0.985 0 0 / 72%);    /* dark-mode --text-muted */
-  --code-chrome-accent: #9a8ecd;                      /* dark-mode --accent-presence */
+  --code-chrome-accent: #9386d0;                      /* dark-mode --accent-presence */
   /* Fixed chrome surfaces. The body surface is the shared --code-surface
      (globals.css); these are its raised header/footer and control steps.
      Theme borders flip to dark ink in light mode and vanish on this chrome,


### PR DESCRIPTION
style(theme): repaint default Coven palette toward neutral graphite

Desaturate the default "Coven" dark and light surfaces toward a
neutral charcoal/graphite ladder (chroma cut ~3x, hue 293 to 291),
matching the reference "New Automation" dialog mock, while nudging
the brand accent slightly (#9a8ecd to #9386d0 dark, #6F62A8 to
#6859ac light) to match the same reference. Surfaces now read as
ink-and-graphite with violet reserved for the brand accent, instead
of a violet-tinted gray throughout.

- src/app/globals.css: rewrite dark/light palette tokens; decouple
  --primary-foreground from --card into a fixed dark-ink value.
  card's lightness increase would otherwise drop text-on-accent
  contrast below AA 4.5:1 (see theme-contrast-audit.test.ts).
- src/lib/theme-palettes.ts: sync the coven entry's hue/accent/bg
  swatches used by the settings theme-preview grid.
- Propagate the new accent/background hex to every hardcoded mirror
  of the old palette: cave-md.css, message-bubble.tsx (mermaid theme
  fallbacks), bottom-terminal.tsx (xterm theme), settings-sections.ts,
  familiar-studio-look-tab.tsx, proxy-helpers.ts (standalone auth-page
  template), preview/fonts/page.tsx.
- Update the two tests that pinned the old literal background value
  (globals.css.test.ts, globals-background.test.ts).

Verified: theme-contrast-audit.test.ts (855 pairs x 21 themes x 2
modes, 0 failures), full test:app suite, tsc --noEmit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
