### PR TITLE
fix(ios): defer-return compile error in ConnectionRefreshCoordinator (cave-zks3)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ConnectionRefreshCoordinator.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ConnectionRefreshCoordinator.swift
@@ -46,9 +46,11 @@ actor ConnectionRefreshCoordinator {
         // Only clear our own task: a cancel + relaunch while we await must
         // not blow away the successor's in-flight slot.
         defer {
-            guard activeNonce == nonce else { return }
-            inFlight = nil
-            activeNonce = nil
+            // `return` is not allowed inside `defer`, so use `if` rather than `guard`.
+            if activeNonce == nonce {
+                inFlight = nil
+                activeNonce = nil
+            }
         }
         let result = await task.value
         // Joiners that piled onto this probe set the flag while `inFlight` was


### PR DESCRIPTION
Commit 6c3ea1300 (#3623) landed `guard activeNonce == nonce else { return }` inside a `defer`, which Swift forbids ('return' cannot transfer control out of a defer statement). The iOS simulator build has been broken since. CI doesn't build the iOS app, so it slipped through.

**Fix:** equivalent `if activeNonce == nonce { … }` inside the defer — identical semantics, no behavior change.

**Verification:** `pnpm mobile:ios:sim` → BUILD SUCCEEDED, app installed and launched on iPhone 16 Pro simulator.

Bead: cave-zks3