### PR TITLE
feat(ios): focus the tab bar — 4 tabs + sidebar-adaptable More section (cave-v69f)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -5,7 +5,20 @@ import WidgetKit
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String { case chats, canvas, tasks, calendar, dev, settings, search }
+enum AppTab: String, CaseIterable { case chats, canvas, tasks, calendar, dev, settings, search }
+
+extension AppTab {
+    /// Tabs pinned to the tab bar. Search is separate — it's declared with
+    /// `role: .search` so the system gives it the trailing search treatment.
+    static let barTabs: [AppTab] = [.chats, .tasks, .canvas]
+    /// Occasional surfaces grouped under "More": shown in the sidebar on iPad
+    /// (`.sidebarAdaptable`), hidden from the iPhone tab bar. Still reachable
+    /// there via the chat drawer, the avatar button (Settings), ⌘ shortcuts,
+    /// slash commands, and deep links — hidden tabs remain selectable.
+    static let moreTabs: [AppTab] = [.calendar, .dev, .settings]
+    /// ⌘1–N keyboard-shortcut order: bar tabs, then search, then More.
+    static let shortcutOrder: [AppTab] = barTabs + [.search] + moreTabs
+}
 
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatDrawer.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatDrawer.swift
@@ -75,6 +75,7 @@ struct ChatDrawer: View {
                     DrawerRow(systemImage: "book.closed", label: "Diary") {
                         close(); app.diaryPresented = true
                     }
+                    DrawerRow(systemImage: "chevron.left.forwardslash.chevron.right", label: "Developer") { go(.dev) }
                     DrawerRow(systemImage: "gearshape", label: "Settings") { go(.settings) }
 
                     if !pinnedThreads.isEmpty {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -67,7 +67,8 @@ struct ChatsHomeView: View {
             .toolbar(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .top, spacing: 0) { header }
             // Search + compose live in a floating bottom bar (iMessage-style),
-            // not the top toolbar; Settings is now its own tab.
+            // not the top toolbar; Settings lives behind the avatar button in
+            // the header (and in the drawer / iPad sidebar).
             .safeAreaInset(edge: .bottom) { bottomBar }
             .sheet(isPresented: $showNewChat) {
                 NewChatView { thread in
@@ -194,6 +195,12 @@ struct ChatsHomeView: View {
                 Text("^[\(app.familiars.count) familiar](inflect: true)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+            }
+            // Telegram-style profile entry: Settings moved off the tab bar
+            // and lives behind the operator avatar here.
+            CircularIconButton(systemImage: "person.crop.circle",
+                               label: "Settings") {
+                app.selectedTab = .settings
             }
             CircularIconButton(systemImage: "square.and.pencil",
                                label: "New chat") {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -197,11 +197,17 @@ struct ChatsHomeView: View {
                     .foregroundStyle(.secondary)
             }
             // Telegram-style profile entry: Settings moved off the tab bar
-            // and lives behind the operator avatar here.
-            CircularIconButton(systemImage: "person.crop.circle",
-                               label: "Settings") {
+            // and lives behind the operator's avatar here.
+            Button {
                 app.selectedTab = .settings
+            } label: {
+                AvatarView(familiar: nil,
+                           url: app.operatorAvatarURL,
+                           size: ChatChrome.control,
+                           fallbackName: app.operatorDisplayName)
             }
+            .buttonStyle(.glassPress)
+            .accessibilityLabel("Settings")
             CircularIconButton(systemImage: "square.and.pencil",
                                label: "New chat") {
                 showNewChat = true

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -174,7 +174,11 @@ private struct ReconnectPill: View {
     }
 }
 
-/// Bottom tab bar shown once connected: Chats, Tasks, Developer, Settings.
+/// Bottom tab bar shown once connected: Chats, Tasks, Canvas, Search, with
+/// Calendar / Developer / Settings grouped in a "More" section — a real
+/// sidebar group on iPad (`.sidebarAdaptable`), hidden from the iPhone tab
+/// bar (reached via the chat drawer, the avatar button, ⌘5–7, slash commands,
+/// and deep links; hidden tabs stay programmatically selectable).
 ///
 /// Uses the modern `Tab(value:)` API (iOS 18+). The legacy `.tabItem`/`.tag`
 /// TabView on the iOS 26 SDK reset the selection to the first tab on a cold
@@ -184,41 +188,44 @@ struct MainTabView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.scenePhase) private var scenePhase
 
-    /// Tab order, used to map ⌘1–7 to the right tab.
-    private let tabOrder: [AppTab] = [.chats, .canvas, .tasks, .calendar, .dev, .settings, .search]
-
     var body: some View {
         @Bindable var app = app
         TabView(selection: $app.selectedTab) {
             Tab("Chats", systemImage: "bubble.left.and.bubble.right.fill", value: AppTab.chats) {
                 ChatsHomeView()
             }
-            Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
-                CanvasView()
-            }
             Tab("Tasks", systemImage: "checklist", value: AppTab.tasks) {
                 TasksView()
             }
-            Tab("Calendar", systemImage: "calendar", value: AppTab.calendar) {
-                CalendarView()
-            }
-            Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
-                DeveloperView()
-            }
-            Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
-                SettingsView()
+            Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
+                CanvasView()
             }
             Tab(value: .search, role: .search) {
                 SearchView()
             }
+            TabSection("More") {
+                Tab("Calendar", systemImage: "calendar", value: AppTab.calendar) {
+                    CalendarView()
+                }
+                Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
+                    DeveloperView()
+                }
+                Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
+                    SettingsView()
+                }
+            }
+            // Keep occasional surfaces out of the iPhone tab bar; they stay
+            // visible in the iPad/Mac sidebar.
+            .defaultVisibility(.hidden, for: .tabBar)
         }
+        .tabViewStyle(.sidebarAdaptable)
         // Command confirmations float above the whole tab bar so they're visible
         // whether a command stays in chat or jumps to the Tasks tab.
         .toast($app.toast)
-        // Hardware-keyboard tab switching (iPad / Mac over Tailscale): ⌘1–6.
+        // Hardware-keyboard tab switching (iPad / Mac over Tailscale): ⌘1–7.
         // Hidden buttons keep the shortcuts active without affecting layout.
         .background {
-            ForEach(Array(tabOrder.enumerated()), id: \.element) { index, tab in
+            ForEach(Array(AppTab.shortcutOrder.enumerated()), id: \.element) { index, tab in
                 Button {
                     app.selectedTab = tab
                 } label: { EmptyView() }

--- a/apps/ios/CovenCave/CovenCaveTests/TabOrderTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/TabOrderTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import CovenCave
+
+/// The tab bar IA: four surfaces in the bar (Chats, Tasks, Canvas, Search),
+/// the occasional ones (Calendar, Developer, Settings) in a "More" section
+/// that is a sidebar group on iPad and hidden from the iPhone tab bar. These
+/// tests pin the invariants that keep every surface reachable and every
+/// persisted/deep-linked tab value decodable.
+final class TabOrderTests: XCTestCase {
+
+    /// Every tab is either in the bar, in More, or the search role tab —
+    /// no surface can silently fall out of the IA when cases are added.
+    func testEveryTabIsPlacedExactlyOnce() {
+        let placed = AppTab.barTabs + [.search] + AppTab.moreTabs
+        XCTAssertEqual(placed.count, Set(placed).count, "a tab is placed twice")
+        XCTAssertEqual(Set(placed), Set(AppTab.allCases),
+                       "every AppTab case must be placed in the tab IA")
+    }
+
+    /// ⌘1–N must cover every tab exactly once so relocated surfaces stay
+    /// keyboard-reachable (hidden tabs remain selectable by value).
+    func testShortcutOrderCoversAllTabsExactlyOnce() {
+        XCTAssertEqual(AppTab.shortcutOrder.count, AppTab.allCases.count)
+        XCTAssertEqual(Set(AppTab.shortcutOrder), Set(AppTab.allCases))
+    }
+
+    /// Bar tabs come first in shortcut order (⌘1–3 match the visible bar,
+    /// ⌘4 is search), so muscle memory tracks what's on screen.
+    func testShortcutOrderLeadsWithBarTabs() {
+        XCTAssertEqual(Array(AppTab.shortcutOrder.prefix(AppTab.barTabs.count)),
+                       AppTab.barTabs)
+        XCTAssertEqual(AppTab.shortcutOrder[AppTab.barTabs.count], .search)
+    }
+
+    /// Raw values are persisted (restored tab) and used in deep links —
+    /// they must never change spelling.
+    func testRawValuesAreStable() {
+        let expected: [AppTab: String] = [
+            .chats: "chats", .canvas: "canvas", .tasks: "tasks",
+            .calendar: "calendar", .dev: "dev", .settings: "settings",
+            .search: "search",
+        ]
+        XCTAssertEqual(expected.count, AppTab.allCases.count)
+        for (tab, raw) in expected {
+            XCTAssertEqual(tab.rawValue, raw)
+            XCTAssertEqual(AppTab(rawValue: raw), tab)
+        }
+    }
+}

--- a/scripts/ios-canvas-tab.test.mjs
+++ b/scripts/ios-canvas-tab.test.mjs
@@ -33,7 +33,7 @@ const assertOrdered = (source, markers, label) => {
   }
 };
 
-assert.match(model, /enum AppTab: String \{[^}]*\bcanvas\b[^}]*\}/, "AppTab includes Canvas");
+assert.match(model, /enum AppTab: String[^{]*\{[^}]*\bcanvas\b[^}]*\}/, "AppTab includes Canvas");
 assert.match(root, /Tab\("Canvas"[\s\S]*CanvasView\(\)/, "RootView mounts the native Canvas tab");
 assert.match(client, /expectedUpdatedAt[\s\S]*expectedAbsent[\s\S]*resolvedAnnotations/, "Canvas saves use guarded revisions");
 assert.match(client, /method: "PATCH"[\s\S]*Canvas annotation save/, "component comments use annotation-only PATCH");


### PR DESCRIPTION
## Summary

Workstream 3 of the iOS UI/UX improvement plan: the tab bar held **seven** tabs, crowding the iPhone bar with occasional surfaces (Developer, Settings, Calendar) in prime positions.

- **Bar tabs:** Chats · Tasks · Canvas · Search (keeps `role: .search`).
- **More section:** Calendar, Developer, Settings in a `TabSection` — a real sidebar group on iPad via `.tabViewStyle(.sidebarAdaptable)`, hidden from the iPhone tab bar (`.defaultVisibility(.hidden, for: .tabBar)`).
- **Reachability preserved:** Telegram-style avatar entry in the Chats header opens Settings; chat drawer gains a Developer row (Calendar/Settings rows already existed); ⌘1–7 re-mapped (`AppTab.shortcutOrder`); slash-command + deep-link jumps (`.calendar`, `.dev`, `.settings`) still work — hidden tabs remain programmatically selectable.
- **Stability:** `AppTab` raw values unchanged (restored-tab persistence, deep links); IA now has a single source of truth (`barTabs`/`moreTabs`/`shortcutOrder`), pinned by `TabOrderTests`.

Design confirmed with operator: More-section variant + Settings behind avatar.

## Verification

- `xcodegen generate` + `xcodebuild build` — **BUILD SUCCEEDED** (iPhone 16 Pro sim)
- `-only-testing:CovenCaveTests/TabOrderTests` — **4 tests, 0 failures**
- Swift isn't in CI; local evidence recorded in bead cave-v69f

Bead: cave-v69f