### PR TITLE
fix(release): defer notary credentials until submission

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -73,6 +73,16 @@ test("Apple ID notarization avoids putting the app password in process arguments
   assert.doesNotMatch(setupFunctions, /--password/);
   assert.doesNotMatch(logFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);
   assert.doesNotMatch(submitFunction, /--password "\$NOTARY_APPLE_PASSWORD"/);
+
+  const setupCall = releaseScript.lastIndexOf("setup_notary_keychain_profile");
+  assert(
+    setupCall > releaseScript.indexOf('echo "==> Signing DMG container"'),
+    "the credential profile must not exist during build or packaging",
+  );
+  assert(
+    setupCall < releaseScript.indexOf('echo "==> Submitting DMG for notarization"'),
+    "the credential profile should be created immediately before notarization",
+  );
 });
 
 test("notary rejection stops before stapling and prints the Apple log", () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -316,7 +316,6 @@ fi
 
 if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
   require_tool security
-  setup_notary_keychain_profile
 elif [ "$NOTARY_AUTH_MODE" = "api-key" ]; then
   require_file "$NOTARY_KEY_FILE"
   echo "==> Validating App Store Connect API key"
@@ -419,6 +418,12 @@ create_dmg_with_retry
 echo "==> Signing DMG container"
 codesign --force --timestamp \
   --sign "$SIGNING_IDENTITY" "$DMG_PATH"
+
+if [ "$NOTARY_AUTH_MODE" = "apple-id" ]; then
+  # Do not expose a usable notarization credential handle to build or
+  # packaging subprocesses. Create it only once the artifact is ready.
+  setup_notary_keychain_profile
+fi
 
 echo "==> Submitting DMG for notarization"
 notarize_with_retries


### PR DESCRIPTION
### Motivation
- A credential-exposure window was created by populating and unlocking a temporary notary `keychain` before running untrusted build/packaging steps, allowing same-user build-time code to access notarization credentials.
- The intent is to eliminate that window by minimizing the lifetime of any notarization credential handle to only the interval immediately required for submission.
- This change defers keychain creation until the artifact is fully built, packaged, and signed so build subprocesses never see a usable credential handle.

### Description
- Stop creating the temporary notary keychain during initial auth validation by removing the early `setup_notary_keychain_profile` call in the `apple-id` branch of `scripts/release.sh`.
- Create the notary keychain only after the DMG has been assembled and signed by invoking `setup_notary_keychain_profile` immediately after DMG signing and immediately before notarization submission in `scripts/release.sh`.
- Preserve the existing stdin-based `store_notary_credentials` flow and the `cleanup_release_artifacts` trap so secrets are still never passed on the command line and are removed on exit.
- Add regression assertions to `scripts/release-macos-signing.test.mjs` that verify `setup_notary_keychain_profile` occurs after DMG signing and before notarization submission.

### Testing
- Ran `git diff --check` which produced no problems.
- Validated shell syntax with `bash -n scripts/release.sh` which succeeded.
- Ran `node --test scripts/release-macos-signing.test.mjs` and all tests passed (11 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a1b7fded4832795be8cec70d93a87)