### PR TITLE
fix: scope poll input-pause to touch devices so the chat composer can't starve the sessions poll

### DIFF
--- a/src/lib/use-pausable-poll.test.ts
+++ b/src/lib/use-pausable-poll.test.ts
@@ -24,6 +24,16 @@ assert.match(
 );
 assert.match(
   src,
+  /if \(typeof window === "undefined" \|\| !window\.matchMedia\(COARSE_POINTER_QUERY\)\.matches\) \{\s*return false;\s*\}/,
+  "the input pause only applies on coarse-pointer (touch) devices — on desktop the always-focused chat composer must not starve polls (cave-i7nz)",
+);
+assert.match(
+  src,
+  /const COARSE_POINTER_QUERY = "\(pointer: coarse\)";/,
+  "the touch gate uses the standard coarse-pointer media query",
+);
+assert.match(
+  src,
   /active instanceof HTMLTextAreaElement[\s\S]*active instanceof HTMLInputElement[\s\S]*active instanceof HTMLSelectElement[\s\S]*active\.isContentEditable/,
   "active text fields, selects, and contentEditable elements can pause nonessential polls",
 );

--- a/src/lib/use-pausable-poll.ts
+++ b/src/lib/use-pausable-poll.ts
@@ -21,8 +21,18 @@ import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
  * The initial mount load stays the caller's job — this hook only schedules the
  * recurring poll + the on-return refresh.
  */
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
 function pollPausedForActiveInput(pauseWhileInputActive: boolean): boolean {
   if (!pauseWhileInputActive || typeof document === "undefined") return false;
+  // The pause exists so nonessential polls don't compete with touch-keyboard
+  // composition on mobile. On desktop, the chat composer keeps focus
+  // essentially permanently, so an unconditional pause starved the sessions
+  // poll indefinitely and froze the siderail while chatting (cave-i7nz).
+  // Scope the pause to coarse-pointer (touch) contexts only.
+  if (typeof window === "undefined" || !window.matchMedia(COARSE_POINTER_QUERY).matches) {
+    return false;
+  }
   const active = document.activeElement;
   if (!active) return false;
   return (


### PR DESCRIPTION
## Problem (cave-i7nz, P1)

`usePausablePoll`'s `pauseWhileInputActive` option is documented as protecting **mobile composition**, but it paused on *any* focused text field. The desktop chat composer keeps focus essentially permanently — ChatView refocuses its textarea after every send/interaction (15+ `focus()` sites) — so the sessions poll in `workspace.tsx` skipped every 4s tick **and** the focus-regain refresh. Result: the chat siderail froze while chatting; new sessions never appeared until focus left the composer.

## Fix

Gate `pollPausedForActiveInput` on `window.matchMedia("(pointer: coarse)")` so the pause only applies in touch contexts. This restores desktop freshness for **all** `pauseWhileInputActive` callers (sessions poll, GitHub tasks, board, digest, automations, …) while preserving the mobile-composition intent. SSR-safe (`typeof window` guard).

## Verification

- `node --test src/lib/use-pausable-poll.test.ts src/lib/pausable-poll-discipline.test.ts` — pass (added pins for the coarse-pointer gate)
- `pnpm typecheck` — clean

Closes bead `cave-i7nz`. Part of the `chat-siderail-freshness` goal (siblings: cave-0g2x, cave-53yx, cave-zhwa, cave-mllp).