### PR TITLE
fix(chat): env panel gates at 2xl width and gets an opaque frosted bg (cave-h8v3)

### DIFF
--- a/src/components/chat-environment-panel.test.ts
+++ b/src/components/chat-environment-panel.test.ts
@@ -45,6 +45,18 @@ assert.match(panel, /resolveEnvPanelVisible\(\{/, "visibility decided by the pur
 assert.match(panel, /pointer-events-none sticky top-0 z-30 flex h-0 w-full justify-end/, "wrapper is sticky, zero-height and pointer-transparent");
 assert.match(panel, /pointer-events-auto/, "the card re-enables pointer events");
 
+// The card must stay legible over the transcript even when the theme /
+// backdrop mode makes --bg-raised translucent: an opaque --bg-base floor
+// under the raised tint, plus a frosted blur (repo convention for floating
+// HUDs, e.g. grimoire-graph-view).
+assert.match(
+  panel,
+  /linear-gradient\(var\(--bg-raised\),[_ ]var\(--bg-raised\)\),[_ ]var\(--bg-base\)/,
+  "card pins an opaque bg-base floor under the raised tint",
+);
+const blurCount = panel.match(/backdrop-blur-md/g)?.length ?? 0;
+assert.ok(blurCount >= 2, "expanded card AND collapsed pill are frosted (backdrop-blur-md)");
+
 // Collapse preference persists under a VERSIONED key, hydrated post-mount
 // (SSR-safe) like CODE_RAIL_PIN_KEY.
 assert.match(panel, /ENV_PANEL_COLLAPSED_KEY = "cave:chat-env-panel:collapsed:v1"/, "versioned localStorage key");

--- a/src/components/chat-environment-panel.tsx
+++ b/src/components/chat-environment-panel.tsx
@@ -21,8 +21,9 @@
 //   anchors the shared GitBranchMenuPopover from the composer git chip.
 // - The panel hides while the inline code rail is open
 //   (cave:code-rail-visibility) — the rail is the full surface this HUD
-//   abbreviates — and on panes narrower than ENV_PANEL_MIN_WIDTH, where the
-//   composer git chip already carries the context.
+//   abbreviates — and on panes narrower than ENV_PANEL_MIN_WIDTH (2xl), where
+//   the card would overlap the conversation column instead of floating in the
+//   spare margin (the composer git chip already carries the context there).
 // - Width gating measures the panel's own sticky wrapper (which spans the
 //   transcript content box), so split panes gate independently and no
 //   ancestor needs container-type containment.
@@ -145,7 +146,7 @@ export function ChatEnvironmentPanel({ projectRoot, runtime, hasTurns, onOpenUrl
       {!visible ? null : collapsed ? (
         <button
           type="button"
-          className="focus-ring pointer-events-auto mt-0.5 flex items-center gap-1.5 rounded-full border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[length:var(--text-2xs)] text-[var(--text-muted)] shadow-md transition-colors hover:text-[var(--text-primary)]"
+          className="focus-ring pointer-events-auto mt-0.5 flex items-center gap-1.5 rounded-full border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 py-1 text-[length:var(--text-2xs)] text-[var(--text-muted)] shadow-md backdrop-blur-md transition-colors hover:text-[var(--text-primary)]"
           aria-expanded={false}
           aria-label="Show environment panel"
           onClick={() => setCollapsedPersist(false)}
@@ -156,7 +157,12 @@ export function ChatEnvironmentPanel({ projectRoot, runtime, hasTurns, onOpenUrl
       ) : (
         <section
           aria-label="Environment"
-          className="pointer-events-auto flex w-[240px] flex-col rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)] shadow-lg"
+          // Explicit card bg + blur: translucent themes / backdrop mode give
+          // --bg-raised alpha, and a see-through HUD ghosts the transcript
+          // underneath. The gradient pins an opaque --bg-base floor under the
+          // raised tint; the blur keeps it frosted if even the floor carries
+          // alpha.
+          className="pointer-events-auto flex w-[240px] flex-col rounded-xl border border-[var(--border-hairline)] shadow-lg backdrop-blur-md [background:linear-gradient(var(--bg-raised),_var(--bg-raised)),_var(--bg-base)]!"
         >
           <header className="flex items-center justify-between px-3 pb-1 pt-2">
             <span className="text-[length:var(--text-2xs)] font-medium uppercase tracking-wide text-[var(--text-muted)]">

--- a/src/lib/chat-environment-panel-model.test.ts
+++ b/src/lib/chat-environment-panel-model.test.ts
@@ -27,6 +27,13 @@ assert.equal(
   false,
   "below the width threshold the panel never overlays the conversation",
 );
+// No-overlap guarantee: the 1024px reading column centers, so each side
+// margin is (paneWidth − 1024) / 2. The gate must leave the 240px card fully
+// in the margin — never on top of chips/content at the column edge (2xl).
+assert.ok(
+  (ENV_PANEL_MIN_WIDTH - 1024) / 2 >= 240 + 16,
+  "width gate keeps the 240px card entirely inside the spare margin",
+);
 assert.equal(
   resolveEnvPanelVisible({ ...base, paneWidth: null }),
   false,

--- a/src/lib/chat-environment-panel-model.ts
+++ b/src/lib/chat-environment-panel-model.ts
@@ -10,12 +10,14 @@
 import { parseConversationRuntime } from "./chat-hosts.ts";
 
 /**
- * Minimum measured transcript content-box width (px) before the panel shows.
- * The reading column caps at --cave-chat-measure (64rem = 1024px) and centers;
- * at 1200px+ of content box the panel's overlay footprint sits mostly in the
- * spare margin instead of on top of the conversation.
+ * Minimum measured transcript content-box width (px) before the panel shows —
+ * matches Tailwind's 2xl breakpoint. The reading column caps at
+ * --cave-chat-measure (64rem = 1024px) and centers, so each side margin is
+ * (paneWidth − 1024) / 2. The card is 240px wide: at 1536px+ the margin is
+ * ≥256px and the panel sits ENTIRELY in the spare margin — it must never
+ * overlap conversation content (suggestion chips reach the column edge).
  */
-export const ENV_PANEL_MIN_WIDTH = 1200;
+export const ENV_PANEL_MIN_WIDTH = 1536;
 
 export type EnvPanelSignals = {
   /** Measured transcript content-box width; null before the first measure. */


### PR DESCRIPTION
Follow-up to #3629 (cave-68vv). As reported with screenshot: the Environment HUD overlapped top-right transcript content (suggestion chips) and rendered see-through.

**Why it overlapped:** the reading column caps at 1024px and centers; at the old 1200px gate each side margin is only ~88px — far less than the 240px card, so it sat on the conversation.

**Fix:**
- `ENV_PANEL_MIN_WIDTH` 1200 → **1536 (2xl)** — margin ≥256px, the card floats entirely in the spare margin.
- **Opaque bg**: layered `linear-gradient(var(--bg-raised)…), var(--bg-base)` pins an opaque floor under themes where `--bg-raised` carries alpha, plus `backdrop-blur-md` (frosted, matching grimoire-graph-view HUD convention). Collapsed pill blurred too.
- Tests pin the width math (`(MIN_WIDTH − 1024)/2 ≥ 256`) and the bg/blur wiring.

**Verification:** targeted `node --test` on both panel test files (pass 2 / fail 0), `pnpm typecheck` clean.

Bead: cave-h8v3