### PR TITLE
style(home): stretch the hearth card to fill the bottom of the panel

### DIFF
--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -1148,11 +1148,15 @@
   }
 }
 
-/* Home doorway to the Ask Salem section — quiet, hairline, muted-until-hover. */
+/* Home doorway to the Ask Salem section — quiet, hairline, muted-until-hover.
+   `margin-top: auto` pins it to the bottom of the stretched hearth card (the
+   card's interior slack lands above it); padding keeps the minimum gap from
+   the snippets section when there is no slack. */
 .home-ask-salem {
   display: flex;
   justify-content: center;
-  margin-top: var(--space-2);
+  margin-top: auto;
+  padding-top: var(--space-2);
 }
 .home-ask-salem__btn {
   display: inline-flex;

--- a/src/styles/home-composer/landing-composer.css
+++ b/src/styles/home-composer/landing-composer.css
@@ -18,7 +18,7 @@
   width: 100%;
   height: 100%;
   min-height: 0;
-  padding: var(--space-10) var(--space-8) 56px;
+  padding: var(--space-10) var(--space-8) var(--space-10);
   gap: var(--space-4);
   overflow-y: auto;
   box-sizing: border-box;
@@ -71,10 +71,13 @@
  *   One centered panel on the washed base holding the greeting, the composer,
  *   and the Continue / Open work / Prompt snippets sections. Translucent panel
  *   fill so the radial wash reads through; the root scrolls when the card
- *   outgrows a short viewport. */
+ *   outgrows a short viewport. On tall viewports the card grows to the root's
+ *   bottom inset (no dead wash strip below it); `0` shrink keeps the intrinsic
+ *   height as the floor so short windows still scroll. */
 .home-hearth-card {
   display: flex;
   flex-direction: column;
+  flex: 1 0 auto;
   width: 100%;
   max-width: min(930px, 100%);
   margin-inline: auto;


### PR DESCRIPTION
## What

User screenshot review: dead wash strip below the hearth card on tall viewports ("fill in the bottom gap too").

- `.home-hearth-card` grows to the root's bottom inset (`flex: 1 0 auto` — shrink 0 keeps the intrinsic height as the floor, so short viewports still scroll exactly as before).
- The Ask Salem doorway pins to the card bottom as a true footer (`margin-top: auto`, padding keeps the old 8px minimum gap from the snippets section when there's no slack).
- The root's bottom padding (56px, predates the card) drops to match the 40px top inset for an even frame.

## Verification

- Playwright measurement at 1946×1220: card was 282→932 with 260px of bare wash below; now 78→1152 with symmetric 40px insets, Ask Salem pinned at the card bottom.
- Short viewport (973×610): root still scrolls (scrollH 726 > clientH 497), card keeps intrinsic height.
- `test:app` suite: 887 files green (includes home-hearth / home-composer / backdrop-scrim / css-module-order pins).

Note: complements #3662 (hearth minimal pass, same surface, different lines — no textual overlap; both branch from current main).