### PR TITLE
fix(api): gate access-group mutations behind local-origin check

### DIFF
--- a/src/app/api/access-groups/[id]/route.ts
+++ b/src/app/api/access-groups/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   invalidShapeResponse,
   memberIdsInput,
   projectGrantsInput,
+  requireLocalHumanGrantMutation,
 } from "../access-groups-route-shared";
 
 export const dynamic = "force-dynamic";
@@ -45,6 +46,8 @@ export async function PATCH(
   req: Request,
   { params: rawParams }: { params: Promise<{ id: string }> },
 ) {
+  const blocked = requireLocalHumanGrantMutation(req);
+  if (blocked) return blocked;
   const params = await rawParams;
   const payload = await readPayload(req);
   if (payload instanceof Response) return payload;
@@ -93,6 +96,8 @@ export async function DELETE(
   req: Request,
   { params: rawParams }: { params: Promise<{ id: string }> },
 ) {
+  const blocked = requireLocalHumanGrantMutation(req);
+  if (blocked) return blocked;
   const params = await rawParams;
   let payload: Record<string, unknown> = {};
   try {

--- a/src/app/api/access-groups/access-groups-route-shared.ts
+++ b/src/app/api/access-groups/access-groups-route-shared.ts
@@ -1,6 +1,21 @@
 import { NextResponse } from "next/server";
 
 import type { ProjectAccessLevel } from "@/lib/project-permissions";
+import { isLocalOrigin } from "@/lib/server/local-origin";
+
+/**
+ * Access-group mutations are the same class as direct project grants (a group
+ * grant is a real grant to every member), so they get the same PR #3306 gate:
+ * only a local desktop request may mutate — mobile/tailnet requests are
+ * rejected even if their Host is spoofed to loopback.
+ */
+export function requireLocalHumanGrantMutation(req: Request): Response | null {
+  if (isLocalOrigin(req)) return null;
+  return NextResponse.json(
+    { ok: false, error: "access group changes must be confirmed from the local desktop" },
+    { status: 403 },
+  );
+}
 
 /** undefined = field absent; null = present but malformed. */
 export function memberIdsInput(value: unknown): string[] | null | undefined {

--- a/src/app/api/access-groups/route.test.ts
+++ b/src/app/api/access-groups/route.test.ts
@@ -42,7 +42,36 @@ for (const [name, source] of [["list", listRoute], ["item", itemRoute]]) {
     /payload\.familiarId != null[\s\S]*payload\.proposedBy != null[\s\S]*payload\.claimedHumanApproval === true/,
     `${name} route relayed-approval guard should reject familiar identity and relayed approval claims`,
   );
+  assert.match(
+    source,
+    /requireLocalHumanGrantMutation\(req\)/,
+    `${name} route mutations should require a local human request, mirroring direct project grants (PR #3306)`,
+  );
 }
+assert.match(
+  shared,
+  /export function requireLocalHumanGrantMutation\(req: Request\)[\s\S]*isLocalOrigin\(req\)/,
+  "the shared local-origin gate should delegate to the centralized isLocalOrigin guard",
+);
+const listMutations = listRoute.match(/export async function POST\(/g) ?? [];
+const itemMutations = itemRoute.match(/export async function (PATCH|DELETE)\(/g) ?? [];
+const listGates = listRoute.match(/requireLocalHumanGrantMutation\(req\)/g) ?? [];
+const itemGates = itemRoute.match(/requireLocalHumanGrantMutation\(req\)/g) ?? [];
+assert.equal(
+  listGates.length,
+  listMutations.length,
+  "every list-route mutation handler should carry the local-origin gate",
+);
+assert.equal(
+  itemGates.length,
+  itemMutations.length,
+  "every item-route mutation handler should carry the local-origin gate",
+);
+assert.doesNotMatch(
+  listRoute.split("export async function GET")[1].split("export async function")[0],
+  /requireLocalHumanGrantMutation/,
+  "GET must stay ungated — mobile clients legitimately read access groups",
+);
 assert.match(
   shared,
   /access !== "read" && access !== "write"/,

--- a/src/app/api/access-groups/route.ts
+++ b/src/app/api/access-groups/route.ts
@@ -5,6 +5,7 @@ import {
   invalidShapeResponse,
   memberIdsInput,
   projectGrantsInput,
+  requireLocalHumanGrantMutation,
 } from "./access-groups-route-shared";
 
 export const dynamic = "force-dynamic";
@@ -42,6 +43,8 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const blocked = requireLocalHumanGrantMutation(req);
+  if (blocked) return blocked;
   const payload = await readPayload(req);
   if (payload instanceof Response) return payload;
   const rejected = rejectRelayedApproval(payload);


### PR DESCRIPTION
## What

Gates the access-groups API mutations (POST create, PATCH update, DELETE remove) behind the same local-origin check that direct project grants got in #3306. Non-local requests now receive `403 { ok: false, error: "access group changes must be confirmed from the local desktop" }` before the payload is read.

## Why

Found in the aardvark security batch (bead `cave-ziux`): an access-group grant is a real grant to every member familiar — the same mutation class as direct grants — but the routes only had the relayed-approval payload guard, so a mobile/tailnet request could mutate group membership and project grants. Same mutation class ⇒ same gate.

## How

- `requireLocalHumanGrantMutation` added to `access-groups-route-shared.ts`, delegating to the centralized `isLocalOrigin` guard (mobile-access header rejected, sidecar token verified, loopback Host required)
- All three mutation handlers gate first, before body parsing
- `GET` stays ungated by design — mobile clients legitimately read access groups

## Verification

- `node --experimental-strip-types src/app/api/access-groups/route.test.ts` — ok (new asserts: gate present on every mutation handler, shared helper delegates to `isLocalOrigin`, GET remains ungated)
- `node --experimental-strip-types src/app/api/project-grants/route.test.ts` — ok (unchanged neighbor)
- `pnpm typecheck` — clean

Bead: `cave-ziux`