### PR TITLE
fix(chat): truthful live progress + full-width task-work conversation (cave-9vkw)

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -514,8 +514,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\)\)[\s\S]*pushProgress\("resume-retry", "Fresh chat started", "done"/,
-  "Transparent resume fallback should be visible in the progress timeline",
+  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*?pushProgress\(\s*"resume-retry",[\s\S]*?"Fresh chat started",\s*"done",?\s*\)[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
+  "Transparent resume fallback should be visible in the progress timeline and settle BEFORE the fresh attempt runs — left running until the attempt ended, 'Resume failed…' headlined the activity strip for the whole reply",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1842,8 +1842,20 @@ export async function POST(req: Request) {
         stderrTail.length = 0;
         stdoutErrTail.length = 0;
         resumeFailed = false;
+        // Settle the retry step BEFORE the fresh attempt runs, not after it
+        // finishes: the step's own work (rebuild context, relaunch) is done
+        // the moment the fresh run launches. Left "running" until the attempt
+        // ended, "Resume failed…" stayed the live headline in the activity
+        // strip for the entire reply — minutes of what read like an
+        // unresolved failure while the fresh chat streamed fine underneath.
+        pushProgress(
+          "resume-retry",
+          retry.replayedHistory
+            ? "Recent context replayed into a fresh chat"
+            : "Fresh chat started",
+          "done",
+        );
         await runAttempt(buildArgs(null, retry.prompt));
-        pushProgress("resume-retry", "Fresh chat started", "done");
       }
 
       // User cancel (CHAT-D5-02): when the client stops the response

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -461,6 +461,27 @@ assert.match(
   "The synthetic Receiving-response row settles (done) at first chunk (CHAT-D12-01)",
 );
 
+// (b2) The server's "Starting <harness>" step (id "harness-start") is only
+// settled server-side at process EXIT, so it spun as the live activity
+// headline for the whole reply. Streamed text or a tool event proves the
+// start completed — both apply sites settle it client-side; the server's
+// exit update (label + duration) still lands via the normal upsert.
+assert.match(
+  source,
+  /function settleProgressEventById\(\s*\n\s*progress: ProgressEvent\[\] \| undefined,\s*\n\s*id: string,/,
+  "settleProgressEventById settles a named running step on later evidence",
+);
+assert.match(
+  source,
+  /const applyAssistantChunk = \([\s\S]*?upsertProgressEvent\(settleProgressEventById\(t\.progress, "harness-start"\), \{\s*\n\s*id: "stream",/,
+  "First streamed chunk settles the harness-start step (it demonstrably started)",
+);
+assert.match(
+  source,
+  /upsertProgressEvent\(settleProgressEventById\(t\.progress, "harness-start"\), \{\s*\n\s*id: "tools",/,
+  "A tool event settles the harness-start step too (tooling turns can run long before prose)",
+);
+
 // (c) CHAT-D3-06: the MetaLine streaming state carries a compact ticking
 // elapsed ("writing… · 14s · esc to cancel") so the wall-clock counter
 // survives past the first token. SR-quiet: the ticker lives in an aria-hidden

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -434,6 +434,22 @@ function settleRunningProgress(
   return progress.map((item) => (item.status === "running" ? { ...item, status } : item));
 }
 
+/** Settle one still-"running" step once later evidence proves it finished.
+ *  The server only settles "harness-start" when the process EXITS, so
+ *  "Starting <harness>" would otherwise spin as the live activity headline for
+ *  the entire reply; streamed text or a tool event proves the start completed.
+ *  Reference-stable when nothing matches, and a later server update for the
+ *  same id (exit label + duration) still lands via the normal upsert. */
+function settleProgressEventById(
+  progress: ProgressEvent[] | undefined,
+  id: string,
+): ProgressEvent[] | undefined {
+  if (!progress?.some((item) => item.id === id && item.status === "running")) return progress;
+  return progress.map((item) =>
+    item.id === id && item.status === "running" ? { ...item, status: "done" as const } : item,
+  );
+}
+
 function fmtDuration(ms?: number): string | null {
   if (ms == null || ms < 0) return null;
   const s = Math.round(ms / 1000);
@@ -4610,8 +4626,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               // CHAT-D12-01: settle the synthetic row the moment text is
               // flowing — the streamed text IS the live signal from here
               // on. Leaving it "running" kept the auto-open ProgressGroup
-              // pulsing for the entire stream.
-              progress: upsertProgressEvent(t.progress, {
+              // pulsing for the entire stream. Same evidence settles the
+              // server's "Starting <harness>" step, which the server itself
+              // only closes at process exit.
+              progress: upsertProgressEvent(settleProgressEventById(t.progress, "harness-start"), {
                 id: "stream",
                 label: "Receiving response",
                 status: "done",
@@ -4754,7 +4772,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               ...t,
               tools: nextTools,
               lifecycle: t.pending ? "tooling" : t.lifecycle,
-              progress: upsertProgressEvent(t.progress, {
+              // A tool event is proof the harness started — settle the
+              // server's "Starting <harness>" step (tooling turns can run
+              // long before any prose streams; see settleProgressEventById).
+              progress: upsertProgressEvent(settleProgressEventById(t.progress, "harness-start"), {
                 id: "tools",
                 label: incoming.status === "running" ? "Tool call running" : "Tool call finished",
                 detail: argSummary ? `${incoming.name}(${argSummary})` : incoming.name,

--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -18,3 +18,11 @@ assert.match(source, /useWorkspaceRailController/);
 assert.match(source, /<WorkspaceRail/);
 assert.match(source, /<WorkspaceRailSheet/);
 assert.doesNotMatch(source, /ChatRouter|ChatList/);
+// The resizable Group must remount per pane set: the library retains a layout
+// per panel-id set, and without the key a collapsed code rail left the
+// conversation panel at its stale two-panel width beside dead space.
+assert.match(
+  source,
+  /<Group\s*\n(?:\s*(?:className|orientation)=[^\n]*\n|\s*\/\/[^\n]*\n)*\s*key=\{railController\.showInline \? "conversation-rail" : "conversation"\}/,
+  "cockpit Group is keyed by the visible pane set so a solo conversation fills the cockpit",
+);

--- a/src/components/task-work-cockpit.tsx
+++ b/src/components/task-work-cockpit.tsx
@@ -165,7 +165,17 @@ export function TaskWorkCockpit({
 
       <div className="task-work-cockpit__body">
         {target.kind === "ready" && familiar ? (
-          <Group className="task-work-cockpit__group" orientation="horizontal">
+          <Group
+            className="task-work-cockpit__group"
+            orientation="horizontal"
+            // The library retains an in-memory layout per panel-id set, so
+            // when the code rail collapses (its Panel unmounts) the surviving
+            // conversation panel kept its stale two-panel width — the chat sat
+            // at ~half the cockpit beside dead space. Remount the Group per
+            // pane set (the chat-split-host convention) so each set lays out
+            // fresh and a solo conversation always fills the cockpit.
+            key={railController.showInline ? "conversation-rail" : "conversation"}
+          >
             <Panel id="task-conversation" className="flex min-h-0 min-w-0" minSize="45%">
               <ChatView
                 familiar={familiar}


### PR DESCRIPTION
Screenshot-driven fixes for the Task Work chat state (bead cave-9vkw). In the reported state, "Resume failed; replaying recent context into a fresh chat" headlined the activity strip for a 265s reply with "2 running" that never settled, and the conversation sat at ~half the cockpit width beside dead space with the code rail closed.

## What changed

1. **`/api/chat/send`** — the `resume-retry` progress step now settles (`done`) when the fresh attempt **starts**, not after it finishes. Its work — rebuild context, relaunch — is complete at launch; leaving it `running` until the attempt ended kept the alarming label as the live headline for the entire reply. Done labels: "Recent context replayed into a fresh chat" / "Fresh chat started".

2. **`chat-view.tsx`** — new `settleProgressEventById`: the first streamed chunk or tool event settles the server's `harness-start` step ("Starting copilot" in the screenshot, spinning at 8s while tools ran). The server only closes that step at process **exit**; text/tool activity proves the start completed. The server's exit update (label + duration) still lands via the normal upsert.

3. **`task-work-cockpit.tsx`** — the resizable `Group` is keyed by the visible pane set (`conversation-rail` / `conversation`), the chat-split-host convention. The library retains an in-memory layout per panel-id set, so collapsing the code rail left the conversation panel at its stale two-panel width.

## Verification
- `task-work-cockpit.test.ts`, `chat-view-lifecycle.test.ts` (3 new CHAT-D12-01 pins), `harness-routing-host-session.test.ts` (reordered resume-retry pin) — all pass with the css-contract hook + alias loader.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)