### PR TITLE
fix(familiar-tab): #3655 review follow-ups — install source 404, memory draft races, robustness

### DIFF
--- a/src/components/familiar-tab-analytics.test.ts
+++ b/src/components/familiar-tab-analytics.test.ts
@@ -25,6 +25,12 @@ test("reuses the shared analytics data layer — no parallel fetch stack", () =>
   assert.doesNotMatch(src, /\bfetch\(/, "no hand-rolled fetch — the loader owns all requests");
   assert.match(src, /usePausablePoll\(\(\) => void load\(\{ quiet: true \}\), 60_000\)/, "60s pausable poll like the analytics page");
   assert.match(src, /const generation = useRef\(0\)/, "generation counter retires stale loads");
+  // Remounts inside one poll interval (tab flips) serve the cached snapshot
+  // instead of re-firing all eight endpoints (PR #3655 follow-up).
+  assert.match(src, /const ANALYTICS_CACHE_TTL_MS = 60_000/, "cache TTL matches the poll cadence");
+  assert.match(src, /analyticsCache\.set\(familiar\.id, \{ data: next, at: Date\.now\(\) \}\)/, "landed loads populate the cache");
+  assert.match(src, /Date\.now\(\) - cached\.at < ANALYTICS_CACHE_TTL_MS/, "mount serves only fresh snapshots");
+  assert.match(src, /setUpdatedAt\(new Date\(cached\.at\)\.toISOString\(\)\)/, "freshness stamp stays truthful — it reports when the data landed");
 });
 
 test("no token KPI and no fabricated numbers", () => {
@@ -41,6 +47,9 @@ test("no token KPI and no fabricated numbers", () => {
     /delta\.current \+ delta\.previous > 0\s*\?/,
     "delta note renders only when the window has anything to compare",
   );
+  // A falling week is a real signal — it must not render as "flat".
+  assert.match(src, /delta\.delta > 0 \? "up" : delta\.delta < 0 \? "down" : "flat"/, "negative deltas get the down tone");
+  assert.match(css, /\.familiar-analytics-tab__kpi-note--down \{[^}]*var\(--color-danger/, "down tone rides the danger token");
   assert.match(src, /attempted > 0 \? `\$\{Math\.round\(\(outcomes\.completed \/ attempted\) \* 100\)\}%` : "—"/,
     "success rate guards divide-by-zero with an em dash");
 });

--- a/src/components/familiar-tab-analytics.tsx
+++ b/src/components/familiar-tab-analytics.tsx
@@ -182,6 +182,13 @@ function Slide({ hidden, children }: { hidden: boolean; children: React.ReactNod
 const RECENT_RUNS_SHOWN = 7;
 const HEAL_REQUESTS_SHOWN = 5;
 
+// Remounting this section (tab flips, familiar switches back and forth) used
+// to re-fire all eight analytics endpoints every time. Cache the last landed
+// snapshot per familiar for one poll interval and serve it on mount; the 60s
+// quiet poll keeps it honest.
+const ANALYTICS_CACHE_TTL_MS = 60_000;
+const analyticsCache = new Map<string, { data: FamiliarAnalyticsData; at: number }>();
+
 export function FamiliarAnalyticsSection({ familiar }: { familiar: Familiar }) {
   const [data, setData] = useState<FamiliarAnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -204,6 +211,7 @@ export function FamiliarAnalyticsSection({ familiar }: { familiar: Familiar }) {
     try {
       const next = await loadFamiliarAnalyticsData(familiar.id);
       if (generation.current !== gen) return;
+      analyticsCache.set(familiar.id, { data: next, at: Date.now() });
       setData(next);
       setUpdatedAt(new Date().toISOString());
     } catch (err) {
@@ -218,10 +226,17 @@ export function FamiliarAnalyticsSection({ familiar }: { familiar: Familiar }) {
   }, [familiar.id]);
 
   useEffect(() => {
+    const cached = analyticsCache.get(familiar.id);
+    if (cached && Date.now() - cached.at < ANALYTICS_CACHE_TTL_MS) {
+      setData(cached.data);
+      setUpdatedAt(new Date(cached.at).toISOString());
+      setLoading(false);
+      return;
+    }
     setData(null);
     setUpdatedAt(null);
     void load();
-  }, [load]);
+  }, [familiar.id, load]);
 
   usePausablePoll(() => void load({ quiet: true }), 60_000);
 
@@ -325,7 +340,7 @@ function AnalyticsBody({
   const sessionsNote = delta.current + delta.previous > 0
     ? delta.delta === 0 ? "steady" : `${delta.delta > 0 ? "+" : "−"}${Math.abs(delta.delta)} wk`
     : null;
-  const sessionsNoteTone = delta.delta > 0 ? "up" : "flat";
+  const sessionsNoteTone = delta.delta > 0 ? "up" : delta.delta < 0 ? "down" : "flat";
 
   return (
     <div className="familiar-analytics-tab">

--- a/src/components/familiar-tab-identity.test.ts
+++ b/src/components/familiar-tab-identity.test.ts
@@ -125,6 +125,10 @@ test("identity contract card scans for real: fetches the contract route, renders
     /contract\.report\.violations\.length\} violation/,
     "non-compliance pill counts the report's real violations",
   );
+  // Violations spanning files carry file: "cross-file"; they count in the
+  // pill, so they must also be locatable in the file list (PR #3655 follow-up).
+  assert.match(src, /v\.file === "cross-file"/, "cross-file violations are collected");
+  assert.match(src, /cross-file[\s\S]{0,400}?\{crossFile\[0\]\.message\}/, "cross-file row surfaces the first message as its blurb");
 });
 
 test("identity CSS is component-owned: BEM prefix, tokens only, container-query collapse", () => {

--- a/src/components/familiar-tab-identity.tsx
+++ b/src/components/familiar-tab-identity.tsx
@@ -332,6 +332,24 @@ function ContractCard({ data }: { data: FamiliarSectionData }) {
               </li>
             );
           })}
+          {(() => {
+            // Violations spanning multiple files carry file: "cross-file" and
+            // belong to no row above — without this they'd count in the pill
+            // but be impossible to locate.
+            const crossFile = contract.report.violations.filter((v) => v.file === "cross-file");
+            if (crossFile.length === 0) return null;
+            return (
+              <li className="familiar-identity__file">
+                <span className="familiar-identity__file-name font-mono">
+                  cross-file
+                  <span className="familiar-identity__file-tag familiar-identity__file-tag--missing">
+                    {crossFile.length} issue{crossFile.length === 1 ? "" : "s"}
+                  </span>
+                </span>
+                <span className="familiar-identity__file-blurb">{crossFile[0].message}</span>
+              </li>
+            );
+          })()}
         </ul>
       )}
     </section>

--- a/src/components/familiar-tab-mcp.test.ts
+++ b/src/components/familiar-tab-mcp.test.ts
@@ -55,11 +55,25 @@ test("rescan refetches /api/capabilities for this harness, uncached, with a busy
 });
 
 test("copy feedback: single timer, check + success flip, role=status band", () => {
-  assert.match(src, /navigator\.clipboard\?\.writeText\(value\)\.catch\(\(\) => \{\}\)/, "clipboard write with catch");
+  assert.match(src, /navigator\.clipboard\.writeText\(value\)/, "clipboard write goes through the async API");
+  // "Copied" must be earned: setCopied only fires in the promise's success
+  // handler — a rejected write (permissions, insecure context) shows nothing.
+  assert.match(src, /write\.then\(\s*\(\) => \{[\s\S]{0,240}?setCopied\(\{ field, value \}\)/, "success handler owns the Copied flip");
+  assert.doesNotMatch(src, /writeText\(value\)\.catch\(\(\) => \{\}\)/, "no swallowed failure with an unconditional Copied");
   const timerClears = src.match(/window\.clearTimeout\(copyTimer\.current\)/g) ?? [];
   assert.ok(timerClears.length >= 2, "one timer ref, cleared on re-copy and on unmount");
   assert.match(src, /copied\?\.field === "name" \? "ph:check" : "ph:copy"/, "icon flips to a check");
   assert.match(src, /role="status"/, "Copied confirmation is a live status region");
+});
+
+test("rescan failures surface in the status band and stale responses are dropped", () => {
+  assert.match(src, /const generation = \+\+rescanGeneration\.current/, "each rescan takes a generation ticket");
+  assert.match(src, /rescanGeneration\.current \+= 1;[\s\S]{0,80}?setFreshManifest\(null\)/, "harness switch retires in-flight rescans");
+  assert.match(src, /if \(rescanGeneration\.current !== generation\) return;/, "superseded responses can't apply a stale manifest");
+  assert.match(src, /Rescan failed — daemon unreachable\. Showing the last snapshot\./, "network failure is stated, not swallowed");
+  assert.match(src, /Rescan returned no capability data — is the daemon running\?/, "empty response is stated too");
+  assert.match(src, /familiar-mcp__status-error" role="alert"/, "error renders as an alert in the status band");
+  assert.match(css, /\.familiar-mcp__status-error \{[^}]*var\(--color-danger/, "error tone rides the danger token");
 });
 
 test("css: copy-pop animation has a reduced-motion guard; pills stay neutral", () => {

--- a/src/components/familiar-tab-mcp.tsx
+++ b/src/components/familiar-tab-mcp.tsx
@@ -106,15 +106,21 @@ export function FamiliarMcpSection({ data }: { data: FamiliarSectionData }) {
   // changes so a stale override never bleeds across familiars.
   const [freshManifest, setFreshManifest] = useState<HarnessCapabilityManifest | null>(null);
   const [rescanning, setRescanning] = useState(false);
+  const [rescanError, setRescanError] = useState<string | null>(null);
   const [catalog, setCatalog] = useState<McpServerInfo[] | null>(null);
 
   const [modalOpen, setModalOpen] = useState(false);
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [copied, setCopied] = useState<CopiedState>(null);
   const copyTimer = useRef<number | null>(null);
+  // Bumped on harness change and on each rescan start so a slow response for
+  // a previous harness (or a superseded click) can't apply a stale manifest.
+  const rescanGeneration = useRef(0);
 
   useEffect(() => {
+    rescanGeneration.current += 1;
     setFreshManifest(null);
+    setRescanError(null);
   }, [data.harnessId]);
 
   useEffect(() => {
@@ -148,32 +154,48 @@ export function FamiliarMcpSection({ data }: { data: FamiliarSectionData }) {
   // /api/capabilities?harness=… forwards refresh=1 to the daemon's per-harness
   // scanner, so this is a genuine rescan — not just a cache-busting refetch.
   const rescan = useCallback(async () => {
+    const generation = ++rescanGeneration.current;
     setRescanning(true);
+    setRescanError(null);
     try {
       const res = await fetch(`/api/capabilities?harness=${encodeURIComponent(data.harnessId)}&refresh=1`, {
         cache: "no-store",
       });
       const body = (await res.json()) as CapabilitiesResponse;
+      if (rescanGeneration.current !== generation) return; // superseded — drop stale result
       const next = body?.harness_capabilities?.[0];
-      if (next) setFreshManifest(next);
+      if (next) {
+        setFreshManifest(next);
+      } else {
+        setRescanError("Rescan returned no capability data — is the daemon running?");
+      }
     } catch {
-      // Daemon offline — keep showing the last snapshot.
+      if (rescanGeneration.current === generation) {
+        setRescanError("Rescan failed — daemon unreachable. Showing the last snapshot.");
+      }
     } finally {
-      setRescanning(false);
+      if (rescanGeneration.current === generation) setRescanning(false);
     }
   }, [data.harnessId]);
 
   const copyText = useCallback((value: string, field: "name" | "command" | "config") => {
     if (!value) return;
+    let write: Promise<void>;
     try {
-      navigator.clipboard?.writeText(value).catch(() => {});
+      write = navigator.clipboard.writeText(value);
     } catch {
-      // Clipboard unavailable (permissions, insecure context) — the visual
-      // confirmation still fires so the user knows what would have copied.
+      return; // Clipboard unavailable (permissions, insecure context) — don't claim success.
     }
-    if (copyTimer.current !== null) window.clearTimeout(copyTimer.current);
-    setCopied({ field, value });
-    copyTimer.current = window.setTimeout(() => setCopied(null), 2000);
+    write.then(
+      () => {
+        if (copyTimer.current !== null) window.clearTimeout(copyTimer.current);
+        setCopied({ field, value });
+        copyTimer.current = window.setTimeout(() => setCopied(null), 2000);
+      },
+      () => {
+        // Write rejected — leave the UI untouched rather than show a false "Copied".
+      },
+    );
   }, []);
 
   const openConnect = useCallback((server?: McpServerInfo) => {
@@ -206,9 +228,15 @@ export function FamiliarMcpSection({ data }: { data: FamiliarSectionData }) {
 
       <div className="familiar-mcp__status">
         <span className="familiar-mcp__status-copy">
-          {hasPlugins
-            ? "From the latest capability scan — rescan after editing your runtime's MCP config."
-            : "No plugins or MCP servers yet — connect a well-known server below, or bring your own."}
+          {rescanError ? (
+            <span className="familiar-mcp__status-error" role="alert">
+              {rescanError}
+            </span>
+          ) : hasPlugins ? (
+            "From the latest capability scan — rescan after editing your runtime's MCP config."
+          ) : (
+            "No plugins or MCP servers yet — connect a well-known server below, or bring your own."
+          )}
         </span>
         <div className="familiar-mcp__status-actions">
           <Button

--- a/src/components/familiar-tab-memory.test.ts
+++ b/src/components/familiar-tab-memory.test.ts
@@ -57,6 +57,26 @@ test("successful saves advance the stored mtime and the preview text", () => {
     /setFile\(\(prev\) => \(\{\s*\.\.\.prev,\s*text: nextText,\s*mtimeMs: typeof json\.mtimeMs === "number" \? json\.mtimeMs : prev\.mtimeMs,/,
     "text + mtime baseline both move to what was written",
   );
+  // A save response that lands after the user switched files must not write
+  // the old file's text/baseline into the new file's pane (PR #3655 follow-up).
+  assert.match(src, /const stillSelected = selectedPathRef\.current === selectedPath;/, "responses check the live selection");
+  assert.match(src, /if \(stillSelected\) \{\s*setFile/, "pane state only moves for the still-selected file");
+  // The list row's size column is bytes on disk, not UTF-16 code units.
+  assert.match(src, /size: new TextEncoder\(\)\.encode\(nextText\)\.length/, "row size counts UTF-8 bytes");
+  assert.doesNotMatch(src, /size: nextText\.length/, "no code-unit size");
+});
+
+test("drafts survive an unmount without a blur, without double-saving", () => {
+  // Tab/familiar/file switches unmount the textarea before blur fires — and
+  // React detaches element refs before passive cleanups, so the only reliable
+  // copy of the draft at cleanup time is a value ref fed by onChange.
+  assert.match(src, /draftRef\.current = \{ path: selectedPath, text: event\.currentTarget\.value \}/, "every keystroke mirrors the draft into a value ref");
+  assert.match(src, /return \(\) => \{\s*const draft = draftRef\.current;[\s\S]{0,280}?commitEditRef\.current\(draft\.text\)/, "effect cleanup commits the mirrored draft");
+  assert.match(src, /\}, \[view, readOnly, selectedPath, refreshToken\]\);/, "cleanup re-arms per file/view, not per commit identity");
+  // Blur + cleanup can both fire for the same draft — the committed-draft ref
+  // collapses the pair to one PUT instead of racing into a 409.
+  assert.match(src, /committedDraftRef\.current\?\.path === selectedPath && committedDraftRef\.current\.text === nextText/, "identical in-flight/settled commits dedupe");
+  assert.match(src, /committedDraftRef\.current = \{ path: selectedPath, text: nextText \}/, "commit records itself before the PUT");
 });
 
 test("Esc returns to preview (saving first), and only a failed save holds the draft", () => {

--- a/src/components/familiar-tab-memory.tsx
+++ b/src/components/familiar-tab-memory.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/familiar-tab-memory.css";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { IconButton } from "@/components/ui/icon-button";
 import { Segmented } from "@/components/ui/settings-controls";
@@ -103,6 +103,7 @@ export function FamiliarMemorySection({ familiar }: { familiar: Familiar }) {
 
   // Fetch the selected file. Redacted text renders as-is — no reveal here.
   useEffect(() => {
+    committedDraftRef.current = null;
     if (!selectedPath) {
       setFile(EMPTY_FILE_STATE);
       return;
@@ -145,11 +146,28 @@ export function FamiliarMemorySection({ familiar }: { familiar: Familiar }) {
     [list.entries, selectedPath],
   );
 
+  // Tracks the live selection so a save response that lands after the user
+  // switched files can't clobber the new file's state or mtime baseline.
+  const selectedPathRef = useRef(selectedPath);
+  useEffect(() => {
+    selectedPathRef.current = selectedPath;
+  }, [selectedPath]);
+
+  // The same draft can reach commitEdit twice (blur + the edit pane's unmount
+  // cleanup, or Esc after a blur save). Records the in-flight/last-committed
+  // draft so the duplicate collapses instead of racing the first PUT into a
+  // spurious mtime conflict. Reset when the file is (re)fetched.
+  const committedDraftRef = useRef<{ path: string; text: string } | null>(null);
+
   /** Persist an edit. Resolves true when the pane may leave the draft behind. */
   const commitEdit = useCallback(
     async (nextText: string): Promise<boolean> => {
       if (!selectedPath) return true;
       if (nextText === (file.text ?? "")) return true; // untouched draft — nothing to save
+      if (committedDraftRef.current?.path === selectedPath && committedDraftRef.current.text === nextText) {
+        return true; // identical commit already in flight or already saved
+      }
+      committedDraftRef.current = { path: selectedPath, text: nextText };
       try {
         const res = await fetch("/api/memory/file", {
           method: "PUT",
@@ -161,33 +179,45 @@ export function FamiliarMemorySection({ familiar }: { familiar: Familiar }) {
           }),
         });
         const json = (await res.json()) as { ok: boolean; mtimeMs?: number; error?: string };
+        // Late responses for a file the user already left must not touch the
+        // newly selected file's pane state or concurrency baseline.
+        const stillSelected = selectedPathRef.current === selectedPath;
         if (res.status === 409) {
-          setSaveError({ kind: "conflict", message: "File changed on disk — reload before editing." });
+          committedDraftRef.current = null;
+          if (stillSelected) setSaveError({ kind: "conflict", message: "File changed on disk — reload before editing." });
           return false;
         }
         if (!json.ok) {
-          setSaveError({ kind: "plain", message: json.error ?? "Save failed" });
+          committedDraftRef.current = null;
+          if (stillSelected) setSaveError({ kind: "plain", message: json.error ?? "Save failed" });
           return false;
         }
         // Success: the preview and the concurrency baseline both move to what
         // was just written, and the list row's freshness follows.
-        setFile((prev) => ({
-          ...prev,
-          text: nextText,
-          mtimeMs: typeof json.mtimeMs === "number" ? json.mtimeMs : prev.mtimeMs,
-        }));
+        if (stillSelected) {
+          setFile((prev) => ({
+            ...prev,
+            text: nextText,
+            mtimeMs: typeof json.mtimeMs === "number" ? json.mtimeMs : prev.mtimeMs,
+          }));
+          setSaveError(null);
+        }
         setList((prev) => ({
           ...prev,
           entries: sortMemoryEntries(
             prev.entries.map((entry) =>
-              entry.fullPath === selectedPath ? { ...entry, modified: new Date().toISOString(), size: nextText.length } : entry,
+              entry.fullPath === selectedPath
+                ? { ...entry, modified: new Date().toISOString(), size: new TextEncoder().encode(nextText).length }
+                : entry,
             ),
           ),
         }));
-        setSaveError(null);
         return true;
       } catch (err) {
-        setSaveError({ kind: "plain", message: err instanceof Error ? err.message : "Save failed" });
+        committedDraftRef.current = null;
+        if (selectedPathRef.current === selectedPath) {
+          setSaveError({ kind: "plain", message: err instanceof Error ? err.message : "Save failed" });
+        }
         return false;
       }
     },
@@ -201,6 +231,29 @@ export function FamiliarMemorySection({ familiar }: { familiar: Familiar }) {
   }, []);
 
   const readOnly = file.redactionCount > 0;
+
+  // Blur is the only save trigger the textarea has, so an unmount without a
+  // blur (switching tab, familiar, file, or view) would silently drop the
+  // draft. React detaches element refs BEFORE passive cleanups run on
+  // unmount, so reading the textarea from a ref here would always see null —
+  // instead every keystroke mirrors the draft into a value ref and the effect
+  // cleanup commits from that; the committedDraftRef dedupe collapses the
+  // blur+cleanup pair into a single PUT.
+  const draftRef = useRef<{ path: string; text: string } | null>(null);
+  const commitEditRef = useRef(commitEdit);
+  useEffect(() => {
+    commitEditRef.current = commitEdit;
+  }, [commitEdit]);
+  useEffect(() => {
+    if (view !== "edit" || readOnly) return;
+    return () => {
+      const draft = draftRef.current;
+      draftRef.current = null;
+      // Cleanup runs before commitEditRef is repointed, so on a file switch
+      // this still commits against the departed file's path and baseline.
+      if (draft) void commitEditRef.current(draft.text);
+    };
+  }, [view, readOnly, selectedPath, refreshToken]);
 
   // ── Empty / loading / error shells ────────────────────────────────────────
   if (list.loaded && !list.error && list.entries.length === 0) {
@@ -336,6 +389,11 @@ export function FamiliarMemorySection({ familiar }: { familiar: Familiar }) {
                 autoFocus
                 aria-label="Edit memory file"
                 className="focus-ring familiar-memory-tab__textarea"
+                onChange={(event) => {
+                  if (!readOnly && selectedPath) {
+                    draftRef.current = { path: selectedPath, text: event.currentTarget.value };
+                  }
+                }}
                 onBlur={(event) => {
                   if (!readOnly) void commitEdit(event.currentTarget.value);
                 }}

--- a/src/components/familiar-tab-skills.test.ts
+++ b/src/components/familiar-tab-skills.test.ts
@@ -46,6 +46,9 @@ test("no-match query gets the compact EmptyState, not a bare gap", () => {
 
 test("provenance pills: role grants get the accent, familiar/global stay quiet", () => {
   assert.match(src, /familiar-skills__source-pill--\$\{kind\}/, "pill variant keyed by sourceKind");
+  // The same on-disk skill can appear as a role grant AND an install in the
+  // "all" tab — the path alone is not a unique React key.
+  assert.match(src, /key=\{`\$\{row\.sourceKind\}:\$\{row\.key\}`\}/, "row keys are sourceKind-qualified");
   assert.match(css, /\.familiar-skills__source-pill--role \{[^}]*var\(--accent-presence\)/, "role pill is accent");
   assert.match(css, /\.familiar-skills__source-pill--global \{[^}]*color: var\(--text-muted\)/, "global pill is muted");
   assert.match(css, /\.familiar-skills__source-pill \{[^}]*border: 1px solid var\(--border-hairline\)/, "hairline base border");
@@ -57,6 +60,15 @@ test("familiar-empty teach state: marketplace CTA + live directory recommendatio
   assert.match(src, /fetch\("\/api\/skills\/directory"\)/, "recommendations come from the real directory route");
   assert.match(src, /\.filter\(\(e\) => !e\.installed\)\.slice\(0, 6\)/, "up to 6 uninstalled entries, no padding with fakes");
   assert.match(src, /fetch\("\/api\/skills\/directory\/install"/, "Install wires to the real install route");
+  // The install body must send what the route can actually match — owner/repo
+  // or the package name. entry.source is a provenance enum ("registry" |
+  // "local" | …) the server compares against neither; sending it 404s every
+  // install (PR #3655 follow-up).
+  assert.match(src, /source: installSource\(entry\)/, "install body goes through installSource");
+  assert.match(src, /return `\$\{entry\.owner\}\/\$\{entry\.repo\}`;[\s\S]{0,60}?entry\.packageName \?\? undefined/, "installSource = owner/repo, else packageName");
+  assert.doesNotMatch(src, /source: entry\.source/, "provenance enum never rides the install body");
+  // A failed install keeps a way forward.
+  assert.match(src, /Install failed[\s\S]{0,400}?onClick=\{\(\) => install\(entry\)\}[\s\S]{0,200}?Retry/, "error state offers a Retry that re-runs the install");
   assert.match(src, /entry\.installsAllTime > 0\s*\? `\$\{entry\.installsAllTime\.toLocaleString\(\)\} installs`\s*: ""/, "install counts render only when the API provides them");
   assert.match(css, /\.familiar-skills__rec-card--featured \{[^}]*var\(--accent-presence\)/, "first pick is accent-tinted");
   assert.match(src, /Couldn't reach the marketplace directory/, "directory failure is an honest line, not a spinner");

--- a/src/components/familiar-tab-skills.tsx
+++ b/src/components/familiar-tab-skills.tsx
@@ -93,6 +93,14 @@ function isInstallable(entry: DirectoryEntry): boolean {
   return Boolean((entry.owner && entry.repo) || entry.packageName);
 }
 
+/** Disambiguator the install route actually matches on (owner/repo or package
+ *  name) — NOT entry.source, which is a provenance enum the server would
+ *  never match, 404ing every install. */
+function installSource(entry: DirectoryEntry): string | undefined {
+  if (entry.owner && entry.repo) return `${entry.owner}/${entry.repo}`;
+  return entry.packageName ?? undefined;
+}
+
 /* ═══════════════════════════════════════════════════════════════ */
 
 export function FamiliarSkillsSection({ data }: { data: FamiliarSectionData }) {
@@ -176,7 +184,7 @@ export function FamiliarSkillsSection({ data }: { data: FamiliarSectionData }) {
         <div className="familiar-skills__list">
           {visible.map((row) => (
             <button
-              key={row.key}
+              key={`${row.sourceKind}:${row.key}`}
               type="button"
               className="familiar-skills__row focus-ring"
               onClick={() => setSelected(row)}
@@ -242,7 +250,7 @@ function FamiliarEmptyTeachState({ familiarName }: { familiarName: string }) {
     fetch("/api/skills/directory/install", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id: entry.id, source: entry.source }),
+      body: JSON.stringify({ id: entry.id, source: installSource(entry) }),
     })
       .then((res) => res.json())
       .then((json: { ok?: boolean }) => {
@@ -330,7 +338,18 @@ function FamiliarEmptyTeachState({ familiarName }: { familiarName: string }) {
                       state === "done" ? (
                         <span className="familiar-skills__rec-installed">Installed</span>
                       ) : state === "error" ? (
-                        <span className="familiar-skills__rec-error">Install failed</span>
+                        <span className="familiar-skills__rec-retry">
+                          <span className="familiar-skills__rec-error">Install failed</span>
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            leadingIcon="ph:arrow-clockwise"
+                            onClick={() => install(entry)}
+                            aria-label={`Retry installing ${entry.name}`}
+                          >
+                            Retry
+                          </Button>
+                        </span>
                       ) : (
                         <Button
                           variant="ghost"
@@ -450,6 +469,7 @@ function SkillFilesPane({ dir }: { dir: string }) {
     setListError(null);
     setActive(null);
     setFileText(null);
+    setFileSize(undefined);
     setFileError(null);
     fetch(`/api/skills/files?dir=${encodeURIComponent(dir)}`)
       .then((res) => res.json())
@@ -475,6 +495,7 @@ function SkillFilesPane({ dir }: { dir: string }) {
   useEffect(() => {
     if (!active || active.kind !== "file") {
       setFileText(null);
+      setFileSize(undefined);
       setFileError(null);
       setFileLoading(false);
       return;
@@ -482,6 +503,7 @@ function SkillFilesPane({ dir }: { dir: string }) {
     let cancelled = false;
     setFileLoading(true);
     setFileText(null);
+    setFileSize(undefined);
     setFileError(null);
     fetch(`/api/skills/files?dir=${encodeURIComponent(dir)}&file=${encodeURIComponent(active.name)}`)
       .then((res) => res.json())

--- a/src/styles/familiar-tab-analytics.css
+++ b/src/styles/familiar-tab-analytics.css
@@ -108,6 +108,10 @@
   color: var(--color-success);
 }
 
+.familiar-analytics-tab__kpi-note--down {
+  color: var(--color-danger-soft, var(--color-danger));
+}
+
 /* ── Card grid ────────────────────────────────────────────────────────── */
 
 .familiar-analytics-tab__grid {

--- a/src/styles/familiar-tab-mcp.css
+++ b/src/styles/familiar-tab-mcp.css
@@ -55,6 +55,10 @@
   text-wrap: pretty;
 }
 
+.familiar-mcp__status-error {
+  color: var(--color-danger-soft, var(--color-danger));
+}
+
 .familiar-mcp__status-actions {
   display: flex;
   flex: none;

--- a/src/styles/familiar-tab-skills.css
+++ b/src/styles/familiar-tab-skills.css
@@ -358,6 +358,12 @@
   color: var(--color-danger-soft, var(--text-muted));
 }
 
+.familiar-skills__rec-retry {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 /* ── Skill detail modal ── */
 
 .familiar-skills__modal {


### PR DESCRIPTION
Lands the 12 post-merge review follow-ups from #3655 (bead **cave-lqr6**).

## Skills
- **P1:** Install now sends `owner/repo` (or `packageName`) as `source` — `entry.source` is a provenance enum the install route's `sourceMatches` never matches, so every teach-state install 404'd.
- Failed installs offer **Retry** instead of a dead-end error state.
- Row keys are `sourceKind`-qualified so a role grant + install of the same on-disk skill can't collide as duplicate React keys.
- Skill file pane resets `fileSize` on switch/error so the meta line can't show the previous file's size.

## Memory
- **P1:** Drafts survive an unmount without a blur (tab/familiar/file/view switch). Every keystroke mirrors the draft into a value ref (`draftRef`); the edit pane's effect cleanup commits from it, and `committedDraftRef` dedupes the blur+cleanup pair into one PUT.
  - *Why a value ref, not an element ref:* verified empirically with a React 19.2.7 Playwright probe — React detaches element refs to `null` **before** passive-effect cleanups run on unmount, and on keyed remounts (file switch) a parent-held element ref already points at the **new** file's textarea at cleanup time. An element-ref cleanup either loses the draft or commits the wrong file's content; the value-ref pattern captured the correct draft + path in all three unmount paths (file switch, view flip, full unmount).
- Late save responses are selection-guarded (`selectedPathRef`) so they can't clobber a newly selected file's text or mtime baseline (spurious 409s).
- List row size counts UTF-8 bytes (`TextEncoder`), not UTF-16 code units.

## MCP
- "Copied" only renders after the clipboard write actually resolves.
- Rescan responses carry a generation ticket (bumped on harness change/restart) so a stale rescan can't overwrite a newer scan; rescan failures now surface in the status band (`role="alert"`) instead of dying silently.

## Analytics
- Module-level 60s TTL cache keyed by familiar id — remount no longer re-fires all 8 endpoints.
- KPI note tone is three-way (`up`/`down`/`flat`); negative deltas get the new `--down` styling.

## Identity
- Cross-file contract violations (`file: "cross-file"`) render as their own row, so the pill count is fully locatable.

## Verification
- `pnpm typecheck` clean
- `node --test` on all five familiar-tab component test files: **42/42 pass** (pins updated to the new patterns, old contradicting pins replaced)
- Playwright ref-timing probe (throwaway, not committed) proving the value-ref cleanup pattern correct across all three unmount paths

Closes bead `cave-lqr6`.
