### PR TITLE
fix(chat): bound conversation writes + document write contract

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -999,6 +999,7 @@ export const SUITES = {
     "src/app/api/project-grants/route.test.ts",
     "src/app/api/flows/runs/route.test.ts",
     "src/lib/server/run-history-guards.test.ts",
+    "src/lib/server/conversation-write-guards.test.ts",
     "src/lib/server/project-grant-targets.test.ts",
     "src/app/api/access-groups/route.test.ts",
     "src/app/api/project-permission-routes.test.ts",
@@ -1228,6 +1229,8 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/milestones-ledger.test.ts",
   // run-history-guards imports local-origin via "@/lib/…" alias
   "src/lib/server/run-history-guards.test.ts",
+  // conversation-write-guards imports ChatTurn via "@/lib/…" alias
+  "src/lib/server/conversation-write-guards.test.ts",
   "src/components/thread-signal-card.test.ts",
   "src/components/thread-signals-section.test.ts",
   "src/components/chat-view.test.ts",

--- a/src/app/api/chat/conversation/[id]/route.test.ts
+++ b/src/app/api/chat/conversation/[id]/route.test.ts
@@ -63,6 +63,15 @@ function paramsFor(id: string) {
 }
 
 const { DELETE } = await import("./route.ts");
+const { PUT, POST } = await import("./route.ts");
+
+function writeReq(bodyObj: unknown) {
+  return new Request("http://test/api/chat/conversation/x", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(bodyObj),
+  });
+}
 
 test("DELETE ?ifEmpty=1 on an empty conversation deletes it and does NOT sacrifice", async () => {
   writeConversation("sess-empty", []);
@@ -111,4 +120,49 @@ test("default DELETE (no ifEmpty) still deletes AND sacrifices, even with turns"
   assert.equal(existsSync(conversationPath("sess-default")), false, "file removed");
   const state = readState();
   assert.equal(typeof state.sessionSacrificed["sess-default"], "string", "sacrificed — other callers depend on this");
+});
+
+// --- #3469: client PUT cannot forge harness telemetry onto assistant turns ---
+test("PUT strips client-forged assistant telemetry (usage/cost/tools/reasoning)", async () => {
+  const res = await PUT(
+    writeReq({
+      familiarId: "milo",
+      harness: "claude",
+      turns: [
+        { role: "user", text: "hi" },
+        {
+          role: "assistant",
+          text: "totally real answer",
+          usage: { inputTokens: 999, outputTokens: 999 },
+          costUsd: 42,
+          tools: [{ id: "t", name: "shell", status: "ok" }],
+          reasoning: "fake",
+        },
+      ],
+    }),
+    paramsFor("sess-forge"),
+  );
+  const json = await res.json();
+  assert.equal(res.status, 200, "legitimate client write still succeeds");
+  const asst = json.conversation.turns.find((t: any) => t.role === "assistant");
+  assert.ok(asst, "assistant turn persisted");
+  assert.equal(asst.text, "totally real answer", "text preserved");
+  for (const f of ["usage", "costUsd", "tools", "reasoning"]) {
+    assert.equal(f in asst, false, `harness-owned ${f} stripped from client write`);
+  }
+});
+
+test("PUT rejects an over-long turn with 413", async () => {
+  const res = await PUT(
+    writeReq({
+      familiarId: "milo",
+      harness: "claude",
+      turns: [{ role: "user", text: "z".repeat(200_001) }],
+    }),
+    paramsFor("sess-toolong"),
+  );
+  assert.equal(res.status, 413, "over-long turn text is rejected with 413");
+  const json = await res.json();
+  assert.equal(json.ok, false);
+  assert.match(json.error, /too long/);
 });

--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -18,6 +18,10 @@ import { loadConversationFromJsonl } from "@/lib/openclaw-conversation";
 import { loadState, recordSessionFamiliar, sacrificeSessionLocal } from "@/lib/cave-config";
 import { defaultChatTitleForSession } from "@/lib/cave-chat-titles";
 import { normalizeTurnUsage, parseCostUsd } from "@/lib/usage-format";
+import {
+  checkTurnBounds,
+  sanitizeClientTurns,
+} from "@/lib/server/conversation-write-guards";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -201,12 +205,17 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   if (!turns || turns.length === 0) {
     return jsonError("turn or turns required", 400);
   }
+  // Client writers cannot forge harness telemetry onto assistant/system turns.
+  const safeTurns = sanitizeClientTurns(turns);
   const existing = await loadConversation(id);
+  const merged = [...(existing?.turns ?? []), ...safeTurns];
+  const bounds = checkTurnBounds(merged);
+  if (bounds) return jsonError(bounds.error, bounds.status);
   const conversation = buildConversation({
     id,
     body,
     existing,
-    turns: [...(existing?.turns ?? []), ...turns],
+    turns: merged,
   });
   if (!conversation) {
     return jsonError("familiarId and harness are required for new history", 400);
@@ -228,8 +237,12 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
   }
   const turns = normalizeTurns(body);
   if (!turns) return jsonError("turns required", 400);
+  // Client writers cannot forge harness telemetry onto assistant/system turns.
+  const safeTurns = sanitizeClientTurns(turns);
+  const bounds = checkTurnBounds(safeTurns);
+  if (bounds) return jsonError(bounds.error, bounds.status);
   const existing = await loadConversation(id);
-  const conversation = buildConversation({ id, body, existing, turns });
+  const conversation = buildConversation({ id, body, existing, turns: safeTurns });
   if (!conversation) {
     return jsonError("familiarId and harness are required", 400);
   }

--- a/src/lib/server/conversation-write-guards.test.ts
+++ b/src/lib/server/conversation-write-guards.test.ts
@@ -33,6 +33,14 @@ assert.equal(
   assert.match(res.error, /text too long/);
 }
 {
+  for (const badText of [null, 42, {}, []]) {
+    const bad = { id: crypto.randomUUID(), role: "user", text: badText, createdAt: new Date().toISOString() };
+    const res = checkTurnBounds([bad]);
+    assert.equal(res?.status, 400, `non-string text (${JSON.stringify(badText)}) returns 400, not a throw`);
+    assert.match(res.error, /must be a string/);
+  }
+}
+{
   // Many medium turns whose serialized size blows the payload cap.
   const chunk = "z".repeat(50_000);
   const many = Array.from({ length: 200 }, () => turn("user", chunk));

--- a/src/lib/server/conversation-write-guards.test.ts
+++ b/src/lib/server/conversation-write-guards.test.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  MAX_CONVERSATION_TURNS,
+  MAX_TURN_TEXT_CHARS,
+  MAX_TURNS_PAYLOAD_BYTES,
+  checkTurnBounds,
+  sanitizeClientTurn,
+  sanitizeClientTurns,
+} from "./conversation-write-guards.ts";
+
+function turn(role, text = "hi", extra = {}) {
+  return { id: crypto.randomUUID(), role, text, createdAt: new Date().toISOString(), ...extra };
+}
+
+// --- checkTurnBounds ---
+
+assert.equal(checkTurnBounds([turn("user")]), null, "small write is within bounds");
+assert.equal(
+  checkTurnBounds(Array.from({ length: MAX_CONVERSATION_TURNS }, () => turn("user"))),
+  null,
+  "exactly at the turn cap is allowed",
+);
+{
+  const over = checkTurnBounds(Array.from({ length: MAX_CONVERSATION_TURNS + 1 }, () => turn("user")));
+  assert.equal(over?.status, 413, "over the turn cap returns 413");
+  assert.match(over.error, /too many turns/);
+}
+{
+  const longText = "z".repeat(MAX_TURN_TEXT_CHARS + 1);
+  const res = checkTurnBounds([turn("user", longText)]);
+  assert.equal(res?.status, 413, "over-long turn text returns 413");
+  assert.match(res.error, /text too long/);
+}
+{
+  // Many medium turns whose serialized size blows the payload cap.
+  const chunk = "z".repeat(50_000);
+  const many = Array.from({ length: 200 }, () => turn("user", chunk));
+  const res = checkTurnBounds(many);
+  assert.equal(res?.status, 413, "over-size payload returns 413");
+  assert.match(res.error, /payload too large/);
+  // sanity: this really exceeds the byte cap
+  assert.ok(Buffer.byteLength(JSON.stringify(many)) > MAX_TURNS_PAYLOAD_BYTES);
+}
+
+// --- sanitizeClientTurn: harness telemetry cannot be forged ---
+
+{
+  const forged = turn("assistant", "totally real", {
+    usage: { inputTokens: 999, outputTokens: 999 },
+    costUsd: 42,
+    tools: [{ id: "t", name: "shell", status: "ok" }],
+    reasoning: "fake chain of thought",
+    durationMs: 1234,
+    responseMetadata: { model: "spoofed" },
+    harnessSessionId: "spoofed-session",
+    attachments: [{ kind: "image" }],
+  });
+  const clean = sanitizeClientTurn(forged);
+  for (const f of ["usage", "costUsd", "tools", "reasoning", "durationMs", "responseMetadata", "harnessSessionId"]) {
+    assert.equal(f in clean, false, `assistant turn must not carry client-forged ${f}`);
+  }
+  // Non-telemetry content is preserved.
+  assert.equal(clean.role, "assistant");
+  assert.equal(clean.text, "totally real");
+  assert.deepEqual(clean.attachments, [{ kind: "image" }], "attachments are kept");
+  // Input is never mutated.
+  assert.equal("usage" in forged, true, "sanitize must not mutate its input");
+}
+{
+  const u = turn("user", "hello", { usage: { inputTokens: 1 }, costUsd: 5 });
+  const clean = sanitizeClientTurn(u);
+  // User turns pass through unchanged (harness never authors user telemetry,
+  // and user turns legitimately carry no such fields — but we don't strip).
+  assert.equal(clean, u, "user turns are returned unchanged (same reference)");
+}
+{
+  const list = [turn("user"), turn("assistant", "x", { costUsd: 9 })];
+  const clean = sanitizeClientTurns(list);
+  assert.equal("costUsd" in clean[1], false, "list sanitize strips assistant telemetry");
+}
+
+console.log("conversation-write-guards.test.ts: ok");

--- a/src/lib/server/conversation-write-guards.ts
+++ b/src/lib/server/conversation-write-guards.ts
@@ -94,8 +94,8 @@ export function checkTurnBounds(turns: ChatTurn[]): TurnBoundsError | null {
 
 /**
  * Strip harness-owned telemetry from a client-authored assistant/system turn.
- * User turns are returned unchanged. Returns a new turn object; never mutates
- * the input.
+ * User turns are returned unchanged. Returns the original turn when no fields
+ * are stripped; otherwise returns a shallow clone. Never mutates the input.
  */
 export function sanitizeClientTurn(turn: ChatTurn): ChatTurn {
   if (turn.role === "user") return turn;

--- a/src/lib/server/conversation-write-guards.ts
+++ b/src/lib/server/conversation-write-guards.ts
@@ -65,6 +65,9 @@ export function checkTurnBounds(turns: ChatTurn[]): TurnBoundsError | null {
     };
   }
   for (const turn of turns) {
+    if (typeof (turn as any).text !== "string") {
+      return { ok: false, status: 400, error: "turn text must be a string" };
+    }
     if (turn.text.length > MAX_TURN_TEXT_CHARS) {
       return {
         ok: false,

--- a/src/lib/server/conversation-write-guards.ts
+++ b/src/lib/server/conversation-write-guards.ts
@@ -1,0 +1,113 @@
+import type { ChatTurn } from "@/lib/cave-conversations";
+
+/**
+ * Conversation write contract + bounds (issue #3469).
+ *
+ * WHO WRITES WHAT.
+ *   - `chat/send` is the harness-truth writer. It calls `saveConversation`
+ *     directly with real assistant turns, tool metadata, usage and cost. It is
+ *     the authoritative producer of assistant/system content and is NOT routed
+ *     through these guards.
+ *   - `chat/conversation/[id]` POST/PUT are client-facing turn writers (branch
+ *     edits, imports, replays). They may persist turn *text*, role, attachments
+ *     and branching pointers, but they must not be able to forge harness
+ *     telemetry onto assistant/system turns. `sanitizeClientTurn` strips the
+ *     server-owned fields below so a client cannot fabricate a "real" assistant
+ *     response with fake usage/cost/tool traces.
+ *
+ * MOBILE. The chat namespace is intentionally reachable by the iOS app over
+ * `tailscale serve` (see local-origin.ts), so these writes are NOT locked to
+ * loopback — doing so would break mobile chat. Trust is instead enforced by
+ * bounding size and by field ownership, which hold regardless of origin.
+ *
+ * BOUNDS. Turn count, per-turn text length, and total serialized payload are
+ * capped so a single write cannot pressure disk or the UI; over-limit writes
+ * return 413.
+ */
+
+/** Max turns persisted in one conversation write (full-list PUT or append POST). */
+export const MAX_CONVERSATION_TURNS = 5000;
+
+/** Max characters in a single turn's text. */
+export const MAX_TURN_TEXT_CHARS = 200_000;
+
+/** Max serialized byte size of an incoming turns payload. */
+export const MAX_TURNS_PAYLOAD_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Fields on a ChatTurn that only the harness (`chat/send`) may author. A
+ * client-supplied assistant/system turn cannot set these — they are stripped
+ * before persistence so run/telemetry truth stays harness-owned.
+ */
+const HARNESS_OWNED_ASSISTANT_FIELDS = [
+  "usage",
+  "costUsd",
+  "tools",
+  "reasoning",
+  "durationMs",
+  "responseMetadata",
+  "harnessSessionId",
+] as const;
+
+export type TurnBoundsError =
+  | { ok: false; status: 400 | 413; error: string };
+
+/**
+ * Enforce count + per-turn + total-payload bounds on a normalized turn list.
+ * Returns null when within bounds, or a typed error for the route to return.
+ */
+export function checkTurnBounds(turns: ChatTurn[]): TurnBoundsError | null {
+  if (turns.length > MAX_CONVERSATION_TURNS) {
+    return {
+      ok: false,
+      status: 413,
+      error: `too many turns (max ${MAX_CONVERSATION_TURNS})`,
+    };
+  }
+  for (const turn of turns) {
+    if (turn.text.length > MAX_TURN_TEXT_CHARS) {
+      return {
+        ok: false,
+        status: 413,
+        error: `turn text too long (max ${MAX_TURN_TEXT_CHARS} chars)`,
+      };
+    }
+  }
+  let bytes: number;
+  try {
+    bytes = Buffer.byteLength(JSON.stringify(turns), "utf8");
+  } catch {
+    return { ok: false, status: 400, error: "turns not serializable" };
+  }
+  if (bytes > MAX_TURNS_PAYLOAD_BYTES) {
+    return {
+      ok: false,
+      status: 413,
+      error: `turns payload too large (max ${MAX_TURNS_PAYLOAD_BYTES} bytes)`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Strip harness-owned telemetry from a client-authored assistant/system turn.
+ * User turns are returned unchanged. Returns a new turn object; never mutates
+ * the input.
+ */
+export function sanitizeClientTurn(turn: ChatTurn): ChatTurn {
+  if (turn.role === "user") return turn;
+  const clone: Record<string, unknown> = { ...turn };
+  let stripped = false;
+  for (const field of HARNESS_OWNED_ASSISTANT_FIELDS) {
+    if (field in clone) {
+      delete clone[field];
+      stripped = true;
+    }
+  }
+  return stripped ? (clone as unknown as ChatTurn) : turn;
+}
+
+/** Apply `sanitizeClientTurn` across a list. */
+export function sanitizeClientTurns(turns: ChatTurn[]): ChatTurn[] {
+  return turns.map(sanitizeClientTurn);
+}


### PR DESCRIPTION
Closes #3469

Sibling hardening to #3470, applied to the conversation write API.

## Problem

`/api/chat/conversation/[id]` POST/PUT turn writers:
- accepted **unbounded** turn lists and unbounded per-turn text (disk/UI pressure), and
- let a client **forge assistant telemetry** — `usage`, `costUsd`, `tools`, `reasoning` — onto persisted turns, so a fabricated 'real' assistant response was indistinguishable from harness truth.

There is **no first-party UI caller** for these turn-writing paths; the harness-truth writer is `chat/send`, which calls `saveConversation` directly and is unaffected.

## Fix

New shared write-contract module `src/lib/server/conversation-write-guards.ts`:

- **Bounds** — cap turns/conversation (5000), per-turn text (200k chars), total serialized payload (8MB); over-limit → **413**.
- **Field ownership** — `sanitizeClientTurns` strips harness-owned fields (`usage`, `costUsd`, `tools`, `reasoning`, `durationMs`, `responseMetadata`, `harnessSessionId`) from client-authored assistant/system turns. User turns + non-telemetry content (text, attachments, branching) pass through unchanged; never mutates input.

## Write contract (AC #1/#3)

Documented in the module header: `chat/send` owns assistant/system truth; `chat/conversation/[id]` client writes may set turn text/role/attachments/branching but cannot forge telemetry.

**Mobile note:** the chat namespace is intentionally reachable by the iOS app over `tailscale serve` (see local-origin.ts), so these writes are **not** loopback-locked — trust is enforced by bounds + field ownership, which hold regardless of origin. (This is the key difference from #3470, where mobile only needed reads.)

## Verification

- Behavioral tests (bounds + sanitize) + route tests (client PUT telemetry stripped; over-long turn → 413). Existing DELETE tests unchanged (4→6 pass).
- api suite green (**221 contracts**); `tsc --noEmit` clean; `check:tests-wired` green (1081 wired).

## Blast radius

+268 / −2 across 5 files; server-side only, no UI changes.