### PR TITLE
fix(research): tick the mission wall-clock reading live between polls (cave-2hdg)

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -16,6 +16,7 @@ import {
   type ResearchMissionActionInput,
 } from "@/lib/research-missions";
 import { relativeTime } from "@/lib/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import { ResearchEvidenceLedger } from "./research-evidence-ledger";
 
 type Props = {
@@ -60,6 +61,9 @@ export function ResearchMissionDetail({
   onAutomationAction,
 }: Props) {
   const { announce } = useAnnouncer();
+  // Keeps the running wall-clock reading and "updated Xm ago" stamps advancing
+  // between mission polls.
+  useMinuteTick();
   const [busy, setBusy] = useState(false);
   const [direction, setDirection] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -113,6 +113,10 @@ test("timestamps are relative and schedules read as prose, not raw data", () => 
   assert.match(detail, /describeResearchSchedule\(mission\.automation\.rrule\)/);
   assert.match(detail, /relativeTime\(mission\.automation\.lastRunAt\)/);
   assert.match(ledger, /relativeTime\(artifact\.updatedAt\)/);
+  // Detail must re-render on a minute tick so the running wall-clock reading
+  // and relative stamps advance between mission polls (cave-2hdg).
+  assert.match(detail, /import \{ useMinuteTick \} from "@\/lib\/use-minute-tick"/);
+  assert.match(detail, /useMinuteTick\(\)/);
   // Uppercase/capitalize chrome must not distort the relative-time text.
   assert.match(css, /\.research-mission-row__meta time \{[^}]*text-transform: none/);
   assert.match(css, /\.research-mission-detail__eyebrow time \{[^}]*text-transform: none/);

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -406,6 +406,7 @@ test("acceptance: no terminal mission ever renders a running or pending phase", 
 // --- researchBoundReadings: over/met bound states must be legible ---
 
 function meterMission(overrides: {
+  status?: "running" | "checkpoint" | "paused" | "completed" | "failed" | "archived";
   startedAt?: string;
   finishedAt?: string;
   sources?: number;
@@ -413,6 +414,7 @@ function meterMission(overrides: {
   bounds?: Partial<{ wallClockMinutes: number; sourceTarget: number; maxSpendUsd: number; checkpointEvery: number }>;
 }) {
   return {
+    status: overrides.status ?? "completed",
     bounds: {
       maxIterations: 1,
       wallClockMinutes: 20,
@@ -438,8 +440,8 @@ function meterMission(overrides: {
   } as Parameters<typeof researchBoundReadings>[0];
 }
 
-function reading(mission: Parameters<typeof researchBoundReadings>[0], id: string) {
-  const found = researchBoundReadings(mission).find((item) => item.id === id);
+function reading(mission: Parameters<typeof researchBoundReadings>[0], id: string, nowMs?: number) {
+  const found = researchBoundReadings(mission, nowMs).find((item) => item.id === id);
   assert.ok(found, `missing ${id} reading`);
   return found;
 }
@@ -500,6 +502,34 @@ test("in-budget readings stay neutral with no badges", () => {
   );
   assert.equal(justOver.value, "20/20 min");
   assert.equal(justOver.tone, "over");
+});
+
+test("an unfinished mission's clock ticks against now, not the last row write", () => {
+  // updatedAt is an hour past start (stale poll write), but only 9.5 real
+  // minutes have elapsed — the live clock must read now - startedAt.
+  const running = meterMission({ status: "running", startedAt: "2026-07-15T00:00:00Z" });
+  assert.equal(reading(running, "time", Date.parse("2026-07-15T00:09:30Z")).value, "10/20 min");
+  // Checkpoint/paused missions still burn wall clock — the stop gate compares
+  // against now regardless of why the run is waiting (stopBeforeNextIteration).
+  const waiting = meterMission({ status: "checkpoint", startedAt: "2026-07-15T00:00:00Z" });
+  assert.equal(reading(waiting, "time", Date.parse("2026-07-15T00:14:00Z")).value, "14/20 min");
+  // Crossing the budget flips to over live, without waiting for a data refresh.
+  const over = reading(running, "time", Date.parse("2026-07-15T00:20:01Z"));
+  assert.equal(over.tone, "over");
+  assert.equal(over.badge, "over");
+});
+
+test("a settled mission's clock freezes even when finishedAt was never recorded", () => {
+  // meterMission pins updatedAt to 01:00Z when finishedAt is absent.
+  const archived = meterMission({ status: "archived", startedAt: "2026-07-15T00:00:00Z" });
+  assert.equal(reading(archived, "time", Date.parse("2026-07-16T12:00:00Z")).value, "60/20 min");
+  // And finishedAt always wins over the live clock.
+  const finished = meterMission({
+    status: "completed",
+    startedAt: "2026-07-15T00:00:00Z",
+    finishedAt: "2026-07-15T00:12:00Z",
+  });
+  assert.equal(reading(finished, "time", Date.parse("2026-07-16T12:00:00Z")).value, "12/20 min");
 });
 
 test("spend reads over only past the cap and stays honest without one", () => {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -527,12 +527,21 @@ export type ResearchBoundReading = {
  * boundary is already explained by the mission's decision banner.
  */
 export function researchBoundReadings(
-  mission: Pick<ResearchMission, "bounds" | "sources" | "iterations" | "startedAt" | "finishedAt" | "updatedAt">,
+  mission: Pick<ResearchMission, "status" | "bounds" | "sources" | "iterations" | "startedAt" | "finishedAt" | "updatedAt">,
+  nowMs: number = Date.now(),
 ): ResearchBoundReading[] {
   const { bounds } = mission;
-  const elapsedMs = mission.startedAt
-    ? Math.max(0, Date.parse(mission.finishedAt ?? mission.updatedAt) - Date.parse(mission.startedAt))
-    : 0;
+  // The wall-clock stop gate compares now - startedAt (stopBeforeNextIteration),
+  // so an unfinished mission's clock keeps running between data refreshes:
+  // measure it against now, and freeze at finishedAt (or the last write, for
+  // settled missions that never recorded one) only once the run is over.
+  const settled = ["completed", "failed", "cancelled", "archived"].includes(mission.status);
+  const clockEndMs = mission.finishedAt
+    ? Date.parse(mission.finishedAt)
+    : settled
+      ? Date.parse(mission.updatedAt)
+      : nowMs;
+  const elapsedMs = mission.startedAt ? Math.max(0, clockEndMs - Date.parse(mission.startedAt)) : 0;
   const elapsedMinutes = Math.round(elapsedMs / 60_000);
   const timeOver = elapsedMs > bounds.wallClockMinutes * 60_000;
   const sourcesMet = mission.sources.length >= bounds.sourceTarget;


### PR DESCRIPTION
## Problem

The Research Desk detail's **Time x/y min** bound reading computes elapsed time as `(finishedAt ?? updatedAt) - startedAt`. For a running mission there is no finishedAt, so the clock pins to the last row write — it stalls between polls and only advances when something rewrites the mission. Meanwhile the actual wall-clock stop gate (`stopBeforeNextIteration`) compares `now - startedAt`: the meter systematically under-reports how much budget a live mission has burned.

## Fix

- `researchBoundReadings(mission, nowMs = Date.now())`: unfinished missions measure elapsed against **now**; the clock freezes at `finishedAt`, or at `updatedAt` only for settled missions (completed/failed/cancelled/archived) that never recorded one. Running, checkpoint, and paused missions tick live — matching the gate, which burns wall clock regardless of why the run is waiting — including flipping to **over** the moment the budget is crossed, without waiting for a refresh.
- `ResearchMissionDetail` re-renders on `useMinuteTick()` (same pattern as chat-list/projects-view), so the minutes value and the relative "updated Xm ago" stamps advance between polls.

## Tests

- Behavioral: unfinished clock ticks against now (not the stale row write); checkpoint missions still burn clock; live over-flip; settled-without-finishedAt freezes at updatedAt; finishedAt always wins over nowMs.
- Wiring pin: detail must import + call useMinuteTick.

## Validation

- `research-missions.test.ts` 32/32, `researcher-surface.test.ts` 19/19 (with the css-source-contract hook), `pnpm typecheck`, `pnpm lint` — all clean.
- No new traced files → sidecar fileCount budget untouched.

Bead: cave-2hdg · Goal: research-desk-polish candidate (b)