### PR TITLE
Home hearth: minimal pass with progressive disclosure (cave-6xf5)

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -36,9 +36,10 @@ assert.match(
   "HomeComposer should load a familiar-scoped project list for the project selector",
 );
 
-// Chat revamp 1a: the hero is the hearth card's heading — greeting kicker,
-// "What are we casting today?", then a live-context subtitle (familiar ·
-// role · model). The project name moved into the composer context pill.
+// Chat revamp 1a + minimal pass: the hero is the hearth card's heading —
+// greeting kicker, "What are we casting today?", then a live-context subtitle
+// (familiar · role). The project name and runtime/model both live in the
+// composer context pill — the hero never repeats them.
 assert.match(
   source,
   /home-composer-headline">What are we casting today\?<\/h1>/,
@@ -51,8 +52,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const contextLine = useMemo\(\(\) => \{[\s\S]*?selectedFamiliar\?\.display_name[\s\S]*?selectedFamiliar\?\.role[\s\S]*?\}, \[selectedFamiliar, selectedRuntime, selectedModelId\]\)/,
-  "the subtitle derives from the live familiar + runtime/model state (no invented user profile)",
+  /const contextLine = useMemo\(\(\) => \{[\s\S]*?selectedFamiliar\?\.display_name[\s\S]*?selectedFamiliar\?\.role[\s\S]*?\}, \[selectedFamiliar\]\)/,
+  "the subtitle derives from the live familiar only (model reads in the context pill; no invented user profile)",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -395,19 +395,17 @@ export function HomeComposer({
   // prompts) and the Open work section (pending-task row).
   const boardCards = useBoardCards();
 
-  // Live-context subtitle under the heading: active familiar · role · model.
+  // Live-context subtitle under the heading: familiar · role only. The
+  // runtime/model already reads verbatim in the composer's context pill one
+  // line below — repeating it in the hero was chrome, not information.
   const contextLine = useMemo(() => {
-    const model = selectedModelId
-      ? `${selectedRuntime}/${selectedModelId}`
-      : selectedRuntime;
     return [
       selectedFamiliar?.display_name ?? null,
       selectedFamiliar?.role?.trim() || null,
-      model,
     ]
       .filter(Boolean)
       .join(" · ");
-  }, [selectedFamiliar, selectedRuntime, selectedModelId]);
+  }, [selectedFamiliar]);
 
   // From-task row (chat revamp 1a): prop-driven and ready, but UNWIRED — no
   // surface routes a task into the home composer today (board cards open
@@ -1120,23 +1118,23 @@ export function HomeComposer({
         </div>
       </div>
 
-      {/* Suggestions demoted below the composer (chat revamp 1a): the
-          From-task row when home opened from a task (unwired today — see
-          home-from-task.tsx), else the quick-action pill row. The digest
-          carousel is hidden from the default home; its signal folds into
-          the sections below. */}
+      {/* Suggestions demoted below the composer (chat revamp 1a, minimal
+          pass): the From-task row when home opened from a task (unwired today
+          — see home-from-task.tsx), else two cold-start pills — and only
+          while the draft is empty. The moment you're typing you don't need
+          prompts for the blank page (progressive disclosure). */}
       {taskOrigin ? (
         <HomeFromTaskRow origin={taskOrigin} onPickSuggestion={insertPrompt} />
-      ) : (
+      ) : !text.trim() ? (
         <HomeSuggestionPills
           cards={boardCards}
           projectName={selectedProject?.name ?? null}
           onPick={insertPrompt}
         />
-      )}
+      ) : null}
 
-      {/* Continue — the two most recent resumable sessions as side-by-side
-          resume cards. */}
+      {/* Continue — the two most recent resumable sessions, behind the same
+          persisted disclosure as the sections below (default open). */}
       <HomeContinue
         sessions={sessions}
         familiarNameById={familiarNameById}
@@ -1163,7 +1161,8 @@ export function HomeComposer({
       />
 
       {/* Ask Salem — quiet doorway to the dedicated docs section (mode
-          "salem"). Deliberately not a sidebar row; Home is its front door. */}
+          "salem"). Deliberately not a sidebar row; Home is its front door.
+          Just the name — the what-it-covers hint lives in the tooltip. */}
       <div className="home-ask-salem">
         <button
           type="button"
@@ -1173,11 +1172,11 @@ export function HomeComposer({
               new CustomEvent("cave:navigate-mode", { detail: { mode: "salem" } }),
             )
           }
+          title="Grounded answers from the Coven index — docs, your Cave, your models"
           aria-label="Open Ask Salem — grounded answers from the Coven index"
         >
           <Icon name="ph:cat" width={14} aria-hidden />
           <span>Ask Salem</span>
-          <span className="home-ask-salem__hint">docs · your Cave · your models</span>
         </button>
       </div>
 

--- a/src/components/home-hearth.test.ts
+++ b/src/components/home-hearth.test.ts
@@ -1,16 +1,17 @@
 // @ts-nocheck
-// Chat revamp 1a — the home hearth card. Pins:
+// Chat revamp 1a + minimal pass — the home hearth card. Pins:
 //   (1) one centered card: kicker → heading → live-context subtitle →
-//       composer → demoted suggestions → Continue → Open work → snippets;
+//       composer → cold-start pills → Continue → Open work → snippets;
 //   (2) Continue resumes real sessions through the workspace handler, with a
-//       presence dot for running sessions;
+//       presence dot for running sessions — behind the same persisted
+//       disclosure pattern as Open work (expanded by default);
 //   (3) Open work reuses the EXISTING git/PR data paths (useChangesSummary +
 //       useBranchPr — the same sources as the composer git chip) and the
 //       shared /api/board snapshot, and persists its disclosure preference;
 //   (4) Prompt snippets reuses the /api/prompts-backed picker list and the
 //       existing PromptSnippetsModal browser, collapsed by default;
-//   (5) suggestion pills obey the uniform-rows rule (data-count-keyed grid,
-//       max 4, never 3+1 — #2672);
+//   (5) suggestion pills are cold-start help: capped at one quiet row of two,
+//       hidden while a draft exists, uniform-rows grid (#2672);
 //   (6) the From-task row is prop-driven and explicitly unwired (no task→home
 //       handoff exists yet).
 import assert from "node:assert/strict";
@@ -55,6 +56,12 @@ assert.match(cont, /home-continue__dot\$\{running \? " is-running" : ""\}/, "run
 assert.match(cont, /relativeAge\(s\.updated_at, nowMs\)/, "the subline reuses the shared relative-age formatter");
 assert.match(css, /\.home-continue__dot\.is-running \{\s*background: var\(--accent-presence\);/, "running dot = accent; idle stays muted");
 assert.match(css, /\.home-continue__cards \{[\s\S]{0,200}?repeat\(2, minmax\(0, 1fr\)\)/, "two side-by-side cards");
+// Minimal pass: Continue speaks the same persisted-disclosure language as
+// Open work / Prompt snippets, so the hearth can collapse to quiet headings.
+assert.match(cont, /HOME_CONTINUE_PREF_KEY = "cave:home:continue-expanded"/, "the Continue disclosure preference persists under a stable key");
+assert.match(cont, /useHomeDisclosure\(HOME_CONTINUE_PREF_KEY, true\)/, "Continue is expanded by default — it's the highest-value row");
+assert.match(cont, /aria-expanded=\{open\}/, "the Continue disclosure header is a button with aria-expanded");
+assert.match(cont, /\{open \? `· \$\{rows\.length\}` : `· \$\{freshest\.title\}`\}/, "collapsed, the header carries the freshest resumable title");
 
 // ── (3) Open work ────────────────────────────────────────────────────────────
 assert.match(openWork, /useChangesSummary\(root, Boolean\(root\)\)/, "branch + dirty count ride the shared /api/changes poll");
@@ -96,9 +103,9 @@ assert.match(
   "Show all opens the existing PromptSnippetsModal browser",
 );
 
-// ── (5) Suggestion pills — uniform rows (#2672) ──────────────────────────────
+// ── (5) Suggestion pills — cold-start help, uniform rows (#2672) ─────────────
 assert.match(pills, /data-count=\{suggestions\.length\}/, "the pill grid is keyed off the pill count");
-assert.match(pills, /buildHomeSuggestions\(\{ cards, projectName \}\)/, "pills reuse the pure suggestion heuristic (max 4 by default)");
+assert.match(pills, /buildHomeSuggestions\(\{ cards, projectName, max: 2 \}\)/, "cold-start pills cap at one quiet row of two (minimal pass)");
 assert.match(
   css,
   /\.home-suggest-pills\[data-count="2"\],\s*\.home-suggest-pills\[data-count="4"\] \{\s*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/,
@@ -116,7 +123,23 @@ assert.match(fromTask, /if \(!origin\) return null/, "the row renders only with 
 assert.match(fromTask, /\.slice\(0, 3\)/, "chips cap at three (uniform-row rule)");
 assert.match(fromTask, /From task/, "the accent 'From task' label renders");
 assert.match(composer, /const taskOrigin: HomeTaskOrigin \| null = null;/, "home passes null — no task→home handoff exists yet (see the NOTE)");
-assert.match(composer, /taskOrigin \? \(\s*<HomeFromTaskRow origin=\{taskOrigin\} onPickSuggestion=\{insertPrompt\} \/>\s*\) : \(\s*<HomeSuggestionPills/, "the row replaces the pill row when a task origin arrives");
+assert.match(
+  composer,
+  /taskOrigin \? \(\s*<HomeFromTaskRow origin=\{taskOrigin\} onPickSuggestion=\{insertPrompt\} \/>\s*\) : !text\.trim\(\) \? \(\s*<HomeSuggestionPills/,
+  "the From-task row outranks the pills; the pills render only while the draft is empty (progressive disclosure)",
+);
+
+// ── Minimal pass: chrome the hero and footer no longer repeat ────────────────
+// The hero subtitle stops at familiar · role — the runtime/model already reads
+// verbatim in the composer's context pill one line below.
+assert.doesNotMatch(
+  composer,
+  /const contextLine[\s\S]{0,400}?selectedModelId/,
+  "the hero subtitle does not duplicate the model shown in the context pill",
+);
+// Ask Salem is just the doorway; the what-it-covers copy lives in the tooltip.
+assert.doesNotMatch(composer, /home-ask-salem__hint/, "the Ask Salem row drops the inline hint text");
+assert.match(composer, /title="Grounded answers from the Coven index — docs, your Cave, your models"/, "the Salem hint survives as a tooltip");
 
 // ── Shared plumbing ──────────────────────────────────────────────────────────
 // Disclosure prefs read AFTER mount (SSR-deterministic, like the greeting).

--- a/src/components/home/home-continue.tsx
+++ b/src/components/home/home-continue.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-// "Continue" — the hearth card's resume strip (chat revamp 1a): the two most
-// recent resumable sessions as side-by-side cards. Status dot reads presence
-// (accent = a familiar is working right now, muted = idle); clicking resumes
-// the session through the same handler the thread rail uses.
+// "Continue" — the hearth card's resume strip (chat revamp 1a, minimal pass):
+// the two most recent resumable sessions as side-by-side cards, behind the
+// same persisted disclosure the Open work / Prompt snippets sections use
+// (expanded by default — it's the highest-value row — collapsible to one
+// quiet line for people who want the hearth down to composer + headings).
+// Status dot reads presence (accent = a familiar is working right now,
+// muted = idle); clicking resumes the session through the same handler the
+// thread rail uses.
 
 import { useMemo, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { Icon, type IconName } from "@/lib/icon";
 import type { SessionRow } from "@/lib/types";
 import { relativeAge } from "@/lib/rss";
+import { useHomeDisclosure } from "@/components/home/use-home-disclosure";
+
+export const HOME_CONTINUE_PREF_KEY = "cave:home:continue-expanded";
 
 /** Newest-first sessions a person can meaningfully resume from home: not
  *  archived, not generator-spawned, and actually titled. */
@@ -26,17 +33,31 @@ type Props = {
 };
 
 export function HomeContinue({ sessions, familiarNameById, onOpenSession }: Props) {
+  const [open, toggle] = useHomeDisclosure(HOME_CONTINUE_PREF_KEY, true);
   // Sampled once per mount — ages are coarse ("17m ago"), so a live ticker
   // would be re-render noise right next to the composer.
   const [nowMs] = useState(() => Date.now());
   const rows = useMemo(() => resumableSessions(sessions), [sessions]);
   if (rows.length === 0 || !onOpenSession) return null;
 
+  const chevron: IconName = open ? "ph:caret-down" : "ph:caret-right";
+  const freshest = rows[0];
+
   return (
-    <section className="home-continue" aria-labelledby="home-continue-label">
-      <h2 id="home-continue-label" className="home-section-label">
-        Continue
-      </h2>
+    <section className="home-disclosure home-continue" aria-label="Continue">
+      <button
+        type="button"
+        className="home-disclosure__head"
+        aria-expanded={open}
+        onClick={toggle}
+      >
+        <Icon name={chevron} width={11} aria-hidden />
+        <span className="home-disclosure__title">Continue</span>
+        <span className="home-disclosure__count">
+          {open ? `· ${rows.length}` : `· ${freshest.title}`}
+        </span>
+      </button>
+      {open ? (
       <div className="home-continue__cards" data-count={rows.length}>
         {rows.map((s) => {
           const familiar = s.familiarId ? familiarNameById.get(s.familiarId) ?? null : null;
@@ -76,6 +97,7 @@ export function HomeContinue({ sessions, familiarNameById, onOpenSession }: Prop
           );
         })}
       </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/home/home-suggestion-pills.tsx
+++ b/src/components/home/home-suggestion-pills.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-// Demoted suggestion pills (chat revamp 1a): the quick-action prompts that
-// used to drift on the digest carousel now sit as a quiet pill row BELOW the
-// composer. Same pure heuristic (buildHomeSuggestions: open board tasks +
-// curated starters), same insert-never-send contract.
+// Demoted suggestion pills (chat revamp 1a, minimal pass): two cold-start
+// prompts in one quiet row below the composer — open board tasks first, then
+// curated starters (buildHomeSuggestions). Same insert-never-send contract.
+// The composer hides the row entirely once a draft exists: suggestions are
+// for the blank-page moment, not for reading around while you type.
 //
 // Row layout obeys the uniform-rows rule (#2672): the grid is keyed off
-// data-count so pills lay out 1, 2, or 3 per row and never orphan a 3+1.
+// data-count so pills lay out 1 or 2 per row and never orphan.
 
 import { useMemo } from "react";
 import { buildHomeSuggestions, type SuggestionCard } from "@/lib/home-suggestions";
@@ -22,7 +23,7 @@ type Props = {
 
 export function HomeSuggestionPills({ cards, projectName, onPick }: Props) {
   const suggestions = useMemo(
-    () => buildHomeSuggestions({ cards, projectName }),
+    () => buildHomeSuggestions({ cards, projectName, max: 2 }),
     [cards, projectName],
   );
   if (suggestions.length === 0) return null;

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -1172,10 +1172,6 @@
   border-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
 }
-.home-ask-salem__hint {
-  color: var(--text-muted);
-  opacity: 0.75;
-}
 
 
 

--- a/src/styles/home-composer/hearth-continuations.css
+++ b/src/styles/home-composer/hearth-continuations.css
@@ -1,21 +1,11 @@
-/* ── Hearth card sections (chat revamp 1a) ────────────────────────────────────
+/* ── Hearth card sections (chat revamp 1a, minimal pass) ─────────────────────
  *   Everything below the composer inside .home-hearth-card: the demoted
- *   suggestion pills / From-task row, the Continue resume cards, and the
- *   Open work + Prompt snippets disclosures. */
+ *   suggestion pills / From-task row, then three matching persisted
+ *   disclosures — Continue, Open work, Prompt snippets. */
 
-/* Shared 10px uppercase section label (Continue). */
-.home-section-label {
-  margin: 0 0 var(--space-2);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-/* Suggestion pills — demoted below the composer; the grid is keyed off
-   data-count so rows stay UNIFORM (1, 2, or 3 per row; 4 = 2×2 — never a
-   3+1 orphan; #2672 rule). */
+/* Suggestion pills — two cold-start prompts below the composer, hidden once
+   a draft exists. The grid is keyed off data-count so rows stay UNIFORM
+   (1, 2, or 3 per row; 4 = 2×2 — never a 3+1 orphan; #2672 rule). */
 .home-suggest-pills {
   display: grid;
   grid-template-columns: 1fr;
@@ -109,14 +99,13 @@
   color: var(--text-primary);
 }
 
-/* Continue — two side-by-side resume cards. */
-.home-continue {
-  margin-top: var(--space-4);
-}
+/* Continue — a persisted disclosure (like Open work below) whose open state
+   shows two side-by-side resume cards. */
 .home-continue__cards {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-2);
+  padding-top: var(--space-2);
 }
 .home-continue__cards[data-count="1"] {
   grid-template-columns: 1fr;


### PR DESCRIPTION
## What

Quiets the home hearth down to its essentials; everything secondary is behind consistent, persisted disclosures.

- **Hero subtitle** stops at `familiar · role` — the runtime/model already reads verbatim in the composer's context pill one line below (was duplicated chrome).
- **Cold-start pills** cap at one quiet row of **two** (was 4 = two full rows), and hide entirely while a draft exists — suggestions serve the blank-page moment, not reading-around-while-typing.
- **Continue** joins Open work / Prompt snippets as a **persisted disclosure** (expanded by default since it's the highest-value row; collapsed it shows the freshest resumable title). The hearth can now collapse to composer + three slim headings.
- **Ask Salem** drops its inline `docs · your Cave · your models` hint; that copy moves to the tooltip.

## Why

User request from a screenshot review: "make more minimalistic with progressive disclosure." The three sections below the composer now speak one disclosure language (same `useHomeDisclosure` persistence, same fade-hairline header row), and nothing repeats what another element already says.

## Validation

- `pnpm typecheck` clean; eslint clean on changed files
- Suites: **891 app / 235 api / 85 mobile** test files green
- Pins updated deliberately with the contract: hearth order, pills `max: 2` + draft gate, Continue disclosure (pref key `cave:home:continue-expanded`, default open, aria-expanded, collapsed summary), no-model subtitle, hint removal
- No Playwright spec references these selectors (grepped `tests/*.spec.ts`)

Bead: cave-6xf5