### PR TITLE
feat(ios): transcript & home micro-polish — unread divider, draft badges, day chip (cave-8jko)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -293,6 +293,12 @@ final class AppModel {
     /// "unread" when its latest activity is newer than this. Persisted.
     var familiarViews: [String: Date] = [:]
 
+    /// threadId → the operator's unsent composer draft, mirrored from the
+    /// per-thread UserDefaults keys so list rows can badge drafted threads
+    /// without hitting UserDefaults on every row render. Seeded on hydrate,
+    /// kept current by the composer's debounced persistence.
+    var threadDrafts: [String: String] = [:]
+
     init() {
         connection = CaveConnection.load()
         // Threads hydrate off-main via the store — no file I/O in init.
@@ -1432,12 +1438,41 @@ final class AppModel {
         return activity > seen
     }
 
+    /// Earliest "last viewed" date across a thread's familiars — the boundary
+    /// the "New Messages" divider is placed against. nil when untracked.
+    func seenBoundary(for thread: ChatThread) -> Date? {
+        thread.familiarIds.compactMap { familiarViews[$0] }.min()
+    }
+
     /// Mark a familiar's chats as read (call when opening them).
     func markFamiliarViewed(_ ids: [String]) {
         guard !ids.isEmpty else { return }
         let now = Date()
         for id in ids { familiarViews[id] = now }
         persistFamiliarViews()
+    }
+
+    /// Per-thread UserDefaults key for the composer's unsent draft.
+    static func draftKey(_ threadId: String) -> String { "cave.chat.draft.\(threadId)" }
+
+    /// Keep the observable draft mirror in step with the composer's debounced
+    /// UserDefaults persistence; list rows read this to badge drafted threads.
+    func setThreadDraft(_ threadId: String, text: String?) {
+        if let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if threadDrafts[threadId] != text { threadDrafts[threadId] = text }
+        } else if threadDrafts[threadId] != nil {
+            threadDrafts.removeValue(forKey: threadId)
+        }
+    }
+
+    /// Load persisted drafts for restored threads into the observable mirror.
+    private func seedThreadDrafts() {
+        for thread in threads where threadDrafts[thread.id] == nil {
+            if let saved = UserDefaults.standard.string(forKey: Self.draftKey(thread.id)),
+               !saved.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                threadDrafts[thread.id] = saved
+            }
+        }
     }
 
     /// Baseline any not-yet-tracked familiar as seen "now" so existing history
@@ -1967,6 +2002,7 @@ final class AppModel {
             .map { ChatThread(snapshot: $0) }
         guard !restored.isEmpty else { return }
         threads = (threads + restored).sorted { $0.updatedAt > $1.updatedAt }
+        seedThreadDrafts()
     }
 
     private var cardLinksFileURL: URL {

--- a/apps/ios/CovenCave/CovenCave/State/UnreadMarker.swift
+++ b/apps/ios/CovenCave/CovenCave/State/UnreadMarker.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Placement logic for the transcript's "New Messages" divider — the
+/// iMessage/Telegram-style marker above the first reply that arrived since
+/// the operator last viewed this familiar's chats. Pure functions so the
+/// placement rules are unit-testable.
+enum UnreadMarker {
+    /// The id of the first unseen message: the earliest assistant reply
+    /// created strictly after `seenBoundary`. A nil boundary (familiar not
+    /// tracked yet) means no divider — new familiars are seeded as "seen
+    /// now", so the whole backlog never reads as unread. The operator's own
+    /// sends and local system notes never count as unseen.
+    static func firstUnseenId(messages: [DisplayMessage], seenBoundary: Date?) -> String? {
+        guard let boundary = seenBoundary else { return nil }
+        return messages.first { $0.role == .assistant && $0.createdAt > boundary }?.id
+    }
+
+    /// How many messages sit at or after the divider. Drives the initial
+    /// scroll: a long unseen run lands the reader on the divider instead of
+    /// hard-bottom so nothing is skipped.
+    static func unseenRunLength(messages: [DisplayMessage], firstUnseenId: String?) -> Int {
+        guard let id = firstUnseenId,
+              let index = messages.firstIndex(where: { $0.id == id }) else { return 0 }
+        return messages.count - index
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -43,6 +43,19 @@ struct ChatView: View {
     @State private var photoItems: [PhotosPickerItem] = []
     @State private var pendingImages: [PendingImage] = []
     @State private var draftPersistenceTask: Task<Void, Never>?
+    /// "New Messages" divider: computed once per visit, *before*
+    /// `markFamiliarViewed` moves the seen boundary, then left in place for
+    /// the whole visit (re-appears from pushes must not dissolve it).
+    @State private var unreadDividerId: String?
+    @State private var unreadRunLength = 0
+    @State private var unreadComputed = false
+    /// Day dates whose separators have scrolled above the viewport top —
+    /// max() names the day the reader is currently inside.
+    @State private var daysAboveTop: Set<Date> = []
+    /// Floating day chip shows only while the transcript is actively
+    /// scrolling (Telegram behaviour), fading shortly after it settles.
+    @State private var dayChipActive = false
+    @State private var dayChipIdleTask: Task<Void, Never>?
     /// How many images one message can carry.
     private let maxAttachments = 4
     private let draftPersistenceDelay: UInt64 = 250_000_000
@@ -57,7 +70,7 @@ struct ChatView: View {
     @State private var zoomTarget: ZoomTarget?
 
     /// Per-thread key for the persisted unsent draft.
-    private var draftKey: String { "cave.chat.draft.\(thread.id)" }
+    private var draftKey: String { AppModel.draftKey(thread.id) }
 
     // The slash autocomplete is driven purely off the in-progress draft: a
     // leading "/" on the first word (no whitespace committed yet).
@@ -81,8 +94,10 @@ struct ChatView: View {
     private func writeDraftPersistence(_ value: String, key: String) {
         if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             UserDefaults.standard.removeObject(forKey: key)
+            app.setThreadDraft(thread.id, text: nil)
         } else {
             UserDefaults.standard.set(value, forKey: key)
+            app.setThreadDraft(thread.id, text: value)
         }
     }
 
@@ -99,6 +114,18 @@ struct ChatView: View {
         draftPersistenceTask?.cancel()
         draftPersistenceTask = nil
         writeDraftPersistence(draft, key: draftKey)
+    }
+
+    /// Compute the divider once per visit against the pre-visit seen boundary.
+    /// Idempotent: both the scroll reader's onAppear (which needs it first for
+    /// the initial scroll target) and the view's onAppear call it.
+    private func computeUnreadDividerIfNeeded() {
+        guard !unreadComputed else { return }
+        unreadComputed = true
+        unreadDividerId = UnreadMarker.firstUnseenId(messages: thread.messages,
+                                                     seenBoundary: app.seenBoundary(for: thread))
+        unreadRunLength = UnreadMarker.unseenRunLength(messages: thread.messages,
+                                                       firstUnseenId: unreadDividerId)
     }
 
     var body: some View {
@@ -231,6 +258,9 @@ struct ChatView: View {
             if draft.isEmpty, let saved = UserDefaults.standard.string(forKey: draftKey) {
                 draft = saved
             }
+            // Place the "New Messages" divider from the seen boundary BEFORE
+            // marking viewed moves it.
+            computeUnreadDividerIfNeeded()
             // Opening the chat clears the unread badge for its familiar(s) and
             // any delivered reply banner for this thread.
             app.markFamiliarViewed(thread.familiarIds)
@@ -268,7 +298,22 @@ struct ChatView: View {
                         switch row {
                         case .day(_, let date):
                             DaySeparator(date: date)
+                                // Track which day sections have scrolled past
+                                // the top edge: the transform runs per frame
+                                // but the action (a state write) only fires on
+                                // the Bool transition, keeping the hot scroll
+                                // path allocation-free.
+                                .onGeometryChange(for: Bool.self) { proxy in
+                                    proxy.frame(in: .scrollView).maxY < 0
+                                } action: { above in
+                                    if above { daysAboveTop.insert(date) }
+                                    else { daysAboveTop.remove(date) }
+                                }
                         case .message(let message):
+                            if message.id == unreadDividerId {
+                                UnreadDividerView()
+                                    .id("unread-divider")
+                            }
                             MessageBubble(message: message,
                                           isGroup: thread.isGroup,
                                           familiar: message.familiarId.flatMap(app.familiar),
@@ -349,6 +394,29 @@ struct ChatView: View {
                 }
             }
             .animation(.snappy(duration: 0.2), value: atBottom)
+            // Floating day chip (Telegram-style): while scrolling, name the
+            // day the reader is inside — the newest day whose separator has
+            // passed the top edge. Fades out shortly after scrolling settles.
+            .overlay(alignment: .top) {
+                if dayChipActive, let day = daysAboveTop.max() {
+                    DayChip(date: day)
+                        .padding(.top, 8)
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .animation(reduceMotion ? nil : .snappy(duration: 0.2), value: dayChipActive)
+            .onScrollPhaseChange { _, newPhase in
+                dayChipIdleTask?.cancel()
+                if newPhase == .idle {
+                    dayChipIdleTask = Task {
+                        try? await Task.sleep(nanoseconds: 900_000_000)
+                        guard !Task.isCancelled else { return }
+                        dayChipActive = false
+                    }
+                } else if !dayChipActive {
+                    dayChipActive = true
+                }
+            }
             // Follow the stream only while the reader is parked at the bottom.
             // Scrolling up to reread must never be yanked back down by each
             // arriving token — the native Messages contract; returning to the
@@ -372,7 +440,17 @@ struct ChatView: View {
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
-            .onAppear { proxy.scrollTo("bottom", anchor: .bottom) }
+            .onAppear {
+                computeUnreadDividerIfNeeded()
+                // A long unseen run lands the reader on the divider so nothing
+                // is skipped; short runs keep the familiar bottom landing
+                // (the divider sits within the first screenful anyway).
+                if unreadDividerId != nil && unreadRunLength >= 6 {
+                    proxy.scrollTo("unread-divider", anchor: .center)
+                } else {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
         }
     }
 
@@ -1094,7 +1172,7 @@ final class ScrollCoalescer {
 private struct DaySeparator: View {
     let date: Date
 
-    private var label: String {
+    static func label(for date: Date) -> String {
         let cal = Calendar.current
         if cal.isDateInToday(date) { return "Today" }
         if cal.isDateInYesterday(date) { return "Yesterday" }
@@ -1106,13 +1184,53 @@ private struct DaySeparator: View {
     }
 
     var body: some View {
-        Text(label)
+        Text(Self.label(for: date))
             .font(.caption2.weight(.semibold))
             .foregroundStyle(.secondary)
             .padding(.horizontal, 12).padding(.vertical, 4)
             .glass(.control, in: Capsule())
             .frame(maxWidth: .infinity)
             .padding(.vertical, 4)
+    }
+}
+
+/// The floating "current day" pill shown at the top of the transcript while
+/// it scrolls — same label rules as `DaySeparator`, lifted with a shadow so
+/// it reads as chrome above the messages rather than a row among them.
+private struct DayChip: View {
+    let date: Date
+
+    var body: some View {
+        Text(DaySeparator.label(for: date))
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12).padding(.vertical, 4)
+            .glassFill(.control, in: Capsule())
+            .shadow(color: .black.opacity(0.12), radius: 5, y: 2)
+            .accessibilityLabel("Viewing \(DaySeparator.label(for: date))")
+    }
+}
+
+/// iMessage/Telegram-style marker above the first reply that arrived since
+/// the operator last viewed this familiar's chats.
+private struct UnreadDividerView: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            hairline
+            Text("New Messages")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Color.accentColor)
+                .fixedSize()
+            hairline
+        }
+        .padding(.vertical, 2)
+        .accessibilityLabel("New messages below")
+    }
+
+    private var hairline: some View {
+        Rectangle()
+            .fill(Color.accentColor.opacity(0.35))
+            .frame(height: 1)
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -600,10 +600,21 @@ struct ThreadRow: View {
                     Text(thread.updatedAt, format: .relative(presentation: .numeric))
                         .font(.caption).foregroundStyle(.tertiary)
                 }
-                Text(previewText)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                if let draftText = app.threadDrafts[thread.id] {
+                    // A persisted unsent draft outranks the last-message
+                    // preview (standard messenger affordance — makes drafts
+                    // discoverable from the list).
+                    (Text("Draft: ").foregroundStyle(Color.accentColor)
+                        + Text(draftText.replacingOccurrences(of: "\n", with: " ")))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                } else {
+                    Text(previewText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
             }
         }
         .padding(.vertical, 2)
@@ -620,7 +631,11 @@ struct ThreadRow: View {
         if thread.pinned { parts.append("pinned") }
         if thread.muted { parts.append("muted") }
         parts.append("last active " + Self.relativeFormatter.localizedString(for: thread.updatedAt, relativeTo: Date()))
-        parts.append(previewText)
+        if let draftText = app.threadDrafts[thread.id] {
+            parts.append("draft: " + draftText)
+        } else {
+            parts.append(previewText)
+        }
         return parts.joined(separator: ", ")
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/UnreadMarkerTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/UnreadMarkerTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import CovenCave
+
+/// Placement rules for the "New Messages" transcript divider: it sits above
+/// the first assistant reply created after the operator's seen boundary, and
+/// its run length decides whether the initial scroll lands on it.
+final class UnreadMarkerTests: XCTestCase {
+
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func message(_ id: String, role: DisplayMessage.Role,
+                         offset: TimeInterval) -> DisplayMessage {
+        DisplayMessage(id: id, role: role, familiarId: role == .assistant ? "fam" : nil,
+                       text: "m-\(id)", createdAt: base.addingTimeInterval(offset))
+    }
+
+    // MARK: firstUnseenId
+
+    func testNilBoundaryMeansNoDivider() {
+        let messages = [message("a", role: .assistant, offset: 10)]
+        XCTAssertNil(UnreadMarker.firstUnseenId(messages: messages, seenBoundary: nil))
+    }
+
+    func testAllSeenMeansNoDivider() {
+        let messages = [
+            message("a", role: .assistant, offset: -20),
+            message("b", role: .assistant, offset: -10),
+        ]
+        XCTAssertNil(UnreadMarker.firstUnseenId(messages: messages, seenBoundary: base))
+    }
+
+    func testFirstAssistantReplyAfterBoundaryIsTheDivider() {
+        let messages = [
+            message("old", role: .assistant, offset: -10),
+            message("new1", role: .assistant, offset: 10),
+            message("new2", role: .assistant, offset: 20),
+        ]
+        XCTAssertEqual(UnreadMarker.firstUnseenId(messages: messages, seenBoundary: base), "new1")
+    }
+
+    func testOperatorSendsAndSystemNotesNeverCountAsUnseen() {
+        let messages = [
+            message("mine", role: .user, offset: 10),
+            message("note", role: .system, offset: 15),
+            message("reply", role: .assistant, offset: 20),
+        ]
+        XCTAssertEqual(UnreadMarker.firstUnseenId(messages: messages, seenBoundary: base), "reply")
+    }
+
+    func testExactlyAtBoundaryReadsAsSeen() {
+        let messages = [message("edge", role: .assistant, offset: 0)]
+        XCTAssertNil(UnreadMarker.firstUnseenId(messages: messages, seenBoundary: base))
+    }
+
+    // MARK: unseenRunLength
+
+    func testRunLengthCountsFromDividerToEnd() {
+        let messages = [
+            message("a", role: .assistant, offset: -10),
+            message("b", role: .assistant, offset: 10),
+            message("c", role: .user, offset: 15),
+            message("d", role: .assistant, offset: 20),
+        ]
+        XCTAssertEqual(UnreadMarker.unseenRunLength(messages: messages, firstUnseenId: "b"), 3)
+    }
+
+    func testRunLengthZeroWithoutDivider() {
+        let messages = [message("a", role: .assistant, offset: 10)]
+        XCTAssertEqual(UnreadMarker.unseenRunLength(messages: messages, firstUnseenId: nil), 0)
+        XCTAssertEqual(UnreadMarker.unseenRunLength(messages: messages, firstUnseenId: "ghost"), 0)
+    }
+}


### PR DESCRIPTION
## Summary

Workstream 5 of the iOS UI/UX improvement plan — three verified gaps, one bundle:

- **"New Messages" divider** — opening a chat cleared unread instantly with no trace. `ChatView` now captures the seen boundary (`AppModel.seenBoundary`, min across the thread's familiars) **before** `markFamiliarViewed` moves it, and renders an accent divider above the first unseen assistant reply. Placement is pure logic (`UnreadMarker`) with 7 unit tests. Unseen runs ≥6 land the initial scroll on the divider (center) instead of hard-bottom.
- **Draft badges on thread rows** — drafts persist per thread (`cave.chat.draft.<id>`) but rows never showed them. `AppModel.threadDrafts` observable mirror (seeded on hydrate; updated by the composer's existing debounced persistence — the pinned typing path is untouched); `ThreadRow` shows `Draft: …` with an accent prefix in place of the last-message preview; VoiceOver reads it.
- **Floating day chip** — while the transcript scrolls, a Telegram-style chip names the day under the viewport top (newest `DaySeparator` past the top edge, tracked with `onGeometryChange` Bool transitions so the hot scroll path stays free of per-frame state writes) and fades ~0.9s after scrolling settles (`onScrollPhaseChange`). Reduce Motion drops the animations.

## Verification

- `xcodegen generate` + `xcodebuild build` — **BUILD SUCCEEDED** (iPhone 16 Pro sim)
- `UnreadMarkerTests` (7) + `TranscriptRowsTests` (12) — **19 tests, 0 failures**
- `node scripts/run-tests.mjs mobile` — **86 files passed** (draft-lag pins intact)
- Swift isn't in CI; evidence recorded in bead cave-8jko

Bead: cave-8jko