### PR TITLE
fix(debug): persist the fetched event tail across debug-modal close/reopen

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -76,6 +76,34 @@ assert.match(
   "Hitting the page-cap must surface a truncation notice with a Load more continuation, not truncate silently",
 );
 
+// ── Event-tail persistence across modal close/reopen (A2) ─────────────────────
+
+assert.match(
+  source,
+  /const \[cachedSnapshot\] = useState\(\(\) => readDebugEventsCache\(paneKey\)\)/,
+  "The pane must seed from the per-session events cache exactly once per mount",
+);
+assert.match(
+  source,
+  /useState<CovenEvent\[\]>\(cachedSnapshot\?\.events \?\? \[\]\)/,
+  "A reopened pane must render the previously drained tail instead of an empty list",
+);
+assert.match(
+  source,
+  /useRef\(cachedSnapshot\?\.cursor \?\? 0\)/,
+  "The afterSeq cursor must resume from the cache so reopen doesn't re-drain from seq 0",
+);
+assert.match(
+  source,
+  /useState\(cachedSnapshot\?\.tailCapped \?\? false\)/,
+  "The Load-more truncation notice must survive close/reopen with the cached tail",
+);
+assert.match(
+  source,
+  /if \(events\.length === 0 && cursorRef\.current === 0\) return;\s*writeDebugEventsCache\(paneKey, \{ events, cursor: cursorRef\.current, tailCapped \}\);/,
+  "The pane must write the tail through to the cache on change, skipping empty panes so untouched chats don't evict real tails",
+);
+
 // ── Stream health (chat-session-debugging S6) ─────────────────────────────────
 
 assert.match(
@@ -248,7 +276,7 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!snapshot\.sessionId && !snapshot\.streamHealth\.runId\?\.trim\(\)\)[\s\S]*?const paneKey = snapshot\.sessionId \?\? `run:\$\{snapshot\.streamHealth\.runId!\.trim\(\)\}`;[\s\S]*?<DebugPaneInner key=\{paneKey\}/,
+  /if \(!snapshot\.sessionId && !snapshot\.streamHealth\.runId\?\.trim\(\)\)[\s\S]*?const paneKey = snapshot\.sessionId \?\? `run:\$\{snapshot\.streamHealth\.runId!\.trim\(\)\}`;[\s\S]*?<DebugPaneInner key=\{paneKey\} paneKey=\{paneKey\}/,
   "A new-chat pane must render once its run ID exists and remount when promoted to a session",
 );
 assert.match(

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -23,8 +23,10 @@ import {
   filterEvents,
   formatEventPayload,
   nextAfterSeq,
+  readDebugEventsCache,
   shouldPollEvents,
   turnMetaSummary,
+  writeDebugEventsCache,
   type CovenEvent,
   type DebugStreamHealth,
   type DebugTurn,
@@ -273,7 +275,7 @@ function EventRow({ event }: { event: CovenEvent }) {
 
 // ── Pane ──────────────────────────────────────────────────────────────────────
 
-function DebugPaneInner({ snapshot }: { snapshot: DebugPaneProps }) {
+function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: DebugPaneProps }) {
   const { sessionId, session, familiar, turns, streamHealth } = snapshot;
   const streamStatusRunId = streamHealth.runId?.trim() ?? "";
   const streamStatusSessionId = sessionId?.trim() ?? "";
@@ -297,7 +299,11 @@ function DebugPaneInner({ snapshot }: { snapshot: DebugPaneProps }) {
   const lastErrorLabel = streamHealth.lastErrorAt
     ? formatTimestamp(streamHealth.lastErrorAt, dtPrefs) || streamHealth.lastErrorAt
     : "—";
-  const [events, setEvents] = useState<CovenEvent[]>([]);
+  // The modal unmounts this pane when closed, so the fetched tail + cursor are
+  // seeded from the per-session cache — a reopen renders the drained tail
+  // instantly and the mount fetch resumes from the cursor instead of seq 0.
+  const [cachedSnapshot] = useState(() => readDebugEventsCache(paneKey));
+  const [events, setEvents] = useState<CovenEvent[]>(cachedSnapshot?.events ?? []);
   const [eventsError, setEventsError] = useState<string | null>(null);
   const [streamStatus, setStreamStatus] = useState<RunBufferStatus | null>(null);
   const [streamStatusLoaded, setStreamStatusLoaded] = useState(false);
@@ -308,7 +314,7 @@ function DebugPaneInner({ snapshot }: { snapshot: DebugPaneProps }) {
   // Tail-follow only makes sense while events are streaming in; opening a
   // finished session shouldn't jump past the Session section.
   const [follow, setFollow] = useState(status === "running");
-  const cursorRef = useRef(0);
+  const cursorRef = useRef(cachedSnapshot?.cursor ?? 0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const fetchInFlightRef = useRef(false);
@@ -320,7 +326,14 @@ function DebugPaneInner({ snapshot }: { snapshot: DebugPaneProps }) {
   const streamStatusRequestKeyRef = useRef<string | null>(null);
   // True when a drain stopped at the page cap with a full final page — more
   // events likely remain server-side and the list is silently incomplete.
-  const [tailCapped, setTailCapped] = useState(false);
+  const [tailCapped, setTailCapped] = useState(cachedSnapshot?.tailCapped ?? false);
+
+  // Write-through: keep the cache current so closing the modal loses nothing.
+  // Empty panes are skipped so untouched chats don't evict real tails.
+  useEffect(() => {
+    if (events.length === 0 && cursorRef.current === 0) return;
+    writeDebugEventsCache(paneKey, { events, cursor: cursorRef.current, tailCapped });
+  }, [paneKey, events, tailCapped]);
 
   useEffect(() => {
     streamStatusLifecycleRef.current = true;
@@ -815,5 +828,5 @@ export function DebugPane(snapshot: DebugPaneProps) {
   }
   // New chats key by run until promotion; established chats remain session-keyed.
   const paneKey = snapshot.sessionId ?? `run:${snapshot.streamHealth.runId!.trim()}`;
-  return <DebugPaneInner key={paneKey} snapshot={snapshot} />;
+  return <DebugPaneInner key={paneKey} paneKey={paneKey} snapshot={snapshot} />;
 }

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -179,6 +179,45 @@ assert.equal(
 assert.equal(debugFileName("s1"), "debug-s1.json");
 assert.equal(debugFileName(null), "debug-session.json");
 
+// ── per-session debug events cache: reopen restores the drained tail (A2) ───
+import {
+  clearDebugEventsCacheForTest,
+  readDebugEventsCache,
+  writeDebugEventsCache,
+} from "./session-debug.ts";
+
+{
+  clearDebugEventsCacheForTest();
+  assert.equal(readDebugEventsCache("s1"), null, "cold cache → null (pane starts from seq 0)");
+
+  const tail = { events: [ev(1), ev(2)], cursor: 2, tailCapped: false };
+  writeDebugEventsCache("s1", tail);
+  assert.equal(readDebugEventsCache("s1"), tail, "hit returns the exact stored snapshot");
+
+  const capped = { events: [ev(1), ev(2), ev(3)], cursor: 3, tailCapped: true };
+  writeDebugEventsCache("s1", capped);
+  assert.equal(readDebugEventsCache("s1"), capped, "rewrite replaces the snapshot for the key");
+  assert.equal(
+    readDebugEventsCache("s1").tailCapped,
+    true,
+    "tailCapped survives the round-trip so the Load-more notice reappears on reopen",
+  );
+
+  // LRU bound: writing beyond the cap evicts the least recently touched key.
+  clearDebugEventsCacheForTest();
+  for (let i = 0; i < 8; i++) {
+    writeDebugEventsCache(`s${i}`, { events: [ev(1)], cursor: 1, tailCapped: false });
+  }
+  readDebugEventsCache("s0"); // touch s0 so s1 is now the oldest
+  writeDebugEventsCache("s8", { events: [ev(1)], cursor: 1, tailCapped: false });
+  assert.notEqual(readDebugEventsCache("s0"), null, "recently read key survives eviction");
+  assert.equal(readDebugEventsCache("s1"), null, "least recently touched key is evicted at the cap");
+  assert.notEqual(readDebugEventsCache("s8"), null, "newest write is retained");
+
+  clearDebugEventsCacheForTest();
+  assert.equal(readDebugEventsCache("s8"), null, "test hook clears the cache");
+}
+
 // ── turnActualModel / turnMetaSummary: served-model + usage meta (S2) ───────
 import { turnActualModel, turnMetaSummary } from "./session-debug.ts";
 

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -111,6 +111,51 @@ export function shouldPollEvents(args: { status: string | null; visible: boolean
   return args.status === "running" && args.visible;
 }
 
+/** Snapshot of one pane's fetched event tail, kept across modal close/reopen. */
+export type DebugEventsSnapshot = {
+  events: CovenEvent[];
+  /** Next ?afterSeq= cursor — resuming from here skips the already-drained tail. */
+  cursor: number;
+  /** Whether the last drain stopped at the page cap (more events server-side). */
+  tailCapped: boolean;
+};
+
+/** Most recently touched pane keys, newest last. Bounded so long sessions
+ *  browsing many chats don't accumulate unbounded event tails in memory. */
+const DEBUG_EVENTS_CACHE_LIMIT = 8;
+const debugEventsCache = new Map<string, DebugEventsSnapshot>();
+
+/** Module-level cache of fetched debug event tails, keyed by pane key
+ *  (session id, or run id for pre-promotion chats). The debug modal unmounts
+ *  its pane when closed (ui/modal.tsx returns null), which used to discard the
+ *  drained tail and afterSeq cursor — every reopen refetched from seq 0. The
+ *  pane seeds its state from here on mount and writes through on change, so a
+ *  reopen renders the cached tail instantly and resumes fetching from the
+ *  cursor. LRU-bounded; read/write only from the client pane. */
+export function readDebugEventsCache(paneKey: string): DebugEventsSnapshot | null {
+  const hit = debugEventsCache.get(paneKey);
+  if (!hit) return null;
+  // Refresh recency so an actively viewed pane isn't the one evicted.
+  debugEventsCache.delete(paneKey);
+  debugEventsCache.set(paneKey, hit);
+  return hit;
+}
+
+export function writeDebugEventsCache(paneKey: string, snapshot: DebugEventsSnapshot): void {
+  debugEventsCache.delete(paneKey);
+  debugEventsCache.set(paneKey, snapshot);
+  while (debugEventsCache.size > DEBUG_EVENTS_CACHE_LIMIT) {
+    const oldest = debugEventsCache.keys().next().value;
+    if (oldest === undefined) break;
+    debugEventsCache.delete(oldest);
+  }
+}
+
+/** Test hook: reset the module-level cache between assertions. */
+export function clearDebugEventsCacheForTest(): void {
+  debugEventsCache.clear();
+}
+
 /** Case-insensitive substring filter over the event tail: matches kind or the
  *  raw payload JSON (so ids, paths, and error text inside payloads hit without
  *  a parse). Reference-stable on a blank query so React memos can bail. */


### PR DESCRIPTION
## Problem

The debug modal unmounts `DebugPaneInner` when closed (`ui/modal.tsx` returns `null`), discarding the drained event tail, the `afterSeq` cursor, and the tail-cap notice. Every reopen refetched the whole tail from seq 0 — up to 50×200 events per open on long sessions.

This is deferred backlog item **A2** from the chat-session-debugging goal audit.

## Fix

- New bounded (LRU 8) module-level per-pane-key events cache in `src/lib/session-debug.ts`: `readDebugEventsCache` / `writeDebugEventsCache` (+ test-only clear hook). Reads refresh recency; writes evict the least-recently-touched key past the cap.
- `DebugPaneInner` seeds `events`/`cursorRef`/`tailCapped` from the cache once per mount (lazy `useState` initializer) and writes through on change — a reopen renders the cached tail instantly and the mount fetch resumes from the cursor instead of re-draining.
- Empty panes are never written, so untouched chats can't evict real tails.
- Pane-key semantics unchanged: session id, or `run:<id>` pre-promotion (run-keyed panes fetch no events, so nothing is cached for them).

## Verification

- `node --test` on `session-debug.test.ts` + `debug-pane.test.ts` — new behavioral tests (hit/miss, rewrite, tailCapped round-trip, LRU eviction + recency touch, clear hook) and wiring pins (seed-once, cursor resume, write-through with empty-pane skip)
- `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1141 files) — clean
- `pnpm test:app` — 843/843 files pass
- `pnpm test:api` — reaches only the known local ElevenLabs-vault env failure (cave-k7i3); fails identically on clean `main`
- `pnpm build` — passes with bundle/standalone budgets

Bead: cave-9hdg