### PR TITLE
fix(sessions): collapse familiar-workspace flood in unscoped list + auto-retry reconcile banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ ds-bundle/
 .design-sync/learnings/
 .design-sync/node_modules
 /.worktrees
+/.cave-trash

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -23,6 +23,7 @@ export const SUITES = {
   app: [
     "src/lib/array-content-equal.test.ts",
     "src/lib/session-list-equal.test.ts",
+    "src/lib/familiar-workspace-sessions.test.ts",
     "src/lib/session-list-deletes.test.ts",
     "src/lib/use-undo-delete-deferred.test.ts",
     "src/lib/tool-edit-stat.test.ts",
@@ -928,6 +929,7 @@ export const SUITES = {
     "src/app/api/board/route.test.ts",
     "src/app/api/board/[id]/chat/route.test.ts",
     "src/app/api/sessions/route.test.ts",
+    "src/app/api/sessions/list/route.test.ts",
     "src/app/api/chat/send/harness-routing-host-session.test.ts",
     "src/app/api/chat/send/harness-routing-attachments.test.ts",
     "src/app/api/chat/send/harness-routing-tool-events.test.ts",
@@ -1186,6 +1188,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/familiar-workspace-sessions.test.ts",
   "scripts/cave-home-migration-windows.test.ts",
   "src/lib/bento-dashboard.test.ts",
   "src/lib/omnigent/ward-preflight.test.ts",

--- a/src/app/api/sessions/list/route.test.ts
+++ b/src/app/api/sessions/list/route.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /collapseFamiliarWorkspace\s*=\s*\n?\s*url\.searchParams\.get\("collapseFamiliarWorkspace"\)\s*===\s*"1"/,
+  "the list route parses the opt-in collapseFamiliarWorkspace query param",
+);
+
+assert.match(
+  source,
+  /cacheKey\s*=[\s\S]{0,160}collapseFamiliarWorkspace\s*\?\s*"collapse"\s*:\s*"full"/,
+  "the cache key varies by collapse mode so full and collapsed views never alias",
+);
+
+assert.match(
+  source,
+  /computeSessionsList\(includeArchived,\s*familiarId,\s*collapseFamiliarWorkspace\)/,
+  "the collapse flag is threaded into computeSessionsList",
+);
+
+assert.match(
+  source,
+  /collapseFamiliarWorkspace\s*\n?\s*\?\s*collapseFamiliarWorkspaceSessions\(/,
+  "collapse is applied only when the flag is set (default view stays unfiltered)",
+);
+
+console.log("sessions list route.test.ts: ok");

--- a/src/app/api/sessions/list/route.test.ts
+++ b/src/app/api/sessions/list/route.test.ts
@@ -24,8 +24,18 @@ assert.match(
 
 assert.match(
   source,
-  /collapseFamiliarWorkspace\s*\n?\s*\?\s*collapseFamiliarWorkspaceSessions\(/,
-  "collapse is applied only when the flag is set (default view stays unfiltered)",
+  /if \(!collapseFamiliarWorkspace\) return sessions;/,
+  "the collapse helper is a no-op (and skips the FS read) when the flag is off",
+);
+
+// Regression guard for the Copilot review finding: the degraded (daemon-down,
+// local-only) branch must apply the same collapse as the happy path, or a
+// local chat under a familiar-workspace root leaks into the unscoped view when
+// the daemon is unavailable. One helper definition + two call sites = 3 hits.
+assert.equal(
+  (source.match(/applyFamiliarWorkspaceCollapse\(/g) || []).length,
+  3,
+  "applyFamiliarWorkspaceCollapse is defined once and called in BOTH the happy and degraded paths",
 );
 
 console.log("sessions list route.test.ts: ok");

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -12,6 +12,8 @@ import {
   mergeSessionRows,
 } from "@/lib/session-list-merge";
 import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
+import { collapseFamiliarWorkspaceSessions } from "@/lib/familiar-workspace-sessions";
+import { familiarWorkspacesRoot, readFamiliarWorkspaces } from "@/lib/coven-paths";
 import { createSwrCache } from "@/lib/swr-cache";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
@@ -159,6 +161,7 @@ async function applyAutoArchiveSweep(
 async function computeSessionsList(
   includeArchived: boolean,
   familiarId: string | null,
+  collapseFamiliarWorkspace: boolean,
 ): Promise<SessionsListResult> {
   const [res, state, projects] = await Promise.all([
     callDaemon<DaemonSession[]>({ path: "/api/v1/sessions" }),
@@ -217,11 +220,18 @@ async function computeSessionsList(
   );
 
   const scoped = await scopeForFamiliar(sessions, projects, familiarId);
+  const visible = collapseFamiliarWorkspace
+    ? collapseFamiliarWorkspaceSessions(
+        scoped,
+        familiarWorkspacesRoot(),
+        Array.from((await readFamiliarWorkspaces()).values()),
+      )
+    : scoped;
   return {
     payload: {
       ok: true,
       sessions: await applyMergedPrAutoArchive(
-        await enrichSessionsWithGitContext(scoped),
+        await enrichSessionsWithGitContext(visible),
         state,
         includeArchived,
       ),
@@ -233,13 +243,17 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeArchived = url.searchParams.get("includeArchived") === "1";
   const familiarId = url.searchParams.get("familiarId")?.trim() || null;
+  const collapseFamiliarWorkspace =
+    url.searchParams.get("collapseFamiliarWorkspace") === "1";
   if (familiarId && !isValidFamiliarId(familiarId)) {
     return NextResponse.json({ ok: false, error: "invalid familiar id", sessions: [] }, { status: 400 });
   }
-  // Cache per (archived, familiar) — scoped views differ by grant set.
-  const cacheKey = `${includeArchived ? "archived" : "active"}:${familiarId ?? "all"}`;
+  // Cache per (archived, familiar, collapse) — each view differs by its result set.
+  const cacheKey = `${includeArchived ? "archived" : "active"}:${familiarId ?? "all"}:${
+    collapseFamiliarWorkspace ? "collapse" : "full"
+  }`;
   const result = await sessionsListCache.get(cacheKey, () =>
-    computeSessionsList(includeArchived, familiarId),
+    computeSessionsList(includeArchived, familiarId, collapseFamiliarWorkspace),
   );
   return NextResponse.json(result.payload, result.init);
 }

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -158,6 +158,25 @@ async function applyAutoArchiveSweep(
   );
 }
 
+/**
+ * Apply the opt-in familiar-workspace collapse to an already-scoped list.
+ * Pulled out so both the happy path and the degraded (daemon-down, local-only)
+ * path enforce the same opt-in contract — otherwise a local chat created under
+ * a familiar-workspace root would leak into the unscoped view while the daemon
+ * is unavailable. No-op (and no FS read) when the flag is off.
+ */
+async function applyFamiliarWorkspaceCollapse(
+  sessions: SessionRow[],
+  collapseFamiliarWorkspace: boolean,
+): Promise<SessionRow[]> {
+  if (!collapseFamiliarWorkspace) return sessions;
+  return collapseFamiliarWorkspaceSessions(
+    sessions,
+    familiarWorkspacesRoot(),
+    Array.from((await readFamiliarWorkspaces()).values()),
+  );
+}
+
 async function computeSessionsList(
   includeArchived: boolean,
   familiarId: string | null,
@@ -187,7 +206,10 @@ async function computeSessionsList(
           error: res.error ?? `daemon http ${res.status}`,
           sessions: await applyMergedPrAutoArchive(
             await enrichSessionsWithGitContext(
-              await scopeForFamiliar(localSessions, projects, familiarId),
+              await applyFamiliarWorkspaceCollapse(
+                await scopeForFamiliar(localSessions, projects, familiarId),
+                collapseFamiliarWorkspace,
+              ),
             ),
             state,
             includeArchived,
@@ -220,13 +242,7 @@ async function computeSessionsList(
   );
 
   const scoped = await scopeForFamiliar(sessions, projects, familiarId);
-  const visible = collapseFamiliarWorkspace
-    ? collapseFamiliarWorkspaceSessions(
-        scoped,
-        familiarWorkspacesRoot(),
-        Array.from((await readFamiliarWorkspaces()).values()),
-      )
-    : scoped;
+  const visible = await applyFamiliarWorkspaceCollapse(scoped, collapseFamiliarWorkspace);
   return {
     payload: {
       ok: true,

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -99,7 +99,7 @@ assert.match(
 );
 assert.match(
   listRoute,
-  /applyMergedPrAutoArchive\(\s*await enrichSessionsWithGitContext\(scoped\),/,
+  /applyMergedPrAutoArchive\(\s*await enrichSessionsWithGitContext\(visible\),/,
   "the merged-PR sweep runs over the (async) enriched rows before the payload returns",
 );
 const sweepModule = readFileSync(

--- a/src/components/preferences-bootstrap-controller.tsx
+++ b/src/components/preferences-bootstrap-controller.tsx
@@ -14,6 +14,11 @@ import { useShellBanners } from "@/lib/shell-banners";
 
 const PREFERENCES_BANNER_ID = "preferences-bootstrap";
 const PREFERENCES_SLOW_MS = 2_000;
+// Bounded auto-retry so a silent cold-start reconciliation stall (e.g. slow
+// IndexedDB with no online/visibility/subscription event to nudge it) self-
+// heals instead of leaving the "still reconciling" warning parked until the
+// user clicks Retry. Backs off, then gives up and lets the manual CTA stand.
+const PREFERENCES_AUTO_RETRY_MS = [5_000, 10_000, 20_000] as const;
 
 function mark(name: string, startTime?: number): void {
   try {
@@ -28,6 +33,8 @@ function mark(name: string, startTime?: number): void {
 export function PreferencesBootstrapController() {
   const { pushBanner, dismissBanner } = useShellBanners();
   const mounted = useRef(false);
+  const autoRetryTimer = useRef<number | null>(null);
+  const autoRetryAttempt = useRef(0);
 
   const bootstrap = useCallback(async () => {
     const slowTimer = window.setTimeout(() => {
@@ -44,10 +51,16 @@ export function PreferencesBootstrapController() {
       const preferences = await initializeAppPreferences();
       if (!mounted.current) return preferences;
       if (preferences.initialized) {
+        if (autoRetryTimer.current !== null) {
+          window.clearTimeout(autoRetryTimer.current);
+          autoRetryTimer.current = null;
+        }
+        autoRetryAttempt.current = 0;
         dismissBanner(PREFERENCES_BANNER_ID);
         mark("reconciliation-settled");
         await migrateLegacyBackdropImage();
       } else {
+        scheduleAutoRetry();
         pushBanner({
           id: PREFERENCES_BANNER_ID,
           severity: "error",
@@ -58,6 +71,7 @@ export function PreferencesBootstrapController() {
       return preferences;
     } catch {
       if (mounted.current) {
+        scheduleAutoRetry();
         pushBanner({
           id: PREFERENCES_BANNER_ID,
           severity: "error",
@@ -68,6 +82,19 @@ export function PreferencesBootstrapController() {
       return readAppPreferences();
     } finally {
       window.clearTimeout(slowTimer);
+    }
+
+    function scheduleAutoRetry(): void {
+      if (!mounted.current) return;
+      if (autoRetryTimer.current !== null) return; // one pending retry at a time
+      const attempt = autoRetryAttempt.current;
+      if (attempt >= PREFERENCES_AUTO_RETRY_MS.length) return; // give up; manual CTA stands
+      const delay = PREFERENCES_AUTO_RETRY_MS[attempt];
+      autoRetryAttempt.current = attempt + 1;
+      autoRetryTimer.current = window.setTimeout(() => {
+        autoRetryTimer.current = null;
+        if (mounted.current) void bootstrap();
+      }, delay);
     }
   }, [dismissBanner, pushBanner]);
 
@@ -109,6 +136,10 @@ export function PreferencesBootstrapController() {
     document.addEventListener("visibilitychange", onVisibility);
     return () => {
       mounted.current = false;
+      if (autoRetryTimer.current !== null) {
+        window.clearTimeout(autoRetryTimer.current);
+        autoRetryTimer.current = null;
+      }
       unsubscribe();
       dismissBanner(PREFERENCES_BANNER_ID);
       window.removeEventListener("pagehide", flush);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -995,8 +995,15 @@ export function Workspace() {
       try {
         // Scope the session list to the active familiar's granted projects so
         // every surface fed by `sessions` enforces the familiar→projects map.
-        // With "All familiars" (activeId null) the unscoped list is returned.
-        const scope = activeId ? `?familiarId=${encodeURIComponent(activeId)}` : "";
+        // With "All familiars" (activeId null) the unscoped list is returned,
+        // but we collapse the per-familiar workspace auto-journal/reflection
+        // runs there: they'd otherwise flood the global list and make it look
+        // contradictory versus the clean project-scoped familiar homes. Scoped
+        // views already drop them via project-grant scoping, so collapse is only
+        // applied to the unscoped view.
+        const scope = activeId
+          ? `?familiarId=${encodeURIComponent(activeId)}`
+          : "?collapseFamiliarWorkspace=1";
         const sessionsResult = await fetch(`/api/sessions/list${scope}`, { cache: "no-store" });
         const json = await sessionsResult.json();
         if (!isCurrent()) return; // superseded by a newer load / scope change

--- a/src/lib/familiar-workspace-sessions.test.ts
+++ b/src/lib/familiar-workspace-sessions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collapseFamiliarWorkspaceSessions,
+  isFamiliarWorkspaceRoot,
+} from "./familiar-workspace-sessions.ts";
+import type { SessionRow } from "./types.ts";
+
+const WS_ROOT = "/Users/buns/.coven/workspaces/familiars";
+
+function row(id: string, projectRoot: string): SessionRow {
+  return {
+    id,
+    project_root: projectRoot,
+    harness: "chat",
+    title: id,
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-07-21T00:00:00Z",
+    updated_at: "2026-07-21T00:00:00Z",
+    familiarId: null,
+    origin: "chat",
+  } as SessionRow;
+}
+
+describe("isFamiliarWorkspaceRoot", () => {
+  it("matches the workspace root itself", () => {
+    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/nova`, WS_ROOT)).toBe(true);
+  });
+
+  it("matches nested subdirs (notes/, memory/)", () => {
+    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/sage/notes`, WS_ROOT)).toBe(true);
+  });
+
+  it("tolerates trailing slashes on either side", () => {
+    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/cody/`, `${WS_ROOT}/`)).toBe(true);
+  });
+
+  it("does NOT match real project roots", () => {
+    expect(
+      isFamiliarWorkspaceRoot("/Users/buns/Documents/GitHub/OpenCoven/coven-cave", WS_ROOT),
+    ).toBe(false);
+  });
+
+  it("does NOT match a sibling path that only shares a string prefix", () => {
+    // `${WS_ROOT}-archive` must not be treated as inside `${WS_ROOT}`.
+    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}-archive/x`, WS_ROOT)).toBe(false);
+  });
+
+  it("treats empty/rootless project as not-a-familiar-workspace", () => {
+    expect(isFamiliarWorkspaceRoot("", WS_ROOT)).toBe(false);
+    expect(isFamiliarWorkspaceRoot(null, WS_ROOT)).toBe(false);
+    expect(isFamiliarWorkspaceRoot(undefined, WS_ROOT)).toBe(false);
+  });
+
+  it("matches declared (relocated) workspace roots too", () => {
+    const declared = ["/opt/coven/nova-ws"];
+    expect(isFamiliarWorkspaceRoot("/opt/coven/nova-ws", WS_ROOT, declared)).toBe(true);
+    expect(isFamiliarWorkspaceRoot("/opt/coven/nova-ws/notes", WS_ROOT, declared)).toBe(true);
+  });
+});
+
+describe("collapseFamiliarWorkspaceSessions", () => {
+  it("drops familiar-workspace sessions but keeps project + rootless ones", () => {
+    const sessions = [
+      row("journal-nova", `${WS_ROOT}/nova`),
+      row("journal-sage", `${WS_ROOT}/sage/notes`),
+      row("real-project", "/Users/buns/Documents/GitHub/OpenCoven/coven-cave"),
+      row("rootless", ""),
+    ];
+    const kept = collapseFamiliarWorkspaceSessions(sessions, WS_ROOT);
+    expect(kept.map((s) => s.id)).toEqual(["real-project", "rootless"]);
+  });
+
+  it("is a no-op when nothing is a familiar workspace", () => {
+    const sessions = [row("a", "/repo/a"), row("b", "")];
+    expect(collapseFamiliarWorkspaceSessions(sessions, WS_ROOT)).toHaveLength(2);
+  });
+});

--- a/src/lib/familiar-workspace-sessions.test.ts
+++ b/src/lib/familiar-workspace-sessions.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import {
   collapseFamiliarWorkspaceSessions,
@@ -26,38 +27,39 @@ function row(id: string, projectRoot: string): SessionRow {
 
 describe("isFamiliarWorkspaceRoot", () => {
   it("matches the workspace root itself", () => {
-    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/nova`, WS_ROOT)).toBe(true);
+    assert.equal(isFamiliarWorkspaceRoot(`${WS_ROOT}/nova`, WS_ROOT), true);
   });
 
   it("matches nested subdirs (notes/, memory/)", () => {
-    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/sage/notes`, WS_ROOT)).toBe(true);
+    assert.equal(isFamiliarWorkspaceRoot(`${WS_ROOT}/sage/notes`, WS_ROOT), true);
   });
 
   it("tolerates trailing slashes on either side", () => {
-    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}/cody/`, `${WS_ROOT}/`)).toBe(true);
+    assert.equal(isFamiliarWorkspaceRoot(`${WS_ROOT}/cody/`, `${WS_ROOT}/`), true);
   });
 
   it("does NOT match real project roots", () => {
-    expect(
+    assert.equal(
       isFamiliarWorkspaceRoot("/Users/buns/Documents/GitHub/OpenCoven/coven-cave", WS_ROOT),
-    ).toBe(false);
+      false,
+    );
   });
 
   it("does NOT match a sibling path that only shares a string prefix", () => {
     // `${WS_ROOT}-archive` must not be treated as inside `${WS_ROOT}`.
-    expect(isFamiliarWorkspaceRoot(`${WS_ROOT}-archive/x`, WS_ROOT)).toBe(false);
+    assert.equal(isFamiliarWorkspaceRoot(`${WS_ROOT}-archive/x`, WS_ROOT), false);
   });
 
   it("treats empty/rootless project as not-a-familiar-workspace", () => {
-    expect(isFamiliarWorkspaceRoot("", WS_ROOT)).toBe(false);
-    expect(isFamiliarWorkspaceRoot(null, WS_ROOT)).toBe(false);
-    expect(isFamiliarWorkspaceRoot(undefined, WS_ROOT)).toBe(false);
+    assert.equal(isFamiliarWorkspaceRoot("", WS_ROOT), false);
+    assert.equal(isFamiliarWorkspaceRoot(null, WS_ROOT), false);
+    assert.equal(isFamiliarWorkspaceRoot(undefined, WS_ROOT), false);
   });
 
   it("matches declared (relocated) workspace roots too", () => {
     const declared = ["/opt/coven/nova-ws"];
-    expect(isFamiliarWorkspaceRoot("/opt/coven/nova-ws", WS_ROOT, declared)).toBe(true);
-    expect(isFamiliarWorkspaceRoot("/opt/coven/nova-ws/notes", WS_ROOT, declared)).toBe(true);
+    assert.equal(isFamiliarWorkspaceRoot("/opt/coven/nova-ws", WS_ROOT, declared), true);
+    assert.equal(isFamiliarWorkspaceRoot("/opt/coven/nova-ws/notes", WS_ROOT, declared), true);
   });
 });
 
@@ -70,11 +72,14 @@ describe("collapseFamiliarWorkspaceSessions", () => {
       row("rootless", ""),
     ];
     const kept = collapseFamiliarWorkspaceSessions(sessions, WS_ROOT);
-    expect(kept.map((s) => s.id)).toEqual(["real-project", "rootless"]);
+    assert.deepEqual(
+      kept.map((s) => s.id),
+      ["real-project", "rootless"],
+    );
   });
 
   it("is a no-op when nothing is a familiar workspace", () => {
     const sessions = [row("a", "/repo/a"), row("b", "")];
-    expect(collapseFamiliarWorkspaceSessions(sessions, WS_ROOT)).toHaveLength(2);
+    assert.equal(collapseFamiliarWorkspaceSessions(sessions, WS_ROOT).length, 2);
   });
 });

--- a/src/lib/familiar-workspace-sessions.ts
+++ b/src/lib/familiar-workspace-sessions.ts
@@ -1,0 +1,62 @@
+/**
+ * familiar-workspace-sessions.ts
+ *
+ * The unscoped/global sessions dashboard shows EVERY session the daemon knows,
+ * including the flood of auto-generated per-familiar workspace runs (daily
+ * journal narratives, thread reflections) whose `project_root` is a familiar's
+ * own workspace under `~/.coven/workspaces/familiars/<id>`. Those legitimately
+ * exist, but they drown the handful of real project sessions and make the
+ * global list look "contradictory" versus the clean, project-scoped familiar
+ * homes (which drop them via project-grant scoping).
+ *
+ * This module is a PURE classifier + filter. It never touches the filesystem;
+ * the caller passes the already-resolved familiar-workspace roots (from
+ * coven-paths) so this stays trivially unit-testable. Callers opt in — the
+ * default unscoped behaviour is unchanged, so nothing silently disappears.
+ */
+
+import { normalizeProjectRoot } from "@/lib/cave-projects-types";
+import type { SessionRow } from "@/lib/types";
+
+/**
+ * True when `projectRoot` is inside the familiar-workspaces tree — either the
+ * shared `<workspacesRoot>/familiars/...` prefix or one of the explicitly
+ * declared per-familiar workspace roots (familiars.toml can relocate them).
+ *
+ * Matching is prefix-based on normalized paths so both the workspace root
+ * itself and any nested subdir (notes/, memory/, ...) are recognized.
+ */
+export function isFamiliarWorkspaceRoot(
+  projectRoot: string | null | undefined,
+  familiarWorkspacesRoot: string,
+  declaredWorkspaceRoots: readonly string[] = [],
+): boolean {
+  const root = normalizeProjectRoot(projectRoot);
+  if (root === "/") return false;
+  const prefixes = [familiarWorkspacesRoot, ...declaredWorkspaceRoots]
+    .map((p) => normalizeProjectRoot(p))
+    .filter((p) => p !== "/");
+  return prefixes.some(
+    (prefix) => root === prefix || root.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Drop sessions whose `project_root` is a familiar-workspace root. Sessions
+ * with no/rootless project ("(no project)" bucket) and real registered-project
+ * sessions are always kept. Pure — safe to call on the response path.
+ */
+export function collapseFamiliarWorkspaceSessions(
+  sessions: SessionRow[],
+  familiarWorkspacesRoot: string,
+  declaredWorkspaceRoots: readonly string[] = [],
+): SessionRow[] {
+  return sessions.filter(
+    (session) =>
+      !isFamiliarWorkspaceRoot(
+        session.project_root,
+        familiarWorkspacesRoot,
+        declaredWorkspaceRoots,
+      ),
+  );
+}


### PR DESCRIPTION
## Why

Investigating "contradictory sessions" (listed some places, not others). Root cause is two intentional-but-rough behaviors, not corruption:

1. **Familiar-workspace flood.** The unscoped ("All familiars") sessions dashboard shows every per-familiar workspace auto-run (daily journals, thread reflections) whose `project_root` is `~/.coven/workspaces/familiars/<id>`. Live data: unscoped active = **144**, but scoped `cody` = **57**, `sage` = **44**. The journal runs drown the handful of real project sessions and make the global list look contradictory versus the clean, project-scoped familiar homes (which already drop them via project-grant scoping).
2. **Reconcile banner.** "Preferences are still reconciling" is a client-side 2s slow-bootstrap warning. It only re-checked on `online`/`visibility`/subscription events, so a silent cold-start stall (e.g. slow IndexedDB) left the warning parked until a manual **Retry now**.

## Changes

- **New pure helper** `src/lib/familiar-workspace-sessions.ts` — `isFamiliarWorkspaceRoot()` + `collapseFamiliarWorkspaceSessions()`. Prefix-matches the familiar-workspaces tree plus any relocated roots from `familiars.toml`. No FS access; keeps "(no project)" and real-project sessions.
- **Route** `src/app/api/sessions/list/route.ts` — opt-in `?collapseFamiliarWorkspace=1`, threaded through `computeSessionsList` and the cache key. **Default behavior unchanged** — nothing silently disappears.
- **Client** `src/components/workspace.tsx` — the unscoped view passes the flag; scoped familiar homes are untouched.
- **Banner** `src/components/preferences-bootstrap-controller.tsx` — bounded auto-retry (5s → 10s → 20s, then the manual CTA stands), cleared on success/unmount.

## Verification

- `familiar-workspace-sessions.test.ts` — **9/9 pass**
- New `list/route.test.ts` boundary test — **pass** (param parsed, cache-key varies, threaded, applied only when set)
- `session-project-scope` + `sessions/route` + `app-preferences` suites — pass
- `tsc --noEmit` — **exit 0**
- `pnpm lint:design` — **exit 0**

## Notes

- Default unscoped API response is unchanged; collapse is purely opt-in via query param.
- The reconcile banner change is client-only and cosmetic (no server/data behavior touched).