### PR TITLE
fix(debug): self-detect events-tail liveness beyond the sessions list (cave-rxjm, A3)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -281,18 +281,28 @@ assert.match(
 );
 assert.match(
   source,
-  /const streamStatusActive =\s*status === "running" \|\|\s*streamHealth\.phase === "connecting" \|\|\s*streamHealth\.phase === "streaming" \|\|\s*streamHealth\.phase === "resuming"/,
-  "Server status activity must include authoritative connecting, streaming, and resuming client phases",
+  /const sessionLive = isDebugSessionLive\(\{\s*status,\s*clientPhase: streamHealth\.phase,\s*serverStatus: streamStatus,\s*\}\)/,
+  "Pane liveness combines the sessions-list row, the client transport phase, and the server run buffer",
 );
 assert.match(
   source,
-  /if \(!streamStatusActive\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
-  "Server status polls on the existing cadence while the combined stream is active and visible",
+  /const \[follow, setFollow\] = useState\(\(\) =>\s*isDebugSessionLive\(\{ status, clientPhase: streamHealth\.phase, serverStatus: null \}\),?\s*\)/,
+  "Initial tail-follow seeds from the client-side witnesses (server status hasn't loaded at mount)",
 );
 assert.match(
   source,
-  /prevStreamStatusActiveRef\.current && !streamStatusActive[\s\S]*?fetchStreamStatus\(\)[\s\S]*?prevStreamStatusActiveRef\.current = streamStatusActive/,
-  "A combined client/server active-to-terminal transition triggers one final server-status refresh",
+  /if \(!sessionLive\) return;[\s\S]*?window\.setInterval[\s\S]*?shouldPollEvents\(\{ live: sessionLive, visible: document\.visibilityState === "visible" \}\)[\s\S]*?fetchEvents\(\)[\s\S]*?POLL_MS/,
+  "The events tail gates on composite liveness, not the poll-lagged sessions list alone",
+);
+assert.match(
+  source,
+  /if \(!sessionLive\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
+  "Server status polls on the existing cadence while any liveness witness is active and visible",
+);
+assert.match(
+  source,
+  /prevLiveRef\.current && !sessionLive[\s\S]*?fetchEvents\(\);[\s\S]*?fetchStreamStatus\(\);[\s\S]*?prevLiveRef\.current = sessionLive/,
+  "A live-to-terminal transition triggers one final events catch-up plus server-status refresh",
 );
 assert.match(
   source,
@@ -328,8 +338,8 @@ assert.ok(
 );
 assert.match(
   source,
-  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{streamStatusActive \|\| streamSummary\.tone !== "healthy"\}/,
-  "Stream health defaults open for any combined active stream or non-healthy client summary",
+  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{sessionLive \|\| streamSummary\.tone !== "healthy"\}/,
+  "Stream health defaults open for any live session or non-healthy client summary",
 );
 assert.match(
   source,

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -22,6 +22,7 @@ import {
   exportDebugTurn,
   filterEvents,
   formatEventPayload,
+  isDebugSessionLive,
   nextAfterSeq,
   readDebugEventsCache,
   shouldPollEvents,
@@ -288,11 +289,6 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const dtPrefs = useDateTimePrefs();
   const cwd = formatRuntime(session?.runtime);
   const streamSummary = useMemo(() => streamHealthSummary(streamHealth), [streamHealth]);
-  const streamStatusActive =
-    status === "running" ||
-    streamHealth.phase === "connecting" ||
-    streamHealth.phase === "streaming" ||
-    streamHealth.phase === "resuming";
   const lastEventLabel = streamHealth.lastEventAt
     ? formatTimestamp(streamHealth.lastEventAt, dtPrefs) || streamHealth.lastEventAt
     : "—";
@@ -311,9 +307,20 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const [eventQuery, setEventQuery] = useState("");
   const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
   const { announce } = useAnnouncer();
+  // Composite liveness: the polled sessions list alone is lagged (and blind to
+  // sessions it has no row for), so the pane's own transport phase and the
+  // server run buffer also witness a live run — either can start the tail.
+  const sessionLive = isDebugSessionLive({
+    status,
+    clientPhase: streamHealth.phase,
+    serverStatus: streamStatus,
+  });
   // Tail-follow only makes sense while events are streaming in; opening a
-  // finished session shouldn't jump past the Session section.
-  const [follow, setFollow] = useState(status === "running");
+  // finished session shouldn't jump past the Session section. At mount the
+  // server witness hasn't loaded yet, so seed from the client-side witnesses.
+  const [follow, setFollow] = useState(() =>
+    isDebugSessionLive({ status, clientPhase: streamHealth.phase, serverStatus: null }),
+  );
   const cursorRef = useRef(cachedSnapshot?.cursor ?? 0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -491,40 +498,37 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
     void fetchStreamStatus();
   }, [fetchStreamStatus]);
 
-  // Live tail while the session is running and the tab is visible.
+  // Live tail while the session is live (any witness) and the tab is visible.
   useEffect(() => {
-    if (status !== "running") return;
+    if (!sessionLive) return;
     const id = window.setInterval(() => {
-      if (shouldPollEvents({ status, visible: document.visibilityState === "visible" })) {
+      if (shouldPollEvents({ live: sessionLive, visible: document.visibilityState === "visible" })) {
         void fetchEvents();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchEvents, status]);
+  }, [fetchEvents, sessionLive]);
   useEffect(() => {
-    if (!streamStatusActive) return;
+    if (!sessionLive) return;
     const id = window.setInterval(() => {
       if (document.visibilityState === "visible") {
         void fetchStreamStatus();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchStreamStatus, streamStatusActive]);
+  }, [fetchStreamStatus, sessionLive]);
 
-  // One-shot catch-up when the session leaves "running", so events emitted in
-  // the final poll window aren't dropped.
-  const prevStatusRef = useRef(status);
+  // One-shot catch-up when every liveness witness goes quiet, so events
+  // emitted in the final poll window aren't dropped and the terminal buffer
+  // state (done/evicted counts) is captured.
+  const prevLiveRef = useRef(sessionLive);
   useEffect(() => {
-    if (prevStatusRef.current === "running" && status !== "running") void fetchEvents();
-    prevStatusRef.current = status;
-  }, [fetchEvents, status]);
-  const prevStreamStatusActiveRef = useRef(streamStatusActive);
-  useEffect(() => {
-    if (prevStreamStatusActiveRef.current && !streamStatusActive) {
+    if (prevLiveRef.current && !sessionLive) {
+      void fetchEvents();
       void fetchStreamStatus();
     }
-    prevStreamStatusActiveRef.current = streamStatusActive;
-  }, [fetchStreamStatus, streamStatusActive]);
+    prevLiveRef.current = sessionLive;
+  }, [fetchEvents, fetchStreamStatus, sessionLive]);
 
   // Auto-follow: stick to the bottom while new events stream in; scrolling
   // up pauses, the pill below resumes.
@@ -635,7 +639,7 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
 
         <Section
           title="Stream health"
-          defaultOpen={streamStatusActive || streamSummary.tone !== "healthy"}
+          defaultOpen={sessionLive || streamSummary.tone !== "healthy"}
         >
           <KVRow k="overall">
             <span className="inline-flex items-center gap-1.5">

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   appendEvents,
   nextAfterSeq,
+  isDebugSessionLive,
   shouldPollEvents,
   formatEventPayload,
   buildDebugBundle,
@@ -38,11 +39,56 @@ assert.deepEqual(
 assert.equal(nextAfterSeq([]), 0);
 assert.equal(nextAfterSeq([ev(1), ev(7)]), 7);
 
-// shouldPollEvents: only while running and visible
-assert.equal(shouldPollEvents({ status: "running", visible: true }), true);
-assert.equal(shouldPollEvents({ status: "running", visible: false }), false);
-assert.equal(shouldPollEvents({ status: "completed", visible: true }), false);
-assert.equal(shouldPollEvents({ status: null, visible: true }), false);
+// isDebugSessionLive: any witness saying "live" wins — sessions-list status,
+// client transport phase, or the server run buffer (done: false)
+{
+  const idle = { status: null, clientPhase: "idle", serverStatus: null };
+  const buffer = (done) => ({
+    done,
+    oldestRetainedSeq: 1,
+    latestSeq: 5,
+    retainedEventCount: 5,
+    retainedBytes: 100,
+    hasEvictedEvents: false,
+    liveTails: 0,
+  });
+  assert.equal(isDebugSessionLive(idle), false, "no witness => not live");
+  assert.equal(isDebugSessionLive({ ...idle, status: "running" }), true, "sessions-list row wins");
+  for (const clientPhase of ["connecting", "streaming", "resuming"]) {
+    assert.equal(
+      isDebugSessionLive({ ...idle, clientPhase }),
+      true,
+      `client ${clientPhase} phase wins without a sessions-list row (poll lag / missing row)`,
+    );
+  }
+  for (const clientPhase of ["settled", "degraded", "stopped"]) {
+    assert.equal(
+      isDebugSessionLive({ ...idle, clientPhase }),
+      false,
+      `terminal client ${clientPhase} phase is not a live witness`,
+    );
+  }
+  assert.equal(
+    isDebugSessionLive({ ...idle, serverStatus: buffer(false) }),
+    true,
+    "an undone server run buffer self-detects runs this pane didn't start",
+  );
+  assert.equal(
+    isDebugSessionLive({ ...idle, serverStatus: buffer(true) }),
+    false,
+    "a finished buffer is not a live witness",
+  );
+  assert.equal(
+    isDebugSessionLive({ status: "completed", clientPhase: "settled", serverStatus: buffer(true) }),
+    false,
+    "all witnesses terminal => not live",
+  );
+}
+
+// shouldPollEvents: only while live and visible
+assert.equal(shouldPollEvents({ live: true, visible: true }), true);
+assert.equal(shouldPollEvents({ live: true, visible: false }), false);
+assert.equal(shouldPollEvents({ live: false, visible: true }), false);
 
 // filterEvents: case-insensitive over kind + raw payload; reference-stable when blank
 import { filterEvents } from "./session-debug.ts";

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -2,7 +2,11 @@ import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
 import { usageSummary, type TurnUsage } from "./usage-format.ts";
 import { stripPreviewOnlyAttachmentFields, type ChatAttachment } from "./chat-attachments.ts";
-import type { ChatStreamClientHealth, RunBufferStatus } from "./chat-stream-health.ts";
+import type {
+  ChatStreamClientHealth,
+  ChatStreamPhase,
+  RunBufferStatus,
+} from "./chat-stream-health.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -107,8 +111,32 @@ export function nextAfterSeq(events: CovenEvent[]): number {
   return events.reduce((max, e) => (e.seq > max ? e.seq : max), 0);
 }
 
-export function shouldPollEvents(args: { status: string | null; visible: boolean }): boolean {
-  return args.status === "running" && args.visible;
+/** Composite liveness witness for the debug pane. The polled sessions list is
+ *  only one (lagged) source of truth: a session missing a row reads status
+ *  null, and a just-started run stays "idle" until the next list poll. The
+ *  pane's own transport phase is authoritative the moment ChatView opens a
+ *  stream, and the server run buffer (GET /api/chat/stream/status, keyed by
+ *  runId or conversation id) self-detects runs this pane didn't start —
+ *  `done: false` means the daemon is still emitting. Any witness saying
+ *  "live" wins; a null buffer (unknown/reaped run) is not a witness. */
+export function isDebugSessionLive(args: {
+  status: string | null;
+  clientPhase: ChatStreamPhase;
+  serverStatus: RunBufferStatus | null;
+}): boolean {
+  if (args.status === "running") return true;
+  if (
+    args.clientPhase === "connecting" ||
+    args.clientPhase === "streaming" ||
+    args.clientPhase === "resuming"
+  ) {
+    return true;
+  }
+  return args.serverStatus !== null && !args.serverStatus.done;
+}
+
+export function shouldPollEvents(args: { live: boolean; visible: boolean }): boolean {
+  return args.live && args.visible;
 }
 
 /** Snapshot of one pane's fetched event tail, kept across modal close/reopen. */


### PR DESCRIPTION
## What

Closes gap **A3** from the chat-session-debugging audit: the debug pane's events live tail gated solely on `session?.status` from chat-router's **polled sessions list** — a session with no row read status `null` and the tail never started; a just-started run stayed idle until the next list poll.

## How

New pure `isDebugSessionLive` (session-debug.ts) combines three liveness witnesses — any one saying "live" wins:

1. **Sessions-list row** (`status === "running"`) — the existing, poll-lagged witness.
2. **Client transport phase** (`connecting`/`streaming`/`resuming` from S6 `ChatStreamClientHealth`) — authoritative the instant this pane's ChatView opens a stream.
3. **Server run buffer** (`RunBufferStatus.done === false` from `GET /api/chat/stream/status`, keyed by runId or conversation id) — self-detects daemon-side runs this pane didn't start. **Zero new endpoints**: the pane already fetches this status once on mount; an undone buffer now activates the polls, which keep re-checking until the buffer flips done.

Gated on the composite: events live tail, stream-status poll, Stream-health `defaultOpen`, and initial tail-follow (client witnesses only at mount — server status hasn't loaded yet). The two catch-up transitions (`running`→finished events drain; stream-status final refresh) merge into one live→quiet transition doing both. `shouldPollEvents` becomes `{live, visible}`.

## Notes

- A crashed run that never calls `finish()` could keep its buffer `done: false`, sustaining the 2s poll while the modal is open — bounded by modal-open time + tab visibility, and `openRunBuffer` replaces stale entries on the next turn in the conversation.
- Slice of the **chat-session-debugging** goal (bead cave-rxjm); prior slices #3339 #3352 #3357 #3361 #3371 #3577 #3597 #3608.

## Verification

- `pnpm test:app` — 851 files green (includes new composite-witness matrix tests + updated wiring pins)
- `pnpm typecheck` clean, `pnpm lint` clean