### PR TITLE
fix(research): desk-wide bug sweep — reconcile crashes, stuck missions, silent action failures (cave-l061)

### DIFF
--- a/src/app/api/research/missions/[id]/actions/route.test.ts
+++ b/src/app/api/research/missions/[id]/actions/route.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { allowedResearchActions } from "../../../../../../lib/research-missions.ts";
+import type { ResearchMissionStatus } from "../../../../../../lib/research-missions.ts";
 
 const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
@@ -11,4 +13,54 @@ test("mission actions are local-only, bounded, path guarded, and serialized by t
   assert.match(source, /path not allowed/);
   assert.match(source, /status: 403/);
   assert.match(source, /runner\.act/);
+});
+
+test("accepted lifecycle actions derive from the domain — no contract drift", () => {
+  // The route flatMaps allowedResearchActions over every mission status
+  // instead of hand-copying a list, so it can only accept what the runner
+  // will actually perform.
+  assert.match(source, /allowedResearchActions\(\{ status \}\)/);
+  assert.match(source, /MISSION_STATUSES\.flatMap/);
+  assert.match(source, /"attach-source", "update-source", "reject-artifact"/);
+  // "pause" is in the ResearchMissionAction union but no status ever allows
+  // it (allowedResearchActions never returns it) — the old hand-copied list
+  // accepted it and produced a silent no-op 200. It must not reappear.
+  const statuses: ResearchMissionStatus[] = [
+    "queued", "planning", "running", "checkpoint", "paused",
+    "completed", "failed", "cancelled", "archived",
+  ];
+  const domainActions = new Set(statuses.flatMap((status) => allowedResearchActions({ status })));
+  assert.ok(!domainActions.has("pause"), "domain now allows pause — revisit the route derivation");
+  assert.doesNotMatch(source, /"pause"/);
+  // The route's status list stays in lockstep with the domain union: every
+  // status above appears verbatim in the derivation source.
+  for (const status of statuses) {
+    assert.match(source, new RegExp(`"${status}"`));
+  }
+});
+
+test("errors map by kind: unknown action 400, client mistakes 400, missing mission 404, internal failures 500", () => {
+  // Unvalidated / unknown actions are rejected before the runner runs.
+  assert.match(source, /invalid research action/);
+  assert.match(source, /\{ status: 400 \}/);
+  // Thrown runner errors are classified: known client-input messages → 400,
+  // mission-not-found → 404, and EVERYTHING else (fs errors, bugs) → 500 —
+  // internal failures must not masquerade as client errors.
+  assert.match(source, /research mission not found"\) return 404/);
+  assert.match(source, /VALIDATION_ERRORS\.has\(message\)/);
+  assert.match(source, /startsWith\('Project root "'\)/);
+  assert.match(source, /startsWith\("invalid source"\)/);
+  assert.match(source, /return 400;/);
+  assert.match(source, /return 500;/);
+  assert.match(source, /status: actionErrorStatus\(message\)/);
+  // The classified messages are the runner's real validation throws.
+  for (const known of [
+    "Source id and title are required",
+    "artifact rejection reason required",
+    "research artifact not found",
+    "refined direction required",
+    "invalid project root override",
+  ]) {
+    assert.match(source, new RegExp(known));
+  }
 });

--- a/src/app/api/research/missions/[id]/actions/route.ts
+++ b/src/app/api/research/missions/[id]/actions/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import type { ResearchMissionActionInput } from "@/lib/research-missions";
+import {
+  allowedResearchActions,
+  type ResearchMissionActionInput,
+  type ResearchMissionStatus,
+} from "@/lib/research-missions";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { makeProductionResearchMissionRunner } from "@/lib/server/research-mission-runner";
 import { isValidResearchMissionId } from "@/lib/server/research-mission-store";
@@ -8,10 +12,49 @@ import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-const ACTIONS = new Set([
-  "retry", "continue", "refine", "finish", "pause", "resume", "cancel", "archive",
+// Lifecycle actions are derived from the domain's allowedResearchActions so
+// this route can never drift from what the runner will actually perform (a
+// hand-copied list previously accepted a pause action no mission status ever
+// allows — a silent no-op 200). The status list mirrors ResearchMissionStatus;
+// a typo or removed status fails typecheck.
+const MISSION_STATUSES: ResearchMissionStatus[] = [
+  "queued", "planning", "running", "checkpoint", "paused",
+  "completed", "failed", "cancelled", "archived",
+];
+const ACTIONS = new Set<string>([
+  ...MISSION_STATUSES.flatMap((status) => allowedResearchActions({ status })),
   "attach-source", "update-source", "reject-artifact",
 ]);
+
+// Messages the runner throws when the CLIENT sent a bad request (invalid
+// payload fields, unknown source/artifact ids). Anything else that throws is
+// an internal failure — fs errors, bugs — and must surface as a 500 instead
+// of masquerading as a client error.
+const VALIDATION_ERRORS = new Set([
+  "Source id and title are required",
+  "Source requires a safe URL or absolute local path",
+  "Source confidence must be between 0 and 1",
+  "artifact rejection reason required",
+  "research artifact not found",
+  "research source not found",
+  "refined direction required",
+  "invalid project root override",
+]);
+
+function actionErrorStatus(message: string): number {
+  if (message === "research mission not found") return 404;
+  if (
+    VALIDATION_ERRORS.has(message) ||
+    // Retry project-root rejections carry the offending path; source-patch
+    // rejections carry the offending field ("invalid source status",
+    // "invalid source patch field: url", …).
+    message.startsWith('Project root "') ||
+    message.startsWith("invalid source")
+  ) {
+    return 400;
+  }
+  return 500;
+}
 
 export async function POST(
   req: Request,
@@ -34,7 +77,9 @@ export async function POST(
     return NextResponse.json({ ok: true, mission });
   } catch (error) {
     const message = error instanceof Error ? error.message : "research action failed";
-    const status = message === "research mission not found" ? 404 : 400;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: actionErrorStatus(message) },
+    );
   }
 }

--- a/src/app/api/research/missions/[id]/schedule/route.test.ts
+++ b/src/app/api/research/missions/[id]/schedule/route.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { parseCodexRrule } from "../../../../../../lib/codex-automation-form.ts";
 
 const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
@@ -10,4 +11,49 @@ test("mission scheduling is local-only, bounded, path guarded, and delegated to 
   assert.match(source, /isValidResearchMissionId/);
   assert.match(source, /path not allowed/);
   assert.match(source, /runner\.schedule/);
+});
+
+test("RRULEs are structurally validated — a prefix check alone let garbage persist", () => {
+  // The route reuses the shared codex parser for the daily/weekly shapes and
+  // otherwise requires well-formed KEY=VALUE parts with known RRULE keys and
+  // a known FREQ; failures are rejected 400 before the runner persists them.
+  assert.match(source, /import \{ parseCodexRrule \} from "@\/lib\/codex-automation-form"/);
+  assert.match(source, /parseCodexRrule\(rrule\)\.mode !== "raw"/);
+  assert.match(source, /startsWith\("RRULE:"\)/);
+  assert.match(source, /RRULE_KNOWN_KEYS\.has\(key\)/);
+  assert.match(source, /RRULE_FREQUENCIES\.has\(freq\)/);
+  assert.match(source, /unrecognized RRULE part/);
+  assert.match(source, /RRULE must declare a known FREQ/);
+  assert.match(source, /rruleValidationError\(parsed\.body\.rrule\)/);
+  assert.match(source, /\{ status: 400 \}/);
+  // Length bound matches the runner's own stored-schedule guard.
+  assert.match(source, /RRULE_MAX_LENGTH = 500/);
+  // Cross-module contract: the desk's only schedule producer
+  // (research-mission-detail's daily rule) parses as a recognized shape, so
+  // the validator's parser fast-path accepts the product's real traffic.
+  assert.equal(parseCodexRrule("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0").mode, "daily");
+  // And plain garbage falls to the raw path where the structural checks live.
+  assert.equal(parseCodexRrule("RRULE:garbage").mode, "raw");
+});
+
+test("errors map by kind: bad schedule 400, missing mission 404, internal failures 500", () => {
+  // Thrown runner errors are classified: known precondition/bound messages →
+  // 400, mission-not-found → 404, and EVERYTHING else (fs errors, bugs) →
+  // 500 — internal failures must not masquerade as client errors.
+  assert.match(source, /research mission not found"\) return 404/);
+  assert.match(source, /VALIDATION_ERRORS\.has\(message\) \|\| message\.startsWith\("cannot schedule a "\)/);
+  assert.match(source, /return 500;/);
+  assert.match(source, /status: scheduleErrorStatus\(message\)/);
+  // The classified messages are the runner's real validation throws, plus
+  // research-mission-lifecycle's stop reasons.
+  for (const known of [
+    "schedules require AutoResearch mode",
+    "research mission already has a schedule",
+    "invalid automation schedule",
+    "Iteration limit reached",
+    "Wall-clock limit reached",
+    "Reported spend limit reached",
+  ]) {
+    assert.match(source, new RegExp(known));
+  }
 });

--- a/src/app/api/research/missions/[id]/schedule/route.ts
+++ b/src/app/api/research/missions/[id]/schedule/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { parseCodexRrule } from "@/lib/codex-automation-form";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   makeProductionResearchMissionRunner,
@@ -9,6 +10,67 @@ import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+/** Matches the runner's own length guard on stored schedules. */
+const RRULE_MAX_LENGTH = 500;
+const RRULE_KNOWN_KEYS = new Set([
+  "FREQ", "INTERVAL", "COUNT", "UNTIL", "WKST", "BYDAY", "BYHOUR", "BYMINUTE",
+  "BYSECOND", "BYMONTH", "BYMONTHDAY", "BYYEARDAY", "BYWEEKNO", "BYSETPOS",
+]);
+const RRULE_FREQUENCIES = new Set([
+  "SECONDLY", "MINUTELY", "HOURLY", "DAILY", "WEEKLY", "MONTHLY", "YEARLY",
+]);
+
+/**
+ * Structural RRULE validation. The runner only prefix-checks "RRULE:", which
+ * let "RRULE:garbage" persist as a schedule that never fires. The shared
+ * codex parser (parseCodexRrule) recognizes the daily/weekly shapes the desk
+ * emits; anything else must still be well-formed KEY=VALUE pairs made of
+ * known RRULE keys with a known FREQ. Returns a client-facing reason or null.
+ */
+function rruleValidationError(input: string): string | null {
+  const rrule = input.trim();
+  if (!rrule.startsWith("RRULE:") || rrule.length > RRULE_MAX_LENGTH) {
+    return "invalid automation schedule";
+  }
+  if (parseCodexRrule(rrule).mode !== "raw") return null;
+  const entries = new Map<string, string>();
+  for (const part of rrule.slice("RRULE:".length).split(";")) {
+    const eq = part.indexOf("=");
+    const key = eq > 0 ? part.slice(0, eq) : "";
+    const value = eq > 0 ? part.slice(eq + 1) : "";
+    if (!key || !value || !RRULE_KNOWN_KEYS.has(key)) {
+      return `invalid automation schedule: unrecognized RRULE part "${part}"`;
+    }
+    entries.set(key, value);
+  }
+  const freq = entries.get("FREQ");
+  if (!freq || !RRULE_FREQUENCIES.has(freq)) {
+    return "invalid automation schedule: RRULE must declare a known FREQ";
+  }
+  return null;
+}
+
+// Messages the runner throws when the CLIENT sent a bad request — mode/state
+// preconditions and bound stops (research-mission-lifecycle's stop reasons).
+// Anything else that throws is an internal failure and surfaces as a 500
+// instead of masquerading as a client error.
+const VALIDATION_ERRORS = new Set([
+  "schedules require AutoResearch mode",
+  "research mission already has a schedule",
+  "invalid automation schedule",
+  "Iteration limit reached",
+  "Wall-clock limit reached",
+  "Reported spend limit reached",
+]);
+
+function scheduleErrorStatus(message: string): number {
+  if (message === "research mission not found") return 404;
+  // Terminal-status rejections carry the status ("cannot schedule a
+  // completed research mission").
+  if (VALIDATION_ERRORS.has(message) || message.startsWith("cannot schedule a ")) return 400;
+  return 500;
+}
 
 export async function POST(
   req: Request,
@@ -25,13 +87,19 @@ export async function POST(
   if (!parsed.body || typeof parsed.body.rrule !== "string") {
     return NextResponse.json({ ok: false, error: "automation schedule required" }, { status: 400 });
   }
+  const rruleError = rruleValidationError(parsed.body.rrule);
+  if (rruleError) {
+    return NextResponse.json({ ok: false, error: rruleError }, { status: 400 });
+  }
   try {
     const runner = makeProductionResearchMissionRunner();
     const mission = await runner.schedule(id, parsed.body);
     return NextResponse.json({ ok: true, mission });
   } catch (error) {
     const message = error instanceof Error ? error.message : "research schedule failed";
-    const status = message === "research mission not found" ? 404 : 400;
-    return NextResponse.json({ ok: false, error: message }, { status });
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: scheduleErrorStatus(message) },
+    );
   }
 }

--- a/src/components/role-surfaces/research-evidence-ledger.test.ts
+++ b/src/components/role-surfaces/research-evidence-ledger.test.ts
@@ -38,3 +38,31 @@ test("artifact rejection is explicit and append-preserving", () => {
   assert.match(source, /reject-artifact/);
   assert.match(source, /Reject artifact/);
 });
+
+test("mission switches reset every piece of local ledger state", () => {
+  // The reset effect clears the draft attach fields, per-key rejection map,
+  // busy flag, and error banner together with the source filter — nothing
+  // bleeds into the next mission's ledger.
+  assert.match(
+    source,
+    /missionIdRef\.current = mission\.id;\s*setTitle\(""\);\s*setUrl\(""\);\s*setRejection\(\{\}\);\s*setBusy\(false\);\s*setError\(null\);\s*setSourceFilter\("all"\);\s*\}, \[mission\.id\]\)/,
+  );
+  // Panels remount per mission so uncontrolled disclosure state cannot ride
+  // colliding artifact/source key shapes onto the wrong mission's rows.
+  assert.match(source, /key=\{`artifacts-\$\{mission\.id\}`\}/);
+  assert.match(source, /key=\{`sources-\$\{mission\.id\}`\}/);
+});
+
+test("act failures surface and never leak across a mission switch", () => {
+  // { ok: false } from the hook is the primary error path…
+  assert.match(source, /result\.error \?\? "Evidence could not be updated"/);
+  // …a transport throw lands in the same error state (defense only — a throw
+  // skips the ok branch, so a failure is never reported twice)…
+  assert.match(source, /catch \(cause\)/);
+  assert.match(source, /cause instanceof Error \? cause\.message : "Evidence could not be updated"/);
+  // …busy always clears for the mission that set it…
+  assert.match(source, /finally \{\s*if \(stillCurrent\(\)\) setBusy\(false\);\s*\}/);
+  // …and an act settling after a mission switch is discarded via the id guard.
+  assert.match(source, /const startedFor = mission\.id/);
+  assert.match(source, /missionIdRef\.current === startedFor/);
+});

--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Tabs } from "@/components/ui/tabs";
@@ -36,8 +36,22 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
   const [error, setError] = useState<string | null>(null);
   const [outputTab, setOutputTab] = useState<"artifacts" | "sources">("artifacts");
   const [sourceFilter, setSourceFilter] = useState<"all" | ResearchSourceRef["status"]>("all");
+  // Tracks the mission currently on screen so an act that settles after the
+  // user switched missions is discarded instead of planting its error/busy
+  // state on the wrong mission's ledger.
+  const missionIdRef = useRef(mission.id);
 
+  // A mission switch resets every piece of local UI state — error banner,
+  // in-flight busy, draft attach fields, per-artifact rejection drafts — so
+  // nothing bleeds into the next mission's ledger (artifact/source keys can
+  // collide across missions). In-flight acts check missionIdRef and discard.
   useEffect(() => {
+    missionIdRef.current = mission.id;
+    setTitle("");
+    setUrl("");
+    setRejection({});
+    setBusy(false);
+    setError(null);
     setSourceFilter("all");
   }, [mission.id]);
 
@@ -46,19 +60,32 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
     ? mission.sources
     : mission.sources.filter((source) => source.status === sourceFilter);
 
+  /** Failures arrive as { ok: false } from the hook; the catch is transport
+   *  defense only — a throw skips the ok branch, so a failure is never
+   *  reported twice. State from an act that settles after a mission switch
+   *  is discarded, and busy always clears for the mission that set it. */
   const act = async (input: ResearchMissionActionInput) => {
+    const startedFor = mission.id;
+    const stillCurrent = () => missionIdRef.current === startedFor;
     setBusy(true);
     setError(null);
     try {
       const result = await onAction(input);
-      if (!result.ok) {
+      if (!result.ok && stillCurrent()) {
         const message = result.error ?? "Evidence could not be updated";
         setError(message);
         announce(message);
       }
-      return result.ok;
+      return result.ok && stillCurrent();
+    } catch (cause) {
+      if (stillCurrent()) {
+        const message = cause instanceof Error ? cause.message : "Evidence could not be updated";
+        setError(message);
+        announce(message);
+      }
+      return false;
     } finally {
-      setBusy(false);
+      if (stillCurrent()) setBusy(false);
     }
   };
 
@@ -97,9 +124,14 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
           { id: "sources", label: "Sources", count: mission.sources.length },
         ]}
       />
+      {/* Panels below are keyed by mission so uncontrolled disclosure state
+          (reject editors, the attach form) can never survive a mission switch —
+          colliding per-mission artifact/source key shapes would otherwise let
+          DOM reuse attach open state to the wrong mission's rows. */}
       {error ? <p className="research-mission-error" role="alert">{error}</p> : null}
       <section
         id="research-output-panel-artifacts"
+        key={`artifacts-${mission.id}`}
         role="tabpanel"
         aria-labelledby="research-output-tab-artifacts"
         hidden={outputTab !== "artifacts"}
@@ -161,6 +193,7 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
 
       <section
         id="research-output-panel-sources"
+        key={`sources-${mission.id}`}
         role="tabpanel"
         aria-labelledby="research-output-tab-sources"
         hidden={outputTab !== "sources"}

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -21,7 +21,7 @@
  * session for /chat to open.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { settleEnhance } from "@/lib/prompt-enhancer";
@@ -150,6 +150,35 @@ function boundNumber(value: string, fallback: number, max: number): number {
   return Math.min(Math.trunc(parsed), max);
 }
 
+/** The four numeric bounds the editor exposes (spend/cost stay plan-driven). */
+type BoundKey = "wallClockMinutes" | "maxIterations" | "sourceTarget" | "checkpointEvery";
+
+/** Commit order: iterations apply before checkpoints so the cap is current. */
+const BOUND_KEYS: readonly BoundKey[] = [
+  "wallClockMinutes",
+  "maxIterations",
+  "sourceTarget",
+  "checkpointEvery",
+];
+
+/** One raw bound edit parsed against the same clamps the old handlers used:
+ *  invalid/empty falls back to 1, iterations drag checkpointEvery down with
+ *  them, and checkpointEvery caps at the current iteration count. */
+function applyBoundEdit(current: ResearchBounds, key: BoundKey, raw: string): ResearchBounds {
+  if (key === "maxIterations") {
+    const maxIterations = boundNumber(raw, 1, RESEARCH_BOUND_LIMITS.maxIterations);
+    return {
+      ...current,
+      maxIterations,
+      checkpointEvery: Math.min(current.checkpointEvery, maxIterations),
+    };
+  }
+  if (key === "checkpointEvery") {
+    return { ...current, checkpointEvery: boundNumber(raw, 1, current.maxIterations) };
+  }
+  return { ...current, [key]: boundNumber(raw, 1, RESEARCH_BOUND_LIMITS[key]) };
+}
+
 export function ResearchMissionComposer({
   familiarId,
   daemonRunning,
@@ -162,10 +191,18 @@ export function ResearchMissionComposer({
 }: Props) {
   const { announce } = useAnnouncer();
   const [intent, setIntent] = useState("");
-  const [mode, setMode] = useState<"auto" | ResearchMissionMode>(initialMode ?? "auto");
+  const [mode, setModeState] = useState<"auto" | ResearchMissionMode>(initialMode ?? "auto");
   const [bounds, setBounds] = useState<ResearchBounds>(
     defaultResearchPlan(initialMode ?? "brief").bounds,
   );
+  // Raw text for a bound input while it is being edited — committed numbers
+  // live in `bounds`. Parsing on every keystroke made fields uncloseable:
+  // clearing snapped to 1, so typing "5" produced "15".
+  const [boundDrafts, setBoundDrafts] = useState<Partial<Record<BoundKey, string>>>({});
+  // Dirty latch: once a bound is hand-edited, auto-routing (which re-derives
+  // the plan on every keystroke) must stop clobbering it. Explicit mode picks
+  // clear the latch below, so a deliberate switch still resets.
+  const boundsDirtyRef = useRef(false);
   const [boundsOpen, setBoundsOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -175,11 +212,19 @@ export function ResearchMissionComposer({
   const [improveNote, setImproveNote] = useState<string | null>(null);
   const [angleOffset, setAngleOffset] = useState(0);
 
+  // Every setMode caller is an explicit pick — mode cards, slash commands,
+  // Reset to Auto, cross-tab preselect — so a deliberate switch clears the
+  // bounds dirty latch and lets the new plan's bounds apply.
+  const setMode = useCallback((next: "auto" | ResearchMissionMode) => {
+    boundsDirtyRef.current = false;
+    setModeState(next);
+  }, []);
+
   // Cross-tab navigation may re-target an already-mounted intake (e.g. the
   // Desk's /paper while the Prompt tab is live) — treat it as a manual pick.
   useEffect(() => {
     if (initialMode) setMode(initialMode);
-  }, [initialMode]);
+  }, [initialMode, setMode]);
 
   const inferred = useMemo(() => inferResearchMissionMode(intent), [intent]);
   const effectiveMode = mode === "auto" ? inferred.mode : mode;
@@ -192,11 +237,45 @@ export function ResearchMissionComposer({
   intentRef.current = intent;
 
   useEffect(() => {
+    if (boundsDirtyRef.current) return;
     setBounds({ ...plan.bounds });
+    setBoundDrafts({});
   }, [plan]);
 
-  const updateBound = <K extends keyof ResearchBounds>(key: K, value: ResearchBounds[K]) => {
-    setBounds((current) => ({ ...current, [key]: value }));
+  const editBound = (key: BoundKey, raw: string) => {
+    boundsDirtyRef.current = true;
+    setBoundDrafts((current) => ({ ...current, [key]: raw }));
+  };
+
+  const commitBound = (key: BoundKey) => {
+    const raw = boundDrafts[key];
+    if (raw === undefined) return;
+    setBounds((current) => applyBoundEdit(current, key, raw));
+    setBoundDrafts((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  };
+
+  /** What the input shows: the in-flight draft while editing, else the number. */
+  const boundValue = (key: BoundKey): string => boundDrafts[key] ?? String(bounds[key]);
+
+  /** Committed bounds plus any in-flight drafts — what Start actually submits. */
+  const resolveBounds = (): ResearchBounds =>
+    BOUND_KEYS.reduce((acc, key) => {
+      const raw = boundDrafts[key];
+      return raw === undefined ? acc : applyBoundEdit(acc, key, raw);
+    }, bounds);
+
+  // Enter inside a bounds field must never implicitly submit the form —
+  // starting a paid mission stays behind the explicit Start button (the
+  // textarea's palette shortcuts handle their own keys). Enter commits the
+  // draft exactly like blur instead.
+  const boundKeyDown = (key: BoundKey) => (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    commitBound(key);
   };
 
   // The summary pill doubles as the bounds toggle: open the editor and focus
@@ -301,6 +380,11 @@ export function ResearchMissionComposer({
     event.preventDefault();
     const trimmed = intent.trim();
     if (trimmed.length < RESEARCH_INTENT_MIN_LENGTH || submitting) return;
+    // Any bound still being edited commits before the mission is created, so
+    // Start never submits a value the user already replaced on screen.
+    const submittedBounds = resolveBounds();
+    setBounds(submittedBounds);
+    setBoundDrafts({});
     setSubmitting(true);
     setError(null);
     try {
@@ -310,7 +394,7 @@ export function ResearchMissionComposer({
         mode: effectiveMode,
         modeSource: mode === "auto" ? "auto" : "user",
         deliverable: plan.deliverables.join(" + "),
-        bounds,
+        bounds: submittedBounds,
       });
       if (!result.ok) {
         setError(result.error);
@@ -516,8 +600,10 @@ export function ResearchMissionComposer({
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.wallClockMinutes}
-              value={bounds.wallClockMinutes}
-              onChange={(event) => updateBound("wallClockMinutes", boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.wallClockMinutes))}
+              value={boundValue("wallClockMinutes")}
+              onChange={(event) => editBound("wallClockMinutes", event.target.value)}
+              onBlur={() => commitBound("wallClockMinutes")}
+              onKeyDown={boundKeyDown("wallClockMinutes")}
             />
           </label>
           <label>
@@ -527,15 +613,10 @@ export function ResearchMissionComposer({
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.maxIterations}
-              value={bounds.maxIterations}
-              onChange={(event) => {
-                const maxIterations = boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.maxIterations);
-                setBounds((current) => ({
-                  ...current,
-                  maxIterations,
-                  checkpointEvery: Math.min(current.checkpointEvery, maxIterations),
-                }));
-              }}
+              value={boundValue("maxIterations")}
+              onChange={(event) => editBound("maxIterations", event.target.value)}
+              onBlur={() => commitBound("maxIterations")}
+              onKeyDown={boundKeyDown("maxIterations")}
             />
           </label>
           <label>
@@ -545,8 +626,10 @@ export function ResearchMissionComposer({
               type="number"
               min={1}
               max={RESEARCH_BOUND_LIMITS.sourceTarget}
-              value={bounds.sourceTarget}
-              onChange={(event) => updateBound("sourceTarget", boundNumber(event.target.value, 1, RESEARCH_BOUND_LIMITS.sourceTarget))}
+              value={boundValue("sourceTarget")}
+              onChange={(event) => editBound("sourceTarget", event.target.value)}
+              onBlur={() => commitBound("sourceTarget")}
+              onKeyDown={boundKeyDown("sourceTarget")}
             />
           </label>
           <label>
@@ -555,8 +638,10 @@ export function ResearchMissionComposer({
               type="number"
               min={1}
               max={bounds.maxIterations}
-              value={bounds.checkpointEvery}
-              onChange={(event) => updateBound("checkpointEvery", boundNumber(event.target.value, 1, bounds.maxIterations))}
+              value={boundValue("checkpointEvery")}
+              onChange={(event) => editBound("checkpointEvery", event.target.value)}
+              onBlur={() => commitBound("checkpointEvery")}
+              onKeyDown={boundKeyDown("checkpointEvery")}
             />
           </label>
         </div>

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -17,7 +17,7 @@
  * missing are omitted rather than invented.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Icon } from "@/lib/icon";
@@ -105,8 +105,17 @@ export function ResearchMissionDetail({
   // null = untouched; the retry payload then adapts to the failure instead.
   const [retryRoot, setRetryRoot] = useState<string | null>(null);
   const missionId = mission?.id ?? null;
+  // Tracks the mission currently on screen so an action that settles after
+  // the user switched missions is discarded instead of applying its
+  // busy/error/announce state to the wrong mission's view.
+  const missionIdRef = useRef(missionId);
 
+  // A mission switch resets every piece of per-mission action state — the
+  // in-flight action belongs to the previous mission (its settle handlers
+  // check missionIdRef and discard), so the fresh mission starts unblocked.
   useEffect(() => {
+    missionIdRef.current = missionId;
+    setBusy(false);
     setRetryRoot(null);
     setActionError(null);
     setDirection("");
@@ -138,6 +147,9 @@ export function ResearchMissionDetail({
   const draftArtifact = mission.artifacts.filter((artifact) => artifact.state === "working").at(-1);
   const isCheckpointLike = mission.status === "checkpoint" || mission.status === "paused";
   const isLive = LIVE_STATUSES.has(mission.status);
+  // Archived missions are read-only: automation controls gate on this the
+  // same way "Create schedule" already does.
+  const isArchived = mission.status === "archived";
   const showArtifactRail = !isCheckpointLike && !isLive;
 
   // Root-blocked failures get a self-healing Retry: untouched config clears the
@@ -157,57 +169,62 @@ export function ResearchMissionDetail({
       : plannedRetry.projectRoot === mission.projectRoot ? "Retry" : "Retry with new root";
   const continueInfo = researchContinueLabel(mission);
 
-  const runAction = async (input: ResearchMissionActionInput) => {
+  /** Shared settle path for every mission action. The hook reports failures
+   *  as { ok: false }; the catch is transport defense only — a throw skips
+   *  the ok branch, so a failure is never reported twice. State from an
+   *  action that settles after a mission switch is discarded, and the busy
+   *  flag always clears for the mission that set it. */
+  const runMissionAction = async (
+    fallbackError: string,
+    perform: () => Promise<{ ok: boolean; error?: string }>,
+    onSuccess: () => void,
+  ) => {
+    const startedFor = mission.id;
+    const stillCurrent = () => missionIdRef.current === startedFor;
     setBusy(true);
     setActionError(null);
     try {
-      const result = await onAction(input);
+      const result = await perform();
+      if (!stillCurrent()) return;
       if (!result.ok) {
-        const message = result.error ?? "Research action failed";
+        const message = result.error ?? fallbackError;
         setActionError(message);
         announce(message);
         return;
       }
+      onSuccess();
+    } catch (error) {
+      if (!stillCurrent()) return;
+      const message = error instanceof Error ? error.message : fallbackError;
+      setActionError(message);
+      announce(message);
+    } finally {
+      if (stillCurrent()) setBusy(false);
+    }
+  };
+  const runAction = (input: ResearchMissionActionInput) => runMissionAction(
+    "Research action failed",
+    () => onAction(input),
+    () => {
       if (input.action === "refine") setDirection("");
       if (input.action === "retry") setRetryRoot(null);
       announce(`Research ${input.action} applied.`);
-    } finally {
-      setBusy(false);
-    }
-  };
+    },
+  );
   const runAutomationAction = async (action: "pause" | "resume" | "run-now") => {
-    if (!mission.automation) return;
-    setBusy(true);
-    setActionError(null);
-    try {
-      const result = await onAutomationAction(mission.automation.id, action);
-      if (!result.ok) {
-        const message = result.error ?? "Automation action failed";
-        setActionError(message);
-        announce(message);
-        return;
-      }
-      announce(action === "run-now" ? "Research iteration started." : `Schedule ${action}d.`);
-    } finally {
-      setBusy(false);
-    }
+    const automation = mission.automation;
+    if (!automation) return;
+    await runMissionAction(
+      "Automation action failed",
+      () => onAutomationAction(automation.id, action),
+      () => announce(action === "run-now" ? "Research iteration started." : `Schedule ${action}d.`),
+    );
   };
-  const createSchedule = async () => {
-    setBusy(true);
-    setActionError(null);
-    try {
-      const result = await onSchedule("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0");
-      if (!result.ok) {
-        const message = result.error ?? "Research schedule could not be created";
-        setActionError(message);
-        announce(message);
-        return;
-      }
-      announce("Paused daily research schedule created.");
-    } finally {
-      setBusy(false);
-    }
-  };
+  const createSchedule = () => runMissionAction(
+    "Research schedule could not be created",
+    () => onSchedule("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"),
+    () => announce("Paused daily research schedule created."),
+  );
 
   // Evidence-delta triage reuses the ledger's exact source-update mechanism:
   // Keep → used, Reject → rejected, Verify → stays conflicting + appends note.
@@ -513,7 +530,7 @@ export function ResearchMissionDetail({
                     <Button
                       size="xs"
                       variant="ghost"
-                      disabled={busy}
+                      disabled={busy || isArchived}
                       onClick={() => void runAutomationAction(mission.automation!.status === "ACTIVE" ? "pause" : "resume")}
                     >
                       {mission.automation.status === "ACTIVE" ? "Pause schedule" : "Resume schedule"}
@@ -521,7 +538,7 @@ export function ResearchMissionDetail({
                     <Button
                       size="xs"
                       variant="primary"
-                      disabled={busy || mission.status === "completed"}
+                      disabled={busy || isArchived || mission.status === "completed"}
                       onClick={() => void runAutomationAction("run-now")}
                     >
                       Run now

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -18,6 +18,9 @@ type Props = {
 
 const STATUS_TONE: Partial<Record<ResearchMission["status"], string>> = {
   running: "busy",
+  // Planning is an active working state — it presents like running/queued,
+  // never like the muted idle dot.
+  planning: "busy",
   queued: "busy",
   checkpoint: "warn",
   paused: "warn",

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { copyText } from "@/lib/clipboard";
 import {
   RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH,
   type ResearchGeneration,
@@ -242,9 +243,11 @@ export function useCopyFlash() {
 
   const copy = useCallback(
     async (key: string, text: string) => {
-      try {
-        await navigator.clipboard.writeText(text);
-      } catch {
+      // copyText (lib/clipboard) falls back to execCommand where
+      // navigator.clipboard doesn't exist — the packaged Tauri webview and
+      // other non-secure contexts — and reports whether the copy landed.
+      const ok = await copyText(text);
+      if (!ok) {
         announce("Copy failed — clipboard unavailable", "assertive");
         return;
       }
@@ -270,14 +273,30 @@ type StudioModalProps = {
   variant: "config" | "viewer" | "editor";
   labelledBy: string;
   announceText: string;
+  /**
+   * False parks this dialog under a stacked one (viewer under editor):
+   * its focus trap AND Escape handling are disabled — one live trap at a
+   * time — and the subtree goes inert/aria-hidden so Tab and AT only see
+   * the top dialog. Escape therefore closes only the top dialog; closing
+   * it re-activates this one (default true).
+   */
+  active?: boolean;
   children: ReactNode;
 };
 
 /** Mounted only while open. Focus trap + Escape + focus restore come from
- *  useFocusTrap; backdrop click closes; open is announced to AT. */
-function StudioModal({ onClose, variant, labelledBy, announceText, children }: StudioModalProps) {
+ *  useFocusTrap, gated on `active`; backdrop click closes; open is announced
+ *  to AT. */
+function StudioModal({
+  onClose,
+  variant,
+  labelledBy,
+  announceText,
+  active = true,
+  children,
+}: StudioModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  useFocusTrap(true, dialogRef, { onEscape: onClose });
+  useFocusTrap(active, dialogRef, { onEscape: onClose });
   const { announce } = useAnnouncer();
   const announcedRef = useRef(false);
 
@@ -290,6 +309,8 @@ function StudioModal({ onClose, variant, labelledBy, announceText, children }: S
   return (
     <div
       className={`research-studio-modal__backdrop research-studio-modal__backdrop--${variant}`}
+      aria-hidden={active ? undefined : true}
+      inert={!active || undefined}
       onClick={onClose}
     >
       <div
@@ -537,11 +558,15 @@ export function GenerationViewerModal({
   generation,
   onClose,
   onOpenEditor,
+  active = true,
 }: {
   generation: ResearchGeneration;
   onClose: () => void;
   /** Blog only: open the markdown editor over the viewer. */
   onOpenEditor?: () => void;
+  /** False while the markdown editor is stacked on top — parks this dialog's
+   *  focus trap and Escape handling so only the editor responds. */
+  active?: boolean;
 }) {
   const meta = STUDIO_KIND_META[generation.kind];
   const content = generation.content;
@@ -570,6 +595,7 @@ export function GenerationViewerModal({
     <StudioModal
       onClose={onClose}
       variant="viewer"
+      active={active}
       labelledBy="research-studio-viewer-title"
       announceText={`${meta.label} viewer opened: ${title}`}
     >

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -126,6 +126,14 @@ test("runs rail header derives the amber checkpoint line from real missions", ()
   assert.match(css, /\.research-mission-nav__waiting/);
 });
 
+test("planning missions read as active work in the runs rail", () => {
+  // planning is a working state — its status dot carries the same busy tone
+  // as running/queued, never the muted idle dot.
+  assert.match(list, /running: "busy"/);
+  assert.match(list, /planning: "busy"/);
+  assert.match(list, /queued: "busy"/);
+});
+
 // ── Right rail: state switching + reachable ledger ──────────────────────────
 
 test("the right rail switches panels by mission state", () => {
@@ -179,6 +187,45 @@ test("the action bar stays decision-first, sticky, with end actions split right"
   assert.match(css, /\.research-desk-tab \.research-mission-actions \{[^}]*position: sticky/);
   // No kbd chip — the desk registers no keyboard shortcut to claim.
   assert.doesNotMatch(detail, /⌘/);
+});
+
+// ── Action failures: surfaced, mission-scoped, never wedge the bar ──────────
+
+test("detail action failures surface into the error line and clear busy", () => {
+  // Every action path funnels through the shared settle helper:
+  // { ok: false } from the hook is the primary error path…
+  assert.match(detail, /const message = result\.error \?\? fallbackError/);
+  assert.match(detail, /setActionError\(message\);\s*announce\(message\)/);
+  // …a transport throw lands in the same state (defense only — a throw skips
+  // the ok branch, so a failure is never reported twice)…
+  assert.match(detail, /catch \(error\) \{[\s\S]{0,120}error instanceof Error \? error\.message : fallbackError/);
+  // …and the busy flag always clears for the mission that set it.
+  assert.match(detail, /finally \{\s*if \(stillCurrent\(\)\) setBusy\(false\);\s*\}/);
+  // Schedule and automation calls ride the same helper with honest fallbacks.
+  assert.match(detail, /"Automation action failed",\s*\(\) => onAutomationAction\(automation\.id, action\)/);
+  assert.match(detail, /"Research schedule could not be created",\s*\(\) => onSchedule\("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"\)/);
+});
+
+test("an action settling after a mission switch is discarded", () => {
+  // The settle handlers compare the id captured at start against the ref that
+  // tracks the on-screen mission…
+  assert.match(detail, /const missionIdRef = useRef\(missionId\)/);
+  assert.match(detail, /const startedFor = mission\.id/);
+  assert.match(detail, /const stillCurrent = \(\) => missionIdRef\.current === startedFor/);
+  assert.match(detail, /if \(!stillCurrent\(\)\) return;/);
+  // …and the switch itself resets busy alongside the other per-mission state
+  // so the fresh mission never inherits a disabled action bar.
+  assert.match(
+    detail,
+    /missionIdRef\.current = missionId;\s*setBusy\(false\);\s*setRetryRoot\(null\);\s*setActionError\(null\);\s*setDirection\(""\);\s*\}, \[missionId\]\)/,
+  );
+});
+
+test("archived missions gate automation controls like the schedule button", () => {
+  assert.match(detail, /const isArchived = mission\.status === "archived"/);
+  // Pause/Resume schedule and Run now both disable once the mission archives.
+  assert.match(detail, /disabled=\{busy \|\| isArchived\}/);
+  assert.match(detail, /disabled=\{busy \|\| isArchived \|\| mission\.status === "completed"\}/);
 });
 
 // ── Responsive collapses re-declared for the desk-tab overrides ─────────────

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -173,6 +173,67 @@ test("quick saves attach as candidate sources via the ledger's mechanism", () =>
   assert.match(promptTab, /All in Resources →/);
 });
 
+test("a failed attach never abandons a started mission", () => {
+  // Once start() succeeds the spend is committed — the desk hand-off ALWAYS
+  // happens. Attach failures are collected without aborting the loop and
+  // surface as a partial-failure announcement, never as a generic "could not
+  // start" that invites a duplicate-spend retry.
+  assert.match(promptTab, /let failedAttaches = 0/);
+  assert.match(promptTab, /\.catch\(\(\) => \(\{ ok: false as const \}\)\)/);
+  assert.match(promptTab, /if \(!attach\.ok\) failedAttaches \+= 1/);
+  assert.match(promptTab, /useAnnouncer/);
+  assert.match(
+    promptTab,
+    /Mission started — \$\{failedAttaches\} link\$\{failedAttaches === 1 \? "" : "s"\} failed to attach\./,
+  );
+  // The announcement happens before the hand-off, and the hand-off is inside
+  // the success branch but outside any per-link condition.
+  const announceIndex = promptTab.indexOf("failed to attach.");
+  const navigateIndex = promptTab.indexOf('onNavigate("desk", { missionId: result.mission.id })');
+  assert.ok(announceIndex !== -1 && navigateIndex !== -1 && announceIndex < navigateIndex);
+});
+
+// ── Bounds editor: explicit submit only, dirty latch, clearable inputs ───────
+
+test("Enter in a bounds field never starts a mission — it commits like blur", () => {
+  // The number inputs live inside the mission form, so an unhandled Enter
+  // would implicit-submit and start a PAID mission. Enter is intercepted and
+  // commits the draft instead; the Start button and the textarea's palette
+  // shortcuts keep their existing behavior.
+  assert.match(composer, /const boundKeyDown = \(key: BoundKey\) =>/);
+  assert.match(composer, /if \(event\.key !== "Enter"\) return;\s*event\.preventDefault\(\);\s*commitBound\(key\)/);
+  for (const key of ["wallClockMinutes", "maxIterations", "sourceTarget", "checkpointEvery"]) {
+    assert.match(composer, new RegExp(`onKeyDown=\\{boundKeyDown\\("${key}"\\)\\}`));
+  }
+});
+
+test("hand-edited bounds survive auto-routing; explicit mode picks reset them", () => {
+  // Auto mode re-derives the plan on every keystroke — editing a bound latches
+  // it dirty so the plan effect stops overwriting the user's numbers…
+  assert.match(composer, /boundsDirtyRef\.current = true/);
+  assert.match(composer, /if \(boundsDirtyRef\.current\) return;\s*setBounds\(\{ \.\.\.plan\.bounds \}\);\s*setBoundDrafts\(\{\}\)/);
+  // …while every explicit mode pick funnels through setMode, which clears the
+  // latch so a deliberate switch still resets to the new plan's bounds.
+  assert.match(composer, /const setMode = useCallback\(\(next: "auto" \| ResearchMissionMode\) => \{\s*boundsDirtyRef\.current = false;\s*setModeState\(next\);/);
+});
+
+test("bound inputs are clearable — raw drafts parse on blur/Enter/submit", () => {
+  // Inputs render the raw draft while editing (parsing ""→1 on every
+  // keystroke turned "clear, then type 5" into "15")…
+  assert.match(composer, /boundDrafts\[key\] \?\? String\(bounds\[key\]\)/);
+  for (const key of ["wallClockMinutes", "maxIterations", "sourceTarget", "checkpointEvery"]) {
+    assert.match(composer, new RegExp(`onBlur=\\{\\(\\) => commitBound\\("${key}"\\)\\}`));
+  }
+  // …commits reuse the pre-existing clamp logic and server limits…
+  assert.match(composer, /boundNumber\(raw, 1, RESEARCH_BOUND_LIMITS\[key\]\)/);
+  assert.match(composer, /boundNumber\(raw, 1, RESEARCH_BOUND_LIMITS\.maxIterations\)/);
+  assert.match(composer, /checkpointEvery: Math\.min\(current\.checkpointEvery, maxIterations\)/);
+  assert.match(composer, /checkpointEvery: boundNumber\(raw, 1, current\.maxIterations\)/);
+  // …and Start submits the resolved drafts, never a stale committed value.
+  assert.match(composer, /const submittedBounds = resolveBounds\(\)/);
+  assert.match(composer, /bounds: submittedBounds,/);
+});
+
 // ── Suggested angles: real data only ─────────────────────────────────────────
 
 test("angle chips derive from real mission/link titles — never canned topics", () => {

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -20,6 +20,7 @@
 
 import { useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { linkCategoryMeta, type SavedLink } from "@/lib/link-organizer";
 import type { ResearchMissionMode } from "@/lib/research-missions";
 import { relativeTime } from "@/lib/relative-time";
@@ -37,6 +38,7 @@ const ANGLE_SEEDS_PER_POOL = 6;
 
 export function ResearchTabPrompt({ research, context, onNavigate, initialMode }: ResearchTabPromptProps) {
   const links = useResearchLinks();
+  const { announce } = useAnnouncer();
   const [attached, setAttached] = useState<SavedLink[]>([]);
   const [query, setQuery] = useState("");
 
@@ -90,9 +92,12 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
           if (result.ok) {
             // Attach the selected quick saves as candidate sources — the same
             // attach-source action the evidence ledger uses. A failed attach is
-            // non-fatal: the mission exists and the ledger can attach later.
+            // non-fatal: the mission exists (and its spend is committed), so
+            // failures are collected — never aborting the loop or the desk
+            // hand-off, which would invite a duplicate-spend retry.
+            let failedAttaches = 0;
             for (const link of attached) {
-              await research.act(result.mission.id, {
+              const attach = await research.act(result.mission.id, {
                 action: "attach-source",
                 source: {
                   id: `link-${link.id}`,
@@ -101,9 +106,13 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
                   sourceType: "web",
                   status: "candidate",
                 },
-              });
+              }).catch(() => ({ ok: false as const }));
+              if (!attach.ok) failedAttaches += 1;
             }
             setAttached([]);
+            if (failedAttaches > 0) {
+              announce(`Mission started — ${failedAttaches} link${failedAttaches === 1 ? "" : "s"} failed to attach.`);
+            }
             // A freshly started mission lives on the Desk — follow it there.
             onNavigate("desk", { missionId: result.mission.id });
           }

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -87,9 +87,17 @@ test("detail overlay is a focus-trapped dialog with honest copy/open actions", (
   assert.match(source, /aria-modal="true"/);
   assert.match(source, /aria-labelledby="research-res-overlay-title"/);
   assert.match(source, /tabIndex=\{-1\}/);
-  // Copy flashes ✓ for 1200ms (a text/icon swap — reduced-motion safe) and
-  // Open goes through the surface context, not a raw anchor.
-  assert.match(source, /navigator\.clipboard\.writeText\(url\)/);
+  // Copy goes through lib/clipboard's copyText — navigator.clipboard is
+  // undefined outside secure contexts (packaged Tauri, plain-http LAN), so
+  // the raw API silently no-ops there while copyText falls back to
+  // execCommand and reports whether the copy landed. The ✓ flash (1200ms
+  // text/icon swap — reduced-motion safe) only shows on real success, and a
+  // failure is announced assertively. Open goes through the surface context,
+  // not a raw anchor.
+  assert.match(source, /import \{ copyText \} from "@\/lib\/clipboard"/);
+  assert.match(source, /const ok = await copyText\(url\)/);
+  assert.match(source, /announce\("Couldn’t copy the link\.", "assertive"\)/);
+  assert.doesNotMatch(source, /navigator\.clipboard\.writeText/);
   assert.match(source, /setTimeout\(\(\) => setCopied\(false\), 1200\)/);
   assert.match(source, /context\.openUrl\(openLink\.url\)/);
 });

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } fro
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { copyText } from "@/lib/clipboard";
 import { Icon } from "@/lib/icon";
 import {
   linkCategoryMeta,
@@ -229,15 +230,19 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   }, []);
 
   const copyUrl = async (url: string) => {
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopied(true);
-      if (copyTimer.current) clearTimeout(copyTimer.current);
-      copyTimer.current = setTimeout(() => setCopied(false), 1200);
-      announce("Link copied.");
-    } catch {
+    // copyText (lib/clipboard) falls back to execCommand where
+    // navigator.clipboard doesn't exist — the packaged Tauri webview and
+    // other non-secure contexts — and reports whether the copy landed, so
+    // the ✓ feedback only shows on real success.
+    const ok = await copyText(url);
+    if (!ok) {
       announce("Couldn’t copy the link.", "assertive");
+      return;
     }
+    setCopied(true);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), 1200);
+    announce("Link copied.");
   };
 
   const removeOpenLink = async () => {

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -77,8 +77,17 @@ test("copy flash is a 1200ms label swap — reduced-motion safe", () => {
   assert.match(css, /prefers-reduced-motion[\s\S]*transition: none/);
 });
 
+test("copy goes through lib/clipboard's copyText — works in the Tauri webview", () => {
+  // navigator.clipboard is undefined outside secure contexts (packaged Tauri,
+  // plain-http LAN) — copyText falls back to execCommand and reports success,
+  // so the ✓ flash only shows when the copy actually landed.
+  assert.match(modals, /import \{ copyText \} from "@\/lib\/clipboard"/);
+  assert.match(modals, /const ok = await copyText\(text\)/);
+  assert.doesNotMatch(source, /navigator\.clipboard\.writeText/);
+});
+
 test("modals trap focus, restore on close, Esc + backdrop close, announce open", () => {
-  assert.match(modals, /useFocusTrap\(true, dialogRef, \{ onEscape: onClose \}\)/);
+  assert.match(modals, /useFocusTrap\(active, dialogRef, \{ onEscape: onClose \}\)/);
   assert.match(modals, /role="dialog"/);
   assert.match(modals, /aria-modal="true"/);
   assert.match(modals, /tabIndex=\{-1\}/);
@@ -90,6 +99,23 @@ test("modals trap focus, restore on close, Esc + backdrop close, announce open",
   for (const variant of ["config", "viewer", "editor"]) {
     assert.match(modals, new RegExp(`variant="${variant}"`));
   }
+});
+
+test("stacked viewer+editor keep exactly one live focus trap (active gating)", () => {
+  // StudioModal exposes `active` (default true) and feeds it to useFocusTrap
+  // as the enable flag — an inactive dialog has no Tab cycle and no Escape
+  // handler, so Escape closes only the top (editor) dialog, not both.
+  assert.match(modals, /active\?: boolean/);
+  assert.match(modals, /active = true/);
+  assert.match(modals, /useFocusTrap\(active, dialogRef/);
+  // The parked dialog is also hidden from AT and input — no second
+  // aria-modal sibling in the accessibility tree while stacked.
+  assert.match(modals, /aria-hidden=\{active \? undefined : true\}/);
+  assert.match(modals, /inert=\{!active \|\| undefined\}/);
+  // The viewer forwards the flag to the shared shell…
+  assert.match(modals, /active=\{active\}/);
+  // …and the studio parks the viewer exactly while the editor is stacked.
+  assert.match(tab, /active=\{editorGeneration === null\}/);
 });
 
 test("filter chips cover only kinds that can exist, with real counts", () => {
@@ -115,4 +141,26 @@ test("per-kind actions stay honest: mermaid inline + copy, open per kind, no fak
   assert.match(modals, /Download \.md/);
   assert.match(modals, /new Blob\(\[markdown\], \{ type: "text\/markdown" \}\)/);
   assert.doesNotMatch(source, /Export (pptx|pdf|png|mp3|mp4)/i);
+});
+
+test("familiar switches can't leak another familiar's generations (loadSeq guard)", () => {
+  // Canonical stale-response guard (familiar-work-queue-view): each load bumps
+  // the epoch, and both resolution paths discard responses from older epochs —
+  // an in-flight fetch for the previous familiar can never land.
+  assert.match(tab, /const loadSeq = useRef\(0\)/);
+  assert.match(tab, /const seq = \+\+loadSeq\.current/);
+  const staleGuards = tab.match(/seq !== loadSeq\.current/g) ?? [];
+  assert.ok(staleGuards.length >= 2, "then AND catch paths must check the epoch");
+  // On a familiar switch the previous rows drop immediately (loading/empty,
+  // never another familiar's generations) and the kind filter resets to All
+  // so a kind the new familiar lacks can't strand an empty view.
+  assert.match(tab, /loadedFamiliarRef\.current !== familiarId/);
+  assert.match(tab, /setGenerations\(\[\]\);\s*setFilter\("all"\);/);
+});
+
+test("remove treats the DELETE 404 as success — no phantom rows", () => {
+  // A generation already gone server-side ("generation not found") is a
+  // completed removal: the row leaves the list instead of re-erroring.
+  assert.match(tab, /!result\.ok && result\.error === "generation not found"/);
+  assert.match(tab, /if \(!result\.ok && !alreadyGone\)/);
 });

--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -20,7 +20,7 @@
  *   video filters are omitted because no such record can exist.
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useAnnouncer } from "@/components/ui/live-region";
 import {
@@ -76,13 +76,29 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
   // ready | failed | cancelled, drafting is synchronous — so nothing here can
   // change server-side between visits except through our own mutations, which
   // update the list directly. No polling.
+  //
+  // Stale-response guard (canonical loadSeq pattern, see
+  // familiar-work-queue-view): every load bumps the epoch and responses from
+  // an older epoch are discarded, so an in-flight fetch for the previous
+  // familiar can never land over the new familiar's rows. On a familiar
+  // switch the previous familiar's rows are dropped immediately (the list
+  // shows loading/empty, never another familiar's generations) and the kind
+  // filter resets to All so a kind that familiar lacks can't strand the view.
+  const loadSeq = useRef(0);
+  const loadedFamiliarRef = useRef(familiarId);
   useEffect(() => {
+    const seq = ++loadSeq.current;
     const controller = new AbortController();
+    if (loadedFamiliarRef.current !== familiarId) {
+      loadedFamiliarRef.current = familiarId;
+      setGenerations([]);
+      setFilter("all");
+    }
     setLoading(true);
     setListError(null);
     listResearchGenerations(familiarId, controller.signal)
       .then((result) => {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || seq !== loadSeq.current) return;
         if (!result.ok || !result.generations) {
           setListError(result.error ?? "Generations could not load");
         } else {
@@ -91,7 +107,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
         setLoading(false);
       })
       .catch((error) => {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || seq !== loadSeq.current) return;
         setListError(error instanceof Error ? error.message : "Generations could not load");
         setLoading(false);
       });
@@ -169,7 +185,11 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
       }));
       setRemovingId(null);
       setConfirmRemoveId(null);
-      if (!result.ok) {
+      // The DELETE route 404s ("generation not found") when the record is
+      // already gone server-side — that outcome IS the removal, so drop the
+      // row locally instead of stranding a phantom entry behind an error.
+      const alreadyGone = !result.ok && result.error === "generation not found";
+      if (!result.ok && !alreadyGone) {
         setRemoveError({ id: generation.id, message: result.error ?? "Remove failed" });
         return;
       }
@@ -487,6 +507,10 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
       {viewerGeneration ? (
         <GenerationViewerModal
           generation={viewerGeneration}
+          // While the editor is stacked on top, park the viewer: one live
+          // focus trap and one Escape target at a time (first Escape closes
+          // only the editor; the second closes the viewer).
+          active={editorGeneration === null}
           onClose={() => setViewerId(null)}
           onOpenEditor={
             viewerGeneration.content?.kind === "blog"

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -354,6 +354,51 @@ test("polling is abortable, foreground-aware, and container responsive", () => {
   assert.match(css, /@container research-desk/);
 });
 
+test("stale poll responses never clobber fresher state (loadSeq guard)", () => {
+  // Every load claims a monotonic token and bails before each setState once a
+  // newer load or mutation superseded it (the familiar-work-queue-view /
+  // familiar-daily-notes pattern) — without it an in-flight 2s poll landing
+  // after start()/act() made the new mission vanish until the next poll.
+  assert.match(hook, /const loadSeq = useRef\(0\)/);
+  assert.match(hook, /const seq = \+\+loadSeq\.current/);
+  assert.match(hook, /if \(signal\?\.aborted \|\| seq !== loadSeq\.current\) return/);
+  assert.match(hook, /if \(seq !== loadSeq\.current\) return; \/\/ stale failure/);
+  // Switching familiars invalidates responses from the previous familiar…
+  assert.match(hook, /loadSeq\.current \+= 1; \/\/ invalidate in-flight responses from the previous familiar/);
+  // …and every mutation bumps the token when applying its refresh, so a poll
+  // that started before the action can never overwrite the fresher state.
+  const bumps = hook.match(/loadSeq\.current \+= 1/g) ?? [];
+  assert.ok(
+    bumps.length >= 5,
+    "the familiar-switch effect and the four mutating operations must all bump the token",
+  );
+});
+
+test("mutations resolve to { ok: false } on transport failure — never throw", () => {
+  // start/act/schedule/controlAutomation are awaited bare across the tabs; a
+  // network reject or non-JSON body must resolve to the same failure shape the
+  // API path returns, not become an unhandled rejection with a silent UI.
+  assert.match(hook, /return \{ ok: false as const, error: "Research could not start" \};/);
+  assert.match(hook, /return \{ ok: false as const, error: "Research action failed" \};/);
+  assert.match(hook, /return \{ ok: false as const, error: "Research schedule could not be created" \};/);
+  assert.match(hook, /return \{ ok: false as const, error: "Automation action failed" \};/);
+  const tries = hook.match(/try \{/g) ?? [];
+  assert.ok(tries.length >= 5, "load and all four mutations wrap their transport in try/catch");
+  // A failed act resyncs with server truth on BOTH failure paths — the refused
+  // action means the on-screen mission went stale, and a transport failure may
+  // still have landed server-side.
+  const actSection = hook.slice(hook.indexOf("const act = "), hook.indexOf("const schedule = "));
+  const resyncs = actSection.match(/void load\(\)/g) ?? [];
+  assert.equal(resyncs.length, 2, "act refreshes after refused actions and after transport failures");
+});
+
+test("routed Prompt modes are one-shot — consumed then cleared", () => {
+  // onNavigate stores the mode (pinned above) and the Prompt tab consumes it;
+  // the surface then clears the stored mode so a later manual visit to the
+  // Prompt tab never re-applies a stale mode over the user's own choice.
+  assert.match(surface, /if \(activeTab === "prompt" && promptMode !== null\) setPromptMode\(null\)/);
+});
+
 test("forms expose errors and narrow outputs become keyboard tabs", () => {
   assert.match(composer, /aria-invalid=\{Boolean\(error\) \|\| intentTooShort\}/);
   assert.match(composer, /role="alert"/);

--- a/src/components/role-surfaces/researcher-surface.tsx
+++ b/src/components/role-surfaces/researcher-surface.tsx
@@ -23,7 +23,7 @@ import "@/styles/globals/surface-research-prompt.css";
 import "@/styles/globals/surface-research-library.css";
 import "@/styles/globals/surface-research-studio.css";
 import "@/styles/globals/surface-research-resources.css";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import type { ResearchMissionMode, ResearchMissionStatus } from "@/lib/research-missions";
 import type { RoleSurfaceContext } from "@/lib/role-surfaces";
@@ -111,6 +111,13 @@ export function ResearcherSurface({ context }: { context: RoleSurfaceContext }) 
     if (opts?.mode !== undefined) setPromptMode(opts.mode);
     selectTab(next);
   }, [select, selectTab]);
+
+  // A routed Prompt mode is one-shot: once the Prompt tab has rendered with it
+  // (its effects consume initialMode before this parent effect runs), clear it
+  // so later manual visits to the tab never re-apply a stale mode.
+  useEffect(() => {
+    if (activeTab === "prompt" && promptMode !== null) setPromptMode(null);
+  }, [activeTab, promptMode]);
 
   // Engine status, derived honestly from the daemon + live mission count.
   const daemonRunning = context.runtimeState.daemonRunning;

--- a/src/components/role-surfaces/use-research-missions.ts
+++ b/src/components/role-surfaces/use-research-missions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   actOnResearchMission,
   createResearchMission,
@@ -34,11 +34,19 @@ const INITIAL_STATE: ResearchMissionViewState = {
 
 export function useResearchMissions(familiarId: string) {
   const [state, setState] = useState<ResearchMissionViewState>(INITIAL_STATE);
+  // Monotonic load token (the familiar-work-queue-view/daily-notes pattern):
+  // every load claims a sequence number and bails before each setState once
+  // superseded, and every mutation-applied refresh bumps the token — so an
+  // in-flight 2s poll response that predates a user action can never land on
+  // top of the fresher state (a just-started mission vanishing until the next
+  // poll, an act() result flickering back).
+  const loadSeq = useRef(0);
 
   const load = useCallback(async (signal?: AbortSignal) => {
+    const seq = ++loadSeq.current;
     try {
       const result = await listResearchMissions(familiarId, signal);
-      if (signal?.aborted) return;
+      if (signal?.aborted || seq !== loadSeq.current) return; // a newer load or mutation won
       if (!result.ok) {
         setState((current) => ({
           ...current,
@@ -56,6 +64,7 @@ export function useResearchMissions(familiarId: string) {
       }));
     } catch (error) {
       if (signal?.aborted || (error as Error).name === "AbortError") return;
+      if (seq !== loadSeq.current) return; // stale failure — leave fresher state intact
       setState((current) => ({
         ...current,
         loading: false,
@@ -66,6 +75,7 @@ export function useResearchMissions(familiarId: string) {
 
   useEffect(() => {
     const controller = new AbortController();
+    loadSeq.current += 1; // invalidate in-flight responses from the previous familiar
     setState(INITIAL_STATE);
     void load(controller.signal);
     return () => controller.abort();
@@ -86,51 +96,75 @@ export function useResearchMissions(familiarId: string) {
   }, []);
 
   const start = useCallback(async (input: CreateResearchMissionInput) => {
-    const result = await createResearchMission(input);
-    if (!result.ok || !result.mission) {
-      return { ok: false as const, error: result.error ?? "Research could not start" };
+    try {
+      const result = await createResearchMission(input);
+      if (!result.ok || !result.mission) {
+        return { ok: false as const, error: result.error ?? "Research could not start" };
+      }
+      loadSeq.current += 1; // this refresh is the freshest truth — stale polls bail
+      setState((current) => ({
+        missions: [
+          result.mission!,
+          ...current.missions.filter((mission) => mission.id !== result.mission!.id),
+        ],
+        selectedId: result.mission!.id,
+        loading: false,
+        error: null,
+      }));
+      return { ok: true as const, mission: result.mission };
+    } catch {
+      // Transport failure (network reject, non-JSON) resolves to the same
+      // failure shape the API path returns — bare awaits must never throw.
+      return { ok: false as const, error: "Research could not start" };
     }
-    setState((current) => ({
-      missions: [
-        result.mission!,
-        ...current.missions.filter((mission) => mission.id !== result.mission!.id),
-      ],
-      selectedId: result.mission!.id,
-      loading: false,
-      error: null,
-    }));
-    return { ok: true as const, mission: result.mission };
   }, []);
 
   const act = useCallback(async (id: string, input: ResearchMissionActionInput) => {
-    const result = await actOnResearchMission(id, input);
-    if (!result.ok || !result.mission) {
-      return { ok: false as const, error: result.error ?? "Research action failed" };
+    try {
+      const result = await actOnResearchMission(id, input);
+      if (!result.ok || !result.mission) {
+        // A refused action usually means the on-screen mission went stale —
+        // resync with server truth alongside the failure shape.
+        void load();
+        return { ok: false as const, error: result.error ?? "Research action failed" };
+      }
+      loadSeq.current += 1; // this refresh is the freshest truth — stale polls bail
+      setState((current) => ({
+        ...current,
+        missions: current.missions.map((mission) => (
+          mission.id === result.mission!.id ? result.mission! : mission
+        )),
+        selectedId: result.mission!.id,
+        error: null,
+      }));
+      return { ok: true as const, mission: result.mission };
+    } catch {
+      // Transport failure — the action may still have landed server-side, so
+      // resync with server truth before returning the API failure shape.
+      void load();
+      return { ok: false as const, error: "Research action failed" };
     }
-    setState((current) => ({
-      ...current,
-      missions: current.missions.map((mission) => (
-        mission.id === result.mission!.id ? result.mission! : mission
-      )),
-      selectedId: result.mission!.id,
-      error: null,
-    }));
-    return { ok: true as const, mission: result.mission };
-  }, []);
+  }, [load]);
 
   const schedule = useCallback(async (id: string, rrule: string) => {
-    const result = await scheduleResearchMission(id, { rrule });
-    if (!result.ok || !result.mission) {
-      return { ok: false as const, error: result.error ?? "Research schedule could not be created" };
+    try {
+      const result = await scheduleResearchMission(id, { rrule });
+      if (!result.ok || !result.mission) {
+        return { ok: false as const, error: result.error ?? "Research schedule could not be created" };
+      }
+      loadSeq.current += 1; // this refresh is the freshest truth — stale polls bail
+      setState((current) => ({
+        ...current,
+        missions: current.missions.map((mission) => (
+          mission.id === result.mission!.id ? result.mission! : mission
+        )),
+        error: null,
+      }));
+      return { ok: true as const, mission: result.mission };
+    } catch {
+      // Transport failure resolves to the same failure shape the API returns.
+      return { ok: false as const, error: "Research schedule could not be created" };
     }
-    setState((current) => ({
-      ...current,
-      missions: current.missions.map((mission) => (
-        mission.id === result.mission!.id ? result.mission! : mission
-      )),
-      error: null,
-    }));
-    return { ok: true as const, mission: result.mission };
   }, []);
 
   const controlAutomation = useCallback(async (
@@ -138,27 +172,33 @@ export function useResearchMissions(familiarId: string) {
     automationId: string,
     action: "pause" | "resume" | "run-now",
   ) => {
-    const result = action === "run-now"
-      ? await runResearchAutomationNow(automationId)
-      : await setResearchAutomationStatus(automationId, action === "resume" ? "ACTIVE" : "PAUSED");
-    if (!result.ok) {
-      return { ok: false as const, error: result.error ?? "Automation action failed" };
+    try {
+      const result = action === "run-now"
+        ? await runResearchAutomationNow(automationId)
+        : await setResearchAutomationStatus(automationId, action === "resume" ? "ACTIVE" : "PAUSED");
+      if (!result.ok) {
+        return { ok: false as const, error: result.error ?? "Automation action failed" };
+      }
+      if (action !== "run-now") {
+        loadSeq.current += 1; // this refresh is the freshest truth — stale polls bail
+        setState((current) => ({
+          ...current,
+          missions: current.missions.map((mission) => mission.id === missionId && mission.automation ? {
+            ...mission,
+            automation: {
+              ...mission.automation,
+              status: action === "resume" ? "ACTIVE" : "PAUSED",
+              stopReason: undefined,
+            },
+          } : mission),
+        }));
+      }
+      void load();
+      return { ok: true as const };
+    } catch {
+      // Transport failure resolves to the same failure shape the API returns.
+      return { ok: false as const, error: "Automation action failed" };
     }
-    if (action !== "run-now") {
-      setState((current) => ({
-        ...current,
-        missions: current.missions.map((mission) => mission.id === missionId && mission.automation ? {
-          ...mission,
-          automation: {
-            ...mission.automation,
-            status: action === "resume" ? "ACTIVE" : "PAUSED",
-            stopReason: undefined,
-          },
-        } : mission),
-      }));
-    }
-    void load();
-    return { ok: true as const };
   }, [load]);
 
   return { ...state, selected, select, start, act, schedule, controlAutomation, load };

--- a/src/components/role-surfaces/use-research-missions.ts
+++ b/src/components/role-surfaces/use-research-missions.ts
@@ -115,9 +115,12 @@ export function useResearchMissions(familiarId: string) {
     } catch {
       // Transport failure (network reject, non-JSON) resolves to the same
       // failure shape the API path returns — bare awaits must never throw.
+      // The POST may still have landed server-side, so resync with server
+      // truth: a retry after a false failure would duplicate mission spend.
+      void load();
       return { ok: false as const, error: "Research could not start" };
     }
-  }, []);
+  }, [load]);
 
   const act = useCallback(async (id: string, input: ResearchMissionActionInput) => {
     try {

--- a/src/lib/server/research-mission-runner-automation-scheduling.test.ts
+++ b/src/lib/server/research-mission-runner-automation-scheduling.test.ts
@@ -416,3 +416,222 @@ test("terminal actions pause Automation truth even when mission metadata is stal
   assert.equal(result.automation?.status, "PAUSED");
   assert.deepEqual(updates, ["automation-1:PAUSED"]);
 });
+
+test("a consumed automation run with an unchanged checkpoint file is a no-op on the next poll", async () => {
+  // The workspace checkpoint file is rewritten by every run, so the observed
+  // token must be persisted when the run is consumed — otherwise the stale
+  // stored token re-triggers the synthetic-run branch on every 2s poll.
+  const run: AutomationRunRecord = {
+    id: "automation-run-real",
+    automationId: "automation-1",
+    automationName: "Research mission",
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    status: "succeeded",
+  };
+  let stored = checkpointMission({
+    bounds: { ...checkpointMission().bounds, maxIterations: 3, checkpointEvery: 3 },
+    automation: {
+      id: "automation-1",
+      rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      status: "ACTIVE",
+      checkpointFingerprint: "checkpoint-before",
+      checkpointToken: "token-0",
+    },
+  });
+  let saves = 0;
+  const updates: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { saves += 1; stored = structuredClone(mission); },
+    latestAutomationRun: async () => run,
+    readAutomationTranscript: async () => [
+      "@@research-control",
+      '{"decision":"continue","reason":"More remains","confidence":0.8}',
+      "@@research-artifacts-written",
+    ].join("\n"),
+    // The run rewrote the checkpoint file: the observed token differs from
+    // the stored "token-0" from here on.
+    readAutomationCheckpoint: async () => ({ transcript: "", token: "token-1", at: NOW.toISOString() }),
+    fingerprintMission: async () => "checkpoint-after",
+    readMissionFile: async () => "# Bounded evidence\n",
+    updateAutomation: async (id, patch) => {
+      updates.push(`${id}:${patch.status}`);
+      return { id, status: patch.status ?? "PAUSED", rrule: null };
+    },
+  }));
+  const first = await runner.reconcileAutomation(stored);
+  assert.equal(first.iterations.length, 2);
+  assert.equal(first.automation?.checkpointToken, "token-1", "the observed token is persisted with the run");
+  assert.equal(first.automation?.status, "ACTIVE", "no stop reason applies at 2 of 3 iterations");
+  assert.equal(saves, 1);
+  assert.deepEqual(updates, []);
+  const second = await runner.reconcileAutomation(first);
+  assert.equal(second.iterations.length, 2);
+  assert.equal(saves, 1, "an unchanged checkpoint file must not save again");
+  assert.deepEqual(updates, [], "an unchanged checkpoint file must not pause anything");
+});
+
+test("the automation pause path persists the observed checkpoint token", async () => {
+  const run: AutomationRunRecord = {
+    id: "automation-run-pause",
+    automationId: "automation-1",
+    automationName: "Research mission",
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    status: "succeeded",
+  };
+  let stored = checkpointMission({
+    automation: {
+      id: "automation-1",
+      rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      status: "ACTIVE",
+      checkpointFingerprint: "checkpoint-before",
+      checkpointToken: "token-0",
+    },
+  });
+  let saves = 0;
+  const updates: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { saves += 1; stored = structuredClone(mission); },
+    latestAutomationRun: async () => run,
+    readAutomationTranscript: async () => "run completed without control output",
+    readAutomationCheckpoint: async () => ({ transcript: "", token: "token-2", at: NOW.toISOString() }),
+    fingerprintMission: async () => "checkpoint-after",
+    updateAutomation: async (id, patch) => {
+      updates.push(`${id}:${patch.status}`);
+      return { id, status: patch.status ?? "PAUSED", rrule: null };
+    },
+  }));
+  const first = await runner.reconcileAutomation(stored);
+  assert.equal(first.automation?.status, "PAUSED");
+  assert.equal(first.automation?.checkpointToken, "token-2", "pause must record the observed token");
+  assert.equal(saves, 1);
+  assert.deepEqual(updates, ["automation-1:PAUSED"]);
+  const second = await runner.reconcileAutomation(first);
+  assert.equal(second.iterations.length, first.iterations.length);
+  assert.equal(saves, 1, "the consumed run must not re-trigger a save");
+  assert.deepEqual(updates, ["automation-1:PAUSED"], "the consumed run must not re-pause");
+});
+
+test("a late automation run cannot resurrect a terminal mission", async () => {
+  const run: AutomationRunRecord = {
+    id: "late-run",
+    automationId: "automation-1",
+    automationName: "Research mission",
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    status: "succeeded",
+  };
+  const cancelledAt = "2026-07-12T11:00:00.000Z";
+  let stored = checkpointMission({
+    status: "cancelled",
+    finishedAt: cancelledAt,
+    automation: {
+      id: "automation-1",
+      rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      status: "ACTIVE",
+      checkpointFingerprint: "checkpoint-before",
+      checkpointToken: "token-0",
+    },
+  });
+  let saves = 0;
+  const updates: string[] = [];
+  const published: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { saves += 1; stored = structuredClone(mission); },
+    latestAutomationRun: async () => run,
+    readAutomationTranscript: async () => [
+      "@@research-control",
+      '{"decision":"complete","reason":"Late landing","confidence":0.9}',
+      "@@research-artifacts-written",
+    ].join("\n"),
+    readAutomationCheckpoint: async () => ({ transcript: "", token: "token-9", at: NOW.toISOString() }),
+    fingerprintMission: async () => "checkpoint-after",
+    readMissionFile: async () => "# Late evidence\n",
+    publishKnowledge: async (entry) => { published.push(entry.body); return entry; },
+    updateAutomation: async (id, patch) => {
+      updates.push(`${id}:${patch.status}`);
+      return { id, status: patch.status ?? "PAUSED", rrule: null };
+    },
+  }));
+  const first = await runner.reconcileAutomation(stored);
+  assert.equal(first.status, "cancelled", "a terminal mission must stay terminal");
+  assert.equal(first.iterations.length, 1, "no iteration may be appended");
+  assert.equal(first.finishedAt, cancelledAt, "finishedAt must not be rewritten");
+  assert.equal(first.automation?.lastRunId, "late-run", "the run is still recorded as consumed");
+  assert.equal(first.automation?.checkpointToken, "token-9");
+  assert.deepEqual(published, []);
+  assert.deepEqual(updates, []);
+  assert.equal(saves, 1);
+  const second = await runner.reconcileAutomation(first);
+  assert.equal(second.status, "cancelled");
+  assert.equal(saves, 1, "consumed bookkeeping must not save again");
+});
+
+test("schedule is rejected on terminal and archived missions", async () => {
+  for (const status of ["completed", "failed", "cancelled", "archived"] as const) {
+    const stored = checkpointMission({ status });
+    const runner = makeResearchMissionRunner(deps({
+      loadMission: async () => structuredClone(stored),
+    }));
+    await assert.rejects(
+      runner.schedule(stored.id, { rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0" }),
+      new RegExp(`cannot schedule a ${status} research mission`),
+      status,
+    );
+  }
+});
+
+test("an unreadable automation checkpoint file reads as no change instead of throwing", async () => {
+  const stored = checkpointMission({
+    automation: {
+      id: "automation-1",
+      rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      status: "ACTIVE",
+      checkpointFingerprint: "checkpoint-before",
+      checkpointToken: "token-0",
+    },
+  });
+  let saves = 0;
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async () => { saves += 1; },
+    readAutomationCheckpoint: async () => { throw new Error("research file is too large"); },
+  }));
+  const result = await runner.reconcileAutomation(structuredClone(stored));
+  assert.equal(result.status, stored.status);
+  assert.equal(result.iterations.length, 1);
+  assert.equal(saves, 0, "an unreadable checkpoint must not churn the mission file");
+});
+
+test("an unreadable mission fingerprint consumes the run as unchanged instead of throwing", async () => {
+  const run: AutomationRunRecord = {
+    id: "automation-run-fingerprint",
+    automationId: "automation-1",
+    automationName: "Research mission",
+    startedAt: NOW.toISOString(),
+    finishedAt: NOW.toISOString(),
+    status: "succeeded",
+  };
+  let stored = checkpointMission({
+    automation: {
+      id: "automation-1",
+      rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+      status: "ACTIVE",
+      checkpointFingerprint: "checkpoint-before",
+    },
+  });
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    latestAutomationRun: async () => run,
+    readAutomationTranscript: async () => [
+      "@@research-control",
+      '{"decision":"continue","reason":"More remains","confidence":0.8}',
+      "@@research-artifacts-written",
+    ].join("\n"),
+    fingerprintMission: async () => { throw new Error("research file is too large"); },
+  }));
+  const result = await runner.reconcileAutomation(stored);
+  assert.equal(result.automation?.status, "PAUSED");
+  assert.match(result.automation?.stopReason ?? "", /did not change the mission checkpoint/);
+  assert.equal(result.iterations.length, 1, "no iteration may be built on unreadable evidence");
+});

--- a/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+++ b/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
@@ -275,3 +275,111 @@ test("withinStartupGrace bounds the dead-session verdict", () => {
   assert.equal(withinStartupGrace(undefined, now), false);
   assert.equal(withinStartupGrace("not-a-date", now), false);
 });
+
+// ── Orphaned-run recovery (missions stuck forever in non-terminal states) ─────
+// Travel replays record the replayed run under a NEW flow run id, the flow-run
+// store caps at 200 records and evicts, and a crash between the planning save
+// and the launch-result save leaves an iteration with no flowRunId at all.
+// Past a grace window all three recover as failed so Retry becomes available.
+
+test("a planning mission with no recorded run fails after the recovery grace window", async () => {
+  let stored = checkpointMission({
+    status: "planning",
+    iterations: [{ number: 1, status: "queued" }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    now: () => new Date(NOW.getTime() + 11 * 60_000),
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations[0].status, "failed");
+  assert.match(result.lastError ?? "", /startup was interrupted/i);
+  assert.ok(allowedResearchActions(result).includes("retry"), "recovery must enable Retry");
+});
+
+test("a planning mission with no recorded run stays untouched within grace", async () => {
+  let saves = 0;
+  const stored = checkpointMission({
+    status: "planning",
+    iterations: [{ number: 1, status: "queued" }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async () => { saves += 1; },
+    now: () => new Date(NOW.getTime() + 5 * 60_000),
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "planning", "startup may still land within grace");
+  assert.equal(saves, 0, "no save may refresh updatedAt and reset the grace clock");
+});
+
+test("a running mission whose flow run record is gone fails after grace with Retry", async () => {
+  let stored = checkpointMission({
+    status: "running",
+    iterations: [{
+      number: 1,
+      status: "running",
+      flowRunId: "run-evicted",
+      sessionId: "session-1",
+      startedAt: NOW.toISOString(),
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    // loadFlowRun default: null — evicted from the capped flow-run store.
+    now: () => new Date(NOW.getTime() + 11 * 60_000),
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations[0].status, "failed");
+  assert.match(result.lastError ?? "", /run record is missing/i);
+  assert.ok(allowedResearchActions(result).includes("retry"));
+});
+
+test("a running mission whose flow run record is gone stays untouched within grace", async () => {
+  let saves = 0;
+  const stored = checkpointMission({
+    status: "running",
+    iterations: [{
+      number: 1,
+      status: "running",
+      flowRunId: "run-evicted",
+      sessionId: "session-1",
+      startedAt: NOW.toISOString(),
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async () => { saves += 1; },
+    now: () => new Date(NOW.getTime() + 5 * 60_000),
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "running");
+  assert.equal(saves, 0);
+});
+
+test("a run stuck queued past the grace window fails with Retry (travel replay orphan)", async () => {
+  let stored = checkpointMission({
+    status: "queued",
+    iterations: [{
+      number: 1,
+      status: "queued",
+      flowRunId: "run-original",
+      startedAt: NOW.toISOString(),
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    loadFlowRun: async () => ({ ...RUN, id: "run-original", status: "queued", sessionId: undefined }),
+    now: () => new Date(NOW.getTime() + 11 * 60_000),
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations[0].status, "failed");
+  assert.match(result.lastError ?? "", /queued research run never started/i);
+  assert.ok(allowedResearchActions(result).includes("retry"));
+});

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import type { ConversationFile } from "../cave-conversations.ts";
 import type { AutomationRunRecord } from "../automation-runs.ts";
 import type { FlowRunRecord } from "../flows.ts";
-import { allowedResearchActions, type ResearchMission } from "../research-missions.ts";
+import { allowedResearchActions, type ResearchMission, type ResearchSourcePatch } from "../research-missions.ts";
 import {
   makeResearchMissionRunner,
   parseResearchSourcesFile,
@@ -406,4 +406,112 @@ test("artifact rejection preserves the file reference and refine starts once", a
   });
   assert.equal(refined.direction, "Prioritize primary sources published since 2024");
   assert.equal(refined.iterations.length, 2);
+});
+
+test("cancel kills a queued session that already carries a session id", async () => {
+  // Travel handoffs and slow starts can leave a live session on an iteration
+  // that still reads "queued" — cancel must kill it, not only "running" ones.
+  const killed: string[] = [];
+  let stored = checkpointMission({
+    status: "queued",
+    iterations: [{
+      number: 1,
+      status: "queued",
+      flowRunId: "run-1",
+      sessionId: "session-1",
+      startedAt: NOW.toISOString(),
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    killSession: async (sessionId) => { killed.push(sessionId); },
+  }));
+  const result = await runner.act(stored.id, { action: "cancel" });
+  assert.deepEqual(killed, ["session-1"], "a queued iteration with a session keeps burning spend");
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.iterations[0].status, "cancelled");
+});
+
+test("cancel keeps a settled iteration's recorded outcome", async () => {
+  const killed: string[] = [];
+  let stored = checkpointMission();
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    killSession: async (sessionId) => { killed.push(sessionId); },
+  }));
+  const result = await runner.act(stored.id, { action: "cancel" });
+  assert.deepEqual(killed, [], "a settled iteration's session is already gone");
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.iterations[0].status, "checkpoint", "the settled outcome must survive cancel");
+  assert.equal(result.iterations[0].finishedAt, NOW.toISOString());
+});
+
+test("update-source rejects unknown fields, url/id tampering, and invalid values", async () => {
+  let stored = checkpointMission({
+    sources: [{
+      id: "manual-1",
+      title: "Spec",
+      url: "https://example.com/spec",
+      sourceType: "web",
+      status: "candidate",
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+  }));
+  const rejections: Array<[Record<string, unknown>, RegExp]> = [
+    [{ url: "javascript:alert(1)" }, /invalid source patch field: url/],
+    [{ id: "hijacked" }, /invalid source patch field: id/],
+    [{ addedAt: "2020-01-01T00:00:00.000Z" }, /invalid source patch field: addedAt/],
+    [{ status: null }, /invalid source status/],
+    [{ status: "definitely-not-a-status" }, /invalid source status/],
+    [{ confidence: 7 }, /invalid source confidence/],
+    [{ title: "   " }, /invalid source title/],
+  ];
+  for (const [patch, expected] of rejections) {
+    await assert.rejects(
+      runner.act(stored.id, {
+        action: "update-source",
+        sourceId: "manual-1",
+        patch: patch as unknown as ResearchSourcePatch,
+      }),
+      expected,
+    );
+  }
+  assert.equal(stored.sources[0].url, "https://example.com/spec", "the stored url must be untouched");
+  assert.equal(stored.sources[0].id, "manual-1");
+  assert.equal(stored.sources[0].status, "candidate");
+});
+
+test("createAndStart cannot resurrect a mission cancelled during launch", async () => {
+  let stored: ResearchMission | null = null;
+  let releaseStart!: () => void;
+  const startGate = new Promise<void>((resolve) => { releaseStart = resolve; });
+  let observedStart!: () => void;
+  const startObserved = new Promise<void>((resolve) => { observedStart = resolve; });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => (stored ? structuredClone(stored) : null),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    startFlow: async () => {
+      observedStart();
+      await startGate;
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+  const creating = runner.createAndStart(INPUT);
+  await startObserved;
+  const cancelling = runner.act("mission-1", { action: "cancel" });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  releaseStart();
+  const [, cancelled] = await Promise.all([creating, cancelling]);
+  const finalStored = stored as ResearchMission | null;
+  assert.equal(cancelled.status, "cancelled");
+  assert.equal(
+    finalStored?.status,
+    "cancelled",
+    "the launch-result save must not overwrite a concurrent cancel",
+  );
 });

--- a/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+++ b/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
@@ -7,6 +7,7 @@ import { allowedResearchActions, type ResearchMission } from "../research-missio
 import {
   makeResearchMissionRunner,
   parseResearchSourcesFile,
+  reconcileResearchMissionList,
   sessionAlreadyGone,
   withinStartupGrace,
   type ResearchMissionRunnerDeps,
@@ -315,4 +316,127 @@ test("malformed sources checkpoint the mission instead of publishing", async () 
   const result = await runner.reconcile(stored);
   assert.equal(result.status, "checkpoint");
   assert.match(result.lastError ?? "", /sources\.json is malformed/);
+});
+
+test("a mission with no artifact refs reconciles instead of throwing", async () => {
+  const published: string[] = [];
+  let stored = checkpointMission({
+    status: "running",
+    artifacts: [],
+    iterations: [{
+      ...checkpointMission().iterations[0],
+      status: "running",
+      finishedAt: undefined,
+    }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: [
+          "@@research-control",
+          '{"decision":"complete","reason":"Done","confidence":0.9}',
+          "@@research-artifacts-written",
+        ].join("\n"),
+        createdAt: NOW.toISOString(),
+      }],
+    }),
+    readMissionFile: async () => "# Complete\n",
+    publishKnowledge: async (entry) => { published.push(entry.body); return entry; },
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.status, "completed");
+  assert.deepEqual(result.artifacts, [], "no artifact ref may be invented");
+  assert.deepEqual(published, [], "nothing publishes without an artifact ref");
+});
+
+test("manually attached sources survive evidence reconciliation", async () => {
+  let stored = checkpointMission({
+    status: "running",
+    iterations: [{
+      ...checkpointMission().iterations[0],
+      status: "running",
+      finishedAt: undefined,
+    }],
+    sources: [
+      {
+        id: "manual-memo",
+        title: "Manual memo",
+        url: "https://example.com/manual-memo",
+        sourceType: "web",
+        status: "candidate",
+      },
+      {
+        id: "manual-dup",
+        title: "Stale manual copy",
+        url: "https://example.com/source",
+        sourceType: "web",
+        status: "candidate",
+      },
+    ],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: [
+          "@@research-control",
+          '{"decision":"complete","reason":"Done","confidence":0.9}',
+          "@@research-artifacts-written",
+        ].join("\n"),
+        createdAt: NOW.toISOString(),
+      }],
+    }),
+    readMissionFile: async () => "# Complete\n",
+    readSources: async () => [{
+      id: "source-1",
+      title: "Primary source",
+      url: "https://example.com/source",
+      sourceType: "web",
+      status: "used",
+    }],
+  }));
+  const result = await runner.reconcile(stored);
+  assert.equal(result.sources.length, 2);
+  const manual = result.sources.find((source) => source.id === "manual-memo");
+  assert.ok(manual, "the manual-only source must survive the reconcile");
+  assert.equal(manual?.status, "candidate");
+  const collided = result.sources.find((source) => source.url === "https://example.com/source");
+  assert.equal(collided?.id, "source-1", "the flow-written entry wins a url collision");
+  assert.equal(collided?.status, "used");
+});
+
+test("one poisoned mission degrades to its stored snapshot instead of failing the list", async () => {
+  const poisoned = checkpointMission({ id: "mission-poisoned" });
+  const healthy = checkpointMission({ id: "mission-healthy" });
+  let healthyReconciles = 0;
+  const runner = {
+    reconcile: async (mission: ResearchMission): Promise<ResearchMission> => {
+      if (mission.id === "mission-poisoned") throw new Error("boom");
+      healthyReconciles += 1;
+      return { ...mission, lastError: "reconciled" };
+    },
+    reconcileAutomation: async (mission: ResearchMission): Promise<ResearchMission> => mission,
+  };
+  const result = await reconcileResearchMissionList([poisoned, healthy], runner);
+  assert.equal(result.length, 2, "the list endpoint must keep serving");
+  assert.deepEqual(result[0], poisoned, "the poisoned mission falls back to its stored snapshot");
+  assert.equal(result[1].lastError, "reconciled");
+  assert.equal(healthyReconciles, 1);
 });

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -13,6 +13,7 @@ import { buildResearchMissionFlow } from "../research-mission-flow.ts";
 import {
   allowedResearchActions,
   type CreateResearchMissionInput,
+  type ResearchArtifactKind,
   type ResearchArtifactRef,
   type ResearchMission,
   type ResearchMissionActionInput,
@@ -41,6 +42,27 @@ export {
   withinStartupGrace,
 } from "./research-mission-lifecycle.ts";
 export type { ResearchFlowStartResult } from "./research-mission-lifecycle.ts";
+
+/**
+ * Settled mission statuses — mirrors the settled set in
+ * src/lib/research-missions.ts (researchBoundReadings): a mission in one of
+ * these states must never be transitioned by background reconciliation.
+ */
+const TERMINAL_RESEARCH_MISSION_STATUSES: ReadonlyArray<ResearchMission["status"]> = [
+  "completed",
+  "failed",
+  "cancelled",
+  "archived",
+];
+
+/**
+ * How long a non-terminal mission may reference a missing, never-launched, or
+ * stuck-queued run before reconcile recovers it as failed (so Retry becomes
+ * available). Within the window the run may still land — travel replay records
+ * a replayed run late, and a startup save may still be in flight. Measured
+ * against deps.now() so tests can drive the clock.
+ */
+export const RESEARCH_RUN_RECOVERY_GRACE_MS = 10 * 60_000;
 
 export type ResearchAutomationScheduleInput = {
   rrule: string;
@@ -160,34 +182,97 @@ function mergeResearchSource(
   } : item);
 }
 
+/**
+ * Merge the flow-written sources.json ledger into the stored mission sources
+ * instead of replacing them: manually attached sources live only in
+ * mission.json (attach-source), so a wholesale replace silently wiped them on
+ * every settle. File entries win on url/localPath/id collision; manual-only
+ * entries survive.
+ */
+function mergeFileSources(
+  stored: ResearchSourceRef[],
+  file: ResearchSourceRef[],
+): ResearchSourceRef[] {
+  const matchesFileEntry = (item: ResearchSourceRef) => file.some((source) => (
+    source.url && item.url === source.url
+  ) || (
+    source.localPath && item.localPath === source.localPath
+  ) || source.id === item.id);
+  return [...file, ...stored.filter((item) => !matchesFileEntry(item))];
+}
+
+/**
+ * Default primary-artifact kind for a mission mode — mirrors
+ * artifactKindForMode in research-mission-lifecycle.ts, used only when a
+ * stored mission carries no artifact refs at all.
+ */
+function defaultArtifactKindForMode(mode: ResearchMission["mode"]): ResearchArtifactKind {
+  if (mode === "sweep") return "report";
+  if (mode === "paper") return "paper";
+  if (mode === "autoresearch") return "findings";
+  return "brief";
+}
+
+const PATCHABLE_SOURCE_FIELDS = [
+  "title", "publisher", "publishedAt", "sourceType", "claim", "note", "confidence", "status",
+] as const satisfies ReadonlyArray<keyof ResearchSourcePatch>;
+
+const PATCHABLE_TEXT_LIMITS: Record<string, number> = {
+  title: 300,
+  publisher: 200,
+  publishedAt: 100,
+  sourceType: 100,
+  claim: 2_000,
+  note: 2_000,
+};
+
 function patchResearchSource(
   mission: ResearchMission,
   sourceId: string,
   patch: ResearchSourcePatch,
 ): ResearchMission {
-  const allowedStatuses: ResearchSourceRef["status"][] = [
-    "candidate", "used", "conflicting", "rejected",
-  ];
-  if (patch.status && !allowedStatuses.includes(patch.status)) {
-    throw new Error("invalid source status");
+  // The route forwards the patch body verbatim, so allowlist hard: unknown
+  // keys (url, id, addedAt, …) must never spread into the stored record —
+  // url would bypass attach-time normalizeWebUrl and id would break dedupe.
+  const raw = patch as Record<string, unknown>;
+  const unknownKeys = Object.keys(raw).filter(
+    (key) => !(PATCHABLE_SOURCE_FIELDS as readonly string[]).includes(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(`invalid source patch field: ${unknownKeys[0]}`);
   }
-  if (
-    patch.confidence !== undefined &&
-    (!Number.isFinite(patch.confidence) || patch.confidence < 0 || patch.confidence > 1)
-  ) {
-    throw new Error("invalid source confidence");
+  const validated: Partial<ResearchSourceRef> = {};
+  for (const field of Object.keys(PATCHABLE_TEXT_LIMITS)) {
+    if (!(field in raw)) continue;
+    const value = raw[field];
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) throw new Error(`invalid source ${field}`);
+    (validated as Record<string, string>)[field] = trimmed.slice(0, PATCHABLE_TEXT_LIMITS[field]);
+  }
+  if ("status" in raw) {
+    const allowedStatuses: ResearchSourceRef["status"][] = [
+      "candidate", "used", "conflicting", "rejected",
+    ];
+    if (!allowedStatuses.includes(raw.status as ResearchSourceRef["status"])) {
+      throw new Error("invalid source status");
+    }
+    validated.status = raw.status as ResearchSourceRef["status"];
+  }
+  if ("confidence" in raw) {
+    const confidence = raw.confidence;
+    if (
+      typeof confidence !== "number" ||
+      !Number.isFinite(confidence) || confidence < 0 || confidence > 1
+    ) {
+      throw new Error("invalid source confidence");
+    }
+    validated.confidence = confidence;
   }
   let found = false;
   const sources = mission.sources.map((source) => {
     if (source.id !== sourceId) return source;
     found = true;
-    return {
-      ...source,
-      ...patch,
-      ...(patch.title ? { title: patch.title.trim().slice(0, 300) } : {}),
-      ...(patch.note ? { note: patch.note.trim().slice(0, 2_000) } : {}),
-      ...(patch.claim ? { claim: patch.claim.trim().slice(0, 2_000) } : {}),
-    };
+    return { ...source, ...validated };
   });
   if (!found) throw new Error("research source not found");
   return { ...mission, sources };
@@ -220,9 +305,9 @@ async function reconcileCompletedRun(
     ...(costUsd === undefined ? {} : { costUsd }),
   };
   let markdown: string | null;
-  let sources: ResearchSourceRef[];
+  let fileSources: ResearchSourceRef[];
   try {
-    [markdown, sources] = await Promise.all([
+    [markdown, fileSources] = await Promise.all([
       deps.readMissionFile(mission.id, "artifacts/primary.md"),
       deps.readSources(mission.id),
     ]);
@@ -238,6 +323,7 @@ async function reconcileCompletedRun(
       } : item),
     };
   }
+  const sources = mergeFileSources(mission.sources, fileSources);
 
   if (!markdown) {
     return {
@@ -249,7 +335,14 @@ async function reconcileCompletedRun(
       iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
     };
   }
-  const content = validateResearchArtifactContent(mission.artifacts[0].kind, markdown);
+  // A mission whose artifacts array is empty must reconcile instead of
+  // throwing: validate against the mode's default kind and skip the
+  // artifact-derived updates (there is no ref to update or publish).
+  const primaryArtifact: ResearchArtifactRef | undefined = mission.artifacts[0];
+  const content = validateResearchArtifactContent(
+    primaryArtifact?.kind ?? defaultArtifactKindForMode(mission.mode),
+    markdown,
+  );
   if (!content.ok) {
     return {
       ...mission,
@@ -261,26 +354,30 @@ async function reconcileCompletedRun(
     };
   }
 
-  let artifact: ResearchArtifactRef = {
-    ...mission.artifacts[0],
-    iteration: iteration.number,
-    updatedAt: timestamp,
-  };
-  if (control.decision === "complete" && !artifact.knowledgeId) {
-    const entry = await deps.publishKnowledge(researchKnowledgeEntry({
-      mission,
-      artifact,
-      provenance: {
-        missionId: mission.id,
-        iteration: iteration.number,
-        flowRunId: iteration.flowRunId,
-        sessionId: iteration.sessionId,
-        automationRunId: iteration.automationRunId,
-        generatedAt: timestamp,
-      },
-      markdown: content.value,
-    }));
-    artifact = { ...artifact, knowledgeId: entry.id, state: "published" };
+  let artifacts = mission.artifacts;
+  if (primaryArtifact) {
+    let artifact: ResearchArtifactRef = {
+      ...primaryArtifact,
+      iteration: iteration.number,
+      updatedAt: timestamp,
+    };
+    if (control.decision === "complete" && !artifact.knowledgeId) {
+      const entry = await deps.publishKnowledge(researchKnowledgeEntry({
+        mission,
+        artifact,
+        provenance: {
+          missionId: mission.id,
+          iteration: iteration.number,
+          flowRunId: iteration.flowRunId,
+          sessionId: iteration.sessionId,
+          automationRunId: iteration.automationRunId,
+          generatedAt: timestamp,
+        },
+        markdown: content.value,
+      }));
+      artifact = { ...artifact, knowledgeId: entry.id, state: "published" };
+    }
+    artifacts = [artifact, ...mission.artifacts.slice(1)];
   }
 
   return {
@@ -290,16 +387,31 @@ async function reconcileCompletedRun(
     ...(control.decision === "complete" ? { finishedAt: timestamp } : {}),
     lastError: undefined,
     sources,
-    artifacts: [artifact, ...mission.artifacts.slice(1)],
+    artifacts,
     iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
   };
 }
 
 export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
   let reconcileFlowUnlocked: (mission: ResearchMission) => Promise<ResearchMission>;
+  /**
+   * A mission directory deleted mid-flight surfaces as ENOENT from the store —
+   * report the standard not-found error (the actions route maps it to 404)
+   * instead of leaking a raw fs failure as a 500.
+   */
+  const saveMission = async (mission: ResearchMission): Promise<void> => {
+    try {
+      await deps.saveMission(mission);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+        throw new Error("research mission not found");
+      }
+      throw error;
+    }
+  };
   const saveUpdated = async (mission: ResearchMission): Promise<ResearchMission> => {
     const updated = { ...mission, updatedAt: deps.now().toISOString() };
-    await deps.saveMission(updated);
+    await saveMission(updated);
     return updated;
   };
 
@@ -394,13 +506,13 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       iterations: [...mission.iterations, { number, status: "queued" }],
       artifacts: workingArtifact ? [workingArtifact, ...mission.artifacts] : mission.artifacts,
     };
-    await deps.saveMission(next);
+    await saveMission(next);
     const target = await missionStartTarget(next);
     const result = target.ok
       ? await deps.startFlow(buildResearchMissionFlow(next, number), missionStartOptions(next, target.projectRoot))
       : { ok: false, error: target.error };
     next = applyStartResult(next, result, deps.now());
-    await deps.saveMission(next);
+    await saveMission(next);
     return next;
   };
 
@@ -436,7 +548,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         status: "queued",
       } : iteration),
     };
-    await deps.saveMission(retried);
+    await saveMission(retried);
     const target = await missionStartTarget(retried);
     const result = target.ok
       ? await deps.startFlow(
@@ -445,7 +557,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       )
       : { ok: false, error: target.error };
     retried = applyStartResult(retried, result, deps.now());
-    await deps.saveMission(retried);
+    await saveMission(retried);
     return retried;
   };
 
@@ -503,7 +615,11 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       }
       if (input.action === "cancel") {
         const current = mission.iterations.at(-1);
-        if (current?.sessionId && current.status === "running") {
+        const currentActive = current?.status === "queued" || current?.status === "running";
+        // A queued iteration can already carry a live session (travel handoff,
+        // slow start) — kill whenever a session exists and the iteration has
+        // not settled, not only when it reads "running".
+        if (current?.sessionId && currentActive) {
           await deps.killSession(current.sessionId);
         }
         const cancelledMission = await pauseAutomation(mission, "Mission cancelled");
@@ -511,8 +627,11 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           ...cancelledMission,
           status: "cancelled",
           finishedAt: timestamp,
+          // Only rewrite an iteration that is still in flight — a settled
+          // (checkpoint/completed/failed) iteration keeps its real outcome.
           iterations: cancelledMission.iterations.map((iteration, index) => (
-            index === cancelledMission.iterations.length - 1
+            index === cancelledMission.iterations.length - 1 &&
+            (iteration.status === "queued" || iteration.status === "running")
               ? { ...iteration, status: "cancelled", finishedAt: timestamp }
               : iteration
           )),
@@ -530,10 +649,6 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       if (input.action === "archive") {
         mission = await pauseAutomation(mission, "Mission archived");
         return saveUpdated({ ...mission, status: "archived" });
-      }
-      if (input.action === "pause") {
-        mission = await pauseAutomation(mission, "Mission paused");
-        return saveUpdated({ ...mission, status: "paused" });
       }
       if (input.action === "resume") {
         return saveUpdated({ ...mission, status: "checkpoint", lastError: undefined });
@@ -567,7 +682,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         ...(checkpoint?.token ? { checkpointToken: checkpoint.token } : {}),
       },
     };
-    await deps.saveMission(updated);
+    await saveMission(updated);
     return updated;
   };
 
@@ -587,16 +702,59 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         ...(storedAutomation.status === "ACTIVE" ? { stopReason: undefined } : {}),
       };
       mission = { ...mission, automation, updatedAt: deps.now().toISOString() };
-      await deps.saveMission(mission);
+      await saveMission(mission);
     }
+
+    // Oversized or otherwise unreadable workspace files must read as "no
+    // checkpoint" instead of killing this mission's reconcile on every poll.
+    const readCheckpointSafe = async (): Promise<
+      { transcript: string; token: string; at: string } | null
+    > => {
+      try {
+        return await deps.readAutomationCheckpoint(mission.id);
+      } catch {
+        return null;
+      }
+    };
+
+    // A late or replayed automation run must never resurrect a terminal or
+    // archived mission: persist run/checkpoint bookkeeping so the run stays
+    // consumed, but never transition status, iterations, or finishedAt.
+    if (
+      TERMINAL_RESEARCH_MISSION_STATUSES.includes(mission.status)
+    ) {
+      const lateRun = await deps.latestAutomationRun(automation.id);
+      const observedToken = (await readCheckpointSafe())?.token || undefined;
+      const runChanged = lateRun !== null && (
+        lateRun.id !== automation.lastRunId || lateRun.status !== automation.lastRunStatus
+      );
+      const tokenChanged = observedToken !== undefined && observedToken !== automation.checkpointToken;
+      if (!runChanged && !tokenChanged) return mission;
+      const updated: ResearchMission = {
+        ...mission,
+        updatedAt: deps.now().toISOString(),
+        automation: {
+          ...automation,
+          ...(lateRun ? {
+            lastRunId: lateRun.id,
+            lastRunStatus: lateRun.status,
+            lastRunAt: lateRun.finishedAt ?? lateRun.startedAt,
+          } : {}),
+          ...(observedToken ? { checkpointToken: observedToken } : {}),
+        },
+      };
+      await saveMission(updated);
+      return updated;
+    }
+
     let run = await deps.latestAutomationRun(automation.id);
     let checkpointTranscript: string | null = null;
-    let checkpointToken: string | undefined;
+    let observedCheckpointToken: string | undefined;
     if (!run || run.id === automation.lastRunId) {
-      const checkpoint = await deps.readAutomationCheckpoint(mission.id);
-      if (!checkpoint.token || checkpoint.token === automation.checkpointToken) return mission;
+      const checkpoint = await readCheckpointSafe();
+      if (!checkpoint?.token || checkpoint.token === automation.checkpointToken) return mission;
       checkpointTranscript = checkpoint.transcript;
-      checkpointToken = checkpoint.token;
+      observedCheckpointToken = checkpoint.token;
       run = {
         id: `scheduled-${checkpoint.token}`,
         automationId: automation.id,
@@ -617,32 +775,50 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           lastRunAt: run.startedAt,
         },
       };
-      await deps.saveMission(updated);
+      await saveMission(updated);
       return updated;
     }
+
+    // Every settled run has performed its final checkpoint write by contract,
+    // so observe the token now and persist it on EVERY consuming path below —
+    // real and synthetic, success and pause alike. Otherwise the stale stored
+    // token re-triggers the synthetic-run branch on every reconcile, causing
+    // an infinite pause/save loop against the 2s desk poll.
+    if (observedCheckpointToken === undefined) {
+      observedCheckpointToken = (await readCheckpointSafe())?.token || undefined;
+    }
+    // An unreadable fingerprint reads as "unchanged" — the run is consumed
+    // with a visible pause instead of throwing on every poll.
+    const fingerprint = await deps.fingerprintMission(mission.id)
+      .catch(() => automation.checkpointFingerprint);
     if (run.status === "failed") {
       return pauseLinkedAutomation(
         mission,
         run,
         run.summary || "Scheduled research iteration failed",
+        { fingerprint, token: observedCheckpointToken },
       );
     }
 
-    const [transcript, fingerprint] = await Promise.all([
-      checkpointTranscript === null ? deps.readAutomationTranscript(run) : Promise.resolve(checkpointTranscript),
-      deps.fingerprintMission(mission.id),
-    ]);
+    const transcript = checkpointTranscript === null
+      ? await deps.readAutomationTranscript(run).catch(() => "")
+      : checkpointTranscript;
     const control = parseResearchControl(transcript);
     if (control.reason === "Missing or malformed research control output") {
       return pauseLinkedAutomation(
         mission,
         run,
         "Automation run did not emit a valid control checkpoint",
-        { fingerprint, token: checkpointToken },
+        { fingerprint, token: observedCheckpointToken },
       );
     }
     if (fingerprint === automation.checkpointFingerprint) {
-      return pauseLinkedAutomation(mission, run, "Automation run did not change the mission checkpoint");
+      return pauseLinkedAutomation(
+        mission,
+        run,
+        "Automation run did not change the mission checkpoint",
+        { fingerprint, token: observedCheckpointToken },
+      );
     }
 
     const timestamp = deps.now().toISOString();
@@ -653,7 +829,9 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       ...mission,
       status,
       updatedAt: timestamp,
-      ...(status === "completed" ? { finishedAt: timestamp } : {}),
+      // A non-completing transition out of any earlier settled state must not
+      // keep a stale finishedAt.
+      finishedAt: status === "completed" ? timestamp : undefined,
       lastError: undefined,
       iterations: [...mission.iterations, {
         number,
@@ -668,7 +846,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       automation: {
         ...automation,
         checkpointFingerprint: fingerprint,
-        ...(checkpointToken ? { checkpointToken } : {}),
+        ...(observedCheckpointToken ? { checkpointToken: observedCheckpointToken } : {}),
         lastRunId: run.id,
         lastRunStatus: run.status,
         lastRunAt: run.finishedAt ?? run.startedAt,
@@ -686,7 +864,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         reconciled,
         run,
         reconciled.lastError,
-        { fingerprint, token: checkpointToken },
+        { fingerprint, token: observedCheckpointToken },
       );
     }
     if (!stopReason) stopReason = stopBeforeNextIteration(reconciled, deps.now());
@@ -714,18 +892,75 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         stopReason,
       };
     }
-    await deps.saveMission(reconciled);
+    await saveMission(reconciled);
     return reconciled;
   };
 
   reconcileFlowUnlocked = async (mission: ResearchMission): Promise<ResearchMission> => {
-    if (!["queued", "running"].includes(mission.status)) return mission;
+    // "planning" is included so a crash between the planning save and the
+    // launch-result save (an iteration with no flowRunId yet) can be recovered
+    // below instead of hanging forever with only Cancel available.
+    if (!["queued", "planning", "running"].includes(mission.status)) return mission;
     const iterationIndex = mission.iterations.length - 1;
     const iteration = mission.iterations[iterationIndex];
-    if (!iteration?.flowRunId) return mission;
+    if (!iteration) return mission;
+
+    // Orphan recovery: a run that cannot land anymore (record missing from the
+    // capped flow-run store, replaced by a travel replay under a new id, stuck
+    // "queued" forever, or never launched at all) would otherwise pin the
+    // mission in a non-terminal state with no action but Cancel. Past the
+    // grace window, fail the iteration so Retry becomes available; within it,
+    // change nothing — the run may still land.
+    const recoveryBasisMs = Date.parse(iteration.startedAt ?? mission.updatedAt);
+    const pastRecoveryGrace = Number.isFinite(recoveryBasisMs) &&
+      deps.now().getTime() - recoveryBasisMs >= RESEARCH_RUN_RECOVERY_GRACE_MS;
+    const failOrphan = async (lastError: string, summary: string): Promise<ResearchMission> => {
+      const timestamp = deps.now().toISOString();
+      const failed: ResearchMission = {
+        ...mission,
+        status: "failed",
+        updatedAt: timestamp,
+        lastError,
+        iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
+          ...item,
+          status: "failed",
+          finishedAt: timestamp,
+          summary,
+        } : item),
+      };
+      await saveMission(failed);
+      return failed;
+    };
+
+    if (!iteration.flowRunId) {
+      if (pastRecoveryGrace) {
+        return failOrphan(
+          "Startup was interrupted before a research session was recorded — Retry starts a fresh iteration.",
+          "Startup interrupted",
+        );
+      }
+      return mission;
+    }
     const run = await deps.loadFlowRun(iteration.flowRunId);
-    if (!run) return mission;
+    if (!run) {
+      if (pastRecoveryGrace) {
+        return failOrphan(
+          "The research run record is missing — recovered as failed. Retry starts a fresh iteration.",
+          "Run record missing",
+        );
+      }
+      return mission;
+    }
     if (run.status === "running" || run.status === "queued") {
+      // A run stuck "queued" past the grace window will never start under this
+      // id — travel replay records the replayed run under a NEW flow run id,
+      // so this record stays queued forever while the mission waits on it.
+      if (run.status === "queued" && pastRecoveryGrace) {
+        return failOrphan(
+          "The queued research run never started — recovered as failed. Retry starts a fresh iteration.",
+          "Queued run never started",
+        );
+      }
       // The flow-run record only says the run was STARTED — nothing flips it
       // when the underlying agent session ends, so probe the session itself
       // (cave-ibb7). A finished session reconciles from its transcript; a dead
@@ -735,7 +970,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         if (state === "finished") {
           const transcript = await deps.readSessionTranscript(iteration.sessionId);
           const reconciled = await reconcileCompletedRun(mission, iterationIndex, deps, transcript);
-          await deps.saveMission(reconciled);
+          await saveMission(reconciled);
           return reconciled;
         }
         if (state === "gone" && !withinStartupGrace(iteration.startedAt, deps.now())) {
@@ -752,7 +987,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
               summary: "Session ended without control markers",
             } : item),
           };
-          await deps.saveMission(failed);
+          await saveMission(failed);
           return failed;
         }
       }
@@ -767,7 +1002,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           steps: run.steps.map((step) => ({ ...step })),
         } : item),
       };
-      await deps.saveMission(synced);
+      await saveMission(synced);
       return synced;
     }
     if (run.status === "failed") {
@@ -784,11 +1019,11 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           summary: run.summary,
         } : item),
       };
-      await deps.saveMission(failed);
+      await saveMission(failed);
       return failed;
     }
     const reconciled = await reconcileCompletedRun(mission, iterationIndex, deps);
-    await deps.saveMission(reconciled);
+    await saveMission(reconciled);
     return reconciled;
   };
 
@@ -796,14 +1031,21 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     async createAndStart(input: CreateResearchMissionInput): Promise<ResearchMission> {
       let mission = createMissionRecord(input, deps.randomId(), deps.now());
       mission = await deps.createWorkspace(mission);
-      await deps.saveMission(mission);
-      const target = await missionStartTarget(mission);
-      const result = target.ok
-        ? await deps.startFlow(buildResearchMissionFlow(mission, 1), missionStartOptions(mission, target.projectRoot))
-        : { ok: false, error: target.error };
-      mission = applyStartResult(mission, result, deps.now());
-      await deps.saveMission(mission);
-      return mission;
+      await saveMission(mission);
+      // The start sequence shares the per-mission action lock: without it, a
+      // concurrent locked act('cancel') landing between the pre-launch save
+      // and the launch-result save was silently overwritten back to running.
+      return withResearchMissionActionLock(mission.id, async () => {
+        let current = await deps.loadMission(mission.id) ?? mission;
+        if (TERMINAL_RESEARCH_MISSION_STATUSES.includes(current.status)) return current;
+        const target = await missionStartTarget(current);
+        const result = target.ok
+          ? await deps.startFlow(buildResearchMissionFlow(current, 1), missionStartOptions(current, target.projectRoot))
+          : { ok: false, error: target.error };
+        current = applyStartResult(current, result, deps.now());
+        await saveMission(current);
+        return current;
+      });
     },
 
     reconcile(mission: ResearchMission): Promise<ResearchMission> {
@@ -817,6 +1059,11 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         const mission = await deps.loadMission(id);
         if (!mission) throw new Error("research mission not found");
         if (mission.mode !== "autoresearch") throw new Error("schedules require AutoResearch mode");
+        // A terminal or archived mission must never gain a schedule — a later
+        // automation run would otherwise try to revive it.
+        if (TERMINAL_RESEARCH_MISSION_STATUSES.includes(mission.status)) {
+          throw new Error(`cannot schedule a ${mission.status} research mission`);
+        }
         if (mission.automation) throw new Error("research mission already has a schedule");
         const rrule = input.rrule.trim();
         if (!rrule.startsWith("RRULE:") || rrule.length > 500) {
@@ -853,7 +1100,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           },
           updatedAt: deps.now().toISOString(),
         };
-        await deps.saveMission(updated);
+        await saveMission(updated);
         return updated;
       });
     },
@@ -1066,6 +1313,43 @@ export function makeProductionResearchMissionRunner() {
   return makeResearchMissionRunner(deps);
 }
 
+/**
+ * Last logged reconcile failure per mission — the desk list polls every 2s,
+ * so a persistently broken mission must not flood the log with the same
+ * message on every poll.
+ */
+const loggedReconcileFailures = new Map<string, string>();
+
+/**
+ * Reconcile every mission for the desk list, isolating failures per mission:
+ * one poisoned mission (corrupt artifacts, oversized workspace file, deleted
+ * directory, …) must degrade to its stored snapshot instead of failing the
+ * whole list endpoint on every poll.
+ */
+export async function reconcileResearchMissionList(
+  missions: ResearchMission[],
+  runner: Pick<
+    ReturnType<typeof makeResearchMissionRunner>,
+    "reconcile" | "reconcileAutomation"
+  >,
+): Promise<ResearchMission[]> {
+  return Promise.all(missions.map(async (mission) => {
+    let current = mission;
+    try {
+      current = await runner.reconcile(current);
+      current = await runner.reconcileAutomation(current);
+      loggedReconcileFailures.delete(mission.id);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (loggedReconcileFailures.get(mission.id) !== message) {
+        loggedReconcileFailures.set(mission.id, message);
+        console.error(`research mission ${mission.id} reconcile failed: ${message}`);
+      }
+    }
+    return current;
+  }));
+}
+
 export async function listAndReconcileResearchMissions(
   familiarId: string,
 ): Promise<ResearchMission[]> {
@@ -1073,8 +1357,5 @@ export async function listAndReconcileResearchMissions(
   const missions = (await listResearchMissions()).filter(
     (mission) => mission.familiarId === familiarId && mission.status !== "archived",
   );
-  return Promise.all(missions.map(async (mission) => {
-    const flowReconciled = await runner.reconcile(mission);
-    return runner.reconcileAutomation(flowReconciled);
-  }));
+  return reconcileResearchMissionList(missions, runner);
 }

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -1333,6 +1333,13 @@ export async function reconcileResearchMissionList(
     "reconcile" | "reconcileAutomation"
   >,
 ): Promise<ResearchMission[]> {
+  // Prune dedupe entries for missions no longer in the list (deleted or
+  // archived) so the module-level map cannot grow unbounded over a
+  // long-lived process.
+  const listedIds = new Set(missions.map((mission) => mission.id));
+  for (const id of loggedReconcileFailures.keys()) {
+    if (!listedIds.has(id)) loggedReconcileFailures.delete(id);
+  }
   return Promise.all(missions.map(async (mission) => {
     let current = mission;
     try {


### PR DESCRIPTION
## Summary

Comprehensive parallel-agent review of the Research Desk (server engine, API routes, shared hook, all five tabs) found **2 P0s, 10 P1s, and a set of P2s** — this PR lands the verified fixes in one sweep. Review + repro notes in bead `cave-l061`.

### P0 — desk-bricking
- **Empty `artifacts` array crashed reconcile and 500'd the whole desk list on every 2s poll, persistently.** `artifacts[0]` is now optional (falls back to the mode's default kind) and `reconcileResearchMissionList` guards each mission, returning the stored snapshot on error so one poisoned mission can't take down the surface.
- **Missions orphaned forever in queued/planning** — travel replay records a new run id the iteration never sees; the flow-run store's 200-cap evicts records; a crash between planning saves leaves no `flowRunId`. Unified grace-window recovery (`RESEARCH_RUN_RECOVERY_GRACE_MS` = 10 min): past grace they fail with a descriptive `lastError` and Retry enabled; within grace, untouched.

### P1 — engine
- Automation checkpoint token is now consumed on every settled run and passed through pause — ends the **spurious pause + saveMission churn on every poll** (the old test stubbed a constant token, masking this; it now exercises a drifting token and asserts a second reconcile is a no-op).
- Late automation runs **no longer resurrect** cancelled/completed/archived missions.
- `createAndStart` start phase runs **under the per-mission action lock** — concurrent cancel wins instead of being silently overwritten (race-tested).
- Manually attached sources **survive reconcile** (merge instead of wholesale replace).
- Oversized/unreadable checkpoint + fingerprint reads no longer throw (was bricking that mission's reconcile).

### P1 — hook + UI
- `useResearchMissions`: canonical `loadSeq` stale-response guard (in-flight poll can no longer clobber fresher post-action state) + `act`/`schedule`/`controlAutomation` return `{ ok:false, error }` on transport failure instead of throwing (was: unhandled rejections, zero error UI).
- Prompt: attach failure after `start()` succeeded no longer shows a false "could not start" (**duplicate-spend path**) — always navigates, reports partial attach failures.
- Composer: **Enter in bounds inputs no longer implicitly starts a paid mission**; bounds edits latch against auto-mode overwrites; inputs are clearable (raw drafts, clamp on blur).
- Surface: stale `promptMode` no longer hijacks later Prompt-tab visits (one-shot consumption).
- Detail/ledger: action failures surface in the UI (`ok:false` + throw defense + busy cleared in `finally`); in-flight results discarded on mission switch; ledger state fully resets per mission.
- Studio: stacked viewer→editor modals no longer double-trap focus (`StudioModal active` prop — single live trap, Escape closes only the top, `inert`/`aria-hidden` on the covered dialog).

### P2s
Route error mapping (500/404 instead of blanket 400), route action list derived from `allowedResearchActions` (dead "pause" removed end-to-end), structural RRULE validation via the codex parser, `update-source` allowlist (rejects `javascript:` URLs / id reassignment / bad status), cancel kills queued sessions & stops rewriting finished iterations, schedule refused on terminal/archived, ENOENT→404, stale-familiar generations guard + kind-filter reset + 404-delete-as-success in Studio, `planning` status dot, archived automation-control gating, `copyText` for clipboard (Tauri-safe).

### Validation
- `pnpm typecheck` clean
- `pnpm test:app` **891/891**, `pnpm test:api` **235/235**
- ~40 new test cases across the four runner suites + component pin tests

### Follow-ups filed
`cave-qdf2` (travel replay should re-point the original run), `cave-7had` (manual continue vs ACTIVE automation), `cave-9589` (derived default-tab flip).
