### PR TITLE
feat(coven): per-participant Debug affordance in the Details drawer (cave-gbde, A5)

### DIFF
--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -16,7 +16,7 @@ import {
   WorkspaceRail,
 } from "@/components/lazy-surfaces";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending, consumeProjectsTabPending } from "@/lib/chat-tab-events";
-import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
+import { requestDebugOpen, useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
@@ -146,6 +146,21 @@ export function ChatSurface({
   const railProjectRoot = activeSession?.project_root ?? null;
   const sessionRunning = activeSession?.status === "running";
   const activateConversation = useCallback(() => setScope("conversation"), []);
+  // Coven "Debug thread": a participant's pinned session is a regular resumable
+  // daemon session, so debugging it = opening it as a conversation with the
+  // debug modal latched (same S1 latch the rail's Debug action uses). The
+  // latch survives until the ChatView mounts, so ordering is forgiving.
+  const debugGroupSession = useCallback(
+    (sessionId: string, familiarId: string) => {
+      onSetActiveFamiliar(familiarId);
+      setScope("conversation");
+      window.setTimeout(() => {
+        routerRef.current?.openSession(sessionId);
+        requestDebugOpen();
+      }, 0);
+    },
+    [onSetActiveFamiliar, routerRef],
+  );
   const railController = useWorkspaceRailController({
     containerRef: surfaceRef,
     projectRoot: railProjectRoot,
@@ -433,6 +448,7 @@ export function ChatSurface({
               familiars={resolvedFamiliars}
               onSessionStarted={onSessionStarted}
               onOpenUrl={onOpenUrl}
+              onDebugSession={debugGroupSession}
             />
           </div>
         ) : (

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -364,3 +364,41 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
     "deleting a coven drops its stashed draft",
   );
 });
+
+test("coven Details drawer offers per-participant Debug (A5: no debug affordance in the coven tab)", () => {
+  // Each participant's pinned session is a regular resumable daemon session;
+  // the drawer lists them with a Debug action instead of hosting a DebugPane.
+  assert.match(
+    view,
+    /onDebugSession\?: \(sessionId: string, familiarId: string\) => void/,
+    "GroupChatView accepts an onDebugSession handler",
+  );
+  assert.match(
+    view,
+    /participants\.some\(\(f\) => activeGroup\.sessions\[f\.id\]\)/,
+    "the Threads section only renders when a participant has a pinned session",
+  );
+  assert.match(
+    view,
+    /onClick=\{\(\) => onDebugSession\(sessionId, f\.id\)\}/,
+    "Debug passes the pinned session AND its familiar so the host can scope the conversation",
+  );
+  assert.match(
+    view,
+    /className="coven-tab__thread-debug focus-ring"/,
+    "the Debug action keeps the shared focus-ring class",
+  );
+  // Host wiring: chat-surface switches to the conversation scope, opens the
+  // session through the router, and latches the debug modal (S1 latch) — the
+  // same machinery the rail's Debug action relies on.
+  assert.match(
+    chatSurface,
+    /const debugGroupSession = useCallback\(\s*\n\s*\(sessionId: string, familiarId: string\) => \{\s*\n\s*onSetActiveFamiliar\(familiarId\);\s*\n\s*setScope\("conversation"\);\s*\n\s*window\.setTimeout\(\(\) => \{\s*\n\s*routerRef\.current\?\.openSession\(sessionId\);\s*\n\s*requestDebugOpen\(\);/,
+    "chat-surface opens the member session as a conversation and latches debug-open",
+  );
+  assert.match(
+    chatSurface,
+    /onDebugSession=\{debugGroupSession\}/,
+    "chat-surface hands the handler to GroupChatView",
+  );
+});

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -90,9 +90,12 @@ type Props = {
    *  refresh its session list and surface the new threads elsewhere. */
   onSessionStarted?: (sessionId: string) => void;
   onOpenUrl?: (url: string) => void;
+  /** Opens a participant's pinned session as a regular conversation with the
+   *  debug modal latched — the coven tab itself has no DebugPane host. */
+  onDebugSession?: (sessionId: string, familiarId: string) => void;
 };
 
-export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props) {
+export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugSession }: Props) {
   const profileSnapshot = useUserProfile();
   const operatorDisplayName = userDisplayName(profileSnapshot?.profile);
   const [groups, setGroups] = useState<CovenGroup[]>([]);
@@ -1185,6 +1188,36 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   Created <RelativeTime iso={activeGroup.createdAt} /> · updated{" "}
                   <RelativeTime iso={activeGroup.updatedAt} />
                 </span>
+                {/* Threads: each participant answers in its own resumable daemon
+                    session (group-chat.ts sessions map). Debug jumps to that
+                    session as a regular conversation with the debug modal
+                    latched — the coven tab has no DebugPane of its own. */}
+                {onDebugSession && participants.some((f) => activeGroup.sessions[f.id]) ? (
+                  <div className="coven-tab__threads">
+                    <span className="coven-tab__field-label">Threads</span>
+                    <ul className="coven-tab__threads-list">
+                      {participants.map((f) => {
+                        const sessionId = activeGroup.sessions[f.id];
+                        if (!sessionId) return null;
+                        return (
+                          <li key={f.id} className="coven-tab__thread-row">
+                            <FamiliarAvatar familiar={f} size="sm" />
+                            <span className="coven-tab__thread-name">{f.display_name}</span>
+                            <button
+                              type="button"
+                              className="coven-tab__thread-debug focus-ring"
+                              title={`Debug ${f.display_name}'s session`}
+                              onClick={() => onDebugSession(sessionId, f.id)}
+                            >
+                              <Icon name="ph:bug-bold" width={12} height={12} aria-hidden />
+                              Debug
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                ) : null}
               </div>
             ) : null}
 

--- a/src/styles/coven-tab.css
+++ b/src/styles/coven-tab.css
@@ -302,6 +302,60 @@ textarea.coven-tab__field-input {
   color: var(--text-muted);
 }
 
+/* Threads: per-participant pinned sessions with a Debug jump-off. */
+.coven-tab__threads {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.coven-tab__threads-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.coven-tab__thread-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.coven-tab__thread-name {
+  overflow: hidden;
+  max-width: 12rem;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.coven-tab__thread-debug {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.coven-tab__thread-debug:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-presence);
+}
+
 /* ── Thread extras ───────────────────────────────────────────────────────── */
 
 /* "…replying" line, aligned with message bodies (same grid as a turn row). */


### PR DESCRIPTION
## What

Closes chat-session-debugging backlog item **A5**: group chats had no path to session diagnostics. Each participant answers in its own resumable daemon session (`group-chat.ts` sessions map), but the coven tab never mounts a DebugPane, and the rail's Debug action only exists in the conversation scope — debugging a member session meant hunting its row in the regular rail.

The coven **Details drawer** now lists pinned participant threads with a **Debug** action. The host (`chat-surface`) switches to the conversation scope, opens the member session through the router, and latches the debug modal via `requestDebugOpen` — the same S1 latch the rail's Debug action uses, consumed by the mounting ChatView's per-pane DebugPane. No global-store publishing from the group view is needed.

## Changes

- `group-chat-view.tsx` — `onDebugSession` prop + Threads section in the Details drawer (renders only when a participant has a pinned session; passes sessionId **and** familiarId).
- `chat-surface.tsx` — `debugGroupSession`: `onSetActiveFamiliar` → `setScope("conversation")` → `routerRef.openSession` + `requestDebugOpen` (mirrors the pendingChatAction "open" pattern).
- `coven-tab.css` — thread row + debug chip styles (design tokens only).
- `group-chat-view.test.ts` — pins: prop contract, conditional render, click payload, focus-ring, host wiring.

## Verification

- targeted: group-chat-view / chat-surface / chat-debug-store / debug-pane tests + design-token-drift — green
- `pnpm lint`, `pnpm typecheck`, `pnpm check:tests-wired` (1151) — green
- `pnpm test:app` — 851 files pass
- `pnpm build` — bundle + standalone budgets green
- Playwright end-to-end on the built app: seeded a coven with two pinned sessions → Threads section renders per-participant Debug chips → clicking one lands in the conversation with the debug modal open on that member session (session id, familiar, stream health visible)

Bead: cave-gbde (goals: chat-session-debugging A5)