### PR TITLE
fix(theme): de-finick appearance color overrides — backdrop disarm, paint-only drags, store-following rows, dual-mode forks (cave-hkfq)

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -15,7 +15,11 @@ const layout = await readFile(
   "utf8",
 );
 const globals = await readFile(
-  new URL("../app/globals.css", import.meta.url),
+  new URL("../styles/globals/foundations.css", import.meta.url),
+  "utf8",
+);
+const themes = await readFile(
+  new URL("../styles/globals/themes.css", import.meta.url),
   "utf8",
 );
 const fontSettings = await readFile(
@@ -401,7 +405,7 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  globals,
+  themes,
   /\[data-theme="pastel-dreams"\]\s*\{[\s\S]*--font-sans:\s*var\(--font-open-sans\)[\s\S]*--font-mono:\s*var\(--font-ibm-plex-mono\)[\s\S]*--radius:\s*1\.5rem[\s\S]*--radius-control:\s*18px[\s\S]*--shadow-popover:[\s\S]*--cave-reading-leading:\s*1\.7/,
   "Pastel Dreams should carry TweakCN typography, radius, shadow, and reading-spacing tokens, not just colors",
 );

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -552,3 +552,30 @@ assert.doesNotMatch(
   /const raw = null;/,
   "applyTokenOverride's dead localStorage-era fork branch stays deleted",
 );
+
+// ── The section must follow the store, not its mount-time snapshot ───────────
+// External theme changes — the 10s /api/theme poll, another tab via the
+// preferences BroadcastChannel, a phone PATCH — land in the store and repaint
+// the app, but AppearanceSection hydrated activeTheme/mode/customData once on
+// mount, so the theme grid and token-row swatches kept showing stale values
+// until a full page reload (cave-hkfq).
+assert.match(
+  settings,
+  /if \(!appearanceHydrated\) return;\s*\n\s*return subscribeAppPreferences\(\(\) => \{[\s\S]{0,300}setActiveTheme\(readPersistedTheme\(\)\);\s*\n\s*setMode\(readPersistedMode\(\)\);[\s\S]{0,600}\}\);\s*\n\s*\}, \[appearanceHydrated\]\);/,
+  "the appearance section re-syncs its selection state on every preferences-store notify",
+);
+assert.match(
+  settings,
+  /setCustomData\(\(prev\) => \{[\s\S]{0,400}JSON\.stringify\(prev\) === JSON\.stringify\(next\)[\s\S]{0,100}return prev;/,
+  "custom-theme state keeps its object identity when content is unchanged — store notifies must not retrigger the persist effect (echo PUTs)",
+);
+assert.match(
+  settings,
+  /reloadKey=\{`\$\{activeTheme\}:\$\{mode\}:\$\{customData \? JSON\.stringify\(customData\.cssVars\) : "preset"\}`\}/,
+  "the token rows' reload key carries the custom payload's CONTENT, so external edits re-resolve the swatches",
+);
+assert.doesNotMatch(
+  settings,
+  /customData \? "c" : "p"/,
+  "the presence-flag reload key is gone — it never changed while staying on the custom theme",
+);

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -489,3 +489,27 @@ assert.doesNotMatch(
   /const handlePick = [\s\S]{0,600}onChange\(\);\n {2}\};/,
   "handlePick must not trigger the per-move daemon sync",
 );
+
+// ── An explicit accent pick must disarm the backdrop auto-match (cave-hkfq) ──
+// With a backdrop enabled and matchAccent armed (the default), every theme
+// reconcile re-fits --accent-presence to the image seed via
+// applyBackdropToDocument — silently overriding the user's pick during the
+// drag, recording the fit color in the synced tokens, and reverting the swatch
+// on reload. An explicit accent edit is a statement of intent: fold
+// matchAccent: false into the SAME preferences patch as the token edit so no
+// reconcile window exists between them. The backdrop settings toggle re-arms.
+assert.match(
+  settings,
+  /const disarmBackdropAccent =\s*\n?\s*key === "--accent-presence" && backdrop\.enabled && backdrop\.matchAccent;/,
+  "an explicit accent edit detects an armed backdrop auto-match",
+);
+assert.match(
+  settings,
+  /updateAppPreferences\(\{\s*\n\s*appearance: \{\s*\n\s*theme: \{ id: "custom", resolvedMode: mode, custom: data \},\s*\n\s*\.\.\.\(disarmBackdropAccent \? \{ backdrop: \{ matchAccent: false \} \} : \{\}\),\s*\n\s*\},\s*\n\s*\}\);/,
+  "the disarm rides the token edit's own atomic patch — no reconcile can re-fit in between",
+);
+assert.doesNotMatch(
+  settings,
+  /const raw = null;/,
+  "applyTokenOverride's dead localStorage-era fork branch stays deleted",
+);

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -471,18 +471,57 @@ assert.match(
   "editing the background must mirror the legacy --background alias legacy-vocab surfaces read",
 );
 
-// The picker fires per pointer-move; the token apply must be rAF-coalesced and
-// the daemon sync (onChange → persistThemeTokens PUT) must wait for commit —
-// one network write per finished edit, not one per move.
+// The picker fires per pointer-move. Drags must stay PAINT-ONLY: each rAF-
+// coalesced frame writes the edited key + companions inline (element.style
+// beats preset CSS), and the preferences store is untouched until commit.
+// Anything else write-amplifies: one measured ~1s drag as a store-write-per-
+// frame produced 8 PATCH /api/preferences + 4 PUT /api/theme, bumped
+// selectionRevision 0→12, and triggered 38 GETs + 58 accent setProperty calls
+// in a second open tab via the BroadcastChannel echo (cave-hkfq).
 assert.match(
   settings,
-  /frameRef\.current = requestAnimationFrame\(\(\) => \{[\s\S]{0,300}applyTokenOverride\(pending\.key, pending\.value/,
-  "live token applies are coalesced to one write per animation frame",
+  /function previewTokenOverride\(key: string, hex: string, mode: Mode\) \{[\s\S]{0,600}?\n\}/,
+  "a paint-only preview path exists for in-drag token edits",
+);
+{
+  const previewBody = settings.match(
+    /function previewTokenOverride\(key: string, hex: string, mode: Mode\) \{([\s\S]{0,600}?)\n\}/,
+  )?.[1] ?? "";
+  assert.match(
+    previewBody,
+    /html\.style\.setProperty\(key, hex\)/,
+    "the preview writes the edited token inline",
+  );
+  assert.match(
+    previewBody,
+    /deriveTokenCompanions\(key, hex, mode\)/,
+    "the preview keeps companion tokens (accent washes, legacy aliases) in step",
+  );
+  assert.doesNotMatch(
+    previewBody,
+    /updateAppPreferences|readAppPreferences|setAttribute/,
+    "the preview must not touch the preferences store or data-theme — no reconcile, no PATCH, no broadcast per frame",
+  );
+}
+assert.match(
+  settings,
+  /frameRef\.current = requestAnimationFrame\(\(\) => \{[\s\S]{0,300}previewTokenOverride\(pending\.key, pending\.value/,
+  "live token previews are coalesced to one paint per animation frame",
+);
+assert.doesNotMatch(
+  settings,
+  /requestAnimationFrame\(\(\) => \{[\s\S]{0,300}applyTokenOverride\(/,
+  "no rAF frame may persist to the store — drags write pixels, commits write preferences",
 );
 assert.match(
   settings,
-  /const handleCommit = [\s\S]{0,300}flushPendingApply\(\);[\s\S]{0,300}onChange\(\);/,
-  "the daemon sync fires on commit (popover close), not per pointer-move",
+  /const handleCommit = [\s\S]{0,200}flushPendingPreview\(\);\s*\n\s*if \(!dirtyRef\.current\.has\(key\)\) return;[\s\S]{0,400}applyTokenOverride\(key, committed, modeRef\.current\);[\s\S]{0,300}onChange\(\);/,
+  "commit persists the finished edit exactly once, and closing the picker without a pick is a no-op (no bogus custom fork)",
+);
+assert.match(
+  settings,
+  /for \(const key of dirtyRef\.current\)[\s\S]{0,200}applyTokenOverride\(key, value, modeRef\.current\)/,
+  "unmounting mid-drag still persists the un-committed edit",
 );
 assert.doesNotMatch(
   settings,

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -450,10 +450,30 @@ assert.match(
   /const THEME_FORK_SNAPSHOT_KEYS = \[\s*\.\.\.THEME_SYNC_KEYS,[\s\S]*"--bg-panel",[\s\S]*"--background",[\s\S]*"--border",/,
   "forking a preset must snapshot the hardcoded per-theme tokens AND the legacy-vocab aliases",
 );
+// A fork must capture BOTH mode palettes. Seeding only the edited mode made
+// the fork single-mode: flipping Light/Dark later kept rendering the edited
+// mode's colors (activeCustomThemeVariables falls back to the only group) and
+// the first edit in the other mode seeded it from the WRONG mode's computed
+// look (cave-hkfq: a dark-only fork seeded lightAccent from the dark accent).
 assert.match(
   settings,
-  /if \(Object\.keys\(group\)\.length === 0\) Object\.assign\(group, resolveTokens\(THEME_FORK_SNAPSHOT_KEYS\)\)/,
-  "an empty mode group is seeded from the current computed look before the DOM mutates",
+  /if \(!existing\) \{\s*\n\s*for \(const name of THEME_FORK_SNAPSHOT_KEYS\) html\.style\.removeProperty\(name\);\s*\n\s*Object\.assign\(group, resolveTokens\(THEME_FORK_SNAPSHOT_KEYS\)\);/,
+  "a fresh fork clears in-drag preview inline vars, then seeds the edited mode from the preset's computed look",
+);
+assert.match(
+  settings,
+  /html\.setAttribute\("data-mode", otherGroupKey\);\s*\n\s*otherSeed = resolveTokens\(THEME_FORK_SNAPSHOT_KEYS\);[\s\S]{0,300}?html\.setAttribute\("data-mode", restore\);/,
+  "a fresh fork snapshots the OTHER mode's preset palette in the same task (getComputedStyle forces a sync recalc — nothing paints mid-flip)",
+);
+assert.match(
+  settings,
+  /\} else if \(Object\.keys\(group\)\.length === 0\) \{\s*\n\s*Object\.assign\(group, resolveTokens\(THEME_FORK_SNAPSHOT_KEYS\)\);/,
+  "an imported custom theme missing this mode group still fills from the current computed look on first edit",
+);
+assert.match(
+  settings,
+  /\.\.\.\(otherSeed \? \{ \[otherGroupKey\]: otherSeed \} : \{\}\),/,
+  "both mode groups land in the forked payload, so a Light/Dark flip actually changes the rendered palette",
 );
 assert.match(
   settings,

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2005,15 +2005,10 @@ function withAlphaFrom(prev: string | undefined, hex: string): string {
  *  companions) changes on the selected theme. */
 function applyTokenOverride(key: string, hex: string, mode: Mode) {
   const html = document.documentElement;
-  const themePreferences = readAppPreferences().appearance.theme;
-  let existing: CustomThemeData | null =
+  const preferences = readAppPreferences();
+  const themePreferences = preferences.appearance.theme;
+  const existing: CustomThemeData | null =
     themePreferences.id === "custom" ? themePreferences.custom : null;
-  try {
-    const raw = null;
-    if (raw) existing = JSON.parse(raw) as CustomThemeData;
-  } catch {
-    /* malformed — treat as none */
-  }
   const groupKey: "light" | "dark" = mode === "light" ? "light" : "dark";
   const group: Record<string, string> = { ...(existing?.cssVars?.[groupKey] ?? {}) };
   // Seed from the current computed look while the preset CSS is still applied
@@ -2031,8 +2026,18 @@ function applyTokenOverride(key: string, hex: string, mode: Mode) {
     name: existing?.name ?? forkName,
     cssVars: { ...(existing?.cssVars ?? {}), [groupKey]: group },
   };
+  // An explicit accent pick is a statement of intent: disarm the backdrop's
+  // auto-match in the same atomic patch, or applyBackdropToDocument re-fits
+  // --accent-presence to the image seed on the very next reconcile and the
+  // pick never renders (the backdrop settings toggle re-arms matching).
+  const backdrop = preferences.appearance.backdrop;
+  const disarmBackdropAccent =
+    key === "--accent-presence" && backdrop.enabled && backdrop.matchAccent;
   updateAppPreferences({
-    appearance: { theme: { id: "custom", resolvedMode: mode, custom: data } },
+    appearance: {
+      theme: { id: "custom", resolvedMode: mode, custom: data },
+      ...(disarmBackdropAccent ? { backdrop: { matchAccent: false } } : {}),
+    },
   });
   // Live-apply the whole group — not just the edited key — so the selected
   // theme's look survives the data-theme flip. Boot (theme-init.js) replays

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2048,6 +2048,19 @@ function applyTokenOverride(key: string, hex: string, mode: Mode) {
   html.setAttribute("data-theme", "custom");
 }
 
+/** Paint-only in-drag preview: writes the edited token + its companions inline
+ *  so the pick renders instantly, without touching the preferences store — no
+ *  reconcile, no PATCH, no cross-tab broadcast per pointer-move. Inline
+ *  element.style beats whichever preset/custom CSS block is active, so no
+ *  data-theme flip is needed; commit (applyTokenOverride) makes it durable. */
+function previewTokenOverride(key: string, hex: string, mode: Mode) {
+  const html = document.documentElement;
+  html.style.setProperty(key, hex);
+  for (const [name, value] of Object.entries(deriveTokenCompanions(key, hex, mode))) {
+    html.style.setProperty(name, value);
+  }
+}
+
 /** One editable token row — swatch button opening the in-app ColorPicker
  *  (spectrum + hex field + theme/recent swatches) in a popover. */
 function TokenColorRow({
@@ -2137,46 +2150,62 @@ function ThemeTokenOverrides({
     setRecents(getRecentColors());
   }, []);
 
-  // The picker fires onChange per pointer-move, and each apply rewrites ~20
-  // root CSS vars + localStorage — coalesce to one apply per animation frame
-  // (mirrors the removed editor's rAF throttle). The daemon sync (onChange →
-  // reloadCustomData → persistThemeTokens PUT) waits for commit: one network
-  // write per finished edit instead of one per move.
+  // The picker fires onChange per pointer-move. Drags stay paint-only — each
+  // rAF-coalesced frame calls previewTokenOverride (inline vars, store
+  // untouched), so nothing reconciles, PATCHes, or broadcasts mid-drag. The
+  // durable write (applyTokenOverride → store → PUT) happens once per finished
+  // edit, at commit (popover close) or unmount.
   const modeRef = useRef(mode);
   modeRef.current = mode;
   const frameRef = useRef<number | null>(null);
   const pendingRef = useRef<{ key: string; value: string } | null>(null);
-  const flushPendingApply = useCallback(() => {
+  const dirtyRef = useRef<Set<(typeof THEME_SYNC_KEYS)[number]>>(new Set());
+  const flushPendingPreview = useCallback(() => {
     if (frameRef.current !== null) {
       cancelAnimationFrame(frameRef.current);
       frameRef.current = null;
     }
     const pending = pendingRef.current;
     pendingRef.current = null;
-    if (pending) applyTokenOverride(pending.key, pending.value, modeRef.current);
+    if (pending) previewTokenOverride(pending.key, pending.value, modeRef.current);
   }, []);
-  // Flush on unmount so a drag-in-progress still persists.
-  useEffect(() => flushPendingApply, [flushPendingApply]);
+  // Persist any un-committed edit on unmount so a drag-in-progress isn't lost
+  // when the user navigates away with the picker still open.
+  useEffect(() => {
+    return () => {
+      flushPendingPreview();
+      for (const key of dirtyRef.current) {
+        const value = valuesRef.current[key];
+        if (value) applyTokenOverride(key, value, modeRef.current);
+      }
+      dirtyRef.current.clear();
+    };
+  }, [flushPendingPreview]);
 
   const handlePick = (key: (typeof THEME_SYNC_KEYS)[number], hex: string) => {
     // Preserve the token's original alpha byte (hairline borders are washes).
     const next = withAlphaFrom(valuesRef.current[key], hex);
     setValues((v) => ({ ...v, [key]: next }));
+    dirtyRef.current.add(key);
     pendingRef.current = { key, value: next };
     if (frameRef.current === null) {
       frameRef.current = requestAnimationFrame(() => {
         frameRef.current = null;
         const pending = pendingRef.current;
         pendingRef.current = null;
-        if (pending) applyTokenOverride(pending.key, pending.value, modeRef.current);
+        if (pending) previewTokenOverride(pending.key, pending.value, modeRef.current);
       });
     }
   };
 
   const handleCommit = (key: (typeof THEME_SYNC_KEYS)[number]) => {
-    flushPendingApply();
-    const committed = (valuesRef.current[key] ?? "").slice(0, 7);
-    if (committed) setRecents(addRecentColor(committed));
+    flushPendingPreview();
+    if (!dirtyRef.current.has(key)) return; // opened + closed without a pick
+    dirtyRef.current.delete(key);
+    const committed = valuesRef.current[key];
+    if (!committed) return;
+    applyTokenOverride(key, committed, modeRef.current);
+    setRecents(addRecentColor(committed.slice(0, 7)));
     onChange();
   };
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2011,11 +2011,29 @@ function applyTokenOverride(key: string, hex: string, mode: Mode) {
   const existing: CustomThemeData | null =
     themePreferences.id === "custom" ? themePreferences.custom : null;
   const groupKey: "light" | "dark" = mode === "light" ? "light" : "dark";
+  const otherGroupKey: "light" | "dark" = groupKey === "light" ? "dark" : "light";
   const group: Record<string, string> = { ...(existing?.cssVars?.[groupKey] ?? {}) };
-  // Seed from the current computed look while the preset CSS is still applied
-  // (also fills a missing mode group when a dark-only custom theme is edited
-  // in light mode, or vice versa).
-  if (Object.keys(group).length === 0) Object.assign(group, resolveTokens(THEME_FORK_SNAPSHOT_KEYS));
+  // Fresh fork from a preset: snapshot BOTH mode palettes while the preset CSS
+  // is still applied. Seeding only the edited mode made the fork single-mode —
+  // a later Light/Dark flip kept rendering this mode's colors
+  // (activeCustomThemeVariables falls back to the only group) and the first
+  // edit in the other mode seeded it from the wrong mode's look. Clear in-drag
+  // preview inline vars first so both snapshots read the preset (the live
+  // re-apply below restores the finished look); flipping data-mode +
+  // getComputedStyle forces a synchronous recalc, so nothing paints mid-flip.
+  // Imported customs missing one mode group keep the fill-on-first-edit
+  // fallback — their preset is long gone, the current look is all there is.
+  let otherSeed: Record<string, string> | null = null;
+  if (!existing) {
+    for (const name of THEME_FORK_SNAPSHOT_KEYS) html.style.removeProperty(name);
+    Object.assign(group, resolveTokens(THEME_FORK_SNAPSHOT_KEYS));
+    const restore = html.getAttribute("data-mode") ?? groupKey;
+    html.setAttribute("data-mode", otherGroupKey);
+    otherSeed = resolveTokens(THEME_FORK_SNAPSHOT_KEYS);
+    html.setAttribute("data-mode", restore);
+  } else if (Object.keys(group).length === 0) {
+    Object.assign(group, resolveTokens(THEME_FORK_SNAPSHOT_KEYS));
+  }
   group[key] = hex;
   Object.assign(group, deriveTokenCompanions(key, hex, mode));
   const baseTheme = html.getAttribute("data-theme");
@@ -2025,7 +2043,11 @@ function applyTokenOverride(key: string, hex: string, mode: Mode) {
       : "Custom";
   const data: CustomThemeData = {
     name: existing?.name ?? forkName,
-    cssVars: { ...(existing?.cssVars ?? {}), [groupKey]: group },
+    cssVars: {
+      ...(existing?.cssVars ?? {}),
+      [groupKey]: group,
+      ...(otherSeed ? { [otherGroupKey]: otherSeed } : {}),
+    },
   };
   // An explicit accent pick is a statement of intent: disarm the backdrop's
   // auto-match in the same atomic patch, or applyBackdropToDocument re-fits

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2339,7 +2339,7 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
   // mount, leaving the theme grid and token-row swatches stale until a full
   // reload (cave-hkfq). Follow the store. setCustomData keeps the previous
   // object when content is unchanged so the persist effect (which watches
-  // customData) doesn't echo a PUT for every unrelated store notify.
+  // customData) doesn't re-emit a PUT for every unrelated store notify.
   useEffect(() => {
     if (!appearanceHydrated) return;
     return subscribeAppPreferences(() => {

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -73,6 +73,7 @@ import {
   flushAppPreferences,
   readAppPreferences,
   refreshAppPreferences,
+  subscribeAppPreferences,
   updateAppPreferences,
 } from "@/lib/app-preferences";
 import {
@@ -2310,6 +2311,28 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
     setAppearanceHydrated(true);
   }, []);
 
+  // External theme changes — the 10s /api/theme poll, another tab via the
+  // preferences BroadcastChannel, a phone PATCH — land in the store and
+  // repaint the app, but this section hydrated its selection state once on
+  // mount, leaving the theme grid and token-row swatches stale until a full
+  // reload (cave-hkfq). Follow the store. setCustomData keeps the previous
+  // object when content is unchanged so the persist effect (which watches
+  // customData) doesn't echo a PUT for every unrelated store notify.
+  useEffect(() => {
+    if (!appearanceHydrated) return;
+    return subscribeAppPreferences(() => {
+      const theme = readAppPreferences().appearance.theme;
+      setActiveTheme(readPersistedTheme());
+      setMode(readPersistedMode());
+      const next = theme.id === "custom" ? theme.custom : null;
+      setCustomData((prev) => {
+        if (prev === next) return prev;
+        if (prev && next && JSON.stringify(prev) === JSON.stringify(next)) return prev;
+        return next;
+      });
+    });
+  }, [appearanceHydrated]);
+
   const handleSelectPreset = (id: PresetTheme) => {
     setActiveTheme(id);
     setCustomData(null);
@@ -2508,7 +2531,7 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
       <SettingsGroup label="Theme tokens">
         <ThemeTokenOverrides
           mode={resolveMode(mode)}
-          reloadKey={`${activeTheme}:${mode}:${customData ? "c" : "p"}`}
+          reloadKey={`${activeTheme}:${mode}:${customData ? JSON.stringify(customData.cssVars) : "preset"}`}
           onChange={reloadCustomData}
         />
         <div className="flex flex-wrap items-center gap-3 border-t border-[var(--border-hairline)] px-4 py-3">


### PR DESCRIPTION
Fixes the four root causes behind "finicky" Settings → Appearance → Colors token overrides (bead: **cave-hkfq**). Each was reproduced and measured live (Playwright against a prod build) before and after.

## Root causes → fixes

**1. Backdrop `matchAccent` silently ate accent edits.** With a backdrop enabled and `matchAccent` armed (the default), every theme reconcile re-fit `--accent-presence` to the image seed — the user's pick never rendered, the *fit* color got synced to other devices, and the swatch reverted on reload. An explicit accent pick now folds `backdrop: { matchAccent: false }` into the **same atomic preferences patch** as the edit (no reconcile window); the backdrop settings toggle re-arms it.

**2. Per-frame write amplification during drags.** Each pointer-move frame did a full store write → reconcile (~21 vars torn down/re-applied) → PATCH → PUT → BroadcastChannel echo. Drags are now **paint-only** (`previewTokenOverride`: inline vars for the edited key + companions); the durable write happens **once per finished edit** at popover close (or unmount, mid-drag). Commits are dirty-guarded — open+close without picking no longer forks the theme to custom.

**3. Stale rows after external changes.** `AppearanceSection` hydrated its selection state once on mount; the 10s poll / other tabs / phone PATCHes repainted the app but not the swatches. The section now subscribes to the preferences store (identity-preserving `setCustomData`, so unrelated notifies don't re-trigger the persist effect), and the rows' `reloadKey` carries the custom payload's *content*.

**4. Single-mode forks.** Editing a token seeded only the edited mode's group, so flipping Light/Dark was a visual no-op and the first edit in the other mode seeded it from the wrong mode's look. A fresh fork now snapshots **both** mode palettes from the preset (clear preview vars → snapshot → flip `data-mode` → snapshot → restore; `getComputedStyle` forces a sync recalc, nothing paints mid-flip). Imports missing a group keep the fill-on-first-edit fallback.

## Measured (prod build, isolated `COVEN_CAVE_HOME`)

| Scenario | Before (1dfaaa0c1) | After (this branch) |
| --- | --- | --- |
| ~1s accent drag | 8 PATCH + 4 PUT mid-drag, selectionRevision 0→12 | **0 writes mid-drag**, 1 PATCH + 2 PUT at commit, revision +1 per edit |
| Backdrop enabled + matchAccent, pick `#5d2880` | pick invisible (stayed at fit `oklch(0.62 0.16 310.2)`), synced token = fit `#a466cd`, reverted on reload | pick renders during drag, `matchAccent → false` (backdrop stays enabled), synced token `#5d2880`, survives reload |
| Fork on dark → flip Light | all 21 custom vars stayed dark (visual no-op) | fork stores light `#f7f6f9` + dark `#1c1b1d` groups; flip renders light palette |
| External accent PATCH while page open | row swatch stale until full reload | row shows `#ff6600` on next poll |
| Drag with 2nd tab open | 38 GET /api/preferences + 58 accent setProperty calls in tab 2 | **1 GET, 2 setProperty calls** |

The commit-time double PUT (settings persist effect + RemoteThemeController publisher) is pre-existing, benign, and tracked separately in a P3 bead.

## Tests
- `settings-appearance.test.ts`: failing-first pins for each fix (backdrop disarm atomicity, paint-only preview with store-write ban, store subscription + content reloadKey, dual-mode fork snapshot). Old pins for replaced behavior updated.
- `pnpm test:app` — 891 files green; `pnpm typecheck` clean.
- Playwright scenario matrix above re-run on the branch build.
