### PR TITLE
refactor(tasks): address Copilot review on the task cockpit (follow-up to #3601)

### DIFF
--- a/src/components/board-table-keyboard.test.ts
+++ b/src/components/board-table-keyboard.test.ts
@@ -46,5 +46,12 @@ assert.match(source, /board-table-sort-btn/, "header label is a real button");
 // Group rows: keyboard collapse/expand.
 assert.match(source, /board-table-group-row" role="button" tabIndex=\{0\}/, "group row is a button");
 assert.match(source, /aria-expanded=\{!collapsed\.has\(key\)\}/, "group row announces expanded state");
+// Copilot review on #3601: keys bubbling from interactive children (selects,
+// buttons) must not trigger the row-level Enter/Space handler.
+assert.match(
+  source,
+  /if \(event\.target !== event\.currentTarget\) return;\s*if \(event\.key !== "Enter" && event\.key !== " "\) return;/,
+  "row keydown ignores events bubbled from child controls",
+);
 
 console.log("board-table-keyboard.test.ts OK");

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -440,6 +440,9 @@ export function BoardTable({ cards, familiars, projects, groupBy, sortKey, sortD
                     className={`${isSel ? "selected" : ""}${rowIdx % 2 === 1 ? " board-table-row--alt" : ""}`.trim()}
                     onClick={() => (selectMode ? onToggleSelect?.(card.id) : onSelect(card.id))}
                     onKeyDown={(event) => {
+                      // Keys bubbling from interactive children (selects,
+                      // buttons) must not toggle/open the row.
+                      if (event.target !== event.currentTarget) return;
                       if (event.key !== "Enter" && event.key !== " ") return;
                       event.preventDefault();
                       if (selectMode) onToggleSelect?.(card.id);

--- a/src/components/mobile-code-rail.test.ts
+++ b/src/components/mobile-code-rail.test.ts
@@ -17,7 +17,7 @@ const css = (
 ).join("\n");
 
 assert.match(controller, /const \[mobileOpen, setMobileOpen\] = useState\(false\)/);
-assert.match(controller, /const mobileAvailable = \(isMobile \|\| paneNarrow\) && rail\.available/);
+assert.match(controller, /const mobileAvailable = active && \(isMobile \|\| paneNarrow\) && rail\.available/);
 assert.match(controller, /useFocusTrap\(mobileOpen, mobileSheetRef, \{ onEscape: \(\) => setMobileOpen\(false\) \}\)/);
 assert.match(controller, /!rail\.available \|\| \(!isMobile && !paneNarrow\) \|\| !active/);
 

--- a/src/components/task-work-github.test.ts
+++ b/src/components/task-work-github.test.ts
@@ -13,6 +13,14 @@ assert.match(source, /onManage/);
 assert.match(source, /Couldn't fully refresh/);
 assert.match(source, /checksJson\?\.error \?\? "GitHub checks lookup failed"/);
 assert.match(source, /catch \(reason\) \{\s*checksError = reason instanceof Error/);
+// Copilot review on #3601: the no-hydratable-links early return must clear
+// loading, and item buttons must not be focusable no-ops without onOpenUrl.
+assert.match(
+  source,
+  /if \(hydratable\.length === 0\) \{\s*setItems\(\{\}\);\s*setError\(null\);\s*setLoading\(false\);/,
+  "empty-links early return clears the loading flag",
+);
+assert.match(source, /disabled=\{!onOpenUrl\}/, "item buttons disable without an onOpenUrl handler");
 assert.doesNotMatch(source, /GitHubView/);
 assert.match(cockpit, /<TaskWorkGitHub/);
 assert.match(cockpit, /stopTerminalOnUnmount: true/);

--- a/src/components/task-work-github.tsx
+++ b/src/components/task-work-github.tsx
@@ -31,6 +31,7 @@ export function TaskWorkGitHub({
     if (hydratable.length === 0) {
       setItems({});
       setError(null);
+      setLoading(false);
       return;
     }
     setLoading(true);
@@ -121,7 +122,8 @@ export function TaskWorkGitHub({
               type="button"
               className="task-work-github__item focus-ring"
               onClick={() => onOpenUrl?.(link.url)}
-              title="Open in app browser"
+              disabled={!onOpenUrl}
+              title={onOpenUrl ? "Open in app browser" : undefined}
             >
               <span className="task-work-github__item-kicker">
                 {link.repo}{link.number != null ? ` #${link.number}` : ""}

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -22,7 +22,17 @@ assert.match(controller, /const effectiveProjectRoot = browseRootOverride \?\? p
 assert.match(controller, /setBrowseRootOverride\(null\)/);
 assert.match(controller, /useState<number \| null>\(null\)/);
 assert.match(controller, /json\.files\?\.length \?\? 0/);
-assert.match(controller, /const showInline = rail\.available && rail\.open && !isMobile && !paneNarrow/);
+// Copilot review on #3601: inactive scopes must never report an open rail.
+assert.match(
+  controller,
+  /const showInline = active && rail\.available && rail\.open && !isMobile && !paneNarrow/,
+  "showInline gates on the active flag",
+);
+assert.match(
+  controller,
+  /const mobileAvailable = active && \(isMobile \|\| paneNarrow\) && rail\.available/,
+  "mobileAvailable gates on the active flag",
+);
 
 for (const source of [chat, task]) {
   assert.match(source, /<WorkspaceRail/);

--- a/src/lib/use-workspace-rail-controller.ts
+++ b/src/lib/use-workspace-rail-controller.ts
@@ -133,8 +133,10 @@ export function useWorkspaceRailController({
     }
   }, [stopTerminalOnUnmount]);
 
-  const showInline = rail.available && rail.open && !isMobile && !paneNarrow;
-  const mobileAvailable = (isMobile || paneNarrow) && rail.available;
+  // Visibility gates on `active` so an inactive scope (e.g. ChatSurface on a
+  // non-conversation tab) never reports an open rail to the shell/layout.
+  const showInline = active && rail.available && rail.open && !isMobile && !paneNarrow;
+  const mobileAvailable = active && (isMobile || paneNarrow) && rail.available;
   const [mobileOpen, setMobileOpen] = useState(false);
   const mobileSheetRef = useRef<HTMLDivElement | null>(null);
   useFocusTrap(mobileOpen, mobileSheetRef, { onEscape: () => setMobileOpen(false) });


### PR DESCRIPTION
Follow-up addressing the four findings from the Copilot review on #3601 (merged as `17ec34a88`).

## Fixes

1. **`task-work-github.tsx` — stuck Refresh button.** The `hydratable.length === 0` early return in `refresh()` cleared items/error but not `loading`, so a stale in-flight refresh could leave the Refresh button permanently disabled. It now calls `setLoading(false)` too.
2. **`task-work-github.tsx` — focusable no-op buttons.** When the optional `onOpenUrl` handler is absent, item buttons rendered as focusable no-ops. They're now `disabled={!onOpenUrl}` with the tooltip suppressed.
3. **`board-table.tsx` — row keydown swallows child keys.** Enter/Space on interactive children inside a row (e.g. the Familiar select) bubbled to the row handler and toggled/opened the row. The handler now ignores events where `event.target !== event.currentTarget`.
4. **`use-workspace-rail-controller.ts` — inactive scope reports open rail.** `showInline`/`mobileAvailable` now gate on the `active` flag, so a ChatSurface scope tab that isn't current never reports an open rail to the shell/layout (the mobile-close effect was already gated; the visibility booleans now match).

Each fix is pinned in the corresponding wiring test (`workspace-rail-wiring`, `task-work-github`, `board-table-keyboard`, `mobile-code-rail`).

## Verification

- `pnpm typecheck` clean
- `pnpm test:app` 851/851
- `pnpm test:mobile` 82/82

Refs cave-t8uz.
