### PR TITLE
fix(mobile): forward request in project-file POST so phone saves honor the opt-in

### DIFF
--- a/src/app/api/project-file/route.ts
+++ b/src/app/api/project-file/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server.js";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAllowedProjectSubpath } from "@/lib/server/project-paths";
@@ -260,6 +260,7 @@ export async function POST(req: NextRequest) {
       familiarId: typeof payload.familiarId === "string" ? payload.familiarId : null,
       path: filePath,
       surface: projectPermissionSurfaceForRequest(req, "file-write"),
+      request: req,
     });
   } catch (error) {
     if (error instanceof ProjectAccessDeniedError) {

--- a/src/app/api/project-local-human-read.test.ts
+++ b/src/app/api/project-local-human-read.test.ts
@@ -89,4 +89,16 @@ for (const rel of [
   assert.match(src, /request: req,/, `${rel} should forward the request to assertProjectApiAccess`);
 }
 
+// The save handler must forward it too — the human-mobile file-write branch
+// reads the proxy marker off the request, and a GET-only match masked its
+// omission once already (review of #3652).
+{
+  const src = await readFile(new URL("./project-file/route.ts", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /surface: projectPermissionSurfaceForRequest\(req, "file-write"\),\s*request: req,/,
+    "project-file POST should forward the request so mobile file writes can be authorized",
+  );
+}
+
 console.log("project-local-human-read.test.ts: ok");

--- a/src/lib/server/trusted-grant-mutation.test.ts
+++ b/src/lib/server/trusted-grant-mutation.test.ts
@@ -7,7 +7,7 @@
 // The phone must never be able to widen its own authority; every mobile
 // capability here is off until the desktop (loopback) enables it.
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -212,6 +212,42 @@ try {
     /not registered/,
     "unregistered paths stay unwritable from the phone even with the opt-in on",
   );
+
+  // --- the real save route ------------------------------------------------
+  // Regression (review of #3652): POST /api/project-file omitted
+  // `request: req` from its assertProjectApiAccess args, so the branch above
+  // never saw the proxy marker and phone saves stayed blocked with the
+  // opt-in on. Exercise the actual handler, not a hand-built arg shape.
+  const { POST: postProjectFile } = await import("../../app/api/project-file/route.ts");
+  await mkdir(projectRoot, { recursive: true });
+  await writeFile(filePath, "original\n", "utf8");
+  const saveBody = (content) =>
+    ({ method: "POST", body: JSON.stringify({ path: filePath, content }) });
+
+  const phoneSave = await postProjectFile(
+    mobile({ "content-type": "application/json" }, saveBody("saved from phone\n")),
+  );
+  assert.equal(phoneSave.status, 200, "the route forwards the request to the trust chain");
+  assert.equal((await phoneSave.json()).ok, true);
+  const { readFile } = await import("node:fs/promises");
+  assert.equal(await readFile(filePath, "utf8"), "saved from phone\n");
+
+  const desktopSave = await postProjectFile(
+    loopback({ "content-type": "application/json" }, saveBody("nope\n")),
+  );
+  assert.equal(
+    desktopSave.status,
+    403,
+    "no-familiar loopback saves keep the familiar requirement — only the marked phone is exempt",
+  );
+
+  await updateMobileWriteAccess({ allowMobileFileWrites: false });
+  const relockedSave = await postProjectFile(
+    mobile({ "content-type": "application/json" }, saveBody("stale\n")),
+  );
+  assert.equal(relockedSave.status, 403, "relocking the opt-in blocks the route again");
+  assert.match((await relockedSave.json()).error, /missing familiarId/);
+  assert.equal(await readFile(filePath, "utf8"), "saved from phone\n", "denied save wrote nothing");
 
   console.log("trusted-grant-mutation.test.ts: ok");
 } finally {


### PR DESCRIPTION
## What

Code review of #3652 (`/review`) found the shipped **mobile file-write opt-in was inert**: `POST /api/project-file` built its `assertProjectApiAccess` args **without `request: req`**, so `isHumanMobileWrite` short-circuited on the missing request and phone saves failed with `missing familiarId for project access` even after enabling **Allow file edits from phone** — while the iOS Code editor kept pointing users at the already-on desktop toggle.

## Fix

Forward `request: req` in the POST handler (one line, plus the `next/server.js` import form so the handler is loadable under the node test runner).

**No behavior change for any other caller** — fail direction was closed, and with the request forwarded:
- no-familiar **loopback** saves: still 403 (`isHumanRead` rejects `file-write`; no proxy marker)
- **familiar-attributed** writes: unchanged (branch only runs on the no-familiarId path)
- **unregistered** paths / **shell** surface: unchanged
- marked phone + opt-in **off**: still 403

## Tests (closing the gap that masked this)

- `trusted-grant-mutation.test.ts` now exercises the **real POST handler** end-to-end: phone save → 200 + content on disk; no-familiar loopback save → 403; relock → 403 with guidance error and nothing written. **Verified the new coverage fails against the pre-fix route** (pass 0 / fail 1).
- `project-local-human-read.test.ts` pins that the **POST call site itself** forwards the request — the old `request: req,` pin was satisfied by the GET handler alone, which is how this slipped through.

## Verification

- `node --test` targeted: trusted-grant-mutation, project-local-human-read, project-permission-routes — 3/3 pass
- `pnpm typecheck` clean
- `pnpm test:api` — 235 files pass

Closes cave-43s2.
