### PR TITLE
feat(ios): show live agent tool/progress activity in chat (cave-l7o3)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// One agent working step surfaced by the chat stream while a reply runs —
+/// a tool call (`tool_use`) or a harness progress line (`progress`). Persisted
+/// with the message so a finished turn keeps a compact trail of what the
+/// familiar actually did.
+struct ActivityStep: Codable, Hashable, Identifiable {
+    enum Kind: String, Codable {
+        case tool, progress
+    }
+
+    /// `running` animates; terminal states render a settled glyph. Raw values
+    /// mirror the server's `tool_use` statuses (`progress` "done" maps to `ok`).
+    enum Status: String, Codable {
+        case running, ok, error
+    }
+
+    var id: String
+    var kind: Kind
+    /// Tool name ("Bash", "Edit") or progress label ("Thinking…").
+    var title: String
+    /// Short input/detail line — a command head, a file path. Capped at fold
+    /// time; chips are tiny, payloads stay on the desktop.
+    var detail: String?
+    var status: Status = .running
+    /// Wall-clock duration the server reported when the step settled.
+    var durationMs: Int?
+}
+
+/// Folds raw stream events into a message's activity list. Pure functions so
+/// the stream handler stays trivial and replay stays testable: updates are
+/// keyed by the server's tool id, which makes re-applying an already-seen
+/// frame (mid-turn resume replays past the cursor) a harmless no-op.
+enum ActivityFold {
+    /// Bound per message so a runaway turn can't grow snapshots without limit.
+    /// The oldest steps drop first — the tail is where the action is.
+    static let maxSteps = 120
+    /// Detail strings are one-line chips, never payloads.
+    static let detailCap = 140
+
+    /// Fold one event into `steps`. Returns the updated list, or nil when the
+    /// event doesn't change the activity (callers skip the mutation + notify).
+    static func fold(_ steps: [ActivityStep], event: StreamEvent) -> [ActivityStep]? {
+        switch event {
+        case .toolUse(let id, let name, let input, _, let status, let durationMs):
+            return foldTool(steps, id: id, name: name, input: input,
+                            status: status, durationMs: durationMs)
+        case .progress(let id, let label, let detail, let status, let durationMs):
+            return foldProgress(steps, id: id, label: label, detail: detail,
+                                status: status, durationMs: durationMs)
+        default:
+            return nil
+        }
+    }
+
+    /// Settle every still-running step when the turn ends. The stream is the
+    /// only writer, so a persisted "running" badge would spin forever after
+    /// reload — successful turns settle to `ok`, failed ones to `error`.
+    static func settle(_ steps: [ActivityStep], success: Bool) -> [ActivityStep]? {
+        guard steps.contains(where: { $0.status == .running }) else { return nil }
+        return steps.map { step in
+            guard step.status == .running else { return step }
+            var settled = step
+            settled.status = success ? .ok : .error
+            return settled
+        }
+    }
+
+    // MARK: - Folding rules
+
+    /// `tool_use` arrives (at most) twice per call — start (`running`) and
+    /// settle (`ok`/`error`) under the same id. A start appends; a settle
+    /// updates its step in place. Events with no id can never be re-keyed,
+    /// so they simply append.
+    private static func foldTool(_ steps: [ActivityStep], id: String?, name: String,
+                                 input: String?, status: String?,
+                                 durationMs: Int?) -> [ActivityStep]? {
+        let parsedStatus = ActivityStep.Status(rawValue: status ?? "") ?? .running
+        if let id, let idx = steps.lastIndex(where: { $0.kind == .tool && $0.id == id }) {
+            var step = steps[idx]
+            var changed = false
+            if step.status != parsedStatus { step.status = parsedStatus; changed = true }
+            if step.detail == nil, let detail = cap(input) { step.detail = detail; changed = true }
+            if let durationMs, step.durationMs != durationMs {
+                step.durationMs = durationMs
+                changed = true
+            }
+            guard changed else { return nil }
+            var updated = steps
+            updated[idx] = step
+            return updated
+        }
+        let step = ActivityStep(id: id ?? UUID().uuidString, kind: .tool, title: name,
+                                detail: cap(input), status: parsedStatus,
+                                durationMs: durationMs)
+        return append(step, to: steps)
+    }
+
+    /// Progress lines are transient status ("Thinking…", "Compacting…"). A
+    /// repeat of the latest label updates that step in place — harnesses
+    /// re-emit the same line as it advances — while a new label appends.
+    private static func foldProgress(_ steps: [ActivityStep], id: String?, label: String,
+                                     detail: String?, status: String?,
+                                     durationMs: Int?) -> [ActivityStep]? {
+        guard !label.isEmpty else { return nil }
+        let parsedStatus: ActivityStep.Status =
+            status == "done" ? .ok : ActivityStep.Status(rawValue: status ?? "") ?? .running
+        let matchesLast = steps.last.map { last in
+            last.kind == .progress && (id.map { $0 == last.id } ?? (last.title == label))
+        } ?? false
+        if matchesLast, let last = steps.last {
+            var step = last
+            var changed = false
+            if step.status != parsedStatus { step.status = parsedStatus; changed = true }
+            if let detail = cap(detail), step.detail != detail { step.detail = detail; changed = true }
+            if let durationMs, step.durationMs != durationMs {
+                step.durationMs = durationMs
+                changed = true
+            }
+            guard changed else { return nil }
+            var updated = steps
+            updated[updated.count - 1] = step
+            return updated
+        }
+        let step = ActivityStep(id: id ?? UUID().uuidString, kind: .progress, title: label,
+                                detail: cap(detail), status: parsedStatus,
+                                durationMs: durationMs)
+        return append(step, to: steps)
+    }
+
+    private static func append(_ step: ActivityStep, to steps: [ActivityStep]) -> [ActivityStep] {
+        var updated = steps
+        updated.append(step)
+        if updated.count > maxSteps {
+            updated.removeFirst(updated.count - maxSteps)
+        }
+        return updated
+    }
+
+    private static func cap(_ text: String?) -> String? {
+        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        // One line only — a multi-line tool input reads as noise in a chip.
+        let firstLine = trimmed.split(separator: "\n", maxSplits: 1,
+                                      omittingEmptySubsequences: false)[0]
+        return String(firstLine.prefix(detailCap))
+    }
+
+    /// Map a persisted conversation turn's tool calls into activity steps so
+    /// history loads keep the trail. Persisted calls are settled by
+    /// definition — anything not marked "error" reads as ok, never running.
+    static func steps(fromTools tools: [ToolCall]?) -> [ActivityStep]? {
+        guard let tools, !tools.isEmpty else { return nil }
+        return tools.suffix(maxSteps).map { tool in
+            ActivityStep(id: tool.id, kind: .tool, title: tool.name,
+                         detail: cap(tool.input),
+                         status: tool.status == "error" ? .error : .ok)
+        }
+    }
+}
+
+extension Array where Element == ActivityStep {
+    /// The step a live chip should narrate: the newest still-running one,
+    /// falling back to the newest overall while the server settles.
+    var currentStep: ActivityStep? {
+        last(where: { $0.status == .running }) ?? last
+    }
+
+    /// Collapsed one-line summary for a finished turn — "Ran 4 tools",
+    /// "Ran 1 tool · 1 failed", or "4 steps" for progress-only turns.
+    var summaryLabel: String {
+        let tools = filter { $0.kind == .tool }
+        let failed = filter { $0.status == .error }.count
+        var label: String
+        if tools.isEmpty {
+            label = count == 1 ? "1 step" : "\(count) steps"
+        } else {
+            label = tools.count == 1 ? "Ran 1 tool" : "Ran \(tools.count) tools"
+        }
+        if failed > 0 { label += " · \(failed) failed" }
+        return label
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Models/StreamEvent.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/StreamEvent.swift
@@ -6,8 +6,8 @@ enum StreamEvent {
     case session(sessionId: String)
     case user(text: String)
     case assistantChunk(text: String)
-    case progress(label: String, detail: String?, status: String?)
-    case toolUse(id: String?, name: String, input: String?, output: String?, status: String?)
+    case progress(id: String?, label: String, detail: String?, status: String?, durationMs: Int?)
+    case toolUse(id: String?, name: String, input: String?, output: String?, status: String?, durationMs: Int?)
     case done(isError: Bool, sessionId: String?)
     case error(message: String)
     case unknown(kind: String)
@@ -28,9 +28,11 @@ enum StreamEvent {
             return .assistantChunk(text: obj["text"] as? String ?? "")
         case "progress":
             return .progress(
+                id: obj["id"] as? String,
                 label: obj["label"] as? String ?? "",
                 detail: obj["detail"] as? String,
-                status: obj["status"] as? String
+                status: obj["status"] as? String,
+                durationMs: obj["durationMs"] as? Int
             )
         case "tool_use":
             return .toolUse(
@@ -38,7 +40,8 @@ enum StreamEvent {
                 name: obj["name"] as? String ?? "tool",
                 input: obj["input"] as? String,
                 output: obj["output"] as? String,
-                status: obj["status"] as? String
+                status: obj["status"] as? String,
+                durationMs: obj["durationMs"] as? Int
             )
         case "done":
             return .done(

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1643,7 +1643,9 @@ final class AppModel {
             return DisplayMessage(role: role,
                                   familiarId: role == .assistant ? assignee : nil,
                                   text: turn.text,
-                                  isError: turn.isError ?? false)
+                                  isError: turn.isError ?? false,
+                                  activity: role == .assistant
+                                      ? ActivityFold.steps(fromTools: turn.tools) : nil)
         }
         persistThreads()
     }
@@ -1803,7 +1805,8 @@ final class AppModel {
         let copiedMessages = thread.messages.map { message in
             DisplayMessage(role: message.role, familiarId: message.familiarId,
                            text: message.text, isError: message.isError,
-                           attachmentDataUrls: message.attachmentDataUrls)
+                           attachmentDataUrls: message.attachmentDataUrls,
+                           activity: message.activity)
         }
         let copy = ChatThread(title: "\(thread.title) (copy)",
                               familiarIds: thread.familiarIds,

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -19,8 +19,12 @@ struct DisplayMessage: Identifiable, Codable, Hashable {
     /// Composed while the desktop was unreachable; waiting for reconnect.
     /// Optional so messages persisted before offline compose still decode.
     var queued: Bool?
+    /// Agent working steps (tool calls / progress lines) surfaced while this
+    /// assistant reply streamed. Optional so older persisted messages decode.
+    var activity: [ActivityStep]?
 
     var isQueued: Bool { queued == true }
+    var activitySteps: [ActivityStep] { activity ?? [] }
 }
 
 /// Plain Codable snapshot used for on-disk persistence.
@@ -207,7 +211,7 @@ final class ChatThread: Identifiable, Hashable {
               let familiarId = messages[idx].familiarId else { return }
         let prompt = messages[..<idx].last(where: { $0.role == .user })?.text ?? ""
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        mutate(messageId) { $0.text = ""; $0.isError = false; $0.streaming = true }
+        mutate(messageId) { $0.text = ""; $0.isError = false; $0.streaming = true; $0.activity = nil }
         updatedAt = Date()
         onChange()
         Task { await self.stream(familiarId: familiarId, prompt: prompt,
@@ -254,7 +258,9 @@ final class ChatThread: Identifiable, Hashable {
             return DisplayMessage(role: role,
                                   familiarId: role == .assistant ? familiarId : nil,
                                   text: turn.text,
-                                  isError: turn.isError ?? false)
+                                  isError: turn.isError ?? false,
+                                  activity: role == .assistant
+                                      ? ActivityFold.steps(fromTools: turn.tools) : nil)
         }
         updatedAt = Date()
     }
@@ -307,7 +313,12 @@ final class ChatThread: Identifiable, Hashable {
                 if let id = frame.id { cursor = id }
             }
             flush(coalescer, into: messageId, onChange: onChange)
-            mutate(messageId) { $0.streaming = false }
+            mutate(messageId) {
+                $0.streaming = false
+                if let settled = ActivityFold.settle($0.activitySteps, success: true) {
+                    $0.activity = settled
+                }
+            }
         } catch {
             // Transport interruption (network handoff, backgrounding, desktop
             // blip). The run is usually STILL LIVE server-side — re-attach to
@@ -339,6 +350,9 @@ final class ChatThread: Identifiable, Hashable {
                     mutate(messageId) {
                         if $0.text.isEmpty { $0.text = error.localizedDescription }
                         $0.isError = true; $0.streaming = false
+                        if let settled = ActivityFold.settle($0.activitySteps, success: false) {
+                            $0.activity = settled
+                        }
                     }
                 }
             }
@@ -369,13 +383,37 @@ final class ChatThread: Identifiable, Hashable {
         case .done(let isError, let sid):
             if let sid, !sid.isEmpty { sessionIds[familiarId] = sid }
             flush(coalescer, into: messageId, onChange: onChange)
-            mutate(messageId) { $0.streaming = false; if isError { $0.isError = true } }
+            mutate(messageId) {
+                $0.streaming = false
+                if isError { $0.isError = true }
+                // A persisted "running" step would spin forever after reload —
+                // the turn is over, so settle the trail with its outcome.
+                if let settled = ActivityFold.settle($0.activitySteps, success: !isError) {
+                    $0.activity = settled
+                }
+            }
             sawDone = true
+        case .toolUse, .progress:
+            // Agent activity: orders of magnitude rarer than tokens, so each
+            // event mutates directly (no coalescing) — but drain buffered
+            // prose first so the text a step interrupted lands before the
+            // activity chip advances past it.
+            flush(coalescer, into: messageId, onChange: onChange)
+            var changed = false
+            mutate(messageId) {
+                guard let folded = ActivityFold.fold($0.activitySteps, event: event) else { return }
+                $0.activity = folded
+                changed = true
+            }
+            if changed { onChange() }
         case .error(let message):
             flush(coalescer, into: messageId, onChange: onChange)
             mutate(messageId) {
                 if $0.text.isEmpty { $0.text = message }
                 $0.isError = true; $0.streaming = false
+                if let settled = ActivityFold.settle($0.activitySteps, success: false) {
+                    $0.activity = settled
+                }
             }
         default:
             break
@@ -456,6 +494,10 @@ final class ChatThread: Identifiable, Hashable {
             $0.text = reply.text
             $0.isError = reply.isError ?? false
             $0.streaming = false
+            if let settled = ActivityFold.settle($0.activitySteps,
+                                                 success: !(reply.isError ?? false)) {
+                $0.activity = settled
+            }
         }
         return true
     }
@@ -490,7 +532,8 @@ final class ChatThread: Identifiable, Hashable {
         if let reply = convo.turns[(lastUser + 1)...].last(where: { $0.role == "assistant" }) {
             let insertAt = messages.firstIndex(where: { $0.isQueued }) ?? messages.endIndex
             messages.insert(DisplayMessage(role: .assistant, familiarId: familiarId,
-                                           text: reply.text, isError: reply.isError ?? false),
+                                           text: reply.text, isError: reply.isError ?? false,
+                                           activity: ActivityFold.steps(fromTools: reply.tools)),
                             at: insertAt)
             updatedAt = Date()
         }

--- a/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// Live "what is the familiar doing" trail for an assistant reply.
+///
+/// While the reply streams, a compact chip narrates the newest running step
+/// ("Bash — ls src/"); once the turn finishes it collapses to a one-line
+/// summary ("Ran 4 tools"). Tapping either state expands the recent steps
+/// with status glyphs, detail lines, and durations.
+struct AgentActivityView: View {
+    let steps: [ActivityStep]
+    /// Whether the owning bubble is still streaming — the only state that may
+    /// animate a spinner, so a persisted step can never spin after reload.
+    let streaming: Bool
+
+    @State private var expanded = false
+    @Environment(\.chrome) private var chrome
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Expanded list cap — the tail is where the action is, and a bubble
+    /// shouldn't scroll for pages of settled steps.
+    private static let expandedCap = 30
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            chipButton
+            if expanded {
+                stepList
+                    .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    // MARK: - Collapsed chip
+
+    private var chipButton: some View {
+        Button {
+            withAnimation(reduceMotion ? nil : .snappy(duration: 0.22)) {
+                expanded.toggle()
+            }
+            Haptics.tap()
+        } label: {
+            HStack(spacing: 6) {
+                if streaming {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .tint(chrome.textSecondary)
+                } else {
+                    Image(systemName: steps.contains(where: { $0.status == .error })
+                            ? "exclamationmark.triangle.fill" : "hammer.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text(chipLabel)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    // A ticking label shouldn't pop — crossfade between steps.
+                    .contentTransition(reduceMotion ? .identity : .opacity)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(expanded ? 180 : 0))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .glassFill(.control, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .animation(reduceMotion ? nil : .snappy(duration: 0.2), value: chipLabel)
+        .accessibilityLabel(accessibilitySummary)
+        .accessibilityHint(expanded ? "Hides the step list." : "Shows the step list.")
+    }
+
+    private var chipLabel: String {
+        if streaming, let current = steps.currentStep {
+            if let detail = current.detail, !detail.isEmpty {
+                return "\(current.title) — \(detail)"
+            }
+            return current.title
+        }
+        return steps.summaryLabel
+    }
+
+    private var accessibilitySummary: String {
+        streaming ? "Agent activity: running \(steps.currentStep?.title ?? "step")"
+                  : "Agent activity: \(steps.summaryLabel)"
+    }
+
+    // MARK: - Expanded steps
+
+    private var stepList: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if steps.count > Self.expandedCap {
+                Text("Earlier steps omitted — showing the last \(Self.expandedCap).")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            ForEach(steps.suffix(Self.expandedCap)) { step in
+                stepRow(step)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .glassFill(.raised, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func stepRow(_ step: ActivityStep) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            statusGlyph(step)
+                .frame(width: 14)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(step.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                if let detail = step.detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 8)
+            if let duration = Self.durationLabel(step.durationMs) {
+                Text(duration)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder private func statusGlyph(_ step: ActivityStep) -> some View {
+        switch step.status {
+        case .running where streaming:
+            ProgressView().controlSize(.mini).tint(chrome.textSecondary)
+        case .running:
+            // Stream over but never settled (transport drop mid-step).
+            Image(systemName: "clock")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        case .ok:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        case .error:
+            Image(systemName: "xmark.circle.fill")
+                .font(.caption2)
+                .foregroundStyle(Color.red)
+        }
+    }
+
+    /// "480ms", "1.2s", "2m 05s" — compact enough for a trailing column.
+    static func durationLabel(_ durationMs: Int?) -> String? {
+        guard let ms = durationMs, ms >= 0 else { return nil }
+        if ms < 1000 { return "\(ms)ms" }
+        let seconds = Double(ms) / 1000
+        if seconds < 60 { return String(format: "%.1fs", seconds) }
+        let minutes = Int(seconds) / 60
+        let rest = Int(seconds) % 60
+        return String(format: "%dm %02ds", minutes, rest)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -222,6 +222,13 @@ struct MessageBubble: View {
                     attachmentImages
                         .contextMenu { messageActions }
                 }
+                // What the familiar is doing (tool calls / progress) — live
+                // while streaming, a collapsed summary once finished.
+                if !isUser, !message.activitySteps.isEmpty {
+                    AgentActivityView(steps: message.activitySteps,
+                                      streaming: message.streaming)
+                        .padding(.leading, 2)
+                }
                 // Hide the (empty) text bubble for image-only messages.
                 if !parsed.visible.isEmpty || message.attachmentDataUrls.isEmpty {
                     bubble

--- a/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
@@ -1,0 +1,259 @@
+import XCTest
+@testable import CovenCave
+
+/// ActivityFold turns raw `tool_use`/`progress` stream events into the
+/// message's activity trail. The rules under test: keyed tool updates (start
+/// appends, settle updates in place — replay-safe), progress dedupe against
+/// the latest step, detail capping, the steps bound, terminal settling, and
+/// the persisted-history mapping.
+final class AgentActivityTests: XCTestCase {
+
+    private func toolEvent(id: String? = "t1", name: String = "Bash",
+                           input: String? = nil, output: String? = nil,
+                           status: String? = "running",
+                           durationMs: Int? = nil) -> StreamEvent {
+        .toolUse(id: id, name: name, input: input, output: output,
+                 status: status, durationMs: durationMs)
+    }
+
+    private func progressEvent(id: String? = nil, label: String,
+                               detail: String? = nil, status: String? = "running",
+                               durationMs: Int? = nil) -> StreamEvent {
+        .progress(id: id, label: label, detail: detail, status: status,
+                  durationMs: durationMs)
+    }
+
+    // MARK: - Tool folding
+
+    func testToolStartAppendsARunningStep() {
+        let steps = ActivityFold.fold([], event: toolEvent(input: "ls -la"))
+        XCTAssertEqual(steps?.count, 1)
+        XCTAssertEqual(steps?[0].id, "t1")
+        XCTAssertEqual(steps?[0].kind, .tool)
+        XCTAssertEqual(steps?[0].title, "Bash")
+        XCTAssertEqual(steps?[0].detail, "ls -la")
+        XCTAssertEqual(steps?[0].status, .running)
+    }
+
+    func testToolSettleUpdatesItsStepInPlace() {
+        let started = ActivityFold.fold([], event: toolEvent(input: "ls"))!
+        let settled = ActivityFold.fold(started, event: toolEvent(status: "ok", durationMs: 420))
+        XCTAssertEqual(settled?.count, 1, "settle must not append a second step")
+        XCTAssertEqual(settled?[0].status, .ok)
+        XCTAssertEqual(settled?[0].durationMs, 420)
+        XCTAssertEqual(settled?[0].detail, "ls", "settle keeps the start's input")
+    }
+
+    func testToolErrorStatusIsPreserved() {
+        let started = ActivityFold.fold([], event: toolEvent())!
+        let settled = ActivityFold.fold(started, event: toolEvent(status: "error"))
+        XCTAssertEqual(settled?[0].status, .error)
+    }
+
+    func testReplayingAnAlreadyAppliedSettleIsANoOp() {
+        // Mid-turn resume replays frames past the cursor — re-applying an
+        // identical settle must report "no change" so the UI isn't re-notified.
+        let started = ActivityFold.fold([], event: toolEvent())!
+        let settled = ActivityFold.fold(started, event: toolEvent(status: "ok", durationMs: 100))!
+        XCTAssertNil(ActivityFold.fold(settled, event: toolEvent(status: "ok", durationMs: 100)))
+    }
+
+    func testToolWithoutIdAppendsEachTime() {
+        let first = ActivityFold.fold([], event: toolEvent(id: nil))!
+        let second = ActivityFold.fold(first, event: toolEvent(id: nil))!
+        XCTAssertEqual(second.count, 2, "id-less events can never be re-keyed")
+        XCTAssertNotEqual(second[0].id, second[1].id, "each gets a distinct identity")
+    }
+
+    func testDistinctToolIdsTrackIndependently() {
+        var steps = ActivityFold.fold([], event: toolEvent(id: "a", name: "Read"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "b", name: "Edit"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "a", name: "Read", status: "ok"))!
+        XCTAssertEqual(steps.map(\.status), [.ok, .running])
+    }
+
+    // MARK: - Progress folding
+
+    func testProgressAppendsAStep() {
+        let steps = ActivityFold.fold([], event: progressEvent(label: "Thinking…"))
+        XCTAssertEqual(steps?.count, 1)
+        XCTAssertEqual(steps?[0].kind, .progress)
+        XCTAssertEqual(steps?[0].title, "Thinking…")
+    }
+
+    func testRepeatedProgressLabelUpdatesTheLatestStep() {
+        let first = ActivityFold.fold([], event: progressEvent(label: "Compacting"))!
+        let second = ActivityFold.fold(first, event: progressEvent(label: "Compacting",
+                                                                   detail: "40%"))!
+        XCTAssertEqual(second.count, 1, "a re-emitted label advances in place")
+        XCTAssertEqual(second[0].detail, "40%")
+    }
+
+    func testNewProgressLabelAppends() {
+        let first = ActivityFold.fold([], event: progressEvent(label: "Thinking"))!
+        let second = ActivityFold.fold(first, event: progressEvent(label: "Writing"))!
+        XCTAssertEqual(second.map(\.title), ["Thinking", "Writing"])
+    }
+
+    func testProgressDoneStatusMapsToOk() {
+        let first = ActivityFold.fold([], event: progressEvent(label: "Indexing"))!
+        let done = ActivityFold.fold(first, event: progressEvent(label: "Indexing",
+                                                                 status: "done"))
+        XCTAssertEqual(done?[0].status, .ok)
+    }
+
+    func testEmptyProgressLabelIsIgnored() {
+        XCTAssertNil(ActivityFold.fold([], event: progressEvent(label: "")))
+    }
+
+    func testProgressBetweenToolsDoesNotSwallowAToolSettle() {
+        // tool start → progress → tool settle: the settle must find its step
+        // even though it is no longer last.
+        var steps = ActivityFold.fold([], event: toolEvent(id: "t9", name: "Bash"))!
+        steps = ActivityFold.fold(steps, event: progressEvent(label: "Streaming"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "t9", name: "Bash", status: "ok"))!
+        XCTAssertEqual(steps.count, 2)
+        XCTAssertEqual(steps[0].status, .ok)
+    }
+
+    // MARK: - Non-activity events
+
+    func testNonActivityEventsReportNoChange() {
+        XCTAssertNil(ActivityFold.fold([], event: .assistantChunk(text: "hi")))
+        XCTAssertNil(ActivityFold.fold([], event: .session(sessionId: "s")))
+        XCTAssertNil(ActivityFold.fold([], event: .done(isError: false, sessionId: nil)))
+    }
+
+    // MARK: - Caps
+
+    func testDetailIsCappedToOneShortLine() {
+        let long = String(repeating: "x", count: 500) + "\nsecond line"
+        let steps = ActivityFold.fold([], event: toolEvent(input: long))!
+        XCTAssertEqual(steps[0].detail?.count, ActivityFold.detailCap)
+        XCTAssertFalse(steps[0].detail?.contains("\n") ?? true)
+    }
+
+    func testStepListIsBoundedDroppingOldestFirst() {
+        var steps: [ActivityStep] = []
+        for n in 0..<(ActivityFold.maxSteps + 10) {
+            steps = ActivityFold.fold(steps, event: toolEvent(id: "t\(n)", name: "T\(n)"))!
+        }
+        XCTAssertEqual(steps.count, ActivityFold.maxSteps)
+        XCTAssertEqual(steps.first?.title, "T10", "oldest steps drop first")
+    }
+
+    // MARK: - Settling
+
+    func testSettleCoercesRunningStepsToTheTurnOutcome() {
+        var steps = ActivityFold.fold([], event: toolEvent(id: "a", status: "ok"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "b", name: "Edit"))!
+        let ok = ActivityFold.settle(steps, success: true)
+        XCTAssertEqual(ok?.map(\.status), [.ok, .ok])
+        let failed = ActivityFold.settle(steps, success: false)
+        XCTAssertEqual(failed?.map(\.status), [.ok, .error],
+                       "already-settled steps keep their own outcome")
+    }
+
+    func testSettleWithNothingRunningReportsNoChange() {
+        let steps = ActivityFold.fold([], event: toolEvent(status: "ok"))!
+        XCTAssertNil(ActivityFold.settle(steps, success: true))
+    }
+
+    // MARK: - Persisted history mapping
+
+    func testStepsFromPersistedToolsAreSettled() {
+        let tools = [
+            ToolCall(id: "1", name: "Bash", input: "pwd", output: nil, status: "ok"),
+            ToolCall(id: "2", name: "Edit", input: nil, output: nil, status: "error"),
+            ToolCall(id: "3", name: "Read", input: nil, output: nil, status: nil),
+        ]
+        let steps = ActivityFold.steps(fromTools: tools)
+        XCTAssertEqual(steps?.map(\.status), [.ok, .error, .ok],
+                       "persisted calls are settled — unknown reads as ok, never running")
+        XCTAssertEqual(steps?[0].detail, "pwd")
+    }
+
+    func testStepsFromNilOrEmptyToolsIsNil() {
+        XCTAssertNil(ActivityFold.steps(fromTools: nil))
+        XCTAssertNil(ActivityFold.steps(fromTools: []))
+    }
+
+    // MARK: - Summaries
+
+    func testSummaryLabelCountsToolsAndFailures() {
+        var steps = ActivityFold.fold([], event: toolEvent(id: "a", status: "ok"))!
+        XCTAssertEqual(steps.summaryLabel, "Ran 1 tool")
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "b", name: "Edit", status: "error"))!
+        XCTAssertEqual(steps.summaryLabel, "Ran 2 tools · 1 failed")
+    }
+
+    func testSummaryLabelForProgressOnlyTurns() {
+        let steps = ActivityFold.fold([], event: progressEvent(label: "Thinking"))!
+        XCTAssertEqual(steps.summaryLabel, "1 step")
+    }
+
+    func testCurrentStepPrefersTheNewestRunningStep() {
+        var steps = ActivityFold.fold([], event: toolEvent(id: "a", name: "Read"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "a", name: "Read", status: "ok"))!
+        steps = ActivityFold.fold(steps, event: toolEvent(id: "b", name: "Edit"))!
+        XCTAssertEqual(steps.currentStep?.title, "Edit")
+        let allSettled = ActivityFold.settle(steps, success: true)!
+        XCTAssertEqual(allSettled.currentStep?.title, "Edit",
+                       "falls back to the newest step once everything settled")
+    }
+
+    // MARK: - Stream decoding
+
+    func testDecodeToolUseCarriesIdStatusAndDuration() throws {
+        let json = #"{"kind":"tool_use","id":"t1","name":"Bash","input":"ls","status":"ok","durationMs":123}"#
+        guard case .toolUse(let id, let name, let input, _, let status, let durationMs)? =
+                StreamEvent.decode(json) else {
+            return XCTFail("expected a toolUse event")
+        }
+        XCTAssertEqual(id, "t1")
+        XCTAssertEqual(name, "Bash")
+        XCTAssertEqual(input, "ls")
+        XCTAssertEqual(status, "ok")
+        XCTAssertEqual(durationMs, 123)
+    }
+
+    func testDecodeProgressCarriesIdAndStatus() throws {
+        let json = #"{"kind":"progress","id":"p1","label":"Thinking","status":"running"}"#
+        guard case .progress(let id, let label, _, let status, _)? = StreamEvent.decode(json) else {
+            return XCTFail("expected a progress event")
+        }
+        XCTAssertEqual(id, "p1")
+        XCTAssertEqual(label, "Thinking")
+        XCTAssertEqual(status, "running")
+    }
+
+    // MARK: - Snapshot compatibility
+
+    func testMessagesPersistedBeforeActivityStillDecode() throws {
+        let legacy = #"{"id":"m1","role":"assistant","text":"hi","streaming":false,"isError":false,"createdAt":0,"attachmentDataUrls":[]}"#
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let message = try decoder.decode(DisplayMessage.self, from: Data(legacy.utf8))
+        XCTAssertNil(message.activity)
+        XCTAssertEqual(message.activitySteps, [])
+    }
+
+    func testActivityRoundTripsThroughTheSnapshotEncoding() throws {
+        var message = DisplayMessage(role: .assistant, familiarId: "nova", text: "done")
+        message.activity = ActivityFold.fold([], event: toolEvent(input: "ls", status: "ok",
+                                                                  durationMs: 5))
+        let data = try JSONEncoder().encode(message)
+        let decoded = try JSONDecoder().decode(DisplayMessage.self, from: data)
+        XCTAssertEqual(decoded.activitySteps, message.activitySteps)
+    }
+
+    // MARK: - Duration formatting
+
+    func testDurationLabelFormats() {
+        XCTAssertEqual(AgentActivityView.durationLabel(480), "480ms")
+        XCTAssertEqual(AgentActivityView.durationLabel(1_200), "1.2s")
+        XCTAssertEqual(AgentActivityView.durationLabel(125_000), "2m 05s")
+        XCTAssertNil(AgentActivityView.durationLabel(nil))
+        XCTAssertNil(AgentActivityView.durationLabel(-1))
+    }
+}


### PR DESCRIPTION
## What

For an agent app, the biggest daily-usability gap in the native iOS app was a **silent screen during tool-heavy turns**: `StreamEvent` decoded `tool_use`/`progress` frames but `ChatThread.apply` silently dropped them. This PR surfaces them as a live activity trail on the streaming assistant bubble.

- **While streaming:** a chip above the bubble ticks through the current step ("Bash — ls -la…") with a spinner.
- **When settled:** collapses to a summary ("Ran 4 tools · 1 failed"), persisted in the thread snapshot.
- **Tap to expand:** compact step list with status glyphs, monospaced detail, and per-step durations.

## How

- `Models/AgentActivity.swift` (new): `ActivityStep` + `ActivityFold` pure fold logic — keyed in-place tool updates (same-id start→settle, replay-safe for mid-turn resume), progress dedupe against the latest step, one-line detail cap (140), bounded list (120, oldest dropped), `settle()` coercing running steps at turn end, `steps(fromTools:)` hydration from persisted `ToolCall` history.
- `StreamEvent`: `.progress`/`.toolUse` now carry the `id` + `durationMs` the server already emits (`src/lib/chat-tool-events.ts` envelopes).
- `ChatThread.apply`: folds activity into the streaming message (flushing the token coalescer first so interleaved prose lands in order); `done`/`error`/transport-error/resync paths all settle running steps so a persisted snapshot can never show a spinner. `retry()` clears activity; `reload`/adopt/history-load map persisted tools into settled steps.
- `Views/AgentActivityView.swift` (new): chip + expandable list; Reduce Motion gated; VoiceOver labels/hints.
- `Views/MessageBubble.swift`: renders the chip above assistant bubbles (Equatable perf pin unaffected — activity is part of `message` equality).

## Verification

- `xcodegen generate` + `xcodebuild build` (iPhone 16 Pro sim): **BUILD SUCCEEDED**
- `xcodebuild test -only-testing:CovenCaveTests/AgentActivityTests -only-testing:CovenCaveTests/TranscriptRowsTests`: **TEST SUCCEEDED** (28 new tests: fold/settle/replay/caps/decode/snapshot-compat/summary/duration + TranscriptRows regression)
- Legacy snapshot compatibility covered by test (messages persisted before `activity` decode fine).

Swift isn't built in CI — verification is local, evidence recorded in bead `cave-l7o3`.

## Notes

- UI/UX plan workstream 1 of 5 (bead cave-l7o3). Workstream 2 (turn notifications + chat Live Activity) builds on these activity labels.
- Group fan-out path in `AppModel.streamText` (Canvas) intentionally unchanged — out of scope.