### PR TITLE
test(worktree-provision): canonicalize the scratch WORKSPACE_ROOT up front

### DIFF
--- a/src/lib/server/issue-worktree-provision.test.ts
+++ b/src/lib/server/issue-worktree-provision.test.ts
@@ -7,7 +7,14 @@ import path from "node:path";
 import { after, test } from "node:test";
 
 const exec = promisify(execFile);
-const root = await mkdtemp(path.join(tmpdir(), "cave-repo-root-"));
+// Canonicalize the scratch root up front: macOS tmpdir() lives behind the
+// /var → /private/var symlink, and the allow-list check compares realpath'd
+// WORKSPACE_ROOT against candidates canonicalized via nearest-existing-ancestor
+// walks. Seeding an already-canonical root keeps both sides identical even if
+// a realpath call degrades (observed once locally as 403 path-not-allowed
+// where the 404 branch was expected — cave-01mq). Same convention as
+// project-paths.test.ts.
+const root = await realpath(await mkdtemp(path.join(tmpdir(), "cave-repo-root-")));
 const originalWorkspaceRoot = process.env.WORKSPACE_ROOT;
 process.env.WORKSPACE_ROOT = root;
 


### PR DESCRIPTION
Bead `cave-01mq` — follow-up to the local-suite triage that produced #3617.

## What happened
During a local `pnpm test:api` run (macOS, lived-in machine), `issue-worktree-provision.test.ts` failed its *missing/non-repo/relative roots* subtest with **403 `path not allowed`** where **404 `projectRoot does not exist`** was expected — then passed on every retry (0/10 standalone loops; full `test:api` now 224/224 green on main).

## Only viable mechanism
`tmpdir()` sits behind macOS's `/var → /private/var` symlink. The allow-list check compares a realpath'd `WORKSPACE_ROOT` against candidates canonicalized via nearest-existing-ancestor walks (`realpathOrResolve`). If either side transiently degrades to the uncanonicalized spelling, the prefix check misses → the 403 gate fires before the 404 branch is reachable.

## Fix (test-side hardening, 1 line + comment)
Seed the scratch root already canonical: `await realpath(await mkdtemp(...))` — both sides then agree regardless of how later realpath calls behave. Matches the existing convention in `project-paths.test.ts`. Linux CI unaffected (no tmp symlink).

## Verification
- targeted test green (suite-style invocation), `pnpm typecheck` clean
- honest caveat: the original failure is not deterministically reproducible; this removes the only identified mechanism rather than proving red→green