### PR TITLE
refactor: complete Phase B interaction surfaces

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -15,58 +15,7 @@ import {
   type BrowserNavigationRequest,
   type ExpectedBrowserNavigation,
 } from "@/lib/browser-navigation-queue";
-
-// ── Favicon helpers (mirrors open-sesame FaviconService pattern) ──────────────
-// Primary: Google S2 API (works from renderer, no CORS)
-// Fallback: colored initial chip (mirrors ColoredInitialAvatar from open-sesame)
-
-function faviconUrl(url: string): string {
-  try {
-    const host = new URL(url).hostname;
-    return `https://www.google.com/s2/favicons?domain=${host}&sz=32`;
-  } catch {
-    return "";
-  }
-}
-
-const INITIAL_COLORS = [
-  "#5b5bd6", "#7c3aed", "#db2777", "#ea580c",
-  "#16a34a", "#0891b2", "#4f46e5", "#0d9488",
-];
-
-function initialColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
-}
-
-function TabFavicon({ url, title, size = 20 }: { url: string; title: string; size?: number }) {
-  const [failed, setFailed] = useState(false);
-  const src = faviconUrl(url);
-  const initial = (title || url).trim().slice(0, 1).toUpperCase() || "?";
-  const color = initialColor(title || url);
-
-  if (!src || failed) {
-    return (
-      <span
-        className="flex shrink-0 items-center justify-center rounded-[var(--radius-control)] text-[length:var(--text-2xs)] font-semibold text-white"
-        style={{ width: size, height: size, background: color }}
-      >
-        {initial}
-      </span>
-    );
-  }
-  return (
-    <img
-      src={src}
-      alt=""
-      width={size}
-      height={size}
-      className="rounded-[var(--radius-control)] object-contain [image-rendering:auto]!"
-      onError={() => setFailed(true)}
-    />
-  );
-}
+import { TabFavicon } from "./browser-tab-favicon";
 
 // Browser pane — uses Tauri's child WebviewBuilder under the hood. A real
 // Chromium webview is overlaid on top of the placeholder <div> below; we

--- a/src/components/browser-tab-favicon.tsx
+++ b/src/components/browser-tab-favicon.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+const INITIAL_COLORS = [
+  "#5b5bd6", "#7c3aed", "#db2777", "#ea580c",
+  "#16a34a", "#0891b2", "#4f46e5", "#0d9488",
+];
+
+function faviconUrl(url: string): string {
+  try {
+    return `https://www.google.com/s2/favicons?domain=${new URL(url).hostname}&sz=32`;
+  } catch {
+    return "";
+  }
+}
+
+function initialColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
+}
+
+/** The tab identity falls back to a deterministic initial when a site has no favicon. */
+export function TabFavicon({ url, title, size = 20 }: { url: string; title: string; size?: number }) {
+  const [failed, setFailed] = useState(false);
+  const src = faviconUrl(url);
+  const initial = (title || url).trim().slice(0, 1).toUpperCase() || "?";
+  if (!src || failed) {
+    return (
+      <span className="flex shrink-0 items-center justify-center rounded-[var(--radius-control)] text-[length:var(--text-2xs)] font-semibold text-white" style={{ width: size, height: size, background: initialColor(title || url) }}>
+        {initial}
+      </span>
+    );
+  }
+  return <img src={src} alt="" width={size} height={size} className="rounded-[var(--radius-control)] object-contain [image-rendering:auto]!" onError={() => setFailed(true)} />;
+}

--- a/src/components/chat-familiar-view.tsx
+++ b/src/components/chat-familiar-view.tsx
@@ -27,6 +27,7 @@ import type { AdapterReport } from "@/lib/harness-adapters";
 import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { getVoiceProvider } from "@/lib/voice/registry";
 import { relativeTime } from "@/lib/relative-time";
+import { navigateFamiliarSurface } from "@/lib/familiar-surface-navigation";
 
 // ── Building blocks ──────────────────────────────────────────────────────────
 
@@ -92,11 +93,6 @@ function KindBadge({ kind }: { kind: string }) {
 /** Navigate the workspace to a management surface (Roles / Capabilities /
  *  Marketplace hub) through the same `cave:navigate-mode` bridge every other
  *  cross-surface link uses. */
-function navigateMode(mode: "roles" | "capabilities" | "marketplace"): void {
-  if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
-}
-
 /** Teach-state CTA — every empty state gets a real affordance, not a
  *  dead-end sentence naming a page. */
 function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
@@ -642,7 +638,7 @@ function FamiliarCapabilityPanel({
         {activeRoles.length === 0 ? (
           <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
             <p>No roles active for this familiar.</p>
-            <CapCta label="Open Roles →" onClick={() => navigateMode("roles")} />
+            <CapCta label="Open Roles →" onClick={() => navigateFamiliarSurface("roles")} />
           </div>
         ) : (
           <div className="familiar-tab__list">
@@ -717,7 +713,7 @@ function FamiliarCapabilityPanel({
             {familiarSkills.length === 0 ? (
               <div className="px-1 pb-1 pt-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
                 <p>No skills installed for this familiar yet.</p>
-                <CapCta label="Browse Marketplace →" onClick={() => navigateMode("marketplace")} />
+                <CapCta label="Browse Marketplace →" onClick={() => navigateFamiliarSurface("marketplace")} />
               </div>
             ) : (
               <ul className="familiar-tab__rows pt-1">
@@ -772,7 +768,7 @@ function FamiliarCapabilityPanel({
         {nonMcpPlugins.length === 0 ? (
           <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
             <p>No plugins in the latest runtime capability scan.</p>
-            <CapCta label="Open Capabilities →" onClick={() => navigateMode("capabilities")} />
+            <CapCta label="Open Capabilities →" onClick={() => navigateFamiliarSurface("capabilities")} />
           </div>
         ) : (
           <div className="familiar-tab__list">

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -9,6 +9,7 @@ const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 const bubbleSource = readFileSync(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+const codeFenceSource = readFileSync(new URL("../lib/message-code-fences.ts", import.meta.url), "utf8");
 
 // After the streamline refactor the header is MetaLine (title + status meta)
 // plus an optional LinkedContextRow — no ChatContextStrip, no headline row.
@@ -364,7 +365,7 @@ assert.match(
   "renderCodeBlock resolves the diff's content grammar from its file headers",
 );
 assert.match(
-  bubbleSource,
+  codeFenceSource,
   /function classifyDiffLines\(/,
   "diff lines are classified (add/del/ctx/meta/hunk) for language-aware rendering",
 );

--- a/src/components/chat-list-collapse.test.ts
+++ b/src/components/chat-list-collapse.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const src = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+const primitives = readFileSync(new URL("./chat-list-primitives.tsx", import.meta.url), "utf8");
 
-assert.match(src, /function ChatListSection\(\{[\s\S]*?collapsed\?: boolean;[\s\S]*?onToggle\?: \(\) => void;/, "ChatListSection accepts collapsed/onToggle");
-assert.match(src, /aria-expanded=\{!collapsed\}/, "toggle header reports aria-expanded");
-assert.match(src, /ph:caret-(right|down)/, "toggle header shows a caret");
+assert.match(primitives, /function ChatListSection\(\{[\s\S]*?collapsed\?: boolean;[\s\S]*?onToggle\?: \(\) => void;/, "ChatListSection accepts collapsed/onToggle");
+assert.match(primitives, /aria-expanded=\{!collapsed\}/, "toggle header reports aria-expanded");
+assert.match(primitives, /ph:caret-(right|down)/, "toggle header shows a caret");
 assert.match(src, /collapsedSections, setCollapsedSections\] = useState<Set<string>>\(\(\) => new Set\(\)\)/, "collapsedSections state defaults empty");
 assert.match(src, /function toggleSection|const toggleSection/, "has a toggleSection updater");
 assert.match(src, /label="Pinned"[\s\S]*?onToggle=\{\(\) => toggleSection\("pinned"\)\}/, "Pinned header is collapsible");

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/chat-session-prefs.ts";
 
 const source = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+const primitives = readFileSync(new URL("./chat-list-primitives.tsx", import.meta.url), "utf8");
 
 assert.doesNotMatch(
   source,
@@ -119,7 +120,7 @@ assert.match(source, /from "@dnd-kit\/core"/, "ChatList should use @dnd-kit for 
 assert.match(source, /const displayIds = useMemo\([\s\S]*displayGroups\.flatMap\(\(group\) => group\.sessions\.map\(\(session\) => session\.id\)\)/, "ChatList should derive one flat list of visible sortable ids");
 assert.match(source, /<DndContext[\s\S]*onDragEnd=\{\(event\) => handleDragEnd\(event, displayIds\)\}/, "The visible chat list should wire drag end with all displayed ids");
 assert.match(source, /<SortableContext items=\{displayIds\} strategy=\{verticalListSortingStrategy\}/, "All visible chat rows should share one SortableContext");
-assert.match(source, /useSortable\(\{ id \}\)/, "ChatList rows should be individually sortable by session id");
+assert.match(primitives, /useSortable\(\{ id \}\)/, "ChatList rows should be individually sortable by session id");
 assert.match(source, /setSessionOrder\(readSessionOrder\(\)\)/, "ChatList should hydrate the persisted manual order after mount");
 assert.match(source, /if \(effectiveSelection === "all"\) \{[\s\S]*scopedGroups\.flatMap\(\(group\) => group\.sessions\)/, "All chats should flatten groups so cross-project drag order can stick");
 assert.match(source, /partitionPinnedFirst\(sortByRecency\(rows\), pinnedIds\)/, "Pinned rows still float, over a recency-sorted rest, in the flat All chats view until manual drag order exists");
@@ -245,7 +246,7 @@ assert.match(
   "Content search shows the shared shimmer skeleton while the first fetch is in flight",
 );
 assert.match(
-  source,
+  primitives,
   /<mark className=/,
   "The matched substring inside the snippet is highlighted with <mark>",
 );

--- a/src/components/chat-list-mobile-rail-port.test.ts
+++ b/src/components/chat-list-mobile-rail-port.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+const primitives = readFileSync(new URL("./chat-list-primitives.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
@@ -16,9 +17,9 @@ assert.match(topBar, /labeled=\{familiarSwitcherLabeled\}/, "TopBar can render t
 assert.match(workspace, /familiarSwitcherLabeled=\{mode === "chat"\}/, "Workspace labels the top-bar selector on the Familiars page");
 
 // ── Counted PINNED / SESSIONS section headers ────────────────────────────────
-assert.match(source, /function ChatListSection/, "ChatList gains a counted section-header primitive");
+assert.match(primitives, /function ChatListSection/, "ChatList gains a counted section-header primitive");
 assert.match(
-  source,
+  primitives,
   /uppercase tracking-\[0\.12em\]/,
   "Section headers are uppercase + letter-spaced like the desktop rail",
 );

--- a/src/components/chat-list-primitives.tsx
+++ b/src/components/chat-list-primitives.tsx
@@ -1,0 +1,51 @@
+import type { CSSProperties, ReactNode } from "react";
+import { CSS } from "@dnd-kit/utilities";
+import { useSortable } from "@dnd-kit/sortable";
+import { Icon } from "@/lib/icon";
+
+export function HighlightedSnippet({ snippet, query }: { snippet: string; query: string }) {
+  const idx = query ? snippet.toLowerCase().indexOf(query.toLowerCase()) : -1;
+  if (idx < 0) return <>{snippet}</>;
+  return (
+    <>
+      {snippet.slice(0, idx)}
+      <mark className="rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_28%,transparent)] px-0.5 text-[var(--text-primary)]">
+        {snippet.slice(idx, idx + query.length)}
+      </mark>
+      {snippet.slice(idx + query.length)}
+    </>
+  );
+}
+
+type SortableHandleProps = {
+  attributes: ReturnType<typeof useSortable>["attributes"];
+  listeners: ReturnType<typeof useSortable>["listeners"];
+  isDragging: boolean;
+};
+
+export function SortableChatListItem({ id, children }: { id: string; children: (handleProps: SortableHandleProps) => ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style: CSSProperties = { transform: CSS.Translate.toString(transform), transition };
+  return <li ref={setNodeRef} style={style} data-dragging={isDragging ? "true" : undefined} className="chat-list-sortable-row">{children({ attributes, listeners, isDragging })}</li>;
+}
+
+export function ChatListSection({
+  label,
+  count,
+  collapsed,
+  onToggle,
+}: {
+  label: string;
+  count?: number;
+  collapsed?: boolean;
+  onToggle?: () => void;
+}) {
+  const inner = <>
+    {onToggle ? <Icon name={collapsed ? "ph:caret-right" : "ph:caret-down"} width={11} className="shrink-0 text-[var(--text-muted)]" aria-hidden /> : null}
+    <span className="truncate text-[length:var(--text-sm)] font-bold uppercase tracking-[0.12em] text-[var(--text-primary)]">{label}</span>
+    {typeof count === "number" ? <span className="font-mono text-[length:var(--text-sm)] text-[var(--text-secondary)] opacity-80">{count}</span> : null}
+  </>;
+  if (onToggle) return <li className="border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)]"><button type="button" onClick={onToggle} aria-expanded={!collapsed} aria-label={`${collapsed ? "Expand" : "Collapse"} ${label}`} className="focus-ring flex w-full items-center gap-1.5 px-4 py-2 text-left hover:bg-[var(--bg-raised)]/40">{inner}</button></li>;
+  return <li className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-4 py-2">{inner}</li>;
+}
+

--- a/src/components/chat-list-primitives.tsx
+++ b/src/components/chat-list-primitives.tsx
@@ -16,7 +16,6 @@ export function HighlightedSnippet({ snippet, query }: { snippet: string; query:
     </>
   );
 }
-
 type SortableHandleProps = {
   attributes: ReturnType<typeof useSortable>["attributes"];
   listeners: ReturnType<typeof useSortable>["listeners"];
@@ -48,4 +47,3 @@ export function ChatListSection({
   if (onToggle) return <li className="border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)]"><button type="button" onClick={onToggle} aria-expanded={!collapsed} aria-label={`${collapsed ? "Expand" : "Collapse"} ${label}`} className="focus-ring flex w-full items-center gap-1.5 px-4 py-2 text-left hover:bg-[var(--bg-raised)]/40">{inner}</button></li>;
   return <li className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-4 py-2">{inner}</li>;
 }
-

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/chat-list.css";
 
-import { Fragment, useMemo, useState, useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from "react";
+import { Fragment, useMemo, useState, useEffect, useRef, useCallback } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji, disambiguateSessionTitles } from "@/lib/cave-chat-titles";
 import { Icon } from "@/lib/icon";
@@ -66,12 +66,11 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
-  useSortable,
   arrayMove,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { ChatListSection, HighlightedSnippet, SortableChatListItem } from "./chat-list-primitives";
 
 type Props = {
   familiar: Familiar | null;
@@ -148,103 +147,6 @@ type ContentSearchHit = {
   matchCount: number;
 };
 
-/** Wrap the first case-insensitive occurrence of `query` in a <mark>. */
-function HighlightedSnippet({ snippet, query }: { snippet: string; query: string }) {
-  const idx = query ? snippet.toLowerCase().indexOf(query.toLowerCase()) : -1;
-  if (idx < 0) return <>{snippet}</>;
-  return (
-    <>
-      {snippet.slice(0, idx)}
-      <mark className="rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_28%,transparent)] px-0.5 text-[var(--text-primary)]">
-        {snippet.slice(idx, idx + query.length)}
-      </mark>
-      {snippet.slice(idx + query.length)}
-    </>
-  );
-}
-
-type SortableHandleProps = {
-  attributes: ReturnType<typeof useSortable>["attributes"];
-  listeners: ReturnType<typeof useSortable>["listeners"];
-  isDragging: boolean;
-};
-
-function SortableChatListItem({
-  id,
-  children,
-}: {
-  id: string;
-  children: (handleProps: SortableHandleProps) => ReactNode;
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
-  const style: CSSProperties = {
-    transform: CSS.Translate.toString(transform),
-    transition,
-  };
-  return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      data-dragging={isDragging ? "true" : undefined}
-      className="chat-list-sortable-row"
-    >
-      {children({ attributes, listeners, isDragging })}
-    </li>
-  );
-}
-
-// Uppercase counted section header — mirrors the desktop rail's RailSection so
-// the phone list reads with the same grouping language (PINNED / SESSIONS).
-function ChatListSection({
-  label,
-  count,
-  collapsed,
-  onToggle,
-}: {
-  label: string;
-  count?: number;
-  collapsed?: boolean;
-  onToggle?: () => void;
-}) {
-  const inner = (
-    <>
-      {onToggle ? (
-        <Icon
-          name={collapsed ? "ph:caret-right" : "ph:caret-down"}
-          width={11}
-          className="shrink-0 text-[var(--text-muted)]"
-          aria-hidden
-        />
-      ) : null}
-      <span className="truncate text-[length:var(--text-sm)] font-bold uppercase tracking-[0.12em] text-[var(--text-primary)]">
-        {label}
-      </span>
-      {typeof count === "number" ? (
-        <span className="font-mono text-[length:var(--text-sm)] text-[var(--text-secondary)] opacity-80">{count}</span>
-      ) : null}
-    </>
-  );
-  if (onToggle) {
-    return (
-      <li className="border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)]">
-        <button
-          type="button"
-          onClick={onToggle}
-          aria-expanded={!collapsed}
-          aria-label={`${collapsed ? "Expand" : "Collapse"} ${label}`}
-          className="focus-ring flex w-full items-center gap-1.5 px-4 py-2 text-left hover:bg-[var(--bg-raised)]/40"
-        >
-          {inner}
-        </button>
-      </li>
-    );
-  }
-  return (
-    <li className="flex items-center gap-1.5 border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-4 py-2">
-      {inner}
-    </li>
-  );
-}
 
 // ── Main component ────────────────────────────────────────────────────────────
 

--- a/src/components/chat-response-metadata.test.ts
+++ b/src/components/chat-response-metadata.test.ts
@@ -5,6 +5,7 @@ import { formatRuntime } from "../lib/chat-response-metadata.ts";
 
 const chatRoute = await readFile(new URL("../app/api/chat/send/route.ts", import.meta.url), "utf8");
 const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const chatTurnState = await readFile(new URL("../lib/chat-turn-state.ts", import.meta.url), "utf8");
 const conversations = await readFile(new URL("../lib/cave-conversations.ts", import.meta.url), "utf8");
 const sessionMerge = await readFile(new URL("../lib/session-list-merge.ts", import.meta.url), "utf8");
 const types = await readFile(new URL("../lib/types.ts", import.meta.url), "utf8");
@@ -89,7 +90,7 @@ assert.match(
 );
 
 assert.match(
-  chatView,
+  chatTurnState,
   /responseMetadata\?: ChatResponseMetadata/,
   "Chat turns should carry response metadata for per-response display",
 );
@@ -101,8 +102,8 @@ assert.match(
 );
 
 assert.match(
-  chatView,
-  /durationMs: t\.durationMs,[\s\S]*responseMetadata: t\.responseMetadata,/,
+  chatTurnState,
+  /durationMs: turn\.durationMs,[\s\S]*responseMetadata: turn\.responseMetadata,/,
   "History loading should restore persisted response metadata",
 );
 

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -83,6 +83,7 @@ assert.match(
 
 const workspaceSource = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const chatSurfaceSource = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const workspaceUrlStateSource = readFileSync(new URL("../lib/workspace-url-state.ts", import.meta.url), "utf8");
 
 const hashSyncEffect =
   source.match(/useEffect\(\(\) => \{[\s\S]*?\}, \[syncUrlHash, view\]\);/)?.[0] ?? "";
@@ -192,11 +193,11 @@ assert.match(
 );
 
 const readChatHashHelper =
-  workspaceSource.match(/function readChatHash\(\): string \| null \{[\s\S]*?\n\}/)?.[0] ?? "";
+  workspaceUrlStateSource.match(/function readChatHash\(\): string \| null \{[\s\S]*?\n\}/)?.[0] ?? "";
 
 assert.match(
   readChatHashHelper,
-  /try \{[\s\S]*decodeURIComponent\(hash\.slice\(CHAT_HASH_PREFIX\.length\)\)[\s\S]*\} catch/,
+  /try \{[\s\S]*decodeURIComponent\(window\.location\.hash\.slice\(CHAT_HASH_PREFIX\.length\)\)[\s\S]*\} catch/,
   "readChatHash should treat malformed percent-encoding as null instead of throwing during render/popstate",
 );
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const turnStateSource = readFileSync(new URL("../lib/chat-turn-state.ts", import.meta.url), "utf8");
 const draftHook = readFileSync(new URL("../lib/use-composer-draft.ts", import.meta.url), "utf8");
 const streamEvents = readFileSync(new URL("../lib/stream-events.ts", import.meta.url), "utf8");
 const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"]
@@ -10,13 +11,13 @@ const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"
   .join("\n");
 
 assert.match(
-  source,
+  turnStateSource,
   /type ChatTurnLifecycle =[\s\S]*"queued"[\s\S]*"connecting"[\s\S]*"streaming"[\s\S]*"tooling"[\s\S]*"cancelled"[\s\S]*"failed"[\s\S]*"complete"/,
   "ChatView should model assistant send lifecycle with explicit phases",
 );
 
 assert.match(
-  source,
+  turnStateSource,
   /lifecycle\?: ChatTurnLifecycle/,
   "Assistant turns should carry lifecycle metadata for trustworthy status UI",
 );
@@ -52,7 +53,7 @@ assert.match(
 );
 
 assert.match(
-  source,
+  turnStateSource,
   /progress\?: ProgressEvent\[\]/,
   "Assistant turns should keep progress events alongside text, thinking, and tools",
 );
@@ -148,13 +149,13 @@ assert.match(
 );
 
 assert.match(
-  source,
+  turnStateSource,
   /const liveChatRegistry = createLiveGenerationRegistry<Turn>\(cloneLiveTurn\)/,
   "In-flight chat generations should be persisted outside the ChatView component so navigation away does not lose them",
 );
 
 assert.match(
-  source,
+  turnStateSource,
   /function subscribeLiveChatGeneration\(\s*sessionId: string,\s*listener: \(snapshot: LiveChatGenerationSnapshot \| null\) => void,\s*\)/,
   "ChatView should subscribe to live generation snapshots when returning to a session",
 );
@@ -327,8 +328,8 @@ assert.match(
 );
 
 assert.match(
-  source,
-  /durationMs: t\.durationMs,\s*\n\s*usage: t\.usage,\s*\n\s*costUsd: t\.costUsd,/,
+  turnStateSource,
+  /durationMs: turn\.durationMs,\s*\n\s*usage: turn\.usage,\s*\n\s*costUsd: turn\.costUsd,/,
   "History load must map persisted usage and cost back onto turns (CHAT-D12-02)",
 );
 
@@ -517,7 +518,7 @@ assert.match(
 // view currently showing that session mirrors the update into setTurns.
 assert.match(
   source,
-  /if \(targetSessionId\) \{[\s\S]*?const stored = liveChatRegistry\.advance\(targetSessionId, updater, nextActiveLeafId\);[\s\S]*?if \(targetSessionId === currentSessionRef\.current\) \{[\s\S]*?setTurns\(stored\.turns\);/,
+  /if \(targetSessionId\) \{[\s\S]*?const stored = advanceLiveChatGeneration\(targetSessionId, updater, nextActiveLeafId\);[\s\S]*?if \(targetSessionId === currentSessionRef\.current\) \{[\s\S]*?setTurns\(stored\.turns\);/,
   "updateLiveTurns accumulates in the module-scope registry first so unmounted views can't drop chunks, mirroring into setTurns only for the on-screen session",
 );
 // A view that adopted (not started) a stream reconciles from disk on settle —

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -20,7 +20,20 @@ import { segmentTurn } from "@/lib/turn-segments";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { invalidateConversation, readCachedConversation, storeConversation } from "@/lib/conversation-cache";
-import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
+import {
+  advanceLiveChatGeneration,
+  clearLiveChatGeneration,
+  mapConversationHistoryTurns,
+  readLiveChatGeneration,
+  recordLiveChatGeneration,
+  subscribeLiveChatGeneration,
+  type ChatTurnLifecycle,
+  type ConversationHistoryPayload,
+  type LiveChatGenerationSnapshot,
+  type ProgressEvent,
+  type ToolEvent,
+  type Turn,
+} from "@/lib/chat-turn-state";
 import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp } from "@/lib/slash-commands";
@@ -172,62 +185,6 @@ import { streamFamiliarText } from "@/lib/familiar-stream";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
 
-type ToolEvent = {
-  id: string;
-  name: string;
-  input?: string;
-  output?: string;
-  status: "running" | "ok" | "error";
-  durationMs?: number;
-  /** CHAT-D4-01: length of the turn's accumulated text when this tool's
-   *  FIRST event arrived — lets TurnRow interleave the tool block at its
-   *  chronological position between prose spans. Absent on tool events from
-   *  stored transcripts that predate the field (legacy turns keep the
-   *  trailing rollup). */
-  textOffset?: number;
-};
-
-type ProgressEvent = {
-  id: string;
-  label: string;
-  detail?: string;
-  status: "running" | "done" | "error";
-  createdAt: string;
-  durationMs?: number;
-};
-
-type ChatTurnLifecycle =
-  | "queued"
-  | "connecting"
-  | "streaming"
-  | "tooling"
-  | "cancelled"
-  | "failed"
-  | "complete";
-
-type Turn = {
-  id: string;
-  parentId?: string | null;
-  role: "user" | "assistant" | "system";
-  text: string;
-  attachments?: ChatAttachment[];
-  reasoning?: string;
-  tools?: ToolEvent[];
-  progress?: ProgressEvent[];
-  createdAt: string;
-  pending?: boolean;
-  error?: boolean;
-  lifecycle?: ChatTurnLifecycle;
-  durationMs?: number;
-  /** Token usage / cost from the harness result event (CHAT-D12-02).
-   *  Absent when the harness emitted none (e.g. the OpenClaw bridge). */
-  usage?: TurnUsage;
-  costUsd?: number;
-  responseMetadata?: ChatResponseMetadata;
-  origin?: "chat" | "voice";
-  voiceCallId?: string;
-};
-
 // CHAT-D3-07 perf: `replyFor` runs for every row on every render and parses the
 // turn text (strip reasoning + Next paths) to decide whether the Reply action
 // shows. During streaming that would re-parse the whole settled transcript on
@@ -236,102 +193,6 @@ type Turn = {
 // (correct miss). Module-scoped and keyed weakly, so dead turns are GC'd; the
 // value is a pure function of the turn, so sharing across instances is safe.
 const replyableTurnCache = new WeakMap<Turn, boolean>();
-
-type LiveChatGenerationSnapshot = LiveGenerationSnapshot<Turn>;
-
-// Raw turn shape returned by GET /api/chat/conversation/:id.
-type ConversationHistoryTurn = {
-  id: string;
-  parentId?: string | null;
-  role: string;
-  text: string;
-  attachments?: ChatAttachment[];
-  reasoning?: string;
-  tools?: ToolEvent[];
-  durationMs?: number;
-  isError?: boolean;
-  usage?: TurnUsage;
-  costUsd?: number;
-  responseMetadata?: ChatResponseMetadata;
-  cancelled?: boolean;
-  createdAt?: string;
-  origin?: "chat" | "voice";
-  voiceCallId?: string;
-};
-
-// Parsed payload of GET /api/chat/conversation/:id — also what the
-// conversation cache stores, so a hover-prefetched payload and a fresh fetch
-// go through the same apply path in the history-load effect.
-type ConversationHistoryPayload = {
-  ok?: boolean;
-  context?: ChatLinkedContext | null;
-  conversation?: {
-    activeLeafId?: string;
-    turns?: ConversationHistoryTurn[];
-  };
-};
-
-function mapConversationHistoryTurns(rawTurns: ConversationHistoryTurn[]): Turn[] {
-  return rawTurns
-    .filter(
-      (t): t is ConversationHistoryTurn & { role: "user" | "assistant" } =>
-        t.role === "user" || t.role === "assistant",
-    )
-    .map((t) => ({
-      id: t.id,
-      parentId: t.parentId,
-      role: t.role,
-      text: t.text,
-      attachments: t.attachments,
-      reasoning: t.reasoning,
-      tools: t.tools,
-      durationMs: t.durationMs,
-      usage: t.usage,
-      costUsd: t.costUsd,
-      responseMetadata: t.responseMetadata,
-      error: t.isError,
-      lifecycle: t.cancelled ? ("cancelled" as const) : undefined,
-      createdAt: t.createdAt ?? new Date().toISOString(),
-      origin: t.origin,
-      voiceCallId: t.voiceCallId,
-    }));
-}
-
-function cloneLiveTurn(turn: Turn): Turn {
-  return {
-    ...turn,
-    attachments: turn.attachments ? [...turn.attachments] : undefined,
-    tools: turn.tools ? turn.tools.map((tool) => ({ ...tool })) : undefined,
-    progress: turn.progress ? turn.progress.map((progress) => ({ ...progress })) : undefined,
-  };
-}
-
-// Module-scope so a generation outlives the ChatView instance that started
-// it (thread switches AND full surface unmounts — cave-0er). All streaming
-// mutations must go through the registry (see updateLiveTurns), never only
-// through component setState: React silently drops setState on an unmounted
-// instance, which used to freeze the snapshot mid-generation and lose the
-// response. See src/lib/live-chat-generations.ts.
-const liveChatRegistry = createLiveGenerationRegistry<Turn>(cloneLiveTurn);
-
-function readLiveChatGeneration(sessionId: string): LiveChatGenerationSnapshot | null {
-  return liveChatRegistry.read(sessionId);
-}
-
-function recordLiveChatGeneration(snapshot: LiveChatGenerationSnapshot): LiveChatGenerationSnapshot {
-  return liveChatRegistry.record(snapshot);
-}
-
-function clearLiveChatGeneration(sessionId: string | null | undefined) {
-  liveChatRegistry.clear(sessionId);
-}
-
-function subscribeLiveChatGeneration(
-  sessionId: string,
-  listener: (snapshot: LiveChatGenerationSnapshot | null) => void,
-) {
-  return liveChatRegistry.subscribe(sessionId, listener);
-}
 
 // `isLiveSnapshotActive` lives in @/lib/live-chat-snapshot so the staleness rule
 // (the guard that stops a remounted view from inheriting a zombie "Streaming…"
@@ -3040,7 +2901,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // ignores setState on unmounted instances), freezing the snapshot and
     // losing the response.
     if (targetSessionId) {
-      const stored = liveChatRegistry.advance(targetSessionId, updater, nextActiveLeafId);
+      const stored = advanceLiveChatGeneration(targetSessionId, updater, nextActiveLeafId);
       if (stored) {
         // Mirror synchronously into THIS view's state when it is showing the
         // streaming session. Reusing the stored array means the microtask
@@ -4019,7 +3880,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // leaf: mid-stream the registry's activeLeafId is the streaming assistant
     // turn, and overwriting it with this view's (possibly stale) state would
     // re-point the rendered branch.
-    const live = currentSessionRef.current ? liveChatRegistry.read(currentSessionRef.current) : null;
+    const live = currentSessionRef.current ? readLiveChatGeneration(currentSessionRef.current) : null;
     updateLiveTurns((prev) => [...prev, newTurn], live?.activeLeafId ?? activeLeafId);
   };
 

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -17,7 +17,6 @@ import {
   PALETTE_CATEGORIES,
   PALETTE_CATEGORY_LABEL,
   filterPaletteRows,
-  paletteCategoryForKind,
   paletteResultCounts,
   paletteResultSummary,
   type PaletteCategory,
@@ -32,46 +31,7 @@ import {
   settingsSectionLabel,
   type SettingsIndexEntry,
 } from "@/components/settings-sections";
-
-function shortProjectRoot(root: string): string {
-  const parts = root.replace(/\/+$/, "").split("/").filter(Boolean);
-  return parts.length <= 2 ? root : `…/${parts.slice(-2).join("/")}`;
-}
-
-// Section label for a row in empty-query "browse" mode, so the default palette
-// reads as grouped clusters (Recent / Go to / …) instead of one flat dump.
-// Returns "" for rows that never appear while browsing (salem-answer, etc.).
-function browseGroup(row: Row): string {
-  switch (row.kind) {
-    case "session":
-      return "Recent chats";
-    case "command":
-      if (row.id.startsWith("surface:")) return "Go to";
-      if (row.id.startsWith("project:")) return "Projects";
-      return "Commands";
-    case "familiar":
-      return "Familiars";
-    case "card":
-      return "Tasks";
-    case "coven-memory":
-    case "fs-memory":
-      return "Memory";
-    case "shortcut":
-      return "Shortcuts";
-    case "setting":
-      return "Settings";
-    default:
-      return "";
-  }
-}
-
-// Section label for a row, used to print group headers. Conversation hits get a
-// "Conversations" header in BOTH browse and search mode (they're a distinct
-// content-search cluster); everything else only groups while browsing.
-function paletteGroup(row: Row, browsing: boolean): string {
-  if (browsing) return browseGroup(row);
-  return PALETTE_CATEGORY_LABEL[paletteCategoryForKind(row.kind)];
-}
+import { paletteGroup, shortProjectRoot } from "@/lib/command-palette-grouping";
 
 // Status → dot class for session rows, mirroring the Sessions tab's colors. Only
 // "notable" states get a dot (running pulses green, failed/queued/paused tint);

--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -129,6 +129,7 @@ const changesPanel = await readFile(
   new URL("./session-changes-panel.tsx", import.meta.url),
   "utf8",
 );
+const changesFormat = await readFile(new URL("../lib/session-changes-format.ts", import.meta.url), "utf8");
 
 assert.match(
   changesPanel,
@@ -191,7 +192,7 @@ assert.match(
   "Changes table should expose File and Diff columns like the task tables",
 );
 assert.match(
-  changesPanel,
+  changesFormat,
   /function splitFilePath[\s\S]*?basename[\s\S]*?dirname/,
   "Changes rows should split basename and parent path so narrow rails preserve the useful file name",
 );

--- a/src/components/familiar-tab-sections.test.ts
+++ b/src/components/familiar-tab-sections.test.ts
@@ -12,10 +12,11 @@ import { readFileSync } from "node:fs";
 
 const src = readFileSync(new URL("./chat-familiar-view.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/familiar-surface-navigation.ts", import.meta.url), "utf8");
 
 test("KindBadge is neutral — the per-kind color map is gone", () => {
   assert.doesNotMatch(src, /const colorMap/, "no per-kind color map");
-  const badge = src.slice(src.indexOf("function KindBadge"), src.indexOf("function navigateMode"));
+  const badge = src.slice(src.indexOf("function KindBadge"), src.indexOf("function CapCta"));
   assert.match(badge, /bg-\[var\(--bg-raised\)\][^"]*text-\[var\(--text-muted\)\]/, "one quiet style for every kind");
   assert.doesNotMatch(badge, /accent-presence|color-success|color-warning/, "no status colors on kind metadata");
 });
@@ -44,11 +45,11 @@ test("skills render through one shared SkillItem row with the path demoted to a 
 });
 
 test("every teach state has a real CTA riding cave:navigate-mode", () => {
-  assert.match(src, /function navigateMode\(mode: "roles" \| "capabilities" \| "marketplace"\)/, "navigate helper");
-  assert.match(src, /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode \} \}\)/, "workspace bridge event");
-  assert.match(src, /No roles active for this familiar\.[\s\S]{0,200}?CapCta label="Open Roles →" onClick=\{\(\) => navigateMode\("roles"\)\}/, "roles empty → Open Roles");
-  assert.match(src, /No plugins in the latest runtime capability scan\.[\s\S]{0,200}?CapCta label="Open Capabilities →" onClick=\{\(\) => navigateMode\("capabilities"\)\}/, "plugins empty → Open Capabilities");
-  assert.match(src, /No skills installed for this familiar yet\.[\s\S]{0,200}?CapCta label="Browse Marketplace →" onClick=\{\(\) => navigateMode\("marketplace"\)\}/, "familiar skills empty → Browse Marketplace");
+  assert.match(navigation, /function navigateFamiliarSurface\(mode: "roles" \| "capabilities" \| "marketplace"\)/, "navigate helper");
+  assert.match(navigation, /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode \} \}\)/, "workspace bridge event");
+  assert.match(src, /No roles active for this familiar\.[\s\S]{0,200}?CapCta label="Open Roles →" onClick=\{\(\) => navigateFamiliarSurface\("roles"\)\}/, "roles empty → Open Roles");
+  assert.match(src, /No plugins in the latest runtime capability scan\.[\s\S]{0,200}?CapCta label="Open Capabilities →" onClick=\{\(\) => navigateFamiliarSurface\("capabilities"\)\}/, "plugins empty → Open Capabilities");
+  assert.match(src, /No skills installed for this familiar yet\.[\s\S]{0,200}?CapCta label="Browse Marketplace →" onClick=\{\(\) => navigateFamiliarSurface\("marketplace"\)\}/, "familiar skills empty → Browse Marketplace");
   assert.match(src, /function CapCta\([\s\S]*?focus-ring/, "CTA buttons carry the shared focus ring");
 });
 

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -77,6 +77,7 @@ import {
   type RosterParticipant,
   type CovenResponseMode,
 } from "@/lib/group-chat";
+import { newId, nowIso } from "@/lib/group-chat-ids";
 
 type Props = {
   familiars: ResolvedFamiliar[];
@@ -85,16 +86,6 @@ type Props = {
   onSessionStarted?: (sessionId: string) => void;
   onOpenUrl?: (url: string) => void;
 };
-
-function newId(): string {
-  return typeof crypto !== "undefined" && crypto.randomUUID
-    ? crypto.randomUUID()
-    : `id-${Math.floor(Math.random() * 1e9)}`;
-}
-
-function nowIso(): string {
-  return new Date().toISOString();
-}
 
 export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props) {
   const profileSnapshot = useUserProfile();

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const destinations = await readFile(new URL("./home/home-destinations.ts", import.meta.url), "utf8");
 
 // ───────── Task 1: Destination-aware placeholder + drop subtitle ─────────
 assert.match(
-  source,
+  destinations,
   /const PLACEHOLDERS: Record<Destination, string> = \{[\s\S]*?chat:[\s\S]*?board:[\s\S]*?\}/,
   "PLACEHOLDERS must be a Record<Destination, string> with chat/board keys",
 );

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -3,12 +3,12 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const destinations = await readFile(new URL("./home/home-destinations.ts", import.meta.url), "utf8");
 const draftHook = await readFile(new URL("../lib/use-composer-draft.ts", import.meta.url), "utf8");
 const attachHook = await readFile(new URL("../lib/use-attachment-staging.ts", import.meta.url), "utf8");
 const menusHook = await readFile(new URL("../lib/use-inline-slash-menus.ts", import.meta.url), "utf8");
 const modelStateHook = await readFile(new URL("./home/use-home-model-state.ts", import.meta.url), "utf8");
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
-const destinations = source.match(/const DESTINATIONS:[\s\S]*?\n\];/)?.[0] ?? "";
 const handleKeyDownBlock = source.match(/const handleKeyDown = useCallback\([\s\S]*?\n  \);/)?.[0] ?? "";
 
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -20,7 +20,7 @@ import {
   useState,
 } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
-import { Icon, type IconName } from "@/lib/icon";
+import { Icon } from "@/lib/icon";
 import { resolveModelArg } from "@/lib/slash-model";
 import { requestSummonFamiliar } from "@/lib/summon-events";
 import {
@@ -79,20 +79,11 @@ import {
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
 import { greetingForHour } from "@/lib/home-greeting";
+import { DESTINATIONS, PLACEHOLDERS, type Destination } from "@/components/home/home-destinations";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type Destination = "chat" | "board";
-
-const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
-  { id: "chat",  label: "Chat", icon: "ph:chat-circle-dots" },
-  { id: "board", label: "Task", icon: "ph:kanban" },
-];
-
-const PLACEHOLDERS: Record<Destination, string> = {
-  chat: "Summon something magical",
-  board: "Describe a new task…",
-};
+export type { Destination } from "@/components/home/home-destinations";
 
 type Props = {
   familiars: Familiar[];

--- a/src/components/home/home-destinations.ts
+++ b/src/components/home/home-destinations.ts
@@ -1,0 +1,13 @@
+import type { IconName } from "@/lib/icon";
+
+export type Destination = "chat" | "board";
+
+export const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
+  { id: "chat", label: "Chat", icon: "ph:chat-circle-dots" },
+  { id: "board", label: "Task", icon: "ph:kanban" },
+];
+
+export const PLACEHOLDERS: Record<Destination, string> = {
+  chat: "Summon something magical",
+  board: "Describe a new task…",
+};

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -39,6 +39,7 @@ import type { PreviewPlugin } from "@create-markdown/preview";
 import type { Highlighter } from "shiki";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 import { Icon } from "@/lib/icon";
+import { classifyDiffLines, parseFenceInfo, type DiffLine } from "@/lib/message-code-fences";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
@@ -101,16 +102,6 @@ function getHighlighter(): Promise<Highlighter> {
 // Parse fence info → { lang, filename }
 // ---------------------------------------------------------------------------
 
-function parseFenceInfo(info: string): { lang: string; filename?: string } {
-  if (!info) return { lang: "text" };
-  // Support `lang:filename.ext` syntax
-  const colonIdx = info.indexOf(":");
-  if (colonIdx > 0) {
-    return { lang: info.slice(0, colonIdx).trim(), filename: info.slice(colonIdx + 1).trim() };
-  }
-  return { lang: info.trim() };
-}
-
 // ---------------------------------------------------------------------------
 // Render a single code block with Shiki + chrome
 // ---------------------------------------------------------------------------
@@ -137,27 +128,6 @@ function plainTextFromHtmlLine(line: string): string {
 // modal reads like code with add/remove strips instead of a flat wall of
 // uniformly "inserted"-colored lines. Diffs whose target has no resolvable
 // grammar keep the bundled `diff` grammar (whole-line coloring) below.
-
-type DiffLineKind = "add" | "del" | "ctx" | "meta" | "hunk";
-type DiffLine = { kind: DiffLineKind; raw: string; marker: string | null; content: string };
-
-const DIFF_META_RE =
-  /^(\+\+\+ |--- |diff --git |index |new file|deleted file|rename |similarity |old mode|new mode|Binary files|\\ No newline)/;
-
-function classifyDiffLines(code: string): DiffLine[] {
-  return code.split("\n").map((raw): DiffLine => {
-    // Meta and @@ hunk rows are blanked out of the document the language
-    // grammar sees (content: "") so they can't derail the parse; the raw text
-    // is re-substituted as muted chrome when the lines are wrapped.
-    if (/^@@/.test(raw)) return { kind: "hunk", raw, marker: null, content: "" };
-    if (DIFF_META_RE.test(raw)) return { kind: "meta", raw, marker: null, content: "" };
-    if (raw.startsWith("+")) return { kind: "add", raw, marker: "+", content: raw.slice(1) };
-    if (raw.startsWith("-")) return { kind: "del", raw, marker: "-", content: raw.slice(1) };
-    if (raw.startsWith(" ")) return { kind: "ctx", raw, marker: " ", content: raw.slice(1) };
-    // e.g. the "… (N more lines truncated)" cap marker — pass through as-is.
-    return { kind: "ctx", raw, marker: null, content: raw };
-  });
-}
 
 async function renderCodeBlock(
   code: string,

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -3,23 +3,24 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
+const primitives = readFileSync(new URL("./quick-chat-primitives.tsx", import.meta.url), "utf8");
+const thread = readFileSync(new URL("./quick-chat-thread.tsx", import.meta.url), "utf8");
 
-assert.match(source, /StandardSelect/, "quick-chat select helper should delegate to StandardSelect");
-assert.doesNotMatch(source, /PopoverBody|PopoverItem|anchorRef/, "quick-chat select helper should not maintain its own popover implementation");
-assert.match(source, /renderValue=/, "quick-chat select helper should keep its compact trigger rendering through StandardSelect");
+assert.match(primitives, /StandardSelect/, "quick-chat select helper should delegate to StandardSelect");
+assert.doesNotMatch(primitives, /PopoverBody|PopoverItem|anchorRef/, "quick-chat select helper should not maintain its own popover implementation");
+assert.match(primitives, /renderValue=/, "quick-chat select helper should keep its compact trigger rendering through StandardSelect");
 
 // Shared conversation thread — used by both the in-app dropdown and the tray.
-assert.match(source, /export function QuickChatThread/, "controls export the shared multi-turn thread renderer");
-assert.match(source, /import \{ MarkdownBlock \} from "@\/components\/message-bubble"/, "familiar replies render markdown via the shared MarkdownBlock");
-assert.match(source, /copyText\(visible\)/, "each familiar reply can be copied to the clipboard — the visible text, not the raw next-paths trailer");
-assert.match(source, /aria-live="polite"/, "the thread is a polite live region so streamed replies are announced");
-assert.match(source, /quick-chat-caret|quick-chat-typing/, "streaming turns show a caret / thinking affordance");
+assert.match(source, /export \{ QuickChatThread \} from "\.\/quick-chat-thread"/, "controls preserve the shared thread export");
+assert.match(thread, /import \{ MarkdownBlock \} from "@\/components\/message-bubble"/, "familiar replies render markdown via the shared MarkdownBlock");
+assert.match(thread, /copyText\(visible\)/, "each familiar reply can be copied to the clipboard — the visible text, not the raw next-paths trailer");
+assert.match(thread, /aria-live="polite"/, "the thread is a polite live region so streamed replies are announced");
+assert.match(thread, /quick-chat-caret|quick-chat-typing/, "streaming turns show a caret / thinking affordance");
 
 // ── Shared building blocks: one source of truth for both surfaces ────────────
 // The overlay and the tray render the same header identity, controls row, and
 // composer — drift between the two (e.g. hint copy, focus behavior) was a bug.
 for (const name of [
-  "QuickChatIdentity",
   "QuickChatControlsRow",
   "QuickChatComposer",
   "useSuggestionPicker",
@@ -31,15 +32,16 @@ for (const name of [
   );
 }
 assert.match(
-  source,
+  primitives,
   /export const QUICK_CHAT_SUGGESTIONS/,
   "the one-tap starter suggestions are defined once and shared",
 );
 assert.match(
-  source,
+  primitives,
   /loading \? "Loading familiars…" : familiar \? `@\$\{familiar\.id\}` : "No familiar selected"/,
   "the shared header identity shows a loading state while the roster loads",
 );
+assert.match(primitives, /export function QuickChatIdentity/, "controls preserve the shared header identity export");
 assert.match(
   source,
   /loading && familiars\.length === 0\s*\?\s*\[\{ value: "", label: "Loading…", disabled: true \}\]/,
@@ -134,7 +136,7 @@ assert.match(
 // rAF-coalesced. The old `< 48px` position re-stick — which yanked a reader
 // pausing near the bottom — stays gone.
 assert.match(
-  source,
+  thread,
   /const \{ schedulePin, stick \} = useStickToBottom\(scrollRef\)/,
   "the thread follows via the shared intent-release hook",
 );
@@ -144,12 +146,12 @@ assert.doesNotMatch(
   "the position-threshold re-stick stays gone",
 );
 assert.match(
-  source,
+  thread,
   /schedulePin\(\);\s*\}, \[messages\.length, lastText, schedulePin\]\)/,
   "streamed tokens pin through the coalesced scheduler",
 );
 assert.match(
-  source,
+  thread,
   /stick\(\);\s*\}, \[messages\.length, stick\]\)/,
   "a new turn re-engages follow-along scrolling",
 );
@@ -162,7 +164,7 @@ assert.match(
 
 // ── Copy affordance resets ────────────────────────────────────────────────────
 assert.match(
-  source,
+  thread,
   /setTimeout\(\(\) => setCopied\(false\), 1500\)/,
   "the copied ✓ hands the button back to copy after a beat (it used to stick forever)",
 );
@@ -173,27 +175,27 @@ assert.match(
 // the half-open block hides too) and renders the suggestions as chips on the
 // LATEST settled reply only — a compact tray can't afford stale chip rows.
 assert.match(
-  source,
+  thread,
   /import \{ extractNextPaths \} from "@\/lib\/next-paths"/,
   "the thread parses the shared next-paths trailer format — no bespoke parser",
 );
 assert.match(
-  source,
+  thread,
   /message\.role === "assistant"\s*\?\s*extractNextPaths\(message\.text\)/,
   "the trailer is stripped from familiar turns (never shown raw)",
 );
 assert.match(
-  source,
+  thread,
   /isLastAssistant && !streaming && onSuggestion && suggestions\.length > 0/,
   "chips render only on the latest settled reply, and only when a composer can accept them",
 );
 assert.match(
-  source,
+  thread,
   /className="quick-chat-next-path"[\s\S]*?onClick=\{\(\) => onSuggestion\(suggestion\)\}/,
   "clicking a chip fills the composer through the shared suggestion path (fill, not send)",
 );
 assert.match(
-  source,
+  thread,
   /aria-label="Suggested next steps"/,
   "the chip row is a labelled group",
 );
@@ -245,7 +247,7 @@ assert.match(
   "each staged file is individually removable",
 );
 assert.match(
-  source,
+  thread,
   /message\.attachments\?\.length \?[\s\S]*?quick-chat-bubble__files/,
   "a sent user turn keeps its paperclip line in the bubble",
 );

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/cave-composer.css";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 // The slash menu popover reuses the home composer's .hc-slash-* affordance —
 // this stylesheet is global-scoped, so importing it here makes the menu render
 // identically in the tray window (which never mounts the home composer).
@@ -15,21 +15,16 @@ import {
 } from "@/lib/command-controls";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { Icon, type IconName } from "@/lib/icon";
-import { AuthedImage } from "@/components/ui/authed-image";
 import type { Familiar } from "@/lib/types";
-import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
+import { StandardSelect } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { useReplyRecommendation, type ReplyRecommendationState } from "@/lib/use-reply-recommendation";
 import { EnhanceControl, EnhanceStrip } from "@/components/composer-enhance";
 import { IconButton } from "@/components/ui/icon-button";
-import { MarkdownBlock } from "@/components/message-bubble";
-import { copyText } from "@/lib/clipboard";
 import { attachmentIcon, type ChatAttachment } from "@/lib/chat-attachments";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import type { QueuedQuickChatMessage, QuickChatMessage } from "@/lib/use-quick-chat";
-import { extractNextPaths } from "@/lib/next-paths";
-import { useStickToBottom } from "@/lib/use-stick-to-bottom";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
 import { HomeSlashMenu } from "@/components/home/home-slash-menu";
 import { SLASH_COMMANDS, canonicalize } from "@/lib/slash-commands";
@@ -47,119 +42,27 @@ import {
   type PromptOption,
 } from "@/lib/slash-prompt";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
+import {
+  FamiliarMark,
+  QuickChatIdentity,
+  QuickChatSelect,
+  type QuickChatSelectOption,
+} from "./quick-chat-primitives";
 
-export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
+export {
+  FamiliarMark,
+  QuickChatIdentity,
+  QuickChatSelect,
+  type QuickChatSelectOption,
+} from "./quick-chat-primitives";
+export { QuickChatThread } from "./quick-chat-thread";
 
-// One-tap starters for a cold thread — they fill the composer, not send.
-export const QUICK_CHAT_SUGGESTIONS = [
-  "Summarize what needs my attention",
-  "Draft a short status update",
-  "What changed recently?",
-];
+export { QUICK_CHAT_SUGGESTIONS } from "./quick-chat-primitives";
 
 // Stable empty reference so QuickChatComposer can pass `messages ?? EMPTY` to
 // the recommendation hook without spawning a fresh array (and effect churn)
 // every render.
 const EMPTY_MESSAGES: QuickChatMessage[] = [];
-
-function initials(familiar: Familiar): string {
-  return (familiar.display_name || familiar.id)
-    .split(/\s+/)
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-}
-
-export function FamiliarMark({ familiar, size = "sm" }: { familiar: Familiar; size?: "sm" | "md" }) {
-  const sizeClass = size === "md" ? "h-6 w-6 text-[length:var(--text-2xs)]" : "h-5 w-5 text-[length:var(--text-2xs)]";
-  return (
-    <AuthedImage
-      src={familiar.avatarUrl}
-      alt=""
-      className={`${sizeClass} rounded-[var(--radius-control)] object-cover`}
-      fallback={
-        <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
-          {initials(familiar)}
-        </span>
-      }
-    />
-  );
-}
-
-// ── Header identity ──────────────────────────────────────────────────────────
-// The avatar + name + handle block both quick-chat surfaces open with.
-
-export function QuickChatIdentity({
-  familiar,
-  loading,
-  as: Heading = "h2",
-}: {
-  familiar: Familiar | null;
-  loading: boolean;
-  /** Heading level — the tray window is a full page (h1), the overlay a dialog (h2). */
-  as?: "h1" | "h2";
-}) {
-  return (
-    <div className="flex min-w-0 items-center gap-2">
-      {familiar ? (
-        <FamiliarMark familiar={familiar} size="md" />
-      ) : (
-        <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
-      )}
-      <div className="min-w-0">
-        <Heading className="truncate text-sm font-semibold">
-          {familiar ? familiar.display_name : "Quick chat"}
-        </Heading>
-        <p className="truncate text-xs text-[var(--fg-muted)]">
-          {/* While the roster loads, say so — "No familiar selected" reads
-              as an error/empty state when it's really just cold. */}
-          {loading ? "Loading familiars…" : familiar ? `@${familiar.id}` : "No familiar selected"}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-export function QuickChatSelect<T extends string>({
-  label,
-  value,
-  options,
-  onChange,
-  disabled,
-  className,
-}: {
-  label: string;
-  value: T;
-  options: QuickChatSelectOption<T>[];
-  onChange: (value: T) => void;
-  disabled?: boolean;
-  className?: string;
-}) {
-  return (
-    <StandardSelect
-      label={label}
-      value={value}
-      options={options}
-      onChange={onChange}
-      disabled={disabled}
-      showCaret={false}
-      className={[
-        "quick-chat-select__trigger min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-left text-xs outline-none disabled:cursor-not-allowed disabled:opacity-55",
-        className ?? "",
-      ].filter(Boolean).join(" ")}
-      renderValue={(selected) => (
-        <>
-          <span className="flex min-w-0 items-center gap-2">
-            {selected?.leading ?? (selected?.icon ? <Icon name={selected.icon} width={13} aria-hidden className="shrink-0 text-[var(--fg-muted)]" /> : null)}
-            <span className="min-w-0 truncate">{selected?.label ?? label}</span>
-          </span>
-          <Icon name="ph:caret-down" width={13} aria-hidden className="shrink-0 text-[var(--fg-muted)]" />
-        </>
-      )}
-    />
-  );
-}
 
 // ── Controls row ─────────────────────────────────────────────────────────────
 // Familiar picker + thinking-effort + response-speed selects — identical in the
@@ -939,235 +842,4 @@ export function useSuggestionPicker(setDraft: (value: string) => void) {
     [setDraft],
   );
   return { composerRef, pickSuggestion };
-}
-
-// ── Conversation thread ──────────────────────────────────────────────────────
-// Shared between the in-app dropdown and the Tauri standalone window so the two
-// render identical turns. Owns its own scroll container + auto-scroll and marks
-// it as a polite live region so streamed replies are announced.
-
-function QuickChatBubble({
-  message,
-  familiar,
-  isLastAssistant,
-  onRegenerate,
-  onSuggestion,
-}: {
-  message: QuickChatMessage;
-  familiar: Familiar | null;
-  isLastAssistant: boolean;
-  onRegenerate?: () => void;
-  /** Fills the composer (caret in) — next-path chips ride the same path as the
-   *  empty-state starters. */
-  onSuggestion?: (value: string) => void;
-}) {
-  const [copied, setCopied] = useState(false);
-
-  // Show the ✓ for a beat, then hand the button back to "copy".
-  useEffect(() => {
-    if (!copied) return;
-    const timer = window.setTimeout(() => setCopied(false), 1500);
-    return () => window.clearTimeout(timer);
-  }, [copied]);
-
-  // Next-path suggestions (the agent's parseable trailer) never render as raw
-  // text: the block is stripped from every familiar turn — streaming-safe, the
-  // half-open block hides too — and surfaced as chips on the latest turn only,
-  // so stale suggestions don't stack up the compact tray.
-  const { visible, suggestions } =
-    message.role === "assistant"
-      ? extractNextPaths(message.text)
-      : { visible: message.text, suggestions: [] };
-
-  if (message.role === "user") {
-    return (
-      <div className="quick-chat-turn quick-chat-turn--user">
-        <div className="quick-chat-bubble quick-chat-bubble--user">
-          {message.text ? (
-            <p className="whitespace-pre-wrap break-words leading-6">{message.text}</p>
-          ) : null}
-          {message.attachments?.length ? (
-            <p className="quick-chat-bubble__files" title={message.attachments.map((a) => a.name).join(", ")}>
-              <Icon name="ph:paperclip" width={11} aria-hidden />
-              {message.attachments.map((a) => a.name).join(" · ")}
-            </p>
-          ) : null}
-        </div>
-      </div>
-    );
-  }
-
-  const streaming = message.pending;
-  const canAct = !streaming && visible.length > 0;
-  return (
-    <div className="quick-chat-turn quick-chat-turn--familiar">
-      {familiar ? (
-        <FamiliarMark familiar={familiar} size="sm" />
-      ) : (
-        <span className="grid h-5 w-5 place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)]">
-          <Icon name="ph:sparkle" width={12} aria-hidden />
-        </span>
-      )}
-      <div className="quick-chat-bubble quick-chat-bubble--familiar">
-        {visible ? (
-          streaming ? (
-            // Render partial text plainly while it streams — re-parsing markdown
-            // per token is wasteful and flashes half-open code fences.
-            <p className="whitespace-pre-wrap break-words leading-6">
-              {visible}
-              <span className="quick-chat-caret" aria-hidden />
-            </p>
-          ) : (
-            <div className="quick-chat-md">
-              <MarkdownBlock text={visible} />
-            </div>
-          )
-        ) : streaming ? (
-          <span className="quick-chat-typing" aria-label="Thinking…">
-            <i />
-            <i />
-            <i />
-          </span>
-        ) : (
-          <p className="text-[var(--fg-muted)]">No response.</p>
-        )}
-
-        {message.error ? (
-          <p className="quick-chat-turn__error">{message.error}</p>
-        ) : null}
-
-        {canAct ? (
-          <div className="quick-chat-turn__actions">
-            <IconButton
-              icon={copied ? "ph:check" : "ph:copy"}
-              size="xs"
-              aria-label={copied ? "Copied" : "Copy reply"}
-              title="Copy reply"
-              onClick={() => {
-                // Copy what the user sees — the next-paths trailer stays out.
-                void copyText(visible).then((ok) => {
-                  if (ok) setCopied(true);
-                });
-              }}
-            />
-            {isLastAssistant && onRegenerate ? (
-              <IconButton
-                icon="ph:arrow-clockwise"
-                size="xs"
-                aria-label="Regenerate reply"
-                title="Regenerate"
-                onClick={onRegenerate}
-              />
-            ) : null}
-          </div>
-        ) : null}
-
-        {/* Suggested follow-ups render LAST — tap-to-fill, so they sit closest
-            to the composer, mirroring the main chat's next-path row. */}
-        {isLastAssistant && !streaming && onSuggestion && suggestions.length > 0 ? (
-          <div className="quick-chat-next-paths" role="group" aria-label="Suggested next steps">
-            {suggestions.map((suggestion, i) => (
-              <Button
-                key={i}
-                size="xs"
-                variant="secondary"
-                className="quick-chat-next-path"
-                onClick={() => onSuggestion(suggestion)}
-              >
-                {suggestion}
-              </Button>
-            ))}
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-export function QuickChatThread({
-  messages,
-  familiar,
-  emptyIcon = "ph:chat-circle-dots",
-  emptyTitle = familiar ? `Ask ${familiar.display_name} anything` : "Ask a familiar anything",
-  emptyHint = "Replies stream right here · @name to switch familiar · Enter to send",
-  suggestions = QUICK_CHAT_SUGGESTIONS,
-  onSuggestion,
-  onRegenerate,
-}: {
-  messages: QuickChatMessage[];
-  familiar: Familiar | null;
-  emptyIcon?: IconName;
-  emptyTitle?: string;
-  emptyHint?: string;
-  suggestions?: string[];
-  onSuggestion?: (value: string) => void;
-  onRegenerate?: () => void;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  // Follow the stream with intent-based release (cave-o8si): scrolling up
-  // detaches, returning to the true bottom re-attaches. The old 48px position
-  // threshold re-stuck a reader pausing near the bottom, so the next streamed
-  // token yanked them back down.
-  const { schedulePin, stick } = useStickToBottom(scrollRef);
-  const lastText = messages.length > 0 ? messages[messages.length - 1].text : "";
-
-  // A new turn (sending / a reply starting) re-engages follow-along; on mount
-  // this doubles as the initial snap to the latest turn.
-  useEffect(() => {
-    stick();
-  }, [messages.length, stick]);
-
-  // Keep the newest turn in view as it streams.
-  useEffect(() => {
-    schedulePin();
-  }, [messages.length, lastText, schedulePin]);
-
-  const lastAssistantId = (() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      // Local notes (slash output like /help) are assistant-styled but not
-      // familiar replies — never the regenerate / next-paths anchor.
-      if (messages[i].role === "assistant" && !messages[i].local) return messages[i].id;
-    }
-    return null;
-  })();
-
-  return (
-    <div ref={scrollRef} className="quick-chat-thread" aria-live="polite">
-      {messages.length === 0 ? (
-        <div className="quick-chat-empty">
-          <span className="quick-chat-empty__glyph" aria-hidden>
-            <Icon name={emptyIcon} width={22} />
-          </span>
-          <p className="quick-chat-empty__title">{emptyTitle}</p>
-          <p className="quick-chat-empty__hint">{emptyHint}</p>
-          {suggestions.length > 0 ? (
-            <div className="quick-chat-empty__chips">
-              {suggestions.map((suggestion) => (
-                <Button
-                  key={suggestion}
-                  size="xs"
-                  variant="secondary"
-                  className="quick-chat-chip"
-                  onClick={() => onSuggestion?.(suggestion)}
-                >
-                  {suggestion}
-                </Button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : (
-        messages.map((message) => (
-          <QuickChatBubble
-            key={message.id}
-            message={message}
-            familiar={familiar}
-            isLastAssistant={message.id === lastAssistantId}
-            onRegenerate={onRegenerate}
-            onSuggestion={onSuggestion}
-          />
-        ))
-      )}
-    </div>
-  );
 }

--- a/src/components/quick-chat-primitives.tsx
+++ b/src/components/quick-chat-primitives.tsx
@@ -1,0 +1,107 @@
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
+import { AuthedImage } from "@/components/ui/authed-image";
+import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
+
+export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
+
+// One-tap starters for a cold thread — they fill the composer, not send.
+export const QUICK_CHAT_SUGGESTIONS = [
+  "Summarize what needs my attention",
+  "Draft a short status update",
+  "What changed recently?",
+];
+
+function initials(familiar: Familiar): string {
+  return (familiar.display_name || familiar.id)
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function FamiliarMark({ familiar, size = "sm" }: { familiar: Familiar; size?: "sm" | "md" }) {
+  const sizeClass = size === "md" ? "h-6 w-6 text-[length:var(--text-2xs)]" : "h-5 w-5 text-[length:var(--text-2xs)]";
+  return (
+    <AuthedImage
+      src={familiar.avatarUrl}
+      alt=""
+      className={`${sizeClass} rounded-[var(--radius-control)] object-cover`}
+      fallback={
+        <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
+          {initials(familiar)}
+        </span>
+      }
+    />
+  );
+}
+
+export function QuickChatIdentity({
+  familiar,
+  loading,
+  as: Heading = "h2",
+}: {
+  familiar: Familiar | null;
+  loading: boolean;
+  /** Heading level — the tray window is a full page (h1), the overlay a dialog (h2). */
+  as?: "h1" | "h2";
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {familiar ? (
+        <FamiliarMark familiar={familiar} size="md" />
+      ) : (
+        <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
+      )}
+      <div className="min-w-0">
+        <Heading className="truncate text-sm font-semibold">
+          {familiar ? familiar.display_name : "Quick chat"}
+        </Heading>
+        <p className="truncate text-xs text-[var(--fg-muted)]">
+          {loading ? "Loading familiars…" : familiar ? `@${familiar.id}` : "No familiar selected"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function QuickChatSelect<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  disabled,
+  className,
+}: {
+  label: string;
+  value: T;
+  options: QuickChatSelectOption<T>[];
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  className?: string;
+}) {
+  return (
+    <StandardSelect
+      label={label}
+      value={value}
+      options={options}
+      onChange={onChange}
+      disabled={disabled}
+      showCaret={false}
+      className={[
+        "quick-chat-select__trigger min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-left text-xs outline-none disabled:cursor-not-allowed disabled:opacity-55",
+        className ?? "",
+      ].filter(Boolean).join(" ")}
+      renderValue={(selected) => (
+        <>
+          <span className="flex min-w-0 items-center gap-2">
+            {selected?.leading ?? (selected?.icon ? <Icon name={selected.icon} width={13} aria-hidden className="shrink-0 text-[var(--fg-muted)]" /> : null)}
+            <span className="min-w-0 truncate">{selected?.label ?? label}</span>
+          </span>
+          <Icon name="ph:caret-down" width={13} aria-hidden className="shrink-0 text-[var(--fg-muted)]" />
+        </>
+      )}
+    />
+  );
+}

--- a/src/components/quick-chat-thread.tsx
+++ b/src/components/quick-chat-thread.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react";
+import { MarkdownBlock } from "@/components/message-bubble";
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import { copyText } from "@/lib/clipboard";
+import { Icon, type IconName } from "@/lib/icon";
+import { extractNextPaths } from "@/lib/next-paths";
+import type { Familiar } from "@/lib/types";
+import { useStickToBottom } from "@/lib/use-stick-to-bottom";
+import type { QuickChatMessage } from "@/lib/use-quick-chat";
+import { FamiliarMark, QUICK_CHAT_SUGGESTIONS } from "./quick-chat-primitives";
+
+function QuickChatBubble({
+  message,
+  familiar,
+  isLastAssistant,
+  onRegenerate,
+  onSuggestion,
+}: {
+  message: QuickChatMessage;
+  familiar: Familiar | null;
+  isLastAssistant: boolean;
+  onRegenerate?: () => void;
+  onSuggestion?: (value: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  const { visible, suggestions } =
+    message.role === "assistant"
+      ? extractNextPaths(message.text)
+      : { visible: message.text, suggestions: [] };
+
+  if (message.role === "user") {
+    return (
+      <div className="quick-chat-turn quick-chat-turn--user">
+        <div className="quick-chat-bubble quick-chat-bubble--user">
+          {message.text ? <p className="whitespace-pre-wrap break-words leading-6">{message.text}</p> : null}
+          {message.attachments?.length ? (
+            <p className="quick-chat-bubble__files" title={message.attachments.map((a) => a.name).join(", ")}>
+              <Icon name="ph:paperclip" width={11} aria-hidden />
+              {message.attachments.map((a) => a.name).join(" · ")}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  const streaming = message.pending;
+  const canAct = !streaming && visible.length > 0;
+  return (
+    <div className="quick-chat-turn quick-chat-turn--familiar">
+      {familiar ? <FamiliarMark familiar={familiar} size="sm" /> : (
+        <span className="grid h-5 w-5 place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)]">
+          <Icon name="ph:sparkle" width={12} aria-hidden />
+        </span>
+      )}
+      <div className="quick-chat-bubble quick-chat-bubble--familiar">
+        {visible ? (
+          streaming ? <p className="whitespace-pre-wrap break-words leading-6">{visible}<span className="quick-chat-caret" aria-hidden /></p> : (
+            <div className="quick-chat-md"><MarkdownBlock text={visible} /></div>
+          )
+        ) : streaming ? (
+          <span className="quick-chat-typing" aria-label="Thinking…"><i /><i /><i /></span>
+        ) : <p className="text-[var(--fg-muted)]">No response.</p>}
+
+        {message.error ? <p className="quick-chat-turn__error">{message.error}</p> : null}
+
+        {canAct ? (
+          <div className="quick-chat-turn__actions">
+            <IconButton
+              icon={copied ? "ph:check" : "ph:copy"}
+              size="xs"
+              aria-label={copied ? "Copied" : "Copy reply"}
+              title="Copy reply"
+              onClick={() => { void copyText(visible).then((ok) => { if (ok) setCopied(true); }); }}
+            />
+            {isLastAssistant && onRegenerate ? <IconButton icon="ph:arrow-clockwise" size="xs" aria-label="Regenerate reply" title="Regenerate" onClick={onRegenerate} /> : null}
+          </div>
+        ) : null}
+
+        {isLastAssistant && !streaming && onSuggestion && suggestions.length > 0 ? (
+          <div className="quick-chat-next-paths" role="group" aria-label="Suggested next steps">
+            {suggestions.map((suggestion, i) => <Button key={i} size="xs" variant="secondary" className="quick-chat-next-path" onClick={() => onSuggestion(suggestion)}>{suggestion}</Button>)}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function QuickChatThread({
+  messages,
+  familiar,
+  emptyIcon = "ph:chat-circle-dots",
+  emptyTitle = familiar ? `Ask ${familiar.display_name} anything` : "Ask a familiar anything",
+  emptyHint = "Replies stream right here · @name to switch familiar · Enter to send",
+  suggestions = QUICK_CHAT_SUGGESTIONS,
+  onSuggestion,
+  onRegenerate,
+}: {
+  messages: QuickChatMessage[];
+  familiar: Familiar | null;
+  emptyIcon?: IconName;
+  emptyTitle?: string;
+  emptyHint?: string;
+  suggestions?: string[];
+  onSuggestion?: (value: string) => void;
+  onRegenerate?: () => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { schedulePin, stick } = useStickToBottom(scrollRef);
+  const lastText = messages.length > 0 ? messages[messages.length - 1].text : "";
+
+  useEffect(() => { stick(); }, [messages.length, stick]);
+  useEffect(() => { schedulePin(); }, [messages.length, lastText, schedulePin]);
+
+  const lastAssistantId = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant" && !messages[i].local) return messages[i].id;
+    }
+    return null;
+  })();
+
+  return (
+    <div ref={scrollRef} className="quick-chat-thread" aria-live="polite">
+      {messages.length === 0 ? (
+        <div className="quick-chat-empty">
+          <span className="quick-chat-empty__glyph" aria-hidden><Icon name={emptyIcon} width={22} /></span>
+          <p className="quick-chat-empty__title">{emptyTitle}</p>
+          <p className="quick-chat-empty__hint">{emptyHint}</p>
+          {suggestions.length > 0 ? <div className="quick-chat-empty__chips">
+            {suggestions.map((suggestion) => <Button key={suggestion} size="xs" variant="secondary" className="quick-chat-chip" onClick={() => onSuggestion?.(suggestion)}>{suggestion}</Button>)}
+          </div> : null}
+        </div>
+      ) : messages.map((message) => (
+        <QuickChatBubble key={message.id} message={message} familiar={familiar} isLastAssistant={message.id === lastAssistantId} onRegenerate={onRegenerate} onSuggestion={onSuggestion} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { arrayContentEqual } from "@/lib/array-content-equal";
 import { fetchChangesSummary } from "@/lib/changes-summary-fetch";
-import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -13,6 +12,7 @@ import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { openExternalUrl } from "@/lib/open-external";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { buildChangesReviewPrompt } from "@/lib/changes-review";
+import { checkpointLabel, formatBytes, splitFilePath } from "@/lib/session-changes-format";
 
 /**
  * "Changes" right-panel tab (CHAT-D8-01): a per-session review surface for the
@@ -51,32 +51,6 @@ type DiffState = {
 };
 
 type CheckpointMeta = { name: string; savedAt: string; bytes: number };
-
-/** "2026-06-13T07-00-33-123Z.patch" → a short, readable local timestamp. */
-function checkpointLabel(name: string): string {
-  const iso = name.replace(/\.patch$/, "").replace(
-    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
-    "$1T$2:$3:$4.$5Z",
-  );
-  const d = new Date(iso);
-  // Honor the app's clock + date preferences instead of the raw browser locale.
-  return Number.isNaN(d.getTime()) ? name : formatTimestamp(iso, readDateTimePrefs());
-}
-
-function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function splitFilePath(path: string): { basename: string; dirname: string } {
-  const idx = path.lastIndexOf("/");
-  if (idx < 0) return { basename: path, dirname: "" };
-  return {
-    basename: path.slice(idx + 1) || path,
-    dirname: path.slice(0, idx),
-  };
-}
 
 const STATUS_META: Record<FileStatus, { letter: string; label: string; color: string }> = {
   modified: { letter: "M", label: "modified", color: "var(--color-warning)" },

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import { MODE_ALIASES } from "../lib/workspace-mode.ts";
 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const urlState = readFileSync(new URL("../lib/workspace-url-state.ts", import.meta.url), "utf8");
 const navState = readFileSync(new URL("../lib/sidebar-nav-state.ts", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 
@@ -60,7 +61,7 @@ assert.match(
 //    vocabulary instead of ad-hoc special cases ──────────────────────────────
 
 assert.match(
-  workspace,
+  urlState,
   /function readModeParam\(\): WorkspaceMode \| null \{[\s\S]{0,300}?isWorkspaceMode\(raw\)/,
   "?mode= deep links validate via isWorkspaceMode (canonical + alias vocabulary)",
 );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -17,6 +17,7 @@ import {
   type CanonicalWorkspaceMode,
   type WorkspaceMode as WorkspaceModeFromDaemon,
 } from "@/lib/workspace-mode";
+import { clearChatHash, clearModeParam, readChatHash, readModeParam } from "@/lib/workspace-url-state";
 import type { PaletteIntent } from "@/components/command-palette";
 // Journal retired as an in-shell surface (redirects to Settings → Familiars),
 // so JournalView is gone; Grimoire is a new in-shell surface from main.
@@ -222,56 +223,11 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
 // Chat deep links (CHAT-D9-01): `#chat-<sessionId>` re-enters a specific
 // thread, same in-app hash idiom as `#card-<id>`.
 // ChatRouter writes the hash (syncUrlHash); Workspace owns restore + popstate.
-const CHAT_HASH_PREFIX = "#chat-";
-
 // GitHub task context is low-churn. At five minutes, uninterrupted idle
 // foreground use makes at most 12 Cave requests/hour instead of piggybacking on
 // the four-second session poll (~900/hour). usePausablePoll also pauses this in
 // hidden windows and while the user is composing input.
 const GITHUB_TASKS_POLL_MS = 5 * 60_000;
-
-function readChatHash(): string | null {
-  if (typeof window === "undefined") return null;
-  const hash = window.location.hash;
-  if (!hash.startsWith(CHAT_HASH_PREFIX)) return null;
-  try {
-    return decodeURIComponent(hash.slice(CHAT_HASH_PREFIX.length));
-  } catch {
-    return null;
-  }
-}
-
-function clearChatHash() {
-  if (typeof window === "undefined") return;
-  if (!window.location.hash.startsWith(CHAT_HASH_PREFIX)) return;
-  window.history.replaceState(null, "", window.location.pathname + window.location.search);
-}
-
-// Mode deep links: workspace modes live inside this SPA shell and aren't
-// URL-addressable on their own. A `?mode=<WorkspaceMode>` query param lets
-// external links land directly on a surface.
-// Only real modes are honoured — canonical surfaces and the compatibility
-// aliases in MODE_ALIASES (setMode routes those onto their canonical
-// surface/tab) — so unknown values are ignored silently.
-function readModeParam(): WorkspaceMode | null {
-  if (typeof window === "undefined") return null;
-  const raw = new URLSearchParams(window.location.search).get("mode");
-  if (raw && isWorkspaceMode(raw)) return raw;
-  return null;
-}
-
-function clearModeParam() {
-  if (typeof window === "undefined") return;
-  const params = new URLSearchParams(window.location.search);
-  if (!params.has("mode")) return;
-  params.delete("mode");
-  const query = params.toString();
-  window.history.replaceState(
-    null,
-    "",
-    window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
-  );
-}
 
 function taskCanAnnotateSession(task: GitHubTask): boolean {
   return Boolean(task.sessionId && (task.prNumber != null || task.prUrl));

--- a/src/lib/authed-image.test.ts
+++ b/src/lib/authed-image.test.ts
@@ -162,7 +162,7 @@ assert.doesNotMatch(
 );
 
 for (const rel of [
-  "../components/quick-chat-controls.tsx",
+  "../components/quick-chat-primitives.tsx",
   "../components/familiar-growth-view.tsx",
   "../components/familiar-analytics-view.tsx",
   "../components/familiars-view.tsx",

--- a/src/lib/chat-turn-state.ts
+++ b/src/lib/chat-turn-state.ts
@@ -1,0 +1,163 @@
+import type { ChatAttachment } from "@/lib/chat-attachments";
+import type { ChatLinkedContext } from "@/lib/chat-linked-context";
+import type { ChatResponseMetadata } from "@/lib/chat-response-metadata";
+import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
+import type { TurnUsage } from "@/lib/usage-format";
+
+/**
+ * The shared state contract for ChatView's persisted transcript and its
+ * client-owned in-flight generation. Keeping this outside the component lets
+ * an SSE reader continue accumulating safely after the visible view unmounts.
+ */
+export type ToolEvent = {
+  id: string;
+  name: string;
+  input?: string;
+  output?: string;
+  status: "running" | "ok" | "error";
+  durationMs?: number;
+  /**
+   * Length of the turn text when this tool's first event arrived. Turn rows
+   * use it to interleave tool activity with prose; legacy transcripts omit it
+   * and keep the trailing rollup.
+   */
+  textOffset?: number;
+};
+
+export type ProgressEvent = {
+  id: string;
+  label: string;
+  detail?: string;
+  status: "running" | "done" | "error";
+  createdAt: string;
+  durationMs?: number;
+};
+
+export type ChatTurnLifecycle =
+  | "queued"
+  | "connecting"
+  | "streaming"
+  | "tooling"
+  | "cancelled"
+  | "failed"
+  | "complete";
+
+export type Turn = {
+  id: string;
+  parentId?: string | null;
+  role: "user" | "assistant" | "system";
+  text: string;
+  attachments?: ChatAttachment[];
+  reasoning?: string;
+  tools?: ToolEvent[];
+  progress?: ProgressEvent[];
+  createdAt: string;
+  pending?: boolean;
+  error?: boolean;
+  lifecycle?: ChatTurnLifecycle;
+  durationMs?: number;
+  /** Token usage and cost from a harness result event. */
+  usage?: TurnUsage;
+  costUsd?: number;
+  responseMetadata?: ChatResponseMetadata;
+  origin?: "chat" | "voice";
+  voiceCallId?: string;
+};
+
+export type ConversationHistoryTurn = {
+  id: string;
+  parentId?: string | null;
+  role: string;
+  text: string;
+  attachments?: ChatAttachment[];
+  reasoning?: string;
+  tools?: ToolEvent[];
+  durationMs?: number;
+  isError?: boolean;
+  usage?: TurnUsage;
+  costUsd?: number;
+  responseMetadata?: ChatResponseMetadata;
+  cancelled?: boolean;
+  createdAt?: string;
+  origin?: "chat" | "voice";
+  voiceCallId?: string;
+};
+
+export type ConversationHistoryPayload = {
+  ok?: boolean;
+  context?: ChatLinkedContext | null;
+  conversation?: {
+    activeLeafId?: string;
+    turns?: ConversationHistoryTurn[];
+  };
+};
+
+/** Normalize the API's permissive persisted turn shape for ChatView. */
+export function mapConversationHistoryTurns(rawTurns: ConversationHistoryTurn[]): Turn[] {
+  return rawTurns
+    .filter(
+      (turn): turn is ConversationHistoryTurn & { role: "user" | "assistant" } =>
+        turn.role === "user" || turn.role === "assistant",
+    )
+    .map((turn) => ({
+      id: turn.id,
+      parentId: turn.parentId,
+      role: turn.role,
+      text: turn.text,
+      attachments: turn.attachments,
+      reasoning: turn.reasoning,
+      tools: turn.tools,
+      durationMs: turn.durationMs,
+      usage: turn.usage,
+      costUsd: turn.costUsd,
+      responseMetadata: turn.responseMetadata,
+      error: turn.isError,
+      lifecycle: turn.cancelled ? ("cancelled" as const) : undefined,
+      createdAt: turn.createdAt ?? new Date().toISOString(),
+      origin: turn.origin,
+      voiceCallId: turn.voiceCallId,
+    }));
+}
+
+function cloneLiveTurn(turn: Turn): Turn {
+  return {
+    ...turn,
+    attachments: turn.attachments ? [...turn.attachments] : undefined,
+    tools: turn.tools ? turn.tools.map((tool) => ({ ...tool })) : undefined,
+    progress: turn.progress ? turn.progress.map((progress) => ({ ...progress })) : undefined,
+  };
+}
+
+export type LiveChatGenerationSnapshot = LiveGenerationSnapshot<Turn>;
+
+// A generation must outlive the ChatView instance that started it: thread
+// switches and surface unmounts otherwise cause React to drop later state
+// updates, freezing the visible snapshot mid-stream.
+const liveChatRegistry = createLiveGenerationRegistry<Turn>(cloneLiveTurn);
+
+export function readLiveChatGeneration(sessionId: string): LiveChatGenerationSnapshot | null {
+  return liveChatRegistry.read(sessionId);
+}
+
+export function recordLiveChatGeneration(snapshot: LiveChatGenerationSnapshot): LiveChatGenerationSnapshot {
+  return liveChatRegistry.record(snapshot);
+}
+
+export function advanceLiveChatGeneration(
+  sessionId: string,
+  updater: (turns: Turn[]) => Turn[],
+  activeLeafId: string,
+): LiveChatGenerationSnapshot | null {
+  return liveChatRegistry.advance(sessionId, updater, activeLeafId);
+}
+
+export function clearLiveChatGeneration(sessionId: string | null | undefined) {
+  liveChatRegistry.clear(sessionId);
+}
+
+export function subscribeLiveChatGeneration(
+  sessionId: string,
+  listener: (snapshot: LiveChatGenerationSnapshot | null) => void,
+) {
+  return liveChatRegistry.subscribe(sessionId, listener);
+}

--- a/src/lib/command-palette-grouping.ts
+++ b/src/lib/command-palette-grouping.ts
@@ -1,0 +1,29 @@
+import { PALETTE_CATEGORY_LABEL, paletteCategoryForKind } from "@/lib/command-palette-search";
+
+type PaletteGroupingRow = { id: string; kind: Parameters<typeof paletteCategoryForKind>[0] };
+
+export function shortProjectRoot(root: string): string {
+  const parts = root.replace(/\/+$/, "").split("/").filter(Boolean);
+  return parts.length <= 2 ? root : `…/${parts.slice(-2).join("/")}`;
+}
+
+function browseGroup(row: PaletteGroupingRow): string {
+  switch (row.kind) {
+    case "session": return "Recent chats";
+    case "command":
+      if (row.id.startsWith("surface:")) return "Go to";
+      if (row.id.startsWith("project:")) return "Projects";
+      return "Commands";
+    case "familiar": return "Familiars";
+    case "card": return "Tasks";
+    case "coven-memory":
+    case "fs-memory": return "Memory";
+    case "shortcut": return "Shortcuts";
+    case "setting": return "Settings";
+    default: return "";
+  }
+}
+
+export function paletteGroup(row: PaletteGroupingRow, browsing: boolean): string {
+  return browsing ? browseGroup(row) : PALETTE_CATEGORY_LABEL[paletteCategoryForKind(row.kind)];
+}

--- a/src/lib/familiar-surface-navigation.ts
+++ b/src/lib/familiar-surface-navigation.ts
@@ -1,0 +1,5 @@
+/** Dispatch the shared in-shell navigation event from familiar capability CTAs. */
+export function navigateFamiliarSurface(mode: "roles" | "capabilities" | "marketplace"): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
+}

--- a/src/lib/group-chat-ids.ts
+++ b/src/lib/group-chat-ids.ts
@@ -1,0 +1,9 @@
+export function newId(): string {
+  return typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `id-${Math.floor(Math.random() * 1e9)}`;
+}
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}

--- a/src/lib/message-code-fences.ts
+++ b/src/lib/message-code-fences.ts
@@ -1,0 +1,25 @@
+export type DiffLineKind = "add" | "del" | "ctx" | "meta" | "hunk";
+export type DiffLine = { kind: DiffLineKind; raw: string; marker: string | null; content: string };
+
+export function parseFenceInfo(info: string): { lang: string; filename?: string } {
+  if (!info) return { lang: "text" };
+  const colonIdx = info.indexOf(":");
+  return colonIdx > 0
+    ? { lang: info.slice(0, colonIdx).trim(), filename: info.slice(colonIdx + 1).trim() }
+    : { lang: info.trim() };
+}
+
+const DIFF_META_RE =
+  /^(\+\+\+ |--- |diff --git |index |new file|deleted file|rename |similarity |old mode|new mode|Binary files|\\ No newline)/;
+
+/** Preserve diff line structure while giving syntax highlighting only code content. */
+export function classifyDiffLines(code: string): DiffLine[] {
+  return code.split("\n").map((raw): DiffLine => {
+    if (/^@@/.test(raw)) return { kind: "hunk", raw, marker: null, content: "" };
+    if (DIFF_META_RE.test(raw)) return { kind: "meta", raw, marker: null, content: "" };
+    if (raw.startsWith("+")) return { kind: "add", raw, marker: "+", content: raw.slice(1) };
+    if (raw.startsWith("-")) return { kind: "del", raw, marker: "-", content: raw.slice(1) };
+    if (raw.startsWith(" ")) return { kind: "ctx", raw, marker: " ", content: raw.slice(1) };
+    return { kind: "ctx", raw, marker: null, content: raw };
+  });
+}

--- a/src/lib/openclaw-conversation-tools.test.ts
+++ b/src/lib/openclaw-conversation-tools.test.ts
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./openclaw-conversation.ts", import.meta.url), "utf8");
 const caveConversations = await readFile(new URL("./cave-conversations.ts", import.meta.url), "utf8");
-const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const chatTurnState = await readFile(new URL("./chat-turn-state.ts", import.meta.url), "utf8");
 
 assert.match(
   caveConversations,
@@ -31,13 +31,13 @@ assert.match(
 );
 
 assert.match(
-  chatView,
-  /tools: t\.tools/,
-  "ChatView should preserve saved tool metadata when loading history",
+  chatTurnState,
+  /tools: turn\.tools/,
+  "Chat turn state should preserve saved tool metadata when loading history",
 );
 
 assert.match(
-  chatView,
-  /reasoning: t\.reasoning/,
-  "ChatView should preserve saved reasoning metadata when loading history",
+  chatTurnState,
+  /reasoning: turn\.reasoning/,
+  "Chat turn state should preserve saved reasoning metadata when loading history",
 );

--- a/src/lib/session-changes-format.ts
+++ b/src/lib/session-changes-format.ts
@@ -1,0 +1,21 @@
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+
+/** Turn a checkpoint filename into the user's preferred local timestamp. */
+export function checkpointLabel(name: string): string {
+  const iso = name.replace(/\.patch$/, "").replace(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/,
+    "$1T$2:$3:$4.$5Z",
+  );
+  return Number.isNaN(new Date(iso).getTime()) ? name : formatTimestamp(iso, readDateTimePrefs());
+}
+
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function splitFilePath(path: string): { basename: string; dirname: string } {
+  const idx = path.lastIndexOf("/");
+  return idx < 0 ? { basename: path, dirname: "" } : { basename: path.slice(idx + 1) || path, dirname: path.slice(0, idx) };
+}

--- a/src/lib/workspace-url-state.ts
+++ b/src/lib/workspace-url-state.ts
@@ -1,0 +1,32 @@
+import { isWorkspaceMode, type WorkspaceMode } from "@/lib/workspace-mode";
+
+const CHAT_HASH_PREFIX = "#chat-";
+
+export function readChatHash(): string | null {
+  if (typeof window === "undefined" || !window.location.hash.startsWith(CHAT_HASH_PREFIX)) return null;
+  try {
+    return decodeURIComponent(window.location.hash.slice(CHAT_HASH_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+export function clearChatHash() {
+  if (typeof window === "undefined" || !window.location.hash.startsWith(CHAT_HASH_PREFIX)) return;
+  window.history.replaceState(null, "", window.location.pathname + window.location.search);
+}
+
+export function readModeParam(): WorkspaceMode | null {
+  if (typeof window === "undefined") return null;
+  const raw = new URLSearchParams(window.location.search).get("mode");
+  return raw && isWorkspaceMode(raw) ? raw : null;
+}
+
+export function clearModeParam() {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has("mode")) return;
+  params.delete("mode");
+  const query = params.toString();
+  window.history.replaceState(null, "", window.location.pathname + (query ? `?${query}` : "") + window.location.hash);
+}


### PR DESCRIPTION
## Summary

Completes the behavior-preserving Phase B refactor for #3498.

* #3508 ChatView: transcript and live-generation state  
* #3509 ChatList: sortable rows, section headers, and content-highlight primitives  
* #3510 MessageBubble: code-fence parsing and diff-line classification  
* #3511 GroupChatView: ID and timestamp factories  
* #3512 CommandPalette: browse/search grouping logic  
* #3513 Quick Chat: shared primitives and conversation renderer  
* #3514 HomeComposer: destination vocabulary  
* #3515 ChatFamiliarView: cross-surface capability navigation  
* #3516 Workspace: deep-link URL state  
* #3517 SessionChangesPanel: checkpoint and file formatting  
* #3518 BrowserPane: tab favicon renderer  

Each extraction keeps the original surface as the orchestration layer and moves a cohesive state, rendering, or integration boundary into a named module.

## Review follow-up

* The authed-image source contract follows FamiliarMark into `quick-chat-primitives.tsx`.
* Phase B source-contract tests follow extracted helpers rather than their former owner components.

## Validation

Local validation passed:

* `pnpm test:app` (796 test files)
* `pnpm test:api` (211 test files)
* `pnpm check:tests-wired`
* `pnpm typecheck`
* `pnpm lint`
* `pnpm build`
* `git diff --check`

GitHub verification at `d2ca20f246259a811ed5e13a83871eecb17af28b`:

* all CI, cross-environment, sidecar, E2E, Rust, and CodeQL checks are green
* mergeable and CLEAN
* transient CodeQL Rust failure was rerun successfully

## Status

Ready for review. No approval or merge has been performed.

## Scope

Behavior-preserving refactor only; no intended product changes.