### PR TITLE
Avoid daemon npm install during signed updates

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -28,10 +28,15 @@ assert.doesNotMatch(
 assert.match(src, /@tauri-apps\/plugin-updater/, "uses the native Tauri updater plugin");
 assert.match(preparationSrc, /update\.download\(/, "downloads through the native updater");
 assert.match(src, /update\.install\(\)/, "installs the prepared native update");
+assert.doesNotMatch(
+  src,
+  /updateDaemonForCaveUpdate\(update\.version, \{ confirmInstall: true \}\)/,
+  "signed app updates must not silently confirm a global npm daemon install",
+);
 assert.match(
   src,
-  /await updateDaemonForCaveUpdate\(update\.version, \{ confirmInstall: true \}\);\s*await update\.install\(\)/,
-  "updates and verifies the Coven daemon before replacing the Cave app",
+  /async function installPreparedUpdate\([^)]*\): Promise<void> \{\s*await update\.install\(\)/,
+  "installs the prepared native update directly (install() is the first action, no daemon npm install in between)",
 );
 assert.doesNotMatch(src, /downloadAndInstall/, "does not combine download with immediate process exit");
 assert.match(src, /@tauri-apps\/plugin-process/, "relaunches via the process plugin");
@@ -113,7 +118,7 @@ assert.match(src, /Download update/, "native path prepares the update without ex
 assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Verifying signature…/, "shows signature verification progress");
 assert.match(src, /Restart &amp; install/, "prepared update offers an explicit restart action");
-assert.match(src, /Updating daemon &amp; installing/, "install state explains that the daemon is updated first");
+assert.match(src, /Installing update/, "install state explains that the verified update is being installed");
 assert.match(src, />\s*Cancel\s*</, "settings row allows preparation cancellation");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
 assert.match(src, /Open installer in Browser/, "fallback keeps installer recovery inside Cave's Browser surface");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -89,7 +89,6 @@ async function checkNativeUpdate(owner: symbol): Promise<NativeCheckResult> {
 
 /** Install an already downloaded and verified update, then relaunch where supported. */
 async function installPreparedUpdate(update: NativeUpdateHandle): Promise<void> {
-  await updateDaemonForCaveUpdate(update.version, { confirmInstall: true });
   await update.install();
   // Windows exits inside install() and AUTOLAUNCHAPP handles restart. Other
   // desktop platforms return and need an explicit relaunch.
@@ -693,7 +692,7 @@ export function UpdateSettingsRow() {
   } else if (state.phase === "installing") {
     control = (
       <span className="text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">
-        Updating daemon &amp; installing…
+        Installing update…
       </span>
     );
   } else if (state.phase === "available") {


### PR DESCRIPTION
### Motivation
- Prevent a signed native update from auto-confirming a global, unpinned `npm install -g @opencoven/cli@latest` by removing the pre-install daemon alignment that triggers the onboarding install route.  
- Preserve the trust boundary of the signed Tauri update by ensuring the verified app update is installed before any separate daemon install steps that require explicit operator consent.

### Description
- Removed the automatic call to `updateDaemonForCaveUpdate(update.version, { confirmInstall: true })` from `installPreparedUpdate` in `src/components/update-available.tsx` so a prepared/verified native update proceeds directly to `update.install()`.  
- Updated install-state UI copy from "Updating daemon & installing…" to "Installing update…" in `src/components/update-available.tsx`.  
- Strengthened the update-availability test in `src/components/update-available.test.ts` to assert that signed updates do not silently confirm a global daemon npm install and to assert the prepared update is still installed directly.

### Testing
- Ran `node --experimental-strip-types src/components/update-available.test.ts` and it completed successfully.  
- Ran `node --experimental-strip-types src/lib/app-update-daemon.test.ts` and it completed successfully.  
- Attempted `pnpm exec tsx src/components/update-available.test.ts` but the `tsx` runtime was not available in this environment, and a broader `pnpm test` invocation with file arguments failed because the project's test runner expects named suites rather than direct file paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bc4cb1d7083278becaa4271254c4b)