### PR TITLE
fix(popover): submenu click after hover-intent no longer re-closes the flyout

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -432,6 +432,7 @@ export function PopoverSubmenu({
   const rowRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const hoverTimer = useRef<number | null>(null);
+  const lastPointerType = useRef("");
   const [selfOpen, setSelfOpen] = useState(false);
   // Pre-measure style carries minWidth so the flip/clamp math measures the
   // panel at its real rendered width (the CSS floor is narrower than the
@@ -560,9 +561,16 @@ export function PopoverSubmenu({
         aria-expanded={open}
         disabled={disabled}
         data-active={open || undefined}
+        onPointerDown={(e) => {
+          lastPointerType.current = e.pointerType;
+        }}
         onClick={() => {
           clearHoverTimer();
-          setOpen(!open);
+          // Mouse: click always opens — hover intent may have opened the
+          // flyout mid-press, and a toggle would immediately shut what the
+          // user is aiming at. Touch/pen taps (and keyboard) still toggle.
+          if (!open) setOpen(true);
+          else if (lastPointerType.current !== "mouse") setOpen(false);
         }}
         onPointerEnter={(e) => {
           if (disabled || e.pointerType !== "mouse") return;


### PR DESCRIPTION
## Summary

Follow-up to #3651 (composer cascade menus). The `PopoverSubmenu` trigger row opens on hover after a 120ms intent delay **and** toggled on click — so a mouse user who hovers a beat and then clicks (the normal way to aim at a menu row) had their click immediately close the flyout that hover had just opened.

Fix: track the last pointer type via `onPointerDown`; **mouse clicks always open**, touch/pen taps (and keyboard activation) keep toggle semantics.

## Context

This was part of my `feat/composer-cascade-menus` branch (#3650), which #3651 superseded by landing the identical feature from the shared checkout — everything else already matches main byte-for-byte; this interaction fix is the one remaining piece.

## Verification

- `pnpm typecheck` clean
- `popover-submenu.test.ts` 8/8 pass
- Hover-intent pin in the test still matches (`onPointerEnter` handler unchanged)