### PR TITLE
feat(familiar): redesign the Familiar tab + shared SurfaceRail primitive (cave-i0eu)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -638,6 +638,7 @@ export const SUITES = {
     "src/components/familiar-tab-sections.test.ts",
     "src/components/familiar-tab-bridges.test.ts",
     "src/components/familiar-tab-scope.test.ts",
+    "src/components/surface-rail.test.ts",
     "src/components/misc-aria-fixes.test.ts",
     "src/components/modal-trap-adoption.test.ts",
     "src/components/mode-toggle.test.ts",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -68,7 +68,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_544/, "runtime closure must stay below 5,544 files");
+assert.match(closureSource, /fileCount: 5_545/, "runtime closure must stay below 5,545 files");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -171,7 +171,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_544;/,
+  /const MAX_FILE_COUNT: u64 = 5_545;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -79,7 +79,9 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // adds one traced file on Windows. CI measured 5,543; keep the exact maximum.
   // 2026-07-21 (Canvas redesign): the full-surface canvas editor adds one
   // traced chunk on Windows. CI measured 5,544; keep the exact maximum.
-  fileCount: 5_544,
+  // 2026-07-21 (Familiar redesign): the SurfaceRail + familiar-tab chunk adds
+  // one traced file on Windows. CI measured 5,545; keep the exact maximum.
+  fileCount: 5_545,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_544);
+  assert.ok(metrics.fileCount <= 5_545);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_544,
+    fileCount: 5_545,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -148,7 +148,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_544);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_545);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -6,7 +6,7 @@ pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
 pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-pub(super) const MAX_FILE_COUNT: u64 = 5_544;
+pub(super) const MAX_FILE_COUNT: u64 = 5_545;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -3,13 +3,14 @@
 /**
  * ChatFamiliarView — the chat surface's Familiar tab.
  *
- * A purpose-built "who am I chatting with?" surface: identity hero first
- * (avatar, serif name, presence, runtime), then the capability grid (roles,
- * skills, plugins, runtime, MCP servers, warnings). Extracted from the
- * retired inspector sidepanel's pane so the tab owns its own landmark,
- * scroll region, and empty state instead of re-hosting a rail component
- * (cave-yqrx); the visual design carries over from cave-7e1l/cave-aovo/
- * cave-w3us unchanged.
+ * Design-handoff redesign: a shared SurfaceRail roster on the left (search,
+ * collapse, resize — local selection only, never the app-wide scope) and an
+ * identity detail on the right: header (avatar, serif name, presence chip,
+ * runtime/model pills, Profile/Analytics/Memory links, New chat) over a
+ * 1.5fr/1fr card grid (Roles · Skills | Runtime · Capabilities · Warnings).
+ * Capability data still flows through useCapabilitySnapshot (/api/roles,
+ * /api/skills/local, /api/capabilities?harness=, /api/harnesses); the
+ * lifecycle/scope state machine (deriveFamiliarTabState) is unchanged.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -18,6 +19,8 @@ import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { SurfaceRail } from "@/components/ui/surface-rail";
+import { SearchInput } from "@/components/ui/search-input";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { deriveFamiliarTabState } from "@/lib/familiar-tab-state";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
@@ -28,57 +31,9 @@ import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { getVoiceProvider } from "@/lib/voice/registry";
 import { relativeTime } from "@/lib/relative-time";
 import { navigateFamiliarSurface } from "@/lib/familiar-surface-navigation";
+import "@/styles/familiar-tab.css";
 
 // ── Building blocks ──────────────────────────────────────────────────────────
-
-function CapSection({
-  title,
-  scope,
-  empty,
-  emptyText,
-  children,
-}: {
-  title: string;
-  scope?: string;
-  empty?: boolean;
-  emptyText?: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <section>
-      <header className="mb-1.5 flex items-baseline justify-between">
-        <h3 className="text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-secondary)]">
-          {title}
-        </h3>
-        {scope ? (
-          <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">{scope}</span>
-        ) : null}
-      </header>
-      {empty ? (
-        <p className="rounded border border-dashed border-[var(--border-hairline)] px-2 py-2 text-[var(--text-muted)]">
-          {emptyText ?? "Nothing here."}
-        </p>
-      ) : (
-        children
-      )}
-    </section>
-  );
-}
-
-function CapRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
-  return (
-    <li className="flex items-baseline justify-between gap-2">
-      <span className="text-[length:var(--text-xs)] uppercase tracking-wider text-[var(--text-muted)]">
-        {label}
-      </span>
-      <span
-        className={`truncate text-[var(--text-primary)] ${mono ? "font-mono text-[length:var(--text-xs)]" : ""}`}
-      >
-        {value}
-      </span>
-    </li>
-  );
-}
 
 /** Neutral kind marker — the kind is metadata, not a status: one quiet style
  *  for every kind (the old per-kind color map was accent soup on every row). */
@@ -90,9 +45,6 @@ function KindBadge({ kind }: { kind: string }) {
   );
 }
 
-/** Navigate the workspace to a management surface (Roles / Capabilities /
- *  Marketplace hub) through the same `cave:navigate-mode` bridge every other
- *  cross-surface link uses. */
 /** Teach-state CTA — every empty state gets a real affordance, not a
  *  dead-end sentence naming a page. */
 function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
@@ -100,15 +52,15 @@ function CapCta({ label, onClick }: { label: string; onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="familiar-tab__cta focus-ring mt-1.5 inline-flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[length:var(--text-xs)] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
+      className="familiar-tab__cta focus-ring inline-flex shrink-0 items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[length:var(--text-xs)] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-hover)]"
     >
       {label}
     </button>
   );
 }
 
-/** One de-boxed skill row, shared by all three provenance groups: quiet name
- *  + kind, one-line description, neutral tag chips — and the source path
+/** One skill row, shared by all three provenance groups: mono name + quiet
+ *  kind badge, one-line description, neutral tag chips — the source path
  *  demoted from body copy to a hover/focus tooltip. */
 function SkillItem({
   name,
@@ -124,13 +76,13 @@ function SkillItem({
   sourcePath?: string;
 }) {
   return (
-    <li className="px-2 py-1.5" title={sourcePath}>
-      <div className="flex items-center gap-1.5">
-        <span className="font-medium text-[var(--text-primary)]">{name}</span>
+    <li className="familiar-tab__skill-row" title={sourcePath}>
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[length:var(--text-base)] font-medium text-[var(--text-primary)]">{name}</span>
         <KindBadge kind={kind} />
       </div>
       {description ? (
-        <p className="mt-0.5 line-clamp-1 text-[length:var(--text-xs)] text-[var(--text-muted)]">{description}</p>
+        <p className="mt-0.5 line-clamp-1 text-[length:var(--text-sm)] text-[var(--text-muted)]">{description}</p>
       ) : null}
       {tags && tags.length > 0 ? (
         <div className="mt-0.5 flex flex-wrap gap-1">
@@ -148,6 +100,49 @@ function SkillItem({
   );
 }
 
+type SkillRowData = {
+  key: string;
+  name: string;
+  kind: string;
+  description?: string;
+  tags?: string[];
+  sourcePath?: string;
+};
+
+/** Groups preview a handful of rows; the rest sit behind "Show N more". */
+const SKILL_GROUP_PREVIEW = 6;
+
+function SkillRows({ rows }: { rows: SkillRowData[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const hiddenCount = rows.length - SKILL_GROUP_PREVIEW;
+  const visible = showAll || hiddenCount <= 0 ? rows : rows.slice(0, SKILL_GROUP_PREVIEW);
+  return (
+    <>
+      <ul className="familiar-tab__rows pt-1">
+        {visible.map((row) => (
+          <SkillItem
+            key={row.key}
+            name={row.name}
+            kind={row.kind}
+            description={row.description}
+            tags={row.tags}
+            sourcePath={row.sourcePath}
+          />
+        ))}
+      </ul>
+      {hiddenCount > 0 ? (
+        <button
+          type="button"
+          className="familiar-tab__more focus-ring"
+          onClick={() => setShowAll((value) => !value)}
+        >
+          {showAll ? "Show fewer" : `Show ${hiddenCount} more`}
+        </button>
+      ) : null}
+    </>
+  );
+}
+
 function CollapsibleSection({
   title,
   badge,
@@ -162,29 +157,51 @@ function CollapsibleSection({
   children: React.ReactNode;
 }) {
   return (
-    <div className="familiar-tab__list">
+    <div>
       <button
         type="button"
         onClick={onToggle}
         aria-expanded={open}
-        className="focus-ring flex w-full items-center gap-1.5 rounded-[inherit] px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]/40"
+        className="familiar-tab__group-toggle focus-ring"
       >
         <Icon
           name={open ? "ph:caret-down" : "ph:caret-right"}
           width={10}
           className="shrink-0 text-[var(--text-muted)]"
         />
-        <span className="text-[length:var(--text-xs)] uppercase tracking-widest text-[var(--text-secondary)]">
+        <span className="flex-1 text-[length:var(--text-xs)] uppercase tracking-widest text-[var(--text-secondary)]">
           {title}
         </span>
-        {badge ? (
-          <span className="ml-auto rounded bg-[var(--bg-raised)] px-1 py-px text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-            {badge}
-          </span>
-        ) : null}
+        {badge ? <span className="familiar-tab__count">{badge}</span> : null}
       </button>
-      {open ? <div className="px-2 pb-2">{children}</div> : null}
+      {open ? <div>{children}</div> : null}
     </div>
+  );
+}
+
+/** Bordered translucent panel with the shared uppercase-title header row. */
+function CapCard({
+  title,
+  count,
+  note,
+  fill,
+  children,
+}: {
+  title: string;
+  count?: string;
+  note?: React.ReactNode;
+  fill?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={fill ? "familiar-tab__card familiar-tab__card--fill" : "familiar-tab__card"}>
+      <header className="familiar-tab__card-head">
+        <h3 className="familiar-tab__card-title">{title}</h3>
+        {count != null ? <span className="familiar-tab__count">{count}</span> : null}
+        {note ? <span className="familiar-tab__card-note">{note}</span> : null}
+      </header>
+      {children}
+    </section>
   );
 }
 
@@ -215,7 +232,6 @@ function FamiliarIdentityHero({
   const roleLine = [resolved?.role || familiar.role, familiar.pronouns]
     .filter(Boolean)
     .join(" · ");
-  const runtimeLine = [familiar.harness, familiar.model].filter(Boolean).join(" · ");
   // The familiar's speaking voice (bound in the Studio's Brain tab), labelled
   // by the canonical voice-provider registry. Silent familiars add no noise —
   // the line only renders when a provider is set.
@@ -239,9 +255,9 @@ function FamiliarIdentityHero({
         </span>
       ) : null}
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
           <h2 className="familiar-tab__name">{resolved?.display_name ?? familiar.display_name}</h2>
-          <span className="familiar-tab__presence text-[length:var(--text-xs)] text-[var(--text-muted)]">
+          <span className="familiar-tab__presence" data-online={daemonRunning ? "true" : "false"}>
             <span
               aria-hidden="true"
               className={`inline-flex h-1.5 w-1.5 rounded-full ${
@@ -255,12 +271,12 @@ function FamiliarIdentityHero({
                 <time dateTime={familiar.last_seen ?? undefined}>{lastSeen}</time>
               </>
             ) : null}
-            {activeSessions > 0 ? (
-              <span className="rounded bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[length:var(--text-2xs)] text-[var(--accent-presence)]">
-                {activeSessions} active session{activeSessions === 1 ? "" : "s"}
-              </span>
-            ) : null}
           </span>
+          {activeSessions > 0 ? (
+            <span className="rounded-[var(--radius-pill)] bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[length:var(--text-2xs)] text-[var(--accent-presence)]">
+              {activeSessions} active session{activeSessions === 1 ? "" : "s"}
+            </span>
+          ) : null}
         </div>
         {roleLine ? (
           <p className="mt-0.5 truncate text-[length:var(--text-xs)] uppercase tracking-widest text-[var(--text-secondary)]">
@@ -272,10 +288,15 @@ function FamiliarIdentityHero({
             {familiar.description}
           </p>
         ) : null}
-        <div className="familiar-tab__links mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[length:var(--text-xs)]">
-          {runtimeLine ? (
-            <span className="font-mono text-[length:var(--text-xs)] text-[var(--text-muted)]" title="Harness · model">
-              {runtimeLine}
+        <div className="familiar-tab__links mt-2 flex flex-wrap items-center gap-1.5">
+          {familiar.harness ? (
+            <span className="familiar-tab__pill font-mono" title="Runtime">
+              {familiar.harness}
+            </span>
+          ) : null}
+          {familiar.model ? (
+            <span className="familiar-tab__pill font-mono" title="Model">
+              {familiar.model}
             </span>
           ) : null}
           {voiceLine ? (
@@ -284,47 +305,46 @@ function FamiliarIdentityHero({
               onClick={() => openFamiliarStudioSettingsTab("brain", familiar.id)}
               aria-label={`Voice settings for ${resolved?.display_name ?? familiar.display_name} — ${voiceLine}`}
               title="Speaking voice — manage in the Studio's Brain tab"
-              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-sm)] font-mono text-[length:var(--text-xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+              className="familiar-tab__pill focus-ring gap-1.5 font-mono transition-colors hover:text-[var(--accent-presence)]"
             >
               <Icon name="ph:waveform-bold" width={11} aria-hidden />
               {voiceLine}
             </button>
           ) : null}
-          <span className="flex flex-wrap items-center gap-3">
-            <Link
-              href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
-              aria-label={`Open profile card for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[length:var(--text-xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
-            >
-              Profile →
-            </Link>
-            <Link
-              href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
-              aria-label={`Open analytics for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[length:var(--text-xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
-            >
-              Analytics →
-            </Link>
-            {/* The retired sidepanel's memory pane isn't reachable from this
-                tab — bridge to the Studio's per-familiar Memory tab, its
-                managed home. */}
-            <button
-              type="button"
-              onClick={() => openFamiliarStudioSettingsTab("memory", familiar.id)}
-              aria-label={`Open memory for ${familiar.display_name}`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[length:var(--text-xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
-            >
-              Memory →
-            </button>
-            <button
-              type="button"
-              onClick={() => openFamiliarStudioSettingsTab("identity", familiar.id)}
-              aria-label={`Edit ${familiar.display_name} in the Familiar Studio`}
-              className="focus-ring shrink-0 rounded-[var(--radius-sm)] text-[length:var(--text-xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
-            >
-              Edit in Studio →
-            </button>
-          </span>
+          <span className="familiar-tab__links-divider" aria-hidden="true" />
+          <Link
+            href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/profile`}
+            aria-label={`Open profile card for ${familiar.display_name}`}
+            className="familiar-tab__link-pill focus-ring"
+          >
+            Profile
+          </Link>
+          <Link
+            href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
+            aria-label={`Open analytics for ${familiar.display_name}`}
+            className="familiar-tab__link-pill focus-ring"
+          >
+            Analytics
+          </Link>
+          {/* The retired sidepanel's memory pane isn't reachable from this
+              tab — bridge to the Studio's per-familiar Memory tab, its
+              managed home. */}
+          <button
+            type="button"
+            onClick={() => openFamiliarStudioSettingsTab("memory", familiar.id)}
+            aria-label={`Open memory for ${familiar.display_name}`}
+            className="familiar-tab__link-pill focus-ring"
+          >
+            Memory
+          </button>
+          <button
+            type="button"
+            onClick={() => openFamiliarStudioSettingsTab("identity", familiar.id)}
+            aria-label={`Edit ${familiar.display_name} in the Familiar Studio`}
+            className="familiar-tab__link-pill focus-ring"
+          >
+            Edit in Studio
+          </button>
         </div>
       </div>
       {onStartChat ? (
@@ -334,7 +354,7 @@ function FamiliarIdentityHero({
           <button
             type="button"
             onClick={() => onStartChat(familiar.id)}
-            className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-2.5 text-[length:var(--text-xs)] font-medium text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-90"
+            className="focus-ring inline-flex h-8 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 text-[length:var(--text-sm)] font-medium text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-90"
           >
             <Icon name="ph:chat-circle-dots" width={13} aria-hidden />
             New chat
@@ -553,10 +573,11 @@ function FamiliarCapabilityPanel({
   daemonRunning?: boolean;
   onStartChat?: (familiarId: string) => void;
 }) {
-  // Collapsible state per sub-group
+  // Collapsible state per skills sub-group + per expandable role row
   const [skillsRoleOpen, setSkillsRoleOpen] = useState(true);
   const [skillsFamiliarOpen, setSkillsFamiliarOpen] = useState(true);
   const [skillsGlobalOpen, setSkillsGlobalOpen] = useState(true);
+  const [openRoleIds, setOpenRoleIds] = useState<Record<string, boolean>>({});
 
   const harnessId = familiar.harness ?? "codex";
   const { roles, localSkills, harnessCapabilities, harnesses, loading, errors } = useCapabilitySnapshot(harnessId);
@@ -566,7 +587,7 @@ function FamiliarCapabilityPanel({
   // like the grid it resolves into.
   if (loading) {
     return (
-      <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
+      <div className="familiar-tab__main">
         <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} onStartChat={onStartChat} />
         <div className="familiar-tab__grid" aria-hidden>
           <SkeletonRows count={5} className="p-3" />
@@ -608,8 +629,36 @@ function FamiliarCapabilityPanel({
     ...Array.from(roleGrantedSkillIds),
   ]);
 
+  const roleGrantedRows: SkillRowData[] = Array.from(roleGrantedSkillIds).map((sid) => {
+    const skill = localSkills.find((s) => s.id === sid);
+    return {
+      key: sid,
+      name: skill?.name ?? sid,
+      kind: skill?.kind ?? "agent",
+      description: skill?.description,
+      tags: skill?.tags,
+      sourcePath: "Granted by an active role",
+    };
+  });
+  const familiarRows: SkillRowData[] = familiarSkills.map((s) => ({
+    key: s.path,
+    name: s.name,
+    kind: s.kind ?? "agent",
+    description: s.description,
+    tags: s.tags,
+    sourcePath: s.path,
+  }));
+  const globalRows: SkillRowData[] = globalSkills.map((s) => ({
+    key: s.path,
+    name: s.name,
+    kind: s.kind ?? "agent",
+    description: s.description,
+    tags: s.tags,
+    sourcePath: s.path,
+  }));
+
   return (
-    <div className="familiar-tab flex flex-col gap-2 p-4 text-xs">
+    <div className="familiar-tab__main">
 
       {/* ── Identity hero ─────────────────────────────────────────────────── */}
       <FamiliarIdentityHero familiar={familiar} daemonRunning={daemonRunning} onStartChat={onStartChat} />
@@ -629,77 +678,65 @@ function FamiliarCapabilityPanel({
         </div>
       ) : null}
 
-      {/* ── Capability grid: two columns on a wide canvas, one below ─────── */}
+      {/* ── Card grid: 1.5fr/1fr on a wide pane, stacked below ────────────── */}
       <div className="familiar-tab__grid">
-      <div className="familiar-tab__col flex min-w-0 flex-col gap-2">
+      <div className="familiar-tab__col">
 
-      {/* ── Section 1: Roles ──────────────────────────────────────────────── */}
-      <CapSection title="Roles" scope={`active: ${activeRoles.length}`}>
+      {/* ── Roles card ────────────────────────────────────────────────────── */}
+      <CapCard title="Roles" count={String(activeRoles.length)} note={`active: ${activeRoles.length}`}>
         {activeRoles.length === 0 ? (
-          <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
+          <div className="familiar-tab__empty">
             <p>No roles active for this familiar.</p>
-            <CapCta label="Open Roles →" onClick={() => navigateFamiliarSurface("roles")} />
+            <CapCta label="Open roles →" onClick={() => navigateFamiliarSurface("roles")} />
           </div>
         ) : (
-          <div className="familiar-tab__list">
-            <ul className="familiar-tab__rows">
-              {activeRoles.map((role) => (
-                <li
-                  key={`${role.familiar}:${role.id}`}
-                  className="px-3 py-2"
-                  title={`Inherited from roles/${role.id}/ROLE.md`}
-                >
-                  <div className="flex items-center gap-1.5">
-                    <Icon name="ph:sparkle" width={13} className="shrink-0 text-[var(--text-secondary)]" aria-hidden />
-                    <span className="font-medium text-[var(--text-primary)]">{role.name}</span>
-                    <span className="ml-auto text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                      {role.familiar}
+          <ul className="familiar-tab__rows">
+            {activeRoles.map((role) => {
+              const roleKey = `${role.familiar}:${role.id}`;
+              const open = !!openRoleIds[roleKey];
+              return (
+                <li key={roleKey}>
+                  <button
+                    type="button"
+                    aria-expanded={open}
+                    onClick={() => setOpenRoleIds((current) => ({ ...current, [roleKey]: !open }))}
+                    className="familiar-tab__row-toggle focus-ring"
+                    title={`Inherited from roles/${role.id}/ROLE.md`}
+                  >
+                    <Icon
+                      name={open ? "ph:caret-down" : "ph:caret-right"}
+                      width={10}
+                      className="shrink-0 text-[var(--text-muted)]"
+                      aria-hidden
+                    />
+                    <span className="familiar-tab__row-name">{role.name}</span>
+                    <span className="familiar-tab__row-meta">
+                      {role.familiar} · {role.skills.length} skill{role.skills.length === 1 ? "" : "s"}
                     </span>
-                    {role.skills.length > 0 ? (
-                      <span className="rounded bg-[var(--bg-raised)] px-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                        {role.skills.length} skill{role.skills.length === 1 ? "" : "s"}
-                      </span>
-                    ) : null}
-                  </div>
-                  {role.description ? (
-                    <p className="mt-0.5 line-clamp-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                      {role.description}
-                    </p>
+                  </button>
+                  {open && role.description ? (
+                    <p className="familiar-tab__row-desc">{role.description}</p>
                   ) : null}
                 </li>
-              ))}
-            </ul>
-          </div>
+              );
+            })}
+          </ul>
         )}
-      </CapSection>
+      </CapCard>
 
-      {/* ── Section 2: Skills (3 sub-groups) ──────────────────────────────── */}
-      <CapSection title="Skills" scope={`${allSkillIds.size} total`}>
-        <div className="flex flex-col gap-1.5">
+      {/* ── Skills card (3 provenance groups) ─────────────────────────────── */}
+      <CapCard title="Skills" count={String(allSkillIds.size)} fill>
+        <div className="familiar-tab__card-scroll flex flex-col gap-1">
 
           {/* Role-granted */}
-          {roleGrantedSkillIds.size > 0 ? (
+          {roleGrantedRows.length > 0 ? (
             <CollapsibleSection
               title="Role-granted"
-              badge={`${roleGrantedSkillIds.size} via active roles`}
+              badge={`${roleGrantedRows.length} via active roles`}
               open={skillsRoleOpen}
               onToggle={() => setSkillsRoleOpen((v) => !v)}
             >
-              <ul className="familiar-tab__rows pt-1">
-                {Array.from(roleGrantedSkillIds).map((sid) => {
-                  const skill = localSkills.find((s) => s.id === sid);
-                  return (
-                    <SkillItem
-                      key={sid}
-                      name={skill?.name ?? sid}
-                      kind={skill?.kind ?? "agent"}
-                      description={skill?.description}
-                      tags={skill?.tags}
-                      sourcePath="Granted by an active role"
-                    />
-                  );
-                })}
-              </ul>
+              <SkillRows rows={roleGrantedRows} />
             </CollapsibleSection>
           ) : null}
 
@@ -711,23 +748,12 @@ function FamiliarCapabilityPanel({
             onToggle={() => setSkillsFamiliarOpen((v) => !v)}
           >
             {familiarSkills.length === 0 ? (
-              <div className="px-1 pb-1 pt-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+              <div className="familiar-tab__empty familiar-tab__empty--indent">
                 <p>No skills installed for this familiar yet.</p>
-                <CapCta label="Browse Marketplace →" onClick={() => navigateFamiliarSurface("marketplace")} />
+                <CapCta label="Browse marketplace →" onClick={() => navigateFamiliarSurface("marketplace")} />
               </div>
             ) : (
-              <ul className="familiar-tab__rows pt-1">
-                {familiarSkills.map((s) => (
-                  <SkillItem
-                    key={s.path}
-                    name={s.name}
-                    kind={s.kind ?? "agent"}
-                    description={s.description}
-                    tags={s.tags}
-                    sourcePath={s.path}
-                  />
-                ))}
-              </ul>
+              <SkillRows rows={familiarRows} />
             )}
           </CollapsibleSection>
 
@@ -739,119 +765,109 @@ function FamiliarCapabilityPanel({
             onToggle={() => setSkillsGlobalOpen((v) => !v)}
           >
             {globalSkills.length === 0 ? (
-              <p className="px-1 pb-1 pt-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+              <p className="px-2 pb-1 pt-1 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
                 No global workspace skills.
               </p>
             ) : (
-              <ul className="familiar-tab__rows pt-1">
-                {globalSkills.map((s) => (
-                  <SkillItem
-                    key={s.path}
-                    name={s.name}
-                    kind={s.kind ?? "agent"}
-                    description={s.description}
-                    tags={s.tags}
-                    sourcePath={s.path}
-                  />
-                ))}
-              </ul>
+              <SkillRows rows={globalRows} />
             )}
           </CollapsibleSection>
         </div>
-      </CapSection>
+      </CapCard>
 
       </div>{/* end left column */}
-      <div className="familiar-tab__col flex min-w-0 flex-col gap-2">
+      <div className="familiar-tab__col">
 
-      {/* ── Section 3: Plugins ────────────────────────────────────────────── */}
-      <CapSection title="Plugins" scope={`${nonMcpPlugins.length} from runtime`}>
-        {nonMcpPlugins.length === 0 ? (
-          <div className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
-            <p>No plugins in the latest runtime capability scan.</p>
-            <CapCta label="Open Capabilities →" onClick={() => navigateFamiliarSurface("capabilities")} />
-          </div>
-        ) : (
-          <div className="familiar-tab__list">
-            <ul className="familiar-tab__rows">
-              {nonMcpPlugins.map((p) => (
-                <li key={p.id} className={`px-3 py-2 ${p.enabled ? "" : "opacity-60"}`}>
-                  <div className="flex items-center gap-1.5">
-                    <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
-                    <KindBadge kind={p.kind} />
-                    {/* Chip diet: enabled is the expected state — only the
-                        exception (disabled) earns a marker. */}
-                    {p.enabled ? null : (
-                      <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-muted)]">
-                        disabled
-                      </span>
-                    )}
-                  </div>
-                  {p.command ? (
-                    <p className="mt-0.5 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">{p.command}</p>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </CapSection>
-
-      {/* ── Section 4: Runtime ───────────────────────────────────────────── */}
-      <CapSection
+      {/* ── Runtime card ──────────────────────────────────────────────────── */}
+      <CapCard
         title="Runtime"
-        scope={
-          harnessReport
-            ? `${harnessReport.label} ${harnessReport.version ?? ""}`.trim()
-            : harnessId
+        note={
+          harnessManifest?.scanned_at
+            ? `scanned ${relativeTime(harnessManifest.scanned_at) || "just now"}`
+            : undefined
         }
       >
-        <ul className="space-y-1">
-          <CapRow label="binary" value={harnessReport?.binary ?? "—"} />
-          <CapRow label="path" value={harnessReport?.path ?? "—"} mono />
-          <CapRow label="version" value={harnessReport?.version ?? "—"} />
-          <CapRow label="model" value={familiar.model ?? "—"} />
-          {harnessManifest?.scanned_at ? (
-            <CapRow label="scanned" value={relativeTime(harnessManifest.scanned_at) || "just now"} />
-          ) : null}
+        <ul className="familiar-tab__facts">
+          <li>
+            <span className="familiar-tab__fact-label">Runtime</span>
+            <span className="text-[var(--text-primary)]">
+              {harnessReport ? `${harnessReport.label} ${harnessReport.version ?? ""}`.trim() : harnessId}
+            </span>
+          </li>
+          <li>
+            <span className="familiar-tab__fact-label">Model</span>
+            <span className="font-mono text-[length:var(--text-xs)] text-[var(--text-primary)]">
+              {familiar.model ?? "—"}
+            </span>
+          </li>
+          <li>
+            <span className="familiar-tab__fact-label">Binary</span>
+            <span
+              className="min-w-0 truncate font-mono text-[length:var(--text-xs)] text-[var(--text-primary)]"
+              title={harnessReport?.path ?? undefined}
+            >
+              {harnessReport?.path ?? harnessReport?.binary ?? "—"}
+            </span>
+          </li>
         </ul>
-      </CapSection>
+      </CapCard>
 
-      {/* ── Section 5: MCP Servers ───────────────────────────────────────── */}
-      <CapSection title="MCP Servers" scope={`${mcpPlugins.length} discovered`}>
-        {mcpPlugins.length === 0 ? (
-          <p className="rounded border border-dashed border-[var(--border-hairline)] px-3 py-2.5 text-[var(--text-muted)]">
-            No MCP servers in the capability scan.
-          </p>
-        ) : (
-          <div className="familiar-tab__list">
-            <ul className="familiar-tab__rows">
-              {mcpPlugins.map((p) => (
-                <li key={p.id} className={`px-3 py-2 ${p.enabled ? "" : "opacity-60"}`}>
-                  <div className="flex items-center gap-1.5">
-                    <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
-                    <KindBadge kind="mcp" />
-                    {p.enabled ? null : (
-                      <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-muted)]">
-                        disabled
-                      </span>
-                    )}
-                  </div>
-                  {p.command ? (
-                    <p className="mt-0.5 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={[p.command, ...(p.args ?? [])].join(" ")}>
-                      {[p.command, ...(p.args ?? [])].join(" ")}
-                    </p>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
+      {/* ── Capabilities card (plugins + MCP servers from the scan) ───────── */}
+      <CapCard
+        title="Capabilities"
+        note={`${nonMcpPlugins.length} plugin${nonMcpPlugins.length === 1 ? "" : "s"} · ${mcpPlugins.length} MCP`}
+      >
+        {harnessPlugins.length === 0 ? (
+          <div className="familiar-tab__empty">
+            <p>No plugins or MCP servers in the latest capability scan.</p>
+            <CapCta label="Open capabilities →" onClick={() => navigateFamiliarSurface("capabilities")} />
           </div>
+        ) : (
+          <ul className="familiar-tab__rows">
+            {nonMcpPlugins.map((p) => (
+              <li key={p.id} className={`px-2 py-1.5 ${p.enabled ? "" : "opacity-60"}`}>
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
+                  <KindBadge kind={p.kind} />
+                  {/* Chip diet: enabled is the expected state — only the
+                      exception (disabled) earns a marker. */}
+                  {p.enabled ? null : (
+                    <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-muted)]">
+                      disabled
+                    </span>
+                  )}
+                </div>
+                {p.command ? (
+                  <p className="mt-0.5 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">{p.command}</p>
+                ) : null}
+              </li>
+            ))}
+            {mcpPlugins.map((p) => (
+              <li key={p.id} className={`px-2 py-1.5 ${p.enabled ? "" : "opacity-60"}`}>
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
+                  <KindBadge kind="mcp" />
+                  {p.enabled ? null : (
+                    <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-muted)]">
+                      disabled
+                    </span>
+                  )}
+                </div>
+                {p.command ? (
+                  <p className="mt-0.5 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={[p.command, ...(p.args ?? [])].join(" ")}>
+                    {[p.command, ...(p.args ?? [])].join(" ")}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
         )}
-      </CapSection>
+      </CapCard>
 
-      {/* ── Section 6: Warnings ─────────────────────────────────────────── */}
+      {/* ── Warnings card ─────────────────────────────────────────────────── */}
       {warnings.length > 0 ? (
-        <CapSection title="Warnings" scope={String(warnings.length)}>
-          <ul className="space-y-1">
+        <CapCard title="Warnings" count={String(warnings.length)}>
+          <ul className="familiar-tab__rows gap-1">
             {warnings.map((w, i) => (
               <li
                 key={i}
@@ -865,22 +881,93 @@ function FamiliarCapabilityPanel({
               </li>
             ))}
           </ul>
-        </CapSection>
+        </CapCard>
       ) : null}
 
       </div>{/* end right column */}
-      </div>{/* end capability grid */}
+      </div>{/* end card grid */}
 
     </div>
   );
 }
 
-// ── Surface ──────────────────────────────────────────────────────────────────
+// ── Roster rail ──────────────────────────────────────────────────────────────
 
 /**
- * The tab owns its landmark, scroll region, and empty state — it is a
- * first-class chat surface, not a re-hosted inspector pane.
+ * The left-hand roster: a SurfaceRail listing every selectable familiar.
+ * Selection here switches the DETAIL only (local state in the surface) — it
+ * never mutates the app-wide familiar scope.
  */
+function FamiliarRosterRail({
+  familiars,
+  selectedId,
+  query,
+  onQueryChange,
+  onSelect,
+}: {
+  familiars: ResolvedFamiliar[];
+  selectedId: string;
+  query: string;
+  onQueryChange: (next: string) => void;
+  onSelect: (id: string) => void;
+}) {
+  const needle = query.trim().toLowerCase();
+  const filtered = needle
+    ? familiars.filter(
+        (item) =>
+          item.display_name.toLowerCase().includes(needle) ||
+          (item.role ?? "").toLowerCase().includes(needle),
+      )
+    : familiars;
+  return (
+    <SurfaceRail
+      storageKey="cave:familiar-tab:rail"
+      title="Familiars"
+      ariaLabel="Familiars"
+      search={
+        <SearchInput
+          value={query}
+          onValueChange={onQueryChange}
+          onClear={() => onQueryChange("")}
+          placeholder="Search familiars…"
+          aria-label="Search familiars"
+        />
+      }
+    >
+      {(open) => (
+        <>
+          {filtered.length === 0 ? (
+            <p className="px-2 py-1.5 text-[length:var(--text-sm)] text-[var(--text-muted)]">
+              No familiars match &ldquo;{query.trim()}&rdquo;.
+            </p>
+          ) : null}
+          {filtered.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className="familiar-tab__rail-row focus-ring"
+              aria-current={item.id === selectedId ? "true" : undefined}
+              title={open ? undefined : item.display_name}
+              aria-label={open ? undefined : item.display_name}
+              onClick={() => onSelect(item.id)}
+            >
+              <FamiliarAvatar familiar={item} size="md" />
+              {open ? (
+                <span className="familiar-tab__rail-text">
+                  <span className="familiar-tab__rail-name">{item.display_name}</span>
+                  <span className="familiar-tab__rail-role">{item.role || "No role"}</span>
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </>
+      )}
+    </SurfaceRail>
+  );
+}
+
+// ── Surface ──────────────────────────────────────────────────────────────────
+
 /**
  * Capability data, identity, and section rendering for the chat Familiar
  * surface. The public ChatFamiliarView module keeps the historic import path
@@ -916,6 +1003,17 @@ export function ChatFamiliarCapabilities({
   const selectedFamiliar = familiar
     ? resolvedFamiliars.find((item) => item.id === familiar.id) ?? null
     : null;
+
+  // Rail-local detail selection: browsing the roster switches the detail pane
+  // only; the app-wide active familiar (and saved scope) never changes from
+  // here. A new app-wide selection re-anchors the detail.
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const [railQuery, setRailQuery] = useState("");
+  const activeFamiliarId = familiar?.id ?? null;
+  useEffect(() => {
+    setDetailId(null);
+  }, [activeFamiliarId]);
+
   const state = deriveFamiliarTabState({
     familiars: selectableFamiliars,
     selectedIds: selectedFamiliarIds,
@@ -1014,18 +1112,30 @@ export function ChatFamiliarCapabilities({
     );
   }
 
+  const detailFamiliar =
+    (detailId ? selectableFamiliars.find((item) => item.id === detailId) : null) ?? state.familiar;
+
   return (
     <section
-      className="chat-familiar-view flex h-full min-h-0 flex-col overflow-y-auto"
+      className="chat-familiar-view familiar-tab flex h-full min-h-0 flex-row"
       aria-label="Familiar profile"
     >
-      {state.rosterWarning ? <FamiliarRosterWarning message={state.rosterWarning} onRetry={onRetryFamiliars} /> : null}
-      <FamiliarCapabilityPanel
-        key={state.familiar.id}
-        familiar={state.familiar}
-        daemonRunning={daemonRunning}
-        onStartChat={onStartChat}
+      <FamiliarRosterRail
+        familiars={selectableFamiliars}
+        selectedId={detailFamiliar.id}
+        query={railQuery}
+        onQueryChange={setRailQuery}
+        onSelect={setDetailId}
       />
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {state.rosterWarning ? <FamiliarRosterWarning message={state.rosterWarning} onRetry={onRetryFamiliars} /> : null}
+        <FamiliarCapabilityPanel
+          key={detailFamiliar.id}
+          familiar={detailFamiliar}
+          daemonRunning={daemonRunning}
+          onStartChat={onStartChat}
+        />
+      </div>
     </section>
   );
 }

--- a/src/components/familiar-tab-bridges.test.ts
+++ b/src/components/familiar-tab-bridges.test.ts
@@ -3,15 +3,16 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Familiar tab bridges + ergonomics (cave-aovo). The tab must not dead-end:
-// from the hero you can reach the familiar's memory, its Studio editor, its
-// profile card / analytics (pinned in familiar-tab-hero.test.ts), and start a
-// fresh chat. Touch targets grow on coarse pointers, and the pane is a
-// labelled landmark.
+// Familiar tab bridges + ergonomics (cave-aovo, redesigned by the design
+// handoff into the header's pill row). The tab must not dead-end: from the
+// header you can reach the familiar's memory, its Studio editor, its profile
+// card / analytics (pinned in familiar-tab-hero.test.ts), and start a fresh
+// chat. Touch targets grow on coarse pointers, and the pane is a labelled
+// landmark.
 
 const src = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/familiar-tab.css", import.meta.url), "utf8");
 
 test("memory bridge: the sibling pane's content is reachable via the Studio memory tab", () => {
   assert.match(
@@ -21,20 +22,20 @@ test("memory bridge: the sibling pane's content is reachable via the Studio memo
   );
   assert.match(
     src,
-    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("memory", familiar\.id\)\}[\s\S]{0,300}?Memory →/,
-    "Memory → opens the Studio memory tab for this familiar",
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("memory", familiar\.id\)\}[\s\S]{0,300}?>\s*Memory\s*</,
+    "Memory pill opens the Studio memory tab for this familiar",
   );
 });
 
 test("studio bridge: Edit in Studio preselects this familiar's identity tab", () => {
   assert.match(
     src,
-    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("identity", familiar\.id\)\}[\s\S]{0,300}?Edit in Studio →/,
-    "Edit in Studio → opens the Studio identity tab",
+    /onClick=\{\(\) => openFamiliarStudioSettingsTab\("identity", familiar\.id\)\}[\s\S]{0,300}?>\s*Edit in Studio\s*</,
+    "Edit in Studio pill opens the Studio identity tab",
   );
 });
 
-test("new chat is the hero's primary action — the one filled-accent control", () => {
+test("new chat is the header's primary action — the one filled-accent control", () => {
   assert.match(src, /onStartChat\?: \(familiarId: string\) => void/, "typed callback seam");
   assert.match(
     src,
@@ -85,8 +86,8 @@ test("voice bridge: a configured speaking voice is shown and opens the Studio Br
 });
 
 test("coarse pointers get honest touch targets without changing pointer-fine rhythm", () => {
-  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,600}?\.familiar-tab__links a,\s*\.familiar-tab__links button \{[^}]*padding-block/, "hero links grow");
-  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,900}?\.familiar-tab__list > button \{[^}]*padding-block/, "group toggles grow");
+  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,600}?\.familiar-tab__links a,\s*\.familiar-tab__links button \{[^}]*min-height: 32px/, "header pills grow");
+  assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,900}?\.familiar-tab__group-toggle,\s*\.familiar-tab__row-toggle \{[^}]*padding-block/, "group and role toggles grow");
   assert.match(css, /@media \(pointer: coarse\) \{[\s\S]{0,1200}?\.familiar-tab__cta \{[^}]*padding-block/, "teach CTAs grow");
-  assert.match(src, /className="familiar-tab__links mt-2/, "hero links row carries the coarse-pointer hook");
+  assert.match(src, /className="familiar-tab__links mt-2/, "header pill row carries the coarse-pointer hook");
 });

--- a/src/components/familiar-tab-hero.test.ts
+++ b/src/components/familiar-tab-hero.test.ts
@@ -3,16 +3,18 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Familiar tab identity hero + wide-canvas layout (cave-5p3y).
+// Familiar tab identity hero + wide-canvas layout (cave-5p3y, redesigned by
+// the design handoff).
 //
 // The chat surface's Familiar tab is a first-class identity surface, not a
 // relocated 320px inspector sidepanel: it must open on WHO the familiar is
 // (avatar, serif display name, role, presence, runtime) before WHAT it can do
-// (the capability grid), and the grid must earn a wide canvas with two columns.
+// (the capability cards), and the card grid must earn a wide pane with the
+// handoff's 1.5fr/1fr columns.
 
 const src = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/familiar-tab.css", import.meta.url), "utf8");
 
 test("identity hero leads the Familiar tab and paints before the capability fetches", () => {
   assert.match(src, /function FamiliarIdentityHero\(/, "hero component declared");
@@ -39,10 +41,18 @@ test("hero identity contract: resolved avatar, serif name, role line, presence",
     "name uses the serif identity face",
   );
   assert.match(src, /\{daemonRunning \? "online" : "offline"\}/, "presence line from daemon reachability");
+  // Presence is a hairline pill chip whose online state tints with the
+  // presence accent (the design language's accent, not the mock's green).
+  assert.match(src, /className="familiar-tab__presence" data-online=\{daemonRunning \? "true" : "false"\}/, "presence chip carries the online state");
+  assert.match(
+    css,
+    /\.familiar-tab__presence\[data-online="true"\] \{[^}]*color: var\(--accent-presence\)/,
+    "online chip tints with the presence accent",
+  );
   assert.match(
     src,
     /activeSessions > 0 \? \([\s\S]*?bg-\[var\(--accent-presence\)\]\/15/,
-    "active-session chip is the accent moment",
+    "active-session chip is the accent moment, adjacent to the online chip",
   );
 });
 
@@ -50,38 +60,50 @@ test("hero bridges: profile card + analytics links (roster idiom, no second iden
   assert.match(
     src,
     /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/profile`\}/,
-    "Profile → links to the cave-ujbr profile card route",
+    "Profile links to the cave-ujbr profile card route",
   );
   assert.match(
     src,
     /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/,
-    "Analytics → links to the analytics route",
+    "Analytics links to the analytics route",
+  );
+  // The handoff's chip row: runtime + model as mono hairline pills, a divider,
+  // then the accent link pills.
+  assert.match(src, /familiar\.harness \? \(\s*<span className="familiar-tab__pill font-mono" title="Runtime">/, "runtime pill");
+  assert.match(src, /familiar\.model \? \(\s*<span className="familiar-tab__pill font-mono" title="Model">/, "model pill");
+  assert.match(src, /className="familiar-tab__links-divider" aria-hidden="true"/, "divider between metadata and links");
+  assert.match(
+    css,
+    /\.familiar-tab__link-pill:hover \{[^}]*background: color-mix\(in oklch, var\(--accent-presence\) 10%, transparent\)/,
+    "link pills hover with the 10% accent tint",
   );
 });
 
-test("wide-canvas layout: container-query grid, two columns >=900px, single below", () => {
-  assert.match(css, /\.familiar-tab \{[^}]*container-type: inline-size/, "panel measures its own inline size");
+test("wide-canvas layout: container-query card grid, 1.5fr/1fr >=840px, single below", () => {
+  assert.match(css, /\.familiar-tab__main \{[^}]*container-type: inline-size/, "detail pane measures its own inline size");
   assert.match(css, /\.familiar-tab__grid \{[^}]*grid-template-columns: minmax\(0, 1fr\)/, "single column default");
   assert.match(
     css,
-    /@container \(min-width: 900px\) \{[\s\S]*?\.familiar-tab__grid \{[\s\S]*?grid-template-columns: minmax\(0, 1\.15fr\) minmax\(0, 1fr\)/,
-    "two-column grid on a wide canvas",
+    /@container \(min-width: 840px\) \{[\s\S]*?\.familiar-tab__grid \{[\s\S]*?grid-template-columns: minmax\(0, 1\.5fr\) minmax\(0, 1fr\)/,
+    "two-column 1.5fr/1fr grid on a wide pane",
   );
   const cols = src.match(/familiar-tab__col/g) ?? [];
-  assert.ok(cols.length >= 2, "capability sections split into two source-ordered columns");
+  assert.ok(cols.length >= 2, "capability cards split into two source-ordered columns");
 });
 
-test("sticky hero pins inside the Familiar tab scroll region without hiding focus", () => {
+test("header stays put; the card grid (or its columns) own the scrolling", () => {
   assert.match(
     src,
-    /className="chat-familiar-view flex h-full min-h-0 flex-col overflow-y-auto"[\s\S]{0,120}?aria-label="Familiar profile"/,
-    "the section remains the labelled scroll container",
+    /className="chat-familiar-view familiar-tab flex h-full min-h-0 flex-row"[\s\S]{0,80}?aria-label="Familiar profile"/,
+    "the section remains the labelled landmark, now hosting rail + detail",
   );
-  assert.match(css, /\.chat-familiar-view \{[^}]*-webkit-overflow-scrolling: touch/, "touch momentum scroll remains enabled");
-  assert.match(css, /\.chat-familiar-view \{[^}]*scroll-padding-top: 112px/, "scroll container reserves space for the pinned hero");
-  assert.match(css, /\.chat-familiar-view :is\(a, button, \[tabindex\]\):focus \{[^}]*scroll-margin-top: 112px/, "focused controls scroll clear of the hero");
-  assert.match(css, /\.familiar-tab__hero \{[^}]*position: sticky;[\s\S]*?top: 0;[\s\S]*?z-index: 2/, "hero pins at the top of the tab");
-  assert.match(css, /\.familiar-tab__hero \{[\s\S]*?background: var\(--glass-raised\);[\s\S]*?backdrop-filter/, "sticky band keeps the glass treatment over scrolled content");
+  assert.match(css, /\.familiar-tab__hero \{[^}]*flex: none/, "identity header never scrolls away");
+  assert.match(css, /\.familiar-tab__grid \{[^}]*overflow-y: auto/, "stacked grid scrolls as one region on narrow panes");
+  assert.match(
+    css,
+    /@container \(min-width: 840px\) \{[\s\S]*?\.familiar-tab__col \{[\s\S]*?overflow-y: auto/,
+    "wide panes give each column its own scroll",
+  );
 });
 
 test("the chat surface gives the tab a wide canvas and threads presence", () => {

--- a/src/components/familiar-tab-scope.test.ts
+++ b/src/components/familiar-tab-scope.test.ts
@@ -26,8 +26,37 @@ test("the view renders explicit lifecycle, scope, and unavailable states", () =>
     assert.match(view, new RegExp(`state\\.kind === "${kind}"`), `${kind} state rendered explicitly`);
   }
   assert.match(view, /state\.kind === "all" \|\| state\.kind === "subset"/, "all and subset share the overview");
-  assert.match(view, /<FamiliarCapabilityPanel[\s\S]*?familiar=\{state\.familiar\}/, "single state retains the capability panel");
+  assert.match(
+    view,
+    /const detailFamiliar =\s*\(detailId \? selectableFamiliars\.find\(\(item\) => item\.id === detailId\) : null\) \?\? state\.familiar;/,
+    "the detail defaults to the app-wide active familiar",
+  );
+  assert.match(view, /<FamiliarCapabilityPanel[\s\S]*?familiar=\{detailFamiliar\}/, "single state retains the capability panel");
   assert.doesNotMatch(view, /No familiar selected/, "nullable single-familiar copy is gone");
+});
+
+test("the roster rail browses locally — it never mutates the app-wide scope", () => {
+  assert.match(view, /<FamiliarRosterRail/, "single state hosts the roster rail");
+  assert.match(view, /storageKey="cave:familiar-tab:rail"/, "rail persists under its own key");
+  assert.match(view, /placeholder="Search familiars…"/, "rail search follows placeholder grammar");
+  assert.match(
+    view,
+    /item\.display_name\.toLowerCase\(\)\.includes\(needle\) \|\|\s*\(item\.role \?\? ""\)\.toLowerCase\(\)\.includes\(needle\)/,
+    "search filters by name and role",
+  );
+  assert.match(view, /aria-current=\{item\.id === selectedId \? "true" : undefined\}/, "selected row announced with aria-current");
+  assert.match(view, /onSelect=\{setDetailId\}/, "row activation only moves the local detail selection");
+  const rail = view.slice(view.indexOf("function FamiliarRosterRail"), view.indexOf("// ── Surface"));
+  assert.ok(rail.length > 0, "rail component located");
+  assert.doesNotMatch(rail, /onFamiliarScopeChange/, "the rail cannot reach the scope mutation path");
+  // A new app-wide selection re-anchors the local detail.
+  assert.match(
+    view,
+    /useEffect\(\(\) => \{\s*setDetailId\(null\);\s*\}, \[activeFamiliarId\]\)/,
+    "active familiar changes reset the local browse selection",
+  );
+  // Collapsed rail rows fall back to avatar-only buttons with tooltip names.
+  assert.match(view, /title=\{open \? undefined : item\.display_name\}/, "collapsed rows keep tooltip names");
 });
 
 test("overview activation is the only action that narrows scope", () => {

--- a/src/components/familiar-tab-sections.test.ts
+++ b/src/components/familiar-tab-sections.test.ts
@@ -3,15 +3,14 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Familiar tab capability sections — de-box / one-accent / teach states
-// (cave-7e1l). The inspector-era section styling put an accent tint, border,
-// or colored chip on nearly every row; empty states named pages with no
-// affordance; raw filesystem paths ran as body copy. This pins the facelift
-// language: washes + hairlines, accent reserved for presence, CTAs on empty
-// states, paths demoted to tooltips.
+// Familiar tab capability sections — cards / one-accent / teach states
+// (cave-7e1l, redesigned by the design handoff into Roles / Skills / Runtime /
+// Capabilities cards). This pins the card language: hairline-bordered
+// translucent panels, neutral kind metadata, accent reserved for presence,
+// CTAs on empty states, paths demoted to tooltips.
 
 const src = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/familiar-tab.css", import.meta.url), "utf8");
 const navigation = readFileSync(new URL("../lib/familiar-surface-navigation.ts", import.meta.url), "utf8");
 
 test("KindBadge is neutral — the per-kind color map is gone", () => {
@@ -21,10 +20,11 @@ test("KindBadge is neutral — the per-kind color map is gone", () => {
   assert.doesNotMatch(badge, /accent-presence|color-success|color-warning/, "no status colors on kind metadata");
 });
 
-test("capability rows are de-boxed: shared list wash + hairline dividers, no accent tints", () => {
-  assert.match(css, /\.familiar-tab__list \{[^}]*color-mix\(in oklch, var\(--bg-raised\) 40%, transparent\)/, "group wash");
-  assert.match(css, /\.familiar-tab__list \{[^}]*inset 0 0 0 1px color-mix\(in oklch, var\(--border-hairline\)/, "soft inset hairline, no hard border");
-  assert.match(css, /\.familiar-tab__rows > li \+ li \{[^}]*border-top: 1px solid color-mix\(in oklch, var\(--border-hairline\)/, "hairline row dividers");
+test("capability cards: hairline border + translucent panel wash, no accent tints on rows", () => {
+  assert.match(css, /\.familiar-tab__card \{[^}]*border: 1px solid var\(--border-hairline\)/, "cards are hairline-bordered");
+  assert.match(css, /\.familiar-tab__card \{[^}]*color-mix\(in oklch, var\(--bg-raised\) 40%, transparent\)/, "40% translucent panel wash");
+  assert.match(src, /function CapCard\(/, "one shared card scaffold");
+  assert.match(css, /\.familiar-tab__card-title \{[^}]*text-transform: uppercase/, "uppercase card headers");
   // The old boxed/tinted row classes must not survive anywhere in the panel.
   assert.doesNotMatch(src, /border-\[color-mix\(in_oklch,var\(--accent-presence\)_20%,transparent\)\]/, "no accent-bordered role boxes");
   assert.doesNotMatch(src, /bg-\[color-mix\(in_oklch,var\(--accent-presence\)_10%,transparent\)\] px-2 py-1/, "no accent-tinted skill rows");
@@ -33,45 +33,87 @@ test("capability rows are de-boxed: shared list wash + hairline dividers, no acc
   assert.doesNotMatch(src, /accentClass/, "collapsible groups lost their colored left-border seam");
 });
 
-test("skills render through one shared SkillItem row with the path demoted to a tooltip", () => {
+test("roles are expandable rows: chevron + name + meta, description on demand", () => {
+  assert.match(src, /aria-expanded=\{open\}[\s\S]{0,300}?title=\{`Inherited from roles\/\$\{role\.id\}\/ROLE\.md`\}/, "role rows toggle with provenance in the tooltip");
+  assert.match(src, /\{role\.familiar\} · \{role\.skills\.length\} skill\{role\.skills\.length === 1 \? "" : "s"\}/, "meta names the scope and skill count");
+  assert.match(src, /\{open && role\.description \? \(\s*<p className="familiar-tab__row-desc">/, "descriptions render only when expanded");
+});
+
+test("skills render through one shared row path with the path demoted to a tooltip", () => {
   assert.match(src, /function SkillItem\(/, "shared row component");
-  const items = src.match(/<SkillItem\b/g) ?? [];
-  assert.ok(items.length >= 3, `all three provenance groups use SkillItem (got ${items.length})`);
-  assert.match(src, /<li className="px-2 py-1\.5" title=\{sourcePath\}>/, "source path is a tooltip, not body copy");
+  const groups = src.match(/<SkillRows\b/g) ?? [];
+  assert.ok(groups.length >= 3, `all three provenance groups render through SkillRows (got ${groups.length})`);
+  assert.match(src, /<li className="familiar-tab__skill-row" title=\{sourcePath\}>/, "source path is a tooltip, not body copy");
+  assert.match(src, /font-mono text-\[length:var\(--text-base\)\] font-medium/, "skill names are mono");
   // Raw workspace paths no longer run as visible copy.
   assert.doesNotMatch(src, /No skills in ~\/\.openclaw/, "empty copy no longer recites raw paths");
   assert.doesNotMatch(src, /inherited from: roles\//, "role provenance path is not body copy");
-  assert.match(src, /title=\{`Inherited from roles\/\$\{role\.id\}\/ROLE\.md`\}/, "role provenance lives in the row tooltip");
+});
+
+test("skill groups preview 6 rows with a Show N more / Show fewer toggle", () => {
+  assert.match(src, /const SKILL_GROUP_PREVIEW = 6/, "preview cap");
+  assert.match(
+    src,
+    /const hiddenCount = rows\.length - SKILL_GROUP_PREVIEW;[\s\S]{0,120}?rows\.slice\(0, SKILL_GROUP_PREVIEW\)/,
+    "rows beyond the cap are held back",
+  );
+  assert.match(src, /\{showAll \? "Show fewer" : `Show \$\{hiddenCount\} more`\}/, "state-aware toggle copy");
 });
 
 test("every teach state has a real CTA riding cave:navigate-mode", () => {
   assert.match(navigation, /function navigateFamiliarSurface\(mode: "roles" \| "capabilities" \| "marketplace"\)/, "navigate helper");
   assert.match(navigation, /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode \} \}\)/, "workspace bridge event");
-  assert.match(src, /No roles active for this familiar\.[\s\S]{0,200}?CapCta label="Open Roles →" onClick=\{\(\) => navigateFamiliarSurface\("roles"\)\}/, "roles empty → Open Roles");
-  assert.match(src, /No plugins in the latest runtime capability scan\.[\s\S]{0,200}?CapCta label="Open Capabilities →" onClick=\{\(\) => navigateFamiliarSurface\("capabilities"\)\}/, "plugins empty → Open Capabilities");
-  assert.match(src, /No skills installed for this familiar yet\.[\s\S]{0,200}?CapCta label="Browse Marketplace →" onClick=\{\(\) => navigateFamiliarSurface\("marketplace"\)\}/, "familiar skills empty → Browse Marketplace");
+  assert.match(src, /No roles active for this familiar\.[\s\S]{0,200}?CapCta label="Open roles →" onClick=\{\(\) => navigateFamiliarSurface\("roles"\)\}/, "roles empty → Open roles");
+  assert.match(src, /No plugins or MCP servers in the latest capability scan\.[\s\S]{0,200}?CapCta label="Open capabilities →" onClick=\{\(\) => navigateFamiliarSurface\("capabilities"\)\}/, "capabilities empty → Open capabilities");
+  assert.match(src, /No skills installed for this familiar yet\.[\s\S]{0,200}?CapCta label="Browse marketplace →" onClick=\{\(\) => navigateFamiliarSurface\("marketplace"\)\}/, "familiar skills empty → Browse marketplace");
   assert.match(src, /function CapCta\([\s\S]*?focus-ring/, "CTA buttons carry the shared focus ring");
+  // Dashed = invitation: the empty rows use the dashed hairline idiom.
+  assert.match(css, /\.familiar-tab__empty \{[^}]*border: 1px dashed var\(--border-hairline\)/, "dashed empty rows");
 });
 
 test("chip diet: enabled is silent, only disabled earns a marker (and a dimmed row)", () => {
   assert.doesNotMatch(src, /\{p\.enabled \? "enabled" : "disabled"\}/, "no enabled/disabled twin chips");
   const disabledMarkers = src.match(/\{p\.enabled \? null : \(/g) ?? [];
-  assert.ok(disabledMarkers.length >= 2, "plugins + MCP rows only mark the disabled exception");
+  assert.ok(disabledMarkers.length >= 2, "plugin + MCP rows only mark the disabled exception");
   const dimmedRows = src.match(/p\.enabled \? "" : "opacity-60"/g) ?? [];
   assert.ok(dimmedRows.length >= 2, "disabled rows dim instead of chipping");
 });
 
 test("collapsible groups are keyboard-honest: aria-expanded + focus ring", () => {
-  const section = src.slice(src.indexOf("function CollapsibleSection"), src.indexOf("// ── Main panel"));
+  const section = src.slice(src.indexOf("function CollapsibleSection"), src.indexOf("function CapCard"));
   assert.match(section, /aria-expanded=\{open\}/, "toggle announces its state");
   assert.match(section, /focus-ring/, "toggle has the shared focus ring");
 });
 
-test("runtime section drops the duplicate runtime row; loading shimmer is grid-shaped", () => {
-  assert.doesNotMatch(src, /<CapRow label="runtime"/, "the header scope already names the runtime");
+test("runtime card: label/value facts with scan freshness; loading shimmer is grid-shaped", () => {
+  assert.doesNotMatch(src, /<CapRow label="runtime"/, "no duplicate runtime row");
+  assert.match(
+    src,
+    /harnessManifest\?\.scanned_at\s*\?\s*`scanned \$\{relativeTime\(harnessManifest\.scanned_at\) \|\| "just now"\}`/,
+    "scan freshness sits in the card header",
+  );
+  assert.match(src, /familiar-tab__fact-label">Runtime<\/span>/, "Runtime fact");
+  assert.match(src, /familiar-tab__fact-label">Model<\/span>/, "Model fact");
+  assert.match(
+    src,
+    /familiar-tab__fact-label">Binary<\/span>[\s\S]{0,300}?title=\{harnessReport\?\.path \?\? undefined\}/,
+    "Binary path is ellipsized with a full-path tooltip",
+  );
+  assert.match(css, /\.familiar-tab__fact-label \{[^}]*width: 64px/, "64px muted fact labels");
   assert.match(
     src,
     /if \(loading\) \{[\s\S]*?<div className="familiar-tab__grid" aria-hidden>[\s\S]*?<SkeletonRows[\s\S]*?<SkeletonRows/,
     "loading shimmer mirrors the two-column grid it resolves into",
   );
+});
+
+test("capabilities card merges plugins + MCP servers with an honest summary", () => {
+  assert.match(
+    src,
+    /title="Capabilities"[\s\S]{0,200}?\$\{nonMcpPlugins\.length\} plugin\$\{nonMcpPlugins\.length === 1 \? "" : "s"\} · \$\{mcpPlugins\.length\} MCP/,
+    "summary counts both kinds",
+  );
+  assert.match(src, /\{nonMcpPlugins\.map\(/, "plugin rows");
+  assert.match(src, /\{mcpPlugins\.map\(/, "MCP rows");
+  assert.match(src, /<KindBadge kind="mcp" \/>/, "MCP rows keep the existing kind label");
 });

--- a/src/components/surface-rail.test.ts
+++ b/src/components/surface-rail.test.ts
@@ -1,0 +1,199 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// SurfaceRail — the shared collapsible/resizable list rail primitive that the
+// design-handoff surfaces (Sessions / Projects / Group / Familiar) reuse.
+// Pure logic (clamp, persistence, keyboard resize) is exercised directly from
+// src/lib/surface-rail-state.ts; the component + stylesheet contracts are
+// pinned as source text per repo convention.
+
+import {
+  SURFACE_RAIL_DEFAULT_WIDTH,
+  SURFACE_RAIL_MIN_WIDTH,
+  SURFACE_RAIL_MAX_WIDTH,
+  SURFACE_RAIL_COLLAPSED_WIDTH,
+  SURFACE_RAIL_KEY_STEP,
+  clampSurfaceRailWidth,
+  readSurfaceRailPrefs,
+  writeSurfaceRailWidth,
+  writeSurfaceRailOpen,
+  surfaceRailWidthKey,
+  surfaceRailOpenKey,
+  surfaceRailKeyboardResize,
+} from "../lib/surface-rail-state.ts";
+
+const src = readFileSync(new URL("./ui/surface-rail.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/surface-rail.css", import.meta.url), "utf8");
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    map,
+    getItem: (key: string) => (map.has(key) ? map.get(key) : null),
+    setItem: (key: string, value: string) => {
+      map.set(key, String(value));
+    },
+  };
+}
+
+const throwingStorage = {
+  getItem() {
+    throw new Error("storage denied");
+  },
+  setItem() {
+    throw new Error("storage denied");
+  },
+};
+
+test("clamp: 200–440 range, rounded, NaN falls back to the default", () => {
+  assert.equal(SURFACE_RAIL_DEFAULT_WIDTH, 280);
+  assert.equal(SURFACE_RAIL_MIN_WIDTH, 200);
+  assert.equal(SURFACE_RAIL_MAX_WIDTH, 440);
+  assert.equal(clampSurfaceRailWidth(280), 280);
+  assert.equal(clampSurfaceRailWidth(320.6), 321, "widths round to whole px");
+  assert.equal(clampSurfaceRailWidth(10), SURFACE_RAIL_MIN_WIDTH);
+  assert.equal(clampSurfaceRailWidth(-50), SURFACE_RAIL_MIN_WIDTH);
+  assert.equal(clampSurfaceRailWidth(9999), SURFACE_RAIL_MAX_WIDTH);
+  assert.equal(clampSurfaceRailWidth(Number.NaN), SURFACE_RAIL_DEFAULT_WIDTH);
+  assert.equal(clampSurfaceRailWidth(Number.NaN, 300), 300, "explicit fallback wins");
+  assert.equal(
+    clampSurfaceRailWidth(Number.POSITIVE_INFINITY, 300),
+    300,
+    "non-finite candidates use the fallback, not the max",
+  );
+});
+
+test("persistence keys derive from storageKey (`<key>:width` / `<key>:open`)", () => {
+  assert.equal(surfaceRailWidthKey("cave:familiar-tab:rail"), "cave:familiar-tab:rail:width");
+  assert.equal(surfaceRailOpenKey("cave:familiar-tab:rail"), "cave:familiar-tab:rail:open");
+});
+
+test("read: defaults on empty storage, persisted values clamp, garbage/failed storage falls back", () => {
+  assert.deepEqual(readSurfaceRailPrefs(fakeStorage(), "k"), {
+    width: SURFACE_RAIL_DEFAULT_WIDTH,
+    open: true,
+  });
+  assert.deepEqual(
+    readSurfaceRailPrefs(fakeStorage({ "k:width": "320", "k:open": "0" }), "k"),
+    { width: 320, open: false },
+  );
+  assert.deepEqual(
+    readSurfaceRailPrefs(fakeStorage({ "k:width": "9999", "k:open": "1" }), "k"),
+    { width: SURFACE_RAIL_MAX_WIDTH, open: true },
+    "persisted widths re-clamp on read",
+  );
+  assert.deepEqual(
+    readSurfaceRailPrefs(fakeStorage({ "k:width": "banana" }), "k", 260),
+    { width: 260, open: true },
+    "unparseable widths keep the caller default",
+  );
+  assert.deepEqual(readSurfaceRailPrefs(null, "k"), {
+    width: SURFACE_RAIL_DEFAULT_WIDTH,
+    open: true,
+  });
+  assert.deepEqual(
+    readSurfaceRailPrefs(throwingStorage, "k"),
+    { width: SURFACE_RAIL_DEFAULT_WIDTH, open: true },
+    "storage failures are silently ignored",
+  );
+});
+
+test("write: clamped width + open flag round-trip; failures never throw", () => {
+  const storage = fakeStorage();
+  writeSurfaceRailWidth(storage, "k", 999);
+  writeSurfaceRailOpen(storage, "k", false);
+  assert.equal(storage.map.get("k:width"), String(SURFACE_RAIL_MAX_WIDTH));
+  assert.equal(storage.map.get("k:open"), "0");
+  writeSurfaceRailOpen(storage, "k", true);
+  assert.equal(storage.map.get("k:open"), "1");
+  assert.deepEqual(readSurfaceRailPrefs(storage, "k"), { width: SURFACE_RAIL_MAX_WIDTH, open: true });
+  assert.doesNotThrow(() => writeSurfaceRailWidth(throwingStorage, "k", 300));
+  assert.doesNotThrow(() => writeSurfaceRailOpen(throwingStorage, "k", true));
+});
+
+test("keyboard resize: Left narrows / Right widens ±16, clamped; other keys are ignored", () => {
+  assert.equal(SURFACE_RAIL_KEY_STEP, 16);
+  assert.equal(surfaceRailKeyboardResize(280, "ArrowLeft"), 264);
+  assert.equal(surfaceRailKeyboardResize(280, "ArrowRight"), 296);
+  assert.equal(surfaceRailKeyboardResize(SURFACE_RAIL_MIN_WIDTH, "ArrowLeft"), SURFACE_RAIL_MIN_WIDTH);
+  assert.equal(surfaceRailKeyboardResize(SURFACE_RAIL_MAX_WIDTH, "ArrowRight"), SURFACE_RAIL_MAX_WIDTH);
+  assert.equal(surfaceRailKeyboardResize(280, "ArrowUp"), null);
+  assert.equal(surfaceRailKeyboardResize(280, "Enter"), null);
+});
+
+test("component: prefs read lazily behind a window guard, written on change", () => {
+  assert.match(
+    src,
+    /typeof window === "undefined" \? null : window\.localStorage/,
+    "storage access is SSR-guarded",
+  );
+  assert.match(
+    src,
+    /useState\(\(\) => readSurfaceRailPrefs\(localStorageOrNull\(\), storageKey, defaultWidth\)\)/,
+    "prefs are read lazily on first render",
+  );
+  assert.match(src, /writeSurfaceRailWidth\(localStorageOrNull\(\), storageKey, width\)/, "width persists on change");
+  assert.match(src, /writeSurfaceRailOpen\(localStorageOrNull\(\), storageKey, open\)/, "open persists on change");
+});
+
+test("component: collapse toggle is a real button with aria-expanded and state-aware names", () => {
+  assert.match(src, /aria-expanded=\{open\}/, "toggle announces expansion state");
+  assert.match(src, /open \? "Collapse sidebar" : "Expand sidebar"/, "state-aware accessible name");
+  assert.match(src, /title=\{toggleLabel\}\s*aria-label=\{toggleLabel\}/, "title and aria-label agree");
+  assert.match(src, /<Icon name="ph:sidebar-simple"/, "curated sidebar icon");
+});
+
+test("component: resize handle is an accessible splitter (separator + arrows + double-click reset)", () => {
+  assert.match(src, /role="separator"/, "splitter role");
+  assert.match(src, /aria-orientation="vertical"/, "vertical orientation");
+  assert.match(src, /aria-label="Resize sidebar"/, "labelled splitter");
+  assert.match(src, /aria-valuemin=\{SURFACE_RAIL_MIN_WIDTH\}[\s\S]{0,80}?aria-valuemax=\{SURFACE_RAIL_MAX_WIDTH\}[\s\S]{0,80}?aria-valuenow=\{width\}/, "splitter reports its value range");
+  assert.match(src, /tabIndex=\{0\}/, "keyboard focusable");
+  assert.match(
+    src,
+    /const next = surfaceRailKeyboardResize\(width, event\.key\);[\s\S]{0,120}?setWidth\(next\)/,
+    "arrow keys resize through the shared clamp",
+  );
+  assert.match(src, /onDoubleClick=\{\(\) => setWidth\(defaultWidth\)\}/, "double-click resets to the default width");
+  assert.match(src, /setPointerCapture\(event\.pointerId\)/, "drag captures the pointer");
+  assert.match(
+    src,
+    /clampSurfaceRailWidth\(drag\.startWidth \+ \(event\.clientX - drag\.startX\)\)/,
+    "drag width stays clamped",
+  );
+});
+
+test("component: children render-prop receives open so rows can collapse to icons", () => {
+  assert.match(
+    src,
+    /typeof children === "function" \? children\(open\) : children/,
+    "render-prop children get the open flag",
+  );
+});
+
+test("stylesheet: 56px collapsed width, tokenized width transition suppressed for drag and reduced motion", () => {
+  assert.match(
+    css,
+    new RegExp(`\\.surface-rail\\[data-open="false"\\] \\{[^}]*width: ${SURFACE_RAIL_COLLAPSED_WIDTH}px`),
+    "collapsed width matches the exported constant",
+  );
+  assert.match(
+    css,
+    /\.surface-rail \{[^}]*transition: width var\(--duration-base\) var\(--ease-standard\)/,
+    "open/collapse width transition uses motion tokens (~.18s ease)",
+  );
+  assert.match(css, /\.surface-rail\[data-dragging="true"\] \{[^}]*transition: none/, "no transition while dragging");
+  assert.match(
+    css,
+    /@media \(prefers-reduced-motion: reduce\) \{[\s\S]{0,200}?\.surface-rail \{[^}]*transition: none/,
+    "reduced motion drops the width transition",
+  );
+  assert.match(
+    css,
+    /\.surface-rail__resize:hover,[\s\S]{0,200}?background: color-mix\(in oklch, var\(--accent-presence\) 25%, transparent\)/,
+    "resize affordance uses the 25% accent tint",
+  );
+  assert.match(css, /\.surface-rail \{[^}]*border-right: 1px solid var\(--border-hairline\)/, "right hairline seam");
+});

--- a/src/components/ui/surface-rail.tsx
+++ b/src/components/ui/surface-rail.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * SurfaceRail — the shared collapsible/resizable list rail for surface tabs
+ * (Sessions / Projects / Group / Familiar share this grammar). An <aside>
+ * with a header row (uppercase title, caller actions, collapse toggle), an
+ * optional search slot, a scrollable content slot, and a drag/keyboard
+ * resizable right edge. Width and open state persist per `storageKey`.
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  SURFACE_RAIL_DEFAULT_WIDTH,
+  SURFACE_RAIL_MAX_WIDTH,
+  SURFACE_RAIL_MIN_WIDTH,
+  clampSurfaceRailWidth,
+  readSurfaceRailPrefs,
+  surfaceRailKeyboardResize,
+  writeSurfaceRailOpen,
+  writeSurfaceRailWidth,
+} from "@/lib/surface-rail-state";
+import "@/styles/surface-rail.css";
+
+function localStorageOrNull(): Storage | null {
+  return typeof window === "undefined" ? null : window.localStorage;
+}
+
+export function SurfaceRail(props: {
+  storageKey: string;
+  title?: string;
+  defaultWidth?: number; // 280
+  /** Header buttons, rendered after the title and before the collapse toggle. */
+  actions?: ReactNode;
+  /** Rendered under the header row only while the rail is open. */
+  search?: ReactNode;
+  children: ReactNode | ((open: boolean) => ReactNode);
+  ariaLabel: string;
+}): React.JSX.Element {
+  const { storageKey, title, actions, search, children, ariaLabel } = props;
+  const defaultWidth = clampSurfaceRailWidth(props.defaultWidth ?? SURFACE_RAIL_DEFAULT_WIDTH);
+
+  // Read persisted prefs lazily on first render (storage failures → defaults).
+  const [initial] = useState(() => readSurfaceRailPrefs(localStorageOrNull(), storageKey, defaultWidth));
+  const [width, setWidth] = useState(initial.width);
+  const [open, setOpen] = useState(initial.open);
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    writeSurfaceRailWidth(localStorageOrNull(), storageKey, width);
+  }, [storageKey, width]);
+  useEffect(() => {
+    writeSurfaceRailOpen(localStorageOrNull(), storageKey, open);
+  }, [storageKey, open]);
+
+  const toggleLabel = open ? "Collapse sidebar" : "Expand sidebar";
+
+  return (
+    <aside
+      className="surface-rail"
+      aria-label={ariaLabel}
+      data-open={open ? "true" : "false"}
+      data-dragging={dragging ? "true" : "false"}
+      style={open ? { width } : undefined}
+    >
+      <div className="surface-rail__header">
+        <div className="surface-rail__header-row">
+          {title && open ? <span className="surface-rail__title">{title}</span> : null}
+          {actions}
+          <button
+            type="button"
+            className="surface-rail__toggle focus-ring"
+            aria-expanded={open}
+            title={toggleLabel}
+            aria-label={toggleLabel}
+            onClick={() => setOpen((value) => !value)}
+          >
+            <Icon name="ph:sidebar-simple" width={15} aria-hidden />
+          </button>
+        </div>
+        {open && search ? <div className="surface-rail__search">{search}</div> : null}
+      </div>
+      <div className="surface-rail__content">
+        {typeof children === "function" ? children(open) : children}
+      </div>
+      {open ? (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          aria-valuemin={SURFACE_RAIL_MIN_WIDTH}
+          aria-valuemax={SURFACE_RAIL_MAX_WIDTH}
+          aria-valuenow={width}
+          tabIndex={0}
+          title="Drag to resize"
+          className="surface-rail__resize focus-ring"
+          onPointerDown={(event) => {
+            if (event.pointerType === "mouse" && event.button !== 0) return;
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startWidth: width };
+            setDragging(true);
+          }}
+          onPointerMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag || event.pointerId !== drag.pointerId) return;
+            setWidth(clampSurfaceRailWidth(drag.startWidth + (event.clientX - drag.startX)));
+          }}
+          onPointerUp={(event) => {
+            if (dragRef.current?.pointerId !== event.pointerId) return;
+            dragRef.current = null;
+            setDragging(false);
+          }}
+          onPointerCancel={(event) => {
+            if (dragRef.current?.pointerId !== event.pointerId) return;
+            dragRef.current = null;
+            setDragging(false);
+          }}
+          onDoubleClick={() => setWidth(defaultWidth)}
+          onKeyDown={(event) => {
+            const next = surfaceRailKeyboardResize(width, event.key);
+            if (next == null) return;
+            event.preventDefault();
+            setWidth(next);
+          }}
+        />
+      ) : null}
+    </aside>
+  );
+}

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -42,9 +42,9 @@ import {
 // Current counts as of the P3 codemod PR. Only lower these (banking progress)
 // or raise them with an explicit justification in your PR.
 const BASELINES = {
-  offScaleFontSizePx: 160, // 10.5px/11.5px/… — need per-case renormalization to the type scale (banked -3: canvas-editor.css shipped fully on the type scale)
-  offScaleSpacingPx: 1348, // off-4px-grid pad/margin/gap components (2px/6px/10px/…) — banked -1: canvas-editor.css shipped fully on the space scale
-  offScaleRadiusPx: 211, // 4px/6px/10px/14px/… radii between the sanctioned steps (banked -1: canvas-editor.css uses the radius tokens)
+  offScaleFontSizePx: 160, // 10.5px/11.5px/… — need per-case renormalization to the type scale (banked: canvas-editor.css on the type scale; familiar-tab retokenized the old hero/section styles)
+  offScaleSpacingPx: 1343, // off-4px-grid pad/margin/gap components — banked: canvas-editor.css on the space scale (-1) + familiar-tab snapped to the 4px grid (-5)
+  offScaleRadiusPx: 211, // 4px/6px/10px/14px/… radii between the sanctioned steps
   hexOutsideDefinitions: 156, // hex in render CSS (token definitions excluded) — +1: canvas-editor.css sketch-frame #fff ground, sketch CONTENT not interface color, same precedent as chat-canvas.css's thumbnail #fff
   inlineTsxStyles: 500, // style={{…}} in TSX; many are legit dynamic values
 };

--- a/src/lib/surface-rail-state.ts
+++ b/src/lib/surface-rail-state.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure state helpers for the shared SurfaceRail primitive
+ * (src/components/ui/surface-rail.tsx): width clamping, localStorage
+ * persistence, and keyboard resize steps. Dependency-free so the unit suite
+ * can exercise them directly.
+ */
+
+export const SURFACE_RAIL_DEFAULT_WIDTH = 280;
+export const SURFACE_RAIL_MIN_WIDTH = 200;
+export const SURFACE_RAIL_MAX_WIDTH = 440;
+export const SURFACE_RAIL_COLLAPSED_WIDTH = 56;
+export const SURFACE_RAIL_KEY_STEP = 16;
+
+export type SurfaceRailPrefs = { width: number; open: boolean };
+
+/** Anything that quacks like Storage — lets tests pass a plain fake. */
+export type SurfaceRailStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function surfaceRailWidthKey(storageKey: string): string {
+  return `${storageKey}:width`;
+}
+
+export function surfaceRailOpenKey(storageKey: string): string {
+  return `${storageKey}:open`;
+}
+
+/** Clamp a candidate width to the rail's resizable range (200–440). */
+export function clampSurfaceRailWidth(
+  width: number,
+  fallback: number = SURFACE_RAIL_DEFAULT_WIDTH,
+): number {
+  const base = Number.isFinite(width) ? width : fallback;
+  return Math.min(
+    SURFACE_RAIL_MAX_WIDTH,
+    Math.max(SURFACE_RAIL_MIN_WIDTH, Math.round(base)),
+  );
+}
+
+/**
+ * Read persisted rail prefs. Storage failures (private mode, quota, JSON
+ * garbage) silently fall back to defaults — the rail must always render.
+ */
+export function readSurfaceRailPrefs(
+  storage: SurfaceRailStorage | null | undefined,
+  storageKey: string,
+  defaultWidth: number = SURFACE_RAIL_DEFAULT_WIDTH,
+): SurfaceRailPrefs {
+  let width = clampSurfaceRailWidth(defaultWidth);
+  let open = true;
+  if (!storage) return { width, open };
+  try {
+    const rawWidth = storage.getItem(surfaceRailWidthKey(storageKey));
+    if (rawWidth != null) width = clampSurfaceRailWidth(Number.parseFloat(rawWidth), width);
+    open = storage.getItem(surfaceRailOpenKey(storageKey)) !== "0";
+  } catch {
+    // Storage unavailable — defaults already set.
+  }
+  return { width, open };
+}
+
+export function writeSurfaceRailWidth(
+  storage: SurfaceRailStorage | null | undefined,
+  storageKey: string,
+  width: number,
+): void {
+  try {
+    storage?.setItem(surfaceRailWidthKey(storageKey), String(clampSurfaceRailWidth(width)));
+  } catch {
+    // Persistence is best-effort.
+  }
+}
+
+export function writeSurfaceRailOpen(
+  storage: SurfaceRailStorage | null | undefined,
+  storageKey: string,
+  open: boolean,
+): void {
+  try {
+    storage?.setItem(surfaceRailOpenKey(storageKey), open ? "1" : "0");
+  } catch {
+    // Persistence is best-effort.
+  }
+}
+
+/**
+ * Arrow-key resize for the separator (accessible-splitter idiom): Left
+ * narrows, Right widens, ±16px, clamped. Returns null for unrelated keys.
+ */
+export function surfaceRailKeyboardResize(
+  width: number,
+  key: string,
+  step: number = SURFACE_RAIL_KEY_STEP,
+): number | null {
+  if (key === "ArrowLeft") return clampSurfaceRailWidth(width - step);
+  if (key === "ArrowRight") return clampSurfaceRailWidth(width + step);
+  return null;
+}

--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -1,0 +1,414 @@
+/* ────────────────────────────────────────────────
+   Chat · Familiar tab — roster rail + identity detail
+   (design-handoff redesign: SurfaceRail roster on the left, identity header
+   + Roles/Skills/Runtime/Capabilities cards on the right. The `.familiar-tab`
+   root class is load-bearing for backdrop glass — see backdrop.css.)
+   ──────────────────────────────────────────────── */
+
+/* Roster rail rows (rendered inside SurfaceRail's content slot). */
+.familiar-tab__rail-row {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.familiar-tab__rail-row:hover {
+  background: color-mix(in oklch, var(--text-primary) 6%, transparent);
+}
+
+/* Selected row = surface bg. */
+.familiar-tab__rail-row[aria-current="true"] {
+  background: var(--bg-raised);
+}
+
+/* Collapsed rail: avatar-only square buttons. */
+.surface-rail[data-open="false"] .familiar-tab__rail-row {
+  width: auto;
+  justify-content: center;
+}
+
+.familiar-tab__rail-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.familiar-tab__rail-name {
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.familiar-tab__rail-role {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Detail pane: the main column measures its own inline size so the card grid
+   goes two-column when the pane (not the viewport) is wide enough. */
+.familiar-tab__main {
+  container-type: inline-size;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+  min-height: 0;
+  padding: var(--space-5) var(--space-6) var(--space-4);
+}
+
+/* ── Identity header ── */
+
+.familiar-tab__hero {
+  display: flex;
+  flex: none;
+  align-items: flex-start;
+  gap: var(--space-4);
+}
+
+.familiar-tab__avatar {
+  display: inline-flex;
+  flex-shrink: 0;
+  border-radius: var(--radius-card);
+  /* Soft inset hairline behind transparent avatar corners — same wash idiom
+     as the roster cards, no hard border. */
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
+}
+
+/* Identity moment: the display name is the one serif element on the tab
+   (--font-serif is the display / hero / identity face). */
+.familiar-tab__name {
+  font-family: var(--font-serif, ui-serif, serif);
+  font-size: clamp(22px, 3.2cqi, 30px);
+  font-weight: 500;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+/* Presence chip: hairline pill, accent-tinted while the daemon is reachable
+   (accent = presence, per the design language — not the mock's green). */
+.familiar-tab__presence {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 22px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.familiar-tab__presence[data-online="true"] {
+  color: var(--accent-presence);
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+}
+
+/* Chip row: runtime/model metadata pills (mono) + surface link pills. */
+.familiar-tab__pill {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.familiar-tab__links-divider {
+  width: 1px;
+  height: 18px;
+  margin: 0 var(--space-1);
+  background: var(--border-hairline);
+}
+
+.familiar-tab__link-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 26px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  font: inherit;
+  font-size: var(--text-sm);
+  color: var(--accent-presence);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.familiar-tab__link-pill:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+}
+
+/* ── Card grid: 1.5fr/1fr on a wide pane, stacked (and page-scrolled) below ── */
+
+.familiar-tab__grid {
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.familiar-tab__col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+  min-height: 0;
+}
+
+@container (min-width: 840px) {
+  .familiar-tab__grid {
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    align-items: stretch;
+    overflow: visible;
+  }
+
+  /* Wide pane: the header stays put and each column owns its own scroll. */
+  .familiar-tab__col {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+}
+
+/* ── Cards ── */
+
+.familiar-tab__card {
+  flex: none;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  overflow: hidden;
+}
+
+/* The Skills card absorbs leftover column height and scrolls internally. */
+.familiar-tab__card--fill {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.familiar-tab__card-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 var(--space-2) var(--space-2);
+}
+
+.familiar-tab__card-head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+}
+
+.familiar-tab__card-title {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.familiar-tab__count {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--bg-raised);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.familiar-tab__card-note {
+  margin-left: auto;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+/* ── Card rows ── */
+
+.familiar-tab__rows {
+  display: flex;
+  flex-direction: column;
+  padding: 0 var(--space-2) var(--space-2);
+}
+
+/* Expandable role rows: chevron + name + meta, description when open. */
+.familiar-tab__row-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.familiar-tab__row-toggle:hover {
+  background: color-mix(in oklch, var(--text-primary) 4%, transparent);
+}
+
+.familiar-tab__row-name {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-base);
+  font-weight: 500;
+}
+
+.familiar-tab__row-meta {
+  flex: none;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.familiar-tab__row-desc {
+  padding: 0 var(--space-2) var(--space-2) var(--space-6);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  text-wrap: pretty;
+}
+
+/* Skill group headers reuse the row-toggle geometry (CollapsibleSection). */
+.familiar-tab__group-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+}
+
+.familiar-tab__group-toggle:hover {
+  background: color-mix(in oklch, var(--text-primary) 4%, transparent);
+}
+
+.familiar-tab__skill-row {
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-6);
+  border-radius: var(--radius-sm);
+}
+
+.familiar-tab__skill-row:hover {
+  background: color-mix(in oklch, var(--text-primary) 4%, transparent);
+}
+
+.familiar-tab__more {
+  border: none;
+  background: transparent;
+  padding: var(--space-1) var(--space-2) var(--space-2) var(--space-6);
+  font: inherit;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.familiar-tab__more:hover {
+  color: var(--accent-presence);
+}
+
+/* Dashed empty rows = invitation (design language: dashed means "something
+   can happen here"). */
+.familiar-tab__empty {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-1) var(--space-2) var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px dashed var(--border-hairline);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.familiar-tab__empty--indent {
+  margin-left: var(--space-6);
+}
+
+.familiar-tab__empty > p {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Runtime facts: fixed muted label + value. */
+.familiar-tab__facts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-4);
+  font-size: var(--text-sm);
+}
+
+.familiar-tab__facts > li {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.familiar-tab__fact-label {
+  flex: none;
+  width: 64px;
+  color: var(--text-muted);
+}
+
+/* Coarse pointers: the pill links and group toggles are compact targets tuned
+   for a cursor — grow their hit areas on touch. */
+@media (pointer: coarse) {
+  .familiar-tab__links a,
+  .familiar-tab__links button {
+    min-height: 32px;
+    padding-block: var(--space-1);
+  }
+
+  .familiar-tab__group-toggle,
+  .familiar-tab__row-toggle {
+    padding-block: var(--space-3);
+  }
+
+  .familiar-tab__cta {
+    padding-block: var(--space-2);
+  }
+}

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -201,23 +201,12 @@
 }
 
 /* ────────────────────────────────────────────────
-   Chat · Familiar tab (identity hero + capability grid)
+   Chat · Familiar tab (scope overview; the roster-rail + detail-card styles
+   live in src/styles/familiar-tab.css, imported by the component)
    ──────────────────────────────────────────────── */
-
-/* The tab is a first-class surface, not a 320px sidepanel: the panel measures
-   its own inline size so the capability grid can go two-column when the chat
-   canvas is wide enough, independent of the viewport. */
-.familiar-tab {
-  container-type: inline-size;
-}
 
 .chat-familiar-view {
   -webkit-overflow-scrolling: touch;
-  scroll-padding-top: 112px;
-}
-
-.chat-familiar-view :is(a, button, [tabindex]):focus {
-  scroll-margin-top: 112px;
 }
 
 .familiar-scope-overview__header,
@@ -270,90 +259,6 @@
 
   .familiar-scope-overview__metrics {
     gap: var(--space-1) var(--space-2);
-  }
-}
-
-.familiar-tab__hero {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  align-items: flex-start;
-  gap: 14px;
-  margin-inline: -16px;
-  padding: var(--space-3) 18px var(--space-4);
-  border-bottom: 1px solid var(--border-hairline);
-  background: var(--glass-raised);
-  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-}
-
-.familiar-tab__avatar {
-  display: inline-flex;
-  flex-shrink: 0;
-  border-radius: var(--radius-card);
-  /* Soft inset hairline behind transparent avatar corners — same wash idiom
-     as the roster cards, no hard border. */
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
-}
-
-/* Identity moment: the display name is the one serif element on the tab
-   (--font-serif is the display / hero / identity face). */
-.familiar-tab__name {
-  font-family: var(--font-serif, ui-serif, serif);
-  font-size: clamp(22px, 3.2cqi, 30px);
-  font-weight: 500;
-  line-height: 1.1;
-  color: var(--text-primary);
-}
-
-.familiar-tab__presence {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-/* One column by default; two balanced columns once the tab itself is wide
-   enough to earn it (~900px of usable canvas). */
-.familiar-tab__grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: var(--space-2) var(--space-5);
-}
-
-@container (min-width: 900px) {
-  .familiar-tab__grid {
-    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
-    align-items: start;
-  }
-}
-
-/* De-boxed capability lists (facelift language): one wash + soft inset
-   hairline per group, hairline dividers between rows — no per-row boxes, no
-   accent tints on metadata. Accent stays reserved for presence. */
-.familiar-tab__list {
-  border-radius: var(--radius-card);
-  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--border-hairline) 55%, transparent);
-}
-
-.familiar-tab__rows > li + li {
-  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent);
-}
-
-/* Coarse pointers: the hero's quiet links/actions and the group toggles are
-   10-11px targets tuned for a cursor — grow their hit areas on touch without
-   changing the pointer-fine rhythm. */
-@media (pointer: coarse) {
-  .familiar-tab__links a,
-  .familiar-tab__links button {
-    padding-block: 6px;
-  }
-  .familiar-tab__list > button {
-    padding-block: 10px;
-  }
-  .familiar-tab__cta {
-    padding-block: var(--space-2);
   }
 }
 

--- a/src/styles/surface-rail.css
+++ b/src/styles/surface-rail.css
@@ -1,0 +1,139 @@
+/* ────────────────────────────────────────────────
+   SurfaceRail — shared collapsible/resizable list rail
+   (Sessions / Projects / Group / Familiar tabs share this grammar:
+   uppercase title + header actions + collapse toggle, optional search,
+   scrollable rows, drag/keyboard-resizable right edge.)
+   ──────────────────────────────────────────────── */
+
+.surface-rail {
+  position: relative;
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  min-height: 0;
+  border-right: 1px solid var(--border-hairline);
+  transition: width var(--duration-base) var(--ease-standard);
+}
+
+/* Open width comes from the inline style (persisted / dragged). */
+.surface-rail[data-open="false"] {
+  width: 56px;
+}
+
+/* Drag must track the pointer 1:1 — the settle transition would rubber-band. */
+.surface-rail[data-dragging="true"] {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .surface-rail {
+    transition: none;
+  }
+}
+
+.surface-rail__header {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  align-self: stretch;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.surface-rail__header-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Collapsed: actions stack under the toggle, centered — column-reverse keeps
+   the toggle on top, mirroring its trailing position in the open row. */
+.surface-rail[data-open="false"] .surface-rail__header-row {
+  flex-direction: column-reverse;
+  align-items: center;
+}
+
+.surface-rail__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  padding-left: var(--space-1);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Header controls (caller actions + the collapse toggle): quiet hairline
+   squares that grow when the rail collapses so they stay easy targets. */
+.surface-rail__header-row :where(button, a) {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard);
+}
+
+.surface-rail__header-row :where(button, a):hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--text-primary) 7%, transparent);
+}
+
+.surface-rail[data-open="false"] .surface-rail__header-row :where(button, a) {
+  width: 32px;
+  height: 32px;
+}
+
+.surface-rail__search {
+  flex: none;
+}
+
+.surface-rail__content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-1);
+  min-height: 0;
+  padding: var(--space-2);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.surface-rail[data-open="false"] .surface-rail__content {
+  align-items: center;
+}
+
+/* Resize handle: a 6px grab strip straddling the border (right: -3px), with
+   an accent wash on hover/drag/focus. Also a keyboard splitter (role=
+   separator, Left/Right arrows) — focus-ring supplies the visible ring. */
+.surface-rail__resize {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  z-index: 5;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.surface-rail__resize:hover,
+.surface-rail__resize:active,
+.surface-rail__resize:focus-visible,
+.surface-rail[data-dragging="true"] .surface-rail__resize {
+  background: color-mix(in oklch, var(--accent-presence) 25%, transparent);
+}


### PR DESCRIPTION
Implements `Familiar.dc.html` from the claude.ai/design **Projects page redesign** handoff, and introduces the shared rail primitive the Sessions/Projects/Group redesigns will reuse.

## SurfaceRail (new, shared)
`ui/surface-rail.tsx` + `surface-rail.css` + `surface-rail-state.ts`: collapsible aside (280px open → 56px icon rail), pointer-drag resize clamped 200–440 with double-click reset and Left/Right arrow keys on an accessible `role="separator"` splitter, per-surface localStorage persistence (`<storageKey>:width` / `:open`), header/search/content slots, reduced-motion-safe transitions. Unit + pin coverage in `surface-rail.test.ts` (wired into `run-tests.mjs`).

## Familiar tab
- Single-familiar state: roster rail (search by name/role, avatar rows, `aria-current`, collapsed = avatar-only) with **local-only selection** — it never mutates the app-wide active familiar (test-pinned).
- Detail per the mock: header (avatar, serif name, presence chip with dot/last-seen/active-session count, uppercase kicker, description, mono runtime+model pills, Profile/Analytics/Memory/Edit-in-Studio pills, accent New chat) over a 1.5fr/1fr container-query grid: **Roles** (expandable), **Skills** (Role-granted/Familiar/Global groups, show-more past 6, marketplace empty state), **Runtime** facts (runtime/model/binary), **Capabilities** (plugins+MCP summary, dashed empty + "Open capabilities →"), Warnings preserved.
- The all/subset scopes keep the existing roster overview; `useCapabilitySnapshot` and the scope state machine are unchanged. familiar-tab test files re-pinned with invariants kept.

## Divergences from the mock
Presence chip uses `--accent-presence` (accent-is-presence rule; no hardcoded green); lowercase "online/offline" and sentence-cased CTAs per design language; voice + Edit-in-Studio chips kept (existing behavior survives); sizes snapped to token scales — drift ratchet baselines *lowered* (font 163→160, space 1349→1344, radius 212→211).

## Verification
tsc clean; app suite green (one env-dependent `opencoven-tools-resolve.test.ts` failure reproduces identically on a clean checkout and passes standalone — unrelated); verified in the running app: rail roster + search, local familiar switching, collapsed icon rail, Roles/Skills/Runtime/Capabilities cards all screenshotted.

Bead: cave-i0eu

🤖 Generated with [Claude Code](https://claude.com/claude-code)