### PR TITLE
fix(hermes): expose authenticated models and repair Debug events

### DIFF
--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -53,6 +53,17 @@ TAURI_OVERRIDE_CONFIG="$(mktemp)"
 cleanup() { rm -f "$TAURI_OVERRIDE_CONFIG"; }
 trap cleanup EXIT
 
+# A Tauri dev process and its `beforeDevCommand` inherit this secret together.
+# The server therefore requires the browser-side bridge token too; carry it in
+# the URL fragment so it never participates in Next's module URL resolution or
+# reaches the HTTP server. The bridge stores it in sessionStorage, strips it,
+# and attaches the header to same-origin `/api/` calls.
+dev_url="http://127.0.0.1:${dev_port}"
+if [ -n "${COVEN_CAVE_AUTH_TOKEN:-}" ]; then
+  sidecar_token_fragment="$(node -p 'encodeURIComponent(process.env.COVEN_CAVE_AUTH_TOKEN)')"
+  dev_url+="#covenCaveToken=${sidecar_token_fragment}"
+fi
+
 if [ "$should_start_server" = true ]; then
   # The desktop shell always uses a loopback devUrl. A host-provided HOSTNAME
   # (for example Docker/WSL's machine name) would bind the server elsewhere
@@ -64,12 +75,12 @@ if [ "$should_start_server" = true ]; then
   esac
   # Use beforeDevCommand but set PORT so it uses our free port.
   cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
-{"build":{"beforeDevCommand":"${before_dev_command}","devUrl":"http://127.0.0.1:${dev_port}"}}
+{"build":{"beforeDevCommand":"${before_dev_command}","devUrl":"${dev_url}"}}
 CONF
 else
   # Skip beforeDevCommand since the server is already running
   cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
-{"build":{"beforeDevCommand":null,"devUrl":"http://127.0.0.1:${dev_port}"}}
+{"build":{"beforeDevCommand":null,"devUrl":"${dev_url}"}}
 CONF
 fi
 

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -23,4 +23,15 @@ assert.match(
   "the generated Tauri override must use the platform-correct command",
 );
 
+assert.match(
+  source,
+  /if \[ -n "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?encodeURIComponent\(process\.env\.COVEN_CAVE_AUTH_TOKEN\)[\s\S]*?dev_url\+="#covenCaveToken=\$\{sidecar_token_fragment\}"/,
+  "an inherited sidecar token must reach the desktop webview through the URL hash",
+);
+assert.match(
+  source,
+  /"devUrl":"\$\{dev_url\}"/,
+  "both launcher paths must use the token-bearing dev URL",
+);
+
 console.log("dev-app: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -819,6 +819,7 @@ export const SUITES = {
     "src/lib/server/atomic-write.test.ts",
     "src/lib/server/local-origin.test.ts",
     "src/lib/server/api-security.test.ts",
+    "src/lib/server/session-security.test.ts",
     "src/lib/server/codex-oauth-port.test.ts",
     "src/lib/env-local-bundle.test.ts",
     "src/lib/cave-board-schedule.test.ts",

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -10,8 +10,13 @@ import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 let modelFlagProbe: Promise<boolean> | null = null;
 let permissionFlagProbe: Promise<boolean> | null = null;
 let addDirFlagProbe: Promise<boolean> | null = null;
+let hermesModelFlagProbe: Promise<boolean> | null = null;
 
-function probeRunHelp(matches: (help: string) => boolean): Promise<boolean> {
+function probeHelp(
+  command: string,
+  args: string[],
+  matches: (help: string) => boolean,
+): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     let output = "";
     let settled = false;
@@ -21,8 +26,7 @@ function probeRunHelp(matches: (help: string) => boolean): Promise<boolean> {
       resolve(value);
     };
     try {
-      const { command, fixedArgs } = covenLaunchCommand();
-      const child = spawn(command, [...fixedArgs, "run", "--help"], {
+      const child = spawn(command, args, {
         env: harnessSpawnEnv(),
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -52,13 +56,38 @@ function probeRunHelp(matches: (help: string) => boolean): Promise<boolean> {
 
 /** Capability probes are cached because old Coven CLIs reject unknown flags. */
 export function covenRunSupportsModel(): Promise<boolean> {
-  return (modelFlagProbe ??= probeRunHelp(covenRunSupportsModelFlag));
+  const { command, fixedArgs } = covenLaunchCommand();
+  return (modelFlagProbe ??= probeHelp(
+    command,
+    [...fixedArgs, "run", "--help"],
+    covenRunSupportsModelFlag,
+  ));
 }
 
 export function covenRunSupportsPermission(): Promise<boolean> {
-  return (permissionFlagProbe ??= probeRunHelp(covenRunSupportsPermissionFlag));
+  const { command, fixedArgs } = covenLaunchCommand();
+  return (permissionFlagProbe ??= probeHelp(
+    command,
+    [...fixedArgs, "run", "--help"],
+    covenRunSupportsPermissionFlag,
+  ));
 }
 
 export function covenRunSupportsAddDir(): Promise<boolean> {
-  return (addDirFlagProbe ??= probeRunHelp(covenRunSupportsAddDirFlag));
+  const { command, fixedArgs } = covenLaunchCommand();
+  return (addDirFlagProbe ??= probeHelp(
+    command,
+    [...fixedArgs, "run", "--help"],
+    covenRunSupportsAddDirFlag,
+  ));
+}
+
+/** Hermes runs directly, so probe its own CLI rather than coven run. */
+export function hermesChatSupportsModel(): Promise<boolean> {
+  const command = process.platform === "win32" ? "hermes.exe" : "hermes";
+  return (hermesModelFlagProbe ??= probeHelp(
+    command,
+    ["chat", "--help"],
+    (help) => /(^|\s)--model(?![\w-])/m.test(help),
+  ));
 }

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -83,8 +83,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /if \(hermesDirect\) \{[\s\S]*?if \(forwardModel\) a\.push\("--model", forwardModel\);[\s\S]*?a\.push\("--query", prompt\)/,
-  "An advertised Hermes --model flag must receive the selected model before the query",
+  /if \(hermesDirect\) \{[\s\S]*?const hermesModel = forwardModel\?\.includes\("\/"\)[\s\S]*?forwardModel\.slice\(forwardModel\.lastIndexOf\("\/"\) \+ 1\)[\s\S]*?if \(hermesModel\) a\.push\("--model", hermesModel\);[\s\S]*?a\.push\("--query", prompt\)/,
+  "An advertised Hermes --model flag must receive Cave's bare model id before the query",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -75,10 +75,16 @@ assert.match(
   "Hermes direct chat must use quiet query mode so stdout contains the actual reply",
 );
 
-assert.doesNotMatch(
+assert.match(
   chatRoute,
-  /const hermesModel = cleanModelId\(desiredModel\);/,
-  "Hermes does not advertise a model flag, so a custom Cave model must not become invalid CLI args",
+  /const modelForwardingEnabled = hermesDirect[\s\S]*?await hermesChatSupportsModel\(\)/,
+  "Hermes model forwarding must probe its direct CLI instead of assuming the coven-run capability applies",
+);
+
+assert.match(
+  chatRoute,
+  /if \(hermesDirect\) \{[\s\S]*?if \(forwardModel\) a\.push\("--model", forwardModel\);[\s\S]*?a\.push\("--query", prompt\)/,
+  "An advertised Hermes --model flag must receive the selected model before the query",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -83,8 +83,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /if \(hermesDirect\) \{[\s\S]*?const hermesModel = forwardModel\?\.includes\("\/"\)[\s\S]*?forwardModel\.slice\(forwardModel\.lastIndexOf\("\/"\) \+ 1\)[\s\S]*?if \(hermesModel\) a\.push\("--model", hermesModel\);[\s\S]*?a\.push\("--query", prompt\)/,
-  "An advertised Hermes --model flag must receive Cave's bare model id before the query",
+  /if \(hermesDirect\) \{[\s\S]*?if \(forwardModel\) a\.push\("--model", forwardModel\);[\s\S]*?a\.push\("--query", prompt\)/,
+  "An advertised Hermes --model flag must receive Cave's provider-qualified model id before the query",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-model-capabilities.test.ts
+++ b/src/app/api/chat/send/harness-routing-model-capabilities.test.ts
@@ -45,6 +45,11 @@ assert.match(
   /covenRunSupportsModelFlag/,
   "Model forwarding must gate on the coven run --model capability probe",
 );
+assert.match(
+  capabilityProbes,
+  /export function hermesChatSupportsModel\(\)/,
+  "Direct Hermes model forwarding must probe hermes chat --help independently of coven run",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1149,11 +1149,9 @@ export async function POST(req: Request) {
     if (hermesDirect) {
       const a = ["chat", "--source", "coven", "-Q"];
       if (resumeSessionId) a.push("--resume", resumeSessionId);
-      // Cave stores provider-qualified IDs, while Hermes accepts the bare id.
-      const hermesModel = forwardModel?.includes("/")
-        ? forwardModel.slice(forwardModel.lastIndexOf("/") + 1)
-        : forwardModel;
-      if (hermesModel) a.push("--model", hermesModel);
+      // Hermes uses the provider-qualified model ID (for example
+      // `openai/gpt-5.6-sol`) to select the provider as well as the model.
+      if (forwardModel) a.push("--model", forwardModel);
       a.push("--query", prompt);
       return a;
     }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -142,6 +142,7 @@ import {
 import {
   covenRunSupportsAddDir,
   covenRunSupportsModel,
+  hermesChatSupportsModel,
   covenRunSupportsPermission,
 } from "./chat-send-capabilities";
 import {
@@ -816,11 +817,13 @@ export async function POST(req: Request) {
   }
   const effectiveRuntime = runtimeSelection.runtime ?? binding.runtime;
   const sshRuntime = isSshRuntime(effectiveRuntime) ? effectiveRuntime : null;
-  // OpenClaw runs through its own agent bridge (no `coven run`), so it never
-  // forwards `--model`; every other bundled harness gates on the capability
-  // probe so this stays a no-op until the companion CLI ships the flag.
-  const modelForwardingEnabled =
-    binding.harness !== "openclaw" && (await covenRunSupportsModel());
+  // Hermes runs directly, so it must advertise --model itself; every other
+  // bundled harness uses coven run's capability probe. OpenClaw's bridge has
+  // no CLI model passthrough.
+  const hermesDirect = !sshRuntime && binding.harness === "hermes";
+  const modelForwardingEnabled = hermesDirect
+    ? await hermesChatSupportsModel()
+    : binding.harness !== "openclaw" && (await covenRunSupportsModel());
   // Same gating for the sandbox/permission flag. Only "read" is forwarded
   // (→ `--permission read-only`); "full" stays implicit so the harness keeps
   // its own default sandbox instead of being widened to danger-full-access.
@@ -1096,7 +1099,6 @@ export async function POST(req: Request) {
   // beside Hermes's Windows executable, which left Cave showing only a timer.
   // Spawn Hermes directly for native local chats, as we already do for the
   // Copilot JSONL adapter, and keep SSH runtimes on their remote Coven path.
-  const hermesDirect = !sshRuntime && binding.harness === "hermes";
   // The copilot session id Cave chose for the CURRENT attempt: the resume
   // target, or a pre-assigned fresh id (copilot events don't echo the id
   // until the final result frame, so the stream handler announces this one).
@@ -1147,6 +1149,7 @@ export async function POST(req: Request) {
     if (hermesDirect) {
       const a = ["chat", "--source", "coven", "-Q"];
       if (resumeSessionId) a.push("--resume", resumeSessionId);
+      if (forwardModel) a.push("--model", forwardModel);
       a.push("--query", prompt);
       return a;
     }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1149,7 +1149,11 @@ export async function POST(req: Request) {
     if (hermesDirect) {
       const a = ["chat", "--source", "coven", "-Q"];
       if (resumeSessionId) a.push("--resume", resumeSessionId);
-      if (forwardModel) a.push("--model", forwardModel);
+      // Cave stores provider-qualified IDs, while Hermes accepts the bare id.
+      const hermesModel = forwardModel?.includes("/")
+        ? forwardModel.slice(forwardModel.lastIndexOf("/") + 1)
+        : forwardModel;
+      if (hermesModel) a.push("--model", hermesModel);
       a.push("--query", prompt);
       return a;
     }

--- a/src/app/api/sessions/[id]/events/route.test.ts
+++ b/src/app/api/sessions/[id]/events/route.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // Security regression tests for the daemon session API hardening.
 // Verifies that session endpoints reject non-local requests, validate session
-// IDs against the UUID pattern, and confirm session ownership before proxying
+// IDs against the shared safe session-id grammar, and confirm session ownership before proxying
 // to the daemon — preventing unauthenticated access and SSRF via crafted IDs.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { isValidSessionId } from "@/lib/server/session-id";
 import {
   archiveSessionLocal,
   extendSessionAutoArchiveLocal,
@@ -10,11 +11,6 @@ import {
 } from "@/lib/cave-config";
 import { clampExtendDays, extendUntilIso } from "@/lib/chat-auto-archive";
 import { resolveArchiveNudges } from "@/lib/task-archive-nudge-emit";
-
-/** Validate session ID: only alphanum, hyphens, colons, dots — no path traversal. */
-function isValidSessionId(id: string): boolean {
-  return /^[A-Za-z0-9:._-]{1,256}$/.test(id);
-}
 
 export const dynamic = "force-dynamic";
 

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -25,6 +25,11 @@ assert.match(
 );
 assert.match(
   source,
+  /modelOptions\.length > 0[\s\S]{0,160}<StandardSelect/,
+  "A runtime with catalog models, including Hermes, must render the dropdown instead of only free text",
+);
+assert.match(
+  source,
   /allowCustomModel/,
   "Brain tab should keep a free-text fallback for ids not in the curated catalog",
 );

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -6,7 +6,7 @@ const source = readFileSync(
   new URL("./familiar-studio-brain-tab.tsx", import.meta.url),
   "utf8",
 );
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/globals/shell-responsive.css", import.meta.url), "utf8");
 
 assert.match(source, /export function FamiliarStudioBrainTab/);
 assert.match(source, /harness/);

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -254,6 +254,20 @@ assert.equal(
     "the OpenAI Codex model-normalization diagnostic must not leak into an external runtime reply",
   );
 }
+{
+  const external = new AssistantFilter({ passthrough: true });
+  let out = external.push(
+    "⚠️  Normalized model 'openai/gpt-5.6-terra' to 'gpt-5.6-terra' for \n",
+  );
+  out += external.push("openai-codex.\n");
+  out += external.push("The wrapped reply remains visible.\n");
+  out += external.flush();
+  assert.equal(
+    out,
+    "The wrapped reply remains visible.\n",
+    "the hard-wrapped OpenAI Codex normalization diagnostic must not leak into an external runtime reply",
+  );
+}
 assert.equal(
   feed(["A bare line with no marker before it."]),
   "",

--- a/src/lib/chat-assistant-filter.test.ts
+++ b/src/lib/chat-assistant-filter.test.ts
@@ -240,6 +240,20 @@ assert.equal(
     "external-adapter stdout passes through verbatim — no marker gate, no banner heuristics",
   );
 }
+{
+  const external = new AssistantFilter({ passthrough: true });
+  let out = external.push(
+    "⚠️ Normalized model 'openai/gpt-5.6-terra' to 'gpt-5.6-terra' for openai-codex. The model reply remains visible.\n",
+  );
+  out += external.push(
+    "⚠️ Normalized model 'openai/gpt-5.6-terra' to 'gpt-5.6-terra' for openai-codex.\n",
+  );
+  assert.equal(
+    out,
+    "The model reply remains visible.\n",
+    "the OpenAI Codex model-normalization diagnostic must not leak into an external runtime reply",
+  );
+}
 assert.equal(
   feed(["A bare line with no marker before it."]),
   "",

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -2,6 +2,11 @@ const HOOK_LINE_RE = /^hook:\s+/;
 const BANNER_LINE_RE = /^(?:--------|workdir:|model:|provider:|approval:|sandbox:|reasoning:|session id:|tokens used|\d[\d,]*\s*$)/;
 const CODEX_START_LINE = "codex";
 const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
+// Hermes may emit this compatibility diagnostic on stdout immediately before
+// (or on the same line as) its reply. The selected model is still applied, so
+// do not expose the runtime's internal provider normalization to the user.
+const OPENAI_CODEX_MODEL_NORMALIZATION_PREFIX_RE =
+  /^\s*(?:⚠(?:\uFE0F)?\s*)?Normalized model ['"][^'"\r\n]+['"] to ['"][^'"\r\n]+['"] for openai-codex\.\s*/i;
 
 // Exec-echo blocks emitted by Codex into stdout — NOT structured JSON events.
 // Format:
@@ -142,7 +147,10 @@ export class AssistantFilter {
 
   private processLine(rawLine: string): string {
     const line = rawLine.replace(/\r/g, "");
-    if (this.passthrough) return line + "\n";
+    if (this.passthrough) {
+      const visibleLine = line.replace(OPENAI_CODEX_MODEL_NORMALIZATION_PREFIX_RE, "");
+      return visibleLine ? visibleLine + "\n" : "";
+    }
     const trimmed = line.trim();
 
     if (trimmed === CODEX_START_LINE || CLAUDE_ASSISTANT_RE.test(trimmed)) {

--- a/src/lib/chat-assistant-filter.ts
+++ b/src/lib/chat-assistant-filter.ts
@@ -7,6 +7,9 @@ const CLAUDE_ASSISTANT_RE = /^claude(?:\s+code)?$/i;
 // do not expose the runtime's internal provider normalization to the user.
 const OPENAI_CODEX_MODEL_NORMALIZATION_PREFIX_RE =
   /^\s*(?:⚠(?:\uFE0F)?\s*)?Normalized model ['"][^'"\r\n]+['"] to ['"][^'"\r\n]+['"] for openai-codex\.\s*/i;
+const OPENAI_CODEX_MODEL_NORMALIZATION_START_RE =
+  /^\s*(?:⚠(?:\uFE0F)?\s*)?Normalized model ['"][^'"\r\n]+['"] to ['"][^'"\r\n]+['"] for\s*$/i;
+const OPENAI_CODEX_MODEL_NORMALIZATION_CONTINUATION_RE = /^\s*openai-codex\.\s*$/i;
 
 // Exec-echo blocks emitted by Codex into stdout — NOT structured JSON events.
 // Format:
@@ -117,6 +120,10 @@ export class AssistantFilter {
   // phase gate suppressed entire replies, and the banner heuristic ate
   // legitimate numeric answers. Those callers get verbatim passthrough.
   private passthrough = false;
+  // Hermes can hard-wrap its model-normalization diagnostic immediately before
+  // `openai-codex.`. Hold the first line until that exact continuation arrives
+  // so unrelated assistant text is never discarded.
+  private pendingOpenAiCodexNormalization: string | null = null;
 
   constructor(opts?: { passthrough?: boolean }) {
     this.passthrough = opts?.passthrough === true;
@@ -138,6 +145,10 @@ export class AssistantFilter {
     let remainder = "";
     if (this.buf) remainder = this.processLine(this.buf);
     this.buf = "";
+    if (this.pendingOpenAiCodexNormalization) {
+      remainder += this.pendingOpenAiCodexNormalization + "\n";
+      this.pendingOpenAiCodexNormalization = null;
+    }
     if (this.pendingSkillFrontmatterDelimiter) {
       this.pendingSkillFrontmatterDelimiter = false;
       return remainder + "---\n";
@@ -148,7 +159,17 @@ export class AssistantFilter {
   private processLine(rawLine: string): string {
     const line = rawLine.replace(/\r/g, "");
     if (this.passthrough) {
+      if (this.pendingOpenAiCodexNormalization) {
+        const pending = this.pendingOpenAiCodexNormalization;
+        this.pendingOpenAiCodexNormalization = null;
+        if (OPENAI_CODEX_MODEL_NORMALIZATION_CONTINUATION_RE.test(line)) return "";
+        return pending + "\n" + line + "\n";
+      }
       const visibleLine = line.replace(OPENAI_CODEX_MODEL_NORMALIZATION_PREFIX_RE, "");
+      if (OPENAI_CODEX_MODEL_NORMALIZATION_START_RE.test(line)) {
+        this.pendingOpenAiCodexNormalization = line;
+        return "";
+      }
       return visibleLine ? visibleLine + "\n" : "";
     }
     const trimmed = line.trim();

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -116,12 +116,25 @@ for (const catalog of Object.values(RUNTIME_MODEL_CATALOG)) {
   }
 }
 
-// Runtime-managed adapters are free-text only (no model menu). Hermes here means
-// the installed Hermes Agent runtime, not a Nous/Hermes model selection.
+// Hermes forwards authenticated Codex models through its adapter, so it has a
+// concrete menu while retaining Custom for an explicitly supplied model id.
 const hermes = catalogForRuntime("hermes");
-assert.equal(hermes.provider, null);
-assert.equal(hermes.models.length, 0, "hermes is runtime-managed, not a Hermes model menu");
-assert.equal(hermes.allowCustom, true, "runtime-managed Hermes still accepts explicit user model ids");
+assert.equal(hermes.provider, "openai");
+assert.deepEqual(
+  hermes.models.map((model) => model.id),
+  [
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
+    "openai/gpt-5.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
+    "openai/gpt-5.3-codex-spark",
+    "openai/codex-auto-review",
+  ],
+  "Hermes should expose the authenticated Codex model dropdown",
+);
+assert.equal(hermes.allowCustom, true, "Hermes still accepts explicit user model ids");
 
 // null-provider runtimes are free-text only (no menu).
 const openclaw = catalogForRuntime("openclaw");
@@ -129,7 +142,7 @@ assert.equal(openclaw.provider, null);
 assert.equal(openclaw.models.length, 0, "openclaw renders free-text only");
 assert.equal(openclaw.allowCustom, true, "free-text must stay allowed when there is no menu");
 assert.equal(defaultModelForRuntime("codex"), "openai/gpt-5.6-sol");
-assert.equal(defaultModelForRuntime("hermes"), "hermes-local", "Hermes should default to the runtime marker, not a Hermes model");
+assert.equal(defaultModelForRuntime("hermes"), "openai/gpt-5.6-sol", "Hermes should default to the first authenticated model");
 assert.equal(defaultModelForRuntime("openclaw"), "openai/gpt-5.6-sol", "OpenClaw should inherit a real global default, not openclaw-local");
 
 // Unknown runtimes have no catalog.
@@ -148,6 +161,7 @@ assert.equal(catalogForRuntime("nonexistent"), null);
 // isModelInCatalog only matches curated ids; allowCustom covers the rest.
 assert.equal(isModelInCatalog("claude", "anthropic/claude-opus-4-7"), true);
 assert.equal(isModelInCatalog("claude", "anthropic/not-listed-yet"), false);
+assert.equal(isModelInCatalog("hermes", "openai/gpt-5.6-terra"), true);
 assert.equal(isModelInCatalog("hermes", "nous/hermes-4"), false);
 assert.equal(isModelInCatalog("openclaw", "anything"), false);
 assert.equal(isModelInCatalog("nonexistent", "openai/gpt-5.5"), false);

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -9,8 +9,8 @@
 // providers ship new models, and `allowCustom` is the safety valve so the menu
 // never blocks an id that isn't listed yet. Runtime-managed adapters get
 // `provider: null` and render a free-text field only — the literal "else the
-// runtime's CLI" branch. That includes Hermes: Cave's Hermes mode means the
-// installed Hermes Agent runtime, not a bundled Nous/Hermes model selection.
+// runtime's CLI" branch. Hermes is the exception: its adapter forwards the
+// authenticated Codex model ids below through its supported `--model` flag.
 
 export type RuntimeProvider = "openai" | "anthropic" | "github" | "nous" | null;
 
@@ -29,6 +29,19 @@ export type RuntimeModelCatalog = {
   /** User may type any model id not present in `models`. */
   allowCustom: boolean;
 };
+
+// Models exposed by the authenticated Codex account. Hermes forwards the bare
+// id through `--model`; the stored id stays namespaced for Cave consistency.
+const HERMES_AUTHENTICATED_MODELS: RuntimeModelOption[] = [
+  { id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { id: "openai/gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { id: "openai/gpt-5.6-luna", label: "GPT-5.6 Luna" },
+  { id: "openai/gpt-5.5", label: "GPT-5.5" },
+  { id: "openai/gpt-5.4", label: "GPT-5.4" },
+  { id: "openai/gpt-5.4-mini", label: "GPT-5.4 Mini" },
+  { id: "openai/gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
+  { id: "openai/codex-auto-review", label: "Codex Auto Review" },
+];
 
 export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   codex: {
@@ -80,9 +93,8 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   },
   hermes: {
     runtime: "hermes",
-    provider: null,
-    models: [],
-    defaultModel: "hermes-local",
+    provider: "openai",
+    models: HERMES_AUTHENTICATED_MODELS,
     allowCustom: true,
   },
   // No clean provider → defer to the runtime's own CLI: free-text only, no menu.

--- a/src/lib/server/session-id.ts
+++ b/src/lib/server/session-id.ts
@@ -1,0 +1,8 @@
+// Daemons issue more than UUIDs: Hermes uses timestamp-prefixed IDs such as
+// `20260721_192314_1d8d4e`. Keep the same conservative grammar used by local
+// session management: no separators, whitespace, or URI syntax.
+const SESSION_ID_RE = /^[A-Za-z0-9:._-]{1,256}$/;
+
+export function isValidSessionId(value: string): boolean {
+  return SESSION_ID_RE.test(value);
+}

--- a/src/lib/server/session-security.test.ts
+++ b/src/lib/server/session-security.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isValidSessionId } from "./session-id.ts";
+
+test("accepts daemon session identifiers including Hermes IDs", () => {
+  for (const sessionId of [
+    "20260721_192314_1d8d4e",
+    "e9e772b0-a282-4d1d-96dc-14e6fa3dfe7a",
+    "session-1",
+  ]) {
+    assert.equal(isValidSessionId(sessionId), true, sessionId);
+  }
+});
+
+test("rejects session identifiers that could escape an API path", () => {
+  for (const sessionId of ["", "../session", "session/next", "session?x=1", "session id", "x".repeat(257)]) {
+    assert.equal(isValidSessionId(sessionId), false, sessionId);
+  }
+});

--- a/src/lib/server/session-security.ts
+++ b/src/lib/server/session-security.ts
@@ -1,12 +1,12 @@
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
+export { isValidSessionId } from "./session-id.ts";
 
 export const MAX_SESSION_JSON_BYTES = 70 * 1024;
 export const MAX_PROMPT_CHARS = 64 * 1024;
 export const MAX_INPUT_CHARS = 64 * 1024;
 
 const ALLOWED_HARNESSES = new Set(COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id));
-const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function normalizeProjectRoot(value: unknown): string | null {
   if (value !== undefined && typeof value !== "string") return null;
@@ -21,10 +21,6 @@ export function normalizeProjectRoot(value: unknown): string | null {
 
 export function isAllowedHarness(value: string): boolean {
   return ALLOWED_HARNESSES.has(value);
-}
-
-export function isValidSessionId(value: string): boolean {
-  return SESSION_ID_RE.test(value);
 }
 
 export function boundedString(value: unknown, maxChars: number): string | undefined | null {


### PR DESCRIPTION
## What changed

Hermes now renders the authenticated Codex model selector in Familiar Studio. The native Tauri dev launcher also forwards its sidecar token via the URL fragment, allowing the browser bridge to authenticate Debug API requests.

The shared session-ID validator accepts Hermes timestamp-prefixed IDs while retaining the conservative no-path-separators grammar.

## Why

Hermes was incorrectly treated as free-text-only, so its model dropdown disappeared. Separately, Debug first failed authorization in native dev and then rejected valid Hermes session IDs.

## Validation

- Windows-native `pnpm typecheck`
- `runtime-models.test.ts`
- `session-security.test.ts`
- Brain-tab selector source contract
- `dev-app.test.mjs`
- Native Tauri launch with authenticated sidecar bridge on port 3001