### PR TITLE
fix(security): don't classify trusted local peers as mobile ingress

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -170,6 +170,21 @@ assert.match(
   /shouldRequireMobileAccessCredential\(\s*req\.headers\.get\("host"\),\s*suppliedTokens\.length > 0,\s*trustedLocalPeer,?\s*\)/,
   "the mobile gate must consult the verified local-peer stamp",
 );
+// The marker classifies mobile INGRESS, not credential possession: a mobile
+// invite cookie in a local desktop browser (auto-sent after a pairing link
+// was once opened there) must not reclassify a trusted local peer as a
+// phone — that marker makes isLocalOrigin() 403 every desktop-only route
+// (research missions/links, automations) for a genuinely local user.
+assert.match(
+  source,
+  /const mobileAccessAuthenticated =\s*!trustedLocalPeer && mobileAccessToken\s*\?/,
+  "a trusted local peer must never be marked as mobile ingress, even when a mobile access cookie rides along",
+);
+assert.match(
+  source,
+  /mobileAccessGate\(req, trustedLocalPeer\)/,
+  "the local-peer stamp is verified once in proxy() and shared with the mobile gate",
+);
 
 // ── HTML access gate for unauthenticated browser navigations ──────────────
 // Same 401 fail-closed posture; only the body differs by client. The page's

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -76,21 +76,11 @@ async function mobileAccessVerification(
   return null;
 }
 
-async function mobileAccessGate(req: NextRequest) {
+async function mobileAccessGate(req: NextRequest, trustedLocalPeer: boolean) {
   const expected = configuredMobileAccessToken();
   if (!expected) return null;
 
   const suppliedTokens = mobileAccessSuppliedTokens(req);
-  // A direct loopback connection (server.ts verified the TCP peer and the
-  // absence of forwarding headers, then stamped the per-boot secret) is the
-  // local desktop app or a local browser — it needs no mobile invite even
-  // while the pairing secret is armed. Tailscale-Serve-forwarded phones also
-  // arrive over loopback but always carry x-forwarded-* headers, so they are
-  // never stamped and stay token-gated.
-  const trustedLocalPeer = isTrustedLocalPeer(
-    req.headers.get(LOCAL_PEER_HEADER),
-    process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
-  );
   if (
     !shouldRequireMobileAccessCredential(
       req.headers.get("host"),
@@ -184,7 +174,17 @@ function nextWithMobileAccessMarker(req: NextRequest, mobileAccessAuthenticated:
 
 export async function proxy(req: NextRequest) {
   const mobileAccessToken = configuredMobileAccessToken();
-  const mobileRes = await mobileAccessGate(req);
+  // A direct loopback connection (server.ts verified the TCP peer and the
+  // absence of forwarding headers, then stamped the per-boot secret) is the
+  // local desktop app or a local browser — it needs no mobile invite even
+  // while the pairing secret is armed. Tailscale-Serve-forwarded phones also
+  // arrive over loopback but always carry x-forwarded-* headers, so they are
+  // never stamped and stay token-gated.
+  const trustedLocalPeer = isTrustedLocalPeer(
+    req.headers.get(LOCAL_PEER_HEADER),
+    process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
+  );
+  const mobileRes = await mobileAccessGate(req, trustedLocalPeer);
   if (mobileRes) return mobileRes;
 
   if (!req.nextUrl.pathname.startsWith("/api/")) {
@@ -208,9 +208,17 @@ export async function proxy(req: NextRequest) {
     req.nextUrl.protocol,
     requestHost,
   );
-  const mobileAccessAuthenticated = mobileAccessToken
-    ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
-    : false;
+  // The mobile-access marker classifies MOBILE INGRESS, not merely "a valid
+  // mobile credential was presented". A trusted local peer is this machine's
+  // desktop app or a local browser; a mobile invite cookie riding along
+  // (e.g. a pairing link once opened in the desktop browser writes the
+  // auto-sent access cookie) must not reclassify it as a phone — that marker
+  // makes isLocalOrigin() 403 every desktop-only route (research missions,
+  // links, automations) for a genuinely local user.
+  const mobileAccessAuthenticated =
+    !trustedLocalPeer && mobileAccessToken
+      ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
+      : false;
   // Tailscale app mode (`pnpm mobile:tailscale:app`) now always provisions the
   // mobile access credential, so a remote-looking (Tailscale Serve) Host is
   // accepted only when that credential verifies. COVEN_CAVE_TAILNET_TRUST no


### PR DESCRIPTION
## Symptom

Researcher surface (familiar `sage`) showed a **"forbidden" warning**: missions failed to start, links failed to load, sources/resources failed to save — while board/milestones/sessions kept working.

## Root cause

Opening a mobile pairing/invite link in the desktop browser writes the `coven_cave_access` cookie there (query-token exchange in `proxy.ts`). Cookies auto-send, so `proxy.ts` computed `mobileAccessAuthenticated` from the cookie alone and stamped `x-coven-cave-mobile-access: 1` on every request from that browser — **ignoring the trusted-local-peer stamp** `server.ts` applies after verifying the raw TCP socket is direct, unforwarded loopback. `isLocalOrigin()` hard-rejects that marker → `rejectNonLocalRequest` 403'd the desktop-only route family (`/api/research/missions` GET/POST, `/api/research/links`, mission actions, generations). Once a desktop browser ever opened an invite link, it was permanently classified as a paired phone.

## Fix

- Hoist the `trustedLocalPeer` verification into `proxy()` (single computation, passed to `mobileAccessGate`).
- Require `!trustedLocalPeer` in the marker computation: the marker now classifies **mobile ingress**, not credential possession.

## Fail-closed invariants (unchanged)

- Serve-forwarded phones always carry `x-forwarded-*` → never stamped → still marked mobile → desktop-only routes still locked.
- Stamp is unforgeable: server.ts deletes client-supplied copies; per-boot secret never leaves the process (existing pins, middleware.test.ts).
- Credential-less remote requests still 401 at the gate.

## Validation

- Live repro on pre-fix server: desktop-only GET with real cookie → **403 forbidden**; same request on fix branch → **200 ok** (missions listed)
- Forwarded request + same valid cookie → still **403**; no credential + forwarded → **401**
- `node --test` middleware/local-origin/api-security/project-permission-routes: **9/9 pass**
- `pnpm typecheck` clean
- New source pins: marker requires `!trustedLocalPeer`; gate shares the hoisted stamp