### PR TITLE
fix(migration): extend discard guard to directories and pin confirms to content tokens (cave-foc2)

### DIFF
--- a/src/app/api/cave-home-migration/route.test.ts
+++ b/src/app/api/cave-home-migration/route.test.ts
@@ -37,11 +37,12 @@ assert.match(
 assert.match(source, /force-dynamic/, "status must never be served from the route cache");
 assert.match(source, /ACTIONS = new Set<ReconciliationAction>/, "review actions are allowlisted");
 assert.match(source, /Unknown legacy migration entry/, "action requests are restricted to the shared manifest");
-assert.match(source, /Invalid confirm flag/, "confirm must be boolean when present");
+assert.match(source, /Invalid confirm token/, "confirm must be the issued discard token when present");
+assert.match(source, /\^\[0-9a-f\]\{64\}\$/, "confirm tokens are validated as sha256 hex before reaching the reconciler");
 assert.match(
   source,
-  /confirmDiscard: body\.confirm === true/,
-  "explicit confirmation is forwarded to the discard guard (cave-5ax2)",
+  /confirmDiscard: typeof body\.confirm === "string" \? body\.confirm : undefined/,
+  "the issued discard token is forwarded to the content-pinned guard (cave-5ax2, cave-foc2)",
 );
 assert.match(source, /req\.body[\s\S]*readJsonBody<[^>]+>\(req, MAX_ACTION_BODY_BYTES\)[\s\S]*: null/, "actions are bounded while body-less legacy POST requests remain compatible");
 

--- a/src/app/api/cave-home-migration/route.ts
+++ b/src/app/api/cave-home-migration/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
     : null;
   if (parsed && !parsed.ok) return parsed.response;
   const body = parsed?.body ?? null;
-  let options: { action?: ReconciliationAction; legacy?: string; confirmDiscard?: boolean } = {};
+  let options: { action?: ReconciliationAction; legacy?: string; confirmDiscard?: string } = {};
   if (body) {
     if (typeof body.action !== "string" || !ACTIONS.has(body.action as ReconciliationAction)) {
       return NextResponse.json({ ok: false, error: "Unsupported migration action" }, { status: 400 });
@@ -45,10 +45,14 @@ export async function POST(req: Request) {
     if (typeof body.legacy !== "string" || !CAVE_HOME_MIGRATIONS.some((entry) => entry.legacy === body.legacy)) {
       return NextResponse.json({ ok: false, error: "Unknown legacy migration entry" }, { status: 400 });
     }
-    if (body.confirm !== undefined && typeof body.confirm !== "boolean") {
-      return NextResponse.json({ ok: false, error: "Invalid confirm flag" }, { status: 400 });
+    if (body.confirm !== undefined && (typeof body.confirm !== "string" || !/^[0-9a-f]{64}$/.test(body.confirm))) {
+      return NextResponse.json({ ok: false, error: "Invalid confirm token" }, { status: 400 });
     }
-    options = { action: body.action as ReconciliationAction, legacy: body.legacy, confirmDiscard: body.confirm === true };
+    options = {
+      action: body.action as ReconciliationAction,
+      legacy: body.legacy,
+      confirmDiscard: typeof body.confirm === "string" ? body.confirm : undefined,
+    };
   }
   const result = await migrateCaveHome(options);
   const status = await caveHomeMigrationStatus();

--- a/src/components/cave-home-migration-banner.test.ts
+++ b/src/components/cave-home-migration-banner.test.ts
@@ -6,7 +6,7 @@ const src = await readFile(new URL("./cave-home-migration-banner.tsx", import.me
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 const status = await readFile(new URL("../lib/server/cave-home-migration-status.ts", import.meta.url), "utf8");
 const reconciliation = await readFile(new URL("../lib/server/cave-home-reconciliation.ts", import.meta.url), "utf8");
-const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/globals/desktop-chrome.css", import.meta.url), "utf8");
 const runner = await readFile(new URL("../../scripts/run-tests.mjs", import.meta.url), "utf8");
 
 assert.match(src, /export function CaveHomeMigrationBannerTrigger/, "exports the shell migration trigger");
@@ -24,8 +24,10 @@ assert.match(src, /Open backup folder/, "review exposes verified recovery bundle
 assert.match(src, /return "Defer"/, "review lets users defer ambiguous decisions");
 assert.match(src, /shell_open_path/, "desktop opens the absolute backup directory through the validated command");
 assert.match(src, /usePausablePoll\(\(\) => void refresh\(\), 5 \* 60_000/, "managed mirrors are rechecked for stale legacy writes while Cave remains open — at a gentle 5min cadence (the endpoint rescans the legacy home per hit; cave-v8hh)");
-assert.match(src, /JSON\.stringify\(confirm\s*\?\s*\{ legacy: detail\.legacy, action, confirm: true \}\s*:\s*\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry and only send confirm after the guard asked for it");
+assert.match(src, /JSON\.stringify\(confirmToken\s*\?\s*\{ legacy: detail\.legacy, action, confirm: confirmToken \}\s*:\s*\{ legacy: detail\.legacy, action \}\)/, "actions identify one manifest entry and only send the issued token after the guard asked for it");
 assert.match(src, /confirmationRequired\?\.find/, "a guard-blocked resolution surfaces its confirmation request");
+assert.match(src, /discardToken: guard\.discardToken/, "a re-blocked confirmation adopts the fresh token issued for the changed copy");
+assert.match(src, /runAction\(detail, confirmRequest\.action, confirmRequest\.discardToken\)/, "the confirmed retry echoes the exact content token the guard issued (cave-foc2)");
 assert.match(src, /Discard larger copy anyway/, "the destructive retry is an explicit, labeled second step (cave-5ax2)");
 assert.match(src, /setConfirmRequest\(null\)/, "the confirmation request can be cancelled");
 assert.match(src, /detail\.legacySize/, "review shows the legacy copy size");

--- a/src/components/cave-home-migration-banner.tsx
+++ b/src/components/cave-home-migration-banner.tsx
@@ -45,6 +45,7 @@ type RunPayload = StatusPayload & {
       action: MigrationAction;
       keptBytes: number;
       discardedBytes: number;
+      discardToken: string;
       summary: string;
     }>;
   };
@@ -114,7 +115,7 @@ export function CaveHomeMigrationBannerTrigger() {
   const [reviewOpen, setReviewOpen] = useState(false);
   const [working, setWorking] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [confirmRequest, setConfirmRequest] = useState<{ legacy: string; action: MigrationAction; summary: string } | null>(null);
+  const [confirmRequest, setConfirmRequest] = useState<{ legacy: string; action: MigrationAction; summary: string; discardToken: string } | null>(null);
 
   const publish = useCallback((next: MigrationStatus) => {
     setStatus(next);
@@ -165,15 +166,15 @@ export function CaveHomeMigrationBannerTrigger() {
     };
   }, [dismissBanner, publish]);
 
-  const runAction = async (detail: MigrationDetail, action: MigrationAction, confirm = false) => {
+  const runAction = async (detail: MigrationDetail, action: MigrationAction, confirmToken?: string) => {
     setWorking(`${detail.legacy}:${action}`);
     setNotice(null);
     try {
       const response = await fetch("/api/cave-home-migration", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(confirm
-          ? { legacy: detail.legacy, action, confirm: true }
+        body: JSON.stringify(confirmToken
+          ? { legacy: detail.legacy, action, confirm: confirmToken }
           : { legacy: detail.legacy, action }),
       });
       const payload = await response.json() as RunPayload;
@@ -181,7 +182,9 @@ export function CaveHomeMigrationBannerTrigger() {
       publish(payload.status);
       const guard = payload.result?.confirmationRequired?.find((entry) => entry.legacy === detail.legacy);
       if (guard) {
-        setConfirmRequest({ legacy: guard.legacy, action: guard.action, summary: guard.summary });
+        // A re-blocked confirm carries a fresh token/summary (the copy changed
+        // after the user reviewed it); always adopt the latest.
+        setConfirmRequest({ legacy: guard.legacy, action: guard.action, summary: guard.summary, discardToken: guard.discardToken });
         setNotice(guard.summary);
         return;
       }
@@ -234,7 +237,7 @@ export function CaveHomeMigrationBannerTrigger() {
                     <button
                       type="button"
                       disabled={working !== null}
-                      onClick={() => void runAction(detail, confirmRequest.action, true)}
+                      onClick={() => void runAction(detail, confirmRequest.action, confirmRequest.discardToken)}
                     >
                       {working === `${detail.legacy}:${confirmRequest.action}` ? "Working…" : "Discard larger copy anyway"}
                     </button>

--- a/src/lib/server/cave-home-migration-discard-guard.test.ts
+++ b/src/lib/server/cave-home-migration-discard-guard.test.ts
@@ -1,11 +1,13 @@
 // @ts-nocheck
-// Discard guard (cave-5ax2): a keep-canonical/recover-legacy resolution that
-// would replace a dramatically larger copy with a much smaller one must be
-// blocked until the caller confirms. Regression for the 2026-07-22 incident
-// where recover-legacy replaced a 206-card canonical board with a 3-card
-// stale legacy file.
+// Discard guard (cave-5ax2, cave-foc2): a keep-canonical/recover-legacy
+// resolution that would replace a dramatically larger copy with a much
+// smaller one must be blocked until the caller confirms — for files AND
+// directories (recursive content size) — and the confirmation is pinned to
+// the discarded content via discardToken. Regression for the 2026-07-22
+// incident where recover-legacy replaced a 206-card canonical board with a
+// 3-card stale legacy file.
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -62,6 +64,7 @@ try {
     assert.equal(guard.legacy, "cave-board.json");
     assert.equal(guard.action, "recover-legacy");
     assert.ok(guard.discardedBytes > guard.keptBytes * 8, "guard reports the size imbalance");
+    assert.match(guard.discardToken, /^[0-9a-f]{64}$/, "the block issues a content token for the discarded copy");
     assert.match(guard.summary, /discard the canonical copy/);
     assert.match(guard.summary, /recovery bundle/);
 
@@ -76,9 +79,27 @@ try {
     assert.equal(typeof detail.canonicalSize, "number", "status reports the canonical size for review");
     assert.ok(detail.actions.includes("recover-legacy"), "the action stays available for a confirmed retry");
 
-    // The same action with explicit confirmation proceeds and keeps the
+    // The confirmation is pinned to the bytes the user reviewed: if the copy
+    // to be discarded changes between the block and the confirm, the stale
+    // token re-blocks with fresh numbers instead of destroying content the
+    // user never saw.
+    const rewritten = { version: 1, cards: bigBoard().cards.slice(0, 150) };
+    await writeFile(path.join(cave, "board.json"), JSON.stringify(rewritten), "utf8");
+    const stale = await migrateCaveHome({ legacy: "cave-board.json", action: "recover-legacy", confirmDiscard: guard.discardToken });
+    assert.deepEqual(stale.errors, []);
+    assert.equal(stale.resolved.includes("cave-board.json"), false);
+    assert.equal(stale.confirmationRequired.length, 1);
+    assert.match(stale.confirmationRequired[0].summary, /changed after the previous confirmation/);
+    assert.notEqual(stale.confirmationRequired[0].discardToken, guard.discardToken, "a re-block issues a fresh token for the changed content");
+    assert.equal((await json(path.join(cave, "board.json"))).cards.length, 150, "the rewritten canonical copy must remain untouched");
+
+    // The same action confirmed with the current token proceeds and keeps the
     // verified recovery bundle for the discarded copy.
-    const confirmed = await migrateCaveHome({ legacy: "cave-board.json", action: "recover-legacy", confirmDiscard: true });
+    const confirmed = await migrateCaveHome({
+      legacy: "cave-board.json",
+      action: "recover-legacy",
+      confirmDiscard: stale.confirmationRequired[0].discardToken,
+    });
     assert.deepEqual(confirmed.errors, []);
     assert.deepEqual(confirmed.confirmationRequired, []);
     assert.equal(confirmed.resolved.includes("cave-board.json"), true);
@@ -100,7 +121,11 @@ try {
     assert.equal(blocked.confirmationRequired[0].action, "keep-canonical");
     assert.match(blocked.confirmationRequired[0].summary, /discard the legacy copy/);
 
-    const confirmed = await migrateCaveHome({ legacy: "cave-board.json", action: "keep-canonical", confirmDiscard: true });
+    const confirmed = await migrateCaveHome({
+      legacy: "cave-board.json",
+      action: "keep-canonical",
+      confirmDiscard: blocked.confirmationRequired[0].discardToken,
+    });
     assert.deepEqual(confirmed.errors, []);
     assert.equal(confirmed.resolved.includes("cave-board.json"), true);
     assert.equal((await json(path.join(cave, "board.json"))).cards.length, 1);
@@ -119,6 +144,44 @@ try {
     assert.deepEqual(resolved.confirmationRequired, []);
     assert.equal(resolved.resolved.includes("cave-board.json"), true);
     assert.equal((await json(path.join(cave, "board.json"))).cards[0].id, "a");
+  }
+
+  // Directory conflicts are guarded by recursive content size (a directory's
+  // lstat size is its inode size, not its contents): recovering a nearly
+  // empty legacy conversations directory over a populated canonical one
+  // requires the same confirmation round-trip (cave-foc2).
+  {
+    const { coven, cave } = await home("guard-directory");
+    const canonicalDir = path.join(cave, "conversations");
+    const legacyDir = path.join(coven, "cave-conversations");
+    await mkdir(canonicalDir, { recursive: true });
+    await mkdir(legacyDir, { recursive: true });
+    for (let index = 0; index < 40; index += 1) {
+      await writeFile(
+        path.join(canonicalDir, `conversation-${index}.json`),
+        JSON.stringify({ id: `conversation-${index}`, transcript: `turn ${index} with enough text to carry weight `.repeat(20) }),
+        "utf8",
+      );
+    }
+    await writeFile(path.join(legacyDir, "conversation-stale.json"), JSON.stringify({ id: "stale" }), "utf8");
+
+    const blocked = await migrateCaveHome({ legacy: "cave-conversations", action: "recover-legacy" });
+    assert.deepEqual(blocked.errors, []);
+    assert.equal(blocked.resolved.includes("cave-conversations"), false);
+    assert.equal(blocked.confirmationRequired.length, 1);
+    const guard = blocked.confirmationRequired[0];
+    assert.equal(guard.action, "recover-legacy");
+    assert.ok(guard.discardedBytes >= 4096, "directories are measured by recursive content bytes, not inode size");
+    assert.equal((await readdir(canonicalDir)).length, 40, "canonical directory must remain untouched while blocked");
+
+    const status = await caveHomeMigrationStatus();
+    const detail = status.details.find((entry) => entry.legacy === "cave-conversations");
+    assert.ok(detail.canonicalSize >= 4096, "status reports recursive directory content size for review");
+
+    const confirmed = await migrateCaveHome({ legacy: "cave-conversations", action: "recover-legacy", confirmDiscard: guard.discardToken });
+    assert.deepEqual(confirmed.errors, []);
+    assert.equal(confirmed.resolved.includes("cave-conversations"), true);
+    assert.deepEqual(await readdir(canonicalDir), ["conversation-stale.json"], "confirmed recover-legacy installs the legacy directory");
   }
 
   console.log("cave-home-migration-discard-guard.test.ts: ok");

--- a/src/lib/server/cave-home-reconciliation-types.ts
+++ b/src/lib/server/cave-home-reconciliation-types.ts
@@ -84,13 +84,16 @@ export type CaveHomeReconciliationResult = {
   /**
    * Destructive resolutions blocked by the discard guard: the requested
    * action would replace a dramatically larger copy with a much smaller one
-   * (see cave-5ax2). Retry with `confirmDiscard: true` to proceed anyway.
+   * (see cave-5ax2). Retry with `confirmDiscard` set to the issued
+   * `discardToken` to proceed anyway.
    */
   confirmationRequired: Array<{
     legacy: string;
     action: "keep-canonical" | "recover-legacy";
     keptBytes: number;
     discardedBytes: number;
+    /** Content hash of the copy that would be discarded; pins the confirmation to the bytes the user reviewed. */
+    discardToken: string;
     summary: string;
   }>;
 };
@@ -109,9 +112,12 @@ export type ReconciliationOptions = {
   legacy?: string;
   /**
    * Explicit user acknowledgement for a keep-canonical/recover-legacy action
-   * that the discard guard flagged as destroying a much larger copy.
+   * that the discard guard flagged as destroying a much larger copy. Must
+   * echo the `discardToken` issued with the confirmation request; a token
+   * that no longer matches the live content re-blocks, because the copy
+   * changed after the user reviewed it.
    */
-  confirmDiscard?: boolean;
+  confirmDiscard?: string;
   /** Test-only fault boundary. Production callers must omit it. */
   faultAt?: string;
   /** Test-only compatibility bridge override. */

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -54,6 +54,8 @@ type PathInfo = {
   hash?: string;
   mtimeMs?: number;
   size?: number;
+  /** Content bytes: the file size, or the recursive file-size sum for directories (lstat size is the inode size, not the contents). */
+  contentBytes?: number;
 };
 
 type MergeOutcome =
@@ -125,17 +127,25 @@ async function sha256File(target: string): Promise<string> {
   return createHash("sha256").update(await readFile(target)).digest("hex");
 }
 
-async function sha256Dir(target: string): Promise<string> {
+async function digestDir(target: string): Promise<{ hash: string; bytes: number }> {
   const hash = createHash("sha256");
+  let bytes = 0;
   for (const name of (await readdir(target)).sort()) {
     if (name === ".DS_Store") continue;
     const child = path.join(target, name);
     const info = await lstat(child);
     hash.update(name);
     if (info.isSymbolicLink()) hash.update(`l:${await readlink(child)}`);
-    else hash.update(info.isDirectory() ? `d:${await sha256Dir(child)}` : `f:${await sha256File(child)}`);
+    else if (info.isDirectory()) {
+      const nested = await digestDir(child);
+      hash.update(`d:${nested.hash}`);
+      bytes += nested.bytes;
+    } else {
+      hash.update(`f:${await sha256File(child)}`);
+      bytes += info.size;
+    }
   }
-  return hash.digest("hex");
+  return { hash: hash.digest("hex"), bytes };
 }
 
 async function pathInfo(target: string): Promise<PathInfo> {
@@ -150,8 +160,11 @@ async function pathInfo(target: string): Promise<PathInfo> {
         size: info.size,
       };
     }
-    if (info.isDirectory()) return { kind: "dir", hash: await sha256Dir(target), mtimeMs: info.mtimeMs, size: info.size };
-    return { kind: "file", hash: await sha256File(target), mtimeMs: info.mtimeMs, size: info.size };
+    if (info.isDirectory()) {
+      const digest = await digestDir(target);
+      return { kind: "dir", hash: digest.hash, mtimeMs: info.mtimeMs, size: info.size, contentBytes: digest.bytes };
+    }
+    return { kind: "file", hash: await sha256File(target), mtimeMs: info.mtimeMs, size: info.size, contentBytes: info.size };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
     throw error;
@@ -1305,12 +1318,15 @@ async function reconcileDirectory(
 }
 
 /**
- * Discard guard for explicit whole-file resolutions (cave-5ax2): a
- * keep-canonical/recover-legacy choice that would replace a dramatically
- * larger copy with a much smaller one is almost always a mistake (a stale
- * writer recreated one side nearly empty). Require explicit confirmation
- * before the smaller copy wins. Both copies are already preserved in the
- * verified recovery bundle when this check runs.
+ * Discard guard for explicit keep-canonical/recover-legacy resolutions
+ * (cave-5ax2): a choice that would replace a dramatically larger copy with a
+ * much smaller one is almost always a mistake (a stale writer recreated one
+ * side nearly empty). Directories are guarded by their recursive content
+ * size, the same class of loss at directory granularity. Confirmation is
+ * pinned to the discarded content: the caller must echo the discardToken
+ * issued with the block, so a copy that changed after the user saw the sizes
+ * re-blocks instead of being destroyed unseen. Both copies are already
+ * preserved in the verified recovery bundle when this check runs.
  */
 const DISCARD_GUARD_RATIO = 8;
 const DISCARD_GUARD_MIN_BYTES = 4096;
@@ -1321,21 +1337,26 @@ function formatByteSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function guardedPathInfo(info: PathInfo): info is PathInfo & { contentBytes: number; hash: string } {
+  return (info.kind === "file" || info.kind === "dir") && typeof info.contentBytes === "number" && typeof info.hash === "string";
+}
+
 function discardConfirmation(
   action: "keep-canonical" | "recover-legacy",
   legacyInfo: PathInfo,
   canonicalInfo: PathInfo,
-): { keptBytes: number; discardedBytes: number; summary: string } | null {
-  if (legacyInfo.kind !== "file" || canonicalInfo.kind !== "file") return null;
-  const discarded = action === "recover-legacy" ? canonicalInfo.size : legacyInfo.size;
-  const kept = action === "recover-legacy" ? legacyInfo.size : canonicalInfo.size;
-  if (typeof discarded !== "number" || typeof kept !== "number") return null;
+): { keptBytes: number; discardedBytes: number; discardToken: string; summary: string } | null {
+  if (!guardedPathInfo(legacyInfo) || !guardedPathInfo(canonicalInfo)) return null;
+  const [discardedInfo, keptInfo] = action === "recover-legacy" ? [canonicalInfo, legacyInfo] : [legacyInfo, canonicalInfo];
+  const discarded = discardedInfo.contentBytes;
+  const kept = keptInfo.contentBytes;
   if (discarded < DISCARD_GUARD_MIN_BYTES || discarded < DISCARD_GUARD_RATIO * Math.max(kept, 1)) return null;
   const discardedSide = action === "recover-legacy" ? "canonical" : "legacy";
   const keptSide = action === "recover-legacy" ? "legacy" : "canonical";
   return {
     keptBytes: kept,
     discardedBytes: discarded,
+    discardToken: discardedInfo.hash,
     summary:
       `Blocked without confirmation: this would discard the ${discardedSide} copy ` +
       `(${formatByteSize(discarded)}) in favor of a much smaller ${keptSide} copy ` +
@@ -1487,10 +1508,16 @@ async function reconcileEntry(
 
   if (options.action === "keep-canonical" || options.action === "recover-legacy") {
     const confirmation = discardConfirmation(options.action, legacyInfo, canonicalInfo);
-    if (confirmation && options.confirmDiscard !== true) {
-      result.confirmationRequired.push({ legacy: entry.legacy, action: options.action, ...confirmation });
+    if (confirmation && options.confirmDiscard !== confirmation.discardToken) {
+      // A supplied-but-mismatched token means the discarded side changed after
+      // the user saw the block: re-block with fresh numbers instead of
+      // destroying bytes the user never reviewed.
+      const summary = options.confirmDiscard === undefined
+        ? confirmation.summary
+        : `${confirmation.summary} The copy to be discarded changed after the previous confirmation was issued; review the new sizes and confirm again.`;
+      result.confirmationRequired.push({ legacy: entry.legacy, action: options.action, ...confirmation, summary });
       journalEntry.decision = "unresolved";
-      journalEntry.summary = confirmation.summary;
+      journalEntry.summary = summary;
       journal.entries[entry.legacy] = journalEntry;
       result.skipped.push(entry.legacy);
       return;
@@ -1650,8 +1677,8 @@ export async function caveHomeReconciliationStatus(
       canonicalHash: canonicalInfo.hash,
       legacyMtimeMs: legacyInfo.mtimeMs,
       canonicalMtimeMs: canonicalInfo.mtimeMs,
-      legacySize: legacyInfo.size,
-      canonicalSize: canonicalInfo.size,
+      legacySize: legacyInfo.contentBytes ?? legacyInfo.size,
+      canonicalSize: canonicalInfo.contentBytes ?? canonicalInfo.size,
       state: isPending ? "pending" : "unresolved",
       summary: legacyInfo.kind === "symlink"
         ? "Legacy symlink is not a valid compatibility bridge and requires review."


### PR DESCRIPTION
Post-merge review of #3683 (cave-5ax2 discard guard) reproduced two gaps; this closes both (bead `cave-foc2`).

## 1. Directory conflicts bypassed the guard

`discardConfirmation()` required both sides to be `kind: "file"`, so `recover-legacy`/`keep-canonical` on a directory entry (`cave-conversations`, `cave-preferences.json.locks`) still destroyed the larger copy one-click — the incident class #3683 was written for, at directory granularity. The size fields also showed the directory *inode* size (~96 B) in the review UI.

- `digestDir` (né `sha256Dir`) now returns `{ hash, bytes }` — recursive content bytes.
- `PathInfo` gains `contentBytes` (file size, or recursive sum for dirs); the guard applies to any file/dir combination.
- Status `legacySize`/`canonicalSize` report content bytes, so the banner shows real directory sizes.

## 2. Confirms are now pinned to the content the user reviewed

A `confirmDiscard` retry bypassed the guard even if the discarded side changed between block and confirm (reviewer repro: rewrote canonical in the gap; the confirm silently installed the stale legacy over the new bytes).

- The block issues a `discardToken` = content hash of the discarded side.
- `confirmDiscard` is now that token (string); mismatch or absence re-blocks — a stale token returns fresh sizes, a new token, and a "changed after the previous confirmation" summary.
- API validates `confirm` as 64-hex sha256; the banner echoes the exact issued token and adopts the fresh one on re-block.

## Also

- Repointed the banner test's CSS pin at `src/styles/globals/desktop-chrome.css` — `.cave-migration-review` styles moved out of `app/globals.css` in #3576, which had left that suite red (pre-existing, verified failing at the parent commit).

## Verification

- `cave-home-migration-discard-guard.test.ts` extended: directory guard block→confirm, stale-token re-block (canonical untouched, fresh token differs), token-confirmed retries for both actions, balanced-size pass-through — green.
- All other migration suites (backup-recovery, json-merge, locks-takeover, status, status-recovery), route + banner pins: green.
- `pnpm typecheck`, `pnpm lint`: clean.
