### PR TITLE
fix(api): reject non-object JSON bodies in readJsonBody with 400

### DIFF
--- a/src/lib/server/api-security.test.ts
+++ b/src/lib/server/api-security.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 
 import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
-import { rejectNonLocalRequest } from "./api-security.ts";
+import { readJsonBody, rejectNonLocalRequest } from "./api-security.ts";
 
 const ORIGINAL_SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN;
 
@@ -52,6 +52,37 @@ test("accepts valid loopback plus sidecar token requests", () => {
   );
 
   assert.equal(res, null);
+});
+
+function jsonBodyRequest(raw: string) {
+  return new Request("http://x/", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: raw,
+  });
+}
+
+test("readJsonBody rejects a literal JSON null root with 400", async () => {
+  const result = await readJsonBody(jsonBodyRequest("null"), 1024);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.response.status, 400);
+  assert.deepEqual(await result.response.json(), { ok: false, error: "invalid json body" });
+});
+
+test("readJsonBody rejects primitive and array roots with 400", async () => {
+  for (const raw of ["42", '"hello"', "true", "[1,2,3]"]) {
+    const result = await readJsonBody(jsonBodyRequest(raw), 1024);
+    assert.equal(result.ok, false, `expected ${raw} to be rejected`);
+    assert.equal(result.response.status, 400);
+  }
+});
+
+test("readJsonBody accepts an object root", async () => {
+  const result = await readJsonBody(jsonBodyRequest('{"field":"value"}'), 1024);
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.body, { field: "value" });
 });
 
 console.log("api-security.test.ts: ok");

--- a/src/lib/server/api-security.ts
+++ b/src/lib/server/api-security.ts
@@ -85,12 +85,25 @@ export async function readJsonBody<T>(req: Request, maxBytes: number): Promise<J
   }
 
   const raw = new TextDecoder().decode(Buffer.concat(chunks));
+  let parsed: unknown;
   try {
-    return { ok: true, body: JSON.parse(raw) as T };
+    parsed = JSON.parse(raw);
   } catch {
     return {
       ok: false,
       response: NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 }),
     };
   }
+
+  // Guarded routes read `parsed.body.field`; a non-object root (JSON null,
+  // primitive, or array) would throw a TypeError → Next 500. Reject it here so
+  // callers get a clean 400 instead.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 }),
+    };
+  }
+
+  return { ok: true, body: parsed as T };
 }


### PR DESCRIPTION
## What

`readJsonBody` (`src/lib/server/api-security.ts`) returned `{ ok: true, body: null }` for a literal JSON `null` request body — and passed through primitives/arrays too. Guarded routes then do `parsed.body.field`, which throws a `TypeError` → Next **500** instead of a clean **400**. Affects every guarded JSON route (e.g. `/api/skills/draft`, `/api/skills/caveman`, research routes).

Found during PR #3205 review.

## Fix

Validate the parsed root once in `readJsonBody`: reject `null`, primitives, and arrays with the existing `400 { ok: false, error: "invalid json body" }` envelope. Object roots pass through unchanged. All 47 callers type the body as an object shape, so no legitimate caller regresses.

## Tests

Added `readJsonBody` coverage to `api-security.test.ts`:
- literal `null` root → 400
- primitive + array roots (`42`, `"hello"`, `true`, `[1,2,3]`) → 400
- object root → `ok: true` with body preserved

```
ℹ tests 6  ℹ pass 6  ℹ fail 0
```

Closes cave-or70

🤖 Generated with [Claude Code](https://claude.com/claude-code)