### PR TITLE
refactor(sessions): address Copilot review on familiar-workspace filter (follow-up to #3590)

### DIFF
--- a/src/lib/familiar-workspace-sessions.ts
+++ b/src/lib/familiar-workspace-sessions.ts
@@ -25,38 +25,66 @@ import type { SessionRow } from "@/lib/types";
  *
  * Matching is prefix-based on normalized paths so both the workspace root
  * itself and any nested subdir (notes/, memory/, ...) are recognized.
+ *
+ * Purely path-based: it has no knowledge of registered projects, so a project
+ * whose root literally lives inside the familiar-workspaces tree would match.
+ * That is not a real configuration (project roots and familiar workspaces are
+ * distinct trees), but callers that need to guarantee an exemption should
+ * filter such roots out before calling.
  */
 export function isFamiliarWorkspaceRoot(
   projectRoot: string | null | undefined,
   familiarWorkspacesRoot: string,
   declaredWorkspaceRoots: readonly string[] = [],
 ): boolean {
-  const root = normalizeProjectRoot(projectRoot);
-  if (root === "/") return false;
-  const prefixes = [familiarWorkspacesRoot, ...declaredWorkspaceRoots]
+  return matchesFamiliarWorkspacePrefix(
+    projectRoot,
+    normalizeFamiliarWorkspacePrefixes(familiarWorkspacesRoot, declaredWorkspaceRoots),
+  );
+}
+
+/**
+ * Normalize the familiar-workspace prefix list once. Pulled out so the filter
+ * below builds it a single time instead of per-session (Copilot review: avoid
+ * re-normalizing the same prefixes for every row on large session lists).
+ */
+function normalizeFamiliarWorkspacePrefixes(
+  familiarWorkspacesRoot: string,
+  declaredWorkspaceRoots: readonly string[] = [],
+): string[] {
+  return [familiarWorkspacesRoot, ...declaredWorkspaceRoots]
     .map((p) => normalizeProjectRoot(p))
     .filter((p) => p !== "/");
-  return prefixes.some(
+}
+
+/** Prefix test against an already-normalized prefix list. */
+function matchesFamiliarWorkspacePrefix(
+  projectRoot: string | null | undefined,
+  normalizedPrefixes: readonly string[],
+): boolean {
+  const root = normalizeProjectRoot(projectRoot);
+  if (root === "/") return false;
+  return normalizedPrefixes.some(
     (prefix) => root === prefix || root.startsWith(`${prefix}/`),
   );
 }
 
 /**
  * Drop sessions whose `project_root` is a familiar-workspace root. Sessions
- * with no/rootless project ("(no project)" bucket) and real registered-project
- * sessions are always kept. Pure — safe to call on the response path.
+ * with no/rootless project (the "(no project)" bucket) are kept, as are all
+ * sessions whose root is not inside the familiar-workspaces tree — which in
+ * normal configurations means every real registered-project session, since
+ * project roots live outside that tree. Pure — safe to call on the response
+ * path.
  */
 export function collapseFamiliarWorkspaceSessions(
   sessions: SessionRow[],
   familiarWorkspacesRoot: string,
   declaredWorkspaceRoots: readonly string[] = [],
 ): SessionRow[] {
+  // Normalize the prefix list once, then test each row inline.
+  const prefixes = normalizeFamiliarWorkspacePrefixes(familiarWorkspacesRoot, declaredWorkspaceRoots);
   return sessions.filter(
-    (session) =>
-      !isFamiliarWorkspaceRoot(
-        session.project_root,
-        familiarWorkspacesRoot,
-        declaredWorkspaceRoots,
-      ),
+    (session) => !matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
   );
 }


### PR DESCRIPTION
Follow-up to #3590 (merged as 781285e60). Copilot's re-review landed two non-blocking findings on `familiar-workspace-sessions.ts` just after the auto-merge fired, so they carry here as a small standalone change.

## Changes
- **Perf:** `collapseFamiliarWorkspaceSessions` re-normalized the prefix list for every session via `isFamiliarWorkspaceRoot`. Extracted `normalizeFamiliarWorkspacePrefixes()` + `matchesFamiliarWorkspacePrefix()` so the filter normalizes **once** and tests each row inline. Public `isFamiliarWorkspaceRoot()` keeps its exact signature.
- **Docs accuracy:** the docstring claimed registered-project sessions are "always kept". The helper is purely path-based, so a project root literally inside the familiar-workspaces tree would match. Reworded to state the real (path-based) contract and note why it holds in normal configs (project roots live outside that tree).

## Why not in #3590
The delegated auto-merge gate correctly merged #3590 on green CI + the resolved degraded-path finding. These two later comments are pure polish (no behavior/correctness change), so a clean follow-up is the right vehicle.

## Verification
- `familiar-workspace-sessions.test.ts` — 9/9 pass (CI invocation)
- `sessions/list/route.test.ts` — ok
- `check:tests-wired` — ok
- `tsc --noEmit` — clean

No behavior change.