### PR TITLE
feat(github): shared Shiki singleton + review-thread diff syntax highlighting (cave-4nfu)

### DIFF
--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -52,18 +52,30 @@ assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the editor installs
 // The JSON import is a shared module singleton, and Shiki normalizes themes
 // IN PLACE (prepends a scope-less global tokenColors entry). moodColor must
 // skip scope-less entries instead of crashing every editor surface loaded
-// after a chat code block rendered, and message-bubble must hand Shiki a
-// clone, never the module instance (cave-h1hi).
+// after a chat code block rendered, and the app-wide Shiki singleton
+// (lib/shiki-highlighter, used by message-bubble + gh-diff-view) must hand
+// Shiki a clone, never the module instance (cave-h1hi).
 assert.match(
   theme,
   /const scopes = Array\.isArray\(tc\.scope\) \? tc\.scope : typeof tc\.scope === "string" \? \[tc\.scope\] : \[\]/,
   "moodColor guards scope-less tokenColors entries (valid TextMate globals; Shiki injects one)",
 );
+const highlighterSource = await readFile(new URL("../lib/shiki-highlighter.ts", import.meta.url), "utf8");
+assert.match(
+  highlighterSource,
+  /themes: \[structuredClone\(moodCTheme\)/,
+  "Shiki receives a clone of the theme, never the shared JSON module instance",
+);
 const bubbleSource = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
 assert.match(
   bubbleSource,
-  /themes: \[structuredClone\(moodCTheme\)/,
-  "Shiki receives a clone of the theme, never the shared JSON module instance",
+  /import \{ getShikiHighlighter \} from "@\/lib\/shiki-highlighter"/,
+  "message-bubble colors code through the shared app-wide Shiki singleton",
+);
+assert.doesNotMatch(
+  bubbleSource,
+  /createHighlighter\(/,
+  "message-bubble must not create its own Shiki instance (the shared singleton owns the clone fix)",
 );
 // The code surface stays dark in EVERY app theme (light modes included), so
 // editor text/gutter inks must be fixed mood-c inks, not theme text tokens

--- a/src/components/gh-diff-view.tsx
+++ b/src/components/gh-diff-view.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { parseDiff, diffStats, diffLineClass } from "@/lib/gh-diff";
+import { useEffect, useMemo, useState } from "react";
+import type { ThemedToken } from "shiki";
+import { parseDiff, diffStats, diffLineClass, type DiffLine } from "@/lib/gh-diff";
+import { resolveShikiLang } from "@/lib/code-lang";
+import { getShikiHighlighter } from "@/lib/shiki-highlighter";
 
 /**
  * Render a GitHub unified-diff hunk as a colorized, line-numbered diff table.
@@ -10,25 +13,64 @@ import { parseDiff, diffStats, diffLineClass } from "@/lib/gh-diff";
  * text). Additions are green, deletions red, hunk headers tinted; old/new line
  * numbers sit in gutter columns. Long hunks collapse to the trailing
  * `previewLines` (the context nearest a review comment) with an expand toggle.
+ *
+ * When `path` resolves to a known grammar (via its file extension), line
+ * contents are syntax-highlighted with the shared Shiki singleton — the
+ * +/-/context marker stays in a separate span so the diff coloring and the
+ * token coloring compose. Until Shiki resolves (or when the language is
+ * unknown) lines render as plain text, so nothing blocks on the WASM load.
+ * Long lines wrap (no horizontal scrolling) — see .gh-diff__line CSS.
  */
 export function DiffHunk({
   hunk,
+  path,
   previewLines = 6,
   className,
 }: {
   hunk: string;
+  /** File path of the diff — its extension picks the Shiki grammar. */
+  path?: string | null;
   previewLines?: number;
   className?: string;
 }) {
   const lines = useMemo(() => parseDiff(hunk), [hunk]);
   const stats = useMemo(() => diffStats(lines), [lines]);
   const [expanded, setExpanded] = useState(false);
+  const lang = resolveShikiLang(path ? path.split(".").pop() : null);
+  // tokens[i] = Shiki tokens for lines[i]'s content (marker stripped); null
+  // until the async highlight lands or when the grammar is unknown.
+  const [tokens, setTokens] = useState<ThemedToken[][] | null>(null);
+
+  useEffect(() => {
+    setTokens(null);
+    if (lang === "text" || lines.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const hl = await getShikiHighlighter();
+        // Highlight the hunk as one document (meta rows blanked) so tokens
+        // stay line-aligned with the parsed rows.
+        const code = lines
+          .map((l) => (l.type === "meta" ? "" : splitMarker(l.text).content))
+          .join("\n");
+        const result = hl.codeToTokens(code, { lang, theme: "mood-c-dark" });
+        if (!cancelled) setTokens(result.tokens);
+      } catch (err) {
+        console.error("[DiffHunk] Shiki highlight failed", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [lines, lang]);
 
   if (lines.length === 0) return null;
 
   const collapsible = lines.length > previewLines;
   const shown = expanded || !collapsible ? lines : lines.slice(-previewLines);
   const hidden = lines.length - shown.length;
+  // Index of shown[0] within lines, so collapsed views index tokens correctly.
+  const offset = lines.length - shown.length;
 
   return (
     <div className={`gh-diff gh-diff--hunk ${className ?? ""}`}>
@@ -53,17 +95,48 @@ export function DiffHunk({
       </div>
       <div className="gh-diff__body" role="table" aria-label="Diff">
         {shown.map((line, i) => (
-          <div key={i} className={diffLineClass(line.type)} role="row">
+          <div key={offset + i} className={diffLineClass(line.type)} role="row">
             <span className="gh-diff__no gh-diff__no--old" aria-hidden>
               {line.oldNo ?? ""}
             </span>
             <span className="gh-diff__no gh-diff__no--new" aria-hidden>
               {line.newNo ?? ""}
             </span>
-            <code className="gh-diff__code">{line.text.length > 0 ? line.text : "​"}</code>
+            <code className="gh-diff__code">{renderLine(line, tokens?.[offset + i])}</code>
           </div>
         ))}
       </div>
     </div>
+  );
+}
+
+/** Split a diff line into its +/-/space marker and the code content. */
+function splitMarker(text: string): { marker: string; content: string } {
+  return /^[+\- ]/.test(text)
+    ? { marker: text[0], content: text.slice(1) }
+    : { marker: "", content: text };
+}
+
+function renderLine(line: DiffLine, lineTokens: ThemedToken[] | undefined) {
+  // Zero-width space keeps blank rows at full height.
+  if (line.type === "meta") return line.text.length > 0 ? line.text : "\u200b";
+  const { marker, content } = splitMarker(line.text);
+  return (
+    <>
+      {marker && (
+        <span className="gh-diff__marker" aria-hidden>
+          {marker}
+        </span>
+      )}
+      {lineTokens && content.length > 0
+        ? lineTokens.map((t, j) => (
+            <span key={j} style={t.color ? { color: t.color } : undefined}>
+              {t.content}
+            </span>
+          ))
+        : content.length > 0
+          ? content
+          : "\u200b"}
+    </>
   );
 }

--- a/src/components/gh-diff-view.tsx
+++ b/src/components/gh-diff-view.tsx
@@ -36,7 +36,7 @@ export function DiffHunk({
   const lines = useMemo(() => parseDiff(hunk), [hunk]);
   const stats = useMemo(() => diffStats(lines), [lines]);
   const [expanded, setExpanded] = useState(false);
-  const lang = resolveShikiLang(path ? path.split(".").pop() : null);
+  const lang = resolveShikiLang(pathLangToken(path));
   // tokens[i] = Shiki tokens for lines[i]'s content (marker stripped); null
   // until the async highlight lands or when the grammar is unknown.
   const [tokens, setTokens] = useState<ThemedToken[][] | null>(null);
@@ -115,6 +115,19 @@ function splitMarker(text: string): { marker: string; content: string } {
   return /^[+\- ]/.test(text)
     ? { marker: text[0], content: text.slice(1) }
     : { marker: "", content: text };
+}
+
+/**
+ * Grammar token for a file path: the basename's extension when it has one,
+ * otherwise the bare basename itself (so extensionless-but-known names like
+ * `infra/Dockerfile` still resolve — resolveShikiLang owns the mapping).
+ */
+function pathLangToken(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const base = path.split("/").pop() ?? "";
+  if (!base) return null;
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot + 1) : base;
 }
 
 function renderLine(line: DiffLine, lineTokens: ThemedToken[] | undefined) {

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1405,7 +1405,7 @@ function GitHubComments({
                     )}
                   </div>
                   {thread.diffHunk && (
-                    <DiffHunk hunk={thread.diffHunk} previewLines={4} className="gh-thread-diff" />
+                    <DiffHunk hunk={thread.diffHunk} path={thread.path} previewLines={4} className="gh-thread-diff" />
                   )}
                   {thread.comments.map((c) => (
                     <div key={c.id} className="gh-comment gh-comment--inline">

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -35,15 +35,14 @@ import { createPortal } from "react-dom";
 import { parse } from "@create-markdown/core";
 import type { Block } from "@create-markdown/core";
 import type { PreviewPlugin } from "@create-markdown/preview";
-import type { Highlighter } from "shiki";
-import moodCTheme from "@/styles/shiki/mood-c-dark.json";
+import { getShikiHighlighter } from "@/lib/shiki-highlighter";
 import { Icon } from "@/lib/icon";
 import { classifyDiffLines, parseFenceInfo, type DiffLine } from "@/lib/message-code-fences";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
-import { SHIKI_LANGS, resolveShikiLang, diffContentLang } from "@/lib/code-lang";
+import { resolveShikiLang, diffContentLang } from "@/lib/code-lang";
 import { unwrapPreviewShell } from "@/lib/markdown-preview-shell";
 import {
   cacheRenderedMarkdown as renderCacheSet,
@@ -54,15 +53,6 @@ import {
 import { FileLinkResolverContext, useWireCopyButtons } from "./message-dom-wiring";
 export { FileLinkResolverContext } from "./message-dom-wiring";
 export type { FileLinkResolver } from "./message-dom-wiring";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-// The bundled grammar list lives in code-lang.ts alongside the
-// extension→grammar resolver, so the highlighter's loaded langs and the
-// resolution table can never drift apart.
-const LANGS = SHIKI_LANGS;
 
 // ---------------------------------------------------------------------------
 // Timestamp formatting
@@ -81,27 +71,10 @@ export function fmtBubbleTime(iso?: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Shiki singleton — lazy, client-only
+// Shiki singleton — lazy, client-only (shared app-wide via lib/shiki-highlighter)
 // ---------------------------------------------------------------------------
 
-let highlighterPromise: Promise<Highlighter> | null = null;
-
-function getHighlighter(): Promise<Highlighter> {
-  if (!highlighterPromise) {
-    highlighterPromise = (async () => {
-      const { createHighlighter } = await import("shiki");
-      return createHighlighter({
-        // Shiki normalizes themes IN PLACE (e.g. prepends a scope-less global
-        // tokenColors entry). The JSON import is a shared module singleton —
-        // code-editor-theme.ts reads the same object — so hand Shiki a clone,
-        // never the module instance (cave-h1hi).
-        themes: [structuredClone(moodCTheme) as Parameters<typeof createHighlighter>[0]["themes"][number]],
-        langs: [...LANGS],
-      });
-    })();
-  }
-  return highlighterPromise;
-}
+const getHighlighter = getShikiHighlighter;
 
 // ---------------------------------------------------------------------------
 // Parse fence info → { lang, filename }

--- a/src/lib/gh-diff.test.ts
+++ b/src/lib/gh-diff.test.ts
@@ -51,10 +51,47 @@ assert.match(diffLineClass("context"), /gh-diff__line--ctx/, "context class");
 const ghView = readFileSync(new URL("../components/github-view.tsx", import.meta.url), "utf8");
 assert.match(ghView, /import \{ DiffHunk \} from "@\/components\/gh-diff-view"/, "github-view imports DiffHunk");
 assert.match(ghView, /<DiffHunk hunk=\{thread\.diffHunk\}/, "review threads render the diff via DiffHunk, not a raw <pre>");
+assert.match(ghView, /<DiffHunk hunk=\{thread\.diffHunk\} path=\{thread\.path\}/, "review threads pass the file path so the diff can pick a Shiki grammar");
 assert.doesNotMatch(ghView, /thread\.diffHunk\.split\("\\n"\)\.slice\(-4\)/, "the old raw last-4-lines <pre> is gone");
 
 const diffView = readFileSync(new URL("../components/gh-diff-view.tsx", import.meta.url), "utf8");
 assert.match(diffView, /export function DiffHunk/, "exports DiffHunk");
 assert.match(diffView, /parseDiff/, "DiffHunk parses the hunk");
+
+// ── Wiring: syntax highlighting rides the shared app-wide Shiki singleton ─────
+assert.match(
+  diffView,
+  /import \{ getShikiHighlighter \} from "@\/lib\/shiki-highlighter"/,
+  "DiffHunk highlights through the shared Shiki singleton (no second createHighlighter instance)",
+);
+assert.doesNotMatch(diffView, /createHighlighter\(/, "DiffHunk must not create its own Shiki instance");
+assert.match(
+  diffView,
+  /resolveShikiLang\(path \? path\.split\("\."\)\.pop\(\) : null\)/,
+  "the diff grammar resolves from the file path's extension",
+);
+assert.match(
+  diffView,
+  /if \(lang === "text" \|\| lines\.length === 0\) return;/,
+  "unknown grammars skip the highlight pass entirely (plain text render, no WASM load)",
+);
+assert.match(
+  diffView,
+  /l\.type === "meta" \? "" : splitMarker\(l\.text\)\.content/,
+  "hunk is highlighted as one document with meta rows blanked so tokens stay line-aligned",
+);
+assert.match(
+  diffView,
+  /className="gh-diff__marker" aria-hidden/,
+  "the +/-/context marker renders in its own non-copyable span so diff and token coloring compose",
+);
+assert.match(diffView, /if \(!cancelled\) setTokens\(result\.tokens\);/, "async highlight lands behind a cancelled guard");
+
+const bubbleView = readFileSync(new URL("../components/message-bubble.tsx", import.meta.url), "utf8");
+assert.match(
+  bubbleView,
+  /import \{ getShikiHighlighter \} from "@\/lib\/shiki-highlighter"/,
+  "chat code fences share the same Shiki singleton as the diff renderer",
+);
 
 console.log("gh-diff.test.ts: ok");

--- a/src/lib/gh-diff.test.ts
+++ b/src/lib/gh-diff.test.ts
@@ -67,8 +67,18 @@ assert.match(
 assert.doesNotMatch(diffView, /createHighlighter\(/, "DiffHunk must not create its own Shiki instance");
 assert.match(
   diffView,
-  /resolveShikiLang\(path \? path\.split\("\."\)\.pop\(\) : null\)/,
-  "the diff grammar resolves from the file path's extension",
+  /resolveShikiLang\(pathLangToken\(path\)\)/,
+  "the diff grammar resolves from the file path via the basename-aware token helper",
+);
+assert.match(
+  diffView,
+  /const base = path\.split\("\/"\)\.pop\(\) \?\? "";/,
+  "pathLangToken extracts the basename first so extensionless names in subdirs (infra/Dockerfile) still resolve",
+);
+assert.match(
+  diffView,
+  /return dot > 0 \? base\.slice\(dot \+ 1\) : base;/,
+  "pathLangToken falls back to the bare basename when there is no extension",
 );
 assert.match(
   diffView,

--- a/src/lib/shiki-highlighter.ts
+++ b/src/lib/shiki-highlighter.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// shiki-highlighter — the app-wide lazy Shiki singleton
+// ---------------------------------------------------------------------------
+//
+// One highlighter instance (theme + full grammar set from SHIKI_LANGS) shared
+// by every surface that colors code: chat code fences (message-bubble.tsx)
+// and the GitHub review-thread diff renderer (gh-diff-view.tsx). Shiki + its
+// WASM engine are heavy, so the import is dynamic and the instance is created
+// once, on first use, client-side only.
+
+import type { Highlighter } from "shiki";
+import moodCTheme from "@/styles/shiki/mood-c-dark.json";
+import { SHIKI_LANGS } from "@/lib/code-lang";
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+export function getShikiHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const { createHighlighter } = await import("shiki");
+      return createHighlighter({
+        // Shiki normalizes themes IN PLACE (e.g. prepends a scope-less global
+        // tokenColors entry). The JSON import is a shared module singleton —
+        // code-editor-theme.ts reads the same object — so hand Shiki a clone,
+        // never the module instance (cave-h1hi).
+        themes: [structuredClone(moodCTheme) as Parameters<typeof createHighlighter>[0]["themes"][number]],
+        langs: [...SHIKI_LANGS],
+      });
+    })();
+  }
+  return highlighterPromise;
+}

--- a/src/styles/board/github-detail.css
+++ b/src/styles/board/github-detail.css
@@ -329,11 +329,12 @@
   font:inherit; font-size:10.5px; color:var(--text-muted); border-radius:5px;
 }
 .gh-diff__expand:hover { color:var(--text-primary); background:var(--bg-hover); }
-.gh-diff__body { overflow-x:auto; }
+.gh-diff__body { overflow-x:hidden; }
 .gh-diff__line {
   display:grid;
   grid-template-columns:var(--gh-diff-gutter, 2.6em) var(--gh-diff-gutter, 2.6em) 1fr;
-  white-space:pre;
+  /* Wrap long code lines instead of forcing horizontal scroll. */
+  white-space:pre-wrap;
 }
 .gh-diff__no {
   padding:0 6px; text-align:right; user-select:none;
@@ -342,7 +343,11 @@
 }
 /* Color set on the line so it inherits to the component's <code> child AND
    applies to the markdown path where text sits directly in the line span. */
-.gh-diff__code { padding:0 8px; color:inherit; background:none; }
+.gh-diff__code {
+  padding:0 var(--space-2); color:inherit; background:none;
+  min-width:0; white-space:pre-wrap; overflow-wrap:anywhere;
+}
+.gh-diff__marker { user-select:none; opacity:0.75; }
 .gh-diff__line--ctx { color:var(--text-muted); }
 .gh-diff__line--add { background:color-mix(in oklch, var(--color-success, #3fb950) 14%, transparent); color:var(--text-primary); }
 .gh-diff__line--del { background:color-mix(in oklch, var(--color-danger, #f85149) 14%, transparent); color:var(--text-primary); }


### PR DESCRIPTION
## Summary

Re-lands the shiki-highlighter extraction archived in the 2026-07-09 stash triage (bead **cave-4nfu**), rebased onto current main.

- **New `src/lib/shiki-highlighter.ts`** — one lazy app-wide Shiki singleton (theme + full `SHIKI_LANGS` grammar set), preserving main's cave-h1hi `structuredClone(moodCTheme)` fix that postdates the stash.
- **`message-bubble.tsx`** — drops its inline `createHighlighter` for the shared `getShikiHighlighter`; chat fences and the diff renderer can no longer double-load the WASM engine.
- **`gh-diff-view.tsx`** — `DiffHunk` gains token-level syntax highlighting: `path`'s extension picks the grammar, the hunk is highlighted as one document with meta rows blanked so tokens stay line-aligned, and the +/-/context marker sits in its own non-copyable `.gh-diff__marker` span so diff-strip coloring and token coloring compose. Unknown grammars skip the pass (plain render, no WASM load). Long lines wrap (`pre-wrap` + `overflow-wrap:anywhere`) instead of forcing horizontal scroll.
- **`github-view.tsx`** — review threads pass `thread.path` to `DiffHunk`.
- Pins: `gh-diff.test.ts` wiring section extended; `code-editor.test.ts` cave-h1hi clone pin follows the singleton into the lib (+ message-bubble must-not-own-an-instance pins).

**Deliberately not re-landed** from the stash: the chat-view `cancelSend` hunk — superseded by the S6 stream-health rework (cancelSend now issues an explicit `/api/chat/stop`; the stash's local-settle version would regress it).

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm test:app` (884 files) green
- Prod build within bundle budgets (design-token drift gate satisfied via `tokenize-css.mjs`)
- Runtime probe: `codeToTokens` line alignment (blank lines → empty token arrays, meta rows blank)
- Real-app Playwright probe: `pre.shiki mood-c-dark` blocks with 5,250 inline-colored token spans through the shared singleton; zero page errors

Closes cave-4nfu.
