### PR TITLE
fix(debug): stop gating the live event tail on the poll-lagged sessions list (cave-u89i, A3)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -281,18 +281,28 @@ assert.match(
 );
 assert.match(
   source,
-  /const streamStatusActive =\s*status === "running" \|\|\s*streamHealth\.phase === "connecting" \|\|\s*streamHealth\.phase === "streaming" \|\|\s*streamHealth\.phase === "resuming"/,
-  "Server status activity must include authoritative connecting, streaming, and resuming client phases",
+  /const serverRunLive = streamStatus \? !streamStatus\.done : null;\s*const debugActive = isDebugSessionActive\(\{\s*status,\s*streamPhase: streamHealth\.phase,\s*serverRunLive,\s*\}\)/,
+  "Pane liveness must combine sessions-list status, the pane's own transport phase, and server run-buffer liveness (A3)",
 );
 assert.match(
   source,
-  /if \(!streamStatusActive\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
+  /if \(!debugActive\) return;[\s\S]*?window\.setInterval[\s\S]*?shouldPollEvents\(\{\s*status,\s*streamPhase: streamHealth\.phase,\s*serverRunLive,\s*visible: document\.visibilityState === "visible",\s*\}\)[\s\S]*?fetchEvents\(\)[\s\S]*?POLL_MS/,
+  "The live event tail must gate on the hybrid signal, not the poll-lagged sessions-list status alone",
+);
+assert.doesNotMatch(
+  source,
+  /if \(status !== "running"\) return/,
+  "No effect may hold the event tail closed on the sessions-list status alone — no row must not mean no tail",
+);
+assert.match(
+  source,
+  /if \(!debugActive\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
   "Server status polls on the existing cadence while the combined stream is active and visible",
 );
 assert.match(
   source,
-  /prevStreamStatusActiveRef\.current && !streamStatusActive[\s\S]*?fetchStreamStatus\(\)[\s\S]*?prevStreamStatusActiveRef\.current = streamStatusActive/,
-  "A combined client/server active-to-terminal transition triggers one final server-status refresh",
+  /prevActiveRef\.current && !debugActive[\s\S]*?fetchEvents\(\);\s*void fetchStreamStatus\(\);[\s\S]*?prevActiveRef\.current = debugActive/,
+  "An active-to-terminal transition triggers one final events drain and server-status refresh",
 );
 assert.match(
   source,
@@ -328,7 +338,7 @@ assert.ok(
 );
 assert.match(
   source,
-  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{streamStatusActive \|\| streamSummary\.tone !== "healthy"\}/,
+  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{debugActive \|\| streamSummary\.tone !== "healthy"\}/,
   "Stream health defaults open for any combined active stream or non-healthy client summary",
 );
 assert.match(

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -22,6 +22,7 @@ import {
   exportDebugTurn,
   filterEvents,
   formatEventPayload,
+  isDebugSessionActive,
   nextAfterSeq,
   readDebugEventsCache,
   shouldPollEvents,
@@ -288,11 +289,6 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const dtPrefs = useDateTimePrefs();
   const cwd = formatRuntime(session?.runtime);
   const streamSummary = useMemo(() => streamHealthSummary(streamHealth), [streamHealth]);
-  const streamStatusActive =
-    status === "running" ||
-    streamHealth.phase === "connecting" ||
-    streamHealth.phase === "streaming" ||
-    streamHealth.phase === "resuming";
   const lastEventLabel = streamHealth.lastEventAt
     ? formatTimestamp(streamHealth.lastEventAt, dtPrefs) || streamHealth.lastEventAt
     : "—";
@@ -311,9 +307,19 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const [eventQuery, setEventQuery] = useState("");
   const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
   const { announce } = useAnnouncer();
+  // Hybrid liveness (A3): the sessions-list status is poll-lagged and null
+  // before the row exists, so it can't be the only tail gate — the pane's own
+  // transport phase and the server run-buffer's done flag are ground truth it
+  // already holds. Any live signal keeps the tails polling.
+  const serverRunLive = streamStatus ? !streamStatus.done : null;
+  const debugActive = isDebugSessionActive({
+    status,
+    streamPhase: streamHealth.phase,
+    serverRunLive,
+  });
   // Tail-follow only makes sense while events are streaming in; opening a
   // finished session shouldn't jump past the Session section.
-  const [follow, setFollow] = useState(status === "running");
+  const [follow, setFollow] = useState(debugActive);
   const cursorRef = useRef(cachedSnapshot?.cursor ?? 0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -491,40 +497,43 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
     void fetchStreamStatus();
   }, [fetchStreamStatus]);
 
-  // Live tail while the session is running and the tab is visible.
+  // Live tail while the session is active and the tab is visible.
   useEffect(() => {
-    if (status !== "running") return;
+    if (!debugActive) return;
     const id = window.setInterval(() => {
-      if (shouldPollEvents({ status, visible: document.visibilityState === "visible" })) {
+      if (
+        shouldPollEvents({
+          status,
+          streamPhase: streamHealth.phase,
+          serverRunLive,
+          visible: document.visibilityState === "visible",
+        })
+      ) {
         void fetchEvents();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchEvents, status]);
+  }, [fetchEvents, debugActive, status, streamHealth.phase, serverRunLive]);
   useEffect(() => {
-    if (!streamStatusActive) return;
+    if (!debugActive) return;
     const id = window.setInterval(() => {
       if (document.visibilityState === "visible") {
         void fetchStreamStatus();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchStreamStatus, streamStatusActive]);
+  }, [fetchStreamStatus, debugActive]);
 
-  // One-shot catch-up when the session leaves "running", so events emitted in
-  // the final poll window aren't dropped.
-  const prevStatusRef = useRef(status);
+  // One-shot catch-up when every liveness signal has gone quiet, so events and
+  // server status emitted in the final poll window aren't dropped.
+  const prevActiveRef = useRef(debugActive);
   useEffect(() => {
-    if (prevStatusRef.current === "running" && status !== "running") void fetchEvents();
-    prevStatusRef.current = status;
-  }, [fetchEvents, status]);
-  const prevStreamStatusActiveRef = useRef(streamStatusActive);
-  useEffect(() => {
-    if (prevStreamStatusActiveRef.current && !streamStatusActive) {
+    if (prevActiveRef.current && !debugActive) {
+      void fetchEvents();
       void fetchStreamStatus();
     }
-    prevStreamStatusActiveRef.current = streamStatusActive;
-  }, [fetchStreamStatus, streamStatusActive]);
+    prevActiveRef.current = debugActive;
+  }, [debugActive, fetchEvents, fetchStreamStatus]);
 
   // Auto-follow: stick to the bottom while new events stream in; scrolling
   // up pauses, the pill below resumes.
@@ -635,7 +644,7 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
 
         <Section
           title="Stream health"
-          defaultOpen={streamStatusActive || streamSummary.tone !== "healthy"}
+          defaultOpen={debugActive || streamSummary.tone !== "healthy"}
         >
           <KVRow k="overall">
             <span className="inline-flex items-center gap-1.5">

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   appendEvents,
   nextAfterSeq,
+  isDebugSessionActive,
   shouldPollEvents,
   formatEventPayload,
   buildDebugBundle,
@@ -38,11 +39,42 @@ assert.deepEqual(
 assert.equal(nextAfterSeq([]), 0);
 assert.equal(nextAfterSeq([ev(1), ev(7)]), 7);
 
-// shouldPollEvents: only while running and visible
-assert.equal(shouldPollEvents({ status: "running", visible: true }), true);
-assert.equal(shouldPollEvents({ status: "running", visible: false }), false);
-assert.equal(shouldPollEvents({ status: "completed", visible: true }), false);
-assert.equal(shouldPollEvents({ status: null, visible: true }), false);
+// isDebugSessionActive: hybrid liveness — any one signal claiming the run is
+// live wins; the poll-lagged (or missing) sessions-list status alone can't
+// hold the tail closed.
+const quiet = { status: null, streamPhase: "idle", serverRunLive: null };
+assert.equal(isDebugSessionActive(quiet), false, "all-unknown signals stay inactive");
+assert.equal(isDebugSessionActive({ ...quiet, status: "running" }), true);
+assert.equal(isDebugSessionActive({ ...quiet, status: "completed" }), false);
+for (const streamPhase of ["connecting", "streaming", "resuming"]) {
+  assert.equal(
+    isDebugSessionActive({ ...quiet, streamPhase }),
+    true,
+    `own-run phase ${streamPhase} activates the tail before the sessions row exists`,
+  );
+}
+for (const streamPhase of ["idle", "settled", "degraded", "stopped"]) {
+  assert.equal(isDebugSessionActive({ ...quiet, streamPhase }), false);
+}
+assert.equal(
+  isDebugSessionActive({ ...quiet, serverRunLive: true }),
+  true,
+  "server run-buffer liveness activates router-opened panes with no row and no own run",
+);
+assert.equal(isDebugSessionActive({ ...quiet, serverRunLive: false }), false);
+assert.equal(
+  isDebugSessionActive({ status: "completed", streamPhase: "settled", serverRunLive: false }),
+  false,
+  "all signals agreeing the run is over deactivates the tail",
+);
+
+// shouldPollEvents: active and visible
+assert.equal(shouldPollEvents({ ...quiet, status: "running", visible: true }), true);
+assert.equal(shouldPollEvents({ ...quiet, status: "running", visible: false }), false);
+assert.equal(shouldPollEvents({ ...quiet, streamPhase: "streaming", visible: true }), true);
+assert.equal(shouldPollEvents({ ...quiet, serverRunLive: true, visible: false }), false);
+assert.equal(shouldPollEvents({ ...quiet, status: "completed", visible: true }), false);
+assert.equal(shouldPollEvents({ ...quiet, visible: true }), false);
 
 // filterEvents: case-insensitive over kind + raw payload; reference-stable when blank
 import { filterEvents } from "./session-debug.ts";

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -2,7 +2,11 @@ import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
 import { usageSummary, type TurnUsage } from "./usage-format.ts";
 import { stripPreviewOnlyAttachmentFields, type ChatAttachment } from "./chat-attachments.ts";
-import type { ChatStreamClientHealth, RunBufferStatus } from "./chat-stream-health.ts";
+import type {
+  ChatStreamClientHealth,
+  ChatStreamPhase,
+  RunBufferStatus,
+} from "./chat-stream-health.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -107,8 +111,37 @@ export function nextAfterSeq(events: CovenEvent[]): number {
   return events.reduce((max, e) => (e.seq > max ? e.seq : max), 0);
 }
 
-export function shouldPollEvents(args: { status: string | null; visible: boolean }): boolean {
-  return args.status === "running" && args.visible;
+/** Signals the debug pane combines to decide whether its session is live. */
+export type DebugActivitySignals = {
+  /** `session.status` from the polled sessions list — poll-lagged, and null
+   *  until the list grows a row for this session. */
+  status: string | null;
+  /** The owning pane's own transport phase (S6 client health) — ground truth
+   *  for runs this ChatView is streaming. */
+  streamPhase: ChatStreamPhase;
+  /** Whether the server run-buffer reports the run unfinished (`!done`);
+   *  null until GET /api/chat/stream/status has answered. */
+  serverRunLive: boolean | null;
+};
+
+/** Hybrid liveness for the debug pane. The sessions-list `status` alone is a
+ *  broken gate: it lags the 30s-ish poll and is null before the row exists, so
+ *  a pane opened on a live run never started its event tail. Any one signal
+ *  claiming the run is live wins. */
+export function isDebugSessionActive(args: DebugActivitySignals): boolean {
+  if (args.status === "running") return true;
+  if (
+    args.streamPhase === "connecting" ||
+    args.streamPhase === "streaming" ||
+    args.streamPhase === "resuming"
+  ) {
+    return true;
+  }
+  return args.serverRunLive === true;
+}
+
+export function shouldPollEvents(args: DebugActivitySignals & { visible: boolean }): boolean {
+  return isDebugSessionActive(args) && args.visible;
 }
 
 /** Snapshot of one pane's fetched event tail, kept across modal close/reopen. */


### PR DESCRIPTION
## Problem (chat-session-debugging gap A3)

`DebugPaneInner` gated its 2s live event tail — and the running→finished catch-up — solely on `session?.status` from chat-router's **polled sessions list**:

- No row yet (pre-promotion chats, router-opened sessions, coven participant threads opened via the Details-drawer Debug chip) → `status === null` → **the tail never starts**.
- Status flips lag the sessions poll, so the tail started/stopped late even when a row existed.

## Fix

New pure `isDebugSessionActive({ status, streamPhase, serverRunLive })` in `session-debug.ts` — any one signal claiming the run is live wins:

| signal | source | covers |
|---|---|---|
| `status === "running"` | polled sessions list | existing behavior |
| `streamPhase` ∈ connecting/streaming/resuming | pane's own S6 client transport health | the pane's own live run, instantly |
| `serverRunLive` (`done: false`) | `GET /api/chat/stream/status` (already fetched once on mount) | router-opened sessions with no row and no own run |

- `shouldPollEvents` extends to the same signals + tick-time visibility.
- Events polling, server stream-status polling, and the two one-shot catch-up effects unify on the single hybrid signal (one final events drain **and** status refresh when every signal goes quiet).
- `follow`'s initial state uses the mount-time hybrid, so opening debug mid-own-run follows the tail.
- Self-correcting: the server-status poll it sustains is also what clears `serverRunLive` when the buffer reports `done` (or vanishes → `status: null`).

## Tests

- `session-debug.test.ts`: truth table for `isDebugSessionActive` + extended `shouldPollEvents` (each signal alone, all-quiet, visibility gate).
- `debug-pane.test.ts`: pins the `serverRunLive`/`debugActive` derivation, the hybrid tail gate (+ `doesNotMatch` on the old status-only gate), unified catch-up, and `defaultOpen`.

## Verification

- targeted: session-debug + debug-pane + chat-debug-store suites pass
- `pnpm typecheck` clean
- `pnpm test:app` **851 files green**

Bead: cave-u89i (goal: chat-session-debugging, slice A3)