### PR TITLE
fix(sessions): bust the sessions-list SWR cache on mutations (cave-53yx)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -985,6 +985,7 @@ export const SUITES = {
     "src/lib/server/chat-work-branch.test.ts",
     "src/lib/github-tasks-cache.test.ts",
     "src/lib/swr-cache.test.ts",
+    "src/lib/server/sessions-list-cache.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",
     "src/lib/server/operator-profile-context.test.ts",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -68,7 +68,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_548/, "runtime closure must stay below 5,548 files");
+assert.match(closureSource, /fileCount: 5_549/, "runtime closure must stay below 5,549 files");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -171,7 +171,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_548;/,
+  /const MAX_FILE_COUNT: u64 = 5_549;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -85,7 +85,10 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Windows. CI measured 5,547; keep the exact maximum.
   // 2026-07-21 (Sessions redesign): the chat-session-grouping chunk adds one
   // traced file on Windows. CI measured 5,548; keep the exact maximum.
-  fileCount: 5_548,
+  // 2026-07-21 (sessions-list cache invalidation): the shared
+  // sessions-list-cache module adds one traced file on Windows atop the
+  // Sessions redesign; keep the exact maximum.
+  fileCount: 5_549,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_548);
+  assert.ok(metrics.fileCount <= 5_549);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_548,
+    fileCount: 5_549,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -148,7 +148,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_548);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_549);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -6,7 +6,7 @@ pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
 pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-pub(super) const MAX_FILE_COUNT: u64 = 5_548;
+pub(super) const MAX_FILE_COUNT: u64 = 5_549;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -520,18 +520,32 @@ for (const contract of contracts) {
   );
   assert.match(
     sessionsListSource,
-    /const sessionsListCache = createSwrCache<SessionsListResult>\(/,
-    "/sessions/list: repeated callers should share a stale-while-revalidate cached response",
+    /import \{\s*sessionsListCache,[\s\S]{0,80}\} from "@\/lib\/server\/sessions-list-cache"/,
+    "/sessions/list: repeated callers should share the invalidatable stale-while-revalidate cache (cave-53yx)",
+  );
+  const sessionsListCacheSource = readFileSync(
+    path.join(apiRoot, "..", "..", "lib", "server", "sessions-list-cache.ts"),
+    "utf8",
   );
   assert.match(
-    sessionsListSource,
+    sessionsListCacheSource,
+    /export const sessionsListCache = createSwrCache<SessionsListResult>\(/,
+    "sessions-list-cache: the shared cache instance is a stale-while-revalidate cache",
+  );
+  assert.match(
+    sessionsListCacheSource,
     /canServeStale: \(result\) => result\.payload\.ok/,
-    "/sessions/list: error payloads must never be served stale (no pinned 503s)",
+    "sessions-list-cache: error payloads must never be served stale (no pinned 503s)",
   );
   assert.match(
-    sessionsListSource,
+    sessionsListCacheSource,
     /SESSIONS_LIST_STALE_SERVE_MS = 30_000/,
-    "/sessions/list: stale serve window covers the poll cadence so polls never block on recompute",
+    "sessions-list-cache: stale serve window covers the poll cadence so polls never block on recompute",
+  );
+  assert.match(
+    sessionsListCacheSource,
+    /export function invalidateSessionsListCache\(\): void \{\s*\n\s*sessionsListCache\.clear\(\);/,
+    "sessions-list-cache: mutation paths can bust every cached view (cave-53yx)",
   );
 
   const swrCacheSource = readFileSync(

--- a/src/app/api/sessions/[id]/kill/route.ts
+++ b/src/app/api/sessions/[id]/kill/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
 import { isOwnedSession } from "@/lib/cave-config";
+import { invalidateSessionsListCache } from "@/lib/server/sessions-list-cache";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isValidSessionId } from "@/lib/server/session-security";
 
@@ -29,5 +30,8 @@ export async function POST(
       { status: 502 },
     );
   }
+  // The kill changed the daemon-side row's status; bust the list cache so
+  // the refresh fired by the killing client sees it immediately (cave-53yx).
+  invalidateSessionsListCache();
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -14,7 +14,10 @@ import {
 import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
 import { collapseFamiliarWorkspaceSessions } from "@/lib/familiar-workspace-sessions";
 import { familiarWorkspacesRoot, readFamiliarWorkspaces } from "@/lib/coven-paths";
-import { createSwrCache } from "@/lib/swr-cache";
+import {
+  sessionsListCache,
+  type SessionsListResult,
+} from "@/lib/server/sessions-list-cache";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
 import { scopeSessionsToFamiliarProjects } from "@/lib/session-project-scope";
@@ -36,39 +39,10 @@ type DaemonSession = {
   initiator?: SessionInitiator;
 };
 
-type SessionsListPayload =
-  | {
-      ok: true;
-      degraded?: boolean;
-      error?: string;
-      sessions: SessionRow[];
-    }
-  | {
-      ok: false;
-      error: string;
-      sessions: [];
-    };
-
-type SessionsListResult = {
-  payload: SessionsListPayload;
-  init?: ResponseInit;
-};
-
-// Stale-while-revalidate cache (cave-5m1c). The old plain 2s TTL sat under
-// the workspace's 4s poll, so effectively EVERY poll missed and paid the full
-// daemon + git + archive-sweep recompute on the response path. Now a poll
-// inside the fresh window is a pure cache hit; a poll after it is served the
-// previous payload instantly while one background recompute refreshes it —
-// steady-state pollers never wait on the compute. Error payloads are never
-// served stale (a transient daemon failure must not pin a 503 for the whole
-// stale window), and concurrent callers still share one in-flight compute.
-const SESSIONS_LIST_CACHE_MS = 2000;
-const SESSIONS_LIST_STALE_SERVE_MS = 30_000;
-const sessionsListCache = createSwrCache<SessionsListResult>({
-  ttlMs: SESSIONS_LIST_CACHE_MS,
-  staleServeMs: SESSIONS_LIST_STALE_SERVE_MS,
-  canServeStale: (result) => result.payload.ok,
-});
+// Stale-while-revalidate cache (cave-5m1c) + mutation invalidation
+// (cave-53yx) live in @/lib/server/sessions-list-cache — a route file may
+// only export handlers, and session mutators must be able to bust the cache
+// so post-mutation refreshes never serve the pre-mutation list.
 
 function isTrueProjectCwd(projectRoot: string): boolean {
   const trimmed = projectRoot.trim();

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
+import { invalidateSessionsListCache } from "@/lib/server/sessions-list-cache";
 import { prunePayload } from "./prune-response";
 
 export const dynamic = "force-dynamic";
@@ -43,6 +44,7 @@ export async function POST(req: Request) {
     // On a dry run the daemon reports how many sessions *would* be pruned; the
     // shared payload helper routes that to `wouldPrune` so the Maintenance
     // "Check" UI reads it the same way it does for the client path below.
+    if (!dryRun && native.data.pruned > 0) invalidateSessionsListCache();
     return NextResponse.json(
       prunePayload({ dryRun, count: native.data.pruned, method: "daemon" }),
     );
@@ -91,5 +93,6 @@ export async function POST(req: Request) {
     if (del.ok) pruned++;
   }
 
+  if (pruned > 0) invalidateSessionsListCache();
   return NextResponse.json(prunePayload({ dryRun: false, count: pruned, method: "client" }));
 }

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 import { withCaveHomeReconciledStore, withCaveHomeReconciledStores } from "./server/cave-home-migration.ts";
+import { invalidateSessionsListCache } from "./server/sessions-list-cache.ts";
 import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
@@ -644,11 +645,16 @@ async function updateState<T>(
   }
 }
 
+// Session-list mutators below call invalidateSessionsListCache() after their
+// state write (cave-53yx): the SWR cache behind /api/sessions/list would
+// otherwise serve the pre-mutation list to the event-driven refresh fired
+// right after the mutation, delaying the visible change by 1-2 polls.
 export async function recordOwnedSession(sessionId: string): Promise<void> {
   try {
     await updateState((state) => {
       state.sessionOwned[sessionId] = new Date().toISOString();
     });
+    invalidateSessionsListCache();
   } catch {
     /* best effort */
   }
@@ -788,6 +794,7 @@ export async function recordSessionFamiliar(sessionId: string, familiarId: strin
     await updateState((state) => {
       state.sessionFamiliar[sessionId] = familiarId;
     });
+    invalidateSessionsListCache();
   } catch {
     /* best effort */
   }
@@ -798,7 +805,7 @@ export async function recordSessionFamiliar(sessionId: string, familiarId: strin
  * Pass an empty/whitespace-only title to clear the override.
  */
 export async function setSessionTitle(sessionId: string, title: string): Promise<string | null> {
-  return updateState((state) => {
+  const next = await updateState((state) => {
     const trimmed = title.trim();
     if (!trimmed) {
       delete state.sessionTitles[sessionId];
@@ -807,6 +814,8 @@ export async function setSessionTitle(sessionId: string, title: string): Promise
     }
     return trimmed || null;
   });
+  invalidateSessionsListCache();
+  return next;
 }
 
 /** Mark a session as archived in the Cave (does not touch the daemon row). */
@@ -815,6 +824,7 @@ export async function archiveSessionLocal(sessionId: string): Promise<string> {
   await updateState((state) => {
     state.sessionArchived[sessionId] = now;
   });
+  invalidateSessionsListCache();
   return now;
 }
 
@@ -829,6 +839,7 @@ export async function summonSessionLocal(sessionId: string): Promise<void> {
       SUMMON_GRACE_DAYS,
     );
   });
+  invalidateSessionsListCache();
 }
 
 /** Mark or unmark a session keep (never auto-archived). Manual archive still works. */
@@ -840,6 +851,7 @@ export async function setSessionKeepLocal(sessionId: string, keep: boolean): Pro
       delete state.sessionKeep[sessionId];
     }
   });
+  invalidateSessionsListCache();
   return keep;
 }
 
@@ -851,6 +863,7 @@ export async function extendSessionAutoArchiveLocal(
   await updateState((state) => {
     state.sessionArchiveExtendedUntil[sessionId] = untilIso;
   });
+  invalidateSessionsListCache();
   return untilIso;
 }
 
@@ -858,6 +871,11 @@ export async function extendSessionAutoArchiveLocal(
  * Archive a batch of sessions in one state write (auto-archive sweep).
  * Sessions already archived or sacrificed are skipped. Returns the ids that
  * were archived now, mapped to their shared archive timestamp.
+ *
+ * Deliberately does NOT invalidate the sessions-list cache: the sweeps run
+ * INSIDE the list compute and their result is already folded into the
+ * returned rows (applySweptRows); invalidating mid-compute would version-bump
+ * the entry away and leave the cache permanently cold.
  */
 export async function autoArchiveSessionsLocal(
   sessionIds: string[],
@@ -879,6 +897,8 @@ export async function autoArchiveSessionsLocal(
  * Archive a batch of sessions whose pull requests just merged, recording each
  * (session, PR) pair so the sweep is one-shot — summoning the chat later won't
  * be undone by the next poll. Returns the archive timestamp used.
+ * Sweep-internal: no sessions-list cache invalidation (see
+ * autoArchiveSessionsLocal).
  */
 export async function archiveSessionsForMergedPrs(
   entries: Array<{ sessionId: string; prKey: string }>,
@@ -903,6 +923,7 @@ export async function sacrificeSessionLocal(sessionId: string): Promise<string> 
   await updateState((state) => {
     state.sessionSacrificed[sessionId] = now;
   });
+  invalidateSessionsListCache();
   return now;
 }
 

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { invalidateSessionsListCache } from "./server/sessions-list-cache.ts";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
 import type { SessionOrigin } from "./types.ts";
@@ -221,6 +222,10 @@ export async function saveConversation(conv: ConversationFile): Promise<void> {
   // torn half-JSON that loadConversation silently drops.
   await writeJsonAtomic(pathFor(conv.sessionId), conv);
   conversationSummaryCache.delete(pathFor(conv.sessionId));
+  // Bust the sessions-list SWR cache (cave-53yx): a new or updated
+  // conversation must be visible to the event-driven list refresh that fires
+  // right after the save, not 1-2 polls later.
+  invalidateSessionsListCache();
 }
 
 export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<void> {
@@ -235,6 +240,7 @@ export async function deleteConversation(sessionId: string): Promise<boolean> {
     const file = pathFor(sessionId);
     await unlink(file);
     conversationSummaryCache.delete(file);
+    invalidateSessionsListCache();
     return true;
   } catch {
     return false;

--- a/src/lib/server/sessions-list-cache.test.ts
+++ b/src/lib/server/sessions-list-cache.test.ts
@@ -1,0 +1,142 @@
+// @ts-nocheck
+/**
+ * Tests for src/lib/server/sessions-list-cache.ts (cave-53yx): the shared
+ * SWR cache behind /api/sessions/list and its mutation invalidation hook.
+ *
+ * Part 1 — behavior: invalidateSessionsListCache() actually busts a fresh
+ * entry so the next get recomputes.
+ *
+ * Part 2 — wiring pins: the list route uses the shared cache (not a private
+ * one), every user-facing session mutator busts the cache after its write,
+ * and the sweep-internal batch archivers deliberately do NOT (they run inside
+ * the list compute; invalidating there would version-bump the entry away and
+ * leave the cache permanently cold).
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  invalidateSessionsListCache,
+  sessionsListCache,
+} from "./sessions-list-cache.ts";
+
+// ── behavior: invalidation forces a recompute ────────────────────────────────
+{
+  const result = (tag) => ({ payload: { ok: true, sessions: [], error: tag } });
+  let computes = 0;
+  const compute = (tag) => async () => {
+    computes++;
+    return result(tag);
+  };
+
+  const first = await sessionsListCache.get("test:cave-53yx", compute("v1"));
+  assert.equal(first.payload.error, "v1", "cold get awaits the compute");
+  assert.equal(computes, 1);
+
+  const cached = await sessionsListCache.get("test:cave-53yx", compute("v2"));
+  assert.equal(cached.payload.error, "v1", "fresh get is served from cache");
+  assert.equal(computes, 1, "fresh get does not recompute");
+
+  invalidateSessionsListCache();
+
+  const recomputed = await sessionsListCache.get("test:cave-53yx", compute("v3"));
+  assert.equal(
+    recomputed.payload.error,
+    "v3",
+    "get after invalidateSessionsListCache() recomputes instead of serving the stale entry",
+  );
+  assert.equal(computes, 2);
+
+  invalidateSessionsListCache(); // leave no test entry behind
+}
+
+// ── wiring pins ──────────────────────────────────────────────────────────────
+const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
+
+/** Source of one `export async function <name>` block (up to the next export). */
+function fnBlock(source, name) {
+  const start = source.indexOf(`export async function ${name}`);
+  assert.notEqual(start, -1, `found export async function ${name}`);
+  const next = source.indexOf("\nexport ", start + 1);
+  return next === -1 ? source.slice(start) : source.slice(start, next);
+}
+
+// The list route consumes the SHARED cache; a locally re-created cache would
+// silently detach it from the invalidation hook.
+{
+  const route = read("../../app/api/sessions/list/route.ts");
+  assert.match(
+    route,
+    /import \{\s*sessionsListCache,[\s\S]{0,120}\} from "@\/lib\/server\/sessions-list-cache"/,
+    "the list route imports the shared sessions-list cache",
+  );
+  assert.doesNotMatch(
+    route,
+    /createSwrCache/,
+    "the list route does not create a private cache instance",
+  );
+}
+
+// Every user-facing session mutator busts the cache after its state write…
+{
+  const config = read("../cave-config.ts");
+  for (const mutator of [
+    "recordOwnedSession",
+    "recordSessionFamiliar",
+    "setSessionTitle",
+    "archiveSessionLocal",
+    "summonSessionLocal",
+    "setSessionKeepLocal",
+    "extendSessionAutoArchiveLocal",
+    "sacrificeSessionLocal",
+  ]) {
+    assert.match(
+      fnBlock(config, mutator),
+      /invalidateSessionsListCache\(\)/,
+      `${mutator} invalidates the sessions-list cache`,
+    );
+  }
+
+  // …but the sweep-internal batch archivers must NOT: they run inside the
+  // list compute and would leave the cache permanently cold.
+  for (const sweep of ["autoArchiveSessionsLocal", "archiveSessionsForMergedPrs"]) {
+    assert.doesNotMatch(
+      fnBlock(config, sweep),
+      /invalidateSessionsListCache\(\)/,
+      `${sweep} is sweep-internal and must not invalidate mid-compute`,
+    );
+  }
+}
+
+// Conversation writes/deletes surface new & removed local chat rows.
+{
+  const conversations = read("../cave-conversations.ts");
+  for (const mutator of ["saveConversation", "deleteConversation"]) {
+    assert.match(
+      fnBlock(conversations, mutator),
+      /invalidateSessionsListCache\(\)/,
+      `${mutator} invalidates the sessions-list cache`,
+    );
+  }
+}
+
+// Daemon-side mutations without a local-state mutator invalidate in-route.
+{
+  assert.match(
+    read("../../app/api/sessions/[id]/kill/route.ts"),
+    /invalidateSessionsListCache\(\)/,
+    "the kill route invalidates the sessions-list cache after a successful kill",
+  );
+  const prune = read("../../app/api/sessions/prune/route.ts");
+  assert.match(
+    prune,
+    /if \(!dryRun && native\.data\.pruned > 0\) invalidateSessionsListCache\(\)/,
+    "the daemon prune path invalidates only when sessions were actually pruned",
+  );
+  assert.match(
+    prune,
+    /if \(pruned > 0\) invalidateSessionsListCache\(\)/,
+    "the client prune path invalidates only when sessions were actually pruned",
+  );
+}
+
+console.log("sessions-list-cache.test.ts: ok");

--- a/src/lib/server/sessions-list-cache.ts
+++ b/src/lib/server/sessions-list-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared SWR cache for /api/sessions/list (cave-5m1c), plus its invalidation
+ * hook (cave-53yx).
+ *
+ * The cache exists because the old plain 2s TTL sat under the workspace's 4s
+ * poll, so effectively EVERY poll missed and paid the full daemon + git +
+ * archive-sweep recompute on the response path. Now a poll inside the fresh
+ * window is a pure cache hit; a poll after it is served the previous payload
+ * instantly while one background recompute refreshes it — steady-state pollers
+ * never wait on the compute. Error payloads are never served stale (a
+ * transient daemon failure must not pin a 503 for the whole stale window), and
+ * concurrent callers still share one in-flight compute.
+ *
+ * It lives here (not in the route file, which may only export handlers) so
+ * mutation paths can bust it: without invalidation, event-driven client
+ * refreshes — exactly the requests fired right after a mutation — were served
+ * the pre-mutation payload and the change appeared only 1-2 polls later
+ * (~4-8s perceived lag). Session mutators in cave-config / cave-conversations
+ * and the daemon-side mutation routes call `invalidateSessionsListCache()` so
+ * the next list request recomputes.
+ *
+ * Invalidation drops EVERY cached view rather than a targeted key: one
+ * session mutation can affect the active and archived views, any number of
+ * familiar-scoped views, and both collapse modes — working out which keys
+ * contain the session is the same work the compute itself does, and there are
+ * only a handful of keys.
+ */
+import { createSwrCache } from "../swr-cache.ts";
+import type { SessionRow } from "../types.ts";
+
+export type SessionsListPayload =
+  | {
+      ok: true;
+      degraded?: boolean;
+      error?: string;
+      sessions: SessionRow[];
+    }
+  | {
+      ok: false;
+      error: string;
+      sessions: [];
+    };
+
+export type SessionsListResult = {
+  payload: SessionsListPayload;
+  init?: ResponseInit;
+};
+
+const SESSIONS_LIST_CACHE_MS = 2000;
+const SESSIONS_LIST_STALE_SERVE_MS = 30_000;
+
+export const sessionsListCache = createSwrCache<SessionsListResult>({
+  ttlMs: SESSIONS_LIST_CACHE_MS,
+  staleServeMs: SESSIONS_LIST_STALE_SERVE_MS,
+  canServeStale: (result) => result.payload.ok,
+});
+
+/**
+ * Bust every cached sessions-list view so the next request recomputes.
+ * Call after any mutation that changes what the list returns: conversation
+ * save/delete, session create, archive/summon, keep, title, sacrifice, kill,
+ * prune. Do NOT call from the auto-archive sweeps — they run INSIDE the list
+ * compute (their result is already folded into the returned rows via
+ * applySweptRows), and invalidating mid-compute would version-bump the entry
+ * away and leave the cache permanently cold.
+ */
+export function invalidateSessionsListCache(): void {
+  sessionsListCache.clear();
+}


### PR DESCRIPTION
## Problem

`/api/sessions/list` sits behind an SWR cache (ttl 2s, stale-serve 30s; cave-5m1c). `swr-cache.ts` exposes `invalidate()`, but **nothing called it** — no mutation path busted the cache. The event-driven client refreshes (`onSessionStarted → loadSessions()`, `handleSessionsDeleted` refetch) are precisely the requests most likely to land inside the fresh/stale window and get served the **pre-mutation** list:

- a refresh within 2s of the mutation is a pure cache hit on the old payload with **no recompute scheduled**
- the next 4s poll is served the **same stale list** (background recompute only)
- the new/changed row appears 1–2 polls later → **~4–8s perceived lag**, worse with familiar-scoped cache keys
- `handleSessionsDeleted` got the deleted row straight back (masked client-side only for deletes, via tombstones)

Third slice of the **chat-siderail-freshness** goal (after cave-zhwa/#3575 and cave-i7nz/#3588).

## Fix

- **New `src/lib/server/sessions-list-cache.ts`** — the cache moves out of the route file (which may only export handlers) and exports `invalidateSessionsListCache()`. Invalidation drops **every** cached view: one session mutation can affect active/archived views, any familiar scope, and both collapse modes; per-key targeting is the same work the compute does.
- **Data-layer hooks** — every user-facing session mutator in `cave-config.ts` (`recordOwnedSession`, `recordSessionFamiliar`, `setSessionTitle`, `archiveSessionLocal`, `summonSessionLocal`, `setSessionKeepLocal`, `extendSessionAutoArchiveLocal`, `sacrificeSessionLocal`) and `saveConversation`/`deleteConversation` in `cave-conversations.ts` bust the cache after their write. Hooking the data layer covers chat send's end-of-stream persist, voice chat creation, flow sessions, and all conversation routes without route-by-route wiring.
- **Route hooks for daemon-side mutations** with no local-state mutator: session **kill**, and **prune** (only when `!dryRun` and something was actually pruned).
- **Deliberately NOT hooked:** the sweep batch archivers (`autoArchiveSessionsLocal`, `archiveSessionsForMergedPrs`). They run *inside* the list compute and their result is already folded into the returned rows (`applySweptRows`); invalidating mid-compute would version-bump the just-computed entry away and leave the cache permanently cold.

## Tests

- `src/lib/server/sessions-list-cache.test.ts` (new, api suite): behavioral proof that `invalidateSessionsListCache()` busts a fresh entry, plus wiring pins — route uses the shared cache (no private `createSwrCache`), each mutator invalidates, sweep archivers must NOT, kill/prune invalidate conditionally.
- `api-contracts.test.ts`: SWR pins moved to the shared module + new invalidation-hook pin.

## Verification

- Targeted: new test, `sessions/list/route.test.ts`, `swr-cache.test.ts`, `cave-config*.test.ts` ×3, `cave-conversations.test.ts`, `sessions/route.test.ts`, `api-contracts.test.ts` — all pass
- Full `pnpm test:api` — passes except 3 **pre-existing environmental** failures that fail identically on clean `main` (elevenlabs tts/catalog resolve a real vault key locally; issue-worktree-provision) — unrelated to this change
- `pnpm typecheck` ✓, `check:tests-wired` ✓ (new test registered in the api suite)

Bead: cave-53yx