### PR TITLE
fix(theme): normalize unprefixed custom-theme keys in applyTokenOverride's live apply (cave-7eno)

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -481,8 +481,8 @@ assert.match(
 );
 assert.match(
   settings,
-  /for \(const \[name, value\] of Object\.entries\(group\)\) \{\s*\n\s*html\.style\.setProperty\(name, value\);[\s\S]{0,200}html\.setAttribute\("data-theme", "custom"\)/,
-  "the whole group is applied live before the data-theme flip so the selected theme's look survives",
+  /for \(const \[name, value\] of Object\.entries\(group\)\) \{\s*\n\s*html\.style\.setProperty\(name\.startsWith\("--"\) \? name : `--\$\{name\}`, value\);[\s\S]{0,200}html\.setAttribute\("data-theme", "custom"\)/,
+  "the whole group is applied live with keys normalized to custom properties — raw tweakcn keys like \"background\" must never set real CSS properties on <html> (cave-7eno) — before the data-theme flip so the selected theme's look survives",
 );
 assert.match(
   settings,

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -2065,8 +2065,11 @@ function applyTokenOverride(key: string, hex: string, mode: Mode) {
   // Live-apply the whole group — not just the edited key — so the selected
   // theme's look survives the data-theme flip. Boot (theme-init.js) replays
   // this exact group, so what you see now is what a reload restores.
+  // Normalize to custom-property names: imported tweakcn groups keep raw keys
+  // ("background", "radius"), and a raw setProperty would set the real CSS
+  // property inline on <html>, which no cleanup path removes (cave-7eno).
   for (const [name, value] of Object.entries(group)) {
-    html.style.setProperty(name, value);
+    html.style.setProperty(name.startsWith("--") ? name : `--${name}`, value);
   }
   html.setAttribute("data-theme", "custom");
 }


### PR DESCRIPTION
Closes the unresolved `copilot-pull-request-reviewer` thread on #3686 (bead `cave-7eno`). Verified real by a post-merge deep review — the bug predates #3686 but lives in the function that PR rewrote.

## Bug

`CustomThemeData` group keys may omit the leading `--`: `CSS_VAR_RE` (preferences-schema.ts) makes the prefix optional, and tweakcn imports store raw keys (`background`, `card`, `radius`, …) verbatim. `applyTokenOverride`'s live-apply loop was the **only** applier passing keys to `setProperty` unnormalized — `applyCustomVars`, `theme-runtime` `cssName()`, and `appearance-restore` all normalize.

**Repro chain:** import a tweakcn theme → edit any token in Settings → Colors → `setProperty("background", "oklch(…)")` sets the *real* CSS `background` property inline on `<html>`. `foundations.css` styles html/body via `var(--bg-base)`, so the stray inline literal wins — and survives every preset switch and mode flip until a full reload, because `clearCustomThemeVariables`/`applyThemeToRoot` normalize to `--background` before `removeProperty` and never remove the raw one.

## Fix

One-line normalization in the loop, matching the sibling appliers:

```ts
html.style.setProperty(name.startsWith("--") ? name : `--${name}`, value);
```

Covers both commit paths (popover close and unmount) — they funnel through the same function. `settings-appearance.test.ts` pin updated to the normalized form so a regression fails the suite.

## Verification

- `settings-appearance.test.ts` green; `pnpm typecheck` clean; eslint on the touched component clean.
- Review agent confirmed the four #3686 fixes are otherwise sound; this was the only outstanding finding.
