### PR TITLE
fix(dashboard): open familiar profile pages from top-collaborators footer

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -60,6 +60,12 @@ assert.match(bento, /matrixRows\(/, "matrix derives from matrixRows");
 assert.match(bento, /githubByRepo\(/, "github rail groups by repo");
 assert.match(bento, /ciSummary\(/, "github footer rolls up CI status");
 assert.match(bento, /topCollaborators\(/, "footer ranks collaborators by session volume");
+assert.match(
+  bento,
+  /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(f\.id\)\}\/profile`\}/,
+  "footer collaborator avatars open the familiar profile page (bare /dashboard/familiars/[id] has no route)",
+);
+assert.match(bento, /aria-label=\{`Open profile for \$\{name\}`\}/, "footer avatar links carry an accessible name");
 assert.match(bento, /useUserProfile\(\)/, "human card reads the operator profile store");
 assert.match(bento, /userAvatarUrl\(/, "human avatar uses the authed object URL, never a raw /api src");
 

--- a/src/components/dashboard/bento-dashboard.tsx
+++ b/src/components/dashboard/bento-dashboard.tsx
@@ -610,10 +610,16 @@ export function BentoDashboard({ model: initialModel }: { model: DashboardModel 
             {collaborators.map((f) => {
               const name = f.display_name || f.name || f.id;
               return (
-                <a key={f.id} href={`/dashboard/familiars/${encodeURIComponent(f.id)}`} className="focus-ring" title={name}>
+                <a
+                  key={f.id}
+                  href={`/dashboard/familiars/${encodeURIComponent(f.id)}/profile`}
+                  className="focus-ring"
+                  title={name}
+                  aria-label={`Open profile for ${name}`}
+                >
                   <AuthedImage
                     src={f.avatarUrl}
-                    alt={name}
+                    alt=""
                     fallback={<span className="bd-footer-letter" aria-hidden>{name.slice(0, 1).toLowerCase()}</span>}
                   />
                 </a>

--- a/tests/dashboard-bento.spec.ts
+++ b/tests/dashboard-bento.spec.ts
@@ -231,6 +231,6 @@ test("activity feed merges sources with machine-readable times; footer ranks col
   // All four familiars fit under the cap of 7; busiest first.
   const foot = page.locator(".bd-footer");
   await expect(foot.locator("a[href^='/dashboard/familiars/']")).toHaveCount(4);
-  await expect(foot.locator("a[href^='/dashboard/familiars/']").first()).toHaveAttribute("href", "/dashboard/familiars/sage");
+  await expect(foot.locator("a[href^='/dashboard/familiars/']").first()).toHaveAttribute("href", "/dashboard/familiars/sage/profile");
   await expect(foot.locator(".bd-footer-stamp")).toContainText("COVEN CAVE");
 });


### PR DESCRIPTION
## What

Clicking a familiar avatar in the dashboard footer's **top collaborators** rail now opens that familiar's profile page (`/dashboard/familiars/[id]/profile`).

## Why

The bento footer linked to bare `/dashboard/familiars/[id]` — a route that has **no page** (only `/profile` and `/analytics` exist under it), so every click 404'd. Broken since the bento import (#3435). The profile-card `CollaboratorsRail` already uses the profile route; this brings the dashboard footer in line.

## Changes

- `bento-dashboard.tsx`: footer avatar `href` → `…/profile`; accessible name moved to the link (`aria-label`, image `alt=""`) matching the CollaboratorsRail pattern so screen readers don't double-announce.
- `dashboard-page.test.ts`: pins the profile href and the aria-label.

## Verification

- `node --experimental-strip-types --no-warnings --test src/app/dashboard-page.test.ts src/lib/authed-image.test.ts src/app/route-inventory.test.ts src/components/profile-card.test.ts` — 9/9 pass
- `pnpm typecheck` — clean

Closes cave-tab3