### PR TITLE
fix(chat): keep interrupted transcripts visible

### DIFF
--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -34,7 +34,7 @@ const sessions = [
   session("old-alpha", "/work/alpha", "2026-06-01T00:00:00.000Z", "sage"),
   session("new-alpha", "/work/alpha", "2026-06-03T00:00:00.000Z", "cody", "running"),
   session("beta", "/work/beta", "2026-06-02T00:00:00.000Z", "nova"),
-  session("hidden", "/work/alpha", "2026-06-04T00:00:00.000Z", "cody", "archived"),
+  session("status-archived", "/work/alpha", "2026-06-04T00:00:00.000Z", "cody", "archived"),
   session("scratch", "", "2026-06-05T00:00:00.000Z", "charm"),
 ];
 
@@ -75,6 +75,24 @@ assert.deepEqual(
     filterVisibleChatSessions(withArchived, "cody", { includeArchived: true }).map((s) => s.id),
     ["stashed", "new-alpha"],
     "includeArchived still applies the familiar scope",
+  );
+}
+
+// Dead-status caveats: `archived` stays hidden outright, while killed/orphaned/
+// stopped chats that still have a Cave-local conversation remain visible as
+// recoverable history. Daemon-only rows with those statuses stay hidden.
+{
+  const recoverable = [
+    { ...session("recoverable-orphan", "", "2026-06-11T09:00:00.000Z", "nova", "orphaned"), hasLocalConversation: true },
+    { ...session("recoverable-killed", "", "2026-06-11T10:00:00.000Z", "cody", "killed"), hasLocalConversation: true },
+    { ...session("recoverable-stopped", "", "2026-06-11T11:00:00.000Z", "charm", "stopped"), hasLocalConversation: true },
+    { ...session("daemon-orphan", "", "2026-06-11T12:00:00.000Z", "sage", "orphaned") },
+    { ...session("status-archived", "", "2026-06-11T13:00:00.000Z", "sage", "archived"), hasLocalConversation: true },
+  ];
+  assert.deepEqual(
+    filterVisibleChatSessions(recoverable, null).map((s) => s.id),
+    ["recoverable-stopped", "recoverable-killed", "recoverable-orphan"],
+    "only Cave-backed recoverable dead-status chats should stay visible, in recency order",
   );
 }
 

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -5,8 +5,6 @@ import { compareProjectsAlphabetically } from "./cave-projects-types.ts";
 export type ChatProject = CaveProject;
 export type { CaveProject };
 
-const DEAD_CHAT_STATUSES = new Set(["killed", "orphaned", "stopped", "archived"]);
-
 export type ChatProjectGroup = {
   projectId: string | null;
   projectRoot: string | null;
@@ -159,7 +157,13 @@ export function filterVisibleChatSessions(
 ): SessionRow[] {
   const includeArchived = opts?.includeArchived ?? false;
   return sessions
-    .filter((session) => !DEAD_CHAT_STATUSES.has(session.status))
+    .filter((session) => {
+      if (session.status === "archived") return false;
+      if (session.status === "killed" || session.status === "orphaned" || session.status === "stopped") {
+        return session.hasLocalConversation === true;
+      }
+      return true;
+    })
     .filter((session) => includeArchived || !session.archived_at)
     .filter((session) => !isGeneratedChatSession(session))
     .filter((session) => familiarId === null || session.familiarId === familiarId)

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { filterVisibleChatSessions } from "./chat-projects.ts";
 import {
   localConversationSessionRows,
   mergeSessionRows,
@@ -39,6 +40,7 @@ assert.deepEqual(
     updated_at: "2026-06-08T20:05:00.000Z",
     familiarId: "charm",
     origin: "chat",
+    hasLocalConversation: true,
     initiator: { kind: "human", label: "Cave user", channel: "cave" },
   },
   "saved Cave conversations should become complete session rows when the daemon loses them",
@@ -74,6 +76,325 @@ assert.deepEqual(
   merged.find((s) => s.id === "daemon-1")?.initiator,
   { kind: "familiar", label: "Cody", agentId: "cody" },
   "daemon sessions should preserve sanitized initiator provenance when present",
+);
+assert.equal(
+  merged.find((s) => s.id === "local-1")?.hasLocalConversation,
+  true,
+  "local-only saved chats should mark that Cave has a local transcript",
+);
+assert.equal(
+  merged.find((s) => s.id === "daemon-1")?.hasLocalConversation,
+  undefined,
+  "daemon-only sessions without a matching local transcript should not gain local provenance",
+);
+
+const matchedMerged = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "matched-1",
+      project_root: "/repo",
+      harness: "codex",
+      title: "Matched chat",
+      status: "orphaned",
+      exit_code: null,
+      archived_at: null,
+      created_at: "2026-06-08T18:00:00.000Z",
+      updated_at: "2026-06-08T18:10:00.000Z",
+      initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+    },
+  ],
+  localConversations: [
+    {
+      sessionId: "matched-1",
+      familiarId: "nova",
+      harness: "codex",
+      title: "Matched chat",
+      updatedAt: "2026-06-08T18:15:00.000Z",
+      status: "completed",
+      exitCode: 0,
+    },
+  ],
+  state,
+  includeArchived: false,
+});
+
+assert.equal(
+  matchedMerged.find((s) => s.id === "matched-1")?.hasLocalConversation,
+  true,
+  "matched daemon/local sessions should record that Cave has a local transcript",
+);
+assert.equal(
+  matchedMerged.find((s) => s.id === "matched-1")?.status,
+  "orphaned",
+  "matched daemon rows should keep an interrupted daemon status when the local transcript updated more recently",
+);
+assert.equal(
+  matchedMerged.find((s) => s.id === "matched-1")?.familiarId,
+  "nova",
+  "matched daemon rows should fall back to the local conversation familiar when state has no mapping",
+);
+assert.deepEqual(
+  filterVisibleChatSessions(matchedMerged, "nova").map((s) => s.id),
+  ["matched-1"],
+  "familiar-scoped chat filters should retain the recovered transcript-backed row",
+);
+
+const validRootArchived = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "valid-root-archived",
+      project_root: "/repo",
+      harness: "codex",
+      title: "Archived chat",
+      status: "archived",
+      exit_code: 143,
+      archived_at: null,
+      created_at: "2026-06-08T18:00:00.000Z",
+      updated_at: "2026-06-08T18:10:00.000Z",
+    },
+  ],
+  localConversations: [
+    {
+      sessionId: "valid-root-archived",
+      familiarId: "nova",
+      harness: "codex",
+      title: "Archived chat",
+      updatedAt: "2026-06-08T18:15:00.000Z",
+      status: "completed",
+      exitCode: 0,
+    },
+  ],
+  state,
+  includeArchived: false,
+  isValidDaemonProjectRoot: (root) => root === "/repo",
+});
+
+const invalidRootInterrupted = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "invalid-root-interrupted",
+      project_root: "/invalid",
+      harness: "codex",
+      title: "Interrupted chat",
+      status: "killed",
+      exit_code: 137,
+      archived_at: null,
+      created_at: "2026-06-08T18:00:00.000Z",
+      updated_at: "2026-06-08T18:10:00.000Z",
+      initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+    },
+  ],
+  localConversations: [
+    {
+      sessionId: "invalid-root-interrupted",
+      familiarId: "nova",
+      harness: "codex",
+      runtime: "local:/repo",
+      title: "Interrupted chat",
+      updatedAt: "2026-06-08T18:15:00.000Z",
+      status: "completed",
+      exitCode: 0,
+      origin: "chat",
+    },
+  ],
+  state,
+  includeArchived: false,
+  isValidDaemonProjectRoot: (root) => root === "/repo",
+  projectRootForCwd: (cwd) => (cwd === "/repo" ? "/repo" : null),
+});
+
+assert.equal(invalidRootInterrupted.length, 1);
+assert.equal(invalidRootInterrupted[0]?.id, "invalid-root-interrupted");
+assert.equal(invalidRootInterrupted[0]?.project_root, "/repo");
+assert.equal(invalidRootInterrupted[0]?.status, "killed");
+assert.equal(invalidRootInterrupted[0]?.exit_code, 137);
+assert.equal(invalidRootInterrupted[0]?.hasLocalConversation, true);
+assert.deepEqual(
+  invalidRootInterrupted[0]?.initiator,
+  { kind: "familiar", label: "Cody", agentId: "cody" },
+  "invalid-root interrupted recovery should preserve daemon initiator provenance",
+);
+
+const invalidRootArchivedMatched = mergeSessionRows({
+  daemonSessions: [
+    {
+      id: "invalid-root-archived",
+      project_root: "/invalid",
+      harness: "codex",
+      title: "Archived chat",
+      status: "archived",
+      exit_code: 143,
+      archived_at: null,
+      created_at: "2026-06-08T18:00:00.000Z",
+      updated_at: "2026-06-08T18:10:00.000Z",
+      initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+    },
+  ],
+  localConversations: [
+    {
+      sessionId: "invalid-root-archived",
+      familiarId: "nova",
+      harness: "codex",
+      runtime: "local:/repo",
+      title: "Archived chat",
+      updatedAt: "2026-06-08T18:15:00.000Z",
+      status: "completed",
+      exitCode: 0,
+      origin: "chat",
+    },
+  ],
+  state,
+  includeArchived: false,
+  isValidDaemonProjectRoot: (root) => root === "/repo",
+  projectRootForCwd: (cwd) => (cwd === "/repo" ? "/repo" : null),
+});
+
+assert.equal(invalidRootArchivedMatched.length, 1, "matched invalid-root archived sessions recover exactly one row");
+assert.equal(invalidRootArchivedMatched[0]?.project_root, "/repo");
+assert.equal(invalidRootArchivedMatched[0]?.status, "archived");
+assert.equal(invalidRootArchivedMatched[0]?.exit_code, 143);
+assert.equal(invalidRootArchivedMatched[0]?.archived_at, null);
+assert.equal(invalidRootArchivedMatched[0]?.hasLocalConversation, true);
+assert.deepEqual(
+  invalidRootArchivedMatched[0]?.initiator,
+  { kind: "familiar", label: "Cody", agentId: "cody" },
+  "invalid-root archived recovery should preserve daemon initiator provenance",
+);
+
+assert.equal(
+  validRootArchived[0]?.status,
+  "archived",
+  "newer local transcripts must not overwrite a valid-root daemon archived status",
+);
+assert.equal(
+  validRootArchived[0]?.exit_code,
+  143,
+  "newer local transcripts must not overwrite the daemon exit code for an archived status",
+);
+assert.equal(validRootArchived[0]?.archived_at, null, "the daemon status is authoritative even without archived_at");
+
+const invalidRootArchived = {
+  ...state,
+  sessionArchived: { "invalid-root-interrupted": "2026-06-08T18:20:00.000Z" },
+};
+
+const invalidRootInterruptedArchived = {
+  ...invalidRootInterrupted[0],
+  archived_at: "2026-06-08T18:25:00.000Z",
+};
+
+assert.equal(
+  mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "invalid-root-interrupted",
+        project_root: "/invalid",
+        harness: "codex",
+        title: "Interrupted chat",
+        status: "killed",
+        exit_code: 137,
+        archived_at: "2026-06-08T18:25:00.000Z",
+        created_at: "2026-06-08T18:00:00.000Z",
+        updated_at: "2026-06-08T18:10:00.000Z",
+        initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+      },
+    ],
+    localConversations: [
+      {
+        sessionId: "invalid-root-interrupted",
+        familiarId: "nova",
+        harness: "codex",
+        runtime: "local:/repo",
+        title: "Interrupted chat",
+        updatedAt: "2026-06-08T18:15:00.000Z",
+        status: "completed",
+        exitCode: 0,
+        origin: "chat",
+      },
+    ],
+    state,
+    includeArchived: false,
+    isValidDaemonProjectRoot: (root) => root === "/repo",
+    projectRootForCwd: (cwd) => (cwd === "/repo" ? "/repo" : null),
+  }).length,
+  0,
+  "invalid-root interrupted chats with daemon archived_at should stay hidden from the active list",
+);
+
+assert.deepEqual(
+  mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "invalid-root-interrupted",
+        project_root: "/invalid",
+        harness: "codex",
+        title: "Interrupted chat",
+        status: "killed",
+        exit_code: 137,
+        archived_at: "2026-06-08T18:25:00.000Z",
+        created_at: "2026-06-08T18:00:00.000Z",
+        updated_at: "2026-06-08T18:10:00.000Z",
+        initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+      },
+    ],
+    localConversations: [
+      {
+        sessionId: "invalid-root-interrupted",
+        familiarId: "nova",
+        harness: "codex",
+        runtime: "local:/repo",
+        title: "Interrupted chat",
+        updatedAt: "2026-06-08T18:15:00.000Z",
+        status: "completed",
+        exitCode: 0,
+        origin: "chat",
+      },
+    ],
+    state,
+    includeArchived: true,
+    isValidDaemonProjectRoot: (root) => root === "/repo",
+    projectRootForCwd: (cwd) => (cwd === "/repo" ? "/repo" : null),
+  }),
+  [invalidRootInterruptedArchived],
+  "invalid-root interrupted recovery should preserve the daemon archived_at when archived rows are visible",
+);
+
+assert.equal(
+  mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "invalid-root-interrupted",
+        project_root: "/invalid",
+        harness: "codex",
+        title: "Interrupted chat",
+        status: "killed",
+        exit_code: 137,
+        archived_at: "2026-06-08T18:25:00.000Z",
+        created_at: "2026-06-08T18:00:00.000Z",
+        updated_at: "2026-06-08T18:10:00.000Z",
+        initiator: { kind: "familiar", label: "Cody", agentId: "cody" },
+      },
+    ],
+    localConversations: [
+      {
+        sessionId: "invalid-root-interrupted",
+        familiarId: "nova",
+        harness: "codex",
+        runtime: "local:/repo",
+        title: "Interrupted chat",
+        updatedAt: "2026-06-08T18:15:00.000Z",
+        status: "completed",
+        exitCode: 0,
+        origin: "chat",
+      },
+    ],
+    state: invalidRootArchived,
+    includeArchived: true,
+    isValidDaemonProjectRoot: (root) => root === "/repo",
+    projectRootForCwd: (cwd) => (cwd === "/repo" ? "/repo" : null),
+  })[0]?.archived_at,
+  "2026-06-08T18:20:00.000Z",
+  "invalid-root interrupted recovery should still honor the Cave-local archive override",
 );
 
 const cwdFiltered = mergeSessionRows({

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -37,6 +37,12 @@ type MergeOptions = {
   projectRootForCwd?: (cwd: string) => string | null;
 };
 
+const DAEMON_AUTHORITATIVE_TERMINAL_STATUSES = new Set(["archived", "killed", "orphaned", "stopped"]);
+
+function isDaemonAuthoritativeTerminalStatus(status: string): boolean {
+  return DAEMON_AUTHORITATIVE_TERMINAL_STATUSES.has(status);
+}
+
 /** Extract the local cwd from a conversation runtime ("local:<cwd>").
  *  Kept dependency-free here (rather than importing the server work-branch
  *  helper) so this module stays pure and unit-testable. */
@@ -79,6 +85,7 @@ function localConversationToSession(
     updated_at: conv.updatedAt,
     familiarId,
     origin: conv.origin ?? "chat",
+    hasLocalConversation: true,
     ...(conv.branch ? { workBranch: conv.branch } : {}),
     initiator: conv.initiator ?? { kind: "human", label: "Cave user", channel: "cave" },
     ...(keep ? { keep: true } : {}),
@@ -130,7 +137,20 @@ export function mergeSessionRows({
   }
 
   for (const session of daemonSessions) {
+    const local = localById.get(session.id);
     if (isValidDaemonProjectRoot && !isValidDaemonProjectRoot(session.project_root)) {
+      if (local && isDaemonAuthoritativeTerminalStatus(session.status)) {
+        seen.add(session.id);
+        const recovered = localConversationToSession(local, state, projectRootForCwd);
+        const row: SessionRow = {
+          ...recovered,
+          status: session.status,
+          exit_code: session.exit_code,
+          archived_at: state.sessionArchived[session.id] ?? session.archived_at,
+          initiator: session.initiator ?? recovered.initiator,
+        };
+        if (visibleSession(row, state, includeArchived)) rows.push(row);
+      }
       continue;
     }
     seen.add(session.id);
@@ -140,17 +160,18 @@ export function mergeSessionRows({
     const extendedUntil = state.sessionArchiveExtendedUntil?.[session.id] ?? null;
     const archived_at = archivedLocal ?? session.archived_at;
     const localUpdatedAt = localUpdatedById.get(session.id);
-    const local = localById.get(session.id);
+    const familiarId = state.sessionFamiliar[session.id] ?? local?.familiarId ?? null;
     const localIsNewer =
       localUpdatedAt != null &&
       Number.isFinite(Date.parse(localUpdatedAt)) &&
       Number.isFinite(Date.parse(session.updated_at)) &&
       Date.parse(localUpdatedAt) > Date.parse(session.updated_at);
+    const daemonStatusIsAuthoritative = isDaemonAuthoritativeTerminalStatus(session.status);
     const row: SessionRow = {
       ...session,
       ...(localUpdatedAt ? { updated_at: localUpdatedAt } : {}),
-      ...(localIsNewer && local?.status ? { status: local.status } : {}),
-      ...(localIsNewer && local ? { exit_code: local.exitCode ?? 0 } : {}),
+      ...(localIsNewer && !daemonStatusIsAuthoritative && local?.status ? { status: local.status } : {}),
+      ...(localIsNewer && !daemonStatusIsAuthoritative && local ? { exit_code: local.exitCode ?? 0 } : {}),
       // Daemon titles derive from the harness prompt, which the chat route
       // prefixes with the identity canon — sanitize so the preamble never
       // surfaces as a session title.
@@ -159,7 +180,6 @@ export function mergeSessionRows({
         sanitizeSessionTitle(session.title) ??
         defaultChatTitleForSession(session.id),
       archived_at,
-      familiarId: state.sessionFamiliar[session.id] ?? null,
       // A Cave conversation records real provenance at send time; harness/
       // title inference is only the fallback for daemon-only sessions.
       origin: local?.origin ?? inferOrigin(session),
@@ -170,11 +190,11 @@ export function mergeSessionRows({
       // a run some generator spawned (journal narrative, flow, automation,
       // CLI), not something a person typed into a chat surface.
       ...(!local && inferOrigin(session) === "chat" ? { generated: true } : {}),
+      ...(local ? { hasLocalConversation: true } : {}),
       ...(keep ? { keep: true } : {}),
       ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
-      initiator:
-        session.initiator ??
-        initiatorFromSessionKey("", state.sessionFamiliar[session.id] ?? session.harness),
+      familiarId,
+      initiator: session.initiator ?? initiatorFromSessionKey("", familiarId ?? session.harness),
     };
     if (visibleSession(row, state, includeArchived)) rows.push(row);
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,8 @@ export type SessionRow = {
   updated_at: string;
   familiarId?: string | null;
   origin?: SessionOrigin;
+  /** Cave has a saved local conversation transcript; preserves recoverable interrupted chats without surfacing daemon-only dead runs. */
+  hasLocalConversation?: boolean;
   /**
    * True for daemon sessions with no Cave conversation behind them — runs
    * spawned by generators (journal narratives, flows, automations, CLI runs)


### PR DESCRIPTION
## Summary
- keep Cave transcript-backed killed, orphaned, and stopped chats reachable in normal chat surfaces
- preserve daemon-authoritative terminal status, archive, initiator, and exit metadata across local transcript merges
- recover invalid daemon roots through trusted local conversation project semantics and preserve familiar ownership

## Verification
- `pnpm typecheck`
- `pnpm test:app` (797 test files passed)
- `git diff --check`

Bead: `cave-zhwa`