### PR TITLE
fix(chat): gate folder auto-expand on chat recency (cave-a9w9)

### DIFF
--- a/src/lib/chat-project-selection.test.ts
+++ b/src/lib/chat-project-selection.test.ts
@@ -10,10 +10,17 @@ import {
   PROJECT_SIDEBAR_KEYS,
 } from "./chat-project-selection.ts";
 
-const group = (projectId, projectRoot, n = 1) => ({
+const T0 = Date.parse("2026-06-11T12:00:00Z"); // baseline capture instant
+const RECENT = "2026-06-11T12:30:00Z"; // created after the baseline
+const OLD = "2026-06-01T00:00:00Z"; // created long before the baseline
+
+const group = (projectId, projectRoot, n = 1, createdAt = RECENT) => ({
   projectId,
   projectRoot,
-  sessions: Array.from({ length: n }, (_, i) => ({ id: `${projectId ?? "none"}-${i}` })),
+  sessions: Array.from({ length: n }, (_, i) => ({
+    id: `${projectId ?? "none"}-${i}`,
+    created_at: createdAt,
+  })),
   defaultFamiliarId: null,
   updatedAt: "2026-06-11T00:00:00Z",
 });
@@ -58,15 +65,17 @@ assert.equal(PROJECT_SIDEBAR_KEYS.open, "cave:chat:project-sidebar-open");
 assert.equal(PROJECT_SIDEBAR_KEYS.expanded, "cave:chat:project-sidebar-expanded");
 assert.equal(PROJECT_SIDEBAR_KEYS.selected, "cave:chat:project-selected");
 
-// ── autoExpandKeysForNewSessions (cave-mllp) ─────────────────────────────────
+// ── autoExpandKeysForNewSessions (cave-mllp, recency guard cave-a9w9) ────────
 
-// first chat in a fresh project folder: new key + first-seen session → expand
+// first chat in a fresh project folder: new key + first-seen recent session →
+// expand
 assert.deepEqual(
   autoExpandKeysForNewSessions({
     groups: [group("a", "/a"), group("b", "/b")],
     knownSessionIds: new Set(["a-0"]),
     knownGroupKeys: new Set(["a"]),
     activeSessionId: null,
+    newSinceMs: T0,
   }),
   ["b"],
 );
@@ -78,6 +87,7 @@ assert.deepEqual(
     knownSessionIds: new Set(),
     knownGroupKeys: new Set(),
     activeSessionId: null,
+    newSinceMs: T0,
   }),
   ["root:/orphan/root"],
 );
@@ -90,8 +100,47 @@ assert.deepEqual(
     knownSessionIds: new Set(["b-0"]),
     knownGroupKeys: new Set(),
     activeSessionId: null,
+    newSinceMs: T0,
   }),
   [],
+);
+
+// recovery/backfill/scope reveal (cave-a9w9): unseen key, first-seen session,
+// but the chat predates the baseline → it's old, not new — stay collapsed
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("b", "/b", 1, OLD)],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: null,
+    newSinceMs: T0,
+  }),
+  [],
+);
+
+// unparsable created_at fails closed for the new-folder path
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("b", "/b", 1, "not-a-date")],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: null,
+    newSinceMs: T0,
+  }),
+  [],
+);
+
+// the ACTIVE chat bypasses recency: end-of-stream persistence can land its
+// row (with an older created_at) well after the chat began
+assert.deepEqual(
+  autoExpandKeysForNewSessions({
+    groups: [group("b", "/b", 1, OLD)],
+    knownSessionIds: new Set(["a-0"]),
+    knownGroupKeys: new Set(["a"]),
+    activeSessionId: "b-0",
+    newSinceMs: T0,
+  }),
+  ["b"],
 );
 
 // background session landing in an existing collapsed folder: don't force open
@@ -101,6 +150,7 @@ assert.deepEqual(
     knownSessionIds: new Set(["a-0"]),
     knownGroupKeys: new Set(["a"]),
     activeSessionId: null,
+    newSinceMs: T0,
   }),
   [],
 );
@@ -112,6 +162,7 @@ assert.deepEqual(
     knownSessionIds: new Set(["a-0"]),
     knownGroupKeys: new Set(["a"]),
     activeSessionId: "a-1",
+    newSinceMs: T0,
   }),
   ["a"],
 );
@@ -123,6 +174,7 @@ assert.deepEqual(
     knownSessionIds: new Set(["a-0"]),
     knownGroupKeys: new Set(["a"]),
     activeSessionId: "a-0",
+    newSinceMs: T0,
   }),
   [],
 );

--- a/src/lib/chat-project-selection.ts
+++ b/src/lib/chat-project-selection.ts
@@ -50,25 +50,38 @@ export function normalizeSelection(
  *  qualifies when its group gained a session id missing from the baseline
  *  (`knownSessionIds`, captured from the UNFILTERED session list at hydration
  *  and grown per refresh) and either:
- *  - the group key itself is new (`knownGroupKeys`) — a brand-new project
- *    folder whose only content is the fresh chat, or
+ *  - the group key itself is new (`knownGroupKeys`) AND the fresh session was
+ *    created at/after `newSinceMs` — a brand-new project folder whose content
+ *    is a genuinely new chat, or
  *  - the fresh session is the active one — the chat this surface just
- *    started, landing in an existing collapsed folder.
- *  Groups merely *revealed* by a filter change (familiar switch) never
- *  qualify: their sessions were already known. Background sessions landing in
- *  existing collapsed folders don't force them open either. */
+ *    started or is watching (no recency gate: end-of-stream persistence can
+ *    land the active chat's row minutes after it began).
+ *  The recency gate is what keeps "first seen by this client" from being
+ *  confused with "new" (cave-a9w9): a failed/partial first load poisons the
+ *  baseline, and error recovery, daemon backfill, or a familiar switch to a
+ *  differently-granted scope then delivers OLD chats under unseen keys —
+ *  those must not mass-expand (and persist over) the user's collapsed
+ *  folders. Background sessions landing in existing collapsed folders don't
+ *  force them open either, however recent. */
 export function autoExpandKeysForNewSessions(args: {
   groups: ChatProjectGroup[];
   knownSessionIds: ReadonlySet<string>;
   knownGroupKeys: ReadonlySet<string>;
   activeSessionId: string | null;
+  /** Only sessions created at/after this instant count as "new chats" for
+   *  the new-folder path; missing/unparsable created_at fails closed. */
+  newSinceMs: number;
 }): string[] {
   const keys: string[] = [];
   for (const group of args.groups) {
     const key = selectionKey(group.projectId, group.projectRoot);
     const fresh = group.sessions.filter((s) => !args.knownSessionIds.has(s.id));
     if (fresh.length === 0) continue;
-    const newGroup = !args.knownGroupKeys.has(key);
+    const hasRecentFresh = fresh.some((s) => {
+      const createdMs = Date.parse(s.created_at ?? "");
+      return Number.isFinite(createdMs) && createdMs >= args.newSinceMs;
+    });
+    const newGroup = !args.knownGroupKeys.has(key) && hasRecentFresh;
     const activeIsFresh =
       args.activeSessionId !== null && fresh.some((s) => s.id === args.activeSessionId);
     if (newGroup || activeIsFresh) keys.push(key);

--- a/src/lib/use-auto-expand-new-groups.test.ts
+++ b/src/lib/use-auto-expand-new-groups.test.ts
@@ -10,11 +10,24 @@ import { readFileSync } from "node:fs";
 const hook = readFileSync(new URL("./use-auto-expand-new-groups.ts", import.meta.url), "utf8");
 
 // First hydrated run captures a baseline and bails — pre-existing collapsed
-// groups (absent from persisted expanded-keys) must stay collapsed.
+// groups (absent from persisted expanded-keys) must stay collapsed. The
+// capture records raw session ids, visible group keys, AND the capture
+// instant (recency anchor for cave-a9w9).
 assert.match(
   hook,
-  /if \(known === null\) \{[\s\S]*?sessionIds: new Set\(\[[\s\S]*?\.\.\.sessions\.map\(\(s\) => s\.id\)[\s\S]*?groupKeys: new Set\(projectSelectionKeys\(groups\)\)[\s\S]*?return;/,
-  "hook baselines raw session ids + visible group keys on first hydrated run without expanding",
+  /if \(known === null\) \{[\s\S]*?sessionIds: new Set\(\[[\s\S]*?\.\.\.sessions\.map\(\(s\) => s\.id\)[\s\S]*?groupKeys: new Set\(projectSelectionKeys\(groups\)\)[\s\S]*?capturedAtMs: Date\.now\(\)[\s\S]*?return;/,
+  "hook baselines raw session ids, visible group keys, and capture time on first hydrated run",
+);
+
+// The new-folder path only fires for chats created after baseline capture
+// (minus skew): a failed first load poisons the baseline, and recovery,
+// backfill, or familiar-scope reveals then deliver OLD chats under unseen
+// keys — those must never mass-expand (cave-a9w9). A genuine first chat
+// after an empty start is recent, so it still expands (cave-mllp preserved).
+assert.match(
+  hook,
+  /newSinceMs: known\.capturedAtMs - BASELINE_SKEW_MS/,
+  "expansion is gated on session recency relative to the baseline capture time",
 );
 
 // Expansion decisions come from the tested pure helper, computed BEFORE the

--- a/src/lib/use-auto-expand-new-groups.ts
+++ b/src/lib/use-auto-expand-new-groups.ts
@@ -7,7 +7,12 @@ import {
   projectSelectionKeys,
 } from "@/lib/chat-project-selection";
 
-type Baseline = { sessionIds: Set<string>; groupKeys: Set<string> };
+type Baseline = { sessionIds: Set<string>; groupKeys: Set<string>; capturedAtMs: number };
+
+/** Sessions created within this window before baseline capture still count
+ *  as "new" — absorbs client/daemon clock skew and a chat started moments
+ *  before this surface hydrated. */
+const BASELINE_SKEW_MS = 5 * 60 * 1000;
 
 /**
  * Auto-expand rail folders that gain a genuinely new chat (cave-mllp).
@@ -17,6 +22,15 @@ type Baseline = { sessionIds: Set<string>; groupKeys: Set<string> };
  * collapsed. After that, each refresh expands the keys
  * `autoExpandKeysForNewSessions` selects, exactly once per key: a later
  * manual re-collapse wins because the session ids are already known by then.
+ *
+ * Recency is the guard that keeps "first seen here" from being mistaken for
+ * "new" (cave-a9w9): a failed/partial first load poisons the baseline
+ * (hydration flips even when /api/sessions/list errors), and poll recovery,
+ * daemon backfill, or a familiar switch onto a differently-granted scope then
+ * delivers OLD chats under unseen keys. New-folder expansion additionally
+ * requires a chat created after baseline capture (minus skew), so those
+ * reveals never bulk-open folders — while a genuine first chat after an
+ * empty start still expands. Only the ACTIVE chat bypasses recency.
  *
  * `sessions` must be the RAW (unfiltered) rows so a familiar switch that
  * merely reveals previously filtered groups never reads as "new chats".
@@ -40,6 +54,7 @@ export function useAutoExpandNewGroups(args: {
           ...groups.flatMap((g) => g.sessions.map((s) => s.id)),
         ]),
         groupKeys: new Set(projectSelectionKeys(groups)),
+        capturedAtMs: Date.now(),
       };
       return;
     }
@@ -48,6 +63,7 @@ export function useAutoExpandNewGroups(args: {
       knownSessionIds: known.sessionIds,
       knownGroupKeys: known.groupKeys,
       activeSessionId,
+      newSinceMs: known.capturedAtMs - BASELINE_SKEW_MS,
     });
     // Grow the baselines only after computing, so this run's fresh sessions
     // count — and the next run treats them as known (expand-once semantics).


### PR DESCRIPTION
Follow-up to #3598, fixing both `/review` findings on the merged auto-expand feature. Bead: **cave-a9w9**.

## Bugs

1. **HIGH — baseline poisoning on failed first load.** `workspace.tsx` flips `sessionsLoaded` in its `finally` block even when `/api/sessions/list` fails, so the hook baselined an empty list. On poll recovery, every folder read as "new" → mass auto-expand persisted into `cave:chat:project-sidebar-expanded`, clobbering the user's collapsed folders.
2. **MEDIUM — familiar-scope reveals expanded wrongly.** The fetch is server-scoped per familiar (`scopeSessionsToFamiliarProjects` default-denies), so the "raw" sessions prop isn't scope-stable; switching familiars delivers never-baselined old chats whose folders auto-expanded.

## Fix

One mechanism covers both: the **new-folder** expansion path now also requires the fresh chat's `created_at` ≥ baseline capture time − 5 min skew (unparsable dates fail closed). Old chats surfacing via error recovery, daemon backfill, or scope reveals can never bulk-open folders. Genuinely new chats still expand — including a first chat after an empty start, since it's recent (cave-mllp behavior preserved). The **active-chat** path stays recency-free (its row can persist late).

## Verification

- `node --experimental-strip-types --test` on chat-project-selection, use-auto-expand-new-groups, chat-thread-rail — pass
- `pnpm typecheck` clean
- `node scripts/check-tests-wired.mjs` — 1151 files wired
- `pnpm test:app` — 851 files green