### PR TITLE
Pairing overhaul: smart iOS connect screen + desktop handoff ladder (cave-y5u0)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveHostAdvice.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveHostAdvice.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Advisory classification of a typed or pasted desktop address. Catches the
+/// classic dead ends BEFORE a doomed probe: `127.0.0.1` copied off the
+/// desktop's own browser bar (that's the phone itself from here), Wi‑Fi-only
+/// LAN addresses, `.local` mDNS names iPhones rarely resolve, and stray
+/// spaces from copying a label along with the host. Advisory only — callers
+/// must never gate the Connect button on it; the connect flow does the real
+/// probing.
+enum CaveHostAdvice: Equatable {
+    /// Whitespace inside the address — almost always a copy that grabbed a
+    /// label ("Cave 100.101.102.103").
+    case hasSpace
+    /// Loopback (`localhost`, `127.*`, `::1`, `0.0.0.0`) — on a phone this
+    /// points at the phone, not the desktop.
+    case loopback
+    /// RFC1918 LAN space (`10.*`, `192.168.*`, `172.16–31.*`) — works only
+    /// while both devices share the same network. Tailscale's CGNAT range
+    /// (`100.64.0.0/10`) is deliberately NOT flagged: that's the good case.
+    case lanAddress
+    /// mDNS `.local` name — frequently unresolvable from iOS.
+    case mdnsLocal
+
+    var message: String {
+        switch self {
+        case .hasSpace:
+            return "That has a space — paste just the address."
+        case .loopback:
+            return "That address is this phone, not your desktop. Use the desktop’s Tailscale address (100.x or *.ts.net) from “Open on phone”."
+        case .lanAddress:
+            return "That looks like a Wi‑Fi-only address — it works just while both devices share a network. Prefer the Tailscale address so it works anywhere."
+        case .mdnsLocal:
+            return "“.local” names often don’t resolve from iPhones. Prefer the Tailscale address from “Open on phone”."
+        }
+    }
+
+    /// Classify raw field input. Returns nil for anything plausible — the
+    /// advice only speaks up for addresses that are provably wrong-shaped.
+    static func evaluate(_ input: String) -> CaveHostAdvice? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.contains(" ") { return .hasSpace }
+        let host = hostPart(of: trimmed)
+        guard !host.isEmpty else { return nil }
+        if isLoopback(host) { return .loopback }
+        if host.hasSuffix(".local") { return .mdnsLocal }
+        if isPrivateLANAddress(host) { return .lanAddress }
+        return nil
+    }
+
+    /// Extract the bare host from whatever shape the field holds: an optional
+    /// scheme, path/query tail, `host:port`, or a bracketed IPv6 literal.
+    static func hostPart(of address: String) -> String {
+        var s = address.lowercased()
+        for scheme in ["covencave://", "https://", "http://"] where s.hasPrefix(scheme) {
+            s = String(s.dropFirst(scheme.count))
+            break
+        }
+        if let slash = s.firstIndex(of: "/") { s = String(s[..<slash]) }
+        if let query = s.firstIndex(of: "?") { s = String(s[..<query]) }
+        if s.hasPrefix("[") {
+            // Bracketed IPv6, possibly with a port after the bracket.
+            guard let close = s.firstIndex(of: "]") else { return String(s.dropFirst()) }
+            return String(s[s.index(after: s.startIndex)..<close])
+        }
+        // Exactly one colon separates host:port; two or more is a bare IPv6
+        // literal that must keep its colons.
+        if s.filter({ $0 == ":" }).count == 1, let colon = s.firstIndex(of: ":") {
+            s = String(s[..<colon])
+        }
+        return s
+    }
+
+    private static func isLoopback(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" || host == "0.0.0.0" { return true }
+        if let octets = ipv4Octets(host) { return octets[0] == 127 }
+        return false
+    }
+
+    private static func isPrivateLANAddress(_ host: String) -> Bool {
+        guard let o = ipv4Octets(host) else { return false }
+        if o[0] == 10 { return true }
+        if o[0] == 192, o[1] == 168 { return true }
+        if o[0] == 172, (16...31).contains(o[1]) { return true }
+        // 100.64.0.0/10 (Tailscale CGNAT) intentionally passes — that's the
+        // address we WANT people to use.
+        return false
+    }
+
+    private static func ipv4Octets(_ host: String) -> [Int]? {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var octets: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, part.allSatisfy(\.isNumber), let value = Int(part),
+                  (0...255).contains(value)
+            else { return nil }
+            octets.append(value)
+        }
+        return octets
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -23,7 +23,10 @@ final class AppModel {
         case unconfigured
         case checking
         case connected
-        case unreachable(String)
+        /// Discovery failed everywhere. Carries the classified diagnosis so
+        /// the connect screen can say WHICH way it failed (DNS vs refused vs
+        /// timeout…) instead of one generic shrug.
+        case unreachable(ConnectionDiagnosis)
         /// The desktop answered but rejected our credential (401/403) — the
         /// device needs pairing, not a different address. Distinct from
         /// `unreachable` so onboarding can say what to actually do.
@@ -40,8 +43,16 @@ final class AppModel {
             if oldValue == .connected, connectionState != .connected {
                 lastConnectedAt = Date()
             }
+            if oldValue != .connected, connectionState == .connected {
+                connectedAt = Date()
+            }
         }
     }
+    /// Stamped each time the state ENTERS `.connected`. RootView uses it to
+    /// show a brief "Connected" confirmation over the freshly mounted tabs
+    /// when pairing just succeeded, so the connect screen's success isn't an
+    /// abrupt teleport.
+    private(set) var connectedAt: Date?
     private let connectionMonitor = NWPathMonitor()
     private let connectionMonitorQueue = DispatchQueue(label: "ai.opencoven.cave.connection-monitor")
     private var connectionMonitorStarted = false
@@ -1103,7 +1114,7 @@ final class AppModel {
             switch outcome {
             case .found(let url): return .found(url)
             case .unauthorized: return .unauthorized
-            case .none: return .unreachable
+            case .unreachable(let failure): return .unreachable(failure)
             }
         }
         guard refresh.launched else { return }
@@ -1147,8 +1158,8 @@ final class AppModel {
             }
         case .unauthorized:
             connectionState = .needsAuth(pairingMessage())
-        case .unreachable:
-            connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
+        case .unreachable(let failure):
+            connectionState = .unreachable(.diagnosis(for: failure))
         }
     }
 
@@ -1230,7 +1241,12 @@ final class AppModel {
         /// At least one candidate was a live Cave server that rejected our
         /// credential — pairing is the fix, not another address.
         case unauthorized
-        case none
+        /// No candidate answered as Cave. Carries the strongest failure class
+        /// seen across candidates ("an HTTP server answered but wasn't Cave"
+        /// beats "connection refused" beats "DNS failure" beats "timeout") so
+        /// the user hears the most actionable story, or nil when nothing was
+        /// classified.
+        case unreachable(ProbeFailure?)
     }
 
     /// Probe candidate base URLs and adjudicate strictly in candidate order: the
@@ -1245,7 +1261,7 @@ final class AppModel {
     /// already succeeded or rejected it. Unpaired probes carry no secret, so they
     /// may still run concurrently for the cold-launch wall-clock win.
     static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
-        guard !candidates.isEmpty else { return .none }
+        guard !candidates.isEmpty else { return .unreachable(nil) }
         if CaveConnection.accessToken != nil {
             return await discoverBaseURLSequentially(candidates)
         }
@@ -1262,25 +1278,47 @@ final class AppModel {
     }
 
     private static func discoverBaseURLSequentially(_ candidates: [URL]) async -> DiscoveryOutcome {
+        var strongest: ProbeFailure?
         for base in candidates {
             switch await Self.probe(base) {
             case .ok: return .found(base)
             case .unauthorized: return .unauthorized
-            case .failed: continue
+            case .failed(let failure): strongest = max(strongest ?? failure, failure)
             }
         }
-        return .none
+        return .unreachable(strongest)
     }
 
     private static func adjudicateDiscoveryResults(_ results: [ProbeResult?], candidates: [URL]) -> DiscoveryOutcome {
+        var strongest: ProbeFailure?
         for (index, result) in results.enumerated() {
             switch result {
             case .ok: return .found(candidates[index])
             case .unauthorized: return .unauthorized
+            case .failed(let failure): strongest = max(strongest ?? failure, failure)
             default: continue
             }
         }
-        return .none
+        return .unreachable(strongest)
+    }
+
+    /// Credential-free concurrent sweep for the connect screen's live
+    /// as-you-type reachability preview. Never sends the paired token — the
+    /// field may point anywhere — so a token-gated desktop reads as
+    /// `.unauthorized`, which the preview renders as "desktop found, pairing
+    /// required". Kept separate from `discoverBaseURL` so the paired
+    /// sequential path keeps its credential-safety semantics untouched.
+    static func previewDiscoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
+        guard !candidates.isEmpty else { return .unreachable(nil) }
+        let results = await withTaskGroup(of: (Int, ProbeResult).self) { group in
+            for (index, base) in candidates.enumerated() {
+                group.addTask { (index, await Self.probe(base, sendCredential: false)) }
+            }
+            var collected = [ProbeResult?](repeating: nil, count: candidates.count)
+            for await (index, result) in group { collected[index] = result }
+            return collected
+        }
+        return adjudicateDiscoveryResults(results, candidates: candidates)
     }
 
     /// Persist a relocated endpoint as `host:port` when the default scheme
@@ -1292,7 +1330,7 @@ final class AppModel {
         return CaveConnection(host: compact).baseURL == url ? compact : url.absoluteString
     }
 
-    private enum ProbeResult { case ok, unauthorized, failed }
+    private enum ProbeResult { case ok, unauthorized, failed(ProbeFailure) }
 
     /// Shared session for discovery probes — ephemeral (no cache/cookie
     /// carry-over) and never recreated, so repeated discovery rounds don't
@@ -1312,20 +1350,27 @@ final class AppModel {
     /// `200..<500` test latched onto it. Decoding the payload guarantees we only
     /// adopt an actual Cave server. Sends the paired credential when one exists
     /// and reports a 401/403 distinctly — that's a Cave token gate talking.
-    private static func probe(_ base: URL) async -> ProbeResult {
+    private static func probe(_ base: URL, sendCredential: Bool = true) async -> ProbeResult {
         var req = URLRequest(url: base.appendingPathComponent("api/familiars"))
         req.timeoutInterval = 6
         req.setValue("application/json", forHTTPHeaderField: "Accept")
-        if let token = CaveConnection.accessToken {
+        if sendCredential, let token = CaveConnection.accessToken {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        guard let (data, resp) = try? await probeSession.data(for: req),
-              let http = resp as? HTTPURLResponse
-        else { return .failed }
+        let data: Data
+        let resp: URLResponse
+        do {
+            (data, resp) = try await probeSession.data(for: req)
+        } catch {
+            // Classify the transport failure so adjudication can tell the
+            // user WHICH way discovery failed (DNS vs refused vs timeout…).
+            return .failed(ProbeFailure(classifying: error))
+        }
+        guard let http = resp as? HTTPURLResponse else { return .failed(.transport) }
         if http.statusCode == 401 || http.statusCode == 403 { return .unauthorized }
         guard (200..<300).contains(http.statusCode),
               (try? JSONDecoder().decode(FamiliarsResponse.self, from: data)) != nil
-        else { return .failed }
+        else { return .failed(.wrongServer) }
         return .ok
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/ConnectionDiagnosis.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ConnectionDiagnosis.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Why a discovery probe failed, ranked by diagnostic strength. Higher raw
+/// values are MORE specific signals: "an HTTP server answered but it wasn't
+/// Cave" pins the problem to one address, while "timed out" could be anything.
+/// When candidates fail for different reasons, `max()` picks the story the
+/// user should hear (`.offline` outranks everything — it explains everything).
+enum ProbeFailure: Int, Equatable, Comparable, Sendable {
+    /// Transport failed in some unclassified way.
+    case transport = 0
+    /// No response inside the probe window — host asleep, tailnet stalled.
+    case timeout = 1
+    /// The name never resolved — MagicDNS only answers while Tailscale is up.
+    case dnsFailure = 2
+    /// TLS negotiation failed — usually a scheme/port mismatch.
+    case tlsFailure = 3
+    /// Route reached the machine but the port refused — Cave isn't listening.
+    case refused = 4
+    /// An HTTP server answered, but the body wasn't the Cave API.
+    case wrongServer = 5
+    /// This phone has no network at all.
+    case offline = 6
+
+    static func < (lhs: ProbeFailure, rhs: ProbeFailure) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// One-line phrasing for the connect screen's live as-you-type preview —
+    /// terse next to the full recovery callout copy in ConnectionDiagnosis.
+    var previewLine: String {
+        switch self {
+        case .offline: return "This phone is offline."
+        case .dnsFailure: return "Name didn’t resolve — is Tailscale connected?"
+        case .refused: return "Reached the machine, but Cave isn’t answering there."
+        case .timeout: return "No answer yet — desktop asleep or off the tailnet?"
+        case .tlsFailure: return "Secure handshake failed at that address."
+        case .wrongServer: return "Something answered, but it isn’t Cave."
+        case .transport: return "Couldn’t reach that address yet."
+        }
+    }
+
+    /// Map a thrown transport error onto a failure class. Pure so the
+    /// adjudication story is unit-testable without spinning up URLSession.
+    init(classifying error: any Error) {
+        guard let urlError = error as? URLError else {
+            self = .transport
+            return
+        }
+        switch urlError.code {
+        case .notConnectedToInternet, .internationalRoamingOff, .dataNotAllowed:
+            self = .offline
+        case .cannotFindHost, .dnsLookupFailed:
+            self = .dnsFailure
+        case .timedOut:
+            self = .timeout
+        case .cannotConnectToHost, .networkConnectionLost:
+            self = .refused
+        case .secureConnectionFailed, .serverCertificateUntrusted,
+             .serverCertificateHasBadDate, .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid, .clientCertificateRejected,
+             .clientCertificateRequired, .appTransportSecurityRequiresSecureConnection:
+            self = .tlsFailure
+        default:
+            self = .transport
+        }
+    }
+}
+
+/// What the connect screen should say when discovery fails: a titled recovery
+/// callout derived from the strongest probe signal instead of one generic
+/// "couldn't reach the desktop" shrug for every distinct failure.
+struct ConnectionDiagnosis: Equatable, Sendable {
+    var title: String
+    var message: String
+    var guidance: String
+    var systemImage: String
+
+    /// The pre-diagnosis copy, kept verbatim for the unclassified case.
+    static let generic = ConnectionDiagnosis(
+        title: "Tailscale disconnected?",
+        message: "Couldn’t reach the desktop. Is it on the tailnet and running?",
+        guidance: "Open Tailscale on this phone and make sure it says Connected. If it is connected, check that Cave is running on the desktop.",
+        systemImage: "exclamationmark.triangle.fill"
+    )
+
+    static func diagnosis(for failure: ProbeFailure?) -> ConnectionDiagnosis {
+        guard let failure else { return .generic }
+        switch failure {
+        case .offline:
+            return ConnectionDiagnosis(
+                title: "This phone is offline",
+                message: "No network connection on this phone — Wi‑Fi and cellular are both unavailable.",
+                guidance: "Turn off Airplane Mode or join a network, then try again.",
+                systemImage: "wifi.slash"
+            )
+        case .dnsFailure:
+            return ConnectionDiagnosis(
+                title: "Name didn’t resolve",
+                message: "The desktop’s name couldn’t be found. MagicDNS names only resolve while Tailscale is connected on this phone.",
+                guidance: "Open Tailscale on this phone and make sure it says Connected, then try again.",
+                systemImage: "questionmark.circle.fill"
+            )
+        case .refused:
+            return ConnectionDiagnosis(
+                title: "Cave isn’t answering",
+                message: "Reached the desktop, but nothing is listening on that port. Cave may not be running.",
+                guidance: "Start Cave on the desktop, or check “Open on phone” for the current address.",
+                systemImage: "bolt.horizontal.circle"
+            )
+        case .timeout:
+            return ConnectionDiagnosis(
+                title: "No answer from the desktop",
+                message: "The address didn’t respond in time — the desktop may be asleep, offline, or off the tailnet.",
+                guidance: "Wake the desktop and check Tailscale says Connected on both devices.",
+                systemImage: "clock.badge.exclamationmark"
+            )
+        case .tlsFailure:
+            return ConnectionDiagnosis(
+                title: "Secure connection failed",
+                message: "The desktop answered, but the secure handshake failed — usually a scheme or port mismatch.",
+                guidance: "Re-scan the QR from “Open on phone” to pick up the desktop’s current address.",
+                systemImage: "lock.trianglebadge.exclamationmark"
+            )
+        case .wrongServer:
+            return ConnectionDiagnosis(
+                title: "That isn’t Cave",
+                message: "Something answered at that address, but it isn’t the Cave desktop app.",
+                guidance: "Double-check the address in Cave under “Open on phone” — the port matters.",
+                systemImage: "server.rack"
+            )
+        case .transport:
+            return ConnectionDiagnosis(
+                title: "Connection failed",
+                message: "The connection to the desktop failed before it could complete.",
+                guidance: "Check Tailscale on this phone, then try again.",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/ConnectionRefreshCoordinator.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ConnectionRefreshCoordinator.swift
@@ -7,7 +7,9 @@ import Foundation
 enum ConnectionRefreshResult: Equatable, Sendable {
     case found(URL)
     case unauthorized
-    case unreachable
+    /// Discovery failed everywhere; carries the strongest classified probe
+    /// failure (nil when nothing was classified) for the diagnosis copy.
+    case unreachable(ProbeFailure?)
     case cancelled
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -5,6 +5,7 @@ struct ConnectionView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var host: String = ""
     @State private var busy = false
     /// Whether the clipboard holds text — drives the "Paste" affordance. We only
@@ -12,7 +13,20 @@ struct ConnectionView: View {
     /// "pasted from" banner just for showing the button.
     @State private var canPaste = false
     @State private var showScanner = false
+    /// Live as-you-edit reachability preview under the address field. Purely
+    /// advisory: never auto-connects, never persists — Connect stays the
+    /// explicit action.
+    @State private var liveCheck: LiveCheckState = .idle
     @FocusState private var focused: Bool
+
+    enum LiveCheckState: Equatable {
+        case idle
+        case checking
+        case found(port: Int?)
+        /// Desktop answered but is token-gated — it IS the desktop; pair it.
+        case pairingRequired
+        case failed(ProbeFailure?)
+    }
 
     var body: some View {
         NavigationStack {
@@ -21,14 +35,18 @@ struct ConnectionView: View {
                     header
                     pairingSteps
 
+                    if scanFirst {
+                        scanHero
+                    }
+
                     addressField
 
-                    if case .unreachable(let message) = app.connectionState {
+                    if case .unreachable(let diagnosis) = app.connectionState {
                         connectionRecoveryCallout(
-                            title: "Tailscale disconnected?",
-                            message: message,
-                            guidance: "Open Tailscale on this phone and make sure it says Connected. If it is connected, check that Cave is running on the desktop.",
-                            systemImage: "exclamationmark.triangle.fill"
+                            title: diagnosis.title,
+                            message: diagnosis.message,
+                            guidance: diagnosis.guidance,
+                            systemImage: diagnosis.systemImage
                         )
                     } else if case .needsAuth(let message) = app.connectionState {
                         // The desktop is alive but token-gated — say how to
@@ -47,6 +65,9 @@ struct ConnectionView: View {
                 }
                 .padding(24)
                 .readableWidth(520)
+                .animation(reduceMotion ? nil : .spring(duration: 0.32), value: liveCheck)
+                .animation(reduceMotion ? nil : .spring(duration: 0.32), value: hostPresent)
+                .animation(reduceMotion ? nil : .spring(duration: 0.32), value: app.connectionState)
             }
             .background(chrome.bgBase.ignoresSafeArea())
             .navigationTitle("Coven Cave")
@@ -66,6 +87,12 @@ struct ConnectionView: View {
                     apply(payload)
                 }
                 .ignoresSafeArea()
+            }
+            // Debounced live reachability preview: every edit re-keys this
+            // task, cancelling the in-flight one (single-flight by
+            // construction); leaving the screen cancels it too.
+            .task(id: host) {
+                await runLiveCheck()
             }
             // While this screen shows "unreachable", quietly re-probe so a
             // desktop that comes back (rebooted, woke from sleep) reconnects
@@ -125,33 +152,121 @@ struct ConnectionView: View {
         .accessibilityLabel("Cave familiar network")
     }
 
+    /// The three-step guide, now live: each chip is a real button whose state
+    /// tracks actual progress (Scan/Paste land a host → done; Connect goes
+    /// green once connected) instead of decorative hardcoded highlights.
     private var pairingSteps: some View {
         HStack(spacing: 8) {
-            stepChip("Scan", systemImage: "qrcode.viewfinder", highlighted: true)
-            stepChip("Paste", systemImage: "doc.on.clipboard", highlighted: false)
-            stepChip("Connect", systemImage: "bolt.horizontal.circle", highlighted: false)
+            stepChip(
+                "Scan", systemImage: "qrcode.viewfinder", state: scanStep,
+                enabled: QRScannerSheet.isSupported && !busy,
+                hint: "Opens the QR scanner"
+            ) { showScanner = true }
+            stepChip(
+                "Paste", systemImage: "doc.on.clipboard", state: pasteStep,
+                enabled: canPaste && !busy,
+                hint: "Pastes the desktop address from the clipboard"
+            ) { pasteHost() }
+            stepChip(
+                "Connect", systemImage: "bolt.horizontal.circle", state: connectStep,
+                enabled: hostPresent && !busy,
+                hint: "Connects to the desktop address"
+            ) { connect() }
         }
         .padding(8)
         .glass(.raised, cornerRadius: 18)
     }
 
-    private func stepChip(_ title: String, systemImage: String, highlighted: Bool) -> some View {
-        Label(title, systemImage: systemImage)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(highlighted ? chrome.accent : chrome.textSecondary)
-            .lineLimit(1)
-            .minimumScaleFactor(0.82)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 9)
-            .padding(.horizontal, 6)
-            .background(
-                Capsule()
-                    .fill(highlighted ? chrome.accent.opacity(0.16) : chrome.bgElevated.opacity(0.55))
-            )
-            .overlay {
-                Capsule()
-                    .strokeBorder(highlighted ? chrome.accent.opacity(0.45) : chrome.border.opacity(0.25), lineWidth: 1)
-            }
+    private enum StepState { case pending, active, done }
+
+    private var hostPresent: Bool {
+        !host.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// Camera-first hierarchy: with no address yet and a camera available,
+    /// scanning the desktop's QR is the shortest correct path.
+    private var scanFirst: Bool {
+        QRScannerSheet.isSupported && !hostPresent
+    }
+
+    private var scanStep: StepState { hostPresent ? .done : .active }
+
+    private var pasteStep: StepState {
+        if hostPresent { return .done }
+        return canPaste ? .active : .pending
+    }
+
+    private var connectStep: StepState {
+        if app.connectionState == .connected { return .done }
+        return hostPresent ? .active : .pending
+    }
+
+    private func stepChip(
+        _ title: String,
+        systemImage: String,
+        state: StepState,
+        enabled: Bool,
+        hint: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: state == .done ? "checkmark.circle.fill" : systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(chipForeground(state))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 9)
+                .padding(.horizontal, 6)
+                .background(
+                    Capsule()
+                        .fill(chipFill(state))
+                )
+                .overlay {
+                    Capsule()
+                        .strokeBorder(chipStroke(state), lineWidth: 1)
+                }
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .accessibilityHint(hint)
+    }
+
+    private func chipForeground(_ state: StepState) -> Color {
+        switch state {
+        case .done: return .green
+        case .active: return chrome.accent
+        case .pending: return chrome.textSecondary
+        }
+    }
+
+    private func chipFill(_ state: StepState) -> Color {
+        switch state {
+        case .done: return Color.green.opacity(0.14)
+        case .active: return chrome.accent.opacity(0.16)
+        case .pending: return chrome.bgElevated.opacity(0.55)
+        }
+    }
+
+    private func chipStroke(_ state: StepState) -> Color {
+        switch state {
+        case .done: return Color.green.opacity(0.4)
+        case .active: return chrome.accent.opacity(0.45)
+        case .pending: return chrome.border.opacity(0.25)
+        }
+    }
+
+    /// Prominent scan entry shown before any address exists — the QR from
+    /// "Open on phone" carries host AND credential, so it's the one-tap path.
+    private var scanHero: some View {
+        VStack(spacing: 8) {
+            scanButton(prominent: true)
+            Text("or enter the address manually")
+                .font(.caption)
+                .foregroundStyle(chrome.textMuted)
+                .frame(maxWidth: .infinity)
+        }
     }
 
     private var addressField: some View {
@@ -188,6 +303,8 @@ struct ConnectionView: View {
                 Label(hostHint, systemImage: "exclamationmark.circle")
                     .font(.caption)
                     .foregroundStyle(.orange)
+            } else if liveCheck != .idle && hostPresent && !busy {
+                liveCheckRow
             } else {
                 Text("Find it in Cave on the desktop under “Open on phone”. QR invite links fill this automatically.")
                     .font(.footnote)
@@ -199,28 +316,126 @@ struct ConnectionView: View {
         .glass(.raised, cornerRadius: 20)
     }
 
+    /// Compact status line for the as-you-edit reachability preview.
+    @ViewBuilder
+    private var liveCheckRow: some View {
+        switch liveCheck {
+        case .idle:
+            EmptyView()
+        case .checking:
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.mini)
+                Text("Checking address…")
+                    .font(.caption)
+                    .foregroundStyle(chrome.textMuted)
+            }
+        case .found(let port):
+            Label(
+                port.map { "Desktop found on port \($0)." } ?? "Desktop found.",
+                systemImage: "checkmark.circle.fill"
+            )
+            .font(.caption.weight(.medium))
+            .foregroundStyle(Color.green)
+        case .pairingRequired:
+            Label(
+                "Desktop found — pairing needed. Connect will walk you through it.",
+                systemImage: "qrcode.viewfinder"
+            )
+            .font(.caption.weight(.medium))
+            .foregroundStyle(chrome.accent)
+        case .failed(let failure):
+            Label(
+                failure.map(\.previewLine) ?? "Couldn’t reach that address yet.",
+                systemImage: "exclamationmark.circle"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+    }
+
+    /// Debounced, single-flight, credential-free preview probe of the field
+    /// value. Never connects, never persists — advisory only. `.task(id:
+    /// host)` cancels the previous run on every edit and on view exit.
+    private func runLiveCheck() async {
+        liveCheck = .idle
+        guard !busy, scenePhase == .active, hostPresent, hostAdvice == nil else { return }
+        // A credential-carrying invite auto-connects via apply() — no preview.
+        guard let invite = CaveInvite.parse(cleanHost(host)), invite.token == nil else { return }
+        try? await Task.sleep(for: .milliseconds(800))
+        guard !Task.isCancelled, !busy, scenePhase == .active else { return }
+        liveCheck = .checking
+        let candidates = CaveConnection(host: invite.host).candidateBaseURLs
+        let outcome = await AppModel.previewDiscoverBaseURL(candidates)
+        guard !Task.isCancelled, !busy else { return }
+        switch outcome {
+        case .found(let url):
+            liveCheck = .found(port: url.port)
+        case .unauthorized:
+            liveCheck = .pairingRequired
+        case .unreachable(let failure):
+            liveCheck = .failed(failure)
+        }
+    }
+
     private var actions: some View {
         VStack(spacing: 12) {
-            Button(action: connect) {
-                Label(busy ? "Connecting…" : "Connect desktop", systemImage: busy ? "arrow.triangle.2.circlepath" : "bolt.horizontal.circle.fill")
-                    .frame(maxWidth: .infinity)
+            connectButton
+
+            if QRScannerSheet.isSupported && !scanFirst {
+                scanButton(prominent: false)
+            }
+        }
+    }
+
+    /// Connect is the prominent CTA once an address exists; while the scan
+    /// hero leads (no address yet), it recedes to a secondary style.
+    @ViewBuilder
+    private var connectButton: some View {
+        if scanFirst {
+            Button(action: connect) { connectLabel }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
+        } else {
+            Button(action: connect) { connectLabel }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
+        }
+    }
+
+    private var connectLabel: some View {
+        Label(busy ? "Connecting…" : "Connect desktop", systemImage: busy ? "arrow.triangle.2.circlepath" : "bolt.horizontal.circle.fill")
+            .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private func scanButton(prominent: Bool) -> some View {
+        if prominent {
+            Button {
+                showScanner = true
+            } label: {
+                scanLabel
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
-            .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
-
-            if QRScannerSheet.isSupported {
-                Button {
-                    showScanner = true
-                } label: {
-                    Label("Scan QR", systemImage: "qrcode.viewfinder")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-                .disabled(busy)
+            .disabled(busy)
+        } else {
+            Button {
+                showScanner = true
+            } label: {
+                scanLabel
             }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .disabled(busy)
         }
+    }
+
+    private var scanLabel: some View {
+        Label("Scan QR", systemImage: "qrcode.viewfinder")
+            .frame(maxWidth: .infinity)
     }
 
     private func connectionRecoveryCallout(
@@ -276,9 +491,11 @@ struct ConnectionView: View {
         guard let invite = CaveInvite.parse(cleanHost(host)) else { return }
         host = invite.host
         busy = true
+        liveCheck = .idle
         Task {
             await app.configure(host: invite.host, token: invite.token)
             busy = false
+            if app.connectionState == .connected { Haptics.success() }
         }
     }
 
@@ -297,9 +514,11 @@ struct ConnectionView: View {
         host = invite.host
         if invite.token != nil {
             busy = true
+            liveCheck = .idle
             Task {
                 await app.configure(host: invite.host, token: invite.token)
                 busy = false
+                if app.connectionState == .connected { Haptics.success() }
             }
         } else {
             focused = true
@@ -316,12 +535,17 @@ struct ConnectionView: View {
         return s
     }
 
-    /// A gentle, non-blocking nudge when the address is obviously malformed — most
-    /// commonly a stray space from copying a label along with the host.
-    private var hostHint: String? {
-        let s = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !s.isEmpty else { return nil }
-        if s.contains(" ") { return "That has a space — paste just the address." }
-        return nil
+    /// Advisory address advice — never gates the Connect button; the connect
+    /// flow's real probing is the truth. Classifies dead ends (loopback, LAN,
+    /// `.local`, stray spaces) via CaveHostAdvice before a doomed probe.
+    private var hostAdvice: CaveHostAdvice? {
+        let advice = CaveHostAdvice.evaluate(host)
+        #if targetEnvironment(simulator)
+        // Loopback IS the dev desktop on the simulator — don't warn there.
+        if advice == .loopback { return nil }
+        #endif
+        return advice
     }
+
+    private var hostHint: String? { hostAdvice?.message }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -45,6 +45,12 @@ struct RootView: View {
             }
         }
         .animation(.snappy(duration: 0.25), value: showsReconnectPill)
+        // Brief "Connected" confirmation over the freshly mounted tabs when a
+        // connection lands — the connect screen's success is no longer an
+        // abrupt teleport into the app. Purely decorative and self-dismissing.
+        .overlay {
+            ConnectedMomentOverlay()
+        }
         // While the pill is up over the tabs, quietly re-probe so a desktop
         // that comes back (restarted, woke from sleep) reconnects on its own.
         // The Connect screen has its own ticker for the pre-surfaces case;
@@ -81,6 +87,52 @@ struct RootView: View {
         switch app.connectionState {
         case .unreachable, .checking: return true
         default: return false
+        }
+    }
+}
+
+/// Brief celebratory "Connected" chip that fades in over the tab tree the
+/// moment a connection lands (fresh pairing or reconnect from the Connect
+/// screen), then self-dismisses. Skips entirely when the connection predates
+/// this view (normal warm launches) and collapses to a plain fade under
+/// Reduce Motion.
+private struct ConnectedMomentOverlay: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var visible = false
+
+    var body: some View {
+        ZStack {
+            if visible {
+                Label("Connected", systemImage: "checkmark.circle.fill")
+                    .font(.headline)
+                    .foregroundStyle(Color.green)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .glass(.elevated, in: Capsule())
+                    .transition(
+                        reduceMotion
+                            ? .opacity.animation(.easeInOut(duration: 0.2))
+                            : .scale(scale: 0.86).combined(with: .opacity)
+                    )
+                    .accessibilityAddTraits(.isStaticText)
+            }
+        }
+        .allowsHitTesting(false)
+        .task(id: app.connectedAt) {
+            // Only celebrate a connection that landed just now — not one
+            // restored long before this overlay appeared (warm launch).
+            guard let connectedAt = app.connectedAt,
+                  Date().timeIntervalSince(connectedAt) < 3
+            else { return }
+            withAnimation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(duration: 0.35)) {
+                visible = true
+            }
+            try? await Task.sleep(for: .seconds(1.4))
+            withAnimation(.easeOut(duration: 0.3)) {
+                visible = false
+            }
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/CaveHostAdviceTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveHostAdviceTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import CovenCave
+
+final class CaveHostAdviceTests: XCTestCase {
+    // MARK: - Loopback (this phone, not the desktop)
+
+    func testLocalhostIsLoopback() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("localhost"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("localhost:3000"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("LOCALHOST"), .loopback)
+    }
+
+    func testLoopbackIPv4RangeIsLoopback() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("127.0.0.1"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("127.0.0.1:3000"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("127.9.8.7"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("0.0.0.0"), .loopback)
+    }
+
+    func testLoopbackIPv6IsLoopback() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("::1"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("[::1]"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("[::1]:3000"), .loopback)
+    }
+
+    func testLoopbackInsideURLIsLoopback() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("http://127.0.0.1:3000"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("https://localhost:3000/path"), .loopback)
+        XCTAssertEqual(CaveHostAdvice.evaluate("covencave://localhost:3000"), .loopback)
+    }
+
+    // MARK: - LAN addresses (same-Wi-Fi only)
+
+    func testRFC1918AddressesAreLAN() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("192.168.1.20"), .lanAddress)
+        XCTAssertEqual(CaveHostAdvice.evaluate("192.168.1.20:3000"), .lanAddress)
+        XCTAssertEqual(CaveHostAdvice.evaluate("10.0.0.5"), .lanAddress)
+        XCTAssertEqual(CaveHostAdvice.evaluate("172.16.0.9"), .lanAddress)
+        XCTAssertEqual(CaveHostAdvice.evaluate("172.31.255.1"), .lanAddress)
+    }
+
+    func testNon1918RangesAreNotLAN() {
+        // 172.32.* is public space, not RFC1918.
+        XCTAssertNil(CaveHostAdvice.evaluate("172.32.0.1"))
+        XCTAssertNil(CaveHostAdvice.evaluate("11.0.0.1"))
+        XCTAssertNil(CaveHostAdvice.evaluate("193.168.1.1"))
+    }
+
+    func testTailscaleCGNATRangeIsTheGoodCaseNotLAN() {
+        // 100.64.0.0/10 is Tailscale's address space — exactly what we WANT.
+        XCTAssertNil(CaveHostAdvice.evaluate("100.101.102.103"))
+        XCTAssertNil(CaveHostAdvice.evaluate("100.64.0.1:3000"))
+        XCTAssertNil(CaveHostAdvice.evaluate("100.127.255.254"))
+    }
+
+    // MARK: - mDNS .local names
+
+    func testDotLocalNamesGetLANFlavoredAdvice() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("my-mac.local"), .mdnsLocal)
+        XCTAssertEqual(CaveHostAdvice.evaluate("My-Mac.LOCAL:3000"), .mdnsLocal)
+    }
+
+    func testTailnetNamesAreClean() {
+        XCTAssertNil(CaveHostAdvice.evaluate("my-mac.example.ts.net"))
+        XCTAssertNil(CaveHostAdvice.evaluate("https://my-mac.example.ts.net"))
+    }
+
+    // MARK: - Stray space (pre-existing hint, now a case)
+
+    func testEmbeddedSpaceIsFlagged() {
+        XCTAssertEqual(CaveHostAdvice.evaluate("my mac.ts.net"), .hasSpace)
+        XCTAssertEqual(CaveHostAdvice.evaluate("address: 100.1.2.3"), .hasSpace)
+    }
+
+    func testSurroundingWhitespaceIsTolerated() {
+        XCTAssertNil(CaveHostAdvice.evaluate("  my-mac.ts.net  "))
+        XCTAssertEqual(CaveHostAdvice.evaluate("  127.0.0.1  "), .loopback)
+    }
+
+    // MARK: - Neutral inputs
+
+    func testEmptyAndCleanInputsGetNoAdvice() {
+        XCTAssertNil(CaveHostAdvice.evaluate(""))
+        XCTAssertNil(CaveHostAdvice.evaluate("   "))
+        XCTAssertNil(CaveHostAdvice.evaluate("example.com"))
+    }
+
+    func testBareIPv6IsNotMangledByPortStripping() {
+        // A bare IPv6 address has many colons — must not be truncated at the
+        // first one and misread.
+        XCTAssertNil(CaveHostAdvice.evaluate("fd7a:115c:a1e0::1234"))
+    }
+
+    func testMessagesAreNonEmptyAndDistinct() {
+        let cases: [CaveHostAdvice] = [.hasSpace, .loopback, .lanAddress, .mdnsLocal]
+        let messages = cases.map(\.message)
+        XCTAssertEqual(Set(messages).count, cases.count)
+        for message in messages {
+            XCTAssertFalse(message.isEmpty)
+        }
+    }
+
+    func testSpaceMessageKeptVerbatim() {
+        // The stray-space copy predates CaveHostAdvice — keep it stable.
+        XCTAssertEqual(CaveHostAdvice.hasSpace.message, "That has a space — paste just the address.")
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/ConnectionDiagnosisTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ConnectionDiagnosisTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+@testable import CovenCave
+
+final class ConnectionDiagnosisTests: XCTestCase {
+    // MARK: - URLError classification
+
+    func testOfflineCodesClassifyAsOffline() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.notConnectedToInternet)), .offline)
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.dataNotAllowed)), .offline)
+    }
+
+    func testDNSCodesClassifyAsDNSFailure() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.cannotFindHost)), .dnsFailure)
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.dnsLookupFailed)), .dnsFailure)
+    }
+
+    func testTimeoutClassifies() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.timedOut)), .timeout)
+    }
+
+    func testRefusedCodesClassify() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.cannotConnectToHost)), .refused)
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.networkConnectionLost)), .refused)
+    }
+
+    func testTLSCodesClassify() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.secureConnectionFailed)), .tlsFailure)
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.serverCertificateUntrusted)), .tlsFailure)
+    }
+
+    func testUnknownErrorsFallBackToTransport() {
+        XCTAssertEqual(ProbeFailure(classifying: URLError(.badURL)), .transport)
+        struct Weird: Error {}
+        XCTAssertEqual(ProbeFailure(classifying: Weird()), .transport)
+    }
+
+    // MARK: - Adjudication ranking (max = strongest diagnosis)
+
+    func testStrongerSignalsOutrankWeaker() {
+        // "Something answered but wasn't Cave" beats "connection refused"
+        // beats "DNS failure" beats "timeout" beats raw transport.
+        XCTAssertEqual(max(ProbeFailure.timeout, .refused), .refused)
+        XCTAssertEqual(max(ProbeFailure.dnsFailure, .wrongServer), .wrongServer)
+        XCTAssertEqual(max(ProbeFailure.transport, .timeout), .timeout)
+        XCTAssertEqual(max(ProbeFailure.tlsFailure, .dnsFailure), .tlsFailure)
+    }
+
+    func testOfflineOutranksEverything() {
+        for other: ProbeFailure in [.transport, .timeout, .dnsFailure, .tlsFailure, .refused, .wrongServer] {
+            XCTAssertEqual(max(ProbeFailure.offline, other), .offline)
+        }
+    }
+
+    // MARK: - Diagnosis copy
+
+    func testNilFailureKeepsTheGenericCopyVerbatim() {
+        let generic = ConnectionDiagnosis.diagnosis(for: nil)
+        XCTAssertEqual(generic, .generic)
+        XCTAssertEqual(generic.title, "Tailscale disconnected?")
+        XCTAssertEqual(generic.message, "Couldn’t reach the desktop. Is it on the tailnet and running?")
+    }
+
+    func testEveryFailureGetsDistinctActionableCopy() {
+        let failures: [ProbeFailure] = [.transport, .timeout, .dnsFailure, .tlsFailure, .refused, .wrongServer, .offline]
+        let diagnoses = failures.map { ConnectionDiagnosis.diagnosis(for: $0) }
+        XCTAssertEqual(Set(diagnoses.map(\.title)).count, failures.count, "every failure class tells its own story")
+        for diagnosis in diagnoses {
+            XCTAssertFalse(diagnosis.title.isEmpty)
+            XCTAssertFalse(diagnosis.message.isEmpty)
+            XCTAssertFalse(diagnosis.guidance.isEmpty)
+            XCTAssertFalse(diagnosis.systemImage.isEmpty)
+        }
+    }
+
+    func testKeyDiagnosesNameTheirCause() {
+        XCTAssertTrue(ConnectionDiagnosis.diagnosis(for: .offline).title.localizedCaseInsensitiveContains("offline"))
+        XCTAssertTrue(ConnectionDiagnosis.diagnosis(for: .dnsFailure).message.localizedCaseInsensitiveContains("magicdns"))
+        XCTAssertTrue(ConnectionDiagnosis.diagnosis(for: .refused).message.localizedCaseInsensitiveContains("port"))
+        XCTAssertTrue(ConnectionDiagnosis.diagnosis(for: .wrongServer).message.localizedCaseInsensitiveContains("isn’t the Cave"))
+    }
+
+    func testPreviewLinesAreDistinctAndNonEmpty() {
+        let failures: [ProbeFailure] = [.transport, .timeout, .dnsFailure, .tlsFailure, .refused, .wrongServer, .offline]
+        let lines = failures.map(\.previewLine)
+        XCTAssertEqual(Set(lines).count, failures.count)
+        for line in lines {
+            XCTAssertFalse(line.isEmpty)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/ConnectionRefreshCoordinatorTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ConnectionRefreshCoordinatorTests.swift
@@ -48,7 +48,7 @@ final class ConnectionRefreshCoordinatorTests: XCTestCase {
         let joiner = Task {
             await coordinator.refresh {
                 await probes.increment()
-                return ConnectionRefreshResult.unreachable
+                return ConnectionRefreshResult.unreachable(nil)
             }
         }
 
@@ -70,14 +70,14 @@ final class ConnectionRefreshCoordinatorTests: XCTestCase {
 
         let first = await coordinator.refresh {
             await probes.increment()
-            return ConnectionRefreshResult.unreachable
+            return ConnectionRefreshResult.unreachable(nil)
         }
         let second = await coordinator.refresh {
             await probes.increment()
             return ConnectionRefreshResult.unauthorized
         }
 
-        XCTAssertEqual(first.result, .unreachable)
+        XCTAssertEqual(first.result, .unreachable(nil))
         XCTAssertEqual(second.result, .unauthorized)
         XCTAssertTrue(first.launched)
         XCTAssertTrue(second.launched)
@@ -109,7 +109,7 @@ final class ConnectionRefreshCoordinatorTests: XCTestCase {
         let joiner = Task {
             await coordinator.refresh(requestSurfaceReload: true) {
                 XCTFail("joiner must not launch its own probe")
-                return ConnectionRefreshResult.unreachable
+                return ConnectionRefreshResult.unreachable(nil)
             }
         }
 
@@ -128,13 +128,13 @@ final class ConnectionRefreshCoordinatorTests: XCTestCase {
 
         // A launcher's own intent carries through…
         let first = await coordinator.refresh(requestSurfaceReload: true) {
-            ConnectionRefreshResult.unreachable
+            ConnectionRefreshResult.unreachable(nil)
         }
         XCTAssertTrue(first.surfaceReloadRequested)
 
         // …and must not leak into the next, unrelated launch.
         let second = await coordinator.refresh(requestSurfaceReload: false) {
-            ConnectionRefreshResult.unreachable
+            ConnectionRefreshResult.unreachable(nil)
         }
         XCTAssertTrue(second.launched)
         XCTAssertFalse(second.surfaceReloadRequested)
@@ -155,7 +155,7 @@ final class ConnectionRefreshCoordinatorTests: XCTestCase {
                 // path parks the test here for the full five seconds and then
                 // fails the `.cancelled` assertion below.
                 try? await Task.sleep(for: .seconds(5))
-                return Task.isCancelled ? .cancelled : .unreachable
+                return Task.isCancelled ? .cancelled : .unreachable(nil)
             }
         }
         await probeStarted.wait()

--- a/scripts/ios-connect-paste.test.mjs
+++ b/scripts/ios-connect-paste.test.mjs
@@ -43,11 +43,22 @@ assert.match(
   "connect should clean and invite-parse the host before configuring",
 );
 
-// --- Gentle, non-blocking malformed hint -------------------------------------
+// --- Gentle, non-blocking address advice (extracted classifier) ---------------
 assert.match(
   src,
-  /private var hostHint: String\? \{[\s\S]*?contains\(" "\)/,
-  "a hostHint should nudge when the address has a stray space",
+  /private var hostAdvice: CaveHostAdvice\? \{[\s\S]*?CaveHostAdvice\.evaluate\(host\)/,
+  "the hint should delegate to the CaveHostAdvice classifier (loopback/LAN/.local/space)",
+);
+assert.match(
+  src,
+  /private var hostHint: String\? \{ hostAdvice\?\.message \}/,
+  "the advisory hint renders the classifier's message",
+);
+const advice = await read("apps/ios/CovenCave/CovenCave/Networking/CaveHostAdvice.swift");
+assert.match(
+  advice,
+  /case \.hasSpace:[\s\S]*?That has a space — paste just the address\./,
+  "the stray-space nudge lives on as a classifier case, copy intact",
 );
 // The hint must NOT disable Connect — validation stays advisory (the connect flow
 // does the real probing); the button stays gated only on empty/busy.

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -35,8 +35,16 @@ assert.match(
 
 assert.match(
   src,
-  /if case \.unreachable\(let message\) = app\.connectionState \{[\s\S]*?connectionRecoveryCallout\(\s*title: "Tailscale disconnected\?",[\s\S]*?guidance: "Open Tailscale on this phone and make sure it says Connected/,
-  "unreachable state should explicitly point at Tailscale being disconnected before asking the user to re-pair",
+  /if case \.unreachable\(let diagnosis\) = app\.connectionState \{[\s\S]*?connectionRecoveryCallout\(\s*title: diagnosis\.title,\s*message: diagnosis\.message,\s*guidance: diagnosis\.guidance,\s*systemImage: diagnosis\.systemImage\s*\)/,
+  "unreachable state should render the classified diagnosis (DNS vs refused vs timeout…), not one generic message",
+);
+
+// The unclassified fallback keeps the original Tailscale-first guidance.
+const diagnosisSrc = await read("apps/ios/CovenCave/CovenCave/State/ConnectionDiagnosis.swift");
+assert.match(
+  diagnosisSrc,
+  /static let generic = ConnectionDiagnosis\(\s*title: "Tailscale disconnected\?"[\s\S]*?guidance: "Open Tailscale on this phone and make sure it says Connected/,
+  "the unclassified fallback still points at Tailscale before asking the user to re-pair",
 );
 
 assert.match(
@@ -61,6 +69,79 @@ assert.match(
   src,
   /private var trustNote: some View \{[\s\S]*?Private Tailscale mesh[\s\S]*?No public internet exposure/,
   "trust footer should summarize the private encrypted path with scannable labels",
+);
+
+// --- The step chips are real buttons wired to real actions --------------------
+assert.match(
+  src,
+  /stepChip\(\s*"Scan"[\s\S]*?\) \{ showScanner = true \}/,
+  "Scan chip opens the QR scanner",
+);
+assert.match(
+  src,
+  /stepChip\(\s*"Paste"[\s\S]*?\) \{ pasteHost\(\) \}/,
+  "Paste chip invokes the paste flow",
+);
+assert.match(
+  src,
+  /stepChip\(\s*"Connect"[\s\S]*?\) \{ connect\(\) \}/,
+  "Connect chip invokes connect",
+);
+assert.match(
+  src,
+  /private func stepChip\([\s\S]*?action: @escaping \(\) -> Void\s*\) -> some View \{\s*Button\(action: action\)/,
+  "chips are Buttons with accessibility hints, not decorative labels",
+);
+assert.match(
+  src,
+  /private var connectStep: StepState \{\s*if app\.connectionState == \.connected \{ return \.done \}/,
+  "the Connect chip reflects the live connection state (done once connected)",
+);
+assert.match(
+  src,
+  /state == \.done \? "checkmark\.circle\.fill" : systemImage/,
+  "completed steps swap to a checkmark",
+);
+
+// --- Scan-first hierarchy + connected moment -----------------------------------
+assert.match(
+  src,
+  /private var scanFirst: Bool \{\s*QRScannerSheet\.isSupported && !hostPresent\s*\}/,
+  "camera-first: scanning leads while no address exists yet",
+);
+assert.match(
+  src,
+  /or enter the address manually/,
+  "manual entry stays discoverable under the scan hero",
+);
+assert.match(
+  src,
+  /if app\.connectionState == \.connected \{ Haptics\.success\(\) \}/,
+  "a successful connect lands with success haptics",
+);
+assert.match(
+  src,
+  /\.animation\(reduceMotion \? nil : \.spring\(duration: 0\.32\), value: liveCheck\)/,
+  "state-change springs respect Reduce Motion",
+);
+
+// The brief "Connected" confirmation lives in RootView, over the freshly
+// mounted tabs — the swap is no longer an abrupt teleport.
+const root = await read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
+assert.match(
+  root,
+  /private struct ConnectedMomentOverlay: View \{[\s\S]*?Label\("Connected", systemImage: "checkmark\.circle\.fill"\)/,
+  "a Connected confirmation chip appears when the connection lands",
+);
+assert.match(
+  root,
+  /\.task\(id: app\.connectedAt\) \{[\s\S]*?timeIntervalSince\(connectedAt\) < 3/,
+  "the confirmation only fires for a connection that landed just now, not warm launches",
+);
+assert.match(
+  root,
+  /ConnectedMomentOverlay\(\)/,
+  "RootView mounts the connected-moment overlay",
 );
 
 console.log("ios-connect-screen-ux: OK");

--- a/scripts/ios-host-advice.test.mjs
+++ b/scripts/ios-host-advice.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Smart address advice on the iOS connect screen: dead-end addresses
+// (loopback, LAN-only, .local mDNS) get a specific, actionable nudge BEFORE a
+// doomed probe — instead of the generic unreachable shrug afterwards. The
+// advice is advisory only; Connect never gets disabled by it.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const advice = await read("apps/ios/CovenCave/CovenCave/Networking/CaveHostAdvice.swift");
+const view = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
+
+// --- Classifier cases ---------------------------------------------------------
+assert.match(
+  advice,
+  /enum CaveHostAdvice: Equatable \{[\s\S]*?case hasSpace[\s\S]*?case loopback[\s\S]*?case lanAddress[\s\S]*?case mdnsLocal/,
+  "classifier covers stray spaces, loopback, LAN addresses, and .local names",
+);
+assert.match(
+  advice,
+  /static func evaluate\(_ input: String\) -> CaveHostAdvice\?/,
+  "single evaluate() entry point returns nil for clean addresses",
+);
+
+// --- Loopback: this phone, not the desktop -------------------------------------
+assert.match(
+  advice,
+  /case \.loopback:[\s\S]*?this phone, not your desktop/,
+  "loopback advice explains the address points at the phone itself",
+);
+assert.match(
+  advice,
+  /100\.x or \*\.ts\.net/,
+  "loopback advice points at the Tailscale address as the fix",
+);
+
+// --- LAN: same-Wi-Fi only — prefer the tailnet ---------------------------------
+assert.match(
+  advice,
+  /case \.lanAddress:[\s\S]*?both devices share a network/,
+  "LAN advice explains the same-network limitation",
+);
+assert.match(
+  advice,
+  /isPrivateLANAddress/,
+  "RFC1918 detection is a named, testable helper",
+);
+// Tailscale's CGNAT range (100.64.0.0/10) is the GOOD case — it must never be
+// classified as a LAN address.
+assert.match(
+  advice,
+  /100\.64\.0\.0\/10|first == 100/,
+  "the classifier explicitly reasons about Tailscale's 100.64.0.0/10 space",
+);
+
+// --- Wiring: ConnectionView delegates, simulator keeps its dev loopback --------
+assert.match(
+  view,
+  /private var hostAdvice: CaveHostAdvice\? \{[\s\S]*?CaveHostAdvice\.evaluate\(host\)/,
+  "ConnectionView delegates hint classification to CaveHostAdvice",
+);
+assert.match(
+  view,
+  /#if targetEnvironment\(simulator\)[\s\S]*?\.loopback \{ return nil \}[\s\S]*?#endif/,
+  "the loopback warning is suppressed on the simulator — loopback IS the dev desktop there",
+);
+assert.match(
+  view,
+  /private var hostHint: String\? \{ hostAdvice\?\.message \}/,
+  "the field hint renders the classifier's message",
+);
+
+console.log("ios-host-advice: OK");

--- a/scripts/ios-live-check.test.mjs
+++ b/scripts/ios-live-check.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Live reachability preview on the iOS connect screen: as the user edits the
+// address, a debounced, single-flight, credential-free probe reports
+// "Desktop found" / a classified failure under the field — the first signal
+// no longer waits for a failed Connect. Purely advisory: never auto-connects,
+// never persists, never sends the stored token at a user-typed host.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const view = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+
+// --- Debounce + cancel-on-edit lifecycle ---------------------------------------
+assert.match(
+  view,
+  /\.task\(id: host\) \{\s*await runLiveCheck\(\)\s*\}/,
+  "the preview re-keys on every edit — SwiftUI cancels the in-flight run (single-flight by construction)",
+);
+assert.match(
+  view,
+  /try\? await Task\.sleep\(for: \.milliseconds\(800\)\)/,
+  "an ~800ms debounce coalesces keystrokes before probing",
+);
+assert.match(
+  view,
+  /guard !Task\.isCancelled, !busy, scenePhase == \.active else \{ return \}/,
+  "a superseded or backgrounded check never mutates state",
+);
+
+// --- Suppression: only probe when a preview is actually useful ------------------
+assert.match(
+  view,
+  /guard !busy, scenePhase == \.active, hostPresent, hostAdvice == nil else \{ return \}/,
+  "suppressed while connecting, backgrounded, empty, or already flagged by address advice",
+);
+assert.match(
+  view,
+  /guard let invite = CaveInvite\.parse\(cleanHost\(host\)\), invite\.token == nil else \{ return \}/,
+  "credential-carrying invites auto-connect via apply() — no preview probe for them",
+);
+
+// --- Advisory only: never connects, never persists ------------------------------
+const liveCheckBody = view.slice(view.indexOf("private func runLiveCheck()"));
+assert.ok(
+  !liveCheckBody.slice(0, liveCheckBody.indexOf("\n    }")).includes("app.configure"),
+  "the preview never auto-connects",
+);
+assert.match(
+  view,
+  /enum LiveCheckState: Equatable \{[\s\S]*?case idle[\s\S]*?case checking[\s\S]*?case found\(port: Int\?\)[\s\S]*?case pairingRequired[\s\S]*?case failed\(ProbeFailure\?\)/,
+  "preview states cover checking/found/pairing-required/classified-failure",
+);
+
+// --- Status row copy -------------------------------------------------------------
+assert.match(
+  view,
+  /Desktop found on port \\\(\$0\)\./,
+  "success names the discovered port",
+);
+assert.match(
+  view,
+  /Desktop found — pairing needed\. Connect will walk you through it\./,
+  "a token-gated desktop reads as found-but-pairing-required, not as a failure",
+);
+assert.match(
+  view,
+  /failure\.map\(\\\.previewLine\)/,
+  "failures render the classified one-line story (DNS vs refused vs timeout…)",
+);
+
+// --- Credential safety: the preview sweep never sends the stored token ----------
+assert.match(
+  model,
+  /static func previewDiscoverBaseURL\(_ candidates: \[URL\]\) async -> DiscoveryOutcome \{[\s\S]*?probe\(base, sendCredential: false\)/,
+  "the preview sweep probes credential-free",
+);
+assert.match(
+  model,
+  /private static func probe\(_ base: URL, sendCredential: Bool = true\) async -> ProbeResult/,
+  "probe() defaults to sending the credential so the paired discovery path is unchanged",
+);
+assert.match(
+  model,
+  /if sendCredential, let token = CaveConnection\.accessToken \{/,
+  "the Authorization header is gated on sendCredential",
+);
+
+console.log("ios-live-check: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1179,6 +1179,8 @@ export const SUITES = {
     "scripts/ios-operator-profile.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-connect-screen-ux.test.mjs",
+    "scripts/ios-host-advice.test.mjs",
+    "scripts/ios-live-check.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -575,6 +575,12 @@ export async function POST(req: Request) {
     }, { status: reset.ok ? 200 : 500 });
   }
 
+  // Cheap paired-signal read for the handoff modal's "phone seen" poll: no
+  // Tailscale spawn, no Serve reconcile — just the last token-refresh beat.
+  if (action === "status") {
+    return NextResponse.json({ ok: true, lastSeenAt: await readMobileLastSeen() });
+  }
+
   if (action === "app-start") {
     return ensureNativeAppServe(req, chatId);
   }

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
+import { PairingStepsList } from "@/components/pairing-steps-list";
 import { copyText } from "@/lib/clipboard";
+import type { PairingStep } from "@/lib/mobile-handoff";
 import { openExternalUrl } from "@/lib/open-external";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 
 type HandoffReady = {
   ok: true;
@@ -18,12 +21,18 @@ type HandoffReady = {
   expiresAtIso?: string;
   qrSvg: string;
   warning?: string;
+  /** The proven probe ladder (cave-jr4r.1) — present on success too, so the
+   *  modal can show the live "Phone seen" rung instead of discarding it. */
+  steps?: PairingStep[];
+  lastSeenAt?: number | null;
 };
 
 type HandoffError = {
   ok: false;
   error?: string;
   stderr?: string;
+  /** Which rung broke — the route reports the whole ladder on failures. */
+  steps?: PairingStep[];
 };
 
 type HandoffResponse = HandoffReady | HandoffError;
@@ -65,6 +74,10 @@ export function MobileHandoffModal({
 }: Props) {
   const [handoff, setHandoff] = useState<HandoffReady | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /** Failure ladder from the route — which rung broke, not just one string. */
+  const [errorSteps, setErrorSteps] = useState<PairingStep[] | null>(null);
+  /** Live paired signal: flips the "Phone seen" rung the moment a scan lands. */
+  const [phoneSeenAt, setPhoneSeenAt] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState<"host" | "invite" | null>(null);
   const lastAutoCopyRequestRef = useRef(0);
@@ -90,6 +103,7 @@ export function MobileHandoffModal({
 
     setLoading(true);
     setError(null);
+    setErrorSteps(null);
     setCopied(null);
     setHandoff(null);
     try {
@@ -105,9 +119,11 @@ export function MobileHandoffModal({
       if (!json.ok) {
         setHandoff(null);
         setError(json.stderr || json.error || "Mobile handoff failed.");
+        setErrorSteps(Array.isArray(json.steps) && json.steps.length > 0 ? json.steps : null);
         return;
       }
       setHandoff(json);
+      setPhoneSeenAt(json.lastSeenAt ?? null);
       if (copyRequest > 0 && copyRequest !== lastAutoCopyRequestRef.current) {
         await copyHandoffUrl(json);
         if (controller.signal.aborted) return;
@@ -143,6 +159,35 @@ export function MobileHandoffModal({
     if (handoff) await copyHandoffUrl(handoff);
   }, [copyHandoffUrl, handoff]);
 
+  // While the modal shows a healthy ladder that's still waiting on the first
+  // scan, poll the cheap paired-signal read (~5s, paused in hidden tabs) so
+  // "Waiting for the first scan" flips to a green "Phone seen" the moment the
+  // phone lands — the loop closes on the desktop, not just on the phone.
+  const phoneRungPending = Boolean(handoff?.steps) && !phoneSeenAt;
+  const pollPhoneSeen = useCallback(async () => {
+    try {
+      const res = await fetch("/api/mobile-handoff", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "status" }),
+      });
+      const json = (await res.json()) as { ok: boolean; lastSeenAt?: number | null };
+      if (json.ok && json.lastSeenAt) setPhoneSeenAt(json.lastSeenAt);
+    } catch {
+      // Best-effort signal — the next tick retries.
+    }
+  }, []);
+  usePausablePoll(() => void pollPhoneSeen(), 5000, { enabled: open && phoneRungPending });
+
+  /** The success ladder with the phone rung kept live by the poll. */
+  const displaySteps = useMemo(() => {
+    if (!handoff?.steps) return null;
+    if (!phoneSeenAt) return handoff.steps;
+    return handoff.steps.map((step) =>
+      step.id === "phone" ? { ...step, state: "ok" as const, detail: undefined } : step,
+    );
+  }, [handoff, phoneSeenAt]);
+
   const copyHost = useCallback(async () => {
     if (!handoff?.nativeHost) return;
     try {
@@ -161,6 +206,7 @@ export function MobileHandoffModal({
 
     setLoading(true);
     setError(null);
+    setErrorSteps(null);
     try {
       const res = await fetch("/api/mobile-handoff", {
         method: "POST",
@@ -271,7 +317,10 @@ export function MobileHandoffModal({
               ) : null}
               <p className="mobile-handoff__hint">
                 The QR opens the Tailscale-served desktop page; the host is what the native app needs.
+                Don’t type your Mac’s 127.0.0.1 or Wi‑Fi LAN address into the phone — it can’t reach
+                your desktop that way.
               </p>
+              {displaySteps ? <PairingStepsList steps={displaySteps} className="mobile-handoff__steps" /> : null}
               {handoff.warning ? (
                 <p className="mobile-handoff__warning">{handoff.warning}</p>
               ) : null}
@@ -293,7 +342,14 @@ export function MobileHandoffModal({
               ) : null}
             </>
           ) : error ? (
-            <p className="mobile-handoff__error">{error}</p>
+            <>
+              {errorSteps ? (
+                // The route's proven ladder: WHICH rung broke and what to do,
+                // instead of one opaque error string.
+                <PairingStepsList steps={errorSteps} className="mobile-handoff__steps" />
+              ) : null}
+              <p className="mobile-handoff__error">{error}</p>
+            </>
           ) : (
             <p className="mobile-handoff__meta">
               Cave will publish this desktop through Tailscale Serve and show the native app host.

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -6,6 +6,7 @@ const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "u
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const modal = await readFile(new URL("./mobile-handoff-modal.tsx", import.meta.url), "utf8");
 const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const stepsList = await readFile(new URL("./pairing-steps-list.tsx", import.meta.url), "utf8");
 const mobileModePref = await readFile(new URL("../lib/mobile-mode-pref.ts", import.meta.url), "utf8");
 const mobileModeReconcile = await readFile(new URL("../lib/mobile-mode-reconcile.ts", import.meta.url), "utf8");
 const handoffRoute = await readFile(new URL("../app/api/mobile-handoff/route.ts", import.meta.url), "utf8");
@@ -81,6 +82,35 @@ assert.match(modal, /handoff\?\.inviteUrl \|\| handoff\?\.url/, "Modal should pr
 assert.match(modal, /mobile-handoff__link[\s\S]*href=\{handoff\.inviteUrl \|\| handoff\.url\}/, "Modal should display the invite link as a clickable link");
 assert.match(css, /\.mobile-handoff__link/, "Invite link should have stable styling");
 assert.match(modal, /action: "reset"/, "Modal should expose explicit Tailscale Serve reset");
+
+// ── Handoff modal renders the ladder too (pairing overhaul W6) ───────────────
+// The route already reported PairingStep[] on success and failure; the modal
+// used to discard it and show one opaque string.
+assert.match(modal, /steps\?: PairingStep\[\]/, "modal payload types carry the route's pairing ladder");
+assert.match(modal, /errorSteps \? \(/, "a failed handoff renders the ladder — which rung broke — not just an error string");
+assert.match(modal, /<PairingStepsList steps=\{errorSteps\}/, "the failure ladder uses the shared renderer");
+assert.match(modal, /<PairingStepsList steps=\{displaySteps\}/, "the success body shows the compact ladder with the live phone rung");
+assert.match(
+  modal,
+  /step\.id === "phone" \? \{ \.\.\.step, state: "ok" as const, detail: undefined \} : step/,
+  "the polled paired signal flips the phone rung to done without refetching the whole handoff",
+);
+assert.match(modal, /action: "status"/, "the phone-seen poll uses the cheap status action, not the Tailscale-spawning handoff");
+assert.match(
+  modal,
+  /usePausablePoll\(\(\) => void pollPhoneSeen\(\), 5000, \{ enabled: open && phoneRungPending \}\)/,
+  "the poll runs only while the modal is open and the phone rung is still pending, pausing in hidden tabs",
+);
+assert.match(
+  modal,
+  /Don’t type your Mac’s 127\.0\.0\.1 or Wi‑Fi LAN address/,
+  "the host card warns against typing loopback/LAN addresses into the phone (aligns with the iOS-side advice)",
+);
+assert.match(
+  handoffRoute,
+  /action === "status"[\s\S]{0,200}readMobileLastSeen\(\)/,
+  "the route exposes a cheap paired-signal read that never spawns tailscale",
+);
 // cave-i74f: the invite may carry a #chat-<id> fragment (Continue on phone),
 // so the canonical field is the fragment-aware inviteUrl.
 assert.match(handoffRoute, /const inviteUrl = withChatFragment\(invite\.url, chatId\);/, "the web invite rides the chat fragment when a handoff targets a conversation");
@@ -184,12 +214,17 @@ assert.match(
   /phoneSeenAt: lastSeenAt,\s*\}\)/,
   "the success response carries the full ladder including the phone rung",
 );
-assert.match(settings, /aria-label="Pairing checklist"/, "the Phone card renders the ladder as a labelled checklist");
+// The ladder renderer is shared between the Settings Phone card and the
+// handoff modal (src/components/pairing-steps-list.tsx) so both surfaces tell
+// the same story about which rung broke.
+assert.match(stepsList, /aria-label="Pairing checklist"/, "the shared ladder renders as a labelled checklist");
 assert.match(
-  settings,
+  stepsList,
   /PAIRING_STEP_GLYPH: Record<PairingStep\["state"\], \{ icon: IconName; className: string; announce: string \}>/,
   "each checklist state pairs an icon with screen-reader text — never color alone",
 );
+assert.match(settings, /<PairingStepsList steps=\{steps\}>/, "the Phone card renders the ladder through the shared component");
+assert.doesNotMatch(settings, /PAIRING_STEP_GLYPH/, "settings no longer owns a private glyph map — the shared component does");
 assert.match(
   settings,
   /mobileModeEnabled && friendly && error && !steps/,

--- a/src/components/pairing-steps-list.tsx
+++ b/src/components/pairing-steps-list.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import type { PairingStep } from "@/lib/mobile-handoff";
+
+/** One glyph per checklist state — never color alone (cave-jr4r.1). */
+const PAIRING_STEP_GLYPH: Record<PairingStep["state"], { icon: IconName; className: string; announce: string }> = {
+  ok: { icon: "ph:check-circle-bold", className: "text-[var(--color-success)]", announce: "done" },
+  fail: { icon: "ph:x-circle", className: "text-[var(--color-warning)]", announce: "failed" },
+  skipped: { icon: "ph:minus-circle", className: "text-[var(--text-muted)]", announce: "skipped" },
+  pending: { icon: "ph:circle-dashed", className: "text-[var(--text-muted)]", announce: "waiting" },
+};
+
+/**
+ * The proven pairing ladder (access → backend → tailscale → route → phone),
+ * rendered as a labelled checklist. Shared between the Settings Phone card and
+ * the top-bar "Open on phone" modal so both surfaces tell the same story about
+ * which rung broke — or that everything is green and we're just waiting for
+ * the first scan.
+ */
+export function PairingStepsList({
+  steps,
+  className,
+  children,
+}: {
+  steps: PairingStep[];
+  className?: string;
+  /** Optional trailing list item(s), e.g. a Retry row after a failed rung. */
+  children?: ReactNode;
+}) {
+  return (
+    <ol
+      className={`flex flex-col gap-1.5 rounded-[var(--radius-card)] border border-[var(--border-hairline)] px-3.5 py-3 ${className ?? ""}`}
+      aria-label="Pairing checklist"
+    >
+      {steps.map((step) => {
+        const glyph = PAIRING_STEP_GLYPH[step.state];
+        return (
+          <li key={step.id} className="flex items-start gap-2 text-[length:var(--text-sm)]">
+            <Icon name={glyph.icon} className={`mt-[1px] shrink-0 ${glyph.className}`} aria-hidden />
+            <span className="min-w-0">
+              <span className={step.state === "skipped" ? "text-[var(--text-muted)]" : "text-[var(--text-primary)]"}>
+                {step.label}
+              </span>
+              <span className="sr-only"> — {glyph.announce}</span>
+              {step.detail && (step.state === "fail" || step.state === "pending") ? (
+                <span className={`block text-[length:var(--text-xs)] leading-relaxed ${step.state === "fail" ? "text-[var(--color-warning)]" : "text-[var(--text-muted)]"}`}>
+                  {step.detail}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
+      {children}
+    </ol>
+  );
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -4,7 +4,7 @@ import "@/styles/dashboard.css";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { Icon, type IconName } from "@/lib/icon";
+import { Icon } from "@/lib/icon";
 import type { PairingStep } from "@/lib/mobile-handoff";
 import { relativeTime } from "@/lib/relative-time";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
@@ -18,6 +18,7 @@ import { prefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
+import { PairingStepsList } from "@/components/pairing-steps-list";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
 import { OpenCovenToolsUpdate } from "@/components/open-coven-tools-update";
@@ -2655,14 +2656,6 @@ type MobileHandoffCardState = {
   lastSeenAt: number | null;
 };
 
-/** One glyph per checklist state — never color alone (cave-jr4r.1). */
-const PAIRING_STEP_GLYPH: Record<PairingStep["state"], { icon: IconName; className: string; announce: string }> = {
-  ok: { icon: "ph:check-circle-bold", className: "text-[var(--color-success)]", announce: "done" },
-  fail: { icon: "ph:x-circle", className: "text-[var(--color-warning)]", announce: "failed" },
-  skipped: { icon: "ph:minus-circle", className: "text-[var(--text-muted)]", announce: "skipped" },
-  pending: { icon: "ph:circle-dashed", className: "text-[var(--text-muted)]", announce: "waiting" },
-};
-
 function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
   const [mobileModeEnabled, setMobileModeEnabled] = useState(readMobileModeEnabled);
   const [handoff, setHandoff] = useState<MobileHandoffCardState | null>(null);
@@ -2786,26 +2779,7 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
 
       {/* The proven ladder — which rung broke, and what to do about it. */}
       {mobileModeEnabled && steps ? (
-        <ol className="flex flex-col gap-1.5 rounded-[var(--radius-card)] border border-[var(--border-hairline)] px-3.5 py-3" aria-label="Pairing checklist">
-          {steps.map((step) => {
-            const glyph = PAIRING_STEP_GLYPH[step.state];
-            return (
-              <li key={step.id} className="flex items-start gap-2 text-[length:var(--text-sm)]">
-                <Icon name={glyph.icon} className={`mt-[1px] shrink-0 ${glyph.className}`} aria-hidden />
-                <span className="min-w-0">
-                  <span className={step.state === "skipped" ? "text-[var(--text-muted)]" : "text-[var(--text-primary)]"}>
-                    {step.label}
-                  </span>
-                  <span className="sr-only"> — {glyph.announce}</span>
-                  {step.detail && (step.state === "fail" || step.state === "pending") ? (
-                    <span className={`block text-[length:var(--text-xs)] leading-relaxed ${step.state === "fail" ? "text-[var(--color-warning)]" : "text-[var(--text-muted)]"}`}>
-                      {step.detail}
-                    </span>
-                  ) : null}
-                </span>
-              </li>
-            );
-          })}
+        <PairingStepsList steps={steps}>
           {steps.some((step) => step.state === "fail") ? (
             <li className="mt-1 flex items-center gap-2" aria-hidden={false}>
               <Button
@@ -2825,7 +2799,7 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
               ) : null}
             </li>
           ) : null}
-        </ol>
+        </PairingStepsList>
       ) : null}
 
       {/* Humanized failure — the jargon lives behind a disclosure now. Only

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -1913,3 +1913,10 @@ a.mobile-handoff__link:hover {
   font-size: var(--text-sm);
   line-height: 1.45;
 }
+
+/* The pairing ladder inside the handoff modal (shared PairingStepsList) —
+   quiet card treatment so it reads as diagnostics, not another CTA. */
+.mobile-handoff__steps {
+  margin: 0;
+  background: color-mix(in srgb, var(--surface-raised, transparent) 55%, transparent);
+}


### PR DESCRIPTION
## What

Overhauls both halves of the pairing experience — the iOS "Connect to Cave" screen and the desktop "Open on phone" modal.

### iOS (W1–W5)
- **Smart address advice** (`CaveHostAdvice`): loopback (`127.*`/`localhost`/`::1`), LAN (`192.168.*`, `172.16–31.*`, `10.*`), and `.local` inputs get a specific explanation *before* a doomed connect; Tailscale CGNAT `100.64/10` stays clean; simulator loopback carve-out keeps the dev workflow quiet. Advisory only — never blocks Connect.
- **Classified probe diagnostics** (`ConnectionDiagnosis`): DNS-failure vs refused vs timeout vs offline vs TLS now produce distinct titles/messages/guidance instead of one generic "Couldn't reach the desktop"; adjudication carries the most actionable failure across candidates.
- **Live reachability preview**: 800 ms-debounced, credential-free probe as you edit, with a compact found/failed row under the field. Never auto-connects.
- **Interactive step chips**: Scan/Paste/Connect are real buttons with derived pending/active/done state.
- **Scan-first polish**: QR scan becomes the hero action when the camera is available and no host is set; success haptic + brief "Connected" moment on fresh connects; springs respect Reduce Motion.

### Desktop (W6)
- Settings' pairing checklist extracted into shared `PairingStepsList`; the handoff modal now renders the route's ladder on **failure** (which rung broke) and **success** (compact, with the live phone rung).
- New cheap `status` action on `/api/mobile-handoff` (reads `readMobileLastSeen` only — no tailscale spawn); the modal polls it at 5 s via `usePausablePoll` while open+pending, so "Waiting for the first scan" flips to "Phone seen" the moment the scan lands.
- Host card hint warns against typing loopback/LAN addresses into the phone.

## Validation
- `pnpm typecheck` clean; eslint 0 errors on changed files
- Suites: **876 app / 228 api / 85 mobile** test files green
- Swift (not CI-gated): `xcodebuild` BUILD SUCCEEDED; `CaveHostAdviceTests`, `ConnectionDiagnosisTests`, `ConnectionRefreshCoordinatorTests` TEST SUCCEEDED (iPhone 16 Pro sim)
- New mjs pins: `ios-host-advice`, `ios-live-check` (registered in run-tests.mjs mobile suite); `ios-connect-paste`/`ios-connect-screen-ux`/`mobile-handoff` pins updated deliberately with the contract changes

Bead: cave-y5u0