### PR TITLE
fix(chat): instant sidebar highlight — mirror the active session as state (cave-d4b9)

### DIFF
--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -100,6 +100,11 @@ type Props = {
   hideRail?: boolean;
   /** Jump from the in-chat project rail to the dedicated Projects tab. */
   onOpenProjectsTab?: () => void;
+  /** Reports the session the router's chat view is showing (null on the list
+   *  or a not-yet-minted new chat). Lets the Workspace mirror the active
+   *  session as state instead of reading the imperative handle during render,
+   *  which always lagged one update behind (the n-1 highlight bug). */
+  onActiveSessionChange?: (sessionId: string | null) => void;
   /** Allow split panes (drag/keyboard multi-pane) on this mount. Only the
    *  full-width main chat surface opts in — the compact companion rail has no
    *  room, and two mounts must not fight over the persisted layout. */
@@ -155,11 +160,30 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     compact = false,
     hideRail = false,
     onOpenProjectsTab,
+    onActiveSessionChange,
     enableSplitPanes = false,
   },
   ref,
 ) {
   const [view, setView] = useState<View>({ kind: "list" });
+  // Mirror the active session upward when it *changes*. Seeding the ref with
+  // the mount value (always null — view starts as the list) means mount never
+  // notifies, so a fresh router can't clobber the Workspace's optimistic
+  // click-time highlight while a pending open is still in its deferred
+  // openSession() hop; every real session (or back-to-list) lands as a later
+  // change and reports normally. Change-detection (not a first-run boolean)
+  // keeps this correct under StrictMode's dev double-mount.
+  const onActiveSessionChangeRef = useRef(onActiveSessionChange);
+  useEffect(() => {
+    onActiveSessionChangeRef.current = onActiveSessionChange;
+  }, [onActiveSessionChange]);
+  const activeSessionId = view.kind === "chat" ? view.sessionId : null;
+  const lastReportedSessionRef = useRef<string | null>(activeSessionId);
+  useEffect(() => {
+    if (lastReportedSessionRef.current === activeSessionId) return;
+    lastReportedSessionRef.current = activeSessionId;
+    onActiveSessionChangeRef.current?.(activeSessionId);
+  }, [activeSessionId]);
   // ── Multi-pane split (drag a convo from the thread rail onto the chat) ────
   // The primary chat is one pane; dropped conversations open beside/above/
   // below it. Pure layout rules live in @/lib/chat-split; panes for deleted

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -97,6 +97,9 @@ type Props = {
    *  routes back to the board with the linked card focused. */
   onOpenTask?: (cardId: string) => void;
   onOpenUrl?: (url: string) => void;
+  /** Forwarded to ChatRouter: reports the session its chat view is showing so
+   *  the Workspace can keep the sidebar highlight in sync as state. */
+  onActiveSessionChange?: (sessionId: string | null) => void;
   /** Drop the in-surface project/thread rail. Set when the outer contextual
    *  Shell nav/sidebar already owns the project-grouped chat list, so the
    *  in-surface rail would duplicate it. */
@@ -133,6 +136,7 @@ export function ChatSurface({
   onSessionsDeleted,
   onOpenTask,
   onOpenUrl,
+  onActiveSessionChange,
   hideThreadRail = false,
 }: Props) {
   // The in-surface project/thread rail is dropped when the outer WorkspaceSidebar
@@ -481,6 +485,7 @@ export function ChatSurface({
                   pendingProjectRoot={pendingProjectRoot}
                   onOpenTask={onOpenTask}
                   onOpenUrl={onOpenUrl}
+                  onActiveSessionChange={onActiveSessionChange}
                   onOpenProjectsTab={() => setScope("projects")}
                   syncUrlHash
                   enableSplitPanes

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -60,6 +60,14 @@ assert.match(workspace, /onToggleList=\{undefined\}/, "top bar exposes no list t
 assert.match(workspace, /navDrawerOpen=\{navDrawerOpen\}\s*listDrawerOpen=\{false\}/, "top bar only reflects the mobile nav drawer");
 const chatSidebarBlock = workspace.match(/const chatSidebar =[\s\S]*?const contextualNav =/)?.[0] ?? "";
 assert.ok(chatSidebarBlock, "workspace should keep the chat sidebar wiring together");
+// Instant highlight (n-1 bug): the active session must come from mirrored
+// state — optimistic at click time, reconciled by ChatRouter's
+// onActiveSessionChange — never from a render-time routerRef read, which
+// always lagged one update behind the deferred openSession() hop.
+assert.match(chatSidebarBlock, /activeSessionId=\{activeChatSessionId\}/, "chat sidebar highlight reads the mirrored active-session state");
+assert.doesNotMatch(workspace, /activeSessionId=\{routerRef\.current\?\.currentSessionId\(\) \?\? null\}/, "no sidebar may read the router handle during render for the active session");
+assert.match(workspace, /const openFamiliarSession = useCallback\(\(sessionId: string[\s\S]*?setActiveChatSessionId\(sessionId\);/, "opening a session sets the highlight optimistically at click time");
+assert.match(workspace, /onActiveSessionChange=\{setActiveChatSessionId\}/, "ChatRouter reconciles the mirrored state (new-chat promotion, back-to-list)");
 assert.doesNotMatch(chatSidebarBlock, /dismissListMobile/, "chat sidebar callbacks should not dismiss the list drawer");
 assert.ok((chatSidebarBlock.match(/dismissNavMobile/g) ?? []).length >= 6, "chat sidebar actions dismiss the mobile nav drawer");
 assert.match(workspace, /onOpenSession=\{\(session\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "opening a chat session dismisses the mobile nav drawer");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -455,6 +455,14 @@ export function Workspace() {
   }, []);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
   const [pendingChatAction, setPendingChatAction] = useState<PendingChatAction>(null);
+  // The session the chat surface is showing, mirrored as state so the sidebar
+  // highlight moves the instant a row is clicked. Set optimistically by the
+  // open/new-chat producers below and reconciled by ChatRouter's
+  // onActiveSessionChange (new-chat promotion, back-to-list, in-router opens).
+  // Never read routerRef.currentSessionId() during render for this — the
+  // router applies opens in a deferred hop, so render-time ref reads always
+  // lagged one update behind (the n-1 highlight bug).
+  const [activeChatSessionId, setActiveChatSessionId] = useState<string | null>(null);
   const [pendingCodeRailOpen, setPendingCodeRailOpen] = useState<PendingCodeRailOpen | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [onboardingResolved, setOnboardingResolved] = useState(false);
@@ -1052,6 +1060,9 @@ export function Workspace() {
       );
       return sameSessionList(currentSessions, nextSessions) ? currentSessions : nextSessions;
     });
+    // Drop a highlight pointing at a deleted session; the sidebars guard by
+    // row lookup anyway, but keep the mirrored state honest.
+    setActiveChatSessionId((cur) => (cur && confirmedIds.includes(cur) ? null : cur));
     for (const sessionId of confirmedIds) invalidateConversation(sessionId);
     void loadSessions();
   }, [loadSessions]);
@@ -1735,6 +1746,7 @@ export function Workspace() {
 
   const openFamiliarSession = useCallback((sessionId: string, familiarId?: string | null, findQuery?: string) => {
     if (familiarId) setActiveId(familiarId);
+    setActiveChatSessionId(sessionId);
     setPendingChatAction({
       kind: "open",
       sessionId,
@@ -1860,6 +1872,7 @@ export function Workspace() {
     }
     if (familiarId) setActiveId(familiarId);
     setPendingProjectChatRoot(projectRoot ?? null);
+    setActiveChatSessionId(null);
     setPendingChatAction({
       kind: "new",
       familiarId,
@@ -1887,6 +1900,7 @@ export function Workspace() {
     if (modeRef.current !== "home") return;
     setActiveId(familiarId);
     setPendingProjectChatRoot(projectRoot ?? null);
+    setActiveChatSessionId(result.sessionId);
     setPendingChatAction({ kind: "open", sessionId: result.sessionId, familiarId, autoVoice: true, nonce: Date.now() });
     setMode("chat");
   }, [pushToast]);
@@ -2026,6 +2040,7 @@ export function Workspace() {
   }, [familiars, activeId, mode, selectFamiliar, startFamiliarChat, nextRouter]);
 
   const showFamiliarChatList = useCallback(() => {
+    setActiveChatSessionId(null);
     setPendingChatAction({ kind: "list", nonce: Date.now() });
     setMode("chat");
   }, []);
@@ -2491,7 +2506,7 @@ export function Workspace() {
   const roleSurfaceSession = useRoleSurfaceSession({
     familiar: active,
     sessions,
-    activeSessionId: routerRef.current?.currentSessionId() ?? null,
+    activeSessionId: activeChatSessionId,
     daemonRunning,
     openUrl: openUrlInAppBrowser,
     openSession: openFamiliarSession,
@@ -2566,7 +2581,7 @@ export function Workspace() {
         description: surface.description,
       }))}
       sessions={sessions}
-      activeSessionId={routerRef.current?.currentSessionId() ?? null}
+      activeSessionId={activeChatSessionId}
       onNewChat={() => {
         startFamiliarChat(activeId);
         shellRef.current?.dismissNavMobile();
@@ -2609,7 +2624,7 @@ export function Workspace() {
       sessions={sessions}
       familiars={resolvedFamiliars}
       activeFamiliarId={activeId}
-      activeSessionId={routerRef.current?.currentSessionId() ?? null}
+      activeSessionId={activeChatSessionId}
       responseNeeded={responseNeeded}
       onSelectFamiliar={selectFamiliarScope}
       onOpenSession={(session) => {
@@ -2715,6 +2730,7 @@ export function Workspace() {
         onClearPendingProjectRoot={() => setPendingProjectChatRoot(null)}
         onPendingChatActionHandled={() => setPendingChatAction(null)}
         onPendingCodeRailOpenHandled={() => setPendingCodeRailOpen(null)}
+        onActiveSessionChange={setActiveChatSessionId}
         onSessionStarted={loadSessions}
         onSlashFromChat={handleSlashIntent}
         onOpenOnboarding={openOnboarding}
@@ -2867,7 +2883,7 @@ export function Workspace() {
   // attached PR via the shared sessionPrStatus derivation). Home has no session
   // context, so it degrades to the active familiar's model + the Tasks count;
   // other surfaces don't render the strip at all.
-  const statusSessionId = routerRef.current?.currentSessionId() ?? null;
+  const statusSessionId = activeChatSessionId;
   const statusSession =
     mode === "chat" && statusSessionId
       ? sessions.find((s) => s.id === statusSessionId) ?? null


### PR DESCRIPTION
Lands finished, test-pinned work found uncommitted in the primary checkout with no live owning session (no duplicate PR exists; verified via PR search + main log).

## The n-1 highlight bug

Sidebars read `routerRef.current?.currentSessionId() ?? null` during render for the active-session highlight. The router applies opens in a deferred hop, so render-time ref reads always lagged one update behind — clicking a chat row highlighted the *previous* session.

## Fix

- `Workspace` mirrors the active chat session as state (`activeChatSessionId`): set optimistically at click time by `openFamiliarSession` / new-chat / voice-chat producers, cleared on back-to-list and when the highlighted session is deleted.
- `ChatRouter` gains `onActiveSessionChange`, reporting the session its chat view is actually showing (reconciles new-chat promotion, back-to-list, in-router opens). Mount seeding means a fresh router never clobbers the optimistic click-time highlight; change-detection keeps it correct under StrictMode double-mount.
- All three render-time `routerRef.currentSessionId()` reads replaced (`useRoleSurfaceSession`, both sidebars, status strip).

## Verification
- `workspace-sidebar-wiring.test.ts` — 4 new pins (mirrored state read, no render-time handle read, optimistic set, reconciliation wiring) — pass.
- 6 chat-router-pinning suites (split-host, siderail-hide-archived, thread-rail, rail-modern-redesign, linked-context, code-view) — pass.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)