### PR TITLE
chore: ignore repository worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ ds-bundle/
 .design-sync/.cache/
 .design-sync/learnings/
 .design-sync/node_modules
+/.worktrees


### PR DESCRIPTION
## Summary
- ignore the repository-local `.worktrees` directory

## Test plan
- not run (gitignore-only change)