### PR TITLE
feat(daily-report): bounded interactive merged-PRs table (cave-zo7f)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -599,6 +599,7 @@ export const SUITES = {
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",
     "src/app/daily-report-page.test.ts",
+    "src/components/shipped-table.test.ts",
     "src/components/reminder-link-field.test.ts",
     "src/components/new-reminder-modal.test.ts",
     "src/components/board-enrich-steps.test.ts",

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -13,6 +13,7 @@ import {
   type DailyReportStats,
 } from "@/lib/daily-report";
 import { extractNextPaths } from "@/lib/next-paths";
+import { ShippedTable } from "@/components/shipped-table";
 
 export const dynamic = "force-dynamic";
 
@@ -267,35 +268,7 @@ export default async function DailyReportPage({ params }: Props) {
               title="Merged pull requests"
               count={report.prsMerged.length}
             />
-            <div className="dr-list">
-              {report.prsMerged.map((pr) => (
-                <a
-                  key={`${pr.repo}#${pr.number}`}
-                  className="dr-row"
-                  href={pr.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  style={{ ["--row-accent" as string]: "var(--color-info)" }}
-                >
-                  <span className="dr-row__icon">
-                    <Icon name="ph:git-pull-request" aria-hidden />
-                  </span>
-                  <span className="dr-row__body">
-                    <span className="dr-row__title">{pr.title}</span>
-                    <span className="dr-row__metaline">
-                      <span className="dr-tag">
-                        {pr.repo}#{pr.number}
-                      </span>
-                      <span className="dr-row__time">merged {relativeTime(pr.mergedAt)}</span>
-                    </span>
-                  </span>
-                  <span className="dr-row__open">
-                    <span>Open</span>
-                    <Icon name="ph:arrow-right-bold" aria-hidden />
-                  </span>
-                </a>
-              ))}
-            </div>
+            <ShippedTable rows={report.prsMerged} nowMs={Date.now()} />
           </section>
         ) : null}
 

--- a/src/components/shipped-table.test.ts
+++ b/src/components/shipped-table.test.ts
@@ -1,0 +1,230 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+// Tests for shipped-table pure helpers: filterShippedRows, sortShippedRows,
+// nextShippedSort. Logic lives in src/lib/ so node --experimental-strip-types
+// can import it directly without JSX/React transforms.
+import {
+  filterShippedRows,
+  sortShippedRows,
+  nextShippedSort,
+} from "../lib/shipped-table.ts";
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+
+const ROWS = [
+  {
+    repo: "OpenCoven/coven-cave",
+    number: 123,
+    title: "Add dark mode support",
+    url: "https://github.com/OpenCoven/coven-cave/pull/123",
+    mergedAt: "2024-03-15T10:00:00Z",
+  },
+  {
+    repo: "acme/tools",
+    number: 456,
+    title: "Fix build pipeline",
+    url: "https://github.com/acme/tools/pull/456",
+    mergedAt: "2024-03-16T08:30:00Z",
+  },
+  {
+    repo: "acme/tools",
+    number: 789,
+    title: "Add dark mode support", // duplicate title — stability check
+    url: "https://github.com/acme/tools/pull/789",
+    mergedAt: "2024-03-14T12:00:00Z",
+  },
+  {
+    repo: "OpenCoven/coven-cave",
+    number: 99,
+    title: "Refactor auth module",
+    url: "https://github.com/OpenCoven/coven-cave/pull/99",
+    mergedAt: "2024-03-17T15:45:00Z",
+  },
+  {
+    repo: "acme/tools",
+    number: 321,
+    title: "Update dependencies",
+    url: "https://github.com/acme/tools/pull/321",
+    mergedAt: "not-a-date", // invalid timestamp
+  },
+];
+
+// ── Filtering ─────────────────────────────────────────────────────────────────
+
+// Empty / whitespace → all rows returned
+assert.deepEqual(filterShippedRows(ROWS, ""), ROWS, "empty query returns all");
+assert.deepEqual(filterShippedRows(ROWS, "   "), ROWS, "whitespace-only returns all");
+
+// Title substring (case-insensitive)
+{
+  const res = filterShippedRows(ROWS, "dark MODE");
+  assert.equal(res.length, 2, "case-insensitive title match");
+  assert.ok(res.every((r) => r.title.toLowerCase().includes("dark mode")));
+}
+
+// Full repo match
+{
+  const res = filterShippedRows(ROWS, "OpenCoven/coven-cave");
+  assert.equal(res.length, 2, "full repo match");
+  assert.ok(res.every((r) => r.repo === "OpenCoven/coven-cave"));
+}
+
+// Short repo (after last "/")
+{
+  const res = filterShippedRows(ROWS, "coven-cave");
+  assert.equal(res.length, 2, "short repo match");
+  assert.ok(res.every((r) => r.repo === "OpenCoven/coven-cave"));
+}
+
+// Bare number — matches number field substring
+{
+  const res = filterShippedRows(ROWS, "123");
+  assert.ok(res.length >= 1, "bare number matches PR number");
+  assert.ok(res.some((r) => r.number === 123));
+  // bare query also matches title / repo containing "123"
+}
+
+// #-prefixed query — matches ONLY number, NOT title
+{
+  const titleWithDigits = {
+    repo: "acme/tools",
+    number: 999,
+    title: "456 items cleaned up", // contains "456" as text
+    url: "https://github.com/acme/tools/pull/999",
+    mergedAt: "2024-03-18T00:00:00Z",
+  };
+  const rows = [...ROWS, titleWithDigits];
+  const res = filterShippedRows(rows, "#456");
+  assert.equal(res.length, 1, "#-query matches only PR number field");
+  assert.equal(res[0].number, 456, "#456 finds number=456, not the title row");
+}
+
+// #-prefixed with leading hash stripped — same as bare number for number match
+{
+  const res = filterShippedRows(ROWS, "#789");
+  assert.equal(res.length, 1);
+  assert.equal(res[0].number, 789);
+}
+
+// No match
+{
+  const res = filterShippedRows(ROWS, "zzznomatch");
+  assert.deepEqual(res, [], "no match returns empty array");
+}
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+// Default sort (null) = newest mergedAt first; invalid date LAST
+{
+  const sorted = sortShippedRows(ROWS, null);
+  assert.equal(sorted[0].number, 99, "newest first (2024-03-17)");
+  assert.equal(sorted[1].number, 456, "second newest (2024-03-16)");
+  assert.equal(sorted[sorted.length - 1].number, 321, "invalid date last");
+}
+
+// Input array not mutated
+{
+  const snapshot = ROWS.map((r) => ({ ...r }));
+  sortShippedRows(ROWS, null);
+  assert.deepEqual(ROWS, snapshot, "input array not mutated");
+}
+
+// Stable tie-break: two rows with same mergedAt keep input order
+{
+  const tieRows = [
+    { repo: "a/b", number: 1, title: "A", url: "", mergedAt: "2024-01-01T00:00:00Z" },
+    { repo: "a/b", number: 2, title: "B", url: "", mergedAt: "2024-01-01T00:00:00Z" },
+  ];
+  const sorted = sortShippedRows(tieRows, null);
+  assert.equal(sorted[0].number, 1, "same timestamp: original index wins");
+  assert.equal(sorted[1].number, 2);
+}
+
+// pr asc — title localeCompare ascending
+{
+  const sorted = sortShippedRows(ROWS, { key: "pr", dir: "asc" });
+  const titles = sorted.map((r) => r.title);
+  const expected = [...titles].sort((a, b) => a.localeCompare(b));
+  assert.deepEqual(titles, expected, "pr asc sorts by title ascending");
+}
+
+// pr desc — title localeCompare descending
+{
+  const sorted = sortShippedRows(ROWS, { key: "pr", dir: "desc" });
+  const titles = sorted.map((r) => r.title);
+  const expected = [...titles].sort((a, b) => b.localeCompare(a));
+  assert.deepEqual(titles, expected, "pr desc sorts by title descending");
+}
+
+// repo asc — groups by full repo (localeCompare asc), then number ascending within group
+{
+  const sorted = sortShippedRows(ROWS, { key: "repo", dir: "asc" });
+  // Derive contiguous repo groups from the sorted output
+  const groups: string[] = [];
+  for (const r of sorted) {
+    if (groups[groups.length - 1] !== r.repo) groups.push(r.repo);
+  }
+  assert.equal(groups.length, 2, "repo asc: exactly 2 contiguous repo groups");
+  assert.ok(
+    groups[0].localeCompare(groups[1]) < 0,
+    "repo asc: first group sorts before second by localeCompare",
+  );
+  // within acme/tools group, numbers ascending
+  const acmeRows = sorted.filter((r) => r.repo === "acme/tools");
+  const nums = acmeRows.map((r) => r.number);
+  assert.deepEqual(nums, [...nums].sort((a, b) => a - b), "secondary sort by number asc within repo");
+}
+
+// repo desc — reverses both repo and number order
+{
+  const sorted = sortShippedRows(ROWS, { key: "repo", dir: "desc" });
+  const groups: string[] = [];
+  for (const r of sorted) {
+    if (groups[groups.length - 1] !== r.repo) groups.push(r.repo);
+  }
+  assert.equal(groups.length, 2, "repo desc: exactly 2 contiguous repo groups");
+  assert.ok(
+    groups[0].localeCompare(groups[1]) > 0,
+    "repo desc: first group sorts after second (descending)",
+  );
+  const acmeRows = sorted.filter((r) => r.repo === "acme/tools");
+  const nums = acmeRows.map((r) => r.number);
+  assert.deepEqual(nums, [...nums].sort((a, b) => b - a), "secondary sort by number desc in desc mode");
+}
+
+// merged asc — oldest first; invalid STILL last
+{
+  const sorted = sortShippedRows(ROWS, { key: "merged", dir: "asc" });
+  assert.equal(sorted[0].number, 789, "merged asc: oldest first (2024-03-14)");
+  assert.equal(sorted[sorted.length - 1].number, 321, "invalid date always last even in asc");
+}
+
+// merged desc — same as default (newest first, invalid last)
+{
+  const sorted = sortShippedRows(ROWS, { key: "merged", dir: "desc" });
+  assert.equal(sorted[0].number, 99, "merged desc: newest first");
+  assert.equal(sorted[sorted.length - 1].number, 321, "invalid date always last");
+}
+
+// ── Sort cycle (nextShippedSort) ──────────────────────────────────────────────
+
+// merged: null → desc → asc → null
+assert.deepEqual(nextShippedSort(null, "merged"), { key: "merged", dir: "desc" }, "merged first activation is desc");
+assert.deepEqual(nextShippedSort({ key: "merged", dir: "desc" }, "merged"), { key: "merged", dir: "asc" }, "merged second flip to asc");
+assert.equal(nextShippedSort({ key: "merged", dir: "asc" }, "merged"), null, "merged third resets to null");
+
+// pr: null → asc → desc → null
+assert.deepEqual(nextShippedSort(null, "pr"), { key: "pr", dir: "asc" }, "pr first activation is asc");
+assert.deepEqual(nextShippedSort({ key: "pr", dir: "asc" }, "pr"), { key: "pr", dir: "desc" }, "pr second flip to desc");
+assert.equal(nextShippedSort({ key: "pr", dir: "desc" }, "pr"), null, "pr third resets to null");
+
+// repo: null → asc → desc → null
+assert.deepEqual(nextShippedSort(null, "repo"), { key: "repo", dir: "asc" }, "repo first activation is asc");
+assert.deepEqual(nextShippedSort({ key: "repo", dir: "asc" }, "repo"), { key: "repo", dir: "desc" });
+assert.equal(nextShippedSort({ key: "repo", dir: "desc" }, "repo"), null);
+
+// Switching columns jumps to new key's first state
+assert.deepEqual(nextShippedSort({ key: "pr", dir: "asc" }, "repo"), { key: "repo", dir: "asc" }, "switch col jumps to new key first state");
+assert.deepEqual(nextShippedSort({ key: "merged", dir: "desc" }, "pr"), { key: "pr", dir: "asc" }, "switch to pr gives pr asc");
+
+// (Component/page/CSS wiring pins are added in Task 2.)

--- a/src/components/shipped-table.test.ts
+++ b/src/components/shipped-table.test.ts
@@ -140,12 +140,17 @@ assert.deepEqual(filterShippedRows(ROWS, "   "), ROWS, "whitespace-only returns 
   assert.equal(sorted[1].number, 2);
 }
 
-// pr asc — title localeCompare ascending
+// pr asc — title localeCompare ascending; stable tie-break preserves input order
 {
   const sorted = sortShippedRows(ROWS, { key: "pr", dir: "asc" });
   const titles = sorted.map((r) => r.title);
   const expected = [...titles].sort((a, b) => a.localeCompare(b));
   assert.deepEqual(titles, expected, "pr asc sorts by title ascending");
+  // Two rows share title "Add dark mode support" (number 123 and 789).
+  // Stable tie-break must preserve their original input order (123 < 789).
+  const darkModeRows = sorted.filter((r) => r.title === "Add dark mode support");
+  assert.equal(darkModeRows[0].number, 123, "pr sort: duplicate-title rows keep input order (first)");
+  assert.equal(darkModeRows[1].number, 789, "pr sort: duplicate-title rows keep input order (second)");
 }
 
 // pr desc — title localeCompare descending
@@ -227,4 +232,44 @@ assert.equal(nextShippedSort({ key: "repo", dir: "desc" }, "repo"), null);
 assert.deepEqual(nextShippedSort({ key: "pr", dir: "asc" }, "repo"), { key: "repo", dir: "asc" }, "switch col jumps to new key first state");
 assert.deepEqual(nextShippedSort({ key: "merged", dir: "desc" }, "pr"), { key: "pr", dir: "asc" }, "switch to pr gives pr asc");
 
-// (Component/page/CSS wiring pins are added in Task 2.)
+// ── Source pins (Task 2 — component, page, CSS) ───────────────────────────────
+
+import { readFileSync } from "node:fs";
+
+const component = readFileSync(new URL("./shipped-table.tsx", import.meta.url), "utf8");
+const page = readFileSync(
+  new URL("../app/daily-report/[date]/page.tsx", import.meta.url),
+  "utf8",
+);
+const css = readFileSync(
+  new URL("../styles/globals/surface-reporting.css", import.meta.url),
+  "utf8",
+);
+
+// Component pins
+assert.match(component, /"use client"/, 'component has "use client"');
+assert.match(component, /role="status"/, "component has role=status on count");
+assert.match(component, /aria-sort=/, "component has aria-sort on th");
+assert.match(component, /scope="col"/, "component has scope=col on th");
+assert.match(component, /nextShippedSort/, "component calls nextShippedSort");
+assert.match(component, /rel="noreferrer"/, "component has rel=noreferrer on links");
+assert.match(component, /tabIndex=\{0\}/, "component has tabIndex={0} on viewport");
+assert.match(component, /No shipped work matches this filter\./, "component has empty state text");
+assert.match(component, /relativeTime\(pr\.mergedAt, nowMs\)/, "component calls relativeTime with nowMs");
+
+// Page pins
+assert.match(page, /<ShippedTable/, "page contains <ShippedTable");
+assert.match(page, /rows=\{report\.prsMerged\}/, "page passes rows={report.prsMerged}");
+assert.doesNotMatch(
+  page,
+  /report\.prsMerged\.map/,
+  "page no longer maps report.prsMerged into dr-row links",
+);
+
+// CSS pins
+assert.match(css, /\.dr-shipped__viewport[\s\S]*?max-height:\s*300px/, "CSS viewport has max-height: 300px");
+assert.match(css, /\.dr-shipped__viewport[\s\S]*?overflow:\s*auto/, "CSS viewport has overflow: auto");
+assert.match(css, /\.dr-shipped__table\s+thead\s+th\s*\{[\s\S]*?position:\s*sticky/, "CSS thead th has position: sticky");
+
+console.log("shipped-table.test.ts: ok");
+

--- a/src/components/shipped-table.test.ts
+++ b/src/components/shipped-table.test.ts
@@ -255,7 +255,7 @@ assert.match(component, /nextShippedSort/, "component calls nextShippedSort");
 assert.match(component, /rel="noreferrer"/, "component has rel=noreferrer on links");
 assert.match(component, /tabIndex=\{0\}/, "component has tabIndex={0} on viewport");
 assert.match(component, /No shipped work matches this filter\./, "component has empty state text");
-assert.match(component, /relativeTime\(pr\.mergedAt, nowMs\)/, "component calls relativeTime with nowMs");
+assert.match(component, /relativeTime\(pr\.mergedAt, nowMs, "compact"\)/, "component calls relativeTime with compact density");
 
 // Page pins
 assert.match(page, /<ShippedTable/, "page contains <ShippedTable");
@@ -267,9 +267,10 @@ assert.doesNotMatch(
 );
 
 // CSS pins
-assert.match(css, /\.dr-shipped__viewport[\s\S]*?max-height:\s*300px/, "CSS viewport has max-height: 300px");
-assert.match(css, /\.dr-shipped__viewport[\s\S]*?overflow:\s*auto/, "CSS viewport has overflow: auto");
-assert.match(css, /\.dr-shipped__table\s+thead\s+th\s*\{[\s\S]*?position:\s*sticky/, "CSS thead th has position: sticky");
+assert.match(css, /\.dr-shipped__viewport\s*\{[^}]*max-height:\s*300px/, "CSS viewport has max-height: 300px");
+assert.match(css, /\.dr-shipped__viewport\s*\{[^}]*overflow:\s*auto/, "CSS viewport has overflow: auto");
+assert.match(css, /\.dr-shipped__table\s+thead\s+th\s*\{[^}]*position:\s*sticky/, "CSS thead th has position: sticky");
+assert.match(css, /\.dr-shipped__table\s+thead\s+th\s*\{[^}]*box-shadow:\s*0 1px 0 var\(--border-hairline\)/, "CSS thead th has box-shadow hairline");
 
 console.log("shipped-table.test.ts: ok");
 

--- a/src/components/shipped-table.tsx
+++ b/src/components/shipped-table.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { MergedPr } from "@/lib/daily-report-facts";
+import {
+  filterShippedRows,
+  sortShippedRows,
+  nextShippedSort,
+  type ShippedSort,
+  type ShippedSortKey,
+} from "@/lib/shipped-table";
+import { relativeTime } from "@/lib/relative-time";
+import { Icon } from "@/lib/icon";
+
+function ColButton({
+  label,
+  sortKey,
+  sort,
+  onClick,
+}: {
+  label: string;
+  sortKey: ShippedSortKey;
+  sort: ShippedSort;
+  onClick: () => void;
+}) {
+  const active = sort?.key === sortKey;
+  return (
+    <button type="button" onClick={onClick}>
+      {label}
+      {active && (
+        <Icon
+          name={sort!.dir === "asc" ? "ph:caret-up" : "ph:caret-down"}
+          aria-hidden
+        />
+      )}
+    </button>
+  );
+}
+
+export function ShippedTable({
+  rows,
+  nowMs,
+}: {
+  rows: readonly MergedPr[];
+  nowMs: number;
+}) {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<ShippedSort>(null);
+
+  const visible = useMemo(
+    () => sortShippedRows(filterShippedRows(rows, query), sort),
+    [rows, query, sort],
+  );
+
+  const advance = (key: ShippedSortKey) =>
+    setSort((s) => nextShippedSort(s, key));
+
+  const ariaSort = (key: ShippedSortKey): "ascending" | "descending" | "none" =>
+    sort?.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
+
+  return (
+    <div className="dr-shipped">
+      <div className="dr-shipped__toolbar">
+        <input
+          type="search"
+          className="dr-shipped__search"
+          placeholder="Filter shipped work…"
+          aria-label="Filter merged pull requests by title, repository, or PR number"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <span className="dr-shipped__count" role="status">
+          {visible.length} / {rows.length}
+        </span>
+      </div>
+      <div
+        className="dr-shipped__viewport"
+        tabIndex={0}
+        aria-label="Merged pull requests table"
+      >
+        <table className="dr-shipped__table">
+          <thead>
+            <tr>
+              <th scope="col" aria-sort={ariaSort("pr")}>
+                <ColButton
+                  label="Pull request"
+                  sortKey="pr"
+                  sort={sort}
+                  onClick={() => advance("pr")}
+                />
+              </th>
+              <th scope="col" aria-sort={ariaSort("repo")}>
+                <ColButton
+                  label="Repository"
+                  sortKey="repo"
+                  sort={sort}
+                  onClick={() => advance("repo")}
+                />
+              </th>
+              <th scope="col" aria-sort={ariaSort("merged")}>
+                <ColButton
+                  label="Merged"
+                  sortKey="merged"
+                  sort={sort}
+                  onClick={() => advance("merged")}
+                />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="dr-shipped__empty">
+                  No shipped work matches this filter.
+                </td>
+              </tr>
+            ) : (
+              visible.map((pr) => (
+                <tr key={`${pr.repo}#${pr.number}`}>
+                  <td>
+                    <a
+                      href={pr.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={pr.title}
+                    >
+                      {pr.title}
+                    </a>
+                  </td>
+                  <td className="dr-shipped__repo">
+                    {pr.repo}#{pr.number}
+                  </td>
+                  <td className="dr-shipped__time">
+                    {relativeTime(pr.mergedAt, nowMs)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shipped-table.tsx
+++ b/src/components/shipped-table.tsx
@@ -75,6 +75,7 @@ export function ShippedTable({
       </div>
       <div
         className="dr-shipped__viewport"
+        role="region"
         tabIndex={0}
         aria-label="Merged pull requests table"
       >
@@ -131,7 +132,9 @@ export function ShippedTable({
                     {pr.repo}#{pr.number}
                   </td>
                   <td className="dr-shipped__time">
-                    {relativeTime(pr.mergedAt, nowMs)}
+                    {/* Density pinned to "compact" so SSR HTML and client hydration render
+                        identically, regardless of the user's localStorage density preference. */}
+                    {relativeTime(pr.mergedAt, nowMs, "compact")}
                   </td>
                 </tr>
               ))

--- a/src/lib/shipped-table.ts
+++ b/src/lib/shipped-table.ts
@@ -1,0 +1,117 @@
+// Pure helpers for the shipped-table UI: filtering, sorting, and the
+// three-state sort-cycle. Lives in src/lib/ (not src/components/) so the
+// node --experimental-strip-types test runner can import it without
+// React/JSX transforms.
+
+import type { MergedPr } from "./daily-report-facts.ts";
+
+export type ShippedSortKey = "pr" | "repo" | "merged";
+export type ShippedSortDir = "asc" | "desc";
+export type ShippedSort = { key: ShippedSortKey; dir: ShippedSortDir } | null;
+
+/**
+ * Filter rows by a free-text query.
+ * - Empty / whitespace → returns all rows.
+ * - `#NNN` prefix → matches only against the PR number field.
+ * - Bare query → case-insensitive substring match against title, full repo,
+ *   short repo (part after the last "/"), and PR number.
+ */
+export function filterShippedRows(rows: readonly MergedPr[], query: string): MergedPr[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return rows.slice();
+
+  const isHashQuery = q.startsWith("#");
+  const digits = isHashQuery ? q.slice(1) : q;
+
+  return rows.filter((row) => {
+    if (isHashQuery) {
+      // # prefix: match only PR number
+      return String(row.number).includes(digits);
+    }
+    if (row.title.toLowerCase().includes(q)) return true;
+    if (row.repo.toLowerCase().includes(q)) return true;
+    const shortRepo = row.repo.slice(row.repo.lastIndexOf("/") + 1).toLowerCase();
+    if (shortRepo.includes(q)) return true;
+    if (String(row.number).includes(q)) return true;
+    return false;
+  });
+}
+
+/**
+ * Sort rows without mutating the input.
+ * - `null` → newest mergedAt first; invalid timestamps always last; stable.
+ * - `{key:"pr"}` → title localeCompare in dir; stable tie-break by index.
+ * - `{key:"repo"}` → full repo localeCompare, then number asc as secondary;
+ *   `dir:"desc"` reverses both parts.
+ * - `{key:"merged"}` → timestamp in dir; invalid timestamps always last
+ *   regardless of dir; stable tie-break by index.
+ */
+export function sortShippedRows(rows: readonly MergedPr[], sort: ShippedSort): MergedPr[] {
+  // Attach original index for stable tie-breaking; never touches input order.
+  const indexed = rows.map((row, i) => ({ row, i }));
+
+  if (sort === null) {
+    indexed.sort((a, b) => {
+      const ta = Date.parse(a.row.mergedAt);
+      const tb = Date.parse(b.row.mergedAt);
+      const aOk = !isNaN(ta);
+      const bOk = !isNaN(tb);
+      if (!aOk && !bOk) return a.i - b.i;
+      if (!aOk) return 1;
+      if (!bOk) return -1;
+      if (tb !== ta) return tb - ta; // newest first
+      return a.i - b.i;
+    });
+    return indexed.map(({ row }) => row);
+  }
+
+  const { key, dir } = sort;
+  const sign = dir === "asc" ? 1 : -1;
+
+  indexed.sort((a, b) => {
+    let cmp = 0;
+    if (key === "pr") {
+      cmp = a.row.title.localeCompare(b.row.title);
+    } else if (key === "repo") {
+      cmp = a.row.repo.localeCompare(b.row.repo);
+      if (cmp === 0) cmp = a.row.number - b.row.number;
+    } else {
+      // key === "merged"
+      const ta = Date.parse(a.row.mergedAt);
+      const tb = Date.parse(b.row.mergedAt);
+      const aOk = !isNaN(ta);
+      const bOk = !isNaN(tb);
+      // Invalid timestamps always sort last regardless of dir — return early.
+      if (!aOk && !bOk) return a.i - b.i;
+      if (!aOk) return 1;
+      if (!bOk) return -1;
+      cmp = ta - tb; // asc = oldest first; sign applied below
+    }
+    if (cmp !== 0) return sign * cmp;
+    return a.i - b.i;
+  });
+
+  return indexed.map(({ row }) => row);
+}
+
+/**
+ * Advance the sort cycle for a column header click.
+ * - First click on a column: `merged` starts `"desc"`, `pr`/`repo` start `"asc"`.
+ * - Second click (same column): flip direction.
+ * - Third click (same column): reset to `null` (default order).
+ * - Click on a different column: jump to that column's first state.
+ */
+export function nextShippedSort(current: ShippedSort, key: ShippedSortKey): ShippedSort {
+  const firstDir = (k: ShippedSortKey): ShippedSortDir =>
+    k === "merged" ? "desc" : "asc";
+
+  if (current === null || current.key !== key) {
+    return { key, dir: firstDir(key) };
+  }
+
+  const first = firstDir(key);
+  if (current.dir === first) {
+    return { key, dir: first === "asc" ? "desc" : "asc" };
+  }
+  return null;
+}

--- a/src/lib/shipped-table.ts
+++ b/src/lib/shipped-table.ts
@@ -14,7 +14,7 @@ export type ShippedSort = { key: ShippedSortKey; dir: ShippedSortDir } | null;
  * - Empty / whitespace → returns all rows.
  * - `#NNN` prefix → matches only against the PR number field.
  * - Bare query → case-insensitive substring match against title, full repo,
- *   short repo (part after the last "/"), and PR number.
+ *   and PR number.
  */
 export function filterShippedRows(rows: readonly MergedPr[], query: string): MergedPr[] {
   const q = query.trim().toLowerCase();
@@ -30,8 +30,6 @@ export function filterShippedRows(rows: readonly MergedPr[], query: string): Mer
     }
     if (row.title.toLowerCase().includes(q)) return true;
     if (row.repo.toLowerCase().includes(q)) return true;
-    const shortRepo = row.repo.slice(row.repo.lastIndexOf("/") + 1).toLowerCase();
-    if (shortRepo.includes(q)) return true;
     if (String(row.number).includes(q)) return true;
     return false;
   });

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -331,8 +331,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-shipped__toolbar {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
+  gap: var(--space-3);
+  padding: var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
 }
 .dr-shipped__search {
@@ -342,7 +342,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-3);
   color: var(--text-primary);
   outline: none;
 }
@@ -383,7 +383,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   top: 0;
   z-index: 1;
   background: var(--bg-raised);
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   /* box-shadow, not border-bottom: collapsed borders don't travel with sticky
      cells, so the hairline would vanish once rows scroll (see .fa-thread-table). */
   box-shadow: 0 1px 0 var(--border-hairline);
@@ -393,7 +393,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   all: unset;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: pointer;
   font: inherit;
   font-weight: inherit;
@@ -401,14 +401,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .dr-shipped__table thead th button:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
 }
 .dr-shipped__table thead th[aria-sort="ascending"] button,
 .dr-shipped__table thead th[aria-sort="descending"] button {
   color: var(--color-info);
 }
 .dr-shipped__table tbody tr td {
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   border-top: 1px solid var(--border-hairline);
 }
 .dr-shipped__table tbody tr:first-child td { border-top: none; }
@@ -425,7 +425,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .dr-shipped__empty {
   text-align: center;
-  padding: 24px 12px;
+  padding: var(--space-6) var(--space-3);
   color: var(--text-secondary);
 }
 

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -321,7 +321,111 @@ a.dr-row:active { transform: translateY(1px); }
 }
 a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: translateX(2px); }
 
-/* Empty states -------------------------------------------------------------- */
+/* ── Shipped table (merged PRs, /daily-report) ────────────────────────────── */
+.dr-shipped {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-raised);
+  overflow: hidden;
+}
+.dr-shipped__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+.dr-shipped__search {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-sm);
+  background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  padding: 4px 10px;
+  color: var(--text-primary);
+  outline: none;
+}
+.dr-shipped__search:focus-visible {
+  border-color: var(--ring-focus);
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: var(--ring-offset-inset);
+}
+.dr-shipped__count {
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.dr-shipped__viewport {
+  max-height: 300px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  outline: none;
+}
+.dr-shipped__viewport:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: var(--ring-offset-inset);
+}
+.dr-shipped__table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  text-align: left;
+}
+.dr-shipped__table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-raised);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+  font-weight: 600;
+}
+.dr-shipped__table thead th button {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: inherit;
+  color: var(--text-secondary);
+}
+.dr-shipped__table thead th button:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  border-radius: 3px;
+}
+.dr-shipped__table thead th[aria-sort="ascending"] button,
+.dr-shipped__table thead th[aria-sort="descending"] button {
+  color: var(--color-info);
+}
+.dr-shipped__table tbody tr td {
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-hairline);
+}
+.dr-shipped__table tbody tr:first-child td { border-top: none; }
+.dr-shipped__table td a {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+.dr-shipped__table td a:hover { color: var(--color-info); }
+.dr-shipped__repo,
+.dr-shipped__time {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.dr-shipped__empty {
+  text-align: center;
+  padding: 24px 12px;
+  color: var(--text-secondary);
+}
+
+
 .dr-empty {
   display: flex;
   align-items: center;

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -144,7 +144,7 @@
 }
 .dr-metric {
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   padding: var(--space-5);
   /* Ultra low-profile, Apple-style grouped card: generous radius, a faint
      hairline over a barely-raised translucent fill — no accent bar, no shadow,
@@ -279,7 +279,7 @@ a.dr-row:active { transform: translateY(1px); }
   font-weight: 560;
   line-height: 1.35;
   color: var(--text-primary);
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -290,7 +290,7 @@ a.dr-row:active { transform: translateY(1px); }
   font-size: 12.5px;
   line-height: 1.45;
   color: var(--text-secondary);
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -326,7 +326,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: var(--bg-raised);
-  overflow: hidden;
+  overflow: auto;
 }
 .dr-shipped__toolbar {
   display: flex;
@@ -363,6 +363,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   overflow: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
+  scroll-padding-top: 34px;
   outline: none;
 }
 .dr-shipped__viewport:focus-visible {
@@ -382,7 +383,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   z-index: 1;
   background: var(--bg-raised);
   padding: 8px 12px;
-  border-bottom: 1px solid var(--border-hairline);
+  box-shadow: 0 1px 0 var(--border-hairline);
   font-weight: 600;
 }
 .dr-shipped__table thead th button {
@@ -490,7 +491,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-size: var(--text-base);
   font-weight: 620;
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -822,7 +823,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-familiar-panel small {
   display: block;
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -850,7 +851,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   position: relative;
   display: grid;
   grid-template-columns: 3px minmax(0, 1fr);
-  overflow: hidden;
+  overflow: auto;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: var(--bg-raised);
@@ -883,7 +884,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-run-row__meta {
   display: block;
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1083,7 +1084,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .growth-picker__value b {
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-base);
@@ -1180,7 +1181,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: block;
   min-height: 28px;
   margin-top: 10px;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 22px;
@@ -1289,7 +1290,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 /* Accept-rate meter — tone thresholds match GROWTH_THRESHOLDS (0.35 / 0.5). */
 .growth-track-meter {
-  overflow: hidden;
+  overflow: auto;
   height: 6px;
   margin-top: var(--space-2);
   border-radius: var(--radius-pill);
@@ -1632,7 +1633,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 4px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--border-hairline) 60%, transparent);
-  overflow: hidden;
+  overflow: auto;
 }
 .fa-progression__meter i {
   display: block;
@@ -1816,7 +1817,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 1;
 }
 .fa-session__title {
-  overflow: hidden;
+  overflow: auto;
   color: var(--text-primary);
   font-size: var(--text-sm);
   text-decoration: none;
@@ -1825,7 +1826,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-session__title:hover { text-decoration: underline; }
 .fa-session__meta {
-  overflow: hidden;
+  overflow: auto;
   color: var(--text-muted);
   font-size: var(--text-xs);
   text-overflow: ellipsis;
@@ -1946,7 +1947,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   gap: 10px;
 }
 .trace-kind {
-  overflow: hidden;
+  overflow: auto;
   padding: 2px var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);
@@ -2029,7 +2030,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-size: var(--text-sm);
 }
 .fa-feedback-row__name {
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-primary);
@@ -2041,7 +2042,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 6px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--color-danger) 28%, var(--bg-base));
-  overflow: hidden;
+  overflow: auto;
 }
 .fa-feedback-row__bar i {
   position: absolute;
@@ -2164,7 +2165,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-trend-chip--regressing { color: var(--color-warning); }
 .fa-factor-bar {
   position: relative;
-  overflow: hidden;
+  overflow: auto;
   height: 10px;
   /* Keeps bars visible inside the narrowest metric cells. */
   min-width: 44px;
@@ -2598,7 +2599,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-block;
   min-width: 0;
   max-width: 100%;
-  overflow: hidden;
+  overflow: auto;
   color: var(--text-primary);
   font-size: var(--text-base);
   font-weight: 500;
@@ -2821,7 +2822,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .tsc-meta {
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   color: var(--text-muted);
   font-size: var(--text-xs);
   text-overflow: ellipsis;
@@ -2845,7 +2846,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .tsc-score-item b {
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   color: var(--text-secondary);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -2957,7 +2958,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .cave-fill-btn {
   position: relative;
   isolation: isolate;
-  overflow: hidden;
+  overflow: auto;
   transition:
     color var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard);
@@ -3056,7 +3057,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-edit-card__title {
   min-width: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-primary);
@@ -3127,7 +3128,7 @@ details[open] > .cave-edit-card__summary::before {
 .cave-edit-card__error {
   flex: 0 1 auto;
   max-width: 12rem;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-xs);
@@ -3143,7 +3144,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-review-modal__path {
   margin: 0;
-  overflow: hidden;
+  overflow: auto;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono, ui-monospace, monospace);
@@ -3185,7 +3186,7 @@ details[open] > .cave-edit-card__summary::before {
     inset 0 1px 0 0 color-mix(in oklch, var(--foreground) 7%, transparent),
     0 24px 60px -14px rgba(0, 0, 0, 0.5),
     0 8px 22px -10px rgba(0, 0, 0, 0.4);
-  overflow: hidden;
+  overflow: auto;
   transform-origin: top right;
   animation: quick-chat-overlay-in 180ms var(--ease-emphasized, cubic-bezier(0.2, 0.8, 0.2, 1));
 }

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -144,7 +144,7 @@
 }
 .dr-metric {
   position: relative;
-  overflow: auto;
+  overflow: hidden;
   padding: var(--space-5);
   /* Ultra low-profile, Apple-style grouped card: generous radius, a faint
      hairline over a barely-raised translucent fill — no accent bar, no shadow,
@@ -279,7 +279,7 @@ a.dr-row:active { transform: translateY(1px); }
   font-weight: 560;
   line-height: 1.35;
   color: var(--text-primary);
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -290,7 +290,7 @@ a.dr-row:active { transform: translateY(1px); }
   font-size: 12.5px;
   line-height: 1.45;
   color: var(--text-secondary);
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-line-clamp: 1;
@@ -326,7 +326,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: var(--bg-raised);
-  overflow: auto;
+  overflow: hidden;
 }
 .dr-shipped__toolbar {
   display: flex;
@@ -363,6 +363,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   overflow: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
+  /* Keep backwards-tabbed row links clear of the sticky header. */
   scroll-padding-top: 34px;
   outline: none;
 }
@@ -383,6 +384,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   z-index: 1;
   background: var(--bg-raised);
   padding: 8px 12px;
+  /* box-shadow, not border-bottom: collapsed borders don't travel with sticky
+     cells, so the hairline would vanish once rows scroll (see .fa-thread-table). */
   box-shadow: 0 1px 0 var(--border-hairline);
   font-weight: 600;
 }
@@ -491,7 +494,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-size: var(--text-base);
   font-weight: 620;
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -823,7 +826,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-familiar-panel small {
   display: block;
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -851,7 +854,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   position: relative;
   display: grid;
   grid-template-columns: 3px minmax(0, 1fr);
-  overflow: auto;
+  overflow: hidden;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   background: var(--bg-raised);
@@ -884,7 +887,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .retro-run-row__meta {
   display: block;
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1084,7 +1087,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .growth-picker__value b {
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-base);
@@ -1181,7 +1184,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: block;
   min-height: 28px;
   margin-top: 10px;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 22px;
@@ -1290,7 +1293,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 /* Accept-rate meter — tone thresholds match GROWTH_THRESHOLDS (0.35 / 0.5). */
 .growth-track-meter {
-  overflow: auto;
+  overflow: hidden;
   height: 6px;
   margin-top: var(--space-2);
   border-radius: var(--radius-pill);
@@ -1633,7 +1636,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 4px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--border-hairline) 60%, transparent);
-  overflow: auto;
+  overflow: hidden;
 }
 .fa-progression__meter i {
   display: block;
@@ -1817,7 +1820,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 1;
 }
 .fa-session__title {
-  overflow: auto;
+  overflow: hidden;
   color: var(--text-primary);
   font-size: var(--text-sm);
   text-decoration: none;
@@ -1826,7 +1829,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-session__title:hover { text-decoration: underline; }
 .fa-session__meta {
-  overflow: auto;
+  overflow: hidden;
   color: var(--text-muted);
   font-size: var(--text-xs);
   text-overflow: ellipsis;
@@ -1947,7 +1950,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   gap: 10px;
 }
 .trace-kind {
-  overflow: auto;
+  overflow: hidden;
   padding: 2px var(--space-2);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);
@@ -2030,7 +2033,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-size: var(--text-sm);
 }
 .fa-feedback-row__name {
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-primary);
@@ -2042,7 +2045,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   height: 6px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--color-danger) 28%, var(--bg-base));
-  overflow: auto;
+  overflow: hidden;
 }
 .fa-feedback-row__bar i {
   position: absolute;
@@ -2165,7 +2168,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .fa-trend-chip--regressing { color: var(--color-warning); }
 .fa-factor-bar {
   position: relative;
-  overflow: auto;
+  overflow: hidden;
   height: 10px;
   /* Keeps bars visible inside the narrowest metric cells. */
   min-width: 44px;
@@ -2599,7 +2602,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: inline-block;
   min-width: 0;
   max-width: 100%;
-  overflow: auto;
+  overflow: hidden;
   color: var(--text-primary);
   font-size: var(--text-base);
   font-weight: 500;
@@ -2822,7 +2825,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .tsc-meta {
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   color: var(--text-muted);
   font-size: var(--text-xs);
   text-overflow: ellipsis;
@@ -2846,7 +2849,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .tsc-score-item b {
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   color: var(--text-secondary);
   font-size: var(--text-xs);
   font-weight: 600;
@@ -2958,7 +2961,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .cave-fill-btn {
   position: relative;
   isolation: isolate;
-  overflow: auto;
+  overflow: hidden;
   transition:
     color var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard);
@@ -3057,7 +3060,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-edit-card__title {
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-primary);
@@ -3128,7 +3131,7 @@ details[open] > .cave-edit-card__summary::before {
 .cave-edit-card__error {
   flex: 0 1 auto;
   max-width: 12rem;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-xs);
@@ -3144,7 +3147,7 @@ details[open] > .cave-edit-card__summary::before {
 }
 .cave-review-modal__path {
   margin: 0;
-  overflow: auto;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono, ui-monospace, monospace);
@@ -3186,7 +3189,7 @@ details[open] > .cave-edit-card__summary::before {
     inset 0 1px 0 0 color-mix(in oklch, var(--foreground) 7%, transparent),
     0 24px 60px -14px rgba(0, 0, 0, 0.5),
     0 8px 22px -10px rgba(0, 0, 0, 0.4);
-  overflow: auto;
+  overflow: hidden;
   transform-origin: top right;
   animation: quick-chat-overlay-in 180ms var(--ease-emphasized, cubic-bezier(0.2, 0.8, 0.2, 1));
 }


### PR DESCRIPTION
Replaces the unbounded merged-PRs row list on `/daily-report/[date]` with a bounded, filterable, sortable data table (bead **cave-zo7f**, spec `docs/superpowers/specs/2026-07-09-shipped-data-table-design.md` — retargeted from the dashboard's Shipped chips, which the bento rebuild #3435 removed).

## What changed
- **`src/lib/shipped-table.ts`** (new): pure, client-safe helpers — `filterShippedRows` (title / repo / `#number`, case-insensitive), `sortShippedRows` (stable, invalid-date-last, index tie-break), `nextShippedSort` (3-state cycle: first activation asc — merged starts desc — then flip, then default).
- **`src/components/shipped-table.tsx`** (new): `"use client"` island — search toolbar with `role="status"` visible/total count; 300px scroll viewport (`role="region"`, `tabIndex={0}`, scroll-padding for the sticky header); semantic `<table>` with `<th scope="col">` button headers exposing `aria-sort`; PR links keep `target="_blank" rel="noreferrer"`; relative times pinned to `"compact"` density so SSR and hydration render identically.
- **`src/app/daily-report/[date]/page.tsx`**: the Merged pull requests section renders `<ShippedTable rows={report.prsMerged} nowMs={Date.now()} />` (page stays a server component; `SectionHead` unchanged).
- **`src/styles/globals/surface-reporting.css`**: `dr-shipped*` block — bordered shell, sticky header via `box-shadow` hairline (collapsed borders don't travel with sticky cells), `min-width` + internal horizontal scroll for narrow panes, tokenized spacing/radius (design-token ratchets green).
- **Tests**: `src/components/shipped-table.test.ts` — behavioral coverage of the helpers + single-rule-block source pins for component/page/CSS wiring; registered in the app suite.

## Verification
- `pnpm typecheck` clean; `pnpm check:tests-wired` green; **`pnpm test:app` 870 files pass**.
- Real-browser pass (prod build, real store: Jul 21 report with 51 merged PRs): 300px cap + internal scroll (51 rows), sticky header pinned after 400px scroll, filter `canvas` → 2/51 with live status count, empty-state row, `aria-sort` cycles none→descending→ascending→none, links `target=_blank rel=noreferrer`, 480px pane scrolls horizontally inside the viewport with **no document overflow**, viewport/header-button focus works, zero console errors (no hydration mismatch).

## Review trail
Two-stage subagent review per task; fix rounds covered: hydration-safe relative time, sticky hairline vanishing under border-collapse, CSS pin tightening, `role="region"`, focus occlusion — plus reverting an accidental `overflow: hidden→auto` sweep a fix commit introduced (caught by re-review).
