### PR TITLE
feat(chat): widen reading column, move context pill to footer band, drop typing hint

### DIFF
--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
-// Source pins for the chat composer's context grammar (chat revamp 1d,
-// superseding the cave-8eo2 band layout): the session's project · runtime/
-// model · git context collapsed into ONE quiet context pill in the control
-// row, the utility cluster collapsed into ONE "+" menu, and the footer band
-// now carries only the linked-work strip (tasks · GitHub · link/create). The
-// write surface stays minimal: textarea + "+" · pill · circular send.
+// Source pins for the chat composer's context grammar (2026-07-21 wide-column
+// pass, superseding chat revamp 1d's control-row pill): the session's project ·
+// runtime/model · git context stays ONE quiet context pill, but it lives in
+// the footer band alongside the linked-work strip (tasks · GitHub ·
+// link/create). The utility cluster stays collapsed into ONE "+" menu, and
+// the write surface stays minimal: textarea + "+" · circular send.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -21,11 +21,11 @@ assert.match(
   "the footer band renders after the composer controls, inside the panel",
 );
 
-// ── Band contents: the linked-work strip only ───────────────────────────────
+// ── Band contents: the context pill + the linked-work strip ─────────────────
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\{linkedContextRow\}\s*\n\s*<\/div>/,
-  "the band carries the linked-context strip (tasks · GitHub · link/create) alone",
+  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill[\s\S]*?\{linkedContextRow\}\s*\n\s*<\/div>/,
+  "the band leads with the context pill, then the linked-context strip (tasks · GitHub · link/create)",
 );
 
 // ── The context pill replaces the band's picker cluster ─────────────────────
@@ -57,15 +57,20 @@ assert.match(
   "the Branch section elides for git-less composers (home, no-project chats)",
 );
 
-// ── The utility row is just "+" then the pill ───────────────────────────────
+// ── The utility row is just "+" — the pill lives in the band ────────────────
 const utilityRow = source.match(
   /className="cave-composer-utility-row">[\s\S]*?<div className="cave-composer-submit-row">/,
 )?.[0] ?? "";
 assert.ok(utilityRow, "chat composer utility row is present");
 assert.match(
   utilityRow,
-  /<ComposerPlusMenu[\s\S]*<ComposerContextPill/,
-  "the utility row leads with the + menu, then the context pill",
+  /<ComposerPlusMenu/,
+  "the utility row leads with the + menu",
+);
+assert.doesNotMatch(
+  utilityRow,
+  /<ComposerContextPill/,
+  "the context pill moved down to the footer band (2026-07-21 wide-column pass)",
 );
 
 // ── The header no longer hosts the linked-context strip ─────────────────────
@@ -105,15 +110,13 @@ assert.match(
   /\.cave-composer-send\[data-typing="true"\] \{\s*\n\s*background: color-mix\(in oklch, var\(--accent-presence\) 18%, transparent\);/,
   "typing adds the ~18% accent tint fill to send",
 );
-assert.match(
-  css,
-  /\.cave-composer-typing-hint \{[\s\S]*?font-family: var\(--font-mono\);[\s\S]*?font-size: 10\.5px;/,
-  "the enter-to-send hint is the 10.5px mono whisper inside the input area",
-);
-assert.match(
-  css,
-  /@media \(max-width: 767px\) \{[\s\S]*?\.cave-composer-typing-hint \{\s*\n\s*display: none;/,
-  "phone widths skip the typing hint",
+// The "↵ send · ⇧↵ newline" typing hint is gone from the chat composer
+// (2026-07-21): the tinted send button already signals sendability. The
+// home composer keeps its own hint, so the shared CSS class stays.
+assert.doesNotMatch(
+  source,
+  /cave-composer-typing-hint/,
+  "the enter-to-send typing hint no longer renders in the chat composer",
 );
 
 // ── Reveal + mobile behavior ─────────────────────────────────────────────────

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -144,8 +144,15 @@ assert.match(
 );
 assert.match(
   source,
-  /<div className="cave-composer-utility-row">[\s\S]*<ComposerPlusMenu[\s\S]*<ComposerContextPill[\s\S]*<ComposerOptionsMenu/,
-  "composer utility row is the + menu and context pill; the Options panel chains off the + anchor",
+  /<div className="cave-composer-utility-row">[\s\S]*<ComposerPlusMenu[\s\S]*<ComposerOptionsMenu/,
+  "composer utility row is the + menu; the Options panel chains off the + anchor",
+);
+// The context pill (Project · Model · branch) lives in the footer band below
+// the controls (2026-07-21 wide-column pass) — not in the utility row.
+assert.match(
+  source,
+  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
+  "the context pill anchors the footer band",
 );
 // Composer core (chat revamp 1d): the dedicated Prompt-snippets button is
 // folded into the "+" menu, so the resting row is just + · context pill.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5805,14 +5805,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               }
               {...mentionAriaOverrides}
             />
-            {/* Typing hint (chat revamp 1d): appears with the first character,
-                inside the input area — not persistent chrome. Hidden on
-                phone widths (CSS). */}
-            {input.trim() && !busy ? (
-              <span className="cave-composer-typing-hint" aria-hidden>
-                ↵ send · ⇧↵ newline
-              </span>
-            ) : null}
             </div>
             {/* Enhance status strip (shared): streaming preview, apply/dismiss
                 for late arrivals, one-tap revert after an in-place apply. */}
@@ -5882,26 +5874,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       loading: promptEnhance.state.phase === "loading",
                     }}
                     onOpenModelTuning={() => setComposerOptionsOpen(true)}
-                  />
-                  {/* One quiet context pill — Project · Model · branch —
-                      replacing the footer band's picker row; every picker
-                      opens from it. */}
-                  <ComposerContextPill
-                    projects={projects}
-                    projectValue={resolvedProjectId}
-                    onProjectChange={setProjectIdDraft}
-                    allowNoProject
-                    familiarId={familiar.id ?? null}
-                    createProject={createProject}
-                    runtime={modelHarness}
-                    modelValue={composerModelValue}
-                    modelOptions={composerModelOptions}
-                    onPickRuntime={handleSelectRuntime}
-                    onPickModel={handleSelectModel}
-                    modelDisabled={busy}
-                    projectRoot={activeProjectRoot}
-                    onOpenUrl={onOpenUrl}
-                    ariaLabel="Chat context: project, model, and branch"
                   />
                   <ComposerOptionsMenu
                     open={composerOptionsOpen}
@@ -5982,11 +5954,29 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               </div>
             </div>
             {/* Footer band — the darker strip attached to the panel's
-                underside now carries only the linked-work strip (tasks ·
-                GitHub · link/create). The project · runtime/model · git
-                pickers it used to host collapsed into the context pill in
-                the control row above (chat revamp 1d). */}
+                underside carries the context pill (Project · Model/runtime ·
+                branch; every picker opens from it) on the left and the
+                linked-work strip (tasks · GitHub · link/create) on the
+                right. The pill moved down from the control row (2026-07-21
+                wide-column pass) so the write surface above stays minimal. */}
             <div className="cave-composer-footer-band">
+              <ComposerContextPill
+                projects={projects}
+                projectValue={resolvedProjectId}
+                onProjectChange={setProjectIdDraft}
+                allowNoProject
+                familiarId={familiar.id ?? null}
+                createProject={createProject}
+                runtime={modelHarness}
+                modelValue={composerModelValue}
+                modelOptions={composerModelOptions}
+                onPickRuntime={handleSelectRuntime}
+                onPickModel={handleSelectModel}
+                modelDisabled={busy}
+                projectRoot={activeProjectRoot}
+                onOpenUrl={onOpenUrl}
+                ariaLabel="Chat context: project, model, and branch"
+              />
               {linkedContextRow}
             </div>
           </div>

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -52,8 +52,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /className="cave-composer-utility-row">[\s\S]{0,4000}?<ComposerContextPill/,
-  "the pill sits in the composer utility row — always visible, session or not",
+  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
+  "the pill anchors the composer footer band — always visible, session or not (2026-07-21 wide-column pass moved it down from the utility row)",
 );
 
 // ── Runtime switching is real: familiar-level config, optimistic + refetch ──

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -101,15 +101,15 @@ assert.match(
   /\.cave-chat-linear \{[^}]*--cave-chat-measure:\s*[\d.]+rem/,
   "the chat surface defines a shared reading measure token",
 );
-// Chat-revamp 1b supersedes cave-973a's 64rem: the avatar-row transcript
-// grammar reads on the design's 760px (47.5rem) column, shared by the
-// suggestion row and composer. Pin the exact value so drift in either
-// direction is a deliberate decision.
+// The 2026-07-21 wide-column pass supersedes chat-revamp 1b's 760px: the
+// transcript reads on a roomier 1024px (64rem) column — long responses and
+// code blocks get width — still shared by the suggestion row and composer.
+// Pin the exact value so drift in either direction is a deliberate decision.
 {
   const measure = /--cave-chat-measure:\s*([\d.]+)rem/.exec(css);
   assert.ok(
-    measure && Number(measure[1]) === 47.5,
-    `the reading measure is the chat-revamp 1b 760px column (47.5rem; got ${measure?.[1] ?? "none"})`,
+    measure && Number(measure[1]) === 64,
+    `the reading measure is the wide-column 1024px column (64rem; got ${measure?.[1] ?? "none"})`,
   );
 }
 const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -497,12 +497,12 @@ details[open] > .cave-tool-summary::before {
   /* Centered reading column (cave-xsq.1): the conversation + composer share one
      comfortable measure and sit in a centered column — the ChatGPT reading
      model — instead of spanning the full pane (reverses the 2026-06-18
-     full-width choice below). Chat-revamp 1b re-narrows cave-973a's 64rem to
-     the design's 760px (47.5rem): the avatar-row grammar reads best on a
-     tight column, and the suggestion row + composer share the same measure.
-     The header stays a full-bleed bar (its divider spans the pane); only the
-     reading/writing column is capped + centered. */
-  --cave-chat-measure: 47.5rem;
+     full-width choice below). Chat-revamp 1b narrowed cave-973a's 64rem to
+     47.5rem; the 2026-07-21 wide-column pass widens it back to 64rem (1024px)
+     so long responses and diffs get room, with the suggestion row + composer
+     sharing the same measure. The header stays a full-bleed bar (its divider
+     spans the pane); only the reading/writing column is capped + centered. */
+  --cave-chat-measure: 64rem;
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);


### PR DESCRIPTION
## What

Three chat-composer UX changes (goal `chat-wide-column-footer-pickers`):

1. **Wider chat column** — `--cave-chat-measure` 47.5rem (760px) → **64rem (1024px)**. One token widens the transcript, suggestion row, and composer together; the header stays full-bleed.
2. **Pickers → footer band** — `ComposerContextPill` (Project · Model/runtime · Branch) moves from the composer utility row down into the footer band, left of the linked-work strip (band is already flex/space-between). The resting write surface is now textarea + "+" · circular send.
3. **Typing hint removed** — the `↵ send · ⇧↵ newline` whisper no longer renders in the chat composer once typing starts; the tinted send button already signals sendability. The home composer keeps its own hint (shared CSS class retained).

## Test pins updated

- `chat-composer-footer-band.test.ts` — band = pill + strip; utility row must NOT contain the pill; chat source must NOT render the typing hint.
- `chat-view-polish-header-composer.test.ts` / `composer-runtime-chip.test.ts` — pill anchors the footer band.
- `message-bubble-code-header.test.ts` — exact measure pin 47.5 → 64.

## Verification

- `pnpm typecheck` ✓
- `pnpm test:app` — 855 files ✓
- `pnpm test:mobile` — 82 files ✓
