### PR TITLE
fix(canvas): uniquify corrupt-aside capture names (cave-z8je)

### DIFF
--- a/src/lib/cave-canvas.test.ts
+++ b/src/lib/cave-canvas.test.ts
@@ -717,6 +717,33 @@ const art = (id, code, extra = {}) => ({
   const fresh = await loadCanvas();
   assert.equal(fresh.artifacts.length, 0, "a missing file is an empty fresh start");
   assert.equal(corruptFiles().length, 2, "a missing file mints no corrupt-aside");
+
+  // Rapid back-to-back corruption events used to collide (cave-z8je): the
+  // aside name had millisecond resolution, so a second rename in the same
+  // millisecond renamed onto the SAME path — rename clobbers, and the second
+  // capture silently destroyed the first ("expects 2 files" flaked on fast
+  // CI). Freeze the clock so every capture lands in one millisecond — the
+  // random suffix must still keep them all.
+  const RealDate = Date;
+  const frozenMs = new RealDate("2026-01-01T00:00:00.000Z").getTime();
+  globalThis.Date = class extends RealDate {
+    constructor() {
+      super(frozenMs);
+    }
+  } as DateConstructor;
+  try {
+    for (let burst = 0; burst < 5; burst++) {
+      writeFileSync(storePath, `{{{ burst ${burst}`);
+      await loadCanvas();
+    }
+  } finally {
+    globalThis.Date = RealDate;
+  }
+  assert.equal(
+    corruptFiles().length,
+    7,
+    "same-millisecond corruption events each keep their own aside capture",
+  );
 }
 
 rmSync(tmpHome, { recursive: true, force: true });

--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -4,6 +4,7 @@
 // are user content with no undo — the load path must never let a bad read turn
 // into an empty save that destroys them (see loadCanvas).
 
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
@@ -85,8 +86,11 @@ export async function loadCanvas(): Promise<CanvasFile> {
     // The file holds bytes that aren't a canvas store (torn write, foreign
     // content). This store now carries user sketches with no undo — reading
     // it as empty made the NEXT save silently destroy all of them. Move the
-    // bad file aside (bytes preserved for recovery) and start fresh.
-    const aside = `${CANVAS_PATH}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    // bad file aside (bytes preserved for recovery) and start fresh. The
+    // timestamp is for humans; the random suffix keeps two corruption events
+    // in the same millisecond from renaming onto the SAME aside path (rename
+    // clobbers, so the second capture silently destroyed the first).
+    const aside = `${CANVAS_PATH}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
     try {
       await rename(CANVAS_PATH, aside);
       console.error(`cave-canvas: unreadable store moved aside to ${aside}`);


### PR DESCRIPTION
## Problem

`loadCanvas` names a corrupt store's move-aside file with a millisecond-resolution ISO timestamp (`cave-canvas.ts:89`). Two corruption events in the same millisecond rename onto the **same** aside path — `rename` clobbers, so the second capture silently destroys the first (defeating the whole point of preserving bytes for recovery).

On fast CI this flaked `cave-canvas.test.ts` — *'shape-invalid JSON is also preserved aside'* (expects 2 files) — seen on PR #3663 run 29904739162 where both move-aside log lines carry identical timestamps.

## Fix

Append an 8-char `randomUUID` slice to the timestamp: `canvas.json.corrupt-<iso>-<rand>`. Timestamp stays for human forensics; the suffix guarantees every capture lands.

## Regression test

Freezes `Date` and forces **five same-millisecond corruption events**:

- old code: kept 1 of the 5 (`actual: 3` total asides vs `expected: 7`) — deterministic reproduction of the flake
- fixed code: all 7 captures present

## Verification

- targeted test green (pre-fix fails deterministically, post-fix passes)
- `pnpm typecheck` clean
- `pnpm test:app` 891 files green

Note: `preferences-store.ts`, `research-links.ts`, `research-generations.ts` share the same ms-resolution pattern via `copyFile` (same silent-overwrite hazard, but their tests assert `>=1` so they don't flake) — follow-up bead filed.

Bead: cave-z8je