### PR TITLE
fix(debug): gate events live-tail on truthful liveness, not the polled row (cave-tvzi, A3)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -281,18 +281,28 @@ assert.match(
 );
 assert.match(
   source,
-  /const streamStatusActive =\s*status === "running" \|\|\s*streamHealth\.phase === "connecting" \|\|\s*streamHealth\.phase === "streaming" \|\|\s*streamHealth\.phase === "resuming"/,
-  "Server status activity must include authoritative connecting, streaming, and resuming client phases",
+  /const live = debugSessionLive\(\{\s*status,\s*streamPhase: streamHealth\.phase,\s*serverRunDone: streamStatus \? streamStatus\.done : null,\s*\}\)/,
+  "Pane liveness must combine the polled row, own transport phase, and server run buffer (A3: poll-lag-free)",
 );
 assert.match(
   source,
-  /if \(!streamStatusActive\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
-  "Server status polls on the existing cadence while the combined stream is active and visible",
+  /const \[follow, setFollow\] = useState\(live\)/,
+  "Tail-follow starts on for any truthfully live session, not only when the row says running",
 );
 assert.match(
   source,
-  /prevStreamStatusActiveRef\.current && !streamStatusActive[\s\S]*?fetchStreamStatus\(\)[\s\S]*?prevStreamStatusActiveRef\.current = streamStatusActive/,
-  "A combined client/server active-to-terminal transition triggers one final server-status refresh",
+  /if \(!live\) return;[\s\S]*?window\.setInterval[\s\S]*?shouldPollEvents\(\{ live, visible: document\.visibilityState === "visible" \}\)[\s\S]*?fetchEvents\(\)[\s\S]*?POLL_MS/,
+  "Events live-tail polls while truthfully live and visible — not only when the poll-lagged row says running",
+);
+assert.match(
+  source,
+  /if \(!live\) return;[\s\S]*?window\.setInterval[\s\S]*?document\.visibilityState === "visible"[\s\S]*?fetchStreamStatus\(\)[\s\S]*?POLL_MS/,
+  "Server status polls on the existing cadence while the combined stream is live and visible",
+);
+assert.match(
+  source,
+  /prevLiveRef\.current && !live[\s\S]*?fetchEvents\(\);\s*void fetchStreamStatus\(\);[\s\S]*?prevLiveRef\.current = live/,
+  "A live-to-terminal transition triggers one final events catch-up and server-status refresh",
 );
 assert.match(
   source,
@@ -328,8 +338,8 @@ assert.ok(
 );
 assert.match(
   source,
-  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{streamStatusActive \|\| streamSummary\.tone !== "healthy"\}/,
-  "Stream health defaults open for any combined active stream or non-healthy client summary",
+  /streamHealthSummary\(streamHealth\)[\s\S]*?defaultOpen=\{live \|\| streamSummary\.tone !== "healthy"\}/,
+  "Stream health defaults open for any live stream or non-healthy client summary",
 );
 assert.match(
   source,

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -19,6 +19,7 @@ import {
   appendEvents,
   buildDebugBundle,
   debugFileName,
+  debugSessionLive,
   exportDebugTurn,
   filterEvents,
   formatEventPayload,
@@ -288,11 +289,6 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const dtPrefs = useDateTimePrefs();
   const cwd = formatRuntime(session?.runtime);
   const streamSummary = useMemo(() => streamHealthSummary(streamHealth), [streamHealth]);
-  const streamStatusActive =
-    status === "running" ||
-    streamHealth.phase === "connecting" ||
-    streamHealth.phase === "streaming" ||
-    streamHealth.phase === "resuming";
   const lastEventLabel = streamHealth.lastEventAt
     ? formatTimestamp(streamHealth.lastEventAt, dtPrefs) || streamHealth.lastEventAt
     : "—";
@@ -308,12 +304,22 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const [streamStatus, setStreamStatus] = useState<RunBufferStatus | null>(null);
   const [streamStatusLoaded, setStreamStatusLoaded] = useState(false);
   const [streamStatusError, setStreamStatusError] = useState<string | null>(null);
+  // Truthful liveness (A3): the polled sessions row alone starts the live tail
+  // late or never — the row can be absent (pre-promotion chats, list lag) and
+  // its status is poll-lagged. The pane's own stream transport and the server
+  // run buffer (done === false while a run is open, even one driven from
+  // another surface) are poll-lag-free evidence events are flowing now.
+  const live = debugSessionLive({
+    status,
+    streamPhase: streamHealth.phase,
+    serverRunDone: streamStatus ? streamStatus.done : null,
+  });
   const [eventQuery, setEventQuery] = useState("");
   const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
   const { announce } = useAnnouncer();
   // Tail-follow only makes sense while events are streaming in; opening a
   // finished session shouldn't jump past the Session section.
-  const [follow, setFollow] = useState(status === "running");
+  const [follow, setFollow] = useState(live);
   const cursorRef = useRef(cachedSnapshot?.cursor ?? 0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -491,40 +497,36 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
     void fetchStreamStatus();
   }, [fetchStreamStatus]);
 
-  // Live tail while the session is running and the tab is visible.
+  // Live tail while the session is live and the tab is visible.
   useEffect(() => {
-    if (status !== "running") return;
+    if (!live) return;
     const id = window.setInterval(() => {
-      if (shouldPollEvents({ status, visible: document.visibilityState === "visible" })) {
+      if (shouldPollEvents({ live, visible: document.visibilityState === "visible" })) {
         void fetchEvents();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchEvents, status]);
+  }, [fetchEvents, live]);
   useEffect(() => {
-    if (!streamStatusActive) return;
+    if (!live) return;
     const id = window.setInterval(() => {
       if (document.visibilityState === "visible") {
         void fetchStreamStatus();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchStreamStatus, streamStatusActive]);
+  }, [fetchStreamStatus, live]);
 
-  // One-shot catch-up when the session leaves "running", so events emitted in
-  // the final poll window aren't dropped.
-  const prevStatusRef = useRef(status);
+  // One-shot catch-up when liveness ends, so events and buffer state emitted
+  // in the final poll window aren't dropped.
+  const prevLiveRef = useRef(live);
   useEffect(() => {
-    if (prevStatusRef.current === "running" && status !== "running") void fetchEvents();
-    prevStatusRef.current = status;
-  }, [fetchEvents, status]);
-  const prevStreamStatusActiveRef = useRef(streamStatusActive);
-  useEffect(() => {
-    if (prevStreamStatusActiveRef.current && !streamStatusActive) {
+    if (prevLiveRef.current && !live) {
+      void fetchEvents();
       void fetchStreamStatus();
     }
-    prevStreamStatusActiveRef.current = streamStatusActive;
-  }, [fetchStreamStatus, streamStatusActive]);
+    prevLiveRef.current = live;
+  }, [fetchEvents, fetchStreamStatus, live]);
 
   // Auto-follow: stick to the bottom while new events stream in; scrolling
   // up pauses, the pill below resumes.
@@ -635,7 +637,7 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
 
         <Section
           title="Stream health"
-          defaultOpen={streamStatusActive || streamSummary.tone !== "healthy"}
+          defaultOpen={live || streamSummary.tone !== "healthy"}
         >
           <KVRow k="overall">
             <span className="inline-flex items-center gap-1.5">

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   appendEvents,
   nextAfterSeq,
+  debugSessionLive,
   shouldPollEvents,
   formatEventPayload,
   buildDebugBundle,
@@ -38,11 +39,35 @@ assert.deepEqual(
 assert.equal(nextAfterSeq([]), 0);
 assert.equal(nextAfterSeq([ev(1), ev(7)]), 7);
 
-// shouldPollEvents: only while running and visible
-assert.equal(shouldPollEvents({ status: "running", visible: true }), true);
-assert.equal(shouldPollEvents({ status: "running", visible: false }), false);
-assert.equal(shouldPollEvents({ status: "completed", visible: true }), false);
-assert.equal(shouldPollEvents({ status: null, visible: true }), false);
+// debugSessionLive: any one of three signals is evidence events are flowing.
+const cold = { status: null, streamPhase: "idle", serverRunDone: null };
+assert.equal(debugSessionLive(cold), false, "no signals => not live");
+assert.equal(debugSessionLive({ ...cold, status: "running" }), true, "polled row says running");
+assert.equal(debugSessionLive({ ...cold, status: "completed" }), false);
+assert.equal(debugSessionLive({ ...cold, status: "failed" }), false);
+for (const streamPhase of ["connecting", "streaming", "resuming"]) {
+  assert.equal(
+    debugSessionLive({ ...cold, streamPhase }),
+    true,
+    `own transport mid-run (${streamPhase}) is live even with no session row`,
+  );
+}
+for (const streamPhase of ["idle", "settled", "degraded", "stopped"]) {
+  assert.equal(debugSessionLive({ ...cold, streamPhase }), false, `${streamPhase} is not live`);
+}
+assert.equal(
+  debugSessionLive({ ...cold, serverRunDone: false }),
+  true,
+  "open server run buffer is live — covers runs driven from another surface",
+);
+assert.equal(debugSessionLive({ ...cold, serverRunDone: true }), false, "finished buffer");
+assert.equal(debugSessionLive({ ...cold, serverRunDone: null }), false, "no buffer is unknown");
+
+// shouldPollEvents: only while live and visible
+assert.equal(shouldPollEvents({ live: true, visible: true }), true);
+assert.equal(shouldPollEvents({ live: true, visible: false }), false);
+assert.equal(shouldPollEvents({ live: false, visible: true }), false);
+assert.equal(shouldPollEvents({ live: false, visible: false }), false);
 
 // filterEvents: case-insensitive over kind + raw payload; reference-stable when blank
 import { filterEvents } from "./session-debug.ts";

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -2,7 +2,11 @@ import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
 import { usageSummary, type TurnUsage } from "./usage-format.ts";
 import { stripPreviewOnlyAttachmentFields, type ChatAttachment } from "./chat-attachments.ts";
-import type { ChatStreamClientHealth, RunBufferStatus } from "./chat-stream-health.ts";
+import type {
+  ChatStreamClientHealth,
+  ChatStreamPhase,
+  RunBufferStatus,
+} from "./chat-stream-health.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -107,8 +111,35 @@ export function nextAfterSeq(events: CovenEvent[]): number {
   return events.reduce((max, e) => (e.seq > max ? e.seq : max), 0);
 }
 
-export function shouldPollEvents(args: { status: string | null; visible: boolean }): boolean {
-  return args.status === "running" && args.visible;
+/** Poll-lag-free session liveness for the debug pane. The sessions-list row
+ *  is polled and can be absent entirely (pre-promotion chats, list lag), so
+ *  `status === "running"` alone starts the live tail late or never. Any of
+ *  three independent signals counts as evidence events are flowing now:
+ *  - the polled row says the session is running (works for external writers
+ *    once the list catches up);
+ *  - this pane's own stream transport is mid-run (connecting/streaming/
+ *    resuming — instant, no poll lag);
+ *  - the server run buffer for this session is still open
+ *    (`RunBufferStatus.done === false` from /api/chat/stream/status, which is
+ *    dual-keyed by conversation id — daemon-side truth even when another
+ *    surface drives the run). `null` means unknown/no buffer and is not
+ *    evidence either way. */
+export function debugSessionLive(args: {
+  status: string | null;
+  streamPhase: ChatStreamPhase;
+  serverRunDone: boolean | null;
+}): boolean {
+  return (
+    args.status === "running" ||
+    args.streamPhase === "connecting" ||
+    args.streamPhase === "streaming" ||
+    args.streamPhase === "resuming" ||
+    args.serverRunDone === false
+  );
+}
+
+export function shouldPollEvents(args: { live: boolean; visible: boolean }): boolean {
+  return args.live && args.visible;
 }
 
 /** Snapshot of one pane's fetched event tail, kept across modal close/reopen. */


### PR DESCRIPTION
## Problem (A3 from the chat-session-debugging audit)

DebugPane's events live-tail polls only while `session?.status === "running"`, where `session` is the chat-router row from the **polled** sessions list:

- **No row** (pre-promotion chats, list lag) → `status === null` → the live tail **never starts**, even while events stream in.
- **Poll lag** → the tail starts late, and the one-shot catch-up on running→finished fires late.
- A run driven **from another surface** (CLI, second tab) shows a stale tail until reopen.

## Fix

New pure `debugSessionLive({status, streamPhase, serverRunDone})` in `session-debug.ts` — live when **any** of three independent signals says events are flowing:

1. the polled row says `running` (existing signal);
2. the pane's **own stream transport** is `connecting`/`streaming`/`resuming` — instant, no poll lag;
3. the **server run buffer is open** — `RunBufferStatus.done === false` from `GET /api/chat/stream/status`, which is dual-keyed by conversation id (`openRunBuffer(keys)`), so it's daemon-side truth even when another surface drives the run. `null` (no buffer) is not evidence either way.

Pane wiring:
- both pollers (events tail + stream status) gate on the combined `live` flag;
- the two live→terminal catch-up transitions merge into one effect refreshing both (final-window events aren't dropped);
- tail-follow seeds from `live`; Stream health section defaults open while `live`;
- `shouldPollEvents` now takes `{live, visible}`.

Termination is server-truth-driven: when the run finishes, `done: true` arrives, `live` flips, one final catch-up fires, polling stops. `live` derives from the `done` boolean, so per-poll object churn doesn't restart intervals.

## Tests

- `session-debug.test.ts`: behavioral truth table for `debugSessionLive` (each signal independently, all-cold, non-live phases) + `shouldPollEvents` combinations.
- `debug-pane.test.ts`: pins for the liveness computation, both poller gates, merged transition, and follow seeding.

## Verification

- `node --test` on session-debug/debug-pane/chat-debug-store/chat-stream-health: pass
- `pnpm typecheck`: clean
- `pnpm test:app`: 851 files green

Bead: cave-tvzi. Goal: chat-session-debugging (slice A3).