### PR TITLE
feat(chat): sidepanel hover archive button + Show archived option (cave-d146)

### DIFF
--- a/src/components/chat-siderail-hide-archived.test.ts
+++ b/src/components/chat-siderail-hide-archived.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 //
-// Guard: archived chats never render in the siderail.
+// Guard: archived chats stay out of every siderail unless the user explicitly
+// opts in.
 //
-// Two layers keep an archived chat out of every rail:
+// Layers that keep an archived chat out of the rails by default:
 //  1. `filterVisibleChatSessions` (the shared visibility filter every rail —
 //     ChatProjectSidebar via chat-list/chat-router, WorkspaceSidebar — builds
 //     from) drops `archived_at` rows by DEFAULT; only an explicit
@@ -11,6 +12,9 @@
 //     sidebar groups are built from an archive-free `railSessions` view, so
 //     toggling archived chats visible in the list can't leak them into the
 //     rail.
+//  3. WorkspaceSidebar (the chat sidepanel) has its own "Show archived"
+//     option: OFF by default (archive-free), and only its explicit toggle
+//     routes `includeArchived` through the shared filter.
 //
 // Source-string pins, same convention as chat-thread-rail.test.ts. The
 // behavioral half (default drop / opt-in keep) lives in
@@ -55,8 +59,8 @@ assert.match(
   "sidebar groups must derive from the archive-free railSessions view",
 );
 
-// 3. The other rails build from the shared filter WITHOUT the archived opt-in,
-//    so they inherit the archive-free default.
+// 3. chat-router builds its rail from the shared filter WITHOUT the archived
+//    opt-in, so it inherits the archive-free default.
 assert.match(
   chatRouter,
   /filterVisibleChatSessions\(sessions, familiar\?\.id \?\? null\)/,
@@ -67,15 +71,30 @@ assert.doesNotMatch(
   /includeArchived: true/,
   "chat-router never opts rails into archived rows",
 );
+
+// 4. WorkspaceSidebar (the chat sidepanel) has its own explicit "Show
+//    archived" option: the toggle defaults OFF, its state is the only thing
+//    that routes includeArchived through the shared filter, and the opt-in
+//    fetch is gated behind the same toggle.
 assert.match(
   workspaceSidebar,
-  /filterVisibleChatSessions\(sessions, activeFamiliarId \?\? null\)/,
-  "the workspace siderail uses the default (archive-free) filter",
+  /const \[showArchived, setShowArchived\] = useState\(false\);/,
+  "the sidepanel's Show-archived option must default off (archive-free)",
 );
-assert.doesNotMatch(
+assert.match(
   workspaceSidebar,
-  /includeArchived/,
-  "the workspace siderail never opts into archived rows",
+  /filterVisibleChatSessions\(rows, activeFamiliarId \?\? null, \{ includeArchived: showArchived \}\)/,
+  "the sidepanel passes its Show-archived option through the shared filter's opt-in",
+);
+assert.match(
+  workspaceSidebar,
+  /if \(!showArchived\) \{\s*\n\s*setArchivedRows\(\[\]\);/,
+  "turning Show archived off must clear the fetched archived rows",
+);
+assert.match(
+  workspaceSidebar,
+  /\/api\/sessions\/list\?includeArchived=1/,
+  "archived rows load via the explicit includeArchived fetch (the workspace poll stays archive-free)",
 );
 
 console.log("chat-siderail-hide-archived.test.ts: ok");

--- a/src/components/code-surface-familiar-scope.test.ts
+++ b/src/components/code-surface-familiar-scope.test.ts
@@ -61,10 +61,12 @@ assert.match(
 
 // 6. WorkspaceSidebar scopes the sessions that drive its project list + per-project
 //    counts/rows to the active familiar (null = count everything), then derives
-//    the project tiles and rows from that scoped set.
+//    the project tiles and rows from that scoped set. (`includeArchived` is its
+//    own Show-archived toggle — familiar scoping applies either way; see
+//    chat-siderail-hide-archived.test.ts.)
 assert.match(
   workspaceSidebar,
-  /filterVisibleChatSessions\(sessions, activeFamiliarId \?\? null\)/,
+  /filterVisibleChatSessions\(rows, activeFamiliarId \?\? null, \{ includeArchived: showArchived \}\)/,
   "WorkspaceSidebar must derive visibleSessions from the active familiar",
 );
 assert.match(

--- a/src/components/workspace-sidebar-pr-badge.test.ts
+++ b/src/components/workspace-sidebar-pr-badge.test.ts
@@ -32,8 +32,8 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /\{prStatus \? null : glyph \? \(/,
-  "real PR context suppresses the dot AND the title-heuristic glyph",
+  /\{prStatus \? null : leadGlyph \? \(/,
+  "real PR context suppresses the dot AND the title-heuristic/archive glyph",
 );
 
 // ── Pinned rail rows carry the badge too ─────────────────────────────────────

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -43,6 +43,21 @@ assert.match(workspaceSidebar, /<header className="cnav__header">[\s\S]*?<Famili
 assert.doesNotMatch(workspaceSidebar, /cnav__eyebrow/, "the old Recent eyebrow stays retired");
 assert.match(workspaceSidebar, /ph:git-pull-request/, "should support PR glyph on thread rows");
 assert.match(workspaceSidebar, /scheduledCount/, "should accept scheduledCount prop");
+// Hover row-actions order: bookmark (pin) → archive → delete, so archive sits
+// to the RIGHT of the bookmark button. The archive button flips to unarchive
+// on archived rows, and the Organize menu exposes the Show-archived option
+// (default-off wiring is pinned in chat-siderail-hide-archived.test.ts).
+assert.match(
+  workspaceSidebar,
+  /onClick=\{onTogglePin\}[\s\S]*?onClick=\{onToggleArchive\}[\s\S]*?onClick=\{onRequestDelete\}/,
+  "row actions must order bookmark → archive → delete",
+);
+assert.match(
+  workspaceSidebar,
+  /name=\{archived \? "ph:arrow-counter-clockwise" : "ph:archive"\}/,
+  "the archive button must flip to unarchive on archived rows",
+);
+assert.match(workspaceSidebar, /Show archived/, "the Organize menu must expose Show archived");
 // Outer CSS classes for e2e compat
 assert.match(workspaceSidebar, /workspace-sidebar chat-sidebar/, "outer div must include both CSS classes for e2e compat");
 assert.doesNotMatch(workspaceSidebar, /workspace-sidebar__rail|chat-sidebar__rail/, "chat sidebar no longer renders a collapsed rail child");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -33,7 +33,7 @@ import {
   emitChatSessionDragEnd,
   emitChatSessionDragStart,
 } from "@/lib/chat-split";
-import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui/popover";
+import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 import { addChatProject, projectNameForRoot } from "@/lib/chat-add-project";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
@@ -59,6 +59,9 @@ type Props = {
   onNavigate: (mode: WorkspaceSidebarMode) => void;
   onNewChat: (projectRoot: string | null) => void;
   onDeleteSession: (session: SessionRow) => Promise<void>;
+  /** Refresh the workspace sessions poll after an archive/unarchive PATCH so
+   *  the row leaves (or re-enters) the live list without waiting a cycle. */
+  onSessionsChanged?: () => void;
   /** Opens the thread's pull request in the in-app browser (PR badge click);
    *  without it the badge falls back to a new tab. Same chain as chat-list. */
   onOpenUrl?: (url: string) => void;
@@ -173,6 +176,10 @@ type ThreadRowProps = {
   /** ⌥↵ / ⌥-click / drag: open beside the current chat in a split pane. */
   onOpenInSplit?: () => void;
   onTogglePin: () => void;
+  /** Archive/unarchive via the sessions PATCH (same endpoint as chat-list). */
+  onToggleArchive: () => void;
+  /** True while any row's archive PATCH is in flight — disables the buttons. */
+  archiving: boolean;
   onRequestDelete: () => void;
   onCancelDelete: () => void;
   onConfirmDelete: () => void;
@@ -191,6 +198,8 @@ function ThreadRow({
   onOpen,
   onOpenInSplit,
   onTogglePin,
+  onToggleArchive,
+  archiving,
   onRequestDelete,
   onCancelDelete,
   onConfirmDelete,
@@ -200,8 +209,14 @@ function ThreadRow({
   // reached an actual pull request, the leading slot shows the clickable
   // state-colored badge instead of the dot or heuristic icon.
   const prStatus = sessionPrStatus(session.pullRequest);
+  // Archived rows (visible via the "Show archived" option) read muted, and the
+  // leading slot shows the archive glyph so they can't pass for live threads.
+  const archived = Boolean(session.archived_at);
+  const leadGlyph = archived ? ("ph:archive" as IconName) : glyph;
   return (
-    <div className={`cnav__thread${indent === "flat" ? " cnav__thread--flat" : ""}${active ? " is-active" : ""}`}>
+    <div
+      className={`cnav__thread${indent === "flat" ? " cnav__thread--flat" : ""}${active ? " is-active" : ""}${archived ? " is-archived" : ""}`}
+    >
       {prStatus ? <ThreadPrBadge prStatus={prStatus} onOpenUrl={onOpenUrl} /> : null}
       <button
         type="button"
@@ -237,8 +252,8 @@ function ThreadRow({
         }}
         className="cnav__thread-main focus-ring"
       >
-        {prStatus ? null : glyph ? (
-          <Icon name={glyph} width={13} className="cnav__lead" aria-hidden />
+        {prStatus ? null : leadGlyph ? (
+          <Icon name={leadGlyph} width={13} className="cnav__lead" aria-hidden />
         ) : (
           <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
         )}
@@ -276,6 +291,16 @@ function ThreadRow({
           </button>
           <button
             type="button"
+            title={archived ? "Unarchive chat" : "Archive chat"}
+            aria-label={`${archived ? "Unarchive" : "Archive"} chat ${title}`}
+            disabled={archiving}
+            onClick={onToggleArchive}
+            className="cnav__icon-btn focus-ring"
+          >
+            <Icon name={archived ? "ph:arrow-counter-clockwise" : "ph:archive"} width={12} aria-hidden />
+          </button>
+          <button
+            type="button"
             title="Delete thread"
             aria-label={`Delete thread ${title}`}
             onClick={onRequestDelete}
@@ -301,6 +326,7 @@ export function WorkspaceSidebar({
   onNavigate,
   onNewChat,
   onDeleteSession,
+  onSessionsChanged,
   onOpenUrl,
   scheduledCount,
   onOpenSettings,
@@ -320,6 +346,14 @@ export function WorkspaceSidebar({
   const [registeringRoot, setRegisteringRoot] = useState<string | null>(null);
   const [registerError, setRegisterError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  // Archived rows are excluded server-side by /api/sessions/list; the Organize
+  // menu's "Show archived" option opts in with its own includeArchived fetch,
+  // mirroring the chat list's toggle (the workspace poll stays archive-free).
+  const [showArchived, setShowArchived] = useState(false);
+  const [archivedRows, setArchivedRows] = useState<SessionRow[]>([]);
+  const [archivingId, setArchivingId] = useState<string | null>(null);
+  const [archiveNonce, setArchiveNonce] = useState(0);
+  const [archiveError, setArchiveError] = useState<string | null>(null);
   const [view, setView] = useState<ChatSidebarView>("recent");
   const [menuOpen, setMenuOpen] = useState(false);
   const menuAnchorRef = useRef<HTMLButtonElement>(null);
@@ -335,10 +369,41 @@ export function WorkspaceSidebar({
     setView(readChatSidebarView());
   }, []);
 
-  const visibleSessions = useMemo(
-    () => filterVisibleChatSessions(sessions, activeFamiliarId ?? null),
-    [sessions, activeFamiliarId],
-  );
+  // Archived sessions only load while "Show archived" is on; archive/unarchive
+  // bumps archiveNonce so the opt-in list refetches after each change (same
+  // idiom as the chat list's toggle).
+  useEffect(() => {
+    if (!showArchived) {
+      setArchivedRows([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        // Scope archived rows to the active familiar's projects, same as the
+        // live list — keeps forbidden-project sessions out of the archive view.
+        const scope = activeFamiliarId ? `&familiarId=${encodeURIComponent(activeFamiliarId)}` : "";
+        const res = await fetch(`/api/sessions/list?includeArchived=1${scope}`, { cache: "no-store" });
+        const json = await res.json().catch(() => ({ ok: false }));
+        if (cancelled || !json.ok || !Array.isArray(json.sessions)) return;
+        setArchivedRows((json.sessions as SessionRow[]).filter((s) => s.archived_at));
+      } catch {
+        // keep whatever archived rows we already have
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [showArchived, archiveNonce, activeFamiliarId]);
+
+  const visibleSessions = useMemo(() => {
+    let rows: SessionRow[] = sessions;
+    if (showArchived && archivedRows.length > 0) {
+      const seen = new Set(sessions.map((s) => s.id));
+      rows = [...sessions, ...archivedRows.filter((s) => !seen.has(s.id))];
+    }
+    return filterVisibleChatSessions(rows, activeFamiliarId ?? null, { includeArchived: showArchived });
+  }, [sessions, showArchived, archivedRows, activeFamiliarId]);
 
   const groups = useMemo(
     () => deriveChatProjectGroups(applyProjectOverrides(visibleSessions, overrides), projects),
@@ -433,6 +498,31 @@ export function WorkspaceSidebar({
     }
   }
 
+  // Archive/unarchive rides the same undo-safe sessions PATCH as the chat
+  // list; a success refreshes both the workspace poll and the opt-in list.
+  async function setSessionArchived(session: SessionRow, archived: boolean) {
+    setArchivingId(session.id);
+    setArchiveError(null);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ archived }),
+      });
+      const json = await res.json().catch(() => ({ ok: false }));
+      if (!res.ok || !json.ok) {
+        setArchiveError(json.error ?? (archived ? "archive failed" : "unarchive failed"));
+        return;
+      }
+      setArchiveNonce((n) => n + 1);
+      onSessionsChanged?.();
+    } catch (err) {
+      setArchiveError(err instanceof Error ? err.message : archived ? "archive failed" : "unarchive failed");
+    } finally {
+      setArchivingId(null);
+    }
+  }
+
   async function handleRegister(group: ChatProjectGroup) {
     if (!group.projectRoot) return;
     setRegisteringRoot(group.projectRoot);
@@ -507,6 +597,17 @@ export function WorkspaceSidebar({
                 <PopoverItem icon="ph:folder" checked={view === "projects"} onSelect={() => selectView("projects")}>
                   By project
                 </PopoverItem>
+                <PopoverSeparator />
+                <PopoverItem
+                  icon="ph:archive"
+                  checked={showArchived}
+                  onSelect={() => {
+                    setShowArchived((v) => !v);
+                    setMenuOpen(false);
+                  }}
+                >
+                  Show archived
+                </PopoverItem>
               </PopoverBody>
             </div>
           </Popover>
@@ -576,6 +677,15 @@ export function WorkspaceSidebar({
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
             <span className="cnav__error-text">{deleteError}</span>
             <button type="button" onClick={() => setDeleteError(null)} aria-label="Dismiss" className="shrink-0">
+              <Icon name="ph:x-bold" width={9} aria-hidden />
+            </button>
+          </div>
+        ) : null}
+        {archiveError ? (
+          <div role="alert" className="cnav__error">
+            <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
+            <span className="cnav__error-text">{archiveError}</span>
+            <button type="button" onClick={() => setArchiveError(null)} aria-label="Dismiss" className="shrink-0">
               <Icon name="ph:x-bold" width={9} aria-hidden />
             </button>
           </div>
@@ -660,6 +770,8 @@ export function WorkspaceSidebar({
                               onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
                             }
                             onTogglePin={() => togglePin(session.id)}
+                            onToggleArchive={() => void setSessionArchived(session, !session.archived_at)}
+                            archiving={archivingId !== null}
                             onRequestDelete={() => setConfirmingSessionId(session.id)}
                             onCancelDelete={() => setConfirmingSessionId(null)}
                             onConfirmDelete={() => void handleDeleteSession(session)}
@@ -771,6 +883,8 @@ export function WorkspaceSidebar({
                                       : undefined
                                   }
                                   onTogglePin={() => togglePin(session.id)}
+                                  onToggleArchive={() => void setSessionArchived(session, !session.archived_at)}
+                                  archiving={archivingId !== null}
                                   onRequestDelete={() => setConfirmingSessionId(session.id)}
                                   onCancelDelete={() => setConfirmingSessionId(null)}
                                   onConfirmDelete={() => void handleDeleteSession(session)}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2660,6 +2660,7 @@ export function Workspace() {
 
         handleSessionsDeleted([session.id]);
       }}
+      onSessionsChanged={loadSessions}
       onOpenUrl={(url) => {
         shellRef.current?.dismissNavMobile();
         openUrlInApp(url);

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -596,7 +596,7 @@
 /* Only when hovered does the title reserve room for the revealed actions; when
    not hovered the row is full-width (no dead space for hidden buttons). */
 .cnav__thread:hover .cnav__thread-main {
-  padding-right: 52px;
+  padding-right: 76px;
 }
 .cnav__thread:hover {
   background: color-mix(in oklch, var(--foreground) 5%, transparent);
@@ -615,6 +615,16 @@
   width: 2.5px;
   border-radius: 2px;
   background: var(--accent-presence);
+}
+/* Archived rows (visible via the sidebar's "Show archived" option) read muted
+   so they can't pass for live threads; hover restores full contrast for the
+   revealed actions (unarchive/delete). */
+.cnav__thread.is-archived .cnav__thread-title,
+.cnav__thread.is-archived .cnav__lead {
+  color: var(--text-muted);
+}
+.cnav__thread.is-archived:hover .cnav__thread-title {
+  color: var(--text-primary);
 }
 .cnav__dot {
   width: 6px;


### PR DESCRIPTION
## What

The chat sidepanel (WorkspaceSidebar) gets first-class archive controls:

- **Hover archive button** on every thread row, to the **right of the bookmark (pin) button** (bookmark → archive → delete). Uses the same undo-safe `PATCH /api/sessions/:id { archived }` as the chat list; flips to **Unarchive** (`ph:arrow-counter-clockwise`) on archived rows.
- **"Show archived" option** in the Organize sidebar menu (⋯). Default **off** — the rail stays archive-free. Toggling on runs an explicit `/api/sessions/list?includeArchived=1` fetch (scoped to the active familiar) and routes the toggle through `filterVisibleChatSessions`, mirroring chat-list's toggle. Archived rows render with an archive glyph and muted title.
- Archiving calls `onSessionsChanged` (→ `loadSessions`) so the row leaves the live poll immediately; `archiveNonce` refetches the opt-in list.

## Tests

- `chat-siderail-hide-archived.test.ts`: re-pinned — default stays archive-free, opt-in is explicit + toggle-gated (was: sidepanel may never opt in).
- `code-surface-familiar-scope.test.ts` / `workspace-sidebar-pr-badge.test.ts`: updated for the new call shape / `leadGlyph`.
- `workspace-sidebar-wiring.test.ts`: pins bookmark → archive → delete order, unarchive flip, and the menu option.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test:app` (891 files) — green.
- Playwright against the prod build: hover shows the three actions in order; Organize menu shows *Show archived*; toggling on rendered 17 archived rows (archive glyph, muted) with an *Unarchive chat* hover action.

Bead: cave-d146