### PR TITLE
Fix OpenClaw chat for Windows npm installs

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -197,13 +197,13 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /import \{ openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv, openClawSupportsUntrustedArgs \} from "@\/lib\/openclaw-bin";/,
-  "OpenClaw native chat should use the Windows-aware binary resolver instead of spawning a bare command",
+  /import \{ openClawLaunchCommand, openClawSpawnEnv \} from "@\/lib\/openclaw-bin";/,
+  "OpenClaw native chat should use the spawn-safe Windows-aware launcher",
 );
 assert.match(
   chatRoute,
-  /if \(!openClawSupportsUntrustedArgs\(openclawCommand\)\)[\s\S]*openclaw_unsafe_shell/,
-  "OpenClaw chat should fail closed before passing untrusted prompts to shell-only Windows shims",
+  /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*if \(openclawLaunch\.unresolvedWindowsShim\)[\s\S]*openclaw_unsafe_shell/,
+  "OpenClaw chat should fail closed when it cannot resolve a Windows npm shim's JavaScript target",
 );
 
 assert.match(
@@ -238,8 +238,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const openclawCommand = openClawBin\(\);[\s\S]*const spawnArgv = openClawSpawnArgs\(argv, openclawCommand\);[\s\S]*spawn\(openclawCommand, spawnArgv,[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: openClawNeedsShell\(openclawCommand\)/,
-  "OpenClaw chat should only spawn an OpenClaw command that can receive untrusted prompt argv safely",
+  /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*const spawnArgv = \[\.\.\.openclawLaunch\.fixedArgs, \.\.\.argv\];[\s\S]*spawn\(openclawLaunch\.command, spawnArgv,[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: false/,
+  "OpenClaw chat should invoke resolved npm shims through Node without shell parsing untrusted prompts",
 );
 
 // Session persistence contract (regression: chats forked into new sessions

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -74,7 +74,7 @@ import { openRunBuffer, type RunBufferHandle } from "@/lib/server/chat-stream-bu
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects } from "@/lib/cave-projects";
 import { chatProjectAccessId } from "@/lib/chat-project-access";
-import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv, openClawSupportsUntrustedArgs } from "@/lib/openclaw-bin";
+import { openClawLaunchCommand, openClawSpawnEnv } from "@/lib/openclaw-bin";
 import {
   OpenClawAgentResolutionError,
   extractOpenClawSessionId,
@@ -440,19 +440,19 @@ function openClawChatResponse(args: {
       const agentId = agentBinding.openclawAgentId;
       pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", `${agentId} (${agentBinding.source})`);
       const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
-      const openclawCommand = openClawBin();
-      if (!openClawSupportsUntrustedArgs(openclawCommand)) {
+      const openclawLaunch = openClawLaunchCommand();
+      if (openclawLaunch.unresolvedWindowsShim) {
         pushProgress(
           "openclaw-start",
           "OpenClaw bridge cannot start safely",
           "error",
-          "The resolved OpenClaw Windows .cmd shim requires shell parsing, so Cave cannot pass chat prompts to it safely. Install or configure a native openclaw executable with OPENCLAW_BIN.",
+          "The resolved OpenClaw Windows npm shim could not be mapped to its JavaScript entry point. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
         );
         push({
           kind: "error",
           code: "openclaw_unsafe_shell",
           message:
-            "OpenClaw chat is unavailable because the resolved Windows .cmd shim requires unsafe shell parsing. Install or configure a native openclaw executable with OPENCLAW_BIN.",
+            "OpenClaw chat is unavailable because its Windows npm shim could not be launched without shell parsing. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
         });
         push({
           kind: "done",
@@ -462,7 +462,7 @@ function openClawChatResponse(args: {
         close();
         return;
       }
-      const spawnArgv = openClawSpawnArgs(argv, openclawCommand);
+      const spawnArgv = [...openclawLaunch.fixedArgs, ...argv];
       let cwd: string;
       try {
         cwd = await resolveLocalRuntimeCwd(
@@ -499,11 +499,11 @@ function openClawChatResponse(args: {
         sessionKey: openClawSessionKey(conversationId),
       };
       pushProgress("openclaw-start", "Starting OpenClaw bridge", "running", cwd);
-      const child = spawn(openclawCommand, spawnArgv, {
+      const child = spawn(openclawLaunch.command, spawnArgv, {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
         env: openClawSpawnEnv(),
-        shell: openClawNeedsShell(openclawCommand),
+        shell: false,
       });
       pushProgress("openclaw-start", "OpenClaw bridge started", "done");
       pushProgress("openclaw-response", "Waiting for OpenClaw response", "running");

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -37,6 +37,11 @@ assert.match(
 );
 assert.match(
   src,
+  /export function openClawLaunchCommandForBinary\(binary: string\): CovenLaunchCommand[\s\S]*covenLaunchCommandForBinary\(binary, shimPlatform\)/,
+  "OpenClaw Windows npm shims should launch their JavaScript target with Node instead of cmd.exe",
+);
+assert.match(
+  src,
   /quoteWindowsShellArg\(arg: string\)[\s\S]*return `"\$\{escaped\}"`/,
   "OpenClaw Windows shell quoting should preserve a multi-word --message as one CLI argument",
 );

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -6,7 +6,11 @@
 
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
-import { covenSpawnEnv } from "./coven-bin";
+import {
+  covenLaunchCommandForBinary,
+  covenSpawnEnv,
+  type CovenLaunchCommand,
+} from "./coven-bin";
 
 let cachedBin: string | null = null;
 
@@ -95,6 +99,21 @@ export function openClawNeedsShell(bin = openClawBin()): boolean {
 
 export function openClawSupportsUntrustedArgs(bin = openClawBin()): boolean {
   return !openClawNeedsShell(bin);
+}
+
+/**
+ * Start OpenClaw without routing a chat prompt through cmd.exe. npm's Windows
+ * shims are batch files, but their final target is a JavaScript entry point;
+ * resolve that target and execute it with the running Node binary instead.
+ */
+export function openClawLaunchCommandForBinary(binary: string): CovenLaunchCommand {
+  const shimPlatform = /\.(cmd|bat)$/i.test(binary) ? "win32" : process.platform;
+  return covenLaunchCommandForBinary(binary, shimPlatform);
+}
+
+/** A spawn-safe OpenClaw command for either a native executable or npm shim. */
+export function openClawLaunchCommand(): CovenLaunchCommand {
+  return openClawLaunchCommandForBinary(openClawBin());
 }
 
 const WINDOWS_SHELL_META_RE = /[\s"&|<>()^%!]/;


### PR DESCRIPTION
## Summary
- launch OpenClaw Windows npm shims through their JavaScript entry point and Node
- keep chat prompts out of cmd.exe shell parsing
- preserve a clear failure when a shim target cannot be resolved

## Validation
- `node --experimental-strip-types src/lib/openclaw-bin.test.ts`
- `node --experimental-strip-types src/app/api/chat/send/harness-routing-host-session.test.ts`
- direct Windows OpenClaw shim resolution confirmed to `node.exe …/openclaw.mjs`

## Note
- `pnpm typecheck` was not runnable in the fresh worktree because dependencies are absent (`node_modules` missing).
- A live OpenClaw turn is currently blocked by its gateway credentials, not Cave routing.