### PR TITLE
fix: remember workspace surface preferences

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -34,6 +34,7 @@ export const SUITES = {
     "src/lib/page-drag.test.ts",
     "src/lib/sidebar-nav-state.test.ts",
     "src/lib/workspace-mode.test.ts",
+    "src/lib/surface-preferences.test.ts",
     "src/lib/workspace-github-task-context.test.ts",
     "src/lib/role-surfaces.test.ts",
     "src/lib/research-missions.test.ts",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { Workspace } from "@/components/workspace";
+import { WorkspaceSurfacePreferencesProvider } from "@/lib/surface-preferences";
 
 export default function Home() {
-  return <Workspace />;
+  return (
+    <WorkspaceSurfacePreferencesProvider>
+      <Workspace />
+    </WorkspaceSurfacePreferencesProvider>
+  );
 }

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -162,7 +162,7 @@ assert.doesNotMatch(
 // the overview's management mode.
 assert.match(source, /type AutomationTab = "overview" \| "calendar" \| "crons"/, "Rituals exposes Overview, Calendar and Crons modes");
 assert.doesNotMatch(source, /bulkPatchReminders|bulkDeleteReminders|ReminderTaskList|reminderSelect/, "the orphaned reminder bulk-select machinery stays deleted");
-assert.match(source, /initialTab === "calendar" && calendarSlot \? "calendar" : initialTab === "crons" \? "crons" : "overview"/, "Overview is the default landing mode; calendar/crons deep links still win");
+assert.match(source, /const \[deepLinkTab, setDeepLinkTab\] = useState<AutomationTab \| null>/, "Calendar and Crons deep links override the saved tab for one visit");
 assert.match(source, /aria-label="Toggle events ribbon"/, "the overview includes a collapsible week ribbon");
 assert.match(source, /Needs you · \{inboxFeed\.needsYou\.length\}/, "the only raised work queue is the Needs-you tier");
 assert.match(source, /aria-label="Show ritual log"/, "the overview exposes the activity log");
@@ -179,7 +179,7 @@ assert.match(source, /INBOX_GROUP_BY_OPTIONS/, "the group-by control offers the 
 // Grouping is deliberately behind the overflow menu in the minimalist shell.
 assert.match(source, /INBOX_GROUP_BY_OPTIONS\.map\(\(option\) => \([\s\S]{0,420}Group selection by \{option\.label\.toLowerCase\(\)\}/, "group-by remains reachable from the overview options menu");
 assert.doesNotMatch(source, /<StandardSelect[\s\S]{0,120}label="Group inbox by"/, "the group-by dropdown is gone");
-assert.match(source, /cave:inbox:group-by/, "the group-by choice persists per install");
+assert.match(source, /useSurfacePreference\(surfacePreferenceSpecs\.schedules\.groupBy\)/, "the group-by choice persists through the shared workspace preference registry");
 assert.match(source, /const inboxSelect = useMultiSelect\(inboxVisible, \(it\) => it\.id\)/, "selection universe = the visible matches");
 assert.match(source, /<SelectionToolbar/, "inbox select mode uses the shared bulk toolbar");
 assert.match(

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -65,6 +65,8 @@ import {
   countByType,
   type AutomationEntry,
 } from "@/lib/automations/automation-entry";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 // AutomationsView — Schedules surface, redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -146,9 +148,15 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const newBtnRef = useRef<HTMLButtonElement | null>(null);
   const manageBtnRef = useRef<HTMLButtonElement | null>(null);
   const overviewSwipeStartRef = useRef<number | null>(null);
-  const [activeTab, setActiveTab] = useState<AutomationTab>(
-    initialTab === "calendar" && calendarSlot ? "calendar" : initialTab === "crons" ? "crons" : "overview",
+  const [storedActiveTab, setStoredActiveTab] = useSurfacePreference(surfacePreferenceSpecs.schedules.activeTab);
+  const [deepLinkTab, setDeepLinkTab] = useState<AutomationTab | null>(
+    initialTab === "calendar" && calendarSlot ? "calendar" : initialTab === "crons" ? "crons" : null,
   );
+  const activeTab = deepLinkTab ?? storedActiveTab;
+  const setActiveTab = useCallback((tab: AutomationTab) => {
+    setDeepLinkTab(null);
+    setStoredActiveTab(tab);
+  }, [setStoredActiveTab]);
   const [newMenuOpen, setNewMenuOpen] = useState(false);
   const [manageMenuOpen, setManageMenuOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -650,20 +658,14 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     () => new Map(resolvedFamiliars.map((f) => [f.id, f])),
     [resolvedFamiliars],
   );
-  const [familiarFilter, setFamiliarFilter] = useState<Set<string>>(() => {
-    if (typeof window === "undefined") return new Set();
-    const raw = window.localStorage.getItem("cave:automations:familiar-filter");
-    if (!raw) return new Set();
-    return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
-  });
+  const [storedFamiliarFilter, setStoredFamiliarFilter] = useSurfacePreference(surfacePreferenceSpecs.schedules.familiarFilter);
+  const familiarFilter = useMemo(
+    () => new Set(storedFamiliarFilter.split(",").map((value) => value.trim()).filter(Boolean)),
+    [storedFamiliarFilter],
+  );
   const updateFamiliarFilter = useCallback((next: Set<string>) => {
-    setFamiliarFilter(next);
-    try {
-      window.localStorage.setItem("cave:automations:familiar-filter", [...next].join(","));
-    } catch {
-      /* ignore storage errors */
-    }
-  }, []);
+    setStoredFamiliarFilter([...next].sort().join(","));
+  }, [setStoredFamiliarFilter]);
 
   const codexActive = useMemo(
     () =>
@@ -698,19 +700,10 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     () => ritualLogItems(inboxVisible).filter((item) => !needsYouIds.has(item.id)),
     [inboxVisible, needsYouIds],
   );
-  const [inboxGroupBy, setInboxGroupBy] = useState<InboxGroupBy>(() => {
-    if (typeof window === "undefined") return "attention";
-    const raw = window.localStorage.getItem("cave:inbox:group-by");
-    return raw === "kind" || raw === "familiar" ? raw : "attention";
-  });
+  const [inboxGroupBy, setInboxGroupBy] = useSurfacePreference(surfacePreferenceSpecs.schedules.groupBy);
   const updateInboxGroupBy = useCallback((next: InboxGroupBy) => {
     setInboxGroupBy(next);
-    try {
-      window.localStorage.setItem("cave:inbox:group-by", next);
-    } catch {
-      /* ignore storage errors */
-    }
-  }, []);
+  }, [setInboxGroupBy]);
   const inboxGroups = useMemo(
     () => buildInboxGroups(inboxVisible, inboxGroupBy, familiarLabel),
     [inboxVisible, inboxGroupBy, familiarLabel],

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -114,6 +114,9 @@ type Props = {
   familiars: Familiar[];
   projects: CaveProject[];
   groupBy: GroupBy;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSortChange: (key: SortKey, direction: SortDir) => void;
   selectedCardId: string | null;
   onSelect: (id: string) => void;
   /** Bulk-select mode: clicking a row toggles its checkbox instead of opening. */
@@ -123,9 +126,7 @@ type Props = {
   onPatch: (id: string, patch: Partial<Card>) => void;
 };
 
-export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId, onSelect, selectMode = false, isSelected, onToggleSelect, onPatch }: Props) {
-  const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
+export function BoardTable({ cards, familiars, projects, groupBy, sortKey, sortDir, onSortChange, selectedCardId, onSelect, selectMode = false, isSelected, onToggleSelect, onPatch }: Props) {
 
   // Which group holds the current selection (null when nothing is selected).
   const selectedGroupKey = useMemo(() => {
@@ -276,8 +277,8 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
   }, [onSelect]);
 
   const handleCol = (key: SortKey) => {
-    if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    else { setSortKey(key); setSortDir("asc"); }
+    if (sortKey === key) onSortChange(key, sortDir === "asc" ? "desc" : "asc");
+    else onSortChange(key, "asc");
   };
 
   const toggleGroup = (key: string) =>

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -37,7 +37,9 @@ import { useProjects } from "@/lib/use-projects";
 import { HarnessFixActions } from "@/components/harness-fix-actions";
 import { parseHarnessFailure } from "@/lib/harness-failure";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
-import { BoardKanbanSkeleton, loadBoardPreference, type ViewMode } from "@/components/board-view-display";
+import { BoardKanbanSkeleton, type ViewMode } from "@/components/board-view-display";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 
 type Props = {
@@ -59,9 +61,17 @@ type Props = {
 
 export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliarIds, onJumpToSession, onOpenUrl, queueSlot, initialTab }: Props) {
   const isMobile = useIsMobile();
-  const [activeTab, setActiveTab] = useState<"tasks" | "queue">(
-    initialTab === "queue" && queueSlot ? "queue" : "tasks",
+  const [storedActiveTab, setStoredActiveTab] = useSurfacePreference(surfacePreferenceSpecs.board.activeTab);
+  // Alias navigation is an explicit, one-visit destination. It wins over the
+  // saved tab without overwriting it; a subsequent user click resumes saving.
+  const [deepLinkTab, setDeepLinkTab] = useState<"tasks" | "queue" | null>(
+    initialTab === "queue" && queueSlot ? "queue" : null,
   );
+  const activeTab = deepLinkTab ?? storedActiveTab;
+  const setActiveTab = useCallback((tab: "tasks" | "queue") => {
+    setDeepLinkTab(null);
+    setStoredActiveTab(tab);
+  }, [setStoredActiveTab]);
   const [cards, setCards] = useState<Card[]>([]);
   // Deferred + undoable task deletion: cards hide immediately, the DELETEs fire
   // only after the undo window, and Undo restores them (mirrors chat/projects).
@@ -76,8 +86,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [hasLoaded, setHasLoaded] = useState(false);
   // Transient feedback when an optimistic mutation fails and is reverted.
   const [actionError, setActionError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>(() => loadBoardPreference("cave:board:viewMode", "kanban", ["kanban", "table", "gantt"]));
-  const [groupBy, setGroupBy] = useState<GroupBy>(() => loadBoardPreference("cave:board:groupBy", "status", ["status", "familiar", "project"]));
+  const [viewMode, setViewMode] = useSurfacePreference(surfacePreferenceSpecs.board.viewMode);
+  const [groupBy, setGroupBy] = useSurfacePreference(surfacePreferenceSpecs.board.groupBy);
   // Per-status WIP limits (loaded after mount to avoid SSR localStorage access).
   const [wipLimits, setWipLimits] = useState<WipLimits>({});
   useEffect(() => { setWipLimits(readWipLimits()); }, []);
@@ -90,7 +100,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   }, []);
   // Gantt has its own grouping: by project (one bar per task) or by task (one
   // bar per checklist step). Separate from the kanban/table groupBy above.
-  const [ganttGroup, setGanttGroup] = useState<"project" | "task" | "familiar">(() => loadBoardPreference("cave:board:ganttGroup", "project", ["project", "task", "familiar"]) as "project" | "task" | "familiar");
+  const [ganttGroup, setGanttGroup] = useSurfacePreference(surfacePreferenceSpecs.board.ganttGroup);
+  const [tableSortKey, setTableSortKey] = useSurfacePreference(surfacePreferenceSpecs.board.tableSortKey);
+  const [tableSortDir, setTableSortDir] = useSurfacePreference(surfacePreferenceSpecs.board.tableSortDir);
   const [searchQuery, setSearchQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -198,7 +210,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, []);
-  useEffect(() => { localStorage.setItem("cave:board:viewMode", viewMode); }, [viewMode]);
   // The command palette can switch the board view directly (e.g. "Tasks: Gantt
   // timeline"); honor it live when the board is already mounted.
   useEffect(() => {
@@ -209,8 +220,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     window.addEventListener("cave:board:set-view", onSetView);
     return () => window.removeEventListener("cave:board:set-view", onSetView);
   }, []);
-  useEffect(() => { localStorage.setItem("cave:board:groupBy", groupBy); }, [groupBy]);
-  useEffect(() => { localStorage.setItem("cave:board:ganttGroup", ganttGroup); }, [ganttGroup]);
 
   // External create paths dispatch `cave:board:reload` after POST so the board
   // picks up the new card without a full surface remount.
@@ -1242,6 +1251,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
         ) : (
           <BoardTable cards={filtered} familiars={familiars} projects={projects}
             groupBy={effectiveGroupBy} selectedCardId={selectedCardId}
+            sortKey={tableSortKey} sortDir={tableSortDir}
+            onSortChange={(key, direction) => { setTableSortKey(key); setTableSortDir(direction); }}
             onSelect={setSelectedCardId}
             selectMode={cardSelect.selectMode} isSelected={cardSelect.isSelected} onToggleSelect={cardSelect.toggle}
             onPatch={patchCard} />

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -113,6 +113,10 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
   // only restores which tab was active and its latest committed URL.
   useEffect(() => {
     if (!preferencesHydrated) return;
+    // A queued cross-surface URL may be consumed while the registry is still
+    // hydrating. It is an explicit one-visit destination, so never replace it
+    // with the saved return tab/address on that first hydrated render.
+    if (transientNavigationUrlRef.current) return;
     const restored = tabs.find((tab) => tab.id === storedActiveTabId) ?? tabs[0];
     if (!restored) return;
     setActiveTabId(restored.id);

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -32,6 +32,7 @@ import {
   loadPinnedTabs,
   loadRailPinned,
   normalizeBrowserUrl,
+  resolveRestoredBrowserNavigation,
   savePinnedTabs,
   saveRailPinned,
   type BrowserTab,
@@ -117,14 +118,15 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     // hydrating. It is an explicit one-visit destination, so never replace it
     // with the saved return tab/address on that first hydrated render.
     if (transientNavigationUrlRef.current) return;
-    const restored = tabs.find((tab) => tab.id === storedActiveTabId) ?? tabs[0];
-    if (!restored) return;
-    setActiveTabId(restored.id);
-    if (storedAddress) {
-      setTabs((current) => current.map((tab) => tab.id === restored.id ? { ...tab, url: storedAddress } : tab));
-      setAddressBar(storedAddress);
-    } else {
-      setAddressBar(restored.url);
+    const restored = resolveRestoredBrowserNavigation(tabs, storedActiveTabId, storedAddress);
+    setActiveTabId(restored.activeTabId);
+    if (restored.restoredTabExists && storedAddress) {
+      setTabs((current) => current.map((tab) => tab.id === restored.activeTabId ? { ...tab, url: storedAddress } : tab));
+    }
+    setAddressBar(restored.address);
+    if (!restored.restoredTabExists) {
+      setStoredActiveTabId(restored.activeTabId);
+      setStoredAddress(restored.address);
     }
   // Restore once after hydration; later tab changes are deliberate user actions.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -615,7 +617,7 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     }
 
     const updatedActiveTab = nextTabs.find((t) => t.id === activeTabId);
-    if (updatedActiveTab) {
+    if (persist && updatedActiveTab) {
       savePinnedTabs(nextTabs);
     }
     // Reveal the page again now that the user has committed a destination.

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -36,6 +36,8 @@ import {
   saveRailPinned,
   type BrowserTab,
 } from "./browser-tab-state";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 export type { BrowserTab } from "./browser-tab-state";
 
@@ -91,10 +93,38 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
 
   // Tab state
   const [tabs, setTabs] = useState<BrowserTab[]>(() => loadPinnedTabs());
+  const [storedActiveTabId, setStoredActiveTabId, preferencesHydrated] = useSurfacePreference(surfacePreferenceSpecs.browser.activeTabId);
+  const [storedAddress, setStoredAddress] = useSurfacePreference(surfacePreferenceSpecs.browser.address);
   const [activeTabId, setActiveTabId] = useState<string>(() => loadPinnedTabs()[0]?.id ?? "home");
   const [tabTitles, setTabTitles] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [addressBar, setAddressBar] = useState<string>(HOME_URL);
+  const transientNavigationUrlRef = useRef<string | null>(null);
+  const selectActiveTab = useCallback((id: string) => {
+    setActiveTabId(id);
+    setStoredActiveTabId(id);
+  }, [setStoredActiveTabId]);
+  const commitAddress = useCallback((url: string) => {
+    setAddressBar(url);
+    setStoredAddress(url);
+  }, [setStoredAddress]);
+
+  // Pinned tabs remain their own browser-specific persistence. The registry
+  // only restores which tab was active and its latest committed URL.
+  useEffect(() => {
+    if (!preferencesHydrated) return;
+    const restored = tabs.find((tab) => tab.id === storedActiveTabId) ?? tabs[0];
+    if (!restored) return;
+    setActiveTabId(restored.id);
+    if (storedAddress) {
+      setTabs((current) => current.map((tab) => tab.id === restored.id ? { ...tab, url: storedAddress } : tab));
+      setAddressBar(storedAddress);
+    } else {
+      setAddressBar(restored.url);
+    }
+  // Restore once after hydration; later tab changes are deliberate user actions.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preferencesHydrated]);
   const [quickOpen, setQuickOpen] = useState(false);
   const quickOpenRef = useRef(false);
   quickOpenRef.current = quickOpen;
@@ -227,7 +257,8 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
         } else {
           if (tabId === activeTabId) {
             setLoading(false);
-            setAddressBar(evUrl);
+            if (transientNavigationUrlRef.current === evUrl) setAddressBar(evUrl);
+            else commitAddress(evUrl);
           }
           // Update tab URL
           setTabs((prev) =>
@@ -272,12 +303,15 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
           delete expectedPageLoadRef.current[tabId];
         }
         setTabTitles((prev) => ({ ...prev, [tabId]: title }));
-        if (tabId === activeTabId) setAddressBar(evUrl);
+        if (tabId === activeTabId) {
+          if (transientNavigationUrlRef.current === evUrl) setAddressBar(evUrl);
+          else commitAddress(evUrl);
+        }
       },
     ).then((fn) => { if (cancelled) fn(); else unlistenTitle = fn; });
 
     return () => { cancelled = true; unlistenLoad?.(); unlistenTitle?.(); };
-  }, [bridge, nativeBrowserAvailable, label, activeTabId]);
+  }, [bridge, nativeBrowserAvailable, label, activeTabId, commitAddress]);
 
   // ── Sync active tab webview bounds ────────────────────────────────
   // The native Tauri child webview is an OS-level overlay rendered ABOVE
@@ -488,26 +522,28 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
       }).catch(() => {
         if (!cancelled) setUnavailable(true);
       });
-      setAddressBar(activeTab.url);
+      if (transientNavigationUrlRef.current === activeTab.url) setAddressBar(activeTab.url);
+      else commitAddress(activeTab.url);
     }, 80);
     return () => {
       cancelled = true;
       clearTimeout(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, bridge, nativeBrowserAvailable, activeTab?.url, activeTab?.id, acknowledgePendingNavigation]);
+  }, [active, bridge, nativeBrowserAvailable, activeTab?.url, activeTab?.id, acknowledgePendingNavigation, commitAddress]);
 
   // ── Tab actions ───────────────────────────────────────────────────
   const switchTab = useCallback((id: string) => {
-    setActiveTabId(id);
+    transientNavigationUrlRef.current = null;
+    selectActiveTab(id);
     const tab = tabs.find((t) => t.id === id);
     if (tab) {
-      setAddressBar(tab.url);
+      commitAddress(tab.url);
       historyRef.current[id] ??= { stack: [tab.url], idx: 0 };
     }
     setLoading(false);
     setToolbarOpen(false);
-  }, [tabs]);
+  }, [tabs, selectActiveTab, commitAddress]);
 
   // Clicking the pane's empty chrome — anything that isn't an interactive
   // control — toggles the rail pinned-open, giving the pin button a large,
@@ -552,14 +588,19 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
   };
 
   // ── Per-tab navigation ────────────────────────────────────────────
-  const navigateTo = (raw: string) => {
+  const navigateTo = (raw: string, persist = true) => {
     const next = normalizeBrowserUrl(raw);
+    if (persist) transientNavigationUrlRef.current = null;
     expectedPageLoadRef.current[activeTabId] = createExpectedBrowserNavigation(next);
     const nextTabs = tabs.map((t) =>
       t.id === activeTabId ? { ...t, url: next } : t,
     );
     setTabs(nextTabs);
-    setAddressBar(next);
+    if (persist) commitAddress(next);
+    else {
+      transientNavigationUrlRef.current = next;
+      setAddressBar(next);
+    }
 
     if (!bridge) {
       const h = historyRef.current[activeTabId] ?? { stack: [activeUrl], idx: 0 };
@@ -590,7 +631,7 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     if (acceptedNavigationIdRef.current !== navigationRequest.id) {
       acceptedNavigationIdRef.current = navigationRequest.id;
       pendingNavigationRef.current = navigationRequest;
-      navigateTo(navigationRequest.url);
+      navigateTo(navigationRequest.url, false);
     }
     if (platform !== "unknown" && (!nativeBrowserAvailable || unavailable)) {
       acknowledgePendingNavigation(navigationRequest);
@@ -610,7 +651,7 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     const prev = hh.stack[hh.idx];
     expectedPageLoadRef.current[activeTabId] = createExpectedBrowserNavigation(prev);
     setTabs((t) => t.map((tab) => tab.id === activeTabId ? { ...tab, url: prev } : tab));
-    setAddressBar(prev);
+    commitAddress(prev);
   };
 
   const goForward = () => {
@@ -620,7 +661,7 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     const next = hh.stack[hh.idx];
     expectedPageLoadRef.current[activeTabId] = createExpectedBrowserNavigation(next);
     setTabs((t) => t.map((tab) => tab.id === activeTabId ? { ...tab, url: next } : tab));
-    setAddressBar(next);
+    commitAddress(next);
   };
 
   // Cmd+K / Ctrl+K → open quick-open palette.

--- a/src/components/browser-tab-state.test.ts
+++ b/src/components/browser-tab-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { browserTabTitle, defaultPinnedTabs, normalizeBrowserUrl } from "./browser-tab-state.ts";
+import { browserTabTitle, defaultPinnedTabs, normalizeBrowserUrl, resolveRestoredBrowserNavigation } from "./browser-tab-state.ts";
 
 test("default browser tabs retain the user-facing pinned destinations", () => {
   assert.deepEqual(defaultPinnedTabs().map((tab) => tab.id), [
@@ -20,4 +20,13 @@ test("browser URLs retain convenience input and safe navigation rules", () => {
 test("tab titles prefer supplied page titles and compact host names", () => {
   assert.equal(browserTabTitle("https://www.opencoven.ai/docs", "Docs"), "Docs");
   assert.equal(browserTabTitle("https://www.opencoven.ai/docs", "https://www.opencoven.ai/docs"), "opencoven.ai");
+});
+
+test("a removed restored tab falls back without applying its old address", () => {
+  const result = resolveRestoredBrowserNavigation(defaultPinnedTabs(), "removed-tab", "https://example.test/old");
+  assert.deepEqual(result, {
+    activeTabId: "home",
+    address: "https://opencoven.ai",
+    restoredTabExists: false,
+  });
 });

--- a/src/components/browser-tab-state.ts
+++ b/src/components/browser-tab-state.ts
@@ -5,6 +5,32 @@ const RAIL_PINNED_STORAGE_KEY = "cave.browser.railPinned.v1";
 
 export type BrowserTab = { id: string; url: string; title: string; pinned: boolean; kind: "pinned" };
 
+/**
+ * Restored registry state is only valid when its tab still exists in the
+ * pinned-tab model. A removed tab must not apply its old address to whichever
+ * tab happens to be first.
+ */
+export function resolveRestoredBrowserNavigation(
+  tabs: BrowserTab[],
+  storedActiveTabId: string,
+  storedAddress: string,
+): { activeTabId: string; address: string; restoredTabExists: boolean } {
+  const restoredTab = tabs.find((tab) => tab.id === storedActiveTabId);
+  if (restoredTab) {
+    return {
+      activeTabId: restoredTab.id,
+      address: storedAddress || restoredTab.url,
+      restoredTabExists: true,
+    };
+  }
+  const fallback = tabs[0];
+  return {
+    activeTabId: fallback?.id ?? "home",
+    address: fallback?.url ?? HOME_URL,
+    restoredTabExists: false,
+  };
+}
+
 export function normalizeBrowserUrl(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return HOME_URL;

--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -183,5 +183,7 @@ assert.match(view, /setNarrowPane\(w > 0 && w < 560\)/, "the fallback keys on co
 assert.match(view, /\{effectiveView === "week" && \(/, "the render switch reads the effective view");
 assert.match(view, /if \(effectiveView === "week"\) return addDays\(prev, dir \* 7\)/, "navigate steps by the VISIBLE unit");
 assert.match(view, /aria-pressed=\{viewMode === id\}/, "the view toggle still reflects the user's stored choice");
+assert.match(view, /if \(isMobile && viewMode !== "agenda"[\s\S]{0,360}setDeepLinkViewMode\("agenda"\)/, "mobile Agenda is a transient viewport override, not a saved preference");
+assert.doesNotMatch(view, /if \(isMobile && viewMode !== "agenda"[\s\S]{0,360}setViewMode\("agenda"\)/, "mobile layout must not replace a desktop calendar preference");
 
 console.log("calendar-actions.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1483,7 +1483,11 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       // desktop view choice (for example Month) comes back on the next visit.
       setDeepLinkViewMode("agenda");
     }
-  }, [isMobile, mobileRibbonDayOpen, viewMode]);
+    // A responsive mobile override must also yield as soon as this surface is
+    // widened again; otherwise Agenda remains pinned for the rest of the mount
+    // even though the stored desktop choice was never changed.
+    if (!isMobile && deepLinkViewMode === "agenda") setDeepLinkViewMode(null);
+  }, [isMobile, mobileRibbonDayOpen, viewMode, deepLinkViewMode]);
   useEffect(() => {
     if (viewMode !== "day" && mobileRibbonDayOpen) setMobileRibbonDayOpen(false);
   }, [mobileRibbonDayOpen, viewMode]);

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1478,7 +1478,10 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   useEffect(() => {
     if (isMobile && viewMode !== "agenda" && !(mobileRibbonDayOpen && viewMode === "day")) {
       setMobileRibbonDayOpen(false);
-      setViewMode("agenda");
+      // Phone layout must use Agenda, but that is a viewport constraint rather
+      // than a user preference. Keep it out of the durable registry so a
+      // desktop view choice (for example Month) comes back on the next visit.
+      setDeepLinkViewMode("agenda");
     }
   }, [isMobile, mobileRibbonDayOpen, viewMode]);
   useEffect(() => {

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/calendar.css";
 
-import { useCallback, useContext, useId, useMemo, useState, useRef, useEffect } from "react";
+import { useCallback, useContext, useId, useMemo, useState, useRef, useEffect, type SetStateAction } from "react";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
@@ -20,6 +20,8 @@ import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
 import { itemDate, packEventColumnsWithOverflow, WEEK_MAX_LANES, DAY_MAX_LANES, type PlacedOverflow } from "@/lib/calendar-layout";
 import { familiarInScope } from "@/lib/familiar-multiselect";
 import { useIsMobile } from "@/lib/use-viewport";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import {
   AgendaDeadlineRow,
   EmptyScheduleState,
@@ -1391,8 +1393,28 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   // SSR returns false from useIsMobile, so initial render is always "week"
   // on the server; the effect below snaps to agenda on mount when the
   // viewport actually matches mobile. Keeps server/client markup in sync.
-  const [viewMode, setViewMode] = useState<ViewMode>("week");
-  const [anchor, setAnchor] = useState<Date>(new Date());
+  const [storedViewMode, setStoredViewMode] = useSurfacePreference(surfacePreferenceSpecs.calendar.viewMode);
+  const [storedAnchorDate, setStoredAnchorDate] = useSurfacePreference(surfacePreferenceSpecs.calendar.anchorDate);
+  const [deepLinkViewMode, setDeepLinkViewMode] = useState<ViewMode | null>(null);
+  const [deepLinkAnchor, setDeepLinkAnchor] = useState<Date | null>(null);
+  const viewMode = deepLinkViewMode ?? storedViewMode;
+  const fallbackAnchorRef = useRef(new Date());
+  const anchor = useMemo(() => {
+    if (deepLinkAnchor) return deepLinkAnchor;
+    const restored = storedAnchorDate ? new Date(storedAnchorDate) : null;
+    return restored && !Number.isNaN(restored.getTime()) ? restored : fallbackAnchorRef.current;
+  }, [deepLinkAnchor, storedAnchorDate]);
+  const setViewMode = useCallback((next: ViewMode) => {
+    setDeepLinkViewMode(null);
+    setStoredViewMode(next);
+  }, [setStoredViewMode]);
+  const setAnchor = useCallback((next: SetStateAction<Date>) => {
+    const resolved = typeof next === "function" ? next(anchor) : next;
+    if (!Number.isNaN(resolved.getTime())) {
+      setDeepLinkAnchor(null);
+      setStoredAnchorDate(resolved.toISOString());
+    }
+  }, [anchor, setStoredAnchorDate]);
   const [mobileRibbonDayOpen, setMobileRibbonDayOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -1402,9 +1424,9 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
       const next = new Date(`${date}T12:00:00`);
       if (Number.isNaN(next.getTime())) return;
-      setAnchor(next);
+      setDeepLinkAnchor(next);
       setMobileRibbonDayOpen(true);
-      setViewMode("day");
+      setDeepLinkViewMode("day");
     };
     const openDate = (event: Event) => {
       openDateValue((event as CustomEvent<{ date?: string }>).detail?.date);

--- a/src/components/familiars-memory-view-detail.test.ts
+++ b/src/components/familiars-memory-view-detail.test.ts
@@ -47,8 +47,8 @@ assert.match(
 
 assert.match(
   source,
-  /const \[sortMode, setSortMode\] = useState<"recent" \| "oldest" \| "name" \| "size" \| "staleFirst">\("recent"\);/,
-  "Files must default to recency sort with the extended sort alternatives",
+  /const \[sortMode, setSortMode\] = useSurfacePreference\(surfacePreferenceSpecs\.familiarMemory\.sort\);/,
+  "Files must retain the recency-default sort preference through the Workspace registry",
 );
 // Sort now lives in the management controls bar (group/sort/stale-only).
 assert.match(source, /value=\{sortMode\}/, "Sort control must be bound to sortMode");

--- a/src/components/familiars-memory-view-filter-paginate.test.ts
+++ b/src/components/familiars-memory-view-filter-paginate.test.ts
@@ -11,8 +11,8 @@ const source = [
 
 assert.match(
   source,
-  /const \[sourceFilter, setSourceFilter\] = useState<"all" \| FileMemoryEntry\["sourceKind"\]>\("all"\);/,
-  "FamiliarsMemoryView must track a source-kind filter",
+  /const \[sourceFilter, setSourceFilter\] = useSurfacePreference\(surfacePreferenceSpecs\.familiarMemory\.source\);/,
+  "FamiliarsMemoryView must persist its source-kind filter through the Workspace registry",
 );
 
 assert.match(

--- a/src/components/familiars-memory-view-filter-paginate.test.ts
+++ b/src/components/familiars-memory-view-filter-paginate.test.ts
@@ -17,13 +17,13 @@ assert.match(
 
 assert.match(
   source,
-  /if \(!lockToFamiliar && activeFamiliar\?\.id\) setFamiliarFilter\(activeFamiliar\.id\);/,
-  "a detail view locked to one familiar must not overwrite the full Memory familiar preference",
+  /storedFamiliarFilter &&\s*familiarIds\.has\(storedFamiliarFilter\)[\s\S]{0,240}return;/,
+  "a valid restored familiar filter must not be overwritten by the active workspace familiar",
 );
 assert.match(
   source,
-  /useEffect\(\(\) => \{\s*if \(lockToFamiliar\) return;\s*const familiarIds/,
-  "locked detail views skip the stale-filter repair that writes the shared preference",
+  /const next = activeFamiliar\?\.id && familiarIds\.has\(activeFamiliar\.id\)/,
+  "the active familiar remains a fallback when no valid Memory preference exists",
 );
 
 assert.match(

--- a/src/components/familiars-memory-view-filter-paginate.test.ts
+++ b/src/components/familiars-memory-view-filter-paginate.test.ts
@@ -17,6 +17,17 @@ assert.match(
 
 assert.match(
   source,
+  /if \(!lockToFamiliar && activeFamiliar\?\.id\) setFamiliarFilter\(activeFamiliar\.id\);/,
+  "a detail view locked to one familiar must not overwrite the full Memory familiar preference",
+);
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*if \(lockToFamiliar\) return;\s*const familiarIds/,
+  "locked detail views skip the stale-filter repair that writes the shared preference",
+);
+
+assert.match(
+  source,
   /sourceFilter === "all" \|\| entry\.sourceKind === sourceFilter/,
   "Memory files must be filtered by the active source-kind filter",
 );

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -212,13 +212,6 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   // (cave-5dnw: this used to double-fetch /api/coven-memory + /api/memory).
   usePausablePoll(() => void load(), 30_000, { enabled: !feed });
 
-  useEffect(() => {
-    // Embedded familiar-detail views are deliberately locked to their owner.
-    // They must not replace the full Memory surface's return preference just
-    // because they mounted with a different active familiar.
-    if (!lockToFamiliar && activeFamiliar?.id) setFamiliarFilter(activeFamiliar.id);
-  }, [activeFamiliar?.id, lockToFamiliar, setFamiliarFilter]);
-
   const familiarById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
   const effectiveFamiliarFilter = lockToFamiliar && activeFamiliar?.id ? activeFamiliar.id : familiarFilter;
   const q = query.trim().toLowerCase();
@@ -327,23 +320,24 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   useEffect(() => {
     if (lockToFamiliar) return;
     const familiarIds = new Set(familiars.map((familiar) => familiar.id));
-    if (activeFamiliar?.id && familiarIds.has(activeFamiliar.id)) {
-      if (activeFamiliar.id !== familiarFilter) setFamiliarFilter(activeFamiliar.id);
-      return;
-    }
-
+    // A valid restored selection is the user's return preference. The active
+    // workspace familiar is only a fallback for an empty or stale preference;
+    // otherwise every remount would immediately overwrite the remembered
+    // Memory filter with whichever familiar happens to be active in Chat.
     const memoryFamiliarIds = new Set(covenEntries.map((entry) => entry.familiar_id));
     if (
-      familiarFilter &&
-      familiarIds.has(familiarFilter) &&
-      (memoryFamiliarIds.size === 0 || memoryFamiliarIds.has(familiarFilter))
+      storedFamiliarFilter &&
+      familiarIds.has(storedFamiliarFilter) &&
+      (memoryFamiliarIds.size === 0 || memoryFamiliarIds.has(storedFamiliarFilter))
     ) {
       return;
     }
 
-    const next = familiars.find((familiar) => memoryFamiliarIds.has(familiar.id))?.id ?? familiars[0]?.id ?? "";
-    if (next && next !== familiarFilter) setFamiliarFilter(next);
-  }, [activeFamiliar?.id, covenEntries, familiarFilter, familiars, lockToFamiliar, setFamiliarFilter]);
+    const next = activeFamiliar?.id && familiarIds.has(activeFamiliar.id)
+      ? activeFamiliar.id
+      : familiars.find((familiar) => memoryFamiliarIds.has(familiar.id))?.id ?? familiars[0]?.id ?? "";
+    if (next && next !== storedFamiliarFilter) setFamiliarFilter(next);
+  }, [activeFamiliar?.id, covenEntries, familiars, lockToFamiliar, setFamiliarFilter, storedFamiliarFilter]);
 
   const selectedFamiliar =
     familiarById.get(effectiveFamiliarFilter) ??

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -213,8 +213,11 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   usePausablePoll(() => void load(), 30_000, { enabled: !feed });
 
   useEffect(() => {
-    if (activeFamiliar?.id) setFamiliarFilter(activeFamiliar.id);
-  }, [activeFamiliar?.id]);
+    // Embedded familiar-detail views are deliberately locked to their owner.
+    // They must not replace the full Memory surface's return preference just
+    // because they mounted with a different active familiar.
+    if (!lockToFamiliar && activeFamiliar?.id) setFamiliarFilter(activeFamiliar.id);
+  }, [activeFamiliar?.id, lockToFamiliar, setFamiliarFilter]);
 
   const familiarById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
   const effectiveFamiliarFilter = lockToFamiliar && activeFamiliar?.id ? activeFamiliar.id : familiarFilter;
@@ -322,6 +325,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   }), [familiarScopedFiles]);
 
   useEffect(() => {
+    if (lockToFamiliar) return;
     const familiarIds = new Set(familiars.map((familiar) => familiar.id));
     if (activeFamiliar?.id && familiarIds.has(activeFamiliar.id)) {
       if (activeFamiliar.id !== familiarFilter) setFamiliarFilter(activeFamiliar.id);
@@ -339,7 +343,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
 
     const next = familiars.find((familiar) => memoryFamiliarIds.has(familiar.id))?.id ?? familiars[0]?.id ?? "";
     if (next && next !== familiarFilter) setFamiliarFilter(next);
-  }, [activeFamiliar?.id, covenEntries, familiarFilter, familiars]);
+  }, [activeFamiliar?.id, covenEntries, familiarFilter, familiars, lockToFamiliar, setFamiliarFilter]);
 
   const selectedFamiliar =
     familiarById.get(effectiveFamiliarFilter) ??

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -40,6 +40,8 @@ import {
   SourceFilterChip,
 } from "@/components/familiars-memory-files";
 import { compactPath, fileBase, fileDir, formatBytes, memoryMatches, type FileMemoryEntry } from "@/components/familiars-memory-utils";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 export type { FileMemoryEntry } from "@/components/familiars-memory-utils";
 
@@ -86,12 +88,13 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [query, setQuery] = useState("");
-  const [familiarFilter, setFamiliarFilter] = useState<string>(activeFamiliar?.id ?? familiars[0]?.id ?? "");
+  const [storedFamiliarFilter, setFamiliarFilter] = useSurfacePreference(surfacePreferenceSpecs.familiarMemory.familiarId);
+  const familiarFilter = storedFamiliarFilter || activeFamiliar?.id || familiars[0]?.id || "";
   const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
-  const [sourceFilter, setSourceFilter] = useState<"all" | FileMemoryEntry["sourceKind"]>("all");
-  const [sortMode, setSortMode] = useState<"recent" | "oldest" | "name" | "size" | "staleFirst">("recent");
-  const [groupMode, setGroupMode] = useState<GroupBy>("none");
-  const [staleOnly, setStaleOnly] = useState(false);
+  const [sourceFilter, setSourceFilter] = useSurfacePreference(surfacePreferenceSpecs.familiarMemory.source);
+  const [sortMode, setSortMode] = useSurfacePreference(surfacePreferenceSpecs.familiarMemory.sort);
+  const [groupMode, setGroupMode] = useSurfacePreference(surfacePreferenceSpecs.familiarMemory.group);
+  const [staleOnly, setStaleOnly] = useSurfacePreference(surfacePreferenceSpecs.familiarMemory.staleOnly);
   const [expandRow, setExpandRow] = useState<MemoryRow | null>(null);
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<{ key: string }>();
   // The real DELETE is deferred 4s for undo, but the 30s poll / on-focus refresh

--- a/src/components/familiars-view-sections.tsx
+++ b/src/components/familiars-view-sections.tsx
@@ -36,6 +36,8 @@ import { SUMMON_FAMILIAR_EVENT, consumeSummonPending } from "@/lib/summon-events
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { Popover, PopoverBody, PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { SessionTraceOverlay, type TraceTarget } from "@/components/session-trace-overlay";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 export function emptyStats(): FamiliarCardStats {
   return {
@@ -466,7 +468,7 @@ export function FamiliarDetailPanel({
   onOpenMemoryFile,
   onOpenUrl,
 }: AgentDetailPanelProps) {
-  const [tab, setTab] = useState<DetailTab>("memory");
+  const [tab, setTab] = useSurfacePreference(surfacePreferenceSpecs.familiars.detailTab);
   // Session trace overlay — the daemon event timeline behind one session.
   const [traceTarget, setTraceTarget] = useState<TraceTarget | null>(null);
   const familiarSessions = useMemo(

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -29,20 +29,14 @@ assert.match(
 
 assert.match(
   source,
-  /const LAST_SELECTED_KEY = "cave:agents\.lastSelected"/,
-  "Selection persistence uses cave:agents.lastSelected localStorage key",
+  /useSurfacePreference\(surfacePreferenceSpecs\.familiars\.selectedId\)/,
+  "Selection persistence uses the shared workspace preference registry",
 );
 
 assert.match(
   source,
-  /window\.localStorage\.getItem\(LAST_SELECTED_KEY\)/,
-  "Initial selectedFamiliarId reads from localStorage",
-);
-
-assert.match(
-  source,
-  /window\.localStorage\.getItem\(LAST_SELECTED_KEY\) \? "detail" : "roster"/,
-  "Initial viewMode boots into detail when a selection is persisted, else roster",
+  /useSurfacePreference\(surfacePreferenceSpecs\.familiars\.viewMode\)/,
+  "The roster/detail preference is restored through the same registry",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -34,6 +34,8 @@ import { SUMMON_FAMILIAR_EVENT, consumeSummonPending } from "@/lib/summon-events
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { Popover, PopoverBody, PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { SessionTraceOverlay, type TraceTarget } from "@/components/session-trace-overlay";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import {
   emptyStats,
   FamiliarsEmptyState,
@@ -53,8 +55,6 @@ type FileMemoryResponse =
   | { ok: false; entries?: FileMemoryEntry[]; error?: string };
 
 type ViewMode = "roster" | "detail" | "agent-memory";
-
-const LAST_SELECTED_KEY = "cave:agents.lastSelected";
 
 type AgentsViewProps = {
   familiars: Familiar[];
@@ -131,25 +131,8 @@ export function FamiliarsView({
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const [previewFamiliar, setPreviewFamiliar] = useState<ResolvedFamiliar | null>(null);
-  const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return window.localStorage.getItem(LAST_SELECTED_KEY);
-  });
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    if (typeof window === "undefined") return "roster";
-    return window.localStorage.getItem(LAST_SELECTED_KEY) ? "detail" : "roster";
-  });
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      if (selectedFamiliarId) window.localStorage.setItem(LAST_SELECTED_KEY, selectedFamiliarId);
-      else window.localStorage.removeItem(LAST_SELECTED_KEY);
-    } catch {
-      // Full localStorage must not crash the surface; the selection just
-      // won't persist across reloads.
-    }
-  }, [selectedFamiliarId]);
+  const [selectedFamiliarId, setSelectedFamiliarId] = useSurfacePreference(surfacePreferenceSpecs.familiars.selectedId);
+  const [viewMode, setViewMode] = useSurfacePreference(surfacePreferenceSpecs.familiars.viewMode);
 
   // "/" jumps to the search (GitHub-style) while this surface is shown — but
   // never when the user is already typing in a field or holding a modifier.

--- a/src/components/github-native-open.test.ts
+++ b/src/components/github-native-open.test.ts
@@ -63,13 +63,23 @@ assert.match(
 );
 assert.match(
   githubView,
-  /deepLinkItem \?\? sorted\.find\(sameSelectedTarget\) \?\? sorted\[0\] \?\? null/,
+  /deepLinkItem \?\? sorted\.find\(sameSelectedTarget\) \?\? sorted\.find\(\(item\) => item\.id === transientSelectedItemId\) \?\? sorted\[0\] \?\? null/,
   "the deep-linked item wins the detail selection until the user picks a row",
 );
 assert.match(
   githubView,
   /const selectRow = useCallback\(\(id: string\) => \{\s*setDeepLink\(null\);[\s\S]{0,360}setSelectedTarget\(/,
   "manual row selection clears the deep link",
+);
+assert.match(
+  githubView,
+  /setTransientSelectedItemId\(id\);[\s\S]{0,360}setSelectedTarget\(/,
+  "a notification without a durable issue number remains selected for the current visit",
+);
+assert.match(
+  githubView,
+  /sorted\.find\(sameSelectedTarget\) \?\? sorted\.find\(\(item\) => item\.id === transientSelectedItemId\)/,
+  "the transient notification selection wins over the default first row",
 );
 assert.match(
   githubView,

--- a/src/components/github-native-open.test.ts
+++ b/src/components/github-native-open.test.ts
@@ -63,12 +63,12 @@ assert.match(
 );
 assert.match(
   githubView,
-  /deepLinkItem \?\? sorted\.find\(\(item\) => item\.id === selectedItemId\) \?\? sorted\[0\] \?\? null/,
+  /deepLinkItem \?\? sorted\.find\(\(item\) =>[\s\S]{0,220}selectedTarget !== null/,
   "the deep-linked item wins the detail selection until the user picks a row",
 );
 assert.match(
   githubView,
-  /const selectRow = useCallback\(\(id: string\) => \{\s*setDeepLink\(null\);\s*setSelectedItemId\(id\);/,
+  /const selectRow = useCallback\(\(id: string\) => \{\s*setDeepLink\(null\);[\s\S]{0,360}setSelectedTarget\(/,
   "manual row selection clears the deep link",
 );
 assert.match(

--- a/src/components/github-native-open.test.ts
+++ b/src/components/github-native-open.test.ts
@@ -63,7 +63,7 @@ assert.match(
 );
 assert.match(
   githubView,
-  /deepLinkItem \?\? sorted\.find\(\(item\) =>[\s\S]{0,220}selectedTarget !== null/,
+  /deepLinkItem \?\? sorted\.find\(sameSelectedTarget\) \?\? sorted\[0\] \?\? null/,
   "the deep-linked item wins the detail selection until the user picks a row",
 );
 assert.match(

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -60,6 +60,8 @@ import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { GithubSubscriptionsModal } from "@/components/github-subscriptions-modal";
 import { openExternalUrl } from "@/lib/open-external";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import {
   GITHUB_PAT_URL, KIND_COLOR, KIND_DETAIL_LABEL, KIND_ICON, KIND_LABEL, KIND_ORDER, STATUS_DOT_COLOR,
   linkedCardsForItem, orgOf, useCards, useFamiliars,
@@ -2282,16 +2284,16 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   const [patStatus, setPatStatus] = useState<PatStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [filter, setFilter] = useState<Filter>("all");
-  const [orgFilter, setOrgFilter] = useState<string>("all");
-  const [repoFilter, setRepoFilter] = useState<string>("all");
+  const [filter, setFilter] = useSurfacePreference(surfacePreferenceSpecs.github.filter);
+  const [orgFilter, setOrgFilter] = useSurfacePreference(surfacePreferenceSpecs.github.organization);
+  const [repoFilter, setRepoFilter] = useSurfacePreference(surfacePreferenceSpecs.github.repository);
   const [query, setQuery] = useState("");
-  const [groupBy, setGroupBy] = useState<GroupBy>("none");
+  const [groupBy, setGroupBy] = useSurfacePreference(surfacePreferenceSpecs.github.groupBy);
   const [showPatModal, setShowPatModal] = useState(false);
   const [showSubsModal, setShowSubsModal] = useState(false);
-  const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
-  const [sortDir, setSortDir] = useState<SortDir>("desc");
-  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useSurfacePreference(surfacePreferenceSpecs.github.sortKey);
+  const [sortDir, setSortDir] = useSurfacePreference(surfacePreferenceSpecs.github.sortDir);
+  const [selectedTarget, setSelectedTarget] = useSurfacePreference(surfacePreferenceSpecs.github.selected);
   // Deep-linked PR/issue from a GitHub-event notification. Cleared when the
   // user picks a row themselves — from then on selection owns the detail.
   const [deepLink, setDeepLink] = useState<GitHubItemTarget | null>(initialTarget ?? null);
@@ -2300,8 +2302,14 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   }, [initialTarget]);
   const selectRow = useCallback((id: string) => {
     setDeepLink(null);
-    setSelectedItemId(id);
-  }, []);
+    const item = activity?.items.find((candidate) => candidate.id === id);
+    // The durable selection is a semantic GitHub identity, not the API row id.
+    // Notifications without a PR/issue number continue to open for the current
+    // visit but are intentionally not persisted.
+    setSelectedTarget(item && typeof item.number === "number"
+      ? { repo: item.repo, number: item.number, kind: item.kind }
+      : null);
+  }, [activity?.items, setSelectedTarget]);
   const timerRef = useRef<number | null>(null);
   // Guards against setState after unmount from an in-flight fetch (mirrors useCards).
   const mountedRef = useRef(true);
@@ -2455,6 +2463,21 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
     if (orgFilter !== org) setOrgFilter(org);
   }, [repoFilter, orgFilter]);
 
+  // Stored repository and organization names are meaningful only while the
+  // connected account still exposes them. Clear stale values after a successful
+  // refresh; use the unfiltered feed so changing the activity tab cannot erase
+  // an otherwise valid scope.
+  useEffect(() => {
+    if (loading || error) return;
+    if (repoFilter !== "all" && !items.some((item) => item.repo === repoFilter)) {
+      setRepoFilter("all");
+      return;
+    }
+    if (orgFilter !== "all" && !items.some((item) => orgOf(item.repo) === orgFilter)) {
+      setOrgFilter("all");
+    }
+  }, [items, loading, error, orgFilter, repoFilter, setOrgFilter, setRepoFilter]);
+
   const scoped = useMemo(
     () =>
       filtered.filter(
@@ -2531,14 +2554,12 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   );
 
   useEffect(() => {
-    if (sorted.length === 0) {
-      if (selectedItemId !== null) setSelectedItemId(null);
-      return;
-    }
-    if (!selectedItemId || !sorted.some((item) => item.id === selectedItemId)) {
-      setSelectedItemId(sorted[0].id);
-    }
-  }, [sorted, selectedItemId]);
+    if (!selectedTarget || loading || error) return;
+    const exists = items.some((item) =>
+      item.repo === selectedTarget.repo && item.number === selectedTarget.number && item.kind === selectedTarget.kind,
+    );
+    if (!exists) setSelectedTarget(null);
+  }, [items, loading, error, selectedTarget, setSelectedTarget]);
 
   // The deep-linked item may not be in the activity list (old PR, other repo):
   // prefer the live row when present (real title/state, row highlight), else
@@ -2560,8 +2581,10 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   }, [deepLink, sorted]);
 
   const selectedItem = useMemo(
-    () => deepLinkItem ?? sorted.find((item) => item.id === selectedItemId) ?? sorted[0] ?? null,
-    [deepLinkItem, sorted, selectedItemId],
+    () => deepLinkItem ?? sorted.find((item) =>
+      selectedTarget !== null && item.repo === selectedTarget.repo && item.number === selectedTarget.number && item.kind === selectedTarget.kind,
+    ) ?? sorted[0] ?? null,
+    [deepLinkItem, sorted, selectedTarget],
   );
   const selectedLinkedCards = selectedItem ? linkedMap.get(selectedItem.id) ?? [] : [];
 

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2294,6 +2294,9 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   const [sortKey, setSortKey] = useSurfacePreference(surfacePreferenceSpecs.github.sortKey);
   const [sortDir, setSortDir] = useSurfacePreference(surfacePreferenceSpecs.github.sortDir);
   const [selectedTarget, setSelectedTarget] = useSurfacePreference(surfacePreferenceSpecs.github.selected);
+  // Notifications without a PR/issue number cannot be restored semantically,
+  // but still need to remain selected for the current visit.
+  const [transientSelectedItemId, setTransientSelectedItemId] = useState<string | null>(null);
   // Deep-linked PR/issue from a GitHub-event notification. Cleared when the
   // user picks a row themselves — from then on selection owns the detail.
   const [deepLink, setDeepLink] = useState<GitHubItemTarget | null>(initialTarget ?? null);
@@ -2302,6 +2305,7 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   }, [initialTarget]);
   const selectRow = useCallback((id: string) => {
     setDeepLink(null);
+    setTransientSelectedItemId(id);
     const item = activity?.items.find((candidate) => candidate.id === id);
     // The durable selection is a semantic GitHub identity, not the API row id.
     // Notifications without a PR/issue number continue to open for the current
@@ -2573,8 +2577,8 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   }, [deepLink, sorted]);
 
   const selectedItem = useMemo(
-    () => deepLinkItem ?? sorted.find(sameSelectedTarget) ?? sorted[0] ?? null,
-    [deepLinkItem, sorted, sameSelectedTarget],
+    () => deepLinkItem ?? sorted.find(sameSelectedTarget) ?? sorted.find((item) => item.id === transientSelectedItemId) ?? sorted[0] ?? null,
+    [deepLinkItem, sorted, sameSelectedTarget, transientSelectedItemId],
   );
   const selectedLinkedCards = selectedItem ? linkedMap.get(selectedItem.id) ?? [] : [];
 

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2437,24 +2437,24 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   );
 
   // Organization options come from the kind-filtered set; repository options
-  // narrow to the chosen org so the two selects cascade (org → repo).
+  // narrow to the chosen org so the two selects cascade (org → repo). Keep a
+  // restored scope present even when it has no current activity: this endpoint
+  // only returns the user's open/assigned items, not the account's complete
+  // repository access list.
   const orgOptions = useMemo(
-    () => Array.from(new Set(filtered.map((i) => orgOf(i.repo)))).sort((a, b) => a.localeCompare(b)),
-    [filtered],
+    () => Array.from(new Set([
+      ...filtered.map((i) => orgOf(i.repo)),
+      ...(orgFilter === "all" ? [] : [orgFilter]),
+    ])).sort((a, b) => a.localeCompare(b)),
+    [filtered, orgFilter],
   );
   const repoOptions = useMemo(() => {
     const base = orgFilter === "all" ? filtered : filtered.filter((i) => orgOf(i.repo) === orgFilter);
-    return Array.from(new Set(base.map((i) => i.repo))).sort((a, b) => a.localeCompare(b));
-  }, [filtered, orgFilter]);
-
-  // Drop a stale org/repo selection when the underlying options change (e.g.
-  // the kind filter or org filter removed the previously-selected value).
-  useEffect(() => {
-    if (orgFilter !== "all" && !orgOptions.includes(orgFilter)) setOrgFilter("all");
-  }, [orgOptions, orgFilter]);
-  useEffect(() => {
-    if (repoFilter !== "all" && !repoOptions.includes(repoFilter)) setRepoFilter("all");
-  }, [repoOptions, repoFilter]);
+    return Array.from(new Set([
+      ...base.map((i) => i.repo),
+      ...(repoFilter === "all" ? [] : [repoFilter]),
+    ])).sort((a, b) => a.localeCompare(b));
+  }, [filtered, orgFilter, repoFilter]);
   // Selecting a repo pins the Org filter to that repo's org (the Org select is
   // disabled while a repo is chosen — clearing the repo re-enables it).
   useEffect(() => {
@@ -2462,21 +2462,6 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
     const org = orgOf(repoFilter);
     if (orgFilter !== org) setOrgFilter(org);
   }, [repoFilter, orgFilter]);
-
-  // Stored repository and organization names are meaningful only while the
-  // connected account still exposes them. Clear stale values after a successful
-  // refresh; use the unfiltered feed so changing the activity tab cannot erase
-  // an otherwise valid scope.
-  useEffect(() => {
-    if (loading || error) return;
-    if (repoFilter !== "all" && !items.some((item) => item.repo === repoFilter)) {
-      setRepoFilter("all");
-      return;
-    }
-    if (orgFilter !== "all" && !items.some((item) => orgOf(item.repo) === orgFilter)) {
-      setOrgFilter("all");
-    }
-  }, [items, loading, error, orgFilter, repoFilter, setOrgFilter, setRepoFilter]);
 
   const scoped = useMemo(
     () =>
@@ -2553,13 +2538,20 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
     [items],
   );
 
+  const sameSelectedTarget = useCallback((item: GitHubItem) =>
+    selectedTarget !== null &&
+    item.repo === selectedTarget.repo &&
+    item.number === selectedTarget.number &&
+    (item.kind === selectedTarget.kind ||
+      ((item.kind === "pr" || item.kind === "review_request") &&
+        (selectedTarget.kind === "pr" || selectedTarget.kind === "review_request"))),
+  [selectedTarget]);
+
   useEffect(() => {
     if (!selectedTarget || loading || error) return;
-    const exists = items.some((item) =>
-      item.repo === selectedTarget.repo && item.number === selectedTarget.number && item.kind === selectedTarget.kind,
-    );
+    const exists = items.some(sameSelectedTarget);
     if (!exists) setSelectedTarget(null);
-  }, [items, loading, error, selectedTarget, setSelectedTarget]);
+  }, [items, loading, error, selectedTarget, sameSelectedTarget, setSelectedTarget]);
 
   // The deep-linked item may not be in the activity list (old PR, other repo):
   // prefer the live row when present (real title/state, row highlight), else
@@ -2581,10 +2573,8 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
   }, [deepLink, sorted]);
 
   const selectedItem = useMemo(
-    () => deepLinkItem ?? sorted.find((item) =>
-      selectedTarget !== null && item.repo === selectedTarget.repo && item.number === selectedTarget.number && item.kind === selectedTarget.kind,
-    ) ?? sorted[0] ?? null,
-    [deepLinkItem, sorted, selectedTarget],
+    () => deepLinkItem ?? sorted.find(sameSelectedTarget) ?? sorted[0] ?? null,
+    [deepLinkItem, sorted, sameSelectedTarget],
   );
   const selectedLinkedCards = selectedItem ? linkedMap.get(selectedItem.id) ?? [] : [];
 

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -69,6 +69,8 @@ import {
   writeStoredTabs,
   type GrimoireSelection,
 } from "./grimoire-nav-state";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 export { MAX_OPEN_TABS } from "./grimoire-nav-state";
 export type { GrimoireSelection } from "./grimoire-nav-state";
@@ -748,6 +750,10 @@ export function GrimoireView({
   const [deleting, setDeleting] = useState(false);
   // Open tabs + the active one. A #grimoire: deep link wins over the restored
   // active tab and is merged into the restored tab set.
+  const [storedSelectionKey, setStoredSelectionKey, preferencesHydrated] = useSurfacePreference(surfacePreferenceSpecs.grimoire.selected);
+  // The hash is a one-visit route target. Keep it separate from the durable
+  // preference so a linked document never replaces the person's return tab.
+  const deepLinkActiveRef = useRef(false);
   const [{ openTabs, selection }, setTabState] = useState<{
     openTabs: GrimoireSelection[];
     selection: GrimoireSelection | null;
@@ -755,6 +761,7 @@ export function GrimoireView({
     const stored = readStoredTabs();
     const fromHash = readGrimoireHash();
     if (fromHash) {
+      deepLinkActiveRef.current = true;
       const key = selectionKey(fromHash);
       const tabs = stored.tabs.some((t) => selectionKey(t) === key)
         ? stored.tabs
@@ -766,6 +773,15 @@ export function GrimoireView({
       : null;
     return { openTabs: stored.tabs, selection: active };
   });
+
+  useEffect(() => {
+    if (!preferencesHydrated || deepLinkActiveRef.current || !storedSelectionKey) return;
+    setTabState((current) => {
+      const restored = current.openTabs.find((tab) => selectionKey(tab) === storedSelectionKey) ?? null;
+      if (!restored || (current.selection && selectionKey(current.selection) === selectionKey(restored))) return current;
+      return { ...current, selection: restored };
+    });
+  }, [preferencesHydrated, storedSelectionKey]);
 
   /** Open (or focus) a document tab. */
   // (grimoire-audit cave-vv2h) Per-tab unsaved-edits flags, reported by each
@@ -877,7 +893,8 @@ export function GrimoireView({
 
   useEffect(() => {
     writeStoredTabs(openTabs, selection ? selectionKey(selection) : null);
-  }, [openTabs, selection]);
+    if (!deepLinkActiveRef.current) setStoredSelectionKey(selection ? selectionKey(selection) : null);
+  }, [openTabs, selection, setStoredSelectionKey]);
 
   const load = useCallback(async () => {
     setLoadError(null);

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -754,6 +754,8 @@ export function GrimoireView({
   // The hash is a one-visit route target. Keep it separate from the durable
   // preference so a linked document never replaces the person's return tab.
   const deepLinkActiveRef = useRef(false);
+  const preferenceRestoreAppliedRef = useRef(false);
+  const restoredSelectionPendingRef = useRef(false);
   const [{ openTabs, selection }, setTabState] = useState<{
     openTabs: GrimoireSelection[];
     selection: GrimoireSelection | null;
@@ -775,10 +777,13 @@ export function GrimoireView({
   });
 
   useEffect(() => {
-    if (!preferencesHydrated || deepLinkActiveRef.current || !storedSelectionKey) return;
+    if (!preferencesHydrated || deepLinkActiveRef.current || preferenceRestoreAppliedRef.current) return;
+    preferenceRestoreAppliedRef.current = true;
+    if (!storedSelectionKey) return;
     setTabState((current) => {
       const restored = current.openTabs.find((tab) => selectionKey(tab) === storedSelectionKey) ?? null;
       if (!restored || (current.selection && selectionKey(current.selection) === selectionKey(restored))) return current;
+      restoredSelectionPendingRef.current = true;
       return { ...current, selection: restored };
     });
   }, [preferencesHydrated, storedSelectionKey]);
@@ -893,8 +898,20 @@ export function GrimoireView({
 
   useEffect(() => {
     writeStoredTabs(openTabs, selection ? selectionKey(selection) : null);
-    if (!deepLinkActiveRef.current) setStoredSelectionKey(selection ? selectionKey(selection) : null);
-  }, [openTabs, selection, setStoredSelectionKey]);
+    if (!preferencesHydrated) return;
+    // The initial hash target is intentionally one-visit only. Once hydration
+    // has had its chance to keep that target ahead of the saved return tab,
+    // release the guard so a later user selection becomes the new preference.
+    if (deepLinkActiveRef.current) {
+      deepLinkActiveRef.current = false;
+      return;
+    }
+    if (restoredSelectionPendingRef.current) {
+      if ((selection ? selectionKey(selection) : null) !== storedSelectionKey) return;
+      restoredSelectionPendingRef.current = false;
+    }
+    setStoredSelectionKey(selection ? selectionKey(selection) : null);
+  }, [openTabs, preferencesHydrated, selection, setStoredSelectionKey, storedSelectionKey]);
 
   const load = useCallback(async () => {
     setLoadError(null);

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -60,6 +60,8 @@ import {
   toSkillDetail,
   type MarketplaceSection,
 } from "@/components/marketplace/marketplace-view-model";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 
 export type { MarketplaceSection } from "@/components/marketplace/marketplace-view-model";
 
@@ -87,9 +89,14 @@ export function MarketplaceViewSurface({
   familiars = [],
 }: Props = {}) {
   // Roles and Capabilities are hidden: their deep links land on Browse.
-  const [section, setSection] = useState<MarketplaceSection>(
-    initialSection === "roles" || initialSection === "capabilities" ? "browse" : initialSection,
+  const [storedSection, setStoredSection] = useSurfacePreference(surfacePreferenceSpecs.marketplace.section);
+  // Alias links are a one-visit destination, not a replacement for a normal
+  // return preference.
+  const initialDestination = initialSection === "roles" || initialSection === "capabilities" ? "browse" : initialSection;
+  const [deepLinkSection, setDeepLinkSection] = useState<MarketplaceSection | null>(
+    initialDestination === "browse" ? null : initialDestination,
   );
+  const section = deepLinkSection ?? storedSection;
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement | null>(null);
 
@@ -97,10 +104,10 @@ export function MarketplaceViewSurface({
   const [plugins, setPlugins] = useState<MarketplacePlugin[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [category, setCategory] = useState("All");
-  const [kind, setKind] = useState<KindFilter>("all");
-  const [sort, setSort] = useState<SortKey>("recommended");
-  const [collectionId, setCollectionId] = useState<string | null>(null);
+  const [category, setCategory] = useSurfacePreference(surfacePreferenceSpecs.marketplace.category);
+  const [kind, setKind] = useSurfacePreference(surfacePreferenceSpecs.marketplace.kind);
+  const [sort, setSort] = useSurfacePreference(surfacePreferenceSpecs.marketplace.sort);
+  const [collectionId, setCollectionId] = useSurfacePreference(surfacePreferenceSpecs.marketplace.collection);
   const [selected, setSelected] = useState<string | null>(null);
   const [creatingCraft, setCreatingCraft] = useState(false);
   // Editing an existing draft reopens the create drawer pre-seeded (F5).
@@ -270,9 +277,10 @@ export function MarketplaceViewSurface({
   // Switch sections (clearing the per-section search). Shared by the tab
   // buttons, the tablist's arrow-key navigation, and cross-section CTAs.
   const selectSection = useCallback((next: MarketplaceSection) => {
-    setSection(next);
+    setDeepLinkSection(null);
+    setStoredSection(next === "roles" || next === "capabilities" ? "browse" : next);
     setQuery("");
-  }, []);
+  }, [setStoredSection]);
 
   const categories = useMemo(() => categoriesFrom(plugins), [plugins]);
   const categoryCounts = useMemo(() => {

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -45,6 +45,7 @@ import {
   sortPlugins,
   countByKind,
   groupPluginsByCategory,
+  normalizeMarketplaceScope,
   resolveCollection,
   COLLECTIONS,
   type KindFilter,
@@ -314,6 +315,15 @@ export function MarketplaceViewSurface({
     () => COLLECTIONS.find((c) => c.id === collectionId) ?? null,
     [collectionId],
   );
+  // Catalog categories are data-driven, so a choice can disappear between
+  // visits. Keep durable filters truthful by dropping only the invalid scope
+  // after the first catalog response has established the available options.
+  useEffect(() => {
+    if (!loaded) return;
+    const normalized = normalizeMarketplaceScope(categories, category, collectionId);
+    if (normalized.category !== category) setCategory(normalized.category);
+    if (normalized.collectionId !== collectionId) setCollectionId(normalized.collectionId);
+  }, [loaded, categories, category, collectionId, setCategory, setCollectionId]);
   const collectionIds = useMemo(
     () => (activeCollection ? resolveCollection(plugins, activeCollection).map((p) => p.id) : undefined),
     [plugins, activeCollection],

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -94,7 +94,9 @@ export function MarketplaceViewSurface({
   // return preference.
   const initialDestination = initialSection === "roles" || initialSection === "capabilities" ? "browse" : initialSection;
   const [deepLinkSection, setDeepLinkSection] = useState<MarketplaceSection | null>(
-    initialDestination === "browse" ? null : initialDestination,
+    initialSection === "roles" || initialSection === "capabilities"
+      ? "browse"
+      : initialDestination === "browse" ? null : initialDestination,
   );
   const section = deepLinkSection ?? storedSection;
   const [query, setQuery] = useState("");

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -106,8 +106,8 @@ assert.doesNotMatch(
 );
 assert.match(
   automations,
-  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*initialTab === "crons" \? "crons" : "overview",?\s*\)/,
-  "Surface defaults to the unified overview unless a deep link asks otherwise",
+  /const \[storedActiveTab, setStoredActiveTab\] = useSurfacePreference\(surfacePreferenceSpecs\.schedules\.activeTab\);[\s\S]*const activeTab = deepLinkTab \?\? storedActiveTab/,
+  "Surface restores the unified overview tab preference unless a deep link asks otherwise",
 );
 assert.match(automations, /<h1[\s\S]*?>\s*Rituals\s*<\/h1>/, "Surface header reads Rituals");
 assert.match(
@@ -133,7 +133,7 @@ assert.match(
 assert.match(automations, /sessionStorage\.setItem\("cave:calendar:pending-open-date", day\.key\)[\s\S]{0,100}selectTab\("calendar"\)/, "a ribbon day queues its date before Calendar mounts");
 assert.match(calendar, /sessionStorage\.getItem\("cave:calendar:pending-open-date"\)[\s\S]{0,180}openDateValue\(pendingDate\)/, "Calendar consumes a queued ribbon date on mount");
 assert.match(calendar, /addEventListener\("cave:calendar:open-date", openDate\)/, "Calendar accepts a day selected from the overview ribbon");
-assert.match(calendar, /setAnchor\(next\);[\s\S]{0,140}setViewMode\("day"\)/, "a ribbon day opens the matching single-day calendar");
+assert.match(calendar, /setDeepLinkAnchor\(next\);[\s\S]{0,140}setDeepLinkViewMode\("day"\)/, "a ribbon day opens the matching single-day calendar without overwriting saved navigation preferences");
 assert.match(calendar, /mobileRibbonDayOpen && viewMode === "day"/, "mobile preserves an explicitly selected ribbon day instead of forcing Agenda");
 assert.doesNotMatch(
   globals,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -314,6 +314,7 @@ export function Workspace() {
   // route straight into Grimoire's Journal tab (see the setMode `journal` branch)
   // and so the choice persists across Grimoire remounts within a session.
   const [grimoireView, setGrimoireView] = useSurfacePreference(surfacePreferenceSpecs.grimoire.view);
+  const [, setBoardViewMode] = useSurfacePreference(surfacePreferenceSpecs.board.viewMode);
   // Alias funnel: MODE_ALIASES (src/lib/workspace-mode.ts) is the single
   // source of truth for where every compatibility mode lands. groupchat /
   // journal / flow are rewritten HERE so `mode` never holds them (Group Chat
@@ -2164,6 +2165,7 @@ export function Workspace() {
     if (intent.kind === "set-board-view") {
       // Persist for a fresh mount, navigate to the board, then signal a live
       // switch in case the board is already mounted.
+      setBoardViewMode(intent.view);
       setMode("board");
       window.setTimeout(
         () => window.dispatchEvent(new CustomEvent("cave:board:set-view", { detail: { view: intent.view } })),

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -21,7 +21,6 @@ import { clearChatHash, clearModeParam, readChatHash, readModeParam } from "@/li
 import type { PaletteIntent } from "@/components/command-palette";
 // Journal retired as an in-shell surface (redirects to Settings → Familiars),
 // so JournalView is gone; Grimoire is a new in-shell surface from main.
-import type { GrimoireViewKind } from "@/components/grimoire-view";
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
@@ -39,6 +38,8 @@ import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
 import { openGrimoireDoc } from "@/lib/grimoire-link";
 import { FamiliarStudioProvider, openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import { useAnnouncer } from "@/components/ui/live-region";
 import {
   getFamiliarScope,
@@ -312,7 +313,7 @@ export function Workspace() {
   // Which tab the Grimoire surface shows. Lifted here so the Journal nav row can
   // route straight into Grimoire's Journal tab (see the setMode `journal` branch)
   // and so the choice persists across Grimoire remounts within a session.
-  const [grimoireView, setGrimoireView] = useState<GrimoireViewKind>("docs");
+  const [grimoireView, setGrimoireView] = useSurfacePreference(surfacePreferenceSpecs.grimoire.view);
   // Alias funnel: MODE_ALIASES (src/lib/workspace-mode.ts) is the single
   // source of truth for where every compatibility mode lands. groupchat /
   // journal / flow are rewritten HERE so `mode` never holds them (Group Chat
@@ -2163,7 +2164,6 @@ export function Workspace() {
     if (intent.kind === "set-board-view") {
       // Persist for a fresh mount, navigate to the board, then signal a live
       // switch in case the board is already mounted.
-      try { localStorage.setItem("cave:board:viewMode", intent.view); } catch { /* ignore */ }
       setMode("board");
       window.setTimeout(
         () => window.dispatchEvent(new CustomEvent("cave:board:set-view", { detail: { view: intent.view } })),

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -11,6 +11,7 @@ import {
   countByKind,
   groupPluginsByCategory,
   categoriesFrom,
+  normalizeMarketplaceScope,
   requiredConfigFromManifest,
   remoteUrlFromManifest,
   resolveCollection,
@@ -103,6 +104,11 @@ assert.deepEqual(filterPlugins(merged, { query: "", category: "All" }).map((p) =
 
 // categoriesFrom — "All" first, then by count desc then name
 assert.deepEqual(categoriesFrom(merged), ["All", "Developer Tools", "Other", "Web"]);
+assert.deepEqual(
+  normalizeMarketplaceScope(["All", "Web"], "Removed category", "removed-collection"),
+  { category: "All", collectionId: null },
+  "stale persisted Marketplace filters must safely fall back after catalog refresh",
+);
 
 // --- requiredConfig + configured + badge state (credential collection) ---
 const rcManifests = {

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -510,3 +510,17 @@ export function categoriesFrom(plugins: MarketplacePlugin[]): string[] {
     .map(([category]) => category);
   return ["All", ...cats];
 }
+
+/** Drop persisted Marketplace scopes that no longer exist in the live catalog. */
+export function normalizeMarketplaceScope(
+  categories: readonly string[],
+  category: string,
+  collectionId: string | null,
+): { category: string; collectionId: string | null } {
+  return {
+    category: categories.includes(category) ? category : "All",
+    collectionId: collectionId !== null && COLLECTIONS.some((collection) => collection.id === collectionId)
+      ? collectionId
+      : null,
+  };
+}

--- a/src/lib/surface-preference-specs.ts
+++ b/src/lib/surface-preference-specs.ts
@@ -1,0 +1,91 @@
+import type { SurfacePreferenceSpec } from "@/lib/surface-preferences";
+
+function enumSpec<T extends string>(key: string, defaultValue: T, values: readonly T[]): SurfacePreferenceSpec<T> {
+  return {
+    key,
+    defaultValue,
+    parse: (value) => typeof value === "string" && values.includes(value as T) ? value as T : undefined,
+  };
+}
+
+function stringSpec(key: string, defaultValue = ""): SurfacePreferenceSpec<string> {
+  return { key, defaultValue, parse: (value) => typeof value === "string" ? value : undefined };
+}
+
+function nullableStringSpec(key: string): SurfacePreferenceSpec<string | null> {
+  return { key, defaultValue: null, parse: (value) => value === null || typeof value === "string" ? value : undefined };
+}
+
+export type GitHubSelection = { repo: string; number: number; kind: "pr" | "review_request" | "issue" | "notification" };
+
+function githubSelectionSpec(key: string): SurfacePreferenceSpec<GitHubSelection | null> {
+  return {
+    key,
+    defaultValue: null,
+    parse: (value) => {
+      if (value === null) return null;
+      if (!value || typeof value !== "object") return undefined;
+      const candidate = value as Partial<GitHubSelection>;
+      return typeof candidate.repo === "string" && typeof candidate.number === "number" && Number.isInteger(candidate.number) &&
+        (candidate.kind === "pr" || candidate.kind === "review_request" || candidate.kind === "issue" || candidate.kind === "notification")
+        ? { repo: candidate.repo, number: candidate.number, kind: candidate.kind }
+        : undefined;
+    },
+  };
+}
+
+export const surfacePreferenceSpecs = {
+  github: {
+    filter: enumSpec("github.filter", "all", ["all", "pr", "review_request", "issue"] as const),
+    organization: stringSpec("github.organization", "all"),
+    repository: stringSpec("github.repository", "all"),
+    groupBy: enumSpec("github.groupBy", "none", ["none", "org", "repo"] as const),
+    sortKey: enumSpec("github.sortKey", "updatedAt", ["kind", "repo", "title", "tasks", "updatedAt"] as const),
+    sortDir: enumSpec("github.sortDir", "desc", ["asc", "desc"] as const),
+    selected: githubSelectionSpec("github.selected"),
+  },
+  board: {
+    activeTab: enumSpec("board.activeTab", "tasks", ["tasks", "queue"] as const),
+    viewMode: enumSpec("board.viewMode", "kanban", ["kanban", "table", "gantt"] as const),
+    groupBy: enumSpec("board.groupBy", "status", ["status", "familiar", "project"] as const),
+    ganttGroup: enumSpec("board.ganttGroup", "project", ["project", "task", "familiar"] as const),
+    tableSortKey: enumSpec("board.tableSortKey", "updatedAt", ["title", "status", "priority", "familiar", "lifecycle", "startDate", "endDate", "updatedAt"] as const),
+    tableSortDir: enumSpec("board.tableSortDir", "desc", ["asc", "desc"] as const),
+  },
+  schedules: {
+    activeTab: enumSpec("schedules.activeTab", "overview", ["overview", "calendar", "crons"] as const),
+    familiarFilter: stringSpec("schedules.familiarFilter", ""),
+    groupBy: enumSpec("schedules.groupBy", "attention", ["attention", "kind", "familiar"] as const),
+  },
+  calendar: {
+    viewMode: enumSpec("calendar.viewMode", "week", ["agenda", "day", "week", "month"] as const),
+    anchorDate: stringSpec("calendar.anchorDate", ""),
+  },
+  familiars: {
+    selectedId: nullableStringSpec("familiars.selectedId"),
+    viewMode: enumSpec("familiars.viewMode", "roster", ["roster", "detail", "agent-memory"] as const),
+    detailTab: enumSpec("familiars.detailTab", "memory", ["memory", "daily-notes", "files", "sessions", "feed"] as const),
+  },
+  familiarMemory: {
+    familiarId: stringSpec("familiarMemory.familiarId", ""),
+    source: enumSpec("familiarMemory.source", "all", ["all", "coven-origin", "external-harness", "runtime"] as const),
+    group: enumSpec("familiarMemory.group", "none", ["none", "type", "source", "date", "familiar"] as const),
+    sort: enumSpec("familiarMemory.sort", "recent", ["recent", "oldest", "name", "size", "staleFirst"] as const),
+    staleOnly: { key: "familiarMemory.staleOnly", defaultValue: false, parse: (value: unknown) => typeof value === "boolean" ? value : undefined } satisfies SurfacePreferenceSpec<boolean>,
+  },
+  marketplace: {
+    section: enumSpec("marketplace.section", "browse", ["browse", "crafts", "skills", "build"] as const),
+    category: stringSpec("marketplace.category", "All"),
+    kind: enumSpec("marketplace.kind", "all", ["all", "mcp", "api", "skill", "prompt", "craft", "knowledge-pack"] as const),
+    sort: enumSpec("marketplace.sort", "recommended", ["recommended", "name", "installed"] as const),
+    collection: nullableStringSpec("marketplace.collection"),
+  },
+  grimoire: {
+    view: enumSpec("grimoire.view", "docs", ["docs", "graph", "journal"] as const),
+    selected: nullableStringSpec("grimoire.selected"),
+  },
+  browser: {
+    activeTabId: stringSpec("browser.activeTabId", "home"),
+    address: stringSpec("browser.address", ""),
+  },
+} as const;

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -75,6 +75,7 @@ test("every remounting surface opts into the registry while searches remain tran
   assert.match(sources.marketplace, /const \[query, setQuery\] = useState\(""\)/, "Marketplace search stays transient");
   assert.match(sources.github, /\(\) => deepLinkItem \?\? sorted\.find/, "an explicit GitHub deep link wins over restored selection");
   assert.match(sources.board, /const activeTab = deepLinkTab \?\? storedActiveTab/, "an explicit Board deep link wins without replacing the saved tab");
+  assert.match(sources.marketplace, /initialSection === "roles" \|\| initialSection === "capabilities"\s*\? "browse"/, "Marketplace aliases override a saved section for the current visit");
   assert.match(sources.grimoire, /useSurfacePreference\(surfacePreferenceSpecs\.grimoire\.selected\)/, "Grimoire restores its durable selected document through the registry");
   assert.match(sources.grimoire, /writeStoredTabs\(/, "Grimoire retains its existing resilient open-tab persistence");
   assert.match(sources.grimoire, /if \(deepLinkActiveRef\.current\) \{\s*deepLinkActiveRef\.current = false;/, "a one-visit Grimoire deep link yields to later user selections");

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -66,6 +66,7 @@ test("every remounting surface opts into the registry while searches remain tran
     browser: read("../components/browser-pane.tsx"),
     grimoire: read("../components/grimoire-view.tsx"),
     workspace: read("../app/page.tsx"),
+    workspaceShell: read("../components/workspace.tsx"),
   };
   for (const [name, source] of Object.entries(sources)) {
     assert.match(source, /useSurfacePreference|WorkspaceSurfacePreferencesProvider/, `${name} participates in workspace preferences`);
@@ -75,7 +76,9 @@ test("every remounting surface opts into the registry while searches remain tran
   assert.match(sources.marketplace, /const \[query, setQuery\] = useState\(""\)/, "Marketplace search stays transient");
   assert.match(sources.github, /\(\) => deepLinkItem \?\? sorted\.find/, "an explicit GitHub deep link wins over restored selection");
   assert.match(sources.board, /const activeTab = deepLinkTab \?\? storedActiveTab/, "an explicit Board deep link wins without replacing the saved tab");
+  assert.match(sources.browser, /if \(transientNavigationUrlRef\.current\) return;/, "a queued Browser URL wins when preferences hydrate after its navigation request");
   assert.match(sources.marketplace, /initialSection === "roles" \|\| initialSection === "capabilities"\s*\? "browse"/, "Marketplace aliases override a saved section for the current visit");
+  assert.match(sources.workspaceShell, /setBoardViewMode\(intent\.view\);[\s\S]{0,120}setMode\("board"\)/, "command-palette board view choices are saved before a fresh BoardView mounts");
   assert.match(sources.grimoire, /useSurfacePreference\(surfacePreferenceSpecs\.grimoire\.selected\)/, "Grimoire restores its durable selected document through the registry");
   assert.match(sources.grimoire, /writeStoredTabs\(/, "Grimoire retains its existing resilient open-tab persistence");
   assert.match(sources.grimoire, /if \(deepLinkActiveRef\.current\) \{\s*deepLinkActiveRef\.current = false;/, "a one-visit Grimoire deep link yields to later user selections");

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  readLegacySurfacePreferences,
+  readSurfacePreferences,
+  SURFACE_PREFERENCES_STORAGE_KEY,
+  writeSurfacePreferences,
+} from "./surface-preferences.ts";
+import { surfacePreferenceSpecs } from "./surface-preference-specs.ts";
+
+function storage(seed: Record<string, string> = {}) {
+  const values = new Map(Object.entries(seed));
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+test("surface preferences round-trip valid values and reject malformed payloads", () => {
+  const local = storage();
+  writeSurfacePreferences(local, { "github.organization": "OpenCoven", "board.viewMode": "gantt" });
+  assert.deepEqual(readSurfacePreferences(local), { "github.organization": "OpenCoven", "board.viewMode": "gantt" });
+  local.setItem(SURFACE_PREFERENCES_STORAGE_KEY, "{not-json");
+  assert.deepEqual(readSurfacePreferences(local), {});
+  local.setItem(SURFACE_PREFERENCES_STORAGE_KEY, JSON.stringify({ version: 99, values: { "github.organization": "wrong" } }));
+  assert.deepEqual(readSurfacePreferences(local), {});
+});
+
+test("legacy fields migrate without replacing a new preference", () => {
+  const local = storage({
+    "cave:board:viewMode": "table",
+    "cave:agents.lastSelected": "familiar-1",
+    "cave:automations:familiar-filter": JSON.stringify(["beta", "alpha", 7]),
+  });
+  const legacy = readLegacySurfacePreferences(local);
+  assert.deepEqual(legacy, {
+    "board.viewMode": "table",
+    "familiars.selectedId": "familiar-1",
+    "schedules.familiarFilter": "alpha,beta",
+  });
+  const newValues = { "board.viewMode": "gantt" };
+  assert.equal({ ...legacy, ...newValues }["board.viewMode"], "gantt");
+});
+
+test("specs normalize allowed values and discard stale enum values", () => {
+  assert.equal(surfacePreferenceSpecs.github.sortDir.parse("asc"), "asc");
+  assert.equal(surfacePreferenceSpecs.github.sortDir.parse("sideways"), undefined);
+  assert.equal(surfacePreferenceSpecs.calendar.viewMode.parse("month"), "month");
+  assert.equal(surfacePreferenceSpecs.calendar.viewMode.parse("year"), undefined);
+  assert.equal(surfacePreferenceSpecs.familiarMemory.staleOnly.parse(true), true);
+  assert.equal(surfacePreferenceSpecs.familiarMemory.staleOnly.parse("true"), undefined);
+});
+
+test("every remounting surface opts into the registry while searches remain transient", () => {
+  const read = (path: string) => readFileSync(new URL(path, import.meta.url), "utf8");
+  const sources = {
+    github: read("../components/github-view.tsx"),
+    board: read("../components/board-view.tsx"),
+    schedules: read("../components/automations-view.tsx"),
+    calendar: read("../components/calendar-view.tsx"),
+    familiars: read("../components/familiars-view.tsx"),
+    memory: read("../components/familiars-memory-view.tsx"),
+    marketplace: read("../components/marketplace-view.tsx"),
+    browser: read("../components/browser-pane.tsx"),
+    grimoire: read("../components/grimoire-view.tsx"),
+    workspace: read("../app/page.tsx"),
+  };
+  for (const [name, source] of Object.entries(sources)) {
+    assert.match(source, /useSurfacePreference|WorkspaceSurfacePreferencesProvider/, `${name} participates in workspace preferences`);
+  }
+  assert.match(sources.github, /const \[query, setQuery\] = useState\(""\)/, "GitHub search stays transient");
+  assert.match(sources.memory, /const \[query, setQuery\] = useState\(""\)/, "Memory search stays transient");
+  assert.match(sources.marketplace, /const \[query, setQuery\] = useState\(""\)/, "Marketplace search stays transient");
+  assert.match(sources.github, /\(\) => deepLinkItem \?\? sorted\.find/, "an explicit GitHub deep link wins over restored selection");
+  assert.match(sources.board, /const activeTab = deepLinkTab \?\? storedActiveTab/, "an explicit Board deep link wins without replacing the saved tab");
+  assert.match(sources.grimoire, /useSurfacePreference\(surfacePreferenceSpecs\.grimoire\.selected\)/, "Grimoire restores its durable selected document through the registry");
+  assert.match(sources.grimoire, /writeStoredTabs\(/, "Grimoire retains its existing resilient open-tab persistence");
+});

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -37,6 +37,7 @@ test("legacy fields migrate without replacing a new preference", () => {
   assert.deepEqual(legacy, {
     "board.viewMode": "table",
     "familiars.selectedId": "familiar-1",
+    "familiars.viewMode": "detail",
     "schedules.familiarFilter": "alpha,beta",
   });
   const newValues = { "board.viewMode": "gantt" };

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -76,4 +76,7 @@ test("every remounting surface opts into the registry while searches remain tran
   assert.match(sources.board, /const activeTab = deepLinkTab \?\? storedActiveTab/, "an explicit Board deep link wins without replacing the saved tab");
   assert.match(sources.grimoire, /useSurfacePreference\(surfacePreferenceSpecs\.grimoire\.selected\)/, "Grimoire restores its durable selected document through the registry");
   assert.match(sources.grimoire, /writeStoredTabs\(/, "Grimoire retains its existing resilient open-tab persistence");
+  assert.match(sources.grimoire, /if \(deepLinkActiveRef\.current\) \{\s*deepLinkActiveRef\.current = false;/, "a one-visit Grimoire deep link yields to later user selections");
+  assert.match(sources.grimoire, /restoredSelectionPendingRef\.current = true;/, "Grimoire marks a restored selection before persistence runs");
+  assert.match(sources.grimoire, /if \(restoredSelectionPendingRef\.current\)/, "Grimoire waits to persist until a restored selection has been applied");
 });

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -77,6 +77,8 @@ test("every remounting surface opts into the registry while searches remain tran
   assert.match(sources.github, /\(\) => deepLinkItem \?\? sorted\.find/, "an explicit GitHub deep link wins over restored selection");
   assert.match(sources.board, /const activeTab = deepLinkTab \?\? storedActiveTab/, "an explicit Board deep link wins without replacing the saved tab");
   assert.match(sources.browser, /if \(transientNavigationUrlRef\.current\) return;/, "a queued Browser URL wins when preferences hydrate after its navigation request");
+  assert.match(sources.browser, /if \(restored\.restoredTabExists && storedAddress\)/, "Browser only restores an address when its saved tab still exists");
+  assert.match(sources.browser, /if \(persist && updatedActiveTab\) \{\s*savePinnedTabs\(nextTabs\);/, "one-visit Browser navigation does not overwrite pinned-tab storage");
   assert.match(sources.marketplace, /initialSection === "roles" \|\| initialSection === "capabilities"\s*\? "browse"/, "Marketplace aliases override a saved section for the current visit");
   assert.match(sources.workspaceShell, /setBoardViewMode\(intent\.view\);[\s\S]{0,120}setMode\("board"\)/, "command-palette board view choices are saved before a fresh BoardView mounts");
   assert.match(sources.grimoire, /useSurfacePreference\(surfacePreferenceSpecs\.grimoire\.selected\)/, "Grimoire restores its durable selected document through the registry");

--- a/src/lib/surface-preferences.ts
+++ b/src/lib/surface-preferences.ts
@@ -1,0 +1,170 @@
+"use client";
+
+import {
+  createElement,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type PropsWithChildren,
+  type SetStateAction,
+} from "react";
+
+/** A single, versioned home for durable Workspace navigation preferences. */
+export const SURFACE_PREFERENCES_STORAGE_KEY = "cave:surface-preferences:v1";
+const STORE_VERSION = 1;
+
+type RawPreferences = Record<string, unknown>;
+
+type StoredSurfacePreferences = {
+  version: number;
+  values: RawPreferences;
+};
+
+export type SurfacePreferenceSpec<T> = {
+  /** Stable, namespaced key such as `github.organization`. */
+  key: string;
+  defaultValue: T;
+  /** Return undefined for malformed, stale, or otherwise unsupported stored input. */
+  parse: (value: unknown) => T | undefined;
+};
+
+type PreferencesContextValue = {
+  values: RawPreferences;
+  setValues: Dispatch<SetStateAction<RawPreferences>>;
+  hydrated: boolean;
+};
+
+const SurfacePreferencesContext = createContext<PreferencesContextValue | null>(null);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse the storage payload defensively. A version mismatch deliberately
+ * starts from defaults so a future schema can migrate without trusting old
+ * shapes.
+ */
+export function readSurfacePreferences(storage: Pick<Storage, "getItem"> | null): RawPreferences {
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(SURFACE_PREFERENCES_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== STORE_VERSION || !isRecord(parsed.values)) return {};
+    return parsed.values;
+  } catch {
+    return {};
+  }
+}
+
+export function writeSurfacePreferences(storage: Pick<Storage, "setItem"> | null, values: RawPreferences): void {
+  if (!storage) return;
+  const payload: StoredSurfacePreferences = { version: STORE_VERSION, values };
+  try {
+    storage.setItem(SURFACE_PREFERENCES_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Storage is an enhancement; quota/privacy failures must not break navigation.
+  }
+}
+
+/**
+ * One-time compatibility bridge for the narrow set of preferences that used
+ * to live in individual localStorage keys. The new registry always wins, so
+ * this cannot overwrite a choice already saved by this system.
+ */
+export function readLegacySurfacePreferences(storage: Pick<Storage, "getItem"> | null): RawPreferences {
+  if (!storage) return {};
+  const read = (key: string) => {
+    try { return storage.getItem(key); } catch { return null; }
+  };
+  const values: RawPreferences = {};
+  const copy = (legacyKey: string, preferenceKey: string) => {
+    const value = read(legacyKey);
+    if (value !== null) values[preferenceKey] = value;
+  };
+  copy("cave:board:viewMode", "board.viewMode");
+  copy("cave:board:groupBy", "board.groupBy");
+  copy("cave:board:ganttGroup", "board.ganttGroup");
+  copy("cave:agents.lastSelected", "familiars.selectedId");
+  copy("cave:inbox:group-by", "schedules.groupBy");
+  const familiarFilter = read("cave:automations:familiar-filter");
+  if (familiarFilter) {
+    try {
+      const parsed: unknown = JSON.parse(familiarFilter);
+      values["schedules.familiarFilter"] = Array.isArray(parsed)
+        ? parsed.filter((item): item is string => typeof item === "string").sort().join(",")
+        : familiarFilter;
+    } catch {
+      values["schedules.familiarFilter"] = familiarFilter;
+    }
+  }
+  return values;
+}
+
+/**
+ * Keeps durable values alive above conditionally-mounted Workspace surfaces and
+ * mirrors the approved subset to localStorage after client hydration.
+ */
+export function WorkspaceSurfacePreferencesProvider({ children }: PropsWithChildren) {
+  const [values, setValues] = useState<RawPreferences>({});
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const current = readSurfacePreferences(window.localStorage);
+    setValues({ ...readLegacySurfacePreferences(window.localStorage), ...current });
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    writeSurfacePreferences(window.localStorage, values);
+  }, [hydrated, values]);
+
+  const contextValue = useMemo(
+    () => ({ values, setValues, hydrated }),
+    [values, hydrated],
+  );
+
+  return createElement(SurfacePreferencesContext.Provider, { value: contextValue }, children);
+}
+
+/**
+ * Field-level API used by a surface. Preferences are opt-in: callers only get
+ * persistence for fields with an explicit spec and validator.
+ */
+export function useSurfacePreference<T>(spec: SurfacePreferenceSpec<T>): [T, (next: SetStateAction<T>) => void, boolean] {
+  const context = useContext(SurfacePreferencesContext);
+  const rawValue = context?.values[spec.key];
+  const parsed = rawValue === undefined ? undefined : spec.parse(rawValue);
+  const value = parsed === undefined ? spec.defaultValue : parsed;
+
+  // Invalid persisted values must not linger forever. Delete only the invalid
+  // field so sibling preferences remain intact.
+  useEffect(() => {
+    if (!context?.hydrated || rawValue === undefined || parsed !== undefined) return;
+    context.setValues((current) => {
+      if (!(spec.key in current)) return current;
+      const { [spec.key]: _discarded, ...rest } = current;
+      return rest;
+    });
+  }, [context, parsed, rawValue, spec.key]);
+
+  const setValue = useCallback((next: SetStateAction<T>) => {
+    if (!context) return;
+    context.setValues((current) => {
+      const currentParsed = current[spec.key] === undefined ? undefined : spec.parse(current[spec.key]);
+      const base = currentParsed === undefined ? spec.defaultValue : currentParsed;
+      const candidate = typeof next === "function" ? (next as (previous: T) => T)(base) : next;
+      const normalized = spec.parse(candidate);
+      if (normalized === undefined) return current;
+      return { ...current, [spec.key]: normalized };
+    });
+  }, [context, spec]);
+
+  return [value, setValue, context?.hydrated ?? false];
+}

--- a/src/lib/surface-preferences.ts
+++ b/src/lib/surface-preferences.ts
@@ -90,7 +90,14 @@ export function readLegacySurfacePreferences(storage: Pick<Storage, "getItem"> |
   copy("cave:board:viewMode", "board.viewMode");
   copy("cave:board:groupBy", "board.groupBy");
   copy("cave:board:ganttGroup", "board.ganttGroup");
-  copy("cave:agents.lastSelected", "familiars.selectedId");
+  const lastSelectedFamiliar = read("cave:agents.lastSelected");
+  if (lastSelectedFamiliar !== null) {
+    values["familiars.selectedId"] = lastSelectedFamiliar;
+    // The legacy surface opened its detail view whenever it restored a
+    // selection. Preserve that behavior rather than leaving the migrated
+    // selection hidden behind the roster.
+    values["familiars.viewMode"] = "detail";
+  }
   copy("cave:inbox:group-by", "schedules.groupBy");
   const familiarFilter = read("cave:automations:familiar-filter");
   if (familiarFilter) {
@@ -162,6 +169,11 @@ export function useSurfacePreference<T>(spec: SurfacePreferenceSpec<T>): [T, (ne
       const candidate = typeof next === "function" ? (next as (previous: T) => T)(base) : next;
       const normalized = spec.parse(candidate);
       if (normalized === undefined) return current;
+      // A number of consumers synchronize a derived preference from an
+      // effect. Avoid replacing the whole registry with an equivalent value,
+      // which would otherwise change the setter identity and re-run that
+      // effect indefinitely.
+      if (Object.is(currentParsed, normalized)) return current;
       return { ...current, [spec.key]: normalized };
     });
   }, [context, spec]);


### PR DESCRIPTION
Closes #3584

## Summary
- add a versioned, typed Workspace preference registry mounted above remounting surfaces
- migrate durable controls across GitHub, Tasks, Schedules/Calendar, Familiars/Memory, Marketplace, Grimoire, and Browser; retain and bridge existing Grimoire open-tab storage
- preserve explicit deep-link destinations, migrate legacy keys, clear stale GitHub scope/selection safely, and leave search/modal state transient
- add registry round-trip/migration/normalization/source-wiring coverage and register it with the app suite

## Deep-link and stale-value behavior
Explicit navigation targets win for the current visit without replacing the saved preference. Saved GitHub organization, repository, and selected semantic target are checked against fresh data and only an invalid field is cleared.

## Non-goals
This does not restore search text, dialogs, popovers, drawers, confirmation or destructive flows, toasts, undo state, busy/error state, or temporary selection modes.

## Verification
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm check:tests-wired`
- targeted registry, GitHub, Board, Calendar, Familiars, Browser, and Schedules source-contract tests
- CI typecheck passed on the prior exact head; the latest exact-head CI is running

## Environment note
`pnpm lint:design` cannot run in this isolated worktree because it has no local `node_modules` (`eslint: not found`).