### PR TITLE
refactor(chat): direct archive/delete/voice header actions, slim session kebab

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -149,6 +149,7 @@ export const SUITES = {
     "src/lib/chat-open-tasks.test.ts",
     "src/lib/chat-starter-suggestions.test.ts",
     "src/lib/chat-session-prefs.test.ts",
+    "src/lib/chat-session-menu-model.test.ts",
     "src/lib/conversation-tree.test.ts",
     "src/lib/stream-text.test.ts",
     "src/lib/chat-sse.test.ts",

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -117,10 +117,11 @@ assert.doesNotMatch(
   "Standalone lifecycle status bar CSS is removed (folded into meta line)",
 );
 
-// In-chat delete lives ONLY in the session overflow (kebab) menu now — the
-// danger "Delete chat…" item swaps the menu body to a confirm view, the
+// In-chat delete is a DIRECT header action (cave-zolo): a trash icon button in
+// the session-actions cluster whose confirm popover (Delete this chat
+// permanently? / Cancel / Delete chat) guards the irreversible commit. The
 // explicit Delete commits via deleteChat, and success reports the confirmed id
-// to Workspace and navigates back. No standalone header trash button remains.
+// to Workspace and navigates back.
 assert.match(
   source,
   /const deleteChat = async[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(sessionId\)\}`, \{ method: "DELETE" \}\)/,
@@ -132,30 +133,35 @@ assert.match(
   "Successful delete reaches the shared boundary and navigates back to the list",
 );
 
-// The kebab's delete is a two-step guard: the danger item arms a confirm view
-// (Delete this chat permanently? / Cancel / Delete chat) inside the popover.
+// The delete is a two-step guard: the trash button arms a confirm popover
+// anchored to itself; only the popover's danger item commits.
 assert.match(
   sessionHeader,
-  /function SessionOverflowMenu[\s\S]*?confirmingDelete \? \([\s\S]*?Delete this chat permanently\?[\s\S]*?disabled=\{deleting\} onSelect=\{\(\) => onDelete\(\)\}[\s\S]*?Delete chat…/,
-  "SessionOverflowMenu guards delete behind an in-popover confirm view",
+  /function DeleteChatButton[\s\S]*?aria-expanded=\{confirming\}[\s\S]*?Delete this chat permanently\?[\s\S]*?disabled=\{deleting\} onSelect=\{\(\) => onDelete\(\)\}/,
+  "DeleteChatButton guards delete behind an anchored confirm popover",
 );
 assert.match(
-  sessionHeader,
-  /onSelect=\{\(\) => setConfirmingDelete\(true\)\}/,
-  "the danger Delete chat… item arms the confirm view instead of deleting outright",
+  source,
+  /<DeleteChatButton deleting=\{deleting\} onDelete=\{\(\) => void deleteChat\(\)\} \/>/,
+  "the header cluster renders the direct delete button",
 );
-// Closing the kebab disarms the confirm so it never reopens pre-armed.
-assert.match(
-  sessionHeader,
-  /const close = \(\) => \{\s*setOpen\(false\);\s*setConfirmingDelete\(false\);\s*\};/,
-  "closing the overflow menu resets the armed delete confirm",
+// The kebab no longer carries delete at all — the menu model owns its items
+// and none of them are the destructive verb. (Scoped to the menu function so
+// DeleteChatButton's own strings don't satisfy the check.)
+const overflowMenuSection = sessionHeader.slice(
+  sessionHeader.indexOf("function SessionOverflowMenu"),
+  sessionHeader.indexOf("function DeleteChatButton"),
 );
-// The standalone header debug/delete buttons are gone — the header's only
-// always-visible controls are Find and the kebab.
+assert.ok(
+  !overflowMenuSection.includes("Delete chat") && !overflowMenuSection.includes("ph:trash"),
+  "SessionOverflowMenu contains no delete item (direct button owns it)",
+);
+// The standalone header debug buttons stay gone — quick actions are Voice/
+// Archive/Find/Delete plus the kebab.
 assert.doesNotMatch(
   source,
   /function HeaderDebugButton|function HeaderDeleteButton|function HeaderThinkingToggle|function HeaderReflectButton/,
-  "the standalone header icon buttons are folded into the overflow menu",
+  "the retired standalone header icon buttons stay removed",
 );
 assert.doesNotMatch(
   source,
@@ -164,11 +170,12 @@ assert.doesNotMatch(
 );
 
 // Project selection is one compact row in the kebab that opens the shared
-// searchable ProjectPickerPopover — not an inline list of every project.
+// searchable ProjectPickerPopover — not an inline list of every project. The
+// row's label comes from the pure menu model.
 assert.match(
   sessionHeader,
-  /function SessionOverflowMenu[\s\S]*?Project: \{activeProject \? activeProject\.name : "No project"\}[\s\S]*?<ProjectPickerPopover/,
-  "the kebab shows a single Project row that opens the shared picker popover",
+  /function SessionOverflowMenu[\s\S]*?sessionMenuSections\(\{[\s\S]*?projectName: activeProject\?\.name \?\? null[\s\S]*?<ProjectPickerPopover/,
+  "the kebab derives its Project row from the menu model and opens the shared picker popover",
 );
 assert.doesNotMatch(
   source,
@@ -397,19 +404,25 @@ assert.match(
   "highlight-failure fallback clears diffLines so markers are not doubled",
 );
 
-// ── Archive (cave-nuzg): delete's reversible sibling in the same kebab ──────
-// Archive chat PATCHes the session; the chat leaves every rail (rails are
-// archive-free by default — chat-siderail-hide-archived.test.ts) but the
-// transcript survives, and the same item reads Unarchive on archived chats.
+// ── Archive (cave-nuzg → cave-zolo): delete's reversible sibling, now a DIRECT
+// header button. Archive chat PATCHes the session; the chat leaves every rail
+// (rails are archive-free by default — chat-siderail-hide-archived.test.ts) but
+// the transcript survives, and the same button flips to Unarchive on archived
+// chats so restore is one click from the header too.
 assert.match(
   sessionHeader,
-  /icon="ph:archive"[\s\S]{0,400}\{archiving \? \(archived \? "Unarchiving…" : "Archiving…"\) : archived \? "Unarchive chat" : "Archive chat"\}/,
-  "the kebab offers Archive chat (Unarchive on archived sessions)",
+  /function ArchiveChatButton[\s\S]{0,400}archiveAction\(\{ archived, archiving \}\)/,
+  "the direct archive button derives its icon/label/verb from the menu model",
 );
 assert.match(
   sessionHeader,
-  /onSelect=\{\(\) => \{\s*onSetArchived\(!archived\);\s*close\(\);/,
-  "selecting the item toggles the session's archived state",
+  /function ArchiveChatButton[\s\S]{0,700}onClick=\{\(\) => onSetArchived\(!archived\)\}/,
+  "clicking the button toggles the session's archived state",
+);
+assert.match(
+  source,
+  /<ArchiveChatButton\s+archived=\{Boolean\(session\.archived_at\)\}\s+archiving=\{archiving\}\s+onSetArchived=\{\(next\) => void setChatArchived\(next\)\}/,
+  "the header cluster renders the direct archive button off the session's archived_at",
 );
 // Archive needs no confirm step — it is reversible, unlike Delete above.
 assert.match(
@@ -424,8 +437,8 @@ assert.match(
 );
 assert.match(
   source,
-  /archived=\{Boolean\(session\?\.archived_at\)\}/,
-  "the menu receives the live archived state of the open session",
+  /archived=\{Boolean\(session\.archived_at\)\}/,
+  "the archive button receives the live archived state of the open session",
 );
 
 console.log("chat-header-row.test.ts: ok");

--- a/src/components/chat-session-header.tsx
+++ b/src/components/chat-session-header.tsx
@@ -1,70 +1,95 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import type { CaveProject } from "@/lib/cave-projects";
 import { NO_PROJECT_ID, chatProjectById } from "@/lib/chat-projects";
+import { archiveAction, sessionMenuSections, voiceAction, type SessionMenuItemId } from "@/lib/chat-session-menu-model";
 import { Icon } from "@/lib/icon";
 import { useShowThinking } from "@/lib/reasoning-visibility";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { ProjectPickerPopover } from "@/components/project-picker";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 
+/** Slim overflow kebab (cave-zolo): only genuinely secondary tools live here.
+ *  Lifecycle verbs (archive, delete) and the voice call are direct header
+ *  buttons beside this menu, and rename rides the title's pencil — none of
+ *  them are duplicated in the menu. Item lists come from the pure
+ *  chat-session-menu-model so the contents are testable without React. */
 export function SessionOverflowMenu({
   projects,
   projectId,
   onProjectChange,
   onAddProject,
-  familiar,
   sessionId,
   hasTurns,
-  voiceActive,
-  onOpenVoice,
   onOpenDebug,
   reflecting,
   onReflect,
-  deleting,
-  onDelete,
-  archived,
-  archiving,
-  onSetArchived,
 }: {
   projects: CaveProject[];
   projectId: string | null;
   onProjectChange: (value: string) => void;
   /** Opens the shared add-project flow (register + grant) — proactive, not 403-recovery-only. */
   onAddProject?: () => void;
-  familiar: Familiar;
   /** Active conversation id — powers "Continue on phone" (cave-i74f). */
   sessionId?: string | null;
   /** Gates the Show-thinking toggle — pointless on an empty transcript. */
   hasTurns: boolean;
-  voiceActive: boolean;
-  onOpenVoice: () => void;
   onOpenDebug: () => void;
   /** Reflect-on-thread (absent when the familiar has no id). */
   reflecting: boolean;
   onReflect?: () => void;
-  deleting: boolean;
-  onDelete: () => void;
-  /** Whether this session is archived — flips the menu item to Unarchive. */
-  archived: boolean;
-  archiving: boolean;
-  onSetArchived: (archived: boolean) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [showThinking, setShowThinking] = useShowThinking();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const activeProject =
     projectId === NO_PROJECT_ID
       ? null
       : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
-  const voiceConfigured = Boolean(familiar.voiceProvider);
 
-  const close = () => {
-    setOpen(false);
-    setConfirmingDelete(false);
+  const sections = sessionMenuSections({
+    sessionId: sessionId ?? null,
+    projectPickerAvailable: projects.length > 0 || Boolean(onAddProject),
+    projectName: activeProject?.name ?? null,
+    projectRoot: activeProject?.root ?? null,
+    hasTurns,
+    showThinking,
+    reflectAvailable: Boolean(onReflect),
+    reflecting,
+  });
+
+  const close = () => setOpen(false);
+
+  const handlers: Record<SessionMenuItemId, () => void> = {
+    "continue-on-phone": () => {
+      close();
+      // Golden path 5: hand off the MOMENT — the pairing modal's QR
+      // carries #chat-<id> so one scan opens this conversation.
+      window.dispatchEvent(
+        new CustomEvent("cave:continue-on-phone", { detail: { chatId: sessionId } }),
+      );
+    },
+    project: () => {
+      // Chain popovers: the kebab closes on this click; the picker
+      // mounts after it, so its outside-click listener misses the
+      // same mousedown and it stays open on the shared anchor.
+      close();
+      setProjectPickerOpen(true);
+    },
+    thinking: () => {
+      setShowThinking(!showThinking);
+      close();
+    },
+    reflect: () => {
+      close();
+      onReflect?.();
+    },
+    debug: () => {
+      onOpenDebug();
+      close();
+    },
   };
 
   return (
@@ -81,139 +106,38 @@ export function SessionOverflowMenu({
           // The picker shares this anchor, so its outside-click handler skips
           // clicks here — close it explicitly or both popovers stack open.
           setProjectPickerOpen(false);
-          if (open) close();
-          else setOpen(true);
+          setOpen(!open);
         }}
       >
         <Icon name="ph:dots-three-vertical" width={15} aria-hidden />
       </button>
       <Popover
         open={open}
-        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        onOpenChange={setOpen}
         anchorRef={triggerRef}
         placement="bottom-end"
         minWidth={216}
         ariaLabel="Chat options"
       >
-        {confirmingDelete ? (
-          <PopoverBody>
-            <PopoverLabel>Delete this chat permanently?</PopoverLabel>
-            <PopoverItem icon="ph:x" onSelect={() => setConfirmingDelete(false)}>
-              Cancel
-            </PopoverItem>
-            <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
-              {deleting ? "Deleting…" : "Delete chat"}
-            </PopoverItem>
-          </PopoverBody>
-        ) : (
-          <PopoverBody>
-            {sessionId ? (
-              <PopoverItem
-                icon="ph:device-mobile"
-                onSelect={() => {
-                  close();
-                  // Golden path 5: hand off the MOMENT — the pairing modal's QR
-                  // carries #chat-<id> so one scan opens this conversation.
-                  window.dispatchEvent(
-                    new CustomEvent("cave:continue-on-phone", { detail: { chatId: sessionId } }),
-                  );
-                }}
-              >
-                Continue on phone
-              </PopoverItem>
-            ) : null}
-            <PopoverItem
-              icon="ph:pencil-simple"
-              onSelect={() => {
-                window.dispatchEvent(new Event("cave:chat-rename"));
-                close();
-              }}
-            >
-              Rename chat
-            </PopoverItem>
-            {projects.length > 0 || onAddProject ? (
-              <PopoverItem
-                icon="ph:folder"
-                title={activeProject?.root ?? "No project"}
-                onSelect={() => {
-                  // Chain popovers: the kebab closes on this click; the picker
-                  // mounts after it, so its outside-click listener misses the
-                  // same mousedown and it stays open on the shared anchor.
-                  close();
-                  setProjectPickerOpen(true);
-                }}
-              >
-                Project: {activeProject ? activeProject.name : "No project"}
-              </PopoverItem>
-            ) : null}
-            <PopoverSeparator />
-            {hasTurns ? (
-              <PopoverItem
-                icon={showThinking ? "ph:brain-bold" : "ph:brain"}
-                checked={showThinking}
-                title={showThinking ? "Hide reasoning blocks" : "Show reasoning blocks"}
-                onSelect={() => {
-                  setShowThinking(!showThinking);
-                  close();
-                }}
-              >
-                {showThinking ? "Hide thinking" : "Show thinking"}
-              </PopoverItem>
-            ) : null}
-            {onReflect ? (
-              <PopoverItem
-                icon={reflecting ? "ph:circle-notch-bold" : "ph:sparkle-bold"}
-                disabled={reflecting}
-                onSelect={() => {
-                  close();
-                  onReflect();
-                }}
-              >
-                {reflecting ? "Reflecting…" : "Reflect on this thread"}
-              </PopoverItem>
-            ) : null}
-            <PopoverItem
-              icon="ph:phone"
-              disabled={!voiceConfigured || voiceActive}
-              onSelect={() => {
-                onOpenVoice();
-                close();
-              }}
-            >
-              {voiceConfigured ? `Call ${familiar.display_name}` : "Voice — set up in Studio"}
-            </PopoverItem>
-            <PopoverItem
-              icon="ph:bug-bold"
-              onSelect={() => {
-                onOpenDebug();
-                close();
-              }}
-            >
-              Debug session
-            </PopoverItem>
-            <PopoverSeparator />
-            {sessionId ? (
-              // Reversible, so no confirm step (unlike Delete below): an
-              // archived chat leaves every rail but stays reachable from the
-              // chat list's "Show archived" toggle, where this same item
-              // reads Unarchive.
-              <PopoverItem
-                icon="ph:archive"
-                disabled={archiving}
-                title={archived ? "Restore this chat to the rail" : "Archive this chat — it leaves the rail but is never deleted"}
-                onSelect={() => {
-                  onSetArchived(!archived);
-                  close();
-                }}
-              >
-                {archiving ? (archived ? "Unarchiving…" : "Archiving…") : archived ? "Unarchive chat" : "Archive chat"}
-              </PopoverItem>
-            ) : null}
-            <PopoverItem icon="ph:trash" danger onSelect={() => setConfirmingDelete(true)}>
-              Delete chat…
-            </PopoverItem>
-          </PopoverBody>
-        )}
+        <PopoverBody>
+          {sections.map((section, si) => (
+            <Fragment key={si}>
+              {si > 0 ? <PopoverSeparator /> : null}
+              {section.map((item) => (
+                <PopoverItem
+                  key={item.id}
+                  icon={item.icon}
+                  checked={item.checked}
+                  disabled={item.disabled}
+                  title={item.title}
+                  onSelect={handlers[item.id]}
+                >
+                  {item.label}
+                </PopoverItem>
+              ))}
+            </Fragment>
+          ))}
+        </PopoverBody>
       </Popover>
       <ProjectPickerPopover
         open={projectPickerOpen}
@@ -228,6 +152,118 @@ export function SessionOverflowMenu({
         ariaLabel="Project for this chat"
       />
     </>
+  );
+}
+
+/** Direct danger action (cave-zolo): the trash icon in the header cluster.
+ *  Delete is irreversible, so it keeps its confirm step — a small popover on
+ *  the button itself instead of a view swap inside the kebab. Quiet at rest:
+ *  reveal-on-hover against the chat header's reveal-scope (design language
+ *  §8), so the destructive verb earns visibility instead of holding it. */
+export function DeleteChatButton({
+  deleting,
+  onDelete,
+}: {
+  deleting: boolean;
+  onDelete: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="focus-ring cave-chat-delete-btn reveal-on-hover"
+        aria-label="Delete this chat"
+        aria-haspopup="dialog"
+        aria-expanded={confirming}
+        title="Delete this chat permanently"
+        onClick={() => setConfirming(!confirming)}
+      >
+        <Icon name="ph:trash" width={14} aria-hidden />
+      </button>
+      <Popover
+        open={confirming}
+        onOpenChange={setConfirming}
+        anchorRef={triggerRef}
+        placement="bottom-end"
+        minWidth={216}
+        ariaLabel="Confirm delete chat"
+      >
+        <PopoverBody>
+          <PopoverLabel>Delete this chat permanently?</PopoverLabel>
+          <PopoverItem icon="ph:x" onSelect={() => setConfirming(false)}>
+            Cancel
+          </PopoverItem>
+          <PopoverItem icon="ph:trash" danger disabled={deleting} onSelect={() => onDelete()}>
+            {deleting ? "Deleting…" : "Delete chat"}
+          </PopoverItem>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
+
+/** Direct session-lifecycle action (cave-zolo): archive on live sessions,
+ *  unarchive on archived ones — the same reversible verb pair the kebab used
+ *  to hide. Reversible, so no confirm step (unlike Delete): an archived chat
+ *  leaves every rail but stays reachable from the chat list's "Show archived"
+ *  toggle. */
+export function ArchiveChatButton({
+  archived,
+  archiving,
+  onSetArchived,
+}: {
+  archived: boolean;
+  archiving: boolean;
+  onSetArchived: (archived: boolean) => void;
+}) {
+  const action = archiveAction({ archived, archiving });
+  return (
+    <button
+      type="button"
+      className="cave-chat-archive-btn focus-ring"
+      onClick={() => onSetArchived(!archived)}
+      disabled={archiving}
+      aria-label={action.label}
+      aria-busy={archiving}
+      title={action.title}
+    >
+      <Icon name={action.icon} width={14} aria-hidden />
+    </button>
+  );
+}
+
+/** Direct voice-call action (cave-zolo): rings the session's familiar without
+ *  opening the kebab. Same gating the kebab item had — needs a configured
+ *  voice provider, and one call at a time. Reveal-on-hover like the delete
+ *  button beside it — the header is the reveal-scope. */
+export function VoiceCallButton({
+  familiar,
+  voiceActive,
+  onOpenVoice,
+}: {
+  familiar: Familiar;
+  voiceActive: boolean;
+  onOpenVoice: () => void;
+}) {
+  const action = voiceAction({
+    voiceConfigured: Boolean(familiar.voiceProvider),
+    voiceActive,
+    familiarName: familiar.display_name,
+  });
+  return (
+    <button
+      type="button"
+      className="focus-ring voice-call-button reveal-on-hover"
+      onClick={onOpenVoice}
+      disabled={action.disabled}
+      aria-label={action.label}
+      title={action.label}
+    >
+      <Icon name="ph:phone" width={14} aria-hidden />
+    </button>
   );
 }
 
@@ -266,14 +302,10 @@ export function ChatTitleEditable({
     inputRef.current?.select();
   }, [editing]);
 
-  // Rename has three entry points into the same edit mode: the pencil button
-  // beside the title, clicking the title text, and the session overflow menu —
-  // which lives outside this component and reaches it via this window event.
-  useEffect(() => {
-    const onRename = () => setEditing(true);
-    window.addEventListener("cave:chat-rename", onRename);
-    return () => window.removeEventListener("cave:chat-rename", onRename);
-  }, []);
+  // Rename has two entry points into the same edit mode: the pencil button
+  // beside the title and clicking the title text. (The overflow menu's Rename
+  // item and its window-event bridge died in cave-zolo — the pencil is the
+  // one affordance.)
 
   const display = baseTitle || session.id;
 

--- a/src/components/chat-view-polish-fixtures.ts
+++ b/src/components/chat-view-polish-fixtures.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 
 export const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 export const sessionHeader = readFileSync(new URL("./chat-session-header.tsx", import.meta.url), "utf8");
+export const menuModel = readFileSync(new URL("../lib/chat-session-menu-model.ts", import.meta.url), "utf8");
 export const attachmentCards = readFileSync(new URL("./chat-attachment-cards.tsx", import.meta.url), "utf8");
 export const emptyStateSource = readFileSync(new URL("./chat-empty-state.tsx", import.meta.url), "utf8");
 export const styles = [

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -325,12 +325,20 @@ assert.doesNotMatch(
 assert.match(
   source,
   /<div className="cave-chat-session-actions">[\s\S]*<ChatFindBar[\s\S]*<SessionOverflowMenu/,
-  "Open chat header actions collapse to a find bar plus a single overflow menu",
+  "Open chat header actions keep the find bar ahead of the overflow menu",
+);
+// cave-zolo: the header cluster carries direct Voice/Archive/Delete buttons;
+// the kebab holds only secondary tools (phone handoff, project, thinking,
+// reflect, debug), sourced from the pure menu model.
+assert.match(
+  source,
+  /<VoiceCallButton[\s\S]*<ArchiveChatButton[\s\S]*<ChatFindBar[\s\S]*<DeleteChatButton[\s\S]*<SessionOverflowMenu/,
+  "Direct session actions (voice, archive, delete) render beside find and the kebab",
 );
 assert.match(
   sessionHeader,
-  /function SessionOverflowMenu[\s\S]*Debug session[\s\S]*Delete chat/,
-  "Secondary session actions (project, voice, debug, delete) live in the overflow menu",
+  /import \{ archiveAction, sessionMenuSections, voiceAction[\s\S]*?\} from "@\/lib\/chat-session-menu-model"/,
+  "Header actions derive their items/states from the pure chat-session-menu-model",
 );
 
 assert.match(
@@ -360,22 +368,34 @@ assert.doesNotMatch(
   "Dead standalone icon-button chrome is removed with the buttons",
 );
 
-// Ultra-minimal header: at rest only the ⋮ kebab shows; the quick actions
-// collapse and reveal on hover / keyboard focus (touch devices show them).
+// Ultra-minimal header: the promoted voice + delete verbs are quiet at rest —
+// they use the shared reveal-on-hover utility (§8) against the header's
+// reveal-scope instead of a bespoke pointer-events dance (which could never
+// outrank its own hide rule). Archive, find and the kebab stay visible.
 assert.match(
   sessionHeader,
   /className="focus-ring cave-chat-actions-kebab"/,
   "The overflow kebab is tagged so it stays visible while sibling actions collapse",
 );
 assert.match(
+  sessionHeader,
+  /className="focus-ring cave-chat-delete-btn reveal-on-hover"/,
+  "The direct delete button is quiet at rest via the shared reveal utility",
+);
+assert.match(
+  sessionHeader,
+  /className="focus-ring voice-call-button reveal-on-hover"/,
+  "The direct voice button is quiet at rest via the shared reveal utility",
+);
+assert.doesNotMatch(
   styles,
-  /@media \(hover: hover\) and \(pointer: fine\)\s*\{[\s\S]*\.cave-chat-session-actions > \.focus-ring:not\(\.cave-chat-actions-kebab\):not\(\.cave-chat-find\)[\s\S]*opacity:\s*0;/,
-  "Quick header actions are hidden at rest on pointer devices",
+  /\.focus-ring:not\(\.cave-chat-actions-kebab\)/,
+  "The bespoke cluster hide rule is gone — its :not() chain outranked every reveal rule",
 );
 assert.match(
   styles,
-  /\.cave-chat-linear-header:hover \.cave-chat-session-actions > \.focus-ring[\s\S]*opacity:\s*1;/,
-  "Quick header actions reveal on header hover",
+  /\.cave-chat-session-actions:has\(\[aria-expanded="true"\]\) \.reveal-on-hover \{\s*opacity: 1;/,
+  "An armed popover keeps the cluster revealed so the anchor doesn't fade under it",
 );
 // "No plan limits" is suppressed — the plan chip only shows a real limit.
 assert.match(
@@ -747,25 +767,32 @@ assert.match(
   "Empty-state hint surfaces the slash-command entry point (skills, prompts, /model)",
 );
 
-assert.match(
+// cave-zolo: rename is deduped out of the kebab — the title's pencil is the
+// affordance, and the dead cave:chat-rename bridge is gone with the item.
+assert.doesNotMatch(
   sessionHeader,
-  /icon="ph:pencil-simple"[\s\S]{0,200}dispatchEvent\(new Event\("cave:chat-rename"\)\)[\s\S]{0,160}Rename chat/,
-  "Rename lives in the session overflow menu (Codex/ChatGPT idiom), firing cave:chat-rename",
+  /cave:chat-rename/,
+  "the rename window-event bridge is removed",
 );
-assert.match(
-  sessionHeader,
-  /addEventListener\("cave:chat-rename", onRename\)[\s\S]{0,80}setEditing\(true\)|onRename = \(\) => setEditing\(true\)/,
-  "ChatTitleEditable enters edit mode when the overflow menu fires cave:chat-rename",
-);
+{
+  const overflowMenu = sessionHeader.slice(
+    sessionHeader.indexOf("function SessionOverflowMenu"),
+    sessionHeader.indexOf("function DeleteChatButton"),
+  );
+  assert.ok(
+    !overflowMenu.includes("Rename chat"),
+    "the overflow menu carries no Rename item (the title pencil owns rename)",
+  );
+}
 assert.match(
   sessionHeader,
   /aria-label="Rename chat"[\s\S]{0,200}setEditing\(true\)/,
-  "Chat title carries an explicit, labeled rename button — click-to-rename and the overflow item alone are not discoverable",
+  "Chat title carries an explicit, labeled rename button — click-to-rename alone is not discoverable",
 );
 assert.match(
   sessionHeader,
   /aria-label="Rename chat"[\s\S]{0,400}ph:pencil-simple/,
-  "The title's rename button uses the same pencil icon as the overflow menu item",
+  "The title's rename button keeps the pencil icon",
 );
 
 // — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —

--- a/src/components/chat-view-polish-tools-activity.test.ts
+++ b/src/components/chat-view-polish-tools-activity.test.ts
@@ -5,6 +5,7 @@ import {
   attachStagingHook,
   emptyStateSource,
   globalsSrc,
+  menuModel,
   menusHookSource,
   sessionHeader,
   source,
@@ -58,8 +59,14 @@ assert.match(
 );
 assert.match(
   sessionHeader,
-  /function SessionOverflowMenu[\s\S]*useShowThinking\(\)[\s\S]*checked=\{showThinking\}[\s\S]*\{showThinking \? "Hide thinking" : "Show thinking"\}/,
+  /function SessionOverflowMenu[\s\S]*useShowThinking\(\)[\s\S]*setShowThinking\(!showThinking\)/,
   "The session overflow menu carries the global Show-thinking toggle",
+);
+// The toggle's label/checked state derive from the pure menu model (cave-zolo).
+assert.match(
+  menuModel,
+  /id: "thinking",\s*label: ctx\.showThinking \? "Hide thinking" : "Show thinking",[\s\S]*?checked: ctx\.showThinking/,
+  "The menu model flips the thinking item label and checkmark with the preference",
 );
 
 assert.match(

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -69,18 +69,26 @@ assert.match(
   "ChatView should distinguish a missing SSE body from an HTTP rejection",
 );
 
+const menuModel = readFileSync(new URL("../lib/chat-session-menu-model.ts", import.meta.url), "utf8");
 assert.match(
-  sessionHeader,
-  /Reflect on this thread[\s\S]{0,600}ph:phone/,
-  "ChatView should expose a Reflect action in the session overflow menu",
+  menuModel,
+  /Reflect on this thread/,
+  "the menu model exposes a Reflect action for the session overflow menu",
 );
 // Reflect must not reuse the thinking toggle's brain — two identical brains
 // in one menu made the actions indistinguishable. Sparkle matches the daily
-// note's Reflection section where reflections land.
+// note's Reflection section where reflections land. The voice call is a
+// direct header button (cave-zolo), so the phone icon lives beside — not
+// inside — the menu.
+assert.match(
+  menuModel,
+  /ctx\.reflecting \? "ph:circle-notch-bold" : "ph:sparkle-bold"/,
+  "the Reflect action keeps its sparkle (spinner while reflecting), distinct from the thinking brain",
+);
 assert.match(
   sessionHeader,
-  /reflecting \? "ph:circle-notch-bold" : "ph:sparkle-bold"/,
-  "the Reflect action keeps its sparkle (spinner while reflecting), distinct from the thinking brain",
+  /function VoiceCallButton[\s\S]{0,900}ph:phone/,
+  "the voice call is a direct header button with the phone icon",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -53,7 +53,7 @@ import { useKeySymbols } from "@/lib/platform-keys";
 import { useVisualViewport } from "@/lib/use-viewport";
 import { FamiliarIcon } from "@/components/familiar-icon";
 import { ChatEmptyState } from "@/components/chat-empty-state";
-import { ChatTitleEditable, SessionOverflowMenu } from "@/components/chat-session-header";
+import { ArchiveChatButton, ChatTitleEditable, DeleteChatButton, SessionOverflowMenu, VoiceCallButton } from "@/components/chat-session-header";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { FamiliarInlineCard } from "@/components/familiar-inline-card";
 import { ArtifactComments } from "@/components/artifact-comments";
@@ -5007,23 +5007,24 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onBack={onBack}
         >
           <div className="cave-chat-session-actions">
-            {/* Chat-revamp 1b: the design's header "Mark done" slot. This
-                app's session lifecycle verb is Archive (reversible, kebab has
-                carried it since cave-nuzg) — icon-only, with the honest verb
-                living in the aria-label/tooltip. Hidden on already-archived
-                sessions (the kebab's Unarchive covers restore). */}
-            {sessionId && session && !session.archived_at ? (
-              <button
-                type="button"
-                className="cave-chat-archive-btn focus-ring"
-                onClick={() => void setChatArchived(true)}
-                disabled={archiving}
-                aria-label={archiving ? "Archiving chat…" : "Archive this chat"}
-                aria-busy={archiving}
-                title="Archive this chat — it leaves the rail but is never deleted"
-              >
-                <Icon name="ph:archive" width={14} aria-hidden />
-              </button>
+            {/* cave-zolo: lifecycle + call verbs are direct icons (the kebab
+                no longer hides them). Voice joins the hover-reveal quick set;
+                Archive stays always-visible (the design's "Mark done" slot,
+                chat-revamp 1b) and flips to Unarchive on archived sessions so
+                restore is one click too. Delete keeps its confirm popover. */}
+            {sessionId && session ? (
+              <VoiceCallButton
+                familiar={familiar}
+                voiceActive={voiceCallOpen}
+                onOpenVoice={() => setVoiceCallOpen(true)}
+              />
+            ) : null}
+            {sessionId && session ? (
+              <ArchiveChatButton
+                archived={Boolean(session.archived_at)}
+                archiving={archiving}
+                onSetArchived={(next) => void setChatArchived(next)}
+              />
             ) : null}
             {turns.length > 0 ? (
               <ChatFindBar
@@ -5039,6 +5040,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onPrev={findPrev}
               />
             ) : null}
+            {sessionId ? (
+              <DeleteChatButton deleting={deleting} onDelete={() => void deleteChat()} />
+            ) : null}
             {sessionId && (
               <SessionOverflowMenu
                 key={sessionId}
@@ -5046,19 +5050,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 projectId={projectIdDraft}
                 onProjectChange={setProjectIdDraft}
                 onAddProject={overflowAddProject.beginAddProject}
-                familiar={familiar}
                 sessionId={sessionId}
                 hasTurns={turns.length > 0}
-                voiceActive={voiceCallOpen}
-                onOpenVoice={() => setVoiceCallOpen(true)}
                 onOpenDebug={openDebug}
                 reflecting={reflecting}
                 onReflect={familiar.id ? () => void reflectOnThread() : undefined}
-                deleting={deleting}
-                onDelete={() => void deleteChat()}
-                archived={Boolean(session?.archived_at)}
-                archiving={archiving}
-                onSetArchived={(next) => void setChatArchived(next)}
               />
             )}
             {overflowAddProject.addProjectModal}

--- a/src/lib/chat-session-menu-model.test.ts
+++ b/src/lib/chat-session-menu-model.test.ts
@@ -1,0 +1,125 @@
+// Behavioral tests for the chat session header action model (cave-zolo):
+// the slim kebab contents and the direct archive/voice button states.
+import assert from "node:assert/strict";
+import {
+  archiveAction,
+  sessionMenuSections,
+  voiceAction,
+} from "./chat-session-menu-model.ts";
+
+const baseCtx = {
+  sessionId: "s1" as string | null,
+  projectPickerAvailable: true,
+  projectName: "coven-cave" as string | null,
+  projectRoot: "/Users/dev/coven-cave" as string | null,
+  hasTurns: true,
+  showThinking: false,
+  reflectAvailable: true,
+  reflecting: false,
+};
+
+// ---- kebab contents -------------------------------------------------------
+
+{
+  const sections = sessionMenuSections(baseCtx);
+  const ids = sections.flat().map((i) => i.id);
+  assert.deepEqual(
+    ids,
+    ["continue-on-phone", "project", "thinking", "reflect", "debug"],
+    "full context yields the slim five-item menu in two sections",
+  );
+  assert.equal(sections.length, 2, "primary and tools sections");
+}
+
+{
+  const ids = sessionMenuSections(baseCtx)
+    .flat()
+    .map((i) => i.id) as string[];
+  for (const promoted of ["archive", "delete", "rename", "voice", "call"]) {
+    assert.ok(
+      !ids.some((id) => id.includes(promoted)),
+      `${promoted} must NOT be a kebab item — it has a direct affordance now`,
+    );
+  }
+}
+
+{
+  const sections = sessionMenuSections({
+    ...baseCtx,
+    sessionId: null,
+    projectPickerAvailable: false,
+    hasTurns: false,
+    reflectAvailable: false,
+  });
+  const ids = sections.flat().map((i) => i.id);
+  assert.deepEqual(ids, ["debug"], "minimal context degrades to debug only");
+  assert.equal(sections.length, 1, "empty primary section is dropped (no dangling separator)");
+}
+
+{
+  const project = sessionMenuSections(baseCtx)
+    .flat()
+    .find((i) => i.id === "project");
+  assert.equal(project?.label, "Project: coven-cave");
+  assert.equal(project?.title, "/Users/dev/coven-cave", "root rides the tooltip");
+  const noProject = sessionMenuSections({ ...baseCtx, projectName: null, projectRoot: null })
+    .flat()
+    .find((i) => i.id === "project");
+  assert.equal(noProject?.label, "Project: No project");
+}
+
+{
+  const thinkingOff = sessionMenuSections(baseCtx).flat().find((i) => i.id === "thinking");
+  assert.equal(thinkingOff?.label, "Show thinking");
+  assert.equal(thinkingOff?.checked, false);
+  const thinkingOn = sessionMenuSections({ ...baseCtx, showThinking: true })
+    .flat()
+    .find((i) => i.id === "thinking");
+  assert.equal(thinkingOn?.label, "Hide thinking");
+  assert.equal(thinkingOn?.checked, true);
+  assert.equal(thinkingOn?.icon, "ph:brain-bold");
+}
+
+{
+  const reflecting = sessionMenuSections({ ...baseCtx, reflecting: true })
+    .flat()
+    .find((i) => i.id === "reflect");
+  assert.equal(reflecting?.label, "Reflecting…");
+  assert.equal(reflecting?.disabled, true, "reflect disables while running");
+}
+
+// ---- direct archive button ------------------------------------------------
+
+{
+  const live = archiveAction({ archived: false, archiving: false });
+  assert.equal(live.icon, "ph:archive");
+  assert.equal(live.label, "Archive this chat");
+  const busy = archiveAction({ archived: false, archiving: true });
+  assert.equal(busy.label, "Archiving chat…");
+}
+
+{
+  // The button flips instead of hiding on archived sessions — restore is a
+  // direct header action too (the kebab no longer carries Unarchive).
+  const archived = archiveAction({ archived: true, archiving: false });
+  assert.equal(archived.icon, "ph:arrow-counter-clockwise");
+  assert.equal(archived.label, "Unarchive this chat");
+  assert.match(archived.title, /Restore/);
+  const busy = archiveAction({ archived: true, archiving: true });
+  assert.equal(busy.label, "Unarchiving chat…");
+}
+
+// ---- direct voice button ----------------------------------------------------
+
+{
+  const ready = voiceAction({ voiceConfigured: true, voiceActive: false, familiarName: "Nova" });
+  assert.deepEqual(ready, { disabled: false, label: "Call Nova" });
+  const unconfigured = voiceAction({ voiceConfigured: false, voiceActive: false, familiarName: "Nova" });
+  assert.equal(unconfigured.disabled, true);
+  assert.equal(unconfigured.label, "Voice — set up in Studio");
+  const inCall = voiceAction({ voiceConfigured: true, voiceActive: true, familiarName: "Nova" });
+  assert.equal(inCall.disabled, true);
+  assert.match(inCall.label, /call in progress/);
+}
+
+console.log("chat-session-menu-model.test.ts: ok");

--- a/src/lib/chat-session-menu-model.ts
+++ b/src/lib/chat-session-menu-model.ts
@@ -1,0 +1,127 @@
+// Pure model for the chat session header's action cluster (cave-zolo).
+//
+// The header splits session actions into two tiers:
+//  - DIRECT actions — high-frequency / lifecycle verbs (voice call, archive,
+//    delete) rendered as icon buttons in the header cluster, so they are no
+//    longer buried behind the ⋮ kebab.
+//  - OVERFLOW items — the kebab menu, now slimmed to genuinely secondary
+//    tools (continue on phone, project, thinking, reflect, debug). Items that
+//    gained a direct affordance (archive, delete, call) and duplicates of
+//    inline affordances (rename — the title carries a pencil) are gone.
+//
+// Framework-free so the item lists are testable under
+// `node --experimental-strip-types` without rendering React.
+
+import type { IconName } from "@/lib/icon";
+
+export type SessionMenuItemId =
+  | "continue-on-phone"
+  | "project"
+  | "thinking"
+  | "reflect"
+  | "debug";
+
+export type SessionMenuItem = {
+  id: SessionMenuItemId;
+  label: string;
+  icon: IconName;
+  /** Renders the Popover checkmark slot (toggle items). */
+  checked?: boolean;
+  disabled?: boolean;
+  /** Hover tooltip when the label alone is terse. */
+  title?: string;
+};
+
+export type SessionMenuSection = SessionMenuItem[];
+
+export function sessionMenuSections(ctx: {
+  sessionId: string | null;
+  /** Whether a project row makes sense (projects exist or add-project is wired). */
+  projectPickerAvailable: boolean;
+  /** Active project display name; null → "No project". */
+  projectName: string | null;
+  /** Root path of the active project (tooltip). */
+  projectRoot: string | null;
+  hasTurns: boolean;
+  showThinking: boolean;
+  /** Reflect-on-thread is wired (familiar has an id). */
+  reflectAvailable: boolean;
+  reflecting: boolean;
+}): SessionMenuSection[] {
+  const primary: SessionMenuItem[] = [];
+  if (ctx.sessionId) {
+    primary.push({
+      id: "continue-on-phone",
+      label: "Continue on phone",
+      icon: "ph:device-mobile",
+    });
+  }
+  if (ctx.projectPickerAvailable) {
+    primary.push({
+      id: "project",
+      label: `Project: ${ctx.projectName ?? "No project"}`,
+      icon: "ph:folder",
+      title: ctx.projectRoot ?? "No project",
+    });
+  }
+
+  const tools: SessionMenuItem[] = [];
+  if (ctx.hasTurns) {
+    tools.push({
+      id: "thinking",
+      label: ctx.showThinking ? "Hide thinking" : "Show thinking",
+      icon: ctx.showThinking ? "ph:brain-bold" : "ph:brain",
+      checked: ctx.showThinking,
+      title: ctx.showThinking ? "Hide reasoning blocks" : "Show reasoning blocks",
+    });
+  }
+  if (ctx.reflectAvailable) {
+    tools.push({
+      id: "reflect",
+      label: ctx.reflecting ? "Reflecting…" : "Reflect on this thread",
+      icon: ctx.reflecting ? "ph:circle-notch-bold" : "ph:sparkle-bold",
+      disabled: ctx.reflecting,
+    });
+  }
+  tools.push({ id: "debug", label: "Debug session", icon: "ph:bug-bold" });
+
+  return [primary, tools].filter((section) => section.length > 0);
+}
+
+/** Direct archive button — flips verb on archived sessions instead of hiding,
+ *  so restore is one click from the header too (the kebab no longer carries
+ *  Archive/Unarchive). */
+export function archiveAction(ctx: { archived: boolean; archiving: boolean }): {
+  icon: IconName;
+  label: string;
+  title: string;
+} {
+  if (ctx.archived) {
+    return {
+      icon: "ph:arrow-counter-clockwise",
+      label: ctx.archiving ? "Unarchiving chat…" : "Unarchive this chat",
+      title: "Restore this chat to the rail",
+    };
+  }
+  return {
+    icon: "ph:archive",
+    label: ctx.archiving ? "Archiving chat…" : "Archive this chat",
+    title: "Archive this chat — it leaves the rail but is never deleted",
+  };
+}
+
+/** Direct voice-call button state — mirrors the old kebab item's gating:
+ *  disabled until the familiar has a voice provider, and while a call runs. */
+export function voiceAction(ctx: {
+  voiceConfigured: boolean;
+  voiceActive: boolean;
+  familiarName: string;
+}): { disabled: boolean; label: string } {
+  if (!ctx.voiceConfigured) {
+    return { disabled: true, label: "Voice — set up in Studio" };
+  }
+  if (ctx.voiceActive) {
+    return { disabled: true, label: `Call ${ctx.familiarName} — call in progress` };
+  }
+  return { disabled: false, label: `Call ${ctx.familiarName}` };
+}

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -261,7 +261,8 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
 
   const sessionHeader = read("../components/chat-session-header.tsx");
   assert.match(sessionHeader, /cave:continue-on-phone[\s\S]*detail: \{ chatId: sessionId \}/, "chat overflow dispatches the continue-on-phone event with the session id");
-  assert.match(sessionHeader, />\s*Continue on phone\s*</, "the overflow menu offers Continue on phone");
+  const menuModel = read("../lib/chat-session-menu-model.ts");
+  assert.match(menuModel, /label: "Continue on phone"/, "the overflow menu model offers Continue on phone");
 
   const workspace = read("../components/workspace.tsx");
   assert.match(workspace, /addEventListener\("cave:continue-on-phone"/, "workspace listens for the handoff event");

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -767,13 +767,35 @@ details[open] > .cave-tool-summary::before {
   opacity: 0.45;
 }
 
-/* Ultra-minimal header (pointer devices): at rest only the ⋮ kebab and the
- * find affordance show — they reveal on header hover or keyboard focus,
- * keeping their layout slots (no reflow on reveal). Touch devices — which
- * have no hover — skip this and show everything. The kebab holds every
- * secondary action, so nothing becomes hover-only. */
+/* cave-zolo: the direct delete button reads danger on approach — quiet
+ * muted-icon at rest like its siblings, red on hover/armed so the destructive
+ * verb is legible before the confirm popover asks. */
+.cave-chat-session-actions > .cave-chat-delete-btn:hover:not(:disabled),
+.cave-chat-session-actions > .cave-chat-delete-btn[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--color-danger) 45%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+  color: var(--color-danger);
+}
+
+/* Ultra-minimal header: at rest only the archive, find and ⋮ kebab
+ * affordances show. The promoted voice + delete verbs stay quiet — they
+ * carry the shared reveal-on-hover utility (design language §8) against the
+ * chat header's reveal-scope, surfacing on header hover or keyboard focus
+ * while keeping their layout slots (opacity-only: still tabbable, still in
+ * the a11y tree, no reflow; coarse pointers show everything). This replaces
+ * a bespoke pointer-events dance whose reveal rules could never outrank
+ * their own hide rule, leaving hover-only controls unreachable (cave-zolo).
+ *
+ * An armed popover (kebab menu, delete confirm) keeps the whole cluster
+ * revealed — the anchor must not fade under its own open popover when the
+ * pointer travels into it. */
+.cave-chat-session-actions:has([aria-expanded="true"]) .reveal-on-hover {
+  opacity: 1;
+}
+
+/* The composer footer band's lone "link a task" chip follows the same
+ * quiet-at-rest rhythm against the band (pointer devices only). */
 @media (hover: hover) and (pointer: fine) {
-  .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find):not(.cave-chat-archive-btn),
   .cave-chat-linked-context .cave-chat-linked-chip--link-task {
     opacity: 0;
     transform: translateX(4px);
@@ -783,9 +805,6 @@ details[open] > .cave-tool-summary::before {
       transform var(--duration-fast) var(--ease-standard);
   }
 
-  .cave-chat-linear-header:hover .cave-chat-session-actions > .focus-ring,
-  .cave-chat-session-actions:focus-within > .focus-ring,
-  .cave-chat-session-actions:has([aria-expanded="true"]) > .focus-ring,
   .cave-composer-footer-band:hover .cave-chat-linked-context .cave-chat-linked-chip--link-task,
   .cave-chat-linked-context:focus-within .cave-chat-linked-chip--link-task {
     opacity: 1;
@@ -795,7 +814,6 @@ details[open] > .cave-tool-summary::before {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find):not(.cave-chat-archive-btn),
   .cave-chat-linked-context .cave-chat-linked-chip--link-task {
     transition: none;
     transform: none;


### PR DESCRIPTION
## Summary

The chat session header's overflow kebab (⋮) had accreted **nine** items — the verbs people reach for most (archive, delete, voice) were buried behind a click. This splits the cluster into direct actions + a slim 5-item kebab, and extracts a pure menu model so the split stays honest. (bead: cave-zolo)

### UX
- **Voice, Archive, Find, Delete, ⋮** now sit directly in the header cluster.
- **Delete** confirms via an anchored popover (danger styling) instead of the old in-menu view swap.
- **Archive** flips to **Unarchive** (counter-clockwise icon) on archived sessions instead of disappearing.
- **Voice** is disabled with a "set up in Studio" hint when the familiar has no voice provider.
- **Kebab** keeps only secondary items: Continue on phone, Project, Show/Hide thinking, Reflect, Debug.
- **Rename** stays with the title pencil — its kebab duplicate and the dead `cave:chat-rename` window bridge are removed.

### Code
- New pure, framework-free `src/lib/chat-session-menu-model.ts` — single source for kebab sections + archive/voice button states; `SessionOverflowMenu` renders from it (17 props → 9).
- New `DeleteChatButton`, `ArchiveChatButton`, `VoiceCallButton` exports in `chat-session-header.tsx`.

### Bug fixed along the way
The bespoke quiet-at-rest CSS could **never reveal**: its hide rule's `:not()` chain (0,5,0) outranked every reveal selector (0,4,0), and it used `pointer-events: none` — hover-only controls were invisible *and* unclickable. The collapsed find toggle was already lost to this on `main`. Replaced with the shared `reveal-on-hover` utility (design language §8) against the header's existing `reveal-scope`, plus a rule keeping the cluster revealed while a popover is armed.

## Verification
- `pnpm test:app` — 869 test files green (new model test registered + wired)
- `pnpm typecheck`, `pnpm lint`, `check-tests-wired` — clean
- `pnpm build` — clean
- Playwright against the built app: rest (Archive/Find/⋮), hover (Voice/Delete revealed), delete confirm popover, slim kebab, archived → Unarchive state all screenshot-verified.