### PR TITLE
fix(chat): resolve first-turn stub rows against the live-run registry (cave-0g2x follow-through)

### DIFF
--- a/src/app/api/chat/send/first-turn-stub.test.ts
+++ b/src/app/api/chat/send/first-turn-stub.test.ts
@@ -79,3 +79,14 @@ assert.doesNotMatch(
   /const userTurnId = crypto\.randomUUID\(\)/,
   "no save path may mint a fresh user-turn id divorced from the stub's — that would duplicate the first turn",
 );
+
+// ── Stop + liveness by conversation id (cave-0g2x follow-through) ────────────
+// A new chat's run registers under only the client runId (body.sessionId is
+// null until the harness mints an id). announceSession must late-key the run
+// registry with the announced id so /api/chat/stop works mid-first-turn and
+// the sessions-list liveness probe (hasActiveChatRun) sees the run.
+assert.match(
+  chatRoute,
+  /const announceSession = \(id: string\) => \{[\s\S]{0,1200}addChatRunKeys\(runHandle, \[announcedId\]\)/,
+  "announceSession late-keys the run registry with the announced conversation id",
+);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -56,6 +56,7 @@ import { parseAgentAttachments } from "@/lib/server/agent-attachments";
 import {
   registerChatRun,
   unregisterChatRun,
+  addChatRunKeys,
   type ChatRunHandle,
 } from "@/lib/server/chat-stop-registry";
 import { openRunBuffer, type RunBufferHandle } from "@/lib/server/chat-stream-buffer";
@@ -1315,6 +1316,12 @@ export async function POST(req: Request) {
         // leak out as a "new session" (it fragmented every continued
         // chat into one sidebar entry per turn).
         const announcedId = body.sessionId ?? sessionId;
+        // A new chat registered with only the client runId (body.sessionId is
+        // null until the harness mints the id) — late-key the run so
+        // /api/chat/stop and the sessions-list liveness probe reach it by
+        // conversation id. runHandle is declared later in this scope but is
+        // always initialized before the stream handlers that call announce.
+        addChatRunKeys(runHandle, [announcedId]);
         // First-turn visibility (cave-0g2x): persist a stub conversation with
         // the pending user turn as soon as the id exists, so the sessions
         // list can surface this chat during its entire first turn (and after

--- a/src/app/api/sessions/list/route.test.ts
+++ b/src/app/api/sessions/list/route.test.ts
@@ -38,4 +38,19 @@ assert.equal(
   "applyFamiliarWorkspaceCollapse is defined once and called in BOTH the happy and degraded paths",
 );
 
+// cave-0g2x crash truth: first-turn stubs are statusless; the list resolves
+// them against the in-process run registry — live run ⇒ running, no run ⇒
+// failed (server died mid-first-turn) — instead of the "completed" default a
+// conversation-only row would otherwise get.
+assert.match(
+  source,
+  /if \(!conv\.pending\) return conv;\s*\n\s*return hasActiveChatRun\(conv\.sessionId\)\s*\n?\s*\? \{ \.\.\.conv, status: "running", exitCode: 0 \}\s*\n?\s*: \{ \.\.\.conv, status: "failed", exitCode: 1 \};/,
+  "pending conversations resolve running/failed via the live-run registry",
+);
+assert.match(
+  source,
+  /import \{ hasActiveChatRun \} from "@\/lib\/server\/chat-stop-registry"/,
+  "the liveness probe comes from the in-process chat run registry",
+);
+
 console.log("sessions list route.test.ts: ok");

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadState, type CaveState } from "@/lib/cave-config";
 import { listConversations } from "@/lib/cave-conversations";
+import { hasActiveChatRun } from "@/lib/server/chat-stop-registry";
 import {
   sweepAutoArchive,
   sweepMergedPrAutoArchive,
@@ -161,7 +162,18 @@ async function computeSessionsList(
     loadState(),
     loadProjects(),
   ]);
-  const localConversations = await listConversations();
+  const localConversations = (await listConversations()).map((conv) => {
+    // First-turn stubs (cave-0g2x) are statusless; resolve them against the
+    // in-process run registry. Run in flight → an honest `running` row (a
+    // conversation-only row would otherwise default to "completed"). No run →
+    // the server died mid-first-turn: `failed`, not a phantom completion.
+    // Registry-truth is process-local, which matches how chat runs live and
+    // die with this server process.
+    if (!conv.pending) return conv;
+    return hasActiveChatRun(conv.sessionId)
+      ? { ...conv, status: "running", exitCode: 0 }
+      : { ...conv, status: "failed", exitCode: 1 };
+  });
   // Backfill for local-only chat rows (UI chats the daemon never sees):
   // map the conversation's recorded cwd to its registered project root so
   // the sidebar's project groups pick new chats up immediately.

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -647,3 +647,72 @@ console.log("cave-conversations.test.ts: ok");
   assert.equal(branched.activeLeafId, "child-turn", "active leaf off the stub is untouched");
 }
 console.log("cave-conversations cache test OK");
+
+// ── First-turn stub pending marker (cave-0g2x crash truth) ───────────────────
+// The stub write stamps pendingUserTurnId on the file and `pending` on the
+// summary; the sessions list resolves pending rows against the live run
+// registry (running vs failed) instead of letting a crashed first turn read
+// as a phantom "completed". Any end-of-stream save settles the marker.
+{
+  const { createConversationStub, stripConversationStubTurn } = await import(
+    "./cave-conversations.ts"
+  );
+
+  await createConversationStub({
+    sessionId: "stub-pending-marker",
+    familiarId: "charm",
+    harness: "codex",
+    userTurn: { id: "pending-turn", text: "long first prompt" },
+  });
+  const stub = await loadConversation("stub-pending-marker");
+  assert.equal(stub?.pendingUserTurnId, "pending-turn", "stub write stamps the pending marker");
+  const pendingSummary = (await listConversations()).find(
+    (s) => s.sessionId === "stub-pending-marker",
+  );
+  assert.equal(pendingSummary?.pending, true, "summary carries the pending flag");
+  assert.equal(pendingSummary?.status, undefined, "pending stays statusless (merge honesty)");
+
+  // Normal settle: the same process strips its own stub turn — marker gone.
+  const settled = await loadConversation("stub-pending-marker");
+  assert.equal(stripConversationStubTurn(settled, "pending-turn"), true);
+  assert.equal(settled.pendingUserTurnId, undefined, "strip clears the pending marker");
+  settled.turns.push(
+    { id: "pending-turn", role: "user", text: "long first prompt", createdAt: "2026-07-21T02:00:00.000Z", parentId: null },
+    { id: "reply", role: "assistant", text: "ok", createdAt: "2026-07-21T02:00:01.000Z", isError: false, parentId: "pending-turn" },
+  );
+  settled.activeLeafId = "reply";
+  await saveConversation(settled);
+  const settledSummary = (await listConversations()).find(
+    (s) => s.sessionId === "stub-pending-marker",
+  );
+  assert.equal(settledSummary?.pending, undefined, "settled conversation drops the flag");
+  assert.equal(settledSummary?.status, "completed");
+
+  // Crash-then-resume: a NEW server process saves a later turn without the
+  // crashed run's in-memory stub id. The marker must still clear — while the
+  // stubbed user turn deliberately stays as the record of the lost prompt.
+  await createConversationStub({
+    sessionId: "stub-crashed",
+    familiarId: "charm",
+    harness: "claude",
+    userTurn: { id: "lost-prompt", text: "prompt the crash orphaned" },
+  });
+  const crashed = await loadConversation("stub-crashed");
+  assert.equal(crashed?.pendingUserTurnId, "lost-prompt");
+  assert.equal(
+    stripConversationStubTurn(crashed, null),
+    false,
+    "a resumed save has no stub id to strip",
+  );
+  assert.equal(crashed.pendingUserTurnId, undefined, "…but the marker still settles");
+  assert.equal(crashed.turns.length, 1, "the orphaned prompt stays in the tree");
+  await saveConversation(crashed);
+  const recoveredSummary = (await listConversations()).find(
+    (s) => s.sessionId === "stub-crashed",
+  );
+  assert.equal(recoveredSummary?.pending, undefined, "recovered chat is no longer pending");
+
+  await deleteConversation("stub-pending-marker");
+  await deleteConversation("stub-crashed");
+}
+console.log("cave-conversations pending-marker test OK");

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -100,6 +100,14 @@ export type ConversationFile = {
   /** Branching lineage (set by fork-to-new-thread in a later PR). */
   parentSessionId?: string;
   branchedFromTurnId?: string;
+  /**
+   * First-turn stub marker (cave-0g2x): id of the pending user turn written by
+   * createConversationStub, cleared by the first end-of-stream save
+   * (stripConversationStubTurn). Still set on a conversation whose run is not
+   * live in the run registry = the server died mid-first-turn; the sessions
+   * list uses that to report `failed` instead of a phantom `completed`.
+   */
+  pendingUserTurnId?: string;
 };
 
 function conversationTerminalStatus(conv: ConversationFile): { status: string; exitCode: number } | null {
@@ -129,6 +137,11 @@ export type ConversationSummary = {
   prUrl?: string;
   status?: string;
   exitCode?: number | null;
+  /** True while the first-turn stub marker is set (see
+   *  ConversationFile.pendingUserTurnId): the first reply is still streaming,
+   *  or its server died mid-turn. The sessions list disambiguates via the
+   *  in-process run registry. */
+  pending?: boolean;
   createdAt?: string;
   updatedAt: string;
 };
@@ -297,6 +310,7 @@ export async function createConversationStub(seed: ConversationStubSeed): Promis
       },
     ],
     activeLeafId: seed.userTurn.id,
+    pendingUserTurnId: seed.userTurn.id,
   });
   return true;
 }
@@ -314,6 +328,11 @@ export function stripConversationStubTurn(
   conv: ConversationFile,
   stubTurnId: string | null | undefined,
 ): boolean {
+  // Any end-of-stream save settles the pending state — including a resumed
+  // turn saved by a NEW server process after a crash (its in-memory stub id
+  // is long gone, and the crashed turn's stub deliberately stays in the tree
+  // as the record of the lost prompt).
+  delete conv.pendingUserTurnId;
   if (!stubTurnId) return false;
   const stub = conv.turns.find((turn) => turn.id === stubTurnId);
   if (!stub) return false;
@@ -395,6 +414,7 @@ async function readConversationSummary(
         ...(conv.branch ? { branch: conv.branch } : {}),
         ...(conv.prUrl ? { prUrl: conv.prUrl } : {}),
         ...(terminal ? { status: terminal.status, exitCode: terminal.exitCode } : {}),
+        ...(conv.pendingUserTurnId ? { pending: true } : {}),
         createdAt: conv.createdAt,
         updatedAt: conv.updatedAt,
       },

--- a/src/lib/server/chat-stop-registry.test.ts
+++ b/src/lib/server/chat-stop-registry.test.ts
@@ -3,9 +3,8 @@
 // tells a deliberate Stop apart from a bare transport drop (cave-id5).
 import assert from "node:assert/strict";
 
-const { registerChatRun, unregisterChatRun, requestChatStop } = await import(
-  "./chat-stop-registry.ts"
-);
+const { registerChatRun, unregisterChatRun, requestChatStop, addChatRunKeys, hasActiveChatRun } =
+  await import("./chat-stop-registry.ts");
 
 // Deliberate stop: kills through the registration and flags the handle.
 {
@@ -56,6 +55,35 @@ assert.equal(requestChatStop("session-1"), false, "unregister drops every key");
   assert.equal(requestChatStop("run-4"), true, "stop succeeds when the child is already gone");
   assert.equal(handle.stopRequested, true, "the cancel flag still lands");
   unregisterChatRun(handle);
+}
+
+// cave-0g2x: a new chat registers with only the client runId — the harness
+// mints the conversation id mid-stream, and announceSession late-keys it so
+// Stop and the sessions-list liveness probe can reach the run by that id.
+{
+  let kills = 0;
+  const handle = registerChatRun(["run-5", null], () => {
+    kills += 1;
+  });
+  assert.equal(hasActiveChatRun("conv-5"), false, "the announced id is unknown before late-keying");
+  addChatRunKeys(handle, ["conv-5", null, undefined, "run-5"]);
+  assert.deepEqual(handle.keys, ["run-5", "conv-5"], "late keys skip falsy and duplicate entries");
+  assert.equal(hasActiveChatRun("conv-5"), true, "the run is live under the announced id");
+  assert.equal(requestChatStop("conv-5"), true, "stop resolves by the late-added conversation id");
+  assert.equal(kills, 1, "the late key kills the same run");
+  unregisterChatRun(handle);
+  assert.equal(hasActiveChatRun("conv-5"), false, "unregister drops late-added keys too");
+  assert.equal(hasActiveChatRun("run-5"), false, "…and the original key");
+}
+
+// Late-keying a settled run is a no-op — the stream finished before the
+// announce callback ran.
+{
+  const handle = registerChatRun(["run-6"], () => {});
+  unregisterChatRun(handle);
+  addChatRunKeys(handle, ["conv-6"]);
+  assert.equal(hasActiveChatRun("conv-6"), false, "no resurrection after unregister");
+  assert.equal(requestChatStop("conv-6"), false, "the late key never registers");
 }
 
 console.log("chat-stop-registry.test.ts: ok");

--- a/src/lib/server/chat-stop-registry.ts
+++ b/src/lib/server/chat-stop-registry.ts
@@ -48,6 +48,38 @@ export function unregisterChatRun(handle: ChatRunHandle): void {
   handle.keys.length = 0;
 }
 
+/**
+ * Late-key a live run. A new chat's conversation id only exists once the
+ * harness announces it, so the initial registration carries just the client
+ * runId; adding the announced id makes the run reachable by conversation id —
+ * for /api/chat/stop on a first turn and for the sessions-list liveness probe
+ * (hasActiveChatRun). No-op after the run settled.
+ */
+export function addChatRunKeys(
+  handle: ChatRunHandle,
+  keys: Array<string | null | undefined>,
+): void {
+  const entry = handle.keys
+    .map((key) => active.get(key))
+    .find((candidate) => candidate?.handle === handle);
+  if (!entry) return;
+  for (const key of keys) {
+    if (!key || handle.keys.includes(key)) continue;
+    active.set(key, entry);
+    handle.keys.push(key);
+  }
+}
+
+/**
+ * True when a streaming run is currently in flight under the key. The
+ * sessions-list read uses this to keep a first-turn stub honest: a pending
+ * conversation whose run this process doesn't hold means the server died
+ * mid-turn — the row reports `failed` instead of a phantom `completed`.
+ */
+export function hasActiveChatRun(key: string): boolean {
+  return active.has(key);
+}
+
 /** Deliberate user stop: mark the run cancelled and SIGTERM its child.
  *  Returns false when nothing is in flight under the key. */
 export function requestChatStop(key: string): boolean {


### PR DESCRIPTION
## Context

Sibling PR #3602 (same bead, parallel session — race acknowledged on cave-0g2x) landed the send-time stub: new chats are persisted (pending user turn) at openclaw spawn / harness `announceSession`, so the sessions list shows them during the whole first turn. This PR was rebuilt on top of that to carry the two honesty gaps it left.

## Gap 1 — a crashed first turn reads as a phantom `completed`

#3602's stubs are deliberately statusless (merge honesty: never flip a live daemon `running`). But a **conversation-only** row (openclaw, or daemon-missing) defaults to `status: "completed"` in the merge — so if the server dies mid-first-turn, the recovered chat forever claims it completed.

Fix: `createConversationStub` stamps `pendingUserTurnId` on the file; the summary carries `pending: true`; `sessions/list` resolves pending rows against the in-process run registry:

- run in flight → honest `running` row (also fixes the live openclaw first turn, which previously showed "completed" while streaming),
- no run → `failed` — the server died mid-turn; the prompt is preserved, the status stops lying.

`stripConversationStubTurn` settles the marker on **any** end-of-stream save — including a resumed turn saved by a new server process after a crash, where the orphaned stub turn deliberately stays in the tree as the record of the lost prompt. Voice/flow conversations (`turns: []`, no marker) are untouched.

## Gap 2 — first-turn runs unreachable by conversation id

A new chat registers in the stop registry under only the client `runId` (`body.sessionId` is null until the harness announces). `announceSession` now late-keys the registry (`addChatRunKeys`), so `/api/chat/stop` by session id works mid-first-turn and the liveness probe (`hasActiveChatRun`) sees harness runs. (openclaw already registers its pre-minted id up front.)

## Tests

- `cave-conversations.test.ts`: marker lifecycle — stamped by stub write, `pending` on summary, settled by strip (normal path) **and** by a resumed save with no stub id (crash path, prompt retained).
- `chat-stop-registry.test.ts`: late-keying reaches the run for stop + liveness; falsy/dup keys skipped; no-op after settle.
- `sessions/list/route.test.ts`: pins for the registry-resolved running/failed mapping.
- `first-turn-stub.test.ts`: pin for the announceSession late-key.

## Verification

- `pnpm typecheck` ✓, `check-tests-wired` ✓
- app suite 848/848 ✓
- api suite 220/220 ✓ (3 skips fail identically on clean `main` on this machine: ElevenLabs vault key env + issue-worktree path allowlist)

Bead: cave-0g2x