### PR TITLE
feat(onboarding): finish project-root guidance + onboarding polish

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 
 import { deleteProject, patchProject } from "@/lib/cave-projects";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import {
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+} from "@/lib/project-root-guidance";
 import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
@@ -33,7 +37,14 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     if (!isAllowedNewProjectRoot(trimmed)) {
       // Containment first: out-of-workspace paths get a uniform 403 so the
       // existence checks below cannot be used to probe arbitrary filesystem paths.
-      return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
+      return NextResponse.json(
+        {
+          ok: false,
+          code: PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+          error: PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+        },
+        { status: 403 },
+      );
     }
     const validatedRoot = validateCaveProjectRoot(trimmed);
     if (!validatedRoot.ok) {

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -5,6 +5,13 @@ import { readFileSync } from "node:fs";
 const listRoute = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 const itemRoute = readFileSync(new URL("./[id]/route.ts", import.meta.url), "utf8");
 const seedRoute = readFileSync(new URL("./seed/route.ts", import.meta.url), "utf8");
+const guidanceModuleUrl = new URL("../../../lib/project-root-guidance.ts", import.meta.url);
+const guidanceSource = readFileSync(guidanceModuleUrl, "utf8");
+const {
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+  PROJECT_ROOT_WORKSPACE_HELP,
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+} = await import(guidanceModuleUrl.href);
 
 assert.match(listRoute, /seedDefaultProjectsIfEmpty/, "GET /api/projects should seed defaults before listing");
 assert.doesNotMatch(
@@ -19,13 +26,43 @@ assert.match(listRoute, /filterProjectsForFamiliar\(projects, familiarId\)/, "GE
 assert.match(listRoute, /export async function POST\(req: Request\)/, "projects route should expose POST");
 assert.match(listRoute, /name and root are required/, "POST /api/projects should validate required fields");
 assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects should validate roots before persisting them");
-assert.match(listRoute, /root must be inside an allowed workspace/, "POST /api/projects should reject unsafe roots");
+assert.equal(
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+  "PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE",
+  "project root guidance should expose a stable outside-workspace code",
+);
+assert.equal(
+  PROJECT_ROOT_WORKSPACE_HELP,
+  "Project folders must be inside a configured Cave workspace (usually ~/.coven/workspaces) or the workspace running Cave.",
+  "project root guidance should expose stable workspace help text",
+);
+assert.equal(
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+  "Choose a folder inside a configured Cave workspace (usually ~/.coven/workspaces) or the workspace running Cave.",
+  "project root guidance should expose stable outside-workspace error text",
+);
+assert.match(
+  guidanceSource,
+  /export const PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE/,
+  "project root guidance module should define the shared outside-workspace code",
+);
+assert.match(
+  listRoute,
+  /from "@\/lib\/project-root-guidance"/,
+  "POST /api/projects should import shared project-root guidance",
+);
+assert.match(
+  listRoute,
+  /code:\s*PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE[\s\S]*error:\s*PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR/,
+  "POST /api/projects should return the shared outside-workspace contract",
+);
+assert.match(listRoute, /status:\s*403/, "POST /api/projects should reject unsafe roots with 403");
 assert.match(listRoute, /validateCaveProjectRoot/, "POST /api/projects should require existing directory roots before persisting them");
 assert.match(listRoute, /status:\s*201/, "POST /api/projects should return 201 when creating");
 assert.match(
   listRoute,
   /export async function POST\(req: Request\)\s*\{\s*const denied = rejectNonLocalRequest\(req\);/,
-  "POST /api/projects must enforce desktop-local access before registering \$HOME-scoped roots",
+  "POST /api/projects must enforce loopback before registering \$HOME-scoped roots",
 );
 assert.doesNotMatch(
   listRoute,
@@ -36,10 +73,21 @@ assert.doesNotMatch(
 assert.match(itemRoute, /export async function PUT/, "project item route should expose PUT");
 assert.match(itemRoute, /export async function DELETE/, "project item route should expose DELETE");
 assert.match(itemRoute, /isAllowedNewProjectRoot\(trimmed\)/, "PUT /api/projects/[id] should validate root patches before persisting them");
+assert.match(
+  itemRoute,
+  /from "@\/lib\/project-root-guidance"/,
+  "PUT /api/projects/\\[id\\] should import shared project-root guidance",
+);
+assert.match(
+  itemRoute,
+  /code:\s*PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE[\s\S]*error:\s*PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR/,
+  "PUT /api/projects/[id] should return the shared outside-workspace contract",
+);
+assert.match(itemRoute, /status:\s*403/, "PUT /api/projects/[id] should reject unsafe roots with 403");
 assert.match(itemRoute, /validateCaveProjectRoot/, "PUT /api/projects/[id] should require existing directory roots before persisting them");
 assert.match(itemRoute, /nothing to update/, "PUT /api/projects/[id] should reject empty patches");
 assert.match(itemRoute, /not found/, "project item route should return not-found errors");
-assert.match(itemRoute, /rejectNonLocalRequest/, "project item route must enforce desktop-local access before mutating project roots");
+assert.match(itemRoute, /rejectNonLocalRequest/, "project item route must enforce loopback before mutating project roots");
 
 assert.match(seedRoute, /seedDefaultProjectsIfEmpty/, "seed route should invoke default seeding");
 assert.match(seedRoute, /export async function POST\(\)/, "seed route should expose POST only");

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 
 import { createProject, loadProjects, seedDefaultProjectsIfEmpty } from "@/lib/cave-projects";
+import {
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+} from "@/lib/project-root-guidance";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
@@ -40,7 +44,14 @@ export async function POST(req: Request) {
   if (!isAllowedNewProjectRoot(root)) {
     // Containment first: out-of-workspace paths get a uniform 403 so the
     // existence checks below cannot be used to probe arbitrary filesystem paths.
-    return NextResponse.json({ ok: false, error: "root must be inside an allowed workspace" }, { status: 403 });
+    return NextResponse.json(
+      {
+        ok: false,
+        code: PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+        error: PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+      },
+      { status: 403 },
+    );
   }
   const validatedRoot = validateCaveProjectRoot(root);
   if (!validatedRoot.ok) {

--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKe
 import { createPortal } from "react-dom";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Button } from "@/components/ui/button";
+import { PROJECT_ROOT_WORKSPACE_HELP } from "@/lib/project-root-guidance";
 
 type DirEntry = { name: string; path: string };
 type BrowseResponse = {
@@ -339,10 +340,11 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
           )}
         </div>
 
-        <div className="flex items-center justify-between gap-2 border-t border-[var(--border-hairline)] px-3 py-2">
-          <span className="min-w-0 flex-1 truncate text-[length:var(--text-xs)] text-[var(--text-muted)]">
-            Select the folder you're browsing, or open a subfolder first.
-          </span>
+        <div className="flex items-start justify-between gap-3 border-t border-[var(--border-hairline)] px-3 py-2">
+          <div className="min-w-0 flex-1 space-y-1 text-[11px] text-[var(--text-muted)]">
+            <p>{PROJECT_ROOT_WORKSPACE_HELP}</p>
+            <p>Select the folder you're browsing, or open a subfolder first.</p>
+          </div>
           <div className="flex shrink-0 items-center gap-2">
             <Button
               variant="secondary"

--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -341,7 +341,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
         </div>
 
         <div className="flex items-start justify-between gap-3 border-t border-[var(--border-hairline)] px-3 py-2">
-          <div className="min-w-0 flex-1 space-y-1 text-[11px] text-[var(--text-muted)]">
+          <div className="min-w-0 flex-1 space-y-1 text-[length:var(--text-xs)] text-[var(--text-muted)]">
             <p>{PROJECT_ROOT_WORKSPACE_HELP}</p>
             <p>Select the folder you're browsing, or open a subfolder first.</p>
           </div>

--- a/src/components/directory-picker.test.ts
+++ b/src/components/directory-picker.test.ts
@@ -34,6 +34,8 @@ test("the modal navigates via the fs-browse API with up/select controls", () => 
   assert.match(src, /aria-label="Up one folder"/, "has an up-a-level control");
   assert.match(src, />\s*New folder\s*</, "shows a visible New folder action");
   assert.match(src, /Select this folder/, "can select the current folder");
+  assert.match(src, /import \{ PROJECT_ROOT_WORKSPACE_HELP \} from "@\/lib\/project-root-guidance"/, "imports the shared workspace guidance copy");
+  assert.match(src, /\{PROJECT_ROOT_WORKSPACE_HELP\}/, "renders the shared workspace guidance in the modal footer");
   assert.match(src, /import \{ Button \}/, "modal actions use the shared Button primitive");
   assert.doesNotMatch(src, /<button\b/, "modal should not hand-roll button controls");
   // cave-psp8: a true modal must trap focus + restore it on close, not just listen

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -34,6 +34,10 @@ import {
   openCovenToolsPrimaryActionLabel,
 } from "@/lib/opencoven-tools-install";
 import { waitForDaemonUpdateIdle } from "@/lib/app-update-daemon";
+import {
+  advanceOnboardingAutoFinishGate,
+  isLatestOnboardingStatusRequest,
+} from "@/lib/onboarding-gate";
 
 // Guided onboarding: one numbered path from "nothing installed" to "ready to
 // summon". Every step carries its own instructions, a one-click action where
@@ -318,6 +322,7 @@ const PLATFORM_COPY: Record<
 type Props = {
   open: boolean;
   onDismiss: () => void;
+  autoFinishWhenComplete?: boolean;
 };
 
 function detectPlatform(): PlatformId {
@@ -355,7 +360,11 @@ function parseOnboardingExecutorUrls(text: string): string[] {
   );
 }
 
-export function OnboardingOverlay({ open, onDismiss }: Props) {
+export function OnboardingOverlay({
+  open,
+  onDismiss,
+  autoFinishWhenComplete = false,
+}: Props) {
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
   const [updateTools, setUpdateTools] = useState<OpenCovenToolStatus[]>([]);
   const [updateChecking, setUpdateChecking] = useState(false);
@@ -427,6 +436,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // harmless second net). Skip/Escape stay non-pushy: no circle for them.
   const statusRef = useRef<OnboardingStatus | null>(null);
   statusRef.current = status;
+  const statusGenerationRef = useRef(0);
+  const autoFinishFiredRef = useRef(false);
   const finishOnboarding = useCallback(() => {
     try {
       localStorage.setItem("cave:onboarding:dismissed", "1");
@@ -439,18 +450,22 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   }, [onDismiss]);
 
   const refresh = useCallback(async () => {
+    const requestId = ++statusGenerationRef.current;
     try {
       const res = await fetch("/api/onboarding/status", { cache: "no-store" });
       if (!res.ok) {
+        if (!isLatestOnboardingStatusRequest({ requestId, currentRequestId: statusGenerationRef.current })) return;
         setStatusFailures((n) => n + 1);
         return;
       }
       const json = (await res.json()) as OnboardingStatus & { ok: boolean };
+      if (!isLatestOnboardingStatusRequest({ requestId, currentRequestId: statusGenerationRef.current })) return;
       setStatus(json);
       setStatusFailures(0);
     } catch {
       // Track consecutive failures so the UI can move past "checking…" once
       // we're sure the poll isn't just slow. One blip stays silent.
+      if (!isLatestOnboardingStatusRequest({ requestId, currentRequestId: statusGenerationRef.current })) return;
       setStatusFailures((n) => n + 1);
     }
   }, []);
@@ -552,6 +567,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       pollRef.current = null;
+      statusGenerationRef.current += 1;
     };
   }, [open, refresh, loadUpdates, loadHarnesses, refreshNpmLane]);
 
@@ -1086,6 +1102,16 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // be "required + skippable" via a client-side AND that could diverge from
   // the workspace auto-open gate).
   const setupComplete = status?.complete ?? false;
+  useEffect(() => {
+    const autoFinishGate = advanceOnboardingAutoFinishGate({
+      open,
+      enabled: autoFinishWhenComplete,
+      complete: setupComplete,
+      fired: autoFinishFiredRef.current,
+    });
+    autoFinishFiredRef.current = autoFinishGate.fired;
+    if (autoFinishGate.shouldFinish) finishOnboarding();
+  }, [open, autoFinishWhenComplete, setupComplete, finishOnboarding]);
 
   const steps = useMemo<GuidedStep[]>(() => {
     const s = status?.steps;

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -437,6 +437,7 @@ export function OnboardingOverlay({
   const statusRef = useRef<OnboardingStatus | null>(null);
   statusRef.current = status;
   const statusGenerationRef = useRef(0);
+  const statusRefreshInFlightRef = useRef(false);
   const autoFinishFiredRef = useRef(false);
   const finishOnboarding = useCallback(() => {
     try {
@@ -450,6 +451,8 @@ export function OnboardingOverlay({
   }, [onDismiss]);
 
   const refresh = useCallback(async () => {
+    if (statusRefreshInFlightRef.current) return;
+    statusRefreshInFlightRef.current = true;
     const requestId = ++statusGenerationRef.current;
     try {
       const res = await fetch("/api/onboarding/status", { cache: "no-store" });
@@ -467,6 +470,8 @@ export function OnboardingOverlay({
       // we're sure the poll isn't just slow. One blip stays silent.
       if (!isLatestOnboardingStatusRequest({ requestId, currentRequestId: statusGenerationRef.current })) return;
       setStatusFailures((n) => n + 1);
+    } finally {
+      statusRefreshInFlightRef.current = false;
     }
   }, []);
 

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -88,6 +88,66 @@ assert.equal(
   2,
   "exactly two finish CTAs — the above-the-fold completion banner and the footer — both via finishOnboarding (the meet-familiars step stays retired)",
 );
+assert.match(
+  source,
+  /type Props = \{[\s\S]*autoFinishWhenComplete\?: boolean;[\s\S]*\}/,
+  "OnboardingOverlay accepts an optional autoFinishWhenComplete prop",
+);
+assert.match(
+  source,
+  /export function OnboardingOverlay\(\{[\s\S]*autoFinishWhenComplete = false,[\s\S]*\}: Props\)/,
+  "autoFinishWhenComplete defaults false at the component boundary",
+);
+assert.match(
+  source,
+  /import \{[\s\S]*advanceOnboardingAutoFinishGate[\s\S]*isLatestOnboardingStatusRequest[\s\S]*\} from "@\/lib\/onboarding-gate"/,
+  "OnboardingOverlay imports the shared onboarding gate helpers",
+);
+assert.match(
+  source,
+  /const statusGenerationRef = useRef\(0\)/,
+  "status polling tracks the latest onboarding-status generation",
+);
+assert.match(
+  source,
+  /const requestId = \+\+statusGenerationRef\.current;/,
+  "each refresh captures a fresh onboarding-status generation id",
+);
+assert.match(
+  source,
+  /if \(!isLatestOnboardingStatusRequest\(\{ requestId, currentRequestId: statusGenerationRef\.current \}\)\) return;\s*setStatus\(json\);\s*setStatusFailures\(0\);/s,
+  "only the latest successful status poll may update status or clear failure count",
+);
+assert.match(
+  source,
+  /if \(!isLatestOnboardingStatusRequest\(\{ requestId, currentRequestId: statusGenerationRef\.current \}\)\) return;\s*setStatusFailures\(\(n\) => n \+ 1\);/s,
+  "stale failed polls cannot increment the failure counter",
+);
+assert.match(
+  source,
+  /return \(\) => \{[\s\S]*statusGenerationRef\.current \+= 1;[\s\S]*\};/s,
+  "closing onboarding invalidates in-flight status generations before late responses resolve",
+);
+assert.match(
+  source,
+  /const autoFinishFiredRef = useRef\(false\)/,
+  "auto-finish tracks whether the current open cycle already fired",
+);
+assert.match(
+  source,
+  /const autoFinishGate = advanceOnboardingAutoFinishGate\(\{\s*open,\s*enabled: autoFinishWhenComplete,\s*complete: setupComplete,\s*fired: autoFinishFiredRef\.current,\s*\}\)/s,
+  "the auto-finish effect delegates one-shot branching to the pure onboarding gate helper",
+);
+assert.match(
+  source,
+  /autoFinishFiredRef\.current = autoFinishGate\.fired;/,
+  "the effect stores the helper-returned auto-finish gate state back into the ref",
+);
+assert.match(
+  source,
+  /if \(autoFinishGate\.shouldFinish\) finishOnboarding\(\);/,
+  "auto-finish still reuses finishOnboarding only when the pure gate says to finish",
+);
 
 // The shared setup-action error banner must be a live alert with a dismiss —
 // every setup action (scaffold, daemon start, connection save) reports

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -110,8 +110,13 @@ assert.match(
 );
 assert.match(
   source,
-  /const requestId = \+\+statusGenerationRef\.current;/,
-  "each refresh captures a fresh onboarding-status generation id",
+  /const statusRefreshInFlightRef = useRef\(false\)/,
+  "status polling tracks whether a request is already in flight",
+);
+assert.match(
+  source,
+  /if \(statusRefreshInFlightRef\.current\) return;[\s\S]*statusRefreshInFlightRef\.current = true;[\s\S]*const requestId = \+\+statusGenerationRef\.current;/,
+  "overlapping poll ticks are skipped before a new status generation is created",
 );
 assert.match(
   source,
@@ -122,6 +127,11 @@ assert.match(
   source,
   /if \(!isLatestOnboardingStatusRequest\(\{ requestId, currentRequestId: statusGenerationRef\.current \}\)\) return;\s*setStatusFailures\(\(n\) => n \+ 1\);/s,
   "stale failed polls cannot increment the failure counter",
+);
+assert.match(
+  source,
+  /finally \{\s*statusRefreshInFlightRef\.current = false;\s*\}/,
+  "status polling releases the in-flight guard after every request outcome",
 );
 assert.match(
   source,

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -44,10 +44,10 @@ assert.match(
 assert.match(projectsView, /const \[projectError, setProjectError\] = useState<string \| null>\(null\)/, "project-creation failures track their own alert state");
 assert.match(
   projectsView,
-  /setCreating\(true\);[\s\S]*try \{[\s\S]*const project = await createProject\(name, root, \{ emitMutation: !activeFamiliarId \}\);[\s\S]*\} catch \(error\) \{[\s\S]*setProjectError\(error instanceof Error \? error\.message : "Could not create that project\."\);[\s\S]*\} finally \{[\s\S]*setCreating\(false\);[\s\S]*\}/,
+  /setCreating\(true\);[\s\S]*try \{[\s\S]*const project = await createProject\(name, root, \{ emitMutation: !activeFamiliarId \}\);[\s\S]*\} catch \(error\) \{[\s\S]*const message = error instanceof Error \? error\.message : "Could not create that project\.";[\s\S]*setCreateError\(message\);[\s\S]*\} finally \{[\s\S]*setCreating\(false\);[\s\S]*\}/,
   "handleCreate uses try/finally so the busy state always clears, even if create or grant unexpectedly throws",
 );
-assert.match(projectsView, /if \(!granted\.ok\) setProjectError\(`Project created, but grant failed: \$\{granted\.error\}`\);/, "grant failures still surface as explicit project alerts");
+assert.match(projectsView, /if \(!granted\.ok\) \{[\s\S]{0,160}?const message = `Project created, but grant failed: \$\{granted\.error\}`;[\s\S]{0,120}?setProjectError\(message\);/, "grant failures still surface as explicit project alerts");
 assert.match(
   projectsView,
   /projectError \? \([\s\S]{0,500}?<span className="min-w-0 truncate">\{projectError\}<\/span>[\s\S]{0,260}?onClick=\{\(\) => setProjectError\(null\)\}/,
@@ -56,6 +56,12 @@ assert.match(
 assert.match(projectsView, /const rootInputRef = useRef<HTMLInputElement>\(null\)/, "new-project flow keeps a root input ref for quick focus");
 assert.match(projectsView, /function openCreateProjectForm/, "ProjectsView should centralize opening the quick-create form");
 assert.match(projectsView, /rootInputRef\.current\?\.focus\(\)/, "quick-create can focus the path field directly");
+assert.match(projectsView, /const \[createError, setCreateError\] = useState<string \| null>\(null\)/, "new-project flow tracks inline create errors");
+assert.match(projectsView, /function openCreateProjectForm\(\)[\s\S]{0,120}?setCreateError\(null\)/, "opening the quick-create form clears any prior create error");
+assert.match(projectsView, /const handleCreate = async \(event: FormEvent<HTMLFormElement>\) => \{[\s\S]{0,160}?setCreating\(true\);[\s\S]{0,120}?setCreateError\(null\);[\s\S]{0,120}?try \{/, "create starts a guarded submit flow with inline error reset");
+assert.match(projectsView, /if \(!granted\.ok\) \{[\s\S]{0,160}?setSessionError\(message\);[\s\S]{0,400}?setShowForm\(false\);[\s\S]{0,240}?selectProject\(project\.id\);/, "grant failures after creation stay on the success path: close the form, select the project, and report through the banner channel");
+assert.match(projectsView, /catch \(error\) \{[\s\S]{0,240}?const message = error instanceof Error \? error\.message : "Could not create that project\.";[\s\S]{0,80}?setCreateError\(message\);[\s\S]{0,80}?setProjectError\(message\);/, "create failures stay inline with the thrown error message (and mirror to the project alert)");
+assert.match(projectsView, /finally \{[\s\S]{0,120}?setCreating\(false\);[\s\S]{0,120}?\}/, "create always clears the busy state in finally");
 
 // ── Master-detail: persisted selection replaces per-card expansion ────────────
 assert.match(
@@ -233,6 +239,16 @@ assert.match(projectsView, /aria-label=\{`New session in /, "new-session action 
 assert.doesNotMatch(projectsView, /Open terminal|cave:terminal-open|mode: "terminal"/, "project actions stay focused on chat actions");
 assert.match(projectsView, /aria-label=\{`Rename \$\{project\.name\}`\}/, "rename action labeled per project");
 assert.match(projectsView, /aria-label=\{`Delete \$\{project\.name\}`\}/, "delete action labeled per project");
+
+assert.match(projectsView, /PROJECT_ROOT_WORKSPACE_HELP/, "ProjectsView imports the shared workspace guidance copy");
+assert.match(projectsView, /id="project-root-help"/, "the root field renders proactive workspace guidance");
+assert.match(projectsView, /aria-invalid=\{Boolean\(createError\)\}/, "the root field reports invalid state when create fails");
+assert.match(projectsView, /aria-describedby="project-root-help project-root-error"/, "the root field links helper and inline error text");
+assert.match(projectsView, /onChange=\{\(event\) => \{[\s\S]{0,80}?setRootDraft\(event\.target\.value\);[\s\S]{0,120}?setCreateError\(null\);[\s\S]{0,120}?\}\}/, "editing the root field clears the inline create error");
+assert.match(projectsView, /\{createError \? \(\s*<p id="project-root-error" role="alert"/, "create failures render as an inline alert under the root field");
+assert.match(projectsView, /setSessionError\(`Couldn.t delete chat: \$\{json\.error \?\? "delete failed"\}`\)/, "delete API failures add their own contextualized banner prefix");
+assert.match(projectsView, /setSessionError\(`Couldn.t delete chat: \$\{err instanceof Error \? err\.message : "delete failed"\}`\)/, "delete exceptions add their own contextualized banner prefix");
+assert.match(projectsView, /<span className="min-w-0 truncate">\{sessionError\}<\/span>/, "the banner renders already-contextualized action errors verbatim");
 
 // The "New project" inline form closes on Escape (parity with its Cancel button + inline edits).
 assert.match(

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -33,8 +33,8 @@ assert.match(projectsView, /export function ProjectsView/, "ProjectsView should 
 assert.match(projectsView, /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView should scope the live projects hook to the active familiar");
 assert.match(
   projectsView,
-  /createProject\(name, root, \{ emitMutation: !activeFamiliarId \}\)/,
-  "ProjectsView should defer its registry notification until the scoped familiar grant completes",
+  /createProjectOrThrow\(name, root, \{ emitMutation: !activeFamiliarId \}\)/,
+  "ProjectsView should preserve actionable API errors while deferring its registry notification until the scoped familiar grant completes",
 );
 assert.match(
   projectsView,
@@ -44,7 +44,7 @@ assert.match(
 assert.match(projectsView, /const \[projectError, setProjectError\] = useState<string \| null>\(null\)/, "project-creation failures track their own alert state");
 assert.match(
   projectsView,
-  /setCreating\(true\);[\s\S]*try \{[\s\S]*const project = await createProject\(name, root, \{ emitMutation: !activeFamiliarId \}\);[\s\S]*\} catch \(error\) \{[\s\S]*const message = error instanceof Error \? error\.message : "Could not create that project\.";[\s\S]*setCreateError\(message\);[\s\S]*\} finally \{[\s\S]*setCreating\(false\);[\s\S]*\}/,
+  /setCreating\(true\);[\s\S]*try \{[\s\S]*const project = await createProjectOrThrow\(name, root, \{ emitMutation: !activeFamiliarId \}\);[\s\S]*\} catch \(error\) \{[\s\S]*const message = error instanceof Error \? error\.message : "Could not create that project\.";[\s\S]*setCreateError\(message\);[\s\S]*\} finally \{[\s\S]*setCreating\(false\);[\s\S]*\}/,
   "handleCreate uses try/finally so the busy state always clears, even if create or grant unexpectedly throws",
 );
 assert.match(projectsView, /if \(!granted\.ok\) \{[\s\S]{0,160}?const message = `Project created, but grant failed: \$\{granted\.error\}`;[\s\S]{0,120}?setProjectError\(message\);/, "grant failures still surface as explicit project alerts");
@@ -243,7 +243,11 @@ assert.match(projectsView, /aria-label=\{`Delete \$\{project\.name\}`\}/, "delet
 assert.match(projectsView, /PROJECT_ROOT_WORKSPACE_HELP/, "ProjectsView imports the shared workspace guidance copy");
 assert.match(projectsView, /id="project-root-help"/, "the root field renders proactive workspace guidance");
 assert.match(projectsView, /aria-invalid=\{Boolean\(createError\)\}/, "the root field reports invalid state when create fails");
-assert.match(projectsView, /aria-describedby="project-root-help project-root-error"/, "the root field links helper and inline error text");
+assert.match(
+  projectsView,
+  /aria-describedby=\{createError \? "project-root-help project-root-error" : "project-root-help"\}/,
+  "the root field links the inline error only while that element is rendered",
+);
 assert.match(projectsView, /onChange=\{\(event\) => \{[\s\S]{0,80}?setRootDraft\(event\.target\.value\);[\s\S]{0,120}?setCreateError\(null\);[\s\S]{0,120}?\}\}/, "editing the root field clears the inline create error");
 assert.match(projectsView, /\{createError \? \(\s*<p id="project-root-error" role="alert"/, "create failures render as an inline alert under the root field");
 assert.match(projectsView, /setSessionError\(`Couldn.t delete chat: \$\{json\.error \?\? "delete failed"\}`\)/, "delete API failures add their own contextualized banner prefix");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -47,6 +47,7 @@ import { ProjectDetail } from "./projects/project-detail";
 import { lastActiveMs, shortRoot, openSessionById } from "./projects/projects-shared";
 import { DirectoryPickerModal } from "@/components/directory-picker-modal";
 import { isTauri } from "@/lib/tauri-platform";
+import { PROJECT_ROOT_WORKSPACE_HELP } from "@/lib/project-root-guidance";
 
 /** Last path segment of an absolute path (handles both / and \ separators). */
 function pathBasename(p: string): string {
@@ -112,6 +113,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   const [pickerOpen, setPickerOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [projectError, setProjectError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [moveToast, setMoveToast] = useState<{ sessionId: string; prevRoot: string | null; label: string } | null>(null);
   // Bulk delete is deferred + undoable: the rows hide immediately, the actual
@@ -370,6 +372,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
 
   function openCreateProjectForm() {
     setShowForm(true);
+    setCreateError(null);
     window.setTimeout(() => rootInputRef.current?.focus(), 0);
   }
 
@@ -380,6 +383,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     if (!name || !root) return;
     setCreating(true);
     setProjectError(null);
+    setCreateError(null);
     try {
       const project = await createProject(name, root, { emitMutation: !activeFamiliarId });
       if (project && activeFamiliarId) {
@@ -392,7 +396,11 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
           existingProjectId: project.id,
           projectJustCreated: true,
         });
-        if (!granted.ok) setProjectError(`Project created, but grant failed: ${granted.error}`);
+        if (!granted.ok) {
+          const message = `Project created, but grant failed: ${granted.error}`;
+          setSessionError(message);
+          setProjectError(message);
+        }
       }
       if (!project) return;
       setNameDraft("");
@@ -404,7 +412,9 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
       selectProject(project.id);
       announce(`Created project ${name}.`);
     } catch (error) {
-      setProjectError(error instanceof Error ? error.message : "Could not create that project.");
+      const message = error instanceof Error ? error.message : "Could not create that project.";
+      setCreateError(message);
+      setProjectError(message);
     } finally {
       setCreating(false);
     }
@@ -416,6 +426,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     const trimmed = dir.trim();
     if (!trimmed) return;
     setRootDraft(trimmed);
+    setCreateError(null);
     setNameDraft((current) => (current.trim() ? current : pathBasename(trimmed)));
     setProjectError(null);
     rootInputRef.current?.focus();
@@ -444,12 +455,12 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
       const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, { method: "DELETE" });
       const json = await res.json().catch(() => ({ ok: false }));
       if (!res.ok || !json.ok) {
-        setSessionError(json.error ?? "delete failed");
+        setSessionError(`Couldn't delete chat: ${json.error ?? "delete failed"}`);
         return false;
       }
       return true;
     } catch (err) {
-      setSessionError(err instanceof Error ? err.message : "delete failed");
+      setSessionError(`Couldn't delete chat: ${err instanceof Error ? err.message : "delete failed"}`);
       return false;
     }
   };
@@ -651,24 +662,40 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
               placeholder="Project name"
               className="focus-ring h-9 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 text-[length:var(--text-base)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
             />
-            <div className="flex items-center gap-2">
-              <input
-                ref={rootInputRef}
-                value={rootDraft}
-                onChange={(event) => setRootDraft(event.target.value)}
-                placeholder="/absolute/path/to/project"
-                className="focus-ring h-9 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 font-mono text-[length:var(--text-sm)] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)]"
-              />
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => void handleBrowse()}
-                title="Browse for a project folder"
-                className="h-9 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 text-[length:var(--text-sm)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
-                leadingIcon="ph:folder-open"
-              >
-                Browse
-              </Button>
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <input
+                  ref={rootInputRef}
+                  value={rootDraft}
+                  onChange={(event) => {
+                    setRootDraft(event.target.value);
+                    setCreateError(null);
+                    setProjectError(null);
+                  }}
+                  placeholder="/absolute/path/to/project"
+                  aria-invalid={Boolean(createError)}
+                  aria-describedby="project-root-help project-root-error"
+                  className="focus-ring h-9 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 font-mono text-[12px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)]"
+                />
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleBrowse()}
+                  title="Browse for a project folder"
+                  className="h-9 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
+                  leadingIcon="ph:folder-open"
+                >
+                  Browse
+                </Button>
+              </div>
+              <p id="project-root-help" className="text-[11px] text-[var(--text-muted)]">
+                {PROJECT_ROOT_WORKSPACE_HELP}
+              </p>
+              {createError ? (
+                <p id="project-root-error" role="alert" className="text-[11px] text-[var(--color-danger,#e5484d)]">
+                  {createError}
+                </p>
+              ) : null}
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -741,7 +768,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
               role="alert"
               className="flex items-center justify-between gap-3 rounded-[var(--radius-control)] border border-[var(--color-danger)]/40 bg-[var(--color-danger)]/10 px-3 py-2 text-[length:var(--text-sm)] text-[var(--color-danger)]"
             >
-              <span className="min-w-0 truncate">Couldn't delete chat: {sessionError}</span>
+              <span className="min-w-0 truncate">{sessionError}</span>
               <Button
                 variant="danger-ghost"
                 size="xs"

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -76,6 +76,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     loading,
     error,
     createProject,
+    createProjectOrThrow,
     renameProject,
     updateRoot,
     updateColor,
@@ -385,7 +386,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     setProjectError(null);
     setCreateError(null);
     try {
-      const project = await createProject(name, root, { emitMutation: !activeFamiliarId });
+      const project = await createProjectOrThrow(name, root, { emitMutation: !activeFamiliarId });
       if (project && activeFamiliarId) {
         // Register alone leaves the project 403ing in chat for this familiar —
         // grant it here so "New project" is usable the moment it's created.

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -676,24 +676,24 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
                   placeholder="/absolute/path/to/project"
                   aria-invalid={Boolean(createError)}
                   aria-describedby={createError ? "project-root-help project-root-error" : "project-root-help"}
-                  className="focus-ring h-9 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 font-mono text-[12px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)]"
+                  className="focus-ring h-9 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 font-mono text-[length:var(--text-sm)] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)]"
                 />
                 <Button
                   variant="secondary"
                   size="sm"
                   onClick={() => void handleBrowse()}
                   title="Browse for a project folder"
-                  className="h-9 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
+                  className="h-9 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 text-[length:var(--text-sm)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)]"
                   leadingIcon="ph:folder-open"
                 >
                   Browse
                 </Button>
               </div>
-              <p id="project-root-help" className="text-[11px] text-[var(--text-muted)]">
+              <p id="project-root-help" className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
                 {PROJECT_ROOT_WORKSPACE_HELP}
               </p>
               {createError ? (
-                <p id="project-root-error" role="alert" className="text-[11px] text-[var(--color-danger,#e5484d)]">
+                <p id="project-root-error" role="alert" className="text-[length:var(--text-xs)] text-[var(--color-danger)]">
                   {createError}
                 </p>
               ) : null}

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -674,7 +674,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
                   }}
                   placeholder="/absolute/path/to/project"
                   aria-invalid={Boolean(createError)}
-                  aria-describedby="project-root-help project-root-error"
+                  aria-describedby={createError ? "project-root-help project-root-error" : "project-root-help"}
                   className="focus-ring h-9 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 font-mono text-[12px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)]"
                 />
                 <Button

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -94,6 +94,46 @@ assert.match(
   /\{\(onboardingOpen \|\| onboardingMounted\) && \(\s*<OnboardingOverlay[\s\S]*open=\{onboardingOpen\}/,
   "onboarding loads on first open but remains mounted so job polling and one-shot refs survive close/reopen",
 );
+assert.match(
+  workspace,
+  /const \[autoFinishOnboarding, setAutoFinishOnboarding\] = useState\(false\);/,
+  "Workspace tracks whether startup-opened onboarding should auto-finish on completion",
+);
+assert.match(
+  workspace,
+  /const manualOnboardingOpenedRef = useRef\(false\);/,
+  "Workspace tracks whether onboarding was opened manually before the startup probe resolves",
+);
+assert.match(
+  workspace,
+  /const openOnboarding = useCallback\(\(\) => \{\s*manualOnboardingOpenedRef\.current = true;\s*setAutoFinishOnboarding\(false\);\s*setOnboardingOpen\(true\);/s,
+  "shared openOnboarding marks manual intent before it clears auto-finish and opens the overlay",
+);
+assert.match(
+  workspace,
+  /const openCreate = \(\) => \{\s*manualOnboardingOpenedRef\.current = true;\s*setAutoFinishOnboarding\(false\);\s*setOnboardingOpen\(true\);/s,
+  "the cave:onboarding-open bridge clears auto-finish before opening the overlay",
+);
+assert.match(
+  workspace,
+  /import \{[\s\S]*shouldApplyStartupOnboardingStatus[\s\S]*\} from "@\/lib\/onboarding-gate"/,
+  "Workspace imports the shared startup-status helper from onboarding-gate",
+);
+assert.match(
+  workspace,
+  /shouldApplyStartupOnboardingStatus\(\{\s*status: json,\s*cancelled,\s*manuallyOpened: manualOnboardingOpenedRef\.current,\s*\}\)/s,
+  "a delayed startup response delegates the manual/cancelled/status gate to the shared helper",
+);
+assert.match(
+  workspace,
+  /onDismiss=\{\(\) => \{\s*setAutoFinishOnboarding\(false\);[\s\S]*closeOnboarding\(\);/s,
+  "overlay dismissal clears auto-finish before closing onboarding",
+);
+assert.match(
+  workspace,
+  /<OnboardingOverlay[\s\S]*autoFinishWhenComplete=\{autoFinishOnboarding\}/,
+  "Workspace forwards the auto-finish flag into OnboardingOverlay",
+);
 
 // The right companion rail was removed in favour of drag-to-split, so the
 // workspace no longer computes rail visibility (showCompanionRail), a rail Chat

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -26,7 +26,7 @@ import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
 import { reconcileMobileModeRequest } from "@/lib/mobile-mode-reconcile";
 import {
-  shouldAutoOpenOnboarding,
+  shouldApplyStartupOnboardingStatus,
   type OnboardingStatusPayload,
 } from "@/lib/onboarding-gate";
 import { draftFromSlashArgs } from "@/lib/reminder-slash-draft";
@@ -531,12 +531,14 @@ export function Workspace() {
   const [pendingCodeRailOpen, setPendingCodeRailOpen] = useState<PendingCodeRailOpen | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [onboardingResolved, setOnboardingResolved] = useState(false);
+  const [autoFinishOnboarding, setAutoFinishOnboarding] = useState(false);
   // Lazy-load onboarding on first use, then keep its host mounted while closed.
   // Its refs and job polling intentionally survive close/reopen cycles so an
   // in-flight install is not forgotten and daemon auto-start stays one-shot.
   const [onboardingMounted, setOnboardingMounted] = useState(false);
   const [projectsInitiallyResolved, setProjectsInitiallyResolved] = useState(false);
   const [pendingFirstProjectGrant, setPendingFirstProjectGrant] = useState<PendingFirstProjectAccessSnapshot | null>(() => readPendingFirstProjectAccessSnapshot());
+  const manualOnboardingOpenedRef = useRef(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
   const [githubAssignedCount, setGithubAssignedCount] = useState(0);
@@ -804,7 +806,11 @@ export function Workspace() {
   // also offers a lighter in-app "New familiar" dialog (POST /api/familiars)
   // for adding to an existing roster without re-running setup.
   useEffect(() => {
-    const openCreate = () => setOnboardingOpen(true);
+    const openCreate = () => {
+      manualOnboardingOpenedRef.current = true;
+      setAutoFinishOnboarding(false);
+      setOnboardingOpen(true);
+    };
     window.addEventListener("cave:onboarding-open", openCreate);
     return () => window.removeEventListener("cave:onboarding-open", openCreate);
   }, []);
@@ -1399,7 +1405,11 @@ export function Workspace() {
     })();
   }, [inboxItems, sessionsLoaded, daemonOffline, familiars, activeId]);
 
-  const openOnboarding = useCallback(() => setOnboardingOpen(true), []);
+  const openOnboarding = useCallback(() => {
+    manualOnboardingOpenedRef.current = true;
+    setAutoFinishOnboarding(false);
+    setOnboardingOpen(true);
+  }, []);
   const closeOnboarding = useCallback(() => {
     setOnboardingOpen(false);
     void loadFamiliars();
@@ -1449,7 +1459,16 @@ export function Workspace() {
         const res = await fetch("/api/onboarding/status", { cache: "no-store" });
         if (!res.ok || cancelled) return;
         const json = (await res.json()) as OnboardingStatusPayload;
-        if (shouldAutoOpenOnboarding(json)) setOnboardingOpen(true);
+        if (
+          shouldApplyStartupOnboardingStatus({
+            status: json,
+            cancelled,
+            manuallyOpened: manualOnboardingOpenedRef.current,
+          })
+        ) {
+          setAutoFinishOnboarding(true);
+          setOnboardingOpen(true);
+        }
       } catch {
         /* ignore — the daemon-offline banner surfaces transport issues */
       } finally {
@@ -3130,8 +3149,10 @@ export function Workspace() {
 
       {(onboardingOpen || onboardingMounted) && (
         <OnboardingOverlay
+          autoFinishWhenComplete={autoFinishOnboarding}
           open={onboardingOpen}
           onDismiss={() => {
+            setAutoFinishOnboarding(false);
             setOnboardingMounted(true);
             closeOnboarding();
           }}

--- a/src/lib/chat-add-project.test.ts
+++ b/src/lib/chat-add-project.test.ts
@@ -96,6 +96,22 @@ assert.equal(projectNameForRoot(""), "");
   assert.equal(granted, false);
 }
 
+// createProject throws a workspace guidance error → surface it, and do not grant.
+{
+  let granted = false;
+  const message = "Choose a folder inside a configured Cave workspace.";
+  const createProject = async () => {
+    throw new Error(message);
+  };
+  const fetchImpl = async () => {
+    granted = true;
+    return { ok: true, json: async () => ({}) };
+  };
+  const result = await addChatProject({ root: "/x", familiarId: "sage", createProject, fetchImpl });
+  assert.deepEqual(result, { ok: false, error: message });
+  assert.equal(granted, false);
+}
+
 // Grant fails → surface the server error.
 {
   resetProjectRegistryListenersForTests();
@@ -164,6 +180,17 @@ assert.equal(projectNameForRoot(""), "");
   assert.equal(result.ok, false);
   assert.equal(notifications, 1, "failed scoped grants still fan out one generic registry refresh for the newly created project");
   unsubscribe();
+}
+
+// Create can succeed even when the grant fetch rejects later → surface the
+// grant failure as a normal result so callers can keep the created project.
+{
+  const createProject = async (name, root) => ({ id: "p4", name, root });
+  const fetchImpl = async () => {
+    throw new Error("network down");
+  };
+  const result = await addChatProject({ root: "/z", familiarId: "sage", createProject, fetchImpl });
+  assert.deepEqual(result, { ok: false, error: "network down" });
 }
 
 // Blank root → guarded before any I/O.

--- a/src/lib/chat-add-project.ts
+++ b/src/lib/chat-add-project.ts
@@ -53,11 +53,18 @@ export async function addChatProject(args: {
   let projectId = args.existingProjectId ?? null;
   let createdProject = false;
   if (!projectId) {
-    const name = (args.name ?? "").trim() || projectNameForRoot(root);
-    const project = await args.createProject(name, root, { emitMutation: false });
-    if (!project) return { ok: false, error: "could not register project" };
-    projectId = project.id;
-    createdProject = true;
+    try {
+      const name = (args.name ?? "").trim() || projectNameForRoot(root);
+      const project = await args.createProject(name, root, { emitMutation: false });
+      if (!project) return { ok: false, error: "could not register project" };
+      projectId = project.id;
+      createdProject = true;
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : "could not register project",
+      };
+    }
   }
 
   // Grant the active familiar access. A no-familiar context (operator/Supreme
@@ -70,21 +77,21 @@ export async function addChatProject(args: {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ targetFamiliarId: args.familiarId, projectId }),
       });
+      if (!res.ok) {
+        // Creation still succeeded, so publish that partial registry mutation
+        // even though the bundled grant did not complete.
+        if (createdProject || args.projectJustCreated) emitProjectRegistryMutation();
+        const data = (await res.json().catch(() => ({}))) as { error?: unknown };
+        return {
+          ok: false,
+          error: typeof data.error === "string" ? data.error : `grant failed (${res.status})`,
+        };
+      }
     } catch (error) {
       if (createdProject || args.projectJustCreated) emitProjectRegistryMutation();
       return {
         ok: false,
-        error: error instanceof Error ? error.message : "grant request failed",
-      };
-    }
-    if (!res.ok) {
-      // Creation still succeeded, so publish that partial registry mutation
-      // even though the bundled grant did not complete.
-      if (createdProject || args.projectJustCreated) emitProjectRegistryMutation();
-      const data = (await res.json().catch(() => ({}))) as { error?: unknown };
-      return {
-        ok: false,
-        error: typeof data.error === "string" ? data.error : `grant failed (${res.status})`,
+        error: error instanceof Error ? error.message : "grant failed",
       };
     }
   }

--- a/src/lib/onboarding-gate.test.ts
+++ b/src/lib/onboarding-gate.test.ts
@@ -1,4 +1,4 @@
-// cave-219 (updated): the workspace auto-open gate and the wizard's finish
+// cave-219 (updated): the workspace auto-open gate and the wizard
 // state must never diverge. Historically the wizard ANDed a client-side
 // "Coven Code satisfied" check into server `complete`, and the gate had to
 // mirror it or a user missing only Coven Code saw contradictory states.
@@ -6,7 +6,11 @@
 // server `complete`, so divergence is impossible by construction. These
 // pins keep that contract — tool state must NEVER re-enter this decision.
 import assert from "node:assert/strict";
+import test from "node:test";
 import {
+  advanceOnboardingAutoFinishGate,
+  isLatestOnboardingStatusRequest,
+  shouldApplyStartupOnboardingStatus,
   shouldAutoOpenOnboarding,
   type OnboardingStatusPayload,
 } from "./onboarding-gate.ts";
@@ -22,6 +26,14 @@ const allStepsOk = {
 
 function payload(overrides: Partial<OnboardingStatusPayload>): OnboardingStatusPayload {
   return { complete: true, steps: allStepsOk, ...overrides };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 // ── Fully set up: never auto-open ────────────────────────────────────────────
@@ -85,5 +97,132 @@ assert.equal(
   true,
   "missing steps map counts as structural-missing → auto-open",
 );
+
+test("delayed startup status yields to a later manual onboarding open", async () => {
+  const status = deferred<OnboardingStatusPayload>();
+  let manuallyOpened = false;
+  const decision = status.promise.then((resolved) =>
+    shouldApplyStartupOnboardingStatus({
+      status: resolved,
+      cancelled: false,
+      manuallyOpened,
+    }),
+  );
+
+  manuallyOpened = true;
+  status.resolve(payload({ complete: false, steps: { ...allStepsOk, adapters: { ok: false } } }));
+
+  assert.equal(
+    await decision,
+    false,
+    "a startup auto-open result must be ignored once onboarding was opened manually first",
+  );
+});
+
+test("startup status applies when setup is incomplete and the request is still live", async () => {
+  const status = deferred<OnboardingStatusPayload>();
+  const decision = status.promise.then((resolved) =>
+    shouldApplyStartupOnboardingStatus({
+      status: resolved,
+      cancelled: false,
+      manuallyOpened: false,
+    }),
+  );
+
+  status.resolve(payload({ complete: false, steps: { ...allStepsOk, adapters: { ok: false } } }));
+
+  assert.equal(await decision, true, "an incomplete live startup status should still auto-open onboarding");
+});
+
+test("cancelled startup status never applies", async () => {
+  const status = deferred<OnboardingStatusPayload>();
+  const decision = status.promise.then((resolved) =>
+    shouldApplyStartupOnboardingStatus({
+      status: resolved,
+      cancelled: true,
+      manuallyOpened: false,
+    }),
+  );
+
+  status.resolve(payload({ complete: false, steps: { ...allStepsOk, adapters: { ok: false } } }));
+
+  assert.equal(await decision, false, "cancelled startup requests must never auto-open onboarding");
+});
+
+test("latest onboarding status request wins when responses resolve out of order", async () => {
+  const firstStatus = deferred<OnboardingStatusPayload>();
+  const secondStatus = deferred<OnboardingStatusPayload>();
+  const accepted: OnboardingStatusPayload[] = [];
+  let currentRequestId = 0;
+
+  const acceptIfLatest = async (requestId: number, pending: Promise<OnboardingStatusPayload>) => {
+    const resolved = await pending;
+    if (!isLatestOnboardingStatusRequest({ requestId, currentRequestId })) return;
+    accepted.push(resolved);
+  };
+
+  const firstRequestId = ++currentRequestId;
+  const firstPending = acceptIfLatest(firstRequestId, firstStatus.promise);
+  const secondRequestId = ++currentRequestId;
+  const secondPending = acceptIfLatest(secondRequestId, secondStatus.promise);
+
+  const incomplete = payload({ complete: false, steps: { ...allStepsOk, adapters: { ok: false } } });
+  const complete = payload({ complete: true });
+
+  assert.equal(
+    isLatestOnboardingStatusRequest({ requestId: firstRequestId, currentRequestId }),
+    false,
+    "starting a newer poll immediately retires the older poll generation",
+  );
+  assert.equal(
+    isLatestOnboardingStatusRequest({ requestId: secondRequestId, currentRequestId }),
+    true,
+    "the newest poll generation stays eligible to write status",
+  );
+
+  secondStatus.resolve(incomplete);
+  await secondPending;
+  firstStatus.resolve(complete);
+  await firstPending;
+
+  assert.deepEqual(
+    accepted,
+    [incomplete],
+    "a later-completing stale response must not overwrite the accepted newer status",
+  );
+});
+
+test("onboarding auto-finish fires once per eligible open cycle", () => {
+  let fired = false;
+  const advance = (open: boolean, enabled: boolean, complete: boolean) => {
+    const result = advanceOnboardingAutoFinishGate({ open, enabled, complete, fired });
+    fired = result.fired;
+    return result;
+  };
+
+  assert.deepEqual(advance(true, true, true), { fired: true, shouldFinish: true });
+  assert.deepEqual(advance(true, true, true), { fired: true, shouldFinish: false });
+  assert.deepEqual(advance(true, true, false), { fired: true, shouldFinish: false });
+  assert.deepEqual(advance(false, true, true), { fired: false, shouldFinish: false });
+  assert.deepEqual(advance(true, true, true), { fired: true, shouldFinish: true });
+});
+
+test("onboarding auto-finish stays idle when disabled or incomplete", () => {
+  assert.deepEqual(
+    advanceOnboardingAutoFinishGate({ open: true, enabled: false, complete: true, fired: true }),
+    { fired: false, shouldFinish: false },
+    "manual/disabled onboarding disarms the one-shot gate instead of finishing",
+  );
+  assert.deepEqual(
+    advanceOnboardingAutoFinishGate({ open: true, enabled: true, complete: false, fired: false }),
+    { fired: false, shouldFinish: false },
+    "incomplete setup never finishes and leaves an unfired gate idle",
+  );
+  assert.deepEqual(
+    advanceOnboardingAutoFinishGate({ open: true, enabled: true, complete: false, fired: true }),
+    { fired: true, shouldFinish: false },
+    "incomplete setup preserves a fired gate so duplicate effects cannot re-finish mid-cycle",
+  );
+});
 
 console.log("onboarding-gate.test.ts: ok");

--- a/src/lib/onboarding-gate.ts
+++ b/src/lib/onboarding-gate.ts
@@ -13,6 +13,29 @@ export type OnboardingStatusPayload = {
   steps?: Record<string, { ok?: boolean }>;
 };
 
+export type StartupOnboardingStatusDecision = {
+  status: OnboardingStatusPayload;
+  cancelled: boolean;
+  manuallyOpened: boolean;
+};
+
+export type OnboardingStatusRequestDecision = {
+  requestId: number;
+  currentRequestId: number;
+};
+
+export type OnboardingAutoFinishGateInput = {
+  open: boolean;
+  enabled: boolean;
+  complete: boolean;
+  fired: boolean;
+};
+
+export type OnboardingAutoFinishGateDecision = {
+  fired: boolean;
+  shouldFinish: boolean;
+};
+
 /**
  * First-run: auto-open onboarding if setup is missing. Keyed on the STRUCTURAL
  * steps (CLI, Coven home, runtime adapters) — not on bare `complete` — because
@@ -32,4 +55,31 @@ export function shouldAutoOpenOnboarding(payload: OnboardingStatusPayload): bool
     !step("covenCli") || !step("covenHome") || !step("adapters");
   const daemonUpButUnfinished = step("daemon");
   return structuralMissing || daemonUpButUnfinished;
+}
+
+export function shouldApplyStartupOnboardingStatus({
+  status,
+  cancelled,
+  manuallyOpened,
+}: StartupOnboardingStatusDecision): boolean {
+  return !cancelled && !manuallyOpened && shouldAutoOpenOnboarding(status);
+}
+
+export function isLatestOnboardingStatusRequest({
+  requestId,
+  currentRequestId,
+}: OnboardingStatusRequestDecision): boolean {
+  return requestId === currentRequestId;
+}
+
+export function advanceOnboardingAutoFinishGate({
+  open,
+  enabled,
+  complete,
+  fired,
+}: OnboardingAutoFinishGateInput): OnboardingAutoFinishGateDecision {
+  if (!open || !enabled) return { fired: false, shouldFinish: false };
+  if (!complete) return { fired, shouldFinish: false };
+  if (fired) return { fired: true, shouldFinish: false };
+  return { fired: true, shouldFinish: true };
 }

--- a/src/lib/project-root-guidance.ts
+++ b/src/lib/project-root-guidance.ts
@@ -1,0 +1,8 @@
+export const PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE =
+  "PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE";
+
+export const PROJECT_ROOT_WORKSPACE_HELP =
+  "Project folders must be inside a configured Cave workspace (usually ~/.coven/workspaces) or the workspace running Cave.";
+
+export const PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR =
+  "Choose a folder inside a configured Cave workspace (usually ~/.coven/workspaces) or the workspace running Cave.";


### PR DESCRIPTION
Completes the in-progress onboarding / project-guidance work that was stranded across a WIP worktree merge (`rescue/main-merges-20260719-1943`).

## What & why

Rebuilt **cleanly on top of current main** (which already carries the Aardvark security fixes #3556/#3560/#3561), deliberately **excluding** the stranded branch's stale copies of `api-security.ts`, `project-permission-requests.ts`, and their tests — so **none of the merged mobile / local-origin hardening is reverted**. Verified: zero security/wiring files in this diff; `rejectNonLocalRequest` guards intact on both project routes.

## Changes

- **Shared project-root guidance** (`project-root-guidance.ts`): stable error `code` + human message for "root outside allowed workspace", consumed by both `POST /api/projects` and `PUT /api/projects/[id]`. The 403 now carries a structured `{ code, error }` — **same 403 containment, richer UI guidance** (not a security change).
- **Onboarding gate + overlay + workspace landing**: finish the first-run polish flow and its guards.
- **projects-view**: dedicated inline `createError` state (with `aria-invalid`), cleared on field edit / form open; grant-failure and create-failure paths report through both inline + banner channels.
- **chat-add-project + directory-picker**: paired refinements.

## Test hygiene

The stranded branch's tests had been left asserting an **older create/catch shape** and referencing an **undefined `runCreateProject` helper**. Fixed those to match actual behavior rather than fabricate source.

## Verification

- All touched tests pass (`projects-view`, `use-projects`, `onboarding-gate`, `onboarding-polish`, `chat-add-project`, `workspace-familiars-landing`, `directory-picker`, `projects/route`).
- `tsc --noEmit` clean.
- Signed commit (ED25519). +551 / −56 across 16 files, no security/wiring files touched.