### PR TITLE
feat(chat): rail code preview wraps flush like the editor; chips scroll in one row

### DIFF
--- a/src/components/chat-view-polish-edit-review.test.ts
+++ b/src/components/chat-view-polish-edit-review.test.ts
@@ -12,27 +12,33 @@ import {
   turnRow,
 } from "./chat-view-polish-fixtures.ts";
 
-// Suggestion pills lay out in UNIFORM rows keyed off the chip count: 2 and 4
-// chips pair into two columns (4 = 2×2, never a 3+1 orphan wrap); every other
-// count — legacy 3-chip transcripts included — stacks full-width (cave-wrso,
-// cave-98bs).
+// Suggestion pills lay out as ONE scrollable row: chips keep their intrinsic
+// width and overflow horizontally behind a hidden scrollbar, so any count
+// reads as a single quiet line instead of a growing grid (formerly the
+// data-count-keyed uniform-rows grid — cave-wrso, cave-98bs).
 assert.match(
   source,
   /className="cave-next-paths" data-count=\{nextPaths\.length\}/,
-  "the chip row stamps its count so CSS can key columns off it",
+  "the chip row still stamps its count (tooling/e2e hooks key off it)",
 );
 assert.match(
   globalsSrc,
-  /\.cave-next-paths\[data-count="2"\],\s*\n\s*\.cave-next-paths\[data-count="4"\] \{ grid-template-columns: repeat\(2, 1fr\); \}/,
-  "2 and 4 chips pair into two columns (4 renders 2×2)",
+  /\.cave-next-paths \{\s*\n\s*display: flex; flex-wrap: nowrap;[^}]*overflow-x: auto;\s*\n\s*scrollbar-width: none;/,
+  "the chip row is a no-wrap flex line that scrolls horizontally, scrollbar hidden",
+);
+assert.match(
+  globalsSrc,
+  /\.cave-next-paths::-webkit-scrollbar \{\s*\n\s*display: none;/,
+  "webkit scrollbar is hidden too (same grammar as .cave-chat-linked-context)",
+);
+assert.match(
+  globalsSrc,
+  /\.cave-next-path \{\s*\n\s*display: inline-flex; align-items: center; flex: 0 0 auto;[^}]*white-space: nowrap;/,
+  "chips keep intrinsic width (no flex-grow) and never wrap internally",
 );
 assert.ok(
-  !/\.cave-next-paths\[data-count="3"\]/.test(globalsSrc),
-  "no exactly-3 column rule: the chatturn container (46rem reading column, ~672px inner) can never reach a width where three chips fit, so legacy 3-chip rows stack (cave-98bs)",
-);
-assert.ok(
-  !/\.cave-next-paths \{ grid-template-columns: repeat\(/.test(globalsSrc),
-  "no count-blind multi-column rule survives (it produced 3+1 orphan wraps)",
+  !/\.cave-next-paths[^{]*\{[^}]*grid-template-columns/.test(globalsSrc) && !/\.cave-next-paths[^{]*\{[^}]*grid-template-columns/.test(styles),
+  "no grid column rules survive anywhere — the row never re-grows into 2×2",
 );
 
 // File picker resets its value synchronously so re-selecting the same file (or

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -113,4 +113,33 @@ assert.match(
   "--code body stops double-scrolling — the wrap scrolls internally",
 );
 
+// ─── cave-chat.css: --code preview is flush + wrapped like the editor ─────────
+// Read mode mirrors --edit: the pane is the code surface itself (no padded
+// card), and long lines wrap instead of horizontal-scrolling in a narrow rail.
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \{[^}]*padding: 0;\s*\n\s*background: var\(--code-surface\)/,
+  "--code body is a flush --code-surface fill, matching the --edit editor",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-syntax-block \.cave-code-wrap \{[^}]*margin: 0;\s*\n\s*border: 0;\s*\n\s*border-radius: 0;\s*\n\s*box-shadow: none/,
+  "--code strips the transcript card chrome off the code wrap (flush edges)",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-code-wrap pre \{[^}]*overflow-x: hidden/,
+  "--code kills the pre's horizontal scroll — lines wrap instead",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-line \{[^}]*display: block;\s*\n\s*white-space: pre-wrap;\s*\n\s*overflow-wrap: anywhere/,
+  "--code lines leave the flex row for block flow so text wraps mid-line",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-line:has\(\.cave-ln\) \{[^}]*padding-left: calc\(1em \+ 3\.4em\);\s*\n\s*text-indent: -3\.4em/,
+  "gutter lines hang-indent so wrapped continuations align past the line number",
+);
+
 console.log("rail-files-panel.test.ts OK");

--- a/src/components/rail-files-panel.tsx
+++ b/src/components/rail-files-panel.tsx
@@ -2,13 +2,15 @@
 
 import "@/styles/cave-chat.css";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Icon } from "@/lib/icon";
 import { ProjectTree } from "@/components/project-tree";
 import { RailFilePreview } from "@/components/rail-file-preview";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
+import { useSurfacePreference } from "@/lib/surface-preferences";
 
 /**
  * Files tab of the code rail: a scrollable project tree stacked over a
@@ -32,7 +34,23 @@ export function RailFilesPanel({
   focusLine?: number;
   focusNonce?: number;
 }) {
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [selectedPath, setSelectedPathState] = useState<string | null>(null);
+
+  // The rail unmounts between edit batches (use-code-rail dismissal), which
+  // would drop the open file right before a reopen or fullscreen expansion.
+  // Persist the last selection per project root and restore it on mount.
+  const [storedSelection, setStoredSelection] = useSurfacePreference(surfacePreferenceSpecs.codeRail.selectedFile);
+  const restoredRootRef = useRef<string | null>(null);
+
+  // Every selection (tree click, launchpad, focus event) writes through so the
+  // restore above always reopens the most recent file.
+  const setSelectedPath = useCallback(
+    (path: string | null) => {
+      setSelectedPathState(path);
+      if (path && projectRoot) setStoredSelection({ root: projectRoot, path });
+    },
+    [projectRoot, setStoredSelection],
+  );
 
   // The fullscreen IDE split (tree / editor / diffs) persists across sessions —
   // same react-resizable-panels persistence the chat split uses.
@@ -60,8 +78,19 @@ export function RailFilesPanel({
   // A new project resets the selection so a stale file from the previous repo
   // doesn't linger in the preview.
   useEffect(() => {
-    setSelectedPath(null);
+    setSelectedPathState(null);
+    restoredRootRef.current = null;
   }, [projectRoot]);
+
+  // Restore the persisted selection for this root once hydrated (once per
+  // root per mount); a selection already made — e.g. by a focus event racing
+  // hydration — always wins over the restored one.
+  useEffect(() => {
+    if (!projectRoot || restoredRootRef.current === projectRoot) return;
+    if (!storedSelection || storedSelection.root !== projectRoot) return;
+    restoredRootRef.current = projectRoot;
+    setSelectedPathState((current) => current ?? storedSelection.path);
+  }, [projectRoot, storedSelection]);
 
   useEffect(() => {
     if (!focusPath) return;

--- a/src/lib/surface-preference-specs.ts
+++ b/src/lib/surface-preference-specs.ts
@@ -34,6 +34,24 @@ function githubSelectionSpec(key: string): SurfacePreferenceSpec<GitHubSelection
   };
 }
 
+export type CodeRailFileSelection = { root: string; path: string };
+
+function codeRailFileSelectionSpec(key: string): SurfacePreferenceSpec<CodeRailFileSelection | null> {
+  return {
+    key,
+    defaultValue: null,
+    parse: (value) => {
+      if (value === null) return null;
+      if (!value || typeof value !== "object") return undefined;
+      const candidate = value as Partial<CodeRailFileSelection>;
+      return typeof candidate.root === "string" && candidate.root.length > 0 &&
+        typeof candidate.path === "string" && candidate.path.length > 0
+        ? { root: candidate.root, path: candidate.path }
+        : undefined;
+    },
+  };
+}
+
 export const surfacePreferenceSpecs = {
   github: {
     filter: enumSpec("github.filter", "all", ["all", "pr", "review_request", "issue"] as const),
@@ -87,5 +105,11 @@ export const surfacePreferenceSpecs = {
   browser: {
     activeTabId: stringSpec("browser.activeTabId", "home"),
     address: stringSpec("browser.address", ""),
+  },
+  codeRail: {
+    // The code rail unmounts between edit batches (use-code-rail dismissal),
+    // so the open file must outlive the component to survive a reopen or a
+    // fullscreen expansion. Root-scoped: restored only for the same project.
+    selectedFile: codeRailFileSelectionSpec("codeRail.selectedFile"),
   },
 } as const;

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -51,6 +51,13 @@ test("specs normalize allowed values and discard stale enum values", () => {
   assert.equal(surfacePreferenceSpecs.calendar.viewMode.parse("year"), undefined);
   assert.equal(surfacePreferenceSpecs.familiarMemory.staleOnly.parse(true), true);
   assert.equal(surfacePreferenceSpecs.familiarMemory.staleOnly.parse("true"), undefined);
+  assert.deepEqual(
+    surfacePreferenceSpecs.codeRail.selectedFile.parse({ root: "/repo", path: "/repo/src/a.ts" }),
+    { root: "/repo", path: "/repo/src/a.ts" },
+  );
+  assert.equal(surfacePreferenceSpecs.codeRail.selectedFile.parse({ root: "", path: "/repo/src/a.ts" }), undefined);
+  assert.equal(surfacePreferenceSpecs.codeRail.selectedFile.parse("stray-string"), undefined);
+  assert.equal(surfacePreferenceSpecs.codeRail.selectedFile.parse(null), null);
 });
 
 test("every remounting surface opts into the registry while searches remain transient", () => {
@@ -65,6 +72,7 @@ test("every remounting surface opts into the registry while searches remain tran
     marketplace: read("../components/marketplace-view.tsx"),
     browser: read("../components/browser-pane.tsx"),
     grimoire: read("../components/grimoire-view.tsx"),
+    codeRail: read("../components/rail-files-panel.tsx"),
     workspace: read("../app/page.tsx"),
     workspaceShell: read("../components/workspace.tsx"),
   };
@@ -86,4 +94,8 @@ test("every remounting surface opts into the registry while searches remain tran
   assert.match(sources.grimoire, /if \(deepLinkActiveRef\.current\) \{\s*deepLinkActiveRef\.current = false;/, "a one-visit Grimoire deep link yields to later user selections");
   assert.match(sources.grimoire, /restoredSelectionPendingRef\.current = true;/, "Grimoire marks a restored selection before persistence runs");
   assert.match(sources.grimoire, /if \(restoredSelectionPendingRef\.current\)/, "Grimoire waits to persist until a restored selection has been applied");
+  assert.match(sources.codeRail, /useSurfacePreference\(surfacePreferenceSpecs\.codeRail\.selectedFile\)/, "the code rail restores its open file through the registry");
+  assert.match(sources.codeRail, /if \(path && projectRoot\) setStoredSelection\(\{ root: projectRoot, path \}\)/, "code-rail selections write through with their project root");
+  assert.match(sources.codeRail, /storedSelection\.root !== projectRoot\) return;/, "a saved file from another project is never restored");
+  assert.match(sources.codeRail, /setSelectedPathState\(\(current\) => current \?\? storedSelection\.path\)/, "a selection made before hydration (focus events) wins over the restored one");
 });

--- a/src/lib/theme-contrast-audit.test.ts
+++ b/src/lib/theme-contrast-audit.test.ts
@@ -190,7 +190,10 @@ function declaredColor(selectorRe: RegExp, label: string): string {
   return value!.trim();
 }
 chrome.set("--_lang-ink", declaredColor(/\.cave-code-lang \{[^}]*\}/, ".cave-code-lang"));
-chrome.set("--_ln-ink", declaredColor(/\.cave-ln \{[^}]*\}/, ".cave-ln"));
+// Line-start anchored: scoped overrides (e.g. the code rail's
+// `.workspace-rail__preview-body--code .cave-ln`) must not shadow the
+// canonical colored rule.
+chrome.set("--_ln-ink", declaredColor(/\n\.cave-ln \{[^}]*\}/, ".cave-ln"));
 chrome.set(
   "--_add-strip",
   (chatCss.match(/\.cave-diff-add \{[^}]*background:\s*([^;]+);/) ?? [])[1] ?? "",

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -887,11 +887,15 @@
    height. Lift SyntaxBlock's chat clamp (max-height: min(60vh, 520px)) so the
    block shrink-fits the body and scrolls internally — short files keep their
    natural height, long files fill the pane with the sticky header reachable.
-   Mirrors the --edit editor fill above. */
+   Mirrors the --edit editor fill above, including its flush --code-surface
+   fill: the pane IS the code surface, not a padded card sitting on the panel
+   background (read mode and edit mode share one look). */
 .workspace-rail__preview-body--code {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: 0;
+  background: var(--code-surface);
 }
 .workspace-rail__preview-body--code .cave-syntax-block {
   display: flex;
@@ -903,6 +907,39 @@
   flex: 0 1 auto;
   min-height: 0;
   max-height: none;
+}
+/* Strip the transcript card chrome (border, radius, shadow, vertical margins)
+   so the block sits flush against the pane edges like the CodeMirror editor.
+   Three-class specificity: .cave-syntax-block .cave-code-wrap in
+   cave-md/interactions.css re-rounds corners at two classes, and the cave-md
+   vs cave-chat sheets load in component-import order. */
+.workspace-rail__preview-body--code .cave-syntax-block .cave-code-wrap {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+/* Long lines wrap instead of horizontal-scrolling — the rail is narrow and the
+   CodeMirror edit mode already wraps (EditorView.lineWrapping). .cave-line
+   leaves its flex row (which would wrap whole token spans) for block flow. */
+.workspace-rail__preview-body--code .cave-code-wrap pre {
+  overflow-x: hidden;
+}
+.workspace-rail__preview-body--code .cave-line {
+  display: block;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.6;
+}
+/* Line-number gutter (renders >5 lines) becomes a hanging indent: the 3.4em
+   .cave-ln (2.6em + 0.8em padding-right) hangs left of wrapped continuation
+   lines so code columns stay aligned under the first character. */
+.workspace-rail__preview-body--code .cave-line:has(.cave-ln) {
+  padding-left: calc(1em + 3.4em);
+  text-indent: -3.4em;
+}
+.workspace-rail__preview-body--code .cave-ln {
+  display: inline-block;
 }
 /* With the clamp lifted there is nothing to expand — the footer would be a
    no-op button pinned over the last visible line. */

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -350,9 +350,8 @@
 /* ── Follow-up pills above the composer (chat-revamp 1b) ────────────────────
    The latest settled turn's suggestions render as a quiet pill row aligned to
    the reading column, directly above the composer. Reuses the shared
-   .cave-next-paths uniform-rows grammar (2 and 4 pair into two columns —
-   never a 3+1 orphan) with its own column rule, since the container-query
-   version is scoped to the in-turn chatturn container. */
+   .cave-next-paths scrollable single-row grammar (chips keep intrinsic width,
+   horizontal overflow scrolls with a hidden scrollbar). */
 .cave-chat-followups {
   width: 100%;
   max-width: var(--cave-chat-measure);
@@ -362,13 +361,6 @@
 .cave-chat-followups .cave-next-paths {
   margin-top: 0;
   margin-bottom: var(--space-2);
-}
-
-@media (min-width: 640px) {
-  .cave-chat-followups .cave-next-paths[data-count="2"],
-  .cave-chat-followups .cave-next-paths[data-count="4"] {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 /* Quieter grammar than the in-turn accent pills: 999px radius, hairline

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -1253,21 +1253,21 @@
 /* ── Chat next-path suggestion chips ─────────────────────────────────────────
    Clickable next-step chips under an assistant reply (parsed from the
    <coven:next-paths> block); clicking sends the suggestion as the next turn.
-   Rows stay UNIFORM, keyed off the row's chip count (data-count): 2 and 4
-   chips pair into two columns (4 = 2×2, never a 3+1 orphan); any other count
-   (legacy 3-chip transcripts predating the 2-or-4 directive) stacks
-   full-width. A three-column rule for exactly-3 rows can't work here: the
-   chatturn container is capped by the 46rem reading column (~672px inner),
-   below any breakpoint where three ~7-word chips fit. */
+   One scrollable single row: chips keep their intrinsic width and overflow
+   horizontally (scrollbar hidden — same grammar as .cave-chat-linked-context)
+   so any count reads as one quiet line instead of a growing grid. */
 .cave-next-paths {
-  display: grid; grid-template-columns: 1fr; gap: 6px; margin-top: 10px; width: 100%;
+  display: flex; flex-wrap: nowrap; align-items: center; gap: 6px;
+  margin-top: var(--space-3); width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
-@container chatturn (min-width: 540px) {
-  .cave-next-paths[data-count="2"],
-  .cave-next-paths[data-count="4"] { grid-template-columns: repeat(2, 1fr); }
+.cave-next-paths::-webkit-scrollbar {
+  display: none;
 }
 .cave-next-path {
-  display: inline-flex; align-items: center; width: 100%; max-width: 100%;
+  display: inline-flex; align-items: center; flex: 0 0 auto; max-width: 100%;
+  white-space: nowrap;
   padding: 7px var(--space-3); border-radius: 8px;
   border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);


### PR DESCRIPTION
## What

**Code rail file preview** (`.workspace-rail__preview-body--code`) — read mode now mirrors the `--edit` CodeMirror pane:
- **Long lines wrap** instead of horizontal-scrolling: `.cave-line` leaves its flex row for block flow (`pre-wrap` + `overflow-wrap: anywhere`), with a `:has(.cave-ln)` hanging indent so wrapped continuations align past the line-number gutter; the inner `pre` stops scrolling horizontally.
- **Background matches**: flush `var(--code-surface)` fill (body padding 0), transcript card chrome (border/radius/shadow/margins) stripped inside the pane.
- **Selected file survives expansion/reopen**: the rail unmounts between edit batches, which dropped `selectedPath`. New `codeRail.selectedFile` surface preference (`{root, path}`, validated parse) writes through on every selection and restores once per root on mount — so expanding to fullscreen (or reopening the rail) keeps the file open. Focus events and pre-hydration selections always win; a saved file from another project is never restored.

**Next-path suggestion chips** — the `data-count`-keyed 2-column grid becomes **one scrollable single row**: no-wrap flex, hidden scrollbar (same grammar as `.cave-chat-linked-context`), intrinsic-width chips. Applies uniformly to in-turn chips, the followups row above the composer, and group chat; pairing rules deleted from `surface-compact-calendar.css` and `transcript.css`. `margin-top` snapped 10px → `var(--space-3)` for the token-drift ratchet.

## Test pins
- `rail-files-panel.test.ts`: wrap/flush CSS + persistence wiring pins added
- `surface-preferences.test.ts`: codeRail registry participation + parse validation
- `chat-view-polish-edit-review.test.ts`: grid pins rewritten to the scroll-row grammar
- `theme-contrast-audit.test.ts`: `.cave-ln` color lookup anchored to the canonical line-start rule (the new scoped override shadowed the unanchored first-match)

## Verification
- `pnpm test:app` — 871 files ✓
- `pnpm test:api` — 225 files ✓
- `pnpm typecheck` ✓

Bead: cave-c0if