### PR TITLE
fix(server): canonicalize nonexistent allow-list candidates via nearest existing ancestor (cave-s2l8)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1088,6 +1088,7 @@ export const SUITES = {
     "src/app/api/sessions/[id]/events/route.test.ts",
     "src/app/api/sessions/prune/prune-response.test.ts",
     "src/lib/server/familiar-contract-files.test.ts",
+    "src/lib/server/canonical-path.test.ts",
     "src/lib/server/project-paths.test.ts",
     "src/lib/server/home-browse.test.ts",
     "src/lib/server/session-project-roots.test.ts",

--- a/src/lib/server/canonical-path.test.ts
+++ b/src/lib/server/canonical-path.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+// Behavioral tests for realpathOrResolve (cave-s2l8): allow-list containment
+// compares candidates against realpathed roots, so nonexistent candidates must
+// canonicalize through their nearest existing ancestor — not fall back to a
+// lexical resolve that diverges under symlinked ancestors (macOS /var ->
+// /private/var tmpdir being the CI-visible case). Symlinks are created
+// explicitly so the behavior is deterministic on every platform ("junction"
+// works unprivileged on Windows and is ignored on POSIX).
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { realpathOrResolve } from "./canonical-path.ts";
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), "canonical-path-"));
+
+try {
+  const real = path.join(tmp, "real");
+  const outside = path.join(tmp, "outside");
+  mkdirSync(path.join(real, "sub"), { recursive: true });
+  mkdirSync(outside, { recursive: true });
+  const link = path.join(tmp, "link");
+  symlinkSync(real, link, "junction");
+  const canonicalReal = realpathSync(real);
+  const canonicalOutside = realpathSync(outside);
+
+  // Existing path through a symlink: plain realpath behavior.
+  assert.equal(
+    realpathOrResolve(path.join(link, "sub")),
+    path.join(canonicalReal, "sub"),
+    "existing path canonicalizes through the symlinked ancestor",
+  );
+
+  // THE bug: a nonexistent tail under an existing (symlinked) directory must
+  // land in the same canonical namespace as a realpathed allow-list root.
+  assert.equal(
+    realpathOrResolve(path.join(link, "sub", "missing")),
+    path.join(canonicalReal, "sub", "missing"),
+    "one missing segment canonicalizes the ancestor and re-appends the tail",
+  );
+  assert.equal(
+    realpathOrResolve(path.join(link, "nope", "deeper", "still")),
+    path.join(canonicalReal, "nope", "deeper", "still"),
+    "multiple missing segments are preserved in order",
+  );
+
+  // Lexical `..` collapse happens before canonicalization (path.resolve
+  // semantics, matching the previous fallback).
+  assert.equal(
+    realpathOrResolve(path.join(link, "sub", "..", "missing")),
+    path.join(canonicalReal, "missing"),
+    "dot-dot segments collapse lexically before ancestor resolution",
+  );
+
+  // Security tightening: a missing tail under a symlink that ESCAPES the root
+  // must surface the escape (the old lexical fallback kept the candidate
+  // looking contained).
+  symlinkSync(outside, path.join(real, "escape"), "junction");
+  assert.equal(
+    realpathOrResolve(path.join(real, "escape", "missing")),
+    path.join(canonicalOutside, "missing"),
+    "missing tail under an escaping symlink canonicalizes out of the root",
+  );
+
+  // Nothing beneath an existing, non-symlinked dir changes shape.
+  assert.equal(
+    realpathOrResolve(path.join(canonicalReal, "plain-missing")),
+    path.join(canonicalReal, "plain-missing"),
+    "already-canonical prefixes are stable",
+  );
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log("canonical-path.test.ts: ok");

--- a/src/lib/server/canonical-path.ts
+++ b/src/lib/server/canonical-path.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Canonicalize a path through the filesystem even when it does not (fully)
+ * exist, for allow-list containment checks.
+ *
+ * `fs.realpathSync` throws on nonexistent paths, and a plain lexical
+ * `path.resolve` fallback diverges from realpathed allow-list roots whenever
+ * an ancestor is a symlink. Concretely: on macOS `os.tmpdir()` lives under
+ * `/var -> /private/var`, so a root canonicalizes to `/private/var/...` while
+ * a nonexistent candidate beneath it lexically resolves to `/var/...` and
+ * containment fails (403 instead of the intended 404). The lexical fallback
+ * was also laxer than realpath for existing paths: a missing tail under a
+ * symlink that escapes the root kept the pre-resolution prefix and passed
+ * containment.
+ *
+ * This resolves the nearest existing ancestor through `realpathSync` and
+ * re-appends the nonexistent tail, so candidates land in the same canonical
+ * namespace as the roots — and symlink escapes are surfaced even when the
+ * final segments don't exist yet. Falls back to the lexical resolution only
+ * when no ancestor exists at all.
+ */
+export function realpathOrResolve(value: string): string {
+  const resolved = path.resolve(/* turbopackIgnore: true */ value);
+  try {
+    return fs.realpathSync(/* turbopackIgnore: true */ resolved);
+  } catch {
+    /* nonexistent (or unreadable) — canonicalize via the nearest ancestor */
+  }
+  let ancestor = resolved;
+  const tail: string[] = [];
+  while (true) {
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) break;
+    tail.unshift(path.basename(ancestor));
+    ancestor = parent;
+    try {
+      return path.join(fs.realpathSync(/* turbopackIgnore: true */ ancestor), ...tail);
+    } catch {
+      /* keep walking up */
+    }
+  }
+  return resolved;
+}

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -169,6 +169,35 @@ try {
     null,
     "OpenClaw workspace roots are not globally allowed for generic project file/tree APIs",
   );
+
+  // cave-s2l8: nonexistent candidates must canonicalize like the roots do.
+  // With WORKSPACE_ROOT reached via a symlink (the shape of macOS's
+  // /var -> /private/var tmpdir), a missing subpath used to fall back to a
+  // lexical resolve, miss the realpathed root, and 403 before routes could
+  // answer 404 "does not exist".
+  const symlinkedWorkspaceTarget = path.join(tmp, "ws-target");
+  await mkdir(symlinkedWorkspaceTarget, { recursive: true });
+  const symlinkedWorkspace = path.join(tmp, "ws-link");
+  await symlink(symlinkedWorkspaceTarget, symlinkedWorkspace, "junction");
+  process.env.WORKSPACE_ROOT = symlinkedWorkspace;
+  try {
+    assert.equal(
+      resolveAllowedProjectPath(path.join(symlinkedWorkspace, "missing", "sub")),
+      path.join(await realpath(symlinkedWorkspaceTarget), "missing", "sub"),
+      "a nonexistent subpath of a symlinked allowed root resolves canonically instead of failing containment",
+    );
+    // Tightening: a missing tail under a symlink escaping the root must not
+    // lexically pass containment.
+    await mkdir(path.join(tmp, "outside-home"), { recursive: true });
+    await symlink(path.join(tmp, "outside-home"), path.join(symlinkedWorkspaceTarget, "escape"), "junction");
+    assert.equal(
+      resolveAllowedProjectPath(path.join(symlinkedWorkspace, "escape", "missing")),
+      null,
+      "a nonexistent tail under an escaping symlink is rejected, not lexically contained",
+    );
+  } finally {
+    delete process.env.WORKSPACE_ROOT;
+  }
 } finally {
   restoreEnv();
   await rm(tmp, { recursive: true, force: true });

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -2,16 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 import { covenHome, caveHome, covenWorkspaceRoot } from "@/lib/coven-paths";
+import { realpathOrResolve } from "@/lib/server/canonical-path";
 import { researchMissionsRoot } from "@/lib/server/research-mission-store";
-
-function realpathOrResolve(value: string): string {
-  const resolved = path.resolve(/* turbopackIgnore: true */ value);
-  try {
-    return fs.realpathSync(/* turbopackIgnore: true */ resolved);
-  } catch {
-    return resolved;
-  }
-}
 
 function expandHomeShortcut(value: string): string {
   const trimmed = value.trim();

--- a/src/lib/server/session-project-roots.ts
+++ b/src/lib/server/session-project-roots.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
 import path from "node:path";
 import { callDaemon } from "@/lib/coven-daemon";
+import { realpathOrResolve } from "@/lib/server/canonical-path";
 
 /**
  * Trusted project roots for the working-tree Changes panel (/api/changes).
@@ -20,15 +20,6 @@ import { callDaemon } from "@/lib/coven-daemon";
  */
 
 type DaemonSession = { project_root?: string };
-
-function realpathOrResolve(value: string): string {
-  const resolved = path.resolve(value);
-  try {
-    return fs.realpathSync(resolved);
-  } catch {
-    return resolved;
-  }
-}
 
 function isWithinRoot(candidate: string, root: string): boolean {
   return candidate === root || candidate.startsWith(root + path.sep);


### PR DESCRIPTION
## Problem

`realpathOrResolve` — duplicated in `project-paths.ts` and `session-project-roots.ts` — fell back to a **lexical** `path.resolve` when the candidate didn't exist. That diverges from realpathed allow-list roots whenever an ancestor is a symlink. On macOS, `os.tmpdir()` sits behind `/var → /private/var`, so:

- `WORKSPACE_ROOT` (a tmp fixture) canonicalized to `/private/var/…`
- a **nonexistent** child lexically resolved to `/var/…`
- containment failed → `resolveRepoRoot` answered **403 "path not allowed"** where its contract says **404 "projectRoot does not exist"**

`src/lib/server/issue-worktree-provision.test.ts` therefore failed on every Mac and passed in CI (bead cave-s2l8). Decision per the bead: **keep the allow-list's lexical containment contract for nonexistent paths** (404, not 403) and fix canonicalization.

## Fix

One shared `realpathOrResolve` in `src/lib/server/canonical-path.ts`: realpath the **nearest existing ancestor**, re-append the missing tail; fall back to lexical resolution only when no ancestor exists. Both resolvers import it; the copy-pasted local helpers are gone.

**Security tightening included:** a missing tail under a symlink that *escapes* the root now canonicalizes out of the root and is rejected — the old lexical fallback kept it looking contained.

## Tests

- `canonical-path.test.ts` (new, registered in the api suite): behavioral matrix with explicit junction-style symlinks — deterministic on macOS/Linux/Windows, no reliance on the platform's tmp layout.
- `project-paths.test.ts`: resolver-level regressions — nonexistent subpath of a symlinked `WORKSPACE_ROOT` resolves canonically (the bead's exact shape); escaping-symlink tail rejected.
- `issue-worktree-provision.test.ts`: **unchanged**, now passes on symlinked-tmp platforms (2/2, was 1/2 locally).

## Verification

- `pnpm typecheck` clean
- `pnpm test:app` 851 files green; `pnpm test:mobile` 82 green
- `pnpm test:api`: all files green except two **pre-existing** elevenlabs vault-key hermeticity failures, equally red on clean main — filed as **cave-ar39**

Bead: cave-s2l8