### PR TITLE
fix(home,chat): center hearth vertically, radius-token chat glass, drop Continue heading (cave-4ls9)

### DIFF
--- a/src/components/home-hearth.test.ts
+++ b/src/components/home-hearth.test.ts
@@ -31,6 +31,11 @@ assert.match(
 );
 assert.match(
   css,
+  /\.home-hearth-card \{[\s\S]{0,700}?margin-block: auto/,
+  "the card centers vertically (auto block margins; collapse to 0 when it overflows)",
+);
+assert.match(
+  css,
   /\.home-composer-root \{[\s\S]{0,900}?radial-gradient\([\s\S]{0,200}?var\(--accent-presence\)/,
   "the base behind the card carries the radial presence wash",
 );
@@ -49,11 +54,13 @@ assert.doesNotMatch(composer, /<HomeDigestCarousel/, "the digest carousel no lon
 // ── (2) Cards-only home: pills removed; Continue cards centered ─────────────
 assert.doesNotMatch(composer, /HomeSuggestionPills|useBoardCards\(\)/, "the cold-start pills (and their board snapshot) are gone from home");
 assert.doesNotMatch(css, /home-suggest-pill/, "the pill CSS is removed with the component");
-assert.match(
-  css,
-  /\.home-continue__label \{[\s\S]{0,300}?text-align: center/,
-  "the Continue label centers under the centered composer",
-);
+// Label strip (2026-07-22): the visible "Continue where you left off" heading
+// is retired — the cards read as resumable sessions on their own (title,
+// "Edited N ago", resume arrow); the section keeps its aria-label.
+const continueTsx = await readFile(new URL("./home/home-continue.tsx", import.meta.url), "utf8");
+assert.doesNotMatch(continueTsx, /home-continue__label/, "no visible Continue heading renders");
+assert.match(continueTsx, /aria-label="Continue where you left off"/, "the section keeps its screen-reader label");
+assert.doesNotMatch(css, /home-continue__label/, "the label CSS is removed with the heading");
 assert.match(
   css,
   /\.home-continue__cards \{[\s\S]{0,300}?justify-content: center/,

--- a/src/components/home/home-continue.tsx
+++ b/src/components/home/home-continue.tsx
@@ -38,7 +38,9 @@ export function HomeContinue({ sessions, familiarNameById, onOpenSession }: Prop
 
   return (
     <section className="home-continue" aria-label="Continue where you left off">
-      <h2 className="home-continue__label">Continue where you left off</h2>
+      {/* No visible heading (2026-07-22): the cards read as resumable sessions
+          on their own — title, "Edited N ago", resume arrow — so the label is
+          screen-reader-only via the section's aria-label. */}
       <div className="home-continue__cards" data-count={rows.length}>
         {rows.map((s) => {
           const familiar = s.familiarId ? familiarNameById.get(s.familiarId) ?? null : null;

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -70,7 +70,9 @@ html[data-backdrop-on] .cave-group-chat-shell {
 }
 
 html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
-  border-radius: 14px;
+  /* --radius-xl (not a hard-coded px) so the glass column follows the
+     Appearance → Corner radius setting like the rest of the chat chrome. */
+  border-radius: var(--radius-xl);
   padding-inline: clamp(14px, 2vw, 22px);
 }
 
@@ -110,7 +112,7 @@ html[data-backdrop-on] .cave-chat-empty-shell {
   background: color-mix(in oklch, var(--bg-base) 55%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  border-radius: 14px;
+  border-radius: var(--radius-xl);
   padding: clamp(16px, 3vh, 28px) clamp(14px, 2.5vw, 24px);
 }
 
@@ -123,7 +125,7 @@ html[data-backdrop-on] .familiar-tab {
   background: color-mix(in oklch, var(--bg-base) 62%, transparent);
   backdrop-filter: blur(50px) saturate(var(--glass-saturate));
   -webkit-backdrop-filter: blur(50px) saturate(var(--glass-saturate));
-  border-radius: 14px;
+  border-radius: var(--radius-xl);
   --text-muted: var(--text-secondary);
 }
 

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -386,7 +386,10 @@
 }
 
 .cave-chat-linear .cave-composer-panel {
-  border-radius: 18px;
+  /* Slightly rounder than the base --radius-xl (1.4×), but still derived from
+     --radius so the Appearance → Corner radius setting applies: 18px at the
+     default 10px base, squarer at sharp, fuller at round. */
+  border-radius: calc(var(--radius) * 1.8);
   box-shadow:
     0 14px 38px oklch(0 0 0 / 22%),
     inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);

--- a/src/styles/home-composer/hearth-continuations.css
+++ b/src/styles/home-composer/hearth-continuations.css
@@ -52,16 +52,8 @@
   margin-top: var(--space-6);
 }
 /* Centered under the centered composer — the cards are the only thing left
- * below it, so the section reads as one symmetric column. */
-.home-continue__label {
-  margin: 0 0 var(--space-3);
-  padding: 0 var(--space-1);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--text-muted);
-  letter-spacing: -0.01em;
-  text-align: center;
-}
+ * below it, so the section reads as one symmetric column. The strip carries
+ * no visible heading (the section's aria-label names it for screen readers). */
 .home-continue__cards {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/styles/home-composer/landing-composer.css
+++ b/src/styles/home-composer/landing-composer.css
@@ -64,9 +64,9 @@
  *   unified launch cluster. The heavy bordered container is retired: the visible
  *   frame emphasised the large empty area below the composer at 1280×720. It is
  *   now an invisible layout wrapper — the radial presence wash on the root is the
- *   only ambient surface. Cluster is capped ~900px and sits slightly ABOVE the
- *   vertical centre of the usable workspace (pushed ~84px down from dead-top via
- *   the root's justify + a top offset), never in a framed dead zone. */
+ *   only ambient surface. Cluster is capped ~900px and centers vertically in the
+ *   usable workspace (auto block margins split the root's free space; when the
+ *   cluster outgrows a short viewport they collapse to 0 and the root scrolls). */
 .home-hearth-card {
   display: flex;
   flex-direction: column;
@@ -76,7 +76,7 @@
   margin-inline: auto;
   padding: 0 var(--space-2);
 
-  margin-block: clamp(48px, 9vh, 96px) auto;
+  margin-block: auto;
   border: 0;
   background: transparent;
 }


### PR DESCRIPTION
## Problem

1. **Home component off-center** — the hearth cluster (greeting + composer + Continue cards) sat well above the vertical center of the workspace: card center y≈265 vs pane center y≈469 at 1440×900, leaving a large dead zone below.
2. **Chat main bg ignored Appearance → Corner radius** — the chat composer panel was hard-coded to `18px`, and the backdrop-mode glass surfaces (`.cave-chat-thread`, `.cave-chat-empty-shell`, `.familiar-tab`) to `14px`, so the sharp/default/round setting never applied to them.
3. **"Continue where you left off" heading** added chrome the cards don't need.

## Fix

- `.home-hearth-card`: `margin-block: clamp(48px, 9vh, 96px) auto` → `margin-block: auto`. Auto flex margins split the root's free space (true vertical centering) and collapse to 0 when the cluster overflows a short viewport, so scrolling is unaffected. Mobile (≤520px) keeps its top-anchored layout.
- Chat composer panel: `border-radius: calc(var(--radius) * 1.8)` — 18px at the default 10px base (pixel-identical to before), squarer at sharp, fuller at round.
- Backdrop glass surfaces: `border-radius: var(--radius-xl)` — 14px at default (pixel-identical), scales with the setting.
- `HomeContinue`: visible `<h2>` removed (more graceful than relocating it — the cards already read as resumable sessions via title, "Edited N ago", and the resume arrow). The section keeps `aria-label="Continue where you left off"` for screen readers; label CSS removed.

## Verification

- Playwright probe at 1440×900 (prod build): hearth card center == pane center (455 == 455); no `.home-continue__label` in DOM.
- Computed radii per appearance level (default/sharp/round): composer 19.8 / 3.96 / 27.72px; backdrop thread + empty shell 15.4 / 3.08 / 21.56px — all scale with `--radius` now (defaults unchanged: 18px/14px at the 10px base ×1.4 zoom probe scale).
- `pnpm typecheck` clean; targeted tests green: home-hearth, backdrop-scrim, home-composer-centering, chat-view-first-class, home-composer(+polish/mobile-gaps), home-needs-you, home-chat-handoff, chat-view-mobile-command-center.

Bead: cave-4ls9