### PR TITLE
style(home): Chat/Task destination toggle as flat inline field tabs (cave-y2d3)

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -135,7 +135,31 @@ assert.match(
 assert.match(
   css,
   /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone composer keeps thumb-sized home-only controls (destination pills)",
+  "phone composer keeps thumb-sized home-only controls (destination tabs)",
+);
+
+// ── Chat/Task destinations render as flat inline field tabs ──
+// The boxed segmented pill treatment (bordered container, solid accent-filled
+// active pill) was retired for quiet inline tabs with an accent underline.
+assert.match(
+  css,
+  /\.hc-dest-pill \{[^}]*border-bottom: 2px solid transparent;/,
+  "every destination tab reserves the 2px underline slot so activation can't shift the row",
+);
+assert.match(
+  css,
+  /\.hc-dest-pill\.active \{[^}]*border-bottom-color: var\(--accent-presence\);/,
+  "the active destination tab is marked by an accent underline, not a solid fill",
+);
+assert.doesNotMatch(
+  css,
+  /\.hc-dest-pills \{[^}]*border: 1px solid/,
+  "the destination tab group is flat — no boxed segmented container",
+);
+assert.doesNotMatch(
+  css,
+  /\.hc-dest-pill\.active \{[^}]*background: var\(--accent-presence\)/,
+  "the solid accent-filled active pill treatment is retired",
 );
 
 // ── "Jump back in" recent-chats strip REMOVED ──

--- a/src/styles/home-composer/landing-composer.css
+++ b/src/styles/home-composer/landing-composer.css
@@ -369,23 +369,21 @@
 /* The standalone footer project chip retired with the band (chat revamp 1d);
  * project selection opens from the composer context pill. */
 
-/* Destination pills — a segmented toggle for Chat vs Task. */
+/* Destination tabs — Chat vs Task as flat inline field tabs: quiet text
+ * sitting directly in the control row (no segmented box), with a 2px accent
+ * underline marking the active destination. */
 .hc-dest-pills {
   display: inline-flex;
-  gap: 2px;
+  align-items: stretch;
+  gap: 10px;
   flex: 0 0 auto;
   min-width: 0;
-  padding: 3px;
-  border-radius: var(--radius-control);
-  background: var(--bg-base);
-  border: 1px solid var(--border-hairline);
 }
 
-/* Inline placement (reference layout): the pills sit inside the card's
+/* Inline placement (reference layout): the tabs sit inside the card's
  * control row next to the + attach button — compact, no outer margin. */
 .hc-dest-pills--inline {
   position: relative;
-  padding: 2px;
 }
 
 .hc-dest-pill {
@@ -395,26 +393,29 @@
   min-height: 28px;
   box-sizing: border-box;
   font-size: var(--text-sm);
-  /* Inactive tabs recede: lighter weight + faded label so the solid-accent
+  /* Inactive tabs recede: lighter weight + faded label so the underlined
    * active tab is unmistakably the selected one. Hover/active brighten. */
   font-weight: 450;
-  padding: var(--space-1) 14px;
-  border-radius: var(--radius-control);
-  border: 1px solid transparent;
+  padding: var(--space-1);
+  border: none;
+  /* Reserve the indicator height on every tab so activation can't shift
+   * the row; only the colour changes. */
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-control) var(--radius-control) 0 0;
   background: transparent;
   color: color-mix(in oklch, var(--text-muted) 68%, transparent);
   cursor: pointer;
-  transition: all 0.12s ease;
+  transition: color 0.12s ease, border-color 0.12s ease;
   white-space: nowrap;
 }
 
 /* The inactive icon fades further than its label so the tab reads as dormant. */
 .hc-dest-pill svg {
   opacity: 0.55;
+  transition: opacity 0.12s ease;
 }
 
 .hc-dest-pill:hover {
-  background: var(--bg-raised);
   color: var(--text-secondary);
 }
 
@@ -423,30 +424,27 @@
 }
 
 .hc-dest-pill.active {
-  background: var(--accent-presence);
-  border-color: var(--accent-presence);
-  color: var(--accent-presence-foreground);
+  color: var(--text-primary);
   font-weight: 600;
-  box-shadow: 0 2px 8px color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  border-bottom-color: var(--accent-presence);
 }
 
-/* Label and icon sit on the solid accent fill, so both take the on-accent
- * foreground colour at full strength for legibility. */
+/* The active icon takes the accent so the tab reads as selected even before
+ * the underline registers; the label stays primary-text for legibility. */
 .hc-dest-pill.active svg {
-  color: var(--accent-presence-foreground);
+  color: var(--accent-presence);
   opacity: 1;
 }
 
 /* ── Phone-width composer (container query on the card wrap) ─────────────────
  * The shared cave-composer footer rules (cave-chat.css) already adapt the icon
- * buttons on small screens; the home-only destination pills also need
+ * buttons on small screens; the home-only destination tabs stay flat but need
  * thumb-sized touch targets. */
 @container (max-width: 620px) {
   .hc-dest-pill {
     min-height: var(--touch-target);
     justify-content: center;
-    border-color: var(--border-hairline);
-    background: color-mix(in oklch, var(--bg-base) 72%, transparent);
+    padding-inline: 10px;
   }
 }
 


### PR DESCRIPTION
## What

Restyles the home composer's Chat/Task destination switch from a boxed segmented pill toggle to **flat inline field tabs**, per user request ("within the chat home page, please make the chat and task tabs inline field tabs" → chosen treatment: flat inline tabs in the control row).

**Before:** bordered pill container; active destination = solid accent-filled pill with glow shadow.
**After:** quiet text tabs sitting directly in the control row; active destination = primary text + 2px accent underline + accent icon. A transparent underline slot is reserved on every tab so switching never shifts the row.

## Chat active / Task active

| Chat | Task |
|---|---|
| accent underline under **Chat**, icon tinted accent | accent underline under **Task**, icon tinted accent |

(Verified visually in the built app on the Home surface, both destinations.)

## Changes

- `src/styles/home-composer/landing-composer.css` — CSS-only restyle of the `.hc-dest-*` block; phone container query keeps the pinned `min-height: var(--touch-target)`.
- `src/components/home-composer-polish.test.ts` — new CSS pins: underline slot on every tab, accent underline on active, boxed container + solid-fill treatment retired.

JSX untouched: radiogroup semantics, arrow-key handling, and `hc-dest-*` class names unchanged.

## Verification

- targeted: home-composer{,-polish,-mobile-gaps} tests + design-token-drift — green (drift runs raw, composer pins through the css contract hook, matching run-tests.mjs)
- `pnpm lint`, `pnpm typecheck`, `pnpm check:tests-wired` (1142 wired) — green
- `pnpm test:app` — 844 files pass
- `pnpm build` — bundle + standalone budgets green
- Playwright screenshot of the built app: tabs render flat with accent underline; placeholder switches per destination

Bead: cave-y2d3