### PR TITLE
Fix Windows Cave launch and Hermes chat

### DIFF
--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -54,9 +54,17 @@ cleanup() { rm -f "$TAURI_OVERRIDE_CONFIG"; }
 trap cleanup EXIT
 
 if [ "$should_start_server" = true ]; then
-  # Use beforeDevCommand but set PORT so it uses our free port
+  # The desktop shell always uses a loopback devUrl. A host-provided HOSTNAME
+  # (for example Docker/WSL's machine name) would bind the server elsewhere
+  # and leave Tauri waiting forever. Tauri invokes beforeDevCommand through
+  # cmd.exe on Windows, so use cmd's `set` form under Git Bash/MSYS.
+  before_dev_command="HOSTNAME=127.0.0.1 PORT=${dev_port} pnpm dev"
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) before_dev_command="set HOSTNAME=127.0.0.1&& set PORT=${dev_port}&& pnpm dev" ;;
+  esac
+  # Use beforeDevCommand but set PORT so it uses our free port.
   cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
-{"build":{"beforeDevCommand":"PORT=${dev_port} pnpm dev","devUrl":"http://127.0.0.1:${dev_port}"}}
+{"build":{"beforeDevCommand":"${before_dev_command}","devUrl":"http://127.0.0.1:${dev_port}"}}
 CONF
 else
   # Skip beforeDevCommand since the server is already running

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const source = readFileSync(
+  fileURLToPath(new URL("./dev-app.sh", import.meta.url)),
+  "utf8",
+);
+
+assert.match(
+  source,
+  /MINGW\*\|MSYS\*\|CYGWIN\*\) before_dev_command="set HOSTNAME=127\.0\.0\.1&& set PORT=\$\{dev_port\}&& pnpm dev"/,
+  "Windows Tauri launches must bind loopback and use cmd.exe's set syntax",
+);
+assert.match(
+  source,
+  /before_dev_command="HOSTNAME=127\.0\.0\.1 PORT=\$\{dev_port\} pnpm dev"/,
+  "POSIX launches must bind the dev server to the desktop shell's loopback devUrl",
+);
+assert.match(
+  source,
+  /beforeDevCommand":"\$\{before_dev_command\}"/,
+  "the generated Tauri override must use the platform-correct command",
+);
+
+console.log("dev-app: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -818,6 +818,7 @@ export const SUITES = {
   api: [
     "scripts/dependency-policy.test.mjs",
     "scripts/build-sandbox-runtime.test.mjs",
+    "scripts/dev-app.test.mjs",
     "scripts/sync-runtimes.test.mjs",
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -74,6 +74,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /captureHermesSessionFromStderr[\s\S]*session_id:\\s\*\(\\S\+\)/,
+  "Hermes quiet mode must capture its resumable session id from stderr",
+);
+
+assert.match(
+  chatRoute,
   /command: process\.platform === "win32" \? "hermes\.exe" : "hermes"/,
   "Hermes direct chat must use the Windows executable name on Windows",
 );

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -535,6 +535,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /Session not found:/,
+  "Transparent resume fallback should also handle Hermes session-store misses",
+);
+
+assert.match(
+  chatRoute,
   /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
   "Fresh-chat retry should clear stale diagnostic tails before the retry attempt",
 );
@@ -1292,6 +1298,12 @@ assert.match(
   chatRoute,
   /if \(copilotStream\) \{\s*\n\s*handleCopilotLine\(line, isJson\);\s*\n\s*return;/,
   "Copilot stdout routes through the copilot JSONL handler, never the AssistantFilter (raw JSON frames must not leak into the bubble)",
+);
+
+assert.match(
+  chatRoute,
+  /const isJson = !hermesDirect && line\.startsWith\("\{"\) && line\.endsWith\("\}"\);/,
+  "Hermes direct stdout must stay plain text even when an assistant reply looks like a JSON object",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -60,6 +60,24 @@ assert.match(
   "Native chat should reject bundled adapters that opt out of native chat",
 );
 
+assert.match(
+  chatRoute,
+  /const hermesDirect = !sshRuntime && binding\.harness === "hermes"/,
+  "local Hermes chats should use its documented direct one-shot command instead of a POSIX-only Coven shim",
+);
+
+assert.match(
+  chatRoute,
+  /const a = \["chat", "--source", "coven", "-Q"\];[\s\S]*a\.push\("--query", prompt\)/,
+  "Hermes direct chat must use quiet query mode so stdout contains the actual reply",
+);
+
+assert.match(
+  chatRoute,
+  /command: process\.platform === "win32" \? "hermes\.exe" : "hermes"/,
+  "Hermes direct chat must use the Windows executable name on Windows",
+);
+
 assert.doesNotMatch(
   chatRoute,
   /const a = \["run", binding\.harness, "--stream-json"\];[\s\S]*binding\.harness === "openclaw"/,
@@ -1254,8 +1272,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const \{ command, fixedArgs \} = copilotStream\s*\n?\s*\? \{ command: copilotStream\.executable, fixedArgs: \[\] as string\[\] \}\s*\n?\s*: covenLaunchCommand\(\);/,
-  "Copilot stream turns spawn the adapter binary directly; everything else spawns coven",
+  /const \{ command, fixedArgs \} = copilotStream\s*\n?\s*\? \{ command: copilotStream\.executable, fixedArgs: \[\] as string\[\] \}\s*\n?\s*: hermesDirect\s*\n?\s*\? \{\s*\n?\s*command: process\.platform === "win32" \? "hermes\.exe" : "hermes",[\s\S]*?: covenLaunchCommand\(\);/,
+  "Copilot and Hermes direct turns spawn their own CLI; other local harnesses spawn coven",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -72,6 +72,12 @@ assert.match(
   "Hermes direct chat must use quiet query mode so stdout contains the actual reply",
 );
 
+assert.doesNotMatch(
+  chatRoute,
+  /const hermesModel = cleanModelId\(desiredModel\);/,
+  "Hermes does not advertise a model flag, so a custom Cave model must not become invalid CLI args",
+);
+
 assert.match(
   chatRoute,
   /captureHermesSessionFromStderr[\s\S]*session_id:\\s\*\(\\S\+\)/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1526,9 +1526,6 @@ export async function POST(req: Request) {
     if (hermesDirect) {
       const a = ["chat", "--source", "coven", "-Q"];
       if (resumeSessionId) a.push("--resume", resumeSessionId);
-      // `hermes-local` is Cave's runtime marker, not a Hermes model id.
-      const hermesModel = cleanModelId(desiredModel);
-      if (hermesModel && hermesModel !== "hermes-local") a.push("--model", hermesModel);
       a.push("--query", prompt);
       return a;
     }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1565,10 +1565,11 @@ export async function POST(req: Request) {
   // id exists only in Cave's local transcript store. Copilot emits "No
   // session, task, or name matched '<id>'" on `--resume` misses — including
   // every conversation recorded before the direct-stream path existed, whose
-  // harnessSessionId lives only in coven's store. In these cases we retry
-  // once without the resume flag so the chat starts fresh instead of erroring.
+  // harnessSessionId lives only in coven's store. Hermes emits "Session not
+  // found: <id>" when its local session is gone. In these cases we retry once
+  // without the resume flag so the chat starts fresh instead of erroring.
   const RESUME_ERR_RE =
-    /thread\/resume failed|no rollout found|code\s*-32600|Session ID \S+ is already in use|No conversation found with session ID|session\s+\S+\s+not found in local store|No session, task, or name matched/i;
+    /thread\/resume failed|no rollout found|code\s*-32600|Session ID \S+ is already in use|No conversation found with session ID|session\s+\S+\s+not found in local store|No session, task, or name matched|Session not found:/i;
 
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
@@ -1810,7 +1811,7 @@ export async function POST(req: Request) {
         const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
         if (!line) return;
         if (RESUME_ERR_RE.test(line)) resumeFailed = true;
-        const isJson = line.startsWith("{") && line.endsWith("}");
+        const isJson = !hermesDirect && line.startsWith("{") && line.endsWith("}");
         if (copilotStream) {
           handleCopilotLine(line, isJson);
           return;

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1701,6 +1701,24 @@ export async function POST(req: Request) {
         ).catch(() => undefined);
       };
 
+      // Hermes's `-Q` mode reserves stdout for the reply and writes the
+      // resumable id to stderr as `session_id: <id>`. Buffer stderr because
+      // Node can split that short line across data events.
+      let hermesStderrBuffer = "";
+      const captureHermesSessionFromStderr = (text: string, flush = false) => {
+        if (!hermesDirect || sessionId) return;
+        hermesStderrBuffer += text;
+        const lines = hermesStderrBuffer.split(/\r?\n/);
+        hermesStderrBuffer = flush ? "" : (lines.pop() ?? "");
+        for (const line of lines) {
+          const hermesSession = line.trim().match(/^session_id:\s*(\S+)\s*$/i);
+          if (hermesSession) {
+            announceSession(hermesSession[1]);
+            return;
+          }
+        }
+      };
+
       // Copilot JSONL stream (cave-yesg): the CLI's own event schema, not
       // claude stream-json. Text arrives as message deltas + a full-content
       // message frame (deduped by CopilotTextAssembler); tool calls arrive as
@@ -1920,9 +1938,8 @@ export async function POST(req: Request) {
         }
         const cleaned = resolveBackspaces(stripAnsi(line));
         const trimmed = cleaned.trim();
-        // Quiet Hermes one-shot turns print the final response followed by the
-        // durable session id. Capture that id for a later `--resume`, but do
-        // not render the implementation detail as assistant prose.
+        // Older Hermes versions can print the durable session id to stdout.
+        // The current quiet path writes it to stderr (captured separately).
         if (hermesDirect) {
           const hermesSession = trimmed.match(/^Session ID:\s*(\S+)\s*$/i);
           if (hermesSession && !sessionId) {
@@ -2059,6 +2076,7 @@ export async function POST(req: Request) {
 
           child.stderr.on("data", (data: Buffer) => {
             const text = stripAnsi(data.toString("utf8"));
+            captureHermesSessionFromStderr(text);
             if (RESUME_ERR_RE.test(text)) resumeFailed = true;
             if (!adapterConflict) {
               adapterConflict = detectBuiltinAdapterConflict(text);
@@ -2101,6 +2119,7 @@ export async function POST(req: Request) {
           });
 
           child.on("close", () => {
+            captureHermesSessionFromStderr("", true);
             pushProgress(
               "harness-start",
               `${binding.harness} exited`,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1469,6 +1469,13 @@ export async function POST(req: Request) {
   // fallback (and every other adapter keeps it unconditionally).
   const copilotStream =
     !sshRuntime && binding.harness === "copilot" ? copilotStreamSpec() : null;
+  // Hermes has a documented one-shot API (`hermes chat -Q -q <prompt>`), but
+  // its Coven adapter convention requires a POSIX shell shim to translate the
+  // positional prompt that `coven run` appends. The shim cannot be installed
+  // beside Hermes's Windows executable, which left Cave showing only a timer.
+  // Spawn Hermes directly for native local chats, as we already do for the
+  // Copilot JSONL adapter, and keep SSH runtimes on their remote Coven path.
+  const hermesDirect = !sshRuntime && binding.harness === "hermes";
   // The copilot session id Cave chose for the CURRENT attempt: the resume
   // target, or a pre-assigned fresh id (copilot events don't echo the id
   // until the final result frame, so the stream handler announces this one).
@@ -1515,6 +1522,15 @@ export async function POST(req: Request) {
         // session/sandbox flags above.
         addDirs: grantDirs,
       });
+    }
+    if (hermesDirect) {
+      const a = ["chat", "--source", "coven", "-Q"];
+      if (resumeSessionId) a.push("--resume", resumeSessionId);
+      // `hermes-local` is Cave's runtime marker, not a Hermes model id.
+      const hermesModel = cleanModelId(desiredModel);
+      if (hermesModel && hermesModel !== "hermes-local") a.push("--model", hermesModel);
+      a.push("--query", prompt);
+      return a;
     }
     const a = ["run", binding.harness, "--stream-json"];
     if (resumeSessionId) a.push("--continue", resumeSessionId);
@@ -1904,6 +1920,16 @@ export async function POST(req: Request) {
         }
         const cleaned = resolveBackspaces(stripAnsi(line));
         const trimmed = cleaned.trim();
+        // Quiet Hermes one-shot turns print the final response followed by the
+        // durable session id. Capture that id for a later `--resume`, but do
+        // not render the implementation detail as assistant prose.
+        if (hermesDirect) {
+          const hermesSession = trimmed.match(/^Session ID:\s*(\S+)\s*$/i);
+          if (hermesSession && !sessionId) {
+            announceSession(hermesSession[1]);
+            return;
+          }
+        }
         // Snapshot error-looking stdout lines for the empty-response diagnostic.
         recordStdoutErrorTail(cleaned);
         // Surface tool-use hook lines as structured events so the chat can
@@ -1987,12 +2013,17 @@ export async function POST(req: Request) {
                 });
               })()
             : (() => {
-                // Copilot stream turns spawn the adapter binary directly with
-                // its manifest-declared JSONL args; everything else goes
+                // Copilot's JSONL mode and Hermes's documented one-shot mode
+                // are direct CLI integrations. Every other local harness goes
                 // through `coven run`.
                 const { command, fixedArgs } = copilotStream
                   ? { command: copilotStream.executable, fixedArgs: [] as string[] }
-                  : covenLaunchCommand();
+                  : hermesDirect
+                    ? {
+                        command: process.platform === "win32" ? "hermes.exe" : "hermes",
+                        fixedArgs: [] as string[],
+                      }
+                    : covenLaunchCommand();
                 return spawn(command, [...fixedArgs, ...spawnArgs], {
                   // Spawn IN the familiar's workspace when no project root was
                   // supplied, so coven's project-root resolver picks that dir as
@@ -2057,7 +2088,9 @@ export async function POST(req: Request) {
                     ? "ssh CLI not found on PATH. Install OpenSSH or run this familiar locally."
                     : copilotStream
                       ? "copilot CLI not found on PATH. Install it with `npm install -g @github/copilot`, then try again."
-                      : "Coven CLI not found on PATH. Open Setup to install it, then try again.",
+                      : hermesDirect
+                        ? "Hermes CLI not found on PATH. Install Hermes, then try again."
+                        : "Coven CLI not found on PATH. Open Setup to install it, then try again.",
               });
             } else {
               push({ kind: "error", message: err.message });


### PR DESCRIPTION
## Summary

- launch the Tauri dev shell with Windows-safe environment syntax and a loopback-bound dev server
- run local Hermes chats through Hermes's documented quiet query command instead of the unavailable POSIX shim
- add launcher and Hermes routing regression coverage

## Root cause

Tauri executes `beforeDevCommand` through `cmd.exe` on Windows, where the POSIX `PORT=... command` form fails. An inherited `HOSTNAME` could also bind the dev server away from Tauri's loopback `devUrl`. Hermes was marked ready while native chat depended on a POSIX-only `hermes-coven` shim, producing timer-only turns.

## Validation

- Windows-native `pnpm build`
- `pnpm exec tsc --noEmit`
- focused launcher, Hermes shim, adapter, and chat-routing tests
- native Tauri launch on `http://127.0.0.1:3000` with `GET /` 200

Tracks Bead `cave-o40`.