### PR TITLE
fix(chat): list new chats from first announce, not end-of-stream (cave-0g2x)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -939,6 +939,7 @@ export const SUITES = {
     "src/app/api/chat/send/harness-routing-model-capabilities.test.ts",
     "src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts",
     "src/app/api/chat/send/offline-queue.test.ts",
+    "src/app/api/chat/send/first-turn-stub.test.ts",
     "src/app/api/onboarding/status/route.test.ts",
     "src/app/api/onboarding/install/route.test.ts",
     "src/app/api/onboarding/setup/route.test.ts",

--- a/src/app/api/chat/send/first-turn-stub.test.ts
+++ b/src/app/api/chat/send/first-turn-stub.test.ts
@@ -1,0 +1,81 @@
+// First-turn visibility (cave-0g2x): new chats must be persisted as a stub
+// conversation the moment their session id exists — not only at end-of-stream
+// — so /api/sessions/list can surface them during the entire first turn, and a
+// mid-turn crash leaves a listed chat holding the user's message. These pins
+// hold the route wiring for both harness paths (coven-run and OpenClaw).
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chatRoute = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  chatRoute,
+  /createConversationStub,[\s\S]*?stripConversationStubTurn,[\s\S]*?\} from "@\/lib\/cave-conversations";/,
+  "Chat send should persist first-turn stubs through the conversation store helpers",
+);
+
+// ── coven-run path ───────────────────────────────────────────────────────────
+
+assert.match(
+  chatRoute,
+  /stubWrite = createConversationStub\(\{\s*sessionId: announcedId,[\s\S]*?\}\)\.catch\(\(\) => undefined\);\s*push\(\{ kind: "session", sessionId: announcedId \}\);/,
+  "announceSession must start the stub write before pushing the session frame, keyed to the stable announced id",
+);
+
+assert.match(
+  chatRoute,
+  /id: pendingUserTurnId,\s*text: promptText,/,
+  "the coven-run stub must carry the pending user turn under the shared pre-minted id",
+);
+
+assert.match(
+  chatRoute,
+  /if \(stubWrite\) await stubWrite;\s*const existing = await loadConversation\(finalSessionId\);/,
+  "the coven-run save must settle the stub write before loading, so a late stub can never clobber the authoritative transcript",
+);
+
+assert.match(
+  chatRoute,
+  /if \(isFirstExchange && !result\.is_error && !cancelledByUser\) \{\s*await autoNameSessionFromFirstExchange\(finalSessionId, promptText\);/,
+  "auto-naming must still fire for new chats whose conversation now pre-exists as a stub",
+);
+
+// ── OpenClaw path ────────────────────────────────────────────────────────────
+
+assert.match(
+  chatRoute,
+  /const stubWrite = createConversationStub\(\{\s*sessionId: conversationId,[\s\S]*?harness: "openclaw",/,
+  "the OpenClaw path must write its stub up front, keyed to the conversation id it mints before spawning",
+);
+
+assert.match(
+  chatRoute,
+  /await stubWrite;\s*const existing = await loadConversation\(sessionId\);/,
+  "the OpenClaw close handler must settle the stub write before loading the conversation",
+);
+
+assert.match(
+  chatRoute,
+  /if \(isFirstExchange && !isError\) \{\s*await autoNameSessionFromFirstExchange\(sessionId, args\.promptText\);/,
+  "OpenClaw auto-naming must key off isFirstExchange now that stubs pre-create the conversation",
+);
+
+// ── Shared turn identity ─────────────────────────────────────────────────────
+
+assert.equal(
+  (chatRoute.match(/const hadFirstTurnStub = existing\s*\? stripConversationStubTurn\(existing, pendingUserTurnId\)\s*: false;/g) ?? []).length,
+  2,
+  "both save paths must strip the stub turn so the authoritative user turn re-lands cleanly",
+);
+
+assert.equal(
+  (chatRoute.match(/const userTurnId = pendingUserTurnId;/g) ?? []).length,
+  2,
+  "both save paths must reuse the stub's pre-minted user-turn id",
+);
+
+assert.doesNotMatch(
+  chatRoute,
+  /const userTurnId = crypto\.randomUUID\(\)/,
+  "no save path may mint a fresh user-turn id divorced from the stub's — that would duplicate the first turn",
+);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -76,8 +76,10 @@ import { isTrustedChatHarness, canonicalHarnessId } from "@/lib/harness-adapters
 import {
   type ConversationFile,
   type ChatTurn,
+  createConversationStub,
   loadConversation,
   saveConversation,
+  stripConversationStubTurn,
 } from "@/lib/cave-conversations";
 import {
   captureWorkBranch,
@@ -527,6 +529,31 @@ function openClawChatResponse(args: {
       const onAbort = () => armDetachKill();
       args.req.signal.addEventListener("abort", onAbort, { once: true });
 
+      // First-turn visibility (cave-0g2x): the OpenClaw path knows its
+      // conversation id up front, so persist the stub (and the default title)
+      // as soon as the bridge is running — the sessions list can surface the
+      // chat during its entire first turn. Best-effort; a no-op for resumed
+      // chats. The close handler strips the stub turn and re-appends the
+      // authoritative one under the same id.
+      const pendingUserTurnId = crypto.randomUUID();
+      const stubTitle =
+        chatTitleFromPrompt(args.promptText) ?? defaultChatTitleForSession(conversationId);
+      void setDefaultSessionTitleIfMissing(conversationId, stubTitle).catch(() => undefined);
+      const stubWrite = createConversationStub({
+        sessionId: conversationId,
+        familiarId: args.body.familiarId,
+        harness: "openclaw",
+        ...(responseMetadata.model ? { model: responseMetadata.model } : {}),
+        ...(responseMetadata.runtime ? { runtime: responseMetadata.runtime } : {}),
+        title: stubTitle,
+        ...(args.body.origin ? { origin: args.body.origin } : {}),
+        userTurn: {
+          id: pendingUserTurnId,
+          text: args.promptText,
+          ...(args.attachments.length ? { attachments: args.attachments } : {}),
+        },
+      }).catch(() => undefined);
+
       child.stdout.on("data", (data: Buffer) => {
         stdout += data.toString("utf8");
       });
@@ -623,9 +650,18 @@ function openClawChatResponse(args: {
         if (sessionId) {
           pushProgress("save-transcript", "Saving transcript", "running");
           await recordSessionFamiliar(sessionId, args.body.familiarId);
+          // Settle the spawn-time stub write first so it can never race (and
+          // clobber) the authoritative transcript saved below.
+          await stubWrite;
           const existing = await loadConversation(sessionId);
+          // First-turn visibility (cave-0g2x): drop the spawn-time stub turn
+          // so the authoritative user turn below re-lands under the same id.
+          const hadFirstTurnStub = existing
+            ? stripConversationStubTurn(existing, pendingUserTurnId)
+            : false;
+          const isFirstExchange = !existing || hadFirstTurnStub;
           const now = new Date().toISOString();
-          const userTurnId = crypto.randomUUID();
+          const userTurnId = pendingUserTurnId;
           const assistantTurnId = crypto.randomUUID();
           const chatTitle = existing?.title ?? defaultChatTitleForSession(sessionId);
           if (!existing) await setDefaultSessionTitleIfMissing(sessionId, chatTitle);
@@ -683,7 +719,7 @@ function openClawChatResponse(args: {
           );
           conv.activeLeafId = assistantTurnId;
           await saveConversation(conv);
-          if (!existing && !isError) {
+          if (isFirstExchange && !isError) {
             await autoNameSessionFromFirstExchange(sessionId, args.promptText);
           }
           pushProgress("save-transcript", "Transcript saved", "done");
@@ -1203,6 +1239,13 @@ export async function POST(req: Request) {
       push({ kind: "user", text: promptText });
 
       let sessionId: string | null = body.sessionId ?? null;
+      // First-turn visibility (cave-0g2x): the id of the in-flight user turn,
+      // minted up front so the announce-time stub conversation and the
+      // end-of-stream authoritative save agree on the turn's identity.
+      const pendingUserTurnId = crypto.randomUUID();
+      // The pending stub write; the end-of-stream save awaits it so a
+      // late-settling stub can never clobber the authoritative transcript.
+      let stubWrite: Promise<unknown> | null = null;
       // The AssistantFilter's suppressions all key on codex/claude output
       // shapes (marker lines, startup banners, exec echoes). External manifest
       // adapters (copilot, opencode, hermes, …) pipe the CLI's raw stdout with
@@ -1271,7 +1314,27 @@ export async function POST(req: Request) {
         // turns the harness mints a fresh internal id, which must not
         // leak out as a "new session" (it fragmented every continued
         // chat into one sidebar entry per turn).
-        const announcedId = body.sessionId ?? id;
+        const announcedId = body.sessionId ?? sessionId;
+        // First-turn visibility (cave-0g2x): persist a stub conversation with
+        // the pending user turn as soon as the id exists, so the sessions
+        // list can surface this chat during its entire first turn (and after
+        // a mid-turn crash). Best-effort and a no-op for resumed chats; the
+        // end-of-stream save strips the stub turn and re-appends the
+        // authoritative one under the same id.
+        stubWrite = createConversationStub({
+          sessionId: announcedId,
+          familiarId: body.familiarId,
+          harness: binding.harness,
+          ...(responseMetadata.model ? { model: responseMetadata.model } : {}),
+          ...(responseMetadata.runtime ? { runtime: responseMetadata.runtime } : {}),
+          title: chatTitleFromPrompt(promptText) ?? defaultChatTitleForSession(announcedId),
+          ...(body.origin ? { origin: body.origin } : {}),
+          userTurn: {
+            id: pendingUserTurnId,
+            text: promptText,
+            ...(persistedAttachments.length ? { attachments: persistedAttachments } : {}),
+          },
+        }).catch(() => undefined);
         push({ kind: "session", sessionId: announcedId });
         // Title the session from the user's prompt as soon as the id
         // exists. The daemon's own title derives from the harness
@@ -1434,21 +1497,9 @@ export async function POST(req: Request) {
               if (echoed) confirmedModel = echoed;
             }
             if (ev.session_id && !sessionId) {
-              sessionId = ev.session_id;
-              // The client tracks the STABLE conversation id — on resumed
-              // turns the harness mints a fresh internal id, which must not
-              // leak out as a "new session" (it fragmented every continued
-              // chat into one sidebar entry per turn).
-              const announcedId = body.sessionId ?? sessionId;
-              push({ kind: "session", sessionId: announcedId });
-              // Title the session from the user's prompt as soon as the id
-              // exists. The daemon's own title derives from the harness
-              // prompt — i.e. the identity-canon preamble — and is what the
-              // UI would otherwise show until the transcript save runs.
-              void setDefaultSessionTitleIfMissing(
-                announcedId,
-                chatTitleFromPrompt(promptText) ?? defaultChatTitleForSession(announcedId),
-              ).catch(() => undefined);
+              // Same contract as announceSession (stable-id announce, default
+              // title, first-turn stub) for the stream-json protocol path.
+              announceSession(ev.session_id);
             }
             if (ev.type === "result") {
               // The result event also carries token usage and total cost
@@ -1901,9 +1952,20 @@ export async function POST(req: Request) {
       if (finalSessionId) {
         pushProgress("save-transcript", "Saving transcript", "running");
         await recordSessionFamiliar(finalSessionId, body.familiarId);
+        // Settle any in-flight stub write first so it can never race (and
+        // clobber) the authoritative transcript saved below.
+        if (stubWrite) await stubWrite;
         const existing = await loadConversation(finalSessionId);
+        // First-turn visibility (cave-0g2x): drop the announce-time stub turn
+        // so the authoritative user turn below re-lands under the same id.
+        // True only when this run's stub created the conversation, which keeps
+        // first-exchange behaviors (auto-naming) firing for new chats.
+        const hadFirstTurnStub = existing
+          ? stripConversationStubTurn(existing, pendingUserTurnId)
+          : false;
+        const isFirstExchange = !existing || hadFirstTurnStub;
         const now = new Date().toISOString();
-        const userTurnId = crypto.randomUUID();
+        const userTurnId = pendingUserTurnId;
         const assistantTurnId = crypto.randomUUID();
         const chatTitle = existing?.title ?? defaultChatTitleForSession(finalSessionId);
         if (!existing) await setDefaultSessionTitleIfMissing(finalSessionId, chatTitle);
@@ -1972,7 +2034,7 @@ export async function POST(req: Request) {
         conv.turns.push(userTurn, assistantTurn);
         conv.activeLeafId = assistantTurnId;
         await saveConversation(conv);
-        if (!existing && !result.is_error && !cancelledByUser) {
+        if (isFirstExchange && !result.is_error && !cancelledByUser) {
           await autoNameSessionFromFirstExchange(finalSessionId, promptText);
         }
         pushProgress("save-transcript", "Transcript saved", "done");

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -531,4 +531,119 @@ console.log("cave-conversations.test.ts: ok");
     "plain writeFile on a conversation path would reintroduce torn writes",
   );
 }
+
+// ── First-turn visibility stubs (cave-0g2x) ──────────────────────────────────
+// A new chat must exist in the conversation store from the moment its session
+// id is announced — not only at end-of-stream — so /api/sessions/list can
+// surface it during the entire first turn, and a mid-turn crash leaves a
+// listed chat holding the user's message.
+{
+  const { createConversationStub, stripConversationStubTurn } = await import(
+    "./cave-conversations.ts"
+  );
+
+  const created = await createConversationStub({
+    sessionId: "stub-first-turn",
+    familiarId: "charm",
+    harness: "claude",
+    model: "claude-4",
+    runtime: "local:/tmp/project",
+    title: "Fix the flaky test",
+    userTurn: { id: "pending-user-turn", text: "fix the flaky test please" },
+  });
+  assert.equal(created, true, "a brand-new chat gets a stub conversation");
+
+  const stub = await loadConversation("stub-first-turn");
+  assert.equal(stub?.turns.length, 1, "stub holds only the pending user turn");
+  assert.equal(stub?.turns[0]?.id, "pending-user-turn");
+  assert.equal(stub?.turns[0]?.role, "user");
+  assert.equal(stub?.turns[0]?.text, "fix the flaky test please");
+  assert.equal(stub?.activeLeafId, "pending-user-turn");
+  assert.equal(stub?.title, "Fix the flaky test");
+
+  // The stub's summary must NOT infer a terminal status from the missing
+  // assistant turn — the session-list merge would otherwise override a live
+  // daemon "running" with "completed".
+  const summaries = await listConversations();
+  const stubSummary = summaries.find((s) => s.sessionId === "stub-first-turn");
+  assert.ok(stubSummary, "stub appears in the conversation list");
+  assert.equal(stubSummary.status, undefined, "pending first reply ⇒ no terminal status");
+  assert.equal(stubSummary.exitCode, undefined, "pending first reply ⇒ no exit code");
+
+  // Resumed turns must never be clobbered: a second stub attempt is a no-op.
+  const again = await createConversationStub({
+    sessionId: "stub-first-turn",
+    familiarId: "other",
+    harness: "codex",
+    userTurn: { id: "other-turn", text: "clobber attempt" },
+  });
+  assert.equal(again, false, "stub creation no-ops when the conversation exists");
+  const untouched = await loadConversation("stub-first-turn");
+  assert.equal(untouched?.familiarId, "charm", "existing conversation is not clobbered");
+  assert.equal(untouched?.turns[0]?.text, "fix the flaky test please");
+
+  // End-of-stream: strip the stub turn and re-append the authoritative pair
+  // under the same user-turn id (mirrors the send route's save).
+  const conv = await loadConversation("stub-first-turn");
+  const hadStub = stripConversationStubTurn(conv, "pending-user-turn");
+  assert.equal(hadStub, true, "strip reports the conversation was stub-only");
+  assert.equal(conv.turns.length, 0, "stub turn is removed");
+  assert.equal(conv.activeLeafId, undefined, "active leaf reverts to the stub's parent");
+  const branchParentId = conv.activeLeafId ?? null;
+  assert.equal(branchParentId, null, "re-appended turn must not self-parent");
+  conv.turns.push(
+    {
+      id: "pending-user-turn",
+      role: "user",
+      text: "fix the flaky test please",
+      createdAt: "2026-07-21T00:00:01.000Z",
+      parentId: branchParentId,
+    },
+    {
+      id: "assistant-turn",
+      role: "assistant",
+      text: "done",
+      createdAt: "2026-07-21T00:00:02.000Z",
+      isError: false,
+      parentId: "pending-user-turn",
+    },
+  );
+  conv.activeLeafId = "assistant-turn";
+  await saveConversation(conv);
+
+  const finished = await loadConversation("stub-first-turn");
+  assert.equal(finished?.turns.length, 2, "authoritative save replaces the stub turn");
+  assert.equal(finished?.turns[0]?.id, "pending-user-turn", "user turn keeps its stub-era id");
+  const finishedSummary = (await listConversations()).find(
+    (s) => s.sessionId === "stub-first-turn",
+  );
+  assert.equal(finishedSummary?.status, "completed", "finished chat reports terminal status");
+  assert.equal(finishedSummary?.exitCode, 0);
+
+  // Resumed-chat path: stripping a turn id that never was a stub is a no-op.
+  const notStub = await loadConversation("stub-first-turn");
+  const turnCountBefore = notStub.turns.length;
+  assert.equal(stripConversationStubTurn(notStub, "never-existed"), false);
+  assert.equal(notStub.turns.length, turnCountBefore, "no-op strip leaves turns alone");
+  assert.equal(stripConversationStubTurn(notStub, undefined), false, "no id ⇒ no-op");
+
+  // Defensive re-parenting: children of the stripped stub turn re-point at the
+  // stub's parent, so no dangling parentId survives.
+  const branched = {
+    sessionId: "stub-branched",
+    familiarId: "charm",
+    harness: "claude",
+    createdAt: "2026-07-21T01:00:00.000Z",
+    updatedAt: "2026-07-21T01:00:00.000Z",
+    turns: [
+      { id: "stub-turn", role: "user", text: "hi", createdAt: "2026-07-21T01:00:00.000Z", parentId: null },
+      { id: "child-turn", role: "assistant", text: "…", createdAt: "2026-07-21T01:00:01.000Z", parentId: "stub-turn" },
+    ],
+    activeLeafId: "child-turn",
+  };
+  assert.equal(stripConversationStubTurn(branched, "stub-turn"), true);
+  assert.equal(branched.turns.length, 1);
+  assert.equal(branched.turns[0]?.parentId, null, "orphaned child re-points at stub's parent");
+  assert.equal(branched.activeLeafId, "child-turn", "active leaf off the stub is untouched");
+}
 console.log("cave-conversations cache test OK");

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -101,12 +101,18 @@ export type ConversationFile = {
   branchedFromTurnId?: string;
 };
 
-function conversationTerminalStatus(conv: ConversationFile): { status: string; exitCode: number } {
+function conversationTerminalStatus(conv: ConversationFile): { status: string; exitCode: number } | null {
   const turns = conv.activeLeafId
     ? resolveActivePath(conv.turns, conv.activeLeafId)
     : conv.turns;
   const latestAssistant = [...turns].reverse().find((turn) => turn.role === "assistant");
-  if (latestAssistant?.isError) return { status: "failed", exitCode: 1 };
+  // No reply on the active path yet — a first-turn stub whose assistant reply
+  // is still streaming (or never arrived; see createConversationStub). There
+  // is no terminal status to report: callers fall back to their own default,
+  // and the session-list merge must never override a live daemon status with
+  // one inferred from a pending stub.
+  if (!latestAssistant) return null;
+  if (latestAssistant.isError) return { status: "failed", exitCode: 1 };
   return { status: "completed", exitCode: 0 };
 }
 
@@ -230,6 +236,93 @@ export async function appendTurn(sessionId: string, turn: ChatTurn): Promise<voi
   await saveConversation(conv);
 }
 
+export type ConversationStubSeed = {
+  sessionId: string;
+  familiarId: string;
+  harness: string;
+  model?: string;
+  runtime?: string;
+  title?: string;
+  origin?: SessionOrigin;
+  /** The in-flight user turn. Its id must be reused by the end-of-stream save
+   *  (after stripConversationStubTurn) so the turn identity is stable across
+   *  the stub → authoritative transition. */
+  userTurn: {
+    id: string;
+    text: string;
+    attachments?: import("./chat-attachments").ChatAttachment[];
+  };
+};
+
+/**
+ * First-turn visibility (cave-0g2x): persist a stub conversation the moment a
+ * new chat's session id is announced, so /api/sessions/list can surface the
+ * chat during its entire first turn — and so a mid-turn crash leaves a listed
+ * chat with the user's message instead of nothing. No-op when a conversation
+ * already exists (resumed turns must never be clobbered). Returns true when
+ * the stub was created.
+ *
+ * The stub deliberately has no assistant turn, so its summary carries no
+ * terminal status (see conversationTerminalStatus) — the session-list merge
+ * then leaves any live daemon status untouched.
+ */
+export async function createConversationStub(seed: ConversationStubSeed): Promise<boolean> {
+  if (await loadConversation(seed.sessionId)) return false;
+  const now = new Date().toISOString();
+  await saveConversation({
+    sessionId: seed.sessionId,
+    familiarId: seed.familiarId,
+    harness: seed.harness,
+    ...(seed.model ? { model: seed.model } : {}),
+    ...(seed.runtime ? { runtime: seed.runtime } : {}),
+    ...(seed.title ? { title: seed.title } : {}),
+    ...(seed.origin ? { origin: seed.origin } : {}),
+    createdAt: now,
+    updatedAt: now,
+    turns: [
+      {
+        id: seed.userTurn.id,
+        role: "user",
+        text: seed.userTurn.text,
+        ...(seed.userTurn.attachments?.length
+          ? { attachments: seed.userTurn.attachments }
+          : {}),
+        createdAt: now,
+        parentId: null,
+      },
+    ],
+    activeLeafId: seed.userTurn.id,
+  });
+  return true;
+}
+
+/**
+ * Remove a pending stub turn (createConversationStub) from a loaded
+ * conversation before the end-of-stream save re-appends the authoritative
+ * user turn under the same id. Re-points the active leaf (and, defensively,
+ * any child turns) at the stub's parent so branch-parent derivation never
+ * self-parents the re-appended turn. Returns true when a stub turn was
+ * removed — i.e. the conversation only exists because of this run's stub,
+ * which callers use to keep first-exchange behaviors (auto-naming) firing.
+ */
+export function stripConversationStubTurn(
+  conv: ConversationFile,
+  stubTurnId: string | null | undefined,
+): boolean {
+  if (!stubTurnId) return false;
+  const stub = conv.turns.find((turn) => turn.id === stubTurnId);
+  if (!stub) return false;
+  const parentId = stub.parentId ?? null;
+  conv.turns = conv.turns.filter((turn) => turn.id !== stubTurnId);
+  for (const turn of conv.turns) {
+    if (turn.parentId === stubTurnId) turn.parentId = parentId;
+  }
+  if (conv.activeLeafId === stubTurnId) {
+    conv.activeLeafId = parentId ?? undefined;
+  }
+  return true;
+}
+
 export async function deleteConversation(sessionId: string): Promise<boolean> {
   try {
     const file = pathFor(sessionId);
@@ -295,8 +388,7 @@ async function readConversationSummary(
         origin: conv.origin,
         ...(conv.branch ? { branch: conv.branch } : {}),
         ...(conv.prUrl ? { prUrl: conv.prUrl } : {}),
-        status: terminal.status,
-        exitCode: terminal.exitCode,
+        ...(terminal ? { status: terminal.status, exitCode: terminal.exitCode } : {}),
         createdAt: conv.createdAt,
         updatedAt: conv.updatedAt,
       },

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -767,4 +767,80 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
   );
 }
 
+// ── First-turn stubs in the merge (cave-0g2x) ────────────────────────────────
+// A stub conversation (pending first reply ⇒ summary has NO status) must
+// (a) list as a local-only row so brand-new chats appear immediately, and
+// (b) never override a live daemon row's "running" status/exit_code even
+// when the local summary is newer.
+{
+  const bareState = {
+    sessionFamiliar: {},
+    sessionTitles: {},
+    sessionArchived: {},
+    sessionSacrificed: {},
+  };
+  const stubConv = {
+    sessionId: "stub-new-chat",
+    familiarId: "nova",
+    harness: "claude",
+    title: "Fix the flaky test",
+    createdAt: "2026-07-21T00:00:00.000Z",
+    updatedAt: "2026-07-21T00:00:00.000Z",
+    // No status/exitCode: conversationTerminalStatus returns null while the
+    // first assistant reply is pending.
+  };
+
+  const localOnly = mergeSessionRows({
+    daemonSessions: [],
+    localConversations: [stubConv],
+    state: bareState,
+    includeArchived: false,
+  });
+  assert.equal(localOnly.length, 1, "a stub-only chat lists immediately");
+  assert.equal(localOnly[0]?.id, "stub-new-chat");
+  assert.equal(localOnly[0]?.title, "Fix the flaky test");
+  assert.equal(localOnly[0]?.status, "completed", "statusless local-only rows fall back safely");
+  assert.equal(
+    filterVisibleChatSessions(localOnly, null).length,
+    1,
+    "the stub row survives the chat-rail visibility filter",
+  );
+
+  const withDaemon = mergeSessionRows({
+    daemonSessions: [
+      {
+        id: "stub-new-chat",
+        project_root: "/repo",
+        harness: "claude",
+        title: "Fix the flaky test",
+        status: "running",
+        exit_code: null,
+        archived_at: null,
+        created_at: "2026-07-21T00:00:00.000Z",
+        // Daemon row is OLDER than the local stub write.
+        updated_at: "2026-07-20T23:59:00.000Z",
+      },
+    ],
+    localConversations: [stubConv],
+    state: bareState,
+    includeArchived: false,
+  });
+  assert.equal(withDaemon.length, 1);
+  assert.equal(
+    withDaemon[0]?.status,
+    "running",
+    "a newer statusless stub must not flip a live daemon status",
+  );
+  assert.equal(
+    withDaemon[0]?.exit_code,
+    null,
+    "a newer statusless stub must not fabricate an exit code",
+  );
+  assert.equal(
+    withDaemon[0]?.updated_at,
+    "2026-07-21T00:00:00.000Z",
+    "message-authoritative local timestamp still wins for ordering",
+  );
+}
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -174,7 +174,10 @@ export function mergeSessionRows({
       ...session,
       ...(localUpdatedAt ? { updated_at: localUpdatedAt } : {}),
       ...(localIsNewer && !daemonStatusIsAuthoritative && local?.status ? { status: local.status } : {}),
-      ...(localIsNewer && !daemonStatusIsAuthoritative && local ? { exit_code: local.exitCode ?? 0 } : {}),
+      // A local summary with no status (a first-turn stub whose reply is still
+      // streaming) must contribute neither status nor exit_code — the daemon's
+      // live "running" row stays untouched.
+      ...(localIsNewer && !daemonStatusIsAuthoritative && local?.status ? { exit_code: local.exitCode ?? 0 } : {}),
       // Daemon titles derive from the harness prompt, which the chat route
       // prefixes with the identity canon — sanitize so the preamble never
       // surfaces as a session title.


### PR DESCRIPTION
## Problem

New chat conversations were persisted only at end-of-stream (`saveConversation` in the chat send route). During the entire first turn — which can run for minutes — the chat existed nowhere the sessions list could see, so:

- the siderail / sessions list didn't show the chat until the first assistant reply finished, and
- a crash (server restart, harness kill) mid-first-turn meant the chat **never** appeared anywhere: the user's message was silently lost.

Third bug of the `chat-siderail-freshness` audit (bead **cave-0g2x**).

## Fix

Persist a **stub conversation** — just the pending user turn — the moment the session id exists:

- **coven-run path:** in `announceSession`, before the `session` SSE frame is pushed. The stream-json announce site now routes through `announceSession` instead of duplicating its contract inline.
- **OpenClaw path:** right after spawn (it mints `conversationId` up front), plus the same early default-title write the other path already had.

The end-of-stream save awaits the stub write (no clobber race), **strips the stub turn** (`stripConversationStubTurn`), and re-appends the authoritative user turn **under the same pre-minted id**, so turn identity, branching (`branchParentId` derivation can't self-parent), and attachments behave exactly as before.

## Honesty guarantees

- A stub has no assistant turn ⇒ its summary carries **no terminal status** (`conversationTerminalStatus` returns `null`). The session-list merge therefore can never flip a live daemon `running` into a stub-inferred `completed`; the merge's `exit_code` override now also requires a local status (it previously could stamp `exit_code: 0` onto a running row from any newer local summary).
- `createConversationStub` is a strict no-op when the conversation exists — resumed turns are never clobbered.
- Auto-naming keys off `isFirstExchange` (`!existing || hadStub`), so first-exchange naming still fires now that the conversation pre-exists at save time.

## Tests

- `cave-conversations.test.ts`: stub lifecycle — create, list-visible, statusless summary, no-op on existing, strip + same-id re-append, defensive child re-parenting.
- `session-list-merge.test.ts`: a statusless stub lists immediately (and survives `filterVisibleChatSessions`); a *newer* statusless stub never flips a daemon row's `running` status or fabricates an exit code.
- `first-turn-stub.test.ts` (new, registered in `run-tests.mjs`): route wiring pins for both paths — stub-before-session-frame, settle-before-load, shared user-turn id, `isFirstExchange` auto-naming, no stray `crypto.randomUUID()` user-turn ids.

## Verification

- `pnpm test:app` — 843/843 ✓
- `pnpm test:api` — green except 3 pre-existing environmental failures (ElevenLabs vault key + issue-worktree provision) that fail identically on clean `main` on this machine; remaining 65 post-failure api tests run individually ✓
- `pnpm typecheck` ✓, `check-tests-wired` ✓

Bead: cave-0g2x