### PR TITLE
feat(home): move context pill to footer band, drop typing hint (chat parity)

### DIFF
--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -154,11 +154,17 @@ assert.match(
 
 // The "↵ send · ⇧↵ newline" typing hint is gone from the chat composer
 // (2026-07-21): the tinted send button already signals sendability. The
-// home composer keeps its own hint, so the shared CSS class stays.
+// home composer dropped its hint in the same day's parity pass, so the
+// shared CSS class is retired with its last consumer.
 assert.doesNotMatch(
   source,
   /cave-composer-typing-hint/,
   "the enter-to-send typing hint no longer renders in the chat composer",
+);
+assert.doesNotMatch(
+  css,
+  /cave-composer-typing-hint/,
+  "the typing-hint CSS is retired with its last consumer (the home composer)",
 );
 
 // ── Reveal + mobile behavior ─────────────────────────────────────────────────

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -26,6 +26,11 @@ assert.match(
   "the home composer's context pill hosts the runtime picker from its own model state",
 );
 assert.match(
+  homeComposer,
+  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
+  "the home pill anchors the composer footer band (2026-07-21 home parity pass moved it down from the utility row)",
+);
+assert.match(
   contextPill,
   /export function ComposerContextActionRows\(/,
   "runtime/model rows are reusable outside the Home pill wrapper",

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -63,14 +63,20 @@ assert.match(
 );
 
 // ───────── Command-bar hierarchy ─────────
-// Chat revamp 1d: one "+" menu (attach · dictation · call · enhance · Model &
-// tuning) and one context pill (Project · Model) lead the utility row, then
-// the Chat/Task pills; the circular send hugs the right. The footer band is
-// gone — its pickers collapsed into the pill and the "+" popover.
+// Chat revamp 1d + 2026-07-21 home parity pass: one "+" menu (attach ·
+// dictation · call · enhance · Model & tuning) leads the utility row, then the
+// Chat/Task pills; the circular send hugs the right. The context pill
+// (Project · Model) anchors the footer band beneath — matching the chat
+// composer's grammar.
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?<ComposerContextPill[\s\S]*?hc-dest-pills hc-dest-pills--inline[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"/,
-  "the utility row leads with the + menu and context pill, then the Chat/Task pill toggle",
+  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?hc-dest-pills hc-dest-pills--inline[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"/,
+  "the utility row leads with the + menu, then the Chat/Task pill toggle",
+);
+assert.match(
+  source,
+  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
+  "the context pill anchors the footer band beneath the control row",
 );
 assert.match(
   source,
@@ -90,7 +96,7 @@ assert.match(
 assert.doesNotMatch(
   source,
   /hc-footer-band/,
-  "the footer band is retired — its pickers live in the context pill + Options panel",
+  "the legacy hc- footer band stays retired — the shared cave-composer-footer-band carries the context pill",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -455,7 +455,7 @@ assert.match(
 // ── Single-row toolbar replaces mode strip + run rail ───────────────────────
 // The top mode strip and the separate run rail were removed. The footer is the
 // chat composer's: attach + Chat/Task pills left, voice/enhance/send right; the
-// footer band beneath carries the project picker and the runtime + model chip.
+// footer band beneath carries the context pill (project · runtime + model).
 assert.doesNotMatch(
   source,
   /className="hc-mode-strip"/,
@@ -468,8 +468,20 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?<ComposerContextPill[\s\S]*?hc-dest-pills--inline[\s\S]*?cave-composer-submit-row[\s\S]*?aria-label="Send"[\s\S]*?<ComposerOptionsMenu/,
-  "Control row: the + menu, context pill, and Chat/Task pills lead; the circular send hugs the right; the Options panel chains off the + anchor",
+  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?hc-dest-pills--inline[\s\S]*?cave-composer-submit-row[\s\S]*?aria-label="Send"[\s\S]*?<ComposerOptionsMenu[\s\S]*?className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
+  "Control row: the + menu and Chat/Task pills lead; the circular send hugs the right; the context pill anchors the footer band beneath (2026-07-21 home parity pass)",
+);
+assert.doesNotMatch(
+  source.match(/className="cave-composer-utility-row">[\s\S]*?hc-dest-pills hc-dest-pills--inline/)?.[0] ?? "",
+  /<ComposerContextPill/,
+  "the utility row stays pill-free — context moved down to the footer band",
+);
+// The "↵ send · ⇧↵ newline" typing hint is gone (2026-07-21 parity with the
+// chat composer): the tinted send button already signals sendability.
+assert.doesNotMatch(
+  source,
+  /cave-composer-typing-hint/,
+  "the enter-to-send typing hint no longer renders in the home composer",
 );
 // Voice input is hidden until it actually works — a permanently disabled mic
 // read as broken chrome (user-reported).

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -880,14 +880,6 @@ export function HomeComposer({
           inputMode="text"
           enterKeyHint="send"
         />
-        {/* Typing hint (chat revamp 1d): appears with the first character,
-            inside the input area — not persistent chrome. Hidden on phone
-            widths (CSS). */}
-        {text.trim() && !sending ? (
-          <span className="cave-composer-typing-hint" aria-hidden>
-            ↵ send · ⇧↵ newline
-          </span>
-        ) : null}
         </div>
 
         {/* Enhance status strip (shared): streaming preview, apply/dismiss
@@ -968,23 +960,6 @@ export function HomeComposer({
                 promptSnippets={{ onSelect: () => setSnippetsBrowserOpen(true) }}
                 onOpenModelTuning={() => setOptionsOpen(true)}
               />
-              {/* One quiet context pill — Project · Model — replacing the
-                  footer band's picker row (home has no git context). */}
-              <ComposerContextPill
-                projects={projects}
-                projectValue={selectedProjectId || null}
-                onProjectChange={setSelectedProjectId}
-                allowNoProject
-                familiarId={selectedFamiliarId || null}
-                createProject={createProject}
-                runtime={selectedRuntime}
-                modelValue={selectedModelId}
-                modelOptions={runtimeModelOptions}
-                onPickRuntime={handleSelectRuntime}
-                onPickModel={handleSelectModel}
-                disabled={sending}
-                ariaLabel="Composer context: project and model"
-              />
               <div
                 className="hc-dest-pills hc-dest-pills--inline"
                 role="radiogroup"
@@ -1031,8 +1006,9 @@ export function HomeComposer({
           </div>
 
           {/* Model & tuning panel — the existing Options popover, opened from
-              the "+" menu and anchored to it (the footer band it used to sit
-              in collapsed into the context pill + "+" popover). */}
+              the "+" menu and anchored to it (host/thinking/speed tuning stays
+              here; the context pill on the footer band carries project ·
+              model). */}
           <ComposerOptionsMenu
             open={optionsOpen}
             onOpenChange={setOptionsOpen}
@@ -1078,6 +1054,29 @@ export function HomeComposer({
                 onChange: (v: string) => setResponseSpeed(v as CommandResponseSpeed),
               } satisfies ComposerOptionSection,
             ]}
+          />
+        </div>
+        {/* Footer band — the darker strip attached to the card's underside
+            carries the context pill (Project · Model; every picker opens from
+            it). Moved down from the control row (2026-07-21 home parity pass,
+            matching the chat composer) so the write surface above stays
+            minimal. Home has no git context or linked-work strip, so the
+            pill rides alone. */}
+        <div className="cave-composer-footer-band">
+          <ComposerContextPill
+            projects={projects}
+            projectValue={selectedProjectId || null}
+            onProjectChange={setSelectedProjectId}
+            allowNoProject
+            familiarId={selectedFamiliarId || null}
+            createProject={createProject}
+            runtime={selectedRuntime}
+            modelValue={selectedModelId}
+            modelOptions={runtimeModelOptions}
+            onPickRuntime={handleSelectRuntime}
+            onPickModel={handleSelectModel}
+            disabled={sending}
+            ariaLabel="Composer context: project and model"
           />
         </div>
         </div>

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -1050,31 +1050,16 @@
   background: var(--color-danger);
 }
 
-/* Typing hint — one line, top-right inside the input area, 10.5px mono muted.
-   Rendered only while the draft is non-empty; never persistent chrome. */
+/* Input wrap — positioning anchor for affordances layered over the input
+   area (the typing hint that used to live here retired 2026-07-21 with its
+   last consumer, the home composer). */
 .cave-composer-input-wrap {
   position: relative;
 }
 
-.cave-composer-typing-hint {
-  position: absolute;
-  top: 8px;
-  right: 12px;
-  pointer-events: none;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  line-height: 1;
-}
-
 @media (max-width: 767px) {
-  /* Skip the hint on mobile widths; grow the new controls to touch size
-     (radius language stays — the plus keeps its 8px corner, the send its
-     circle). */
-  .cave-composer-typing-hint {
-    display: none;
-  }
-
+  /* Grow the new controls to touch size (radius language stays — the plus
+     keeps its 8px corner, the send its circle). */
   .cave-composer-footer-action,
   .cave-composer-plus,
   .cave-composer-send {


### PR DESCRIPTION
## What
Sweep the home composer with the chat composer's footer-pill treatment (follow-up to #3625):

- **Context pill → footer band.** `ComposerContextPill` (Project · Model) moves out of the utility row into a re-introduced `cave-composer-footer-band` as the card's last child. The shared band CSS (flex, space-between, darker strip) applies as-is; home has no linked-work strip, so the pill rides alone on the left.
- **Typing hint removed.** The "↵ send · ⇧↵ newline" hint is gone from the home composer — its last consumer — so the shared `.cave-composer-typing-hint` CSS and its mobile override retire with it.

## Why
Chat got this grammar in #3625; home keeping the pill in the control row and its own hint left the two composers inconsistent.

## Verification
- `pnpm typecheck` ✓
- `pnpm test:app` — 868 files ✓
- `pnpm test:mobile` — 83 files ✓
- Pins updated: home-composer, home-composer-polish, composer-runtime-chip, chat-composer-footer-band
