### PR TITLE
feat(reminders): redesign new reminder modal

### DIFF
--- a/docs/superpowers/plans/2026-07-19-new-reminder-design.md
+++ b/docs/superpowers/plans/2026-07-19-new-reminder-design.md
@@ -58,8 +58,7 @@ Expected: FAIL because `WHEN_EXAMPLES`, `detailsOpen`, and the new plan identifi
 
 ```bash
 git add src/components/new-reminder-modal.test.ts src/components/reminder-link-field.test.ts
-git commit -S -m "test(reminders): pin compact modal redesign" \
-  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git commit -S -m "test(reminders): pin compact modal redesign"
 git push
 ```
 

--- a/docs/superpowers/plans/2026-07-19-new-reminder-design.md
+++ b/docs/superpowers/plans/2026-07-19-new-reminder-design.md
@@ -1,0 +1,190 @@
+# New Reminder Modal Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-port the approved compact New Reminder modal redesign onto current `main` without carrying stale branch history or raw pixel typography.
+
+**Architecture:** Keep `NewReminderModal` as the existing orchestration component and preserve its create/edit data contracts. Add the approved phrase examples, Advanced details disclosure, and plan summary in place; update source-contract tests to pin accessibility, state transitions, responsive containment, and link placement.
+
+**Tech Stack:** React, TypeScript, Next.js, Node test runner, Tailwind-style design tokens, pnpm.
+
+---
+
+### Task 1: Port the reminder redesign contracts
+
+**Files:**
+- Modify: `src/components/new-reminder-modal.test.ts`
+- Modify: `src/components/reminder-link-field.test.ts`
+
+- [ ] **Step 1: Port the failing source contracts**
+
+Copy only the assertions introduced by commit `8a37eba93` that require:
+
+```ts
+const WHEN_EXAMPLES = [
+  "in 30m",
+  "tomorrow at 9am",
+  "every tuesday 4pm",
+  "jul 20",
+] as const;
+```
+
+The tests must also require:
+
+```ts
+const [detailsOpen, setDetailsOpen] = useState(false);
+aria-expanded={detailsOpen}
+aria-controls="new-reminder-details"
+id="new-reminder-details"
+data-reminder-plan="true"
+id="new-reminder-plan-summary"
+```
+
+Keep the existing balanced-block helpers from the stale commit so mapped buttons and the disclosure trigger are checked within bounded JSX regions.
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+node --experimental-strip-types --no-warnings --test \
+  src/components/new-reminder-modal.test.ts \
+  src/components/reminder-link-field.test.ts
+```
+
+Expected: FAIL because `WHEN_EXAMPLES`, `detailsOpen`, and the new plan identifiers do not exist on current `main`.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add src/components/new-reminder-modal.test.ts src/components/reminder-link-field.test.ts
+git commit -S -m "test(reminders): pin compact modal redesign" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+### Task 2: Implement the compact modal
+
+**Files:**
+- Modify: `src/components/new-reminder-modal.tsx`
+
+- [ ] **Step 1: Add phrase examples and selection state**
+
+Add the `WHEN_EXAMPLES` constant and a `selectWhenExample` handler that performs exactly:
+
+```ts
+const selectWhenExample = (example: WhenExample) => {
+  setWhenText(example);
+  setManualFireAt("");
+  setWhenDirty(true);
+  setError(null);
+};
+```
+
+Render each example with the existing `Button` component and `key={example}`.
+
+- [ ] **Step 2: Add the Advanced details disclosure**
+
+Add:
+
+```ts
+const [detailsOpen, setDetailsOpen] = useState(false);
+```
+
+Reset it to `false` for a new reminder. In edit mode, set it with:
+
+```ts
+setDetailsOpen(mapped.preset !== "none" || editing.link != null);
+```
+
+The trigger must expose `aria-expanded`, target `new-reminder-details`, and toggle the boolean. Place recurrence and link controls inside the conditional region.
+
+- [ ] **Step 3: Add the compact plan summary**
+
+Keep `describeRecurrence` and `nextOccurrences` as the data sources. Render a live region with:
+
+```tsx
+id="new-reminder-plan-summary"
+data-reminder-plan="true"
+aria-live="polite"
+```
+
+Show a concise once/repeat label, the parsed phrase or cadence, and up to three upcoming occurrences.
+
+- [ ] **Step 4: Port the approved layout using design tokens**
+
+Follow commit `8a37eba93` for layout and responsive containment, but replace every raw text class:
+
+```text
+text-[11px] -> text-[length:var(--text-xs)]
+text-[12px] or text-[13px] -> text-[length:var(--text-sm)]
+text-[14px] or text-[15px] -> text-[length:var(--text-base)]
+text-[19px] -> text-[length:var(--text-xl)]
+```
+
+Reuse existing border, radius, color, focus-ring, and button utilities. Do not modify persistence or recurrence helpers.
+
+- [ ] **Step 5: Run the focused tests and design codemod**
+
+```bash
+node --experimental-strip-types --no-warnings --test \
+  src/components/new-reminder-modal.test.ts \
+  src/components/reminder-link-field.test.ts
+node scripts/codemods/tokenize-tsx-design.mjs
+pnpm lint
+pnpm typecheck
+```
+
+Expected: both tests pass, codemod reports no remaining drift after rewrites, lint exits 0, and TypeScript exits 0.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add src/components/new-reminder-modal.tsx \
+  src/components/new-reminder-modal.test.ts \
+  src/components/reminder-link-field.test.ts
+git commit -S -m "feat(reminders): redesign new reminder modal" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+### Task 3: Review, merge, and remove stale branches
+
+**Files:**
+- Verify: `docs/superpowers/specs/2026-07-19-new-reminder-design.md`
+- Verify: `docs/superpowers/plans/2026-07-19-new-reminder-design.md`
+
+- [ ] **Step 1: Run final branch checks**
+
+```bash
+pnpm test:app
+pnpm lint
+pnpm typecheck
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Open and review the focused PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/new-reminder-design-v2 \
+  --title "feat(reminders): redesign new reminder modal" \
+  --body "Focused re-port of the approved compact New Reminder design with phrase examples, accessible Advanced details, plan preview, and token-compliant typography."
+```
+
+Run a read-only code review against `origin/main`, resolve all conversations, and wait for every required check.
+
+- [ ] **Step 3: Squash-merge and clean branches**
+
+```bash
+gh pr merge --squash --delete-branch
+git worktree remove .worktrees/feat-new-reminder-design-v2
+git branch -D feat/new-reminder-design-v2
+git push origin --delete feat/new-reminder-design
+git branch -D feat/new-reminder-design
+```
+
+Expected: the focused PR is merged, both reminder branches are deleted, and no reminder worktree remains.

--- a/docs/superpowers/plans/2026-07-19-new-reminder-design.md
+++ b/docs/superpowers/plans/2026-07-19-new-reminder-design.md
@@ -142,8 +142,7 @@ Expected: both tests pass, codemod reports no remaining drift after rewrites, li
 git add src/components/new-reminder-modal.tsx \
   src/components/new-reminder-modal.test.ts \
   src/components/reminder-link-field.test.ts
-git commit -S -m "feat(reminders): redesign new reminder modal" \
-  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git commit -S -m "feat(reminders): redesign new reminder modal"
 git push
 ```
 

--- a/docs/superpowers/specs/2026-07-19-new-reminder-design.md
+++ b/docs/superpowers/specs/2026-07-19-new-reminder-design.md
@@ -1,0 +1,50 @@
+# New Reminder Modal Redesign
+
+## Goal
+
+Re-port the useful New Reminder redesign from stale branch `feat/new-reminder-design` onto current `main` without carrying its merge history or unrelated changes.
+
+## Scope
+
+Change only:
+
+- `src/components/new-reminder-modal.tsx`
+- `src/components/new-reminder-modal.test.ts`
+- `src/components/reminder-link-field.test.ts`
+
+Delete the stale branch after the focused replacement PR merges.
+
+## Interaction Design
+
+- Keep the existing create and edit contracts unchanged.
+- Add four selectable natural-language time examples: `in 30m`, `tomorrow at 9am`, `every tuesday 4pm`, and `jul 20`.
+- Selecting an example updates the phrase, clears a conflicting manual date, and re-runs phrase parsing.
+- Keep recurrence and link controls behind an accessible Advanced details disclosure.
+- Open Advanced details automatically in edit mode when an existing reminder already has recurrence or link data.
+- Present the reminder plan as a concise live summary with upcoming occurrences.
+- Keep the dialog scroll-safe and preserve focus trapping, Escape handling, and coarse-pointer behavior.
+
+## Visual Design
+
+- Preserve the approved compact hierarchy from commit `8a37eba93`.
+- Use repository typography tokens such as `--text-xs`, `--text-sm`, and `--text-base`; introduce no raw pixel text classes.
+- Reuse existing colors, borders, radii, buttons, and focus-ring utilities.
+- Keep the primary action visually dominant without changing the modal's semantic structure.
+
+## Error Handling
+
+- Preserve existing validation for title, familiar, date parsing, recurrence, and submission failures.
+- Selecting a phrase example clears stale validation errors.
+- Do not add broad catches or silent fallback behavior.
+
+## Testing
+
+- Port the source-contract coverage for examples, disclosure state, plan summary, edit prefill, responsive layout, and scroll containment.
+- Keep reminder-link-field contracts aligned with the new Advanced details placement.
+- Run the focused tests, typecheck, design lint, and required PR CI.
+
+## Exclusions
+
+- No project, onboarding, chat, Hermes, API, or daemon changes.
+- No design-session notes or screenshots.
+- No changes to reminder persistence or recurrence semantics.

--- a/src/components/new-reminder-modal.test.ts
+++ b/src/components/new-reminder-modal.test.ts
@@ -4,6 +4,68 @@ import { readFileSync } from "node:fs";
 
 const modal = readFileSync(new URL("./new-reminder-modal.tsx", import.meta.url), "utf8");
 
+function requireIndex(source: string, needle: string, message: string): number {
+  const index = source.indexOf(needle);
+  assert.notEqual(index, -1, `${message} (missing ${JSON.stringify(needle)})`);
+  return index;
+}
+
+function extractBalancedParenBlock(source: string, startMarker: string, message: string): string {
+  const start = requireIndex(source, startMarker, message);
+  let index = start + startMarker.length - 1;
+  let depth = 0;
+
+  for (; index < source.length; index += 1) {
+    const ch = source[index];
+    if (ch === "(") {
+      depth += 1;
+    } else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        const end = source[index + 1] === "}" ? index + 2 : index + 1;
+        return source.slice(start, end);
+      }
+    }
+  }
+
+  assert.fail(`${message} (unterminated block starting at ${JSON.stringify(startMarker)})`);
+}
+
+function extractJsxOpeningTag(source: string, startIndex: number, message: string): string {
+  let index = startIndex;
+  let braceDepth = 0;
+  let quote: "'" | '"' | "`" | null = null;
+
+  for (; index < source.length; index += 1) {
+    const ch = source[index];
+    const prev = source[index - 1];
+
+    if (quote) {
+      if (ch === quote && prev !== "\\") quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === "`") {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === "{") {
+      braceDepth += 1;
+      continue;
+    }
+    if (ch === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+    if (ch === ">" && braceDepth === 0) {
+      return source.slice(startIndex, index + 1);
+    }
+  }
+
+  assert.fail(`${message} (unterminated JSX opening tag at index ${startIndex})`);
+}
+
 // ── Edit mode ────────────────────────────────────────────────────────────────
 assert.match(modal, /editing\?: ReminderEdit;/, "modal should accept an optional editing prop");
 assert.match(modal, /onUpdate\?: \(id: string, draft: NewReminderDraft\) => Promise<void> \| void;/, "modal should accept an onUpdate handler");
@@ -35,12 +97,116 @@ assert.match(modal, /if \(preset === "custom"\) return customRec \?\? \{ type: "
 assert.match(modal, /whenText: whenText\.trim\(\) \|\| null,/, "the human phrase is persisted with the draft");
 assert.match(modal, /const \[whenDirty, setWhenDirty\] = useState\(false\);/, "edit mode tracks phrase dirtiness");
 assert.match(modal, /if \(isEditing && !whenDirty\) return;/, "retyping the phrase in edit mode retakes the picker");
+const whenExamplesBody = (() => {
+  const startMarker = "const WHEN_EXAMPLES = [";
+  const endMarker = "] as const;";
+  const start = requireIndex(modal, startMarker, "phrase examples constant should exist");
+  const end = modal.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(end, -1, "phrase examples constant should terminate with as const");
+  assert.ok(end > start, "phrase examples constant should have a body");
+  return modal.slice(start + startMarker.length, end);
+})();
+const whenExampleStringLiterals = [...whenExamplesBody.matchAll(/(['"])((?:\\.|(?!\1)[\s\S])*?)\1/g)].map((match) => match[2]);
+assert.match(
+  whenExamplesBody.replace(/(['"])((?:\\.|(?!\1)[\s\S])*?)\1/g, ""),
+  /^[\s,]*$/,
+  "phrase examples should contain only string literals plus commas/whitespace",
+);
+assert.deepEqual(
+  whenExampleStringLiterals,
+  ["in 30m", "tomorrow at 9am", "every tuesday 4pm", "jul 20"],
+  "phrase examples should be pinned as a four-value constant",
+);
+const whenExamplesMapBlock = extractBalancedParenBlock(
+  modal,
+  "{WHEN_EXAMPLES.map((example) => (",
+  "phrase examples should render as a bounded map block",
+);
+assert.ok(whenExamplesMapBlock.includes("<Button"), "mapped phrase examples should render Button controls");
+const whenExamplesButtonTag = extractJsxOpeningTag(
+  whenExamplesMapBlock,
+  requireIndex(whenExamplesMapBlock, "<Button", "mapped phrase examples should render a Button opening tag"),
+  "mapped phrase examples should stay within one Button opening tag",
+);
+assert.ok(
+  whenExamplesButtonTag.includes("key={example}"),
+  "mapped phrase examples should key each Button by the example",
+);
+assert.ok(
+  whenExamplesButtonTag.includes("onClick={() => selectWhenExample(example)}"),
+  "mapped phrase examples should call selectWhenExample(example) from the Button click handler",
+);
+const selectWhenExampleBody = (() => {
+  const startMarker = /const selectWhenExample = \(example(?:\s*:\s*[^)]+)?\) => \{/;
+  const endMarker = "\n  };";
+  const startMatch = modal.match(startMarker);
+  assert.ok(startMatch, "phrase-example selection handler should exist");
+  const start = requireIndex(modal, startMatch![0], "phrase-example selection handler should exist");
+  const end = modal.indexOf(endMarker, start + startMatch[0].length);
+  assert.notEqual(end, -1, "phrase-example selection handler should terminate with a closing };");
+  assert.ok(end > start, "phrase-example selection handler should have a bounded body");
+  return modal.slice(start, end + endMarker.length);
+})();
+assert.match(
+  selectWhenExampleBody,
+  /setWhenText\(example\);[\s\S]*?setManualFireAt\(""\);[\s\S]*?setWhenDirty\(true\);/,
+  "phrase-example selection should set the phrase, clear manual fire time, then mark it dirty",
+);
+assert.match(
+  modal,
+  /const \[detailsOpen, setDetailsOpen\] = useState\(false\);/,
+  "modal should keep advanced controls behind a disclosure toggle",
+);
+const disclosureAttrIndex = requireIndex(modal, "aria-expanded={detailsOpen}", "advanced disclosure should expose aria-expanded state");
+const disclosureButtonIndex = modal.lastIndexOf("<Button", disclosureAttrIndex);
+assert.notEqual(
+  disclosureButtonIndex,
+  -1,
+  "advanced disclosure should begin with a Button opening tag before the aria-expanded attribute",
+);
+const disclosureButtonBlock = extractJsxOpeningTag(
+  modal,
+  disclosureButtonIndex,
+  "advanced disclosure should stay within one Button opening tag",
+);
+assert.ok(
+  disclosureButtonBlock.includes('aria-expanded={detailsOpen}'),
+  "advanced disclosure should expose aria-expanded state",
+);
+assert.ok(
+  disclosureButtonBlock.includes('aria-controls="new-reminder-details"'),
+  "advanced disclosure should point at the details region",
+);
+assert.ok(
+  disclosureButtonBlock.includes("onClick={() => setDetailsOpen((open) => !open)}"),
+  "disclosure trigger should toggle detailsOpen",
+);
+const detailsRegion = (() => {
+  const startMarker = "{detailsOpen ? (";
+  const endMarker = ") : null}";
+  const start = requireIndex(modal, startMarker, "controlled details region should begin with the detailsOpen conditional");
+  const end = modal.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(end, -1, "controlled details region should close with a null branch");
+  assert.ok(end > start, "controlled details region should have bounded content");
+  return modal.slice(start, end + endMarker.length);
+})();
+assert.ok(
+  detailsRegion.includes('id="new-reminder-details"'),
+  "controlled details region should carry the details id",
+);
+assert.match(
+  modal,
+  /setDetailsOpen\(mapped\.preset !== "none"\s*\|\|\s*editing\.link != null\);/,
+  "edit prefill should open details only when recurrence or link state requires it",
+);
 
 // The plan echo shows the cadence sentence and upcoming fires, announced to AT.
 assert.match(modal, /describeRecurrence\(planRecurrence, \{ hour12 \}\)/, "plan echo describes the cadence in words");
 assert.match(modal, /nextOccurrences\(planRecurrence, Date\.now\(\), 3\)/, "plan echo lists the next 3 concrete fires");
 assert.match(modal, /aria-live="polite"/, "plan echo is announced politely to AT");
 assert.match(modal, /\{planCadence \? "Repeats" : "Once"\}/, "plan echo distinguishes one-shots from repeats");
+assert.match(modal, /data-reminder-plan="true"/, "plan echo should identify the reminder plan container");
+assert.match(modal, /id="new-reminder-plan-summary"/, "plan echo should have a stable summary id");
 
 // ── Both paths carry link ────────────────────────────────────────────────────
 assert.match(modal, /link,/, "draft submitted to create/update should include the link");

--- a/src/components/new-reminder-modal.tsx
+++ b/src/components/new-reminder-modal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
 import { parseWhen } from "@/lib/parse-when";
 import { describeRecurrence, nextOccurrences } from "@/lib/schedule-plan";
 import { parseCron } from "@/lib/cron";
+import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { readDateTimePrefs } from "@/lib/datetime-format";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
@@ -45,6 +46,14 @@ const RECUR_PRESETS: { value: RecurPreset; label: string }[] = [
   { value: "every-weekend", label: "Every weekend (same time)" },
   { value: "cron", label: "Cron expression…" },
 ];
+
+const WHEN_EXAMPLES = [
+  "in 30m",
+  "tomorrow at 9am",
+  "every tuesday 4pm",
+  "jul 20",
+] as const;
+type WhenExample = (typeof WHEN_EXAMPLES)[number];
 
 function recurrenceFor(
   preset: RecurPreset,
@@ -150,6 +159,7 @@ export function NewReminderModal({
   // user retypes the phrase does the parse retake the picker (whenDirty).
   const [whenDirty, setWhenDirty] = useState(false);
   const [link, setLink] = useState<LinkRef | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const coarse = useIsCoarsePointer();
@@ -163,11 +173,12 @@ export function NewReminderModal({
       setWhenText(editing.whenText ?? "");
       setManualFireAt(editing.whenText ? "" : toLocalInput(editing.fireAt));
       setFamiliarId(defaultFamiliarId);
-      const { preset, cronExpr: cron, customRec: custom } = presetForRecurrence(editing.recurrence);
-      setRecurPreset(preset);
-      setCronExpr(cron ?? "*/15 * * * *");
-      setCustomRec(custom ?? null);
+      const mapped = presetForRecurrence(editing.recurrence);
+      setRecurPreset(mapped.preset);
+      setCronExpr(mapped.cronExpr ?? "*/15 * * * *");
+      setCustomRec(mapped.customRec ?? null);
       setLink(editing.link ?? null);
+      setDetailsOpen(mapped.preset !== "none" || editing.link != null);
       setWhenDirty(false);
       setError(null);
       return;
@@ -180,6 +191,7 @@ export function NewReminderModal({
     setCronExpr("*/15 * * * *");
     setCustomRec(null);
     setLink(null);
+    setDetailsOpen(false);
     setWhenDirty(false);
     setError(null);
   }, [open, defaultFamiliarId, defaultFireAt, defaultWhenText, defaultTitle, editing]);
@@ -232,6 +244,13 @@ export function NewReminderModal({
     if (parsed) return parsed.fireAt;
     return null;
   }, [manualFireAt, parsed, recurPreset, cronNextFire]);
+
+  const selectWhenExample = (example: WhenExample) => {
+    setWhenText(example);
+    setManualFireAt("");
+    setWhenDirty(true);
+    setError(null);
+  };
 
   if (!open) return null;
 
@@ -292,12 +311,31 @@ export function NewReminderModal({
     planRecurrence && planRecurrence.type !== "none"
       ? nextOccurrences(planRecurrence, Date.now(), 3)
       : [];
+  const planSummary = planCadence ?? previewLabel;
+  const planDetail = planCadence
+    ? planUpcoming.length > 0
+      ? `Next: ${planUpcoming
+          .map((isoDate) =>
+            new Date(isoDate).toLocaleString(undefined, {
+              weekday: "short",
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit",
+              hour12,
+            }),
+          )
+          .join(" · ")}`
+      : "Next occurrences are not available yet."
+    : previewLabel
+      ? "Fires once."
+      : null;
 
   return (
     <div
       onClick={onClose}
       role="presentation"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-3 backdrop-blur-sm"
     >
       <div
         ref={dialogRef}
@@ -306,233 +344,343 @@ export function NewReminderModal({
         aria-modal="true"
         aria-labelledby="new-reminder-title"
         tabIndex={-1}
-        className="w-[560px] max-w-[94vw] max-h-[90vh] overflow-y-auto rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-base)] p-6 shadow-2xl"
+        className="flex max-h-[calc(100dvh-1.5rem)] w-[560px] max-w-[94vw] flex-col overflow-hidden rounded-[var(--radius-panel)] border border-[var(--border-hairline)] bg-[var(--bg-raised)] shadow-[0_24px_70px_color-mix(in_oklch,var(--bg-base)_72%,transparent)] outline-none"
       >
-        <div className="mb-5 flex items-start justify-between">
-          <div>
-            <h2 id="new-reminder-title" className="text-lg font-semibold text-[var(--text-primary)]">
+        <header className="flex items-start justify-between gap-4 px-6 pb-3 pt-6">
+          <div className="min-w-0">
+            <h2
+              id="new-reminder-title"
+              className="text-[length:var(--text-xl)] font-medium leading-tight text-[var(--text-primary)]"
+            >
               {isEditing ? "Edit reminder" : "New reminder"}
             </h2>
-            <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
-              Type a natural phrase like “in 30m” or “every tuesday 4pm” — the plan below shows exactly what will fire.
+            <p className="mt-1 text-[length:var(--text-base)] leading-5 text-[var(--text-muted)]">
+              Say when in plain words — the plan below shows exactly what fires.
             </p>
           </div>
           <IconButton
             onClick={onClose}
             icon="ph:x-bold"
             aria-label="Close"
-            className="border border-[var(--border-hairline)]"
+            size="sm"
+            className="shrink-0 border border-[var(--border-hairline)] bg-[var(--bg-base)]/45"
           />
-        </div>
+        </header>
 
-        <Field label="Remind me to">
-          <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="check the deploy"
-            autoFocus={!coarse}
-            className="w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
-          />
-        </Field>
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
+          <div className="space-y-4">
+            <FloatingField id="new-reminder-what" label="Remind me to">
+              <input
+                id="new-reminder-what"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="check the deploy"
+                autoFocus={!coarse}
+                className="focus-ring h-11 w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-transparent px-3 text-[length:var(--text-md)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]"
+              />
+            </FloatingField>
 
-        <Field label="When">
-          <input
-            value={whenText}
-            onChange={(e) => {
-              setWhenText(e.target.value);
-              setWhenDirty(true);
-              if (e.target.value.trim()) setManualFireAt("");
-            }}
-            placeholder="in 30m · tomorrow at 9am · every tuesday 4pm · jul 20"
-            className={`w-full rounded-[var(--radius-control)] border bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] ${
-              whenText && !parsed
-                ? "border-[color-mix(in_oklch,var(--color-warning)_60%,transparent)]"
-                : "border-[var(--border-hairline)] focus:border-[var(--accent-presence)]"
-            }`}
-          />
-          <div
-            aria-live="polite"
-            className="mt-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]"
-          >
-            {whenText && !parsed ? (
-              <span>Couldn't parse — try “in 30m”, “tomorrow at 9am”, “every tuesday 4pm”, or use the picker below.</span>
-            ) : resolvedFireAt ? (
-              <div className="rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2.5 py-1.5">
-                <div className="flex items-baseline gap-1.5">
-                  <span className="font-semibold uppercase tracking-widest text-[var(--accent-presence)]">
-                    {planCadence ? "Repeats" : "Once"}
-                  </span>
-                  <span className="text-[length:var(--text-xs)] text-[var(--text-primary)]">
-                    {planCadence ?? previewLabel}
-                  </span>
+            <FloatingField id="new-reminder-when" label="When">
+              <input
+                id="new-reminder-when"
+                value={whenText}
+                onChange={(e) => {
+                  setWhenText(e.target.value);
+                  setWhenDirty(true);
+                  if (e.target.value.trim()) setManualFireAt("");
+                }}
+                placeholder="in 30m · tomorrow at 9am · every tuesday 4pm · jul 20"
+                className={`focus-ring h-11 w-full rounded-[var(--radius-control)] border bg-transparent px-3 text-[length:var(--text-md)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)] ${
+                  whenText && !parsed
+                    ? "border-[color-mix(in_oklch,var(--color-warning)_60%,transparent)]"
+                    : "border-[var(--border-hairline)]"
+                }`}
+              />
+            </FloatingField>
+
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="mr-0.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">Try</span>
+              {WHEN_EXAMPLES.map((example) => (
+                <Button
+                  key={example}
+                  variant="secondary"
+                  size="xs"
+                  onClick={() => selectWhenExample(example)}
+                  className="!h-6 !rounded-full !border-[var(--border-hairline)] !bg-transparent !px-2.5 !text-[length:var(--text-xs)] !font-normal !text-[var(--text-secondary)] hover:!bg-[var(--bg-hover)] hover:!text-[var(--text-primary)]"
+                >
+                  {example}
+                </Button>
+              ))}
+            </div>
+
+            <div aria-live="polite">
+              {whenText && !parsed ? (
+                <div className="rounded-[var(--radius-control)] border border-[color-mix(in_oklch,var(--color-warning)_42%,var(--border-hairline))] bg-[color-mix(in_oklch,var(--color-warning)_8%,var(--bg-raised))] px-3 py-2 text-[length:var(--text-sm)] leading-5 text-[var(--text-secondary)]">
+                  Couldn't parse that phrase. Try one of the examples, or open Adjust details
+                  to set an exact date and time.
                 </div>
-                {planUpcoming.length > 0 ? (
-                  <div className="mt-0.5">
-                    Next:{" "}
-                    {planUpcoming
-                      .map((isoDate) =>
-                        new Date(isoDate).toLocaleString(undefined, {
-                          weekday: "short",
-                          month: "short",
-                          day: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit",
-                          hour12,
-                        }),
-                      )
-                      .join(" · ")}
+              ) : resolvedFireAt ? (
+                <div
+                  data-reminder-plan="true"
+                  className="relative overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_52%,var(--bg-raised))] py-3 pl-5 pr-4"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="absolute bottom-2 left-0 top-2 w-0.5 rounded-full bg-[var(--accent-presence)]"
+                  />
+                  <div className="flex items-center gap-2">
+                    <span className="rounded-full bg-[var(--accent-presence)] px-2 py-0.5 text-[length:var(--text-2xs)] font-semibold uppercase tracking-[0.12em] text-[var(--accent-presence-foreground)]">
+                      {planCadence ? "Repeats" : "Once"}
+                    </span>
+                    <p
+                      id="new-reminder-plan-summary"
+                      className="min-w-0 text-[length:var(--text-base)] font-medium leading-5 text-[var(--text-primary)]"
+                    >
+                      {planSummary}
+                    </p>
                   </div>
+                  {planDetail ? (
+                    <p className="mt-1 text-[length:var(--text-xs)] leading-4 text-[var(--text-muted)]">
+                      {planDetail}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                  Enter a phrase to preview the reminder plan.
+                </p>
+              )}
+            </div>
+
+            <div
+              aria-hidden="true"
+              className="h-px bg-[linear-gradient(90deg,transparent,var(--border-hairline)_18%,var(--border-hairline)_82%,transparent)]"
+            />
+
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-expanded={detailsOpen}
+              aria-controls="new-reminder-details"
+              onClick={() => setDetailsOpen((open) => !open)}
+              className="!h-auto !p-0 !text-[length:var(--text-sm)] !font-medium !text-[var(--text-secondary)] hover:!bg-transparent hover:!text-[var(--text-primary)]"
+            >
+              <Icon
+                name="ph:caret-right"
+                width={12}
+                aria-hidden
+                className={`transition-transform ${detailsOpen ? "rotate-90" : ""}`}
+              />
+              {detailsOpen ? "Hide details" : "Adjust details"}
+            </Button>
+
+            {detailsOpen ? (
+              <div
+                id="new-reminder-details"
+                className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2"
+              >
+                <Field id="new-reminder-exact-date" label="Exact date / time">
+                  <input
+                    id="new-reminder-exact-date"
+                    type="datetime-local"
+                    value={manualFireAt}
+                    onChange={(e) => {
+                      setManualFireAt(e.target.value);
+                      if (e.target.value) setWhenText("");
+                    }}
+                    min={toLocalInput(new Date().toISOString())}
+                    className="focus-ring h-10 w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 px-3 text-sm text-[var(--text-primary)] focus:border-[var(--accent-presence)]"
+                  />
+                </Field>
+
+                <Field id="new-reminder-repeat" label="Repeat">
+                  <Select
+                    id="new-reminder-repeat"
+                    label="Repeat"
+                    value={recurPreset}
+                    onChange={(v) => setRecurPreset(v as RecurPreset)}
+                    options={
+                      // "Custom" only exists while a phrase/edit holds an exact
+                      // schedule no named preset represents — never hand-pickable.
+                      recurPreset === "custom"
+                        ? [
+                            {
+                              value: "custom",
+                              label: `Custom — ${describeRecurrence(customRec ?? { type: "none" }, { hour12 }) ?? "from phrase"}`,
+                            },
+                            ...RECUR_PRESETS,
+                          ]
+                        : RECUR_PRESETS
+                    }
+                  />
+                </Field>
+
+                <Field id="new-reminder-familiar" label="Familiar">
+                  <Select
+                    id="new-reminder-familiar"
+                    label="Familiar"
+                    value={familiarId ?? ""}
+                    onChange={(v) => setFamiliarId(v || null)}
+                    options={[
+                      { value: "", label: "No familiar" },
+                      ...familiars.map((f) => ({
+                        value: f.id,
+                        label: `${f.display_name} · ${f.harness ?? "?"}`,
+                      })),
+                    ]}
+                  />
+                </Field>
+
+                <fieldset className="min-w-0 sm:col-span-2">
+                  <legend className="mb-1.5 text-[length:var(--text-xs)] font-medium text-[var(--text-muted)]">
+                    Link (optional)
+                  </legend>
+                  <ReminderLinkField value={link} onChange={setLink} />
+                </fieldset>
+
+                {recurPreset === "cron" ? (
+                  <Field
+                    id="new-reminder-cron"
+                    label="Cron expression (min hour day month weekday)"
+                    className="sm:col-span-2"
+                  >
+                    <input
+                      id="new-reminder-cron"
+                      value={cronExpr}
+                      onChange={(e) => setCronExpr(e.target.value)}
+                      placeholder="*/15 * * * *"
+                      className={`focus-ring h-10 w-full rounded-[var(--radius-control)] border bg-[var(--bg-base)]/40 px-3 font-mono text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)] ${
+                        cronExpr && !cronFields
+                          ? "border-[color-mix(in_oklch,var(--color-warning)_60%,transparent)]"
+                          : "border-[var(--border-hairline)]"
+                      }`}
+                    />
+                    <div className="mt-1 text-[length:var(--text-2xs)] leading-4 text-[var(--text-muted)]">
+                      {cronExpr && !cronFields
+                        ? "Invalid cron expression."
+                        : cronNextFire
+                          ? `Next fire → ${new Date(cronNextFire).toLocaleString(undefined, {
+                              weekday: "short",
+                              month: "short",
+                              day: "numeric",
+                              hour: "numeric",
+                              minute: "2-digit",
+                              hour12: readDateTimePrefs().clock !== "24h",
+                            })}`
+                          : "Try “0 9 * * 1-5” for weekdays at 9am."}
+                    </div>
+                  </Field>
                 ) : null}
               </div>
-            ) : (
-              <span>Or pick exactly:</span>
-            )}
+            ) : null}
           </div>
-        </Field>
-
-        <Field label="Exact date / time">
-          <input
-            type="datetime-local"
-            value={manualFireAt}
-            onChange={(e) => {
-              setManualFireAt(e.target.value);
-              if (e.target.value) setWhenText("");
-            }}
-            min={toLocalInput(new Date().toISOString())}
-            className="w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] outline-none focus:border-[var(--accent-presence)]"
-          />
-        </Field>
-
-        <div className="mb-4 grid grid-cols-2 gap-4">
-          <Field label="Repeat">
-            <Select
-              value={recurPreset}
-              onChange={(v) => setRecurPreset(v as RecurPreset)}
-              options={
-                // "Custom" only exists while a phrase/edit holds an exact
-                // schedule no named preset represents — never hand-pickable.
-                recurPreset === "custom"
-                  ? [
-                      {
-                        value: "custom",
-                        label: `Custom — ${describeRecurrence(customRec ?? { type: "none" }, { hour12 }) ?? "from phrase"}`,
-                      },
-                      ...RECUR_PRESETS,
-                    ]
-                  : RECUR_PRESETS
-              }
-            />
-          </Field>
-          <Field label="Familiar">
-            <Select
-              value={familiarId ?? ""}
-              onChange={(v) => setFamiliarId(v || null)}
-              options={[
-                { value: "", label: "No familiar" },
-                ...familiars.map((f) => ({
-                  value: f.id,
-                  label: `${f.display_name} · ${f.harness ?? "?"}`,
-                })),
-              ]}
-            />
-          </Field>
         </div>
 
-        {recurPreset === "cron" ? (
-          <Field label="Cron expression (min hour day month weekday)">
-            <input
-              value={cronExpr}
-              onChange={(e) => setCronExpr(e.target.value)}
-              placeholder="*/15 * * * *"
-              className={`w-full rounded-[var(--radius-control)] border bg-[var(--bg-raised)]/40 px-3 py-2 font-mono text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] ${
-                cronExpr && !cronFields
-                  ? "border-[color-mix(in_oklch,var(--color-warning)_60%,transparent)]"
-                  : "border-[var(--border-hairline)] focus:border-[var(--accent-presence)]"
-              }`}
-            />
-            <div className="mt-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-              {cronExpr && !cronFields
-                ? "Invalid cron expression."
-                : cronNextFire
-                ? `Next fire → ${new Date(cronNextFire).toLocaleString(undefined, {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                    hour: "numeric",
-                    minute: "2-digit",
-                    // Match the fire-time preview above — honor the 12h/24h pref.
-                    hour12: readDateTimePrefs().clock !== "24h",
-                  })}`
-                : "Try “0 9 * * 1-5” for weekdays at 9am."}
-            </div>
-          </Field>
-        ) : null}
-
-        <Field label="Link (optional)">
-          <ReminderLinkField value={link} onChange={setLink} />
-        </Field>
-
         {error ? (
-          <div className="mb-3 rounded-[var(--radius-control)] border border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] px-3 py-1.5 text-xs text-[var(--color-warning)]">
+          <div className="mx-6 mb-2 rounded-[var(--radius-control)] border border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_12%,transparent)] px-3 py-2 text-xs text-[var(--color-warning)]">
             {error}
           </div>
         ) : null}
 
-        <div className="flex items-center justify-end gap-2">
-          <Button
-            variant="danger"
-            onClick={create}
-            disabled={!title.trim() || !resolvedFireAt || busy}
-          >
-            {isEditing
-              ? busy
-                ? "Saving…"
-                : "Save"
-              : busy
-              ? "Creating…"
-              : previewLabel
-              ? `Remind ${previewLabel}`
-              : "Create"}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={onClose}
-          >
-            Cancel
-          </Button>
-        </div>
+        <footer className="px-6 pb-5 pt-3">
+          <div
+            aria-hidden="true"
+            className="mb-3 h-px bg-[linear-gradient(90deg,transparent,var(--border-hairline)_18%,var(--border-hairline)_82%,transparent)]"
+          />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <Button variant="secondary" onClick={onClose} className="w-full sm:w-auto">
+              Cancel
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={create}
+              disabled={!title.trim() || !resolvedFireAt || busy}
+              className="w-full min-w-24 sm:w-auto !border-[color-mix(in_oklch,var(--accent-presence)_52%,var(--border-strong))] !bg-transparent !whitespace-normal !text-center hover:!bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))]"
+            >
+              {isEditing
+                ? busy
+                  ? "Saving…"
+                  : "Save"
+                : busy
+                  ? "Creating…"
+                  : previewLabel
+                    ? `Remind ${previewLabel}`
+                    : "Create"}
+            </Button>
+          </div>
+        </footer>
       </div>
     </div>
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function FloatingField({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: string;
+  children: ReactNode;
+}) {
   return (
-    <label className="mb-4 block">
-      <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+    <div className="relative pt-1">
+      <label
+        htmlFor={id}
+        className="absolute left-3 top-1 z-10 -translate-y-1/2 bg-[var(--bg-raised)] px-1 text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)]"
+      >
         {label}
-      </div>
+      </label>
       {children}
-    </label>
+    </div>
+  );
+}
+
+function Field({
+  id,
+  label,
+  children,
+  className = "",
+}: {
+  id: string;
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <label
+        htmlFor={id}
+        className="mb-1.5 block text-[length:var(--text-xs)] font-medium text-[var(--text-muted)]"
+      >
+        {label}
+      </label>
+      {children}
+    </div>
   );
 }
 
 function Select({
+  id,
+  label,
   value,
   onChange,
   options,
 }: {
+  id: string;
+  label: string;
   value: string;
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
 }) {
   return (
     <StandardSelect
-      label="Choose value"
+      id={id}
+      label={label}
       value={value}
       onChange={onChange}
       options={options}
-      className="w-full border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--accent-presence)]"
+      className="h-10 w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 px-3 py-2 text-sm text-[var(--text-primary)] focus:border-[var(--accent-presence)]"
     />
   );
 }

--- a/src/components/reminder-link-field.test.ts
+++ b/src/components/reminder-link-field.test.ts
@@ -42,8 +42,11 @@ assert.doesNotMatch(field, /rounded-md/, "link controls should not hard-code Tai
 
 // ── Wired into the modal ─────────────────────────────────────────────────────
 assert.match(modal, /import \{ ReminderLinkField \}/, "modal should import the link field");
-assert.match(modal, /<Field label="Link \(optional\)">/, "modal should render a Link field");
-assert.match(modal, /<ReminderLinkField value=\{link\} onChange=\{setLink\}/, "modal should wire the link field to local state");
+assert.match(
+  modal,
+  /<fieldset\b[\s\S]*?<legend\b[^>]*>\s*Link \(optional\)\s*<\/legend>[\s\S]*?<ReminderLinkField\b[^>]*value=\{link\}[^>]*onChange=\{setLink\}[^>]*\/>[\s\S]*?<\/fieldset>/,
+  "modal should wrap the link field in a labeled fieldset and wire it to local state",
+);
 assert.match(modal, /link\?: LinkRef \| null;/, "NewReminderDraft should carry an optional link");
 
 console.log("reminder-link-field.test.ts: ok");


### PR DESCRIPTION
## Summary

- add selectable natural-language scheduling examples
- move recurrence and link controls behind an accessible Advanced details disclosure
- present a compact live reminder plan with upcoming occurrences
- keep the modal scroll-safe and use repository design tokens

## Validation

- focused reminder modal and link-field tests
- pnpm lint
- pnpm typecheck
- pnpm test:app

## Scope

Focused re-port from stale branch `feat/new-reminder-design`; no persistence or recurrence semantic changes.