### PR TITLE
fix(security): gate project stores on Cave-home reconciliation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -96,6 +96,7 @@ export const SUITES = {
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/familiar-roster-guard.test.ts",
     "src/lib/cave-projects.test.ts",
+    "src/lib/cave-home-project-store-reconciliation.test.ts",
     "src/lib/cave-inbox-create.test.ts",
     "src/lib/cave-inbox-prefs.test.ts",
     "src/lib/cave-inbox-bulk.test.ts",

--- a/src/lib/cave-home-project-store-reconciliation.test.ts
+++ b/src/lib/cave-home-project-store-reconciliation.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = await mkdtemp(path.join(os.tmpdir(), "cave-home-project-store-reconciliation-"));
+process.env.COVEN_HOME = tmp;
+delete process.env.COVEN_CAVE_HOME;
+delete process.env.CAVE_PROJECTS_PATH_OVERRIDE;
+delete process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE;
+delete process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE;
+delete globalThis.__caveHomeMigration;
+
+try {
+  const legacyProject = {
+    id: "secret-project-id",
+    name: "Secret",
+    root: path.join(tmp, "secret"),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  await writeFile(
+    path.join(tmp, "cave-projects.json"),
+    JSON.stringify({ version: 1, projects: [legacyProject] }, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    path.join(tmp, "cave-project-permissions.json"),
+    JSON.stringify(
+      {
+        version: 2,
+        projectGrants: [
+          {
+            familiarId: "supreme",
+            projectId: "secret-project-id",
+            access: "write",
+            source: "human",
+            grantedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        accessGroups: [],
+        grantProposals: [],
+        permissionAudit: [],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const { loadProjects } = await import("./cave-projects.ts");
+  const { loadProjectPermissions } = await import("./project-permissions.ts");
+
+  const projects = await loadProjects();
+  assert.deepEqual(
+    projects.map((project) => project.id),
+    ["secret-project-id"],
+    "loadProjects reconciles legacy Cave-home project state before returning authoritative grants scope",
+  );
+  assert.equal(
+    await readFile(path.join(tmp, "cave", "projects.json"), "utf8").then((raw) => JSON.parse(raw).projects[0].id),
+    "secret-project-id",
+  );
+
+  const permissions = await loadProjectPermissions();
+  assert.deepEqual(
+    permissions.projectGrants.map((grant) => grant.projectId),
+    ["secret-project-id"],
+    "loadProjectPermissions reconciles legacy grants before returning authorization data",
+  );
+  console.log("cave-home-project-store-reconciliation.test.ts: ok");
+} finally {
+  delete process.env.COVEN_HOME;
+  delete globalThis.__caveHomeMigration;
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -12,6 +12,7 @@ export {
 import type { CaveProject } from "./cave-projects-types.ts";
 import { dedupeProjectsByRoot as dedupeByRoot } from "./cave-projects-types.ts";
 import { caveHome } from "./coven-paths.ts";
+import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
 
 type ProjectsFile = {
   version: 1;
@@ -70,7 +71,12 @@ function withWriteMutex<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-export async function loadProjects(): Promise<CaveProject[]> {
+function withProjectsStore<T>(operation: () => Promise<T>): Promise<T> {
+  if (process.env.CAVE_PROJECTS_PATH_OVERRIDE) return operation();
+  return withCaveHomeReconciledStore("cave-projects.json", operation);
+}
+
+async function loadProjectsUnlocked(): Promise<CaveProject[]> {
   const raw = await readFileOrNull(projectsFilePath());
   if (!raw) return [];
   try {
@@ -89,6 +95,10 @@ export async function loadProjects(): Promise<CaveProject[]> {
   }
 }
 
+export async function loadProjects(): Promise<CaveProject[]> {
+  return withProjectsStore(loadProjectsUnlocked);
+}
+
 async function saveProjects(projects: CaveProject[]): Promise<void> {
   const file: ProjectsFile = { version: 1, projects };
   await writeProjectsFile(projectsFilePath(), JSON.stringify(file, null, 2));
@@ -99,8 +109,8 @@ export function createProject(input: {
   root: string;
   color?: string;
 }): Promise<CaveProject> {
-  return withWriteMutex(async () => {
-    const projects = await loadProjects();
+  return withProjectsStore(() => withWriteMutex(async () => {
+    const projects = await loadProjectsUnlocked();
     const root = normalizeRoot(input.root);
     // One project per root. Creating at an already-registered root would persist
     // a duplicate on disk that the UI hides via dedupeProjectsByRoot but the
@@ -120,7 +130,7 @@ export function createProject(input: {
     };
     await saveProjects([...projects, project]);
     return project;
-  });
+  }));
 }
 
 export function patchProject(
@@ -129,8 +139,8 @@ export function patchProject(
   // root-hash tint); undefined leaves it untouched.
   patch: { name?: string; root?: string; color?: string | null },
 ): Promise<CaveProject | null> {
-  return withWriteMutex(async () => {
-    const projects = await loadProjects();
+  return withProjectsStore(() => withWriteMutex(async () => {
+    const projects = await loadProjectsUnlocked();
     const idx = projects.findIndex((project) => project.id === id);
     if (idx < 0) return null;
     const current = projects[idx];
@@ -160,17 +170,17 @@ export function patchProject(
     next[idx] = updated;
     await saveProjects(next);
     return updated;
-  });
+  }));
 }
 
 export function deleteProject(id: string): Promise<boolean> {
-  return withWriteMutex(async () => {
-    const projects = await loadProjects();
+  return withProjectsStore(() => withWriteMutex(async () => {
+    const projects = await loadProjectsUnlocked();
     const next = projects.filter((project) => project.id !== id);
     if (next.length === projects.length) return false;
     await saveProjects(next);
     return true;
-  });
+  }));
 }
 
 export async function seedDefaultProjectsIfEmpty(): Promise<void> {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
+import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
 
 import { loadProjects, projectForRoot } from "./cave-projects.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
@@ -163,13 +164,22 @@ function withWriteMutex<T>(fn: () => Promise<T>): Promise<T> {
   return next;
 }
 
-export async function loadHumanPermissionConfig(): Promise<HumanPermissionConfigFile> {
-  const fromEnv = process.env.CAVE_SUPREME_FAMILIAR_ID?.trim();
-  if (fromEnv) return { version: 1, supremeFamiliarId: fromEnv };
+function withProjectPermissionsStore<T>(operation: () => Promise<T>): Promise<T> {
+  if (process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE) return operation();
+  return withCaveHomeReconciledStore("cave-project-permissions.json", operation);
+}
 
+async function loadHumanPermissionConfigUnlocked(): Promise<HumanPermissionConfigFile> {
   const parsed = await readJsonFile<Partial<HumanPermissionConfigFile>>(humanPermissionConfigPath());
   const supremeFamiliarId = parsed?.supremeFamiliarId?.trim() || DEFAULT_SUPREME_FAMILIAR_ID;
   return { version: 1, supremeFamiliarId };
+}
+
+export async function loadHumanPermissionConfig(): Promise<HumanPermissionConfigFile> {
+  const fromEnv = process.env.CAVE_SUPREME_FAMILIAR_ID?.trim();
+  if (fromEnv) return { version: 1, supremeFamiliarId: fromEnv };
+  if (process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE) return loadHumanPermissionConfigUnlocked();
+  return withCaveHomeReconciledStore("cave-permission-config.json", loadHumanPermissionConfigUnlocked);
 }
 
 function normalizeGrant(grant: Partial<ProjectGrant>): ProjectGrant | null {
@@ -210,7 +220,7 @@ function normalizeAccessGroup(group: Partial<FamiliarAccessGroup>): FamiliarAcce
   };
 }
 
-export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> {
+async function loadProjectPermissionsUnlocked(): Promise<ProjectPermissionsFile> {
   const parsed = await readJsonFile<
     Partial<ProjectPermissionsFile> & { version?: number }
   >(permissionsFilePath());
@@ -232,6 +242,10 @@ export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> 
   };
   materializeDueGrantProposals(file, new Date());
   return file;
+}
+
+export async function loadProjectPermissions(): Promise<ProjectPermissionsFile> {
+  return withProjectPermissionsStore(loadProjectPermissionsUnlocked);
 }
 
 /**
@@ -435,11 +449,11 @@ export async function assertProjectRootAccess(
 }
 
 async function appendAudit(entry: Omit<PermissionAuditEntry, "id" | "at">): Promise<void> {
-  await withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  await withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     file.permissionAudit.push({ id: randomUUID(), at: new Date().toISOString(), ...entry });
     await saveProjectPermissions(file);
-  });
+  }));
 }
 
 export async function grantProjectToFamiliar(input: {
@@ -448,20 +462,20 @@ export async function grantProjectToFamiliar(input: {
   source: ProjectGrantSource;
   access?: ProjectAccessLevel;
 }): Promise<void> {
-  await withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  await withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     if (ensureProjectGrant(file, input)) {
       await saveProjectPermissions(file);
     }
-  });
+  }));
 }
 
 export async function revokeProjectFromFamiliar(input: {
   familiarId: string;
   projectId: string;
 }): Promise<boolean> {
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const next = file.projectGrants.filter(
       (grant) => !(grant.familiarId === input.familiarId && grant.projectId === input.projectId),
     );
@@ -469,7 +483,7 @@ export async function revokeProjectFromFamiliar(input: {
     file.projectGrants = next;
     await saveProjectPermissions(file);
     return true;
-  });
+  }));
 }
 
 export async function bootstrapSupremeProjectGrants(projects: CaveProject[]): Promise<void> {
@@ -501,8 +515,8 @@ export async function createGrantProposal(input: {
     throw new ProjectAccessDeniedError("relayed human approval is not accepted");
   }
 
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const proposal: GrantProposal = {
       id: randomUUID(),
       proposedBy: input.proposedBy,
@@ -515,15 +529,15 @@ export async function createGrantProposal(input: {
     file.grantProposals.push(proposal);
     await saveProjectPermissions(file);
     return proposal;
-  });
+  }));
 }
 
 export async function resolveGrantProposal(input: {
   proposalId: string;
   decision: "accepted" | "rejected";
 }): Promise<GrantProposal> {
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const grantProposal = file.grantProposals.find((proposal) => proposal.id === input.proposalId);
     if (!grantProposal) {
       throw new ProjectAccessDeniedError("grant proposal not found");
@@ -546,7 +560,7 @@ export async function resolveGrantProposal(input: {
     }
     await saveProjectPermissions(file);
     return grantProposal;
-  });
+  }));
 }
 
 /**
@@ -555,8 +569,8 @@ export async function resolveGrantProposal(input: {
  * already materialized the grant and the proposal reads as `accepted`.
  */
 export async function undoGrantProposal(input: { proposalId: string }): Promise<GrantProposal> {
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const grantProposal = file.grantProposals.find((proposal) => proposal.id === input.proposalId);
     if (!grantProposal) {
       throw new ProjectAccessDeniedError("grant proposal not found");
@@ -575,7 +589,7 @@ export async function undoGrantProposal(input: { proposalId: string }): Promise<
     delete grantProposal.finalizesAt;
     await saveProjectPermissions(file);
     return grantProposal;
-  });
+  }));
 }
 
 // --- Access groups -----------------------------------------------------------
@@ -643,8 +657,8 @@ export async function createAccessGroup(input: {
 }): Promise<FamiliarAccessGroup> {
   const name = input.name.trim();
   if (!name) throw new Error("access group name is required");
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const now = new Date().toISOString();
     const group: FamiliarAccessGroup = {
       id: randomUUID(),
@@ -658,7 +672,7 @@ export async function createAccessGroup(input: {
     file.accessGroups.push(group);
     await saveProjectPermissions(file);
     return group;
-  });
+  }));
 }
 
 export async function updateAccessGroup(input: {
@@ -668,8 +682,8 @@ export async function updateAccessGroup(input: {
   memberFamiliarIds?: string[];
   projectGrants?: { projectId: string; access?: ProjectAccessLevel }[];
 }): Promise<FamiliarAccessGroup> {
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const group = file.accessGroups.find((candidate) => candidate.id === input.groupId);
     if (!group) throw new AccessGroupNotFoundError();
     if (input.name !== undefined) {
@@ -689,16 +703,16 @@ export async function updateAccessGroup(input: {
     group.updatedAt = new Date().toISOString();
     await saveProjectPermissions(file);
     return group;
-  });
+  }));
 }
 
 export async function deleteAccessGroup(groupId: string): Promise<boolean> {
-  return withWriteMutex(async () => {
-    const file = await loadProjectPermissions();
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
     const next = file.accessGroups.filter((group) => group.id !== groupId);
     if (next.length === file.accessGroups.length) return false;
     file.accessGroups = next;
     await saveProjectPermissions(file);
     return true;
-  });
+  }));
 }


### PR DESCRIPTION
### Motivation
- Prevent a startup race where routes read unmigrated legacy `~/.coven/cave-*.json` state as authoritative and allow project-grant checks to fail open during background migration.
- Ensure project and project-permission reads/writes wait for Cave-home reconciliation so authorization decisions never rely on a missing canonical store while legacy files remain unreconciled.

### Description
- Gate project reads and mutations through the Cave-home reconciliation gate by using `withCaveHomeReconciledStore("cave-projects.json", ...)` and an unlocked `loadProjectsUnlocked` path; changes in `src/lib/cave-projects.ts` ensure `loadProjects()` and all mutations wait for reconciliation unless an explicit override is set.
- Gate permission-related reads and mutations via `withCaveHomeReconciledStore("cave-project-permissions.json", ...)` and exposing unlocked helpers in `src/lib/project-permissions.ts` so `loadProjectPermissions()` and human permission config reads are reconciled before use.
- Add a regression test `src/lib/cave-home-project-store-reconciliation.test.ts` that creates legacy-only `cave-projects.json` and `cave-project-permissions.json`, verifies the migration completes and that `loadProjects()` / `loadProjectPermissions()` return the migrated, authoritative data.
- Wire the new regression test into the app test suite by adding it to `scripts/run-tests.mjs` so it runs during the app test run.

### Testing
- Typecheck: ran `pnpm exec tsc --noEmit --pretty false` and it succeeded.
- Unit tests: ran `node --experimental-strip-types src/lib/cave-projects.test.ts`, `node --experimental-strip-types src/lib/project-permissions.test.ts`, and the new `node --experimental-strip-types src/lib/cave-home-project-store-reconciliation.test.ts`, and each passed.
- Integration: ran the full application test suite with `pnpm test:app` and it completed successfully (all app tests passed, including the new regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b4f27e9c483279878a8701d5f51ff)