### PR TITLE
fix: standardize desktop top bar controls

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -4,7 +4,15 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const desktopChrome = readFileSync(
+  new URL("../styles/globals/desktop-chrome.css", import.meta.url),
+  "utf8",
+);
+const foundations = readFileSync(
+  new URL("../styles/globals/foundations.css", import.meta.url),
+  "utf8",
+);
+const notificationBell = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
 // The switcher moved to the sidenav header (cave-vtk9); its compact geometry
 // is pinned in sidebar-minimal.test.ts against the rail rules instead.
 
@@ -120,6 +128,56 @@ assert.match(
   /scheduleNeedsCount > 0 \? \(\s*<span className="menu-bar__badge">/,
   "the Schedules badge matches the Tasks badge chrome (no alert tint) and hides at zero",
 );
+assert.match(
+  source,
+  /typeof runningCount === "number" && runningCount > 0 \? \(\s*<span\s+className="menu-bar__status"[^>]*role="status"[^>]*aria-label=\{`\$\{runningCount\} session\$\{runningCount === 1 \? "" : "s"\} running`\}[^>]*title=\{`\$\{runningCount\} session\$\{runningCount === 1 \? "" : "s"\} running`\}[^>]*>[\s\S]{0,260}?<Icon name="ph:waveform"[\s\S]{0,250}?<span className="menu-bar__badge" aria-hidden>\s*\{fmtBadge\(runningCount\)\}\s*<\/span>[\s\S]{0,120}?\)\s*:\s*null/,
+  "running sessions render as a compact status control that hides at zero and carries the exact label",
+);
+assert.doesNotMatch(
+  source,
+  /menu-bar__running-dot/,
+  "the running status no longer uses a presence dot",
+);
+assert.doesNotMatch(
+  source,
+  /\{runningCount\} running/,
+  "the running status no longer renders the literal running pill text",
+);
+assert.match(
+  notificationBell,
+  /displayBadgeCount > 0 \? \(\s*<span[^>]*className="notification-bell__badge"[^>]*>[\s\S]{0,120}?\)\s*:\s*null/,
+  "notification alerts render their badge only inside the displayBadgeCount conditional and fall back to null",
+);
+assert.match(
+  desktopChrome,
+  /\.menu-bar__badge,\s*\n\.menu-bar \.notification-bell__badge \{\s*\n\s*min-width:\s*15px;\s*\n\s*height:\s*15px;\s*\n\s*border-radius:\s*var\(--radius-control\);/,
+  "desktop corner badges share the same compact geometry",
+);
+assert.match(
+  desktopChrome,
+  /\.notification-bell__badge \{[\s\S]{0,180}?padding:\s*0 var\(--space-1\);/,
+  "notification badges keep horizontal padding only on the base rule",
+);
+assert.match(
+  desktopChrome,
+  /\.notification-bell__badge \{[^}]*background:\s*var\(--color-danger\);/,
+  "notification badges use the danger background",
+);
+assert.match(
+  foundations,
+  /:root \{[\s\S]*?--color-danger:\s*oklch\(0\.74 0\.18 24\);\s*\n\s*--color-danger-foreground:\s*#111111;\s*\n\s*--color-danger-soft:/,
+  "the default dark danger palette uses deterministic near-black foreground ink",
+);
+assert.match(
+  foundations,
+  /:root\[data-mode="light"\] \{[\s\S]*?--color-danger:\s*oklch\(0\.52 0\.20 24\);\s*\n\s*--color-danger-foreground:\s*#ffffff;\s*\n\s*--color-danger-soft:/,
+  "the light danger palette overrides the foreground with deterministic white ink",
+);
+assert.match(
+  desktopChrome,
+  /\.notification-bell__badge \{[^}]*color:\s*var\(--color-danger-foreground\);/,
+  "notification badges use the semantic danger foreground",
+);
 
 // Wiring in the workspace: the bar mounts in the Shell topBar slot with the
 // real scope/navigation handlers and live counts.
@@ -171,9 +229,9 @@ assert.match(
 );
 
 // Desktop-only: the bar shows ≥1024px (where the mobile .top-bar is hidden).
-assert.match(globals, /\.menu-bar \{\s*display: none;/, "menu bar is hidden by default");
+assert.match(desktopChrome, /\.menu-bar \{\s*display: none;/, "menu bar is hidden by default");
 assert.match(
-  globals,
+  desktopChrome,
   /@media \(min-width: 1024px\) \{\s*\.menu-bar \{\s*display: flex;/,
   "menu bar shows on desktop (≥1024px)",
 );

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -11,11 +11,11 @@ type Props = {
   /** Active familiar display name — personalizes the command-bar placeholder
    *  ("Search or ask <name>…"). Falls back to Salem, the docs familiar. */
   activeFamiliarName?: string | null;
-  /** Live count of running daemon sessions — drives the "N running" pill
+  /** Live count of running daemon sessions — drives the compact status control
    *  (hidden at zero). */
   runningCount?: number;
   /** Notification bell, rendered by the workspace (it owns the inbox state)
-   *  so this bar stays markup-thin. Sits at the bar's right edge. */
+   *  so this bar stays markup-thin. Joins the right-side status controls. */
   bell?: ReactNode;
   /** Open task count (board cards not yet done) — drives the Tasks badge. */
   taskCount: number;
@@ -176,17 +176,20 @@ export function FamiliarMenuBar({
         </button>
       </div>
 
-      {/* Right edge (chat-revamp phase D): live running-session pill (accent
-          presence dot + count, hidden at zero) and the notification bell. */}
+      {/* Right edge (chat-revamp phase D): compact running-session status
+          (waveform + count, hidden at zero) and the notification bell. */}
       <div className="menu-bar__group menu-bar__group--status">
         {typeof runningCount === "number" && runningCount > 0 ? (
           <span
-            className="menu-bar__running"
+            className="menu-bar__status"
             role="status"
+            aria-label={`${runningCount} session${runningCount === 1 ? "" : "s"} running`}
             title={`${runningCount} session${runningCount === 1 ? "" : "s"} running`}
           >
-            <span className="menu-bar__running-dot" aria-hidden />
-            {runningCount} running
+            <Icon name="ph:waveform" width={22} height={22} aria-hidden />
+            <span className="menu-bar__badge" aria-hidden>
+              {fmtBadge(runningCount)}
+            </span>
           </span>
         ) : null}
         {bell}

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -1,14 +1,25 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(
+  new URL("../styles/globals/desktop-chrome.css", import.meta.url),
+  "utf8",
+);
 // One compact top-chrome glyph size, var(--icon-sm) (14px) — shared by the
-// menu-bar action icons, the search glyph, and the sidepanel toggle.
-assert.match(css, /\.menu-bar__task > svg\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "task icon is var(--icon-sm)");
-assert.match(css, /\.menu-bar__search-icon\s*\{[\s\S]*?width:\s*var\(--icon-sm\)[\s\S]*?height:\s*var\(--icon-sm\)/, "search icon is var(--icon-sm)");
+// menu-bar action/status icons, the search glyph, and the sidepanel toggle.
+assert.match(
+  css,
+  /\.menu-bar__task > svg,\s*\n\.menu-bar__status > svg \{[^}]*width:\s*var\(--icon-sm\)[^}]*height:\s*var\(--icon-sm\)[^}]*\}/,
+  "task and status icons are var(--icon-sm)",
+);
+assert.match(css, /\.menu-bar__search-icon\s*\{[^}]*width:\s*var\(--icon-sm\)[^}]*height:\s*var\(--icon-sm\)[^}]*\}/, "search icon is var(--icon-sm)");
 // Action buttons + search input use the design-token body size, not ad-hoc px.
-assert.match(css, /\.menu-bar__new,\s*\n\.menu-bar__task\s*\{[\s\S]*?font-size:\s*var\(--text-base\)/, "menu-bar buttons use var(--text-base)");
-assert.match(css, /\.menu-bar__search-input\s*\{[\s\S]*?font-size:\s*var\(--text-base\)/, "search input uses var(--text-base)");
+assert.match(
+  css,
+  /\.menu-bar__new,\s*\n\.menu-bar__task,\s*\n\.menu-bar__status \{[^}]*font-size:\s*var\(--text-base\)[^}]*\}/,
+  "menu-bar buttons use var(--text-base)",
+);
+assert.match(css, /\.menu-bar__search-input\s*\{[^}]*font-size:\s*var\(--text-base\)[^}]*\}/, "search input uses var(--text-base)");
 // The sidepanel/nav toggle glyph stays unified with the action icons.
 const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -323,10 +323,7 @@ export function NotificationBell({
         <Icon name="ph:bell-fill" aria-hidden />
 
         {displayBadgeCount > 0 ? (
-          <span
-            aria-hidden
-            className="absolute -right-1 -top-1 grid h-4 min-w-4 place-items-center rounded-full bg-[var(--color-danger)] px-1 text-[length:var(--text-2xs)] font-bold leading-none text-[var(--text-primary)]"
-          >
+          <span aria-hidden className="notification-bell__badge">
             {displayBadgeCount > 9 ? "9+" : displayBadgeCount}
           </span>
         ) : null}

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -4,7 +4,7 @@
 //      Settings + account avatar at the bottom; quiet surfaces demoted to the
 //      expanded panel (still reachable via ⌘B / hover-peek / ⌘K).
 //   2. 52px-band command bar: "Search or ask <familiar>…" + ⌘K keycap,
-//      right cluster = "N running" pill + notification bell.
+//      right cluster = compact running status + notification bell.
 //   3. Bottom status bar: session context chips (project/model/branch/cwd) +
 //      PR and Tasks chips, mounted under the Home/Chat detail column.
 import assert from "node:assert/strict";
@@ -76,26 +76,21 @@ assert.match(
 );
 assert.match(
   menuBar,
-  /<div className="menu-bar__group menu-bar__group--status">[\s\S]{0,700}?menu-bar__running[\s\S]{0,500}?\{bell\}\s*<\/div>/,
-  "the right cluster hosts the running pill and the bell slot",
+  /<div className="menu-bar__group menu-bar__group--status">[\s\S]*?className="menu-bar__status"[\s\S]*?\{bell\}\s*<\/div>/,
+  "the right cluster hosts the compact running status before the bell slot",
 );
-assert.match(
+assert.doesNotMatch(
   menuBar,
-  /role="status"\s*\n\s*title=\{`\$\{runningCount\} session\$\{runningCount === 1 \? "" : "s"\} running`\}/,
-  "the running pill is a live status with an exact-count tooltip",
+  /className="menu-bar__running"/,
+  "the right cluster no longer uses the old running pill",
 );
-assert.match(
+assert.doesNotMatch(
   menuBar,
-  /typeof runningCount === "number" && runningCount > 0 \?/,
-  "the running pill hides at zero",
+  /menu-bar__running-dot/,
+  "the right cluster no longer uses the old running dot",
 );
-assert.match(
-  globals,
-  /\.menu-bar__running-dot \{[\s\S]{0,180}?background: var\(--accent-presence\);/,
-  "the running dot uses the accent presence token",
-);
-// Workspace feeds the pill from the shared session-status vocabulary and
-// mounts the same NotificationBell the mobile TopBar uses.
+// Detailed waveform, badge, zero-hide, and accessibility contracts live in
+// familiar-menu-bar.test.ts. This suite keeps only the shell-level wiring.
 assert.match(
   workspace,
   /const runningSessionCount = useMemo\(\s*\n\s*\(\) => sessions\.filter\(\(s\) => !s\.archived_at && sessionStatusTone\(s\.status\) === "running"\)\.length,\s*\n\s*\[sessions\],\s*\n\s*\);/,

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -609,10 +609,10 @@ button:active > .edge-rail-chip {
    keyboard shortcuts keep search available.
    ──────────────────────────────────────────────── */
 
-/* Desktop top menu bar — quick chat with familiars (left) + view tasks
-   (right). Hidden below 1024px, where the mobile `.top-bar` takes over (the
-   two are mutually exclusive so they never both render). Lives in the Shell's
-   `topBar` slot above `.shell-body`. */
+/* Desktop top menu bar — centered search with compact action/status controls.
+   Hidden below 1024px, where the mobile `.top-bar` takes over (the two are
+   mutually exclusive so they never both render). Lives in the Shell's `topBar`
+   slot above `.shell-body`. */
 .menu-bar {
   display: none;
   /* Search is absolutely centered in the bar (Codex-style); the task chrome
@@ -660,7 +660,7 @@ button:active > .edge-rail-chip {
   left: 50%;
   transform: translateX(-50%);
   /* Stay geometrically centered, but reserve equal room on both sides for the
-     action cluster (task verbs + running pill + bell) plus breathing room.
+     action cluster (task verbs + compact status controls) plus breathing room.
      Basing the third cap on this bar's own width makes compact native windows
      shrink gracefully. Phase-D command bar: 557px max per the revamp design. */
   width: min(557px, 42vw, calc(100% - 560px));
@@ -748,7 +748,8 @@ button:active > .edge-rail-chip {
 }
 
 .menu-bar__new,
-.menu-bar__task {
+.menu-bar__task,
+.menu-bar__status {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -766,10 +767,18 @@ button:active > .edge-rail-chip {
   color: var(--text-muted);
   font-size: var(--text-base);
   white-space: nowrap;
-  cursor: pointer;
   transition: background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard);
+}
+
+.menu-bar__task {
+  cursor: pointer;
+}
+
+.menu-bar__status {
+  cursor: default;
+  color: var(--text-secondary);
 }
 
 /* Live enrich progress is visible text (information, not chrome) — let that
@@ -790,10 +799,11 @@ button:active > .edge-rail-chip {
   display: inline;
 }
 
-/* One compact standard across the top chrome (var(--icon-sm), 14px): the
-   Enhance/Tasks/Inbox glyphs, the search glyph, and the sidepanel toggle all
-   share this size, rather than scaling with their own label. */
-.menu-bar__task > svg {
+/* One compact standard across the top chrome (var(--icon-sm), 14px): action
+   and status glyphs, the search glyph, and the sidepanel toggle all share this
+   size, rather than scaling with their own label. */
+.menu-bar__task > svg,
+.menu-bar__status > svg {
   flex-shrink: 0;
   width: var(--icon-sm);
   height: var(--icon-sm);
@@ -816,57 +826,59 @@ button:active > .edge-rail-chip {
   color: var(--text-primary);
 }
 
-/* The count badge overlaps its button's corner (like the mobile top-bar's
-   tasks badge) so the 28px square never stretches around it. The bg-base ring
-   separates it from the icon underneath. */
-.menu-bar__badge {
+/* Notification badge baseline matches the mobile top-bar geometry and alert
+   semantics. Desktop overrides only its geometry inside `.menu-bar`. */
+.notification-bell__badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  display: grid;
+  place-items: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-pill);
+  color: var(--color-danger-foreground);
+  background: var(--color-danger);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* Desktop count badges overlap compact controls so every 28px square stays
+   uniform. The bg-base ring separates each badge from its icon. */
+.menu-bar__badge,
+.menu-bar .notification-bell__badge {
+  min-width: 15px;
+  height: 15px;
+  border-radius: var(--radius-control);
   position: absolute;
   top: -4px;
   right: -4px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 15px;
-  height: 15px;
   padding: 0 5px;
-  border-radius: var(--radius-control);
   font-size: var(--text-2xs);
   font-weight: 600;
   line-height: 1;
-  color: var(--accent-presence-foreground);
-  /* Solid accent so the paired foreground keeps its contrast. A 60%-alpha fill
-     composited over the dark app background dropped the count to ~1:1 (WCAG). */
-  background: var(--accent-presence);
   box-shadow: 0 0 0 2px var(--bg-base);
   pointer-events: none;
 }
 
+.menu-bar__badge {
+  color: var(--accent-presence-foreground);
+  /* Solid accent so the paired foreground keeps its contrast. A 60%-alpha fill
+     composited over the dark app background dropped the count to ~1:1 (WCAG). */
+  background: var(--accent-presence);
+}
+
 /* ── Right status cluster (chat-revamp phase D) ──────────────────────────────
- * "N running" pill (accent presence dot + live daemon-session count) and the
- * notification bell, anchoring the bar's right edge. */
+ * Compact running-session status and notification controls anchor the bar's
+ * right edge. */
 .menu-bar__group--status {
   flex: 0 0 auto;
-}
-
-.menu-bar__running {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  height: 28px;
-  padding: 0 var(--space-2);
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  white-space: nowrap;
-}
-
-.menu-bar__running-dot {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  border-radius: var(--radius-pill);
-  background: var(--accent-presence);
 }
 
 /* The bell popover hangs from the slim title band; keep it clear of the

--- a/src/styles/globals/foundations.css
+++ b/src/styles/globals/foundations.css
@@ -184,6 +184,7 @@
   --color-warning: oklch(0.83 0.13 78);
   --color-warning-soft: oklch(0.86 0.05 78);
   --color-danger: oklch(0.74 0.18 24);
+  --color-danger-foreground: #111111;
   --color-danger-soft: oklch(0.82 0.08 24);
   --color-info: var(--accent-presence);
   /* Inline danger-alert vocabulary (craft dossier, marketplace, skill
@@ -342,6 +343,7 @@
   --color-warning: oklch(0.58 0.16 78);
   --color-warning-soft: oklch(0.72 0.10 78);
   --color-danger: oklch(0.52 0.20 24);
+  --color-danger-foreground: #ffffff;
   --color-danger-soft: oklch(0.70 0.12 24);
 }
 


### PR DESCRIPTION
## Summary
- standardize desktop top-bar actions and running status as one 28px square control family
- align Tasks, Rituals, Running, and Notifications badge geometry while preserving danger semantics for unread notifications
- add deterministic danger foreground tokens with WCAG-compliant contrast and focused chrome contracts

## Test plan
- [x] `node --experimental-strip-types --no-warnings --test src/components/familiar-menu-bar.test.ts src/components/menu-bar-icon-size.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test:app` (827 test files)
- [x] `git diff --check`
- [x] native Tauri app builds and launches via `bash scripts/dev-app.sh`

Bead: `cave-b8s2`