### PR TITLE
fix(debug): events tail self-detects liveness under a lagged or absent sessions-list row (cave-386l, A3)

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -281,7 +281,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const streamStatusActive =\s*status === "running" \|\|\s*streamHealth\.phase === "connecting" \|\|\s*streamHealth\.phase === "streaming" \|\|\s*streamHealth\.phase === "resuming"/,
+  /const streamPhaseActive =\s*streamPhase === "connecting" \|\| streamPhase === "streaming" \|\| streamPhase === "resuming";\s*const streamStatusActive = status === "running" \|\| streamPhaseActive/,
   "Server status activity must include authoritative connecting, streaming, and resuming client phases",
 );
 assert.match(
@@ -293,6 +293,38 @@ assert.match(
   source,
   /prevStreamStatusActiveRef\.current && !streamStatusActive[\s\S]*?fetchStreamStatus\(\)[\s\S]*?prevStreamStatusActiveRef\.current = streamStatusActive/,
   "A combined client/server active-to-terminal transition triggers one final server-status refresh",
+);
+
+// ── A3: the events tail self-detects liveness under a lagged/absent row ─────
+assert.match(
+  source,
+  /const tailMayRun = status === "running" \|\| streamPhaseActive \|\| \(status === null && !probeExpired\);/,
+  "A3: the tail timer runs on a running row, this pane's active transport phase, or an open statusless probe — never solely on the polled row",
+);
+assert.match(
+  source,
+  /if \(!eventsTailActive\(signals\)\) \{[\s\S]*?setProbeExpired\(true\);[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(shouldPollEvents\(\{ \.\.\.signals, visible: document\.visibilityState === "visible" \}\)\)/,
+  "A3: each tick re-evaluates the pure liveness gate — an expired statusless probe stops the timer instead of polling forever",
+);
+assert.match(
+  source,
+  /const newest = latestEventTimestampMs\(incoming\);[\s\S]*?lastEventAtRef\.current = newest;[\s\S]*?setProbeExpired\(false\);/,
+  "A3: drains anchor liveness on daemon event timestamps and re-open an expired probe when fresh events surface (manual Retry resumes the tail)",
+);
+assert.match(
+  source,
+  /const lastEventAtRef = useRef<number \| null>\(\s*cachedSnapshot \? latestEventTimestampMs\(cachedSnapshot\.events\) : null,?\s*\)/,
+  "A3: the probe anchor seeds from the cached tail so reopening an old statusless session doesn't fake 15s of liveness",
+);
+assert.match(
+  source,
+  /const \[follow, setFollow\] = useState\(status === "running" \|\| streamPhaseActive\)/,
+  "A3: tail-follow starts for a just-sent run even while the polled row still reports the old status",
+);
+assert.match(
+  source,
+  /prevStreamPhaseActiveRef\.current && !streamPhaseActive[\s\S]*?fetchEvents\(\)[\s\S]*?prevStreamPhaseActiveRef\.current = streamPhaseActive/,
+  "A3: settling this pane's own run triggers the one-shot events catch-up — the row transition never fires when the list lags",
 );
 assert.match(
   source,

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -19,9 +19,11 @@ import {
   appendEvents,
   buildDebugBundle,
   debugFileName,
+  eventsTailActive,
   exportDebugTurn,
   filterEvents,
   formatEventPayload,
+  latestEventTimestampMs,
   nextAfterSeq,
   readDebugEventsCache,
   shouldPollEvents,
@@ -288,11 +290,10 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const dtPrefs = useDateTimePrefs();
   const cwd = formatRuntime(session?.runtime);
   const streamSummary = useMemo(() => streamHealthSummary(streamHealth), [streamHealth]);
-  const streamStatusActive =
-    status === "running" ||
-    streamHealth.phase === "connecting" ||
-    streamHealth.phase === "streaming" ||
-    streamHealth.phase === "resuming";
+  const streamPhase = streamHealth.phase;
+  const streamPhaseActive =
+    streamPhase === "connecting" || streamPhase === "streaming" || streamPhase === "resuming";
+  const streamStatusActive = status === "running" || streamPhaseActive;
   const lastEventLabel = streamHealth.lastEventAt
     ? formatTimestamp(streamHealth.lastEventAt, dtPrefs) || streamHealth.lastEventAt
     : "—";
@@ -312,10 +313,25 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
   const visibleEvents = useMemo(() => filterEvents(events, eventQuery), [events, eventQuery]);
   const { announce } = useAnnouncer();
   // Tail-follow only makes sense while events are streaming in; opening a
-  // finished session shouldn't jump past the Session section.
-  const [follow, setFollow] = useState(status === "running");
+  // finished session shouldn't jump past the Session section. The pane's own
+  // transport phase counts alongside the polled row (A3): a just-sent run
+  // should follow even while the sessions list still reports the old status.
+  const [follow, setFollow] = useState(status === "running" || streamPhaseActive);
   const cursorRef = useRef(cachedSnapshot?.cursor ?? 0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // A3 liveness signals: the polled sessions list can lag a poll cycle or lack
+  // a row entirely (null status), so the tail self-detects. The probe anchor
+  // is the newest daemon event seen (seeded from the cached tail), falling
+  // back to the mount time before the first drain returns anything.
+  const probedAtRef = useRef(Date.now());
+  const lastEventAtRef = useRef<number | null>(
+    cachedSnapshot ? latestEventTimestampMs(cachedSnapshot.events) : null,
+  );
+  // Flips true when the statusless activity window closes, stopping the poll
+  // timer; fresh events (a reappearing run, a manual Retry that finds new
+  // ones) re-open it from fetchEvents.
+  const [probeExpired, setProbeExpired] = useState(false);
 
   const fetchInFlightRef = useRef(false);
   const streamStatusInFlightRef = useRef(false);
@@ -402,6 +418,14 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
         const incoming = json.events ?? [];
         setEvents((prev) => appendEvents(prev, incoming));
         cursorRef.current = Math.max(cursorRef.current, nextAfterSeq(incoming));
+        // Advance the liveness anchor on daemon truth (event timestamps, not
+        // arrival time) and re-open the statusless probe — a Retry that finds
+        // fresh events resumes the live tail.
+        const newest = latestEventTimestampMs(incoming);
+        if (newest !== null && (lastEventAtRef.current === null || newest > lastEventAtRef.current)) {
+          lastEventAtRef.current = newest;
+          setProbeExpired(false);
+        }
         lastPageFull = incoming.length >= 200;
         if (!lastPageFull) break;
       }
@@ -491,16 +515,33 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
     void fetchStreamStatus();
   }, [fetchStreamStatus]);
 
-  // Live tail while the session is running and the tab is visible.
+  // Live tail while the session is demonstrably live and the tab is visible.
+  // The polled row status is only a hint (A3): this pane's transport phase
+  // covers post-send row lag, and a statusless row (absent from the polled
+  // list) gets a bounded activity probe — eventsTailActive owns the policy.
+  const tailMayRun = status === "running" || streamPhaseActive || (status === null && !probeExpired);
   useEffect(() => {
-    if (status !== "running") return;
+    if (!tailMayRun) return;
     const id = window.setInterval(() => {
-      if (shouldPollEvents({ status, visible: document.visibilityState === "visible" })) {
+      const signals = {
+        status,
+        streamPhase,
+        lastEventAt: lastEventAtRef.current,
+        probedAt: probedAtRef.current,
+        now: Date.now(),
+      };
+      if (!eventsTailActive(signals)) {
+        // Statusless probe went quiet — stop the timer; fetchEvents re-opens
+        // it when fresh events surface.
+        setProbeExpired(true);
+        return;
+      }
+      if (shouldPollEvents({ ...signals, visible: document.visibilityState === "visible" })) {
         void fetchEvents();
       }
     }, POLL_MS);
     return () => window.clearInterval(id);
-  }, [fetchEvents, status]);
+  }, [fetchEvents, status, streamPhase, tailMayRun]);
   useEffect(() => {
     if (!streamStatusActive) return;
     const id = window.setInterval(() => {
@@ -518,6 +559,14 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
     if (prevStatusRef.current === "running" && status !== "running") void fetchEvents();
     prevStatusRef.current = status;
   }, [fetchEvents, status]);
+  // Mirror catch-up when this pane's own run settles — the row can still say
+  // "completed" from before the send (A3), so the status transition above
+  // never fires for it.
+  const prevStreamPhaseActiveRef = useRef(streamPhaseActive);
+  useEffect(() => {
+    if (prevStreamPhaseActiveRef.current && !streamPhaseActive) void fetchEvents();
+    prevStreamPhaseActiveRef.current = streamPhaseActive;
+  }, [fetchEvents, streamPhaseActive]);
   const prevStreamStatusActiveRef = useRef(streamStatusActive);
   useEffect(() => {
     if (prevStreamStatusActiveRef.current && !streamStatusActive) {

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -38,11 +38,111 @@ assert.deepEqual(
 assert.equal(nextAfterSeq([]), 0);
 assert.equal(nextAfterSeq([ev(1), ev(7)]), 7);
 
-// shouldPollEvents: only while running and visible
-assert.equal(shouldPollEvents({ status: "running", visible: true }), true);
-assert.equal(shouldPollEvents({ status: "running", visible: false }), false);
-assert.equal(shouldPollEvents({ status: "completed", visible: true }), false);
-assert.equal(shouldPollEvents({ status: null, visible: true }), false);
+// eventsTailActive / shouldPollEvents (A3): the polled row is only a hint —
+// transport phase and observed daemon events keep the tail truthful when the
+// sessions list lags or has no row.
+import { eventsTailActive, latestEventTimestampMs, EVENTS_ACTIVITY_WINDOW_MS } from "./session-debug.ts";
+{
+  const idle = { streamPhase: "idle", lastEventAt: null, probedAt: 0, now: 0 };
+
+  // Running row is definitive, regardless of phase or event recency.
+  assert.equal(
+    eventsTailActive({ ...idle, status: "running", now: 9_999_999 }),
+    true,
+    "running row → active even with no recent events",
+  );
+
+  // The pane's own transport phase wins over a stale settled row — the list
+  // can still say "completed" from before this pane started a fresh run.
+  for (const streamPhase of ["connecting", "streaming", "resuming"]) {
+    assert.equal(
+      eventsTailActive({ ...idle, status: "completed", streamPhase, now: 9_999_999 }),
+      true,
+      `active transport phase (${streamPhase}) overrides a settled row`,
+    );
+  }
+  assert.equal(
+    eventsTailActive({ ...idle, status: "completed" }),
+    false,
+    "settled row with an idle transport → no polling",
+  );
+  for (const streamPhase of ["settled", "degraded", "stopped", "idle"]) {
+    assert.equal(
+      eventsTailActive({ ...idle, status: "failed", streamPhase }),
+      false,
+      `inactive phase (${streamPhase}) does not keep a settled row polling`,
+    );
+  }
+
+  // Statusless row (absent from the polled list): bounded activity probe.
+  assert.equal(
+    eventsTailActive({ ...idle, status: null, probedAt: 1_000, now: 1_000 }),
+    true,
+    "statusless session polls from mount (probe window open)",
+  );
+  assert.equal(
+    eventsTailActive({
+      ...idle,
+      status: null,
+      probedAt: 1_000,
+      now: 1_000 + EVENTS_ACTIVITY_WINDOW_MS,
+    }),
+    false,
+    "probe window is strict: exactly window-old anchor stops the tail",
+  );
+  assert.equal(
+    eventsTailActive({ ...idle, status: null, lastEventAt: 5_000, probedAt: 0, now: 6_000 }),
+    true,
+    "recent daemon events keep a statusless tail alive",
+  );
+  assert.equal(
+    eventsTailActive({
+      ...idle,
+      status: null,
+      lastEventAt: 1_000,
+      probedAt: 100_000,
+      now: 100_000,
+    }),
+    false,
+    "an old cached tail closes the probe immediately — stale events beat a fresh mount",
+  );
+}
+
+// shouldPollEvents: visibility gates on top of the liveness signals
+const pollBase = { streamPhase: "idle", lastEventAt: null, probedAt: 0, now: 0 };
+assert.equal(shouldPollEvents({ ...pollBase, status: "running", visible: true }), true);
+assert.equal(shouldPollEvents({ ...pollBase, status: "running", visible: false }), false);
+assert.equal(shouldPollEvents({ ...pollBase, status: "completed", visible: true }), false);
+assert.equal(
+  shouldPollEvents({ ...pollBase, status: null, visible: true }),
+  true,
+  "statusless session polls within the probe window (was: never started)",
+);
+
+// latestEventTimestampMs: daemon-truth anchor for the statusless probe
+assert.equal(latestEventTimestampMs([]), null);
+assert.equal(
+  latestEventTimestampMs([
+    { ...ev(1), created_at: "2026-06-10T00:00:00Z" },
+    { ...ev(2), created_at: "2026-06-10T00:00:05Z" },
+    { ...ev(3), created_at: "2026-06-10T00:00:01Z" },
+  ]),
+  Date.parse("2026-06-10T00:00:05Z"),
+  "newest parseable created_at wins, regardless of order",
+);
+assert.equal(
+  latestEventTimestampMs([{ ...ev(1), created_at: "not a date" }]),
+  null,
+  "unparseable timestamps are skipped, not NaN-poisoned",
+);
+assert.equal(
+  latestEventTimestampMs([
+    { ...ev(1), created_at: "garbage" },
+    { ...ev(2), created_at: "2026-06-10T00:00:05Z" },
+  ]),
+  Date.parse("2026-06-10T00:00:05Z"),
+  "mixed tails use the parseable entries",
+);
 
 // filterEvents: case-insensitive over kind + raw payload; reference-stable when blank
 import { filterEvents } from "./session-debug.ts";

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -2,7 +2,11 @@ import type { SessionRow } from "./types.ts";
 import { stripAnsi } from "./ansi.ts";
 import { usageSummary, type TurnUsage } from "./usage-format.ts";
 import { stripPreviewOnlyAttachmentFields, type ChatAttachment } from "./chat-attachments.ts";
-import type { ChatStreamClientHealth, RunBufferStatus } from "./chat-stream-health.ts";
+import type {
+  ChatStreamClientHealth,
+  ChatStreamPhase,
+  RunBufferStatus,
+} from "./chat-stream-health.ts";
 
 /** Raw daemon event as returned by GET /api/sessions/[id]/events.
  *  Mirrors the shape in src/app/api/sessions/[id]/events/route.ts. */
@@ -107,8 +111,62 @@ export function nextAfterSeq(events: CovenEvent[]): number {
   return events.reduce((max, e) => (e.seq > max ? e.seq : max), 0);
 }
 
-export function shouldPollEvents(args: { status: string | null; visible: boolean }): boolean {
-  return args.status === "running" && args.visible;
+/** How long the statusless activity probe keeps the tail polling past the
+ *  last evidence of liveness (newest daemon event, or the probe start). */
+export const EVENTS_ACTIVITY_WINDOW_MS = 15_000;
+
+/** Liveness signals for the live event tail. The polled sessions list can lag
+ *  reality by a poll cycle or lack a row for the session entirely (pre-listing
+ *  runs, sessions opened from outside the polled view) — so the row status is
+ *  only one hint among three. */
+export type EventsTailSignals = {
+  /** Polled sessions-list status; null when the session has no row. */
+  status: string | null;
+  /** The owning pane's live transport phase — leads the polled row when this
+   *  pane itself is streaming (a fresh run on a row still marked settled). */
+  streamPhase: ChatStreamPhase;
+  /** Newest daemon event timestamp observed so far (epoch ms), null before
+   *  any drain returned a parseable event. */
+  lastEventAt: number | null;
+  /** When the statusless probe started (pane mount), epoch ms. */
+  probedAt: number;
+  now: number;
+};
+
+/** Whether the live event tail should keep polling (A3). A running row or an
+ *  active transport phase is definitive. A settled row is trusted — no
+ *  polling. A statusless row gets a bounded activity probe instead of never
+ *  starting: poll while the newest observed event (falling back to the probe
+ *  start before the first drain) is within {@link EVENTS_ACTIVITY_WINDOW_MS};
+ *  an old cached tail closes the window immediately. */
+export function eventsTailActive(signals: EventsTailSignals): boolean {
+  if (signals.status === "running") return true;
+  if (
+    signals.streamPhase === "connecting" ||
+    signals.streamPhase === "streaming" ||
+    signals.streamPhase === "resuming"
+  ) {
+    return true;
+  }
+  if (signals.status !== null) return false;
+  const anchor = signals.lastEventAt ?? signals.probedAt;
+  return signals.now - anchor < EVENTS_ACTIVITY_WINDOW_MS;
+}
+
+export function shouldPollEvents(args: EventsTailSignals & { visible: boolean }): boolean {
+  return args.visible && eventsTailActive(args);
+}
+
+/** Newest parseable `created_at` among events, as epoch ms; null when none
+ *  parse. Anchors the statusless activity probe on daemon truth so draining
+ *  an old finished tail doesn't read as live activity. */
+export function latestEventTimestampMs(events: CovenEvent[]): number | null {
+  let max: number | null = null;
+  for (const event of events) {
+    const t = Date.parse(event.created_at);
+    if (!Number.isNaN(t) && (max === null || t > max)) max = t;
+  }
+  return max;
 }
 
 /** Snapshot of one pane's fetched event tail, kept across modal close/reopen. */


### PR DESCRIPTION
## What

Closes the A3 gap from the chat-session-debugging audit: the debug pane's live event tail was gated **solely** on the polled sessions list's row status (`session?.status`), which lags reality by a poll cycle and can lack a row for the session entirely. Consequences:

- **No row → the live tail never started** (pre-listing runs, sessions opened from outside the polled view).
- **Post-send lag**: a fresh run on a row still marked `completed` only started tailing after the next sessions-list poll.

## How

New pure gate `eventsTailActive(signals)` in `src/lib/session-debug.ts` — the polled row becomes one hint among three:

1. **Running row** — definitive, as before.
2. **This pane's transport phase** (`connecting`/`streaming`/`resuming`) — starts the tail immediately after a send, ahead of the lagged list; its settling now fires the same one-shot final-events catch-up the row transition already had. Tail-follow's initial state honors it too.
3. **Statusless row → bounded activity probe** anchored on the newest daemon event timestamp (`latestEventTimestampMs`, seeded from the A2 cached tail, falling back to pane mount). Live sessions keep extending the window; draining an old finished tail closes it immediately; a quiet probe stops the poll timer (`probeExpired`) instead of ticking forever. Fresh events surfacing later — including via the manual **Retry** — re-open it.

## Testing

- Behavioral tests for `eventsTailActive` precedence (phase beats a stale settled row; settled row with idle transport never polls; probe window boundary is strict) and `latestEventTimestampMs` (order-independent max, unparseable timestamps skipped).
- Source pins for the pane wiring: composite timer gate, per-tick pure-gate re-evaluation + expiry flip, daemon-truth anchor stamping + probe re-open in `fetchEvents`, cache-seeded anchor, follow seed, phase-settle catch-up.
- `pnpm test:app` 851 files green; `pnpm typecheck` clean.

Known bounded residual (recorded in bead cave-386l): a *statusless* session whose tab stays hidden past the 15s window stops probing until Retry or a reappearing row — the row normally appears within one poll cycle, so this is an edge of an edge.

Bead: cave-386l (goal chat-session-debugging, backlog item A3).