### PR TITLE
perf(debug-pane): render-virtualize the event tail

### DIFF
--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./debug-pane.tsx", import.meta.url), "utf8");
+// globals.css is a stable entry stub — the render-virtualization rules live in
+// the split module sheets, so the containment pin reads primitives.css.
+const primitivesCss = await readFile(
+  new URL("../styles/globals/primitives.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -670,6 +676,36 @@ assert.match(
   changesRoute,
   /could not create safety checkpoint, revert aborted/,
   "A failed safety checkpoint must abort the revert rather than destroy without a backup",
+);
+
+// ── C2: render-virtualized event tail ────────────────────────────────────────
+// EventRow is memoized so the 2s live-tail append (appendEvents keeps existing
+// item references stable) re-renders only new rows, not the whole tail.
+assert.match(
+  source,
+  /const EventRow = memo\(function EventRow\(/,
+  "EventRow must be memoized so live-tail appends only render new rows",
+);
+assert.match(
+  source,
+  /className="debug-event-row rounded-md border/,
+  "Event rows must carry the debug-event-row containment class",
+);
+assert.match(
+  source,
+  /<EventRow key=\{event\.seq\} event=\{event\} dtPrefs=\{dtPrefs\} \/>/,
+  "Clock prefs must be threaded into memoized rows so a prefs change re-renders them",
+);
+assert.match(
+  source,
+  /formatClock\(event\.created_at, dtPrefs, \{ seconds: true \}\)/,
+  "Event clocks must format with the live prefs prop, not the one-shot default",
+);
+// The class must actually virtualize: containment rules live in primitives.css.
+assert.match(
+  primitivesCss,
+  /\.debug-event-row\s*\{[^}]*content-visibility:\s*auto;[^}]*contain-intrinsic-size:\s*auto\s+\d+px;[^}]*\}/,
+  "primitives.css must give .debug-event-row content-visibility containment",
 );
 
 console.log("debug-pane.test.ts: ok");

--- a/src/components/debug-pane.tsx
+++ b/src/components/debug-pane.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
-import { formatClock, formatTimestamp, useDateTimePrefs } from "@/lib/datetime-format";
+import { formatClock, formatTimestamp, useDateTimePrefs, type DateTimePrefs } from "@/lib/datetime-format";
 import { formatRuntime } from "@/lib/chat-response-metadata";
 import { usageBreakdown } from "@/lib/usage-format";
 import { APP_VERSION } from "@/lib/app-version";
@@ -246,10 +246,15 @@ function TurnRow({ index, turn }: { index: number; turn: DebugTurn }) {
   );
 }
 
-function EventRow({ event }: { event: CovenEvent }) {
+// Memoized: the 2s live-tail append changes only the tail of visibleEvents
+// (appendEvents keeps existing item references stable), so a 10k-event session
+// re-renders just the new rows, not every row per poll. Off-screen rows skip
+// layout/paint via .debug-event-row containment (C2). Clock prefs come in as a
+// prop so a prefs change still re-renders memoized rows.
+const EventRow = memo(function EventRow({ event, dtPrefs }: { event: CovenEvent; dtPrefs: DateTimePrefs }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="rounded-md border border-[var(--border-hairline)]">
+    <div className="debug-event-row rounded-md border border-[var(--border-hairline)]">
       <button
         type="button"
         className="focus-ring flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[length:var(--text-2xs)]"
@@ -259,7 +264,7 @@ function EventRow({ event }: { event: CovenEvent }) {
         <span className="w-10 shrink-0 font-mono text-[var(--text-muted)]">{event.seq}</span>
         <span className="min-w-0 flex-1 truncate font-medium text-[var(--text-secondary)]">{event.kind}</span>
         <span className="shrink-0 font-mono text-[var(--text-muted)]">
-          {formatClock(event.created_at, undefined, { seconds: true })}
+          {formatClock(event.created_at, dtPrefs, { seconds: true })}
         </span>
       </button>
       {open ? (
@@ -272,7 +277,7 @@ function EventRow({ event }: { event: CovenEvent }) {
       ) : null}
     </div>
   );
-}
+});
 
 // ── Pane ──────────────────────────────────────────────────────────────────────
 
@@ -774,7 +779,7 @@ function DebugPaneInner({ paneKey, snapshot }: { paneKey: string; snapshot: Debu
           ) : (
             <div className="flex flex-col gap-1">
               {visibleEvents.map((event) => (
-                <EventRow key={event.seq} event={event} />
+                <EventRow key={event.seq} event={event} dtPrefs={dtPrefs} />
               ))}
             </div>
           )}

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -1451,6 +1451,19 @@ html[data-backdrop-on] .glass-overlay {
   content-visibility: auto;
   contain-intrinsic-size: auto 32px;
 }
+/* Debug pane: render-virtualize off-screen event rows (same content-visibility
+   strategy as chat turns and projects rows). A 10k-event session otherwise
+   lays out and paints every row on each 2s live-tail append. The row's only
+   descendants are its toggle button and the inline expanded JSON block — no
+   fixed/portaled children — so layout/paint containment is safe. The auto
+   intrinsic-size caches each row's real height after first paint (collapsed
+   ~30px, expanded rows keep their measured height), so follow-scroll and the
+   resume pill never jump. Rows stay in the DOM (vs JS windowing), preserving
+   the S4 filter, find-in-page, and the aria-expanded toggles. */
+.debug-event-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 30px;
+}
 .ui-popover-body {
   padding: 6px;
 }


### PR DESCRIPTION
Goal **chat-session-debugging**, slice **C2** (bead `cave-xp1s`).

## Problem
A long-lived session's debug modal holds thousands of event rows; every 2s live-tail append re-lays-out and repaints all of them, and every poll re-renders every `EventRow`.

## Change
Same content-visibility strategy already proven on chat turns (`.cave-linear-turn`) and projects rows (`.projects-session-row`):

- **`.debug-event-row`** in `primitives.css`: `content-visibility: auto; contain-intrinsic-size: auto 30px;` — off-screen rows skip layout/paint; auto intrinsic-size caches measured heights (collapsed ~30px, expanded rows keep theirs) so follow-scroll never jumps. Rows stay in the DOM: the kind-filter, find-in-page, and `aria-expanded` toggles all keep working. Containment is safe — rows have no fixed/portaled descendants (CopyButton + JsonBlock are inline).
- **`memo(EventRow)`**: `appendEvents` keeps existing item references stable, so per-poll re-renders now touch only the new rows. Clock prefs thread in as a `dtPrefs` prop (stable `useSyncExternalStore` snapshot), so a 12h/24h prefs change still re-renders memoized rows — this also resolves the **events-clock prefs** backlog item.

## Tests
Pins in `debug-pane.test.ts`: memo wrapper, containment class on the row, prefs-prop threading, and the `primitives.css` rule (readFile pattern mirrors `projects-view.test.ts`).

## Verification
- targeted: `debug-pane.test.ts`, `session-debug.test.ts`, `projects-view.test.ts` ✓
- `pnpm typecheck` ✓
- `pnpm test:app` — 851 files ✓