### PR TITLE
fix(permissions): preserve write surfaces for mobile project APIs

### DIFF
--- a/src/app/api/project-permission-routes.test.ts
+++ b/src/app/api/project-permission-routes.test.ts
@@ -54,8 +54,18 @@ assert.match(
 );
 assert.match(
   helper,
-  /export function projectPermissionSurfaceForRequest\([\s\S]*MOBILE_ACCESS_HEADER[\s\S]*return "mobile"/,
-  "project API helper should map verified mobile requests to the mobile audit/check surface",
+  /const MOBILE_READ_FALLBACK_SURFACES:[\s\S]*"file-browse",[\s\S]*"file-read",[\s\S]*"project-api",/,
+  "project API helper should only map verified mobile read-capable fallbacks to the mobile audit/check surface",
+);
+assert.match(
+  helper,
+  /req\.headers\.get\(MOBILE_ACCESS_HEADER\) === "1" &&[\s\S]*MOBILE_READ_FALLBACK_SURFACES\.has\(fallback\)[\s\S]*return "mobile"/,
+  "project API helper should preserve write-capable fallback surfaces for verified mobile requests",
+);
+assert.doesNotMatch(
+  helper,
+  /MOBILE_READ_FALLBACK_SURFACES:[\s\S]*"file-write"/,
+  "mobile project API writes must keep the file-write surface so read-only grants cannot mutate files",
 );
 
 for (const [name, source] of [

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -102,11 +102,22 @@ export async function assertProjectApiAccess(args: {
   await assertProjectAccess({ familiarId }, project.id, surface);
 }
 
+const MOBILE_READ_FALLBACK_SURFACES: ReadonlySet<ProjectPermissionSurface> = new Set([
+  "file-browse",
+  "file-read",
+  "project-api",
+]);
+
 export function projectPermissionSurfaceForRequest(
   req: Request,
   fallback: ProjectPermissionSurface,
 ): ProjectPermissionSurface {
-  if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") return "mobile";
+  if (
+    req.headers.get(MOBILE_ACCESS_HEADER) === "1" &&
+    MOBILE_READ_FALLBACK_SURFACES.has(fallback)
+  ) {
+    return "mobile";
+  }
   return fallback;
 }
 

--- a/src/lib/server/project-permission-requests.ts
+++ b/src/lib/server/project-permission-requests.ts
@@ -48,8 +48,10 @@ const LOCAL_HUMAN_READ_SURFACES: ReadonlySet<ProjectPermissionSurface> = new Set
  * True when this is the human operator reading (not a familiar, not a write).
  * Two shapes:
  *   - their own desktop on a loopback origin, for the read surfaces above;
- *   - the same human on their own phone — the native app sends the mobile header
- *     (→ surface "mobile") and only ever GETs to read. The request already
+ *   - the same human on their own phone — the native app sends the mobile header,
+ *     and read fallbacks are remapped to surface "mobile"; non-read surfaces keep
+ *     their fallback (e.g., file-write). The app only ever GETs to read. The
+ *     request already
  *     cleared the server's front gate (token / same-origin / tailnet-trust) to
  *     reach this route, so a mobile GET is the trusted human; writes (POST) still
  *     fall through to the familiar requirement.


### PR DESCRIPTION
### Motivation
- Verified mobile requests were being remapped to the generic `mobile` surface unconditionally, which downgraded write-capable routes (e.g. `file-write`) to a read-level check and allowed read-only familiars to perform file writes/moves via the mobile API.
- The change restores the intended read/write boundary so that mobile-marked requests do not bypass write-level enforcement.

### Description
- Introduce `MOBILE_READ_FALLBACK_SURFACES` and update `projectPermissionSurfaceForRequest` in `src/lib/server/project-permission-requests.ts` to remap to `"mobile"` only when the route's fallback surface is a read-capable surface (`"file-browse"`, `"file-read"`, `"project-api"`).
- Preserve write-capable fallbacks (such as `"file-write"` and `"shell"`) so enforcement continues to require write-level access when appropriate.
- Update `src/app/api/project-permission-routes.test.ts` to assert the new behavior and explicitly ensure `"file-write"` is excluded from mobile read remapping.

### Testing
- Ran the targeted unit test with `pnpm exec node --experimental-strip-types src/app/api/project-permission-routes.test.ts`, which passed.
- Ran the API test suite with `pnpm exec node scripts/run-tests.mjs api`, which executed many API tests and reported 149 passing tests before the run stopped due to an environment issue (`zstd` not installed) causing `scripts/sidecar-archive-manifest.test.mjs` to fail; the failing test is unrelated to the permission-surface change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545be2b4a083278bd279260dfbd8f3)