### PR TITLE
feat(coven): redesign the Group surface to the design handoff (cave-cesi)

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -68,7 +68,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_545/, "runtime closure must stay below 5,545 files");
+assert.match(closureSource, /fileCount: 5_547/, "runtime closure must stay below 5,547 files");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -171,7 +171,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_545;/,
+  /const MAX_FILE_COUNT: u64 = 5_547;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -81,7 +81,9 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // traced chunk on Windows. CI measured 5,544; keep the exact maximum.
   // 2026-07-21 (Familiar redesign): the SurfaceRail + familiar-tab chunk adds
   // one traced file on Windows. CI measured 5,545; keep the exact maximum.
-  fileCount: 5_545,
+  // 2026-07-21 (Group redesign): the coven-tab chunk adds two traced files on
+  // Windows. CI measured 5,547; keep the exact maximum.
+  fileCount: 5_547,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_545);
+  assert.ok(metrics.fileCount <= 5_547);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_545,
+    fileCount: 5_547,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -148,7 +148,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_545);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_547);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -6,7 +6,7 @@ pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
 pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-pub(super) const MAX_FILE_COUNT: u64 = 5_545;
+pub(super) const MAX_FILE_COUNT: u64 = 5_547;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -190,6 +190,44 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
   );
 });
 
+test("Group surface follows the design handoff: SurfaceRail covens + details drawer", () => {
+  // The coven list is the shared SurfaceRail primitive (persisted width /
+  // collapse, search slot) instead of a bespoke fixed-width aside.
+  assert.match(
+    view,
+    /import \{ SurfaceRail \} from "@\/components\/ui\/surface-rail"/,
+    "rail comes from the shared SurfaceRail primitive",
+  );
+  assert.match(view, /storageKey="cave:coven:rail"/, "rail prefs persist under the coven rail key");
+  assert.match(view, /placeholder="Search covens…"/, "rail search filters covens by name");
+  assert.match(view, /aria-label="New coven"/, "the rail header keeps the create-coven action");
+  assert.match(view, /requestDeleteGroup\(g\.id, g\.name\)/, "rows keep the confirmed delete affordance");
+
+  // Details drawer: subject + running summary on the local group model,
+  // committed on blur through the same saveGroups path as other mutations.
+  assert.match(view, /setGroupDetails\(group, patch, nowIso\(\)\)/, "details commits go through the pure helper");
+  assert.match(view, /if \(next === group\) return;/, "an untouched blur neither persists nor reorders the rail");
+  assert.match(view, /placeholder="What is this coven about\?"/, "subject field uses the handoff placeholder");
+  assert.match(
+    view,
+    /placeholder="Short running summary of the conversation…"/,
+    "summary field uses the handoff placeholder",
+  );
+  assert.match(view, /aria-expanded=\{detailsOpen\}/, "the details strip is a disclosure button");
+
+  // Header grammar: double-click rename (keyboard parity kept), member chips
+  // + dashed "+ Add" pill anchoring the existing roster picker.
+  assert.match(view, /onDoubleClick=\{\(\) => setRenaming\(true\)\}/, "pointer rename is double-click");
+  assert.match(view, /coven-tab__member-chip/, "members render as header chips");
+  assert.match(view, /coven-tab__add-member/, "the dashed add pill opens the roster picker");
+
+  // Composer affordances from the mock: mention kicker + explicit empty state,
+  // and a typing line while replies are in flight.
+  assert.match(view, /coven-tab__mention-kicker">Tag a familiar</, "mention popover keeps its kicker");
+  assert.match(view, /No matching familiar in this coven/, "mention popover has an explicit empty state");
+  assert.match(view, /replyingNames\.join\(", "\)\} replying…/, "in-flight replies surface the typing line");
+});
+
 test("Group chat is a world-class chat surface (a11y + resilience)", () => {
   // Smart autoscroll (cave-o8si): intent-based release via the shared hook —
   // scrolling up detaches, only the true bottom re-attaches. No position

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -3,6 +3,7 @@
 import "@/styles/cave-chat.css";
 import "@/styles/cave-md.css";
 import "@/styles/cave-composer.css";
+import "@/styles/coven-tab.css";
 
 /**
  * GroupChatView — the "coven" group-chat surface.
@@ -29,6 +30,8 @@ import { parseHarnessFailure } from "@/lib/harness-failure";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Popover } from "@/components/ui/popover";
+import { SearchInput } from "@/components/ui/search-input";
+import { SurfaceRail } from "@/components/ui/surface-rail";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useStickToBottom } from "@/lib/use-stick-to-bottom";
@@ -56,6 +59,7 @@ import {
   resolveGroupMessageTargets,
   mentionSuggestionAuthor,
   setGroupResponseMode,
+  setGroupDetails,
   orderRoundRobinFamiliarIds,
   nextRoundRobinLeadId,
   renderCovenRoundtablePrompt,
@@ -98,6 +102,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const [busy, setBusy] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
+  // Rail search query + the Details drawer disclosure (session-local UI state).
+  const [railQuery, setRailQuery] = useState("");
+  const [detailsOpen, setDetailsOpen] = useState(false);
   // @mention autocomplete in the composer.
   const [mention, setMention] = useState<{ start: number; query: string } | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
@@ -391,6 +398,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       );
     },
     [persistGroups],
+  );
+
+  // Details drawer: subject/summary commit on blur through the same
+  // saveGroups path as every other group mutation. setGroupDetails returns
+  // the identical object on a no-op commit, so an untouched blur neither
+  // persists nor reorders the rail.
+  const commitDetails = useCallback(
+    (patch: { subject?: string; summary?: string }) => {
+      const group = activeGroupRef.current;
+      if (!group) return;
+      const next = setGroupDetails(group, patch, nowIso());
+      if (next === group) return;
+      persistGroups(upsertGroup(groupsRef.current, next));
+      announce("Coven details saved.");
+    },
+    [persistGroups, announce],
   );
 
   const changeResponseMode = useCallback(
@@ -816,7 +839,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     () => (mention ? matchMentions(mention.query, mentionable) : []),
     [mention, mentionable],
   );
-  const mentionOpen = mention !== null && mentionMatches.length > 0;
+  // Open whenever an @token is being typed (a no-match query shows the
+  // "No matching familiar in this coven" empty state instead of vanishing);
+  // key navigation below only engages while there are matches.
+  const mentionOpen = mention !== null && mentionable.length > 0;
 
   // Recompute the active mention token from the textarea's current caret.
   const syncMention = useCallback(() => {
@@ -846,6 +872,39 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     return groupChatTranscriptThreads(transcript);
   }, [transcript]);
 
+  // Rail rows: "N familiars · last activity". Last activity prefers the
+  // stored transcript's newest turn and falls back to the group's updatedAt.
+  // Recomputed when the groups list changes (create/rename/roster/session
+  // record), never per streaming token — the OPEN coven's recency instead
+  // reads the live in-memory transcript at render.
+  const lastActivityByGroup = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const g of groups) {
+      const turns = loadTranscript(g.id);
+      m.set(g.id, turns[turns.length - 1]?.createdAt ?? g.updatedAt);
+    }
+    return m;
+  }, [groups]);
+  const liveLastTurnAt = transcript.length > 0 ? transcript[transcript.length - 1].createdAt : null;
+
+  const railNeedle = railQuery.trim().toLowerCase();
+  const filteredGroups = railNeedle
+    ? groups.filter((g) => g.name.toLowerCase().includes(railNeedle))
+    : groups;
+
+  // Names for the "… replying" typing line — replies still in flight this turn.
+  const replyingNames = useMemo(() => {
+    if (!busy) return [];
+    const names: string[] = [];
+    for (const t of transcript) {
+      if (t.role !== "assistant") continue;
+      if (t.status !== "queued" && t.status !== "streaming") continue;
+      const name = byId.get(t.familiarId)?.display_name ?? t.familiarId;
+      if (!names.includes(name)) names.push(name);
+    }
+    return names;
+  }, [busy, transcript, byId]);
+
   const participants = activeGroup
     ? activeGroup.familiarIds.map((id) => byId.get(id)).filter(Boolean as unknown as (f: ResolvedFamiliar | undefined) => f is ResolvedFamiliar)
     : [];
@@ -856,73 +915,95 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // --- render --------------------------------------------------------------
   return (
     <div className="cave-group-chat-shell flex h-full min-h-0 w-full min-w-0 flex-1">
-      {/* Coven list rail */}
-      <aside className="cave-group-chat-rail flex w-56 shrink-0 flex-col border-r [border-color:var(--border-hairline)]!">
-        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
-          <span className="text-[length:var(--text-sm)] font-semibold uppercase tracking-wide [color:var(--text-muted)]!">
-            Covens
-          </span>
-          <Button size="xs" variant="ghost" leadingIcon="ph:plus-bold" onClick={createGroup}>
-            New
-          </Button>
-        </div>
-        <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
-          {groups.length === 0 ? (
-            <p className="px-2 py-3 text-[length:var(--text-sm)] leading-relaxed [color:var(--text-muted)]!">
-              A coven is a group of familiars you talk to together. Create one to choose how they take turns responding.
-            </p>
-          ) : (
-            <ul className="flex flex-col gap-0.5">
-              {groups.map((g) => {
-                const members = g.familiarIds.map((id) => byId.get(id)).filter(Boolean) as ResolvedFamiliar[];
-                const isActive = g.id === activeId;
-                return (
-                  // Row = a real button (keyboard + roving focus). The delete
-                  // control is a sibling overlay, not a nested button (which is
-                  // invalid HTML and traps keyboard focus).
-                  <li key={g.id} className="group/coven relative">
-                    <button
-                      type="button"
-                      className="focus-ring flex w-full items-center gap-2 rounded-md px-2 py-1.5 pr-8 text-left transition-colors hover:bg-[var(--bg-raised)]"
-                      aria-current={isActive ? "true" : undefined}
-                      style={isActive ? { background: "var(--bg-raised)" } : undefined}
-                      onClick={() => setActiveId(g.id)}
-                    >
-                      <div className="flex -space-x-1.5">
-                        {members.slice(0, 3).map((m) => (
-                          <FamiliarAvatar key={m.id} familiar={m} size="sm" className="rounded-full ring-1 ring-[var(--bg-base)] object-cover" />
-                        ))}
-                        {members.length === 0 && (
-                          <span className="grid h-4 w-4 place-items-center rounded-full [background:var(--bg-raised)]!">
-                            <Icon name="ph:users-three" width={11} height={11} />
+      {/* Coven list rail — the shared SurfaceRail (persisted width/collapse). */}
+      <SurfaceRail
+        storageKey="cave:coven:rail"
+        title="Covens"
+        ariaLabel="Covens"
+        actions={
+          <button
+            type="button"
+            className="coven-tab__rail-add focus-ring"
+            title="New coven"
+            aria-label="New coven"
+            onClick={createGroup}
+          >
+            <Icon name="ph:plus-bold" width={15} aria-hidden />
+          </button>
+        }
+        search={
+          <SearchInput
+            value={railQuery}
+            onValueChange={setRailQuery}
+            onClear={() => setRailQuery("")}
+            placeholder="Search covens…"
+            aria-label="Search covens"
+          />
+        }
+      >
+        {(open) => (
+          <>
+            {groups.length === 0 ? (
+              <p className="px-2 py-3 text-[length:var(--text-sm)] leading-relaxed [color:var(--text-muted)]!">
+                A coven is a group of familiars you talk to together. Create one to choose how they take turns responding.
+              </p>
+            ) : filteredGroups.length === 0 ? (
+              <p className="px-2 py-1.5 text-[length:var(--text-sm)] [color:var(--text-muted)]!">
+                No covens match &ldquo;{railQuery.trim()}&rdquo;.
+              </p>
+            ) : (
+              <ul className="coven-tab__rail-list">
+                {filteredGroups.map((g) => {
+                  const memberCount = g.familiarIds.filter((id) => byId.has(id)).length;
+                  const isActive = g.id === activeId;
+                  const lastActivity =
+                    (isActive && liveLastTurnAt) || lastActivityByGroup.get(g.id) || g.updatedAt;
+                  return (
+                    // Row = a real button (keyboard + roving focus). The delete
+                    // control is a sibling overlay, not a nested button (which is
+                    // invalid HTML and traps keyboard focus).
+                    <li key={g.id} className="group/coven relative">
+                      <button
+                        type="button"
+                        className="coven-tab__rail-row focus-ring"
+                        aria-current={isActive ? "true" : undefined}
+                        title={open ? undefined : g.name}
+                        aria-label={open ? undefined : g.name}
+                        onClick={() => setActiveId(g.id)}
+                      >
+                        <span className="coven-tab__rail-glyph" aria-hidden>
+                          <Icon name="ph:users-three" width={13} height={13} />
+                        </span>
+                        {open ? (
+                          <span className="coven-tab__rail-text">
+                            <span className="coven-tab__rail-name" title={g.name}>
+                              {g.name}
+                            </span>
+                            <span className="coven-tab__rail-meta">
+                              {memberCount} familiar{memberCount === 1 ? "" : "s"} · <RelativeTime iso={lastActivity} />
+                            </span>
                           </span>
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-[length:var(--text-base)] [color:var(--text-primary)]!" title={g.name}>
-                          {g.name}
-                        </div>
-                        <div className="text-[length:var(--text-xs)] [color:var(--text-muted)]!">
-                          {members.length} familiar{members.length === 1 ? "" : "s"} · <RelativeTime iso={g.updatedAt} />
-                        </div>
-                      </div>
-                    </button>
-                    <button
-                      type="button"
-                      className="focus-ring touch-always-visible absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover/coven:opacity-100"
-                      title="Delete coven — removes this group chat only"
-                      aria-label={`Delete ${g.name}`}
-                      onClick={() => void requestDeleteGroup(g.id, g.name)}
-                    >
-                      <Icon name="ph:trash" width={14} height={14} />
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </aside>
+                        ) : null}
+                      </button>
+                      {open ? (
+                        <button
+                          type="button"
+                          className="focus-ring touch-always-visible absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover/coven:opacity-100"
+                          title="Delete coven — removes this group chat only"
+                          aria-label={`Delete ${g.name}`}
+                          onClick={() => void requestDeleteGroup(g.id, g.name)}
+                        >
+                          <Icon name="ph:trash" width={14} height={14} />
+                        </button>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </>
+        )}
+      </SurfaceRail>
 
       {/* Active coven */}
       <section className="cave-group-chat-main flex min-w-0 flex-1 flex-col">
@@ -942,80 +1023,89 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         ) : (
           <>
             {/* Header */}
-            <header className="flex items-center gap-3 border-b px-4 py-2.5 [border-color:var(--border-hairline)]!">
-              <div className="min-w-0 flex-1">
-                {renaming ? (
-                  <input
-                    autoFocus
-                    defaultValue={activeGroup.name}
-                    aria-label="Coven name — Enter saves, Escape cancels"
-                    className="focus-ring-inset w-full rounded bg-transparent text-[length:var(--text-md)] font-semibold outline-none [color:var(--text-primary)]!"
-                    onBlur={(e) => {
-                      renameGroup(e.target.value);
-                      setRenaming(false);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.nativeEvent.isComposing) return;
-                      if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-                      if (e.key === "Escape") setRenaming(false);
-                    }}
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    className="focus-ring truncate text-[length:var(--text-md)] font-semibold [color:var(--text-primary)]!"
-                    title="Rename coven"
-                    aria-label={`Rename coven: ${activeGroup.name}`}
-                    onClick={() => setRenaming(true)}
-                  >
-                    {activeGroup.name}
-                  </button>
-                )}
-                <div className="mt-0.5 flex items-center gap-1.5">
-                  {participants.length === 0 ? (
-                    <span className="text-[length:var(--text-sm)] [color:var(--text-muted)]!">
-                      No familiars yet — add some to start
-                    </span>
-                  ) : (
-                    participants.map((f) => (
-                      <span key={f.id} className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[length:var(--text-xs)] [background:var(--bg-raised)]! [color:var(--text-secondary)]!">
-                        <FamiliarAvatar familiar={f} size="sm" className="rounded-full object-cover" />
-                        {f.display_name}
-                      </span>
-                    ))
-                  )}
-                </div>
+            <header className="coven-tab__header">
+              {renaming ? (
+                <input
+                  autoFocus
+                  defaultValue={activeGroup.name}
+                  aria-label="Coven name — Enter saves, Escape cancels"
+                  className="coven-tab__title-input focus-ring-inset"
+                  onBlur={(e) => {
+                    renameGroup(e.target.value);
+                    setRenaming(false);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.nativeEvent.isComposing) return;
+                    if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+                    if (e.key === "Escape") setRenaming(false);
+                  }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  className="coven-tab__title focus-ring"
+                  title="Double-click to rename"
+                  aria-label={`Rename coven: ${activeGroup.name}`}
+                  onDoubleClick={() => setRenaming(true)}
+                  onKeyDown={(e) => {
+                    // Pointer rename is double-click (per the handoff mock);
+                    // keyboard rename stays single-keystroke on the button.
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setRenaming(true);
+                    }
+                  }}
+                >
+                  {activeGroup.name}
+                </button>
+              )}
+              <div className="coven-tab__members">
+                {participants.map((f) => (
+                  <span key={f.id} className="coven-tab__member-chip">
+                    <FamiliarAvatar familiar={f} size="sm" className="rounded-full object-cover" />
+                    {f.display_name}
+                  </span>
+                ))}
+                <button
+                  ref={addBtnRef}
+                  type="button"
+                  className="coven-tab__add-member focus-ring"
+                  aria-label="Add familiars to this coven"
+                  aria-haspopup="dialog"
+                  aria-expanded={pickerOpen}
+                  onClick={() => setPickerOpen((v) => !v)}
+                >
+                  + Add
+                </button>
               </div>
-              <div className="flex flex-col items-end gap-1">
+              <div className="coven-tab__mode">
                 <fieldset disabled={busy} className="disabled:opacity-60">
                   <Segmented
                     options={COVEN_RESPONSE_MODES}
                     value={activeGroup.responseMode}
                     onChange={changeResponseMode}
                     getLabel={(mode) => mode === "broadcast" ? "Broadcast" : "Round robin"}
+                    getTitle={(mode) =>
+                      mode === "broadcast"
+                        ? "Everyone responds at once"
+                        : "One familiar at a time, in turn"
+                    }
                     ariaLabel="Coven response mode"
                   />
                 </fieldset>
-                <span className="text-[length:var(--text-2xs)] [color:var(--text-muted)]!">
+                {/* The surface's status line: roster size + how it responds. */}
+                <span className="coven-tab__status">
+                  {participants.length} familiar{participants.length === 1 ? "" : "s"} ·{" "}
                   {activeGroup.responseMode === "broadcast"
-                    ? "Everyone responds at once"
+                    ? "broadcast"
                     : `${nextRoundRobinLead?.display_name ?? "First familiar"} leads next`}
                 </span>
               </div>
-              <Button
-                ref={addBtnRef}
-                size="sm"
-                variant="secondary"
-                leadingIcon="ph:plus-bold"
-                onClick={() => setPickerOpen((v) => !v)}
-              >
-                Add
-              </Button>
               <Popover
                 open={pickerOpen}
                 onOpenChange={setPickerOpen}
                 anchorRef={addBtnRef}
-                placement="bottom-end"
+                placement="bottom-start"
                 ariaLabel="Choose familiars"
                 minWidth={240}
               >
@@ -1053,6 +1143,51 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
               </Popover>
             </header>
 
+            {/* Details drawer — subject + running summary, saved on blur. */}
+            <button
+              type="button"
+              className="coven-tab__details-toggle focus-ring-inset"
+              aria-expanded={detailsOpen}
+              onClick={() => setDetailsOpen((v) => !v)}
+            >
+              <Icon name="ph:caret-right" width={11} height={11} className="coven-tab__details-chevron" aria-hidden />
+              <span className="coven-tab__details-kicker">Details</span>
+              <span className="coven-tab__details-preview">
+                {activeGroup.subject || activeGroup.summary || "Add a subject and summary"}
+              </span>
+            </button>
+            {detailsOpen ? (
+              <div className="coven-tab__details">
+                <label className="coven-tab__field">
+                  <span className="coven-tab__field-label">Subject</span>
+                  {/* key: re-seed the uncontrolled draft when the coven changes. */}
+                  <input
+                    key={`${activeGroup.id}:subject`}
+                    type="text"
+                    defaultValue={activeGroup.subject ?? ""}
+                    placeholder="What is this coven about?"
+                    className="coven-tab__field-input focus-ring-inset"
+                    onBlur={(e) => commitDetails({ subject: e.target.value })}
+                  />
+                </label>
+                <label className="coven-tab__field">
+                  <span className="coven-tab__field-label">Summary</span>
+                  <textarea
+                    key={`${activeGroup.id}:summary`}
+                    rows={2}
+                    defaultValue={activeGroup.summary ?? ""}
+                    placeholder="Short running summary of the conversation…"
+                    className="coven-tab__field-input focus-ring-inset"
+                    onBlur={(e) => commitDetails({ summary: e.target.value })}
+                  />
+                </label>
+                <span className="coven-tab__details-meta">
+                  Created <RelativeTime iso={activeGroup.createdAt} /> · updated{" "}
+                  <RelativeTime iso={activeGroup.updatedAt} />
+                </span>
+              </div>
+            ) : null}
+
             {/* Transcript */}
             <div className="relative min-h-0 flex-1">
             <div
@@ -1060,19 +1195,26 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
               role="log"
               aria-label="Coven transcript"
               aria-live="off"
-              className="h-full overflow-y-auto px-4 py-4"
+              className="h-full overflow-y-auto px-6 py-5"
             >
               {threads.length === 0 ? (
                 <div className="grid h-full place-items-center">
                   <EmptyState
                     icon="ph:chats-circle"
-                      headline={participants.length === 0 ? "Add familiars to begin" : "Start the conversation"}
+                    headline={participants.length === 0 ? "Add familiars to begin" : "Start the conversation"}
                     subtitle={
                       participants.length === 0
-                        ? "Use Add to pick the familiars in this coven."
+                        ? "A coven is a group chat — pick who's in it."
                         : activeGroup.responseMode === "broadcast"
                           ? "Every familiar responds at once in its own thread."
                           : "Familiars respond in turn and see earlier replies."
+                    }
+                    actions={
+                      participants.length === 0 ? (
+                        <Button variant="primary" leadingIcon="ph:plus-bold" onClick={() => setPickerOpen(true)}>
+                          Add familiars
+                        </Button>
+                      ) : undefined
                     }
                     compact
                   />
@@ -1217,6 +1359,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     </div>
                     );
                   })}
+                  {/* Typing line: who is still replying this turn (the bubbles
+                      above carry the detailed queued/streaming affordances). */}
+                  {replyingNames.length > 0 ? (
+                    <div className="coven-tab__typing">
+                      <span>{replyingNames.join(", ")} replying…</span>
+                    </div>
+                  ) : null}
                 </div>
               )}
             </div>
@@ -1235,7 +1384,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             </div>
 
             {/* Composer */}
-            <div className="border-t px-4 py-3 [border-color:var(--border-hairline)]!">
+            <div className="border-t px-5 py-3.5 [border-color:var(--border-hairline)]!">
               <div ref={composerRef} className="mx-auto flex max-w-3xl items-end gap-2">
                 <textarea
                   ref={textareaRef}
@@ -1254,17 +1403,17 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     // draft. Mirrors ChatView's composer guard.
                     if (e.nativeEvent.isComposing) return;
                     if (mentionOpen) {
-                      if (e.key === "ArrowDown") {
+                      if (e.key === "ArrowDown" && mentionMatches.length > 0) {
                         e.preventDefault();
                         setMentionIndex((i) => (i + 1) % mentionMatches.length);
                         return;
                       }
-                      if (e.key === "ArrowUp") {
+                      if (e.key === "ArrowUp" && mentionMatches.length > 0) {
                         e.preventDefault();
                         setMentionIndex((i) => (i - 1 + mentionMatches.length) % mentionMatches.length);
                         return;
                       }
-                      if (e.key === "Enter" || e.key === "Tab") {
+                      if ((e.key === "Enter" || e.key === "Tab") && mentionMatches.length > 0) {
                         e.preventDefault();
                         chooseMention(mentionMatches[mentionIndex] ?? mentionMatches[0]);
                         return;
@@ -1288,7 +1437,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                       : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}… (@ to tag one)`
                   }
                   disabled={participants.length === 0}
-                  className="max-h-40 min-h-[var(--space-10)] flex-1 resize-none rounded-lg border px-3 py-2 text-[length:var(--text-md)] outline-none disabled:opacity-50 [border-color:var(--border-hairline)]! [background:var(--bg-base)]! [color:var(--text-primary)]!"
+                  className="max-h-40 min-h-[var(--space-10)] flex-1 resize-none rounded-lg border px-3 py-2 text-[length:var(--text-md)] outline-none disabled:opacity-50 [border-color:var(--border-hairline)]! [background:color-mix(in_oklch,var(--bg-raised)_70%,transparent)]! [color:var(--text-primary)]!"
                 />
                 <Popover
                   open={mentionOpen}
@@ -1301,6 +1450,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   minWidth={220}
                 >
                   <div className="max-h-64 overflow-y-auto p-1">
+                    <span className="coven-tab__mention-kicker">Tag a familiar</span>
+                    {mentionMatches.length === 0 ? (
+                      <p className="coven-tab__mention-empty">No matching familiar in this coven</p>
+                    ) : null}
                     {mentionMatches.map((f, i) => {
                       const resolved = byId.get(f.id);
                       return (
@@ -1336,7 +1489,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   </div>
                 </Popover>
                 {busy ? (
-                  <Button variant="danger-ghost" leadingIcon="ph:stop-fill" onClick={stop}>
+                  <Button variant="secondary" className="coven-tab__stop" leadingIcon="ph:stop-fill" onClick={stop}>
                     Stop
                   </Button>
                 ) : (

--- a/src/components/ui/settings-controls.tsx
+++ b/src/components/ui/settings-controls.tsx
@@ -42,6 +42,7 @@ export function Segmented<T extends string>({
   value,
   onChange,
   getLabel,
+  getTitle,
   ariaLabel,
   equalWidth = false,
 }: {
@@ -49,6 +50,8 @@ export function Segmented<T extends string>({
   value: T;
   onChange: (next: T) => void;
   getLabel: (option: T) => string;
+  /** Optional per-option tooltip explaining what picking it does. */
+  getTitle?: (option: T) => string;
   ariaLabel: string;
   /** Force every segment to the same min width (good for short numeric labels). */
   equalWidth?: boolean;
@@ -67,6 +70,7 @@ export function Segmented<T extends string>({
             type="button"
             aria-pressed={active}
             aria-label={`${ariaLabel}: ${getLabel(option)}`}
+            title={getTitle?.(option)}
             onClick={() => onChange(option)}
             className={`focus-ring rounded-[var(--radius-control)] px-2.5 py-1.5 text-[length:var(--text-xs)] font-medium transition-colors ${
               equalWidth ? "min-w-12 text-center" : ""

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -10,6 +10,7 @@ import {
   setGroupSession,
   setGroupParticipants,
   setGroupResponseMode,
+  setGroupDetails,
   orderRoundRobinFamiliarIds,
   nextRoundRobinLeadId,
   parseMentions,
@@ -22,6 +23,7 @@ import {
   renderCovenContext,
   runCovenReplySchedule,
   loadGroups,
+  saveGroups,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -213,6 +215,74 @@ test("loadGroups: legacy groups default to broadcast without losing session pins
     assert.equal(loaded.responseMode, "broadcast");
     assert.equal(loaded.nextRoundRobinLeadId, "a");
     assert.equal(loaded.sessions.a, "sess-a");
+  } finally {
+    if (previous) Object.defineProperty(globalThis, "localStorage", previous);
+    else delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+});
+
+// --- details drawer (subject / summary) ------------------------------------
+
+test("setGroupDetails: sets subject/summary and bumps updatedAt; no-op returns the same object", () => {
+  const g = makeGroup("X", ["a"], "2026-06-24T00:00:00.000Z", "g1");
+  const withSubject = setGroupDetails(g, { subject: "Memory system" }, "2026-06-24T01:00:00.000Z");
+  assert.equal(withSubject.subject, "Memory system");
+  assert.equal(withSubject.summary, undefined);
+  assert.equal(withSubject.updatedAt, "2026-06-24T01:00:00.000Z");
+  const withBoth = setGroupDetails(withSubject, { summary: "Short recap" }, "2026-06-24T02:00:00.000Z");
+  assert.equal(withBoth.subject, "Memory system");
+  assert.equal(withBoth.summary, "Short recap");
+  // A no-change commit (blur without edits) returns the identical object so
+  // callers can skip the persist/reorder entirely.
+  assert.equal(setGroupDetails(withBoth, { subject: "Memory system" }, "2026-06-24T03:00:00.000Z"), withBoth);
+  assert.equal(setGroupDetails(withBoth, {}, "2026-06-24T03:00:00.000Z"), withBoth);
+});
+
+test("group details round-trip through save/load; legacy groups without them still load", () => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+    },
+  });
+  try {
+    const detailed = setGroupDetails(
+      makeGroup("Echo & Sage", ["echo", "sage"], "2026-06-24T00:00:00.000Z", "g1"),
+      { subject: "New memory system", summary: "Consolidation gaps; decay-weighted pruning favored." },
+      "2026-06-24T01:00:00.000Z",
+    );
+    const legacy = {
+      // A pre-details stored group (no subject/summary keys at all).
+      id: "legacy",
+      name: "Legacy coven",
+      familiarIds: ["a"],
+      sessions: {},
+      createdAt: "t1",
+      updatedAt: "t2",
+    };
+    const garbage = {
+      // Non-string details garbage must be dropped, not crash the drawer.
+      id: "garbage",
+      name: "Odd coven",
+      familiarIds: ["a"],
+      sessions: {},
+      subject: 42,
+      summary: { nested: true },
+      createdAt: "t1",
+      updatedAt: "t1",
+    };
+    saveGroups([detailed, legacy as never, garbage as never]);
+    const loaded = loadGroups();
+    const byId = new Map(loaded.map((g) => [g.id, g]));
+    assert.equal(byId.get("g1")?.subject, "New memory system");
+    assert.equal(byId.get("g1")?.summary, "Consolidation gaps; decay-weighted pruning favored.");
+    assert.equal(byId.get("legacy")?.subject, undefined);
+    assert.equal(byId.get("legacy")?.summary, undefined);
+    assert.equal(byId.get("garbage")?.subject, undefined);
+    assert.equal(byId.get("garbage")?.summary, undefined);
   } finally {
     if (previous) Object.defineProperty(globalThis, "localStorage", previous);
     else delete (globalThis as { localStorage?: unknown }).localStorage;

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -39,6 +39,10 @@ export type CovenGroup = {
   responseMode: CovenResponseMode;
   /** Familiar that should lead the next multi-recipient round-robin turn. */
   nextRoundRobinLeadId?: string;
+  /** Optional one-line "what is this coven about?" (details drawer). */
+  subject?: string;
+  /** Optional short running summary of the conversation (details drawer). */
+  summary?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -445,6 +449,22 @@ export function setGroupResponseMode(
   };
 }
 
+/**
+ * Update the optional details-drawer fields (subject / running summary).
+ * Returns the SAME object when nothing changed so callers can skip a persist
+ * (and the updatedAt-driven rail reorder) on a no-op blur commit.
+ */
+export function setGroupDetails(
+  group: CovenGroup,
+  details: { subject?: string; summary?: string },
+  now: string,
+): CovenGroup {
+  const subject = details.subject !== undefined ? details.subject : group.subject;
+  const summary = details.summary !== undefined ? details.summary : group.summary;
+  if (subject === group.subject && summary === group.summary) return group;
+  return { ...group, subject, summary, updatedAt: now };
+}
+
 /** Rotate selected recipients around the persisted Coven lead. */
 export function orderRoundRobinFamiliarIds(
   familiarIds: string[],
@@ -796,5 +816,10 @@ function normalizeCovenGroup(group: CovenGroup): CovenGroup {
     responseMode,
     nextRoundRobinLeadId:
       nextLead && group.familiarIds.includes(nextLead) ? nextLead : group.familiarIds[0],
+    // Details fields are optional and later additions: absent on legacy groups
+    // (stays undefined), and non-string garbage is dropped rather than crashing
+    // the details drawer.
+    subject: typeof group.subject === "string" ? group.subject : undefined,
+    summary: typeof group.summary === "string" ? group.summary : undefined,
   };
 }

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -900,17 +900,8 @@
 }
 
 @media (max-width: 720px) {
-  .cave-group-chat-shell {
-    flex-direction: column;
-  }
-
-  .cave-group-chat-rail {
-    width: 100%;
-    max-height: 156px;
-    border-right: 0;
-    border-bottom: 1px solid var(--border-hairline);
-  }
-
+  /* The coven list is the shared SurfaceRail now — it collapses to an icon
+     rail on narrow widths instead of stacking above the thread. */
   .cave-group-chat-main {
     min-height: 0;
   }

--- a/src/styles/coven-tab.css
+++ b/src/styles/coven-tab.css
@@ -1,0 +1,350 @@
+/* ────────────────────────────────────────────────
+   Chat · Group ("coven") tab — design-handoff redesign.
+   SurfaceRail coven list on the left; header with inline rename, member
+   chips, dashed "+ Add" pill and the response-mode toggle; a collapsible
+   Details strip (subject / running summary); restyled thread + composer.
+   Transcript row grammar (.cave-group-chat-*) stays in cave-chat/transcript.css.
+   ──────────────────────────────────────────────── */
+
+/* ── Coven rail (rendered inside the shared SurfaceRail) ─────────────────── */
+
+.coven-tab__rail-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.coven-tab__rail-row {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.coven-tab__rail-row:hover {
+  background: color-mix(in oklch, var(--text-primary) 5%, transparent);
+}
+
+/* Selected row = surface bg + a quiet accent spine. */
+.coven-tab__rail-row[aria-current="true"] {
+  background: var(--bg-raised);
+  box-shadow: inset 2px 0 0 var(--accent-presence);
+}
+
+/* Accent-tinted rounded-square glyph tile. */
+.coven-tab__rail-glyph {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--accent-presence);
+}
+
+.coven-tab__rail-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.coven-tab__rail-name {
+  overflow: hidden;
+  font-size: var(--text-base);
+  font-weight: 500;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.coven-tab__rail-meta {
+  overflow: hidden;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Collapsed rail: glyph-only tiles, centered. */
+.surface-rail[data-open="false"] .coven-tab__rail-row {
+  width: auto;
+  justify-content: center;
+}
+
+/* The header "+ New coven" action reads accent (creation affordance). */
+.coven-tab__rail-add {
+  color: var(--accent-presence);
+}
+
+.surface-rail__header-row .coven-tab__rail-add:hover {
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.coven-tab__header {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.coven-tab__title {
+  flex: none;
+  max-width: 18rem;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  cursor: text;
+}
+
+.coven-tab__title-input {
+  flex: none;
+  width: 14rem;
+  min-height: 32px;
+  padding: 0 var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-md);
+  font-weight: 500;
+  outline: none;
+}
+
+.coven-tab__members {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* Member chip: avatar + name in a 28px hairline pill. */
+.coven-tab__member-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 28px;
+  padding: 0 var(--space-3) 0 var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
+/* Dashed accent pill = invitation to grow the roster. */
+.coven-tab__add-member {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 28px;
+  padding: 0 var(--space-3);
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent-presence);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.coven-tab__add-member:hover {
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+}
+
+.coven-tab__mode {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+}
+
+.coven-tab__status {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+/* ── Details strip ───────────────────────────────────────────────────────── */
+
+.coven-tab__details-toggle {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-5);
+  border: none;
+  border-bottom: 1px solid var(--border-hairline);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+}
+
+.coven-tab__details-toggle:hover {
+  background: color-mix(in oklch, var(--text-primary) 3%, transparent);
+}
+
+.coven-tab__details-chevron {
+  flex: none;
+  color: var(--text-muted);
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.coven-tab__details-toggle[aria-expanded="true"] .coven-tab__details-chevron {
+  transform: rotate(90deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .coven-tab__details-chevron {
+    transition: none;
+  }
+}
+
+.coven-tab__details-kicker {
+  flex: none;
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.coven-tab__details-preview {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.coven-tab__details {
+  display: grid;
+  flex: none;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.coven-tab__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.coven-tab__field-label {
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.coven-tab__field-input {
+  width: 100%;
+  min-height: 32px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-base);
+  outline: none;
+}
+
+textarea.coven-tab__field-input {
+  min-height: 56px;
+  resize: vertical;
+}
+
+.coven-tab__field-input::placeholder {
+  color: var(--text-muted);
+}
+
+.coven-tab__details-meta {
+  grid-column: 1 / -1;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* ── Thread extras ───────────────────────────────────────────────────────── */
+
+/* "…replying" line, aligned with message bodies (same grid as a turn row). */
+.coven-tab__typing {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.coven-tab__typing::before {
+  content: "";
+}
+
+@media (max-width: 720px) {
+  /* Track the narrower mobile turn grid (38px avatars). */
+  .coven-tab__typing {
+    grid-template-columns: 38px minmax(0, 1fr);
+    gap: var(--space-2);
+  }
+}
+
+/* ── Composer ────────────────────────────────────────────────────────────── */
+
+/* Stop keeps the mock's accent stop mark on a quiet secondary button. */
+.coven-tab__stop svg {
+  color: var(--accent-presence);
+}
+
+.coven-tab__mention-kicker {
+  display: block;
+  padding: var(--space-1) var(--space-2) 0;
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.coven-tab__mention-empty {
+  margin: 0;
+  padding: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}


### PR DESCRIPTION
Implements `Group.dc.html` from the claude.ai/design **Projects page redesign** handoff, on top of the shared SurfaceRail (#3593).

- **Coven rail**: SurfaceRail (`cave:coven:rail`) with search, "+ New coven", accent-tile rows (member count + last activity from the transcript), collapsed icon rail, reveal-on-hover confirmed delete preserved.
- **Header**: double-click rename (keyboard-parity button kept for a11y), member chips + dashed "+ Add" anchoring the existing roster picker as a popover, Broadcast / Round-robin segmented with the mock's tooltips, status line ("N familiars · broadcast" / "X leads next").
- **Details drawer (new)**: optional `subject`/`summary` on the local group model — normalized back-compat load, commit-on-blur via a no-op-safe `setGroupDetails` (untouched blur neither persists nor reorders the rail), created/updated meta line. Round-trip + legacy-load covered in `group-chat.test.ts`.
- **Thread/composer**: mock presentation over the existing turn model — typing line from in-flight reply statuses, mention popover with "Tag a familiar" kicker + no-match empty state, secondary Stop, translucent composer. All broadcast/round-robin, delegation, streaming/retry, stick-to-bottom, drafts, and announcer behaviors preserved (pre-existing pin suite passes unmodified).

Verification: tsc clean; `run-tests.mjs app` → 842 files pass; verified in the running app — rail + search, member picker, details drawer round-trip, round-robin coven with "Charm leads next", collapsed rail (screenshots).

Bead: cave-cesi

🤖 Generated with [Claude Code](https://claude.com/claude-code)