### PR TITLE
fix(familiar): hide Coven Code from the runtime binding pickers

### DIFF
--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -30,7 +30,7 @@ import { deriveFamiliarSectionData } from "@/lib/familiar-tab-section-model";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
-import type { AdapterReport } from "@/lib/harness-adapters";
+import { isBindableRuntimeChoice, type AdapterReport } from "@/lib/harness-adapters";
 import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { listVoiceProviders } from "@/lib/voice/registry";
 import { catalogForRuntime } from "@/lib/runtime-models";
@@ -99,11 +99,15 @@ function FamiliarIdentityHero({
   const runtimeValue = familiar.harnessOverride ?? "";
   const runtimeOptions: StandardSelectOption<string>[] = [
     { value: "", label: `Default${defaultHarness ? ` · ${defaultHarness.label}` : ""}`, detail: "Inherit the cave runtime" },
-    ...harnesses.map((h) => ({
-      value: h.id,
-      label: h.label,
-      detail: [h.version, h.installed ? null : "not installed"].filter(Boolean).join(" · ") || undefined,
-    })),
+    // Same binding-picker policy as the Studio Brain tab: tool installs the
+    // daemon reports (Coven Code) aren't per-familiar runtime choices.
+    ...harnesses
+      .filter((h) => isBindableRuntimeChoice(h.id))
+      .map((h) => ({
+        value: h.id,
+        label: h.label,
+        detail: [h.version, h.installed ? null : "not installed"].filter(Boolean).join(" · ") || undefined,
+      })),
   ];
 
   // Model select: sourced from the same runtime → provider catalog the chat

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -78,8 +78,8 @@ assert.match(
 );
 assert.match(
   source,
-  /label: "Available runtimes"[\s\S]{0,240}harnesses\.map/,
-  "Other available runtimes should be grouped below the inherited default option",
+  /label: "Available runtimes"[\s\S]{0,360}harnesses\s*\.filter\(\(h\) => isBindableRuntimeChoice\(h\.id\)\)[\s\S]{0,120}\.map/,
+  "Other available runtimes group below the inherited default, filtered to bindable choices (no Coven Code)",
 );
 assert.match(
   source,

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/daemon-sync-status";
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import { StandardSelect, type StandardSelectGroup } from "@/components/ui/select";
+import { isBindableRuntimeChoice } from "@/lib/harness-adapters";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import type { RuntimeModelOption } from "@/lib/grok-build";
 import { useRuntimeModelOptions } from "@/lib/use-runtime-model-options";
@@ -585,10 +586,15 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                       { value: "", label: `Inherit workspace default: ${defaultHarnessLabel}` },
                       {
                         label: "Available runtimes",
-                        options: harnesses.map((h) => ({
-                          value: h.id,
-                          label: `${h.label}${h.installed ? "" : " (not installed)"}`,
-                        })),
+                        // Binding-picker policy: the daemon's adapter list
+                        // includes tool installs (Coven Code) that aren't
+                        // per-familiar runtime choices.
+                        options: harnesses
+                          .filter((h) => isBindableRuntimeChoice(h.id))
+                          .map((h) => ({
+                            value: h.id,
+                            label: `${h.label}${h.installed ? "" : " (not installed)"}`,
+                          })),
                       } satisfies StandardSelectGroup<string>,
                     ]}
                   />

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -10,6 +10,7 @@ import {
   covenHelpSupportsAdapterList,
   covenRunSupportsModelFlag,
   covenRunSupportsAddDirFlag,
+  isBindableRuntimeChoice,
   isSummonableLocalHarness,
   isTrustedChatHarness,
   isTrustedOnboardingHarness,
@@ -113,6 +114,15 @@ assert.equal(isSummonableLocalHarness("grok"), true);
 assert.equal(isSummonableLocalHarness("openclaw"), false, "OpenClaw is summoned through the dedicated agent vessel");
 assert.equal(isSummonableLocalHarness("coven-code"), false, "Coven Code is an app/tool install, not a familiar runtime choice");
 assert.equal(isSummonableLocalHarness("opencode"), false, "registry runtimes stay hidden until the creation flow has explicit support");
+
+// Binding pickers (Studio Brain tab, Familiar tab hero) hide tool installs the
+// daemon's adapter list re-introduces past the COMPATIBILITY_ADAPTERS policy
+// exclusion. Everything else stays choosable, even not-yet-summonable runtimes.
+assert.equal(isBindableRuntimeChoice("coven-code"), false, "Coven Code never appears in runtime binding pickers");
+assert.equal(isBindableRuntimeChoice("Coven-Code"), false, "the exclusion is casing-proof against daemon spelling drift");
+assert.equal(isBindableRuntimeChoice("codex"), true);
+assert.equal(isBindableRuntimeChoice("openclaw"), true, "non-summonable runtimes remain bindable for existing familiars");
+assert.equal(isBindableRuntimeChoice("opencode"), true);
 
 assert.deepEqual(openClawAdapterReport(2), {
   id: "openclaw",

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -202,6 +202,20 @@ export function isSummonableLocalHarness(harness: string): boolean {
   return SUMMONABLE_LOCAL_HARNESSES.has(canonicalHarnessId(harness));
 }
 
+// Coven Code is an app/tool install the daemon still reports through
+// `coven adapter list`, not a per-familiar runtime — COMPATIBILITY_ADAPTERS
+// already policy-excludes it, but the daemon merge path re-introduces it into
+// /api/harnesses. Hidden from the runtime BINDING pickers (Studio Brain tab,
+// Familiar tab hero) for now; the adapters/settings surfaces still list it as
+// an installable tool.
+const BINDING_PICKER_EXCLUDED_HARNESSES = new Set(["coven-code"]);
+
+export function isBindableRuntimeChoice(harness: string): boolean {
+  // canonicalHarnessId echoes unknown ids in their original casing — the
+  // exclusion must still catch "Coven-Code" however the daemon spells it.
+  return !BINDING_PICKER_EXCLUDED_HARNESSES.has(canonicalHarnessId(harness).trim().toLowerCase());
+}
+
 // The single display-label authority for runtime/harness ids: curated Cave
 // copy wins, then the synced registry's accepted label, then the raw id.
 // UI surfaces (runtime logo, capabilities map, adapter rows) should delegate


### PR DESCRIPTION
## Summary

Coven Code showed up as a choosable **Runtime** in the familiar's Studio Brain tab (and the Familiar-tab hero's Runtime select, which edits the same binding). It's an app/tool install, not a per-familiar runtime — `COMPATIBILITY_ADAPTERS` already policy-excludes it, but the daemon's `coven adapter list` merge path re-introduces it into `/api/harnesses`, past that exclusion.

- New `isBindableRuntimeChoice()` in `harness-adapters.ts` carries the policy to the binding pickers (casing-proof against daemon spelling drift).
- Both pickers — Studio Brain tab and Familiar-tab hero — filter their runtime options through it.
- Scope deliberately narrow ("for now"): the adapters/settings surfaces still list Coven Code as an installable tool, and non-summonable-but-bindable runtimes (openclaw, opencode) remain choosable.

## Testing
- `harness-adapters.test.ts`: new pins — coven-code excluded (both spellings), codex/openclaw/opencode stay bindable.
- `familiar-studio-brain-tab.test.ts`: runtime-group pin updated to require the bindable filter.
- Full `app` + `api` suites: 1126/1126 files pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)