### PR TITLE
fix(task-work): fill the conversation panel — task-chat alignment (cave-115a)

### DIFF
--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -26,3 +26,12 @@ assert.match(
   /<Group\s*\n(?:\s*(?:className|orientation)=[^\n]*\n|\s*\/\/[^\n]*\n)*\s*key=\{railController\.showInline \? "conversation-rail" : "conversation"\}/,
   "cockpit Group is keyed by the visible pane set so a solo conversation fills the cockpit",
 );
+// ChatView's root carries no width of its own; inside the conversation
+// Panel (a horizontal flex row) it shrink-wrapped to content and the thread
+// sat left-crammed beside dead space. The cockpit CSS must stretch it.
+const cockpitCss = await readFile(new URL("../styles/task-work-cockpit.css", import.meta.url), "utf8");
+assert.match(
+  cockpitCss,
+  /\.task-work-cockpit__group \.cave-chat-linear \{[\s\S]{0,200}?flex: 1;[\s\S]{0,200}?min-width: 0;/,
+  "the cockpit conversation fills its panel (task-chat alignment)",
+);

--- a/src/styles/task-work-cockpit.css
+++ b/src/styles/task-work-cockpit.css
@@ -210,6 +210,16 @@
   flex: 1;
 }
 
+/* The conversation Panel is a horizontal flex row; ChatView's root
+ * (.cave-chat-linear) carries no width of its own, so as a flex item it
+ * shrink-wrapped to its content — the thread + composer sat left-crammed
+ * beside dead space when viewing a task's chat. Fill the panel so the
+ * cockpit conversation aligns exactly like the standalone chat surface. */
+.task-work-cockpit__group .cave-chat-linear {
+  flex: 1;
+  min-width: 0;
+}
+
 .task-work-cockpit__state {
   display: flex;
   width: min(420px, calc(100% - 32px));


### PR DESCRIPTION
## Problem

Opening a task's chat from the Board (kanban card → **Open**) rendered the conversation crammed into a ~607px column on the left of the Task Work cockpit, with dead space beside it — misaligned vs the standalone chat surface.

## Root cause

The cockpit's conversation `Panel` is a horizontal flex row; ChatView's root (`.cave-chat-linear`) is `flex h-full flex-col` with **no width or flex of its own**, so as a flex item it shrink-wraps to its content. The standalone chat surface doesn't hit this because its host stretches it.

## Fix

Scoped rule in `task-work-cockpit.css` (not global — avoids touching chat-split-host multi-pane layouts):

```css
.task-work-cockpit__group .cave-chat-linear {
  flex: 1;
  min-width: 0;
}
```

Plus a source pin in `task-work-cockpit.test.ts`.

## Verification

Measured in the running app (Playwright, prod build, 1440×900, mocked board card + session + conversation):

| surface | before | after |
|---|---|---|
| cockpit `.cave-chat-linear` | left 56, **width 607** (shrink-wrapped) | left 56, **width 885** (fills panel beside Files) |
| standalone chat surface | width 1180 | width 1180 (unchanged) |

Screenshot confirms thread + composer now span the panel edge-to-edge.

- `pnpm typecheck` clean
- Suites: **891 app / 235 api / 87 mobile** green (one unrelated timing flake, `cave-home-migration-locks-takeover`, passed isolated and on rerun)

Bead: cave-115a