### PR TITLE
fix(stream): parse SSE frames that carry id: lines (cave-am2b)

### DIFF
--- a/src/lib/canvas-generate.test.ts
+++ b/src/lib/canvas-generate.test.ts
@@ -24,12 +24,38 @@ assert.equal(parseSseFrame("event: ping"), null, "non-data lines are ignored");
 assert.equal(parseSseFrame("data: "), null, "empty data payload yields null");
 assert.equal(parseSseFrame("data: {not json"), null, "malformed JSON yields null, not a throw");
 
+// /api/chat/send frames every event as "id: N\ndata: {json}" so the stream can
+// be resumed — a parser requiring the frame to START with "data:" dropped every
+// event and the journal/canvas saw an empty reply (cave-am2b).
+assert.deepEqual(
+  parseSseFrame('id: 7\ndata: {"kind":"assistant_chunk","text":"hi"}'),
+  { kind: "assistant_chunk", text: "hi" },
+  "an id line ahead of the data payload is tolerated",
+);
+
+assert.deepEqual(
+  parseSseFrame('id: 7\r\ndata: {"kind":"done","sessionId":"s1"}'),
+  { kind: "done", sessionId: "s1" },
+  "CRLF line endings inside a frame are tolerated",
+);
+
+assert.deepEqual(
+  parseSseFrame('event: message\nid: 2\ndata: {"kind":"session","sessionId":"s2"}'),
+  { kind: "session", sessionId: "s2" },
+  "event: and id: lines are skipped, data still parses",
+);
+
+assert.equal(parseSseFrame("id: 9"), null, "a frame with no data line yields null");
+
 const originalFetch = globalThis.fetch;
 const encoder = new TextEncoder();
+// Mirror the real wire shape: /api/chat/send prefixes every frame with an
+// "id: N" line (resume cursor). The generator must parse these, not just
+// bare "data:" frames (cave-am2b).
 const responseFor = (frames) => new Response(
   new ReadableStream({
     start(controller) {
-      for (const frame of frames) controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+      frames.forEach((frame, i) => controller.enqueue(encoder.encode(`id: ${i + 1}\ndata: ${JSON.stringify(frame)}\n\n`)));
       controller.close();
     },
   }),

--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -13,10 +13,24 @@ export type SketchStreamEvent = {
   message?: string;
 };
 
-/** Parse one SSE frame ("data: {...}") into its event object, or null. */
+/**
+ * Parse one SSE frame into its event object, or null.
+ *
+ * A frame is everything between blank-line separators and may carry `id:`,
+ * `event:`, and comment lines ahead of its `data:` payload — /api/chat/send
+ * frames every event as "id: N\ndata: {json}" so /api/chat/stream can resume
+ * from the last seen id. A parser that required the frame to *start with*
+ * "data:" dropped every id-carrying event, which read as "the familiar didn't
+ * return a reflection" in the journal and a blind stream everywhere else
+ * (cave-am2b). Multi-line data is joined with newlines per the SSE spec; CRLF
+ * line endings are tolerated for platform WebViews that normalize them.
+ */
 export function parseSseFrame(frame: string): SketchStreamEvent | null {
-  if (!frame.startsWith("data:")) return null;
-  const payload = frame.slice(5).trim();
+  const data: string[] = [];
+  for (const line of frame.split(/\r?\n/)) {
+    if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
+  }
+  const payload = data.join("\n").trim();
   if (!payload) return null;
   try {
     return JSON.parse(payload) as SketchStreamEvent;

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -119,6 +119,18 @@ test("parseSseBuffer: skips malformed frames without throwing", () => {
   assert.equal(events[0].kind, "error");
 });
 
+test("parseSseBuffer: tolerates id: lines ahead of the data payload (cave-am2b)", () => {
+  const buf =
+    'id: 1\ndata: {"kind":"session","sessionId":"s1"}\n\n' +
+    ': hb\n\n' +
+    'id: 2\ndata: {"kind":"assistant_chunk","text":"hi"}\n\n';
+  const { events, rest } = parseSseBuffer(buf);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].kind, "session");
+  assert.deepEqual(events[1], { kind: "assistant_chunk", text: "hi" });
+  assert.equal(rest, "");
+});
+
 test("defaultGroupName: friendly summaries by participant count", () => {
   assert.equal(defaultGroupName([]), "New coven");
   assert.equal(defaultGroupName(["Aria"]), "Aria");

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -148,6 +148,9 @@ export function applyGroupEvent(reply: GroupReply, ev: GroupStreamEvent): GroupR
 /**
  * Parse the rolling SSE buffer into complete `data:` events, returning the
  * leftover partial frame. Same `\n\n`-delimited framing as chat-view.tsx.
+ * Frames may carry `id:` lines ahead of the `data:` payload (/api/chat/send
+ * frames every event as "id: N\ndata: {json}" for stream resume) — requiring
+ * the frame to *start with* "data:" dropped every id-carrying event (cave-am2b).
  */
 export function parseSseBuffer(buffer: string): { events: GroupStreamEvent[]; rest: string } {
   const events: GroupStreamEvent[] = [];
@@ -156,8 +159,11 @@ export function parseSseBuffer(buffer: string): { events: GroupStreamEvent[]; re
   while ((idx = rest.indexOf("\n\n")) >= 0) {
     const frame = rest.slice(0, idx);
     rest = rest.slice(idx + 2);
-    if (!frame.startsWith("data:")) continue;
-    const payload = frame.slice(5).trim();
+    const data: string[] = [];
+    for (const line of frame.split(/\r?\n/)) {
+      if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
+    }
+    const payload = data.join("\n").trim();
     if (!payload) continue;
     try {
       events.push(JSON.parse(payload) as GroupStreamEvent);

--- a/src/lib/journal-generate.test.ts
+++ b/src/lib/journal-generate.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { buildReflectionPrompt } from "./journal-generate.ts";
+import { buildReflectionPrompt, generateReflection } from "./journal-generate.ts";
 
 {
   const p = buildReflectionPrompt("2026-06-20: 2 responses.\n- Reply to Sage");
@@ -26,6 +26,37 @@ import { buildReflectionPrompt } from "./journal-generate.ts";
     /const trimmed = extractNextPaths\(text\)\.visible\.trim\(\);/,
     "the directive block is stripped from the reflection text",
   );
+}
+
+// ── id-framed SSE events must not read as an empty reply (cave-am2b) ─────────
+// /api/chat/send frames every event as "id: N\ndata: {json}" (resume cursor).
+// The old frame parser required frames to START with "data:", so every chunk
+// was dropped and generation always failed with "didn't return a reflection".
+{
+  const originalFetch = globalThis.fetch;
+  const encoder = new TextEncoder();
+  try {
+    globalThis.fetch = async () => new Response(
+      new ReadableStream({
+        start(controller) {
+          const frames = [
+            { kind: "session", sessionId: "j1" },
+            { kind: "assistant_chunk", text: "A quiet, steady day" },
+            { kind: "assistant_chunk", text: " of tending memory." },
+            { kind: "done", sessionId: "j1", isError: false },
+          ];
+          frames.forEach((f, i) => controller.enqueue(encoder.encode(`id: ${i + 1}\ndata: ${JSON.stringify(f)}\n\n`)));
+          controller.close();
+        },
+      }),
+      { status: 200 },
+    );
+    const result = await generateReflection({ familiarId: "nova", context: "ctx" });
+    assert.equal(result.error, null, "an id-framed stream is not an error");
+    assert.equal(result.text, "A quiet, steady day of tending memory.", "chunks accumulate across id-framed frames");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 }
 
 console.log("journal-generate.test.ts: ok");


### PR DESCRIPTION
## Problem

**Journal → "Generate today's entry" always failed** with *"The familiar didn't return a reflection. Try again."* — even though the underlying `/api/chat/send` stream completed successfully with full assistant text.

## Root cause

Since the Phase D lifecycle refactor (#3572), `/api/chat/send` frames every SSE event with a resume cursor:

```
id: 5
data: {"kind":"assistant_chunk","text":"…"}
```

Two client parsers required frames to **start with** `data:` and returned `null` otherwise:

- `parseSseFrame` (src/lib/canvas-generate.ts) — consumed by **journal-generate**, **canvas-generate**, and **familiar-stream**
- `parseSseBuffer` (src/lib/group-chat.ts) — consumed by **group-chat-view**

Every id-carrying event was silently dropped, so these flows saw an empty reply. The journal surfaced it as the error above; canvas artifact generation and group-chat streaming were equally blind. (The main chat view uses `chat-sse.ts`, which was already id-tolerant — that's why regular chat kept working.)

## Fix

Both parsers now scan frame lines per the SSE spec: `id:`/`event:`/comment lines are skipped, `data:` lines are joined with newlines, CRLF endings tolerated (mirrors `chat-sse.ts`).

## Validation

- Reproduced live before the fix: Playwright click on **Generate today's entry** → POST 200 with a healthy 16-frame stream, yet UI errored in ~5s with zero parsed chunks.
- After the fix (isolated dev server from this branch): same click → reflection streams, saves (`Reflected by Nova · 1m ago`), renders, and the stored entry has the `<coven:next-paths>` block stripped.
- New tests pin the id-framed wire shape: `parseSseFrame` unit cases (id line, CRLF, event+id, id-only), `generateReflection` end-to-end over an id-framed mock stream, `parseSseBuffer` with id + heartbeat frames, and the `generateArtifactCode` mock stream now emits `id: N` prefixes.
- `node --test` on the four touched test files: 83+70 pass. `pnpm typecheck` clean.

Bead: cave-am2b