### PR TITLE
fix(onboarding): stop 2s status polling once setup is complete and idle

### DIFF
--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -171,6 +171,10 @@ export function OnboardingOverlay({
   statusRef.current = status;
   const statusGenerationRef = useRef(0);
   const statusRefreshInFlightRef = useRef(false);
+  // The open-time load and the heartbeat's immediate tick can overlap before
+  // the first render settles. Keep that from issuing two identical lane
+  // probes (unlike status, this request was not previously coalesced).
+  const npmLaneRefreshInFlightRef = useRef(false);
   const autoFinishFiredRef = useRef(false);
   const finishOnboarding = useCallback(() => {
     try {
@@ -233,6 +237,8 @@ export function OnboardingOverlay({
   }, []);
 
   const refreshNpmLane = useCallback(async () => {
+    if (npmLaneRefreshInFlightRef.current) return;
+    npmLaneRefreshInFlightRef.current = true;
     try {
       const res = await fetch("/api/onboarding/install", { cache: "no-store" });
       if (!res.ok) return;
@@ -253,6 +259,8 @@ export function OnboardingOverlay({
       }
     } catch {
       /* Retain the last observed lane state until the next successful poll. */
+    } finally {
+      npmLaneRefreshInFlightRef.current = false;
     }
   }, []);
 

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -292,11 +292,37 @@ export function OnboardingOverlay({
     }
   }, []);
 
+  // One-shot loads when the wizard opens; the recurring heartbeat below owns
+  // the 2s cadence.
   useEffect(() => {
     if (!open) return;
     void refresh();
     void loadUpdates();
     void loadHarnesses();
+    void refreshNpmLane();
+  }, [open, refresh, loadUpdates, loadHarnesses, refreshNpmLane]);
+
+  // The 2s status/npm-lane heartbeat runs only while something can still
+  // change underneath the wizard: an incomplete required step, a running or
+  // queued install, a busy shared npm lane, or a setup action in flight.
+  // Once every step is confirmed and nothing is running, stop re-probing the
+  // CLI every 2 seconds (cave-0hhd) — the confirmed state stays on screen,
+  // manual Re-check and each action's own refresh() still work, and any new
+  // activity (an install click, the queue draining) resumes the heartbeat.
+  const heartbeatIdle =
+    (status?.complete ?? false) &&
+    npmLane === null &&
+    installQueue.length === 0 &&
+    !Object.values(installJobs).some((job) => job.status === "running") &&
+    picking === null &&
+    !startingDaemon &&
+    !savingOnboardingConnection;
+
+  useEffect(() => {
+    if (!open || heartbeatIdle) return;
+    // Immediate tick when the heartbeat (re)starts — refresh() collapses the
+    // duplicate with the open-time load via its in-flight guard.
+    void refresh();
     void refreshNpmLane();
     pollRef.current = setInterval(() => {
       void refresh();
@@ -307,7 +333,7 @@ export function OnboardingOverlay({
       pollRef.current = null;
       statusGenerationRef.current += 1;
     };
-  }, [open, refresh, loadUpdates, loadHarnesses, refreshNpmLane]);
+  }, [open, heartbeatIdle, refresh, refreshNpmLane]);
 
   // The harness probe races first paint: it loads once at open, so a slow or
   // failed first fetch left the runtime step's grid empty until a manual

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1002,7 +1002,8 @@ export function OnboardingOverlay({
               Follow the numbered steps. Each one carries its own instructions,
               a one-click action where Cave can do the work for you, and the
               exact command if you&rsquo;d rather use a terminal. Finished
-              steps tick themselves — status re-checks every 2 seconds.
+              steps tick themselves while setup is in progress — status
+              re-checks every 2 seconds until everything is ready.
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -78,6 +78,25 @@ assert.match(
   "both error responses and network throws count toward the give-up budget",
 );
 
+// cave-0hhd: the 2s status/npm-lane heartbeat stops once every required step
+// is confirmed and nothing is running — a completed, idle wizard must not
+// keep re-probing the CLI install forever.
+assert.match(
+  source,
+  /const heartbeatIdle =\s*\n\s*\(status\?\.complete \?\? false\) &&/,
+  "the heartbeat idles only when the server says setup is complete",
+);
+assert.match(
+  source,
+  /heartbeatIdle[\s\S]{0,700}npmLane === null[\s\S]{0,700}installQueue\.length === 0[\s\S]{0,700}job\.status === "running"/,
+  "a busy npm lane, a queued install, or a running job keeps the heartbeat alive",
+);
+assert.match(
+  source,
+  /if \(!open \|\| heartbeatIdle\) return;[\s\S]{0,400}setInterval\(\(\) => \{\s*\n\s*void refresh\(\);\s*\n\s*void refreshNpmLane\(\);/,
+  "the recurring status/npm-lane interval is gated on the idle check",
+);
+
 // Finishing setup must record the dismissal exactly like "Skip for now" —
 // otherwise the workspace auto-open relaunches the whole wizard for a
 // finished user whenever the daemon happens to be down (complete flips false).

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -96,6 +96,16 @@ assert.match(
   /if \(!open \|\| heartbeatIdle\) return;[\s\S]{0,400}setInterval\(\(\) => \{\s*\n\s*void refresh\(\);\s*\n\s*void refreshNpmLane\(\);/,
   "the recurring status/npm-lane interval is gated on the idle check",
 );
+assert.match(
+  source,
+  /const npmLaneRefreshInFlightRef = useRef\(false\)/,
+  "overlapping open-time and heartbeat npm-lane probes share an in-flight guard",
+);
+assert.match(
+  source,
+  /const refreshNpmLane = useCallback\(async \(\) => \{\s*if \(npmLaneRefreshInFlightRef\.current\) return;\s*npmLaneRefreshInFlightRef\.current = true;[\s\S]{0,1400}finally \{\s*npmLaneRefreshInFlightRef\.current = false;/,
+  "the npm-lane in-flight guard is released after every response outcome",
+);
 
 // Finishing setup must record the dismissal exactly like "Skip for now" —
 // otherwise the workspace auto-open relaunches the whole wizard for a


### PR DESCRIPTION
## What

The onboarding wizard's 2s heartbeat polled `/api/onboarding/status` + the npm install lane (`/api/onboarding/install`) unconditionally while open — the status route re-probes the local Coven CLI on every hit, so the install page kept checking the CLI forever after it was already confirmed.

This gates the recurring interval on a `heartbeatIdle` check:
- server-confirmed `status.complete`
- npm lane free, install queue empty, no running install job
- no scaffold / daemon-start / connection-save action in flight

One-shot loads on open are unchanged; manual Re-check and each action's own `refresh()` still work; any new activity (install click, queue drain) resumes the heartbeat with an immediate tick.

## Verification

- `node --experimental-strip-types src/components/onboarding-polish.test.ts` ✅ (new heartbeat-idle assertions included)
- `node --experimental-strip-types src/components/onboarding-guided-steps.test.ts` ✅
- `node --experimental-strip-types src/components/workspace-familiars-landing.test.ts` ✅
- `pnpm typecheck` ✅

Bead: cave-0hhd (chat-handoff from session 93e52497).