### PR TITLE
refactor: isolate Phase D server lifecycle contracts

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -384,6 +384,10 @@ for (const contract of contracts) {
     path.join(apiRoot, "chat", "send", "route.ts"),
     "utf8",
   );
+  const sseSource = readFileSync(
+    path.join(apiRoot, "chat", "send", "chat-send-sse.ts"),
+    "utf8",
+  );
   const stopReads = [
     ...sendSource.matchAll(/const cancelledByUser = runHandle\.stopRequested;/g),
   ];
@@ -457,11 +461,11 @@ for (const contract of contracts) {
   // — which every consumer skips (frames not starting with "data:") — and
   // clear the interval when the stream closes.
   assert.match(
-    sendSource,
-    /const SSE_HEARTBEAT = new TextEncoder\(\)\.encode\(": hb\\n\\n"\)/,
+    sseSource,
+    /const HEARTBEAT = new TextEncoder\(\)\.encode\(": hb\\n\\n"\)/,
     "/chat/send: heartbeat is an SSE comment frame, invisible to data: parsers",
   );
-  const heartbeatStarts = [...sendSource.matchAll(/const heartbeat = startSseHeartbeat\(controller,/g)];
+  const heartbeatStarts = [...sendSource.matchAll(/const heartbeat = startChatSseHeartbeat\(controller,/g)];
   assert.equal(
     heartbeatStarts.length,
     2,

--- a/src/app/api/chat/send/chat-send-attachments.ts
+++ b/src/app/api/chat/send/chat-send-attachments.ts
@@ -1,0 +1,95 @@
+import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  MAX_ATTACHMENT_IMAGE_BYTES,
+  type ChatAttachment,
+} from "@/lib/chat-attachments";
+
+const ATTACHMENT_TMP_DIR = path.join(tmpdir(), "coven-cave-attachments");
+const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
+  jpeg: "jpg",
+  "svg+xml": "svg",
+};
+const MAX_MENTIONED_FILES = 10;
+
+function imageExtension(mimeType?: string): string {
+  const subtype = mimeType?.split("/")[1]?.toLowerCase() ?? "";
+  const mapped = IMAGE_EXT_BY_SUBTYPE[subtype] ?? subtype;
+  return /^[a-z0-9]{1,8}$/.test(mapped) ? mapped : "img";
+}
+
+/** Write validated image payloads to owner-only files for local harnesses. */
+export async function writeImageAttachmentsToTemp(
+  attachments: ChatAttachment[],
+): Promise<Map<number, string>> {
+  const filePaths = new Map<number, string>();
+  for (const [index, attachment] of attachments.entries()) {
+    if (!attachment.dataUrl || !attachment.mimeType?.startsWith("image/")) continue;
+    const base64 = attachment.dataUrl.slice(attachment.dataUrl.indexOf(",") + 1);
+    const payload = Buffer.from(base64, "base64");
+    if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_IMAGE_BYTES) continue;
+    try {
+      await mkdir(ATTACHMENT_TMP_DIR, { recursive: true, mode: 0o700 });
+      const filePath = path.join(
+        ATTACHMENT_TMP_DIR,
+        `${crypto.randomUUID()}.${imageExtension(attachment.mimeType)}`,
+      );
+      await writeFile(filePath, payload, { mode: 0o600 });
+      filePaths.set(index, filePath);
+    } catch {
+      // Best effort: callers render a not-delivered attachment notice instead.
+    }
+  }
+  return filePaths;
+}
+
+export function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {
+  for (const filePath of filePaths.values()) {
+    void rm(filePath, { force: true }).catch(() => undefined);
+  }
+}
+
+/**
+ * Resolve at most ten repository-relative files without allowing absolute,
+ * traversal, or symlink-escape paths into a harness prompt.
+ */
+export async function resolveMentionedFiles(
+  relPaths: unknown,
+  root: unknown,
+): Promise<string[]> {
+  if (!Array.isArray(relPaths) || relPaths.length === 0) return [];
+  if (typeof root !== "string" || !path.isAbsolute(root)) return [];
+  let realRoot: string;
+  try {
+    realRoot = await realpath(path.resolve(root));
+    if (!(await stat(realRoot)).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  const resolved: string[] = [];
+  for (const rel of relPaths.slice(0, MAX_MENTIONED_FILES)) {
+    if (typeof rel !== "string" || !rel || rel.includes("\0") || path.isAbsolute(rel)) continue;
+    if (rel.split(/[\\/]+/).includes("..")) continue;
+    const candidate = path.resolve(realRoot, rel);
+    if (candidate === realRoot || !candidate.startsWith(realRoot + path.sep)) continue;
+    try {
+      const real = await realpath(candidate);
+      if (real !== candidate && !real.startsWith(realRoot + path.sep)) continue;
+      if (!(await stat(real)).isFile()) continue;
+      if (!resolved.includes(candidate)) resolved.push(candidate);
+    } catch {
+      // Missing or unreadable files are deliberately omitted.
+    }
+  }
+  return resolved;
+}
+
+export function appendMentionedFilesBlock(prompt: string, absPaths: string[]): string {
+  if (absPaths.length === 0) return prompt;
+  const block = [
+    "Referenced files (open with the Read tool):",
+    ...absPaths.map((item) => `- ${item}`),
+  ].join("\n");
+  return prompt ? `${prompt}\n\n${block}` : block;
+}

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -1,0 +1,64 @@
+import { spawn } from "node:child_process";
+import { covenLaunchCommand } from "@/lib/coven-bin";
+import {
+  covenRunSupportsAddDirFlag,
+  covenRunSupportsModelFlag,
+  covenRunSupportsPermissionFlag,
+} from "@/lib/harness-adapters";
+import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
+
+let modelFlagProbe: Promise<boolean> | null = null;
+let permissionFlagProbe: Promise<boolean> | null = null;
+let addDirFlagProbe: Promise<boolean> | null = null;
+
+function probeRunHelp(matches: (help: string) => boolean): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let output = "";
+    let settled = false;
+    const done = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    try {
+      const { command, fixedArgs } = covenLaunchCommand();
+      const child = spawn(command, [...fixedArgs, "run", "--help"], {
+        env: harnessSpawnEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout.on("data", (chunk) => (output += chunk.toString()));
+      child.stderr.on("data", (chunk) => (output += chunk.toString()));
+      const timeout = setTimeout(() => {
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          // The capability is unsupported when the probe cannot complete.
+        }
+        done(false);
+      }, 2500);
+      child.on("close", () => {
+        clearTimeout(timeout);
+        done(matches(output));
+      });
+      child.on("error", () => {
+        clearTimeout(timeout);
+        done(false);
+      });
+    } catch {
+      done(false);
+    }
+  });
+}
+
+/** Capability probes are cached because old Coven CLIs reject unknown flags. */
+export function covenRunSupportsModel(): Promise<boolean> {
+  return (modelFlagProbe ??= probeRunHelp(covenRunSupportsModelFlag));
+}
+
+export function covenRunSupportsPermission(): Promise<boolean> {
+  return (permissionFlagProbe ??= probeRunHelp(covenRunSupportsPermissionFlag));
+}
+
+export function covenRunSupportsAddDir(): Promise<boolean> {
+  return (addDirFlagProbe ??= probeRunHelp(covenRunSupportsAddDirFlag));
+}

--- a/src/app/api/chat/send/chat-send-models.ts
+++ b/src/app/api/chat/send/chat-send-models.ts
@@ -1,0 +1,97 @@
+import type { CaveConfig, FamiliarBinding } from "@/lib/cave-config";
+import type { ConversationFile } from "@/lib/cave-conversations";
+import {
+  cleanModelId,
+  resolveChatModelState,
+  type ChatModelState,
+} from "@/lib/chat-model-state";
+import { buildNextPathsDirective } from "@/lib/next-paths";
+
+type ModelRequest = {
+  familiarId: string;
+  modelOverride?: string;
+  modelOverrideScope?: "next-message" | "session";
+};
+
+type ResponseControlRequest = {
+  reasoningEffort?: string;
+  responseSpeed?: string;
+};
+
+type ReasoningEffort = "low" | "medium" | "high";
+type ResponseSpeed = "fast" | "balanced" | "careful";
+
+export function resolveSendModelMetadata(args: {
+  body: ModelRequest;
+  config: CaveConfig;
+  binding: FamiliarBinding;
+  existingConversation: ConversationFile | null;
+  modelForwardingEnabled: boolean;
+}): { desiredModel: string; modelState: ChatModelState } {
+  const requestedModel = cleanModelId(args.body.modelOverride);
+  const sessionModel =
+    args.body.modelOverrideScope === "session"
+      ? requestedModel
+      : args.existingConversation?.modelIntent?.model ?? null;
+  const modelState = resolveChatModelState({
+    familiarId: args.body.familiarId,
+    harness: args.binding.harness,
+    runtime: null,
+    globalDefaultModel: args.config.defaults.model,
+    familiarModel: args.config.familiars[args.body.familiarId]?.model ?? null,
+    sessionModel,
+    nextMessageModel: args.body.modelOverrideScope === "next-message" ? requestedModel : null,
+    application: { supported: args.modelForwardingEnabled },
+  });
+  const desiredModel = modelState.effectiveModel === "unknown" ? args.binding.model : modelState.effectiveModel;
+  return { desiredModel, modelState };
+}
+
+export function persistSendModelIntent(
+  conversation: ConversationFile,
+  body: ModelRequest,
+  modelState: ChatModelState,
+) {
+  if (body.modelOverrideScope !== "session" || modelState.source !== "session") return;
+  conversation.modelIntent = {
+    model: modelState.effectiveModel,
+    source: "session",
+    applicationState: modelState.applicationState,
+    reason: modelState.reason ?? "Saved for this chat.",
+  };
+}
+
+function normalizeReasoningEffort(value: unknown): ReasoningEffort {
+  return value === "low" || value === "medium" || value === "high" ? value : "high";
+}
+
+function normalizeResponseSpeed(value: unknown): ResponseSpeed {
+  return value === "fast" || value === "balanced" || value === "careful" ? value : "fast";
+}
+
+/** Add the stable, non-user-visible response-control and next-path directives. */
+export function buildPromptWithResponseControls(prompt: string, body: ResponseControlRequest): string {
+  const effort = normalizeReasoningEffort(body.reasoningEffort);
+  const speed = normalizeResponseSpeed(body.responseSpeed);
+  const effortInstruction: Record<ReasoningEffort, string> = {
+    low: "Use minimal internal planning and answer directly.",
+    medium: "Balance planning with a concise answer.",
+    high: "Spend extra internal planning on correctness before answering.",
+  };
+  const speedInstruction: Record<ResponseSpeed, string> = {
+    fast: "Prioritize a fast, terse, action-first response.",
+    balanced: "Balance speed, detail, and clarity.",
+    careful: "Prioritize careful completeness over speed.",
+  };
+  return [
+    "<response_controls>",
+    `thinking: ${effort} — ${effortInstruction[effort]}`,
+    `speed: ${speed} — ${speedInstruction[speed]}`,
+    "Do not mention these controls unless the user asks about them.",
+    "</response_controls>",
+    "",
+    buildNextPathsDirective(),
+    "",
+    prompt,
+  ].join("\n");
+}

--- a/src/app/api/chat/send/chat-send-runtime.ts
+++ b/src/app/api/chat/send/chat-send-runtime.ts
@@ -1,0 +1,66 @@
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import { loadConversation } from "@/lib/cave-conversations";
+import {
+  familiarWorkspacesRoot,
+  readFamiliarWorkspaces,
+} from "@/lib/coven-paths";
+
+/** Resolve the local cwd recorded when a conversation was first created. */
+export async function conversationCwd(sessionId?: string): Promise<string | undefined> {
+  if (!sessionId) return undefined;
+  try {
+    const conv = await loadConversation(sessionId);
+    const runtime = conv?.runtime;
+    if (runtime?.startsWith("local:")) {
+      const cwd = runtime.slice("local:".length).trim();
+      return cwd || undefined;
+    }
+  } catch {
+    /* fall back to the caller's default */
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a familiar workspace while keeping familiar IDs and symlink targets
+ * within the configured Coven workspace root.
+ */
+export async function resolveFamiliarWorkspace(
+  familiarId: string,
+): Promise<string | undefined> {
+  if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
+  const declared = await readFamiliarWorkspaces();
+  const declaredWorkspace = declared.get(familiarId);
+  if (declaredWorkspace) {
+    try {
+      const resolvedDeclared = await realpath(declaredWorkspace);
+      const s = await stat(resolvedDeclared);
+      if (s.isDirectory()) return resolvedDeclared;
+    } catch {
+      /* fall through to the derived workspace path */
+    }
+  }
+  const familiarsRoot = familiarWorkspacesRoot();
+  const candidate = path.resolve(familiarsRoot, familiarId);
+  const relative = path.relative(familiarsRoot, candidate);
+  if (
+    relative.startsWith("..") ||
+    path.isAbsolute(relative) ||
+    relative.split(path.sep).includes("..")
+  ) {
+    return undefined;
+  }
+  try {
+    const root = await realpath(familiarsRoot);
+    const resolvedCandidate = await realpath(candidate);
+    if (resolvedCandidate !== root && !resolvedCandidate.startsWith(root + path.sep)) {
+      return undefined;
+    }
+    const s = await stat(resolvedCandidate);
+    if (s.isDirectory()) return resolvedCandidate;
+  } catch {
+    /* not found */
+  }
+  return undefined;
+}

--- a/src/app/api/chat/send/chat-send-sse.ts
+++ b/src/app/api/chat/send/chat-send-sse.ts
@@ -1,0 +1,29 @@
+import type { StreamEvent } from "@/lib/stream-events";
+
+/** Encode a resumable chat event using the stable SSE wire contract. */
+export function chatSse(event: StreamEvent, seq?: number): Uint8Array {
+  const id = seq != null ? `id: ${seq}\n` : "";
+  return new TextEncoder().encode(`${id}data: ${JSON.stringify(event)}\n\n`);
+}
+
+const HEARTBEAT = new TextEncoder().encode(": hb\n\n");
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+/** Keep quiet long-running streams alive without exposing synthetic events. */
+export function startChatSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  isDone: () => boolean,
+): NodeJS.Timeout {
+  const heartbeat = setInterval(() => {
+    if (isDone()) {
+      clearInterval(heartbeat);
+      return;
+    }
+    try {
+      controller.enqueue(HEARTBEAT);
+    } catch {
+      clearInterval(heartbeat);
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+  return heartbeat;
+}

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -23,6 +23,10 @@ const attachmentDelivery = await readFile(
   new URL("./chat-send-attachments.ts", import.meta.url),
   "utf8",
 );
+const capabilityProbes = await readFile(
+  new URL("./chat-send-capabilities.ts", import.meta.url),
+  "utf8",
+);
 const streamEvents = await readFile(
   new URL("../../../../lib/stream-events.ts", import.meta.url),
   "utf8",
@@ -1165,7 +1169,7 @@ console.log("tool persistence tracker tests passed");
 
 // ── Model parity (gated --model passthrough) ───────────────────────────────
 assert.match(
-  chatRoute,
+  capabilityProbes,
   /covenRunSupportsModelFlag/,
   "Model forwarding must gate on the coven run --model capability probe",
 );
@@ -1208,7 +1212,7 @@ assert.ok(
 // prompt-text-only: the runtime-scope preamble describes the grants, but a
 // harness that only trusts its cwd denies every access to them.
 assert.match(
-  chatRoute,
+  capabilityProbes,
   /covenRunSupportsAddDirFlag/,
   "--add-dir forwarding must gate on the coven run capability probe",
 );

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -326,7 +326,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const push = \(e: StreamEvent\) => \{[\s\S]*?if \(closed \|\| req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(e, seq\)\);[\s\S]*?catch/,
+  /const push = \(e: StreamEvent\) => \{[\s\S]*?if \(closed \|\| req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(chatSse\(e, seq\)\);[\s\S]*?catch/,
   "Native stream pushes should be ignored after close/abort so late child output cannot enqueue into a closed stream",
 );
 assert.match(
@@ -336,7 +336,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(event, seq\)\);[\s\S]*?catch/,
+  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(chatSse\(event, seq\)\);[\s\S]*?catch/,
   "OpenClaw stream pushes should be ignored after close/abort so late child close/error output cannot enqueue into a cancelled stream",
 );
 assert.doesNotMatch(

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -19,6 +19,10 @@ const chatRoute = await readFile(
   new URL("./route.ts", import.meta.url),
   "utf8",
 );
+const attachmentDelivery = await readFile(
+  new URL("./chat-send-attachments.ts", import.meta.url),
+  "utf8",
+);
 const streamEvents = await readFile(
   new URL("../../../../lib/stream-events.ts", import.meta.url),
   "utf8",
@@ -611,13 +615,13 @@ assert.match(
 );
 
 assert.match(
-  chatRoute,
+  attachmentDelivery,
   /await writeFile\(filePath, payload, \{ mode: 0o600 \}\)/,
   "Saved image payloads should be private temp files (mode 0600)",
 );
 
 assert.match(
-  chatRoute,
+  attachmentDelivery,
   /crypto\.randomUUID\(\)\}\.\$\{imageExtension\(attachment\.mimeType\)/,
   "Temp image filenames should be random with an extension derived from the validated mime type, never user input",
 );

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -27,6 +27,10 @@ const capabilityProbes = await readFile(
   new URL("./chat-send-capabilities.ts", import.meta.url),
   "utf8",
 );
+const modelHelpers = await readFile(
+  new URL("./chat-send-models.ts", import.meta.url),
+  "utf8",
+);
 const streamEvents = await readFile(
   new URL("../../../../lib/stream-events.ts", import.meta.url),
   "utf8",
@@ -301,7 +305,7 @@ assert.match(
   "Response metadata should expose unsupported/saved state instead of claiming application",
 );
 assert.match(
-  chatRoute,
+  modelHelpers,
   /const sessionModel =[\s\S]*modelOverrideScope === "session"[\s\S]*\? requestedModel[\s\S]*: args\.existingConversation\?\.modelIntent\?\.model \?\? null/,
   "Session-scoped model overrides should feed the response model state, not only desiredModel",
 );
@@ -367,14 +371,14 @@ assert.match(
   "The send route should carry composer responseSpeed through offline queue payloads",
 );
 assert.match(
-  chatRoute,
+  modelHelpers,
   /function buildPromptWithResponseControls/,
-  "Send route should turn composer controls into harness-visible instructions",
+  "Chat send model helpers should turn composer controls into harness-visible instructions",
 );
 assert.match(
-  chatRoute,
+  modelHelpers,
   /const speed = normalizeResponseSpeed\(body\.responseSpeed\)/,
-  "Chat send route should continue accepting responseSpeed from all composer send bodies",
+  "Chat send model helpers should continue accepting responseSpeed from all composer send bodies",
 );
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -60,7 +60,6 @@ import {
   type ChatRunHandle,
 } from "@/lib/server/chat-stop-registry";
 import { openRunBuffer, type RunBufferHandle } from "@/lib/server/chat-stream-buffer";
-import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects } from "@/lib/cave-projects";
 import { chatProjectAccessId } from "@/lib/chat-project-access";
@@ -93,8 +92,6 @@ import { buildResumeRetryPrompt } from "@/lib/chat-history-fallback";
 import {
   cleanModelId,
   modelApplicationForHarness,
-  resolveChatModelState,
-  type ChatModelState,
 } from "@/lib/chat-model-state";
 import {
   RuntimeScopeError,
@@ -146,6 +143,11 @@ import {
   covenRunSupportsModel,
   covenRunSupportsPermission,
 } from "./chat-send-capabilities";
+import {
+  buildPromptWithResponseControls,
+  persistSendModelIntent,
+  resolveSendModelMetadata,
+} from "./chat-send-models";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -199,9 +201,6 @@ type SendBody = {
    *  conversation file once, when it's first created. */
   origin?: SessionOrigin;
 };
-
-type ReasoningEffort = "low" | "medium" | "high";
-type ResponseSpeed = "fast" | "balanced" | "careful";
 
 type OfflineChatQueuePayload = Pick<
   SendBody,
@@ -439,86 +438,6 @@ async function maybeQueueOfflineChat(args: {
       connection: "keep-alive",
     },
   });
-}
-
-function resolveSendModelMetadata(args: {
-  body: SendBody;
-  config: CaveConfig;
-  binding: FamiliarBinding;
-  existingConversation: ConversationFile | null;
-  /**
-   * Whether `coven run --model` will actually be forwarded for this turn. When
-   * true the application state reads `pending` (saved, awaiting confirmation)
-   * instead of `unsupported`; the stream's init event later promotes it to
-   * `applied`.
-   */
-  modelForwardingEnabled: boolean;
-}): { desiredModel: string; modelState: ChatModelState } {
-  const requestedModel = cleanModelId(args.body.modelOverride);
-  const sessionModel =
-    args.body.modelOverrideScope === "session"
-      ? requestedModel
-      : args.existingConversation?.modelIntent?.model ?? null;
-  const modelState = resolveChatModelState({
-    familiarId: args.body.familiarId,
-    harness: args.binding.harness,
-    runtime: null,
-    globalDefaultModel: args.config.defaults.model,
-    familiarModel: args.config.familiars[args.body.familiarId]?.model ?? null,
-    sessionModel,
-    nextMessageModel: args.body.modelOverrideScope === "next-message" ? requestedModel : null,
-    application: { supported: args.modelForwardingEnabled },
-  });
-  const desiredModel = modelState.effectiveModel === "unknown" ? args.binding.model : modelState.effectiveModel;
-  return { desiredModel, modelState };
-}
-
-function persistSendModelIntent(
-  conversation: ConversationFile,
-  body: SendBody,
-  modelState: ChatModelState,
-) {
-  if (body.modelOverrideScope !== "session" || modelState.source !== "session") return;
-  conversation.modelIntent = {
-    model: modelState.effectiveModel,
-    source: "session",
-    applicationState: modelState.applicationState,
-    reason: modelState.reason ?? "Saved for this chat.",
-  };
-}
-
-function normalizeReasoningEffort(value: unknown): ReasoningEffort {
-  return value === "low" || value === "medium" || value === "high" ? value : "high";
-}
-
-function normalizeResponseSpeed(value: unknown): ResponseSpeed {
-  return value === "fast" || value === "balanced" || value === "careful" ? value : "fast";
-}
-
-function buildPromptWithResponseControls(prompt: string, body: SendBody): string {
-  const effort = normalizeReasoningEffort(body.reasoningEffort);
-  const speed = normalizeResponseSpeed(body.responseSpeed);
-  const effortInstruction: Record<ReasoningEffort, string> = {
-    low: "Use minimal internal planning and answer directly.",
-    medium: "Balance planning with a concise answer.",
-    high: "Spend extra internal planning on correctness before answering.",
-  };
-  const speedInstruction: Record<ResponseSpeed, string> = {
-    fast: "Prioritize a fast, terse, action-first response.",
-    balanced: "Balance speed, detail, and clarity.",
-    careful: "Prioritize careful completeness over speed.",
-  };
-  return [
-    "<response_controls>",
-    `thinking: ${effort} — ${effortInstruction[effort]}`,
-    `speed: ${speed} — ${speedInstruction[speed]}`,
-    "Do not mention these controls unless the user asks about them.",
-    "</response_controls>",
-    "",
-    buildNextPathsDirective(),
-    "",
-    prompt,
-  ].join("\n");
 }
 
 function openClawChatResponse(args: {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
-import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import { resolveBackspaces, stripAnsi } from "@/lib/ansi";
 import {
@@ -20,7 +20,6 @@ import {
 } from "@/lib/cave-chat-titles";
 import {
   buildPromptWithAttachments,
-  MAX_ATTACHMENT_IMAGE_BYTES,
   normalizeChatAttachments,
   stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
@@ -137,6 +136,12 @@ import {
 import type { ChatResponseMetadata } from "@/lib/chat-response-metadata";
 import type { StreamEvent } from "@/lib/stream-events";
 import { deriveTravelClientStatus } from "@/lib/travel-client-state";
+import {
+  appendMentionedFilesBlock,
+  cleanupImageTempFiles,
+  resolveMentionedFiles,
+  writeImageAttachmentsToTemp,
+} from "./chat-send-attachments";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -294,110 +299,6 @@ async function resolveFamiliarWorkspace(
     /* not found */
   }
   return undefined;
-}
-
-// ── Image attachment delivery ────────────────────────────────────────────
-// Local coven-run harnesses are agentic CLIs with a Read tool that can open
-// image files, so image payloads are written to private temp files and the
-// prompt points the harness at them. Bridges/remotes that cannot read this
-// machine's filesystem get an explicit unsupported notice instead.
-
-const ATTACHMENT_TMP_DIR = path.join(tmpdir(), "coven-cave-attachments");
-const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
-  jpeg: "jpg",
-  "svg+xml": "svg",
-};
-
-function imageExtension(mimeType?: string): string {
-  const subtype = mimeType?.split("/")[1]?.toLowerCase() ?? "";
-  const mapped = IMAGE_EXT_BY_SUBTYPE[subtype] ?? subtype;
-  // Extension derives from the validated mime subtype only — never from a
-  // user-controlled filename — and falls back to a fixed token.
-  return /^[a-z0-9]{1,8}$/.test(mapped) ? mapped : "img";
-}
-
-async function writeImageAttachmentsToTemp(
-  attachments: ChatAttachment[],
-): Promise<Map<number, string>> {
-  const filePaths = new Map<number, string>();
-  for (const [index, attachment] of attachments.entries()) {
-    if (!attachment.dataUrl || !attachment.mimeType?.startsWith("image/")) continue;
-    const base64 = attachment.dataUrl.slice(attachment.dataUrl.indexOf(",") + 1);
-    const payload = Buffer.from(base64, "base64");
-    // Defense in depth: normalizeChatAttachments already enforces the cap,
-    // but never write more than the cap regardless.
-    if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_IMAGE_BYTES) continue;
-    try {
-      await mkdir(ATTACHMENT_TMP_DIR, { recursive: true, mode: 0o700 });
-      const filePath = path.join(
-        ATTACHMENT_TMP_DIR,
-        `${crypto.randomUUID()}.${imageExtension(attachment.mimeType)}`,
-      );
-      await writeFile(filePath, payload, { mode: 0o600 });
-      filePaths.set(index, filePath);
-    } catch {
-      /* best effort — the prompt falls back to the not-delivered notice */
-    }
-  }
-  return filePaths;
-}
-
-function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {
-  for (const filePath of filePaths.values()) {
-    void rm(filePath, { force: true }).catch(() => undefined);
-  }
-}
-
-// ── @-mentioned file delivery (CHAT-D1-04) ───────────────────────────────
-// The composer's `@` picker records repo-relative paths; the prompt gets a
-// compact "Referenced files" block of absolute paths the harness can open
-// with its Read tool. Validation mirrors /api/changes: repo-relative paths
-// only, resolved against the realpathed root with a prefix containment
-// check — absolute paths, NUL bytes, `..` segments, and symlinks that
-// escape the root are silently skipped, never errors.
-
-const MAX_MENTIONED_FILES = 10;
-
-async function resolveMentionedFiles(
-  relPaths: unknown,
-  root: unknown,
-): Promise<string[]> {
-  if (!Array.isArray(relPaths) || relPaths.length === 0) return [];
-  if (typeof root !== "string" || !path.isAbsolute(root)) return [];
-  let realRoot: string;
-  try {
-    realRoot = await realpath(path.resolve(root));
-    if (!(await stat(realRoot)).isDirectory()) return [];
-  } catch {
-    return [];
-  }
-  const resolved: string[] = [];
-  for (const rel of relPaths.slice(0, MAX_MENTIONED_FILES)) {
-    if (typeof rel !== "string" || !rel || rel.includes("\0") || path.isAbsolute(rel)) continue;
-    if (rel.split(/[\\/]+/).includes("..")) continue;
-    const candidate = path.resolve(realRoot, rel);
-    if (candidate === realRoot || !candidate.startsWith(realRoot + path.sep)) continue;
-    try {
-      // Containment must hold for the real file too, or a symlink inside the
-      // root could point the prompt at an arbitrary path outside it.
-      const real = await realpath(candidate);
-      if (real !== candidate && !real.startsWith(realRoot + path.sep)) continue;
-      if (!(await stat(real)).isFile()) continue;
-      if (!resolved.includes(candidate)) resolved.push(candidate);
-    } catch {
-      /* missing or unreadable — skip */
-    }
-  }
-  return resolved;
-}
-
-function appendMentionedFilesBlock(prompt: string, absPaths: string[]): string {
-  if (absPaths.length === 0) return prompt;
-  const block = [
-    "Referenced files (open with the Read tool):",
-    ...absPaths.map((p) => `- ${p}`),
-  ].join("\n");
-  return prompt ? `${prompt}\n\n${block}` : block;
 }
 
 async function setDefaultSessionTitleIfMissing(sessionId: string, title: string) {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,7 +1,5 @@
 import { spawn } from "node:child_process";
-import { realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import path from "node:path";
 import { resolveBackspaces, stripAnsi } from "@/lib/ansi";
 import {
   bindingFor,
@@ -64,10 +62,6 @@ import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects } from "@/lib/cave-projects";
 import { chatProjectAccessId } from "@/lib/chat-project-access";
 import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv, openClawSupportsUntrustedArgs } from "@/lib/openclaw-bin";
-import {
-  familiarWorkspacesRoot,
-  readFamiliarWorkspaces,
-} from "@/lib/coven-paths";
 import {
   OpenClawAgentResolutionError,
   extractOpenClawSessionId,
@@ -149,6 +143,7 @@ import {
   resolveSendModelMetadata,
 } from "./chat-send-models";
 import { chatSse, startChatSseHeartbeat } from "./chat-send-sse";
+import { conversationCwd, resolveFamiliarWorkspace } from "./chat-send-runtime";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -233,76 +228,6 @@ const TOOL_HOOK_RE =
 
 async function sleep(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Cwd recorded on the conversation's first turn (`runtime: "local:<cwd>"`).
- *
- * Continued turns don't carry `projectRoot` in the body, but harness session
- * stores are scoped per working directory — resuming `--continue <id>` from
- * homedir instead of the original project either fails resume or silently
- * continues an unrelated homedir session. Both presented as "a new session
- * spun up mid-chat" with the project context gone. Deriving the cwd from the
- * saved conversation keeps resume directory-stable for every turn.
- */
-async function conversationCwd(sessionId?: string): Promise<string | undefined> {
-  if (!sessionId) return undefined;
-  try {
-    const conv = await loadConversation(sessionId);
-    const runtime = conv?.runtime;
-    if (runtime?.startsWith("local:")) {
-      const cwd = runtime.slice("local:".length).trim();
-      return cwd || undefined;
-    }
-  } catch {
-    /* fall back to the caller's default */
-  }
-  return undefined;
-}
-
-/** Resolve the familiar's Coven workspace dir.
- *  Uses ~/.coven/familiars.toml workspace when present, otherwise
- *  ~/.coven/workspaces/familiars/<id>. Falls back to undefined if the dir
- *  doesn't exist so callers can skip --cwd.
- */
-async function resolveFamiliarWorkspace(
-  familiarId: string,
-): Promise<string | undefined> {
-  // Guard against path traversal: familiar IDs should be simple slugs.
-  if (!/^[a-z0-9_-]+$/i.test(familiarId)) return undefined;
-  const declared = await readFamiliarWorkspaces();
-  const declaredWorkspace = declared.get(familiarId);
-  if (declaredWorkspace) {
-    try {
-      const resolvedDeclared = await realpath(declaredWorkspace);
-      const s = await stat(resolvedDeclared);
-      if (s.isDirectory()) return resolvedDeclared;
-    } catch {
-      /* fall through to the derived workspace path */
-    }
-  }
-  const familiarsRoot = familiarWorkspacesRoot();
-  const candidate = path.resolve(familiarsRoot, familiarId);
-  const relative = path.relative(familiarsRoot, candidate);
-  if (
-    relative.startsWith("..") ||
-    path.isAbsolute(relative) ||
-    relative.split(path.sep).includes("..")
-  ) {
-    return undefined;
-  }
-  try {
-    const root = await realpath(familiarsRoot);
-    const resolvedCandidate = await realpath(candidate);
-    if (resolvedCandidate !== root && !resolvedCandidate.startsWith(root + path.sep)) {
-      return undefined;
-    }
-    const s = await stat(resolvedCandidate);
-    if (s.isDirectory()) return resolvedCandidate;
-  } catch {
-    /* not found */
-  }
-  return undefined;
 }
 
 async function setDefaultSessionTitleIfMissing(sessionId: string, title: string) {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -32,6 +32,7 @@ import {
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
 import { covenLaunchCommand } from "@/lib/coven-bin";
+import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { sweepStuckCreatedSessions } from "@/lib/server/stuck-created-sweep";
 import {
   detectBuiltinAdapterConflict,
@@ -86,6 +87,8 @@ import { buildResumeRetryPrompt } from "@/lib/chat-history-fallback";
 import {
   cleanModelId,
   modelApplicationForHarness,
+  resolveChatModelState,
+  type ChatModelState,
 } from "@/lib/chat-model-state";
 import {
   RuntimeScopeError,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -34,7 +34,6 @@ import {
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
 import { covenLaunchCommand } from "@/lib/coven-bin";
-import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { sweepStuckCreatedSessions } from "@/lib/server/stuck-created-sweep";
 import {
   detectBuiltinAdapterConflict,
@@ -79,7 +78,7 @@ import {
   resolveOpenClawAgentBinding,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
-import { isTrustedChatHarness, covenRunSupportsModelFlag, covenRunSupportsPermissionFlag, covenRunSupportsAddDirFlag, canonicalHarnessId } from "@/lib/harness-adapters";
+import { isTrustedChatHarness, canonicalHarnessId } from "@/lib/harness-adapters";
 import {
   type ConversationFile,
   type ChatTurn,
@@ -142,6 +141,11 @@ import {
   resolveMentionedFiles,
   writeImageAttachmentsToTemp,
 } from "./chat-send-attachments";
+import {
+  covenRunSupportsAddDir,
+  covenRunSupportsModel,
+  covenRunSupportsPermission,
+} from "./chat-send-capabilities";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -435,146 +439,6 @@ async function maybeQueueOfflineChat(args: {
       connection: "keep-alive",
     },
   });
-}
-
-// Model parity: probe once per process whether the installed `coven run`
-// advertises `--model`. `coven run` rejects unknown flags, so forwarding must be
-// a no-op until the companion CLI change ships. Cached; failures resolve false.
-let covenRunModelFlagProbe: Promise<boolean> | null = null;
-function covenRunSupportsModel(): Promise<boolean> {
-  if (!covenRunModelFlagProbe) {
-    covenRunModelFlagProbe = new Promise<boolean>((resolve) => {
-      let out = "";
-      let settled = false;
-      const done = (value: boolean) => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-      };
-      try {
-        const { command, fixedArgs } = covenLaunchCommand();
-        const child = spawn(command, [...fixedArgs, "run", "--help"], {
-          env: harnessSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        child.stdout.on("data", (d) => (out += d.toString()));
-        child.stderr.on("data", (d) => (out += d.toString()));
-        const t = setTimeout(() => {
-          try {
-            child.kill("SIGTERM");
-          } catch {
-            /* ignore */
-          }
-          done(false);
-        }, 2500);
-        child.on("close", () => {
-          clearTimeout(t);
-          done(covenRunSupportsModelFlag(out));
-        });
-        child.on("error", () => {
-          clearTimeout(t);
-          done(false);
-        });
-      } catch {
-        done(false);
-      }
-    });
-  }
-  return covenRunModelFlagProbe;
-}
-
-// Parallel capability probe for `coven run --permission` (the sandbox flag added
-// in @opencoven/cli). Same shape/caching as the model probe; a CLI that predates
-// the flag rejects unknown flags, so forwarding must stay gated to a no-op.
-let covenRunPermissionFlagProbe: Promise<boolean> | null = null;
-function covenRunSupportsPermission(): Promise<boolean> {
-  if (!covenRunPermissionFlagProbe) {
-    covenRunPermissionFlagProbe = new Promise<boolean>((resolve) => {
-      let out = "";
-      let settled = false;
-      const done = (value: boolean) => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-      };
-      try {
-        const { command, fixedArgs } = covenLaunchCommand();
-        const child = spawn(command, [...fixedArgs, "run", "--help"], {
-          env: harnessSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        child.stdout.on("data", (d) => (out += d.toString()));
-        child.stderr.on("data", (d) => (out += d.toString()));
-        const t = setTimeout(() => {
-          try {
-            child.kill("SIGTERM");
-          } catch {
-            /* ignore */
-          }
-          done(false);
-        }, 2500);
-        child.on("close", () => {
-          clearTimeout(t);
-          done(covenRunSupportsPermissionFlag(out));
-        });
-        child.on("error", () => {
-          clearTimeout(t);
-          done(false);
-        });
-      } catch {
-        done(false);
-      }
-    });
-  }
-  return covenRunPermissionFlagProbe;
-}
-
-// Same gated probe for `coven run --add-dir <DIR>` (repeatable). Granted
-// project roots must be trusted by the spawned harness itself — the
-// runtime-scope preamble only DESCRIBES the grants, and a harness that trusts
-// nothing but its cwd denies every access to them (non-interactive sessions
-// cannot re-request permission mid-turn). Cached; failures resolve false.
-let covenRunAddDirFlagProbe: Promise<boolean> | null = null;
-function covenRunSupportsAddDir(): Promise<boolean> {
-  if (!covenRunAddDirFlagProbe) {
-    covenRunAddDirFlagProbe = new Promise<boolean>((resolve) => {
-      let out = "";
-      let settled = false;
-      const done = (value: boolean) => {
-        if (settled) return;
-        settled = true;
-        resolve(value);
-      };
-      try {
-        const { command, fixedArgs } = covenLaunchCommand();
-        const child = spawn(command, [...fixedArgs, "run", "--help"], {
-          env: harnessSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        child.stdout.on("data", (d) => (out += d.toString()));
-        child.stderr.on("data", (d) => (out += d.toString()));
-        const t = setTimeout(() => {
-          try {
-            child.kill("SIGTERM");
-          } catch {
-            /* ignore */
-          }
-          done(false);
-        }, 2500);
-        child.on("close", () => {
-          clearTimeout(t);
-          done(covenRunSupportsAddDirFlag(out));
-        });
-        child.on("error", () => {
-          clearTimeout(t);
-          done(false);
-        });
-      } catch {
-        done(false);
-      }
-    });
-  }
-  return covenRunAddDirFlagProbe;
 }
 
 function resolveSendModelMetadata(args: {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -148,6 +148,7 @@ import {
   persistSendModelIntent,
   resolveSendModelMetadata,
 } from "./chat-send-models";
+import { chatSse, startChatSseHeartbeat } from "./chat-send-sse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -337,40 +338,6 @@ async function autoNameSessionFromFirstExchange(
   }
 }
 
-function sse(event: StreamEvent, seq?: number): Uint8Array {
-  // `id:` carries the run buffer's seq (cave-h40l): a client that saw it can
-  // resume mid-turn via GET /api/chat/stream?cursor=<last id> after a drop.
-  const id = seq != null ? `id: ${seq}\n` : "";
-  return new TextEncoder().encode(`${id}data: ${JSON.stringify(event)}\n\n`);
-}
-
-// SSE comment frame + cadence keeping quiet streams alive: NATs, proxies, and
-// client idle timeouts can drop a connection that goes silent for the length
-// of a long tool run. Comments are invisible to every consumer — the web
-// readers and the iOS app all skip frames that don't start with `data:`.
-const SSE_HEARTBEAT = new TextEncoder().encode(": hb\n\n");
-const SSE_HEARTBEAT_INTERVAL_MS = 20_000;
-
-// Emit `: hb` comments until the stream closes/aborts; self-cleaning, but
-// callers also clear it from close() so a finished turn stops immediately.
-function startSseHeartbeat(
-  controller: ReadableStreamDefaultController<Uint8Array>,
-  isDone: () => boolean,
-): NodeJS.Timeout {
-  const heartbeat = setInterval(() => {
-    if (isDone()) {
-      clearInterval(heartbeat);
-      return;
-    }
-    try {
-      controller.enqueue(SSE_HEARTBEAT);
-    } catch {
-      clearInterval(heartbeat);
-    }
-  }, SSE_HEARTBEAT_INTERVAL_MS);
-  return heartbeat;
-}
-
 async function maybeQueueOfflineChat(args: {
   body: SendBody;
   config: CaveConfig;
@@ -411,7 +378,7 @@ async function maybeQueueOfflineChat(args: {
 
   const stream = new ReadableStream<Uint8Array>({
     start: (controller) => {
-      const push = (event: StreamEvent) => controller.enqueue(sse(event));
+      const push = (event: StreamEvent) => controller.enqueue(chatSse(event));
       push({ kind: "session", sessionId });
       push({ kind: "user", text: args.promptText });
       push({
@@ -465,7 +432,7 @@ function openClawChatResponse(args: {
         const seq = runBuffer?.record(event);
         if (closed || args.req.signal.aborted) return;
         try {
-          controller.enqueue(sse(event, seq));
+          controller.enqueue(chatSse(event, seq));
         } catch (error) {
           closed = true;
           if (!args.req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
@@ -487,7 +454,7 @@ function openClawChatResponse(args: {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
-      const heartbeat = startSseHeartbeat(controller, () => closed || args.req.signal.aborted);
+      const heartbeat = startChatSseHeartbeat(controller, () => closed || args.req.signal.aborted);
       const close = () => {
         if (closed) return;
         closed = true;
@@ -1266,7 +1233,7 @@ export async function POST(req: Request) {
         const seq = runBuffer?.record(e);
         if (closed || req.signal.aborted) return;
         try {
-          controller.enqueue(sse(e, seq));
+          controller.enqueue(chatSse(e, seq));
         } catch (error) {
           closed = true;
           if (!req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
@@ -1288,7 +1255,7 @@ export async function POST(req: Request) {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
-      const heartbeat = startSseHeartbeat(controller, () => closed || req.signal.aborted);
+      const heartbeat = startChatSseHeartbeat(controller, () => closed || req.signal.aborted);
       const close = () => {
         if (closed) return;
         closed = true;

--- a/src/app/api/chat/stream/route.test.ts
+++ b/src/app/api/chat/stream/route.test.ts
@@ -78,7 +78,7 @@ const send = readFileSync(new URL("../send/route.ts", import.meta.url), "utf8");
 test("send route tees both harness stream paths through the run buffer", () => {
   const tees = send.match(/const seq = runBuffer\?\.record\(e(?:vent)?\);\s*\n\s*if \(closed \|\| (?:args\.)?req\.signal\.aborted\) return;/g);
   assert.equal(tees?.length, 2, "both push() implementations record before the closed/aborted guard");
-  const seqEmits = send.match(/controller\.enqueue\(sse\(e(?:vent)?, seq\)\)/g);
+  const seqEmits = send.match(/controller\.enqueue\(chatSse\(e(?:vent)?, seq\)\)/g);
   assert.equal(seqEmits?.length, 2, "both paths emit the seq as the SSE id — live clients always hold a resume cursor");
   const opens = send.match(/openRunBuffer\(\[/g);
   assert.equal(opens?.length, 2, "both paths open a buffer under runId + conversation keys");

--- a/src/app/api/onboarding/install/install-job-output.ts
+++ b/src/app/api/onboarding/install/install-job-output.ts
@@ -1,0 +1,41 @@
+import { stripAnsi } from "@/lib/ansi";
+import { redactSecretText } from "@/lib/secret-redaction";
+
+export type InstallJobOutput = {
+  output: string;
+  trace: string[];
+};
+
+const OUTPUT_CAP = 8_192;
+const CLIENT_TAIL_CAP = 2_000;
+const TRACE_LINE_CAP = 240;
+const TRACE_LINES_CAP = 8;
+
+/** Remove secrets before installer output is retained or sent to a client. */
+export function redactSensitiveInstallOutput(value: string): string {
+  return redactSecretText(value).replace(
+    /^.*(?:GITHUB_(?:PAT|PERSONAL_ACCESS_TOKEN)|NPM_CONFIG_.*(?:AUTH|TOKEN)|(?:^|[_-])TOKEN)\s*=.*$/gim,
+    "[redacted sensitive installer output]",
+  );
+}
+
+export function appendOutput(job: InstallJobOutput, chunk: string) {
+  job.output = redactSensitiveInstallOutput(job.output + stripAnsi(chunk)).slice(-OUTPUT_CAP);
+}
+
+export function appendTrace(job: InstallJobOutput, line: string) {
+  const safeLine = redactSensitiveInstallOutput(stripAnsi(line))
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, TRACE_LINE_CAP);
+  if (!safeLine) return;
+  job.trace = [...job.trace, safeLine].slice(-TRACE_LINES_CAP);
+}
+
+/** Keep lifecycle facts stable while retaining the most useful raw output. */
+export function installJobTail(job: InstallJobOutput): string {
+  const trace = job.trace.join("\n").slice(-CLIENT_TAIL_CAP);
+  const separator = trace && job.output ? "\n" : "";
+  const outputBudget = Math.max(0, CLIENT_TAIL_CAP - trace.length - separator.length);
+  return `${trace}${separator}${job.output.slice(-outputBudget)}`;
+}

--- a/src/app/api/onboarding/install/install-process.ts
+++ b/src/app/api/onboarding/install/install-process.ts
@@ -1,0 +1,41 @@
+import { spawn } from "node:child_process";
+import { stripAnsi } from "@/lib/ansi";
+import { covenSpawnEnv } from "@/lib/coven-bin";
+import { redactSensitiveInstallOutput } from "./install-job-output";
+
+export type InstallProcessResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  output: string;
+};
+
+/** Run a fixed installer command with bounded lifetime and redacted output. */
+export function runInstallProcess(
+  command: string,
+  args: string[],
+  options: { shell: boolean; timeoutMs: number },
+): Promise<InstallProcessResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: covenSpawnEnv(),
+      shell: options.shell,
+    });
+    let output = "";
+    const timer = setTimeout(() => child.kill("SIGTERM"), options.timeoutMs);
+    child.stdout.on("data", (data) => {
+      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
+    });
+    child.stderr.on("data", (data) => {
+      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      resolve({ code: 1, signal: null, output: error.message });
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal, output });
+    });
+  });
+}

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -7,6 +7,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+const installOutput = await readFile(
+  new URL("./install-job-output.ts", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -243,7 +247,7 @@ assert.match(
 );
 
 assert.match(
-  source,
+  installOutput,
   /redactSensitiveInstallOutput\(job\.output \+ stripAnsi\(chunk\)\)/,
   "installer tails re-redact the combined buffer so secrets split across chunks cannot leak",
 );
@@ -369,18 +373,18 @@ assert.match(
 );
 
 assert.match(
-  source,
+  installOutput,
   /redactSensitiveInstallOutput\(job\.output \+ stripAnsi\(chunk\)\)/,
   "installer output is ANSI-stripped and redacted before the capped diagnostics tail is stored",
 );
 
 assert.match(
-  source,
+  installOutput,
   /slice\(-OUTPUT_CAP\)/,
   "job output is capped, not unbounded",
 );
 assert.match(
-  source,
+  installOutput,
   /function installJobTail\([\s\S]*?CLIENT_TAIL_CAP[\s\S]*?outputBudget[\s\S]*?job\.output\.slice\(-outputBudget\)/,
   "the client tail keeps stable trace facts plus bounded raw output",
 );

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -4,7 +4,6 @@ import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { stripAnsi } from "@/lib/ansi";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   globalNpmInstallOwner,
@@ -30,7 +29,6 @@ import { isVerifiedOpenCovenInstallSuccess } from "@/lib/opencoven-tool-verifica
 import { resolveStaleOpenCovenLaunchers } from "@/lib/opencoven-tools-resolve";
 import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
 import { startLocalDaemon } from "@/lib/daemon-start";
-import { redactSecretText } from "@/lib/secret-redaction";
 import {
   markDaemonCliInstalling,
   daemonUpdateTraceLine,
@@ -40,6 +38,13 @@ import {
   type DaemonUpdateDependencies,
   type DaemonUpdateLifecycle,
 } from "@/lib/daemon-update-lifecycle";
+import {
+  appendOutput,
+  appendTrace,
+  installJobTail,
+  redactSensitiveInstallOutput,
+  type InstallJobOutput,
+} from "./install-job-output";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -319,15 +324,7 @@ type InstallJob = {
   /** Cancels preparation or the spawned process; never exposed to clients. */
   cancel?: () => void;
   cancelRequested?: boolean;
-};
-
-/** Last ~8 KB of installer output is plenty for a progress tail and keeps
- *  long installs (Hermes bootstraps a Python toolchain) from growing
- *  unbounded in memory. */
-const OUTPUT_CAP = 8_192;
-const CLIENT_TAIL_CAP = 2_000;
-const TRACE_LINE_CAP = 240;
-const TRACE_LINES_CAP = 8;
+} & InstallJobOutput;
 
 // Next dev re-evaluates this module on HMR; a plain module-level Map would
 // orphan running jobs. globalThis survives re-evaluation.
@@ -336,13 +333,6 @@ const globalScope = globalThis as unknown as {
 };
 const jobs: Map<InstallTarget, InstallJob> = (globalScope.__covenInstallJobs ??=
   new Map());
-
-function redactSensitiveInstallOutput(value: string): string {
-  return redactSecretText(value).replace(
-    /^.*(?:GITHUB_(?:PAT|PERSONAL_ACCESS_TOKEN)|NPM_CONFIG_.*(?:AUTH|TOKEN)|(?:^|[_-])TOKEN)\s*=.*$/gim,
-    "[redacted sensitive installer output]",
-  );
-}
 
 type NpmLaneView = {
   npmBusy: boolean;
@@ -393,27 +383,6 @@ function npmBusyResponse(owner: InstallTarget) {
     },
     { status: 409, headers: { "Retry-After": "2" } },
   );
-}
-
-function appendOutput(job: InstallJob, chunk: string) {
-  job.output = redactSensitiveInstallOutput(job.output + stripAnsi(chunk)).slice(-OUTPUT_CAP);
-}
-
-function appendTrace(job: InstallJob, line: string) {
-  const safeLine = redactSensitiveInstallOutput(stripAnsi(line))
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, TRACE_LINE_CAP);
-  if (!safeLine) return;
-  job.trace = [...job.trace, safeLine].slice(-TRACE_LINES_CAP);
-}
-
-/** Keep lifecycle facts stable while retaining the most useful raw output. */
-function installJobTail(job: InstallJob): string {
-  const trace = job.trace.join("\n").slice(-CLIENT_TAIL_CAP);
-  const separator = trace && job.output ? "\n" : "";
-  const outputBudget = Math.max(0, CLIENT_TAIL_CAP - trace.length - separator.length);
-  return `${trace}${separator}${job.output.slice(-outputBudget)}`;
 }
 
 function releaseNpmLease(job: InstallJob, npmLease?: NpmInstallLease) {

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { dirname, join } from "node:path";
@@ -13,6 +13,7 @@ import {
 } from "@/lib/server/global-npm-install-lane";
 import {
   covenBin,
+  covenSpawnEnv,
   pickWindowsLauncher,
   refreshCovenBin,
   refreshCovenSpawnEnv,

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { execFile, spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { dirname, join } from "node:path";
@@ -13,7 +13,6 @@ import {
 } from "@/lib/server/global-npm-install-lane";
 import {
   covenBin,
-  covenSpawnEnv,
   pickWindowsLauncher,
   refreshCovenBin,
   refreshCovenSpawnEnv,
@@ -45,6 +44,7 @@ import {
   redactSensitiveInstallOutput,
   type InstallJobOutput,
 } from "./install-job-output";
+import { runInstallProcess } from "./install-process";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -403,36 +403,6 @@ function verificationTraceLine(verification: OpenCovenToolVerification): string 
   );
 }
 
-function runCommand(
-  command: string,
-  args: string[],
-  options: { shell: boolean; timeoutMs: number },
-): Promise<{ code: number | null; signal: NodeJS.Signals | null; output: string }> {
-  return new Promise((resolve) => {
-    const child = spawn(command, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: covenSpawnEnv(),
-      shell: options.shell,
-    });
-    let output = "";
-    const timer = setTimeout(() => child.kill("SIGTERM"), options.timeoutMs);
-    child.stdout.on("data", (data) => {
-      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
-    });
-    child.stderr.on("data", (data) => {
-      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      resolve({ code: 1, signal: null, output: err.message });
-    });
-    child.on("close", (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, signal, output });
-    });
-  });
-}
-
 type LocalDaemonHealth = { ok?: boolean; daemon?: { pid?: number } };
 
 function commandResultDetail(result: {
@@ -468,7 +438,7 @@ function daemonLifecycleDependencies(job: InstallJob): DaemonUpdateDependencies 
       };
     },
     stop: async (): Promise<DaemonCommandResult> => {
-      const stop = await runCommand(covenBin(), ["daemon", "stop"], {
+      const stop = await runInstallProcess(covenBin(), ["daemon", "stop"], {
         shell: process.platform === "win32",
         timeoutMs: 8_000,
       });

--- a/src/components/chat-response-metadata.test.ts
+++ b/src/components/chat-response-metadata.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import { formatRuntime } from "../lib/chat-response-metadata.ts";
 
 const chatRoute = await readFile(new URL("../app/api/chat/send/route.ts", import.meta.url), "utf8");
+const chatModels = await readFile(new URL("../app/api/chat/send/chat-send-models.ts", import.meta.url), "utf8");
 const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const chatTurnState = await readFile(new URL("../lib/chat-turn-state.ts", import.meta.url), "utf8");
 const conversations = await readFile(new URL("../lib/cave-conversations.ts", import.meta.url), "utf8");
@@ -63,12 +64,12 @@ assert.match(
   "Response metadata should carry desired model separately from confirmed model",
 );
 assert.match(
-  chatRoute,
+  chatModels,
   /const desiredModel = modelState\.effectiveModel === "unknown" \? args\.binding\.model : modelState\.effectiveModel;/,
   "Desired model should come from resolved model state so source and model cannot diverge",
 );
 assert.match(
-  chatRoute,
+  chatModels,
   /const sessionModel =[\s\S]*args\.body\.modelOverrideScope === "session"[\s\S]*\? requestedModel[\s\S]*: args\.existingConversation\?\.modelIntent\?\.model \?\? null;/,
   "Session-scoped send overrides should flow through the same model-state source as desiredModel",
 );

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1168,24 +1168,32 @@ const mentionSendSource = readFileSync(
   new URL("../app/api/chat/send/route.ts", import.meta.url),
   "utf8",
 );
+const mentionAttachmentSource = readFileSync(
+  new URL("../app/api/chat/send/chat-send-attachments.ts", import.meta.url),
+  "utf8",
+);
+const chatRuntimeSource = readFileSync(
+  new URL("../app/api/chat/send/chat-send-runtime.ts", import.meta.url),
+  "utf8",
+);
 assert.match(
-  mentionSendSource,
+  mentionAttachmentSource,
   /async function resolveMentionedFiles\([\s\S]*?relPaths\.slice\(0, MAX_MENTIONED_FILES\)[\s\S]*?\.includes\("\.\."\)[\s\S]*?candidate\.startsWith\(realRoot \+ path\.sep\)/,
   "/chat/send must validate each mention: cap, repo-relative only, no `..`, prefix containment under the realpathed root",
 );
 assert.match(
-  mentionSendSource,
+  chatRuntimeSource,
   /async function resolveFamiliarWorkspace\([\s\S]*?readFamiliarWorkspaces\(\)[\s\S]*?path\.resolve\(familiarsRoot, familiarId\)[\s\S]*?path\.relative\(familiarsRoot, candidate\)[\s\S]*?relative\.startsWith\("\.\."\)/,
   "/chat/send must validate default familiar workspace paths under the familiar root while preserving configured workspaces",
 );
 assert.match(
-  mentionSendSource,
+  mentionAttachmentSource,
   /const real = await realpath\(candidate\);[\s\S]*?real\.startsWith\(realRoot \+ path\.sep\)/,
   "/chat/send must re-check containment on the realpathed file so in-repo symlinks cannot smuggle outside paths",
 );
 assert.match(
-  mentionSendSource,
-  /"Referenced files \(open with the Read tool\):",\s*\n\s*\.\.\.absPaths\.map\(\(p\) => `- \$\{p\}`\)/,
+  mentionAttachmentSource,
+  /"Referenced files \(open with the Read tool\):",\s*\n\s*\.\.\.absPaths\.map\(\(item\) => `- \$\{item\}`\)/,
   "Validated mentions must render as the compact Referenced-files prompt block of absolute paths",
 );
 assert.match(

--- a/src/lib/cave-config-normalize.ts
+++ b/src/lib/cave-config-normalize.ts
@@ -1,0 +1,154 @@
+import {
+  isSshRuntime,
+  normalizeFamiliarRuntime,
+} from "./familiar-runtime.ts";
+import type {
+  CaveMultiHostConfig,
+  CaveOmnigentConfig,
+  CaveRemoteHost,
+  CaveTravelQueueItem,
+  CaveTravelState,
+  FamiliarOmnigentBinding,
+} from "./cave-config.ts";
+
+export function normalizeRemoteHosts(input: CaveRemoteHost[] | undefined): CaveRemoteHost[] {
+  const seen = new Set<string>();
+  const hosts: CaveRemoteHost[] = [];
+  for (const entry of Array.isArray(input) ? input : []) {
+    const runtime = normalizeFamiliarRuntime({
+      kind: "ssh",
+      host: entry?.host,
+      cwd: entry?.cwd,
+      command: entry?.command,
+    });
+    if (!isSshRuntime(runtime) || seen.has(runtime.host)) continue;
+    seen.add(runtime.host);
+    hosts.push({
+      host: runtime.host,
+      cwd: runtime.cwd,
+      ...(runtime.command !== "coven" ? { command: runtime.command } : {}),
+    });
+  }
+  return hosts;
+}
+
+export function normalizeMultiHostConfig(input: Partial<CaveMultiHostConfig> | undefined): CaveMultiHostConfig {
+  const mode = input?.mode === "hub" ? "hub" : "local";
+  const hubUrl = typeof input?.hubUrl === "string" ? input.hubUrl.trim() : "";
+  const executorUrls = Array.from(
+    new Set(
+      (Array.isArray(input?.executorUrls) ? input.executorUrls : [])
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+  return { mode, hubUrl, executorUrls };
+}
+
+function normalizeStringRecord(input: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!input || typeof input !== "object" || Array.isArray(input)) return out;
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    const normalizedKey = typeof key === "string" ? key.trim() : "";
+    const normalizedValue = typeof value === "string" ? value.trim() : "";
+    if (normalizedKey && normalizedValue) out[normalizedKey] = normalizedValue;
+  }
+  return out;
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+}
+
+export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
+  const rawUrl = typeof input?.baseUrl === "string" ? trimTrailingSlashes(input.baseUrl.trim()) : "";
+  let baseUrl = rawUrl;
+  if (rawUrl) {
+    try {
+      const parsed = new URL(rawUrl.includes("://") ? rawUrl : `https://${rawUrl}`);
+      baseUrl = `${parsed.protocol}//${parsed.host}`;
+    } catch {
+      baseUrl = rawUrl;
+    }
+  }
+  return {
+    enabled: input?.enabled === true,
+    baseUrl,
+    defaultAgentId: typeof input?.defaultAgentId === "string" ? input.defaultAgentId.trim() : "",
+    defaultHostId: typeof input?.defaultHostId === "string" ? input.defaultHostId.trim() : "",
+    defaultWorkspace: typeof input?.defaultWorkspace === "string" ? input.defaultWorkspace.trim() : "",
+    hostMap: normalizeStringRecord(input?.hostMap),
+    hostWorkspaceMap: normalizeStringRecord(input?.hostWorkspaceMap),
+    exposeHostsInComposer: input?.exposeHostsInComposer !== false,
+  };
+}
+
+export function normalizeFamiliarOmnigent(
+  input: FamiliarOmnigentBinding | undefined,
+): FamiliarOmnigentBinding | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
+  const hostId = typeof input.hostId === "string" ? input.hostId.trim() : "";
+  const workspace = typeof input.workspace === "string" ? input.workspace.trim() : "";
+  if (!agentId && !hostId && !workspace) return undefined;
+  return {
+    ...(agentId ? { agentId } : {}),
+    ...(hostId ? { hostId } : {}),
+    ...(workspace ? { workspace } : {}),
+  };
+}
+
+export function defaultTravelState(): CaveTravelState {
+  return {
+    manualOffline: false,
+    hubUnreachableSince: null,
+    lastHubReachableAt: null,
+    staleCache: false,
+    localSubdaemonWakeRequestedAt: null,
+    localBindHost: "127.0.0.1",
+    offlineQueue: [],
+  };
+}
+
+function isoOrNull(value: unknown): string | null {
+  return typeof value === "string" && Number.isFinite(Date.parse(value)) ? value : null;
+}
+
+function normalizeTravelQueue(input: unknown): CaveTravelQueueItem[] {
+  if (!Array.isArray(input)) return [];
+  return input.flatMap((item): CaveTravelQueueItem[] => {
+    if (!item || typeof item !== "object") return [];
+    const entry = item as Partial<CaveTravelQueueItem>;
+    const id = typeof entry.id === "string" && entry.id.trim() ? entry.id.trim() : "";
+    const summary = typeof entry.summary === "string" && entry.summary.trim() ? entry.summary.trim() : "";
+    const createdAt = isoOrNull(entry.createdAt);
+    if (!id || !summary || !createdAt) return [];
+    const status = entry.status === "syncing" || entry.status === "failed" || entry.status === "synced"
+      ? entry.status
+      : "pending";
+    return [{
+      id,
+      kind: entry.kind === "workflow" || entry.kind === "job" ? entry.kind : "chat",
+      summary,
+      createdAt,
+      status,
+      payload: entry.payload,
+      lastError: typeof entry.lastError === "string" && entry.lastError.trim() ? entry.lastError.trim() : undefined,
+    }];
+  });
+}
+
+export function normalizeTravelState(input: Partial<CaveTravelState> | undefined): CaveTravelState {
+  return {
+    manualOffline: input?.manualOffline === true,
+    hubUnreachableSince: isoOrNull(input?.hubUnreachableSince),
+    lastHubReachableAt: isoOrNull(input?.lastHubReachableAt),
+    staleCache: input?.staleCache === true,
+    localSubdaemonWakeRequestedAt: isoOrNull(input?.localSubdaemonWakeRequestedAt),
+    localBindHost: "127.0.0.1",
+    offlineQueue: normalizeTravelQueue(input?.offlineQueue),
+  };
+}

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -12,10 +12,26 @@ import {
 } from "./chat-auto-archive.ts";
 import {
   type FamiliarRuntime,
-  isSshRuntime,
   normalizeFamiliarRuntime,
 } from "./familiar-runtime.ts";
 import type { UserProfile } from "./user-profile-shared.ts";
+import {
+  defaultTravelState,
+  normalizeFamiliarOmnigent,
+  normalizeMultiHostConfig,
+  normalizeOmnigentConfig,
+  normalizeRemoteHosts,
+  normalizeTravelState,
+} from "./cave-config-normalize.ts";
+
+export {
+  defaultTravelState,
+  normalizeFamiliarOmnigent,
+  normalizeMultiHostConfig,
+  normalizeOmnigentConfig,
+  normalizeRemoteHosts,
+  normalizeTravelState,
+} from "./cave-config-normalize.ts";
 
 const CONFIG_PATH = path.join(caveHome(), "config.json");
 const STATE_PATH = path.join(caveHome(), "state.json");
@@ -383,153 +399,6 @@ function sanitizeMultiHostHubToken(config: Pick<CaveConfig, "multiHost">): boole
   if (!token || !rememberHubAccessToken(token)) return false;
   config.multiHost = { ...config.multiHost, hubUrl: url };
   return true;
-}
-
-export function normalizeRemoteHosts(input: CaveRemoteHost[] | undefined): CaveRemoteHost[] {
-  const seen = new Set<string>();
-  const hosts: CaveRemoteHost[] = [];
-  for (const entry of Array.isArray(input) ? input : []) {
-    const runtime = normalizeFamiliarRuntime({
-      kind: "ssh",
-      host: entry?.host,
-      cwd: entry?.cwd,
-      command: entry?.command,
-    });
-    if (!isSshRuntime(runtime) || seen.has(runtime.host)) continue;
-    seen.add(runtime.host);
-    hosts.push({
-      host: runtime.host,
-      cwd: runtime.cwd,
-      ...(runtime.command !== "coven" ? { command: runtime.command } : {}),
-    });
-  }
-  return hosts;
-}
-
-export function normalizeMultiHostConfig(input: Partial<CaveMultiHostConfig> | undefined): CaveMultiHostConfig {
-  const mode = input?.mode === "hub" ? "hub" : "local";
-  const hubUrl = typeof input?.hubUrl === "string" ? input.hubUrl.trim() : "";
-  const executorUrls = Array.from(
-    new Set(
-      (Array.isArray(input?.executorUrls) ? input.executorUrls : [])
-        .filter((value): value is string => typeof value === "string")
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ),
-  );
-  return { mode, hubUrl, executorUrls };
-}
-
-function normalizeStringRecord(input: unknown): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (!input || typeof input !== "object" || Array.isArray(input)) return out;
-  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    const key = typeof k === "string" ? k.trim() : "";
-    const val = typeof v === "string" ? v.trim() : "";
-    if (key && val) out[key] = val;
-  }
-  return out;
-}
-
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value[end - 1] === "/") end -= 1;
-  return value.slice(0, end);
-}
-
-export function normalizeOmnigentConfig(input: Partial<CaveOmnigentConfig> | undefined): CaveOmnigentConfig {
-  const rawUrl = typeof input?.baseUrl === "string" ? trimTrailingSlashes(input.baseUrl.trim()) : "";
-  let baseUrl = rawUrl;
-  if (rawUrl) {
-    try {
-      const parsed = new URL(rawUrl.includes("://") ? rawUrl : `https://${rawUrl}`);
-      baseUrl = `${parsed.protocol}//${parsed.host}`;
-    } catch {
-      baseUrl = rawUrl;
-    }
-  }
-  return {
-    // Explicit opt-in: anything but literal true (absent on pre-toggle
-    // configs) normalizes to off.
-    enabled: input?.enabled === true,
-    baseUrl,
-    defaultAgentId: typeof input?.defaultAgentId === "string" ? input.defaultAgentId.trim() : "",
-    defaultHostId: typeof input?.defaultHostId === "string" ? input.defaultHostId.trim() : "",
-    defaultWorkspace: typeof input?.defaultWorkspace === "string" ? input.defaultWorkspace.trim() : "",
-    hostMap: normalizeStringRecord(input?.hostMap),
-    hostWorkspaceMap: normalizeStringRecord(input?.hostWorkspaceMap),
-    exposeHostsInComposer: input?.exposeHostsInComposer !== false,
-  };
-}
-
-export function normalizeFamiliarOmnigent(
-  input: FamiliarOmnigentBinding | undefined,
-): FamiliarOmnigentBinding | undefined {
-  if (!input || typeof input !== "object") return undefined;
-  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
-  const hostId = typeof input.hostId === "string" ? input.hostId.trim() : "";
-  const workspace = typeof input.workspace === "string" ? input.workspace.trim() : "";
-  if (!agentId && !hostId && !workspace) return undefined;
-  return {
-    ...(agentId ? { agentId } : {}),
-    ...(hostId ? { hostId } : {}),
-    ...(workspace ? { workspace } : {}),
-  };
-}
-
-export function defaultTravelState(): CaveTravelState {
-  return {
-    manualOffline: false,
-    hubUnreachableSince: null,
-    lastHubReachableAt: null,
-    staleCache: false,
-    localSubdaemonWakeRequestedAt: null,
-    localBindHost: "127.0.0.1",
-    offlineQueue: [],
-  };
-}
-
-function isoOrNull(value: unknown): string | null {
-  return typeof value === "string" && Number.isFinite(Date.parse(value)) ? value : null;
-}
-
-function normalizeTravelQueue(input: unknown): CaveTravelQueueItem[] {
-  if (!Array.isArray(input)) return [];
-  return input.flatMap((item): CaveTravelQueueItem[] => {
-    if (!item || typeof item !== "object") return [];
-    const entry = item as Partial<CaveTravelQueueItem>;
-    const id = typeof entry.id === "string" && entry.id.trim() ? entry.id.trim() : "";
-    const summary = typeof entry.summary === "string" && entry.summary.trim() ? entry.summary.trim() : "";
-    const createdAt = isoOrNull(entry.createdAt);
-    if (!id || !summary || !createdAt) return [];
-    const status =
-      entry.status === "syncing" ||
-      entry.status === "failed" ||
-      entry.status === "synced"
-        ? entry.status
-        : "pending";
-    return [{
-      id,
-      kind: entry.kind === "workflow" || entry.kind === "job" ? entry.kind : "chat",
-      summary,
-      createdAt,
-      status,
-      payload: entry.payload,
-      lastError: typeof entry.lastError === "string" && entry.lastError.trim() ? entry.lastError.trim() : undefined,
-    }];
-  });
-}
-
-export function normalizeTravelState(input: Partial<CaveTravelState> | undefined): CaveTravelState {
-  return {
-    manualOffline: input?.manualOffline === true,
-    hubUnreachableSince: isoOrNull(input?.hubUnreachableSince),
-    lastHubReachableAt: isoOrNull(input?.lastHubReachableAt),
-    staleCache: input?.staleCache === true,
-    localSubdaemonWakeRequestedAt: isoOrNull(input?.localSubdaemonWakeRequestedAt),
-    localBindHost: "127.0.0.1",
-    offlineQueue: normalizeTravelQueue(input?.offlineQueue),
-  };
 }
 
 function mergeFamiliarConfigs(

--- a/src/lib/coven-paths.test.ts
+++ b/src/lib/coven-paths.test.ts
@@ -106,6 +106,7 @@ assert.ok(roleSource.includes('path.join(covenHome(), "roles")'));
 assert.doesNotMatch(roleSource, /\.openclaw/);
 
 const chatSend = await readFile("src/app/api/chat/send/route.ts", "utf8");
-assert.match(chatSend, /familiarWorkspace/);
-assert.match(chatSend, /Coven workspace dir/);
+const chatSendRuntime = await readFile("src/app/api/chat/send/chat-send-runtime.ts", "utf8");
+assert.match(chatSend, /resolveFamiliarWorkspace/);
+assert.match(chatSendRuntime, /Resolve a familiar workspace/);
 assert.doesNotMatch(chatSend, /\.openclaw\/workspace/);

--- a/src/lib/server/cave-home-reconciliation-types.ts
+++ b/src/lib/server/cave-home-reconciliation-types.ts
@@ -1,0 +1,124 @@
+import type { rename, symlink } from "node:fs/promises";
+
+export type ReconciliationStrategy = "inbox" | "state" | "preferences" | "directory" | "manual";
+
+export type CaveHomeReconciliationEntry = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+};
+
+export type ReconciliationDecision =
+  | "absent"
+  | "moved"
+  | "linked"
+  | "managed-mirror"
+  | "identical"
+  | "merged"
+  | "kept-canonical"
+  | "recovered-legacy"
+  | "unresolved"
+  | "deferred";
+
+export type MigrationJournalEntry = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+  legacyPath: string;
+  canonicalPath: string;
+  legacyHash?: string;
+  canonicalHash?: string;
+  legacyMtimeMs?: number;
+  canonicalMtimeMs?: number;
+  decision: ReconciliationDecision;
+  compatibility?: "symlink" | "mirror";
+  managedMirrorHash?: string;
+  backupId?: string;
+  decidedAt: string;
+  summary?: string;
+};
+
+export type MigrationJournal = {
+  version: 1;
+  migrationVersion: 2;
+  updatedAt: string;
+  entries: Record<string, MigrationJournalEntry>;
+};
+
+export type CaveHomeConflictDetail = {
+  legacy: string;
+  next: string;
+  strategy: ReconciliationStrategy;
+  legacyPath: string;
+  canonicalPath: string;
+  legacyHash?: string;
+  canonicalHash?: string;
+  legacyMtimeMs?: number;
+  canonicalMtimeMs?: number;
+  state: "pending" | "unresolved" | "managed";
+  summary: string;
+  differences: string[];
+  backupPath?: string;
+  actions: Array<"merge" | "keep-canonical" | "recover-legacy" | "defer">;
+};
+
+export type CaveHomeReconciliationStatus = {
+  pending: string[];
+  conflicts: string[];
+  migrated: boolean;
+  details: CaveHomeConflictDetail[];
+  backupRoot: string;
+  journalPath: string;
+};
+
+export type CaveHomeReconciliationResult = {
+  moved: string[];
+  linked: string[];
+  skipped: string[];
+  merged: Array<{ legacy: string; files: number; collisions: number }>;
+  backedUp: string[];
+  resolved: string[];
+  errors: Array<{ legacy: string; error: string }>;
+};
+
+export type ReconciliationAction = "merge" | "keep-canonical" | "recover-legacy" | "defer";
+
+export type ReconciliationLockDiagnostic = {
+  phase: "waiting" | "acquired" | "failed";
+  durationMs: number;
+  result: "pending" | "acquired" | "timeout" | "error";
+  errorCode?: string;
+};
+
+export type ReconciliationOptions = {
+  action?: ReconciliationAction;
+  legacy?: string;
+  /** Test-only fault boundary. Production callers must omit it. */
+  faultAt?: string;
+  /** Test-only compatibility bridge override. */
+  createSymlink?: typeof symlink;
+  /** Test-only lock lifecycle probe. */
+  lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
+  /** Test-only unlock rename override. */
+  lockReleaseRename?: typeof rename;
+  /** Test-only candidate owner-record writer override. */
+  lockCandidateOwnerWrite?: (candidate: string, owner: { pid: number; token: string; startedAt: string }) => Promise<void>;
+  /** Test-only candidate publication rename override. */
+  lockCandidateRename?: typeof rename;
+  /** Test-only stale-lock fencing rename override. */
+  lockFenceRename?: typeof rename;
+  /** Test-only acquisition deadline override. */
+  lockTimeoutMs?: number;
+  /** Test-only lock diagnostic observer. */
+  lockDiagnostic?: (diagnostic: ReconciliationLockDiagnostic) => void;
+  /** Test-only hook after an exclusive takeover claim is published. */
+  takeoverPublishProbe?: (takeoverToken: string) => void | Promise<void>;
+  /** Test-only hook before a reclaimable takeover claim is advanced. */
+  takeoverRemovalProbe?: (takeover: string, takeoverToken: string | null) => void | Promise<void>;
+  /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
+  compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
+  /** Test-only hook after managed-mirror canonical validation. */
+  managedMirrorProbe?: (canonicalPath: string) => void | Promise<void>;
+  /** Test-only hook before an explicit/automatic canonical replacement. */
+  resolutionProbe?: (canonicalPath: string) => void | Promise<void>;
+};

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -21,129 +21,33 @@ import path from "node:path";
 import { caveHome, covenHome } from "../coven-paths.ts";
 import { normalizeCavePreferences, type CavePreferences } from "../preferences-schema.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
+import type {
+  CaveHomeConflictDetail,
+  CaveHomeReconciliationEntry,
+  CaveHomeReconciliationResult,
+  CaveHomeReconciliationStatus,
+  MigrationJournal,
+  MigrationJournalEntry,
+  ReconciliationAction,
+  ReconciliationDecision,
+  ReconciliationLockDiagnostic,
+  ReconciliationOptions,
+  ReconciliationStrategy,
+} from "./cave-home-reconciliation-types.ts";
 
-export type ReconciliationStrategy = "inbox" | "state" | "preferences" | "directory" | "manual";
-
-export type CaveHomeReconciliationEntry = {
-  legacy: string;
-  next: string;
-  strategy: ReconciliationStrategy;
-};
-
-export type ReconciliationDecision =
-  | "absent"
-  | "moved"
-  | "linked"
-  | "managed-mirror"
-  | "identical"
-  | "merged"
-  | "kept-canonical"
-  | "recovered-legacy"
-  | "unresolved"
-  | "deferred";
-
-export type MigrationJournalEntry = {
-  legacy: string;
-  next: string;
-  strategy: ReconciliationStrategy;
-  legacyPath: string;
-  canonicalPath: string;
-  legacyHash?: string;
-  canonicalHash?: string;
-  legacyMtimeMs?: number;
-  canonicalMtimeMs?: number;
-  decision: ReconciliationDecision;
-  compatibility?: "symlink" | "mirror";
-  managedMirrorHash?: string;
-  backupId?: string;
-  decidedAt: string;
-  summary?: string;
-};
-
-export type MigrationJournal = {
-  version: 1;
-  migrationVersion: 2;
-  updatedAt: string;
-  entries: Record<string, MigrationJournalEntry>;
-};
-
-export type CaveHomeConflictDetail = {
-  legacy: string;
-  next: string;
-  strategy: ReconciliationStrategy;
-  legacyPath: string;
-  canonicalPath: string;
-  legacyHash?: string;
-  canonicalHash?: string;
-  legacyMtimeMs?: number;
-  canonicalMtimeMs?: number;
-  state: "pending" | "unresolved" | "managed";
-  summary: string;
-  differences: string[];
-  backupPath?: string;
-  actions: Array<"merge" | "keep-canonical" | "recover-legacy" | "defer">;
-};
-
-export type CaveHomeReconciliationStatus = {
-  pending: string[];
-  conflicts: string[];
-  migrated: boolean;
-  details: CaveHomeConflictDetail[];
-  backupRoot: string;
-  journalPath: string;
-};
-
-export type CaveHomeReconciliationResult = {
-  moved: string[];
-  linked: string[];
-  skipped: string[];
-  merged: Array<{ legacy: string; files: number; collisions: number }>;
-  backedUp: string[];
-  resolved: string[];
-  errors: Array<{ legacy: string; error: string }>;
-};
-
-export type ReconciliationAction = "merge" | "keep-canonical" | "recover-legacy" | "defer";
-
-export type ReconciliationOptions = {
-  action?: ReconciliationAction;
-  legacy?: string;
-  /** Test-only fault boundary. Production callers must omit it. */
-  faultAt?: string;
-  /** Test-only compatibility bridge override. */
-  createSymlink?: typeof symlink;
-  /** Test-only lock lifecycle probe. */
-  lockProbe?: (event: "stale-observed" | "acquired" | "released") => void | Promise<void>;
-  /** Test-only unlock rename override. */
-  lockReleaseRename?: typeof rename;
-  /** Test-only candidate owner-record writer override. */
-  lockCandidateOwnerWrite?: (candidate: string, owner: { pid: number; token: string; startedAt: string }) => Promise<void>;
-  /** Test-only candidate publication rename override. */
-  lockCandidateRename?: typeof rename;
-  /** Test-only stale-lock fencing rename override. */
-  lockFenceRename?: typeof rename;
-  /** Test-only acquisition deadline override. */
-  lockTimeoutMs?: number;
-  /** Test-only lock diagnostic observer. */
-  lockDiagnostic?: (diagnostic: ReconciliationLockDiagnostic) => void;
-  /** Test-only hook after an exclusive takeover claim is published. */
-  takeoverPublishProbe?: (takeoverToken: string) => void | Promise<void>;
-  /** Test-only hook before a reclaimable takeover claim is advanced. */
-  takeoverRemovalProbe?: (takeover: string, takeoverToken: string | null) => void | Promise<void>;
-  /** Test-only hook before a legacy path is replaced by its compatibility bridge. */
-  compatibilityProbe?: (legacyPath: string) => void | Promise<void>;
-  /** Test-only hook after managed-mirror canonical validation. */
-  managedMirrorProbe?: (canonicalPath: string) => void | Promise<void>;
-  /** Test-only hook before an explicit/automatic canonical replacement. */
-  resolutionProbe?: (canonicalPath: string) => void | Promise<void>;
-};
-
-export type ReconciliationLockDiagnostic = {
-  phase: "waiting" | "acquired" | "failed";
-  durationMs: number;
-  result: "pending" | "acquired" | "timeout" | "error";
-  errorCode?: string;
-};
+export type {
+  CaveHomeConflictDetail,
+  CaveHomeReconciliationEntry,
+  CaveHomeReconciliationResult,
+  CaveHomeReconciliationStatus,
+  MigrationJournal,
+  MigrationJournalEntry,
+  ReconciliationAction,
+  ReconciliationDecision,
+  ReconciliationLockDiagnostic,
+  ReconciliationOptions,
+  ReconciliationStrategy,
+} from "./cave-home-reconciliation-types.ts";
 
 type PathInfo = {
   kind: "missing" | "symlink" | "file" | "dir";

--- a/src/lib/server/research-mission-lifecycle.ts
+++ b/src/lib/server/research-mission-lifecycle.ts
@@ -1,0 +1,136 @@
+import type {
+  CreateResearchMissionInput,
+  ResearchArtifactKind,
+  ResearchMission,
+} from "../research-missions.ts";
+import type { FlowRunRecord } from "../flows.ts";
+
+export type ResearchFlowStartResult = {
+  ok: boolean;
+  executor?: "session" | "travel-queue";
+  sessionId?: string;
+  run?: FlowRunRecord;
+  queued?: boolean;
+  unavailable?: boolean;
+  error?: string;
+};
+
+function artifactKindForMode(mode: ResearchMission["mode"]): ResearchArtifactKind {
+  if (mode === "sweep") return "report";
+  if (mode === "paper") return "paper";
+  if (mode === "autoresearch") return "findings";
+  return "brief";
+}
+
+function missionTitle(input: CreateResearchMissionInput): string {
+  const explicit = input.title?.trim();
+  if (explicit) return explicit.slice(0, 160);
+  const intent = input.intent.trim().replace(/\s+/g, " ");
+  return intent.length <= 80 ? intent : `${intent.slice(0, 77)}…`;
+}
+
+/** Create the durable pre-launch mission record. */
+export function createMissionRecord(
+  input: CreateResearchMissionInput,
+  id: string,
+  now: Date,
+): ResearchMission {
+  const timestamp = now.toISOString();
+  const kind = artifactKindForMode(input.mode);
+  return {
+    version: 1,
+    id,
+    familiarId: input.familiarId,
+    title: missionTitle(input),
+    intent: input.intent.trim(),
+    mode: input.mode,
+    modeSource: input.modeSource,
+    deliverable: input.deliverable,
+    ...(input.audience?.trim() ? { audience: input.audience.trim() } : {}),
+    ...(input.projectRoot?.trim() ? { projectRoot: input.projectRoot.trim() } : {}),
+    constraints: (input.constraints ?? []).map((item) => item.trim()).filter(Boolean),
+    bounds: { ...input.bounds },
+    status: "planning",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    iterations: [{ number: 1, status: "queued" }],
+    artifacts: [{
+      key: "primary",
+      kind,
+      title: missionTitle(input),
+      relativePath: "artifacts/primary.md",
+      iteration: 1,
+      state: "working",
+      updatedAt: timestamp,
+    }],
+    sources: [],
+  };
+}
+
+/** Apply a flow-launch result without losing the pre-persisted mission. */
+export function applyStartResult(
+  mission: ResearchMission,
+  result: ResearchFlowStartResult,
+  now: Date,
+): ResearchMission {
+  const timestamp = now.toISOString();
+  const iterationIndex = mission.iterations.length - 1;
+  const current = mission.iterations[iterationIndex];
+  if (!result.ok) {
+    return {
+      ...mission,
+      status: "failed",
+      updatedAt: timestamp,
+      lastError: result.error || "Research session failed to start",
+      iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
+        ...current,
+        status: "failed",
+        finishedAt: timestamp,
+        summary: result.error || "Research session failed to start",
+      } : item),
+    };
+  }
+  const queued = result.queued || result.executor === "travel-queue" || result.run?.status === "queued";
+  return {
+    ...mission,
+    status: queued ? "queued" : "running",
+    startedAt: mission.startedAt ?? timestamp,
+    updatedAt: timestamp,
+    lastError: undefined,
+    iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
+      ...current,
+      status: queued ? "queued" : "running",
+      flowRunId: result.run?.id,
+      sessionId: result.sessionId ?? result.run?.sessionId,
+      startedAt: result.run?.startedAt ?? timestamp,
+    } : item),
+  };
+}
+
+const SESSION_STARTUP_GRACE_MS = 60_000;
+
+/** Keep registration races from being misclassified as dead agent sessions. */
+export function withinStartupGrace(startedAt: string | undefined, now: Date): boolean {
+  if (!startedAt) return false;
+  const started = Date.parse(startedAt);
+  if (Number.isNaN(started)) return false;
+  return Math.abs(now.getTime() - started) < SESSION_STARTUP_GRACE_MS;
+}
+
+export function stopBeforeNextIteration(mission: ResearchMission, now: Date): string | null {
+  if (mission.iterations.length >= mission.bounds.maxIterations) return "Iteration limit reached";
+  const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
+  if (Number.isFinite(startedAt) && now.getTime() - startedAt >= mission.bounds.wallClockMinutes * 60_000) {
+    return "Wall-clock limit reached";
+  }
+  const knownCosts = mission.iterations
+    .map((iteration) => iteration.costUsd)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  if (mission.bounds.stopWhenCostUnavailable && mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)) {
+    return "Cost unavailable; review before another iteration";
+  }
+  if (mission.bounds.maxSpendUsd !== undefined && knownCosts.reduce((sum, value) => sum + value, 0) >= mission.bounds.maxSpendUsd) {
+    return "Reported spend limit reached";
+  }
+  return null;
+}

--- a/src/lib/server/research-mission-lock.ts
+++ b/src/lib/server/research-mission-lock.ts
@@ -1,0 +1,20 @@
+declare global {
+  var __caveResearchMissionActionLocks: Map<string, Promise<void>> | undefined;
+}
+
+/** Serialize all read-modify-write mission actions for one durable mission. */
+export function withResearchMissionActionLock<T>(
+  id: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  globalThis.__caveResearchMissionActionLocks ??= new Map();
+  const locks = globalThis.__caveResearchMissionActionLocks;
+  const previous = locks.get(id) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  const tail = result.then(() => undefined, () => undefined);
+  locks.set(id, tail);
+  void tail.then(() => {
+    if (locks.get(id) === tail) locks.delete(id);
+  });
+  return result;
+}

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -13,7 +13,6 @@ import { buildResearchMissionFlow } from "../research-mission-flow.ts";
 import {
   allowedResearchActions,
   type CreateResearchMissionInput,
-  type ResearchArtifactKind,
   type ResearchArtifactRef,
   type ResearchMission,
   type ResearchMissionActionInput,
@@ -30,16 +29,18 @@ import {
   saveResearchMission,
 } from "./research-mission-store.ts";
 import { withResearchMissionActionLock } from "./research-mission-lock.ts";
+import {
+  applyStartResult,
+  createMissionRecord,
+  stopBeforeNextIteration,
+  withinStartupGrace,
+  type ResearchFlowStartResult,
+} from "./research-mission-lifecycle.ts";
 
-export type ResearchFlowStartResult = {
-  ok: boolean;
-  executor?: "session" | "travel-queue";
-  sessionId?: string;
-  run?: FlowRunRecord;
-  queued?: boolean;
-  unavailable?: boolean;
-  error?: string;
-};
+export {
+  withinStartupGrace,
+} from "./research-mission-lifecycle.ts";
+export type { ResearchFlowStartResult } from "./research-mission-lifecycle.ts";
 
 export type ResearchAutomationScheduleInput = {
   rrule: string;
@@ -127,110 +128,6 @@ function automationPrompt(mission: ResearchMission, workspace: string): string {
   ].join("\n");
 }
 
-function artifactKindForMode(mode: ResearchMission["mode"]): ResearchArtifactKind {
-  if (mode === "sweep") return "report";
-  if (mode === "paper") return "paper";
-  if (mode === "autoresearch") return "findings";
-  return "brief";
-}
-
-function missionTitle(input: CreateResearchMissionInput): string {
-  const explicit = input.title?.trim();
-  if (explicit) return explicit.slice(0, 160);
-  const intent = input.intent.trim().replace(/\s+/g, " ");
-  return intent.length <= 80 ? intent : `${intent.slice(0, 77)}…`;
-}
-
-function createMissionRecord(
-  input: CreateResearchMissionInput,
-  id: string,
-  now: Date,
-): ResearchMission {
-  const timestamp = now.toISOString();
-  const kind = artifactKindForMode(input.mode);
-  return {
-    version: 1,
-    id,
-    familiarId: input.familiarId,
-    title: missionTitle(input),
-    intent: input.intent.trim(),
-    mode: input.mode,
-    modeSource: input.modeSource,
-    deliverable: input.deliverable,
-    ...(input.audience?.trim() ? { audience: input.audience.trim() } : {}),
-    ...(input.projectRoot?.trim() ? { projectRoot: input.projectRoot.trim() } : {}),
-    constraints: (input.constraints ?? []).map((item) => item.trim()).filter(Boolean),
-    bounds: { ...input.bounds },
-    status: "planning",
-    createdAt: timestamp,
-    updatedAt: timestamp,
-    iterations: [{ number: 1, status: "queued" }],
-    artifacts: [{
-      key: "primary",
-      kind,
-      title: missionTitle(input),
-      relativePath: "artifacts/primary.md",
-      iteration: 1,
-      state: "working",
-      updatedAt: timestamp,
-    }],
-    sources: [],
-  };
-}
-
-function applyStartResult(
-  mission: ResearchMission,
-  result: ResearchFlowStartResult,
-  now: Date,
-): ResearchMission {
-  const timestamp = now.toISOString();
-  const iterationIndex = mission.iterations.length - 1;
-  const current = mission.iterations[iterationIndex];
-  if (!result.ok) {
-    return {
-      ...mission,
-      status: "failed",
-      updatedAt: timestamp,
-      lastError: result.error || "Research session failed to start",
-      iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
-        ...current,
-        status: "failed",
-        finishedAt: timestamp,
-        summary: result.error || "Research session failed to start",
-      } : item),
-    };
-  }
-  const queued = result.queued || result.executor === "travel-queue" || result.run?.status === "queued";
-  return {
-    ...mission,
-    status: queued ? "queued" : "running",
-    startedAt: mission.startedAt ?? timestamp,
-    updatedAt: timestamp,
-    lastError: undefined,
-    iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
-      ...current,
-      status: queued ? "queued" : "running",
-      flowRunId: result.run?.id,
-      sessionId: result.sessionId ?? result.run?.sessionId,
-      startedAt: result.run?.startedAt ?? timestamp,
-    } : item),
-  };
-}
-
-/** A just-started session may not be observable yet — don't declare a
- *  running iteration dead within its first minute (registration races). */
-const SESSION_STARTUP_GRACE_MS = 60_000;
-
-export function withinStartupGrace(startedAt: string | undefined, now: Date): boolean {
-  if (!startedAt) return false;
-  const started = Date.parse(startedAt);
-  if (Number.isNaN(started)) return false;
-  // Symmetric window: a slightly-future startedAt (clock skew) still gets
-  // grace, but a far-future one (bad data) can't suppress dead-session
-  // detection indefinitely.
-  return Math.abs(now.getTime() - started) < SESSION_STARTUP_GRACE_MS;
-}
-
 function conversationTranscript(conversation: ConversationFile | null): string {
   return (conversation?.turns ?? [])
     .filter((turn) => turn.role === "assistant")
@@ -244,33 +141,6 @@ function conversationCost(conversation: ConversationFile | null): number | undef
     .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   if (reported.length === 0) return undefined;
   return reported.reduce((sum, value) => sum + value, 0);
-}
-
-function stopBeforeNextIteration(mission: ResearchMission, now: Date): string | null {
-  if (mission.iterations.length >= mission.bounds.maxIterations) return "Iteration limit reached";
-  const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
-  if (
-    Number.isFinite(startedAt) &&
-    now.getTime() - startedAt >= mission.bounds.wallClockMinutes * 60_000
-  ) {
-    return "Wall-clock limit reached";
-  }
-  const knownCosts = mission.iterations
-    .map((iteration) => iteration.costUsd)
-    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
-  if (
-    mission.bounds.stopWhenCostUnavailable &&
-    mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
-  ) {
-    return "Cost unavailable; review before another iteration";
-  }
-  if (
-    mission.bounds.maxSpendUsd !== undefined &&
-    knownCosts.reduce((sum, value) => sum + value, 0) >= mission.bounds.maxSpendUsd
-  ) {
-    return "Reported spend limit reached";
-  }
-  return null;
 }
 
 function mergeResearchSource(

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -29,6 +29,7 @@ import {
   researchMissionWorkspacePath,
   saveResearchMission,
 } from "./research-mission-store.ts";
+import { withResearchMissionActionLock } from "./research-mission-lock.ts";
 
 export type ResearchFlowStartResult = {
   ok: boolean;
@@ -243,23 +244,6 @@ function conversationCost(conversation: ConversationFile | null): number | undef
     .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   if (reported.length === 0) return undefined;
   return reported.reduce((sum, value) => sum + value, 0);
-}
-
-declare global {
-  var __caveResearchMissionActionLocks: Map<string, Promise<void>> | undefined;
-}
-
-function withResearchMissionActionLock<T>(id: string, operation: () => Promise<T>): Promise<T> {
-  globalThis.__caveResearchMissionActionLocks ??= new Map();
-  const locks = globalThis.__caveResearchMissionActionLocks;
-  const previous = locks.get(id) ?? Promise.resolve();
-  const result = previous.then(operation, operation);
-  const tail = result.then(() => undefined, () => undefined);
-  locks.set(id, tail);
-  void tail.then(() => {
-    if (locks.get(id) === tail) locks.delete(id);
-  });
-  return result;
 }
 
 function stopBeforeNextIteration(mission: ResearchMission, now: Date): string | null {


### PR DESCRIPTION
Closes #3500
Closes #3533
Closes #3534
Closes #3535
Closes #3536
Closes #3537
Closes #3545
Closes #3546
Closes #3547
Closes #3548

## Tracking

- Milestone: [Maintainability Refactor Program](https://github.com/OpenCoven/coven-cave/milestone/2)
- Project: [Coven Cave Maintainability Refactor Program](https://github.com/orgs/OpenCoven/projects/6)

## What changed

This is a behavior-preserving extraction of server-side ownership boundaries, keeping existing public imports, HTTP/SSE contracts, persistence formats, lock behavior, and platform-specific command handling intact.

- Chat send: separates attachment/mentioned-file delivery, harness capability probes, model and response controls, SSE framing/heartbeat, and saved-conversation/runtime workspace resolution.
- Cave-home reconciliation: extracts public reconciliation contracts without moving lock, takeover, journal, recovery, or compatibility behavior.
- Research missions: separates per-mission action locking and lifecycle record/startup/stop-gate handling.
- Onboarding install: separates bounded/redacted job output and fixed subprocess execution while retaining npm-lane and daemon lifecycle behavior in the route.
- Cave config: separates normalization and travel defaults while retaining public cave-config exports and persistence semantics.

## Contract safeguards

- Attachment temp files retain owner-only permissions, randomized extensions, cleanup, and mentioned-file containment checks.
- SSE event framing and heartbeat behavior remain unchanged.
- Installer subprocesses retain fixed argv, shell policy, timeout handling, ANSI cleanup, output redaction, and error result shape.
- Reconciliation and research retain their existing externally imported type/function surfaces.
- Config normalization remains a type-only dependency edge, preserving runtime initialization order.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:api` (212 files)
- `pnpm test:app` (797 files)
- `pnpm build`
- `git diff --check`

The native `node-pty` postinstall could not compile in this WSL environment because `make` is unavailable; JavaScript dependencies were then installed with scripts disabled. Typecheck, app/API suites, and the production build completed successfully.

## Review plan

This PR stays draft while CI runs. I will resolve actionable CI findings, then perform repeated exact-head review passes until three consecutive passes report no issues.

## Scope

No product behavior, storage schema, public API, or platform policy changes are intended.