### PR TITLE
fix(research): desk sweep follow-ups — travel replay run re-pointing, ACTIVE-automation guard, default-tab latch

### DIFF
--- a/src/app/api/research/missions/[id]/actions/route.test.ts
+++ b/src/app/api/research/missions/[id]/actions/route.test.ts
@@ -53,6 +53,12 @@ test("errors map by kind: unknown action 400, client mistakes 400, missing missi
   assert.match(source, /return 400;/);
   assert.match(source, /return 500;/);
   assert.match(source, /status: actionErrorStatus\(message\)/);
+  // Manual runs vs an ACTIVE linked automation is a state conflict (409),
+  // resolved by pausing the schedule — not a client error (cave-7had).
+  assert.match(
+    source,
+    /if \(message === "pause the linked automation before running manually"\) return 409;/,
+  );
   // The classified messages are the runner's real validation throws.
   for (const known of [
     "Source id and title are required",

--- a/src/app/api/research/missions/[id]/actions/route.ts
+++ b/src/app/api/research/missions/[id]/actions/route.ts
@@ -43,6 +43,9 @@ const VALIDATION_ERRORS = new Set([
 
 function actionErrorStatus(message: string): number {
   if (message === "research mission not found") return 404;
+  // Manual runs are refused while the linked automation is ACTIVE — a state
+  // conflict the user resolves by pausing the schedule, not a bad request.
+  if (message === "pause the linked automation before running manually") return 409;
   if (
     VALIDATION_ERRORS.has(message) ||
     // Retry project-root rejections carry the offending path; source-patch

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -407,3 +407,14 @@ test("forms expose errors and narrow outputs become keyboard tabs", () => {
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
   assert.match(css, /@container research-desk \(max-width: 760px\)/);
 });
+
+test("no-preference default tab latches once loading settles", () => {
+  // A mission appearing mid-visit (automation firing) or the list emptying
+  // must not flip tabs under the user and discard an in-progress prompt
+  // draft (cave-9589) — the derived default is committed to state once.
+  assert.match(surface, /if \(tab !== null \|\| research\.loading\) return;/);
+  assert.match(
+    surface,
+    /setTab\(research\.missions\.length > 0 \? "desk" : "prompt"\);\s*\n\s*\}, \[tab, research\.loading, research\.missions\.length\]\);/,
+  );
+});

--- a/src/components/role-surfaces/researcher-surface.tsx
+++ b/src/components/role-surfaces/researcher-surface.tsx
@@ -90,10 +90,16 @@ export function ResearcherSurface({ context }: { context: RoleSurfaceContext }) 
 
   // No stored preference: land on the desk when missions exist (or are still
   // loading — the desk shows its own loading state), otherwise start at the
-  // Prompt intake. Only explicit selections persist, so the default keeps
-  // tracking reality instead of freezing the first visit's answer.
+  // Prompt intake. The answer latches once loading settles: a mission
+  // appearing later (an automation firing mid-visit) or the list emptying
+  // must not flip tabs under the user and discard an in-progress prompt
+  // draft (cave-9589). Only explicit selections persist to storage.
   const activeTab: ResearchDeskTab =
     tab ?? (research.loading || research.missions.length > 0 ? "desk" : "prompt");
+  useEffect(() => {
+    if (tab !== null || research.loading) return;
+    setTab(research.missions.length > 0 ? "desk" : "prompt");
+  }, [tab, research.loading, research.missions.length]);
 
   const selectTab = useCallback((next: ResearchDeskTab) => {
     setTab(next);

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -59,3 +59,23 @@ assert.match(
 );
 
 console.log("flow-executor.test.ts: ok");
+
+// Travel-queued flows: the placeholder run is recorded BEFORE enqueueing so
+// its id rides in the payload — replay then updates that run in place instead
+// of recording a second one, keeping research mission iterations (which store
+// the id) pointed at the run that actually executes (cave-qdf2).
+assert.match(
+  source,
+  /const run = await recordFlowRun\(\{[\s\S]*?status: "queued",[\s\S]*?\}\);[\s\S]*?await enqueueOfflineTravelItem\(/,
+  "queued placeholder run must exist before the travel item that references it",
+);
+assert.match(
+  source,
+  /placeholderRunId: run\.id,/,
+  "queued travel payload must carry the placeholder run id",
+);
+assert.match(
+  source,
+  /status: "failed",[\s\S]*?summary: "offline enqueue failed",/,
+  "an enqueue failure must not leave an un-replayable queued run behind",
+);

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -26,7 +26,7 @@ import { familiarWorkspace } from "@/lib/coven-paths";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import type { FlowRunRecord, FlowRunStepStatus } from "@/lib/flows";
-import { recordFlowRun } from "@/lib/server/flow-store";
+import { recordFlowRun, updateFlowRun } from "@/lib/server/flow-store";
 import { startCopilotFlowRun } from "@/lib/server/flow-copilot-session";
 import { copilotStreamSpec } from "@/lib/copilot-stream";
 import { isSshRuntime } from "@/lib/familiar-runtime";
@@ -144,38 +144,59 @@ export async function startFlowSession(
   if (travelStatus) {
     const order = options.targetNodeId ? flowPartialExecutionOrder(flow, options.targetNodeId) : flowExecutionOrder(flow);
     const byId = new Map(flow.nodes.map((node) => [node.id, node]));
-    const queued = await enqueueOfflineTravelItem({
-      kind: "workflow",
-      summary: options.targetNodeId ? `Flow step: ${flow.name} / ${options.targetNodeId}` : `Flow: ${flow.name}`,
-      payload: {
-        route: "flow-session",
-        flow,
-        options,
-        familiarId,
-        harness: binding.harness,
-      },
-    });
+    // Record the queued placeholder run BEFORE enqueueing so its id can ride
+    // in the travel payload: replay then updates this run in place instead of
+    // recording a second one, keeping callers that stored the id (research
+    // mission iterations) pointed at the run that actually executes.
     const run = await recordFlowRun({
       flowId: flow.id,
       flowName: flow.name,
       status: "queued",
       mode: options.mode ?? "manual",
-      startedAt: queued.createdAt,
+      startedAt: new Date().toISOString(),
       steps: order.map((stepId) => ({
         id: stepId,
         type: byId.get(stepId)?.type ?? "unknown",
         status: "pending",
       })),
-      summary: `queued offline ${queued.id}`,
+      summary: "queued offline",
       source: "cave",
       flowSnapshot: flow,
+    });
+    let queued: CaveTravelQueueItem;
+    try {
+      queued = await enqueueOfflineTravelItem({
+        kind: "workflow",
+        summary: options.targetNodeId ? `Flow step: ${flow.name} / ${options.targetNodeId}` : `Flow: ${flow.name}`,
+        payload: {
+          route: "flow-session",
+          flow,
+          options,
+          familiarId,
+          harness: binding.harness,
+          placeholderRunId: run.id,
+        },
+      });
+    } catch (error) {
+      // Never leave an un-replayable queued run behind — it would sit in the
+      // runs list (and hold a research iteration) forever.
+      await updateFlowRun(run.id, {
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        summary: "offline enqueue failed",
+      });
+      throw error;
+    }
+    const stamped = await updateFlowRun(run.id, {
+      startedAt: queued.createdAt,
+      summary: `queued offline ${queued.id}`,
     });
     return {
       ok: true,
       executor: "travel-queue",
       queued: true,
       queueItem: queued,
-      run,
+      run: stamped ?? run,
     };
   }
 

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -515,3 +515,34 @@ test("createAndStart cannot resurrect a mission cancelled during launch", async 
     "the launch-result save must not overwrite a concurrent cancel",
   );
 });
+
+test("continue and refine are refused while the linked automation is ACTIVE", async () => {
+  const activeAutomation = {
+    id: "automation-1",
+    rrule: "RRULE:FREQ=DAILY",
+    status: "ACTIVE" as const,
+    checkpointFingerprint: "fp",
+  };
+  let stored = checkpointMission({ automation: activeAutomation });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+  }));
+  // Two agents writing one mission workspace: manual iterations are refused
+  // until the schedule is paused (cave-7had).
+  await assert.rejects(
+    runner.act(stored.id, { action: "continue" }),
+    /pause the linked automation before running manually/,
+  );
+  await assert.rejects(
+    runner.act(stored.id, { action: "refine", direction: "dig deeper" }),
+    /pause the linked automation before running manually/,
+  );
+  assert.equal(stored.iterations.length, 1, "no manual iteration may start under an ACTIVE schedule");
+
+  stored = checkpointMission({
+    automation: { ...activeAutomation, status: "PAUSED" as const },
+  });
+  const result = await runner.act(stored.id, { action: "continue" });
+  assert.equal(result.iterations.length, 2, "a paused schedule releases the manual-run guard");
+});

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -598,6 +598,15 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       }
 
       if (!allowedResearchActions(mission).includes(input.action)) return mission;
+      // A manual iteration would run concurrently with the linked ACTIVE
+      // autoresearch schedule — two agents writing one mission workspace
+      // (cave-7had). Require pausing the automation first.
+      if (
+        (input.action === "refine" || input.action === "continue") &&
+        mission.automation?.status === "ACTIVE"
+      ) {
+        throw new Error("pause the linked automation before running manually");
+      }
       if (input.action === "refine") {
         const direction = input.direction?.trim().slice(0, 2_000) ?? "";
         if (!direction) throw new Error("refined direction required");

--- a/src/lib/travel-offline-replay.test.ts
+++ b/src/lib/travel-offline-replay.test.ts
@@ -97,3 +97,11 @@ assert.match(
 );
 
 console.log("travel-offline-replay.test.ts: ok");
+
+assert.match(
+  replay,
+  /const placeholderRunId = stringValue\(payload\.placeholderRunId\);[\s\S]*?if \(placeholderRunId\) \{[\s\S]*?await updateFlowRun\(placeholderRunId, runFields\);[\s\S]*?if \(updated\) return;[\s\S]*?await recordFlowRun\(runFields\);/,
+  "flow replay must update the queued placeholder run in place (mission iterations keep its id), falling back to a fresh record only for legacy/evicted items",
+);
+
+console.log("travel-offline-replay.test.ts: placeholder-run pin ok");

--- a/src/lib/travel-offline-replay.ts
+++ b/src/lib/travel-offline-replay.ts
@@ -21,7 +21,7 @@ import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import { flowRunRedactsData } from "@/lib/flow/flow-doc";
 import type { FlowRunStepStatus } from "@/lib/flows";
 import { startAutomationRun } from "@/lib/server/automation-runner";
-import { recordFlowRun } from "@/lib/server/flow-store";
+import { recordFlowRun, updateFlowRun } from "@/lib/server/flow-store";
 import { assertProjectRootAccess } from "@/lib/project-permissions";
 import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-security";
 import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
@@ -251,10 +251,10 @@ async function replayFlow(item: CaveTravelQueueItem, config: CaveConfig): Promis
   const customData = extractFlowCustomData(flow);
   const redacted = flowRunRedactsData(flow, options.mode as never);
   const seenActiveAgentStep = { value: false };
-  await recordFlowRun({
+  const runFields = {
     flowId: flow.id,
     flowName: flow.name,
-    status: "running",
+    status: "running" as const,
     mode: flowExecutionMode(options.mode),
     ...(Object.keys(customData).length > 0 ? { customData } : {}),
     ...(redacted ? { redacted: true } : {}),
@@ -265,10 +265,20 @@ async function replayFlow(item: CaveTravelQueueItem, config: CaveConfig): Promis
       status: initialFlowRunStepStatus(flow, stepId, seenActiveAgentStep),
     })),
     summary: `replayed agent session ${sessionId.slice(0, 8)}`,
-    source: "cave",
+    source: "cave" as const,
     sessionId,
     flowSnapshot: flow,
-  });
+  };
+  // The queued placeholder run's id rides in the payload — update that run in
+  // place so callers that stored it (research mission iterations, the runs
+  // list) keep pointing at the run that actually executes. Fall back to a
+  // fresh record for legacy queue items or a placeholder evicted by the cap.
+  const placeholderRunId = stringValue(payload.placeholderRunId);
+  if (placeholderRunId) {
+    const updated = await updateFlowRun(placeholderRunId, runFields);
+    if (updated) return;
+  }
+  await recordFlowRun(runFields);
 }
 
 async function replayJob(item: CaveTravelQueueItem): Promise<void> {


### PR DESCRIPTION
Follow-ups deferred from the Research Desk bug sweep (#3680). Three small, independent fixes:

## cave-qdf2 — travel replay re-points the placeholder run
`startFlowSession`'s travel branch now records the queued placeholder run **before** enqueueing and threads `placeholderRunId` through the travel payload. `replayFlow` updates that run in place (falling back to `recordFlowRun` for legacy/evicted items), so research mission iterations — which store the placeholder's id — end up pointing at the run that actually executed instead of staying "queued" forever. Enqueue failures stamp the placeholder `failed` rather than stranding it.

## cave-7had — manual continue/refine vs ACTIVE automation
`act()` refuses `continue`/`refine` while `mission.automation.status === "ACTIVE"` (two writers on one mission workspace); the route classifies the message as **409**. `retry` stays allowed — it recovers the same iteration rather than starting a new one. Pause the schedule to run manually.

## cave-9589 — derived default tab latch
The researcher surface's no-preference default (`desk` if missions exist, else `prompt`) was live-derived, so the first mission appearing mid-visit (poll/automation) flipped the tab and discarded an in-progress prompt draft. The default now latches into state once loading settles; only explicit selections persist to storage.

## Verification
- `pnpm typecheck` clean
- `pnpm test:api` 235/235, `pnpm test:app` 891/891
- New: behavioral guard test (runner lifecycle), 409 pin (actions route), placeholder-run pins (flow-executor + travel replay), latch pin (researcher surface)
