### PR TITLE
feat(ios): turn-completion notifications + chat Live Activity (cave-eh4a)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -31,8 +31,8 @@ struct CovenCaveApp: App {
                 .preferredColorScheme(resolved.scheme)
                 .task {
                     app.startConnectionSupervisor()
-                    // Route notification taps to the reminders list, and show
-                    // reminder banners while the app is foregrounded.
+                    // Route notification taps (reminders, chat replies) to the
+                    // deep-link handler, and show banners while foregrounded.
                     notificationDelegate.onOpen = { app.handleDeepLink($0) }
                     UNUserNotificationCenter.current().delegate = notificationDelegate
                     if app.connection != nil {

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/ChatActivityAttributes.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/ChatActivityAttributes.swift
@@ -1,0 +1,15 @@
+import ActivityKit
+import Foundation
+
+/// Shared between the app (which starts/ends the activity) and the widget
+/// extension (which renders it). The thread + familiar name and start time are
+/// fixed for the life of the turn; only the status label changes as the
+/// agent's activity trail advances.
+struct ChatActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var statusLabel: String
+    }
+    var threadId: String
+    var familiarName: String
+    var startedAt: Date
+}

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/LiveActivityManager.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/LiveActivityManager.swift
@@ -50,4 +50,47 @@ final class LiveActivityManager {
         current = nil
         currentTaskId = nil
     }
+
+    // MARK: - Chat turns
+
+    private var currentChat: Activity<ChatActivityAttributes>?
+    /// The thread whose running turn is on the Lock Screen, if any.
+    private(set) var currentChatThreadId: String?
+
+    /// Start (or retarget) the chat-turn Live Activity. One at a time: a new
+    /// turn in another thread takes the slot over.
+    func startChat(threadId: String, familiarName: String) async {
+        guard isSupported else { return }
+        if currentChatThreadId == threadId, currentChat != nil { return }
+        await endChat(threadId: nil)
+        let attributes = ChatActivityAttributes(threadId: threadId,
+                                                familiarName: familiarName,
+                                                startedAt: Date())
+        let state = ChatActivityAttributes.ContentState(statusLabel: "Working…")
+        do {
+            currentChat = try Activity.request(attributes: attributes,
+                                               content: .init(state: state, staleDate: nil))
+            currentChatThreadId = threadId
+        } catch {
+            currentChat = nil
+            currentChatThreadId = nil
+        }
+    }
+
+    /// Advance the island's status line ("Bash", "Reading files…").
+    func updateChat(threadId: String, statusLabel: String) async {
+        guard let activity = currentChat, currentChatThreadId == threadId else { return }
+        let state = ChatActivityAttributes.ContentState(statusLabel: statusLabel)
+        await activity.update(.init(state: state, staleDate: nil))
+    }
+
+    /// End the chat activity. Pass nil to end regardless of owner (replacement).
+    func endChat(threadId: String?) async {
+        guard let activity = currentChat else { currentChatThreadId = nil; return }
+        if let threadId, currentChatThreadId != threadId { return }
+        await activity.end(.init(state: activity.content.state, staleDate: nil),
+                           dismissalPolicy: .immediate)
+        currentChat = nil
+        currentChatThreadId = nil
+    }
 }

--- a/apps/ios/CovenCave/CovenCave/Notifications/ChatNotifications.swift
+++ b/apps/ios/CovenCave/CovenCave/Notifications/ChatNotifications.swift
@@ -1,0 +1,103 @@
+import Foundation
+import UserNotifications
+
+/// Local notifications for chat turns that finish while the app is in the
+/// background — send a prompt, pocket the phone, and the phone still tells you
+/// the reply landed. The pure decision/content helpers live here so they can
+/// be unit-tested; `ChatTurnNotifier` drives them from the stream lifecycle.
+///
+/// Identifiers are thread-scoped (`cave.chat.<threadId>`) so a newer reply in
+/// the same thread replaces the previous banner instead of stacking, and so
+/// `ReminderNotifications` (prefix `cave.reminder.`) never touches ours.
+@MainActor
+enum ChatNotifications {
+    static let idPrefix = "cave.chat."
+    /// Settings → Notifications toggle (default on; authorization still gates).
+    static let enabledKey = "cave.chat.notifications"
+    /// Longest reply preview shown in the banner body.
+    static let previewCap = 160
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+    }
+
+    // MARK: - Decision (pure)
+
+    /// Whether a finished turn should post a banner. Foreground turns are
+    /// visible in the transcript already; muted threads asked for silence;
+    /// the toggle is the global off-switch. Error turns DO notify — a failed
+    /// run is exactly what you want to learn about while away.
+    nonisolated static func shouldNotify(appActive: Bool, threadMuted: Bool,
+                                         enabled: Bool) -> Bool {
+        enabled && !appActive && !threadMuted
+    }
+
+    /// Banner body from the final reply: first non-empty line, capped. Errors
+    /// get a readable fallback when the message carries no text.
+    nonisolated static func preview(text: String, isError: Bool) -> String {
+        let firstLine = text.split(separator: "\n", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty } ?? ""
+        if firstLine.isEmpty {
+            return isError ? "The run failed." : "Reply ready."
+        }
+        let capped = firstLine.count > previewCap
+            ? String(firstLine.prefix(previewCap)) + "…" : firstLine
+        return isError ? "⚠️ \(capped)" : capped
+    }
+
+    // MARK: - Deep link (pure)
+
+    /// `covencave://thread/<id>` — routed by `AppModel.handleDeepLink` to the
+    /// existing `requestOpen` one-shot (same hook the chat list already uses).
+    nonisolated static func deepLinkURL(threadId: String) -> URL? {
+        var comps = URLComponents()
+        comps.scheme = "covencave"
+        comps.host = "thread"
+        comps.path = "/" + threadId
+        return comps.url
+    }
+
+    /// The thread id carried by a chat deep link, or nil for any other URL.
+    nonisolated static func threadId(fromDeepLink url: URL) -> String? {
+        guard url.scheme == "covencave", url.host == "thread" else { return nil }
+        let id = url.pathComponents.count > 1 ? url.pathComponents[1] : ""
+        return id.isEmpty ? nil : id
+    }
+
+    // MARK: - Posting
+
+    /// Ask once. Safe to call repeatedly — the system only prompts while the
+    /// status is undetermined; afterwards this is a cheap no-op.
+    static func requestAuthorizationIfNeeded() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+    }
+
+    /// Post the turn-completion banner. Tapping opens the thread.
+    static func post(threadId: String, title: String, body: String) async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .authorized
+                || settings.authorizationStatus == .provisional else { return }
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        content.threadIdentifier = idPrefix + threadId
+        if let url = deepLinkURL(threadId: threadId) {
+            content.userInfo = ["deepLink": url.absoluteString]
+        }
+        let request = UNNotificationRequest(identifier: idPrefix + threadId,
+                                            content: content, trigger: nil)
+        try? await center.add(request)
+    }
+
+    /// Opening a thread makes its banner stale — clear it from the shade.
+    static func removeDelivered(threadId: String) {
+        UNUserNotificationCenter.current()
+            .removeDeliveredNotifications(withIdentifiers: [idPrefix + threadId])
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Notifications/ChatTurnNotifier.swift
+++ b/apps/ios/CovenCave/CovenCave/Notifications/ChatTurnNotifier.swift
@@ -1,0 +1,81 @@
+import Foundation
+import UIKit
+
+/// Bridges the chat stream lifecycle to away-from-app surfaces: local
+/// notifications when a turn finishes while backgrounded, a Live Activity for
+/// the running turn (Dynamic Island / Lock Screen), and a background-task
+/// grace window so an in-flight stream can finish after the user pockets the
+/// phone. `ChatThread.stream` calls the three hooks; everything else is
+/// resolved here so the thread model stays UIKit-free beyond this seam.
+@MainActor
+final class ChatTurnNotifier {
+    static let shared = ChatTurnNotifier()
+    private init() {}
+
+    /// Set once at app construction — resolves familiar display names.
+    weak var app: AppModel?
+
+    /// One background grace window per in-flight turn (keyed by message id) so
+    /// backgrounding mid-stream leaves ~30s for the reply + banner to land.
+    private var graceTasks: [String: UIBackgroundTaskIdentifier] = [:]
+    /// Last status label pushed to the Live Activity — skip no-op updates.
+    private var lastStatusLabel: String?
+
+    /// A turn began streaming into `messageId`.
+    func turnStarted(thread: ChatThread, familiarId: String, messageId: String) {
+        let token = UIApplication.shared.beginBackgroundTask(withName: "cave.chat.turn") {
+            [weak self] in self?.endGrace(messageId)
+        }
+        if token != .invalid { graceTasks[messageId] = token }
+        guard ChatNotifications.isEnabled else { return }
+        Task { await ChatNotifications.requestAuthorizationIfNeeded() }
+        let name = familiarName(familiarId)
+        Task {
+            await LiveActivityManager.shared.startChat(threadId: thread.id,
+                                                       familiarName: name)
+        }
+    }
+
+    /// The running turn's activity trail advanced — mirror it on the island.
+    func turnStatus(thread: ChatThread, label: String?) {
+        guard let label, !label.isEmpty, label != lastStatusLabel else { return }
+        lastStatusLabel = label
+        Task {
+            await LiveActivityManager.shared.updateChat(threadId: thread.id,
+                                                        statusLabel: label)
+        }
+    }
+
+    /// The stream into `messageId` ended (any path — done, error, resync, or
+    /// re-queued offline). Posts the banner when the reply landed while the
+    /// app was away, and retires the Live Activity once the thread is idle.
+    func turnFinished(thread: ChatThread, messageId: String) {
+        defer { endGrace(messageId) }
+        if !thread.isStreaming {
+            lastStatusLabel = nil
+            Task { await LiveActivityManager.shared.endChat(threadId: thread.id) }
+        }
+        // Re-queued offline sends remove the placeholder — nothing landed.
+        guard let message = thread.messages.first(where: { $0.id == messageId }),
+              !message.streaming else { return }
+        let active = UIApplication.shared.applicationState == .active
+        guard ChatNotifications.shouldNotify(appActive: active,
+                                             threadMuted: thread.muted,
+                                             enabled: ChatNotifications.isEnabled)
+        else { return }
+        let title = message.familiarId.map(familiarName) ?? thread.title
+        let body = ChatNotifications.preview(text: message.text,
+                                             isError: message.isError)
+        let threadId = thread.id
+        Task { await ChatNotifications.post(threadId: threadId, title: title, body: body) }
+    }
+
+    private func familiarName(_ id: String) -> String {
+        app?.familiar(id)?.displayName ?? id
+    }
+
+    private func endGrace(_ messageId: String) {
+        guard let token = graceTasks.removeValue(forKey: messageId) else { return }
+        UIApplication.shared.endBackgroundTask(token)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -288,6 +288,7 @@ final class AppModel {
         loadFamiliarOrder()
         loadFamiliarViews()
         if connection != nil { connectionState = .checking }
+        ChatTurnNotifier.shared.app = self
     }
 
     func familiar(_ id: String) -> Familiar? {
@@ -554,6 +555,14 @@ final class AppModel {
         if url.host == "connect" {
             guard let invite = CaveInvite.parse(url.absoluteString) else { return }
             Task { await configure(host: invite.host, token: invite.token) }
+            return
+        }
+        // covencave://thread/<id> — a chat notification / Live Activity tap
+        // jumps straight into its thread via the existing one-shot intent.
+        if let threadId = ChatNotifications.threadId(fromDeepLink: url) {
+            if let thread = threads.first(where: { $0.id == threadId }) {
+                requestOpen(thread)
+            }
             return
         }
         guard let target = DeepLink(rawValue: url.host ?? "") else { return }
@@ -1741,7 +1750,7 @@ final class AppModel {
     }
 
     /// Mute or unmute a thread's notifications (persisted; honoured by the
-    /// notification path when it lands).
+    /// turn-completion notification path).
     func setThreadMuted(_ thread: ChatThread, _ muted: Bool) {
         guard let target = threads.first(where: { $0.id == thread.id }),
               target.muted != muted else { return }

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -296,6 +296,8 @@ final class ChatThread: Identifiable, Hashable {
         // (cave-h40l), so even a brand-new chat (no sessionId yet) can
         // re-attach mid-turn after a transport drop.
         let runId = UUID().uuidString
+        ChatTurnNotifier.shared.turnStarted(thread: self, familiarId: familiarId,
+                                            messageId: messageId)
         let body = CaveClient.SendBody(familiarId: familiarId, prompt: prompt,
                                        sessionId: sessionIds[familiarId],
                                        attachments: attachments.isEmpty ? nil : attachments,
@@ -359,6 +361,7 @@ final class ChatThread: Identifiable, Hashable {
         }
         updatedAt = Date()
         onChange()
+        ChatTurnNotifier.shared.turnFinished(thread: self, messageId: messageId)
     }
 
     /// Apply one stream event to the thread — shared by the original send
@@ -400,12 +403,17 @@ final class ChatThread: Identifiable, Hashable {
             // activity chip advances past it.
             flush(coalescer, into: messageId, onChange: onChange)
             var changed = false
+            var stepLabel: String?
             mutate(messageId) {
                 guard let folded = ActivityFold.fold($0.activitySteps, event: event) else { return }
                 $0.activity = folded
                 changed = true
+                stepLabel = folded.currentStep?.title
             }
-            if changed { onChange() }
+            if changed {
+                onChange()
+                ChatTurnNotifier.shared.turnStatus(thread: self, label: stepLabel)
+            }
         case .error(let message):
             flush(coalescer, into: messageId, onChange: onChange)
             mutate(messageId) {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -228,8 +228,10 @@ struct ChatView: View {
             if draft.isEmpty, let saved = UserDefaults.standard.string(forKey: draftKey) {
                 draft = saved
             }
-            // Opening the chat clears the unread badge for its familiar(s).
+            // Opening the chat clears the unread badge for its familiar(s) and
+            // any delivered reply banner for this thread.
             app.markFamiliarViewed(thread.familiarIds)
+            ChatNotifications.removeDelivered(threadId: thread.id)
         }
         // Persist every edit per-thread; send() clears the draft, which removes
         // the stored copy here so a sent message leaves nothing behind. Debounce

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -4,6 +4,7 @@ struct SettingsView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
+    @AppStorage(ChatNotifications.enabledKey) private var chatNotificationsEnabled = true
     @State private var editingHost: String = ""
     @State private var showDisconnectConfirm = false
     @State private var exportArchive: ExportArchive?
@@ -177,6 +178,14 @@ struct SettingsView: View {
 
     private var chatsSection: some View {
         Section {
+            Toggle(isOn: $chatNotificationsEnabled) {
+                Label("Reply notifications", systemImage: "bell.badge")
+                    .foregroundStyle(.primary)
+            }
+            .onChange(of: chatNotificationsEnabled) { _, enabled in
+                guard enabled else { return }
+                Task { await ChatNotifications.requestAuthorizationIfNeeded() }
+            }
             Button {
                 do {
                     exportArchive = ExportArchive(url: try app.exportAllThreadsZip())
@@ -191,7 +200,7 @@ struct SettingsView: View {
         } header: {
             Text("Chats")
         } footer: {
-            Text("Save every conversation as Markdown files in a single .zip.")
+            Text("Get notified when a familiar finishes replying while you're away. Muted chats stay silent. Export saves every conversation as Markdown files in a single .zip.")
         }
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/ChatNotificationsTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatNotificationsTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import CovenCave
+
+/// The notify/suppress decision, banner-body construction, and deep-link
+/// round-trip for chat turn-completion notifications. All pure logic — the
+/// UNUserNotificationCenter plumbing is intentionally not under test.
+final class ChatNotificationsTests: XCTestCase {
+
+    // MARK: - Notify/suppress decision
+
+    func testNotifiesWhenBackgroundedUnmutedAndEnabled() {
+        XCTAssertTrue(ChatNotifications.shouldNotify(appActive: false,
+                                                     threadMuted: false,
+                                                     enabled: true))
+    }
+
+    func testForegroundSuppresses() {
+        XCTAssertFalse(ChatNotifications.shouldNotify(appActive: true,
+                                                      threadMuted: false,
+                                                      enabled: true))
+    }
+
+    func testMutedThreadSuppresses() {
+        XCTAssertFalse(ChatNotifications.shouldNotify(appActive: false,
+                                                      threadMuted: true,
+                                                      enabled: true))
+    }
+
+    func testDisabledToggleSuppresses() {
+        XCTAssertFalse(ChatNotifications.shouldNotify(appActive: false,
+                                                      threadMuted: false,
+                                                      enabled: false))
+    }
+
+    // MARK: - Banner body
+
+    func testPreviewUsesTheFirstNonEmptyLine() {
+        XCTAssertEqual(ChatNotifications.preview(text: "\n\n  Done!  \nMore detail",
+                                                 isError: false),
+                       "Done!")
+    }
+
+    func testPreviewCapsLongReplies() {
+        let long = String(repeating: "a", count: 400)
+        let preview = ChatNotifications.preview(text: long, isError: false)
+        XCTAssertEqual(preview.count, ChatNotifications.previewCap + 1) // + ellipsis
+        XCTAssertTrue(preview.hasSuffix("…"))
+    }
+
+    func testErrorTurnsStillProduceABody() {
+        XCTAssertEqual(ChatNotifications.preview(text: "", isError: true),
+                       "The run failed.")
+        XCTAssertEqual(ChatNotifications.preview(text: "boom", isError: true),
+                       "⚠️ boom")
+    }
+
+    func testEmptySuccessGetsAFallbackBody() {
+        XCTAssertEqual(ChatNotifications.preview(text: "  \n ", isError: false),
+                       "Reply ready.")
+    }
+
+    // MARK: - Deep link round-trip
+
+    func testDeepLinkRoundTripsThreadId() throws {
+        let url = try XCTUnwrap(ChatNotifications.deepLinkURL(threadId: "T-123"))
+        XCTAssertEqual(url.absoluteString, "covencave://thread/T-123")
+        XCTAssertEqual(ChatNotifications.threadId(fromDeepLink: url), "T-123")
+    }
+
+    func testForeignURLsCarryNoThreadId() {
+        for raw in ["covencave://reminders", "covencave://thread", "covencave://thread/",
+                    "https://thread/abc", "covencave://tasks/xyz"] {
+            let url = URL(string: raw)!
+            XCTAssertNil(ChatNotifications.threadId(fromDeepLink: url), raw)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -58,6 +58,66 @@ struct TaskLiveActivity: Widget {
     }
 }
 
+// MARK: - Chat turn Live Activity
+
+/// The "familiar is working" Live Activity — mirrors a running chat turn on
+/// the Lock Screen and Dynamic Island, ticking through the agent's current
+/// step. Tapping anywhere deep-links back into the thread.
+struct ChatLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: ChatActivityAttributes.self) { context in
+            HStack(spacing: 12) {
+                Image(systemName: "bubble.left.and.text.bubble.right.fill")
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.attributes.familiarName)
+                        .font(.caption2).foregroundStyle(.secondary)
+                    Text(context.state.statusLabel)
+                        .font(.headline).lineLimit(2)
+                }
+                Spacer(minLength: 8)
+                Text(context.attributes.startedAt, style: .timer)
+                    .font(.title3.monospacedDigit())
+                    .frame(maxWidth: 64, alignment: .trailing)
+            }
+            .padding()
+            .activityBackgroundTint(Color.black.opacity(0.35))
+            .activitySystemActionForegroundColor(.primary)
+            .widgetURL(URL(string: "covencave://thread/\(context.attributes.threadId)"))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "bubble.left.and.text.bubble.right.fill")
+                        .foregroundStyle(.tint)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.attributes.startedAt, style: .timer)
+                        .font(.body.monospacedDigit())
+                        .frame(maxWidth: 64, alignment: .trailing)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.attributes.familiarName)
+                        .font(.subheadline.weight(.medium)).lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.statusLabel)
+                        .font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                }
+            } compactLeading: {
+                Image(systemName: "bubble.left.fill").foregroundStyle(.tint)
+            } compactTrailing: {
+                Text(context.attributes.startedAt, style: .timer)
+                    .font(.caption2.monospacedDigit())
+                    .frame(maxWidth: 44)
+            } minimal: {
+                Image(systemName: "bubble.left.fill").foregroundStyle(.tint)
+            }
+            .widgetURL(URL(string: "covencave://thread/\(context.attributes.threadId)"))
+        }
+    }
+}
+
 // MARK: - Home-screen "Up Next" widget
 
 struct UpNextEntry: TimelineEntry {
@@ -256,6 +316,7 @@ struct UpNextWidget: Widget {
 struct CovenCaveWidgetsBundle: WidgetBundle {
     var body: some Widget {
         TaskLiveActivity()
+        ChatLiveActivity()
         UpNextWidget()
         RemindersControl()
         TasksControl()

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -92,9 +92,9 @@ targets:
     dependencies:
       - target: CovenCave
 
-  # Widget extension hosting the "task running" Live Activity (Lock Screen +
-  # Dynamic Island) and the home-screen "Up Next" widget. Shares
-  # TaskActivityAttributes.swift + WidgetSnapshot.swift with the app target;
+  # Widget extension hosting the "task running" + "chat turn" Live Activities
+  # (Lock Screen + Dynamic Island) and the home-screen "Up Next" widget. Shares
+  # the ActivityAttributes files + WidgetSnapshot.swift with the app target;
   # the App Group lets the widget read the snapshot the app publishes.
   CovenCaveWidgets:
     type: app-extension
@@ -102,6 +102,7 @@ targets:
     sources:
       - path: CovenCaveWidgets
       - path: CovenCave/LiveActivity/TaskActivityAttributes.swift
+      - path: CovenCave/LiveActivity/ChatActivityAttributes.swift
       - path: CovenCave/LiveActivity/WidgetSnapshot.swift
       - path: CovenCave/Intents/WidgetReminderIntents.swift
     settings:


### PR DESCRIPTION
## What

UI/UX plan **workstream 2 of 5** — close the loop when you leave. Send a prompt, pocket the phone, and the phone now tells you the reply landed:

- **Local notification** when a turn finishes while the app isn't active — title = familiar name, body = reply preview (errors notify too, with a ⚠️ prefix). Honors the persisted per-thread mute and a new Settings toggle. Tap → jumps straight into the thread.
- **Chat Live Activity** (Lock Screen + Dynamic Island) mirrors the running turn: familiar name, elapsed timer, and the agent's current step (fed by #3658's activity trail). Tap → opens the thread.
- **Background grace window** per in-flight turn (`beginBackgroundTask`) so backgrounding mid-stream leaves time for the reply + banner to land.

This is the Phase 2 item from `docs/ios-native-rebuild.md` that never shipped (`AppModel` mute comment said "honoured by the notification path *when it lands*" — it landed).

## How

- `ChatNotifications` (new): **pure, tested** decision + content helpers — notify/suppress matrix (foreground / muted / toggle), first-line capped preview with error fallbacks, `covencave://thread/<id>` deep-link round-trip. Thread-scoped notification identifiers so a newer reply replaces the banner; `cave.reminder.*` namespace untouched.
- `ChatTurnNotifier` (new): the stream-lifecycle seam. `ChatThread.stream` calls `turnStarted` / `turnStatus` (from activity folds) / `turnFinished` — the single end-of-stream funnel covers done, error, resume, resync, and re-queued-offline paths (a re-queued send removes its placeholder → no banner).
- `LiveActivityManager`: chat-turn activity alongside the existing task one (single instance, keyed to thread, status dedupe). `ChatActivityAttributes` shared with the widget target via `project.yml`; `ChatLiveActivity` rendered in the widget bundle with `widgetURL` deep link.
- `AppModel.handleDeepLink`: `covencave://thread/<id>` routes through the existing `requestOpen` one-shot (same hook the chat list uses); widget/Live-Activity taps ride `onOpenURL`, notification taps ride the existing delegate.
- Settings → Chats: "Reply notifications" toggle (default on), lazy authorization request (`ReminderNotifications` pattern).
- Opening a thread clears its delivered banner.

## Verification

- `xcodegen generate` + `xcodebuild build` (iPhone 16 Pro sim): **BUILD SUCCEEDED**
- `xcodebuild test -only-testing:ChatNotificationsTests -only-testing:AgentActivityTests`: **TEST SUCCEEDED** (decision matrix, preview construction, deep-link round-trip + foreign URLs; activity regression)
- Swift isn't built in CI — local evidence recorded in bead `cave-eh4a`.

## Notes

- Canvas group fan-out (`AppModel.streamText`) intentionally unchanged — same scope boundary as #3658.
- Live Activity is a fixed "single current turn" slot (newest turn wins), mirroring the task-activity pattern.