### PR TITLE
fix(home): round hearth backdrop scrim with Appearance radius tokens (cave-1nft)

### DIFF
--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -13,6 +13,11 @@ assert.match(
   /html\[data-backdrop-on\] \.home-hearth-card \{[^}]*background: color-mix\(in oklch, var\(--bg-base\) 72%, transparent\);[^}]*\}/,
   "Home uses one uniform theme-derived hearth surface while a backdrop is active",
 );
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.home-hearth-card \{[^}]*border-radius: var\(--radius-xl\);[^}]*\}/,
+  "the hearth surface rounds with the Appearance corner-radius tokens, not square corners",
+);
 assert.doesNotMatch(
   css,
   /html\[data-backdrop-on\] \.home-composer-root::before/,

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -104,6 +104,9 @@ html[data-backdrop-on] .cave-group-chat-shell {
    around it. */
 html[data-backdrop-on] .home-hearth-card {
   background: color-mix(in oklch, var(--bg-base) 72%, transparent);
+  /* --radius-xl (not a hard-coded px / square corner) so the hearth glass
+     follows the Appearance → Corner radius setting like the chat glass. */
+  border-radius: var(--radius-xl);
 }
 
 /* Chat landing (no thread yet): the greeting/identity/suggestions cluster


### PR DESCRIPTION
## Problem

With a backdrop image on, the home hearth card's readability fill (`html[data-backdrop-on] .home-hearth-card`) has no `border-radius`, so the glass panel renders **square** — ignoring Appearance → Corner radius. User-reported with screenshot. This rule wasn't touched by #3679, which fixed the chat glass surfaces.

## Fix

- `src/styles/backdrop.css`: add `border-radius: var(--radius-xl)` to the hearth backdrop rule — same token the chat glass (`.cave-chat-empty-shell`, thread, familiar-tab) adopted in #3679, so it tracks the Appearance setting. The `prefers-reduced-transparency` variant only overrides `background`, so the radius carries there too.
- `src/components/backdrop-scrim.test.ts`: positive pin that the hearth scrim rounds via the token.

## Verification

- Targeted tests green (backdrop-scrim, home-hearth).
- Prod build + Playwright probe with `data-backdrop-on` forced: computed radius **14px** (default) / **2.8px** (sharp) / **19.6px** (round) — scales with `--radius`; screenshot shows the rounded scrim.

Bead: cave-1nft