### PR TITLE
feat(sessions): redesign the Sessions surface from the design handoff (cave-6d6x)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -145,6 +145,7 @@ export const SUITES = {
     "src/lib/chat-stream-health.test.ts",
     "src/lib/chat-project-selection.test.ts",
     "src/lib/chat-session-order.test.ts",
+    "src/lib/chat-session-grouping.test.ts",
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/chat-add-project.test.ts",
     "src/lib/project-registry-events.test.ts",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -68,7 +68,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_547/, "runtime closure must stay below 5,547 files");
+assert.match(closureSource, /fileCount: 5_548/, "runtime closure must stay below 5,548 files");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -171,7 +171,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_547;/,
+  /const MAX_FILE_COUNT: u64 = 5_548;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -83,7 +83,9 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // one traced file on Windows. CI measured 5,545; keep the exact maximum.
   // 2026-07-21 (Group redesign): the coven-tab chunk adds two traced files on
   // Windows. CI measured 5,547; keep the exact maximum.
-  fileCount: 5_547,
+  // 2026-07-21 (Sessions redesign): the chat-session-grouping chunk adds one
+  // traced file on Windows. CI measured 5,548; keep the exact maximum.
+  fileCount: 5_548,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_547);
+  assert.ok(metrics.fileCount <= 5_548);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_547,
+    fileCount: 5_548,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -148,7 +148,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_547);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_548);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -6,7 +6,7 @@ pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
 pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-pub(super) const MAX_FILE_COUNT: u64 = 5_547;
+pub(super) const MAX_FILE_COUNT: u64 = 5_548;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/chat-list-collapse.test.ts
+++ b/src/components/chat-list-collapse.test.ts
@@ -21,8 +21,8 @@ assert.match(src, /!rowCollapsed && \(/, "collapsed section's rows are not rende
 // "Select all" + Delete can never remove chats hidden in a collapsed section.
 assert.match(
   src,
-  /const visibleIds = useMemo\(\(\) => \{\s*\n\s*if \(effectiveSelection !== "all" \|\| collapsedSections\.size === 0\) return displayIds;\s*\n\s*return displayIds\.filter\(\s*\n\s*\(id\) => !collapsedSections\.has\(isSessionPinned\(pinnedIds, id\) \? "pinned" : "sessions"\),/,
-  "visibleIds excludes rows in a collapsed section",
+  /const visibleIds = useMemo\(\(\) => \{[\s\S]{0,320}?if \(effectiveSelection !== "all" \|\| groupBy !== "none" \|\| collapsedSections\.size === 0\) return displayIds;\s*\n\s*return displayIds\.filter\(\s*\n\s*\(id\) => !collapsedSections\.has\(isSessionPinned\(pinnedIds, id\) \? "pinned" : "sessions"\),/,
+  "visibleIds excludes rows in a collapsed section (sections exist only in the flat ungrouped view)",
 );
 assert.doesNotMatch(
   src,

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -123,7 +123,7 @@ assert.match(source, /<DndContext[\s\S]*onDragEnd=\{\(event\) => handleDragEnd\(
 assert.match(source, /<SortableContext items=\{displayIds\} strategy=\{verticalListSortingStrategy\}/, "All visible chat rows should share one SortableContext");
 assert.match(primitives, /useSortable\(\{ id \}\)/, "ChatList rows should be individually sortable by session id");
 assert.match(source, /setSessionOrder\(readSessionOrder\(\)\)/, "ChatList should hydrate the persisted manual order after mount");
-assert.match(source, /if \(effectiveSelection === "all"\) \{[\s\S]*scopedGroups\.flatMap\(\(group\) => group\.sessions\)/, "All chats should flatten groups so cross-project drag order can stick");
+assert.match(source, /if \(effectiveSelection === "all" && groupBy !== "project"\) \{[\s\S]*scopedGroups\.flatMap\(\(group\) => group\.sessions\)/, "All chats should flatten groups (unless grouping by project) so cross-project drag order can stick");
 assert.match(source, /partitionPinnedFirst\(sortChatRowsByRecency\(rows\), pinnedIds\)/, "Pinned rows still float, over a recency-sorted rest, in the flat All chats view until manual drag order exists");
 assert.match(source, /applyManualOrder\(group\.sessions, sessionOrder\)/, "ChatList should apply the manual order inside visible project groups");
 assert.match(source, /mergeVisibleOrder\(prev\.length > 0 \? prev : fallbackOrderIds, nextVisible\)/, "ChatList should merge dragged visible rows back into the full saved order");
@@ -354,7 +354,10 @@ assert.match(source, /const \[selectedIds, setSelectedIds\] = useState<Set<strin
 assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\)/, "the header Select toggle clears any selection");
 assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
-assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setActiveId\(s\.id\); onOpen/, "a row click selects in select mode, otherwise opens");
+// Expandable rows (Sessions redesign): a single click toggles the inline
+// detail disclosure; double-click and Enter keep the fast open path.
+assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setExpandedRowId\(\(cur\) => \(cur === s\.id \? null : s\.id\)\)/, "a row click selects in select mode, otherwise toggles the detail strip");
+assert.match(source, /onDoubleClick=\{\(\) => \{ if \(selectMode\) return; setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); \}\}/, "double-click still opens the session immediately");
 assert.match(source, /const bulkDelete = \(\) =>/, "bulk delete handler exists (deferred/undoable)");
 assert.match(source, /const bulkArchive = async \(archived: boolean\)/, "bulk archive/unarchive handler exists");
 assert.match(source, /Promise\.all\([\s\S]{0,80}fetch\(`\/api\/chat\/conversation\//, "bulk delete runs the per-chat deletes in parallel");

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -355,8 +355,9 @@ assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\
 assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
 // Expandable rows (Sessions redesign): a single click toggles the inline
-// detail disclosure; double-click and Enter keep the fast open path.
-assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setExpandedRowId\(\(cur\) => \(cur === s\.id \? null : s\.id\)\)/, "a row click selects in select mode, otherwise toggles the detail strip");
+// detail disclosure; double-click and Enter keep the fast open path. Mobile
+// keeps tap = open — the disclosure is a desktop affordance.
+assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} if \(isMobile\) \{ setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); return; \} setExpandedRowId\(\(cur\) => \(cur === s\.id \? null : s\.id\)\)/, "a row click selects in select mode, opens directly on mobile, otherwise toggles the detail strip");
 assert.match(source, /onDoubleClick=\{\(\) => \{ if \(selectMode\) return; setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); \}\}/, "double-click still opens the session immediately");
 assert.match(source, /const bulkDelete = \(\) =>/, "bulk delete handler exists (deferred/undoable)");
 assert.match(source, /const bulkArchive = async \(archived: boolean\)/, "bulk archive/unarchive handler exists");

--- a/src/components/chat-list-mobile-rail-port.test.ts
+++ b/src/components/chat-list-mobile-rail-port.test.ts
@@ -36,11 +36,17 @@ assert.match(
 // Headers are placed by first-member index so order/interleaving can't dupe them.
 assert.match(source, /const firstPinnedIdx = pinnedFlags\.indexOf\(true\)/, "PINNED header anchors to the first pinned row");
 assert.match(source, /const firstRestIdx = pinnedFlags\.indexOf\(false\)/, "SESSIONS header anchors to the first non-pinned row");
-// Section headers only split the flat (null-project) list, not scoped folders.
+// Section headers only split the flat ungrouped (null-project) list, not
+// scoped folders or the project/date grouping modes.
 assert.match(
   source,
-  /projectRoot === null && idx === firstPinnedIdx/,
-  "Sections only apply to the flat all-chats list",
+  /const sectioned = projectRoot === null && groupBy === "none";/,
+  "Sections only apply to the flat ungrouped all-chats list",
+);
+assert.match(
+  source,
+  /sectioned && idx === firstPinnedIdx/,
+  "The PINNED header anchors through the sectioned flag",
 );
 
 // ── Preserved: existing rows still sortable by session id ────────────────────

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -203,6 +203,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [groupBy, setGroupBy] = useState<ChatSessionGroupBy>("none");
   // Expandable-row disclosure: a single click opens an inline detail strip
   // (Resume/Open + Archive); double-click and Enter keep the fast open path.
+  // Mobile keeps tap = open (messengers' convention; double-tap is awkward on
+  // touch) — the disclosure is a desktop affordance.
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
   useEffect(() => { setExpandedRowId(null); }, [familiar?.id]);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
@@ -1184,7 +1186,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           aria-expanded={selectMode ? undefined : isExpanded}
                           aria-controls={isExpanded ? detailId : undefined}
                           tabIndex={0}
-                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } setExpandedRowId((cur) => (cur === s.id ? null : s.id)); }}
+                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } if (isMobile) { setActiveId(s.id); onOpen(s.id, s.familiarId); return; } setExpandedRowId((cur) => (cur === s.id ? null : s.id)); }}
                           onDoubleClick={() => { if (selectMode) return; setActiveId(s.id); onOpen(s.id, s.familiarId); }}
                           onMouseEnter={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
                           onMouseLeave={cancelHoverPrefetch}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -23,7 +23,7 @@ import { cancelHoverPrefetch, hoverPrefetchConversation } from "@/lib/conversati
 import { successfulSessionIds } from "@/lib/session-list-deletes";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
-import { relativeTime, isRelativePhrase } from "@/lib/relative-time";
+import { relativeTime } from "@/lib/relative-time";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useDateTimePrefs, formatDate, type DateTimePrefs } from "@/lib/datetime-format";
 import {
@@ -72,6 +72,13 @@ import {
 } from "@dnd-kit/sortable";
 import { ChatListSection, HighlightedSnippet, SortableChatListItem } from "./chat-list-primitives";
 import { chatListCandidates, filterChatListRows, sortChatRowsByRecency } from "@/lib/chat-list-model";
+import {
+  CHAT_GROUP_BY_KEY,
+  deriveChatDaySections,
+  normalizeChatGroupBy,
+  sessionCountLine,
+  type ChatSessionGroupBy,
+} from "@/lib/chat-session-grouping";
 
 type Props = {
   familiar: Familiar | null;
@@ -95,8 +102,12 @@ type Props = {
    *  not evidence there are no chats (cave-x6k5). */
   sessionsError?: boolean;
   /** When true, hides the project sidebar rail so the list fits in a narrow
-   *  companion panel (e.g. the Browser right-rail). */
+   *  companion panel (e.g. the Browser right-rail). Also drops the toolbar
+   *  (All/Active, group-by, count) — a companion panel has no width for it. */
   compact?: boolean;
+  /** Hides only the in-surface project rail (the outer WorkspaceSidebar owns
+   *  chats beside the surface) while the full-width toolbar stays. */
+  hideRail?: boolean;
 };
 
 function chatDate(iso: string, prefs: DateTimePrefs): string {
@@ -139,7 +150,7 @@ type ContentSearchHit = {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, onSessionsDeleted, onOpenUrl, sessionsLoaded = true, sessionsError = false, compact = false }: Props) {
+export function ChatList({ familiar, familiars = [], sessions, daemonRunning, onOpen, onNewChat, onSessionsChanged, onSessionsDeleted, onOpenUrl, sessionsLoaded = true, sessionsError = false, compact = false, hideRail = false }: Props) {
   useMinuteTick(); // keep the "Xm ago" timestamps current without a data refresh
   // Scope the project rail to what the active familiar is granted; with no
   // active familiar (all-familiars view) this loads every project as before.
@@ -188,7 +199,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [contentHits, setContentHits] = useState<ContentSearchHit[]>([]);
   const [contentLoading, setContentLoading] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Toolbar group-by (none / project / date), persisted as a plain string.
+  const [groupBy, setGroupBy] = useState<ChatSessionGroupBy>("none");
+  // Expandable-row disclosure: a single click opens an inline detail strip
+  // (Resume/Open + Archive); double-click and Enter keep the fast open path.
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  useEffect(() => { setExpandedRowId(null); }, [familiar?.id]);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [selection, setSelection] = useState<ProjectSelection>("all");
   const [sidebarHydrated, setSidebarHydrated] = useState(false);
@@ -272,6 +288,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
         e.preventDefault();
         searchRef.current?.focus();
+        return;
+      }
+      // Escape collapses the expanded row first (mock behavior); anything that
+      // already consumed the key (popovers, modals) wins.
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        setExpandedRowId((cur) => (cur ? null : cur));
       }
     };
     window.addEventListener("keydown", handler);
@@ -284,7 +306,11 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     if (sidebarPrefsLoadedRef.current) return;
     if (sessionsLoaded === false) return;
     sidebarPrefsLoadedRef.current = true;
-    setSidebarOpen(readPersisted<unknown>(PROJECT_SIDEBAR_KEYS.open, true) !== false);
+    try {
+      setGroupBy(normalizeChatGroupBy(window.localStorage.getItem(CHAT_GROUP_BY_KEY)));
+    } catch {
+      // storage unavailable — default grouping stands
+    }
     const hasStoredExpanded =
       typeof window !== "undefined" && window.localStorage.getItem(PROJECT_SIDEBAR_KEYS.expanded) !== null;
     sidebarDefaultExpandedRef.current = !hasStoredExpanded;
@@ -304,8 +330,13 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     setExpandedKeys(projectSelectionKeys(sidebarGroups));
   }, [sidebarHydrated, sidebarGroups]);
   useEffect(() => {
-    if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.open, JSON.stringify(sidebarOpen));
-  }, [sidebarHydrated, sidebarOpen]);
+    if (!sidebarHydrated) return;
+    try {
+      window.localStorage.setItem(CHAT_GROUP_BY_KEY, groupBy);
+    } catch {
+      // persistence is best-effort
+    }
+  }, [sidebarHydrated, groupBy]);
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.expanded, JSON.stringify(expandedKeys));
   }, [sidebarHydrated, expandedKeys]);
@@ -374,7 +405,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   }, [search]);
 
   const displayGroups = useMemo(() => {
-    if (effectiveSelection === "all") {
+    // "Group by project" reuses the per-project grouped path even in the flat
+    // "All" scope; "none" and "date" keep the flat single-group view (date
+    // headers are painted over the flat rows without re-sorting them).
+    if (effectiveSelection === "all" && groupBy !== "project") {
       let rows = scopedGroups.flatMap((group) => group.sessions);
       rows = sessionOrder.length === 0
         ? partitionPinnedFirst(sortChatRowsByRecency(rows), pinnedIds)
@@ -398,7 +432,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       return { ...group, sessions: ordered };
     });
     return changed ? next : scopedGroups;
-  }, [effectiveSelection, scopedGroups, sessionOrder, pinnedIds, fallbackFamiliarId]);
+  }, [effectiveSelection, groupBy, scopedGroups, sessionOrder, pinnedIds, fallbackFamiliarId]);
+  // Calendar-day sections for the "Group by date" mode: header metadata keyed
+  // by the first row index of each local day (Today / Yesterday / formatted).
+  const daySectionsByIndex = useMemo(() => {
+    if (groupBy !== "date" || effectiveSelection !== "all") return null;
+    const rows = displayGroups[0]?.sessions ?? [];
+    const sections = deriveChatDaySections(rows, Date.now(), (iso) => formatDate(iso, dtPrefs));
+    return new Map(sections.map((section) => [section.startIndex, section]));
+  }, [groupBy, effectiveSelection, displayGroups, dtPrefs]);
   const displayIds = useMemo(
     () => displayGroups.flatMap((group) => group.sessions.map((session) => session.id)),
     [displayGroups],
@@ -410,11 +452,14 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   // exist in the flat "All" view; there a row is hidden when its section is
   // collapsed. Mirrors the per-row `rowCollapsed` computed during render.
   const visibleIds = useMemo(() => {
-    if (effectiveSelection !== "all" || collapsedSections.size === 0) return displayIds;
+    // The collapsible Pinned/Sessions sections only exist in the flat
+    // ungrouped view — project/date grouping renders every row, so nothing is
+    // hidden and displayIds is already the visible set.
+    if (effectiveSelection !== "all" || groupBy !== "none" || collapsedSections.size === 0) return displayIds;
     return displayIds.filter(
       (id) => !collapsedSections.has(isSessionPinned(pinnedIds, id) ? "pinned" : "sessions"),
     );
-  }, [displayIds, effectiveSelection, collapsedSections, pinnedIds]);
+  }, [displayIds, effectiveSelection, groupBy, collapsedSections, pinnedIds]);
   const visibleRows = useMemo(
     () => scopedGroups.reduce((n, g) => n + g.sessions.length, 0),
     [scopedGroups],
@@ -639,14 +684,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
   return (
     <div className="flex h-full min-w-0">
-      {!compact && sidebarOpen && (
+      {!compact && !hideRail && (
       <ChatProjectSidebar
         groups={sidebarGroups}
         selection={effectiveSelection}
         expandedKeys={expandedKeys}
-        open={sidebarOpen}
         activeSessionId={activeId}
-        onSetOpen={setSidebarOpen}
         onSelect={setSelection}
         onToggleExpanded={(key) => {
           sidebarDefaultExpandedRef.current = false;
@@ -730,19 +773,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
         {/* Search + filter row */}
         <div className="mt-3 flex items-center gap-2 px-4 pb-3">
-          {!compact && !sidebarOpen && (
-            <button
-              type="button"
-              onClick={() => setSidebarOpen(true)}
-              title="Show sessions"
-              aria-label="Show sessions"
-              aria-expanded={false}
-              className="chat-list-reopen-rail focus-ring hidden h-8 w-8 shrink-0 place-items-center rounded-lg border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)] lg:grid"
-            >
-              <Icon name="ph:sidebar-simple" width={14} aria-hidden />
-            </button>
-          )}
-          <label className="chat-list-search-control flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]">
+          <label className="chat-list-search-control flex h-8 min-w-0 max-w-[520px] flex-1 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]">
             <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />
             <input
               ref={searchRef}
@@ -750,7 +781,14 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Escape" && search) {
+                if (e.key !== "Escape") return;
+                // Escape collapses an expanded row first, then clears search.
+                if (expandedRowId) {
+                  e.preventDefault();
+                  setExpandedRowId(null);
+                  return;
+                }
+                if (search) {
                   e.preventDefault();
                   setSearch("");
                 }
@@ -777,6 +815,58 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               </button>
             )}
           </label>
+
+          {!compact && (
+            <>
+              {/* All / Active segmented filter — same state as the dot toggle
+                  below (active = status running). */}
+              <div
+                role="group"
+                aria-label="Filter sessions by activity"
+                className="chat-list-activity-filter flex h-7 shrink-0 items-stretch overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)]"
+              >
+                <button
+                  type="button"
+                  aria-pressed={!unreadsOnly}
+                  onClick={() => setUnreadsOnly(false)}
+                  className={[
+                    "focus-ring-inset px-3 text-[length:var(--text-xs)] transition-colors",
+                    !unreadsOnly
+                      ? "bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] font-medium text-[var(--accent-presence)] shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--accent-presence)_38%,transparent)]"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+                  ].join(" ")}
+                >
+                  All
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={unreadsOnly}
+                  onClick={() => setUnreadsOnly(true)}
+                  className={[
+                    "focus-ring-inset px-3 text-[length:var(--text-xs)] transition-colors",
+                    unreadsOnly
+                      ? "bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] font-medium text-[var(--accent-presence)] shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--accent-presence)_38%,transparent)]"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+                  ].join(" ")}
+                >
+                  Active
+                </button>
+              </div>
+              <select
+                value={groupBy}
+                onChange={(e) => setGroupBy(normalizeChatGroupBy(e.target.value))}
+                aria-label="Group sessions by"
+                className="chat-list-group-select focus-ring h-7 shrink-0 cursor-pointer rounded-[var(--radius-pill)] border border-[var(--border-hairline)] bg-transparent px-2.5 text-[length:var(--text-xs)] text-[var(--text-secondary)]"
+              >
+                <option value="none">No grouping</option>
+                <option value="project">Group by project</option>
+                <option value="date">Group by date</option>
+              </select>
+              <span className="chat-list-count-line ml-auto hidden shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)] min-[900px]:inline">
+                {sessionCountLine(visibleRows, mine.length)}
+              </span>
+            </>
+          )}
 
           <button
             type="button"
@@ -938,7 +1028,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
             <Icon name="ph:magnifying-glass" width={20} className="text-[var(--text-muted)]" />
             <p className="text-sm text-[var(--text-muted)]">
-              {search.trim() ? `No results for "${search}"` : "No sessions match the current filters"}
+              {search.trim() ? `No sessions match “${search}”` : "No sessions match the current filters"}
             </p>
             <button
               type="button"
@@ -1013,22 +1103,24 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               const firstRestIdx = pinnedFlags.indexOf(false);
               return (
               <li key={projectRoot ?? "__none__"}>
-                {/* Project group header */}
-                {projectRoot !== null && effectiveSelection === "all" && (
-                  <div className="group relative flex items-center gap-1.5 px-4 py-2 bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] border-b border-[var(--border-hairline)]">
-                    <Icon name="ph:folder" width={12} className="shrink-0 text-[var(--text-secondary)]" />
-                    <span className="truncate text-[length:var(--text-sm)] font-bold text-[var(--text-primary)] uppercase tracking-wide">
-                      {repoName(projectRoot)}
+                {/* Project group header — uppercase label + count + fading rule
+                    (rendered for every group in the "Group by project" mode,
+                    including the no-project bucket). */}
+                {effectiveSelection === "all" && (projectRoot !== null || groupBy === "project") && (
+                  <div className="chat-list-group-header group relative flex items-center gap-2 px-4 pb-1 pt-3">
+                    <span className="truncate text-[length:var(--text-2xs)] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                      {projectRoot ? repoName(projectRoot) : "No project"}
                     </span>
-                    <span className="font-mono text-[length:var(--text-sm)] text-[var(--text-secondary)] opacity-80">{rows.length}</span>
+                    <span className="shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)]">{rows.length}</span>
+                    <span aria-hidden className="h-px min-w-0 flex-1 bg-gradient-to-r from-[var(--border-hairline)] to-transparent" />
                     <button
-                      className="chat-list-group-new touch-always-visible absolute right-2 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center w-5 h-5 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+                      className="chat-list-group-new touch-always-visible flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
                       onClick={(e) => {
                         e.stopPropagation();
-                        onNewChat(projectRoot, defaultFamiliarId ?? fallbackFamiliarId);
+                        onNewChat(projectRoot ?? undefined, defaultFamiliarId ?? fallbackFamiliarId);
                       }}
-                      title={`New session in ${repoName(projectRoot)}`}
-                      aria-label={`New session in ${repoName(projectRoot)}`}
+                      title={`New session in ${projectRoot ? repoName(projectRoot) : "no project"}`}
+                      aria-label={`New session in ${projectRoot ? repoName(projectRoot) : "no project"}`}
                     >
                       <Icon name="ph:plus" width="0.7rem" height="0.7rem" />
                     </button>
@@ -1044,14 +1136,28 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                     const rowFamiliar = s.familiarId ? familiarsById.get(s.familiarId) : null;
                     const rowFamiliarName = rowFamiliar?.display_name ?? familiar?.display_name ?? "Familiar";
                     const pinned = isSessionPinned(pinnedIds, s.id);
-                    const sectioned = projectRoot === null;
+                    // Pinned/Sessions sections only split the flat ungrouped
+                    // list; project/date grouping owns its own headers.
+                    const sectioned = projectRoot === null && groupBy === "none";
                     const rowCollapsed =
                       sectioned && (pinned ? collapsedSections.has("pinned") : collapsedSections.has("sessions"));
                     const rowName = s.title || s.id;
+                    const daySection = daySectionsByIndex?.get(idx) ?? null;
+                    const isExpanded = !selectMode && expandedRowId === s.id;
+                    const detailId = `chat-list-row-detail-${s.id}`;
 
                     return (
                       <Fragment key={s.id}>
-                      {projectRoot === null && idx === firstPinnedIdx ? (
+                      {daySection ? (
+                        <li className="chat-list-date-header flex items-center gap-2 px-4 pb-1 pt-3">
+                          <span className="truncate text-[length:var(--text-2xs)] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                            {daySection.label}
+                          </span>
+                          <span className="shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)]">{daySection.count}</span>
+                          <span aria-hidden className="h-px min-w-0 flex-1 bg-gradient-to-r from-[var(--border-hairline)] to-transparent" />
+                        </li>
+                      ) : null}
+                      {sectioned && idx === firstPinnedIdx ? (
                         <ChatListSection
                           label="Pinned"
                           count={pinnedCount}
@@ -1059,7 +1165,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           onToggle={() => toggleSection("pinned")}
                         />
                       ) : null}
-                      {projectRoot === null && idx === firstRestIdx ? (
+                      {sectioned && idx === firstRestIdx ? (
                         <ChatListSection
                           label="Sessions"
                           count={restCount}
@@ -1070,12 +1176,16 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                       {!rowCollapsed && (
                       <SortableChatListItem id={s.id}>
                         {({ attributes, listeners }) => (
+                        <>
                         <div
                           role={selectMode ? "checkbox" : "button"}
                           aria-checked={selectMode ? selectedIds.has(s.id) : undefined}
                           aria-current={!selectMode && isActive ? "true" : undefined}
+                          aria-expanded={selectMode ? undefined : isExpanded}
+                          aria-controls={isExpanded ? detailId : undefined}
                           tabIndex={0}
-                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } setActiveId(s.id); onOpen(s.id, s.familiarId); }}
+                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } setExpandedRowId((cur) => (cur === s.id ? null : s.id)); }}
+                          onDoubleClick={() => { if (selectMode) return; setActiveId(s.id); onOpen(s.id, s.familiarId); }}
                           onMouseEnter={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
                           onMouseLeave={cancelHoverPrefetch}
                           onFocus={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
@@ -1085,16 +1195,26 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               e.preventDefault();
                               if (selectMode) { toggleSelect(s.id); return; }
                               setActiveId(s.id); onOpen(s.id, s.familiarId);
+                              return;
+                            }
+                            // Space toggles the inline detail disclosure —
+                            // Enter stays the fast open path.
+                            if (e.key === " ") {
+                              e.preventDefault();
+                              setExpandedRowId((cur) => (cur === s.id ? null : s.id));
                             }
                           }}
                           data-selected={selectMode && selectedIds.has(s.id) ? "true" : undefined}
                           data-status={st.label}
                           data-active={isActive ? "true" : undefined}
+                          data-expanded={isExpanded ? "true" : undefined}
                           className={[
                             "chat-list-row focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
                             isActive
                               ? "bg-[var(--bg-raised)]"
-                              : "hover:bg-[var(--bg-raised)]/50",
+                              : isExpanded
+                                ? "bg-[var(--bg-raised)]/60"
+                                : "hover:bg-[var(--bg-raised)]/50",
                             selectMode && selectedIds.has(s.id) ? "bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)]" : "",
                           ].join(" ")}
                         >
@@ -1161,55 +1281,60 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
 
                           {/* Content */}
                           <span className="chat-list-row-content flex min-w-0 flex-1 flex-col gap-0.5">
-                            {/* Row 1: familiar/project name + timestamp */}
-                            <span className="chat-list-row-meta flex items-baseline justify-between gap-2">
-                              <span className="chat-list-row-tags flex items-center gap-1.5 min-w-0">
-                                <span className="truncate text-[length:var(--text-sm)] font-medium text-[var(--text-secondary)]">
-                                  {project || rowFamiliarName}
+                            {/* Row 1: session title (bold subject line) + a
+                                neutral project tag + the relative-age column.
+                                Running sessions get full white; others are
+                                slightly muted — mirrors the unread/read
+                                convention in email clients. */}
+                            <span className="chat-list-row-meta flex items-center justify-between gap-2">
+                              <span className="chat-list-row-title flex min-w-0 flex-1 items-center gap-1.5">
+                                {pinned && (
+                                  <Icon
+                                    name="ph:bookmark-simple-fill"
+                                    width={11}
+                                    className="shrink-0 text-[var(--accent-presence)]"
+                                    aria-hidden
+                                  />
+                                )}
+                                <span className={[
+                                  "truncate text-[length:var(--text-md)] font-semibold",
+                                  s.status === "running"
+                                    ? "text-white"
+                                    : "text-[var(--text-primary)]",
+                                ].join(" ")}>
+                                  {stripLeadingTrailingEmoji((sessionTitles.get(s.id) ?? s.title) || "(untitled chat)")}
                                 </span>
-                                {s.origin ? <OriginChip origin={s.origin} /> : null}
-                                <SessionInitiatorChip initiator={s.initiator} />
-                                {s.model ? (
-                                  <span
-                                    className="chat-list-row-model inline-flex shrink-0 items-center gap-0.5 rounded-[var(--radius-control)] bg-[var(--bg-raised)]/70 px-1 py-px text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)]"
-                                    title={`Model: ${s.model}`}
-                                  >
-                                    <Icon name={modelIcon(s.model)} width={10} aria-hidden />
-                                    <span className="truncate">{modelLabel(s.model)}</span>
-                                  </span>
-                                ) : null}
                               </span>
-                              <span className="chat-list-row-time flex shrink-0 items-baseline gap-1 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-                                <span>{chatDate(s.updated_at, dtPrefs)}</span>
-                                {isRelativePhrase(rel) ? (
-                                  <>
-                                    <span aria-hidden>·</span>
-                                    <span>{rel}</span>
-                                  </>
-                                ) : null}
+                              {project ? (
+                                <span className="chat-list-row-project-tag hidden shrink-0 items-center rounded-[var(--radius-pill)] border border-[var(--border-hairline)] px-1.5 py-px text-[length:var(--text-2xs)] text-[var(--text-muted)] sm:inline-flex">
+                                  {project}
+                                </span>
+                              ) : null}
+                              <span className="chat-list-row-time w-[88px] shrink-0 text-right text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                                {rel}
                               </span>
                             </span>
 
-                            {/* Row 2: session title (bold subject line)
-                           Running sessions get full white; others are slightly muted
-                           — mirrors the unread/read convention in email clients. */}
-                            <span className="chat-list-row-title flex min-w-0 items-center gap-1.5">
-                              {pinned && (
-                                <Icon
-                                  name="ph:bookmark-simple-fill"
-                                  width={11}
-                                  className="shrink-0 text-[var(--accent-presence)]"
-                                  aria-hidden
-                                />
-                              )}
-                              <span className={[
-                                "truncate text-[length:var(--text-base)] font-semibold",
-                                s.status === "running"
-                                  ? "text-white"
-                                  : "text-[var(--text-primary)]",
-                              ].join(" ")}>
-                                {stripLeadingTrailingEmoji((sessionTitles.get(s.id) ?? s.title) || "(untitled chat)")}
+                            {/* Row 2: familiar · project · date, plus the
+                                origin/initiator/model chips */}
+                            <span className="chat-list-row-tags flex min-w-0 items-center gap-1.5">
+                              <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                                {rowFamiliarName}
+                                {project ? ` · ${project}` : ""}
+                                {" · "}
+                                {chatDate(s.updated_at, dtPrefs)}
                               </span>
+                              {s.origin ? <OriginChip origin={s.origin} /> : null}
+                              <SessionInitiatorChip initiator={s.initiator} />
+                              {s.model ? (
+                                <span
+                                  className="chat-list-row-model inline-flex shrink-0 items-center gap-0.5 rounded-[var(--radius-control)] bg-[var(--bg-raised)]/70 px-1 py-px text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)]"
+                                  title={`Model: ${s.model}`}
+                                >
+                                  <Icon name={modelIcon(s.model)} width={10} aria-hidden />
+                                  <span className="truncate">{modelLabel(s.model)}</span>
+                                </span>
+                              ) : null}
                             </span>
 
                             {/* Row 3: status preview */}
@@ -1394,6 +1519,45 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             </span>
                           ))}
                         </div>
+                        {/* Inline detail strip — the row's disclosure target.
+                            Resume/Open is the existing open-session action;
+                            Archive reuses the undo-safe archive PATCH. */}
+                        {isExpanded && (
+                          <div
+                            id={detailId}
+                            className="chat-list-row-detail mb-2 ml-[26px] mr-4 mt-1 flex items-center gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3.5 py-2.5"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                              {rowFamiliarName}
+                              {" · "}
+                              {project || "no project"}
+                              {" · "}
+                              {s.status === "running" ? "running now" : "idle"}
+                              {" · last activity "}
+                              {rel}
+                            </span>
+                            <Button
+                              variant="primary"
+                              size="sm"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setActiveId(s.id);
+                                onOpen(s.id, s.familiarId);
+                              }}
+                            >
+                              {s.status === "running" ? "Resume" : "Open"}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={archivingId !== null}
+                              onClick={(e) => void setSessionArchived(e, s.id, !s.archived_at)}
+                            >
+                              {s.archived_at ? "Unarchive" : "Archive"}
+                            </Button>
+                          </div>
+                        )}
+                        </>
                         )}
                       </SortableChatListItem>
                       )}
@@ -1465,8 +1629,12 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       </div>
 
       {/* ── Footer ── */}
-      <footer className="chat-list-footer border-t border-[var(--border-hairline)] px-4 py-2 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-        {keys.enter} open · {keys.mod}K palette · / commands in chat
+      <footer className="chat-list-footer flex flex-none items-center gap-1.5 border-t border-[var(--border-hairline)] px-4 py-2 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+        <kbd className="chat-list-kbd">{keys.enter}</kbd> open
+        <span aria-hidden>·</span>
+        <kbd className="chat-list-kbd">/</kbd> search
+        <span aria-hidden>·</span>
+        <kbd className="chat-list-kbd">{keys.mod}K</kbd> palette
       </footer>
       </section>
       {deletePending ? (

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -7,7 +7,6 @@ import type { SessionRow } from "@/lib/types";
 import { type ChatProjectGroup } from "@/lib/chat-projects";
 import { selectionKey, type ProjectSelection } from "@/lib/chat-project-selection";
 import { setProjectOverride } from "@/lib/chat-project-overrides";
-import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { cancelHoverPrefetch, hoverPrefetchConversation } from "@/lib/conversation-cache";
 import { relativeTime } from "@/lib/relative-time";
@@ -23,9 +22,19 @@ import {
   readSessionOrder,
   writeSessionOrder,
 } from "@/lib/chat-session-order";
+import {
+  CHAT_RAIL_MODE_KEY,
+  normalizeChatRailMode,
+  railGroupPreview,
+  railMoreLabel,
+  type ChatRailMode,
+} from "@/lib/chat-session-grouping";
 import { Icon, type IconName } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { SearchInput } from "@/components/ui/search-input";
+import { SurfaceRail } from "@/components/ui/surface-rail";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import {
   CHAT_SESSION_DRAG_MIME,
@@ -65,9 +74,7 @@ type Props = {
   groups: ChatProjectGroup[];
   selection: ProjectSelection;
   expandedKeys: string[];
-  open: boolean;
   activeSessionId?: string | null;
-  onSetOpen: (open: boolean) => void;
   onSelect: (selection: ProjectSelection) => void;
   onToggleExpanded: (key: string) => void;
   onOpenSession: (session: SessionRow) => void;
@@ -209,7 +216,7 @@ function ThreadRow({
         {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
         className={[
-          "focus-ring-inset relative flex min-h-[36px] w-full items-center gap-1.5 py-2 pl-2 pr-1.5 text-left text-[length:var(--text-sm)] transition-colors",
+          "focus-ring-inset relative flex min-h-[36px] w-full items-center gap-1.5 rounded-[var(--radius-control)] py-2 pl-2 pr-1.5 text-left text-[length:var(--text-sm)] transition-colors",
           active
             ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
@@ -327,7 +334,7 @@ function FolderChatRow({
         {...sessionDragProps(session.id, title)}
         aria-current={active ? "true" : undefined}
         className={[
-          "relative flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-2 pr-2 text-left text-[length:var(--text-sm)] transition-colors",
+          "relative flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-6 pr-2 text-left text-[length:var(--text-sm)] transition-colors",
           active
             ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
             : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
@@ -355,6 +362,63 @@ function FolderChatRow({
           </button>
         </span>
         <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
+        <span className="chat-thread-age shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)] group-hover/row:hidden">
+          {shortAge(session.updated_at)}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+// A flat Recent-mode row: small status dot + title + age, recency-sorted.
+// Presentation-only alternative to the folder tree — pins, reorder and moves
+// stay on the By-project view; opens/split/prefetch behave identically.
+function RecentChatRow({
+  session,
+  active,
+  onOpen,
+  onOpenInSplit,
+}: {
+  session: SessionRow;
+  active: boolean;
+  onOpen: () => void;
+  onOpenInSplit?: () => void;
+}) {
+  const title = sessionRailTitle(session);
+  return (
+    <li className="group/row relative">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onMouseEnter={() => hoverPrefetchConversation(session.id)}
+        onMouseLeave={cancelHoverPrefetch}
+        onFocus={() => hoverPrefetchConversation(session.id)}
+        onBlur={cancelHoverPrefetch}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          if (e.altKey && onOpenInSplit) {
+            e.preventDefault();
+            onOpenInSplit();
+            return;
+          }
+          onOpen();
+        }}
+        {...sessionDragProps(session.id, title)}
+        aria-current={active ? "true" : undefined}
+        className={[
+          "focus-ring-inset relative flex min-h-[var(--space-8)] w-full items-center gap-2 rounded-[var(--radius-control)] px-2 py-1.5 text-left text-[length:var(--text-sm)] transition-colors",
+          active
+            ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+            : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
+        ].join(" ")}
+      >
+        {active ? <AccentBar /> : null}
+        <span aria-hidden className={`h-[5px] w-[5px] shrink-0 rounded-full ${statusDotClass(session.status)}`} />
+        <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
+        <span className="chat-thread-age shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+          {shortAge(session.updated_at)}
+        </span>
       </div>
     </li>
   );
@@ -364,9 +428,7 @@ export function ChatProjectSidebar({
   groups,
   selection,
   expandedKeys,
-  open,
   activeSessionId,
-  onSetOpen,
   onSelect,
   onToggleExpanded,
   onOpenSession,
@@ -379,12 +441,31 @@ export function ChatProjectSidebar({
   // still local (this rail is its only writer).
   const pinnedIds = usePinnedSessions();
   const [order, setOrder] = useState<string[]>([]);
+  // By project (folder tree, default) vs Recent (flat recency list) — the
+  // rail's presentation mode, persisted as a plain string.
+  const [railMode, setRailModeState] = useState<ChatRailMode>("projects");
+  // Per-group preview cap: groups render at most 6 rows until "Show N more".
+  const [showMoreKeys, setShowMoreKeys] = useState<Set<string>>(() => new Set());
 
   // The manual order loads after mount so SSR markup and the first client
   // render agree — same idiom as the chat list's persistence.
   useEffect(() => {
     setOrder(readSessionOrder());
+    try {
+      setRailModeState(normalizeChatRailMode(window.localStorage.getItem(CHAT_RAIL_MODE_KEY)));
+    } catch {
+      // storage unavailable — default mode stands
+    }
   }, []);
+
+  const setRailMode = (mode: ChatRailMode) => {
+    setRailModeState(mode);
+    try {
+      window.localStorage.setItem(CHAT_RAIL_MODE_KEY, mode);
+    } catch {
+      // persistence is best-effort
+    }
+  };
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -496,266 +577,349 @@ export function ChatProjectSidebar({
     setProjectOverride(activeId, target.projectRoot ?? "");
   }
 
-  if (!open) {
-    return (
-      <aside className="hidden shrink-0 border-r border-[var(--border-hairline)] lg:flex">
-        <button
-          type="button"
-          onClick={() => onSetOpen(true)}
-          title="Show sessions"
-          aria-label="Show sessions"
-          aria-expanded={false}
-          className="focus-ring flex w-7 flex-col items-center pt-3 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]"
-        >
-          <span className="edge-rail-chip">
-            <Icon name="ph:sidebar-simple" width={14} aria-hidden />
-          </span>
-        </button>
-      </aside>
-    );
+  // Rail-mode mini toggle (26px): By project = folder tree, Recent = flat
+  // recency rows. aria-pressed buttons, not a tablist — the rail's modes are
+  // views of one list, not panels.
+  function railModeSegmentClass(on: boolean): string {
+    return [
+      "focus-ring-inset h-full min-w-0 flex-1 truncate px-2 text-[length:var(--text-xs)] transition-colors",
+      on
+        ? "bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] font-medium text-[var(--accent-presence)] shadow-[inset_0_0_0_1px_color-mix(in_oklch,var(--accent-presence)_38%,transparent)]"
+        : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+    ].join(" ");
   }
 
-  return (
-    <aside className="chat-thread-rail hidden w-[230px] shrink-0 flex-col border-r border-[var(--border-hairline)] lg:flex">
-      <div
-        className="flex shrink-0 items-center gap-2 px-3 pb-1 pt-2"
-        aria-label="Chat projects header"
-      >
-        <span className="min-w-0 flex-1 truncate text-[length:var(--text-2xs)] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-          Projects
-        </span>
-        <button
-          type="button"
-          onClick={() => onSelect("all")}
-          aria-current={selection === "all" ? "true" : undefined}
-          className={[
-            "shrink-0 rounded px-1.5 py-0.5 text-[length:var(--text-2xs)] transition-colors",
-            selection === "all"
-              ? "text-[var(--accent-presence)]"
-              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
-          ].join(" ")}
-        >
-          All sessions
-        </button>
-        <button
-          type="button"
-          title="Open Projects tab"
-          aria-label="Open Projects tab"
-          onClick={openProjectsTab}
-          className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/40 hover:text-[var(--text-primary)]"
-        >
-          <Icon name="ph:folder-open-bold" width={13} aria-hidden />
-        </button>
-        <button
-          type="button"
-          onClick={() => onSetOpen(false)}
-          title="Hide sessions"
-          aria-label="Hide sessions"
-          aria-expanded
-          className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/40 hover:text-[var(--text-primary)]"
-        >
-          <Icon name="ph:sidebar-simple-fill" width={14} aria-hidden />
-        </button>
-      </div>
+  const recentRows = allSessions;
 
-      {/* Search */}
-      <div className="px-2 pb-2 pt-0 border-b border-[var(--border-hairline)]">
-        <label className="flex h-7 items-center gap-1.5 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]">
-          <Icon name="ph:magnifying-glass" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search sessions…"
-            aria-label="Search sessions"
-            className="min-w-0 flex-1 bg-transparent text-[length:var(--text-sm)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none"
-          />
-          {search && (
+  return (
+    <div className="hidden lg:contents">
+      <SurfaceRail
+        storageKey="cave:chat:rail"
+        title="Chats"
+        ariaLabel="Chats"
+        actions={
+          <>
             <button
               type="button"
-              onClick={() => setSearch("")}
-              aria-label="Clear search"
-              className="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              onClick={() => onNewChat(null)}
+              title="New chat"
+              aria-label="New chat"
+              className="focus-ring text-[var(--accent-presence)]"
             >
-              <Icon name="ph:x" width={11} aria-hidden />
+              <Icon name="ph:plus-bold" width={14} aria-hidden />
             </button>
-          )}
-        </label>
-      </div>
-
-      <nav aria-label="Familiar sessions" className="min-h-0 flex-1 overflow-y-auto pb-2">
-        {/* ── Flat results appear only while searching; projects stay primary. ── */}
-        {hasSearch ? (
-          display.length === 0 ? (
-            <p className="px-3 pb-3 pt-1 text-center text-[length:var(--text-xs)] text-[var(--text-muted)]">
-              No sessions match your search
-            </p>
-          ) : (
-            <DndContext id="chat-sidebar-projects" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-              <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
-                <ul>
-                  <li>
-                    <RailSection label="Results" count={display.length} />
-                  </li>
-                  {display.map((session) => (
-                    <ThreadRow
-                      key={session.id}
-                      session={session}
-                      active={activeSessionId === session.id}
-                      pinned={isSessionPinned(pinnedIds, session.id)}
-                      onOpen={() => onOpenSession(session)}
-                      onOpenInSplit={
-                        onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
-                      }
-                      onTogglePin={() => togglePin(session.id)}
-                    />
-                  ))}
-                </ul>
-              </SortableContext>
-            </DndContext>
-          )
-        ) : null}
-
-        {/* ── Zero sessions — a friendly invitation instead of a blank rail.
-              Without this, a familiar with no sessions yet rendered an empty
-              nav and the rail read as broken. onNewChat(null) opens a fresh
-              compose view (no project scope) — the same path as the folder
-              "+" buttons. */}
-        {!hasSearch && groups.length === 0 ? (
-          <div className="px-3 pt-4">
-            <EmptyState
-              compact
-              className="rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/35"
-              icon="ph:chat-circle-dots"
-              headline="No conversations yet"
-              subtitle="Start a chat and your sessions will appear here."
-              actions={
-                <Button size="sm" variant="primary" leadingIcon="ph:plus" onClick={() => onNewChat(null)}>
-                  Start a chat
-                </Button>
-              }
-            />
-          </div>
-        ) : null}
-
-        {/* ── Projects — scope the list to one working directory ── */}
-        {groups.length > 0 && (
+            <button
+              type="button"
+              title="Open Projects tab"
+              aria-label="Open Projects tab"
+              onClick={openProjectsTab}
+              className="focus-ring"
+            >
+              <Icon name="ph:folder-open-bold" width={13} aria-hidden />
+            </button>
+          </>
+        }
+        search={
+          <SearchInput
+            value={search}
+            onValueChange={setSearch}
+            onClear={() => setSearch("")}
+            placeholder="Search chats…"
+            aria-label="Search chats"
+          />
+        }
+      >
+        {(open, setOpen) => (
           <>
-            {hasSearch ? <div className="mt-1 border-t border-[var(--border-hairline)]" /> : null}
+            {open ? (
+              <div
+                role="group"
+                aria-label="Chats rail view"
+                className="flex h-[26px] shrink-0 items-stretch overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)]"
+              >
+                <button
+                  type="button"
+                  aria-pressed={railMode === "projects"}
+                  onClick={() => setRailMode("projects")}
+                  className={railModeSegmentClass(railMode === "projects")}
+                >
+                  By project
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={railMode === "recent"}
+                  onClick={() => setRailMode("recent")}
+                  className={railModeSegmentClass(railMode === "recent")}
+                >
+                  Recent
+                </button>
+              </div>
+            ) : null}
 
-            <DndContext id="cps-folders" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleFolderDragEnd}>
-              {groups.map((group) => {
-                const key = selectionKey(group.projectId, group.projectRoot);
-                const expanded = expandedKeys.includes(key);
-                const isSelected = selection === key;
-                const label = repoLabel(group);
-                const orderedSessions = applyManualOrder(group.sessions, order);
-                const orderedIds = orderedSessions.map((s) => s.id);
-                return (
-                  <FolderDroppable key={key} id={`folder:${key}`}>
-                    <div
-                      className={[
-                        // Project folders are task-section headers: a mode-aware
-                        // fill (darker than the page in light mode, lighter in
-                        // dark — the ramp inverts per mode) + a hairline divider
-                        // so each group reads clearly as a header, matching the
-                        // RailSection treatment. Selected keeps an accent tint.
-                        "group relative flex w-full items-center border-b border-[var(--border-hairline)] transition-colors",
-                        isSelected
-                          ? "bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--accent-presence)_20%)]"
-                          : "bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] hover:bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--foreground)_20%)]",
-                      ].join(" ")}
-                    >
-                    {isSelected ? <AccentBar tall /> : null}
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onSelect(key);
-                        onToggleExpanded(key);
-                      }}
-                      aria-expanded={expanded}
-                      aria-label={`${expanded ? "Collapse" : "Expand"} ${label} sessions`}
-                      aria-current={isSelected ? "true" : undefined}
-                      className={[
-                        "focus-ring flex min-h-[38px] min-w-0 flex-1 items-center gap-1.5 rounded py-2 pl-1.5 pr-2 text-left text-[length:var(--text-sm)] transition-colors",
-                        isSelected
-                          ? "text-[var(--text-primary)]"
-                          : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
-                      ].join(" ")}
-                    >
-                      <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden className="shrink-0 text-[var(--text-muted)]" />
-                      <Icon
-                        name={expanded ? "ph:folder-open" : "ph:folder"}
-                        width={13}
-                        aria-hidden
-                        className="shrink-0 text-[var(--text-muted)]"
-                      />
-                      <span
-                        className={[
-                          "min-w-0 flex-1 truncate font-bold",
-                          isSelected ? "text-[var(--accent-presence)]" : "text-[var(--text-primary)]",
-                        ].join(" ")}
-                      >
-                        {label}
-                      </span>
-                      <span className="shrink-0 font-mono text-[length:var(--text-xs)] text-[var(--text-secondary)] opacity-80">
-                        {group.sessions.length}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onNewChat(group.projectRoot)}
-                      title={`New session in ${label}`}
-                      aria-label={`New session in ${label}`}
-                      className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
-                    >
-                      <Icon name="ph:plus" width={11} aria-hidden />
-                    </button>
-                  </div>
-                  {expanded ? (
-                    <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+            <nav aria-label="Familiar sessions" className="flex min-h-0 flex-col pb-2">
+              {/* ── Flat results appear only while searching; projects stay primary. ── */}
+              {open && hasSearch ? (
+                display.length === 0 ? (
+                  <p className="px-3 pb-3 pt-1 text-center text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                    No chats match your search
+                  </p>
+                ) : (
+                  <DndContext id="chat-sidebar-projects" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                    <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
                       <ul>
-                        {orderedSessions.map((session) => (
-                          <FolderChatRow
+                        <li>
+                          <RailSection label="Results" count={display.length} />
+                        </li>
+                        {display.map((session) => (
+                          <ThreadRow
                             key={session.id}
                             session={session}
                             active={activeSessionId === session.id}
+                            pinned={isSessionPinned(pinnedIds, session.id)}
                             onOpen={() => onOpenSession(session)}
                             onOpenInSplit={
                               onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
                             }
+                            onTogglePin={() => togglePin(session.id)}
                           />
                         ))}
                       </ul>
                     </SortableContext>
-                  ) : null}
-                </FolderDroppable>
-              );
-            })}
-            </DndContext>
+                  </DndContext>
+                )
+              ) : null}
+
+              {/* ── Zero sessions — a friendly invitation instead of a blank rail.
+                    Without this, a familiar with no sessions yet rendered an empty
+                    nav and the rail read as broken. onNewChat(null) opens a fresh
+                    compose view (no project scope) — the same path as the folder
+                    "+" buttons. */}
+              {!hasSearch && groups.length === 0 ? (
+                open ? (
+                  <div className="px-1 pt-4">
+                    <EmptyState
+                      compact
+                      className="rounded-lg border border-dashed border-[var(--border-hairline)] bg-[var(--bg-raised)]/35"
+                      icon="ph:chat-circle-dots"
+                      headline="No conversations yet"
+                      subtitle="Start a chat and your sessions will appear here."
+                      actions={
+                        <Button size="sm" variant="primary" leadingIcon="ph:plus" onClick={() => onNewChat(null)}>
+                          Start a chat
+                        </Button>
+                      }
+                    />
+                  </div>
+                ) : null
+              ) : null}
+
+              {/* ── Recent — flat recency-sorted rows (open rail only) ── */}
+              {open && !hasSearch && railMode === "recent" && recentRows.length > 0 ? (
+                <ul className="flex flex-col gap-px">
+                  {recentRows.map((session) => (
+                    <RecentChatRow
+                      key={session.id}
+                      session={session}
+                      active={activeSessionId === session.id}
+                      onOpen={() => onOpenSession(session)}
+                      onOpenInSplit={
+                        onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
+                      }
+                    />
+                  ))}
+                </ul>
+              ) : null}
+
+              {/* ── Collapsed rail: project identity tiles only. Activating one
+                    expands the rail, scopes the list to that project, and opens
+                    the group. ── */}
+              {!open && groups.length > 0 ? (
+                <div className="flex flex-col items-center gap-1">
+                  {groups.map((group) => {
+                    const key = selectionKey(group.projectId, group.projectRoot);
+                    const label = repoLabel(group);
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        title={label}
+                        aria-label={`Open ${label} chats`}
+                        aria-current={selection === key ? "true" : undefined}
+                        onClick={() => {
+                          setOpen(true);
+                          onSelect(key);
+                          if (!expandedKeys.includes(key)) onToggleExpanded(key);
+                        }}
+                        className={[
+                          "focus-ring grid h-8 w-8 place-items-center rounded-[var(--radius-control)] transition-colors",
+                          selection === key
+                            ? "bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)]"
+                            : "hover:bg-[var(--bg-raised)]/60",
+                        ].join(" ")}
+                      >
+                        <ProjectAvatar name={label} root={group.projectRoot} color={group.projectColor} size="md" />
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+
+              {/* ── Projects — scope the list to one working directory ── */}
+              {open && (railMode === "projects" || hasSearch) && groups.length > 0 && (
+                <>
+                  {hasSearch ? <div className="mt-1 border-t border-[var(--border-hairline)]" /> : null}
+
+                  <button
+                    type="button"
+                    onClick={() => onSelect("all")}
+                    aria-current={selection === "all" ? "true" : undefined}
+                    className={[
+                      "focus-ring mb-0.5 rounded px-2 py-1 text-left text-[length:var(--text-2xs)] font-medium uppercase tracking-[0.08em] transition-colors",
+                      selection === "all"
+                        ? "text-[var(--accent-presence)]"
+                        : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]",
+                    ].join(" ")}
+                  >
+                    All sessions
+                  </button>
+
+                  <DndContext id="cps-folders" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleFolderDragEnd}>
+                    {groups.map((group) => {
+                      const key = selectionKey(group.projectId, group.projectRoot);
+                      const expanded = expandedKeys.includes(key);
+                      const isSelected = selection === key;
+                      const label = repoLabel(group);
+                      const orderedSessions = applyManualOrder(group.sessions, order);
+                      const showAll = showMoreKeys.has(key);
+                      const { shown, hiddenCount } = railGroupPreview(orderedSessions, showAll);
+                      const orderedIds = shown.map((s) => s.id);
+                      const latestIso = group.updatedAt ?? group.sessions[0]?.updated_at ?? null;
+                      const groupMeta = `${group.sessions.length} chat${group.sessions.length === 1 ? "" : "s"}${latestIso ? ` · ${shortAge(latestIso)}` : ""}`;
+                      return (
+                        <FolderDroppable key={key} id={`folder:${key}`}>
+                          <div
+                            className={[
+                              // Project folders are task-section headers: a mode-aware
+                              // fill (darker than the page in light mode, lighter in
+                              // dark — the ramp inverts per mode) + a hairline divider
+                              // so each group reads clearly as a header, matching the
+                              // RailSection treatment. Selected keeps an accent tint.
+                              "group relative flex w-full items-center border-b border-[var(--border-hairline)] transition-colors",
+                              isSelected
+                                ? "bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--accent-presence)_20%)]"
+                                : "bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] hover:bg-[color-mix(in_oklch,var(--bg-base)_80%,var(--foreground)_20%)]",
+                            ].join(" ")}
+                          >
+                            {isSelected ? <AccentBar tall /> : null}
+                            <button
+                              type="button"
+                              onClick={() => {
+                                onSelect(key);
+                                onToggleExpanded(key);
+                              }}
+                              aria-expanded={expanded}
+                              aria-label={`${expanded ? "Collapse" : "Expand"} ${label} sessions`}
+                              aria-current={isSelected ? "true" : undefined}
+                              className={[
+                                "focus-ring flex min-h-[38px] min-w-0 flex-1 items-center gap-1.5 rounded py-2 pl-1.5 pr-2 text-left text-[length:var(--text-sm)] transition-colors",
+                                isSelected
+                                  ? "text-[var(--text-primary)]"
+                                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
+                              ].join(" ")}
+                            >
+                              <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden className="shrink-0 text-[var(--text-muted)]" />
+                              <ProjectAvatar
+                                name={label}
+                                root={group.projectRoot}
+                                color={group.projectColor}
+                                size="md"
+                                className="shrink-0"
+                              />
+                              <span
+                                className={[
+                                  "min-w-0 flex-1 truncate font-bold",
+                                  isSelected ? "text-[var(--accent-presence)]" : "text-[var(--text-primary)]",
+                                ].join(" ")}
+                              >
+                                {label}
+                              </span>
+                              <span className="shrink-0 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                                {groupMeta}
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => onNewChat(group.projectRoot)}
+                              title={`New session in ${label}`}
+                              aria-label={`New session in ${label}`}
+                              className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
+                            >
+                              <Icon name="ph:plus" width={11} aria-hidden />
+                            </button>
+                          </div>
+                          {expanded ? (
+                            <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+                              <ul>
+                                {shown.map((session) => (
+                                  <FolderChatRow
+                                    key={session.id}
+                                    session={session}
+                                    active={activeSessionId === session.id}
+                                    onOpen={() => onOpenSession(session)}
+                                    onOpenInSplit={
+                                      onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
+                                    }
+                                  />
+                                ))}
+                              </ul>
+                              {hiddenCount > 0 || showAll ? (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setShowMoreKeys((prev) => {
+                                      const next = new Set(prev);
+                                      if (next.has(key)) next.delete(key);
+                                      else next.add(key);
+                                      return next;
+                                    })
+                                  }
+                                  className="focus-ring w-full rounded-[var(--radius-sm)] py-1 pl-6 pr-2 text-left text-[length:var(--text-2xs)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
+                                >
+                                  {railMoreLabel(showAll, hiddenCount)}
+                                </button>
+                              ) : null}
+                            </SortableContext>
+                          ) : null}
+                        </FolderDroppable>
+                      );
+                    })}
+                  </DndContext>
+                </>
+              )}
+            </nav>
+
+            {/* ── Advanced operations ── quick launchers for the right-side panels
+                  (Git diff / Inspector / Debug). They reach the chat surface's right
+                  panel through the same window-event bridge as the MetaLine bug
+                  button, so the rail stays decoupled from the panel's owner. */}
+            <div className="chat-thread-ops mt-auto flex shrink-0 items-center gap-1 border-t border-[var(--border-hairline)] pt-1.5 data-[open=false]:flex-col" data-open={open ? "true" : "false"}>
+              {ADVANCED_OPS.map((op) => (
+                <button
+                  key={op.event}
+                  type="button"
+                  onClick={() => window.dispatchEvent(new CustomEvent(op.event))}
+                  title={op.title}
+                  aria-label={op.title}
+                  className="focus-ring flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md px-1 py-1 text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/60 hover:text-[var(--text-secondary)]"
+                >
+                  <Icon name={op.icon} width={12} aria-hidden />
+                  {open ? <span className="truncate">{op.label}</span> : null}
+                </button>
+              ))}
+            </div>
           </>
         )}
-      </nav>
-
-      {/* ── Advanced operations ── quick launchers for the right-side panels
-            (Git diff / Inspector / Debug). They reach the chat surface's right
-            panel through the same window-event bridge as the MetaLine bug
-            button, so the rail stays decoupled from the panel's owner. */}
-      <div className="chat-thread-ops flex shrink-0 items-center gap-1 border-t border-[var(--border-hairline)] px-2 py-1.5">
-        {ADVANCED_OPS.map((op) => (
-          <button
-            key={op.event}
-            type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent(op.event))}
-            title={op.title}
-            aria-label={op.title}
-            className="focus-ring flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md px-1 py-1 text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/60 hover:text-[var(--text-secondary)]"
-          >
-            <Icon name={op.icon} width={12} aria-hidden />
-            <span className="truncate">{op.label}</span>
-          </button>
-        ))}
-      </div>
-    </aside>
+      </SurfaceRail>
+    </div>
   );
 }

--- a/src/components/chat-rail-modern-redesign.test.ts
+++ b/src/components/chat-rail-modern-redesign.test.ts
@@ -50,8 +50,13 @@ assert.match(
 );
 assert.match(
   source,
-  /aria-label="Chat projects header"[\s\S]*Projects[\s\S]*aria-label="Hide sessions"/,
-  "Projects lives in the same top row as the collapse toggle",
+  /<SurfaceRail\s*\n\s*storageKey="cave:chat:rail"\s*\n\s*title="Chats"/,
+  "The rail rides the shared SurfaceRail primitive (persisted width/open under cave:chat:rail)",
+);
+assert.match(
+  source,
+  /aria-label="New chat"[\s\S]{0,500}aria-label="Open Projects tab"/,
+  "New chat and the Projects-tab jump live in the SurfaceRail header actions",
 );
 assert.doesNotMatch(source, /<RailSection\s+label="Projects"/, "Projects is not repeated as a separate section row");
 assert.doesNotMatch(source, /Pin a session to keep it here/, "Pinned hints are gone with the permanent flat list");
@@ -60,7 +65,7 @@ assert.doesNotMatch(source, /chat-thread-filters/, "All/Active/Tasks/Pinned tabs
 // ── Familiar selection lives in the page header, not this rail ───────────────
 assert.doesNotMatch(source, /function RailFamiliarStrip/, "Rail no longer carries a duplicate familiar-avatar strip");
 assert.doesNotMatch(source, /<FamiliarAvatar familiar=\{f\} size="sm"/, "Familiar chips moved out of the session rail");
-assert.match(source, /placeholder="Search sessions…"/, "Rail search uses session language");
+assert.match(source, /placeholder="Search chats…"/, "Rail search uses chat language (§10: chats are what people open)");
 assert.match(source, /aria-label="Familiar sessions"/, "Rail names the region as familiar sessions");
 
 // ── Ops footer (Git / Inspect / Debug) is preserved ─────────────────────────

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -94,6 +94,9 @@ type Props = {
   /** Compact mode for the narrow companion sidepanel (FamiliarPanel). Hides the
    *  project sidebar in both list and chat views to reclaim the limited width. */
   compact?: boolean;
+  /** Hides only the project rail (the outer WorkspaceSidebar owns chats);
+   *  the list keeps its full-width toolbar, unlike compact. */
+  hideRail?: boolean;
   /** Jump from the in-chat project rail to the dedicated Projects tab. */
   onOpenProjectsTab?: () => void;
   /** Allow split panes (drag/keyboard multi-pane) on this mount. Only the
@@ -149,6 +152,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onOpenUrl,
     syncUrlHash,
     compact = false,
+    hideRail = false,
     onOpenProjectsTab,
     enableSplitPanes = false,
   },
@@ -195,7 +199,6 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   }, [onOpenProjectsTab]);
   const sidebarPrefsLoadedRef = useRef(false);
   const sidebarDefaultExpandedRef = useRef(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [selection, setSelection] = useState<ProjectSelection>("all");
   const [sidebarHydrated, setSidebarHydrated] = useState(false);
@@ -252,7 +255,6 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     if (sidebarPrefsLoadedRef.current) return;
     if (sessionsLoaded === false) return;
     sidebarPrefsLoadedRef.current = true;
-    setSidebarOpen(readPersisted<unknown>(PROJECT_SIDEBAR_KEYS.open, true) !== false);
     const hasStoredExpanded =
       typeof window !== "undefined" && window.localStorage.getItem(PROJECT_SIDEBAR_KEYS.expanded) !== null;
     sidebarDefaultExpandedRef.current = !hasStoredExpanded;
@@ -270,9 +272,6 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     if (!sidebarHydrated || !sidebarDefaultExpandedRef.current) return;
     setExpandedKeys(projectSelectionKeys(sidebarGroups));
   }, [sidebarHydrated, sidebarGroups]);
-  useEffect(() => {
-    if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.open, JSON.stringify(sidebarOpen));
-  }, [sidebarHydrated, sidebarOpen]);
   useEffect(() => {
     if (sidebarHydrated) window.localStorage.setItem(PROJECT_SIDEBAR_KEYS.expanded, JSON.stringify(expandedKeys));
   }, [sidebarHydrated, expandedKeys]);
@@ -675,6 +674,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         sessionsLoaded={sessionsLoaded}
         sessionsError={sessionsError}
         compact={compact}
+        hideRail={hideRail}
         onSessionsChanged={onSessionsChanged}
         onSessionsDeleted={onSessionsDeleted}
         onOpenUrl={onOpenUrl}
@@ -821,14 +821,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
 
   return (
     <div className="flex h-full min-w-0">
-      {!compact && (
+      {!compact && !hideRail && (
       <ChatProjectSidebar
         groups={sidebarGroups}
         selection={effectiveSelection}
         expandedKeys={expandedKeys}
-        open={sidebarOpen}
         activeSessionId={view.kind === "chat" ? view.sessionId : null}
-        onSetOpen={setSidebarOpen}
         onSelect={setSelection}
         onToggleExpanded={(key) => {
           sidebarDefaultExpandedRef.current = false;

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -62,7 +62,11 @@ assert.match(
   /const compactRail = hideThreadRail/,
   "ChatSurface should fold hideThreadRail into the compact rail flag",
 );
-assert.match(chatSurface, /compact=\{compactRail\}/, "ChatRouter should receive the combined compact flag");
+assert.match(
+  chatSurface,
+  /hideRail=\{compactRail\}/,
+  "ChatRouter should receive the rail-only flag — the outer sidebar owns chats, but the full-width toolbar must stay (hideRail, not compact)",
+);
 
 // ── Recreated sidepanel: project-grouped threads + register-as-project. ───────
 assert.match(

--- a/src/components/chat-split-host.test.ts
+++ b/src/components/chat-split-host.test.ts
@@ -124,11 +124,12 @@ assert.match(router, /onPromotePane=\{handlePromotePane\}/, "promote opens the p
 assert.match(sidebar, /function sessionDragProps\(/, "rows share one native-drag helper");
 assert.match(sidebar, /emitChatSessionDragStart\(\{ sessionId, title \}\)/, "row drag announces itself");
 assert.match(sidebar, /emitChatSessionDragEnd\(\)/, "row drag end clears the drop zone");
-// Both row flavors are draggable to the chat.
+// Every row flavor is draggable to the chat (search results, folder rows,
+// and the Recent-mode flat rows).
 assert.equal(
   (sidebar.match(/\{\.\.\.sessionDragProps\(session\.id, title\)\}/g) ?? []).length,
-  2,
-  "search-result rows and folder rows are both drag sources",
+  3,
+  "search-result, folder, and recent rows are all drag sources",
 );
 // The dnd-kit reorder handle keeps sole ownership of its slot: a native drag
 // started from inside it is cancelled.
@@ -209,8 +210,8 @@ assert.match(router, /focusedPaneId=\{effectiveFocusedPane\}/, "the host renders
 assert.match(sidebar, /onOpenSessionInSplit\?: \(session: SessionRow\) => void;/, "sidebar accepts the split opener");
 assert.equal(
   (sidebar.match(/if \(e\.altKey && onOpenInSplit\) \{/g) ?? []).length,
-  2,
-  "both row flavors handle ⌥↵",
+  3,
+  "search-result, folder, and recent rows all handle ⌥↵",
 );
 
 // ── Live IA wiring (the shell list panel is the real thread rail) ────────────

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -185,8 +185,8 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /<ChatRouter[\s\S]*?compact=\{compactRail\}/,
-  "ChatSurface should suppress the in-chat project sidebar via compact when chat-mode ChatSidebar owns threads",
+  /<ChatRouter[\s\S]*?hideRail=\{compactRail\}/,
+  "ChatSurface should suppress only the in-chat project rail (hideRail) when chat-mode ChatSidebar owns threads — the full-width toolbar stays",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -666,7 +666,7 @@ export function ChatSurface({
                   familiarsLoaded={familiarsLoaded}
                   familiarsError={familiarsError}
                   onRetryFamiliars={onRetryFamiliars}
-                  compact={compactRail}
+                  hideRail={compactRail}
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}
                   onSessionsChanged={onSessionsChanged}

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -42,7 +42,7 @@ assert.match(
 );
 
 // ── Search only; no mode filters (All / Active / Tasks / Pinned) ─────────────
-assert.match(source, /placeholder="Search sessions…"/, "Rail offers inline session search");
+assert.match(source, /placeholder="Search chats…"/, "Rail offers inline chat search");
 assert.doesNotMatch(source, /type ChatFilter =/, "Rail no longer owns filter tab state");
 assert.doesNotMatch(source, /role="tablist"/, "All/Active/Tasks/Pinned tablist is removed");
 assert.doesNotMatch(source, /s\.origin === "board"/, "Tasks filtering is gone from this simplified rail");
@@ -179,20 +179,34 @@ assert.match(
   /className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5/,
   "Project folder plus buttons should overlay at the right edge instead of reducing the label row width",
 );
+// Collapsed rail (SurfaceRail, 56px): project identity tiles remain, and
+// activating one re-expands the rail and opens that group.
 assert.match(
   source,
-  /edge-rail-chip[\s\S]{0,120}ph:sidebar-simple/,
-  "Collapsed rail keeps the pressable reopen chip",
+  /\{!open && groups\.length > 0 \?[\s\S]{0,700}setOpen\(true\);\s*\n\s*onSelect\(key\);\s*\n\s*if \(!expandedKeys\.includes\(key\)\) onToggleExpanded\(key\);/,
+  "Collapsed rail renders group tiles that expand the rail and open the group",
 );
 assert.match(
   source,
-  /aria-label="Chat projects header"[\s\S]*onSelect\("all"\)[\s\S]*aria-label="Hide sessions"/,
-  "Projects header keeps All sessions and the collapse toggle in one compact top row",
+  /onClick=\{\(\) => onSelect\("all"\)\}\s*\n\s*aria-current=\{selection === "all" \? "true" : undefined\}/,
+  "The All sessions unscope affordance survives the SurfaceRail migration",
 );
 assert.match(
   source,
-  /className="px-2 pb-2 pt-0 border-b border-\[var\(--border-hairline\)\]"/,
-  "Search sits directly under the header and separates the project tree with a hairline",
+  /search=\{\s*\n\s*<SearchInput/,
+  "Search renders through SurfaceRail's under-header search slot",
+);
+// By project / Recent mini toggle: aria-pressed buttons (not a tablist),
+// persisted under cave:chat:rail:mode via the pure normalize helper.
+assert.match(
+  source,
+  /aria-pressed=\{railMode === "projects"\}[\s\S]{0,220}By project[\s\S]{0,700}aria-pressed=\{railMode === "recent"\}[\s\S]{0,220}Recent/,
+  "The rail exposes the By project / Recent view toggle",
+);
+assert.match(
+  source,
+  /normalizeChatRailMode\(window\.localStorage\.getItem\(CHAT_RAIL_MODE_KEY\)\)/,
+  "The rail mode hydrates from its persisted key",
 );
 
 // The open conversation row announces itself to assistive tech (was visual-only:

--- a/src/components/code-rail-fit.test.ts
+++ b/src/components/code-rail-fit.test.ts
@@ -50,10 +50,13 @@ assert.match(
   "The code rail should have an outer drag-to-resize separator before it",
 );
 
+// The internal left rail migrated onto the shared SurfaceRail (Sessions
+// redesign): still in-flow with a fixed flex-none width, but user-resizable
+// (200-440px, persisted under cave:chat:rail) instead of a hardcoded 230px.
 assert.match(
   projectSidebar,
-  /chat-thread-rail[\s\S]*w-\[230px\]/,
-  "The internal left rail stays 230px",
+  /<SurfaceRail\s*\n\s*storageKey="cave:chat:rail"/,
+  "The internal left rail reserves its width through the shared SurfaceRail",
 );
 
 // ── Collapsed code rail — the reflection of the left nav's collapsed rail ──

--- a/src/components/code-surface-familiar-scope.test.ts
+++ b/src/components/code-surface-familiar-scope.test.ts
@@ -29,8 +29,8 @@ assert.match(
 //    compact chat-mode path — without the familiar prop the list can't scope.
 assert.match(
   chatSurface,
-  /<ChatRouter[\s\S]*?familiar=\{activeFamiliar\}[\s\S]*?sessions=\{sessions\}[\s\S]*?compact=\{compactRail\}/,
-  "ChatSurface must forward activeFamiliar + sessions into ChatRouter (compact on the chat-mode ChatSidebar path)",
+  /<ChatRouter[\s\S]*?familiar=\{activeFamiliar\}[\s\S]*?sessions=\{sessions\}[\s\S]*?hideRail=\{compactRail\}/,
+  "ChatSurface must forward activeFamiliar + sessions into ChatRouter (rail hidden on the chat-mode ChatSidebar path; toolbar stays)",
 );
 
 // 3. ChatRouter scopes the sidebar/thread list to the familiar (null = show all,

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -207,10 +207,13 @@ assert.doesNotMatch(
   /familiarPanelRail=/,
   "workspace no longer passes a right edge-rail tab toggle to the shell",
 );
+// The chat projects rail migrated onto the shared SurfaceRail (Sessions
+// redesign): the collapsed 56px rail's own toggle is the reopen affordance,
+// so the bespoke edge-rail reopen chip is gone from this sidebar.
 assert.match(
   projectSidebar,
-  /edge-rail-chip[\s\S]{0,120}ph:sidebar-simple/,
-  "collapsed projects sidebar reopen tab uses the pressable chip",
+  /import \{ SurfaceRail \} from "@\/components\/ui\/surface-rail"/,
+  "collapsed projects sidebar reopen affordance comes from the shared SurfaceRail toggle",
 );
 
 assert.match(

--- a/src/components/surface-rail.test.ts
+++ b/src/components/surface-rail.test.ts
@@ -165,11 +165,11 @@ test("component: resize handle is an accessible splitter (separator + arrows + d
   );
 });
 
-test("component: children render-prop receives open so rows can collapse to icons", () => {
+test("component: children render-prop receives open + setOpen so rows can collapse to icons and re-expand the rail", () => {
   assert.match(
     src,
-    /typeof children === "function" \? children\(open\) : children/,
-    "render-prop children get the open flag",
+    /typeof children === "function" \? children\(open, setOpen\) : children/,
+    "render-prop children get the open flag and the setter",
   );
 });
 

--- a/src/components/ui/surface-rail.tsx
+++ b/src/components/ui/surface-rail.tsx
@@ -34,7 +34,9 @@ export function SurfaceRail(props: {
   actions?: ReactNode;
   /** Rendered under the header row only while the rail is open. */
   search?: ReactNode;
-  children: ReactNode | ((open: boolean) => ReactNode);
+  /** Render-prop children receive the open flag plus a setter so collapsed
+   *  content (e.g. avatar-only rows) can expand the rail on activation. */
+  children: ReactNode | ((open: boolean, setOpen: (open: boolean) => void) => ReactNode);
   ariaLabel: string;
 }): React.JSX.Element {
   const { storageKey, title, actions, search, children, ariaLabel } = props;
@@ -82,7 +84,7 @@ export function SurfaceRail(props: {
         {open && search ? <div className="surface-rail__search">{search}</div> : null}
       </div>
       <div className="surface-rail__content">
-        {typeof children === "function" ? children(open) : children}
+        {typeof children === "function" ? children(open, setOpen) : children}
       </div>
       {open ? (
         <div

--- a/src/lib/chat-session-grouping.test.ts
+++ b/src/lib/chat-session-grouping.test.ts
@@ -1,0 +1,202 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Sessions-list redesign invariants: the pure grouping/filter helpers
+// (group-by select, calendar-day sections, count line, rail mode, preview
+// cap) plus source pins for the expandable-row disclosure and toolbar
+// contracts in chat-list.tsx.
+
+import {
+  CHAT_GROUP_BY_KEY,
+  CHAT_RAIL_MODE_KEY,
+  CHAT_RAIL_PREVIEW_LIMIT,
+  deriveChatDaySections,
+  normalizeChatGroupBy,
+  normalizeChatRailMode,
+  railGroupPreview,
+  railMoreLabel,
+  sessionCountLine,
+  sessionDayKey,
+  sessionDayLabel,
+} from "./chat-session-grouping.ts";
+
+const chatList = readFileSync(new URL("../components/chat-list.tsx", import.meta.url), "utf8");
+
+test("normalizeChatGroupBy: project/date pass, everything else is none", () => {
+  assert.equal(normalizeChatGroupBy("project"), "project");
+  assert.equal(normalizeChatGroupBy("date"), "date");
+  assert.equal(normalizeChatGroupBy("none"), "none");
+  assert.equal(normalizeChatGroupBy("banana"), "none");
+  assert.equal(normalizeChatGroupBy(null), "none");
+  assert.equal(normalizeChatGroupBy(undefined), "none");
+  assert.equal(CHAT_GROUP_BY_KEY, "cave:chat:list:group-by");
+});
+
+test("sessionDayKey: local calendar day, garbage → undated", () => {
+  const key = sessionDayKey("2026-07-20T12:30:00");
+  assert.equal(key, "2026-07-20");
+  assert.equal(sessionDayKey("not a date"), "undated");
+});
+
+test("sessionDayLabel: Today / Yesterday / formatted fallback", () => {
+  const now = new Date("2026-07-21T09:00:00").getTime();
+  const fmt = (iso) => `fmt:${iso}`;
+  assert.equal(sessionDayLabel("2026-07-21T01:00:00", now, fmt), "Today");
+  assert.equal(sessionDayLabel("2026-07-20T23:59:00", now, fmt), "Yesterday");
+  assert.equal(sessionDayLabel("2026-07-18T10:00:00", now, fmt), "fmt:2026-07-18T10:00:00");
+  assert.equal(sessionDayLabel("garbage", now, fmt), "Undated");
+  // Future timestamps clamp to Today rather than inventing a section.
+  assert.equal(sessionDayLabel("2026-07-22T10:00:00", now, fmt), "Today");
+});
+
+test("deriveChatDaySections: sections follow row order without re-sorting", () => {
+  const now = new Date("2026-07-21T09:00:00").getTime();
+  const row = (id, iso) => ({ id, updated_at: iso, created_at: iso });
+  const rows = [
+    row("a", "2026-07-21T08:00:00"),
+    row("b", "2026-07-21T07:00:00"),
+    row("c", "2026-07-20T22:00:00"),
+    row("d", "2026-07-18T10:00:00"),
+    row("e", "2026-07-18T09:00:00"),
+  ];
+  const sections = deriveChatDaySections(rows, now, () => "Jul 18");
+  assert.deepEqual(
+    sections.map((s) => ({ label: s.label, count: s.count, startIndex: s.startIndex })),
+    [
+      { label: "Today", count: 2, startIndex: 0 },
+      { label: "Yesterday", count: 1, startIndex: 2 },
+      { label: "Jul 18", count: 2, startIndex: 3 },
+    ],
+  );
+  // A pinned row hoisted out of day order simply opens its own section — the
+  // helper never reorders rows.
+  const interleaved = deriveChatDaySections(
+    [row("d", "2026-07-18T10:00:00"), row("a", "2026-07-21T08:00:00")],
+    now,
+    () => "Jul 18",
+  );
+  assert.equal(interleaved.length, 2);
+  assert.equal(interleaved[0].label, "Jul 18");
+  assert.deepEqual(deriveChatDaySections([], now, () => ""), []);
+});
+
+test("sessionCountLine: shown of total with pluralization on total", () => {
+  assert.equal(sessionCountLine(3, 16), "3 of 16 sessions");
+  assert.equal(sessionCountLine(1, 1), "1 of 1 session");
+  assert.equal(sessionCountLine(0, 4), "0 of 4 sessions");
+});
+
+test("normalizeChatRailMode: recent passes, everything else is projects", () => {
+  assert.equal(normalizeChatRailMode("recent"), "recent");
+  assert.equal(normalizeChatRailMode("projects"), "projects");
+  assert.equal(normalizeChatRailMode("x"), "projects");
+  assert.equal(normalizeChatRailMode(null), "projects");
+  assert.equal(CHAT_RAIL_MODE_KEY, "cave:chat:rail:mode");
+});
+
+test("railGroupPreview + railMoreLabel: 6-row cap with Show N more / fewer", () => {
+  assert.equal(CHAT_RAIL_PREVIEW_LIMIT, 6);
+  const rows = Array.from({ length: 9 }, (_, i) => i);
+  const capped = railGroupPreview(rows, false);
+  assert.deepEqual(capped.shown, [0, 1, 2, 3, 4, 5]);
+  assert.equal(capped.hiddenCount, 3);
+  const expanded = railGroupPreview(rows, true);
+  assert.equal(expanded.shown.length, 9);
+  assert.equal(expanded.hiddenCount, 0);
+  const small = railGroupPreview([1, 2], false);
+  assert.deepEqual(small.shown, [1, 2]);
+  assert.equal(small.hiddenCount, 0);
+  assert.equal(railMoreLabel(false, 3), "Show 3 more");
+  assert.equal(railMoreLabel(true, 0), "Show fewer");
+});
+
+// ── Source pins: expandable-row disclosure semantics (chat-list.tsx) ─────────
+
+test("chat-list: rows are proper disclosures (aria-expanded + aria-controls)", () => {
+  assert.match(
+    chatList,
+    /aria-expanded=\{selectMode \? undefined : isExpanded\}/,
+    "the row button reports its disclosure state outside select mode",
+  );
+  assert.match(
+    chatList,
+    /aria-controls=\{isExpanded \? detailId : undefined\}/,
+    "the expanded row points at its detail strip",
+  );
+  assert.match(
+    chatList,
+    /const detailId = `chat-list-row-detail-\$\{s\.id\}`/,
+    "detail strips carry stable per-session ids",
+  );
+});
+
+test("chat-list: detail strip carries Resume/Open (existing open path) + Archive", () => {
+  assert.match(
+    chatList,
+    /\{s\.status === "running" \? "Resume" : "Open"\}/,
+    "the primary action is Resume while running, Open otherwise",
+  );
+  assert.match(
+    chatList,
+    /chat-list-row-detail[\s\S]{0,1400}setActiveId\(s\.id\);\s*\n\s*onOpen\(s\.id, s\.familiarId\);/,
+    "Resume/Open routes through the existing open-session action",
+  );
+  assert.match(
+    chatList,
+    /onClick=\{\(e\) => void setSessionArchived\(e, s\.id, !s\.archived_at\)\}/,
+    "Archive reuses the existing archive PATCH action",
+  );
+});
+
+test("chat-list: Escape collapses the expanded row before clearing search", () => {
+  assert.match(
+    chatList,
+    /if \(expandedRowId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setExpandedRowId\(null\);\s*\n\s*return;\s*\n\s*\}\s*\n\s*if \(search\) \{/,
+    "the search field's Escape handler collapses first, clears second",
+  );
+  assert.match(
+    chatList,
+    /if \(e\.key === "Escape" && !e\.defaultPrevented\) \{\s*\n\s*setExpandedRowId\(\(cur\) => \(cur \? null : cur\)\);/,
+    "a global Escape collapses the expanded row (deferring to consumers that already handled it)",
+  );
+});
+
+// ── Source pins: toolbar contracts (chat-list.tsx) ───────────────────────────
+
+test("chat-list: All / Active segmented control drives the running-only filter", () => {
+  assert.match(
+    chatList,
+    /aria-pressed=\{!unreadsOnly\}\s*\n\s*onClick=\{\(\) => setUnreadsOnly\(false\)\}/,
+    "All clears the active-only filter",
+  );
+  assert.match(
+    chatList,
+    /aria-pressed=\{unreadsOnly\}\s*\n\s*onClick=\{\(\) => setUnreadsOnly\(true\)\}/,
+    "Active enables the running-only filter (same state as the dot toggle)",
+  );
+});
+
+test("chat-list: group-by select + persisted key + count line", () => {
+  assert.match(
+    chatList,
+    /aria-label="Group sessions by"[\s\S]{0,400}<option value="none">No grouping<\/option>\s*\n\s*<option value="project">Group by project<\/option>\s*\n\s*<option value="date">Group by date<\/option>/,
+    "the group-by select offers none / project / date",
+  );
+  assert.match(
+    chatList,
+    /window\.localStorage\.setItem\(CHAT_GROUP_BY_KEY, groupBy\)/,
+    "the choice persists under the shared key",
+  );
+  assert.match(
+    chatList,
+    /sessionCountLine\(visibleRows, mine\.length\)/,
+    "the toolbar count line reports shown-of-total through the pure helper",
+  );
+  assert.match(
+    chatList,
+    /deriveChatDaySections\(rows, Date\.now\(\), \(iso\) => formatDate\(iso, dtPrefs\)\)/,
+    "date sections derive through the pure helper with the pref-aware day formatter",
+  );
+});

--- a/src/lib/chat-session-grouping.ts
+++ b/src/lib/chat-session-grouping.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure helpers for the Sessions list redesign (chat-list.tsx) and the chats
+ * rail (chat-project-sidebar.tsx): the toolbar's group-by select (none /
+ * project / date), calendar-day sections for the date mode, the "shown of
+ * total" count line, the rail's By project / Recent view mode, and the rail's
+ * per-group preview cap ("Show N more"). Dependency-free so the unit suite
+ * can exercise them directly.
+ */
+
+import type { SessionRow } from "./types";
+
+// ── Group-by (list toolbar) ─────────────────────────────────────────────────
+
+export type ChatSessionGroupBy = "none" | "project" | "date";
+
+/** localStorage key for the persisted group-by choice (raw string value). */
+export const CHAT_GROUP_BY_KEY = "cave:chat:list:group-by";
+
+export function normalizeChatGroupBy(value: unknown): ChatSessionGroupBy {
+  return value === "project" || value === "date" ? value : "none";
+}
+
+// ── Calendar-day sections (group-by: date) ──────────────────────────────────
+
+export type ChatDaySection = {
+  /** Local calendar-day key (YYYY-MM-DD), or "undated" for unparsable rows. */
+  key: string;
+  /** Header label: "Today", "Yesterday", or the caller-formatted day. */
+  label: string;
+  /** Row count inside this section. */
+  count: number;
+  /** Index of the section's first row in the flat row list. */
+  startIndex: number;
+};
+
+function startOfLocalDay(timestamp: number): number {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+}
+
+export function sessionDayKey(iso: string): string {
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return "undated";
+  const date = new Date(timestamp);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/** "Today" / "Yesterday" / caller-formatted day (repo date-format prefs). */
+export function sessionDayLabel(
+  iso: string,
+  now: number,
+  formatDay: (iso: string) => string,
+): string {
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return "Undated";
+  const dayDiff = Math.round((startOfLocalDay(now) - startOfLocalDay(timestamp)) / 86_400_000);
+  if (dayDiff <= 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  return formatDay(iso);
+}
+
+/**
+ * Partition an already-ordered flat row list into calendar-day sections by
+ * `updated_at` (falling back to `created_at`). Sections appear in row order —
+ * the rows themselves are never re-sorted, so manual drag order and
+ * pinned-first still decide what leads inside each day.
+ */
+export function deriveChatDaySections(
+  rows: readonly SessionRow[],
+  now: number,
+  formatDay: (iso: string) => string,
+): ChatDaySection[] {
+  const sections: ChatDaySection[] = [];
+  let current: ChatDaySection | null = null;
+  rows.forEach((row, index) => {
+    const iso = row.updated_at || row.created_at;
+    const key = sessionDayKey(iso);
+    if (current && current.key === key) {
+      current.count += 1;
+      return;
+    }
+    current = { key, label: sessionDayLabel(iso, now, formatDay), count: 1, startIndex: index };
+    sections.push(current);
+  });
+  return sections;
+}
+
+// ── Count line (toolbar, right-aligned) ─────────────────────────────────────
+
+export function sessionCountLine(shown: number, total: number): string {
+  return `${shown} of ${total} session${total === 1 ? "" : "s"}`;
+}
+
+// ── Chats-rail view mode (By project / Recent) ──────────────────────────────
+
+export type ChatRailMode = "projects" | "recent";
+
+/** localStorage key for the persisted rail view mode (raw string value). */
+export const CHAT_RAIL_MODE_KEY = "cave:chat:rail:mode";
+
+export function normalizeChatRailMode(value: unknown): ChatRailMode {
+  return value === "recent" ? "recent" : "projects";
+}
+
+// ── Rail per-group preview cap ("Show N more") ──────────────────────────────
+
+export const CHAT_RAIL_PREVIEW_LIMIT = 6;
+
+export function railGroupPreview<T>(
+  rows: readonly T[],
+  showAll: boolean,
+  limit: number = CHAT_RAIL_PREVIEW_LIMIT,
+): { shown: T[]; hiddenCount: number } {
+  if (showAll || rows.length <= limit) return { shown: [...rows], hiddenCount: 0 };
+  return { shown: rows.slice(0, limit), hiddenCount: rows.length - limit };
+}
+
+export function railMoreLabel(showAll: boolean, hiddenCount: number): string {
+  return showAll ? "Show fewer" : `Show ${hiddenCount} more`;
+}

--- a/src/styles/chat-list.css
+++ b/src/styles/chat-list.css
@@ -64,3 +64,33 @@
   color: var(--text-primary);
   background: color-mix(in oklch, var(--foreground) 6%, transparent);
 }
+
+/* Expandable-row detail strip (Sessions redesign): the disclosure target under
+   a clicked row fades in on motion tokens; reduced motion renders it static. */
+@keyframes chat-list-detail-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.chat-list-row-detail {
+  animation: chat-list-detail-fade var(--duration-fast) var(--ease-standard);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-list-row-detail {
+    animation: none;
+  }
+}
+
+/* Footer keyboard hints (↵ open · / search) — hairline kbd chips. */
+.chat-list-kbd {
+  padding: 0 var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-2xs);
+  line-height: 16px;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
Implements `Sessions.dc.html` from the projects-page-redesign handoff (bead `cave-6d6x`), continuing the arc of #3591 (Canvas), #3592 (Settings), #3593 (Familiar + SurfaceRail), #3594 (Group).

## Sessions list (visible on the chat surface's Sessions tab)
- **Toolbar**: All/Active segmented filter, group-by select (none / project / date, persisted under `cave:chat:list:group-by`), right-aligned `N of M sessions` count line.
- **Group by date** paints calendar-day headers (Today / Yesterday / formatted) over the flat rows without re-sorting — manual drag order and pinned-first still decide order inside each day. **Group by project** reuses the grouped path with the new uppercase header + count + fading-rule treatment.
- **Expandable rows**: single click opens an inline detail strip (status line + Resume/Open + Archive); double-click and Enter keep the fast open path; Space toggles; Escape collapses the strip first, then clears search.
- **Row grammar** per the handoff: bold title line, `familiar · project · date` meta line, neutral project tag, fixed-width relative-age column.
- Footer keyboard hints as kbd chips.

## Chats rail (chat-project-sidebar)
- Migrates onto the shared `SurfaceRail` primitive (persisted width/open under `cave:chat:rail`): **By project / Recent** view modes (persisted), per-group preview cap with "Show N more", collapsed-rail project tiles that re-expand + scope, `SearchInput` in the rail's search slot. `SurfaceRail`'s render-prop children now also receive `setOpen` so collapsed content can expand the rail.
- `ChatSurface` now passes `hideRail` (rail-only suppression) instead of `compact`, so the list keeps its full-width toolbar under the two-host chat IA (the outer WorkspaceSidebar still owns chats beside the surface).

## Support
- New dependency-free helpers in `src/lib/chat-session-grouping.ts` + wired unit suite.
- Test pins across the chat list/rail suites updated to the new contracts.

## Verification
Screenshot-verified in the running app (prod build): list toolbar + rows, expanded detail strip, group-by date ("TODAY 6"), group-by project ("SAGE 5"), Active filter empty state ("0 of 68 sessions" with daemon offline). Gates: app suite 844 files ✓, `tsc` ✓, design lint ✓ (post-codemod), tests-wired ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)