### PR TITLE
feat(research): collapse archived missions out of the ledger list (cave-etj8)

### DIFF
--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -38,9 +38,14 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
   const [archivedOpen, setArchivedOpen] = useState(false);
 
   // Selecting an archived mission (e.g. a stable selection that got archived
-  // by a poll refresh) must keep its row reachable, so the group opens.
+  // by a poll refresh) must keep its row reachable, so the group opens — but
+  // only once per selection, so a deliberate re-collapse survives later poll
+  // refreshes that recreate the missions array.
+  const autoOpenedFor = useRef<string | null>(null);
   useEffect(() => {
-    if (selectedId && archivedMissions.some((mission) => mission.id === selectedId)) {
+    if (!selectedId || autoOpenedFor.current === selectedId) return;
+    if (archivedMissions.some((mission) => mission.id === selectedId)) {
+      autoOpenedFor.current = selectedId;
       setArchivedOpen(true);
     }
   }, [selectedId, archivedMissions]);

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -25,13 +25,38 @@ const STATUS_TONE: Partial<Record<ResearchMission["status"], string>> = {
 const ROVING_KEYS = new Set<string>(["ArrowDown", "ArrowUp", "Home", "End"]);
 
 export function ResearchMissionList({ missions, selectedId, loading, onSelect }: Props) {
-  const missionIds = useMemo(() => missions.map((mission) => mission.id), [missions]);
-  const [rovingId, setRovingId] = useState<string | null>(() => resolveRovingId(missionIds, selectedId, selectedId));
+  // Archived missions leave the working ledger and collapse into a disclosure
+  // group at the bottom so finished noise never buries active work.
+  const { activeMissions, archivedMissions } = useMemo(() => {
+    const active: ResearchMission[] = [];
+    const archived: ResearchMission[] = [];
+    for (const mission of missions) {
+      (mission.status === "archived" ? archived : active).push(mission);
+    }
+    return { activeMissions: active, archivedMissions: archived };
+  }, [missions]);
+  const [archivedOpen, setArchivedOpen] = useState(false);
+
+  // Selecting an archived mission (e.g. a stable selection that got archived
+  // by a poll refresh) must keep its row reachable, so the group opens.
+  useEffect(() => {
+    if (selectedId && archivedMissions.some((mission) => mission.id === selectedId)) {
+      setArchivedOpen(true);
+    }
+  }, [selectedId, archivedMissions]);
+
+  // Keyboard roving covers exactly the rendered rows: active rows always,
+  // archived rows only while the group is expanded.
+  const visibleIds = useMemo(() => [
+    ...activeMissions.map((mission) => mission.id),
+    ...(archivedOpen ? archivedMissions.map((mission) => mission.id) : []),
+  ], [activeMissions, archivedMissions, archivedOpen]);
+  const [rovingId, setRovingId] = useState<string | null>(() => resolveRovingId(visibleIds, selectedId, selectedId));
   const buttonRefs = useRef(new Map<string, HTMLButtonElement>());
 
   useEffect(() => {
-    setRovingId((current) => resolveRovingId(missionIds, current, selectedId));
-  }, [missionIds, selectedId]);
+    setRovingId((current) => resolveRovingId(visibleIds, current, selectedId));
+  }, [visibleIds, selectedId]);
 
   const focusMission = (id: string | null) => {
     if (!id) return;
@@ -41,16 +66,54 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
   const onListKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
     if (!ROVING_KEYS.has(event.key)) return;
     event.preventDefault();
-    const nextId = nextRovingId(missionIds, rovingId, event.key as RovingKey);
+    const nextId = nextRovingId(visibleIds, rovingId, event.key as RovingKey);
     setRovingId(nextId);
     focusMission(nextId);
+  };
+
+  const renderRow = (mission: ResearchMission) => {
+    const selected = mission.id === selectedId;
+    const iteration = mission.iterations.at(-1);
+    return (
+      <li key={mission.id}>
+        <button
+          type="button"
+          ref={(node) => {
+            if (node) {
+              buttonRefs.current.set(mission.id, node);
+            } else {
+              buttonRefs.current.delete(mission.id);
+            }
+          }}
+          className={`research-mission-row focus-ring${selected ? " is-selected" : ""}`}
+          aria-current={selected ? "true" : undefined}
+          tabIndex={mission.id === rovingId ? 0 : -1}
+          onFocus={() => setRovingId(mission.id)}
+          onClick={() => {
+            setRovingId(mission.id);
+            onSelect(mission.id);
+          }}
+        >
+          <span className="research-mission-row__top">
+            <span className={`research-status-dot research-status-dot--${STATUS_TONE[mission.status] ?? "muted"}`} aria-hidden />
+            <strong>{mission.title}</strong>
+          </span>
+          <span className="research-mission-row__meta">
+            <span>{mission.mode}</span>
+            <span>{mission.status}</span>
+            {iteration ? <span>i{iteration.number}/{mission.bounds.maxIterations}</span> : null}
+            <time dateTime={mission.updatedAt}>{relativeTime(mission.updatedAt) || "just now"}</time>
+          </span>
+        </button>
+      </li>
+    );
   };
 
   return (
     <nav className="research-mission-nav" aria-label="Research missions">
       <div className="research-mission-nav__head">
         <span>Mission ledger</span>
-        <span>{missions.length}</span>
+        <span>{activeMissions.length}</span>
       </div>
       {loading ? (
         <p className="research-mission-nav__empty">Loading missions…</p>
@@ -61,45 +124,34 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect }:
           <span>Describe an investigation to start the first one.</span>
         </div>
       ) : (
-        <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
-          {missions.map((mission) => {
-            const selected = mission.id === selectedId;
-            const iteration = mission.iterations.at(-1);
-            return (
-              <li key={mission.id}>
-                <button
-                  type="button"
-                  ref={(node) => {
-                    if (node) {
-                      buttonRefs.current.set(mission.id, node);
-                    } else {
-                      buttonRefs.current.delete(mission.id);
-                    }
-                  }}
-                  className={`research-mission-row focus-ring${selected ? " is-selected" : ""}`}
-                  aria-current={selected ? "true" : undefined}
-                  tabIndex={mission.id === rovingId ? 0 : -1}
-                  onFocus={() => setRovingId(mission.id)}
-                  onClick={() => {
-                    setRovingId(mission.id);
-                    onSelect(mission.id);
-                  }}
-                >
-                  <span className="research-mission-row__top">
-                    <span className={`research-status-dot research-status-dot--${STATUS_TONE[mission.status] ?? "muted"}`} aria-hidden />
-                    <strong>{mission.title}</strong>
-                  </span>
-                  <span className="research-mission-row__meta">
-                    <span>{mission.mode}</span>
-                    <span>{mission.status}</span>
-                    {iteration ? <span>i{iteration.number}/{mission.bounds.maxIterations}</span> : null}
-                    <time dateTime={mission.updatedAt}>{relativeTime(mission.updatedAt) || "just now"}</time>
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        <>
+          {activeMissions.length === 0 ? (
+            <p className="research-mission-nav__empty">No active missions.</p>
+          ) : (
+            <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
+              {activeMissions.map(renderRow)}
+            </ul>
+          )}
+          {archivedMissions.length > 0 ? (
+            <div className="research-mission-nav__group">
+              <button
+                type="button"
+                className="research-mission-nav__group-toggle focus-ring"
+                aria-expanded={archivedOpen}
+                onClick={() => setArchivedOpen((open) => !open)}
+              >
+                <Icon name={archivedOpen ? "ph:caret-down" : "ph:caret-right"} width={12} height={12} aria-hidden />
+                <span>Archived</span>
+                <span className="research-mission-nav__group-count">{archivedMissions.length}</span>
+              </button>
+              {archivedOpen ? (
+                <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
+                  {archivedMissions.map(renderRow)}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+        </>
       )}
     </nav>
   );

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -93,8 +93,10 @@ test("archived missions collapse into a disclosure group below active work", () 
   assert.match(list, /aria-expanded=\{archivedOpen\}/);
   assert.match(list, /research-mission-nav__group-toggle focus-ring/);
   assert.match(list, /research-mission-nav__group-count">\{archivedMissions\.length\}/);
-  // Selecting an archived mission keeps its row reachable by opening the group.
-  assert.match(list, /archivedMissions\.some\(\(mission\) => mission\.id === selectedId\)[\s\S]{0,40}setArchivedOpen\(true\)/);
+  // Selecting an archived mission keeps its row reachable by opening the group
+  // exactly once per selection — re-collapse survives poll refreshes.
+  assert.match(list, /autoOpenedFor\.current === selectedId\) return/);
+  assert.match(list, /archivedMissions\.some\(\(mission\) => mission\.id === selectedId\)[\s\S]{0,80}setArchivedOpen\(true\)/);
   // An all-archived ledger says so instead of claiming there are no missions.
   assert.match(list, /No active missions\./);
   assert.match(css, /\.research-mission-nav__group-toggle/);

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -8,6 +8,7 @@ const list = readFileSync(new URL("./research-mission-list.tsx", import.meta.url
 const detail = readFileSync(new URL("./research-mission-detail.tsx", import.meta.url), "utf8");
 const ledger = readFileSync(new URL("./research-evidence-ledger.tsx", import.meta.url), "utf8");
 const hook = readFileSync(new URL("./use-research-missions.ts", import.meta.url), "utf8");
+const clientLib = readFileSync(new URL("../../lib/research-mission-client.ts", import.meta.url), "utf8");
 const missionsLib = readFileSync(new URL("../../lib/research-missions.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
 
@@ -73,12 +74,32 @@ test("the plan summary pill is the bounds toggle — honest, labeled, focusing",
 
 
 test("mission list uses roving tabindex keyboard navigation", () => {
-  assert.match(list, /resolveRovingId\(missionIds, current, selectedId\)/);
-  assert.match(list, /nextRovingId\(missionIds, rovingId, event\.key as RovingKey\)/);
+  // Roving covers exactly the rendered rows: active always, archived only
+  // while the disclosure group is expanded.
+  assert.match(list, /resolveRovingId\(visibleIds, current, selectedId\)/);
+  assert.match(list, /nextRovingId\(visibleIds, rovingId, event\.key as RovingKey\)/);
   assert.match(list, /tabIndex=\{mission\.id === rovingId \? 0 : -1\}/);
   assert.match(list, /onKeyDown=\{onListKeyDown\}/);
   assert.match(list, /buttonRefs\.current\.get\(id\)\?\.focus\(\)/);
   assert.match(list, /research-mission-row focus-ring/);
+});
+
+test("archived missions collapse into a disclosure group below active work", () => {
+  // Partition: archived rows leave the working ledger…
+  assert.match(list, /mission\.status === "archived" \? archived : active/);
+  // …the header counts active missions only…
+  assert.match(list, /<span>\{activeMissions\.length\}<\/span>/);
+  // …and the group is a real count-labeled disclosure.
+  assert.match(list, /aria-expanded=\{archivedOpen\}/);
+  assert.match(list, /research-mission-nav__group-toggle focus-ring/);
+  assert.match(list, /research-mission-nav__group-count">\{archivedMissions\.length\}/);
+  // Selecting an archived mission keeps its row reachable by opening the group.
+  assert.match(list, /archivedMissions\.some\(\(mission\) => mission\.id === selectedId\)[\s\S]{0,40}setArchivedOpen\(true\)/);
+  // An all-archived ledger says so instead of claiming there are no missions.
+  assert.match(list, /No active missions\./);
+  assert.match(css, /\.research-mission-nav__group-toggle/);
+  // Auto-selection never lands inside the collapsed group.
+  assert.match(clientLib, /mission\.status !== "archived"/);
 });
 
 test("mission list and evidence trajectory expose semantic state", () => {

--- a/src/lib/research-mission-client.test.ts
+++ b/src/lib/research-mission-client.test.ts
@@ -73,6 +73,22 @@ test("stable selection survives polling and active states are explicit", () => {
   assert.equal(isActiveResearchMission(missions[1]), false);
 });
 
+test("fallback selection skips archived missions unless nothing else exists", () => {
+  const missions = [
+    mission("old", "archived"),
+    mission("fresh", "completed"),
+    mission("older", "archived"),
+  ];
+  // No selection → first unarchived mission wins even when archived rows sort first.
+  assert.equal(selectStableMission(null, missions), "fresh");
+  assert.equal(selectStableMission("missing", missions), "fresh");
+  // A deliberate archived selection remains stable.
+  assert.equal(selectStableMission("old", missions), "old");
+  // All-archived ledgers still select something rather than nothing.
+  assert.equal(selectStableMission(null, [mission("only", "archived")]), "only");
+  assert.equal(selectStableMission(null, []), null);
+});
+
 test("actions post to the encoded mission endpoint", async () => {
   const originalFetch = globalThis.fetch;
   const requests: Array<{ input: string; method?: string; body?: BodyInit | null }> = [];

--- a/src/lib/research-mission-client.ts
+++ b/src/lib/research-mission-client.ts
@@ -31,7 +31,10 @@ export function selectStableMission(
   missions: ResearchMission[],
 ): string | null {
   if (selectedId && missions.some((mission) => mission.id === selectedId)) return selectedId;
-  return missions[0]?.id ?? null;
+  // Never auto-select into the collapsed archived group; archived rows are
+  // only selected deliberately.
+  const firstUnarchived = missions.find((mission) => mission.status !== "archived");
+  return firstUnarchived?.id ?? missions[0]?.id ?? null;
 }
 
 export async function listResearchMissions(

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -948,6 +948,26 @@
 .research-mission-nav__list { display: flex; flex-direction: column; padding: 7px; }
 .research-mission-nav__list li + li { margin-top: 3px; }
 
+.research-mission-nav__group { border-top: 1px solid var(--border); }
+.research-mission-nav__group .research-mission-nav__list { padding-top: 3px; }
+.research-mission-nav__group-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2) 14px;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.research-mission-nav__group-toggle:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.research-mission-nav__group-count { margin-left: auto; font-weight: 500; }
+
 .research-mission-row {
   display: flex;
   width: 100%;


### PR DESCRIPTION
research-desk-polish NEXT CANDIDATE c (bead **cave-etj8**): archived missions stayed interleaved in the mission ledger forever, burying active work under finished noise.

## Changes

- **`research-mission-list.tsx`** — the ledger partitions: active missions render first; archived missions collapse into a count-labeled disclosure group (`aria-expanded`) at the bottom. The sticky header now counts active missions only (the group carries its own count). An all-archived ledger renders "No active missions." plus the group, instead of pretending the ledger is empty.
- **Keyboard nav stays coherent** — roving tabindex covers exactly the rendered rows: active rows always, archived rows only while the group is expanded (`visibleIds`). Selecting an archived mission (e.g. a stable selection that a poll refresh archived) auto-opens the group so its row stays reachable; the user can still re-collapse.
- **`selectStableMission`** (`research-mission-client.ts`) — fallback auto-selection prefers the first unarchived mission, so a load never silently selects into the collapsed group; deliberate archived selections remain stable; an all-archived ledger still selects something.
- **Tests** — behavioral coverage for the fallback ordering in `research-mission-client.test.ts`; source pins for the partition/disclosure/roving wiring in `researcher-surface.test.ts` (existing roving pins updated `missionIds` → `visibleIds`).
- **CSS** — group-toggle styles in `surface-role-workspaces.css`, tokenized via `scripts/codemods/tokenize-css.mjs` (design-token drift gate green).

## Verification

- `pnpm typecheck` clean
- Targeted: researcher-surface, research-mission-client, research-missions, research-evidence-ledger — all pass
- `pnpm test:app` 851/851 (includes the design-token drift gate)

Refs cave-etj8 · goal research-desk-polish (slice log: #3129, #3250, this).
