### PR TITLE
fix(github): remove duplicate filter carets

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -126,6 +126,7 @@ export const SUITES = {
     "src/lib/beads-work-queue.test.ts",
     "src/components/familiar-work-queue-view.test.ts",
     "src/components/gh-review-actions.test.ts",
+    "src/components/github-filter-caret.test.ts",
     "src/lib/gfm-autolink.test.ts",
     "src/lib/gh-diff.test.ts",
     "src/lib/gh-review-html.test.ts",

--- a/src/components/github-filter-caret.test.ts
+++ b/src/components/github-filter-caret.test.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const selectSrc = readFileSync(new URL("./ui/select.tsx", import.meta.url), "utf8");
+const githubListCss = readFileSync(new URL("../styles/board/github-list.css", import.meta.url), "utf8");
+
+function extractRule(css: string, selector: string): string {
+  const match = css.match(new RegExp(`${selector}\\s*\\{([\\s\\S]*?)\\}`, "m"));
+  assert.ok(match, `missing ${selector} rule`);
+  return match[1];
+}
+
+assert.match(selectSrc, /ph:caret-down-bold/, "StandardSelect still renders the shared caret icon");
+
+const ghSelectRule = extractRule(githubListCss, String.raw`\.gh-select`);
+
+assert.doesNotMatch(ghSelectRule, /background-image\s*:/, ".gh-select no longer uses a legacy background-image");
+assert.doesNotMatch(ghSelectRule, /background-repeat\s*:/, ".gh-select no longer uses a legacy background-repeat");
+assert.doesNotMatch(ghSelectRule, /background-position\s*:/, ".gh-select no longer uses a legacy background-position");
+assert.match(ghSelectRule, /padding\s*:\s*0 8px;/, ".gh-select keeps the shared trigger padding");
+
+console.log("github-filter-caret.test.ts ok");

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -239,7 +239,7 @@
 .gh-familiar-stack-more { margin-left:5px; color:var(--text-muted); font-size:10.5px; }
 
 /* Org/repo filter + group-by controls (right of the kind tabs) */
-.gh-select { appearance:none; -webkit-appearance:none; max-width:170px; height:var(--gh-control-h); padding:0 22px 0 8px; border:1px solid var(--border-hairline); border-radius:var(--radius-control); background-color:var(--bg-base); color:var(--text-secondary); font-size:11px; cursor:pointer; background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath d='M0 0l4 5 4-5z' fill='%238a8a96'/%3E%3C/svg%3E"); background-repeat:no-repeat; background-position:right 8px center; transition:background-color .12s,border-color .12s,color .12s; }
+.gh-select { appearance:none; -webkit-appearance:none; max-width:170px; height:var(--gh-control-h); padding:0 8px; border:1px solid var(--border-hairline); border-radius:var(--radius-control); background-color:var(--bg-base); color:var(--text-secondary); font-size:11px; cursor:pointer; transition:background-color .12s,border-color .12s,color .12s; }
 .gh-select:hover:not(:disabled) { border-color:var(--border-strong); color:var(--text-primary); background-color:var(--bg-hover); }
 .gh-select:focus-visible { outline:none; border-color:var(--accent-presence); }
 .gh-select:disabled { opacity:.45; cursor:not-allowed; }


### PR DESCRIPTION
## Summary
- remove the legacy CSS dropdown arrow from GitHub organization and repository filters
- keep the shared `StandardSelect` caret as the sole selection icon
- add a focused regression test and wire it into the app suite

## Test plan
- [x] focused caret regression test
- [x] test wiring check
- [x] TypeScript typecheck

## Tracking
- `cave-jf21`