### PR TITLE
fix(theme): restore custom theme accent when backdrop releases --accent-presence

### DIFF
--- a/src/lib/cave-backdrop.test.ts
+++ b/src/lib/cave-backdrop.test.ts
@@ -279,6 +279,25 @@ assert.match(
   /root\.style\.removeProperty\("--accent-presence"\)/,
   "disabling the match restores the theme accent untouched",
 );
+// Custom themes carry their accent as an inline property (no preset CSS
+// behind them), so the restore path must hand the token back to the theme
+// instead of blind-removing it — removal reverted user-edited accents the
+// moment the layer re-applied (issue #3672).
+assert.match(
+  lib,
+  /const themeAccent = customThemeAccent\(\);\s*if \(themeAccent\) root\.style\.setProperty\("--accent-presence", themeAccent\);\s*else root\.style\.removeProperty\("--accent-presence"\);/,
+  "the restore path re-installs a custom theme's own accent (#3672)",
+);
+assert.match(
+  lib,
+  /if \(theme\.id !== "custom" \|\| !theme\.custom\) return null;/,
+  "presets keep plain removal — their accent lives in theme CSS",
+);
+assert.match(
+  lib,
+  /activeCustomThemeVariables\(theme\.custom, mode\)\["--accent-presence"\]/,
+  "the restored accent resolves through the same mode-group logic as applyThemeToRoot",
+);
 
 // The layer stays mounted and crossfades; only home/chat lift the opaque panes.
 assert.match(layer, /data-on=\{active \? "true" : "false"\}/, "the layer crossfades via data-on");

--- a/src/lib/cave-backdrop.ts
+++ b/src/lib/cave-backdrop.ts
@@ -27,7 +27,8 @@ import {
   createBackdropImageState,
   type BackdropMigrationResult,
 } from "@/lib/backdrop-image-state";
-import { MAX_FAMILIAR_BACKDROPS } from "@/lib/preferences-schema";
+import { MAX_FAMILIAR_BACKDROPS, type CaveMode } from "@/lib/preferences-schema";
+import { activeCustomThemeVariables } from "@/lib/theme-runtime";
 
 const PREFS_KEY = "cave:backdrop:v1";
 const DB_NAME = "cave-backdrop";
@@ -375,6 +376,19 @@ export function fitAccentToBackground(seed: BackdropAccentSeed, bgCss: string): 
 
 // ── applying to the document ─────────────────────────────────────────────────
 
+/** The active custom theme's own `--accent-presence`, if it installs one.
+ *  Custom/forked themes carry their accent as an inline property (there is no
+ *  preset CSS behind them), so the backdrop layer must hand the token back to
+ *  the theme rather than blind-remove it (#3672). */
+function customThemeAccent(): string | null {
+  const theme = readAppPreferences().appearance.theme;
+  if (theme.id !== "custom" || !theme.custom) return null;
+  const attr =
+    typeof document !== "undefined" ? document.documentElement.getAttribute("data-mode") : null;
+  const mode: CaveMode = attr === "light" || attr === "dark" ? attr : theme.resolvedMode;
+  return activeCustomThemeVariables(theme.custom, mode)["--accent-presence"] ?? null;
+}
+
 /** Applies prefs (and optionally the image object URL) to <html>. Pass
  *  `imageUrl: undefined` to leave the current image untouched (pref-only
  *  updates); `null` clears it. */
@@ -393,7 +407,12 @@ export function applyBackdropToDocument(prefs: BackdropPrefs, imageUrl?: string 
     const bg = getComputedStyle(root).getPropertyValue("--bg-base").trim() || "oklch(0.13 0.022 293)";
     root.style.setProperty("--accent-presence", fitAccentToBackground(prefs.accentSeed, bg));
   } else {
-    root.style.removeProperty("--accent-presence");
+    // Restore the theme's own accent. For presets that means removing the
+    // inline override so the theme CSS shows; a custom theme's accent IS an
+    // inline property, so removal would revert the user's edit (#3672).
+    const themeAccent = customThemeAccent();
+    if (themeAccent) root.style.setProperty("--accent-presence", themeAccent);
+    else root.style.removeProperty("--accent-presence");
   }
 }
 


### PR DESCRIPTION
Fixes #3672

## Bug

Editing the accent color in Settings → Appearance visibly applies, but navigating back to Home reverts it to the theme default. Preset theme switching was unaffected.

## Root cause

- Editing a token forks the preset into a **custom theme** whose snapshot — including `--accent-presence` — is installed as **inline style properties** on `:root` (`applyThemeToRoot`). There is no preset CSS behind a custom theme.
- `CaveBackdropLayer` mounts only on home/chat (`workspace.tsx`), not on `/settings`. Returning from Settings remounts it, and its effect re-runs `applyBackdropToDocument`.
- With backdrop accent-match off, the restore path unconditionally ran `removeProperty("--accent-presence")` — correct for presets (reveals theme CSS), but for custom themes it deleted the user's edit and the `:root` default showed through.

## Fix

`applyBackdropToDocument`'s restore path now hands the token back to the active theme: a new `customThemeAccent()` helper re-installs the custom theme's own accent (resolved via the same `activeCustomThemeVariables` mode-group logic `applyThemeToRoot` uses, mode read from live `data-mode`); presets keep plain removal. Backdrop accent-match still wins when enabled, and custom→preset switches still clear the override.

## Verification

- `pnpm typecheck` ✓
- Targeted suites (suite-faithful invocation incl. css-source-contract hook + alias loader): cave-backdrop, settings-appearance, remote-theme-controller, theme-runtime, theme-script, preferences-schema — all pass
- Full `node scripts/run-tests.mjs app`: **891/891 pass**
- 3 new regex pins in `cave-backdrop.test.ts` lock the restore-path shape

Bead: cave-hpjh