### PR TITLE
feat(chrome): waveform header button opens a running-processes popover (cave-82e3)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -828,6 +828,7 @@ export const SUITES = {
     "src/components/security/sidecar-auth-bridge.test.ts",
     "src/components/familiar-switcher.test.ts",
     "src/components/familiar-menu-bar.test.ts",
+    "src/components/running-sessions-popover.test.ts",
     "src/components/top-bar-polish.test.ts",
     "src/components/menu-bar-icon-size.test.ts",
     "src/components/tray-quick-chat.test.ts",

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -128,20 +128,44 @@ assert.match(
   /scheduleNeedsCount > 0 \? \(\s*<span className="menu-bar__badge">/,
   "the Schedules badge matches the Tasks badge chrome (no alert tint) and hides at zero",
 );
+// The running-processes control is workspace-owned (it needs the sessions
+// state and chat navigation): the bar renders it as the `runningStatus` slot
+// in the right status cluster, exactly like the bell — no hand-rolled markup.
 assert.match(
   source,
-  /typeof runningCount === "number" && runningCount > 0 \? \(\s*<span\s+className="menu-bar__status"[^>]*role="status"[^>]*aria-label=\{`\$\{runningCount\} session\$\{runningCount === 1 \? "" : "s"\} running`\}[^>]*title=\{`\$\{runningCount\} session\$\{runningCount === 1 \? "" : "s"\} running`\}[^>]*>[\s\S]{0,260}?<Icon name="ph:waveform"[\s\S]{0,250}?<span className="menu-bar__badge" aria-hidden>\s*\{fmtBadge\(runningCount\)\}\s*<\/span>[\s\S]{0,120}?\)\s*:\s*null/,
-  "running sessions render as a compact status control that hides at zero and carries the exact label",
+  /<div className="menu-bar__group menu-bar__group--status">\s*\{runningStatus\}\s*\{bell\}\s*<\/div>/,
+  "the status cluster hosts the workspace-owned running-processes control beside the bell",
+);
+assert.doesNotMatch(
+  source,
+  /menu-bar__status|runningCount|ph:waveform/,
+  "the bar no longer hand-rolls the running-status markup (it lives in RunningSessionsPopover)",
 );
 assert.doesNotMatch(
   source,
   /menu-bar__running-dot/,
   "the running status no longer uses a presence dot",
 );
-assert.doesNotMatch(
-  source,
-  /\{runningCount\} running/,
-  "the running status no longer renders the literal running pill text",
+// Clicking the waveform trigger must SHOW the running processes: the workspace
+// feeds the popover the live running-session rows and the chat-open handler.
+const runningSessionsPopover = readFileSync(
+  new URL("./running-sessions-popover.tsx", import.meta.url),
+  "utf8",
+);
+assert.match(
+  workspace,
+  /runningStatus=\{\s*<RunningSessionsPopover\s+sessions=\{runningSessions\}\s+familiars=\{familiars\}\s+onOpenSession=\{openFamiliarSession\}\s*\/>\s*\}/,
+  "workspace mounts RunningSessionsPopover in the menu bar's runningStatus slot, fed live running sessions and the session-open handler",
+);
+assert.match(
+  workspace,
+  /runningSessions = useMemo\(\s*\(\) => sessions\.filter\(\(s\) => !s\.archived_at && sessionStatusTone\(s\.status\) === "running"\)/,
+  "running rows use the shared sessionStatusTone vocabulary and exclude archived sessions",
+);
+assert.match(
+  runningSessionsPopover,
+  /className="menu-bar__status focus-ring"[\s\S]{0,200}?aria-haspopup="dialog"[\s\S]{0,120}?aria-expanded=\{open\}/,
+  "the popover trigger keeps the menu-bar status chrome and announces the popover",
 );
 assert.match(
   notificationBell,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -11,9 +11,10 @@ type Props = {
   /** Active familiar display name — personalizes the command-bar placeholder
    *  ("Search or ask <name>…"). Falls back to Salem, the docs familiar. */
   activeFamiliarName?: string | null;
-  /** Live count of running daemon sessions — drives the compact status control
-   *  (hidden at zero). */
-  runningCount?: number;
+  /** Running-processes control (waveform trigger + popover), rendered by the
+   *  workspace (it owns the sessions state and chat navigation) so this bar
+   *  stays markup-thin. Hidden at zero by the control itself. */
+  runningStatus?: ReactNode;
   /** Notification bell, rendered by the workspace (it owns the inbox state)
    *  so this bar stays markup-thin. Joins the right-side status controls. */
   bell?: ReactNode;
@@ -59,7 +60,7 @@ function fmtBadge(n: number): string {
 export function FamiliarMenuBar({
   activeFamiliarId,
   activeFamiliarName,
-  runningCount,
+  runningStatus,
   bell,
   taskCount,
   scheduleNeedsCount,
@@ -176,22 +177,11 @@ export function FamiliarMenuBar({
         </button>
       </div>
 
-      {/* Right edge (chat-revamp phase D): compact running-session status
-          (waveform + count, hidden at zero) and the notification bell. */}
+      {/* Right edge (chat-revamp phase D): the running-processes control
+          (waveform + count trigger opening the process list, hidden at zero)
+          and the notification bell. */}
       <div className="menu-bar__group menu-bar__group--status">
-        {typeof runningCount === "number" && runningCount > 0 ? (
-          <span
-            className="menu-bar__status"
-            role="status"
-            aria-label={`${runningCount} session${runningCount === 1 ? "" : "s"} running`}
-            title={`${runningCount} session${runningCount === 1 ? "" : "s"} running`}
-          >
-            <Icon name="ph:waveform" width={22} height={22} aria-hidden />
-            <span className="menu-bar__badge" aria-hidden>
-              {fmtBadge(runningCount)}
-            </span>
-          </span>
-        ) : null}
+        {runningStatus}
         {bell}
       </div>
     </nav>

--- a/src/components/running-sessions-popover.test.ts
+++ b/src/components/running-sessions-popover.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./running-sessions-popover.tsx", import.meta.url), "utf8");
+
+// ── Trigger ──────────────────────────────────────────────────────────────────
+// The waveform control is a real button now: selecting it shows the running
+// processes. It keeps the menu-bar status chrome + corner count badge and
+// hides at zero like every other zero-hidden badge in the bar.
+assert.match(
+  source,
+  /if \(count === 0\) return null;/,
+  "the control hides entirely at zero running processes",
+);
+assert.match(
+  source,
+  /<button\s+type="button"\s+className="menu-bar__status focus-ring"\s+onClick=\{\(\) => setOpen\(\(v\) => !v\)\}\s+aria-haspopup="dialog"\s+aria-expanded=\{open\}/,
+  "the trigger is a focus-ring button that toggles the process list and announces the popover state",
+);
+assert.match(
+  source,
+  /const label = `\$\{count\} running process\$\{count === 1 \? "" : "es"\}`;/,
+  "the exact process count is carried by the trigger label",
+);
+assert.match(
+  source,
+  /<Icon name="ph:waveform"[\s\S]{0,160}?<span className="menu-bar__badge" aria-hidden>\s*\{fmtBadge\(count\)\}\s*<\/span>/,
+  "the trigger keeps the waveform icon + capped corner badge",
+);
+
+// ── Popover ──────────────────────────────────────────────────────────────────
+// Focus-trapped dialog (Escape closes, focus restores to the trigger) with an
+// outside-click close — same pattern as NotificationBell.
+assert.match(
+  source,
+  /useFocusTrap\(open, popoverRef, \{ onEscape: \(\) => setOpen\(false\) \}\)/,
+  "the popover traps focus and closes on Escape",
+);
+assert.match(
+  source,
+  /role="dialog"\s+aria-modal="true"\s+aria-label="Running processes"\s+tabIndex=\{-1\}/,
+  "the popover is an accessible Running processes dialog",
+);
+assert.match(
+  source,
+  /window\.addEventListener\("pointerdown", onDown\)/,
+  "the popover closes on outside click",
+);
+
+// ── Rows ─────────────────────────────────────────────────────────────────────
+// Each running process reads familiar · project · started time, newest first,
+// and a click jumps into that chat and closes the list.
+assert.match(
+  source,
+  /\[\.\.\.sessions\]\.sort\(\(a, b\) => \(b\.created_at \|\| ""\)\.localeCompare\(a\.created_at \|\| ""\)\)/,
+  "processes list newest-first",
+);
+assert.match(
+  source,
+  /familiars\.find\(\(f\) => f\.id === session\.familiarId\)\?\.display_name \?\? session\.familiarId/,
+  "rows name the owning familiar (id fallback)",
+);
+assert.match(
+  source,
+  /\[familiarName \?\? session\.harness, shortProjectRoot\(session\.project_root\)\]/,
+  "rows fall back to the harness name and show the short project root",
+);
+assert.match(
+  source,
+  /\{sessionDisplayTitle\(session\)\}/,
+  "rows show the sanitized session title",
+);
+assert.match(
+  source,
+  /started <RelativeTime iso=\{session\.created_at\} fallback="—" \/>/,
+  "rows show when the process started",
+);
+assert.match(
+  source,
+  /useMinuteTick\(\);/,
+  "row timestamps tick each minute while the popover stays open",
+);
+assert.match(
+  source,
+  /onOpen=\{\(session\) => \{\s*setOpen\(false\);\s*onOpenSession\(session\.id, session\.familiarId\);\s*\}\}/,
+  "clicking a process closes the list and opens that chat session",
+);
+
+console.log("running-sessions-popover.test.ts: ok");

--- a/src/components/running-sessions-popover.tsx
+++ b/src/components/running-sessions-popover.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
+import { useFocusTrap } from "@/lib/use-focus-trap";
+import { sessionDisplayTitle } from "@/lib/session-title";
+import { shortProjectRoot } from "@/lib/command-palette-grouping";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+type Props = {
+  /** Running (non-archived) daemon sessions — the workspace filters with the
+   *  shared sessionStatusTone vocabulary so this control and the count badge
+   *  can never disagree. */
+  sessions: SessionRow[];
+  familiars: Familiar[];
+  /** Jump to the process's chat (workspace openFamiliarSession). */
+  onOpenSession: (sessionId: string, familiarId?: string | null) => void;
+};
+
+function fmtBadge(n: number): string {
+  // Cap at 9+ like every other corner badge in the bar — the trigger's
+  // aria-label/tooltip still carries the exact count.
+  return n > 9 ? "9+" : String(n);
+}
+
+// Live per-row timestamps: tick each minute so a popover left open doesn't
+// show a stale "started 2m ago" forever. Rows unmount with the popover, so
+// the always-mounted trigger pays nothing while closed.
+function RunningSessionList({
+  sessions,
+  familiars,
+  onOpen,
+}: {
+  sessions: SessionRow[];
+  familiars: Familiar[];
+  onOpen: (session: SessionRow) => void;
+}) {
+  useMinuteTick();
+  return (
+    <ul className="running-sessions__list max-h-80 overflow-y-auto p-1">
+      {sessions.map((session) => {
+        const familiarName = session.familiarId
+          ? familiars.find((f) => f.id === session.familiarId)?.display_name ?? session.familiarId
+          : null;
+        const meta = [familiarName ?? session.harness, shortProjectRoot(session.project_root)]
+          .filter(Boolean)
+          .join(" · ");
+        return (
+          <li key={session.id}>
+            <button
+              type="button"
+              className="running-sessions__row focus-ring flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--bg-hover)]"
+              onClick={() => onOpen(session)}
+              title={`Open this chat — ${sessionDisplayTitle(session)}`}
+            >
+              <span
+                aria-hidden
+                className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-[var(--color-success)]"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
+                  {sessionDisplayTitle(session)}
+                </span>
+                <span className="mt-0.5 block truncate text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {meta} · started <RelativeTime iso={session.created_at} fallback="—" />
+                </span>
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * The desktop menu bar's running-processes control: the waveform + count
+ * trigger (hidden at zero, like every other zero-hidden badge in the bar)
+ * now opens a popover listing each live daemon process — familiar, chat
+ * title, project, and start time — and a click jumps into that chat.
+ */
+export function RunningSessionsPopover({ sessions, familiars, onOpenSession }: Props) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  // Newest process first — mirrors how `ps` output reads for "what just started".
+  const rows = useMemo(
+    () => [...sessions].sort((a, b) => (b.created_at || "").localeCompare(a.created_at || "")),
+    [sessions],
+  );
+  const count = rows.length;
+
+  // Trap focus while the popover is open: Escape closes, Tab cycles inside,
+  // closing restores focus to the trigger. Same pattern as NotificationBell.
+  useFocusTrap(open, popoverRef, { onEscape: () => setOpen(false) });
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("pointerdown", onDown);
+    return () => window.removeEventListener("pointerdown", onDown);
+  }, [open]);
+
+  if (count === 0) return null;
+
+  const label = `${count} running process${count === 1 ? "" : "es"}`;
+  return (
+    <span ref={wrapRef} className="running-sessions relative">
+      <button
+        type="button"
+        className="menu-bar__status focus-ring"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={`${label} — show list`}
+        title={`${label} — click to view`}
+      >
+        <Icon name="ph:waveform" width={22} height={22} aria-hidden />
+        <span className="menu-bar__badge" aria-hidden>
+          {fmtBadge(count)}
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Running processes"
+          tabIndex={-1}
+          className="running-sessions__popover glass-overlay absolute right-0 top-full z-50 mt-1 w-[340px] rounded-xl border border-[var(--border-strong)] shadow-2xl"
+        >
+          <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
+            <span className="text-[length:var(--text-xs)] font-medium text-[var(--text-primary)]">
+              Running processes
+            </span>
+            <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">{label}</span>
+          </div>
+          <RunningSessionList
+            sessions={rows}
+            familiars={familiars}
+            onOpen={(session) => {
+              setOpen(false);
+              onOpenSession(session.id, session.familiarId);
+            }}
+          />
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -76,8 +76,8 @@ assert.match(
 );
 assert.match(
   menuBar,
-  /<div className="menu-bar__group menu-bar__group--status">[\s\S]*?className="menu-bar__status"[\s\S]*?\{bell\}\s*<\/div>/,
-  "the right cluster hosts the compact running status before the bell slot",
+  /<div className="menu-bar__group menu-bar__group--status">\s*\{runningStatus\}\s*\{bell\}\s*<\/div>/,
+  "the right cluster hosts the running-processes slot before the bell slot",
 );
 assert.doesNotMatch(
   menuBar,
@@ -89,17 +89,18 @@ assert.doesNotMatch(
   /menu-bar__running-dot/,
   "the right cluster no longer uses the old running dot",
 );
-// Detailed waveform, badge, zero-hide, and accessibility contracts live in
-// familiar-menu-bar.test.ts. This suite keeps only the shell-level wiring.
+// Detailed waveform trigger, badge, zero-hide, popover, and accessibility
+// contracts live in running-sessions-popover.test.ts. This suite keeps only
+// the shell-level wiring.
 assert.match(
   workspace,
-  /const runningSessionCount = useMemo\(\s*\n\s*\(\) => sessions\.filter\(\(s\) => !s\.archived_at && sessionStatusTone\(s\.status\) === "running"\)\.length,\s*\n\s*\[sessions\],\s*\n\s*\);/,
-  "runningSessionCount derives from sessionStatusTone over the live sessions list",
+  /const runningSessions = useMemo\(\s*\n\s*\(\) => sessions\.filter\(\(s\) => !s\.archived_at && sessionStatusTone\(s\.status\) === "running"\),\s*\n\s*\[sessions\],\s*\n\s*\);/,
+  "runningSessions derives from sessionStatusTone over the live sessions list",
 );
 assert.match(
   workspace,
-  /<FamiliarMenuBar\s*\n\s*activeFamiliarId=\{activeId\}\s*\n\s*activeFamiliarName=\{active\?\.display_name \?\? null\}\s*\n\s*runningCount=\{runningSessionCount\}/,
-  "the menu bar receives the active familiar name and the running count",
+  /<FamiliarMenuBar\s*\n\s*activeFamiliarId=\{activeId\}\s*\n\s*activeFamiliarName=\{active\?\.display_name \?\? null\}[\s\S]{0,400}?<RunningSessionsPopover\s*\n\s*sessions=\{runningSessions\}/,
+  "the menu bar receives the active familiar name and the running-processes popover",
 );
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -127,6 +127,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useShellBanners } from "@/lib/shell-banners";
 import { TopBar } from "@/components/top-bar";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
+import { RunningSessionsPopover } from "@/components/running-sessions-popover";
 import { NotificationBell } from "@/components/notification-bell";
 import { StatusBar } from "@/components/status-bar";
 import { sessionStatusTone } from "@/lib/session-status";
@@ -2427,12 +2428,12 @@ export function Workspace() {
     [openTaskCards, activeId],
   );
 
-  // Live daemon activity for the top bar's "N running" pill: sessions whose
-  // status reads as running (shared sessionStatusTone vocabulary — running /
-  // starting / working), excluding archived rows. Derived from the same
-  // 4s-polled sessions list every other chrome badge uses.
-  const runningSessionCount = useMemo(
-    () => sessions.filter((s) => !s.archived_at && sessionStatusTone(s.status) === "running").length,
+  // Live daemon activity for the top bar's running-processes control: sessions
+  // whose status reads as running (shared sessionStatusTone vocabulary —
+  // running / starting / working), excluding archived rows. Derived from the
+  // same 4s-polled sessions list every other chrome badge uses.
+  const runningSessions = useMemo(
+    () => sessions.filter((s) => !s.archived_at && sessionStatusTone(s.status) === "running"),
     [sessions],
   );
 
@@ -3014,7 +3015,15 @@ export function Workspace() {
             <FamiliarMenuBar
               activeFamiliarId={activeId}
               activeFamiliarName={active?.display_name ?? null}
-              runningCount={runningSessionCount}
+              // Running processes: clicking the waveform trigger lists each
+              // live daemon session; a row jumps into that chat.
+              runningStatus={
+                <RunningSessionsPopover
+                  sessions={runningSessions}
+                  familiars={familiars}
+                  onOpenSession={openFamiliarSession}
+                />
+              }
               // Desktop notifications: the same NotificationBell the mobile
               // TopBar hosts, mounted in this bar's right status cluster.
               bell={

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -776,9 +776,17 @@ button:active > .edge-rail-chip {
   cursor: pointer;
 }
 
+/* The running-processes control is interactive now (it opens the process
+   list popover) — same affordance as its .menu-bar__task neighbors. */
 .menu-bar__status {
-  cursor: default;
+  cursor: pointer;
   color: var(--text-secondary);
+}
+
+.menu-bar__status:hover {
+  background: var(--bg-raised);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
 }
 
 /* Live enrich progress is visible text (information, not chrome) — let that


### PR DESCRIPTION
## What

The desktop menu bar's **"N sessions running" waveform indicator** was a passive `<span>` — selecting it did nothing. It's now a real button: selecting it **shows the running processes**.

- New `RunningSessionsPopover`: focus-trapped popover (`role=dialog`, Escape/outside-click close, focus restore) listing each running daemon process — session title, familiar (harness fallback), short project root, and `started Nm ago` (minute-ticking), newest first.
- Clicking a row jumps into that chat (`openFamiliarSession`) and closes the list.
- Trigger keeps the corner count badge (9+ cap), hides at zero, gains pointer/hover affordance (`.menu-bar__status`).
- Workspace-owned via a `runningStatus` slot in `FamiliarMenuBar` (same markup-thin pattern as the notification `bell` slot); rows derive from the shared `sessionStatusTone` filter (running/starting/working, archived excluded) — the badge and list can never disagree.

## Validation

- `running-sessions-popover.test.ts` (new, wired into the app suite) + updated pins in `familiar-menu-bar.test.ts` / `shell-chrome-revamp.test.ts`; `check-tests-wired` and `pnpm typecheck` green.
- Verified in the **built app** with Playwright (mocked `/api/sessions/list`): badge shows 3, popover lists the 3 running rows newest-first (a completed session is excluded), row click lands on the chat surface with that session selected, Escape closes.


Bead: cave-82e3
