### PR TITLE
feat(chat): merge threads into the primary sidebar

### DIFF
--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -7,8 +7,8 @@ const workspaceSidebar = await readFile(new URL("./workspace-sidebar.tsx", impor
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
-// ── Chat-mode shell wiring: global nav stays in nav; Chats lives in the shell's
-//    persistent list pane on desktop (and the list drawer on mobile). ───────────
+// ── Chat-mode shell wiring: Chats replaces the global nav in the primary shell
+//    nav slot, including the mobile nav drawer. ────────────────────────────────
 assert.match(
   workspace,
   /const chatSidebar =\s*\(\s*<WorkspaceSidebar/,
@@ -16,23 +16,34 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const list = mode === "chat" \? chatSidebar : undefined;/,
-  "workspace should mount Chats as the list pane only in chat mode",
+  /const contextualNav = mode === "chat" \? chatSidebar : sidebar;/,
+  "workspace should select Chats as the primary nav only in chat mode",
 );
+assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/);
 assert.match(
   workspace,
-  /navPolicy=\{mode === "chat" \? "visit-collapsed" : "remembered"\}/,
-  "chat visits should start with the global nav collapsed",
+  /navPolicy=\{mode === "chat" \? "chat-contextual" : "remembered"\}/,
+  "chat mode should activate the contextual nav policy",
 );
-assert.match(
+assert.doesNotMatch(
   workspace,
   /listPolicy=\{mode === "chat" \? "persistent" : "collapsible"\}/,
-  "chat mode should keep the Chats list persistent on desktop",
+  "chat mode should not reserve a persistent list pane",
 );
 assert.match(
   workspace,
-  /nav=\{sidebar\}\s*list=\{list\}/,
-  "workspace should keep SidebarMinimal in nav and pass Chats separately as list content",
+  /nav=\{contextualNav\}\s*list=\{undefined\}/,
+  "workspace should pass contextual navigation and no list content",
+);
+assert.match(workspace, /topBar=\{\(\{ navDrawerOpen \}\) =>/, "top bar should only receive nav drawer state");
+assert.match(workspace, /onToggleList=\{undefined\}/, "top bar should expose no list drawer toggle");
+assert.match(workspace, /listDrawerOpen=\{false\}/, "top bar should report no list drawer");
+const chatSidebarBlock = workspace.match(/const chatSidebar =[\s\S]*?const contextualNav =/)?.[0] ?? "";
+assert.ok(chatSidebarBlock, "workspace should keep a distinct chatSidebar block");
+assert.doesNotMatch(chatSidebarBlock, /dismissListMobile/, "chat sidebar callbacks should not dismiss the list drawer");
+assert.ok(
+  (chatSidebarBlock.match(/dismissNavMobile/g) ?? []).length >= 6,
+  "chat sidebar actions should dismiss the mobile nav drawer",
 );
 assert.match(
   workspaceSidebar,
@@ -50,7 +61,7 @@ assert.doesNotMatch(workspace, /const exitChatMode = useCallback/, "workspace sh
 assert.doesNotMatch(workspace, /lastNonChatMode/, "workspace should not track a stale prior-surface contract");
 
 // ── Subpanel removal: the in-surface thread rail is dropped in chat mode,
-//    because the outer WorkspaceSidebar already owns the project-grouped list. ─
+//    because the contextual WorkspaceSidebar already owns the grouped threads. ─
 assert.match(
   workspace,
   /hideThreadRail/,

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -214,10 +214,10 @@ assert.equal(
   "search-result, folder, and recent rows all handle ⌥↵",
 );
 
-// ── Live IA wiring (the shell list panel is the real thread rail) ────────────
+// ── Live IA wiring (the contextual nav is the outer thread rail) ─────────────
 // Workspace mounts ChatSurface with hideThreadRail while WorkspaceSidebar owns
-// the project-grouped chat list in the shell list pane (desktop) / list drawer
-// (mobile), so splits must reach the chat through that outer list: its rows are
+// the one project-grouped chat list in the primary contextual nav (desktop) /
+// nav drawer (mobile). Splits still enter through that outer list: its rows are
 // drag sources + ⌥↵/⌥-click split openers, routed through the pending action.
 
 const shellNav = await readFile(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -97,9 +97,9 @@ type Props = {
    *  routes back to the board with the linked card focused. */
   onOpenTask?: (cardId: string) => void;
   onOpenUrl?: (url: string) => void;
-  /** Drop the in-surface project/thread rail. Set when the outer
-   *  WorkspaceSidebar already owns the project-grouped chat list (desktop list
-   *  pane or mobile list drawer), so the in-surface rail would duplicate it. */
+  /** Drop the in-surface project/thread rail. Set when the outer contextual
+   *  Shell nav/sidebar already owns the project-grouped chat list, so the
+   *  in-surface rail would duplicate it. */
   hideThreadRail?: boolean;
 };
 

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -52,8 +52,8 @@ assert.match(
   /const SURFACE_ORDER: WorkspaceMode\[\] = \[\s*"home", "chat", "board", "inbox", "browser",\s*\]/,
   "keyboard surface order should not include a standalone Terminal destination",
 );
-assert.match(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/, "chat mode mounts WorkspaceSidebar as the independent Chats list");
-assert.match(workspace, /nav=\{sidebar\}\s*list=\{list\}/, "workspace keeps SidebarMinimal as the global nav while Chat mounts WorkspaceSidebar separately");
+assert.match(workspace, /const contextualNav = mode === "chat" \? chatSidebar : sidebar;/, "chat mode replaces the global nav with the contextual Chats sidebar");
+assert.match(workspace, /nav=\{contextualNav\}\s*list=\{undefined\}/, "workspace mounts the contextual Chat nav without an independent list pane");
 
 assert.doesNotMatch(
   chatSurface,

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./familiar-quick-switch.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
 const menuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
 // ── Familiar selection is dropdown-only ───────────────────────────────────────
@@ -19,17 +20,22 @@ assert.doesNotMatch(source, /computeQuickSwitch/, "the strip's pin/recency selec
 assert.doesNotMatch(globals, /\.familiar-quickswitch__strip \{/, "strip CSS removed");
 assert.match(globals, /\.familiar-quickswitch \{/, "wrapper CSS remains for the top-bar call site");
 
-// ── Familiar selection: global nav header + Chats list header ─────────────────
-// Chat keeps the global nav independent, so BOTH hosts are intentional: the
-// SidebarMinimal header carries the switcher in the global nav, and the Chats
-// list header keeps a labeled switcher beside thread navigation on chat.
+// ── Familiar selection follows the active primary sidebar ─────────────────────
+// WorkspaceSidebar replaces SidebarMinimal as the primary contextual nav during
+// Chat. Each host keeps a labeled switcher for the mode where it is active, and
+// SidebarMinimal returns when Chat exits.
 assert.doesNotMatch(menuBar, /FamiliarQuickSwitch|FamiliarSwitcher/, "the menu bar no longer hosts familiar selection");
 assert.match(sidebar, /<FamiliarSwitcher[\s\S]*?labeled/, "the Chats list header keeps a labeled familiar switcher beside thread navigation");
 const sidenav = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 assert.match(
   sidenav,
   /<div className="sidebar-familiar-switch">[\s\S]*?<FamiliarQuickSwitch[\s\S]*?onSelectFamiliar=\{onFamiliarScopeChange\}[\s\S]*?labeled/,
-  "the global sidenav header keeps the labeled familiar switcher in the nav pane",
+  "the normal sidenav header keeps the labeled familiar switcher when Chat is inactive",
+);
+assert.match(
+  workspace,
+  /const contextualNav = mode === "chat" \? chatSidebar : sidebar;[\s\S]*nav=\{contextualNav\}\s*list=\{undefined\}/,
+  "WorkspaceSidebar replaces the normal sidenav during Chat and SidebarMinimal returns on exit",
 );
 
 console.log("familiar-quick-switch component: all assertions passed");

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -87,8 +87,8 @@ assert.match(
 
 // Selecting a destination dismisses the active mobile OVERLAY drawer, but must
 // use the mobile-only `dismissNavMobile`/`dismissListMobile` helpers — NOT
-// `closeNav`/`closeList`, which collapse the independent DESKTOP global nav or
-// persistent Chats list panels. Desktop chat keeps both panes available.
+// `closeNav`/`closeList`, which alter desktop panels. Chat uses only the nav
+// drawer, where WorkspaceSidebar replaces the normal navigation.
 assert.match(
   workspace,
   /onModeChange=\{\(m\) => \{[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*setMode\(m as CaveMode\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -94,10 +94,17 @@ assert.match(
   /onModeChange=\{\(m\) => \{[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*setMode\(m as CaveMode\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
   "Mobile sidebar destination taps should dismiss the nav drawer (mobile-only) without collapsing the desktop nav",
 );
+const normalSidebarBlock = workspace.match(/const sidebar =[\s\S]*?const chatSidebar =/)?.[0] ?? "";
+assert.ok(normalSidebarBlock, "Workspace should keep the normal SidebarMinimal wiring together");
 assert.match(
-  workspace,
+  normalSidebarBlock,
+  /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
+  "Normal mobile session taps should dismiss the nav drawer that becomes Chat's contextual sidebar",
+);
+assert.doesNotMatch(
+  normalSidebarBlock,
   /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
-  "Mobile list drawer session taps should dismiss the list drawer (mobile-only) without collapsing the desktop list",
+  "Normal mobile session taps should not target the absent Chat list drawer",
 );
 const chatSidebarBlock = workspace.match(/const chatSidebar =[\s\S]*?const contextualNav =/)?.[0] ?? "";
 assert.ok(chatSidebarBlock, "Workspace should keep the contextual Chat nav wiring together");

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -15,7 +15,27 @@ const automationsView = [
   await readFile(new URL("./automations/inbox-feed-list.tsx", import.meta.url), "utf8"),
   await readFile(new URL("./automations/schedule-list.tsx", import.meta.url), "utf8"),
 ].join("\n");
-const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const globals = (
+  await Promise.all(
+    [
+      "../app/globals.css",
+      "../styles/sidebar-minimal.css",
+      "../styles/status-bar.css",
+      "../styles/globals/foundations.css",
+      "../styles/globals/shell-navigation.css",
+      "../styles/globals/primitives.css",
+      "../styles/globals/themes.css",
+      "../styles/globals/desktop-chrome.css",
+      "../styles/globals/shell-responsive.css",
+      "../styles/globals/calendar-agenda.css",
+      "../styles/globals/surface-compact-calendar.css",
+      "../styles/globals/surface-reporting.css",
+      "../styles/globals/surface-chat-overlays.css",
+      "../styles/globals/surface-marketplace.css",
+      "../styles/globals/surface-role-workspaces.css",
+    ].map((path) => readFile(new URL(path, import.meta.url), "utf8")),
+  )
+).join("\n");
 
 assert.match(
   bottomTerminal,
@@ -79,30 +99,37 @@ assert.match(
   /onOpenSession=\{\(id\) => \{[\s\S]*openFamiliarSession\(id\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
   "Mobile list drawer session taps should dismiss the list drawer (mobile-only) without collapsing the desktop list",
 );
-assert.match(
-  workspace,
-  /onOpenSession=\{\(session\) => \{[\s\S]*openFamiliarSession\(session\.id, session\.familiarId\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
-  "Chat list session opens should dismiss the mobile list drawer without collapsing the persistent desktop Chats list",
+const chatSidebarBlock = workspace.match(/const chatSidebar =[\s\S]*?const contextualNav =/)?.[0] ?? "";
+assert.ok(chatSidebarBlock, "Workspace should keep the contextual Chat nav wiring together");
+assert.doesNotMatch(
+  chatSidebarBlock,
+  /dismissListMobile/,
+  "Chat contextual-nav actions should never target the unused list drawer",
 );
 assert.match(
-  workspace,
-  /onNewChat=\{\(projectRoot\) => \{[\s\S]*startFamiliarChat\(activeId, projectRoot\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
-  "Chat list new-chat actions should dismiss the mobile list drawer without touching the desktop list pane",
+  chatSidebarBlock,
+  /onOpenSession=\{\(session\) => \{[\s\S]*openFamiliarSession\(session\.id, session\.familiarId\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
+  "Chat session opens should dismiss the mobile contextual nav without changing desktop layout",
 );
 assert.match(
-  workspace,
-  /onNavigate=\{\(nextMode\) => \{[\s\S]*setMode\(nextMode\);[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*\}\}/,
-  "Chat list Home, Scheduled, and Plugins actions should dismiss the mobile list drawer without touching the desktop list pane",
+  chatSidebarBlock,
+  /onNewChat=\{\(projectRoot\) => \{[\s\S]*startFamiliarChat\(activeId, projectRoot\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
+  "Chat new-chat actions should dismiss the mobile contextual nav without changing desktop layout",
 );
 assert.match(
-  workspace,
-  /onOpenUrl=\{\(url\) => \{[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*openUrlInApp\(url\);[\s\S]*\}\}/,
-  "Chat list PR links should dismiss only the mobile list drawer before opening",
+  chatSidebarBlock,
+  /onNavigate=\{\(nextMode\) => \{[\s\S]*setMode\(nextMode\);[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*\}\}/,
+  "Chat Home, Scheduled, and Plugins actions should dismiss the mobile contextual nav without changing desktop layout",
 );
 assert.match(
-  workspace,
-  /onOpenSettings=\{\(\) => \{[\s\S]*shellRef\.current\?\.dismissListMobile\(\);[\s\S]*nextRouter\.push\("\/settings"\);[\s\S]*\}\}/,
-  "Chat list settings should dismiss only the mobile list drawer before routing",
+  chatSidebarBlock,
+  /onOpenUrl=\{\(url\) => \{[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*openUrlInApp\(url\);[\s\S]*\}\}/,
+  "Chat PR links should dismiss only the mobile contextual nav before opening",
+);
+assert.match(
+  chatSidebarBlock,
+  /onOpenSettings=\{\(\) => \{[\s\S]*shellRef\.current\?\.dismissNavMobile\(\);[\s\S]*nextRouter\.push\("\/settings"\);[\s\S]*\}\}/,
+  "Chat settings should dismiss only the mobile contextual nav before routing",
 );
 
 // The mobile-only dismissers must be gated on isMobile and must NOT call the
@@ -126,13 +153,13 @@ assert.match(
 );
 assert.match(
   workspace,
-  /onToggleList=\{list \? \(\) => shellRef\.current\?\.toggleList\(\) : undefined\}/,
-  "Workspace should wire the TopBar list button to the shell list toggle",
+  /onToggleNav=\{\(\) => shellRef\.current\?\.toggleNav\(\)\}[\s\S]*onToggleList=\{undefined\}/,
+  "Mobile Chat should expose the contextual nav toggle and no list toggle",
 );
 assert.match(
   workspace,
-  /listDrawerOpen=\{listDrawerOpen\}/,
-  "Workspace should pass the shell's list drawer state through to the TopBar",
+  /navDrawerOpen=\{navDrawerOpen\}\s*listDrawerOpen=\{false\}/,
+  "Mobile Chat should expose nav drawer state while reporting the absent list drawer as closed",
 );
 
 assert.match(

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -77,8 +77,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /shell-top-toggle--nav[\s\S]*?aria-label=\{chatContextual[\s\S]*?: navOpen\s*\?\s*"Collapse navigation to icons"\s*:\s*"Expand navigation"\}/,
-  "nav toggle label reflects nav state (and the contextual Chat sidebar variant)",
+  /shell-top-toggle--nav[\s\S]*?aria-label=\{chatContextual[\s\S]*?\? "Collapse Chat sidebar"[\s\S]*?: "Expand Chat sidebar"[\s\S]*?\? "Collapse navigation to icons"[\s\S]*?: "Expand navigation"\}/,
+  "nav toggle label reflects both contextual Chat and normal navigation state",
 );
 assert.match(
   shell,

--- a/src/components/shell-layout.ts
+++ b/src/components/shell-layout.ts
@@ -1,0 +1,55 @@
+export type ShellPanelLayout = Record<string, number>;
+
+type ResolveShellDestinationLayoutOptions = {
+  panelIds: string[];
+  savedLayout: ShellPanelLayout | undefined;
+  groupSize: number;
+  defaultPanelPixels: Partial<Record<string, number>>;
+  requireOpenNav: boolean;
+};
+
+const roundPercentage = (value: number) => Number.parseFloat(value.toFixed(3));
+
+export function resolveShellDestinationLayout({
+  panelIds,
+  savedLayout,
+  groupSize,
+  defaultPanelPixels,
+  requireOpenNav,
+}: ResolveShellDestinationLayoutOptions): ShellPanelLayout | undefined {
+  if (
+    savedLayout &&
+    panelIds.every((panelId) => Number.isFinite(savedLayout[panelId])) &&
+    (!requireOpenNav || (savedLayout.nav ?? 0) > 0)
+  ) {
+    return Object.fromEntries(panelIds.map((panelId) => [panelId, savedLayout[panelId]]));
+  }
+
+  if (!Number.isFinite(groupSize) || groupSize <= 0 || panelIds.length === 0) {
+    return undefined;
+  }
+
+  const layout: ShellPanelLayout = {};
+  const flexiblePanelIds: string[] = [];
+  let assigned = 0;
+
+  for (const panelId of panelIds) {
+    const defaultPixels = defaultPanelPixels[panelId];
+    if (typeof defaultPixels === "number" && Number.isFinite(defaultPixels)) {
+      const percentage = roundPercentage((defaultPixels / groupSize) * 100);
+      layout[panelId] = percentage;
+      assigned += percentage;
+    } else {
+      flexiblePanelIds.push(panelId);
+    }
+  }
+
+  if (flexiblePanelIds.length > 0) {
+    const flexibleSize = roundPercentage((100 - assigned) / flexiblePanelIds.length);
+    for (const panelId of flexiblePanelIds) {
+      layout[panelId] = flexibleSize;
+    }
+  }
+
+  return layout;
+}

--- a/src/components/shell-layout.ts
+++ b/src/components/shell-layout.ts
@@ -13,6 +13,15 @@ const roundPercentage = (value: number) => Number.parseFloat(value.toFixed(3));
 const LAYOUT_SUM_TOLERANCE = 0.1;
 const COLLAPSED_PIXEL_TOLERANCE = 1;
 
+export function resolveShellNavOpenPreference(
+  persistedOpen: boolean | null,
+  defaultOpen: boolean,
+): { open: boolean; shouldPersist: boolean } {
+  return persistedOpen === null
+    ? { open: defaultOpen, shouldPersist: true }
+    : { open: persistedOpen, shouldPersist: false };
+}
+
 function isCompleteLayout(
   layout: ShellPanelLayout,
   panelIds = Object.keys(layout),
@@ -32,16 +41,76 @@ function isCompleteLayout(
   return Math.abs(sum - 100) <= LAYOUT_SUM_TOLERANCE;
 }
 
-export function shouldPersistShellLayout({
+export function isShellNavCollapsedLayout({
+  layout,
+  panelIds,
+  groupSize,
+  collapsedNavPixels,
+}: {
+  layout: ShellPanelLayout | undefined;
+  panelIds: string[];
+  groupSize: number;
+  collapsedNavPixels: number;
+}): boolean {
+  if (
+    !layout ||
+    !isCompleteLayout(layout, panelIds) ||
+    !Number.isFinite(groupSize) ||
+    groupSize <= 0
+  ) {
+    return false;
+  }
+  return ((layout.nav ?? 0) / 100) * groupSize <=
+    collapsedNavPixels + COLLAPSED_PIXEL_TOLERANCE;
+}
+
+export function resolveShellLayoutPersistence({
   isMobile,
   navCollapsed,
   layout,
+  savedExpandedLayout,
+  previousCollapsedLayout,
 }: {
   isMobile: boolean;
   navCollapsed: boolean;
   layout: ShellPanelLayout;
-}): boolean {
-  return !isMobile && !navCollapsed && isCompleteLayout(layout);
+  savedExpandedLayout: ShellPanelLayout | undefined;
+  previousCollapsedLayout?: ShellPanelLayout;
+}): ShellPanelLayout | undefined {
+  const panelIds = Object.keys(layout);
+  if (isMobile || !isCompleteLayout(layout, panelIds)) return undefined;
+  if (!navCollapsed) {
+    return Object.fromEntries(panelIds.map((panelId) => [panelId, layout[panelId]]));
+  }
+  if (
+    !savedExpandedLayout ||
+    !isCompleteLayout(savedExpandedLayout, panelIds) ||
+    savedExpandedLayout.nav <= layout.nav + LAYOUT_SUM_TOLERANCE
+  ) {
+    return undefined;
+  }
+
+  const saved = Object.fromEntries(
+    panelIds.map((panelId) => [panelId, savedExpandedLayout[panelId]]),
+  );
+  // The first collapsed callback only establishes a baseline. Later callbacks
+  // apply list-like panel deltas to the saved expanded layout; detail remains
+  // the flexible remainder and the expanded nav width never changes.
+  if (!previousCollapsedLayout || !isCompleteLayout(previousCollapsedLayout, panelIds)) {
+    return saved;
+  }
+
+  const merged = { ...saved };
+  let assigned = merged.nav;
+  for (const panelId of panelIds) {
+    if (panelId === "nav" || panelId === "detail") continue;
+    merged[panelId] = roundPercentage(
+      saved[panelId] + layout[panelId] - previousCollapsedLayout[panelId],
+    );
+    assigned += merged[panelId];
+  }
+  merged.detail = roundPercentage(100 - assigned);
+  return isCompleteLayout(merged, panelIds) ? merged : saved;
 }
 
 export function resolveShellDestinationLayout({
@@ -61,11 +130,17 @@ export function resolveShellDestinationLayout({
     return undefined;
   }
 
-  const savedNavPixels = ((savedLayout?.nav ?? 0) / 100) * groupSize;
+  const savedLayoutIsComplete =
+    savedLayout !== undefined && isCompleteLayout(savedLayout, panelIds);
+  const savedNavIsCollapsed = isShellNavCollapsedLayout({
+    layout: savedLayout,
+    panelIds,
+    groupSize,
+    collapsedNavPixels,
+  });
   if (
-    savedLayout &&
-    isCompleteLayout(savedLayout, panelIds) &&
-    savedNavPixels > collapsedNavPixels + COLLAPSED_PIXEL_TOLERANCE
+    savedLayoutIsComplete &&
+    !savedNavIsCollapsed
   ) {
     return Object.fromEntries(panelIds.map((panelId) => [panelId, savedLayout[panelId]]));
   }

--- a/src/components/shell-layout.ts
+++ b/src/components/shell-layout.ts
@@ -5,28 +5,69 @@ type ResolveShellDestinationLayoutOptions = {
   savedLayout: ShellPanelLayout | undefined;
   groupSize: number;
   defaultPanelPixels: Partial<Record<string, number>>;
-  requireOpenNav: boolean;
+  collapsedNavPixels: number;
+  isMobile: boolean;
 };
 
 const roundPercentage = (value: number) => Number.parseFloat(value.toFixed(3));
+const LAYOUT_SUM_TOLERANCE = 0.1;
+const COLLAPSED_PIXEL_TOLERANCE = 1;
+
+function isCompleteLayout(
+  layout: ShellPanelLayout,
+  panelIds = Object.keys(layout),
+): boolean {
+  if (
+    panelIds.length < 2 ||
+    !panelIds.every(
+      (panelId) =>
+        typeof layout[panelId] === "number" &&
+        Number.isFinite(layout[panelId]) &&
+        layout[panelId] >= 0,
+    )
+  ) {
+    return false;
+  }
+  const sum = panelIds.reduce((total, panelId) => total + layout[panelId], 0);
+  return Math.abs(sum - 100) <= LAYOUT_SUM_TOLERANCE;
+}
+
+export function shouldPersistShellLayout({
+  isMobile,
+  navCollapsed,
+  layout,
+}: {
+  isMobile: boolean;
+  navCollapsed: boolean;
+  layout: ShellPanelLayout;
+}): boolean {
+  return !isMobile && !navCollapsed && isCompleteLayout(layout);
+}
 
 export function resolveShellDestinationLayout({
   panelIds,
   savedLayout,
   groupSize,
   defaultPanelPixels,
-  requireOpenNav,
+  collapsedNavPixels,
+  isMobile,
 }: ResolveShellDestinationLayoutOptions): ShellPanelLayout | undefined {
   if (
-    savedLayout &&
-    panelIds.every((panelId) => Number.isFinite(savedLayout[panelId])) &&
-    (!requireOpenNav || (savedLayout.nav ?? 0) > 0)
+    isMobile ||
+    !Number.isFinite(groupSize) ||
+    groupSize <= 0 ||
+    panelIds.length === 0
   ) {
-    return Object.fromEntries(panelIds.map((panelId) => [panelId, savedLayout[panelId]]));
+    return undefined;
   }
 
-  if (!Number.isFinite(groupSize) || groupSize <= 0 || panelIds.length === 0) {
-    return undefined;
+  const savedNavPixels = ((savedLayout?.nav ?? 0) / 100) * groupSize;
+  if (
+    savedLayout &&
+    isCompleteLayout(savedLayout, panelIds) &&
+    savedNavPixels > collapsedNavPixels + COLLAPSED_PIXEL_TOLERANCE
+  ) {
+    return Object.fromEntries(panelIds.map((panelId) => [panelId, savedLayout[panelId]]));
   }
 
   const layout: ShellPanelLayout = {};
@@ -45,11 +86,16 @@ export function resolveShellDestinationLayout({
   }
 
   if (flexiblePanelIds.length > 0) {
+    if (assigned >= 100) return undefined;
     const flexibleSize = roundPercentage((100 - assigned) / flexiblePanelIds.length);
-    for (const panelId of flexiblePanelIds) {
-      layout[panelId] = flexibleSize;
+    for (let index = 0; index < flexiblePanelIds.length; index += 1) {
+      const panelId = flexiblePanelIds[index];
+      layout[panelId] =
+        index === flexiblePanelIds.length - 1
+          ? roundPercentage(100 - assigned - flexibleSize * index)
+          : flexibleSize;
     }
   }
 
-  return layout;
+  return isCompleteLayout(layout, panelIds) ? layout : undefined;
 }

--- a/src/components/shell-left-panels-fit.test.ts
+++ b/src/components/shell-left-panels-fit.test.ts
@@ -25,7 +25,7 @@ assert.match(
 );
 assert.match(
   shell,
-  /const cur = group\.getLayout\(\);[\s\S]{0,220}?const railPct = nav \* \(NAV_RAIL_PX \/ NAV_OPEN_PX\);[\s\S]{0,160}?group\.setLayout\(\{ \.\.\.cur, nav: railPct, detail: cur\.detail \+ \(nav - railPct\) \}\)/,
+  /const cur = group\.getLayout\(\);[\s\S]{0,220}?const railPct = nav \* \(NAV_RAIL_PX \/ NAV_OPEN_PX\);[\s\S]{0,240}?group\.setLayout\(\{ \.\.\.cur, nav: railPct, detail: cur\.detail \+ \(nav - railPct\) \}\)/,
   "on settle, a fresh group is minimized by setting the whole layout (nav→rail, freed width→detail)",
 );
 assert.match(

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -9,9 +9,27 @@ import * as shellLayout from "./shell-layout.ts";
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
 const compactWhitespace = (input: string) => input.replace(/\s+/g, " ").trim();
 const { resolveShellDestinationLayout } = shellLayout;
-const shouldPersistShellLayout =
-  shellLayout.shouldPersistShellLayout ??
-  (() => true);
+const isShellNavCollapsedLayout =
+  shellLayout.isShellNavCollapsedLayout ??
+  (() => false);
+const resolveShellLayoutPersistence =
+  shellLayout.resolveShellLayoutPersistence ??
+  (() => undefined);
+const resolveShellNavOpenPreference =
+  shellLayout.resolveShellNavOpenPreference ??
+  (() => ({ open: true, shouldPersist: false }));
+
+assert.deepEqual(
+  resolveShellNavOpenPreference(null, false),
+  { open: false, shouldPersist: true },
+  "first-run minimization seeds the separate normal-nav preference as collapsed",
+);
+
+assert.deepEqual(
+  resolveShellNavOpenPreference(true, false),
+  { open: true, shouldPersist: false },
+  "first-run minimization never overwrites an existing user preference",
+);
 
 assert.equal(
   resolveShellDestinationLayout({
@@ -27,12 +45,13 @@ assert.equal(
 );
 
 assert.equal(
-  shouldPersistShellLayout({
+  resolveShellLayoutPersistence({
     isMobile: true,
     navCollapsed: false,
     layout: { nav: 30, list: 25, detail: 45 },
+    savedExpandedLayout: { nav: 30, list: 25, detail: 45 },
   }),
-  false,
+  undefined,
   "mobile drawer layouts never overwrite desktop persistence",
 );
 
@@ -101,26 +120,77 @@ assert.deepEqual(
   "rounded persisted rail percentages are still recognized as collapsed layouts",
 );
 
+const legacyCollapsedNormal = { nav: 5.6, list: 27, detail: 67.4 };
+assert.equal(
+  isShellNavCollapsedLayout({
+    layout: legacyCollapsedNormal,
+    panelIds: ["nav", "list", "detail"],
+    groupSize: 1_000,
+    collapsedNavPixels: 56,
+  }),
+  true,
+  "legacy normal rail layouts are identified for collapsed-preference migration",
+);
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "list", "detail"],
+    savedLayout: legacyCollapsedNormal,
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 240, list: 260 },
+    collapsedNavPixels: 56,
+    isMobile: false,
+  }),
+  { nav: 24, list: 26, detail: 50 },
+  "legacy collapsed layouts reconstruct a safe complete expanded fallback",
+);
+
 const normalExpanded = { nav: 34, list: 27, detail: 39 };
-let savedNormalLayout: Record<string, number> | undefined;
-if (
-  shouldPersistShellLayout({
+const initialCollapsedNormal = { nav: 5.6, list: 55.4, detail: 39 };
+assert.deepEqual(
+  resolveShellLayoutPersistence({
+    isMobile: false,
+    navCollapsed: true,
+    layout: initialCollapsedNormal,
+    savedExpandedLayout: normalExpanded,
+    previousCollapsedLayout: undefined,
+  }),
+  normalExpanded,
+  "the collapse redistribution itself does not change the saved expanded list/detail layout",
+);
+const savedNormalLayout = resolveShellLayoutPersistence({
+  isMobile: false,
+  navCollapsed: true,
+  layout: { nav: 5.6, list: 59.4, detail: 35 },
+  savedExpandedLayout: normalExpanded,
+  previousCollapsedLayout: initialCollapsedNormal,
+});
+assert.deepEqual(
+  savedNormalLayout,
+  { nav: 34, list: 31, detail: 35 },
+  "list/detail separator changes in the normal nav rail merge into the expanded layout without replacing nav width",
+);
+assert.deepEqual(
+  resolveShellLayoutPersistence({
     isMobile: false,
     navCollapsed: false,
     layout: normalExpanded,
-  })
-) {
-  savedNormalLayout = normalExpanded;
-}
-if (
-  shouldPersistShellLayout({
+    savedExpandedLayout: undefined,
+    previousCollapsedLayout: undefined,
+  }),
+  normalExpanded,
+  "expanded desktop callbacks still persist their complete layout",
+);
+assert.equal(
+  resolveShellLayoutPersistence({
     isMobile: false,
     navCollapsed: true,
-    layout: { nav: 5.6, list: 27, detail: 67.4 },
-  })
-) {
-  savedNormalLayout = { nav: 5.6, list: 27, detail: 67.4 };
-}
+    layout: normalExpanded,
+    savedExpandedLayout: normalExpanded,
+    previousCollapsedLayout: undefined,
+  }),
+  undefined,
+  "a stale collapsed imperative state cannot establish an expanded layout as the collapsed baseline",
+);
 assert.deepEqual(
   resolveShellDestinationLayout({
     panelIds: ["nav", "list", "detail"],
@@ -130,35 +200,28 @@ assert.deepEqual(
     collapsedNavPixels: 56,
     isMobile: false,
   }),
-  normalExpanded,
-  "normal navigation keeps its user-resized expanded width and list/detail proportions across collapse -> Chat -> return",
+  savedNormalLayout,
+  "normal navigation restores the merged list/detail proportions across collapse -> Chat -> return",
 );
 assert.equal(
-  Object.values(normalExpanded).reduce((sum, size) => sum + size, 0),
+  Object.values(savedNormalLayout ?? {}).reduce((sum, size) => sum + size, 0),
   100,
-  "the remembered normal layout remains a complete valid group layout",
+  "the merged normal layout remains a complete valid group layout",
 );
 
 const chatExpanded = { nav: 31, detail: 69 };
-let savedChatLayout: Record<string, number> | undefined;
-if (
-  shouldPersistShellLayout({
-    isMobile: false,
-    navCollapsed: false,
-    layout: chatExpanded,
-  })
-) {
-  savedChatLayout = chatExpanded;
-}
-if (
-  shouldPersistShellLayout({
-    isMobile: false,
-    navCollapsed: true,
-    layout: { nav: 0, detail: 100 },
-  })
-) {
-  savedChatLayout = { nav: 0, detail: 100 };
-}
+const savedChatLayout = resolveShellLayoutPersistence({
+  isMobile: false,
+  navCollapsed: true,
+  layout: { nav: 0, detail: 100 },
+  savedExpandedLayout: chatExpanded,
+  previousCollapsedLayout: undefined,
+});
+assert.deepEqual(
+  savedChatLayout,
+  chatExpanded,
+  "Chat zero-collapse callbacks preserve its last expanded contextual width",
+);
 assert.deepEqual(
   resolveShellDestinationLayout({
     panelIds: ["nav", "detail"],
@@ -193,6 +256,12 @@ assert.match(
 
 assert.match(
   shell,
+  /minimizedGroupsRef\.current\.add\(groupId\);\s*seedNavOpenPref\(false\);\s*markShellMinimizeApplied\(groupId\);/,
+  "first-run minimization seeds the collapsed preference before recording completion",
+);
+
+assert.match(
+  shell,
   /export type ShellNavPolicy = "remembered" \| "visit-collapsed" \| "chat-contextual";/,
   "Shell exports the route-scoped nav policy contract",
 );
@@ -205,8 +274,8 @@ assert.match(
 
 assert.match(
   shell,
-  /import \{[\s\S]*resolveShellDestinationLayout,[\s\S]*shouldPersistShellLayout,[\s\S]*\} from "\.\/shell-layout";/,
-  "Shell uses the tested destination-layout resolver and persistence gate",
+  /import \{[\s\S]*isShellNavCollapsedLayout,[\s\S]*resolveShellDestinationLayout,[\s\S]*resolveShellLayoutPersistence,[\s\S]*resolveShellNavOpenPreference,[\s\S]*\} from "\.\/shell-layout";/,
+  "Shell uses the tested destination, persistence-merge, and preference helpers",
 );
 
 const destinationLayoutEffect =
@@ -224,13 +293,18 @@ assert.match(
 );
 assert.match(
   destinationLayoutEffect,
+  /if \(\s*!chatContextual &&\s*isShellNavCollapsedLayout\(\{[\s\S]*?layout: defaultLayout,[\s\S]*?collapsedNavPixels: NAV_RAIL_PX,[\s\S]*?\}\)\s*\) \{\s*seedNavOpenPref\(false\);\s*\}[\s\S]*?resolveShellDestinationLayout\(/,
+  "legacy collapsed normal layouts migrate the collapsed preference before their expanded fallback is restored",
+);
+assert.match(
+  destinationLayoutEffect,
   /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ nav: chatContextual \? 260 : NAV_OPEN_PX, \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?collapsedNavPixels: chatContextual \? 0 : NAV_RAIL_PX,[\s\S]*?isMobile,/,
   "every desktop group transition resolves an expanded destination layout from its own saved width or pixel defaults",
 );
 assert.match(
   destinationLayoutEffect,
-  /layoutPersistenceGroupRef\.current = groupId;\s*restoredGroupRef\.current = groupId;\s*group\.setLayout\(destinationLayout\);/,
-  "the destination group is armed only when its complete layout is ready to apply",
+  /expandedLayoutRef\.current = \{ groupId, layout: destinationLayout \};\s*collapsedLayoutRef\.current = null;\s*layoutPersistenceGroupRef\.current = groupId;\s*restoredGroupRef\.current = groupId;\s*group\.setLayout\(destinationLayout\);/,
+  "the destination group resets collapsed deltas, remembers, and arms its complete expanded layout before applying it",
 );
 
 // Boot/group-switch application: after the group settles, a saved preference
@@ -245,8 +319,8 @@ assert.match(
 );
 assert.match(
   applyEffect,
-  /const pref = readNavOpenPref\(\);/,
-  "boot reads the persisted sidebar preference",
+  /const pref = seedNavOpenPref\(false\);/,
+  "boot backfills a missing collapsed default preference while preserving an existing preference",
 );
 assert.match(
   applyEffect,
@@ -323,8 +397,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /onLayoutChanged=\{\(layout, detail\) => \{\s*if \(layoutPersistenceGroupRef\.current !== groupId\) return;[\s\S]{0,300}?if \(\s*shouldPersistShellLayout\(\{\s*isMobile,\s*navCollapsed: navRef\.current\?\.isCollapsed\(\) \?\? true,\s*layout,\s*\}\)\s*\) \{\s*onLayoutChanged\(layout, detail\);\s*\}\s*\}\}/,
-  "group-swap churn, mobile drawer layouts, and collapsed layouts cannot overwrite each group's last expanded layout",
+  /onLayoutChanged=\{\(layout, detail\) => \{\s*if \(layoutPersistenceGroupRef\.current !== groupId\) return;[\s\S]*?const navCollapsed = navRef\.current\?\.isCollapsed\(\) \?\? true;[\s\S]*?const persistedLayout = resolveShellLayoutPersistence\(\{[\s\S]*?navCollapsed,[\s\S]*?savedExpandedLayout:\s*expandedLayoutRef\.current\?\.groupId === groupId[\s\S]*?previousCollapsedLayout:\s*collapsedLayoutRef\.current\?\.groupId === groupId[\s\S]*?\}\);[\s\S]*?if \(!persistedLayout\) return;\s*collapsedLayoutRef\.current = navCollapsed \? \{ groupId, layout \} : null;\s*expandedLayoutRef\.current = \{ groupId, layout: persistedLayout \};\s*onLayoutChanged\(persistedLayout, detail\);\s*\}\}/,
+  "desktop collapsed callbacks merge non-nav changes into each group's expanded layout while mobile and group-swap churn stay disarmed",
 );
 
 // Writes are user-driven only: the group must be armed (group-swap layout

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -4,10 +4,37 @@
 // reading or overwriting the global cave:shell:nav-open preference.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { resolveShellDestinationLayout } from "./shell-layout.ts";
+import * as shellLayout from "./shell-layout.ts";
 
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
 const compactWhitespace = (input: string) => input.replace(/\s+/g, " ").trim();
+const { resolveShellDestinationLayout } = shellLayout;
+const shouldPersistShellLayout =
+  shellLayout.shouldPersistShellLayout ??
+  (() => true);
+
+assert.equal(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "list", "detail"],
+    savedLayout: { nav: 30, list: 25, detail: 45 },
+    groupSize: 375,
+    defaultPanelPixels: { nav: 240, list: 260 },
+    collapsedNavPixels: 56,
+    isMobile: true,
+  }),
+  undefined,
+  "mobile drawers never restore desktop resizable-panel layouts",
+);
+
+assert.equal(
+  shouldPersistShellLayout({
+    isMobile: true,
+    navCollapsed: false,
+    layout: { nav: 30, list: 25, detail: 45 },
+  }),
+  false,
+  "mobile drawer layouts never overwrite desktop persistence",
+);
 
 assert.deepEqual(
   resolveShellDestinationLayout({
@@ -15,7 +42,8 @@ assert.deepEqual(
     savedLayout: { nav: 35, detail: 65 },
     groupSize: 1_000,
     defaultPanelPixels: { nav: 260 },
-    requireOpenNav: true,
+    collapsedNavPixels: 0,
+    isMobile: false,
   }),
   { nav: 35, detail: 65 },
   "Chat restores its own user-resized layout instead of inheriting the normal group's live width",
@@ -27,7 +55,8 @@ assert.deepEqual(
     savedLayout: { nav: 0, detail: 100 },
     groupSize: 1_000,
     defaultPanelPixels: { nav: 260 },
-    requireOpenNav: true,
+    collapsedNavPixels: 0,
+    isMobile: false,
   }),
   { nav: 26, detail: 74 },
   "Chat falls back to its 260px default when no nonzero saved Chat width exists",
@@ -39,7 +68,8 @@ assert.deepEqual(
     savedLayout: undefined,
     groupSize: 1_000,
     defaultPanelPixels: { nav: 240, list: 260 },
-    requireOpenNav: false,
+    collapsedNavPixels: 56,
+    isMobile: false,
   }),
   { nav: 24, list: 26, detail: 50 },
   "a fresh normal group restores both left-panel defaults without borrowing Chat or corrupting detail",
@@ -51,10 +81,108 @@ assert.deepEqual(
     savedLayout: { nav: 5.6, detail: 94.4 },
     groupSize: 1_000,
     defaultPanelPixels: { nav: 240 },
-    requireOpenNav: false,
+    collapsedNavPixels: 56,
+    isMobile: false,
   }),
-  { nav: 5.6, detail: 94.4 },
-  "normal navigation preserves its own saved collapsed rail layout before applying the remembered open preference",
+  { nav: 24, detail: 76 },
+  "a legacy collapsed rail layout restores an expanded default before applying the remembered open preference",
+);
+
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "detail"],
+    savedLayout: { nav: 4.667, detail: 95.333 },
+    groupSize: 1_200,
+    defaultPanelPixels: { nav: 240 },
+    collapsedNavPixels: 56,
+    isMobile: false,
+  }),
+  { nav: 20, detail: 80 },
+  "rounded persisted rail percentages are still recognized as collapsed layouts",
+);
+
+const normalExpanded = { nav: 34, list: 27, detail: 39 };
+let savedNormalLayout: Record<string, number> | undefined;
+if (
+  shouldPersistShellLayout({
+    isMobile: false,
+    navCollapsed: false,
+    layout: normalExpanded,
+  })
+) {
+  savedNormalLayout = normalExpanded;
+}
+if (
+  shouldPersistShellLayout({
+    isMobile: false,
+    navCollapsed: true,
+    layout: { nav: 5.6, list: 27, detail: 67.4 },
+  })
+) {
+  savedNormalLayout = { nav: 5.6, list: 27, detail: 67.4 };
+}
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "list", "detail"],
+    savedLayout: savedNormalLayout,
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 240, list: 260 },
+    collapsedNavPixels: 56,
+    isMobile: false,
+  }),
+  normalExpanded,
+  "normal navigation keeps its user-resized expanded width and list/detail proportions across collapse -> Chat -> return",
+);
+assert.equal(
+  Object.values(normalExpanded).reduce((sum, size) => sum + size, 0),
+  100,
+  "the remembered normal layout remains a complete valid group layout",
+);
+
+const chatExpanded = { nav: 31, detail: 69 };
+let savedChatLayout: Record<string, number> | undefined;
+if (
+  shouldPersistShellLayout({
+    isMobile: false,
+    navCollapsed: false,
+    layout: chatExpanded,
+  })
+) {
+  savedChatLayout = chatExpanded;
+}
+if (
+  shouldPersistShellLayout({
+    isMobile: false,
+    navCollapsed: true,
+    layout: { nav: 0, detail: 100 },
+  })
+) {
+  savedChatLayout = { nav: 0, detail: 100 };
+}
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "detail"],
+    savedLayout: savedChatLayout,
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 260 },
+    collapsedNavPixels: 0,
+    isMobile: false,
+  }),
+  chatExpanded,
+  "Chat keeps its own last expanded width across contextual transitions",
+);
+
+assert.equal(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "list", "detail"],
+    savedLayout: undefined,
+    groupSize: 400,
+    defaultPanelPixels: { nav: 240, list: 260 },
+    collapsedNavPixels: 56,
+    isMobile: false,
+  }),
+  undefined,
+  "impossible pixel defaults never produce negative detail proportions",
 );
 
 assert.match(
@@ -77,13 +205,18 @@ assert.match(
 
 assert.match(
   shell,
-  /import \{ resolveShellDestinationLayout \} from "\.\/shell-layout";/,
-  "Shell uses the tested destination-layout resolver",
+  /import \{[\s\S]*resolveShellDestinationLayout,[\s\S]*shouldPersistShellLayout,[\s\S]*\} from "\.\/shell-layout";/,
+  "Shell uses the tested destination-layout resolver and persistence gate",
 );
 
 const destinationLayoutEffect =
-  shell.match(/const layoutPersistenceGroupRef = useRef<string \| null>\(null\);[\s\S]*?\}, \[mounted, groupId, chatContextual, defaultLayout, twoPane\]\);/)?.[0] ?? "";
+  shell.match(/const layoutPersistenceGroupRef = useRef<string \| null>\(null\);[\s\S]*?\}, \[mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane\]\);/)?.[0] ?? "";
 assert.ok(destinationLayoutEffect.length > 0, "the destination group restoration effect exists");
+assert.match(
+  destinationLayoutEffect,
+  /if \(!mounted \|\| isMobile\) \{[\s\S]*?layoutPersistenceGroupRef\.current = null;[\s\S]*?restoredGroupRef\.current = null;[\s\S]*?return;/,
+  "mobile mode disarms persistence and desktop restoration until the viewport returns",
+);
 assert.match(
   destinationLayoutEffect,
   /Array\.from\(groupElement\.children\)\.reduce\([\s\S]*?child\.hasAttribute\("data-panel"\)[\s\S]*?child\.offsetWidth/,
@@ -91,8 +224,8 @@ assert.match(
 );
 assert.match(
   destinationLayoutEffect,
-  /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ nav: chatContextual \? 260 : NAV_OPEN_PX, \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?requireOpenNav: chatContextual,/,
-  "every group transition resolves the destination's saved layout or its own Chat/normal pixel defaults",
+  /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ nav: chatContextual \? 260 : NAV_OPEN_PX, \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?collapsedNavPixels: chatContextual \? 0 : NAV_RAIL_PX,[\s\S]*?isMobile,/,
+  "every desktop group transition resolves an expanded destination layout from its own saved width or pixel defaults",
 );
 assert.match(
   destinationLayoutEffect,
@@ -185,8 +318,13 @@ assert.equal(
 
 assert.match(
   shell,
-  /onLayoutChanged=\{\(layout, detail\) => \{\s*if \(layoutPersistenceGroupRef\.current !== groupId\) return;[\s\S]{0,240}?if \(!chatContextual \|\| \(layout\.nav \?\? 0\) > 0\) \{\s*onLayoutChanged\(layout, detail\);\s*\}\s*\}\}/,
-  "group-swap churn cannot overwrite the destination layout, and Chat keeps its last expanded width",
+  /defaultLayout=\{isMobile \? undefined : defaultLayout\}/,
+  "mobile rendering does not feed desktop saved layouts into the resizable group",
+);
+assert.match(
+  shell,
+  /onLayoutChanged=\{\(layout, detail\) => \{\s*if \(layoutPersistenceGroupRef\.current !== groupId\) return;[\s\S]{0,300}?if \(\s*shouldPersistShellLayout\(\{\s*isMobile,\s*navCollapsed: navRef\.current\?\.isCollapsed\(\) \?\? true,\s*layout,\s*\}\)\s*\) \{\s*onLayoutChanged\(layout, detail\);\s*\}\s*\}\}/,
+  "group-swap churn, mobile drawer layouts, and collapsed layouts cannot overwrite each group's last expanded layout",
 );
 
 // Writes are user-driven only: the group must be armed (group-swap layout

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -279,7 +279,7 @@ assert.match(
 );
 
 const destinationLayoutEffect =
-  shell.match(/const layoutPersistenceGroupRef = useRef<string \| null>\(null\);[\s\S]*?\}, \[mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane\]\);/)?.[0] ?? "";
+  shell.match(/const layoutPersistenceGroupRef = useRef<string \| null>\(null\);[\s\S]*?\}, \[mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane, navPolicy\]\);/)?.[0] ?? "";
 assert.ok(destinationLayoutEffect.length > 0, "the destination group restoration effect exists");
 assert.match(
   destinationLayoutEffect,
@@ -305,6 +305,16 @@ assert.match(
   destinationLayoutEffect,
   /expandedLayoutRef\.current = \{ groupId, layout: destinationLayout \};\s*collapsedLayoutRef\.current = null;\s*layoutPersistenceGroupRef\.current = groupId;\s*restoredGroupRef\.current = groupId;\s*group\.setLayout\(destinationLayout\);/,
   "the destination group resets collapsed deltas, remembers, and arms its complete expanded layout before applying it",
+);
+assert.match(
+  destinationLayoutEffect,
+  /const rememberedNavOpen =\s*navPolicy === "remembered" \? seedNavOpenPref\(false\) : null;[\s\S]*?expandedLayoutRef\.current = \{ groupId, layout: destinationLayout \};[\s\S]*?group\.setLayout\(destinationLayout\);\s*if \(rememberedNavOpen !== null\) \{\s*railAutoCollapsedNavRef\.current = false;\s*userOverrodeNavRef\.current = false;\s*applyPanelOpenState\(navRef\.current, rememberedNavOpen\);\s*setNavOpen\(rememberedNavOpen\);\s*minimizedGroupsRef\.current\.add\(groupId\);\s*markShellMinimizeApplied\(groupId\);\s*\}/,
+  "normal destination restoration applies the remembered state before paint while retaining the expanded layout",
+);
+assert.match(
+  destinationLayoutEffect,
+  /\}, \[mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane, navPolicy\]\);/,
+  "destination restoration reruns with the active nav policy",
 );
 
 // Boot/group-switch application: after the group settles, a saved preference

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -4,9 +4,58 @@
 // reading or overwriting the global cave:shell:nav-open preference.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { resolveShellDestinationLayout } from "./shell-layout.ts";
 
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
 const compactWhitespace = (input: string) => input.replace(/\s+/g, " ").trim();
+
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "detail"],
+    savedLayout: { nav: 35, detail: 65 },
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 260 },
+    requireOpenNav: true,
+  }),
+  { nav: 35, detail: 65 },
+  "Chat restores its own user-resized layout instead of inheriting the normal group's live width",
+);
+
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "detail"],
+    savedLayout: { nav: 0, detail: 100 },
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 260 },
+    requireOpenNav: true,
+  }),
+  { nav: 26, detail: 74 },
+  "Chat falls back to its 260px default when no nonzero saved Chat width exists",
+);
+
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "list", "detail"],
+    savedLayout: undefined,
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 240, list: 260 },
+    requireOpenNav: false,
+  }),
+  { nav: 24, list: 26, detail: 50 },
+  "a fresh normal group restores both left-panel defaults without borrowing Chat or corrupting detail",
+);
+
+assert.deepEqual(
+  resolveShellDestinationLayout({
+    panelIds: ["nav", "detail"],
+    savedLayout: { nav: 5.6, detail: 94.4 },
+    groupSize: 1_000,
+    defaultPanelPixels: { nav: 240 },
+    requireOpenNav: false,
+  }),
+  { nav: 5.6, detail: 94.4 },
+  "normal navigation preserves its own saved collapsed rail layout before applying the remembered open preference",
+);
 
 assert.match(
   shell,
@@ -24,6 +73,31 @@ assert.match(
   shell,
   /navPolicy = "remembered"/,
   "Shell defaults nav policy to remembered",
+);
+
+assert.match(
+  shell,
+  /import \{ resolveShellDestinationLayout \} from "\.\/shell-layout";/,
+  "Shell uses the tested destination-layout resolver",
+);
+
+const destinationLayoutEffect =
+  shell.match(/const layoutPersistenceGroupRef = useRef<string \| null>\(null\);[\s\S]*?\}, \[mounted, groupId, chatContextual, defaultLayout, twoPane\]\);/)?.[0] ?? "";
+assert.ok(destinationLayoutEffect.length > 0, "the destination group restoration effect exists");
+assert.match(
+  destinationLayoutEffect,
+  /Array\.from\(groupElement\.children\)\.reduce\([\s\S]*?child\.hasAttribute\("data-panel"\)[\s\S]*?child\.offsetWidth/,
+  "destination defaults use the panel library's available panel width rather than the group width including separators",
+);
+assert.match(
+  destinationLayoutEffect,
+  /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ nav: chatContextual \? 260 : NAV_OPEN_PX, \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?requireOpenNav: chatContextual,/,
+  "every group transition resolves the destination's saved layout or its own Chat/normal pixel defaults",
+);
+assert.match(
+  destinationLayoutEffect,
+  /layoutPersistenceGroupRef\.current = groupId;\s*restoredGroupRef\.current = groupId;\s*group\.setLayout\(destinationLayout\);/,
+  "the destination group is armed only when its complete layout is ready to apply",
 );
 
 // Boot/group-switch application: after the group settles, a saved preference
@@ -58,7 +132,7 @@ assert.match(
 );
 
 const routePolicyEffect =
-  shell.match(/const previousNavPolicyRef = useRef<ShellNavPolicy>\("remembered"\);[\s\S]*?\}, \[mounted, groupId, isMobile, navPolicy, defaultLayout\?\.nav\]\);/)?.[0] ?? "";
+  shell.match(/const previousNavPolicyRef = useRef<ShellNavPolicy>\("remembered"\);[\s\S]*?\}, \[mounted, groupId, isMobile, navPolicy\]\);/)?.[0] ?? "";
 assert.ok(
   routePolicyEffect.length > 0,
   "the route-policy layout effect reruns after the real nav panel mounts",
@@ -79,13 +153,6 @@ assert.equal(
           chatContextualGroupRef.current !== groupId
         ) {
           chatContextualGroupRef.current = groupId;
-          const panel = navRef.current;
-          if (panel?.isCollapsed()) {
-            const savedSize = defaultLayout?.nav;
-            panel.resize(
-              typeof savedSize === "number" && savedSize > 0 ? \`\${savedSize}%\` : "260px",
-            );
-          }
           setNavOpen(true);
         }
         previousNavPolicyRef.current = navPolicy;
@@ -111,15 +178,15 @@ assert.equal(
         setNavOpen(false);
       }
       previousNavPolicyRef.current = navPolicy;
-    }, [mounted, groupId, isMobile, navPolicy, defaultLayout?.nav]);
+    }, [mounted, groupId, isMobile, navPolicy]);
   `),
-  "Chat restores once per contextual group entry without arming memory, while visit-collapsed keeps its desktop-only behavior",
+  "Chat opens after destination restoration without arming memory, while visit-collapsed keeps its desktop-only behavior",
 );
 
 assert.match(
   shell,
-  /onLayoutChanged=\{\(layout, detail\) => \{[\s\S]{0,240}?if \(!chatContextual \|\| \(layout\.nav \?\? 0\) > 0\) \{\s*onLayoutChanged\(layout, detail\);\s*\}\s*\}\}/,
-  "Chat keeps its last expanded layout instead of persisting the collapsed zero-width layout",
+  /onLayoutChanged=\{\(layout, detail\) => \{\s*if \(layoutPersistenceGroupRef\.current !== groupId\) return;[\s\S]{0,240}?if \(!chatContextual \|\| \(layout\.nav \?\? 0\) > 0\) \{\s*onLayoutChanged\(layout, detail\);\s*\}\s*\}\}/,
+  "group-swap churn cannot overwrite the destination layout, and Chat keeps its last expanded width",
 );
 
 // Writes are user-driven only: the group must be armed (group-swap layout

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -27,8 +27,11 @@ import {
   type PanelShortcutBindings,
 } from "@/lib/panel-shortcuts";
 import {
+  isShellNavCollapsedLayout,
   resolveShellDestinationLayout,
-  shouldPersistShellLayout,
+  resolveShellLayoutPersistence,
+  resolveShellNavOpenPreference,
+  type ShellPanelLayout,
 } from "./shell-layout";
 
 // Shell — multi-pane app chrome. Horizontal Group of nav/list/detail,
@@ -146,6 +149,11 @@ function writeNavOpenPref(open: boolean): void {
   } catch {
     /* ignore — strict privacy mode or quota */
   }
+}
+function seedNavOpenPref(defaultOpen: boolean): boolean {
+  const resolved = resolveShellNavOpenPreference(readNavOpenPref(), defaultOpen);
+  if (resolved.shouldPersist) writeNavOpenPref(resolved.open);
+  return resolved.open;
 }
 
 // The left nav collapses to an icons-only rail (instead of vanishing) so the
@@ -508,6 +516,7 @@ function ShellInner({
     const railPct = nav * (NAV_RAIL_PX / NAV_OPEN_PX);
     if (railPct >= nav) return; // already at/under the rail
     minimizedGroupsRef.current.add(groupId);
+    seedNavOpenPref(false);
     markShellMinimizeApplied(groupId);
     group.setLayout({ ...cur, nav: railPct, detail: cur.detail + (nav - railPct) });
   }, [settled, isMobile, groupId, chatContextual]);
@@ -517,11 +526,15 @@ function ShellInner({
   // before applying its open/collapsed policy so widths cannot cross groups.
   const navPrefArmedGroupRef = useRef<string | null>(null);
   const layoutPersistenceGroupRef = useRef<string | null>(null);
+  const expandedLayoutRef = useRef<{ groupId: string; layout: ShellPanelLayout } | null>(null);
+  const collapsedLayoutRef = useRef<{ groupId: string; layout: ShellPanelLayout } | null>(null);
   const restoredGroupRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     if (!mounted || isMobile) {
       if (isMobile) {
         layoutPersistenceGroupRef.current = null;
+        expandedLayoutRef.current = null;
+        collapsedLayoutRef.current = null;
         restoredGroupRef.current = null;
       }
       return;
@@ -543,6 +556,17 @@ function ShellInner({
           : 0),
       0,
     );
+    if (
+      !chatContextual &&
+      isShellNavCollapsedLayout({
+        layout: defaultLayout,
+        panelIds,
+        groupSize,
+        collapsedNavPixels: NAV_RAIL_PX,
+      })
+    ) {
+      seedNavOpenPref(false);
+    }
     const destinationLayout = resolveShellDestinationLayout({
       panelIds,
       savedLayout: defaultLayout,
@@ -556,6 +580,8 @@ function ShellInner({
     // Group keeps an in-memory layout keyed only by panel ids, even after its
     // id changes. Arm persistence immediately before replacing that stale
     // source layout so transition churn cannot overwrite the destination.
+    expandedLayoutRef.current = { groupId, layout: destinationLayout };
+    collapsedLayoutRef.current = null;
     layoutPersistenceGroupRef.current = groupId;
     restoredGroupRef.current = groupId;
     group.setLayout(destinationLayout);
@@ -610,9 +636,9 @@ function ShellInner({
       return;
     }
     if (!settled || isMobile) return;
-    const pref = readNavOpenPref();
+    const pref = seedNavOpenPref(false);
     const panel = navRef.current;
-    if (panel && pref !== null && !railAutoCollapsedNavRef.current) {
+    if (panel && !railAutoCollapsedNavRef.current) {
       if (pref && panel.isCollapsed()) {
         panel.expand();
         setNavOpen(true);
@@ -754,17 +780,24 @@ function ShellInner({
       defaultLayout={isMobile ? undefined : defaultLayout}
       onLayoutChanged={(layout, detail) => {
         if (layoutPersistenceGroupRef.current !== groupId) return;
-        // Persist the complete expanded layout; collapsed state is remembered
-        // separately so RRP can rebuild its per-panel expansion target on return.
-        if (
-          shouldPersistShellLayout({
-            isMobile,
-            navCollapsed: navRef.current?.isCollapsed() ?? true,
-            layout,
-          })
-        ) {
-          onLayoutChanged(layout, detail);
-        }
+        const navCollapsed = navRef.current?.isCollapsed() ?? true;
+        const persistedLayout = resolveShellLayoutPersistence({
+          isMobile,
+          navCollapsed,
+          layout,
+          savedExpandedLayout:
+            expandedLayoutRef.current?.groupId === groupId
+              ? expandedLayoutRef.current.layout
+              : undefined,
+          previousCollapsedLayout:
+            collapsedLayoutRef.current?.groupId === groupId
+              ? collapsedLayoutRef.current.layout
+              : undefined,
+        });
+        if (!persistedLayout) return;
+        collapsedLayoutRef.current = navCollapsed ? { groupId, layout } : null;
+        expandedLayoutRef.current = { groupId, layout: persistedLayout };
+        onLayoutChanged(persistedLayout, detail);
       }}
       data-mobile-drawer={isMobile && mobileDrawer ? mobileDrawer : undefined}
     >

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -100,6 +100,12 @@ function togglePanel(panel: PanelImperativeHandle | null) {
   else panel.collapse();
 }
 
+function applyPanelOpenState(panel: PanelImperativeHandle | null, open: boolean) {
+  if (!panel || panel.isCollapsed() === !open) return;
+  if (open) panel.expand();
+  else panel.collapse();
+}
+
 // The minimized-by-default nav is applied exactly ONCE per group per browser,
 // tracked by this flag (the panel library persists layouts under its own
 // `react-resizable-panels:*` keys, so we can't reuse those; a self-owned flag is
@@ -567,6 +573,8 @@ function ShellInner({
     ) {
       seedNavOpenPref(false);
     }
+    const rememberedNavOpen =
+      navPolicy === "remembered" ? seedNavOpenPref(false) : null;
     const destinationLayout = resolveShellDestinationLayout({
       panelIds,
       savedLayout: defaultLayout,
@@ -585,7 +593,15 @@ function ShellInner({
     layoutPersistenceGroupRef.current = groupId;
     restoredGroupRef.current = groupId;
     group.setLayout(destinationLayout);
-  }, [mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane]);
+    if (rememberedNavOpen !== null) {
+      railAutoCollapsedNavRef.current = false;
+      userOverrodeNavRef.current = false;
+      applyPanelOpenState(navRef.current, rememberedNavOpen);
+      setNavOpen(rememberedNavOpen);
+      minimizedGroupsRef.current.add(groupId);
+      markShellMinimizeApplied(groupId);
+    }
+  }, [mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane, navPolicy]);
 
   const previousNavPolicyRef = useRef<ShellNavPolicy>("remembered");
   const visitCollapsedGroupRef = useRef<string | null>(null);

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -26,6 +26,7 @@ import {
   matchesPanelShortcut,
   type PanelShortcutBindings,
 } from "@/lib/panel-shortcuts";
+import { resolveShellDestinationLayout } from "./shell-layout";
 
 // Shell — multi-pane app chrome. Horizontal Group of nav/list/detail,
 // optionally wrapped in a vertical Group when a bottom slot (terminal) is set.
@@ -353,6 +354,7 @@ function ShellInner({
   });
 
   const groupRef = useRef<GroupImperativeHandle | null>(null);
+  const groupElementRef = useRef<HTMLDivElement | null>(null);
 
   const [navOpen, setNavOpen] = useState(() => {
     // Mobile keeps its drawer. On desktop, start closed so the rail content paints
@@ -507,16 +509,47 @@ function ShellInner({
     group.setLayout({ ...cur, nav: railPct, detail: cur.detail + (nav - railPct) });
   }, [settled, isMobile, groupId, chatContextual]);
 
-  // Apply the remembered sidebar state on boot and on every panel-group switch
-  // (two-pane and other remembered groups persist their layouts separately, so
-  // without this the OTHER group's stale width wins).
-  // Runs after the minimize-by-default effect above so a saved preference beats
-  // the first-run rail. Non-remembered policies skip this effect entirely and do
-  // not consult or overwrite the global nav-open preference. onResize only writes
-  // the preference once this effect has armed the CURRENT group — the layout
-  // churn a group swap fires must never clobber the user's choice with the
-  // incoming group's stale width.
+  // The library retains an in-memory layout by panel-id set when Group's id
+  // changes. Restore the destination group's complete saved/default layout
+  // before applying its open/collapsed policy so widths cannot cross groups.
   const navPrefArmedGroupRef = useRef<string | null>(null);
+  const layoutPersistenceGroupRef = useRef<string | null>(null);
+  const restoredGroupRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    if (!mounted || restoredGroupRef.current === groupId) return;
+    navPrefArmedGroupRef.current = null;
+
+    const group = groupRef.current;
+    const groupElement = groupElementRef.current;
+    if (!group || !groupElement) return;
+
+    // react-resizable-panels measures the sum of panel widths, excluding its
+    // separators, when converting pixel defaults to percentages.
+    const groupSize = Array.from(groupElement.children).reduce(
+      (size, child) =>
+        size +
+        (child instanceof HTMLElement && child.hasAttribute("data-panel")
+          ? child.offsetWidth
+          : 0),
+      0,
+    );
+    const destinationLayout = resolveShellDestinationLayout({
+      panelIds,
+      savedLayout: defaultLayout,
+      groupSize,
+      defaultPanelPixels: { nav: chatContextual ? 260 : NAV_OPEN_PX, ...(!twoPane && { list: 260 }) },
+      requireOpenNav: chatContextual,
+    });
+    if (!destinationLayout) return;
+
+    // Group keeps an in-memory layout keyed only by panel ids, even after its
+    // id changes. Arm persistence immediately before replacing that stale
+    // source layout so transition churn cannot overwrite the destination.
+    layoutPersistenceGroupRef.current = groupId;
+    restoredGroupRef.current = groupId;
+    group.setLayout(destinationLayout);
+  }, [mounted, groupId, chatContextual, defaultLayout, twoPane]);
+
   const previousNavPolicyRef = useRef<ShellNavPolicy>("remembered");
   const visitCollapsedGroupRef = useRef<string | null>(null);
   const chatContextualGroupRef = useRef<string | null>(null);
@@ -530,13 +563,6 @@ function ShellInner({
         chatContextualGroupRef.current !== groupId
       ) {
         chatContextualGroupRef.current = groupId;
-        const panel = navRef.current;
-        if (panel?.isCollapsed()) {
-          const savedSize = defaultLayout?.nav;
-          panel.resize(
-            typeof savedSize === "number" && savedSize > 0 ? `${savedSize}%` : "260px",
-          );
-        }
         setNavOpen(true);
       }
       previousNavPolicyRef.current = navPolicy;
@@ -562,7 +588,11 @@ function ShellInner({
       setNavOpen(false);
     }
     previousNavPolicyRef.current = navPolicy;
-  }, [mounted, groupId, isMobile, navPolicy, defaultLayout?.nav]);
+  }, [mounted, groupId, isMobile, navPolicy]);
+
+  // Apply the remembered sidebar state on boot and after the destination layout
+  // is restored. Non-remembered policies neither consult nor overwrite the
+  // global preference. Writes stay disarmed throughout group-swap layout churn.
   useEffect(() => {
     if (navPolicy !== "remembered") {
       navPrefArmedGroupRef.current = null;
@@ -709,8 +739,10 @@ function ShellInner({
       className="shell-root flex-1 min-h-0"
       orientation="horizontal"
       groupRef={groupRef}
+      elementRef={groupElementRef}
       defaultLayout={defaultLayout}
       onLayoutChanged={(layout, detail) => {
+        if (layoutPersistenceGroupRef.current !== groupId) return;
         // Chat always reopens on entry. Keep the last expanded layout so a
         // collapsed 0% layout cannot erase the user's width across re-entry.
         if (!chatContextual || (layout.nav ?? 0) > 0) {

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -26,7 +26,10 @@ import {
   matchesPanelShortcut,
   type PanelShortcutBindings,
 } from "@/lib/panel-shortcuts";
-import { resolveShellDestinationLayout } from "./shell-layout";
+import {
+  resolveShellDestinationLayout,
+  shouldPersistShellLayout,
+} from "./shell-layout";
 
 // Shell — multi-pane app chrome. Horizontal Group of nav/list/detail,
 // optionally wrapped in a vertical Group when a bottom slot (terminal) is set.
@@ -98,9 +101,9 @@ function togglePanel(panel: PanelImperativeHandle | null) {
 // tracked by this flag (the panel library persists layouts under its own
 // `react-resizable-panels:*` keys, so we can't reuse those; a self-owned flag is
 // simpler and lets tests opt out by pre-seeding it). After the first minimize the
-// library's own persistence takes over — a user who later expands the nav keeps
-// it, because we no longer re-minimize. Returns true on the server / when storage
-// is unreadable, i.e. "already applied" → don't minimize.
+// library's expanded-layout persistence and the separate open preference take
+// over, because we no longer re-minimize. Returns true on the server / when
+// storage is unreadable, i.e. "already applied" → don't minimize.
 const SHELL_MIN_APPLIED_PREFIX = "cave:shell:min-applied:";
 function shellMinimizeApplied(id: string): boolean {
   if (typeof window === "undefined") return true;
@@ -516,7 +519,14 @@ function ShellInner({
   const layoutPersistenceGroupRef = useRef<string | null>(null);
   const restoredGroupRef = useRef<string | null>(null);
   useLayoutEffect(() => {
-    if (!mounted || restoredGroupRef.current === groupId) return;
+    if (!mounted || isMobile) {
+      if (isMobile) {
+        layoutPersistenceGroupRef.current = null;
+        restoredGroupRef.current = null;
+      }
+      return;
+    }
+    if (restoredGroupRef.current === groupId) return;
     navPrefArmedGroupRef.current = null;
 
     const group = groupRef.current;
@@ -538,7 +548,8 @@ function ShellInner({
       savedLayout: defaultLayout,
       groupSize,
       defaultPanelPixels: { nav: chatContextual ? 260 : NAV_OPEN_PX, ...(!twoPane && { list: 260 }) },
-      requireOpenNav: chatContextual,
+      collapsedNavPixels: chatContextual ? 0 : NAV_RAIL_PX,
+      isMobile,
     });
     if (!destinationLayout) return;
 
@@ -548,7 +559,7 @@ function ShellInner({
     layoutPersistenceGroupRef.current = groupId;
     restoredGroupRef.current = groupId;
     group.setLayout(destinationLayout);
-  }, [mounted, groupId, chatContextual, defaultLayout, twoPane]);
+  }, [mounted, isMobile, groupId, chatContextual, defaultLayout, twoPane]);
 
   const previousNavPolicyRef = useRef<ShellNavPolicy>("remembered");
   const visitCollapsedGroupRef = useRef<string | null>(null);
@@ -740,12 +751,18 @@ function ShellInner({
       orientation="horizontal"
       groupRef={groupRef}
       elementRef={groupElementRef}
-      defaultLayout={defaultLayout}
+      defaultLayout={isMobile ? undefined : defaultLayout}
       onLayoutChanged={(layout, detail) => {
         if (layoutPersistenceGroupRef.current !== groupId) return;
-        // Chat always reopens on entry. Keep the last expanded layout so a
-        // collapsed 0% layout cannot erase the user's width across re-entry.
-        if (!chatContextual || (layout.nav ?? 0) > 0) {
+        // Persist the complete expanded layout; collapsed state is remembered
+        // separately so RRP can rebuild its per-panel expansion target on return.
+        if (
+          shouldPersistShellLayout({
+            isMobile,
+            navCollapsed: navRef.current?.isCollapsed() ?? true,
+            layout,
+          })
+        ) {
           onLayoutChanged(layout, detail);
         }
       }}

--- a/src/components/sidebar-footer.test.ts
+++ b/src/components/sidebar-footer.test.ts
@@ -7,9 +7,9 @@ const minimal = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 const chatNav = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 
-// The side-panel footer (Dashboard + Settings + version) is a single shared
-// component so it renders identically in every host — the global nav
-// SidebarMinimal and Chat's independent WorkspaceSidebar thread list.
+// The side-panel footer (Dashboard + Settings + version) is shared by whichever
+// primary sidebar host is active: SidebarMinimal normally, or WorkspaceSidebar
+// while Chat replaces it.
 
 // The shared component owns the whole footer.
 assert.match(footer, /export function SidebarFooter\(\{ onOpenSettings \}/, "SidebarFooter is a shared component taking onOpenSettings");
@@ -17,7 +17,7 @@ assert.match(footer, /href="\/dashboard"/, "footer links to the Dashboard route"
 assert.match(footer, /onClick=\{onOpenSettings\}[\s\S]*?aria-label="Settings"/, "footer Settings button calls onOpenSettings");
 assert.match(footer, /className="sidebar-version"[\s\S]*?v\{APP_VERSION\}/, "footer shows the app version line");
 
-// Both nav hosts render it (so the footer can't drift between them)…
+// Each alternate nav host renders it, so the active footer cannot drift…
 assert.match(minimal, /import \{ SidebarFooter \} from "@\/components\/sidebar-footer"/, "SidebarMinimal imports the shared footer");
 assert.match(minimal, /<SidebarFooter onOpenSettings=\{onOpenSettings\} \/>/, "SidebarMinimal renders the shared footer");
 assert.match(chatNav, /import \{ SidebarFooter \} from "@\/components\/sidebar-footer"/, "the chat nav imports the shared footer");

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -6,10 +6,10 @@ import { APP_VERSION } from "@/lib/app-version";
 /**
  * The left side-panel footer — Dashboard + Settings, then the app-version line.
  *
- * Extracted so it renders identically in BOTH hosts: the global-nav
- * `SidebarMinimal` and Chat's independent `WorkspaceSidebar` thread list.
- * Without this, the Chats list could drift from the global nav footer or lose
- * its Dashboard / Settings / version row entirely. Styles (`.sidebar-foot*`,
+ * Extracted so it renders identically through whichever primary sidebar host is
+ * active: `SidebarMinimal` normally, or `WorkspaceSidebar` while Chat replaces
+ * it. This keeps Dashboard / Settings / version available across the host swap.
+ * Styles (`.sidebar-foot*`,
  * `.sidebar-version`) live in sidebar-minimal.css, which globals.css imports
  * app-wide, so they apply here regardless of host.
  */

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -5,8 +5,8 @@ import { readFileSync } from "node:fs";
 const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
 const source = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-// The footer (Dashboard + Settings + version) now lives in a shared component so
-// it stays identical in the global nav and Chat's independent WorkspaceSidebar list.
+// The footer (Dashboard + Settings + version) lives in a shared component so it
+// stays identical when Chat replaces SidebarMinimal with WorkspaceSidebar.
 const footer = readFileSync(new URL("./sidebar-footer.tsx", import.meta.url), "utf8");
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -330,9 +330,8 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         />
       </div>
 
-      {/* Bottom: Dashboard + Settings, then the version line — shared with
-          Chat's independent WorkspaceSidebar list so both hosts keep the
-          same footer. */}
+      {/* Bottom: Dashboard + Settings, then the version line — shared with the
+          WorkspaceSidebar that replaces this host during Chat. */}
       <SidebarFooter onOpenSettings={onOpenSettings} />
 
       {/* Account avatar — rail-only (CSS-gated, like the brand mark): the 28px

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -158,9 +158,9 @@ assert.match(
   "Selection handler is nullable so the menu can scope to all familiars",
 );
 
-// Mobile quick actions: Tasks. New chat now lives at the top of the left
-// sidebar (SidebarMinimal) for both desktop and mobile, so the top bar no
-// longer renders a New chat button. The task quick actions themselves moved
+// Mobile quick actions: Tasks. New chat lives in WorkspaceSidebar, the
+// contextual primary nav in Chat; SidebarMinimal returns outside Chat. The top
+// bar therefore no longer renders a New chat button. The task quick actions moved
 // into the shared overflow menu (§8 chrome budget — occasional verbs don't
 // earn always-visible chrome), with the live open-task badge kept on the
 // trigger.
@@ -172,7 +172,7 @@ assert.match(
 assert.doesNotMatch(
   source,
   /aria-label="New chat"/,
-  "the New chat button has moved out of the mobile top bar to the sidebar",
+  "New chat belongs to Chat's contextual WorkspaceSidebar; SidebarMinimal returns outside Chat",
 );
 assert.match(
   source,

--- a/src/components/workspace-sidebar-pr-badge.test.ts
+++ b/src/components/workspace-sidebar-pr-badge.test.ts
@@ -76,8 +76,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /<WorkspaceSidebar[\s\S]*?onOpenUrl=\{\(url\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?openUrlInApp\(url\);[\s\S]*?\}\}/,
-  "workspace wraps chat-sidebar PR opens so the mobile Chats drawer dismisses before the GitHub-aware app opener runs",
+  /<WorkspaceSidebar[\s\S]*?onOpenUrl=\{\(url\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?openUrlInApp\(url\);[\s\S]*?\}\}/,
+  "workspace wraps chat-sidebar PR opens so the mobile contextual nav dismisses before the GitHub-aware app opener runs",
 );
 
 // ── Styling: GitHub's state colors + gutter alignment ────────────────────────

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -36,11 +36,9 @@ assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("home"\)\}/, "Home
 assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("inbox"\)\}/, "Scheduled button should navigate through the explicit sidebar callback");
 assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("marketplace"\)\}/, "Plugins button should navigate through the explicit sidebar callback");
 assert.doesNotMatch(workspaceSidebar, /cave:navigate-mode/, "workspace-sidebar should not dispatch raw mode events for its own navigation buttons");
-// The Chats list header keeps a labeled familiar switcher near thread
-// navigation. The global nav stays SidebarMinimal, so chat intentionally keeps
-// this list-pane control even though the top bar and expanded nav may also show
-// familiar controls (#2747, restored by cave-l3ay after #2750 briefly removed
-// it as a supposed duplicate).
+// The Chats primary-nav header keeps a labeled familiar switcher near thread
+// navigation (#2747, restored by cave-l3ay after #2750 briefly removed it as a
+// supposed duplicate).
 assert.match(workspaceSidebar, /<header className="cnav__header">[\s\S]*?<FamiliarSwitcher/, "the chat sidebar header hosts the familiar switcher");
 assert.doesNotMatch(workspaceSidebar, /cnav__eyebrow/, "the old Recent eyebrow stays retired");
 assert.match(workspaceSidebar, /ph:git-pull-request/, "should support PR glyph on thread rows");
@@ -52,16 +50,25 @@ assert.doesNotMatch(workspaceSidebar, /workspace-sidebar__rail|chat-sidebar__rai
 // "Search projects or threads…" clipped); the aria-label keeps the full scope.
 assert.match(workspaceSidebar, /placeholder="Search chats…"/, "search placeholder fits the narrow panel");
 assert.match(workspaceSidebar, /aria-label="Search projects and threads"/, "search keeps its descriptive accessible name");
-assert.match(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/, "workspace mounts Chats as the persistent list pane only in chat mode");
-assert.match(workspace, /navPolicy=\{mode === "chat" \? "visit-collapsed" : "remembered"\}/, "chat mode visits start with the global nav collapsed");
-assert.match(workspace, /listPolicy=\{mode === "chat" \? "persistent" : "collapsible"\}/, "chat mode keeps the Chats list persistent on desktop");
-assert.match(workspace, /nav=\{sidebar\}\s*list=\{list\}/, "workspace always passes the global nav as nav and the chat sidebar as list");
-assert.match(workspace, /onOpenSession=\{\(session\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?\}\}/, "opening a chat session dismisses the mobile list drawer");
-assert.match(workspace, /onOpenSessionInSplit=\{\(session\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?\}\}/, "opening a split chat dismisses the mobile list drawer");
-assert.match(workspace, /onNewChat=\{\(projectRoot\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?\}\}/, "starting a new chat dismisses the mobile list drawer");
-assert.match(workspace, /onNavigate=\{\(nextMode\) => \{[\s\S]*?setMode\(nextMode\);[\s\S]*?dismissListMobile\(\);[\s\S]*?\}\}/, "sidebar Home, Scheduled, and Plugins routes dismiss the mobile list drawer");
-assert.match(workspace, /onOpenUrl=\{\(url\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?openUrlInApp\(url\);[\s\S]*?\}\}/, "sidebar PR links dismiss the mobile list drawer before opening");
-assert.match(workspace, /onOpenSettings=\{\(\) => \{[\s\S]*?dismissListMobile\(\);[\s\S]*?nextRouter\.push\("\/settings"\);[\s\S]*?\}\}/, "chat sidebar settings dismisses the mobile list drawer");
+assert.match(workspace, /const contextualNav = mode === "chat" \? chatSidebar : sidebar;/, "workspace selects Chats as the contextual primary nav");
+assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/, "workspace should not mount Chats in the list slot");
+assert.match(workspace, /navPolicy=\{mode === "chat" \? "chat-contextual" : "remembered"\}/, "chat mode activates the contextual nav policy");
+assert.doesNotMatch(workspace, /navPolicy=\{mode === "chat" \? "visit-collapsed" : "remembered"\}/, "chat mode should not use the obsolete visit-collapsed policy");
+assert.doesNotMatch(workspace, /listPolicy=\{mode === "chat" \? "persistent" : "collapsible"\}/, "chat mode should not reserve a persistent list pane");
+assert.match(workspace, /nav=\{contextualNav\}\s*list=\{undefined\}/, "workspace passes contextual nav and no list content");
+assert.match(workspace, /onToggleList=\{undefined\}/, "top bar exposes no list toggle");
+assert.match(workspace, /navDrawerOpen=\{navDrawerOpen\}\s*listDrawerOpen=\{false\}/, "top bar only reflects the mobile nav drawer");
+const chatSidebarBlock = workspace.match(/const chatSidebar =[\s\S]*?const contextualNav =/)?.[0] ?? "";
+assert.ok(chatSidebarBlock, "workspace should keep the chat sidebar wiring together");
+assert.doesNotMatch(chatSidebarBlock, /dismissListMobile/, "chat sidebar callbacks should not dismiss the list drawer");
+assert.ok((chatSidebarBlock.match(/dismissNavMobile/g) ?? []).length >= 6, "chat sidebar actions dismiss the mobile nav drawer");
+assert.match(workspace, /onOpenSession=\{\(session\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "opening a chat session dismisses the mobile nav drawer");
+assert.match(workspace, /onOpenSessionInSplit=\{\(session\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "opening a split chat dismisses the mobile nav drawer");
+assert.match(workspace, /onNewChat=\{\(projectRoot\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "starting a new chat dismisses the mobile nav drawer");
+assert.match(workspace, /onNavigate=\{\(nextMode\) => \{[\s\S]*?setMode\(nextMode\);[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "sidebar Home, Scheduled, and Plugins routes dismiss the mobile nav drawer");
+assert.match(workspace, /onOpenUrl=\{\(url\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?openUrlInApp\(url\);[\s\S]*?\}\}/, "sidebar PR links dismiss the mobile nav drawer before opening");
+assert.match(workspace, /onOpenSettings=\{\(\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?nextRouter\.push\("\/settings"\);[\s\S]*?\}\}/, "chat sidebar settings dismisses the mobile nav drawer");
+assert.match(workspace, /hideThreadRail/, "ChatSurface keeps its internal thread rail hidden");
 assert.doesNotMatch(workspace, /const exitChatMode = useCallback/, "workspace should not keep an unused chat-exit helper");
 assert.doesNotMatch(workspace, /lastNonChatMode/, "workspace should not track an unused prior-surface exit contract");
 // chat-view wiring (unchanged — just verify it still exists)

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -453,10 +453,10 @@ export function WorkspaceSidebar({
   return (
     <div className="workspace-sidebar chat-sidebar flex h-full min-h-0 flex-col">
       <div className="workspace-sidebar__full chat-sidebar__full cnav">
-        {/* Header — the labeled familiar switcher (#2747). The global nav stays
-            mounted beside Chats now; this header remains the chat-local scope
-            control restored by cave-l3ay after #2750 removed it as a supposed
-            duplicate. */}
+        {/* Header — the labeled familiar switcher (#2747). WorkspaceSidebar owns
+            the primary Shell nav during Chat; Home exits Chat and restores the
+            normal navigation. This scope control was restored by cave-l3ay
+            after #2750 removed it as a supposed duplicate. */}
         <header className="cnav__header">
           <div className="cnav__switcher">
             <FamiliarSwitcher

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -360,9 +360,8 @@ export function Workspace() {
     }
     setModeRaw(next);
   }, []);
-  // Chat mode keeps the global nav in the nav pane and mounts the project-
-  // grouped Chats list beside it. The Chats header button explicitly routes
-  // back Home rather than restoring a prior surface.
+  // Chat mode replaces the global nav with the project-grouped Chats sidebar.
+  // Its Home button exits Chat, restoring the normal navigation.
   // Whether the first daemon status poll has resolved. Until it has, the daemon
   // state is *unknown* (not "offline"), so the offline banner must stay hidden.
   const [daemonStatusResolved, setDaemonStatusResolved] = useState(false);
@@ -2608,7 +2607,7 @@ export function Workspace() {
       onSelectFamiliar={selectFamiliarScope}
       onOpenSession={(session) => {
         openFamiliarSession(session.id, session.familiarId);
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
       }}
       onOpenSessionInSplit={(session) => {
         // Open beside the current chat: same pending-action pipeline as a
@@ -2617,15 +2616,15 @@ export function Workspace() {
         // active familiar is left alone — the pane carries its own.
         setPendingChatAction({ kind: "open-split", sessionId: session.id, nonce: Date.now() });
         setMode("chat");
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
       }}
       onNewChat={(projectRoot) => {
         startFamiliarChat(activeId, projectRoot);
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
       }}
       onNavigate={(nextMode) => {
         setMode(nextMode);
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
       }}
       onDeleteSession={async (session) => {
         const res = await fetch(`/api/chat/conversation/${encodeURIComponent(session.id)}`, { method: "DELETE" });
@@ -2637,18 +2636,18 @@ export function Workspace() {
         handleSessionsDeleted([session.id]);
       }}
       onOpenUrl={(url) => {
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
         openUrlInApp(url);
       }}
       scheduledCount={scheduleNeedsCount}
       onOpenSettings={() => {
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
         nextRouter.push("/settings");
       }}
     />
   );
 
-  const list = mode === "chat" ? chatSidebar : undefined;
+  const contextualNav = mode === "chat" ? chatSidebar : sidebar;
 
   // renderSurface maps a workspace mode to its surface element. Extracted so the
   // same machinery renders both the primary detail and a dragged-in split
@@ -2982,9 +2981,8 @@ export function Workspace() {
         onCloseSplitTile={closeSplitTile}
         onPromoteSplitTile={promoteSplitTile}
         onDropSplitPage={openSplitPage}
-        navPolicy={mode === "chat" ? "visit-collapsed" : "remembered"}
-        listPolicy={mode === "chat" ? "persistent" : "collapsible"}
-        topBar={({ navDrawerOpen, listDrawerOpen }) => (
+        navPolicy={mode === "chat" ? "chat-contextual" : "remembered"}
+        topBar={({ navDrawerOpen }) => (
           <>
             <FamiliarMenuBar
               activeFamiliarId={activeId}
@@ -3059,14 +3057,14 @@ export function Workspace() {
               }}
               onNotificationPrefsChanged={refreshPrefs}
               onToggleNav={() => shellRef.current?.toggleNav()}
-              onToggleList={list ? () => shellRef.current?.toggleList() : undefined}
+              onToggleList={undefined}
               navDrawerOpen={navDrawerOpen}
-            listDrawerOpen={listDrawerOpen}
-          />
+              listDrawerOpen={false}
+            />
           </>
         )}
-        nav={sidebar}
-        list={list}
+        nav={contextualNav}
+        list={undefined}
         detail={detail}
       />
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2579,7 +2579,7 @@ export function Workspace() {
       }}
       onOpenSession={(id) => {
         openFamiliarSession(id);
-        shellRef.current?.dismissListMobile();
+        shellRef.current?.dismissNavMobile();
       }}
       inboxItems={inboxItemsWithEphemeral}
       inboxPrefs={inboxPrefs}

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -955,7 +955,8 @@
 }
 
 /* Full-height reopen rail on the chat surface's right edge — the reflection of
-   the left-side shell chrome beside Chat (collapsed global nav / Chats list):
+   the left-side shell chrome beside Chat (WorkspaceSidebar is the contextual
+   primary nav in Chat; SidebarMinimal returns outside Chat):
    icon over a vertical uppercase label ("Code"), reading top→bottom with the
    glyph face to the right/outside (vertical-rl). An in-flow flex child (NOT
    absolutely positioned): the rail reserves its own layout width so content

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -81,7 +81,7 @@ test.describe("chat sidebar (session navigator)", () => {
     await expect(expandToggle).toHaveAttribute("aria-expanded", "false");
     await expect(sidebar).toBeHidden();
 
-    await page.keyboard.press("Meta+b");
+    await page.keyboard.press("ControlOrMeta+b");
     await expect(search).toBeVisible();
     await expect(page.getByRole("button", { name: "Collapse Chat sidebar" })).toHaveAttribute("aria-expanded", "true");
     await expect.poll(() => page.evaluate(() => window.localStorage.getItem("cave:shell:nav-open"))).toBe("1");

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// Verifies Chat mode's Chats sidebar in the shell list pane while the global
-// Sidebar stays a separate nav rail. The list defaults to a time-bucketed
+// Verifies Chat mode's WorkspaceSidebar in the Shell nav. It replaces the
+// normal SidebarMinimal while Chat is active and defaults to a time-bucketed
 // "Recent chats" view (Today / Yesterday / Previous 7 days / Previous 30 days /
 // Older). A ⋯ "Sidebar options" button opens an Organize menu (role=dialog)
-// with menuitemradio items to switch to "By project" folder grouping. The list
-// panel owns thread navigation while ChatSurface hides the duplicate internal
-// rail. Desktop only. /api/familiars + /api/sessions/list are mocked.
+// with menuitemradio items to switch to "By project" folder grouping. The Shell
+// nav owns thread navigation while ChatSurface hides the duplicate internal
+// rail. Desktop collapse/expand and the mobile nav drawer are both covered.
+// /api/familiars + /api/sessions/list are mocked.
 
 // Timestamps are relative to the test run so bucket labels are deterministic:
 // s1 → Today, s2 → Yesterday, s3 → Previous 7 days, s4 → Older.
@@ -33,7 +34,7 @@ async function ensureChatSurface(page: Page) {
     await page.locator('aside[aria-label="Sidebar"]').getByRole("button", { name: /^Chat\b/ }).first().click();
   }
   await page.waitForSelector(".chat-surface", { timeout: 30_000 });
-  await page.waitForSelector('aside[aria-label="List pane"] .chat-sidebar', { timeout: 30_000 });
+  await page.waitForSelector('aside[aria-label="Sidebar"] .chat-sidebar', { timeout: 30_000 });
 }
 
 async function gotoChat(page: Page) {
@@ -41,8 +42,8 @@ async function gotoChat(page: Page) {
     window.localStorage.setItem("cave:active-familiar", "nova");
     window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
-    // Seed the remembered global-nav preference OPEN; chat visits must still
-    // collapse the nav for the visit while keeping the separate Chats list open.
+    // Seed the remembered normal-nav preference OPEN. Chat owns a separate
+    // contextual nav layout and must not overwrite that outside-Chat preference.
     window.localStorage.setItem("cave:shell:nav-open", "1");
   });
   await page.route("**/api/familiars**", (route) =>
@@ -58,37 +59,37 @@ async function gotoChat(page: Page) {
 }
 
 test.describe("chat sidebar (session navigator)", () => {
-  test("chat visit collapses remembered nav but keeps the persistent Chats list", async ({ page }) => {
+  test("desktop nav toggle and Command-B fully hide and restore the Chat sidebar", async ({ page }) => {
     await gotoChat(page);
-    const sidebar = page.locator('aside[aria-label="List pane"] .chat-sidebar');
+    const sidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
     const nav = page.locator('aside[aria-label="Sidebar"]');
     const search = sidebar.getByRole("searchbox", { name: "Search projects and threads" });
+    const collapseToggle = page.getByRole("button", { name: "Collapse Chat sidebar" });
 
-    // Chat mode keeps the global nav separate and temporarily collapsed even if
-    // the remembered preference is open; the persistent Chats list remains live.
+    // WorkspaceSidebar is the contextual primary nav in Chat.
     await expect(sidebar).toBeVisible();
     await expect(search).toBeVisible();
     await expect(nav).toBeVisible();
-    await expect(nav.locator(".chat-sidebar")).toHaveCount(0);
+    await expect(nav.locator(".chat-sidebar")).toHaveCount(1);
+    await expect(page.locator('aside[aria-label="List pane"]')).toHaveCount(0);
     await expect(page.locator(".chat-thread-rail")).toHaveCount(0);
     await expect.poll(() => page.evaluate(() => window.localStorage.getItem("cave:shell:nav-open"))).toBe("1");
-    const navToggle = page.getByRole("button", { name: "Expand navigation" });
-    await expect(navToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(collapseToggle).toHaveAttribute("aria-expanded", "true");
 
-    // The desktop list shortcut must not collapse the persistent Chats list.
-    await page.keyboard.press("Control+\\");
-    await expect(search).toBeVisible();
-    await expect(navToggle).toHaveAttribute("aria-expanded", "false");
+    await collapseToggle.click();
+    const expandToggle = page.getByRole("button", { name: "Expand Chat sidebar" });
+    await expect(expandToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(sidebar).toBeHidden();
 
-    await navToggle.click();
+    await page.keyboard.press("Meta+b");
     await expect(search).toBeVisible();
-    await expect(page.getByRole("button", { name: /Expand navigation|Collapse navigation to icons/ })).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByRole("button", { name: "Collapse Chat sidebar" })).toHaveAttribute("aria-expanded", "true");
     await expect.poll(() => page.evaluate(() => window.localStorage.getItem("cave:shell:nav-open"))).toBe("1");
   });
 
   test("defaults to the Recent view; Organize menu switches to project folders", async ({ page }) => {
     await gotoChat(page);
-    const sidebar = page.locator('aside[aria-label="List pane"] .chat-sidebar');
+    const sidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
 
     // Search control survives in both views.
     await expect(sidebar.getByRole("searchbox", { name: "Search projects and threads" })).toBeVisible();
@@ -114,15 +115,15 @@ test.describe("chat sidebar (session navigator)", () => {
     // The organize choice persists across a reload.
     await page.reload();
     await ensureChatSurface(page);
-    const reloadedSidebar = page.locator('aside[aria-label="List pane"] .chat-sidebar');
-    await expect(page.getByRole("button", { name: "Expand navigation" })).toHaveAttribute("aria-expanded", "false");
+    const reloadedSidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
+    await expect(page.getByRole("button", { name: "Collapse Chat sidebar" })).toHaveAttribute("aria-expanded", "true");
     await expect(reloadedSidebar.getByRole("button", { name: /(Collapse|Expand) alpha threads/ })).toBeVisible();
     await expect(reloadedSidebar.getByText("Today", { exact: true })).toHaveCount(0);
   });
 
   test("search filters threads to matches, with an empty state", async ({ page }) => {
     await gotoChat(page);
-    const sidebar = page.locator('aside[aria-label="List pane"] .chat-sidebar');
+    const sidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
     const search = sidebar.getByRole("searchbox", { name: "Search projects and threads" });
 
     await search.fill("deploy");
@@ -132,5 +133,35 @@ test.describe("chat sidebar (session navigator)", () => {
 
     await search.fill("no-such-session-xyz");
     await expect(sidebar.getByText("No threads match your search")).toBeVisible();
+  });
+});
+
+test.describe("chat sidebar on mobile", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("opens and dismisses the contextual nav drawer without a list drawer", async ({ page }) => {
+    await gotoChat(page);
+    const shell = page.locator(".shell-root");
+    const sidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
+    const search = sidebar.getByRole("searchbox", { name: "Search projects and threads" });
+    const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+
+    await expect(openNav).toBeVisible();
+    await expect(openNav).toHaveAttribute("aria-expanded", "false");
+    await expect(page.getByRole("button", { name: /Open list|Close list/ })).toHaveCount(0);
+    await expect(page.locator('aside[aria-label="List pane"]')).toHaveCount(0);
+    await expect(shell).not.toHaveAttribute("data-mobile-drawer");
+
+    await openNav.click();
+    await expect(shell).toHaveAttribute("data-mobile-drawer", "nav");
+    await expect(page.getByRole("button", { name: "Close navigation" })).toHaveAttribute("aria-expanded", "true");
+    await expect(search).toBeVisible();
+    const backdrop = page.locator('.mobile-drawer-backdrop[data-drawer-slot="nav"]');
+    await expect(backdrop).toBeVisible();
+
+    await backdrop.click({ position: { x: 380, y: 420 } });
+    await expect(shell).not.toHaveAttribute("data-mobile-drawer");
+    await expect(page.getByRole("button", { name: "Open navigation (⌘B)" })).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator(".mobile-drawer-backdrop")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- host the existing Chat workspace sidebar in the primary Shell nav slot
- add an isolated, open-on-entry Chat nav policy with full collapse and durable per-surface widths
- route mobile Chat through the nav drawer and update source/E2E contracts

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `pnpm test:app`
- [x] `PORT=3001 pnpm exec playwright test --no-deps tests/chat-sidebar-nav.spec.ts`
- [x] `git diff --check`

Bead: `cave-wy3x`