### PR TITLE
fix(preferences): retry reconciliation silently, drop banner (cave-573l)

### DIFF
--- a/src/components/preferences-bootstrap-controller.tsx
+++ b/src/components/preferences-bootstrap-controller.tsx
@@ -10,14 +10,12 @@ import {
 } from "@/lib/app-preferences";
 import { reapplyIndependentAppearance } from "@/lib/appearance-restore";
 import { migrateLegacyBackdropImage } from "@/lib/cave-backdrop";
-import { useShellBanners } from "@/lib/shell-banners";
 
-const PREFERENCES_BANNER_ID = "preferences-bootstrap";
-const PREFERENCES_SLOW_MS = 2_000;
-// Bounded auto-retry so a silent cold-start reconciliation stall (e.g. slow
-// IndexedDB with no online/visibility/subscription event to nudge it) self-
-// heals instead of leaving the "still reconciling" warning parked until the
-// user clicks Retry. Backs off, then gives up and lets the manual CTA stand.
+// Silent bounded auto-retry: a failed or stalled cold-start reconciliation
+// (e.g. slow IndexedDB with no online/visibility/subscription event to nudge
+// it) self-heals in the background. Backs off, then gives up after three
+// attempts — no banner is ever surfaced; the app keeps running on the last
+// known-good snapshot and later online/visibility events still re-trigger.
 const PREFERENCES_AUTO_RETRY_MS = [5_000, 10_000, 20_000] as const;
 
 function mark(name: string, startTime?: number): void {
@@ -31,22 +29,11 @@ function mark(name: string, startTime?: number): void {
 
 /** Completes authenticated preference migration and flushes queued writes. */
 export function PreferencesBootstrapController() {
-  const { pushBanner, dismissBanner } = useShellBanners();
   const mounted = useRef(false);
   const autoRetryTimer = useRef<number | null>(null);
   const autoRetryAttempt = useRef(0);
 
   const bootstrap = useCallback(async () => {
-    const slowTimer = window.setTimeout(() => {
-      if (!mounted.current) return;
-      pushBanner({
-        id: PREFERENCES_BANNER_ID,
-        severity: "warning",
-        title: "Preferences are still reconciling. Navigation remains available.",
-        cta: { label: "Retry now", onClick: () => void bootstrap() },
-      });
-    }, PREFERENCES_SLOW_MS);
-
     try {
       const preferences = await initializeAppPreferences();
       if (!mounted.current) return preferences;
@@ -56,39 +43,22 @@ export function PreferencesBootstrapController() {
           autoRetryTimer.current = null;
         }
         autoRetryAttempt.current = 0;
-        dismissBanner(PREFERENCES_BANNER_ID);
         mark("reconciliation-settled");
         await migrateLegacyBackdropImage();
       } else {
         scheduleAutoRetry();
-        pushBanner({
-          id: PREFERENCES_BANNER_ID,
-          severity: "error",
-          title: "Preferences could not be reconciled. Your settings remain unchanged.",
-          cta: { label: "Retry", onClick: () => void bootstrap() },
-        });
       }
       return preferences;
     } catch {
-      if (mounted.current) {
-        scheduleAutoRetry();
-        pushBanner({
-          id: PREFERENCES_BANNER_ID,
-          severity: "error",
-          title: "Preferences could not be reconciled. Your settings remain unchanged.",
-          cta: { label: "Retry", onClick: () => void bootstrap() },
-        });
-      }
+      if (mounted.current) scheduleAutoRetry();
       return readAppPreferences();
-    } finally {
-      window.clearTimeout(slowTimer);
     }
 
     function scheduleAutoRetry(): void {
       if (!mounted.current) return;
       if (autoRetryTimer.current !== null) return; // one pending retry at a time
       const attempt = autoRetryAttempt.current;
-      if (attempt >= PREFERENCES_AUTO_RETRY_MS.length) return; // give up; manual CTA stands
+      if (attempt >= PREFERENCES_AUTO_RETRY_MS.length) return; // give up silently after 3 retries
       const delay = PREFERENCES_AUTO_RETRY_MS[attempt];
       autoRetryAttempt.current = attempt + 1;
       autoRetryTimer.current = window.setTimeout(() => {
@@ -96,7 +66,7 @@ export function PreferencesBootstrapController() {
         if (mounted.current) void bootstrap();
       }, delay);
     }
-  }, [dismissBanner, pushBanner]);
+  }, []);
 
   useEffect(() => {
     mounted.current = true;
@@ -120,7 +90,6 @@ export function PreferencesBootstrapController() {
         preserveCustomDefaults: readAppPreferences().appearance.theme.id === "custom",
       });
       if (readAppPreferences().initialized) {
-        dismissBanner(PREFERENCES_BANNER_ID);
         retryBackdropMigration();
       }
     });
@@ -141,12 +110,11 @@ export function PreferencesBootstrapController() {
         autoRetryTimer.current = null;
       }
       unsubscribe();
-      dismissBanner(PREFERENCES_BANNER_ID);
       window.removeEventListener("pagehide", flush);
       window.removeEventListener("online", retryBackdropMigration);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [bootstrap, dismissBanner]);
+  }, [bootstrap]);
 
   return null;
 }

--- a/src/lib/app-preferences.test.ts
+++ b/src/lib/app-preferences.test.ts
@@ -110,9 +110,17 @@ assert.match(
   /await initializeAppPreferences\(\)[\s\S]*migrateLegacyBackdropImage\(\)/,
   "preference and legacy backdrop migration should run after hydration/auth bootstrap",
 );
-assert.match(controller, /PREFERENCES_SLOW_MS = 2_000[\s\S]*severity: "warning"/, "slow reconciliation is surfaced after shell mount");
-assert.match(controller, /severity: "error"[\s\S]*label: "Retry"/, "terminal bootstrap failure has an actionable retry");
-assert.match(controller, /dismissBanner\(PREFERENCES_BANNER_ID\)/, "successful recovery clears degraded status");
+assert.match(
+  controller,
+  /PREFERENCES_AUTO_RETRY_MS = \[5_000, 10_000, 20_000\]/,
+  "failed bootstrap retries silently with bounded backoff",
+);
+assert.match(
+  controller,
+  /attempt >= PREFERENCES_AUTO_RETRY_MS\.length\) return;/,
+  "silent auto-retry gives up after three attempts",
+);
+assert.doesNotMatch(controller, /pushBanner|useShellBanners|dismissBanner/, "reconciliation never surfaces a banner");
 for (const timing of ["response-commit", "shell-visible", "reconciliation-settled"]) {
   assert.ok(controller.includes(`\"${timing}\"`), `bootstrap controller records ${timing}`);
 }


### PR DESCRIPTION
## What

Removes the preferences reconciliation shell banner entirely — both the 2s "still reconciling" warning and the terminal "could not be reconciled" error with its Retry CTA. Reconciliation failures now self-heal silently via the existing bounded auto-retry (5s/10s/20s backoff, **max 3 attempts**), then give up quietly. The app keeps running on the last known-good snapshot; `online`/visibility/subscription events still re-trigger bootstrap as before.

## Why

Per user directive: the banner is noise — retry should just happen in the background, capped at 3 attempts.

## Changes

- `src/components/preferences-bootstrap-controller.tsx`: drop `useShellBanners`, `PREFERENCES_BANNER_ID`, `PREFERENCES_SLOW_MS`, and the slow-warning timer; keep silent `scheduleAutoRetry` (3 attempts, backoff).
- `src/lib/app-preferences.test.ts`: replace banner pins with pins for bounded backoff, the 3-attempt cap, and a `doesNotMatch` guard that the controller never touches the banner system.

## Validation

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/app-preferences.test.ts src/lib/cave-backdrop.test.ts src/components/theme-script.test.ts` — 3/3 pass
- `pnpm typecheck` — clean
- `eslint` on changed controller — clean

Bead: cave-573l (supersedes its "preserve terminal failure/retry UI" note per explicit user instruction).