### PR TITLE
test(voice): make route tests vault-hermetic — never consult the real secret store

### DIFF
--- a/src/app/api/voice/elevenlabs/catalog/route.test.ts
+++ b/src/app/api/voice/elevenlabs/catalog/route.test.ts
@@ -1,6 +1,22 @@
 // @ts-nocheck
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Hermetic vault: resolveSecret falls back to <cwd>/.env.local, <cwd>/vault.yaml
+// (the repo root maps ELEVENLABS_API_KEY to a 1Password ref) and the local
+// encrypted store under caveHome() — on a lived-in machine the 400
+// vault_key_unresolved subtest would resolve the developer's REAL key and
+// hit the live API. Point every fallback at an empty scratch dir BEFORE the
+// route (and its vault module) is imported; all readers treat missing files as
+// empty.
+const TMP = mkdtempSync(join(tmpdir(), "elevenlabs-catalog-route-"));
+process.env.COVEN_HOME = TMP;
+process.env.COVEN_CAVE_HOME = join(TMP, "cave");
+process.env.COVEN_VAULT_FILE = join(TMP, "vault.yaml");
+process.env.COVEN_CAVE_ENV_FILE = join(TMP, ".env.local");
 
 const realFetch = globalThis.fetch;
 // URL-aware mock: the route fetches /v1/voices and /v1/models in parallel.

--- a/src/app/api/voice/elevenlabs/tts/route.test.ts
+++ b/src/app/api/voice/elevenlabs/tts/route.test.ts
@@ -1,6 +1,21 @@
 // @ts-nocheck
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Hermetic vault: resolveSecret falls back to <cwd>/.env.local, <cwd>/vault.yaml
+// (the repo root maps ELEVENLABS_API_KEY to a 1Password ref) and the local
+// encrypted store under caveHome() — on a lived-in machine the 400
+// vault_key_unresolved subtest would resolve the developer's REAL key and hit
+// the live API. Point every fallback at an empty scratch dir BEFORE the route
+// (and its vault module) is imported; all readers treat missing files as empty.
+const TMP = mkdtempSync(join(tmpdir(), "elevenlabs-tts-route-"));
+process.env.COVEN_HOME = TMP;
+process.env.COVEN_CAVE_HOME = join(TMP, "cave");
+process.env.COVEN_VAULT_FILE = join(TMP, "vault.yaml");
+process.env.COVEN_CAVE_ENV_FILE = join(TMP, ".env.local");
 
 const realFetch = globalThis.fetch;
 let nextFetchResponse: Response | null = null;

--- a/src/app/api/voice/preview/route.test.ts
+++ b/src/app/api/voice/preview/route.test.ts
@@ -5,9 +5,13 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Hermetic secret resolution: no real vault, no repo .env.local.
+// Hermetic secret resolution: no real vault, no repo .env.local. COVEN_VAULT_FILE
+// must also point away from <cwd>/vault.yaml — the repo root maps OPENAI_API_KEY
+// to a 1Password ref, so loadVaultMap's cwd fallback would shell out to `op`
+// (slow, and resolves a REAL key when the item exists).
 const TMP = mkdtempSync(join(tmpdir(), "voice-preview-route-"));
 process.env.HOME = TMP;
+process.env.COVEN_VAULT_FILE = join(TMP, "vault.yaml");
 process.env.COVEN_CAVE_ENV_FILE = join(TMP, "absent.env.local");
 
 function req(voice: string | null) {

--- a/src/app/api/voice/session/route.test.ts
+++ b/src/app/api/voice/session/route.test.ts
@@ -7,6 +7,11 @@ import { join } from "node:path";
 
 const TMP = mkdtempSync(join(tmpdir(), "voice-session-route-"));
 process.env.HOME = TMP;
+// Hermetic vault: without these, resolveSecret's fallbacks read <cwd>/vault.yaml
+// (repo root maps OPENAI_API_KEY to a 1Password ref → shells out to `op`) and
+// <cwd>/.env.local — slow, and resolves REAL keys on a lived-in machine.
+process.env.COVEN_VAULT_FILE = join(TMP, "vault.yaml");
+process.env.COVEN_CAVE_ENV_FILE = join(TMP, ".env.local");
 
 const FAMILIAR_ID = "milo";
 const SESSION_ID = "sess-route";


### PR DESCRIPTION
Bead `cave-ar39`.

## Problem
On a lived-in machine, the elevenlabs tts/catalog `400 vault_key_unresolved` subtests **resolve the developer's real ElevenLabs key and call the live API**: `resolveSecret` falls back to `<cwd>/vault.yaml` (repo root maps `ELEVENLABS_API_KEY` → `op://` ref), `<cwd>/.env.local`, and the encrypted store under `caveHome()`. Result: 502 instead of 400, local `pnpm test:api` aborts at file 156. CI is green only because the runner's `op` has no items.

`voice/preview` + `voice/session` tests had partial isolation (`HOME`) but missed the cwd `vault.yaml` fallback — each run shelled out to `op` for ~40s of ref-read timeouts, and would resolve a real `OPENAI_API_KEY` the same way.

## Fix
Point every resolveSecret fallback at an empty `mkdtemp` scratch **before the route modules are imported** (all vault readers treat missing files as empty): `COVEN_HOME`, `COVEN_CAVE_HOME`, `COVEN_VAULT_FILE`, `COVEN_CAVE_ENV_FILE`. Same convention as the cave-home isolation fixes (PR #3329, conversation/[id] route test).

## Evidence (on the failing machine)
- old: tts+catalog **9 pass / 2 fail** in 44s (real op + live API); preview+session 19 pass in 42s of op timeouts
- new: all four voice route files **30/30 in 12.5s**, zero network
- `pnpm test:api` now clears the voice block; next local blocker is the pre-existing `issue-worktree-provision.test.ts` failure (also red on clean main — filed as its own bead)
- `pnpm typecheck` clean