### PR TITLE
fix(ios): pin Canvas title while composer hides on scroll (cave-lrei)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/CanvasHeaderScrollState.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CanvasHeaderScrollState.swift
@@ -1,0 +1,66 @@
+import CoreGraphics
+
+struct CanvasHeaderScrollState {
+    private enum Direction: Equatable {
+        case up
+        case down
+    }
+
+    private(set) var controlsVisible = true
+    private var lastOffset: CGFloat?
+    private var accumulatedDistance: CGFloat = 0
+    private var lastDirection: Direction?
+
+    static func normalizedOffset(contentOffsetY: CGFloat, topInset: CGFloat) -> CGFloat {
+        max(0, contentOffsetY + topInset)
+    }
+
+    @discardableResult
+    mutating func observe(offset: CGFloat) -> Bool {
+        if offset <= 4 {
+            controlsVisible = true
+            resetMotionTracking(for: offset)
+            return controlsVisible
+        }
+
+        guard let previousOffset = lastOffset else {
+            lastOffset = offset
+            accumulatedDistance = 0
+            lastDirection = nil
+            return controlsVisible
+        }
+
+        let delta = offset - previousOffset
+        if abs(delta) < 0.5 {
+            return controlsVisible
+        }
+
+        let direction: Direction = delta > 0 ? .up : .down
+        if direction != lastDirection {
+            accumulatedDistance = 0
+            lastDirection = direction
+        }
+
+        accumulatedDistance += abs(delta)
+        lastOffset = offset
+
+        switch direction {
+        case .up:
+            guard controlsVisible, accumulatedDistance >= 24 else { return controlsVisible }
+            controlsVisible = false
+            resetMotionTracking(for: offset)
+            return controlsVisible
+        case .down:
+            guard !controlsVisible, accumulatedDistance >= 8 else { return controlsVisible }
+            controlsVisible = true
+            resetMotionTracking(for: offset)
+            return controlsVisible
+        }
+    }
+
+    private mutating func resetMotionTracking(for offset: CGFloat) {
+        lastOffset = offset
+        accumulatedDistance = 0
+        lastDirection = nil
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
@@ -7,11 +7,14 @@ import SwiftUI
 struct CanvasView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var prompt = ""
     @State private var selectedFamiliarId: String?
     @State private var genTask: Task<Void, Never>?
     @State private var detail: CanvasArtifact?
+    @State private var headerScrollState = CanvasHeaderScrollState()
+    @State private var headerControlsVisible = true
     @FocusState private var promptFocused: Bool
 
     private let columns = [GridItem(.adaptive(minimum: 158), spacing: 12)]
@@ -73,29 +76,55 @@ struct CanvasView: View {
         .scrollDismissesKeyboard(.interactively)
         .refreshable { await app.loadCanvas() }
         .safeAreaInset(edge: .top, spacing: 0) { header }
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            CanvasHeaderScrollState.normalizedOffset(
+                contentOffsetY: geometry.contentOffset.y,
+                topInset: geometry.contentInsets.top
+            )
+        } action: { _, offset in
+            let controlsVisible = headerScrollState.observe(offset: offset)
+            guard controlsVisible != headerControlsVisible else { return }
+            if !controlsVisible {
+                promptFocused = false
+            }
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                headerControlsVisible = controlsVisible
+            }
+        }
     }
 
     // MARK: - Header + composer
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Canvas")
-                    .font(.largeTitle.weight(.bold))
-                Spacer()
-                if !app.canvasArtifacts.isEmpty {
-                    Text("^[\(app.canvasArtifacts.count) artifact](inflect: true)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+            titleRow
+                .zIndex(1)
+            if headerControlsVisible {
+                VStack(alignment: .leading, spacing: 12) {
+                    composer
+                    starterBar
                 }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .zIndex(0)
             }
-            composer
-            starterBar
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
         .padding(.bottom, 12)
         .background(.bar)
+    }
+
+    private var titleRow: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Canvas")
+                .font(.largeTitle.weight(.bold))
+            Spacer()
+            if !app.canvasArtifacts.isEmpty {
+                Text("^[\(app.canvasArtifacts.count) artifact](inflect: true)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     private var composer: some View {

--- a/apps/ios/CovenCave/CovenCaveTests/CanvasHeaderScrollStateTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CanvasHeaderScrollStateTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import CovenCave
+
+final class CanvasHeaderScrollStateTests: XCTestCase {
+    func testNormalizedOffsetAddsInsetAndClampsAtZero() {
+        XCTAssertEqual(CanvasHeaderScrollState.normalizedOffset(contentOffsetY: -12, topInset: 8), 0)
+        XCTAssertEqual(CanvasHeaderScrollState.normalizedOffset(contentOffsetY: 12, topInset: 8), 20)
+    }
+
+    func testIncreasingNormalizedOffsetHidesAfterTwentyFourPoints() {
+        var state = CanvasHeaderScrollState()
+
+        XCTAssertTrue(state.observe(offset: 40))
+        XCTAssertTrue(state.observe(offset: 52))
+        XCTAssertFalse(state.observe(offset: 64))
+        XCTAssertFalse(state.controlsVisible)
+    }
+
+    func testDecreasingNormalizedOffsetRevealsAfterEightPointsAfterDirectionChange() {
+        var state = CanvasHeaderScrollState()
+
+        _ = state.observe(offset: 40)
+        _ = state.observe(offset: 52)
+        _ = state.observe(offset: 64)
+        XCTAssertFalse(state.controlsVisible)
+
+        XCTAssertFalse(state.observe(offset: 60))
+        XCTAssertTrue(state.observe(offset: 56))
+        XCTAssertTrue(state.controlsVisible)
+    }
+
+    func testDirectionChangeResetsAccumulatedDistanceBeforeHiding() {
+        var state = CanvasHeaderScrollState()
+
+        XCTAssertTrue(state.observe(offset: 40))
+        XCTAssertTrue(state.observe(offset: 50))
+        XCTAssertTrue(state.observe(offset: 45))
+
+        XCTAssertTrue(state.observe(offset: 55))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertTrue(state.observe(offset: 68))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertFalse(state.observe(offset: 69))
+        XCTAssertFalse(state.controlsVisible)
+    }
+
+    func testRepeatedSubHalfPointMotionEventuallyHidesWithoutAdvancingBaseline() {
+        var state = CanvasHeaderScrollState()
+
+        XCTAssertTrue(state.observe(offset: 40))
+        for step in 1..<80 {
+            XCTAssertTrue(state.observe(offset: 40 + (0.3 * CGFloat(step))))
+        }
+        XCTAssertFalse(state.observe(offset: 64))
+        XCTAssertFalse(state.controlsVisible)
+    }
+
+    func testOscillatingJitterBelowHalfPointStaysVisible() {
+        var state = CanvasHeaderScrollState()
+
+        XCTAssertTrue(state.observe(offset: 40))
+        XCTAssertTrue(state.observe(offset: 39.7))
+        XCTAssertTrue(state.observe(offset: 40.1))
+        XCTAssertTrue(state.observe(offset: 39.8))
+        XCTAssertTrue(state.controlsVisible)
+    }
+
+    func testNearTopAlwaysRevealsAndReturnsCurrentVisibility() {
+        var visibleState = CanvasHeaderScrollState()
+        XCTAssertTrue(visibleState.observe(offset: 3))
+        XCTAssertTrue(visibleState.controlsVisible)
+
+        var state = CanvasHeaderScrollState()
+
+        _ = state.observe(offset: 40)
+        _ = state.observe(offset: 52)
+        _ = state.observe(offset: 64)
+        XCTAssertFalse(state.controlsVisible)
+
+        XCTAssertTrue(state.observe(offset: 3))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertTrue(state.observe(offset: 5))
+        XCTAssertTrue(state.controlsVisible)
+        XCTAssertTrue(state.observe(offset: 17))
+        XCTAssertTrue(state.controlsVisible)
+    }
+
+    func testNearTopResetClearsPriorAccumulationBeforeHiding() {
+        var state = CanvasHeaderScrollState()
+
+        XCTAssertTrue(state.observe(offset: 40))
+        XCTAssertTrue(state.observe(offset: 52))
+
+        XCTAssertTrue(state.observe(offset: 4))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertTrue(state.observe(offset: 16))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertTrue(state.observe(offset: 27))
+        XCTAssertTrue(state.controlsVisible)
+
+        XCTAssertFalse(state.observe(offset: 28))
+        XCTAssertFalse(state.controlsVisible)
+    }
+}

--- a/scripts/ios-canvas-tab.test.mjs
+++ b/scripts/ios-canvas-tab.test.mjs
@@ -10,6 +10,28 @@ const client = await read(`${iosRoot}/Networking/CaveClient.swift`);
 const artifact = await read(`${iosRoot}/Models/CanvasArtifact.swift`);
 const detail = await read(`${iosRoot}/Views/ArtifactDetailView.swift`);
 const webView = await read(`${iosRoot}/Views/ArtifactWebView.swift`);
+const canvas = await read(`${iosRoot}/Views/CanvasView.swift`);
+
+const boundedSlice = (source, startMarker, endMarker, label) => {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `${label}: missing start marker "${startMarker}"`);
+
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(end, -1, `${label}: missing end marker "${endMarker}"`);
+  assert(end > start, `${label}: end marker "${endMarker}" must follow start marker "${startMarker}"`);
+
+  return source.slice(start, end);
+};
+
+const assertOrdered = (source, markers, label) => {
+  let cursor = -1;
+  for (const marker of markers) {
+    const next = source.indexOf(marker, cursor + 1);
+    assert.notEqual(next, -1, `${label}: missing "${marker}"`);
+    assert(next > cursor, `${label}: "${marker}" must appear after the previous marker`);
+    cursor = next;
+  }
+};
 
 assert.match(model, /enum AppTab: String \{[^}]*\bcanvas\b[^}]*\}/, "AppTab includes Canvas");
 assert.match(root, /Tab\("Canvas"[\s\S]*CanvasView\(\)/, "RootView mounts the native Canvas tab");
@@ -23,5 +45,52 @@ assert.match(webView, /WKContentWorld\.world/, "artifact code cannot forge inspe
 assert.match(webView, /setURLSchemeHandler/, "React sandbox assets load through the authenticated native scheme");
 assert.match(webView, /Authorization/, "native sandbox asset requests carry the paired credential");
 assert.doesNotMatch(detail, /\.onDisappear\s*\{[^}]*cancel/, "leaving Canvas does not cancel generation");
+assert.match(canvas, /@Environment\(\\\.accessibilityReduceMotion\)\s+private var reduceMotion/, "Canvas honors Reduce Motion");
+assert.match(canvas, /@State\s+private var headerScrollState = CanvasHeaderScrollState\(\)/, "Canvas owns header scroll state");
+assert.match(canvas, /@State\s+private var headerControlsVisible = true/, "Canvas tracks header control visibility");
+assert.match(canvas, /\.onScrollGeometryChange\(for:\s*CGFloat\.self\)/, "Canvas observes CGFloat scroll geometry");
+assert.match(
+  canvas,
+  /CanvasHeaderScrollState\.normalizedOffset\(\s*contentOffsetY:\s*geometry\.contentOffset\.y,\s*topInset:\s*geometry\.contentInsets\.top\s*\)/,
+  "Canvas normalizes scroll offset with the top content inset",
+);
+assert.match(
+  canvas,
+  /headerScrollState\.observe\(offset:\s*offset\)/,
+  "Canvas forwards scroll changes to the header scroll state",
+);
+assert.match(
+  canvas,
+  /guard\s+controlsVisible\s*!=\s*headerControlsVisible\s+else\s*\{\s*return\s*\}/,
+  "Canvas no-ops when header visibility is unchanged",
+);
+assert.match(
+  canvas,
+  /if\s*!controlsVisible\s*\{\s*promptFocused\s*=\s*false\s*\}\s*withAnimation\(reduceMotion\s*\?\s*nil\s*:\s*\.easeOut\(duration:\s*0\.2\)\)\s*\{\s*headerControlsVisible\s*=\s*controlsVisible\s*\}/s,
+  "Canvas clears focus before animating the header visibility change",
+);
+
+const header = boundedSlice(
+  canvas,
+  "    private var header: some View {",
+  "    private var titleRow: some View {",
+  "Canvas header",
+);
+
+const titleRow = boundedSlice(
+  canvas,
+  "    private var titleRow: some View {",
+  "    private var composer: some View {",
+  "Canvas titleRow",
+);
+
+assertOrdered(header, ["titleRow", ".zIndex(1)", "if headerControlsVisible {"], "Canvas header order");
+assert.match(header, /titleRow\s*\n\s*\.zIndex\(1\)/, "Canvas header keeps titleRow above the collapsible controls");
+assert.match(header, /if headerControlsVisible \{[\s\S]*composer[\s\S]*starterBar[\s\S]*\}/, "Canvas header keeps composer and starterBar in the collapsible controls region");
+assert.match(header, /\.transition\(\.move\(edge:\s*\.top\)\.combined\(with:\s*\.opacity\)\)/, "Canvas header controls combine a top move with an opacity transition");
+assert.match(header, /\.zIndex\(0\)/, "Canvas header assigns zIndex 0 to the collapsible controls");
+
+assert.match(titleRow, /Text\("Canvas"\)/, "Canvas titleRow renders the Canvas title");
+assert.match(titleRow, /Text\("\^\[\\\(app\.canvasArtifacts\.count\) artifact\]\(inflect: true\)"\)/, "Canvas titleRow renders the artifact count");
 
 console.log("ios-canvas-tab.test.mjs: ok");


### PR DESCRIPTION
Fixes bead **cave-lrei** — iOS Canvas composer collapses on scroll.

## What changed
- New `CanvasHeaderScrollState` model: direction-aware hysteresis that keeps the Canvas title pinned while hiding the describe composer + starter chips on upward gallery scroll, revealing them immediately on downward scroll; sub-half-point jitter is gated so oscillation doesn't flap the chrome.
- `CanvasView` drives the header from the scroll state and honors Reduce Motion.
- `scripts/ios-canvas-tab.test.mjs` extended to pin the new wiring.

## Verification
- `CanvasHeaderScrollStateTests`: 8 tests, 0 failures (iPhone 16 Pro sim, re-run pre-PR)
- `node scripts/ios-canvas-tab.test.mjs` — ok
- `git diff --check` clean
