### PR TITLE
fix(backdrop): name the matchAccent switch for screen readers (cave-rc09)

### DIFF
--- a/src/components/a11y-audit-fixes.test.ts
+++ b/src/components/a11y-audit-fixes.test.ts
@@ -112,3 +112,15 @@ test("table lightbox traps Tab and restores focus to its trigger (CHAT-D11-02)",
   assert.match(fn, /\(event\.shiftKey \? last : first\)\.focus\(\);/, "escaped focus must be recaptured into the dialog");
   assert.match(src, /import \{ FOCUSABLE \} from "@\/lib\/use-focus-trap";/);
 });
+
+test("backdrop matchAccent switch carries its own accessible name (cave-rc09)", async () => {
+  // Wrapping a button in a <label> does not name it per HTML-AAM — without an
+  // aria-label, screen readers announce only "On"/"Off". Same fix as the
+  // Look-tab familiar switch in #3421 (1ac9d1ce).
+  const src = await read("./backdrop-settings.tsx");
+  assert.match(
+    src,
+    /role="switch"\s*aria-checked=\{prefs\.matchAccent\}\s*aria-label="Match accent to the image"/,
+    "the matchAccent switch must carry an explicit aria-label",
+  );
+});

--- a/src/components/backdrop-settings.tsx
+++ b/src/components/backdrop-settings.tsx
@@ -160,6 +160,7 @@ export function BackdropSettings() {
               type="button"
               role="switch"
               aria-checked={prefs.matchAccent}
+              aria-label="Match accent to the image"
               onClick={() => writeBackdropPrefs({ matchAccent: !prefs.matchAccent })}
               className={`focus-ring rounded-[var(--radius-control)] border px-3 py-1 text-[length:var(--text-sm)] transition-colors ${
                 prefs.matchAccent


### PR DESCRIPTION
## What

The backdrop settings `matchAccent` toggle is a `role="switch"` button wrapped in a `<label>` — but a label element does not give a **button** an accessible name per HTML-AAM, so screen readers announced only "On"/"Off". This adds an explicit `aria-label="Match accent to the image"`.

## Why this shape

Identical to the Look-tab familiar switch fix from #3421 (commit `1ac9d1ce`), which this bead (`cave-rc09`) asked to replicate. Pinned with a source assertion in `a11y-audit-fixes.test.ts`, matching that file's existing convention.

## Verification

- `a11y-audit-fixes.test.ts`: **9/9 pass** (1 new)
- `pnpm typecheck`: clean
- Diff: +13 lines, 2 files

Closes cave-rc09. Found by Copilot PR review on #3421.