### PR TITLE
feat(canvas): iOS Canvas view mode behind a fail-closed desktop opt-in (cave-ivjs)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/PermissionModels.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/PermissionModels.swift
@@ -174,6 +174,7 @@ struct MobilePermissionsResponse: Codable, Sendable {
     var ok: Bool
     var grantMutations: Bool?
     var fileWrites: Bool?
+    var canvasWrites: Bool?
     var error: String?
 }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Permissions.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Permissions.swift
@@ -72,13 +72,18 @@ extension CaveClient {
     }
 
     /// The desktop's opt-ins for what this phone may write.
-    func mobilePermissions() async throws -> (grantMutations: Bool, fileWrites: Bool) {
+    func mobilePermissions() async throws
+        -> (grantMutations: Bool, fileWrites: Bool, canvasWrites: Bool) {
         let data = try await permissionsData(try permissionsRequest("api/mobile-permissions"))
         let decoded = try permissionsDecode(MobilePermissionsResponse.self, data)
         guard decoded.ok else {
             throw CaveError.transport(decoded.error ?? "Couldn’t load mobile permissions.")
         }
-        return (decoded.grantMutations == true, decoded.fileWrites == true)
+        return (
+            decoded.grantMutations == true,
+            decoded.fileWrites == true,
+            decoded.canvasWrites == true
+        )
     }
 
     // MARK: - Mutations (server-gated behind the desktop opt-in)

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -261,6 +261,11 @@ final class AppModel {
     var canvasArtifacts: [CanvasArtifact] = []
     var canvasError: String?
     var canvasLoaded = false
+    /// Desktop opt-in ("Allow canvas edits from phone"). Fails closed: the
+    /// Canvas tab is view mode until the desktop says otherwise — the server
+    /// enforces the same gate on every canvas write, so this flag only shapes
+    /// the UI (composer/refine/delete affordances), never grants authority.
+    var canvasWritesAllowed = false
     /// True while a generate/refine stream is in flight.
     var isGeneratingCanvas = false
     /// The familiar's reply text as it streams in (for the "sketching…" preview).
@@ -654,6 +659,11 @@ final class AppModel {
 
     func loadCanvas() async {
         guard let client else { return }
+        // The write opt-in rides along with every gallery load so the tab's
+        // mode tracks the desktop toggle without its own refresh path. A
+        // failed permissions read keeps the last known value — the server
+        // gate stays authoritative either way.
+        async let permissionsCall = try? client.mobilePermissions()
         do {
             canvasArtifacts = sortedArtifacts(try await client.canvasArtifacts())
             canvasError = nil
@@ -664,6 +674,9 @@ final class AppModel {
             // transient first-load error heals instead of leaving the gallery
             // permanently empty behind the view's one-shot load guard.
             canvasError = handleSurfaceError(error)
+        }
+        if let permissions = await permissionsCall {
+            canvasWritesAllowed = permissions.canvasWrites
         }
         canvasLoaded = true
     }

--- a/apps/ios/CovenCave/CovenCave/Views/ArtifactDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ArtifactDetailView.swift
@@ -22,6 +22,11 @@ struct ArtifactDetailView: View {
         self.familiarId = familiarId
     }
 
+    /// Desktop opt-in gate ("Allow canvas edits from phone"). View mode keeps
+    /// the live preview, code view, copy, and share; refine/comment/delete
+    /// affordances disappear — the server refuses those writes anyway.
+    private var canEdit: Bool { app.canvasWritesAllowed }
+
     var body: some View {
         ZStack {
             if showCode { codeView } else { previewView }
@@ -31,9 +36,11 @@ struct ArtifactDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar { toolbarContent }
         .safeAreaInset(edge: .bottom) {
-            VStack(spacing: 0) {
-                if selectedTarget != nil { commentBar }
-                refineBar
+            if canEdit {
+                VStack(spacing: 0) {
+                    if selectedTarget != nil { commentBar }
+                    refineBar
+                }
             }
         }
     }
@@ -44,6 +51,8 @@ struct ArtifactDetailView: View {
         ArtifactWebView(artifact: current,
                         serverBaseURL: app.connection?.baseURL,
                         interactive: true) { target in
+            // Component selection exists to write a comment — inert in view mode.
+            guard canEdit else { return }
             selectedTarget = target
             commentDraft = current.annotations?
                 .first(where: { $0.target.selector == target.selector })?.note ?? ""
@@ -93,7 +102,7 @@ struct ArtifactDetailView: View {
                 ShareLink(item: current.code) {
                     Label("Share code", systemImage: "square.and.arrow.up")
                 }
-                if !(current.annotations ?? []).isEmpty {
+                if canEdit && !(current.annotations ?? []).isEmpty {
                     Button { applyComments() } label: {
                         Label(
                             "Apply \(current.annotations?.count ?? 0) comments",
@@ -102,9 +111,11 @@ struct ArtifactDetailView: View {
                     }
                     .disabled(app.isGeneratingCanvas || familiarId.isEmpty)
                 }
-                Divider()
-                Button(role: .destructive) { delete() } label: {
-                    Label("Delete", systemImage: "trash")
+                if canEdit {
+                    Divider()
+                    Button(role: .destructive) { delete() } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
                 }
             } label: {
                 Image(systemName: "ellipsis.circle")

--- a/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CanvasView.swift
@@ -103,9 +103,15 @@ struct CanvasView: View {
             titleRow
                 .zIndex(1)
             if headerControlsVisible {
-                VStack(alignment: .leading, spacing: 12) {
-                    composer
-                    starterBar
+                Group {
+                    if app.canvasWritesAllowed {
+                        VStack(alignment: .leading, spacing: 12) {
+                            composer
+                            starterBar
+                        }
+                    } else {
+                        viewOnlyBanner
+                    }
                 }
                 .transition(.move(edge: .top).combined(with: .opacity))
                 .zIndex(0)
@@ -115,6 +121,17 @@ struct CanvasView: View {
         .padding(.top, 8)
         .padding(.bottom, 12)
         .background(.bar)
+    }
+
+    /// View mode: the desktop hasn't opted in to canvas edits from this
+    /// phone, so the composer stays hidden and the gallery is read-only.
+    /// Mirrors the Permissions console's read-only banner.
+    private var viewOnlyBanner: some View {
+        Label("View only — enable “Allow canvas edits from phone” in desktop Settings → Phone.",
+              systemImage: "lock.fill")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var titleRow: some View {
@@ -335,14 +352,16 @@ struct CanvasView: View {
             Label("Copy code", systemImage: "doc.on.doc")
         }
         ShareLink(item: artifact.code) { Label("Share code", systemImage: "square.and.arrow.up") }
-        Divider()
-        Button(role: .destructive) {
-            Task {
-                await app.deleteArtifact(artifact)
-                app.showToast("Deleted", systemImage: "trash", style: .info)
+        if app.canvasWritesAllowed {
+            Divider()
+            Button(role: .destructive) {
+                Task {
+                    await app.deleteArtifact(artifact)
+                    app.showToast("Deleted", systemImage: "trash", style: .info)
+                }
+            } label: {
+                Label("Delete", systemImage: "trash")
             }
-        } label: {
-            Label("Delete", systemImage: "trash")
         }
     }
 
@@ -352,7 +371,9 @@ struct CanvasView: View {
         ContentUnavailableView {
             Label("Nothing on the canvas yet", systemImage: "wand.and.stars")
         } description: {
-            Text("Describe a UI above — a pricing page, a to-do app, a dashboard — and a familiar will sketch it live.")
+            Text(app.canvasWritesAllowed
+                ? "Describe a UI above — a pricing page, a to-do app, a dashboard — and a familiar will sketch it live."
+                : "Artifacts sketched on the desktop appear here, live and browsable.")
         }
         .frame(maxWidth: .infinity, minHeight: 320)
     }
@@ -383,6 +404,9 @@ struct CanvasView: View {
     }
 
     private func generate(_ text: String) {
+        // Belt over the hidden composer: the server refuses phone writes
+        // without the desktop opt-in regardless.
+        guard app.canvasWritesAllowed else { return }
         let toSend = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !toSend.isEmpty, !app.isGeneratingCanvas else { return }
         guard let familiarId = selectedFamiliarId ?? app.familiars.first?.id else {

--- a/src/app/api/canvas/route.test.ts
+++ b/src/app/api/canvas/route.test.ts
@@ -7,12 +7,17 @@ import { after, test } from "node:test";
 const testHome = path.join(process.cwd(), ".test-artifacts", `canvas-route-${process.pid}`);
 mkdirSync(testHome, { recursive: true });
 process.env.COVEN_CAVE_HOME = testHome;
+// Hermetic write-gate inputs: no sidecar token, permission config in the
+// test home (fail-closed defaults — canvas writes from the phone are off).
+delete process.env.COVEN_CAVE_AUTH_TOKEN;
+process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(testHome, "permission-config.json");
 
 after(() => {
+  delete process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE;
   rmSync(testHome, { recursive: true, force: true });
 });
 
-const { DELETE, PATCH, POST } = await import("./route.ts");
+const { DELETE, PATCH, POST, PUT } = await import("./route.ts");
 
 function artifact(code: string, updatedAt: string, annotations?: unknown[]) {
   return {
@@ -38,9 +43,11 @@ function annotation(id: string, updatedAt: string, note = id) {
 }
 
 function request(method: string, body: unknown) {
-  return new Request("http://test/api/canvas", {
+  // Mutating verbs are gated by requireTrustedHumanCanvasMutation — these
+  // behavioral tests exercise the store, so they call as the loopback desktop.
+  return new Request("http://127.0.0.1/api/canvas", {
     method,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", host: "127.0.0.1:3000" },
     body: JSON.stringify(body),
   });
 }
@@ -202,4 +209,43 @@ test("POST protects ambiguous create retries with expected-absent", async () => 
     expectedUpdatedAt: createdAt,
   }));
   assert.equal(invalid.status, 400, "create and revision preconditions are mutually exclusive");
+});
+
+test("every mutating verb is view-mode gated: verified phone 403s until the desktop opts in", async () => {
+  const { MOBILE_ACCESS_HEADER } = await import("../../../proxy-helpers.ts");
+  const { updateMobileWriteAccess } = await import("../../../lib/project-permissions.ts");
+  const { GET } = await import("./route.ts");
+
+  const mobileRequest = (method: string, body: unknown) =>
+    new Request("http://100.101.102.103:8443/api/canvas", {
+      method,
+      headers: {
+        "content-type": "application/json",
+        host: "100.101.102.103:8443",
+        [MOBILE_ACCESS_HEADER]: "1",
+      },
+      body: JSON.stringify(body),
+    });
+
+  const attempts: Array<[string, Promise<Response>]> = [
+    ["PUT", PUT(mobileRequest("PUT", { positions: {} }))],
+    ["POST", POST(mobileRequest("POST", { artifact: artifact("<main>phone</main>", "2026-07-22T00:00:00Z") }))],
+    ["PATCH", PATCH(mobileRequest("PATCH", { id: "route-revision", annotation: annotation("a1", "2026-07-22T00:00:00Z") }))],
+    ["DELETE", DELETE(mobileRequest("DELETE", { id: "route-revision" }))],
+  ];
+  for (const [verb, pending] of attempts) {
+    const res = await pending;
+    assert.equal(res.status, 403, `${verb} from the phone is refused while the opt-in is off`);
+    assert.match((await res.json()).error, /Allow canvas edits from phone/, `${verb} 403 names the toggle`);
+  }
+
+  // Reading never gates — view mode keeps the gallery alive.
+  const read = await GET();
+  assert.equal(read.status, 200, "GET stays open regardless of the opt-in");
+
+  // The desktop opt-in unlocks the same phone request.
+  await updateMobileWriteAccess({ allowMobileCanvasWrites: true });
+  const unlocked = await PUT(mobileRequest("PUT", { positions: {} }));
+  assert.equal(unlocked.status, 200, "opted-in phone layout writes reach the store");
+  await updateMobileWriteAccess({ allowMobileCanvasWrites: false });
 });

--- a/src/app/api/canvas/route.ts
+++ b/src/app/api/canvas/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/cave-canvas";
 import type { CanvasArtifact } from "@/lib/canvas-artifacts";
 import type { CanvasPositions } from "@/lib/canvas-layout";
+import { requireTrustedHumanCanvasMutation } from "@/lib/server/trusted-grant-mutation";
 
 export const dynamic = "force-dynamic";
 
@@ -30,6 +31,10 @@ export async function GET() {
 }
 
 export async function PUT(req: Request) {
+  // Every mutating verb is desktop-trusted or phone-opt-in; reading stays
+  // open so the phone's Canvas tab keeps working in view mode.
+  const denied = await requireTrustedHumanCanvasMutation(req);
+  if (denied) return denied;
   let body: { positions?: CanvasPositions };
   try {
     body = await req.json();
@@ -48,6 +53,8 @@ export async function PUT(req: Request) {
 }
 
 export async function POST(req: Request) {
+  const denied = await requireTrustedHumanCanvasMutation(req);
+  if (denied) return denied;
   let body: {
     artifact?: CanvasArtifact;
     expectedUpdatedAt?: unknown;
@@ -105,6 +112,8 @@ export async function POST(req: Request) {
 }
 
 export async function PATCH(req: Request) {
+  const denied = await requireTrustedHumanCanvasMutation(req);
+  if (denied) return denied;
   let body: unknown;
   try {
     body = await req.json();
@@ -137,6 +146,8 @@ export async function PATCH(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const denied = await requireTrustedHumanCanvasMutation(req);
+  if (denied) return denied;
   let body: { id?: string };
   try {
     body = await req.json();

--- a/src/app/api/mobile-permissions/route.ts
+++ b/src/app/api/mobile-permissions/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
     ok: true,
     grantMutations: config.allowMobileGrantMutations,
     fileWrites: config.allowMobileFileWrites,
+    canvasWrites: config.allowMobileCanvasWrites,
   });
 }
 
@@ -35,7 +36,11 @@ export async function PATCH(req: Request) {
   } catch {
     return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
   }
-  const patch: { allowMobileGrantMutations?: boolean; allowMobileFileWrites?: boolean } = {};
+  const patch: {
+    allowMobileGrantMutations?: boolean;
+    allowMobileFileWrites?: boolean;
+    allowMobileCanvasWrites?: boolean;
+  } = {};
   if (payload.grantMutations !== undefined) {
     if (typeof payload.grantMutations !== "boolean") {
       return NextResponse.json(
@@ -54,9 +59,22 @@ export async function PATCH(req: Request) {
     }
     patch.allowMobileFileWrites = payload.fileWrites;
   }
-  if (patch.allowMobileGrantMutations === undefined && patch.allowMobileFileWrites === undefined) {
+  if (payload.canvasWrites !== undefined) {
+    if (typeof payload.canvasWrites !== "boolean") {
+      return NextResponse.json(
+        { ok: false, error: "canvasWrites must be a boolean" },
+        { status: 400 },
+      );
+    }
+    patch.allowMobileCanvasWrites = payload.canvasWrites;
+  }
+  if (
+    patch.allowMobileGrantMutations === undefined
+    && patch.allowMobileFileWrites === undefined
+    && patch.allowMobileCanvasWrites === undefined
+  ) {
     return NextResponse.json(
-      { ok: false, error: "grantMutations or fileWrites is required" },
+      { ok: false, error: "grantMutations, fileWrites, or canvasWrites is required" },
       { status: 400 },
     );
   }
@@ -65,5 +83,6 @@ export async function PATCH(req: Request) {
     ok: true,
     grantMutations: next.allowMobileGrantMutations,
     fileWrites: next.allowMobileFileWrites,
+    canvasWrites: next.allowMobileCanvasWrites,
   });
 }

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2915,9 +2915,11 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
  *  /api/mobile-permissions). Both default off; the route only accepts the
  *  PATCH from this desktop (loopback), so the phone can never widen its own
  *  authority — flipping these here is the trust decision. */
+type MobileWriteFlagKey = "grantMutations" | "fileWrites" | "canvasWrites";
+
 function MobileWriteAccessCard() {
-  const [flags, setFlags] = useState<{ grantMutations: boolean; fileWrites: boolean } | null>(null);
-  const [busyKey, setBusyKey] = useState<"grantMutations" | "fileWrites" | null>(null);
+  const [flags, setFlags] = useState<Record<MobileWriteFlagKey, boolean> | null>(null);
+  const [busyKey, setBusyKey] = useState<MobileWriteFlagKey | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { announce } = useAnnouncer();
 
@@ -2927,7 +2929,11 @@ function MobileWriteAccessCard() {
       .then((res) => res.json())
       .then((body) => {
         if (cancelled || !body?.ok) return;
-        setFlags({ grantMutations: body.grantMutations === true, fileWrites: body.fileWrites === true });
+        setFlags({
+          grantMutations: body.grantMutations === true,
+          fileWrites: body.fileWrites === true,
+          canvasWrites: body.canvasWrites === true,
+        });
       })
       .catch(() => {
         if (!cancelled) setError("Couldn't load phone write access.");
@@ -2937,7 +2943,7 @@ function MobileWriteAccessCard() {
     };
   }, []);
 
-  const toggle = async (key: "grantMutations" | "fileWrites") => {
+  const toggle = async (key: MobileWriteFlagKey) => {
     if (!flags || busyKey) return;
     const next = !flags[key];
     setBusyKey(key);
@@ -2953,10 +2959,15 @@ function MobileWriteAccessCard() {
         setError(body?.error ?? "Couldn't update phone write access.");
         return;
       }
-      setFlags({ grantMutations: body.grantMutations === true, fileWrites: body.fileWrites === true });
+      setFlags({
+        grantMutations: body.grantMutations === true,
+        fileWrites: body.fileWrites === true,
+        canvasWrites: body.canvasWrites === true,
+      });
       const labels: Record<typeof key, string> = {
         grantMutations: "Permission changes from phone",
         fileWrites: "File edits from phone",
+        canvasWrites: "Canvas edits from phone",
       };
       announce(`${labels[key]} ${next ? "enabled" : "disabled"}.`, "polite");
     } catch {
@@ -2966,7 +2977,7 @@ function MobileWriteAccessCard() {
     }
   };
 
-  const switchButton = (key: "grantMutations" | "fileWrites") => {
+  const switchButton = (key: MobileWriteFlagKey) => {
     const on = flags?.[key] === true;
     return (
       <button
@@ -2999,6 +3010,12 @@ function MobileWriteAccessCard() {
         description="Save files in the Code tab from your phone. Off keeps phone access read-only."
       >
         {switchButton("fileWrites")}
+      </SettingsRow>
+      <SettingsRow
+        label="Allow canvas edits from phone"
+        description="Generate, refine, comment on, and delete canvas artifacts from the Cave app. Off keeps the phone's Canvas tab view-only."
+      >
+        {switchButton("canvasWrites")}
       </SettingsRow>
       {error ? (
         <p role="status" className="px-4 pb-3 text-[length:var(--text-xs)] text-[var(--color-warning)]">

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -353,13 +353,21 @@ try {
   const defaults = await loadMobileWriteAccess();
   assert.deepEqual(
     defaults,
-    { allowMobileGrantMutations: false, allowMobileFileWrites: false },
+    {
+      allowMobileGrantMutations: false,
+      allowMobileFileWrites: false,
+      allowMobileCanvasWrites: false,
+    },
     "mobile write access defaults to fully off",
   );
   const enabled = await updateMobileWriteAccess({ allowMobileGrantMutations: true });
   assert.deepEqual(
     enabled,
-    { allowMobileGrantMutations: true, allowMobileFileWrites: false },
+    {
+      allowMobileGrantMutations: true,
+      allowMobileFileWrites: false,
+      allowMobileCanvasWrites: false,
+    },
     "a partial patch flips only the addressed flag",
   );
   const persisted = await loadMobileWriteAccess();
@@ -370,11 +378,17 @@ try {
   assert.equal(bothOff.allowMobileGrantMutations, false, "the opt-in can be revoked");
   await writeFile(
     process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE,
-    JSON.stringify({ version: 1, supremeFamiliarId: "supreme", allowMobileFileWrites: "yes" }),
+    JSON.stringify({
+      version: 1,
+      supremeFamiliarId: "supreme",
+      allowMobileFileWrites: "yes",
+      allowMobileCanvasWrites: 1,
+    }),
     "utf8",
   );
   const junk = await loadMobileWriteAccess();
   assert.equal(junk.allowMobileFileWrites, false, "non-boolean flag values fail closed");
+  assert.equal(junk.allowMobileCanvasWrites, false, "non-boolean canvas flag fails closed");
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -122,6 +122,13 @@ type HumanPermissionConfigFile = {
    * Familiar-scoped writes keep full grant enforcement regardless.
    */
   allowMobileFileWrites: boolean;
+  /**
+   * Desktop opt-in (default false): the human's paired phone may mutate the
+   * canvas (generate/refine/annotate/delete artifacts, move layout). Off
+   * keeps the iOS Canvas tab in view mode — the gallery and previews stay
+   * fully readable.
+   */
+  allowMobileCanvasWrites: boolean;
 };
 
 export type ProjectAccessContext = {
@@ -191,6 +198,7 @@ async function loadHumanPermissionConfigUnlocked(): Promise<HumanPermissionConfi
     supremeFamiliarId,
     allowMobileGrantMutations: parsed?.allowMobileGrantMutations === true,
     allowMobileFileWrites: parsed?.allowMobileFileWrites === true,
+    allowMobileCanvasWrites: parsed?.allowMobileCanvasWrites === true,
   };
 }
 
@@ -206,11 +214,13 @@ export async function loadHumanPermissionConfig(): Promise<HumanPermissionConfig
 export type MobileWriteAccessConfig = {
   allowMobileGrantMutations: boolean;
   allowMobileFileWrites: boolean;
+  allowMobileCanvasWrites: boolean;
 };
 
 export async function loadMobileWriteAccess(): Promise<MobileWriteAccessConfig> {
-  const { allowMobileGrantMutations, allowMobileFileWrites } = await loadHumanPermissionConfig();
-  return { allowMobileGrantMutations, allowMobileFileWrites };
+  const { allowMobileGrantMutations, allowMobileFileWrites, allowMobileCanvasWrites } =
+    await loadHumanPermissionConfig();
+  return { allowMobileGrantMutations, allowMobileFileWrites, allowMobileCanvasWrites };
 }
 
 /**
@@ -229,11 +239,13 @@ export async function updateMobileWriteAccess(
         allowMobileGrantMutations:
           patch.allowMobileGrantMutations ?? current.allowMobileGrantMutations,
         allowMobileFileWrites: patch.allowMobileFileWrites ?? current.allowMobileFileWrites,
+        allowMobileCanvasWrites: patch.allowMobileCanvasWrites ?? current.allowMobileCanvasWrites,
       };
       await writeJsonFile(humanPermissionConfigPath(), next);
       return {
         allowMobileGrantMutations: next.allowMobileGrantMutations,
         allowMobileFileWrites: next.allowMobileFileWrites,
+        allowMobileCanvasWrites: next.allowMobileCanvasWrites,
       };
     };
     if (process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE) return operation();

--- a/src/lib/server/trusted-grant-mutation.test.ts
+++ b/src/lib/server/trusted-grant-mutation.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 // Behavioral coverage for the desktop-opt-in mobile trust chain:
 //   - requireTrustedHumanGrantMutation (grant/proposal mutation gate)
+//   - requireTrustedHumanCanvasMutation (canvas write gate → iOS view mode)
 //   - /api/mobile-permissions (the toggles route: GET open, PATCH loopback-only)
 //   - assertProjectApiAccess human-mobile file-write branch
 // The phone must never be able to widen its own authority; every mobile
@@ -18,9 +19,11 @@ delete process.env.COVEN_CAVE_AUTH_TOKEN;
 
 try {
   const { MOBILE_ACCESS_HEADER } = await import("../../proxy-helpers.ts");
-  const { requireTrustedHumanGrantMutation, isVerifiedMobileRequest } = await import(
-    "./trusted-grant-mutation.ts"
-  );
+  const {
+    requireTrustedHumanGrantMutation,
+    requireTrustedHumanCanvasMutation,
+    isVerifiedMobileRequest,
+  } = await import("./trusted-grant-mutation.ts");
   const { updateMobileWriteAccess } = await import("../project-permissions.ts");
   const { GET: getMobilePermissions, PATCH: patchMobilePermissions } = await import(
     "../../app/api/mobile-permissions/route.ts"
@@ -84,8 +87,8 @@ try {
   const initial = await (await getMobilePermissions(mobile())).json();
   assert.deepEqual(
     initial,
-    { ok: true, grantMutations: false, fileWrites: false },
-    "GET is readable from the phone and reports both flags off",
+    { ok: true, grantMutations: false, fileWrites: false, canvasWrites: false },
+    "GET is readable from the phone and reports every flag off",
   );
 
   const phonePatch = await patchMobilePermissions(
@@ -108,7 +111,12 @@ try {
     ),
   );
   assert.equal(desktopPatch.status, 200);
-  assert.deepEqual(await desktopPatch.json(), { ok: true, grantMutations: true, fileWrites: false });
+  assert.deepEqual(await desktopPatch.json(), {
+    ok: true,
+    grantMutations: true,
+    fileWrites: false,
+    canvasWrites: false,
+  });
 
   assert.equal(
     await requireTrustedHumanGrantMutation(mobile()),
@@ -119,6 +127,55 @@ try {
     request({ host: "evil.example" }),
   );
   assert.equal(relockedSpoof?.status, 403, "the opt-in trusts only proxy-verified phone requests");
+
+  // --- the canvas gate ----------------------------------------------------
+
+  assert.equal(
+    await requireTrustedHumanCanvasMutation(loopback()),
+    null,
+    "loopback desktop mutates the canvas with every opt-in off",
+  );
+  const canvasDenied = await requireTrustedHumanCanvasMutation(mobile());
+  assert.equal(canvasDenied?.status, 403, "phone canvas writes are refused while the opt-in is off");
+  assert.match(
+    (await canvasDenied.json()).error,
+    /Allow canvas edits from phone/,
+    "the 403 names the desktop toggle to flip",
+  );
+  const canvasStranger = await requireTrustedHumanCanvasMutation(request({ host: "evil.example" }));
+  assert.equal(canvasStranger?.status, 403, "non-loopback, non-mobile canvas writers are refused");
+
+  // The canvas opt-in is its own flag — the grant opt-in flipped above must
+  // not leak canvas authority, and vice versa.
+  assert.equal((await requireTrustedHumanCanvasMutation(mobile()))?.status, 403);
+  const canvasPatch = await patchMobilePermissions(
+    loopback(
+      { "content-type": "application/json" },
+      { method: "PATCH", body: JSON.stringify({ canvasWrites: true }) },
+    ),
+  );
+  assert.equal(canvasPatch.status, 200);
+  assert.deepEqual(await canvasPatch.json(), {
+    ok: true,
+    grantMutations: true,
+    fileWrites: false,
+    canvasWrites: true,
+  });
+  assert.equal(
+    await requireTrustedHumanCanvasMutation(mobile()),
+    null,
+    "once the desktop opts in, the verified phone may mutate the canvas",
+  );
+  const phoneCanvasPatch = await patchMobilePermissions(
+    mobile(
+      { "content-type": "application/json" },
+      { method: "PATCH", body: JSON.stringify({ canvasWrites: true }) },
+    ),
+  );
+  assert.equal(phoneCanvasPatch.status, 403, "the phone can never flip the canvas opt-in itself");
+  // Relock for the file-write section below (its flag must start clean).
+  await updateMobileWriteAccess({ allowMobileCanvasWrites: false });
+  assert.equal((await requireTrustedHumanCanvasMutation(mobile()))?.status, 403, "relocked");
 
   // --- human mobile file writes -----------------------------------------
 

--- a/src/lib/server/trusted-grant-mutation.ts
+++ b/src/lib/server/trusted-grant-mutation.ts
@@ -43,3 +43,31 @@ export async function requireTrustedHumanGrantMutation(req: Request): Promise<Re
     { status: 403 },
   );
 }
+
+/**
+ * Gate for canvas mutations (generate/refine saves, annotations, layout,
+ * deletes). Same trust shape as grant mutations: the local desktop always
+ * qualifies; the human's paired phone qualifies ONLY behind the desktop
+ * opt-in `allowMobileCanvasWrites` (mutable only from loopback). With the
+ * flag off the phone's Canvas tab is view mode — GET /api/canvas stays open,
+ * every write lands here.
+ */
+export async function requireTrustedHumanCanvasMutation(req: Request): Promise<Response | null> {
+  if (isLocalOrigin(req)) return null;
+  if (isVerifiedMobileRequest(req)) {
+    const { allowMobileCanvasWrites } = await loadMobileWriteAccess();
+    if (allowMobileCanvasWrites) return null;
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "canvas edits from the phone are disabled — enable “Allow canvas edits from phone” in desktop Settings",
+      },
+      { status: 403 },
+    );
+  }
+  return NextResponse.json(
+    { ok: false, error: "canvas edits must come from the local desktop" },
+    { status: 403 },
+  );
+}


### PR DESCRIPTION
## Summary

Ensures the iOS app's Canvas can run in **view mode**. Previously the phone had full, ungated mutation power over `/api/canvas` (generate, refine, annotate, delete). Canvas now joins the #3652 desktop-gated mobile write-access pattern, failing closed:

**Server**
- `allowMobileCanvasWrites` joins the permission config (default **false**; non-boolean junk fails closed) and `/api/mobile-permissions` (GET readable anywhere so the phone can shape its UI; PATCH stays loopback-only — the phone can never widen its own authority).
- New `requireTrustedHumanCanvasMutation` gates every mutating `/api/canvas` verb (PUT/POST/PATCH/DELETE): loopback desktop always passes; the proxy-verified phone passes only behind the opt-in; everything else 403s with guidance naming the toggle. **GET stays open** — view mode keeps the gallery and live previews fully working.

**Desktop**
- Settings → Phone gains "Allow canvas edits from phone" beside the existing grant/file toggles.

**iOS**
- `AppModel.canvasWritesAllowed` refreshes with every gallery load (failed permission reads keep the last value — the server gate is authoritative regardless).
- View mode: `CanvasView` swaps the composer + quick-starts for a read-only banner (Permissions-console idiom) and drops Delete from card context menus; `ArtifactDetailView` hides the refine bar, comment bar, "Apply comments", and Delete, and component tap-to-comment goes inert. Browsing, live preview, code view, copy, and share all keep working.
- A phone browser using the served web app degrades the same way: web canvas callers already fail quietly on non-ok mutations, so mobile-web becomes read-only without error spam.

## Testing
- New canvas-route gating test: all four verbs 403 from a verified phone with the toggle named, GET stays open, the desktop opt-in unlocks, relock verified.
- `trusted-grant-mutation` suite extended (canvas gate parity: loopback/spoof/stranger cases, flag independence from the grant opt-in, phone can't self-enable).
- `project-permissions` suite extended (fail-closed default, junk normalization, partial-patch isolation).
- Full `app` + `api` suites: **1126/1126 files pass**; `tsc --noEmit` clean; api-contracts green.
- iOS: `xcodegen` + `xcodebuild` (iOS Simulator) — **BUILD SUCCEEDED**.

Bead: cave-ivjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)