### PR TITLE
feat(ios): hide the bottom tab bar while a conversation is open

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -129,6 +129,9 @@ struct ChatView: View {
         .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle(thread.title)
         .navigationBarTitleDisplayMode(.inline)
+        // Full-screen conversation: the root tab bar yields to the composer —
+        // Chats' pushed detail reads as its own surface, like Messages.
+        .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 // Agent pill: who you're talking to, and (direct chats) the door

--- a/apps/ios/CovenCave/CovenCaveUITests/ChatTabBarUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/ChatTabBarUITests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+/// Verifies the conversation screen hides the bottom tab bar (ChatView's
+/// `.toolbar(.hidden, for: .tabBar)`) and that it returns on the way back.
+/// Runs as an XCUITest because host-side synthetic taps need macOS
+/// Accessibility grants; the runner inside the simulator needs none.
+final class ChatTabBarUITests: XCTestCase {
+
+    @MainActor
+    func testOpeningAChatHidesTheTabBar() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // The sim is already paired in dev runs; if this launch landed on the
+        // Connect screen instead, there is nothing meaningful to assert here.
+        let tabBar = app.tabBars.firstMatch
+        guard tabBar.waitForExistence(timeout: 60) else {
+            throw XCTSkip("App is not paired with a Cave server — no tab bar to test against.")
+        }
+
+        // Roster → the familiar's thread list (the tab bar stays here).
+        let nova = app.staticTexts["Nova"].firstMatch
+        XCTAssertTrue(nova.waitForExistence(timeout: 30), "Chats roster should list the Nova familiar")
+        nova.tap()
+        XCTAssertTrue(app.navigationBars["Nova"].waitForExistence(timeout: 10),
+                      "Nova's thread list should be on screen")
+        XCTAssertTrue(tabBar.isHittable, "Tab bar should stay on the thread list")
+
+        // Thread list → the conversation itself.
+        let thread = app.cells.firstMatch
+        XCTAssertTrue(thread.waitForExistence(timeout: 15), "Nova should have at least one thread")
+        thread.tap()
+        let composer = app.textFields["Message"].firstMatch
+        let composerView = app.textViews["Message"].firstMatch
+        XCTAssertTrue(composer.waitForExistence(timeout: 10) || composerView.waitForExistence(timeout: 5),
+                      "Conversation composer should be on screen")
+
+        // The tab bar must be gone — hidden bars can linger in the hierarchy
+        // with an offscreen frame, so accept not-exists or not-hittable.
+        var hidden = false
+        for _ in 0..<20 {
+            if !tabBar.exists || !tabBar.isHittable { hidden = true; break }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        XCTAssertTrue(hidden, "Tab bar should hide while a conversation is open")
+
+        // …and it returns on the way back to the thread list.
+        let back = app.navigationBars.buttons["BackButton"].firstMatch
+        if back.waitForExistence(timeout: 5) {
+            back.tap()
+        } else {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.02, dy: 0.5))
+                .press(forDuration: 0.05, thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)))
+        }
+        var returned = false
+        for _ in 0..<20 {
+            if tabBar.exists && tabBar.isHittable { returned = true; break }
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+        XCTAssertTrue(returned, "Tab bar should return after leaving the conversation")
+    }
+}

--- a/scripts/ios-chat-hides-tab-bar.test.mjs
+++ b/scripts/ios-chat-hides-tab-bar.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chatView = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatView.swift", import.meta.url),
+  "utf8",
+);
+
+// The pushed conversation is a full-screen surface (like Messages): the root
+// tab bar yields to the composer instead of stacking beneath it.
+assert.match(
+  chatView,
+  /\.toolbar\(\.hidden, for: \.tabBar\)/,
+  "ChatView should hide the root tab bar while a conversation is open",
+);
+
+console.log("ios-chat-hides-tab-bar.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1217,6 +1217,7 @@ export const SUITES = {
     "scripts/ios-message-bubble-equatable.test.mjs",
     "scripts/ios-chat-draft-lag.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",
+    "scripts/ios-chat-hides-tab-bar.test.mjs",
     "scripts/ios-development-code-title.test.mjs",
     "scripts/ios-development-github-title.test.mjs",
     "scripts/ios-development-terminal-chrome.test.mjs",


### PR DESCRIPTION
## What

User request: "remove the bottom tabs when in chat screen" (iOS app).

- `ChatView` adds `.toolbar(.hidden, for: .tabBar)` on its body — the pushed conversation reads as its own full-screen surface (like Messages), and the modifier covers all three presentation sites (roster switch, thread-list `navigationDestination`, search).
- The tab bar returns when popping back to the thread list / roster.

## Verification

- New **XCUITest** `ChatTabBarUITests.testOpeningAChatHidesTheTabBar` — ran green on the iPhone 16 Pro simulator: tab bar hittable on the roster and Nova's thread list, gone (not-exists/not-hittable) in the conversation with the composer on screen, back after tapping Back. (XCUITest because host-side synthetic taps need macOS Accessibility grants; the in-sim runner needs none.)
- New source-pin test `scripts/ios-chat-hides-tab-bar.test.mjs` wired into `test:mobile` — suite green: 86 files; `check-tests-wired` 1206 ok.

CI note: Swift doesn't build in CI — the XCUITest is for local/sim runs, same as the existing `DiaryUITests`.