### PR TITLE
feat(chat): make the header Archive action icon-only

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5215,18 +5215,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           <div className="cave-chat-session-actions">
             {/* Chat-revamp 1b: the design's header "Mark done" slot. This
                 app's session lifecycle verb is Archive (reversible, kebab has
-                carried it since cave-nuzg) — honest verbs rule, so the ghost
-                button says Archive. Hidden on already-archived sessions (the
-                kebab's Unarchive covers restore). */}
+                carried it since cave-nuzg) — icon-only, with the honest verb
+                living in the aria-label/tooltip. Hidden on already-archived
+                sessions (the kebab's Unarchive covers restore). */}
             {sessionId && session && !session.archived_at ? (
               <button
                 type="button"
                 className="cave-chat-archive-btn focus-ring"
                 onClick={() => void setChatArchived(true)}
                 disabled={archiving}
+                aria-label={archiving ? "Archiving chat…" : "Archive this chat"}
+                aria-busy={archiving}
                 title="Archive this chat — it leaves the rail but is never deleted"
               >
-                {archiving ? "Archiving…" : "Archive"}
+                <Icon name="ph:archive" width={14} aria-hidden />
               </button>
             ) : null}
             {turns.length > 0 ? (

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -731,20 +731,21 @@ details[open] > .cave-tool-summary::before {
 }
 
 /* Chat-revamp 1b: the header's ghost session-lifecycle action (the design's
-   "Mark done" slot — this app's honest verb is Archive). Text button, always
-   visible (exempt from the hover-quiet collapse below). */
+   "Mark done" slot — this app's honest verb is Archive). Icon-only button,
+   always visible (exempt from the hover-quiet collapse below); the verb
+   lives in its aria-label/tooltip. */
 .cave-chat-session-actions > .cave-chat-archive-btn {
-  display: inline-flex;
-  align-items: center;
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
   height: 24px;
+  min-width: 24px;
+  min-height: 24px;
   flex: 0 0 auto;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  padding: 0 var(--space-2);
   background: transparent;
   color: var(--text-secondary);
-  font-size: var(--text-sm);
-  white-space: nowrap;
   transition:
     background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard),


### PR DESCRIPTION
## What

Converts the chat header's **Archive** action from a ghost text button ("Archive" / "Archiving…") to an icon-only button, per user request.

## Changes

- `src/components/chat-view.tsx` — header archive button now renders `<Icon name="ph:archive" width={14} />`; the verb stays accessible via `aria-label` ("Archive this chat" / "Archiving chat…"), `aria-busy` while archiving, and the existing `title` tooltip.
- `src/styles/cave-chat/activity.css` — `.cave-chat-archive-btn` squared to the cluster's 24×24 icon-button geometry (`inline-grid` / `place-items: center`), dropping the text-button padding/font rules. It remains exempt from the pointer-device hover-quiet collapse, so it's still always visible.

## Verification

- `node --test src/components/chat-view-polish-header-composer.test.ts` (with strip-types + css/alias hooks) — pass
- `pnpm typecheck` — clean
- No test pins reference the button's text label or `cave-chat-archive-btn` selector (checked `src/`, `tests/`).
