### PR TITLE
fix(security): reject mobile access on local-only APIs

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -756,6 +756,7 @@ export const SUITES = {
     "src/lib/cave-board-atomic.test.ts",
     "src/lib/server/atomic-write.test.ts",
     "src/lib/server/local-origin.test.ts",
+    "src/lib/server/api-security.test.ts",
     "src/lib/server/codex-oauth-port.test.ts",
     "src/lib/env-local-bundle.test.ts",
     "src/lib/cave-board-schedule.test.ts",

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -25,7 +25,7 @@ assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 w
 assert.match(
   listRoute,
   /export async function POST\(req: Request\)\s*\{\s*const denied = rejectNonLocalRequest\(req\);/,
-  "POST /api/projects must enforce loopback before registering \$HOME-scoped roots",
+  "POST /api/projects must enforce desktop-local access before registering \$HOME-scoped roots",
 );
 assert.doesNotMatch(
   listRoute,
@@ -39,7 +39,7 @@ assert.match(itemRoute, /isAllowedNewProjectRoot\(trimmed\)/, "PUT /api/projects
 assert.match(itemRoute, /validateCaveProjectRoot/, "PUT /api/projects/[id] should require existing directory roots before persisting them");
 assert.match(itemRoute, /nothing to update/, "PUT /api/projects/[id] should reject empty patches");
 assert.match(itemRoute, /not found/, "project item route should return not-found errors");
-assert.match(itemRoute, /rejectNonLocalRequest/, "project item route must enforce loopback before mutating project roots");
+assert.match(itemRoute, /rejectNonLocalRequest/, "project item route must enforce desktop-local access before mutating project roots");
 
 assert.match(seedRoute, /seedDefaultProjectsIfEmpty/, "seed route should invoke default seeding");
 assert.match(seedRoute, /export async function POST\(\)/, "seed route should expose POST only");

--- a/src/lib/server/api-security.test.ts
+++ b/src/lib/server/api-security.test.ts
@@ -1,47 +1,57 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { afterEach, test } from "node:test";
 
-const source = readFileSync(new URL("./api-security.ts", import.meta.url), "utf8");
+import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
+import { rejectNonLocalRequest } from "./api-security.ts";
 
-// The desktop-only policy (mobile marker, sidecar token, loopback Host) lives
-// in the shared isLocalOrigin gate (see local-origin.ts, behaviorally covered
-// by local-origin.test.ts). api-security must DELEGATE to that gate rather than
-// re-implement the checks, so the security policy can't drift across two files.
-assert.match(
-  source,
-  /import \{ isLocalOrigin \} from "\.\/local-origin"/,
-  "rejectNonLocalRequest should delegate the desktop-only policy to the shared isLocalOrigin gate",
-);
-assert.match(
-  source,
-  /if \(!isLocalOrigin\(req\)\) \{[\s\S]*?status:\s*403/,
-  "a request that fails the shared local-origin gate must be rejected with 403",
-);
+const ORIGINAL_SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN;
 
-// The duplicated sidecar-token machinery must NOT be re-implemented here.
-assert.doesNotMatch(
-  source,
-  /timingSafeEqualString/,
-  "api-security must not re-implement the timing-safe sidecar-token comparison",
-);
-assert.doesNotMatch(
-  source,
-  /COVEN_CAVE_AUTH_TOKEN/,
-  "api-security must not read the sidecar token directly (single source of truth in local-origin)",
-);
-assert.doesNotMatch(
-  source,
-  /MOBILE_ACCESS_HEADER/,
-  "api-security must not re-check the mobile proxy marker (delegated to isLocalOrigin)",
-);
+function restoreEnv() {
+  if (ORIGINAL_SIDECAR_TOKEN === undefined) delete process.env.COVEN_CAVE_AUTH_TOKEN;
+  else process.env.COVEN_CAVE_AUTH_TOKEN = ORIGINAL_SIDECAR_TOKEN;
+}
 
-// This route family still layers its stricter cross-origin Origin-header check
-// on top of the shared gate.
-assert.match(
-  source,
-  /const origin = req\.headers\.get\("origin"\)/,
-  "cross-origin Origin check is preserved on top of the shared gate",
-);
+function request(headers: HeadersInit) {
+  return new Request("http://x/", { headers });
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+test("rejects mobile-marked requests with 403", async () => {
+  delete process.env.COVEN_CAVE_AUTH_TOKEN;
+
+  const res = rejectNonLocalRequest(
+    request({ host: "127.0.0.1:3000", [MOBILE_ACCESS_HEADER]: "1" }),
+  );
+
+  assert.ok(res);
+  assert.equal(res.status, 403);
+  assert.deepEqual(await res.json(), { ok: false, error: "forbidden" });
+});
+
+test("rejects sidecar token mismatches with 403", async () => {
+  process.env.COVEN_CAVE_AUTH_TOKEN = "sidecar-secret";
+
+  const res = rejectNonLocalRequest(
+    request({ host: "127.0.0.1:3000", [TOKEN_HEADER]: "wrong" }),
+  );
+
+  assert.ok(res);
+  assert.equal(res.status, 403);
+  assert.deepEqual(await res.json(), { ok: false, error: "forbidden" });
+});
+
+test("accepts valid loopback plus sidecar token requests", () => {
+  process.env.COVEN_CAVE_AUTH_TOKEN = "sidecar-secret";
+
+  const res = rejectNonLocalRequest(
+    request({ host: "127.0.0.1:3000", [TOKEN_HEADER]: "sidecar-secret" }),
+  );
+
+  assert.equal(res, null);
+});
 
 console.log("api-security.test.ts: ok");

--- a/src/lib/server/api-security.test.ts
+++ b/src/lib/server/api-security.test.ts
@@ -4,16 +4,44 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./api-security.ts", import.meta.url), "utf8");
 
-assert.match(source, /MOBILE_ACCESS_HEADER/, "shared local guard should know about mobile proxy marker");
+// The desktop-only policy (mobile marker, sidecar token, loopback Host) lives
+// in the shared isLocalOrigin gate (see local-origin.ts, behaviorally covered
+// by local-origin.test.ts). api-security must DELEGATE to that gate rather than
+// re-implement the checks, so the security policy can't drift across two files.
 assert.match(
   source,
-  /req\.headers\.get\(MOBILE_ACCESS_HEADER\) === "1"[\s\S]*?status:\s*403/,
-  "mobile-authenticated requests must be rejected even with loopback-looking Host headers",
+  /import \{ isLocalOrigin \} from "\.\/local-origin"/,
+  "rejectNonLocalRequest should delegate the desktop-only policy to the shared isLocalOrigin gate",
 );
-assert.match(source, /COVEN_CAVE_AUTH_TOKEN/, "packaged sidecar auth token should be enforced when configured");
-assert.match(source, /timingSafeEqualString/, "sidecar token comparison should use timing-safe equality");
-assert.match(source, /TOKEN_HEADER/, "sidecar token should be read from the first-party token header");
-assert.match(source, /const host = req\.headers\.get\("host"\)/, "loopback Host check is still preserved");
-assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "loopback Origin check is still preserved");
+assert.match(
+  source,
+  /if \(!isLocalOrigin\(req\)\) \{[\s\S]*?status:\s*403/,
+  "a request that fails the shared local-origin gate must be rejected with 403",
+);
+
+// The duplicated sidecar-token machinery must NOT be re-implemented here.
+assert.doesNotMatch(
+  source,
+  /timingSafeEqualString/,
+  "api-security must not re-implement the timing-safe sidecar-token comparison",
+);
+assert.doesNotMatch(
+  source,
+  /COVEN_CAVE_AUTH_TOKEN/,
+  "api-security must not read the sidecar token directly (single source of truth in local-origin)",
+);
+assert.doesNotMatch(
+  source,
+  /MOBILE_ACCESS_HEADER/,
+  "api-security must not re-check the mobile proxy marker (delegated to isLocalOrigin)",
+);
+
+// This route family still layers its stricter cross-origin Origin-header check
+// on top of the shared gate.
+assert.match(
+  source,
+  /const origin = req\.headers\.get\("origin"\)/,
+  "cross-origin Origin check is preserved on top of the shared gate",
+);
 
 console.log("api-security.test.ts: ok");

--- a/src/lib/server/api-security.test.ts
+++ b/src/lib/server/api-security.test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./api-security.ts", import.meta.url), "utf8");
+
+assert.match(source, /MOBILE_ACCESS_HEADER/, "shared local guard should know about mobile proxy marker");
+assert.match(
+  source,
+  /req\.headers\.get\(MOBILE_ACCESS_HEADER\) === "1"[\s\S]*?status:\s*403/,
+  "mobile-authenticated requests must be rejected even with loopback-looking Host headers",
+);
+assert.match(source, /COVEN_CAVE_AUTH_TOKEN/, "packaged sidecar auth token should be enforced when configured");
+assert.match(source, /timingSafeEqualString/, "sidecar token comparison should use timing-safe equality");
+assert.match(source, /TOKEN_HEADER/, "sidecar token should be read from the first-party token header");
+assert.match(source, /const host = req\.headers\.get\("host"\)/, "loopback Host check is still preserved");
+assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "loopback Origin check is still preserved");
+
+console.log("api-security.test.ts: ok");

--- a/src/lib/server/api-security.ts
+++ b/src/lib/server/api-security.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 
-import { isLocalOrigin } from "./local-origin";
+import { isLocalOrigin } from "./local-origin.ts";
 
 const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
 

--- a/src/lib/server/api-security.ts
+++ b/src/lib/server/api-security.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { MOBILE_ACCESS_HEADER, TOKEN_HEADER, timingSafeEqualString } from "../../proxy-helpers.ts";
+import { isLocalOrigin } from "./local-origin";
 
 const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
 
@@ -19,20 +19,11 @@ function isLocalHost(value: string | null): boolean {
 }
 
 export function rejectNonLocalRequest(req: Request): NextResponse | null {
-  if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") {
-    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
-  }
-
-  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
-  if (
-    sidecarToken &&
-    !timingSafeEqualString(req.headers.get(TOKEN_HEADER) ?? "", sidecarToken)
-  ) {
-    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
-  }
-
-  const host = req.headers.get("host");
-  if (!isLocalHost(host)) {
+  // Delegate the mobile-proxy marker, packaged sidecar-token, and loopback-Host
+  // checks to the shared isLocalOrigin gate so the desktop-only security policy
+  // lives in exactly one place (see local-origin.ts). We then layer this
+  // route family's stricter Origin-header parsing on top.
+  if (!isLocalOrigin(req)) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
   }
 

--- a/src/lib/server/api-security.ts
+++ b/src/lib/server/api-security.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { MOBILE_ACCESS_HEADER, TOKEN_HEADER, timingSafeEqualString } from "../../proxy-helpers.ts";
+
 const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
 
 export type JsonBodyResult<T> =
@@ -17,6 +19,18 @@ function isLocalHost(value: string | null): boolean {
 }
 
 export function rejectNonLocalRequest(req: Request): NextResponse | null {
+  if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") {
+    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
+  }
+
+  const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
+  if (
+    sidecarToken &&
+    !timingSafeEqualString(req.headers.get(TOKEN_HEADER) ?? "", sidecarToken)
+  ) {
+    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
+  }
+
   const host = req.headers.get("host");
   if (!isLocalHost(host)) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });


### PR DESCRIPTION
### Motivation

- The project-root widening to accept any strict descendant of `$HOME` increased the attack surface for project registration and repointing.  
- The existing `rejectNonLocalRequest` guard only checked `Host`/`Origin` and did not reject proxy-authenticated mobile/tailnet requests, allowing a mobile client to register sensitive home subdirectories.  

### Description

- Harden `rejectNonLocalRequest` in `src/lib/server/api-security.ts` to reject requests with the proxy mobile marker (`MOBILE_ACCESS_HEADER`) and to enforce `COVEN_CAVE_AUTH_TOKEN` via the first-party token header using `timingSafeEqualString`.  
- Import the proxy helper symbols (`MOBILE_ACCESS_HEADER`, `TOKEN_HEADER`, `timingSafeEqualString`) and preserve the existing loopback `Host`/`Origin` checks after the new mobile/token checks.  
- Add `src/lib/server/api-security.test.ts` to assert the presence and behavior of the mobile-marker and sidecar-token checks.  
- Update `src/app/api/projects/route.test.ts` wording to reflect the strengthened desktop-local guard and wire the new test into the test runner (`scripts/run-tests.mjs`).

### Testing

- Ran `node --experimental-strip-types src/lib/server/api-security.test.ts` and it passed.  
- Ran `node --experimental-strip-types src/app/api/projects/route.test.ts` and it passed.  
- Ran `pnpm check:tests-wired` and `pnpm typecheck` which succeeded.  
- Ran `pnpm test:api`: 190 tests passed in this environment before a test failure unrelated to these changes (`scripts/sidecar-archive-manifest.test.mjs` failed due to missing `zstd`), so all added/modified tests for the guard ran green prior to that external failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d41b5de5883279235da508999c33d)