### PR TITLE
feat(ios): motion & transition polish — zoom push to chat, queued-send entrance (cave-9mnx)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -330,10 +330,14 @@ struct ChatView: View {
                             .id(message.id)
                             // New bubbles settle in with a soft rise-and-fade
                             // (native Messages behaviour) instead of popping;
+                            // queued-offline sends enter subdued (opacity
+                            // only) so they read as parked, not sent;
                             // deletions fade out. Driven by the count-keyed
                             // animation below; Reduce Motion turns it off.
                             .transition(.asymmetric(
-                                insertion: .opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)),
+                                insertion: message.isQueued
+                                    ? .opacity
+                                    : .opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)),
                                 removal: .opacity))
                         }
                     }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -35,6 +35,9 @@ struct ChatsHomeView: View {
     /// Left slide-out drawer (menu button in the header).
     @State private var drawerOpen = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Anchors the iOS 18 zoom transition: thread rows mark themselves as
+    /// sources; the pushed conversation zooms out of its row.
+    @Namespace private var zoomNamespace
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -115,7 +118,8 @@ struct ChatsHomeView: View {
             Group {
                 switch selection {
                 case .familiar(let familiar):
-                    FamiliarThreadsView(familiar: familiar, path: $detailPath)
+                    FamiliarThreadsView(familiar: familiar, path: $detailPath,
+                                        zoomNamespace: zoomNamespace)
                 case .thread(let thread):
                     ChatView(thread: thread)
                 case nil:
@@ -129,11 +133,26 @@ struct ChatsHomeView: View {
             .navigationDestination(for: ChatRoute.self) { route in
                 switch route {
                 case .familiar(let familiar):
-                    FamiliarThreadsView(familiar: familiar, path: $detailPath)
+                    FamiliarThreadsView(familiar: familiar, path: $detailPath,
+                                        zoomNamespace: zoomNamespace)
                 case .thread(let thread):
-                    ChatView(thread: thread)
+                    chatDestination(thread)
                 }
             }
+        }
+    }
+
+    /// The pushed conversation, zooming out of its thread row (iOS 18 zoom
+    /// transition; the row is the `matchedTransitionSource`). Reduce Motion
+    /// keeps the standard push. Selection-driven opens (home list) have no
+    /// row source and use the default presentation either way.
+    @ViewBuilder
+    private func chatDestination(_ thread: ChatThread) -> some View {
+        if reduceMotion {
+            ChatView(thread: thread)
+        } else {
+            ChatView(thread: thread)
+                .navigationTransition(.zoom(sourceID: thread.id, in: zoomNamespace))
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -9,6 +9,9 @@ struct FamiliarThreadsView: View {
     @Environment(AppModel.self) private var app
     let familiar: Familiar
     @Binding var path: [ChatRoute]
+    /// Namespace owned by `ChatsHomeView`; local thread rows register as
+    /// zoom-transition sources so the pushed conversation grows out of them.
+    var zoomNamespace: Namespace.ID
     @State private var renamingThread: ChatThread?
     /// An on-device thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
@@ -310,6 +313,7 @@ struct FamiliarThreadsView: View {
         switch entry {
         case .local(let thread):
             ThreadRow(thread: thread)
+                .matchedTransitionSource(id: thread.id, in: zoomNamespace)
         case .server(let session):
             ServerSessionRow(session: session)
         }

--- a/scripts/ios-ipad-split-chats.test.mjs
+++ b/scripts/ios-ipad-split-chats.test.mjs
@@ -36,7 +36,7 @@ assert.match(
 );
 assert.match(
   src,
-  /case \.familiar\(let familiar\):\s*\n\s*FamiliarThreadsView\(familiar: familiar, path: \$detailPath\)/,
+  /case \.familiar\(let familiar\):\s*\n\s*FamiliarThreadsView\(familiar: familiar, path: \$detailPath[,)]/,
   "selecting a familiar should show its threads in the detail column",
 );
 assert.match(

--- a/scripts/ios-modern-polish.test.mjs
+++ b/scripts/ios-modern-polish.test.mjs
@@ -97,7 +97,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /\.transition\(\.asymmetric\([\s\S]{0,160}?insertion: \.opacity\.combined\(with: \.scale\(scale: 0\.9\d, anchor: \.bottom\)\)/,
+  /\.transition\(\.asymmetric\([\s\S]{0,220}?: \.opacity\.combined\(with: \.scale\(scale: 0\.9\d, anchor: \.bottom\)\)/,
   "new bubbles should rise-and-fade in rather than popping",
 );
 assert.match(

--- a/scripts/ios-motion-polish.test.mjs
+++ b/scripts/ios-motion-polish.test.mjs
@@ -1,0 +1,50 @@
+// Pins the iOS motion-polish contracts (cave-9mnx):
+//  1. Thread-row → ChatView pushes use the iOS 18 zoom transition, anchored
+//     on the row via matchedTransitionSource, and fall back to the standard
+//     push under Reduce Motion.
+//  2. Queued-offline sends enter subdued (opacity only) instead of the
+//     rise-and-scale entrance used for real sends.
+// These are source pins because Swift isn't compiled in CI.
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(root, "apps/ios/CovenCave/CovenCave", p), "utf8");
+
+const chatsHome = read("Views/ChatsHomeView.swift");
+const familiarThreads = read("Views/FamiliarThreadsView.swift");
+const chatView = read("Views/ChatView.swift");
+
+test("ChatsHomeView owns the zoom namespace and applies the zoom push", () => {
+  assert.match(chatsHome, /@Namespace private var zoomNamespace/);
+  assert.match(
+    chatsHome,
+    /navigationTransition\(\.zoom\(sourceID: thread\.id, in: zoomNamespace\)\)/,
+  );
+});
+
+test("zoom transition is gated on Reduce Motion", () => {
+  assert.match(
+    chatsHome,
+    /if reduceMotion \{\s*ChatView\(thread: thread\)\s*\} else \{/,
+    "Reduce Motion must keep the standard push (no navigationTransition)",
+  );
+});
+
+test("thread rows anchor the zoom via matchedTransitionSource", () => {
+  assert.match(
+    familiarThreads,
+    /ThreadRow\(thread: thread\)\s*\.matchedTransitionSource\(id: thread\.id, in: zoomNamespace\)/,
+  );
+});
+
+test("queued-offline sends enter subdued (opacity only)", () => {
+  assert.match(
+    chatView,
+    /insertion: message\.isQueued\s*\? \.opacity\s*: \.opacity\.combined\(with: \.scale\(scale: 0\.97, anchor: \.bottom\)\)/,
+    "queued sends must skip the rise-and-scale entrance",
+  );
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1215,6 +1215,7 @@ export const SUITES = {
     "scripts/ios-message-forwarding.test.mjs",
     "scripts/ios-message-retry.test.mjs",
     "scripts/ios-message-bubble-equatable.test.mjs",
+    "scripts/ios-motion-polish.test.mjs",
     "scripts/ios-chat-draft-lag.test.mjs",
     "scripts/ios-chat-thread-no-search.test.mjs",
     "scripts/ios-chat-hides-tab-bar.test.mjs",


### PR DESCRIPTION
Workstream 4 (final) of the iOS UI/UX improvement plan. Bead: cave-9mnx.

## What
- **iOS 18 zoom push**: thread rows in `FamiliarThreadsView` register as `matchedTransitionSource`; the pushed `ChatView` (via `navigationDestination`) zooms out of its row with `.navigationTransition(.zoom)`. Namespace owned by `ChatsHomeView`.
- **Reduce Motion**: gated — standard push when enabled. Selection-driven opens (iPad detail column) keep default presentation.
- **Queued-send entrance**: queued-offline sends insert with opacity only (subdued, reads as parked) vs. the rise-and-scale entrance for live sends.

## Tests
- New `scripts/ios-motion-polish.test.mjs` (4 pins) registered in mobile suite.
- Loosened two existing pins for the new shapes (`ios-modern-polish`, `ios-ipad-split-chats`).

## Verification (Swift not compiled in CI)
- `xcodebuild build` iPhone 16 Pro sim: **BUILD SUCCEEDED**
- `-only-testing:CovenCaveTests`: **TEST SUCCEEDED**
- `node scripts/run-tests.mjs mobile`: **87 files pass**
- DiaryUITests failure is environmental (iPad-only entry point + live daemon; ran daemon-less on iPhone).