### PR TITLE
style(theme): darken default Coven surfaces

### DIFF
--- a/src/app/globals-background.test.ts
+++ b/src/app/globals-background.test.ts
@@ -4,11 +4,17 @@ import { readFile } from "node:fs/promises";
 
 const globals = await readFile(new URL("./globals.css", import.meta.url), "utf8");
 
-assert.match(
-  globals,
-  /:root \{[\s\S]*?--background:\s*oklch\(0\.24 0\.006 291\);/,
-  "Default Coven Cave background should stay on the dark neutral-inked oklch foundation",
-);
+const covenRoot = globals.match(/:root\s*\{([\s\S]*?)\n\}/)?.[1] ?? "";
+
+assert.match(covenRoot, /--background:\s*oklch\(0\.225 0\.004 291\);/);
+assert.match(covenRoot, /--card:\s*oklch\(0\.245 0\.005 291\);/);
+assert.match(covenRoot, /--popover:\s*oklch\(0\.245 0\.005 291\);/);
+assert.match(covenRoot, /--secondary:\s*oklch\(0\.275 0\.006 291\);/);
+assert.match(covenRoot, /--muted:\s*oklch\(0\.275 0\.006 291\);/);
+assert.match(covenRoot, /--accent:\s*oklch\(0\.275 0\.006 291\);/);
+assert.match(covenRoot, /--bg-panel:\s*oklch\(0\.205 0\.004 291\);/);
+assert.match(covenRoot, /--bg-elevated:\s*oklch\(0\.275 0\.006 291\);/);
+assert.match(covenRoot, /--bg-hover:\s*oklch\(0\.305 0\.007 291\);/);
 
 assert.match(
   globals,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,11 +37,11 @@
      whisper) with the violet reserved for the brand accent — reads as
      ink-and-graphite, not a tinted gray, matching the reference "New
      automation" mock (cave: default-theme-repaint). */
-  --background: oklch(0.24 0.006 291);
+  --background: oklch(0.225 0.004 291);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.26 0.007 291);
+  --card: oklch(0.245 0.005 291);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.26 0.007 291);
+  --popover: oklch(0.245 0.005 291);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.92 0.004 291);
   /* Dark ink, not tied to --card — --primary-foreground also paints text on
@@ -49,11 +49,11 @@
      dark ink for 4.5:1, not whatever lightness the raised surface happens
      to be (theme-contrast-audit.test.ts). */
   --primary-foreground: oklch(0.16 0.008 291);
-  --secondary: oklch(0.29 0.008 291);
+  --secondary: oklch(0.275 0.006 291);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.29 0.008 291);
+  --muted: oklch(0.275 0.006 291);
   --muted-foreground: oklch(0.66 0.010 291);
-  --accent: oklch(0.29 0.008 291);
+  --accent: oklch(0.275 0.006 291);
   --accent-foreground: oklch(0.985 0 0);
   --border: color-mix(in oklch, var(--foreground) 12%, transparent);
   /* WCAG 1.4.11: --border-strong marks interactive boundaries (inputs,
@@ -81,7 +81,7 @@
   /* Fixed near-opaque dark "ink" for code surfaces — read code blocks AND the
      file editor share it so the Code page's read↔edit toggle keeps one bg. */
   --code-surface: oklch(0.12 0.012 280 / 92%);
-  --bg-panel: oklch(0.22 0.006 291);        /* deepest — app shell / sidebar floor */
+  --bg-panel: oklch(0.205 0.004 291);        /* deepest — app shell / sidebar floor */
   --code-foreground: oklch(0.92 0.01 280);
   --bg-raised: var(--card);
   /* Subtle inline fill (chips, keycaps, recent-search pills). Derived from
@@ -93,8 +93,8 @@
      base. Referenced while undefined (cave-309m); derived from --bg-base so
      every theme tracks. Light mode overrides below. */
   --bg-sunken: color-mix(in oklch, var(--bg-base) 88%, black);
-  --bg-elevated: oklch(0.29 0.008 291);     /* dropdowns / popovers */
-  --bg-hover: oklch(0.32 0.009 291);        /* hover state */
+  --bg-elevated: oklch(0.275 0.006 291);     /* dropdowns / popovers */
+  --bg-hover: oklch(0.305 0.007 291);        /* hover state */
   --border-hairline: var(--border);
   --fg-base: var(--text-primary);
   --fg-muted: var(--text-secondary);

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -36,7 +36,7 @@ assert.doesNotMatch(
 //    Anchored to the first :root { … } block (no attribute selector) so the
 //    assertion can't drift into another theme's background.
 const covenRootBlock = css.match(/:root\s*\{([\s\S]*?)\n\}/)?.[1] ?? "";
-assert.match(covenRootBlock, /--background\s*:\s*oklch\(0\.24 0\.006 291\)/, "coven dark background");
+assert.match(covenRootBlock, /--background\s*:\s*oklch\(0\.225 0\.004 291\)/, "coven dark background");
 assert.match(
   covenRootBlock,
   /--accent-presence-foreground\s*:\s*var\(--primary-foreground\)/,

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -90,6 +90,7 @@ assert.equal(THEME_META.contrast.accentDark, "#ffd60a");
 assert.equal(THEME_META.contrast.accentLight, "#0f62fe");
 assert.equal(THEME_META.beacon.name, "Beacon");
 assert.equal(THEME_META.solstice.name, "Solstice");
+assert.equal(THEME_META.coven.bgDark, "oklch(0.225 0.004 291)");
 
 // Storage keys are stable strings.
 assert.equal(COVEN_THEME_KEY, "coven-theme");

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -53,7 +53,7 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     name: "Coven",
     description: "Lavender-inked grimoire. The house default; mind the runes.",
     hue: 291, accentDark: "#9386d0", accentLight: "#6859ac",
-    bgDark: "oklch(0.24 0.006 291)", bgLight: "oklch(0.975 0.004 291)",
+    bgDark: "oklch(0.225 0.004 291)", bgLight: "oklch(0.975 0.004 291)",
   },
   tide: {
     name: "Tide",


### PR DESCRIPTION
## Summary
- move the default Coven dark surface ladder perceptually closer to #1C1C1C
- preserve the subtle violet-graphite chroma and existing elevation spacing
- synchronize the appearance swatch and pin the full ladder in tests

## Test plan
- [x] default globals/theme metadata tests
- [x] cross-theme contrast audit (855 pairs, 0 failures)

Bead: cave-8p4u