### PR TITLE
fix(mobile-mode): pairing status self-heals — TTL half-open on the retry breaker (cave-v57i)

### DIFF
--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -178,7 +178,26 @@ assert.match(
 assert.match(settings, /MobileModeToggle/, "Settings should render a mobile mode toggle component");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");
 assert.match(settings, /onMobileModeChange/, "Settings should expose a toggle callback for mobile mode");
-assert.match(settings, /usePausablePoll\(\(\) => void reconcileMobileMode\(true\), 60_000, \{\s*enabled: mobileModeEnabled && !autoRetryBlocked,?\s*\}\)/, "Settings should stop automatic polling after a known prerequisite 503");
+// The poll must keep ticking through prerequisite failures — the reconciler's
+// TTL breaker rate-limits real probes, and the card self-heals once Tailscale
+// comes up (a gated poll shipped a stale "Tailscale isn't running" over a
+// live connection).
+assert.match(settings, /usePausablePoll\(\(\) => void reconcileMobileMode\(true\), 60_000, \{\s*enabled: mobileModeEnabled,?\s*\}\)/, "Settings keeps polling; the shared TTL breaker owns retry pacing");
+assert.doesNotMatch(settings, /autoRetryBlocked/, "the poll-stopping latch is gone from Settings");
+{
+  const workspaceSrc = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+  assert.match(
+    workspaceSrc,
+    /usePausablePoll\(\(\) => void reconcileMobileMode\(mobileModeEnabled\), 60_000, \{\s*enabled: mobileModeEnabled,?\s*\}\)/,
+    "Workspace keeps polling too; both consumers rely on the shared TTL breaker",
+  );
+  assert.doesNotMatch(workspaceSrc, /mobileModeAutoRetryBlocked/, "the poll-stopping latch is gone from Workspace");
+}
+{
+  const reconciler = await readFile(new URL("../lib/mobile-mode-reconcile.ts", import.meta.url), "utf8");
+  assert.match(reconciler, /RETRY_BLOCK_TTL_MS = 45_000/, "the breaker half-opens on a TTL instead of latching forever");
+  assert.match(reconciler, /now\(\) - blocked\.at < RETRY_BLOCK_TTL_MS/, "cached failures expire so the status tracks reality");
+}
 assert.match(settings, /Mobile mode/, "Settings should label the one-click native iOS route switch");
 assert.doesNotMatch(settings, /CopyValue value="pnpm mobile:tailscale:app"/, "Settings should not require copying a terminal command for normal mobile mode");
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2665,7 +2665,6 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
   const [steps, setSteps] = useState<PairingStep[] | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoRetryBlocked, setAutoRetryBlocked] = useState(false);
   const [copied, setCopied] = useState<"link" | "app" | "host" | null>(null);
   const initialReconcileDoneRef = useRef(false);
 
@@ -2674,7 +2673,6 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
     setError(null);
     try {
       const result = await reconcileMobileModeRequest(enabled, { force: options?.force });
-      setAutoRetryBlocked(result.retryBlocked);
       // The proven ladder rides both success and unavailable responses.
       setSteps(enabled && Array.isArray(result.steps) ? result.steps : null);
       if (!result.ok) {
@@ -2700,7 +2698,6 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
   const onMobileModeChange = async (enabled: boolean) => {
     writeMobileModeEnabled(enabled);
     setMobileModeEnabled(enabled);
-    setAutoRetryBlocked(false);
     await reconcileMobileMode(enabled, { busy: true, force: true });
   };
 
@@ -2711,8 +2708,12 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
     void reconcileMobileMode(mobileModeEnabled);
   }, [mobileModeEnabled, reconcileMobileMode]);
   // Recurring reconcile only while mobile mode is on; pauses in a hidden tab.
+  // Prerequisite failures do NOT stop the poll — the shared reconciler's TTL
+  // breaker turns most ticks into cached no-ops and lets one real probe
+  // through per TTL, so "Tailscale isn't running" heals itself once the
+  // connection is actually up (it used to latch until a manual Retry).
   usePausablePoll(() => void reconcileMobileMode(true), 60_000, {
-    enabled: mobileModeEnabled && !autoRetryBlocked,
+    enabled: mobileModeEnabled,
   });
 
   const copy = (kind: "link" | "app" | "host", value: string) => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -516,7 +516,6 @@ export function Workspace() {
   const [mobileModeEnabled, setMobileModeEnabledState] = useState(readMobileModeEnabled);
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
-  const [mobileModeAutoRetryBlocked, setMobileModeAutoRetryBlocked] = useState(false);
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
   // Deep-link target captured at mount, held until the async sessions fetch
@@ -556,13 +555,11 @@ export function Workspace() {
 
   const setMobileModeEnabled = useCallback((enabled: boolean) => {
     writeMobileModeEnabled(enabled);
-    setMobileModeAutoRetryBlocked(false);
     setMobileModeEnabledState(enabled);
   }, []);
 
   const reconcileMobileMode = useCallback(async (enabled: boolean, options?: { force?: boolean; suppressError?: boolean }) => {
     const result = await reconcileMobileModeRequest(enabled, options);
-    setMobileModeAutoRetryBlocked(result.retryBlocked);
     if (!result.ok) {
       // suppressError covers the one-time boot reconcile with the pref off:
       // the shared reconciler reports transport failures as !ok too, so both
@@ -596,9 +593,12 @@ export function Workspace() {
     });
   }, [mobileModeEnabled, reconcileMobileMode]);
   // Recurring reconcile only while mobile mode is on; usePausablePoll pauses it
-  // in a hidden tab and refreshes on return.
+  // in a hidden tab and refreshes on return. The poll keeps ticking through
+  // prerequisite failures — the shared reconciler's TTL breaker decides when a
+  // tick becomes a real probe, so the status heals itself once Tailscale
+  // comes up instead of latching stale until a manual Retry.
   usePausablePoll(() => void reconcileMobileMode(mobileModeEnabled), 60_000, {
-    enabled: mobileModeEnabled && !mobileModeAutoRetryBlocked,
+    enabled: mobileModeEnabled,
   });
 
   // Milestone crossings → renown ledger → inbox toasts. Self-contained

--- a/src/lib/mobile-mode-reconcile.test.ts
+++ b/src/lib/mobile-mode-reconcile.test.ts
@@ -20,6 +20,49 @@ test("clean optional-unavailable responses open the circuit until a forced retry
   assert.equal(calls, 2, "the explicit Retry/toggle path probes immediately");
 });
 
+test("the breaker half-opens after its TTL so the status tracks a changing world", async () => {
+  let healthy = false;
+  let clock = 0;
+  const reconcile = createMobileModeReconciler(
+    async () =>
+      healthy
+        ? Response.json({ ok: true, nativeHost: "cave.tail.test" })
+        : Response.json({ ok: false, unavailable: true, error: "Tailscale isn't running" }, { status: 503 }),
+    () => clock,
+  );
+
+  assert.equal((await reconcile(true)).retryBlocked, true, "first probe fails and arms the breaker");
+  clock += 30_000;
+  assert.equal((await reconcile(true)).skipped, true, "inside the TTL the cached failure is replayed");
+
+  // The human opens Tailscale and connects; the next tick past the TTL must
+  // discover it WITHOUT a manual Retry — this exact staleness shipped a
+  // "Tailscale isn't running" card over a live connection.
+  healthy = true;
+  clock += 20_000;
+  const healed = await reconcile(true);
+  assert.equal(healed.skipped, undefined, "past the TTL the poll runs a real probe");
+  assert.equal(healed.ok, true, "the card heals to the true status");
+  assert.equal((await reconcile(true)).ok, true, "a healed breaker stays closed");
+});
+
+test("a failed half-open probe re-arms the breaker with a fresh TTL", async () => {
+  let calls = 0;
+  let clock = 0;
+  const reconcile = createMobileModeReconciler(async () => {
+    calls += 1;
+    return Response.json({ ok: false, unavailable: true, error: "still down" }, { status: 503 });
+  }, () => clock);
+
+  await reconcile(true);
+  clock += 46_000;
+  await reconcile(true);
+  assert.equal(calls, 2, "the TTL lets one real probe through");
+  clock += 30_000;
+  assert.equal((await reconcile(true)).skipped, true, "the re-armed breaker caches again");
+  assert.equal(calls, 2);
+});
+
 test("legacy sidecar 503 responses still open the automatic-retry circuit", async () => {
   let calls = 0;
   const reconcile = createMobileModeReconciler(async () => {

--- a/src/lib/mobile-mode-reconcile.ts
+++ b/src/lib/mobile-mode-reconcile.ts
@@ -21,21 +21,37 @@ export type MobileModeResponse = {
 type MobileModeRequest = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 /**
+ * A prerequisite 503 (Tailscale off, no token yet) opens the breaker so
+ * automatic refreshes stop hammering the probe ladder — but the world it
+ * failed against KEEPS CHANGING (the human opens Tailscale and connects).
+ * After this TTL the breaker half-opens: the next automatic poll runs one
+ * real probe, which either heals the card or re-arms the breaker. Without
+ * this, a single failure latched "Tailscale isn't running" on screen until a
+ * manual Retry, long after the connection was actually up.
+ */
+const RETRY_BLOCK_TTL_MS = 45_000;
+
+/**
  * Coalesces the Workspace and Settings reconcilers and opens a small circuit
  * breaker for deliberate 503 "prerequisite unavailable" responses. Automatic
- * focus/interval refreshes then reuse the recorded result without touching the
- * network. A user toggle or Retry passes force:true and probes immediately.
- * Unexpected responses and transport failures stay retryable.
+ * focus/interval refreshes reuse the recorded result until the breaker's TTL
+ * lapses, then probe again so the card tracks reality. A user toggle or Retry
+ * passes force:true and probes immediately. Unexpected responses and
+ * transport failures stay retryable.
  */
-export function createMobileModeReconciler(request: MobileModeRequest) {
-  let blocked: { enabled: boolean; result: MobileModeResponse } | null = null;
+export function createMobileModeReconciler(request: MobileModeRequest, now: () => number = Date.now) {
+  let blocked: { enabled: boolean; result: MobileModeResponse; at: number } | null = null;
   let inFlight: { enabled: boolean; promise: Promise<MobileModeResponse> } | null = null;
 
   return async function reconcile(
     enabled: boolean,
     options?: { force?: boolean },
   ): Promise<MobileModeResponse> {
-    if (!options?.force && blocked?.enabled === enabled) {
+    if (
+      !options?.force
+      && blocked?.enabled === enabled
+      && now() - blocked.at < RETRY_BLOCK_TTL_MS
+    ) {
       return { ...blocked.result, skipped: true };
     }
     if (inFlight?.enabled === enabled) return inFlight.promise;
@@ -58,7 +74,7 @@ export function createMobileModeReconciler(request: MobileModeRequest) {
           status: response.status,
           retryBlocked,
         };
-        blocked = result.retryBlocked ? { enabled, result } : null;
+        blocked = result.retryBlocked ? { enabled, result, at: now() } : null;
         return result;
       } catch (error) {
         blocked = null;


### PR DESCRIPTION
## Summary

The Pair → Mobile mode card kept showing a failed "Tailscale connected" rung ("Tailscale isn't running") after the user opened Tailscale and connected. Diagnosed live: `POST /api/mobile-handoff {action:"app-start"}` proved **all five rungs ok** while the card displayed the stale failure.

**Root cause** — a one-way latch: a single prerequisite 503 opened the shared reconciler's circuit breaker (cached failure replayed to every non-forced caller) *and* both consumers (Workspace + Settings) gated their 60s polls on `!autoRetryBlocked`. Nothing ever re-probed; only the manual **Retry** button (force) could heal the card, even though "the world changed" (Tailscale coming up) is exactly the event pairing waits for.

**Fix**
- `createMobileModeReconciler` gets a **45s TTL half-open**: inside the TTL automatic ticks replay the cached failure (no network); past it, one real probe runs — healing the card or re-arming the breaker with a fresh timestamp. Clock injectable for tests.
- Workspace and Settings polls keep ticking while mobile mode is on; the breaker owns retry pacing (~1 real probe/minute while prerequisites are down — same cost as the healthy-path poll).
- The `autoRetryBlocked` poll latches are deleted from both components.

Net effect: connect Tailscale and the card shows the true status within ~a minute, no Retry click required. Manual Retry still probes immediately.

## Testing
- New reconciler tests with a fake clock: cached replay inside the TTL, self-heal past it, re-arm on a failed half-open probe; existing breaker/coalescing/500-retryable tests unchanged and green.
- `mobile-handoff.test.ts` pins updated: both polls always tick, latches absent, TTL present in the reconciler.
- Full `app` + `api` suites: 1126/1126 files pass; `tsc --noEmit` clean.
- Live verification during diagnosis: all candidate tailscale binaries and the app's exact resolver/spawn-env path classify `Running`; the live server's reconcile returns all-ok steps.

Bead: cave-v57i

🤖 Generated with [Claude Code](https://claude.com/claude-code)
