### PR TITLE
feat(settings): restyle chat settings to the design-handoff card (cave-otrn)

### DIFF
--- a/src/components/chat-settings-view.tsx
+++ b/src/components/chat-settings-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { SettingsGroup } from "@/components/ui/settings-group";
 import {
   normalizeChatAutoArchivePolicy,
   type ChatAutoArchivePolicy,
@@ -14,6 +13,10 @@ import {
  * event-driven archiving (task completion, thread reflections), and the idle
  * windows. Reads/writes the `chatAutoArchive` key through `/api/config`, whose
  * PATCH merges partial policies over the stored one.
+ *
+ * Presentation follows the Settings.dc.html redesign mock: one bordered card
+ * whose child rows dim as a block while the master switch is off. Styles live
+ * in cave-chat/auxiliary-surfaces.css under `.chat-settings*`.
  */
 
 type SaveState = "idle" | "saving" | "error";
@@ -21,19 +24,17 @@ type SaveState = "idle" | "saving" | "error";
 function PolicyRow({
   label,
   description,
-  dimmed,
   children,
 }: {
   label: string;
   description?: string;
-  dimmed?: boolean;
   children: ReactNode;
 }) {
   return (
-    <div className={`flex items-center justify-between gap-4 px-4 py-3 ${dimmed ? "opacity-50" : ""}`}>
-      <div className="min-w-0">
-        <p className="text-[length:var(--text-base)] text-[var(--text-primary)]">{label}</p>
-        {description && <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">{description}</p>}
+    <div className="chat-settings__row">
+      <div className="chat-settings__row-text">
+        <p className="chat-settings__row-title">{label}</p>
+        {description && <p className="chat-settings__row-desc">{description}</p>}
       </div>
       {children}
     </div>
@@ -59,9 +60,9 @@ function PolicySwitch({
       aria-label={label}
       disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`settings-switch focus-ring${checked ? " is-on" : ""}`}
+      className={`chat-settings__switch focus-ring${checked ? " is-on" : ""}`}
     >
-      <span className="settings-switch__knob" aria-hidden />
+      <span className="chat-settings__knob" aria-hidden />
     </button>
   );
 }
@@ -87,7 +88,7 @@ function PolicyDays({
     if (days !== value) onCommit(days);
   };
   return (
-    <label className="flex shrink-0 items-center gap-1.5 text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+    <label className="chat-settings__days">
       <input
         type="number"
         min={0}
@@ -100,7 +101,7 @@ function PolicyDays({
         onKeyDown={(e) => {
           if (e.key === "Enter") (e.target as HTMLInputElement).blur();
         }}
-        className="w-16 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-right text-[length:var(--text-sm)] text-[var(--text-primary)] focus-ring"
+        className="chat-settings__days-input focus-ring"
       />
       days
     </label>
@@ -156,27 +157,27 @@ export function ChatSettingsView() {
 
   return (
     <div className="chat-settings-view min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-8">
-        <header>
-          <h2 className="text-[length:var(--text-md)] font-semibold text-[var(--text-primary)]">Chat settings</h2>
-          <p className="mt-1 text-[length:var(--text-sm)] text-[var(--text-muted)]">
-            Applies to every chat on this device. Per-familiar behavior (like auto
-            self-report) lives with each familiar under Familiars → Brain.
-          </p>
-        </header>
+      <div className="chat-settings">
+        <h2 className="chat-settings__title">Chat settings</h2>
+        <p className="chat-settings__subtitle">
+          Applies to every chat on this device. Per-familiar behavior (like auto
+          self-report) lives with each familiar under Familiars → Brain.
+        </p>
 
         {loadError ? (
-          <p role="alert" className="text-[length:var(--text-sm)] text-[var(--color-danger)]">
+          <p role="alert" className="chat-settings__hint text-[var(--color-danger)]">
             {loadError}
           </p>
         ) : !policy ? (
-          <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">Loading…</p>
+          <p className="chat-settings__hint">Loading…</p>
         ) : (
           <>
-            <SettingsGroup
-              label="Auto-archive"
-              description="Move finished chats out of the list automatically. Chats marked keep are never auto-archived."
-            >
+            <p className="chat-settings__kicker">Auto-archive</p>
+            <p className="chat-settings__hint">
+              Move finished chats out of the list automatically. Chats marked keep are
+              never auto-archived.
+            </p>
+            <div className="chat-settings__card">
               <PolicyRow
                 label="Auto-archive"
                 description="Master switch for event- and time-based archiving."
@@ -187,68 +188,68 @@ export function ChatSettingsView() {
                   onChange={(enabled) => update({ enabled })}
                 />
               </PolicyRow>
-              <PolicyRow
-                label="After task completion"
-                description="Archive a chat when its linked task completes, instead of only nudging."
-                dimmed={sweepOff}
-              >
-                <PolicySwitch
-                  label="Archive after task completion"
-                  checked={policy.archiveOnTaskCompletion}
-                  disabled={sweepOff}
-                  onChange={(archiveOnTaskCompletion) => update({ archiveOnTaskCompletion })}
-                />
-              </PolicyRow>
-              <PolicyRow
-                label="After thread reflection"
-                description="Archive a thread once its reflection lands. Manual reflections archive right away; automatic ones only archive threads already idle."
-                dimmed={sweepOff}
-              >
-                <PolicySwitch
-                  label="Archive after thread reflection"
-                  checked={policy.archiveOnReflection}
-                  disabled={sweepOff}
-                  onChange={(archiveOnReflection) => update({ archiveOnReflection })}
-                />
-              </PolicyRow>
-              <PolicyRow
-                label="After PR merge"
-                description="Archive a chat once the pull request its work produced merges."
-                dimmed={sweepOff}
-              >
-                <PolicySwitch
-                  label="Archive after PR merge"
-                  checked={policy.archiveOnPrMerge}
-                  disabled={sweepOff}
-                  onChange={(archiveOnPrMerge) => update({ archiveOnPrMerge })}
-                />
-              </PolicyRow>
-              <PolicyRow
-                label="External chats idle for"
-                description="Chats created outside the chat surface (cron, flows, generated runs). 0 turns this window off."
-                dimmed={sweepOff}
-              >
-                <PolicyDays
-                  label="Archive external chats after days idle"
-                  value={policy.externalAfterDays}
-                  disabled={sweepOff}
-                  onCommit={(externalAfterDays) => update({ externalAfterDays })}
-                />
-              </PolicyRow>
-              <PolicyRow
-                label="Any chat idle for"
-                description="Every chat, regardless of origin. 0 turns this window off."
-                dimmed={sweepOff}
-              >
-                <PolicyDays
-                  label="Archive any chat after days idle"
-                  value={policy.idleAfterDays}
-                  disabled={sweepOff}
-                  onCommit={(idleAfterDays) => update({ idleAfterDays })}
-                />
-              </PolicyRow>
-            </SettingsGroup>
-            <p aria-live="polite" className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
+              {/* The mock dims/disables the child rows as one block while the
+                  master switch is off; the controls also carry `disabled` so
+                  the state reaches screen readers, not just pointer-events. */}
+              <div className={`chat-settings__children${sweepOff ? " is-disabled" : ""}`}>
+                <PolicyRow
+                  label="After task completion"
+                  description="Archive a chat when its linked task completes, instead of only nudging."
+                >
+                  <PolicySwitch
+                    label="Archive after task completion"
+                    checked={policy.archiveOnTaskCompletion}
+                    disabled={sweepOff}
+                    onChange={(archiveOnTaskCompletion) => update({ archiveOnTaskCompletion })}
+                  />
+                </PolicyRow>
+                <PolicyRow
+                  label="After thread reflection"
+                  description="Archive a thread once its reflection lands. Manual reflections archive right away; automatic ones only archive threads already idle."
+                >
+                  <PolicySwitch
+                    label="Archive after thread reflection"
+                    checked={policy.archiveOnReflection}
+                    disabled={sweepOff}
+                    onChange={(archiveOnReflection) => update({ archiveOnReflection })}
+                  />
+                </PolicyRow>
+                <PolicyRow
+                  label="After PR merge"
+                  description="Archive a chat once the pull request its work produced merges."
+                >
+                  <PolicySwitch
+                    label="Archive after PR merge"
+                    checked={policy.archiveOnPrMerge}
+                    disabled={sweepOff}
+                    onChange={(archiveOnPrMerge) => update({ archiveOnPrMerge })}
+                  />
+                </PolicyRow>
+                <PolicyRow
+                  label="External chats idle for"
+                  description="Chats created outside the chat surface (cron, flows, generated runs). 0 turns this window off."
+                >
+                  <PolicyDays
+                    label="Archive external chats after days idle"
+                    value={policy.externalAfterDays}
+                    disabled={sweepOff}
+                    onCommit={(externalAfterDays) => update({ externalAfterDays })}
+                  />
+                </PolicyRow>
+                <PolicyRow
+                  label="Any chat idle for"
+                  description="Every chat, regardless of origin. 0 turns this window off."
+                >
+                  <PolicyDays
+                    label="Archive any chat after days idle"
+                    value={policy.idleAfterDays}
+                    disabled={sweepOff}
+                    onCommit={(idleAfterDays) => update({ idleAfterDays })}
+                  />
+                </PolicyRow>
+              </div>
+            </div>
+            <p aria-live="polite" className="chat-settings__save">
               {saveState === "error"
                 ? "Saving failed — change reverted. Try again."
                 : saveState === "saving"

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -1008,3 +1008,150 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+
+/* ── Chat Settings tab (chat surface → Settings scope) ───────────────────────
+   Settings.dc.html redesign: page column, kicker + hint over one bordered
+   translucent card, child rows dimming as a block under the master switch.
+   The switch is a scoped restyle — the shared .settings-switch (dashboard.css)
+   is pinned by other surfaces' tests and uses a solid accent fill, while this
+   one follows the tint recipe (accent 15% fill / 38% border, solid knob). */
+.chat-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-6) var(--space-8);
+}
+.chat-settings__title {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.chat-settings__subtitle {
+  font-size: var(--text-base);
+  color: var(--text-muted);
+  text-wrap: pretty;
+}
+.chat-settings__kicker {
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.chat-settings__hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.chat-settings__card {
+  margin-top: var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  overflow: hidden;
+}
+.chat-settings__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+}
+.chat-settings__children > .chat-settings__row {
+  border-top: 1px solid var(--border-hairline);
+}
+.chat-settings__row-text {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+}
+.chat-settings__row-title {
+  font-size: var(--text-md);
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.chat-settings__row-desc {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  text-wrap: pretty;
+}
+/* Master off: the whole child block dims and stops taking pointer input; the
+   controls inside also carry `disabled` for screen readers. Reduced motion is
+   handled by the global transition-duration collapse in foundations.css. */
+.chat-settings__children {
+  transition: opacity var(--duration-fast) var(--ease-standard);
+}
+.chat-settings__children.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+.chat-settings__switch {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-start;
+  width: 36px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--bg-base);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+/* Inset negative hit-area keeps the small control comfortably tappable. */
+.chat-settings__switch::after {
+  content: "";
+  position: absolute;
+  inset: -12px;
+}
+.chat-settings__switch:disabled {
+  cursor: default;
+}
+.chat-settings__knob {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
+  /* 2px track inset without off-scale padding: nudge the knob off the edge. */
+  transform: translateX(2px);
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+.chat-settings__switch.is-on {
+  justify-content: flex-end;
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 15%, transparent);
+}
+.chat-settings__switch.is-on .chat-settings__knob {
+  transform: translateX(-2px);
+  background: var(--accent-presence);
+}
+.chat-settings__days {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.chat-settings__days-input {
+  width: 64px;
+  min-height: 32px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  font-size: var(--text-base);
+  text-align: center;
+  color: var(--text-primary);
+}
+.chat-settings__save {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}


### PR DESCRIPTION
Implements `Settings.dc.html` from the claude.ai/design **Projects page redesign** handoff.

- One bordered auto-archive card: master-switch row, three event-toggle rows, two idle-day rows, per the mock; uppercase kicker + helper copy; "Changes save automatically." footer.
- Mock-style switches (36×20 pill, tint-recipe on-state, translated knob) scoped as `chat-settings__*` — the shared `.settings-switch` used by settings-shell and the studio Brain tab is untouched (both pinned by tests).
- Behavior preserved byte-for-byte where pinned: `/api/config` load + optimistic PATCH with revert-on-failure, `role="switch"`/`aria-checked`, real `disabled` on children when the master is off (mock's dim treatment is additive), 0–365 clamp + commit-on-blur day fields, `aria-live` save state.
- Divergences from the mock: day-field max stays 365 and commit-on-blur (behavior wins); "Familiars → Brain" stays plain text (adding navigation would be new behavior); sizes snapped to the token scales per the design-token-drift ratchet (no baselines raised).

Verification: tsc clean; `run-tests.mjs app` → 839 files pass incl. `chat-settings-view.test.ts`; verified in the running app — master-on and master-off (dimmed children) states screenshotted.

Bead: cave-otrn

🤖 Generated with [Claude Code](https://claude.com/claude-code)