### PR TITLE
chore(chat): review residuals from #3630 — draft flush-on-unmount, adapter-heal early settle (cave-wtqd)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1813,8 +1813,17 @@ export async function POST(req: Request) {
         stdoutErrTail.length = 0;
         resumeFailed = false;
         adapterConflict = null;
+        // Settle the heal step BEFORE the retry attempt runs (same shape as
+        // the resume-retry step below): the quarantine itself is finished at
+        // relaunch, and a step left "running" until the attempt ended would
+        // headline the activity strip for the whole reply.
+        pushProgress(
+          "adapter-heal",
+          `Stale ${conflict.id} adapter manifest quarantined; retried`,
+          "done",
+          conflict.manifestPath,
+        );
         await runAttempt(args);
-        pushProgress("adapter-heal", "Retry after manifest quarantine finished", "done");
       }
 
       // Transparent retry: if codex reported its rollout-resume failed and

--- a/src/lib/use-composer-draft.test.ts
+++ b/src/lib/use-composer-draft.test.ts
@@ -19,8 +19,25 @@ assert.match(
 // ── Debounce (extracted verbatim from the two composers) ─────────────────────
 assert.match(
   src,
-  /useEffect\(\(\) => \{\s*const timer = window\.setTimeout\(\(\) => \{\s*writeComposerDraft\(key, value\);\s*\}, delayMs\);\s*return \(\) => window\.clearTimeout\(timer\);\s*\}, \[key, value, delayMs\]\);/,
+  /useEffect\(\(\) => \{\s*latestRef\.current = \{ key, value \};\s*const timer = window\.setTimeout\(\(\) => \{\s*writeComposerDraft\(key, value\);\s*\}, delayMs\);\s*return \(\) => window\.clearTimeout\(timer\);\s*\}, \[key, value, delayMs\]\);/,
   "draft writes are debounced so mobile typing does not hit localStorage per keystroke",
+);
+
+// ── Flush on unmount ─────────────────────────────────────────────────────────
+// The debounce cleanup CANCELS a pending write, so an unmount within delayMs
+// of the last keystroke dropped the draft's tail (pane-set remounts, mode
+// switches). A ref-driven empty-dep cleanup flushes the latest value instead.
+assert.match(
+  src,
+  /useEffect\(\s*\(\) => \(\) => writeComposerDraft\(latestRef\.current\.key, latestRef\.current\.value\),\s*\[\],\s*\);/,
+  "unmount flushes the latest draft value the cancelled debounce never wrote",
+);
+// clearNow must update latestRef too, or a send that unmounts the composer in
+// the same tick would flush the PRE-send text — resurrecting the sent prompt.
+assert.match(
+  src,
+  /const clearNow = useCallback\(\(\) => \{\s*latestRef\.current = \{ key, value: "" \};\s*writeComposerDraft\(key, ""\);\s*\}, \[key\]\);/,
+  "clearNow updates latestRef so a send-then-unmount flushes empty, never pre-send text",
 );
 
 // ── Remove-on-empty ──────────────────────────────────────────────────────────
@@ -33,7 +50,7 @@ assert.match(
 // ── Synchronous clear for send paths ─────────────────────────────────────────
 assert.match(
   src,
-  /const clearNow = useCallback\(\(\) => writeComposerDraft\(key, ""\), \[key\]\);/,
+  /const clearNow = useCallback\(\(\) => \{[\s\S]*?writeComposerDraft\(key, ""\);\s*\}, \[key\]\);/,
   "clearNow writes the empty draft synchronously — a send can unmount the composer and cancel the debounced writer",
 );
 

--- a/src/lib/use-composer-draft.ts
+++ b/src/lib/use-composer-draft.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Persist a composer's in-progress text so a page reload doesn't eat a
@@ -47,13 +47,31 @@ export function useDraftPersistence(
   value: string,
   delayMs = 250,
 ): { clearNow: () => void } {
+  // Latest key/value for the unmount flush below, kept current by the
+  // debounce effect (which runs after every value change) and by clearNow.
+  const latestRef = useRef({ key, value });
+
   useEffect(() => {
+    latestRef.current = { key, value };
     const timer = window.setTimeout(() => {
       writeComposerDraft(key, value);
     }, delayMs);
     return () => window.clearTimeout(timer);
   }, [key, value, delayMs]);
 
-  const clearNow = useCallback(() => writeComposerDraft(key, ""), [key]);
+  // Flush on unmount: the debounce cleanup above CANCELS a pending write, so
+  // unmounting within delayMs of the last keystroke dropped the draft's tail
+  // (pane-set remounts, mode switches). Safe against sent-prompt
+  // resurrection: send paths call clearNow before any same-tick unmount, and
+  // clearNow updates latestRef, so the flush writes "" — never pre-send text.
+  useEffect(
+    () => () => writeComposerDraft(latestRef.current.key, latestRef.current.value),
+    [],
+  );
+
+  const clearNow = useCallback(() => {
+    latestRef.current = { key, value: "" };
+    writeComposerDraft(key, "");
+  }, [key]);
   return { clearNow };
 }


### PR DESCRIPTION
Follow-up landing the two residuals identified in the post-merge review of #3630 (bead cave-wtqd).

## 1. Composer draft flush-on-unmount (`use-composer-draft.ts`)

The debounced draft writer's cleanup **cancels without flushing**, so any unmount within `delayMs` (250ms) of the last keystroke dropped the draft's tail. #3630's pane-set Group key added a new unmount path (toggling the task-work code rail remounts the chat pane); mode switches and split-pane changes always had this exposure.

Fix: a `latestRef`-driven empty-dep cleanup flushes the latest key/value on real unmount. **Send-path safety** (the reason the original design cancelled instead of flushing): `clearNow` now updates `latestRef` too, so a send that clears + unmounts the composer in the same tick — before the debounce effect re-runs with the cleared value — flushes `""`, never the pre-send text. Both composers call `clearNow()` synchronously on every send path (verified: chat-view 2 sites, home-composer 3 sites). StrictMode's dev double-mount flush writes back the value it just read — a no-op.

## 2. `adapter-heal` early settle (`/api/chat/send`)

Same late-settle shape #3630 fixed for `resume-retry`: the quarantine step was pushed `running` and only settled after the entire retry attempt, so "Quarantined stale … manifest; retrying" would headline the activity strip for the whole reply. It now settles at relaunch with "Stale <id> adapter manifest quarantined; retried"; the attempt's own `harness-start`/stream/tool steps take the headline from there.

## Verification
- `use-composer-draft.test.ts` (updated debounce pin + 2 new flush pins), `adapter-conflict-heal.test.ts`, `harness-routing-host-session.test.ts` — 11/11 pass.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)