### PR TITLE
feat(profiles): stretch profile cards to fill the page (cave-7lmp)

### DIFF
--- a/src/components/profile-card.test.ts
+++ b/src/components/profile-card.test.ts
@@ -80,4 +80,17 @@ describe("Profile card wiring (cave-ujbr)", () => {
       assert.match(css, new RegExp(`\\.pfc-cell\\[data-level="${level}"\\]`));
     }
   });
+
+  it("stretches the card to fill the page height and width (no 1200px island)", () => {
+    const css = readFileSync(new URL("../styles/profile-card.css", import.meta.url), "utf8");
+    // The page is a flex column so the card can absorb the remaining height…
+    assert.match(css, /\.pfc-page \{[^}]*display: flex;[^}]*flex-direction: column;/s);
+    // …and the card takes it, pinning the footer row to the card's bottom edge.
+    assert.match(css, /\.pfc-card \{[^}]*flex: 1;/s);
+    assert.match(css, /\.pfc-card \{[^}]*grid-template-rows: 1fr auto;/s);
+    // The metric panels absorb vertical growth inside the main column.
+    assert.match(css, /\.pfc-panels \{[^}]*flex: 1;/s);
+    // No fixed width caps anywhere — the card, topnav and callout track the page.
+    assert.doesNotMatch(css, /max-width: 1200px/);
+  });
 });

--- a/src/styles/profile-card.css
+++ b/src/styles/profile-card.css
@@ -22,6 +22,8 @@
   --pfc-mint-4: #83e3b4;
 
   min-height: 100%;
+  display: flex;
+  flex-direction: column;
   padding: clamp(12px, 3vw, 40px);
   background: var(--pfc-bg);
   color: var(--pfc-text);
@@ -47,8 +49,7 @@
 .pfc-topnav {
   display: flex;
   justify-content: space-between;
-  max-width: 1200px;
-  margin: 0 auto 10px;
+  margin: 0 0 10px;
 }
 
 .pfc-topnav-link {
@@ -66,8 +67,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  max-width: 1200px;
-  margin: 0 auto 10px;
+  margin: 0 0 10px;
   padding: var(--space-2) var(--space-3);
   border: 1px solid #4d3a1e;
   border-radius: 10px;
@@ -81,11 +81,14 @@
 .pfc-card {
   display: grid;
   grid-template-columns: minmax(220px, 280px) 1fr;
+  /* Fill the page: the rail/main row absorbs the height, the footer pins to
+     the card's bottom edge (max h + w, matching the human profile treatment). */
+  grid-template-rows: 1fr auto;
   grid-template-areas:
     "rail main"
     "foot foot";
-  max-width: 1200px;
-  margin: 0 auto;
+  flex: 1;
+  width: 100%;
   border: 1px solid var(--pfc-border);
   border-radius: 18px;
   background: var(--pfc-card);
@@ -312,6 +315,8 @@
 .pfc-panels {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  /* Absorb the card's vertical stretch; sparklines sink via margin-top: auto. */
+  flex: 1;
   border-bottom: 1px solid var(--pfc-border-soft);
 }
 .pfc-panel {
@@ -443,6 +448,7 @@
 @media (max-width: 840px) {
   .pfc-card {
     grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
     grid-template-areas:
       "rail"
       "main"


### PR DESCRIPTION
## What

The standalone profile pages — `/profile` (human) and `/dashboard/familiars/[id]/profile` (familiars) — rendered the Kaito-style stat card as a **1200px island** centered in the viewport with natural height. Per request, the card now stretches to **max height and width**, matching the fill-the-pane treatment the human profile gets in Settings.

## How

All in the shared `src/styles/profile-card.css` (only the two profile routes consume `.pfc-*`):

- `.pfc-page` becomes a flex column so the card can absorb the remaining height below the topnav.
- `.pfc-card` gets `flex: 1; width: 100%` and `grid-template-rows: 1fr auto` — the rail/main row takes the stretch, the footer pins to the card's bottom edge. The `max-width: 1200px; margin: 0 auto` cap is gone.
- `.pfc-topnav` / `.pfc-callout` lose their matching 1200px caps so edges align.
- `.pfc-panels` gets `flex: 1` to absorb vertical growth inside the main column (sparklines already sink via `margin-top: auto`; the rail chip likewise).
- Mobile (≤840px) stacking keeps `rail/main/foot` with `auto 1fr auto` rows.

## Verification

- New pin in `profile-card.test.ts` ("stretches the card to fill the page height and width") — failing-first, now green.
- `pnpm test:app` — 891 test files green; `pnpm typecheck` clean.
- Prod build served + Playwright at 1440×900: **both** routes fill 1304×788 (was 1200×677), footer bottom = card bottom. 480px mobile: stacking + 240px avatar cap intact.

| | before | after |
|---|---|---|
| card @1440×900 | 1200×677, centered island | 1304×788, fills the page, footer pinned |

Bead: cave-7lmp (surface confirmed with the user: standalone profile pages).