### PR TITLE
Fix daemon status during Cave-home lock contention

### DIFF
--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -113,8 +113,10 @@ try {
   const candidateFailureCave = path.join(candidateFailureHome, "cave");
   await mkdir(candidateFailureCave, { recursive: true });
   let candidateAttempts = 0;
-  const persistentEperm = async () => {
+  const candidates = new Set<string>();
+  const persistentEperm = async (candidate: string) => {
     candidateAttempts += 1;
+    candidates.add(candidate);
     const error = new Error("injected persistent Windows EPERM") as NodeJS.ErrnoException;
     error.code = "EPERM";
     throw error;
@@ -124,6 +126,7 @@ try {
     (error) => error?.code === "ETIMEDOUT",
   );
   assert.ok(candidateAttempts >= 2);
+  assert.equal(candidates.size, 1, "candidate retries reuse one directory on Windows");
   assert.equal(
     (await readdir(candidateFailureCave)).some((name) => name.startsWith(".migration.lock.candidate-")),
     false,

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -6,8 +6,20 @@ const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /import \{[^}]*loadConfig[^}]*\} from "@\/lib\/cave-config"/,
-  "daemon status should read Cave config before calling the daemon",
+  /import \{[^}]*loadDaemonStatusSnapshot[^}]*\} from "@\/lib\/cave-config"/,
+  "daemon status should read a lock-protected Cave snapshot before calling the daemon",
+);
+
+assert.match(
+  source,
+  /snapshot = await loadDaemonStatusSnapshot\(\)[\s\S]*?return caveHomeStatusUnavailable\(\)/,
+  "Cave home lock failures should return a structured status response instead of HTTP 500",
+);
+
+assert.match(
+  source,
+  /availability: "status-unavailable"[\s\S]*?Cave home is temporarily busy/,
+  "the structured degraded response should distinguish local Cave storage from daemon availability",
 );
 
 assert.match(

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { loadConfig, loadState, recordLocalSubdaemonWakeRequest, recordTravelHubReachability } from "@/lib/cave-config";
+import {
+  loadDaemonStatusSnapshot,
+  loadState,
+  recordLocalSubdaemonWakeRequest,
+  recordTravelHubReachability,
+} from "@/lib/cave-config";
 import {
   callDaemonTarget,
   daemonTargetForConfig,
@@ -55,11 +60,38 @@ function failureAvailability(target: DaemonTarget, res: DaemonResponse<unknown>)
   });
 }
 
+function isCaveHomeStatusFailure(error: unknown): boolean {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as NodeJS.ErrnoException).code ?? "")
+    : "";
+  if (["EACCES", "EPERM", "ETIMEDOUT"].includes(code)) return true;
+  return error instanceof Error && error.message.startsWith("Cave home reconciliation failed");
+}
+
+function caveHomeStatusUnavailable() {
+  return NextResponse.json({
+    running: false,
+    availability: "status-unavailable",
+    reason: "Cave home is temporarily busy; status will retry automatically",
+  });
+}
+
 export async function GET() {
-  const config = await loadConfig();
+  let snapshot: Awaited<ReturnType<typeof loadDaemonStatusSnapshot>>;
+  try {
+    snapshot = await loadDaemonStatusSnapshot();
+  } catch (error) {
+    if (!isCaveHomeStatusFailure(error)) throw error;
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? String((error as NodeJS.ErrnoException).code ?? "")
+      : "reconciliation";
+    console.warn("[daemon-status] Cave home status snapshot unavailable", { code });
+    return caveHomeStatusUnavailable();
+  }
+  const { config } = snapshot;
   const target = daemonTargetForConfig(config);
   const executorStatuses = await executorStatusesForConfig(config);
-  let travelState = (await loadState()).travel;
+  let travelState = snapshot.state.travel;
   let hubReachable: boolean | null = target.mode === "local" ? true : null;
   if (target.mode === "unconfigured-hub") {
     const root = covenWorkspaceRoot();

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -2,7 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
-import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
+import { withCaveHomeReconciledStore, withCaveHomeReconciledStores } from "./server/cave-home-migration.ts";
 import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
@@ -736,6 +736,14 @@ async function loadStateUnlocked(): Promise<CaveState> {
 
 export function loadState(): Promise<CaveState> {
   return withCaveHomeReconciledStore("cave-state.json", loadStateUnlocked);
+}
+
+/** A coherent, lock-protected snapshot for the frequent daemon status poll. */
+export function loadDaemonStatusSnapshot(): Promise<{ config: CaveConfig; state: CaveState }> {
+  return withCaveHomeReconciledStores(["cave-config.json", "cave-state.json"], async () => ({
+    config: await loadConfigUnlocked(),
+    state: await loadStateUnlocked(),
+  }));
 }
 
 async function saveStateUnlocked(state: CaveState): Promise<void> {

--- a/src/lib/daemon-status-classification.test.ts
+++ b/src/lib/daemon-status-classification.test.ts
@@ -122,6 +122,18 @@ for (const [name, input] of [
       },
     },
   ],
+  [
+    "Cave home temporarily busy",
+    {
+      responseStatus: 200,
+      responseOk: true,
+      payload: {
+        running: false,
+        availability: "status-unavailable",
+        reason: "Cave home is temporarily busy; status will retry automatically",
+      },
+    },
+  ],
 ]) {
   assert.equal(classifyDaemonStatusPoll(input).kind, "unavailable", name);
 }

--- a/src/lib/daemon-status-classification.ts
+++ b/src/lib/daemon-status-classification.ts
@@ -4,7 +4,8 @@ export type DaemonAvailability =
   | "unreachable"
   | "unhealthy"
   | "unauthorized"
-  | "misconfigured";
+  | "misconfigured"
+  | "status-unavailable";
 
 export type DaemonTargetMode = "local" | "hub" | "unconfigured-hub";
 
@@ -15,6 +16,7 @@ const AVAILABILITY_VALUES = new Set<DaemonAvailability>([
   "unhealthy",
   "unauthorized",
   "misconfigured",
+  "status-unavailable",
 ]);
 
 export function classifyDaemonFailureAvailability(input: {

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1141,6 +1141,30 @@ try {
     );
   }
 
+  // A transient failure while writing the owner record leaves the retained
+  // candidate directory behind. Retrying must reuse that directory rather
+  // than treating its next mkdir as external lock contention until timeout.
+  {
+    const { cave } = await home("candidate-owner-write-eperm");
+    await mkdir(cave, { recursive: true });
+    let ownerWriteAttempts = 0;
+    const candidates = new Set<string>();
+    const transientOwnerWrite = async (candidate: string, owner: unknown) => {
+      ownerWriteAttempts += 1;
+      candidates.add(candidate);
+      if (ownerWriteAttempts === 1) {
+        const error = new Error("injected Windows candidate owner write failure") as NodeJS.ErrnoException;
+        error.code = "EPERM";
+        throw error;
+      }
+      await writeFile(path.join(candidate, "owner.json"), JSON.stringify(owner));
+    };
+    const result = await migrateCaveHome({ lockCandidateOwnerWrite: transientOwnerWrite });
+    assert.deepEqual(result.errors, []);
+    assert.equal(ownerWriteAttempts, 2, "candidate owner write retries after transient EPERM");
+    assert.equal(candidates.size, 1, "candidate owner write reuses the retained directory");
+  }
+
   // Persistent Windows EPERM while publishing a candidate is retryable but
   // bounded. No lock is published and no candidate debris survives timeout.
   {

--- a/src/lib/server/cave-home-migration.test.ts
+++ b/src/lib/server/cave-home-migration.test.ts
@@ -1147,8 +1147,10 @@ try {
     const { cave } = await home("candidate-eperm-timeout");
     await mkdir(cave, { recursive: true });
     let renameAttempts = 0;
-    const epermRename = async () => {
+    const candidates = new Set<string>();
+    const epermRename = async (candidate: string) => {
       renameAttempts += 1;
+      candidates.add(candidate);
       const error = new Error("injected Windows candidate failure") as NodeJS.ErrnoException;
       error.code = "EPERM";
       throw error;
@@ -1158,6 +1160,7 @@ try {
       (error) => error?.code === "ETIMEDOUT",
     );
     assert.ok(renameAttempts >= 2, "candidate publication retries until the deadline");
+    assert.equal(candidates.size, 1, "candidate publication reuses one directory for every retry");
     assert.equal(
       (await readdir(cave)).some((name) => name.startsWith(".migration.lock.candidate-")),
       false,

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -101,11 +101,25 @@ export async function withCaveHomeReconciledStore<T>(
   legacy: string,
   operation: () => Promise<T>,
 ): Promise<T> {
-  await ensureCaveHomeReconciled(legacy);
+  return withCaveHomeReconciledStores([legacy], operation);
+}
+
+/**
+ * Keep one read-only snapshot of several Cave-owned stores outside migration
+ * replacements without acquiring and releasing the cross-process lock for
+ * each individual file.
+ */
+export async function withCaveHomeReconciledStores<T>(
+  legacies: readonly string[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  for (const legacy of legacies) await ensureCaveHomeReconciled(legacy);
   return withCaveHomeReconciliationLock(async () => {
     // Another process may have reconciled the entry between the preflight and
     // lock acquisition. Revalidate preserved stores while we own the lock.
-    await validateCaveHomeReconciliationStore(CAVE_HOME_MIGRATIONS, legacy);
+    for (const legacy of legacies) {
+      await validateCaveHomeReconciliationStore(CAVE_HOME_MIGRATIONS, legacy);
+    }
     return operation();
   });
 }

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -116,6 +116,8 @@ export type ReconciliationOptions = {
   lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
   /** Test-only unlock rename override. */
   lockReleaseRename?: typeof rename;
+  /** Test-only candidate owner-record writer override. */
+  lockCandidateOwnerWrite?: (candidate: string, owner: { pid: number; token: string; startedAt: string }) => Promise<void>;
   /** Test-only candidate publication rename override. */
   lockCandidateRename?: typeof rename;
   /** Test-only stale-lock fencing rename override. */
@@ -536,8 +538,17 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
     }
     try {
       if (!candidatePrepared) {
-        await mkdir(candidate);
-        await writeJsonAtomic(path.join(candidate, "owner.json"), { pid: process.pid, token, startedAt: nowIso() });
+        try {
+          await mkdir(candidate);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        }
+        const owner = { pid: process.pid, token, startedAt: nowIso() };
+        if (options.lockCandidateOwnerWrite) {
+          await options.lockCandidateOwnerWrite(candidate, owner);
+        } else {
+          await writeJsonAtomic(path.join(candidate, "owner.json"), owner);
+        }
         candidatePrepared = true;
       }
       await renameLockCandidate(candidate, lock, options.lockCandidateRename);

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -515,8 +515,17 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
   };
   diagnostic("waiting", "pending");
 
+  // A Windows directory rename can transiently retain the source directory.
+  // Keep one candidate for this acquisition instead of creating a new random
+  // candidate every 50ms; that bounds leftover debris if cleanup is delayed.
+  const token = randomBytes(16).toString("hex");
+  const candidate = `${lock}.candidate-${token}`;
+  let candidatePrepared = false;
+  const removeCandidate = () => rm(candidate, { recursive: true, force: true }).catch(() => {});
+
   for (;;) {
     if (Date.now() >= deadline) {
+      await removeCandidate();
       const timeout = new Error(`timed out acquiring cave home reconciliation lock after ${timeoutMs}ms`) as NodeJS.ErrnoException;
       timeout.code = "ETIMEDOUT";
       throw terminalError(timeout);
@@ -525,17 +534,13 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
       slowDiagnosticEmitted = true;
       diagnostic("waiting", "pending", undefined, true);
     }
-    const token = randomBytes(16).toString("hex");
-    const candidate = `${lock}.candidate-${token}`;
     try {
-      await mkdir(candidate);
-      try {
+      if (!candidatePrepared) {
+        await mkdir(candidate);
         await writeJsonAtomic(path.join(candidate, "owner.json"), { pid: process.pid, token, startedAt: nowIso() });
-        await renameLockCandidate(candidate, lock, options.lockCandidateRename);
-      } catch (error) {
-        await rm(candidate, { recursive: true, force: true });
-        throw error;
+        candidatePrepared = true;
       }
+      await renameLockCandidate(candidate, lock, options.lockCandidateRename);
       activeLockTokens().add(token);
       const release = async () => {
         const owner = await readLockOwner(lock);
@@ -590,8 +595,8 @@ async function acquireLock(options: ReconciliationOptions): Promise<() => Promis
       diagnostic("acquired", "acquired");
       return release;
     } catch (error) {
-      await rm(candidate, { recursive: true, force: true }).catch(() => {});
       if (!["EEXIST", "ENOTEMPTY", "EACCES", "EPERM"].includes((error as NodeJS.ErrnoException).code ?? "")) {
+        await removeCandidate();
         throw terminalError(error);
       }
       try {


### PR DESCRIPTION
## Summary

- return a structured, retryable status response when Cave-home reconciliation prevents the daemon-status snapshot
- read config and state through one reconciliation-lock acquisition for the five-second status poll
- reuse a single candidate directory across transient Windows `EPERM` retries to bound lock artifact churn

## Root cause

On Windows, an `EPERM` while publishing or reclaiming the Cave-home lock could run to the 15-second deadline. `/api/daemon/status` allowed that exception to become an HTTP 500, and each retry allocated another candidate directory.

## Validation

- Windows-native `daemon-status-classification.test.ts`
- Windows-native daemon-status route contract test
- Windows-native Cave-home migration harness
- `pnpm typecheck`
- `pnpm check:tests-wired`