### PR TITLE
chore(release): stamp v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-22
+
+> 🏠 **Refined home, richer iOS, and new runtimes.** The launch home gets a unified hearth cluster with Continue cards and a split composer toolbar. iOS gains a focused 4-tab bar, turn-completion notifications, Live Activity, Canvas view mode, and motion polish. New runtimes: Grok Build, OpenCode, and a native Tailscale Server Hub connection.
+
+### Added
+- **Refined launch home** — unified hearth cluster, split composer toolbar (utility row + submit row), Continue cards for reference parity, violet persistent composer border, context pill in footer band, and a settle animation for a calmer cold-start (#3670, #3662, #3664).
+- **iOS tab bar & Live Activity** — a focused 4-tab bar with a sidebar-adaptable More section, bottom tab bar hides while a conversation is open, turn-completion notifications, chat Live Activity, and live agent tool/progress activity in chat (#3666, #3667, #3661, #3658).
+- **New runtimes** — native Grok Build and OpenCode chat runtimes; Tailscale Server Hub connection synced with the desktop daemon (#3649, #3647, #3641).
+- **iOS Canvas & polish** — Canvas view mode behind a fail-closed desktop opt-in; iOS transcript micro-polish (unread divider, draft badges, day chip); zoom-push-to-chat and subdued queued-send entrance motion (#3657, #3668, #3669).
+- **Chat & composer improvements** — `/image` command, familiar image-gen settings, image skill templates; unified ComposerAddMenu with cascading submenus; rail code preview wraps flush; `/image` familiar-level settings (#3648, #3651, #3645).
+- **Familiar redesign** — five-section rebuild from skills-page design handoff (#3655).
+
+### Fixed
+- **Mobile & pairing** — pairing status self-heals with TTL half-open on retry breaker; forward request in project-file POST so phone saves honor the opt-in; smart iOS connect screen + desktop handoff ladder; don't classify trusted local peers as mobile ingress (#3665, #3663, #3654, #3646).
+- **Chat resilience** — parse SSE frames carrying `id:` lines; env panel gates at 2xl width; popover submenu click after hover-intent no longer re-closes flyout; draft flush-on-unmount and adapter-heal early settle (#3656, #3642, #3653, #3637).
+- **Hermes & stream** — expose authenticated models and repair Debug events (#3636).
+- **Misc** — launch OpenClaw npm shims without cmd; hide Coven Code from runtime binding pickers (#3660, #3659).
+
 ## [0.1.4] - 2026-07-19
 
 > 🏠 **Home-first, safer, and calmer.** The Cave now opens on Home with a redesigned navigation and chat interface, a broad security-hardening pass locks down mobile and project surfaces, iOS chat gets noticeably smoother, and a neutral-graphite repaint unifies the whole design system.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "block2",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.4"
+version = "0.1.5"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Bump all six version locations 0.1.4 → 0.1.5 and add CHANGELOG section.

**What's in v0.1.5:**
- Refined launch home — unified hearth cluster, Continue cards, split composer toolbar, violet composer border (#3670)
- iOS 4-tab bar, turn-completion notifications, Live Activity, Canvas view mode (#3666–#3669, #3658, #3657)
- New runtimes: Grok Build, OpenCode, Tailscale Server Hub (#3649, #3647, #3641)
- Familiar five-section redesign (#3655)
- Mobile/chat/stream fixes (#3636, #3637, #3642, #3645, #3646, #3651, #3653, #3654, #3656, #3659–#3660, #3663, #3665)

Val explicitly approved merge-to-main + release for this version.