### PR TITLE
fix(chat): auto-expand rail folder when a genuinely new chat lands (cave-mllp)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -144,6 +144,7 @@ export const SUITES = {
     "src/lib/chat-sse.test.ts",
     "src/lib/chat-stream-health.test.ts",
     "src/lib/chat-project-selection.test.ts",
+    "src/lib/use-auto-expand-new-groups.test.ts",
     "src/lib/chat-session-order.test.ts",
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/chat-add-project.test.ts",

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -42,6 +42,7 @@ import {
   PROJECT_SIDEBAR_KEYS,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
+import { useAutoExpandNewGroups } from "@/lib/use-auto-expand-new-groups";
 import {
   isSessionPinned,
   sortPinnedFirst,
@@ -312,6 +313,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.selected, JSON.stringify(selection));
   }, [sidebarHydrated, selection]);
+  // First chat in a fresh project folder (or this surface's just-started
+  // chat) must not hide inside a collapsed group (cave-mllp).
+  useAutoExpandNewGroups({
+    hydrated: sidebarHydrated,
+    sessions,
+    groups: sidebarGroups,
+    activeSessionId: activeId,
+    setExpandedKeys,
+  });
 
   // Archived sessions only load while the toggle is on; archive/unarchive
   // bumps archiveNonce so the opt-in list refetches after each change.

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -54,6 +54,7 @@ import {
   selectionKey,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
+import { useAutoExpandNewGroups } from "@/lib/use-auto-expand-new-groups";
 import type { InitialCommandControls } from "@/lib/command-controls";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 
@@ -279,6 +280,15 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.selected, JSON.stringify(selection));
   }, [sidebarHydrated, selection]);
+  // First chat in a fresh project folder (or this surface's just-started
+  // chat) must not hide inside a collapsed group (cave-mllp).
+  useAutoExpandNewGroups({
+    hydrated: sidebarHydrated,
+    sessions,
+    groups: sidebarGroups,
+    activeSessionId: view.kind === "chat" ? view.sessionId : null,
+    setExpandedKeys,
+  });
 
   // ── URL hash sync (CHAT-D9-01) ────────────────────────────────────────────
   // Follows the existing in-app hash idiom (`#card-<id>`):

--- a/src/lib/chat-project-selection.test.ts
+++ b/src/lib/chat-project-selection.test.ts
@@ -4,6 +4,7 @@ import {
   selectionKey,
   projectSelectionKeys,
   applyProjectScope,
+  autoExpandKeysForNewSessions,
   normalizeSelection,
   readPersisted,
   PROJECT_SIDEBAR_KEYS,
@@ -56,5 +57,74 @@ assert.deepEqual(readPersisted("cave:test:key", []), []);
 assert.equal(PROJECT_SIDEBAR_KEYS.open, "cave:chat:project-sidebar-open");
 assert.equal(PROJECT_SIDEBAR_KEYS.expanded, "cave:chat:project-sidebar-expanded");
 assert.equal(PROJECT_SIDEBAR_KEYS.selected, "cave:chat:project-selected");
+
+// ── autoExpandKeysForNewSessions (cave-mllp) ─────────────────────────────────
+
+// first chat in a fresh project folder: new key + first-seen session → expand
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("a", "/a"), group("b", "/b")],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: null,
+  }),
+  ["b"],
+);
+
+// root-fallback keys expand under their root-scoped key
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group(null, "/orphan/root")],
+    knownSessionIds: new Set(),
+    knownGroupKeys: new Set(),
+    activeSessionId: null,
+  }),
+  ["root:/orphan/root"],
+);
+
+// filter reveal (familiar switch): new key but every session already known →
+// the user's collapsed state wins
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("b", "/b")],
+    knownSessionIds: new Set(["b-0"]),
+    knownGroupKeys: new Set(),
+    activeSessionId: null,
+  }),
+  [],
+);
+
+// background session landing in an existing collapsed folder: don't force open
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("a", "/a", 2)], // a-0 known, a-1 fresh
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: null,
+  }),
+  [],
+);
+
+// …unless the fresh session is the active one (this surface just started it)
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("a", "/a", 2)],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: "a-1",
+  }),
+  ["a"],
+);
+
+// an already-known active session never re-expands a collapsed folder
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("a", "/a")],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: "a-0",
+  }),
+  [],
+);
 
 console.log("chat-project-selection tests passed");

--- a/src/lib/chat-project-selection.ts
+++ b/src/lib/chat-project-selection.ts
@@ -42,6 +42,40 @@ export function normalizeSelection(
   return groups.some((g) => selectionKey(g.projectId, g.projectRoot) === selection) ? selection : "all";
 }
 
+/** Group keys that should auto-expand after a sessions refresh (cave-mllp).
+ *
+ *  Once the user has ANY persisted expanded-keys, groups render collapsed
+ *  unless stored — so the first chat in a fresh project folder lands inside a
+ *  collapsed group and reads as "my new chat never showed up". A key
+ *  qualifies when its group gained a session id missing from the baseline
+ *  (`knownSessionIds`, captured from the UNFILTERED session list at hydration
+ *  and grown per refresh) and either:
+ *  - the group key itself is new (`knownGroupKeys`) — a brand-new project
+ *    folder whose only content is the fresh chat, or
+ *  - the fresh session is the active one — the chat this surface just
+ *    started, landing in an existing collapsed folder.
+ *  Groups merely *revealed* by a filter change (familiar switch) never
+ *  qualify: their sessions were already known. Background sessions landing in
+ *  existing collapsed folders don't force them open either. */
+export function autoExpandKeysForNewSessions(args: {
+  groups: ChatProjectGroup[];
+  knownSessionIds: ReadonlySet<string>;
+  knownGroupKeys: ReadonlySet<string>;
+  activeSessionId: string | null;
+}): string[] {
+  const keys: string[] = [];
+  for (const group of args.groups) {
+    const key = selectionKey(group.projectId, group.projectRoot);
+    const fresh = group.sessions.filter((s) => !args.knownSessionIds.has(s.id));
+    if (fresh.length === 0) continue;
+    const newGroup = !args.knownGroupKeys.has(key);
+    const activeIsFresh =
+      args.activeSessionId !== null && fresh.some((s) => s.id === args.activeSessionId);
+    if (newGroup || activeIsFresh) keys.push(key);
+  }
+  return keys;
+}
+
 /** localStorage JSON read that survives SSR (no window) and corrupt values. */
 export function readPersisted<T>(key: string, fallback: T): T {
   if (typeof window === "undefined") return fallback;

--- a/src/lib/use-auto-expand-new-groups.test.ts
+++ b/src/lib/use-auto-expand-new-groups.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+// Wiring pins for useAutoExpandNewGroups (cave-mllp): the hook must baseline
+// before expanding, expand exactly once per key, and both rail owners
+// (ChatRouter, ChatList) must feed it RAW sessions so filter reveals never
+// read as new chats. Behavior of the key-selection logic itself is covered in
+// chat-project-selection.test.ts (autoExpandKeysForNewSessions).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const hook = readFileSync(new URL("./use-auto-expand-new-groups.ts", import.meta.url), "utf8");
+
+// First hydrated run captures a baseline and bails — pre-existing collapsed
+// groups (absent from persisted expanded-keys) must stay collapsed.
+assert.match(
+  hook,
+  /if \(known === null\) \{[\s\S]*?sessionIds: new Set\(\[[\s\S]*?\.\.\.sessions\.map\(\(s\) => s\.id\)[\s\S]*?groupKeys: new Set\(projectSelectionKeys\(groups\)\)[\s\S]*?return;/,
+  "hook baselines raw session ids + visible group keys on first hydrated run without expanding",
+);
+
+// Expansion decisions come from the tested pure helper, computed BEFORE the
+// baselines grow — otherwise this run's fresh sessions would read as known.
+assert.match(
+  hook,
+  /const expandKeys = autoExpandKeysForNewSessions\(\{[\s\S]*?\}\);[\s\S]*?known\.sessionIds\.add\(/,
+  "hook computes expand keys via autoExpandKeysForNewSessions before growing the baseline",
+);
+
+// Functional setState with dedupe: never clobber concurrent expanded-keys
+// updates, never push duplicate keys.
+assert.match(
+  hook,
+  /setExpandedKeys\(\(prev\) => \{\s*const missing = expandKeys\.filter\(\(key\) => !prev\.includes\(key\)\);\s*return missing\.length \? \[\.\.\.prev, \.\.\.missing\] : prev;/,
+  "hook merges new keys into prev expanded state with dedupe and a no-op bail",
+);
+
+// Both rail owners wire the hook with the raw sessions array (not the
+// familiar-filtered rows) and their own active-session source.
+const chatRouter = readFileSync(new URL("../components/chat-router.tsx", import.meta.url), "utf8");
+assert.match(
+  chatRouter,
+  /useAutoExpandNewGroups\(\{\s*hydrated: sidebarHydrated,\s*sessions,\s*groups: sidebarGroups,\s*activeSessionId: view\.kind === "chat" \? view\.sessionId : null,\s*setExpandedKeys,\s*\}\)/,
+  "ChatRouter auto-expands folders for new chats (raw sessions + view-derived active id)",
+);
+const chatList = readFileSync(new URL("../components/chat-list.tsx", import.meta.url), "utf8");
+assert.match(
+  chatList,
+  /useAutoExpandNewGroups\(\{\s*hydrated: sidebarHydrated,\s*sessions,\s*groups: sidebarGroups,\s*activeSessionId: activeId,\s*setExpandedKeys,\s*\}\)/,
+  "ChatList auto-expands folders for new chats (raw sessions + activeId)",
+);
+
+console.log("use-auto-expand-new-groups tests passed");

--- a/src/lib/use-auto-expand-new-groups.ts
+++ b/src/lib/use-auto-expand-new-groups.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
+import type { ChatProjectGroup } from "@/lib/chat-projects";
+import {
+  autoExpandKeysForNewSessions,
+  projectSelectionKeys,
+} from "@/lib/chat-project-selection";
+
+type Baseline = { sessionIds: Set<string>; groupKeys: Set<string> };
+
+/**
+ * Auto-expand rail folders that gain a genuinely new chat (cave-mllp).
+ *
+ * The first hydrated run only captures a baseline — groups the user
+ * deliberately collapsed (absent from the persisted expanded-keys) must stay
+ * collapsed. After that, each refresh expands the keys
+ * `autoExpandKeysForNewSessions` selects, exactly once per key: a later
+ * manual re-collapse wins because the session ids are already known by then.
+ *
+ * `sessions` must be the RAW (unfiltered) rows so a familiar switch that
+ * merely reveals previously filtered groups never reads as "new chats".
+ */
+export function useAutoExpandNewGroups(args: {
+  hydrated: boolean;
+  sessions: readonly { id: string }[];
+  groups: ChatProjectGroup[];
+  activeSessionId: string | null;
+  setExpandedKeys: Dispatch<SetStateAction<string[]>>;
+}): void {
+  const { hydrated, sessions, groups, activeSessionId, setExpandedKeys } = args;
+  const baselineRef = useRef<Baseline | null>(null);
+  useEffect(() => {
+    if (!hydrated) return;
+    const known = baselineRef.current;
+    if (known === null) {
+      baselineRef.current = {
+        sessionIds: new Set([
+          ...sessions.map((s) => s.id),
+          ...groups.flatMap((g) => g.sessions.map((s) => s.id)),
+        ]),
+        groupKeys: new Set(projectSelectionKeys(groups)),
+      };
+      return;
+    }
+    const expandKeys = autoExpandKeysForNewSessions({
+      groups,
+      knownSessionIds: known.sessionIds,
+      knownGroupKeys: known.groupKeys,
+      activeSessionId,
+    });
+    // Grow the baselines only after computing, so this run's fresh sessions
+    // count — and the next run treats them as known (expand-once semantics).
+    for (const s of sessions) known.sessionIds.add(s.id);
+    for (const g of groups) for (const s of g.sessions) known.sessionIds.add(s.id);
+    for (const key of projectSelectionKeys(groups)) known.groupKeys.add(key);
+    if (expandKeys.length === 0) return;
+    setExpandedKeys((prev) => {
+      const missing = expandKeys.filter((key) => !prev.includes(key));
+      return missing.length ? [...prev, ...missing] : prev;
+    });
+  }, [hydrated, sessions, groups, activeSessionId, setExpandedKeys]);
+}


### PR DESCRIPTION
Closes the last P-ranked bug in the chat-siderail-freshness audit (bead **cave-mllp**; follows #3575, #3588, #3590/#3595).

## Problem
Once the user has ANY persisted expanded-keys (`cave:chat:project-sidebar-expanded`), `sidebarDefaultExpandedRef` is false and folders render collapsed unless stored. A **new** project group's key is never in the stored array, so the first chat in a fresh project root appears inside a collapsed folder — the user perceives "my new chat never showed up". Nothing auto-expanded the active session's group either (only `syncSidebarProjectRoot` on explicit project-root change).

## Fix
New `useAutoExpandNewGroups` hook, wired in **both** rail owners (`ChatRouter`, `ChatList`):
- Baselines **raw (unfiltered)** session ids + visible group keys on the first hydrated run — pre-existing collapsed folders stay collapsed.
- After that, a folder auto-expands **exactly once** when it gains a first-seen session id AND either:
  - its key is brand new (first chat in a fresh project folder), or
  - the fresh session is the **active** one (a chat this surface just started, landing in an existing collapsed folder).
- Deliberate non-triggers: filter reveals (familiar switch — sessions already known from the raw list), background sessions landing in existing collapsed folders, and re-expansion after a manual re-collapse.

Key selection is a pure helper, `autoExpandKeysForNewSessions` (chat-project-selection.ts); the hook is thin wiring with a growing baseline ref and a dedup'd functional `setExpandedKeys`. Expansion persists via the existing expanded-keys effect.

## Tests
- Behavioral: 6 scenarios in `chat-project-selection.test.ts` (fresh folder, root-fallback key, filter reveal, background session, active fresh session, known active session).
- Wiring pins: new `use-auto-expand-new-groups.test.ts` (baseline-before-expand, compute-before-baseline-growth, dedupe merge, both component wirings); registered in `run-tests.mjs`.

## Verification
- Targeted: chat-project-selection + use-auto-expand-new-groups + chat-thread-rail tests pass
- `pnpm typecheck` clean; `check-tests-wired` green (1142 files)
- Full `pnpm test:app`: **844 test files passed**

Bead: cave-mllp · Session: 28c2b88b-d576-4d50-a987-b386adc25dfd · Worktree: .worktrees/fix-new-project-group-expanded