### PR TITLE
feat(voice): fail connect gracefully with in-place vault key fix (cave-xz57)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1068,6 +1068,7 @@ export const SUITES = {
     "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",
     "src/lib/voice/elevenlabs.test.ts",
+    "src/lib/voice/vault-key-recovery.test.ts",
     "src/lib/voice/hydrate-instructions.test.ts",
     "src/lib/voice/append-voice-turn.test.ts",
     "src/lib/voice/openai-realtime.test.ts",

--- a/src/app/api/voice/session/route.test.ts
+++ b/src/app/api/voice/session/route.test.ts
@@ -120,6 +120,41 @@ test("502 provider_mint_failed surfaces provider message verbatim", async () => 
   assert.equal(res.status, 502);
   assert.equal(json.error, "provider_mint_failed");
   assert.match(json.providerMessage, /quota exhausted/);
+  // Not a credentials failure — the overlay must not offer a key editor.
+  assert.equal(json.missingKey, undefined);
+});
+
+test("502 surfaces the machine code + vault key when ElevenLabs rejects the key (cave-xz57)", async () => {
+  writeFamiliar({ display_name: "M", role: "x", voiceProvider: "elevenlabs" });
+  writeSession([]);
+  process.env.ELEVENLABS_API_KEY = "xi-bad";
+  nextFetchResponse = new Response("{}", { status: 401 });
+  const res = await POST(req({ familiarId: FAMILIAR_ID, sessionId: SESSION_ID }));
+  const json = await res.json();
+  delete process.env.ELEVENLABS_API_KEY;
+  assert.equal(res.status, 502);
+  // The probe's `code: detail` shape splits into an overlay-mappable error
+  // plus a human hint, and names the key so the error card can fix it in
+  // place.
+  assert.equal(json.error, "elevenlabs_key_invalid");
+  assert.match(json.hint, /rejected the API key/);
+  assert.equal(json.missingKey, "ELEVENLABS_API_KEY");
+});
+
+test("502 names the vault key when OpenAI rejects credentials as free text (cave-xz57)", async () => {
+  writeFamiliar({ display_name: "M", role: "x", voiceProvider: "openai" });
+  writeSession([]);
+  process.env.OPENAI_API_KEY = "sk-bad";
+  nextFetchResponse = new Response(
+    JSON.stringify({ error: { message: "Incorrect API key provided: sk-bad" } }),
+    { status: 401 },
+  );
+  const res = await POST(req({ familiarId: FAMILIAR_ID, sessionId: SESSION_ID }));
+  const json = await res.json();
+  assert.equal(res.status, 502);
+  assert.equal(json.error, "provider_mint_failed");
+  assert.match(json.providerMessage, /Incorrect API key/);
+  assert.equal(json.missingKey, "OPENAI_API_KEY");
 });
 
 test("200 happy path returns grant and ULID-shaped callId", async () => {

--- a/src/app/api/voice/session/route.ts
+++ b/src/app/api/voice/session/route.ts
@@ -11,15 +11,14 @@ import {
   DEFAULT_ELEVENLABS_VOICE_ID,
 } from "../../../../lib/voice/elevenlabs-shared.ts";
 import { isSafeConversationSessionId } from "../../../../lib/cave-conversations.ts";
+import {
+  VOICE_VAULT_KEY_BY_PROVIDER,
+  isVoiceKeyErrorMessage,
+  voiceRecoveryVaultKey,
+} from "../../../../lib/voice/vault-key-recovery.ts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const VAULT_KEY_BY_PROVIDER: Record<string, string> = {
-  openai: "OPENAI_API_KEY",
-  gemini: "GOOGLE_API_KEY",
-  elevenlabs: "ELEVENLABS_API_KEY",
-};
 
 // Providers whose brain lives on this machine (or behind our own chat bridge)
 // and therefore mint without any vault secret.
@@ -105,7 +104,7 @@ export async function POST(req: Request) {
   // needs a vault key.
   let apiKey = "";
   if (!KEYLESS_PROVIDERS.has(provider.id)) {
-    const vaultKey = VAULT_KEY_BY_PROVIDER[provider.id];
+    const vaultKey = VOICE_VAULT_KEY_BY_PROVIDER[provider.id];
     if (!vaultKey) {
       return NextResponse.json({ ok: false, error: "provider_missing_vault_key" }, { status: 500 });
     }
@@ -142,10 +141,24 @@ export async function POST(req: Request) {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    // Providers throw `machine_code: human detail` for known failures
+    // (elevenlabs_key_invalid, not_implemented, …). Surface the code so the
+    // overlay can map it to actionable copy instead of a generic mint
+    // failure, and name the vault key when the failure is key-shaped so the
+    // error card can offer an in-place fix. (cave-xz57)
+    const structured = /^([a-z][a-z0-9_]*):\s*([\s\S]+)$/.exec(msg);
+    const code = structured ? structured[1] : "provider_mint_failed";
+    const vaultKey = VOICE_VAULT_KEY_BY_PROVIDER[provider.id];
+    const keyFixable = Boolean(vaultKey) && (
+      voiceRecoveryVaultKey({ errorCode: code, providerId: provider.id }) !== null ||
+      isVoiceKeyErrorMessage(msg)
+    );
     return NextResponse.json({
       ok: false,
-      error: "provider_mint_failed",
+      error: code,
       providerMessage: msg,
+      ...(structured ? { hint: structured[2] } : {}),
+      ...(keyFixable ? { missingKey: vaultKey } : {}),
     }, { status: 502 });
   }
 

--- a/src/components/voice-call-overlay-state.test.ts
+++ b/src/components/voice-call-overlay-state.test.ts
@@ -136,6 +136,19 @@ test("PROVIDER_ERROR without hint clears any stale hint", () => {
   assert.equal(next.hint, undefined);
 });
 
+test("PROVIDER_ERROR clears a stale missingKey so unrelated errors don't offer a key fix", () => {
+  let s = reduce(initialState, { type: "START" });
+  s = reduce(s, { type: "MIC_READY" });
+  s = reduce(s, {
+    type: "SESSION_FAILED",
+    errorCode: "vault_key_unresolved",
+    missingKey: "ELEVENLABS_API_KEY",
+  });
+  const next = reduce(s, { type: "PROVIDER_ERROR", errorCode: "connect_failed" });
+  assert.equal(next.state, "error");
+  assert.equal(next.missingKey, undefined);
+});
+
 test("error → requesting-mic on RETRY (clears errorCode)", () => {
   const errored = reduce(reduce(initialState, { type: "START" }), { type: "MIC_DENIED" });
   const next = reduce(errored, { type: "RETRY" });

--- a/src/components/voice-call-overlay-state.ts
+++ b/src/components/voice-call-overlay-state.ts
@@ -62,7 +62,9 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
       if (s.state !== "connecting") return s;
       return { ...s, state: "live", startedAt: ev.startedAt, earsEngine: ev.earsEngine };
     case "PROVIDER_ERROR":
-      return { ...s, state: "error", errorCode: ev.errorCode, hint: ev.hint };
+      // Explicitly clear missingKey — a stale key name from an earlier mint
+      // failure must not dress an unrelated connect error as key-fixable.
+      return { ...s, state: "error", errorCode: ev.errorCode, missingKey: undefined, hint: ev.hint };
     case "CLOSE_REQUEST":
       if (s.state === "live") return { ...s, state: "ending" };
       return { ...s, state: "closed" };

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -169,4 +169,69 @@ assert.match(
   "the provider hint renders under the headline when present",
 );
 
+// ── In-place recovery: key-shaped failures are fixable without leaving the
+// call (cave-xz57). Was: every connect failure dead-ended at "Try again" —
+// a missing/rejected ElevenLabs (or any provider) key sent the user hunting
+// through Vault settings while the call overlay sat useless.
+assert.match(
+  component,
+  /import\s+\{[^}]*voiceRecoveryVaultKey[^}]*\}\s+from\s+["']@\/lib\/voice\/vault-key-recovery["']/,
+  "overlay derives key-fixability from the shared recovery module",
+);
+assert.match(
+  component,
+  /voiceRecoveryVaultKey\(\{\s*errorCode:\s*state\.errorCode,\s*missingKey:\s*state\.missingKey,\s*providerId:\s*familiar\.voiceProvider,\s*\}\)/,
+  "fixable key resolution threads the server's missingKey and the familiar's provider",
+);
+assert.match(
+  component,
+  /\{fixableKey && \([\s\S]{0,80}<form[\s\S]{0,80}className="voice-call-overlay__fix"/,
+  "a key-shaped failure renders the in-place vault editor form",
+);
+assert.match(
+  component,
+  /type="password"[\s\S]{0,120}autoComplete="off"/,
+  "the key input is a password field that never autocompletes",
+);
+assert.match(
+  component,
+  /fetch\("\/api\/vault",\s*\{\s*method:\s*"POST",[\s\S]{0,200}storage:\s*"encrypted"/,
+  "saving writes the key to the vault as a local encrypted secret",
+);
+assert.match(
+  component,
+  /setKeyDraft\(""\);\s*dispatch\(\{\s*type:\s*"RETRY"\s*\}\)/,
+  "a successful save clears the draft and retries the call in place",
+);
+assert.match(
+  component,
+  /setKeySaveError\("Couldn't save the key — is the daemon running\?"\)/,
+  "a failed vault write degrades to an inline message, never a crash",
+);
+assert.match(
+  component,
+  /\{keySaveError && \([\s\S]{0,120}role="alert"/,
+  "vault save failures are announced to assistive tech",
+);
+assert.match(
+  component,
+  /getVoiceProvider\(grant\?\.provider \?\? familiar\.voiceProvider \?\? ""\)/,
+  "the connect phase trusts the minted grant's provider over the possibly-stale familiar prop",
+);
+assert.match(
+  component,
+  /case "not_implemented":[\s\S]{0,80}isn't available yet/,
+  "unshipped providers fail with honest copy instead of a generic error",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__fix\s*\{[\s\S]*?display:\s*grid;/,
+  "the in-place fix form has overlay styling",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__retry:disabled\s*\{[\s\S]*?opacity:/,
+  "the save button reads as disabled while the draft is empty or saving",
+);
+
 console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -10,6 +10,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { getVoiceProvider } from "@/lib/voice/registry";
 import type { LiveSession, VoiceSessionGrant, VoiceEarsEngine } from "@/lib/voice/types";
 import { voiceErrorHint } from "@/lib/voice/types";
+import { voiceRecoveryVaultKey } from "@/lib/voice/vault-key-recovery";
 import { reduce, initialState, type CallState } from "./voice-call-overlay-state";
 
 type Props = {
@@ -64,8 +65,11 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           dispatch({ type: "SESSION_FAILED", errorCode: "network" });
         }
       } else if (state.state === "connecting") {
-        const provider = getVoiceProvider(familiar.voiceProvider ?? "");
         const grant = grantRef.current;
+        // The grant names the provider that actually minted — trust it over
+        // the familiar prop, which can be stale right after an in-place
+        // settings fix (cave-xz57).
+        const provider = getVoiceProvider(grant?.provider ?? familiar.voiceProvider ?? "");
         const mic = micStreamRef.current;
         const callId = state.callId;
         if (!provider || !grant || !mic || !callId) {
@@ -138,6 +142,53 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
     return () => clearInterval(id);
   }, [state.state]);
 
+  // In-place recovery (cave-xz57): a key-shaped failure offers a vault
+  // editor right in the error card — save the key and retry without leaving
+  // the call.
+  const [keyDraft, setKeyDraft] = useState("");
+  const [savingKey, setSavingKey] = useState(false);
+  const [keySaveError, setKeySaveError] = useState<string | null>(null);
+  useEffect(() => {
+    if (state.state !== "error") {
+      setKeyDraft("");
+      setKeySaveError(null);
+    }
+  }, [state.state]);
+
+  const fixableKey = state.state === "error"
+    ? voiceRecoveryVaultKey({
+        errorCode: state.errorCode,
+        missingKey: state.missingKey,
+        providerId: familiar.voiceProvider,
+      })
+    : null;
+
+  const saveKeyAndRetry = async () => {
+    const key = fixableKey;
+    const value = keyDraft.trim();
+    if (!key || !value || savingKey) return;
+    setSavingKey(true);
+    setKeySaveError(null);
+    try {
+      const res = await fetch("/api/vault", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ key, storage: "encrypted", value }),
+      });
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+      if (!json?.ok) {
+        setKeySaveError(`Couldn't save the key${json?.error ? ` — ${json.error}` : ` (http ${res.status})`}.`);
+        return;
+      }
+      setKeyDraft("");
+      dispatch({ type: "RETRY" });
+    } catch {
+      setKeySaveError("Couldn't save the key — is the daemon running?");
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
   const cleanup = () => {
     micStreamRef.current?.getTracks().forEach(t => t.stop());
     micStreamRef.current = null;
@@ -175,6 +226,38 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
             <div className="voice-call-overlay__error" role="alert">
               <div id="voice-call-overlay-error">{errorMessage(state.errorCode)}</div>
               {state.hint && <div className="voice-call-overlay__hint">{state.hint}</div>}
+              {fixableKey && (
+                <form
+                  className="voice-call-overlay__fix"
+                  onSubmit={(e) => { e.preventDefault(); void saveKeyAndRetry(); }}
+                >
+                  <label className="voice-call-overlay__fix-label" htmlFor="voice-call-overlay-key">
+                    Update {fixableKey} and retry
+                  </label>
+                  <div className="voice-call-overlay__fix-row">
+                    <input
+                      id="voice-call-overlay-key"
+                      className="voice-call-overlay__fix-input focus-ring"
+                      type="password"
+                      autoComplete="off"
+                      placeholder="Paste a new key"
+                      value={keyDraft}
+                      onChange={(e) => setKeyDraft(e.target.value)}
+                      disabled={savingKey}
+                    />
+                    <button
+                      type="submit"
+                      className="voice-call-overlay__retry focus-ring"
+                      disabled={savingKey || keyDraft.trim() === ""}
+                    >
+                      {savingKey ? "Saving…" : "Save & retry"}
+                    </button>
+                  </div>
+                  {keySaveError && (
+                    <div className="voice-call-overlay__fix-error" role="alert">{keySaveError}</div>
+                  )}
+                </form>
+              )}
               <button
                 type="button"
                 className="voice-call-overlay__retry focus-ring"
@@ -261,6 +344,8 @@ function errorMessage(code: string | undefined): string {
       return "A required API key isn't set up in your Vault.";
     case "voice_not_configured":
       return "This familiar has no voice provider configured.";
+    case "not_implemented":
+      return "This voice provider isn't available yet.";
     // ElevenLabs-specific
     case "elevenlabs_key_invalid":
     case "elevenlabs_key_missing":
@@ -272,8 +357,9 @@ function errorMessage(code: string | undefined): string {
       return "ElevenLabs speech synthesis failed.";
     // Brain / familiar runtime issues
     case "familiar_brain_failed":
-    case "provider_mint_failed":
       return "The familiar's voice brain couldn't start.";
+    case "provider_mint_failed":
+      return "The voice provider couldn't start the call.";
     default:
       return "The call ran into a problem. Please try again.";
   }

--- a/src/lib/voice/vault-key-recovery.test.ts
+++ b/src/lib/voice/vault-key-recovery.test.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  VOICE_VAULT_KEY_BY_PROVIDER,
+  isVoiceKeyErrorMessage,
+  voiceRecoveryVaultKey,
+} from "./vault-key-recovery.ts";
+
+// ── Provider → vault key map ─────────────────────────────────────────────────
+
+test("every keyed provider maps to its vault key; keyless providers do not", () => {
+  assert.equal(VOICE_VAULT_KEY_BY_PROVIDER.openai, "OPENAI_API_KEY");
+  assert.equal(VOICE_VAULT_KEY_BY_PROVIDER.gemini, "GOOGLE_API_KEY");
+  assert.equal(VOICE_VAULT_KEY_BY_PROVIDER.elevenlabs, "ELEVENLABS_API_KEY");
+  assert.equal(VOICE_VAULT_KEY_BY_PROVIDER.local, undefined);
+  assert.equal(VOICE_VAULT_KEY_BY_PROVIDER.familiar, undefined);
+});
+
+// ── voiceRecoveryVaultKey ────────────────────────────────────────────────────
+
+test("an explicit server-provided missingKey always wins", () => {
+  assert.equal(
+    voiceRecoveryVaultKey({
+      errorCode: "provider_mint_failed",
+      missingKey: "OPENAI_API_KEY",
+      providerId: "elevenlabs",
+    }),
+    "OPENAI_API_KEY",
+  );
+});
+
+test("ElevenLabs key codes name their vault key even without a provider", () => {
+  // The TTS proxy can reject the key mid-call, after a clean mint — the
+  // PROVIDER_ERROR path carries only the code.
+  assert.equal(
+    voiceRecoveryVaultKey({ errorCode: "elevenlabs_key_invalid" }),
+    "ELEVENLABS_API_KEY",
+  );
+  assert.equal(
+    voiceRecoveryVaultKey({ errorCode: "elevenlabs_key_missing" }),
+    "ELEVENLABS_API_KEY",
+  );
+});
+
+test("an unauthorized SDP exchange resolves through the provider map", () => {
+  assert.equal(
+    voiceRecoveryVaultKey({ errorCode: "sdp_exchange_failed_401", providerId: "openai" }),
+    "OPENAI_API_KEY",
+  );
+  // Keyless providers have nothing to fix in the vault.
+  assert.equal(
+    voiceRecoveryVaultKey({ errorCode: "sdp_exchange_failed_401", providerId: "local" }),
+    null,
+  );
+  // No provider, no inference.
+  assert.equal(voiceRecoveryVaultKey({ errorCode: "sdp_exchange_failed_401" }), null);
+});
+
+test("vault_key_unresolved falls back to the provider map when missingKey was dropped", () => {
+  assert.equal(
+    voiceRecoveryVaultKey({ errorCode: "vault_key_unresolved", providerId: "elevenlabs" }),
+    "ELEVENLABS_API_KEY",
+  );
+});
+
+test("non-key failures never offer a key editor", () => {
+  for (const errorCode of [
+    "network",
+    "microphone_denied",
+    "internal",
+    "connect_failed",
+    "not_implemented",
+    "elevenlabs_unreachable",
+    "elevenlabs_probe_failed",
+    "sdp_exchange_failed_400",
+    "familiar_brain_failed",
+    undefined,
+  ]) {
+    assert.equal(
+      voiceRecoveryVaultKey({ errorCode, providerId: "elevenlabs" }),
+      null,
+      `expected no vault key for ${errorCode}`,
+    );
+  }
+});
+
+// ── isVoiceKeyErrorMessage ───────────────────────────────────────────────────
+
+test("free-text credential failures read as key errors", () => {
+  assert.equal(isVoiceKeyErrorMessage("Incorrect API key provided: sk-abc***"), true);
+  assert.equal(isVoiceKeyErrorMessage("invalid_api_key"), true);
+  assert.equal(isVoiceKeyErrorMessage("provider_http_401"), true);
+  assert.equal(isVoiceKeyErrorMessage("401 Unauthorized"), true);
+  assert.equal(isVoiceKeyErrorMessage("Request unauthorized"), true);
+});
+
+test("non-credential failures do not read as key errors", () => {
+  assert.equal(isVoiceKeyErrorMessage("quota exhausted"), false);
+  assert.equal(isVoiceKeyErrorMessage("provider_http_429"), false);
+  assert.equal(isVoiceKeyErrorMessage("connection refused"), false);
+  // A bare 401 inside a longer number is not an auth status.
+  assert.equal(isVoiceKeyErrorMessage("error 14012 while dialing"), false);
+});

--- a/src/lib/voice/vault-key-recovery.ts
+++ b/src/lib/voice/vault-key-recovery.ts
@@ -1,0 +1,64 @@
+// In-place recovery for voice-call connect failures (cave-xz57).
+//
+// A failed call must never dead-end at "try again": when the failure is
+// key-shaped (a missing or rejected vault secret for ElevenLabs, OpenAI, or
+// any keyed provider), the call overlay offers an inline editor that saves
+// the key to the Vault and retries without leaving the call. This module is
+// the single source of truth for which vault key backs each keyed voice
+// provider, and for deciding whether an error is fixable by updating it.
+
+/** Vault key backing each keyed voice provider. The "local" and "familiar"
+ *  providers mint keyless (their brain is a loopback server or the
+ *  familiar's own harness) and deliberately have no entry here. */
+export const VOICE_VAULT_KEY_BY_PROVIDER: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  gemini: "GOOGLE_API_KEY",
+  elevenlabs: "ELEVENLABS_API_KEY",
+};
+
+/** Error codes that name their own vault key, whatever provider raised them
+ *  (the ElevenLabs TTS proxy can fail mid-call after a clean mint). */
+const KEY_ERROR_VAULT_KEYS: Record<string, string> = {
+  elevenlabs_key_invalid: "ELEVENLABS_API_KEY",
+  elevenlabs_key_missing: "ELEVENLABS_API_KEY",
+};
+
+/** Error codes whose fix is the provider's own vault key. */
+const PROVIDER_KEY_ERROR_CODES = new Set([
+  // Vault lookup came back empty at mint time.
+  "vault_key_unresolved",
+  // The WebRTC SDP exchange was rejected as unauthorized — the ephemeral
+  // grant's underlying key is bad.
+  "sdp_exchange_failed_401",
+]);
+
+/**
+ * True when a provider's free-text mint failure reads like a credentials
+ * problem (OpenAI throws its HTTP error body verbatim, e.g. "Incorrect API
+ * key provided: sk-…"), so the session route can still name the vault key.
+ */
+export function isVoiceKeyErrorMessage(message: string): boolean {
+  // Bare "401" only counts when it isn't part of a longer number
+  // (provider_http_401 yes, "error 14012" no).
+  return /unauthorized|api.?key|(?:^|[^0-9])401(?:[^0-9]|$)/i.test(message);
+}
+
+/**
+ * The vault key this error can be fixed with in place, or null when updating
+ * a key would not help (mic denied, network trouble, unimplemented
+ * provider…). An explicit server-provided `missingKey` always wins.
+ */
+export function voiceRecoveryVaultKey(opts: {
+  errorCode?: string;
+  missingKey?: string;
+  providerId?: string;
+}): string | null {
+  if (opts.missingKey) return opts.missingKey;
+  const code = opts.errorCode ?? "";
+  const named = KEY_ERROR_VAULT_KEYS[code];
+  if (named) return named;
+  if (PROVIDER_KEY_ERROR_CODES.has(code) && opts.providerId) {
+    return VOICE_VAULT_KEY_BY_PROVIDER[opts.providerId] ?? null;
+  }
+  return null;
+}

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -915,6 +915,48 @@ details[open] > .cave-tool-summary::before {
   line-height: 1.45;
 }
 
+/* In-place recovery (cave-xz57): a key-shaped failure offers a vault editor
+   right in the error card — fix the setting and retry without leaving the
+   call. */
+.voice-call-overlay__fix {
+  display: grid;
+  width: min(300px, 100%);
+  gap: 6px;
+  justify-items: stretch;
+  text-align: left;
+}
+
+.voice-call-overlay__fix-label {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  letter-spacing: 0.02em;
+}
+
+.voice-call-overlay__fix-row {
+  display: flex;
+  gap: 6px;
+}
+
+.voice-call-overlay__fix-input {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 70%, transparent);
+  padding: 6px var(--space-2);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.voice-call-overlay__fix-input:disabled {
+  opacity: 0.55;
+}
+
+.voice-call-overlay__fix-error {
+  color: var(--color-danger);
+  font-size: var(--text-xs);
+}
+
 .voice-call-overlay__footer {
   display: flex;
   align-items: center;
@@ -948,13 +990,14 @@ details[open] > .cave-tool-summary::before {
 }
 
 .voice-call-overlay__control:hover:not(:disabled),
-.voice-call-overlay__retry:hover {
+.voice-call-overlay__retry:hover:not(:disabled) {
   border-color: color-mix(in oklch, var(--border-strong) 70%, transparent);
   background: color-mix(in oklch, var(--bg-hover) 70%, transparent);
   color: var(--text-primary);
 }
 
-.voice-call-overlay__control:disabled {
+.voice-call-overlay__control:disabled,
+.voice-call-overlay__retry:disabled {
   cursor: default;
   opacity: 0.45;
 }


### PR DESCRIPTION
## Problem

A voice call that failed to connect — ElevenLabs rejecting the API key, an OpenAI 401, an unset vault secret — dead-ended at **Try again**. The user had to abandon the call, find Vault settings, fix the key, and start over. Structured provider failures also collapsed into a generic `provider_mint_failed` headline.

## What changed

**Graceful failure**
- `/api/voice/session` now splits structured mint errors (`machine_code: human detail`, e.g. `elevenlabs_key_invalid: …`) into an overlay-mappable `error` code plus a human `hint`, instead of one generic code.
- New headlines: `not_implemented` → “This voice provider isn't available yet.”, `provider_mint_failed` → “The voice provider couldn't start the call.” (no longer mislabeled as a brain failure).

**In-place ability to update**
- When the failure is key-shaped (missing key, ElevenLabs `elevenlabs_key_invalid`/`elevenlabs_key_missing`, OpenAI free-text credential rejections, unauthorized SDP exchange), the route names the fixable vault key (`missingKey`) and the error card renders an inline editor: paste a key → saved to `/api/vault` as a local encrypted secret → the call retries immediately. Vault-save failures degrade to an inline alert, never a crash.
- New `src/lib/voice/vault-key-recovery.ts` is the single source of truth for the provider→vault-key map + key-fixable detection (shared by route and overlay).
- Reducer hygiene: `PROVIDER_ERROR` clears stale `missingKey` so unrelated errors don't offer a key fix; connect phase trusts the minted grant's provider over the possibly-stale familiar prop.

## Verification

- `vault-key-recovery.test.ts` (new, behavioral): map coverage, precedence, key-code inference, non-key codes stay null, free-text credential detection.
- `voice/session/route.test.ts`: 13/13 — incl. new pins for ElevenLabs 401 → `elevenlabs_key_invalid` + `missingKey`, OpenAI free-text 401 → `missingKey`, quota failure stays non-fixable.
- `voice-call-overlay-state.test.ts` + `voice-call-overlay.test.ts`: reducer + wiring pins for the fix form, encrypted vault POST, retry-on-save, a11y alerts.
- `pnpm typecheck` clean; eslint clean on changed files; new test wired into `test:app` (check-tests-wired ✓).

Closes bead: cave-xz57