### PR TITLE
Attribute familiar-chat PRs to their sessions via transcript-derived context

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -129,6 +129,7 @@ export const SUITES = {
     "src/lib/gh-diff.test.ts",
     "src/lib/gh-review-html.test.ts",
     "src/lib/chat-projects.test.ts",
+    "src/lib/chat-pr-link.test.ts",
     "src/lib/changes-review.test.ts",
     "src/lib/chat-hosts.test.ts",
     "src/lib/chat-recency.test.ts",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -83,6 +83,7 @@ import {
   captureWorkBranch,
   cwdFromConversationRuntime,
 } from "@/lib/server/chat-work-branch";
+import { latestPrUrlFromText } from "@/lib/chat-pr-link";
 import { buildResumeRetryPrompt } from "@/lib/chat-history-fallback";
 import {
   cleanModelId,
@@ -655,6 +656,10 @@ function openClawChatResponse(args: {
           // failed capture keeps the previous snapshot.
           const workBranch = await captureWorkBranch(cwdFromConversationRuntime(conv.runtime));
           if (workBranch) conv.branch = workBranch;
+          // Transcript PR snapshot: the reply's last reported PR URL (fallback
+          // attribution for chats whose work happens in agent worktrees).
+          const reportedPrUrl = latestPrUrlFromText(assistantText);
+          if (reportedPrUrl) conv.prUrl = reportedPrUrl;
           conv.turns.push(
             {
               id: userTurnId,
@@ -1959,6 +1964,10 @@ export async function POST(req: Request) {
         // failed capture keeps the previous snapshot.
         const workBranch = await captureWorkBranch(cwdFromConversationRuntime(conv.runtime));
         if (workBranch) conv.branch = workBranch;
+        // Transcript PR snapshot: the reply's last reported PR URL (fallback
+        // attribution for chats whose work happens in agent worktrees).
+        const reportedPrUrl = latestPrUrlFromText(cleanedAssistantText);
+        if (reportedPrUrl) conv.prUrl = reportedPrUrl;
         if (harnessSessionId) conv.harnessSessionId = harnessSessionId;
         conv.turns.push(userTurn, assistantTurn);
         conv.activeLeafId = assistantTurnId;

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -5,7 +5,7 @@
 // list enriches rows with branch PR context (never blocking the poll) and
 // auto-archives chats whose PR merged.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 
 const chatList = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
 const chatRouter = readFileSync(new URL("./chat-router.tsx", import.meta.url), "utf8");
@@ -15,7 +15,15 @@ const listRoute = readFileSync(
   new URL("../app/api/sessions/list/route.ts", import.meta.url),
   "utf8",
 );
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// #3576 decomposed globals.css into @imported sheets under src/styles —
+// pin against the whole global cascade, wherever a rule now lives.
+const stylesDir = new URL("../styles/", import.meta.url);
+const css = [
+  readFileSync(new URL("../app/globals.css", import.meta.url), "utf8"),
+  ...readdirSync(stylesDir, { recursive: true, encoding: "utf8" })
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => readFileSync(new URL(f, stylesDir), "utf8")),
+].join("\n");
 const caveConfig = readFileSync(new URL("../lib/cave-config.ts", import.meta.url), "utf8");
 
 // ── Chat list: PR badge replaces the status dot where applicable ─────────────
@@ -81,8 +89,13 @@ assert.match(
 );
 assert.match(
   gitEnrichLib,
-  /session\.workBranch \?\?\s*\n\s*\(entry\.gitContext\?\.isWorktree \? entry\.gitContext\.branch \?\? null : null\)/,
+  /session\.workBranch \?\?\s*\n\s*\(entry\?\.gitContext\?\.isWorktree \? entry\.gitContext\.branch \?\? null : null\)/,
   "PR context is attributed per session (recorded work branch, or a branch-stable worktree root) — never the shared root's current branch (cave-9q24)",
+);
+assert.match(
+  gitEnrichLib,
+  /if \(!enriched\.pullRequest && session\.chatPrUrl\) \{\s*\n\s*const pr = urlPrCache\.get\(session\.chatPrUrl\);\s*\n\s*if \(pr\) enriched\.pullRequest = \{ \.\.\.pr, attribution: "transcript" \};/,
+  "transcript-reported PR URLs are a badge-only fallback, tagged so the merged sweep skips them (cave-u9wl)",
 );
 assert.match(
   listRoute,

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -3,14 +3,21 @@
 // edge and matching the row's compact icon-button controls. (The right
 // side-panel + expand toggles were removed with the right companion panel.)
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const projectSidebar = readFileSync(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// #3576 decomposed globals.css into @imported sheets under src/styles —
+// pin against the whole global cascade, wherever a rule now lives.
+const stylesDir = new URL("../styles/", import.meta.url);
+const css = [
+  readFileSync(new URL("../app/globals.css", import.meta.url), "utf8"),
+  ...readdirSync(stylesDir, { recursive: true, encoding: "utf8" })
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => readFileSync(new URL(f, stylesDir), "utf8")),
+].join("\n");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
-
 assert.match(
   shell,
   /import \{ Icon, CAVE_ICON_SIZE, type IconName \} from "@\/lib\/icon"/,
@@ -70,8 +77,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /shell-top-toggle--nav[\s\S]*?aria-label=\{navOpen \? "Collapse navigation to icons" : "Expand navigation"\}/,
-  "nav toggle label reflects nav state",
+  /shell-top-toggle--nav[\s\S]*?aria-label=\{chatContextual[\s\S]*?: navOpen\s*\?\s*"Collapse navigation to icons"\s*:\s*"Expand navigation"\}/,
+  "nav toggle label reflects nav state (and the contextual Chat sidebar variant)",
 );
 assert.match(
   shell,

--- a/src/components/workspace-sidebar-pr-badge.test.ts
+++ b/src/components/workspace-sidebar-pr-badge.test.ts
@@ -5,11 +5,19 @@
 // the session carries real PR context; clicking routes PR URLs through the
 // native GitHubView deep-linker (browser/new-tab fallback) without opening the chat.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 
 const sidebar = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// #3576 decomposed globals.css into @imported sheets under src/styles —
+// pin against the whole global cascade, wherever a rule now lives.
+const stylesDir = new URL("../styles/", import.meta.url);
+const css = [
+  readFileSync(new URL("../app/globals.css", import.meta.url), "utf8"),
+  ...readdirSync(stylesDir, { recursive: true, encoding: "utf8" })
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => readFileSync(new URL(f, stylesDir), "utf8")),
+].join("\n");
 
 // ── ThreadRow: real PR context wins the leading slot ─────────────────────────
 assert.match(

--- a/src/lib/branch-pr-context.test.ts
+++ b/src/lib/branch-pr-context.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createBranchPrCache, parseBranchPr } from "./branch-pr-context.ts";
+import { createBranchPrCache, createPrUrlCache, parseBranchPr } from "./branch-pr-context.ts";
 
 const ghJson = (over = {}) =>
   JSON.stringify({
@@ -99,4 +99,44 @@ test("concurrent refreshes are capped", async () => {
   assert.equal(started, 2);
   release();
   await tick();
+});
+
+// ── URL-keyed cache (transcript-derived attribution, cave-u9wl) ──
+
+test("parseBranchPr without a branch omits the field", () => {
+  const pr = parseBranchPr(ghJson());
+  assert.equal(pr.branch, undefined);
+  assert.equal(pr.repo, "OpenCoven/coven-cave");
+});
+
+test("prUrlCache: first read misses, background fetch keyed on the URL", async () => {
+  const urls = [];
+  const cache = createPrUrlCache({
+    runner: async (url) => {
+      urls.push(url);
+      return ghJson();
+    },
+  });
+  const url = "https://github.com/OpenCoven/coven-cave/pull/42";
+  assert.equal(cache.get(url), undefined);
+  await tick();
+  const pr = cache.get(url);
+  assert.equal(pr?.state, "merged");
+  assert.equal(pr?.branch, undefined, "URL lookups carry no branch");
+  assert.deepEqual(urls, [url]);
+});
+
+test("prUrlCache: failures negative-cache as null", async () => {
+  let calls = 0;
+  const cache = createPrUrlCache({
+    runner: async () => {
+      calls += 1;
+      throw new Error("gh: not found");
+    },
+  });
+  cache.get("https://github.com/o/r/pull/1");
+  await tick();
+  assert.equal(cache.get("https://github.com/o/r/pull/1"), null);
+  await tick();
+  assert.equal(calls, 1, "negative entry served from memory within TTL");
 });

--- a/src/lib/branch-pr-context.ts
+++ b/src/lib/branch-pr-context.ts
@@ -19,10 +19,12 @@ const PR_URL_RE = /https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/;
 /** stdout of `gh pr view <branch> --json number,url,state,isDraft` in `root`. */
 export type BranchPrRunner = (root: string, branch: string) => Promise<string>;
 
-/** Parse gh's JSON into the SessionRow.pullRequest shape (state lowercased). */
+/** Parse gh's JSON into the SessionRow.pullRequest shape (state lowercased).
+ *  `branch` is stamped when known (branch-keyed lookups); URL-keyed lookups
+ *  omit it. */
 export function parseBranchPr(
   stdout: string,
-  branch: string,
+  branch?: string,
 ): SessionPullRequestContext | null {
   let parsed: { number?: unknown; url?: unknown; state?: unknown; isDraft?: unknown };
   try {
@@ -38,7 +40,7 @@ export function parseBranchPr(
     number: parsed.number,
     url: match[0],
     state: typeof parsed.state === "string" ? parsed.state.toLowerCase() : "open",
-    branch,
+    ...(branch ? { branch } : {}),
     draft: parsed.isDraft === true,
   };
 }
@@ -49,6 +51,20 @@ const defaultRunner: BranchPrRunner = (root, branch) =>
       "gh",
       ["pr", "view", branch, "--json", "number,url,state,isDraft"],
       { cwd: root, timeout: 10_000, env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }) },
+      (err, stdout) => (err ? reject(err) : resolve(stdout)),
+    );
+  });
+
+/** stdout of `gh pr view <url> --json number,url,state,isDraft` (repo inferred
+ *  from the URL, so no project cwd is needed). */
+export type UrlPrRunner = (url: string) => Promise<string>;
+
+const defaultUrlRunner: UrlPrRunner = (url) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      "gh",
+      ["pr", "view", url, "--json", "number,url,state,isDraft"],
+      { timeout: 10_000, env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }) },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });
@@ -114,3 +130,66 @@ export function createBranchPrCache(options?: {
 
 /** Process-wide cache instance for API routes (module state survives requests). */
 export const branchPrCache: BranchPrCache = createBranchPrCache();
+
+export type PrUrlCache = {
+  /** Cached PR for a canonical PR URL — null = known unresolvable, undefined =
+   *  not yet resolved. Schedules a background refresh when missing or stale. */
+  get(url: string): SessionPullRequestContext | null | undefined;
+};
+
+/**
+ * URL-keyed sibling of the branch cache, for transcript-derived attribution
+ * (cave-u9wl): familiar chats report the PR they landed in a reply, and the
+ * chat's own cwd never sits on that branch — so the lookup keys on the PR URL
+ * itself. Same stale-while-revalidate posture: synchronous reads, one
+ * background `gh pr view <url>` per URL, negative-cache on failure.
+ */
+export function createPrUrlCache(options?: {
+  runner?: UrlPrRunner;
+  ttlMs?: number;
+  /** Merged/closed PRs are terminal — cache them longer. */
+  settledTtlMs?: number;
+  maxConcurrent?: number;
+  now?: () => number;
+}): PrUrlCache {
+  const runner = options?.runner ?? defaultUrlRunner;
+  const ttlMs = options?.ttlMs ?? 60_000;
+  const settledTtlMs = options?.settledTtlMs ?? 15 * 60_000;
+  const maxConcurrent = options?.maxConcurrent ?? 3;
+  const now = options?.now ?? Date.now;
+
+  const entries = new Map<string, CacheEntry>();
+  const inFlight = new Set<string>();
+
+  function ttlFor(entry: CacheEntry): number {
+    const state = entry.value?.state;
+    return state === "merged" || state === "closed" ? settledTtlMs : ttlMs;
+  }
+
+  function refresh(url: string): void {
+    if (inFlight.has(url) || inFlight.size >= maxConcurrent) return;
+    inFlight.add(url);
+    void runner(url)
+      .then((stdout) => {
+        entries.set(url, { value: parseBranchPr(stdout), fetchedAt: now() });
+      })
+      .catch(() => {
+        // PR gone, or gh missing/unauthenticated — negative-cache.
+        entries.set(url, { value: null, fetchedAt: now() });
+      })
+      .finally(() => {
+        inFlight.delete(url);
+      });
+  }
+
+  return {
+    get(url) {
+      const entry = entries.get(url);
+      if (!entry || now() - entry.fetchedAt >= ttlFor(entry)) refresh(url);
+      return entry?.value;
+    },
+  };
+}
+
+/** Process-wide URL-keyed cache instance for API routes. */
+export const prUrlCache: PrUrlCache = createPrUrlCache();

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -83,6 +83,13 @@ export type ConversationFile = {
    * must use it — never the project root's branch at poll time.
    */
   branch?: string;
+  /**
+   * PR URL the chat reported in an assistant reply, snapshotted when a turn
+   * is saved (last reported PR wins; see chat-pr-link.ts). Fallback PR
+   * attribution for chats whose work happens in agent worktrees — badge-only,
+   * never feeds the merged-PR auto-archive sweep.
+   */
+  prUrl?: string;
   createdAt: string;
   updatedAt: string;
   turns: ChatTurn[];
@@ -112,6 +119,7 @@ export type ConversationSummary = {
   title?: string;
   origin?: SessionOrigin;
   branch?: string;
+  prUrl?: string;
   status?: string;
   exitCode?: number | null;
   createdAt?: string;
@@ -286,6 +294,7 @@ async function readConversationSummary(
         title: conv.title,
         origin: conv.origin,
         ...(conv.branch ? { branch: conv.branch } : {}),
+        ...(conv.prUrl ? { prUrl: conv.prUrl } : {}),
         status: terminal.status,
         exitCode: terminal.exitCode,
         createdAt: conv.createdAt,

--- a/src/lib/chat-pr-link.test.ts
+++ b/src/lib/chat-pr-link.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { latestPrUrlFromText } from "./chat-pr-link.ts";
+
+test("extracts a plain PR URL", () => {
+  assert.equal(
+    latestPrUrlFromText("Merged as https://github.com/OpenCoven/coven-cave/pull/3249 — done."),
+    "https://github.com/OpenCoven/coven-cave/pull/3249",
+  );
+});
+
+test("the LAST PR URL wins", () => {
+  const text = [
+    "Follow-up from https://github.com/OpenCoven/coven-cave/pull/2983.",
+    "Landed as **PR #3125** (https://github.com/OpenCoven/coven-cave/pull/3125).",
+  ].join("\n");
+  assert.equal(latestPrUrlFromText(text), "https://github.com/OpenCoven/coven-cave/pull/3125");
+});
+
+test("trailing paths, fragments, and punctuation are normalized away", () => {
+  assert.equal(
+    latestPrUrlFromText("see https://github.com/o/r/pull/12/files#diff-abc),"),
+    "https://github.com/o/r/pull/12",
+  );
+  assert.equal(
+    latestPrUrlFromText("(https://github.com/o/r/pull/7)"),
+    "https://github.com/o/r/pull/7",
+  );
+  assert.equal(
+    latestPrUrlFromText('link: "https://github.com/o/r/pull/9#issuecomment-1"'),
+    "https://github.com/o/r/pull/9",
+  );
+});
+
+test("issues, repos, and non-GitHub hosts do not match", () => {
+  assert.equal(latestPrUrlFromText("https://github.com/o/r/issues/5"), null);
+  assert.equal(latestPrUrlFromText("https://github.com/o/r"), null);
+  assert.equal(latestPrUrlFromText("https://gitlab.com/o/r/pull/5"), null);
+  assert.equal(latestPrUrlFromText("https://evil.example/github.com/o/r/pull/1"), null);
+});
+
+test("a later non-PR link does not clobber an earlier PR link", () => {
+  const text =
+    "PR https://github.com/o/r/pull/3 and repo https://github.com/o/r plus issue https://github.com/o/r/issues/8";
+  assert.equal(latestPrUrlFromText(text), "https://github.com/o/r/pull/3");
+});
+
+test("null/empty/PR-free text yields null", () => {
+  assert.equal(latestPrUrlFromText(null), null);
+  assert.equal(latestPrUrlFromText(undefined), null);
+  assert.equal(latestPrUrlFromText(""), null);
+  assert.equal(latestPrUrlFromText("no links here"), null);
+});
+
+test("www.github.com is accepted and canonicalized", () => {
+  assert.equal(
+    latestPrUrlFromText("https://www.github.com/o/r/pull/2"),
+    "https://github.com/o/r/pull/2",
+  );
+});

--- a/src/lib/chat-pr-link.ts
+++ b/src/lib/chat-pr-link.ts
@@ -1,0 +1,34 @@
+// Transcript-derived PR link for a conversation (cave-u9wl).
+//
+// Familiar chats do their implementation work in agent worktrees, so the
+// chat's own cwd never sits on the PR branch and branch-based PR attribution
+// (chat-work-branch.ts → branch-pr-context.ts) yields nothing for them. The
+// one reliable per-chat signal is the chat itself: when a familiar lands
+// work it reports the PR URL in its assistant reply. This module extracts
+// that URL so the send route can snapshot it at turn-save (alongside the
+// work-branch capture) — the LAST PR URL in the reply wins, matching how
+// familiars summarize ("merged as PR #N" at the end of a task).
+//
+// Pure and dependency-light so it pins/tests without a route or DOM.
+
+import { parseGitHubItemUrl } from "./github-item-url.ts";
+
+const GITHUB_URL_RE = /https?:\/\/(?:www\.)?github\.com\/[^\s)\]>"'`]+/g;
+
+/**
+ * The canonical URL of the last github.com pull-request link in `text`, or
+ * null when the text mentions no PR. Trailing paths/fragments/queries on the
+ * matched link (`/files`, `#issuecomment-…`) are normalized away so the URL
+ * is stable as a cache key.
+ */
+export function latestPrUrlFromText(text: string | null | undefined): string | null {
+  if (!text) return null;
+  let last: string | null = null;
+  for (const match of text.matchAll(GITHUB_URL_RE)) {
+    const target = parseGitHubItemUrl(match[0]);
+    if (target?.kind === "pr") {
+      last = `https://github.com/${target.repo}/pull/${target.number}`;
+    }
+  }
+  return last;
+}

--- a/src/lib/merged-chat-auto-archive.test.ts
+++ b/src/lib/merged-chat-auto-archive.test.ts
@@ -118,3 +118,21 @@ test("mergedPrKey prefers repo#number, falls back to url, else null", () => {
   assert.equal(mergedPrKey({ repo: "o/r", url: "https://github.com/o/r/pull/5" }), "https://github.com/o/r/pull/5");
   assert.equal(mergedPrKey({ repo: "o/r" }), null);
 });
+
+test("transcript-attributed PRs are badge-only — never swept (cave-u9wl)", () => {
+  const transcriptRow = row({
+    pullRequest: {
+      repo: "OpenCoven/coven-cave",
+      number: 42,
+      url: "https://github.com/OpenCoven/coven-cave/pull/42",
+      state: "merged",
+      attribution: "transcript",
+    },
+  });
+  assert.deepEqual(mergedChatAutoArchiveDecisions([transcriptRow], {}, ctx()), []);
+  // Explicit "branch" attribution still sweeps like the default.
+  const branchRow = row({
+    pullRequest: { ...transcriptRow.pullRequest, attribution: "branch" },
+  });
+  assert.equal(mergedChatAutoArchiveDecisions([branchRow], {}, ctx()).length, 1);
+});

--- a/src/lib/merged-chat-auto-archive.ts
+++ b/src/lib/merged-chat-auto-archive.ts
@@ -7,6 +7,8 @@
 // Safety properties:
 //  - Only fires on a real, lowercased "merged" PR state (server-side
 //    `gh pr view` enrichment) — GitHub-task lifecycle words never match.
+//  - Only fires on branch-attributed PR context: transcript-derived
+//    attribution (chat-pr-link.ts) is badge-only and never sweeps.
 //  - Never touches rows that look like they may still be doing work.
 //  - One-shot per (session, PR): a session the sweep already archived for a
 //    given PR is recorded in cave state (`mergedPrAutoArchived`), so summoning
@@ -71,6 +73,10 @@ export function mergedChatAutoArchiveDecisions(
     if (underExtension(context.extendedUntil, row.id, context.now)) continue;
     const pr = row.pullRequest;
     if (!pr || (pr.state ?? "").toLowerCase() !== "merged") continue;
+    // Transcript-derived attribution is badge-only: a long-lived familiar
+    // chat reports many PRs over its lifetime, and the latest one merging
+    // says nothing about the chat being done (cave-u9wl).
+    if (pr.attribution === "transcript") continue;
     const prKey = mergedPrKey(pr);
     if (!prKey) continue;
     if (handled[row.id] === prKey) continue;

--- a/src/lib/session-git-enrich.test.ts
+++ b/src/lib/session-git-enrich.test.ts
@@ -239,7 +239,10 @@ const REPO_SCRIPT = {
   const { runner, calls } = fakeGit(REPO_SCRIPT);
   const bare = { id: "s1", project_root: "", harness: "codex", title: "s1", status: "completed" };
   const rows = await enrichSessionsWithGitContext([bare], runner);
-  assert.equal(rows[0], bare, "rootless rows keep their identity");
+  // Value equality (not identity): rootless rows now flow through the map so
+  // transcript PR attribution can reach them (cave-u9wl) — but with no
+  // chatPrUrl they must come out byte-identical and never touch git.
+  assert.deepEqual(rows[0], bare, "rootless rows keep their content");
   assert.equal(calls.length, 0);
 }
 
@@ -317,6 +320,83 @@ const REPO_SCRIPT = {
     const rows = await enrichSessionsWithGitContext([session("wt", root)], runner, prCache);
     assert.equal(rows[0].git.isWorktree, true);
     assert.deepEqual(rows[0].pullRequest, mergedPr("feat/thing"));
+  }
+}
+
+// 12. Transcript fallback (cave-u9wl): a chat that reported a PR URL in a
+// reply gets URL-resolved PR context tagged attribution:"transcript" — even
+// with no project root — and branch attribution always wins when present.
+{
+  /** Fake PrUrlCache scripted per URL; records lookups. */
+  function fakeUrlCache(byUrl) {
+    const lookups = [];
+    return {
+      lookups,
+      get(url) {
+        lookups.push(url);
+        return byUrl[url] ?? null;
+      },
+    };
+  }
+  const url = "https://github.com/acme/app/pull/77";
+  const transcriptPr = { repo: "acme/app", number: 77, url, state: "merged" };
+  const noGit = async () => null;
+  const noPrCache = { get: () => null };
+
+  // 12a. Rootless chat with a reported PR URL → transcript-attributed badge.
+  {
+    const urlCache = fakeUrlCache({ [url]: transcriptPr });
+    const rows = await enrichSessionsWithGitContext(
+      [{ ...session("familiar-chat", ""), chatPrUrl: url }],
+      noGit,
+      noPrCache,
+      urlCache,
+    );
+    assert.deepEqual(rows[0].pullRequest, { ...transcriptPr, attribution: "transcript" });
+    assert.deepEqual(urlCache.lookups, [url]);
+  }
+
+  // 12b. Rooted chat whose branch attribution found nothing falls back too.
+  {
+    const root = makeRoot("repo-transcript-fallback");
+    const { runner } = fakeGit(REPO_SCRIPT);
+    const urlCache = fakeUrlCache({ [url]: transcriptPr });
+    const rows = await enrichSessionsWithGitContext(
+      [{ ...session("chat", root), chatPrUrl: url }],
+      runner,
+      noPrCache,
+      urlCache,
+    );
+    assert.equal(rows[0].pullRequest?.attribution, "transcript");
+  }
+
+  // 12c. Branch attribution wins over the transcript URL.
+  {
+    const root = makeRoot("repo-branch-beats-transcript");
+    const { runner } = fakeGit(REPO_SCRIPT);
+    const branchPr = { repo: "acme/app", number: 9, url: "https://github.com/acme/app/pull/9", state: "open", branch: "feat/mine" };
+    const urlCache = fakeUrlCache({ [url]: transcriptPr });
+    const rows = await enrichSessionsWithGitContext(
+      [{ ...session("chat", root), workBranch: "feat/mine", chatPrUrl: url }],
+      runner,
+      { get: (_root, branch) => (branch === "feat/mine" ? branchPr : null) },
+      urlCache,
+    );
+    assert.deepEqual(rows[0].pullRequest, branchPr);
+    assert.equal(urlCache.lookups.length, 0, "branch-attributed rows never probe the URL cache");
+  }
+
+  // 12d. No reported URL → URL cache untouched.
+  {
+    const urlCache = fakeUrlCache({});
+    const rows = await enrichSessionsWithGitContext(
+      [session("plain", "")],
+      noGit,
+      noPrCache,
+      urlCache,
+    );
+    assert.equal(rows[0].pullRequest, undefined);
+    assert.equal(urlCache.lookups.length, 0);
   }
 }
 

--- a/src/lib/session-git-enrich.ts
+++ b/src/lib/session-git-enrich.ts
@@ -22,7 +22,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
-import { branchPrCache, type BranchPrCache } from "./branch-pr-context.ts";
+import { branchPrCache, prUrlCache, type BranchPrCache, type PrUrlCache } from "./branch-pr-context.ts";
 import type { SessionGitContext, SessionRow } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
@@ -156,6 +156,7 @@ export async function enrichSessionsWithGitContext(
   sessions: SessionRow[],
   git: GitRunner = defaultGitRunner,
   prCache: BranchPrCache = branchPrCache,
+  urlPrCache: PrUrlCache = prUrlCache,
 ): Promise<SessionRow[]> {
   // Collect unique roots and, per root, the branches sessions sit on — the
   // per-root git work happens once regardless of how many sessions share it.
@@ -198,14 +199,11 @@ export async function enrichSessionsWithGitContext(
 
   return sessions.map((session) => {
     const root = session.project_root?.trim();
-    if (!root) return session;
-    const entry = enrichmentByRoot.get(root);
-    if (!entry) return session;
-
+    const entry = root ? enrichmentByRoot.get(root) : undefined;
     const enriched: SessionRow = { ...session };
-    if (entry.gitContext) enriched.git = entry.gitContext;
-    const branch = entry.gitContext?.branch;
-    const diff = branch ? entry.diffByBranch.get(branch) ?? null : null;
+    if (entry?.gitContext) enriched.git = entry.gitContext;
+    const branch = entry?.gitContext?.branch;
+    const diff = branch ? entry?.diffByBranch.get(branch) ?? null : null;
     if (diff) enriched.diff = diff;
     // PR context for the thread — synchronous read from the stale-while-
     // revalidate cache (never blocks the poll; see branch-pr-context.ts).
@@ -219,10 +217,19 @@ export async function enrichSessionsWithGitContext(
     // without a recorded branch gets no PR context (and is never PR-swept).
     const attributedBranch =
       session.workBranch ??
-      (entry.gitContext?.isWorktree ? entry.gitContext.branch ?? null : null);
-    if (attributedBranch) {
+      (entry?.gitContext?.isWorktree ? entry.gitContext.branch ?? null : null);
+    if (root && attributedBranch) {
       const pr = prCache.get(root, attributedBranch);
       if (pr) enriched.pullRequest = pr;
+    }
+    // Transcript fallback (cave-u9wl): familiar chats do their work in agent
+    // worktrees, so branch attribution finds nothing on the chat's own cwd —
+    // but the chat reported the PR URL in a reply. Resolve it by URL (works
+    // even for rootless chats) and tag the attribution so the merged-PR
+    // auto-archive sweep never archives a long-lived chat over a reported PR.
+    if (!enriched.pullRequest && session.chatPrUrl) {
+      const pr = urlPrCache.get(session.chatPrUrl);
+      if (pr) enriched.pullRequest = { ...pr, attribution: "transcript" };
     }
     return enriched;
   });

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -695,6 +695,7 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
         updatedAt: "2026-06-08T18:06:00.000Z",
         origin: "chat",
         branch: "feat/fix-flaky-spec",
+        prUrl: "https://github.com/OpenCoven/coven-cave/pull/3249",
       },
       {
         sessionId: "local-branched",
@@ -704,6 +705,7 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
         updatedAt: "2026-06-08T18:07:00.000Z",
         origin: "chat",
         branch: "feat/local-work",
+        prUrl: "https://github.com/OpenCoven/coven-cave/pull/3344",
       },
     ],
     state: bareState,
@@ -712,6 +714,9 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
   const byId = new Map(rows.map((r) => [r.id, r]));
   assert.equal(byId.get("branched")?.workBranch, "feat/fix-flaky-spec", "conversation branch surfaces on the merged daemon row");
   assert.equal(byId.get("local-branched")?.workBranch, "feat/local-work", "local-only rows carry their recorded branch too");
+  // Transcript-reported PR URL passthrough (cave-u9wl): both merge paths.
+  assert.equal(byId.get("branched")?.chatPrUrl, "https://github.com/OpenCoven/coven-cave/pull/3249", "conversation prUrl surfaces on the merged daemon row");
+  assert.equal(byId.get("local-branched")?.chatPrUrl, "https://github.com/OpenCoven/coven-cave/pull/3344", "local-only rows carry their reported PR URL too");
 }
 
 // Project backfill (cave-9nj1): sidebar/rail project groups key on

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -24,6 +24,8 @@ export type LocalConversationSummary = {
   origin?: SessionOrigin;
   /** Work-branch snapshot recorded from the chat's cwd at its last turn. */
   branch?: string;
+  /** PR URL the chat reported in an assistant reply (transcript snapshot). */
+  prUrl?: string;
 };
 
 type MergeOptions = {
@@ -87,6 +89,7 @@ function localConversationToSession(
     origin: conv.origin ?? "chat",
     hasLocalConversation: true,
     ...(conv.branch ? { workBranch: conv.branch } : {}),
+    ...(conv.prUrl ? { chatPrUrl: conv.prUrl } : {}),
     initiator: conv.initiator ?? { kind: "human", label: "Cave user", channel: "cave" },
     ...(keep ? { keep: true } : {}),
     ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
@@ -186,6 +189,9 @@ export function mergeSessionRows({
       // Per-session branch snapshot (chat's own cwd at its last saved turn).
       // PR attribution must key off this — never the root's current branch.
       ...(local?.branch ? { workBranch: local.branch } : {}),
+      // Transcript-reported PR URL — badge fallback when the chat's own cwd
+      // never sat on the PR branch (familiar chats working via worktrees).
+      ...(local?.prUrl ? { chatPrUrl: local.prUrl } : {}),
       // No conversation + nothing better than the inferred-"chat" default =
       // a run some generator spawned (journal narrative, flow, automation,
       // CLI), not something a person typed into a chat surface.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,10 @@ export type SessionRow = {
    * "this session's branch").
    */
   workBranch?: string | null;
+  /** PR URL the chat itself reported in an assistant reply (transcript
+   *  snapshot; see chat-pr-link.ts) — fallback PR attribution for chats whose
+   *  work happens in agent worktrees rather than their own cwd. */
+  chatPrUrl?: string | null;
   pullRequest?: SessionPullRequestContext | null;
   /** Working-tree change size vs HEAD, for the Recent Activity roll-up's `+N -N`. */
   diff?: { additions: number; deletions: number } | null;
@@ -113,6 +117,12 @@ export type SessionPullRequestContext = {
   state?: string;
   branch?: string;
   draft?: boolean;
+  /** How the PR was attributed to the session. Absent/"branch" = resolved
+   *  from the session's own work branch (authoritative — feeds the merged-PR
+   *  auto-archive sweep). "transcript" = derived from a PR URL the chat
+   *  reported in a reply — badge-only, never swept (long-lived familiar chats
+   *  report many PRs over their lifetime). */
+  attribution?: "branch" | "transcript";
 };
 
 export type SessionOrigin =

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -95,21 +95,13 @@ html[data-backdrop-on] .cave-group-chat-shell {
    (faces, props) fights the copy. Ground the centered content clusters
    without dulling the scene at its edges. */
 
-/* Home: a radial ground behind the hero + composer column. Sits as the
-   root's first child so all in-flow content paints above it. */
-html[data-backdrop-on] .home-composer-root {
-  position: relative;
-}
-html[data-backdrop-on] .home-composer-root::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(
-    ellipse 72% 58% at 50% 42%,
-    color-mix(in oklch, var(--bg-base) 52%, transparent),
-    transparent 78%
-  );
+/* Home: one uniform, theme-derived readability surface on the existing
+   hearth card (cave-hct3). The old full-area radial ground behind the whole
+   column read as a blurry oval over busy imagery; the card is the thing that
+   needs the contrast, so deepen ITS fill instead and leave the scene visible
+   around it. */
+html[data-backdrop-on] .home-hearth-card {
+  background: color-mix(in oklch, var(--bg-base) 72%, transparent);
 }
 
 /* Chat landing (no thread yet): the greeting/identity/suggestions cluster
@@ -172,9 +164,10 @@ html[data-backdrop-on] .home-composer-root {
     padding-inline: 0;
   }
 
-  /* Same reasoning for the new grounds: no image → no scrim needed. */
-  html[data-backdrop-on] .home-composer-root::before {
-    display: none;
+  /* Same reasoning for the new grounds: no image → no deepened fill; restore
+     the hearth card's normal translucent panel fill. */
+  html[data-backdrop-on] .home-hearth-card {
+    background: color-mix(in oklch, var(--bg-panel) 55%, transparent);
   }
 
   html[data-backdrop-on] .cave-chat-empty-shell {


### PR DESCRIPTION
## Summary
Familiar chats run their implementation in agent worktrees, so branch-based attribution (`captureWorkBranch` on the chat's own cwd, which sits on `main`) never attaches PR context — their rows showed a plain status dot instead of the PR badge (#2983/#3249/#3344 lineage).

**Transcript-derived attribution:**
- `chat-pr-link.ts` (new): `latestPrUrlFromText` — last GitHub PR URL in an assistant reply, canonicalized.
- Chat send route captures `conv.prUrl` at both turn-save sites → `SessionRow.chatPrUrl`.
- `branch-pr-context`: URL-keyed SWR cache (`gh pr view <url>`, no cwd needed).
- `session-git-enrich`: transcript fallback when branch attribution yields nothing; rootless rows now flow through enrichment; tagged `attribution: "transcript"` (branch wins when both exist).
- **Safety:** merged-PR auto-archive sweep skips transcript-attributed PRs — long-lived familiar chats report many PRs; the latest merging says nothing about the chat being done.

## Coupled repairs (main is currently red)
- Badge/shell test CSS pins read the whole decomposed cascade (#3576 split globals.css).
- shell-edge-rails nav-toggle pin follows the new `chatContextual` ternary (#3577/#3578).
- `backdrop.css`: implements the cave-hct3 hearth-card facelift that `backdrop-scrim.test.ts` pins — the test commits (`8fa284f14` etc.) landed directly on main without the implementation.

## Verification
- `pnpm typecheck` ✅
- `pnpm test:app` — 830 files ✅ (7 new chat-pr-link tests + extended enrich/archive/merge/badge coverage)
- `pnpm check:tests-wired` ✅ (1126 wired)

Beads: cave-u9wl