### PR TITLE
Reject SVG workspace avatars to prevent same-origin XSS

### DIFF
--- a/src/app/api/familiars/[id]/avatar/route.test.ts
+++ b/src/app/api/familiars/[id]/avatar/route.test.ts
@@ -38,6 +38,11 @@ assert.match(
   "avatars-dir helper must re-assert the id guard before building the path",
 );
 
+// Workspace-controlled SVGs are active content when opened as same-origin
+// documents, so GET must never serve raw image/svg+xml bytes.
+assert.doesNotMatch(source, /image\/svg\+xml/, "GET should not serve same-origin SVG avatars");
+assert.doesNotMatch(source, /serve verbatim|as-is/, "GET should not bypass rasterization for SVG avatars");
+
 // Size is bounded before the expensive decode.
 assert.match(source, /MAX_AVATAR_BYTES/, "POST should bound the upload size");
 

--- a/src/app/api/familiars/[id]/avatar/route.ts
+++ b/src/app/api/familiars/[id]/avatar/route.ts
@@ -51,10 +51,11 @@ function cacheSet(key: string, value: RenderedAvatar): void {
  * Serve a familiar's avatar image from its workspace:
  *   ~/.coven/workspaces/familiars/<id>/avatars/<image>.<ext>
  *
- * Raster avatars are downscaled to <=256px and re-encoded as PNG so a 30MB
+ * Avatars are downscaled to <=256px and re-encoded as PNG so a 30MB
  * source doesn't ship for a 48px avatar while still rendering in desktop
- * WebViews that lack WebP codec support; SVGs are served as-is (already small,
- * and vector). The `id` segment (the only user input) is slug-guarded, and the
+ * WebViews that lack WebP codec support. SVGs are intentionally unsupported:
+ * serving workspace-controlled active content from this same-origin API would
+ * create an XSS primitive. The `id` segment (the only user input) is slug-guarded, and the
  * served filename is chosen from the directory listing — never from the request
  * — so this can't read outside the avatars dir. 404 when the familiar has no
  * avatar; the UI then falls back to the glyph.
@@ -95,21 +96,16 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   let rendered: RenderedAvatar;
-  if (avatar.contentType === "image/svg+xml") {
-    // Vector source — already tiny; serve verbatim rather than rasterizing.
-    rendered = { body: new Uint8Array(bytes), contentType: "image/svg+xml" };
-  } else {
-    try {
-      const png = await sharp(bytes)
-        .rotate() // honor EXIF orientation before resizing
-        .resize(AVATAR_MAX_DIM, AVATAR_MAX_DIM, { fit: "inside", withoutEnlargement: true })
-        .png({ compressionLevel: 9, adaptiveFiltering: true })
-        .toBuffer();
-      rendered = { body: new Uint8Array(png), contentType: "image/png" };
-    } catch {
-      // Not a decodable raster image — treat as missing rather than 500.
-      return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
-    }
+  try {
+    const png = await sharp(bytes)
+      .rotate() // honor EXIF orientation before resizing
+      .resize(AVATAR_MAX_DIM, AVATAR_MAX_DIM, { fit: "inside", withoutEnlargement: true })
+      .png({ compressionLevel: 9, adaptiveFiltering: true })
+      .toBuffer();
+    rendered = { body: new Uint8Array(png), contentType: "image/png" };
+  } catch {
+    // Not a decodable supported image — treat as missing rather than 500.
+    return NextResponse.json({ ok: false, error: "no avatar" }, { status: 404 });
   }
 
   cacheSet(cacheKey, rendered);

--- a/src/lib/server/familiar-avatar.test.ts
+++ b/src/lib/server/familiar-avatar.test.ts
@@ -6,7 +6,7 @@ import { pickAvatarFile, isImageFile, contentTypeForFile } from "./familiar-avat
 assert.equal(isImageFile("cody.png"), true);
 assert.equal(isImageFile("cody.PNG"), true);
 assert.equal(isImageFile("cody.webp"), true);
-assert.equal(isImageFile("cody.svg"), true);
+assert.equal(isImageFile("cody.svg"), false);
 assert.equal(isImageFile("SOUL.md"), false);
 assert.equal(isImageFile("notes.txt"), false);
 assert.equal(isImageFile("cody"), false);
@@ -14,7 +14,7 @@ assert.equal(isImageFile("cody"), false);
 // contentTypeForFile maps extensions; unknown → octet-stream.
 assert.equal(contentTypeForFile("cody.png"), "image/png");
 assert.equal(contentTypeForFile("a.JPG"), "image/jpeg");
-assert.equal(contentTypeForFile("a.svg"), "image/svg+xml");
+assert.equal(contentTypeForFile("a.svg"), "application/octet-stream");
 assert.equal(contentTypeForFile("a.bin"), "application/octet-stream");
 
 // The canonical case: cody/avatars/cody.png.
@@ -26,9 +26,10 @@ assert.equal(pickAvatarFile(["aaa.png", "cody.png"], "cody"), "cody.png");
 // `<id>` match is case-insensitive.
 assert.equal(pickAvatarFile(["Cody.PNG"], "cody"), "Cody.PNG");
 
-// Among multiple `<id>.<ext>`, png beats jpg/svg (EXT_PRIORITY).
+// Among multiple `<id>.<ext>`, png beats jpg (EXT_PRIORITY); SVG is ignored.
 assert.equal(pickAvatarFile(["cody.svg", "cody.jpg", "cody.png"], "cody"), "cody.png");
 assert.equal(pickAvatarFile(["cody.svg", "cody.webp"], "cody"), "cody.webp");
+assert.equal(pickAvatarFile(["cody.svg"], "cody"), null);
 
 // Non-image files are ignored when choosing.
 assert.equal(pickAvatarFile(["README.md", "cody.png", ".keep"], "cody"), "cody.png");

--- a/src/lib/server/familiar-avatar.ts
+++ b/src/lib/server/familiar-avatar.ts
@@ -20,13 +20,12 @@ const CONTENT_TYPE_BY_EXT: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".webp": "image/webp",
   ".gif": "image/gif",
-  ".svg": "image/svg+xml",
   ".avif": "image/avif",
 };
 
 // Preference order when several images exist and none matches `<id>.<ext>` —
-// also the tiebreak order for the exact-id match (png first, vector last).
-const EXT_PRIORITY = [".png", ".webp", ".jpg", ".jpeg", ".avif", ".gif", ".svg"];
+// also the tiebreak order for the exact-id match (png first).
+const EXT_PRIORITY = [".png", ".webp", ".jpg", ".jpeg", ".avif", ".gif"];
 
 export function isImageFile(name: string): boolean {
   return path.extname(name).toLowerCase() in CONTENT_TYPE_BY_EXT;


### PR DESCRIPTION
### Motivation
- Workspace-provided SVG avatars were being served verbatim from the same-origin API as `image/svg+xml`, creating a stored same-origin XSS primitive that could leak sidecar/auth tokens.  

### Description
- Remove `.svg` from the avatar extension allowlist in `src/lib/server/familiar-avatar.ts` so workspace SVG files are no longer treated as supported images.  
- Eliminate the code path that served `image/svg+xml` bytes from `src/app/api/familiars/[id]/avatar/route.ts` and instead always decode and re-encode avatar bytes through `sharp` to produce a safe `image/png` response.  
- Update unit tests in `src/lib/server/familiar-avatar.test.ts` and `src/app/api/familiars/[id]/avatar/route.test.ts` to assert that SVG is not recognized or served verbatim and to cover the regression.  
- Preserve existing cache, size bounds, slug guards, and upload normalization behavior while rejecting/ignoring unsupported SVG workspace avatars.  

### Testing
- Ran `pnpm test:api`, which executed the API test suite (126 test files) and completed with all tests passing.  
- Ran `pnpm typecheck`, which failed due to pre-existing type-resolution/implicit-any errors in `src/components/md-editor/md-editor-visual.tsx` that are unrelated to this change.  
- Added/updated unit tests for avatar resolution and the avatar route; these tests were exercised as part of the API suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca7e7977883278e12d45072e44707)