### PR TITLE
fix(research): pre-approve tools for unattended copilot flow spawns (cave-c3ef)

### DIFF
--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -107,6 +107,34 @@ assert.deepEqual(
   "resumed read-only turns use --resume, still trust granted roots via --add-dir (cave-n1yc: read-only sessions previously got no grant access at all), and keep the manifest's deny-tool sandbox args",
 );
 
+const unattendedArgs = buildCopilotStreamArgs({
+  spec,
+  prompt: "run one bounded iteration",
+  resumeSessionId: null,
+  newSessionId: "22222222-3333-4444-8555-666666666666",
+  model: null,
+  permissionMode: "unattended",
+  addDirs: ["/Users/example/.coven/cave/research-missions/research-1"],
+});
+assert.deepEqual(
+  unattendedArgs,
+  [
+    "--session-id",
+    "22222222-3333-4444-8555-666666666666",
+    "--add-dir",
+    "/Users/example/.coven/cave/research-missions/research-1",
+    "--allow-all-tools",
+    "--allow-all-urls",
+    "--output-format",
+    "json",
+    "--stream",
+    "on",
+    "-p",
+    "run one bounded iteration",
+  ],
+  "unattended one-shots (flow sessions) pre-approve tools and URLs — a -p run can't answer prompts, so approvals otherwise auto-deny and every workspace write fails — while path verification stays on (no --allow-all/--allow-all-paths), keeping writes inside cwd + --add-dir grants",
+);
+
 // ── identity preamble (mirror of coven's FamiliarContext) ─────────────────────
 
 assert.equal(

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -52,6 +52,15 @@ export type CopilotStreamSpec = {
 // shipped in every CLI version this stream path supports (verified 1.0.70).
 const COPILOT_ADD_DIR_FLAG = "--add-dir";
 
+// Approval argv for unattended one-shot runs (flow sessions). A `-p` spawn
+// cannot answer approval prompts, so without these the CLI auto-denies every
+// tool — the "mission workspace was read-only all session" failure that left
+// research missions without artifacts/primary.md. Deliberately narrower than
+// the manifest's full_args (`--allow-all`): tools and URLs are approved, but
+// file-path verification stays ON, confining writes to the spawn cwd plus the
+// explicit `--add-dir` grants (native flags verified against CLI 1.0.73).
+const COPILOT_UNATTENDED_ARGS = ["--allow-all-tools", "--allow-all-urls"];
+
 function stringArray(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
   if (!value.every((entry) => typeof entry === "string")) return null;
@@ -136,7 +145,14 @@ export type CopilotStreamLaunch = {
   newSessionId: string | null;
   /** Cleaned model id; a `provider/` namespace is stripped for copilot. */
   model: string | null;
-  permissionMode: "full" | "read";
+  /**
+   * `full` — interactive chat turns: access stays implicit (no widening args;
+   * #3297). `read` — manifest deny-tool sandbox. `unattended` — non-interactive
+   * one-shots that can't answer approval prompts (flow sessions): tools and
+   * URLs are pre-approved but path verification keeps writes inside the spawn
+   * cwd + `addDirs`. Never expose `unattended` to request-supplied modes.
+   */
+  permissionMode: "full" | "read" | "unattended";
   /**
    * Granted directories to trust at the harness level (repeatable
    * `--add-dir`). Without these the runtime-scope preamble's grants are
@@ -174,8 +190,12 @@ export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
   // Sandbox mapping from the manifest. Read-only is enforced explicitly;
   // full access stays implicit so the direct Copilot stream path does not widen
   // the local harness sandbox with manifest full_args such as `--allow-all`.
+  // Unattended one-shots pre-approve tools/URLs (auto-deny otherwise) while
+  // path verification keeps the cwd + --add-dir write boundary.
   if (launch.permissionMode === "read") {
     args.push(...spec.sandboxReadOnlyArgs);
+  } else if (launch.permissionMode === "unattended") {
+    args.push(...COPILOT_UNATTENDED_ARGS);
   }
   args.push(...spec.prefixArgs, launch.prompt);
   return args;

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -64,6 +64,13 @@ test("spawns with the prompt as one argv element and persists the transcript", a
   assert.equal(argv.length, promptIndex + 1, "nothing trails the prompt argument");
   assert.ok(argv.includes("--session-id"), "fresh session id is pre-assigned");
   assert.ok(!argv.includes("--add-dir"), "no trust flags when addDirs is omitted");
+  // One-shot flow runs can't answer approval prompts — without pre-approved
+  // tools the CLI auto-denies every write and research iterations end with
+  // "completed without artifacts/primary.md". Path verification must stay on.
+  assert.ok(argv.includes("--allow-all-tools"), "unattended runs pre-approve tools");
+  assert.ok(argv.includes("--allow-all-urls"), "unattended runs pre-approve URL fetches");
+  assert.ok(!argv.includes("--allow-all"), "path verification stays on (no blanket --allow-all)");
+  assert.ok(!argv.includes("--allow-all-paths"), "writes stay confined to cwd + --add-dir grants");
 
   // The finished transcript is a Cave conversation under the session id, with
   // the assistant's final content (trailing control markers intact).

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -87,7 +87,12 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     resumeSessionId: null,
     newSessionId: sessionId,
     model: null,
-    permissionMode: "full",
+    // Flow runs are Cave-initiated one-shots with nobody at the prompt: they
+    // need pre-approved tools/URLs or the CLI auto-denies every write and the
+    // iteration "completes" with an untouched workspace (the research-mission
+    // "completed without artifacts/primary.md" failure). Path verification
+    // stays on — writes are confined to the spawn cwd plus addDirs.
+    permissionMode: "unattended",
     addDirs,
   });
 

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -45,11 +45,12 @@ assert.match(
 // Flow prompts direct familiars to write memory/self-reports into their own
 // workspace, but the spawn cwd is the project root and a non-interactive run
 // can't prompt for permission — the workspace must ride as a harness-level
-// trust grant or every such write hard-fails.
+// trust grant or every such write hard-fails. Callers (e.g. research
+// missions) can grant additional roots such as the mission workspace.
 assert.match(
   source,
-  /startCopilotFlowRun\(\{[\s\S]*?addDirs: await flowFamiliarAddDirs\(familiarId, projectRoot\),[\s\S]*?\}\);/,
-  "direct copilot flow spawn must trust the familiar's own workspace via addDirs",
+  /startCopilotFlowRun\(\{[\s\S]*?addDirs: \[[\s\S]*?\.\.\.\(options\.addDirs \?\? \[\]\),[\s\S]*?\.\.\.await flowFamiliarAddDirs\(familiarId, projectRoot\),[\s\S]*?\],[\s\S]*?\}\);/,
+  "direct copilot flow spawn must trust caller grants and the familiar's own workspace via addDirs",
 );
 assert.match(
   source,

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -106,6 +106,13 @@ export async function startFlowSession(
     targetNodeId?: string;
     triggerInput?: FlowTriggerInput;
     mode?: FlowExecutionMode;
+    /**
+     * Extra directories to trust at the harness level alongside the
+     * familiar's own workspace (e.g. a research mission workspace when the
+     * flow runs in a different project root). Non-interactive runs can't
+     * prompt, so an untrusted workspace write hard-fails.
+     */
+    addDirs?: string[];
   } = {},
 ): Promise<StartFlowSessionResult> {
   const blocked = flowRunBlockReason(flow, options.targetNodeId);
@@ -237,7 +244,10 @@ export async function startFlowSession(
         familiarId,
         familiarName: "display_name" in binding ? binding.display_name : undefined,
         familiarRole: "role" in binding ? binding.role : undefined,
-        addDirs: await flowFamiliarAddDirs(familiarId, projectRoot),
+        addDirs: [
+          ...(options.addDirs ?? []),
+          ...await flowFamiliarAddDirs(familiarId, projectRoot),
+        ],
       });
       return finishStart(sessionId);
     }

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -185,6 +185,21 @@ test("the default project root is the pre-resolved mission workspace", async () 
   assert.equal(result.status, "running");
 });
 
+test("every launch grants the mission workspace as a harness trust dir", async () => {
+  // A configured project root moves the spawn cwd away from the workspace;
+  // without an --add-dir grant a non-interactive run cannot write there and
+  // the iteration ends with "completed without artifacts/primary.md".
+  const grants: Array<string[] | undefined> = [];
+  const runner = makeResearchMissionRunner(deps({
+    startFlow: async (_flow, options) => {
+      grants.push(options.addDirs);
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+  await runner.createAndStart({ ...INPUT, projectRoot: "/allowed/repo" });
+  assert.deepEqual(grants, [["/tmp/research-missions/mission-1"]]);
+});
+
 test("an unallowed configured project root fails fast with an actionable error", async () => {
   let starts = 0;
   const runner = makeResearchMissionRunner(deps({

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -73,7 +73,7 @@ export type ResearchMissionRunnerDeps = {
   saveMission(mission: ResearchMission): Promise<void>;
   startFlow(
     flow: FlowDoc,
-    options: { projectRoot: string | null },
+    options: { projectRoot: string | null; addDirs?: string[] },
   ): Promise<ResearchFlowStartResult>;
   loadFlowRun(id: string): Promise<FlowRunRecord | null>;
   loadConversation(sessionId: string): Promise<ConversationFile | null>;
@@ -326,6 +326,22 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
   };
 
   /**
+   * Start options for one iteration: the resolved run root plus the mission
+   * workspace as a harness-level trust grant. When a configured project root
+   * makes the spawn cwd differ from the workspace, a non-interactive run
+   * cannot prompt for permission — without the grant every workspace write
+   * hard-fails and the iteration ends without artifacts/primary.md. A grant
+   * equal to the spawn cwd is dropped by the flow spawn itself.
+   */
+  const missionStartOptions = (
+    mission: ResearchMission,
+    projectRoot: string,
+  ): { projectRoot: string; addDirs: string[] } => ({
+    projectRoot,
+    addDirs: [deps.missionWorkspacePath(mission.id)],
+  });
+
+  /**
    * Apply a retry-time project root override: a string is validated and
    * persisted, null/empty clears the configured root so the mission falls
    * back to its own workspace.
@@ -381,7 +397,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     await deps.saveMission(next);
     const target = await missionStartTarget(next);
     const result = target.ok
-      ? await deps.startFlow(buildResearchMissionFlow(next, number), { projectRoot: target.projectRoot })
+      ? await deps.startFlow(buildResearchMissionFlow(next, number), missionStartOptions(next, target.projectRoot))
       : { ok: false, error: target.error };
     next = applyStartResult(next, result, deps.now());
     await deps.saveMission(next);
@@ -423,9 +439,10 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     await deps.saveMission(retried);
     const target = await missionStartTarget(retried);
     const result = target.ok
-      ? await deps.startFlow(buildResearchMissionFlow(retried, current.number), {
-        projectRoot: target.projectRoot,
-      })
+      ? await deps.startFlow(
+        buildResearchMissionFlow(retried, current.number),
+        missionStartOptions(retried, target.projectRoot),
+      )
       : { ok: false, error: target.error };
     retried = applyStartResult(retried, result, deps.now());
     await deps.saveMission(retried);
@@ -782,7 +799,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       await deps.saveMission(mission);
       const target = await missionStartTarget(mission);
       const result = target.ok
-        ? await deps.startFlow(buildResearchMissionFlow(mission, 1), { projectRoot: target.projectRoot })
+        ? await deps.startFlow(buildResearchMissionFlow(mission, 1), missionStartOptions(mission, target.projectRoot))
         : { ok: false, error: target.error };
       mission = applyStartResult(mission, result, deps.now());
       await deps.saveMission(mission);
@@ -894,7 +911,10 @@ export function makeProductionResearchMissionRunner() {
     saveMission: saveResearchMission,
     startFlow: async (flow, options) => {
       const { startFlowSession } = await import("./flow-executor.ts");
-      return startFlowSession(flow, { projectRoot: options.projectRoot });
+      return startFlowSession(flow, {
+        projectRoot: options.projectRoot,
+        addDirs: options.addDirs,
+      });
     },
     loadFlowRun: async (id) => {
       const { listFlowRuns } = await import("./flow-store.ts");


### PR DESCRIPTION
## Problem

Every Research Desk run since Jul 18 ends with:

> **Research run completed without artifacts/primary.md**

The familiar finishes the whole research iteration, but the mission workspace is untouched — no `artifacts/primary.md`, no findings, no sources.

## Cause

Research iterations run as **non-interactive one-shot** direct copilot spawns (`flow-copilot-session.ts`, `-p` + JSONL stream). PR #3297 stopped emitting the manifest's `--allow-all` for full-permission direct spawns — correct hardening for *interactive chat*, but a `-p` one-shot **cannot answer approval prompts**, so the copilot CLI auto-denies every tool: write, shell, even web_fetch.

Evidence:
- Live transcript (session `f06d34ce`): *“Bash file writes are blocked… Edit denied too… **mission workspace was read-only all session**; validated artifacts staged in session-state.”*
- Timeline: missions on Jul 15 produced `artifacts/primary.md`; every mission after #3297 merged (Jul 17) left a pristine workspace.
- Reproduced locally: the pre-fix argv exits 0 with the write denied and no file created.

## Fix (tighter than the pre-#3297 sandbox)

1. **New `"unattended"` permission mode** in `buildCopilotStreamArgs`: emits `--allow-all-tools --allow-all-urls` while **keeping file-path verification ON** — writes stay confined to the spawn cwd + explicit `--add-dir` grants. This is narrower than the old `--allow-all` (which also disabled path and URL verification). Chat's implicit-full behavior from #3297 is untouched, and the mode is never reachable from request-supplied values.
2. **Flow spawns use unattended mode** (`flow-copilot-session.ts`) — they are Cave-initiated automations with nobody at the prompt.
3. **Mission workspace rides as an `--add-dir` trust grant** on every research launch (`startFlowSession` now accepts caller `addDirs`): iterations configured with a custom `projectRoot` spawn with cwd elsewhere, and path verification would otherwise still deny the workspace write. Grants equal to the spawn cwd are dropped, as before.

## Verification

- **E2E with real copilot CLI 1.0.73**: patched argv → `artifacts/primary.md` written, exit 0. Pre-fix argv (negative control) → write denied, no file.
- `pnpm typecheck` clean.
- App suite: **891 test files pass**; API suite: **235 test files pass**.
- New pins: unattended argv mapping (`copilot-stream.test.ts`), approval flags + no `--allow-all(-paths)` on flow spawns (`flow-copilot-session.test.ts`), caller-grant merge (`flow-executor.test.ts`), workspace grant on launch (`research-mission-runner-lifecycle-actions.test.ts`).

Bead: cave-c3ef