### PR TITLE
fix(home): flatten the background — retire the radial washes and hearth halo (cave-imes)

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -80,10 +80,10 @@ assert.match(
   /home-composer-eyebrow\$\{greeting \? " is-ready" : ""\}/,
   "the eyebrow fades in via .is-ready once the client greeting lands",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /className="home-halo" aria-hidden/,
-  "the hearth-glow halo renders behind the composer card and is hidden from AT",
+  /home-halo/,
+  "the hearth-glow halo is retired — its breathing radial oval read as blurry background color",
 );
 
 // Project selection lives in the composer's context pill (chat revamp 1d):

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -725,11 +725,6 @@ export function HomeComposer({
           card without being clipped by the card's `overflow: hidden`. */}
       <div className="home-composer-card-wrap">
 
-        {/* Hearth glow — the ambient presence halo behind the composer. It
-            breathes slowly and brightens while the composer holds focus
-            (static under prefers-reduced-motion). */}
-        <div className="home-halo" aria-hidden />
-
         {/* Slash suggestion popover — anchored above the card so it doesn't
             push the rest of the layout when it opens. */}
         {modelMenuActive && modelOptions ? (

--- a/src/components/home-hearth.test.ts
+++ b/src/components/home-hearth.test.ts
@@ -34,11 +34,15 @@ assert.match(
   /\.home-hearth-card \{[\s\S]{0,700}?margin-block: auto/,
   "the card centers vertically (auto block margins; collapse to 0 when it overflows)",
 );
-assert.match(
+// Flat ground (2026-07-22): the radial presence washes and the hearth-glow
+// halo are retired — soft radial gradients read as out-of-focus color smears
+// ("blurriness in the bg color") over the clean base.
+assert.doesNotMatch(
   css,
-  /\.home-composer-root \{[\s\S]{0,900}?radial-gradient\([\s\S]{0,200}?var\(--accent-presence\)/,
-  "the base behind the card carries the radial presence wash",
+  /\.home-composer-root \{[\s\S]{0,900}?radial-gradient\(/,
+  "the base behind the card is flat — no radial washes",
 );
+assert.doesNotMatch(css, /home-halo/, "the hearth-glow halo CSS is removed");
 // The subtitle derives from live state — no invented user-profile name.
 assert.doesNotMatch(composer, /casting today, /, "no invented user name in the heading");
 

--- a/src/styles/home-composer/landing-composer.css
+++ b/src/styles/home-composer/landing-composer.css
@@ -13,17 +13,8 @@
   overflow-y: auto;
   box-sizing: border-box;
 
-  background:
-    radial-gradient(
-      640px 420px at 84% 14%,
-      color-mix(in oklch, var(--accent-presence) 10%, transparent),
-      transparent 70%
-    ),
-    radial-gradient(
-      560px 520px at 8% 92%,
-      color-mix(in oklch, var(--accent-presence) 5%, transparent),
-      transparent 70%
-    );
+  /* Flat base — the soft radial accent washes read as out-of-focus color
+     smears over the clean ground, so Home paints no ambient gradients. */
 
   transition: none;
 }
@@ -53,20 +44,19 @@
 }
 
 /* ── Hearth card (chat revamp 1a) ─────────────────────────────────────────────
- *   One centered panel on the washed base holding the greeting, the composer,
- *   and the Continue / Open work / Prompt snippets sections. Translucent panel
- *   fill so the radial wash reads through; the root scrolls when the card
- *   outgrows a short viewport. On tall viewports the card grows to the root's
- *   bottom inset (no dead wash strip below it); `0` shrink keeps the intrinsic
- *   height as the floor so short windows still scroll. */
+ *   One centered panel on the flat base holding the greeting, the composer,
+ *   and the Continue / Open work / Prompt snippets sections. The root scrolls
+ *   when the card outgrows a short viewport. On tall viewports the card grows
+ *   to the root's bottom inset (no dead strip below it); `0` shrink keeps the
+ *   intrinsic height as the floor so short windows still scroll. */
 /* ── Hearth card — refinement pass (2026-07-22) ────────────────────────────
  *   The greeting, headline, agent label, composer, and suggestions read as one
  *   unified launch cluster. The heavy bordered container is retired: the visible
  *   frame emphasised the large empty area below the composer at 1280×720. It is
- *   now an invisible layout wrapper — the radial presence wash on the root is the
- *   only ambient surface. Cluster is capped ~900px and centers vertically in the
- *   usable workspace (auto block margins split the root's free space; when the
- *   cluster outgrows a short viewport they collapse to 0 and the root scrolls). */
+ *   now an invisible layout wrapper on the flat base. Cluster is capped ~900px
+ *   and centers vertically in the usable workspace (auto block margins split
+ *   the root's free space; when the cluster outgrows a short viewport they
+ *   collapse to 0 and the root scrolls). */
 .home-hearth-card {
   display: flex;
   flex-direction: column;
@@ -173,47 +163,9 @@
   container-type: inline-size;
 }
 
-/* ── Hearth glow — the page's signature ──────────────────────────────────────
- *   A soft lavender halo behind the composer: the accent-is-presence rule made
- *   ambient. It breathes slowly, brightens while the composer holds focus, and
- *   holds still under prefers-reduced-motion. Kept inside the page padding so
- *   it never trips horizontal overflow on the scrollable root. */
-.home-halo {
-  position: absolute;
-  inset: -110px -20px -70px;
-  z-index: -1;
-  pointer-events: none;
-  background: radial-gradient(
-    46% 68% at 50% 44%,
-    color-mix(in oklch, var(--accent-presence) 22%, transparent),
-    transparent 72%
-  );
-  opacity: 0.75;
-  transition: opacity 600ms var(--ease-standard);
-}
-
-.home-composer-card-wrap:focus-within .home-halo {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .home-halo {
-    animation: home-halo-breathe 9s var(--ease-standard) infinite alternate;
-  }
-}
-
-@keyframes home-halo-breathe {
-  from { transform: scale(0.97); }
-  to { transform: scale(1.04); }
-}
-
-/* Light mode: the halo tints rather than glows — damp it. */
-[data-mode="light"] .home-halo {
-  opacity: 0.5;
-}
-[data-mode="light"] .home-composer-card-wrap:focus-within .home-halo {
-  opacity: 0.75;
-}
+/* The hearth-glow halo behind the composer is retired with the washes above:
+   its breathing radial oval was the largest "blurry background color" source
+   on the page. The card's own chrome carries the focus treatment. */
 
 /* ── Composer card ─────────────────────────────────────────────────────────
  *   Chrome comes from the shared .cave-composer-panel class (cave-chat.css) so


### PR DESCRIPTION
## Problem

Home painted three soft radial gradients — two corner accent washes on `.home-composer-root` and the breathing `.home-halo` oval behind the composer. Over the flat base they read as out-of-focus color smears ("blurriness in the bg color", user report) — the same complaint class as the full-area radial ground retired in cave-hct3.

## Fix

- `src/styles/home-composer/landing-composer.css`: removed the two radial washes from `.home-composer-root` and the entire `.home-halo` block (breathe animation, focus brighten, light-mode damping). Flat base; the composer card's own chrome carries focus.
- `src/components/home-composer.tsx`: removed the halo div.
- Pins flipped: `home-hearth.test.ts` asserts no radial-gradient on the root + no halo CSS; `home-composer.test.ts` asserts the halo div is gone.

## Verification

Prod build + Playwright: computed `.home-composer-root` `background-image: none`, no `.home-halo` node; screenshot shows a crisp flat ground. Targeted suites green (home-hearth, home-composer, home-composer-centering, backdrop-scrim, home-composer-polish, design-token-drift).

Bead: cave-imes