### PR TITLE
feat(chat): split footer context pill into project · model · branch chips (cave-g21f)

### DIFF
--- a/docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
+++ b/docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
@@ -1,0 +1,113 @@
+# Chat footer: split context pill into project · model · branch chips
+
+- **Date:** 2026-07-22
+- **Bead:** cave-g21f
+- **Status:** approved (design review in chat, 2026-07-22)
+
+## Problem
+
+The chat composer's footer band folds project, model, and git context into one
+combined `ComposerContextPill` ("Project · Model · branch"). Clicking it opens
+a hub popover that chains to the real pickers — two clicks for every change,
+and the combined label is ambiguous. The home composer already solved this
+(2026-07-22 refinement, PR #3670): its footer toolbar renders project and
+model as two separate, individually labelled chips via the pill's
+`splitControls` mode. Chat should match, and git context should keep a
+first-class footer affordance.
+
+## Decision
+
+Extend the split-chip mode to be the **only** rendering of the context
+control, add a **branch chip** for repo-rooted chats, and flip the chat footer
+band to it. Approved as "Approach A" over (B) remounting the legacy
+ProjectPicker/runtime-chip/git-chip cluster and (C) a partial split.
+
+## Design
+
+### 1. Component — `src/components/composer-context-pill.tsx`
+
+- The combined-pill + hub-popover rendering retires (dead code once chat
+  flips). The chips rendering becomes unconditional; the `splitControls` prop
+  is removed.
+- The component is renamed `ComposerContextChips`. The file name stays
+  `composer-context-pill.tsx` to keep source-pin test paths stable; the header
+  comment is rewritten to the new grammar.
+- Shared exports used by `ComposerActionsMenu` survive unchanged:
+  `useComposerContextActions`, `ComposerContextPickers`, and
+  `ComposerContextView`. `ComposerContextActionRows` is mounted only by the
+  hub, so it retires with it (source-pin tests in `composer-actions-menu`,
+  `composer-runtime-chip`, `composer-git-chip`, and `project-picker` test
+  files update accordingly).
+- **New branch chip**, rendered only when `context.hasGit` (requires
+  `projectRoot`; home passes none, so home renders exactly its current two
+  chips):
+  - Anatomy: `ph:git-branch` icon · branch name · `+N` dirty-count suffix when
+    `count > 0` · worktree name suffix when present. Ellipsizes.
+  - `aria-label`: `Branch: <branch> — switch branch or create a worktree`.
+  - Click opens `GitBranchMenuPopover` anchored to the chip (one click to the
+    branch list).
+- Model chip stays disabled while streaming (`modelDisabled`), project chip
+  while `disabled` — both as today.
+
+### 2. Git popover extras — `src/components/composer-git-chip.tsx`
+
+`GitBranchMenuPopover` gains optional props so the PR link and "Open Git
+changes" rows (previously hub-only) survive the hub's removal:
+
+- `pr?: BranchPr | null` + `onOpenPr?: (url: string) => void` — renders a
+  separator and an "Open PR #N" row when present.
+- `onOpenChanges?: () => void` — renders an "Open Git changes" row.
+
+`ComposerContextPickers` passes these from the existing context
+(`context.pr`, `config.onOpenUrl`, the `cave:changes-open` dispatch), so both
+the footer branch chip and the actions-menu "Branch…" flow get the same
+popover contents. When the props are absent the popover renders exactly as
+today.
+
+### 3. Chat wiring — `src/components/chat-view.tsx`
+
+The footer band swaps `<ComposerContextPill …>` for
+`<ComposerContextChips …>` with identical props (including
+`projectRoot={activeProjectRoot}` and `onOpenUrl`). The linked-work strip
+stays on the right; no state or handler changes.
+
+### 4. CSS
+
+- `.cave-context-chip*` rules move from
+  `src/styles/home-composer/landing-composer.css` (home-scoped) into
+  `src/styles/cave-composer.css`, which the component already imports — chat
+  gets the styles without loading home sheets. Home-only toolbar layout rules
+  stay in `landing-composer.css`.
+- `.cave-context-pill*` rules (including `__hub`) retire with the hub.
+- Fit: chips keep `min-width: 0` + ellipsis; the footer band's left cluster
+  allows shrinking so three chips coexist with the linked-work strip. On
+  mobile (≤767px) the linked strip already hides; chips truncate. The
+  home-specific `max-width: 42%` cap is relaxed to a fixed `max-width` (e.g.
+  `13rem`) that works for two or three chips.
+
+## Error handling
+
+No new async paths. `GitBranchMenuPopover` keeps its existing fetch/error
+states; the PR row renders only when `useBranchPr` produced one; git-less
+chats (no project, non-repo root) render no branch chip.
+
+## Testing
+
+- Rewrite `src/components/chat-composer-footer-band.test.ts` pins: the band
+  leads with the three-chip cluster (project, model, branch-when-git); the
+  combined pill, hub popover, and `.cave-context-pill` CSS are gone;
+  `.cave-context-chip` lives in `cave-composer.css`; the popover-extras wiring
+  exists.
+- Update any `home-composer*` test pins referencing `splitControls`.
+- Extend `composer-git-chip.test.ts` pins for the optional popover rows.
+- Validate: targeted `node --experimental-strip-types --test` on the touched
+  test files (with the CSS facade hook where globals are read), then
+  `pnpm typecheck`; full `pnpm test:app` before PR.
+
+## Out of scope
+
+- The `ComposerActionsMenu` context-group duplication (2026-07-21 "both"
+  reconciliation) stays as is.
+- Home composer visuals beyond the shared-CSS move.
+- The legacy `ComposerGitChip` component (unused by these surfaces) is not
+  redesigned here.

--- a/docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
+++ b/docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
@@ -100,6 +100,9 @@ chats (no project, non-repo root) render no branch chip.
   exists.
 - Update any `home-composer*` test pins referencing `splitControls`.
 - Extend `composer-git-chip.test.ts` pins for the optional popover rows.
+- Update `tests/composer-runtime-chip.spec.ts` (Playwright, required CI check):
+  it selects the hub pill by aria-label and clicks the hub's Model row — it
+  must drive the model chip directly instead.
 - Validate: targeted `node --experimental-strip-types --test` on the touched
   test files (with the CSS facade hook where globals are read), then
   `pnpm typecheck`; full `pnpm test:app` before PR.

--- a/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
+++ b/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
@@ -1,0 +1,1025 @@
+# Chat Footer Split Context Chips — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the chat composer footer's combined "Project · Model · branch" pill with three separate chips (project · model · branch), shared with the home composer's existing split grammar.
+
+**Architecture:** `ComposerContextPill` becomes `ComposerContextChips` — the split-chip rendering is the only mode; the hub popover and `ComposerContextActionRows` retire. A new branch chip (repo-rooted chats only) opens `GitBranchMenuPopover`, which gains optional "Open PR #N" / "Open Git changes" footer rows so the hub's git actions survive. `.cave-context-chip` CSS moves from home-scoped `landing-composer.css` to shared `cave-composer.css`.
+
+**Tech Stack:** Next.js/React (TSX), plain CSS token sheets, node:test source-pin tests (`--experimental-strip-types`), Playwright e2e.
+
+**Spec:** `docs/specs/2026-07-22-chat-footer-split-context-chips-design.md` · **Bead:** cave-g21f · **Worktree:** `.worktrees/feat-chat-footer-split-chips` (branch `feat/chat-footer-split-chips`)
+
+**Repo context an engineer needs:**
+- Tests here are mostly *source pins*: they `readFileSync` a component and regex-assert its grammar. When a design decision changes, the pins are rewritten to describe the new grammar — update them deliberately, never loosen them to `.*`.
+- Targeted test run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test <files…>` from the worktree root. Full suite: `pnpm test:app`. Types: `pnpm typecheck`.
+- `main` is protected; land via PR with green `Frontend build`, `Rust check`, `CodeQL`, `E2E (Playwright)`. Sign commits (`-S`). Push after every commit.
+- All files below are relative to the worktree root.
+
+---
+
+### Task 1: GitBranchMenuPopover gains optional PR + Git-changes rows
+
+**Files:**
+- Modify: `src/components/composer-git-chip.tsx:103-117` (props), `:294-308` (rows)
+- Test: `src/components/composer-git-chip.test.ts`
+
+- [ ] **Step 1: Add failing pins**
+
+Append to `src/components/composer-git-chip.test.ts` just above the final `console.log` line:
+
+```ts
+// ── The branch menu carries PR + changes rows (post-hub grammar, cave-g21f) ──
+// The footer's branch chip opens this menu directly; the PR link and the
+// Git-changes drill-through that used to live in the pill's hub ride along as
+// optional footer rows so nothing regresses.
+assert.match(
+  chip,
+  /pr\?: BranchPr \| null;[\s\S]*?onOpenPr\?: \(url: string\) => void;[\s\S]*?onOpenChanges\?: \(\) => void;/,
+  "the branch menu takes optional PR/changes rows so the footer chip keeps hub parity",
+);
+assert.match(
+  chip,
+  /\{pr \|\| onOpenChanges \? <PopoverSeparator \/> : null\}/,
+  "the extra rows sit behind a separator and render only when provided",
+);
+assert.match(
+  chip,
+  /closeMenu\(\);\s*\n\s*onOpenPr\?\.\(pr\.url\);[\s\S]{0,120}?Open PR #\{pr\.number\}/,
+  "the PR row closes the menu and defers to the host's URL opener",
+);
+assert.match(
+  chip,
+  /closeMenu\(\);\s*\n\s*onOpenChanges\(\);[\s\S]{0,120}?Open Git changes/,
+  "the changes row closes the menu and fires the host's drill-through",
+);
+```
+
+- [ ] **Step 2: Run to verify the new pins fail**
+
+```bash
+cd .worktrees/feat-chat-footer-split-chips
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test src/components/composer-git-chip.test.ts
+```
+Expected: FAIL on "the branch menu takes optional PR/changes rows…" (the earlier pins still pass).
+
+- [ ] **Step 3: Implement the props**
+
+In `src/components/composer-git-chip.tsx`, extend the `GitBranchMenuPopover` signature (lines 103-117):
+
+```tsx
+export function GitBranchMenuPopover({
+  open,
+  onOpenChange,
+  anchorRef,
+  projectRoot,
+  onSwitched,
+  pr,
+  onOpenPr,
+  onOpenChanges,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  /** Repo root the menu operates on (undefined disables everything). */
+  projectRoot: string | undefined;
+  /** Called after a successful branch switch (e.g. reload the status poll). */
+  onSwitched?: () => void;
+  /** Optional footer rows (post-hub grammar, cave-g21f): the branch's PR… */
+  pr?: BranchPr | null;
+  /** …opened via the host's URL handler… */
+  onOpenPr?: (url: string) => void;
+  /** …and the Git-changes drill-through. */
+  onOpenChanges?: () => void;
+}) {
+```
+
+- [ ] **Step 4: Implement the rows**
+
+Still in `composer-git-chip.tsx`, immediately after the `creating ? (form) : (New worktree… PopoverItem)` conditional closes (after line ~303, before the `{menuError ? …}` block):
+
+```tsx
+        {pr || onOpenChanges ? <PopoverSeparator /> : null}
+        {pr ? (
+          <PopoverItem
+            icon="ph:git-pull-request"
+            title={`Open PR #${pr.number} (${pr.isDraft ? "draft" : pr.state.toLowerCase()})`}
+            onSelect={() => {
+              closeMenu();
+              onOpenPr?.(pr.url);
+            }}
+          >
+            Open PR #{pr.number}
+          </PopoverItem>
+        ) : null}
+        {onOpenChanges ? (
+          <PopoverItem
+            icon="ph:git-diff"
+            onSelect={() => {
+              closeMenu();
+              onOpenChanges();
+            }}
+          >
+            Open Git changes
+          </PopoverItem>
+        ) : null}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test src/components/composer-git-chip.test.ts
+```
+Expected: PASS (`composer-git-chip.test.ts: ok`).
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add src/components/composer-git-chip.tsx src/components/composer-git-chip.test.ts
+git commit -S -m "feat(composer): optional PR + Git-changes rows in the branch menu (cave-g21f)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin feat/chat-footer-split-chips
+```
+
+---
+
+### Task 2: Chips-only context component + chat/home rewiring + CSS move + pin updates
+
+This is one atomic commit: the component rename breaks every consumer and pin at once, so all of it moves together. Steps are ordered so the band test acts as the failing spec.
+
+**Files:**
+- Modify: `src/components/composer-context-pill.tsx` (full rewrite below)
+- Modify: `src/components/chat-view.tsx:72` (import), `:5903-5928` (band)
+- Modify: `src/components/home-composer.tsx:55` (import), `:1087-1117` (band)
+- Modify: `src/components/composer-plus-menu.tsx:48` (comment only)
+- Modify: `src/styles/cave-composer.css:963-1019` (pill → chips), `:1080-1084` (mobile)
+- Modify: `src/styles/home-composer/landing-composer.css:301-339` (delete moved rules)
+- Test (rewrite): `src/components/chat-composer-footer-band.test.ts`
+- Test (pin updates): `composer-runtime-chip.test.ts`, `composer-git-chip.test.ts`, `project-picker.test.ts`, `composer-actions-menu.test.ts`, `chat-view-first-class.test.ts`, `chat-view-polish-header-composer.test.ts`, `chat-header-row.test.ts`, `composer-density.test.ts`, `home-composer.test.ts`, `home-composer-polish.test.ts`
+
+- [ ] **Step 1: Rewrite the band test as the failing spec**
+
+Replace the sections of `src/components/chat-composer-footer-band.test.ts` between the control-row pins (keep lines 1-56 as they are, but update line 53) and the measure/send/mobile pins (keep lines 121-204 unchanged). The full replacement for lines 53 and 57-119:
+
+Line 53 becomes:
+
+```ts
+assert.doesNotMatch(controlRow, /<ComposerContextChips/, "the context chips live in the footer band, not the control row");
+```
+
+Lines 57-119 become:
+
+```ts
+// ── The footer band is the panel's last section, after the control row ──────
+assert.match(
+  source,
+  /className="cave-composer-control-row"[\s\S]*?className="cave-composer-footer-band"/,
+  "the footer band renders after the composer controls, inside the panel",
+);
+assert.match(
+  source,
+  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?<\/div>\s*\n\s*\{linkedContextRow\}\s*\n\s*<\/div>/,
+  "the band leads with the context-chips cluster, then the linked-context strip (tasks · GitHub · link/create)",
+);
+
+// ── Split chips (cave-g21f): project · model · branch as separate controls ──
+assert.match(
+  source,
+  /<ComposerContextChips\s*\n\s*projects=\{projects\}\s*\n\s*projectValue=\{resolvedProjectId\}\s*\n\s*onProjectChange=\{setProjectIdDraft\}\s*\n\s*allowNoProject/,
+  "the chips show the RESOLVED project selection (draft → task project → session cwd) and write the draft",
+);
+assert.match(
+  source,
+  /createProject=\{createProject\}[\s\S]{0,600}?projectRoot=\{activeProjectRoot\}[\s\S]{0,120}?onOpenUrl=\{onOpenUrl\}/,
+  "the chips fold in the add-project flow and the git/PR context (register + grant, branch, PR open)",
+);
+assert.doesNotMatch(
+  source,
+  /cave-composer-footer-band__context|<ProjectPicker\b|<ComposerRuntimeChip|<ComposerGitChip|<ComposerContextPill\b/,
+  "neither the legacy picker cluster nor the combined pill render — the chips are the band's context grammar",
+);
+
+// ── Each chip opens its own picker; the hub popover is gone ─────────────────
+assert.match(
+  pill,
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?aria-label=\{`Model: \$\{modelLabel\} — change model`\}[\s\S]*?aria-label=\{`Branch: \$\{context\.branch\} — switch branch or create a worktree`\}/,
+  "the chips read Project / Model / Branch as separately labelled controls in order",
+);
+assert.match(pill, /context\.hasGit \? \(/, "the branch chip elides for git-less composers (home, no-project chats)");
+assert.doesNotMatch(
+  pill,
+  /"hub"|<PopoverLabel>|ComposerContextActionRows|splitControls/,
+  "the combined pill's hub popover, action rows, and the splitControls flag are retired",
+);
+assert.match(
+  pill,
+  /<GitBranchMenuPopover[\s\S]*?\{\.\.\.branchPopoverExtras\(context\)\}/,
+  "the branch chip's menu carries the PR + Git-changes rows (hub parity)",
+);
+
+// ── The header no longer hosts the linked-context strip ─────────────────────
+const header = source.match(/<header className="cave-chat-linear-header[\s\S]*?<\/header>/)?.[0] ?? "";
+assert.ok(header, "chat header is present");
+assert.doesNotMatch(
+  header,
+  /linkedContextRow/,
+  "the header renders MetaLine only — the linked-context strip stays in the band",
+);
+
+// ── Band chrome: attached underside strip, one tone deeper ──────────────────
+assert.match(
+  css,
+  /\.cave-composer-footer-band \{[\s\S]*?border-top: 1px solid var\(--border-hairline\);[\s\S]*?background: color-mix\(in oklch, var\(--bg-base\) 62%, transparent\);/,
+  "the band is the darker hairline-topped strip clipped into the panel's bottom corners",
+);
+
+// ── Chip chrome: shared quiet 28px chips in the composer sheet ──────────────
+assert.match(
+  css,
+  /\.cave-composer-footer-band__cluster \{[\s\S]{0,200}?min-width: 0;[\s\S]{0,120}?flex: 1 1 auto;/,
+  "the band's chip cluster flexes and allows shrinking so three chips coexist with the linked strip",
+);
+assert.match(
+  css,
+  /\.cave-context-chip \{[\s\S]{0,400}?height: 28px;[\s\S]{0,300}?border-radius: var\(--radius-control\);\s*\n\s*background: transparent;\s*\n\s*color: var\(--text-secondary\);\s*\n\s*font-size: var\(--text-sm\);/,
+  "the context chips are the quiet 28px control-radius family, defined in the shared composer sheet",
+);
+assert.match(
+  css,
+  /\.cave-context-chip\[aria-expanded="true"\] \{[\s\S]{0,200}?--accent-presence/,
+  "an open chip shows the accent open-state (pill parity)",
+);
+assert.doesNotMatch(css, /\.cave-context-pill/, "the combined pill's CSS is retired with it");
+```
+
+Note the update inside the retained pill header comment at the top of the test file (lines 2-8): rewrite the comment paragraph to describe the chips grammar, e.g.:
+
+```ts
+// Source pins for the chat composer's context grammar after the 2026-07-22
+// split (cave-g21f): the footer band carries project · model · branch as
+// three separate chips (ComposerContextChips) on the left — each opening its
+// own picker — and the linked-work strip (tasks · GitHub · link/create) on
+// the right. The grouped ComposerActionsMenu keeps its four groups. The
+// write surface stays minimal: textarea, then attach · voice · grouped menu ·
+// circular send.
+```
+
+- [ ] **Step 2: Run to verify the spec fails**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test src/components/chat-composer-footer-band.test.ts
+```
+Expected: FAIL (chips not implemented yet).
+
+- [ ] **Step 3: Rewrite `src/components/composer-context-pill.tsx`**
+
+Replace the entire file with:
+
+```tsx
+"use client";
+
+import "@/styles/cave-composer.css";
+
+// ComposerContextChips — the composer footer's context controls (cave-g21f):
+// project, model, and (for repo-rooted chats) branch ride as separate,
+// individually labelled chips. Each opens its own picker popover anchored to
+// the chip itself (ProjectPickerPopover, ComposerRuntimePopover,
+// GitBranchMenuPopover), so every existing flow — project switching +
+// add-project, runtime/model switching, branch switch / new worktree / PR
+// open / git-changes drill-through — stays one click away. This replaced the
+// combined "Project · Model · branch" pill and its hub popover (2026-07-22)
+// on both the chat and home composers.
+
+import { useMemo, useRef, useState, type RefObject } from "react";
+import { Icon } from "@/lib/icon";
+import { ProjectAvatar } from "@/components/project-avatar";
+import { ProjectPickerPopover, useAddProjectFlow } from "@/components/project-picker";
+import {
+  ComposerRuntimePopover,
+  runtimeModelLabel,
+} from "@/components/composer-runtime-chip";
+import { GitBranchMenuPopover, useBranchPr } from "@/components/composer-git-chip";
+import { RuntimeLogo, runtimeDisplayName } from "@/components/runtime-logo";
+import { useChangesSummary } from "@/lib/use-changes-summary";
+import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import { sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
+import type { CreateProjectOptions } from "@/lib/chat-add-project";
+import type { RuntimeModelOption } from "@/lib/runtime-models";
+
+export type ComposerContextView = null | "project" | "model" | "branch";
+
+export type ComposerContextProps = {
+  projects: CaveProject[];
+  /** Project id, NO_PROJECT_ID, or null (null falls back to the first project). */
+  projectValue: string | null;
+  onProjectChange: (id: string) => void;
+  allowNoProject?: boolean;
+  familiarId?: string | null;
+  /** From the caller's useProjects(); presence enables the "Add project…" row. */
+  createProject?: (
+    name: string,
+    root: string,
+    options?: CreateProjectOptions,
+  ) => Promise<CaveProject | null>;
+  runtime: string;
+  modelValue: string;
+  modelOptions: RuntimeModelOption[];
+  onPickRuntime: (runtime: string) => void;
+  onPickModel: (id: string) => void;
+  /** Chat disables model switching while streaming (runtime-chip parity). */
+  modelDisabled?: boolean;
+  /** Enables the branch chip for repo-rooted chats (undefined/non-repo
+   *  roots elide it, git-chip parity). */
+  projectRoot?: string;
+  /** Opens the branch PR in the app's browser pane; falls back to window.open. */
+  onOpenUrl?: (url: string) => void;
+  disabled?: boolean;
+};
+
+export type ComposerContextController = ReturnType<typeof useComposerContextActions>;
+
+export function useComposerContextActions(config: ComposerContextProps) {
+  const sortedProjects = useMemo(
+   () => sortProjectsAlphabetically(config.projects),
+   [config.projects],
+  );
+  const selectedProject =
+   config.projectValue === NO_PROJECT_ID
+     ? null
+     : (config.projectValue
+         ? sortedProjects.find((project) => project.id === config.projectValue) ?? sortedProjects[0]
+         : sortedProjects[0]) ?? null;
+
+  const addFlow = useAddProjectFlow({
+   familiarId: config.familiarId ?? null,
+   createProject: config.createProject ?? (async () => null),
+   projects: config.projects,
+   onAdded: config.onProjectChange,
+  });
+
+  const runtimeName = runtimeDisplayName(config.runtime);
+  const modelLabel = runtimeModelLabel(config.modelValue, config.modelOptions);
+
+  const root = config.projectRoot?.trim() ? config.projectRoot : undefined;
+  const { loaded, notARepo, branch, count, worktree, reload } = useChangesSummary(
+    root,
+    Boolean(root),
+  );
+  const pr = useBranchPr(root, branch);
+  const hasGit = Boolean(root && loaded && !notARepo && branch);
+
+  const dirtyLabel =
+    count > 0 ? `${count} uncommitted change${count === 1 ? "" : "s"}` : "clean";
+  const summary = [
+    selectedProject ? selectedProject.name : "No project",
+    modelLabel ?? runtimeName,
+  ].join(" · ");
+
+  return {
+   config,
+   sortedProjects,
+   selectedProject,
+   addFlow,
+    runtimeName,
+    modelLabel,
+    root,
+    loaded,
+    notARepo,
+    branch,
+    count,
+    worktree,
+    reload,
+    pr,
+    hasGit,
+    dirtyLabel,
+    summary,
+  };
+}
+
+// The branch menu's footer rows (PR · Git changes) — shared by the footer's
+// branch chip and the actions-menu "Branch…" flow so both keep parity with
+// the retired hub's git section.
+function branchPopoverExtras(context: ComposerContextController) {
+  return {
+    pr: context.pr,
+    onOpenPr: (url: string) => {
+      if (context.config.onOpenUrl) context.config.onOpenUrl(url);
+      else window.open(url, "_blank", "noopener,noreferrer");
+    },
+    onOpenChanges: () => window.dispatchEvent(new CustomEvent("cave:changes-open")),
+  };
+}
+
+export function ComposerContextPickers({
+  view,
+  onViewChange,
+  anchorRef,
+  context,
+}: {
+  view: ComposerContextView;
+  onViewChange: (view: ComposerContextView) => void;
+  anchorRef: RefObject<HTMLElement | null>;
+  context: ComposerContextController;
+}) {
+  return (
+    <>
+      <ProjectPickerPopover
+        open={view === "project"}
+        onOpenChange={(open) => onViewChange(open ? "project" : null)}
+        anchorRef={anchorRef}
+        projects={context.config.projects}
+        value={context.config.projectValue}
+        onChange={context.config.onProjectChange}
+        allowNoProject={context.config.allowNoProject}
+        onAddProject={context.config.createProject ? context.addFlow.beginAddProject : undefined}
+        addingProject={context.addFlow.adding}
+        ariaLabel="Choose project"
+      />
+      <ComposerRuntimePopover
+        open={view === "model"}
+        onOpenChange={(open) => onViewChange(open ? "model" : null)}
+        anchorRef={anchorRef}
+        runtime={context.config.runtime}
+        modelValue={context.config.modelValue}
+        modelOptions={context.config.modelOptions}
+        onPickRuntime={context.config.onPickRuntime}
+        onPickModel={context.config.onPickModel}
+      />
+      <GitBranchMenuPopover
+        open={view === "branch"}
+        onOpenChange={(open) => onViewChange(open ? "branch" : null)}
+        anchorRef={anchorRef}
+        projectRoot={context.root}
+        onSwitched={context.reload}
+        {...branchPopoverExtras(context)}
+      />
+      {context.addFlow.addError ? (
+        <span className="cave-project-picker__error" role="alert">
+          {context.addFlow.addError}
+        </span>
+      ) : null}
+      {context.config.createProject ? context.addFlow.addProjectModal : null}
+    </>
+  );
+}
+
+export function ComposerContextChips(props: ComposerContextProps) {
+  const [menu, setMenu] = useState<ComposerContextView>(null);
+  const projectRef = useRef<HTMLButtonElement | null>(null);
+  const modelRef = useRef<HTMLButtonElement | null>(null);
+  const branchRef = useRef<HTMLButtonElement | null>(null);
+  const context = useComposerContextActions(props);
+  const projectLabel = context.selectedProject?.name ?? "No project";
+  const modelLabel = context.modelLabel ?? context.runtimeName;
+
+  return (
+    <>
+      <button
+        ref={projectRef}
+        type="button"
+        className="cave-context-chip focus-ring"
+        disabled={props.disabled}
+        aria-haspopup="dialog"
+        aria-expanded={menu === "project"}
+        aria-label={`Project: ${projectLabel} — change project`}
+        title={context.selectedProject?.root ?? "No project selected"}
+        onClick={() => setMenu((c) => (c === "project" ? null : "project"))}
+      >
+        <span className="cave-context-chip__lead" aria-hidden>
+          {context.selectedProject ? (
+            <ProjectAvatar
+              name={context.selectedProject.name}
+              root={context.selectedProject.root}
+              color={context.selectedProject.color}
+              size="sm"
+            />
+          ) : (
+            <Icon name="ph:folder" width={13} aria-hidden />
+          )}
+        </span>
+        <span className="cave-context-chip__text">{projectLabel}</span>
+        <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+      </button>
+      <button
+        ref={modelRef}
+        type="button"
+        className="cave-context-chip focus-ring"
+        disabled={props.disabled || context.config.modelDisabled}
+        aria-haspopup="dialog"
+        aria-expanded={menu === "model"}
+        aria-label={`Model: ${modelLabel} — change model`}
+        title={`Runtime: ${context.runtimeName}${context.modelLabel ? ` · Model: ${context.modelLabel}` : ""}`}
+        onClick={() => setMenu((c) => (c === "model" ? null : "model"))}
+      >
+        <span className="cave-context-chip__lead cave-runtime-chip__logo" aria-hidden>
+          <RuntimeLogo runtime={context.config.runtime} size={13} />
+        </span>
+        <span className="cave-context-chip__text">{modelLabel}</span>
+        <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+      </button>
+      {context.hasGit ? (
+        <button
+          ref={branchRef}
+          type="button"
+          className="cave-context-chip focus-ring"
+          disabled={props.disabled}
+          aria-haspopup="menu"
+          aria-expanded={menu === "branch"}
+          aria-label={`Branch: ${context.branch} — switch branch or create a worktree`}
+          title={`Branch: ${context.branch} · ${context.dirtyLabel}${context.worktree ? ` · Worktree: ${context.worktree}` : ""}`}
+          onClick={() => setMenu((c) => (c === "branch" ? null : "branch"))}
+        >
+          <span className="cave-context-chip__lead" aria-hidden>
+            <Icon name="ph:git-branch" width={13} aria-hidden />
+          </span>
+          <span className="cave-context-chip__text">
+            {context.branch}
+            {context.count > 0 ? ` · +${context.count}` : ""}
+            {context.worktree ? ` · ${context.worktree}` : ""}
+          </span>
+          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+        </button>
+      ) : null}
+
+      <ProjectPickerPopover
+        open={menu === "project"}
+        onOpenChange={(open) => setMenu(open ? "project" : null)}
+        anchorRef={projectRef}
+        projects={context.config.projects}
+        value={context.config.projectValue}
+        onChange={context.config.onProjectChange}
+        allowNoProject={context.config.allowNoProject}
+        onAddProject={context.config.createProject ? context.addFlow.beginAddProject : undefined}
+        addingProject={context.addFlow.adding}
+        ariaLabel="Choose project"
+      />
+      <ComposerRuntimePopover
+        open={menu === "model"}
+        onOpenChange={(open) => setMenu(open ? "model" : null)}
+        anchorRef={modelRef}
+        runtime={context.config.runtime}
+        modelValue={context.config.modelValue}
+        modelOptions={context.config.modelOptions}
+        onPickRuntime={context.config.onPickRuntime}
+        onPickModel={context.config.onPickModel}
+      />
+      {context.hasGit ? (
+        <GitBranchMenuPopover
+          open={menu === "branch"}
+          onOpenChange={(open) => setMenu(open ? "branch" : null)}
+          anchorRef={branchRef}
+          projectRoot={context.root}
+          onSwitched={context.reload}
+          {...branchPopoverExtras(context)}
+        />
+      ) : null}
+      {context.addFlow.addError ? (
+        <span className="cave-project-picker__error" role="alert">
+          {context.addFlow.addError}
+        </span>
+      ) : null}
+      {context.config.createProject ? context.addFlow.addProjectModal : null}
+    </>
+  );
+}
+```
+
+What changed vs. the old file: `ComposerContextPill` (hub + split branches) → `ComposerContextChips` (chips only, plus the branch chip); `ComposerContextActionRows` deleted; `splitControls` and `ariaLabel` props deleted; `branchPopoverExtras` added and threaded into both `GitBranchMenuPopover` mounts; the `ui/popover` import removed (nothing in the file uses it now); the chips fragment gains the `addError` span the old split mode was missing.
+
+- [ ] **Step 4: Rewire the chat footer band**
+
+In `src/components/chat-view.tsx`:
+
+Line 72, the import becomes:
+
+```tsx
+import { ComposerContextChips } from "@/components/composer-context-pill";
+```
+
+Lines 5903-5928 (comment + band) become:
+
+```tsx
+            {/* Footer band — the darker strip attached to the panel's
+                underside carries the context chips (project · model · branch
+                as separate controls, cave-g21f; each opens its own picker) on
+                the left and the linked-work strip (tasks · GitHub ·
+                link/create) on the right. */}
+            <div className="cave-composer-footer-band">
+              <div className="cave-composer-footer-band__cluster">
+                <ComposerContextChips
+                  projects={projects}
+                  projectValue={resolvedProjectId}
+                  onProjectChange={setProjectIdDraft}
+                  allowNoProject
+                  familiarId={familiar.id ?? null}
+                  createProject={createProject}
+                  runtime={modelHarness}
+                  modelValue={composerModelValue}
+                  modelOptions={composerModelOptions}
+                  onPickRuntime={handleSelectRuntime}
+                  onPickModel={handleSelectModel}
+                  modelDisabled={busy}
+                  projectRoot={activeProjectRoot}
+                  onOpenUrl={onOpenUrl}
+                />
+              </div>
+              {linkedContextRow}
+            </div>
+```
+
+⚠️ The band-test regex in Step 1 expects `<ComposerContextChips` on the line after the cluster div and `{linkedContextRow}` after the cluster's `</div>` — match this indentation shape exactly.
+
+- [ ] **Step 5: Rewire the home composer**
+
+In `src/components/home-composer.tsx`:
+
+Line 55, the import becomes:
+
+```tsx
+import { ComposerContextChips } from "@/components/composer-context-pill";
+```
+
+Lines 1087-1117 (the two stale comment blocks + band) become:
+
+```tsx
+        {/* Footer toolbar — a clean bottom bar inside the composer. The left
+            cluster carries project + model as two SEPARATE labelled chips
+            (shared ComposerContextChips grammar with the chat composer,
+            cave-g21f; home passes no git root, so no branch chip). The
+            segmented Chat/Task control and attach live in the control row
+            above. Send hugs bottom-right, vertically aligned. */}
+        <div className="cave-composer-footer-band home-composer-toolbar">
+          <div className="home-composer-toolbar__left">
+            <ComposerContextChips
+              projects={projects}
+              projectValue={selectedProjectId || null}
+              onProjectChange={setSelectedProjectId}
+              allowNoProject
+              familiarId={selectedFamiliarId || null}
+              createProject={createProject}
+              runtime={selectedRuntime}
+              modelValue={selectedModelId}
+              modelOptions={runtimeModelOptions}
+              onPickRuntime={handleSelectRuntime}
+              onPickModel={handleSelectModel}
+              disabled={sending}
+            />
+          </div>
+        </div>
+```
+
+Also update the comment at `src/components/composer-plus-menu.tsx:48` from "mirrors the footer-band context pill" to "mirrors the footer-band context chips".
+
+- [ ] **Step 6: Move the chip CSS into the shared sheet**
+
+In `src/styles/cave-composer.css`, replace lines 963-1019 (the comment + `.cave-context-pill` block through `.cave-context-pill__chevron`) with:
+
+```css
+/* Footer context chips (cave-g21f) — project · model · branch ride as
+   separate quiet controls in the footer band; each opens its own picker
+   anchored to the chip. Shared by the chat and home composers. */
+.cave-composer-footer-band__cluster {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.cave-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 13rem;
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 450;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.cave-context-chip:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
+  color: var(--text-primary);
+}
+
+.cave-context-chip[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-strong));
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--text-primary);
+}
+
+.cave-context-chip:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.cave-context-chip__lead {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.cave-context-chip__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cave-context-chip__chevron {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+```
+
+In the same file's `@media (max-width: 767px)` block, replace the `.cave-context-pill { … }` rule (lines ~1080-1084) with:
+
+```css
+  .cave-context-chip {
+    height: var(--touch-target);
+    min-height: var(--touch-target);
+    max-width: 9rem;
+    -webkit-tap-highlight-color: transparent;
+  }
+```
+
+In `src/styles/home-composer/landing-composer.css`, delete lines 301-339 (`.cave-context-chip` base rules through `.cave-context-chip__chevron` — now shared) but **keep** the home-scoped container query at lines 341-343:
+
+```css
+@container (max-width: 620px) {
+  .cave-context-chip { max-width: 46%; height: var(--touch-target); }
+}
+```
+
+(Home's card is the `container-type: inline-size` context — landing-composer.css:173 — so this query only ever fires on home; the chat composer has no container and uses the shared media rule instead.)
+
+- [ ] **Step 7: Run the band spec — expect PASS**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test src/components/chat-composer-footer-band.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 8: Update the remaining source pins**
+
+Each edit below is a pin whose decision changed. Exact edits, file by file:
+
+**`src/components/composer-runtime-chip.test.ts`**
+- Line 25 regex: `/<ComposerContextPill[\s\S]*?runtime=…/` → `/<ComposerContextChips[\s\S]*?runtime=\{selectedRuntime\}[\s\S]*?modelValue=\{selectedModelId\}[\s\S]*?modelOptions=\{runtimeModelOptions\}[\s\S]*?onPickRuntime=\{handleSelectRuntime\}[\s\S]*?onPickModel=\{handleSelectModel\}/` (message: "the home composer's context chips host the runtime picker from its own model state").
+- Line 30 regex: `<ComposerContextPill` → `<ComposerContextChips`; message: "the chips anchor the composer footer band".
+- Lines 33-37 (ActionRows export pin): replace with
+
+```ts
+assert.match(
+  contextPill,
+  /aria-label=\{`Model: \$\{modelLabel\} — change model`\}/,
+  "the model chip is a separately labelled control (split grammar, cave-g21f)",
+);
+```
+- Lines 48-52 (wrapper pin): replace the regex with `/const context = useComposerContextActions\(props\);[\s\S]*?<ComposerRuntimePopover[\s\S]*?onPickModel=\{context\.config\.onPickModel\}/` (message: "the chips mount the shared runtime popover from the same context controller").
+- Line 86 regex: `<ComposerContextPill` → `<ComposerContextChips`.
+
+**`src/components/composer-git-chip.test.ts`**
+- Lines 14-17 comment: describe the chips grammar ("branch/PR/change actions ride the branch chip's GitBranchMenuPopover; ComposerContextPickers keeps the actions-menu flow").
+- Line 30 (ActionRows pin): replace with
+
+```ts
+assert.match(pill, /function branchPopoverExtras\(context: ComposerContextController\)/, "the PR/changes rows are built once and shared by the chip and the actions-menu flow");
+```
+- Lines 41-45 (wrapper pin): replace regex with `/const context = useComposerContextActions\(props\);[\s\S]*?<GitBranchMenuPopover[\s\S]*?\{\.\.\.branchPopoverExtras\(context\)\}/` (message: "the chips mount the branch menu with the PR/changes extras on the chip anchor").
+
+**`src/components/project-picker.test.ts`**
+- Line 42: `<ComposerContextPill` → `<ComposerContextChips`; message: "home composer's context chips host the shared project picker".
+- Lines 52-56 (ActionRows project-row pin): replace with
+
+```ts
+assert.match(
+  contextPill,
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?<ProjectPickerPopover/,
+  "the project chip is a labelled control that opens the shared ProjectPickerPopover",
+);
+```
+- Lines 57-61 (`<ComposerContextPickers` mount pin): the pill file no longer mounts it — repoint the pin at the surviving consumer:
+
+```ts
+const actionsMenu = readFileSync(new URL("./composer-actions-menu.tsx", import.meta.url), "utf8");
+assert.match(
+  actionsMenu,
+  /<ComposerContextPickers[\s\S]*?context=\{context\}/,
+  "the actions menu still threads the shared context into the extracted pickers",
+);
+```
+
+**`src/components/composer-actions-menu.test.ts`**
+- Line 141 (`export function ComposerContextActionRows` pin) and lines 142-146 (`itemSemantic?: PopoverItemSemantic` pin): delete both; replace with
+
+```ts
+assert.match(context, /export\s+function\s+ComposerContextChips/);
+```
+- Line 213: `assert.match(home, /<ComposerContextPill/);` → `assert.match(home, /<ComposerContextChips/);`
+
+**`src/components/chat-view-first-class.test.ts`**
+- Line 150: count `source.match(/<ComposerContextChips/g)?.length === 1`; message: "the context chips mount exactly once — in the footer band".
+- Line 156 regex → `/className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips/` (message: "the context chips live in the footer band, not the control row").
+
+**`src/components/chat-view-polish-header-composer.test.ts`**
+- Line 157 regex → same cluster-aware regex as above.
+- Line 179 count pin → `<ComposerContextChips` count === 1.
+- Update the comment at lines 154-155 and 177-178 ("context pill" → "context chips").
+
+**`src/components/chat-header-row.test.ts`**
+- Line 66 regex → `/className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?\{linkedContextRow\}/` (message: "the footer band carries the context chips and the linked-context strip").
+
+**`src/components/composer-density.test.ts`**
+- Line 25: `/<ComposerContextPill/` → `/<ComposerContextChips/` (the doesNotMatch on the control-row slice).
+
+**`src/components/home-composer.test.ts`**
+- Line 94 regex: `<ComposerContextPill` → `<ComposerContextChips` (rest unchanged).
+- Line 472 regex: trailing `<ComposerContextPill` → `<ComposerContextChips`.
+- Line 477 (utility-row doesNotMatch): `<ComposerContextPill` → `<ComposerContextChips`.
+
+**`src/components/home-composer-polish.test.ts`**
+- Line 78 regex: `<ComposerContextPill` → `<ComposerContextChips`; update the comment above it ("context pill (Project · Model)" → "context chips (Project · Model)").
+
+- [ ] **Step 9: Run the full affected batch**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --no-warnings --test \
+  src/components/chat-composer-footer-band.test.ts \
+  src/components/composer-git-chip.test.ts \
+  src/components/composer-runtime-chip.test.ts \
+  src/components/project-picker.test.ts \
+  src/components/composer-actions-menu.test.ts \
+  src/components/chat-view-first-class.test.ts \
+  src/components/chat-view-polish-header-composer.test.ts \
+  src/components/chat-header-row.test.ts \
+  src/components/composer-density.test.ts \
+  src/components/home-composer.test.ts \
+  src/components/home-composer-polish.test.ts
+```
+Expected: all PASS. If a regex misses, diff the pinned pattern against the actual source shape — fix the pin's whitespace expectations, never the assertion's meaning.
+
+- [ ] **Step 10: Typecheck**
+
+```bash
+pnpm typecheck
+```
+Expected: clean. (Catches any missed `ComposerContextPill`/`ariaLabel`/`splitControls` stragglers.)
+
+- [ ] **Step 11: Grep for stragglers**
+
+```bash
+grep -rn "ComposerContextPill\|ComposerContextActionRows\|splitControls\|cave-context-pill" src/ tests/ --include="*.ts" --include="*.tsx" --include="*.css"
+```
+Expected: only `tests/composer-runtime-chip.spec.ts` hits (Task 3) and historical mentions in comments you intentionally rewrote (should be none in src/).
+
+- [ ] **Step 12: Commit and push**
+
+```bash
+git add -A src/components src/styles
+git commit -S -m "feat(chat): split footer context pill into project · model · branch chips (cave-g21f)
+
+The chat composer footer band now carries three separate, individually
+labelled chips (ComposerContextChips) instead of the combined pill + hub
+popover; the branch chip opens the branch menu directly with PR and
+Git-changes rows. Chip CSS moves to the shared composer sheet; home keeps
+its two-chip rendering through the same component.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+---
+
+### Task 3: E2E — drive the model chip instead of the hub pill
+
+**Files:**
+- Modify: `tests/composer-runtime-chip.spec.ts:93-128`
+
+- [ ] **Step 1: Update the spec**
+
+In the first test (lines 96-104), replace:
+
+```ts
+    const pill = page.getByRole("button", { name: "Chat context: project, model, and branch" });
+    await expect(pill).toBeVisible({ timeout: 45_000 });
+    // toContainText retries — the pill settles once model-state hydrates.
+    await expect(pill).toContainText("GPT-5.5", { timeout: 15_000 });
+
+    await pill.click();
+    // Hub popover → Model section row opens the Runtime/Model picker.
+    await page.getByRole("menuitem", { name: /Codex · GPT-5\.5/ }).click();
+```
+
+with:
+
+```ts
+    const modelChip = page.getByRole("button", { name: /change model/ });
+    await expect(modelChip).toBeVisible({ timeout: 45_000 });
+    // toContainText retries — the chip settles once model-state hydrates.
+    await expect(modelChip).toContainText("GPT-5.5", { timeout: 15_000 });
+
+    // Split chips (cave-g21f): the model chip opens the picker directly.
+    await modelChip.click();
+```
+
+In the second test (lines 119-128), replace:
+
+```ts
+    const pill = page.getByRole("button", { name: "Chat context: project, model, and branch" });
+    await expect(pill).toBeVisible({ timeout: 45_000 });
+    await expect(pill).toContainText("GPT-5.5", { timeout: 15_000 });
+```
+with:
+
+```ts
+    const pill = page.getByRole("button", { name: /change model/ });
+    await expect(pill).toBeVisible({ timeout: 45_000 });
+    await expect(pill).toContainText("GPT-5.5", { timeout: 15_000 });
+```
+and delete the hub line `await page.getByRole("menuitem", { name: /Codex · GPT-5\.5/ }).click();` that follows `await pill.click();` (keep `await pill.click();`). The later assertions (`toContainText("Claude Opus")`, `toContainText("Claude Sonnet 5")`) stay — the chip text is the model label.
+
+Also update the describe title on line 93: `"composer runtime picker (context pill)"` → `"composer runtime picker (context chips)"`.
+
+- [ ] **Step 2: Run the spec locally**
+
+```bash
+pnpm e2e:install
+pnpm exec playwright test tests/composer-runtime-chip.spec.ts
+```
+Expected: PASS (the config's webServer starts Next automatically; allow several minutes cold). If the local run is environment-blocked, say so in the PR and rely on the required `E2E (Playwright)` check.
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add tests/composer-runtime-chip.spec.ts
+git commit -S -m "test(e2e): drive the split model chip instead of the hub pill (cave-g21f)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+---
+
+### Task 4: Full validation, PR, merge, cleanup
+
+- [ ] **Step 1: Full app suite + typecheck**
+
+```bash
+pnpm test:app && pnpm typecheck
+```
+Expected: all suites pass. Fix any missed pin (the failure message names the file and decision).
+
+- [ ] **Step 2: Manual smoke (optional but recommended)**
+
+`bash scripts/dev-app.sh` from the worktree, open a repo-rooted chat: footer band shows three chips; project chip → project popover; model chip → runtime/model radios; branch chip → branch list with PR + "Open Git changes" rows; home shows two chips, unchanged. Ctrl-C when done.
+
+- [ ] **Step 3: Update the bead + open the PR**
+
+```bash
+bd update cave-g21f --notes "branch feat/chat-footer-split-chips, worktree .worktrees/feat-chat-footer-split-chips; verified: pnpm test:app, pnpm typecheck, targeted playwright spec"
+gh pr create --base main --head feat/chat-footer-split-chips \
+  --title "feat(chat): split footer context pill into project · model · branch chips (cave-g21f)" \
+  --body "Separates project and model selection in the chat composer footer (home parity) and gives git context its own chip.
+
+- ComposerContextPill → ComposerContextChips: split chips are the only mode; hub popover + ComposerContextActionRows retired
+- New branch chip (repo-rooted chats) opens GitBranchMenuPopover, which gains PR + Open-Git-changes rows (hub parity, also reachable from the actions-menu Branch… flow)
+- .cave-context-chip CSS moved to shared cave-composer.css; .cave-context-pill CSS retired
+- Source pins + e2e updated to the new grammar
+
+Spec: docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
+Plan: docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
+Bead: cave-g21f"
+```
+
+- [ ] **Step 4: Pre-merge race check** (parallel sessions race this repo)
+
+```bash
+gh pr list --limit 15
+bd list --status in_progress | head -20
+```
+Expected: no other open PR touching the composer footer. If one exists, reconcile before merging.
+
+- [ ] **Step 5: Merge once the 4 required checks are green, then clean up**
+
+```bash
+gh pr checks <PR#> --watch
+gh pr merge <PR#> --squash --delete-branch
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git worktree remove .worktrees/feat-chat-footer-split-chips
+git branch -D feat/chat-footer-split-chips
+git worktree list
+bd close cave-g21f
+```
+
+(Note: bot pushes — Copilot Autofix / copilot-swe-agent — sometimes land on fresh PRs within minutes; `git pull` and re-review the net diff before merging if any appear.)

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -1,11 +1,11 @@
 // @ts-nocheck
-// Source pins for the chat composer's context grammar after the 2026-07-21
-// "both" reconciliation (user call): the wide-column pass's footer band STAYS
-// — context pill (project · runtime/model · git) left, linked-work strip
-// (tasks · GitHub · link/create) right — AND the minimal-composer pass's
-// grouped ComposerActionsMenu keeps all four groups (context · linked work ·
-// improve · response), accepting the duplication. The write surface stays
-// minimal: textarea, then attach · voice · grouped menu · circular send.
+// Source pins for the chat composer's context grammar after the 2026-07-22
+// split (cave-g21f): the footer band carries project · model · branch as
+// three separate chips (ComposerContextChips) on the left — each opening its
+// own picker — and the linked-work strip (tasks · GitHub · link/create) on
+// the right. The grouped ComposerActionsMenu keeps its four groups. The
+// write surface stays minimal: textarea, then attach · voice · grouped menu ·
+// circular send.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -50,7 +50,7 @@ assert.doesNotMatch(
   "the standalone attach button is gone from the control row (it lives in the + menu now)",
 );
 assert.doesNotMatch(controlRow, /<ComposerPlusMenu/, "the composer actions should no longer expose the legacy plus menu");
-assert.doesNotMatch(controlRow, /<ComposerContextPill/, "the context pill lives in the footer band, not the control row");
+assert.doesNotMatch(controlRow, /<ComposerContextChips/, "the context chips live in the footer band, not the control row");
 assert.doesNotMatch(controlRow, /<ComposerOptionsMenu/, "the composer actions should no longer expose the legacy options menu");
 assert.doesNotMatch(source, /<ComposerLinkedWorkActions\b/, "ChatView should not mount the menu-row linked-work actions directly — the band uses the chip strip");
 
@@ -62,37 +62,43 @@ assert.match(
 );
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill[\s\S]*?\{linkedContextRow\}\s*\n\s*<\/div>/,
-  "the band leads with the context pill, then the linked-context strip (tasks · GitHub · link/create)",
+  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?<\/div>\s*\n\s*\{linkedContextRow\}\s*\n\s*<\/div>/,
+  "the band leads with the context-chips cluster, then the linked-context strip (tasks · GitHub · link/create)",
 );
 
-// ── The context pill folds project/runtime/git behind one control ───────────
+// ── Split chips (cave-g21f): project · model · branch as separate controls ──
 assert.match(
   source,
-  /<ComposerContextPill\s*\n\s*projects=\{projects\}\s*\n\s*projectValue=\{resolvedProjectId\}\s*\n\s*onProjectChange=\{setProjectIdDraft\}\s*\n\s*allowNoProject/,
-  "the pill shows the RESOLVED project selection (draft → task project → session cwd) and writes the draft",
+  /<ComposerContextChips\s*\n\s*projects=\{projects\}\s*\n\s*projectValue=\{resolvedProjectId\}\s*\n\s*onProjectChange=\{setProjectIdDraft\}\s*\n\s*allowNoProject/,
+  "the chips show the RESOLVED project selection (draft → task project → session cwd) and write the draft",
 );
 assert.match(
   source,
   /createProject=\{createProject\}[\s\S]{0,600}?projectRoot=\{activeProjectRoot\}[\s\S]{0,120}?onOpenUrl=\{onOpenUrl\}/,
-  "the pill folds in the add-project flow and the git/PR context (register + grant, branch, PR open)",
+  "the chips fold in the add-project flow and the git/PR context (register + grant, branch, PR open)",
 );
 assert.doesNotMatch(
   source,
-  /cave-composer-footer-band__context|<ProjectPicker\b|<ComposerRuntimeChip|<ComposerGitChip/,
-  "the band's old picker cluster is gone — project/runtime/git live behind the pill",
+  /cave-composer-footer-band__context|<ProjectPicker\b|<ComposerRuntimeChip|<ComposerGitChip|<ComposerContextPill\b/,
+  "neither the legacy picker cluster nor the combined pill render — the chips are the band's context grammar",
 );
 
-// ── The pill's hub popover has the three sections ───────────────────────────
+// ── Each chip opens its own picker; the hub popover is gone ─────────────────
 assert.match(
   pill,
-  /<PopoverLabel>Project<\/PopoverLabel>[\s\S]*?<PopoverLabel>Model<\/PopoverLabel>[\s\S]*?<PopoverLabel>Branch<\/PopoverLabel>/,
-  "the pill's hub popover sections read Project / Model / Branch in order",
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?aria-label=\{`Model: \$\{modelLabel\} — change model`\}[\s\S]*?aria-label=\{`Branch: \$\{context\.branch\} — switch branch or create a worktree`\}/,
+  "the chips read Project / Model / Branch as separately labelled controls in order",
+);
+assert.match(pill, /context\.hasGit \? \(/, "the branch chip elides for git-less composers (home, no-project chats)");
+assert.doesNotMatch(
+  pill,
+  /"hub"|<PopoverLabel>|ComposerContextActionRows|splitControls/,
+  "the combined pill's hub popover, action rows, and the splitControls flag are retired",
 );
 assert.match(
   pill,
-  /hasGit \? \(/,
-  "the Branch section elides for git-less composers (home, no-project chats)",
+  /<GitBranchMenuPopover[\s\S]*?\{\.\.\.branchPopoverExtras\(context\)\}/,
+  "the branch chip's menu carries the PR + Git-changes rows (hub parity)",
 );
 
 // ── The header no longer hosts the linked-context strip ─────────────────────
@@ -111,12 +117,23 @@ assert.match(
   "the band is the darker hairline-topped strip clipped into the panel's bottom corners",
 );
 
-// ── Pill chrome: control radius, hairline border, quiet 6% text tint ────────
+// ── Chip chrome: shared quiet 28px chips in the composer sheet ──────────────
 assert.match(
   css,
-  /\.cave-context-pill \{[\s\S]{0,400}?height: 30px;[\s\S]{0,200}?border: 1px solid var\(--border-hairline\);\s*\n\s*border-radius: var\(--radius-control\);\s*\n\s*background: color-mix\(in oklch, var\(--text-primary\) 6%, transparent\);\s*\n\s*color: var\(--text-secondary\);\s*\n\s*font-size: var\(--text-sm\);/,
-  "the context pill is the quiet 30px control-radius pill (hairline border, 6% text tint, 12px text token)",
+  /\.cave-composer-footer-band__cluster \{[\s\S]{0,200}?min-width: 0;[\s\S]{0,120}?flex: 1 1 auto;/,
+  "the band's chip cluster flexes and allows shrinking so three chips coexist with the linked strip",
 );
+assert.match(
+  css,
+  /\.cave-context-chip \{[\s\S]{0,400}?height: 28px;[\s\S]{0,300}?border-radius: var\(--radius-control\);\s*\n\s*background: transparent;\s*\n\s*color: var\(--text-secondary\);\s*\n\s*font-size: var\(--text-sm\);/,
+  "the context chips are the quiet 28px control-radius family, defined in the shared composer sheet",
+);
+assert.match(
+  css,
+  /\.cave-context-chip\[aria-expanded="true"\] \{[\s\S]{0,200}?--accent-presence/,
+  "an open chip shows the accent open-state (pill parity)",
+);
+assert.doesNotMatch(css, /\.cave-context-pill/, "the combined pill's CSS is retired with it");
 
 // ── The wide reading measure: 64rem, shared by thread · follow-ups · composer
 assert.match(

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -63,8 +63,8 @@ assert.doesNotMatch(
 // pill + linked-work chip strip) alongside the grouped composer menu.
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill[\s\S]*?\{linkedContextRow\}/,
-  "the footer band carries the context pill and the linked-context strip",
+  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?\{linkedContextRow\}/,
+  "the footer band carries the context chips and the linked-context strip",
 );
 
 assert.match(

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -147,14 +147,14 @@ assert.doesNotMatch(source, /<ComposerPlusMenu/, "legacy plus-menu composition s
 // "Both" reconciliation (2026-07-21): the context pill returned with the
 // footer band — but only there, never back in the control row.
 assert.equal(
-  source.match(/<ComposerContextPill/g)?.length,
+  source.match(/<ComposerContextChips/g)?.length,
   1,
-  "the context pill mounts exactly once — in the footer band",
+  "the context chips mount exactly once — in the footer band",
 );
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
-  "the context pill lives in the footer band, not the control row",
+  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips/,
+  "the context chips live in the footer band, not the control row",
 );
 assert.doesNotMatch(source, /<ComposerOptionsMenu/, "legacy options-menu composition should be gone");
 

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -150,12 +150,12 @@ assert.match(
   /context=\{\{[\s\S]*linkedWork=\{\{[\s\S]*improve=\{\{[\s\S]*response=\{\{/,
   "the grouped menu receives Context, Linked Work, Improve, and Response contracts in visual order",
 );
-// The context pill (Project · Model · branch) lives in the footer band below
+// The context chips (project · model · branch) live in the footer band below
 // the controls (2026-07-21 wide-column pass) — not in the utility row.
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<ComposerContextPill/,
-  "the context pill anchors the footer band",
+  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips/,
+  "the context chips anchor the footer band",
 );
 assert.doesNotMatch(
   source,
@@ -173,12 +173,12 @@ assert.match(
   "the grouped Response section carries Host, Access, Model, Thinking, and Speed in order",
 );
 assert.doesNotMatch(source, /<ComposerPlusMenu/, "legacy plus-menu composition should be gone");
-// "Both" reconciliation (2026-07-21): the context pill returned with the
-// footer band — but only there, never back in the control row.
+// "Both" reconciliation (2026-07-21): the context chips ride the footer
+// band — but only there, never back in the control row.
 assert.equal(
-  source.match(/<ComposerContextPill/g)?.length,
+  source.match(/<ComposerContextChips/g)?.length,
   1,
-  "the context pill mounts exactly once — in the footer band",
+  "the context chips mount exactly once — in the footer band",
 );
 assert.doesNotMatch(source, /<ComposerOptionsMenu/, "legacy options-menu composition should be gone");
 assert.doesNotMatch(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -69,7 +69,7 @@ import type { Card } from "@/lib/cave-board-types";
 import { openExternalUrl } from "@/lib/open-external";
 import { githubIcon, githubLabel, repoName } from "@/components/composer-linked-work-actions";
 import { LinkedContextRow } from "@/components/composer-linked-work-actions";
-import { ComposerContextPill } from "@/components/composer-context-pill";
+import { ComposerContextChips } from "@/components/composer-context-pill";
 import {
   attachmentIcon,
   cleanImageDataUrl,
@@ -5829,7 +5829,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       modelDisabled: busy,
                       projectRoot: activeProjectRoot,
                       onOpenUrl,
-                      ariaLabel: "Chat context: project, model, and branch",
                     }}
                     linkedWork={{
                       linkedContext,
@@ -5901,29 +5900,29 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               </div>
             </div>
             {/* Footer band — the darker strip attached to the panel's
-                underside carries the context pill (Project · Model/runtime ·
-                branch; every picker opens from it) on the left and the
-                linked-work strip (tasks · GitHub · link/create) on the
-                right. The pill moved down from the control row (2026-07-21
-                wide-column pass) so the write surface above stays minimal. */}
+                underside carries the context chips (project · model · branch
+                as separate controls, cave-g21f; each opens its own picker) on
+                the left and the linked-work strip (tasks · GitHub ·
+                link/create) on the right. */}
             <div className="cave-composer-footer-band">
-              <ComposerContextPill
-                projects={projects}
-                projectValue={resolvedProjectId}
-                onProjectChange={setProjectIdDraft}
-                allowNoProject
-                familiarId={familiar.id ?? null}
-                createProject={createProject}
-                runtime={modelHarness}
-                modelValue={composerModelValue}
-                modelOptions={composerModelOptions}
-                onPickRuntime={handleSelectRuntime}
-                onPickModel={handleSelectModel}
-                modelDisabled={busy}
-                projectRoot={activeProjectRoot}
-                onOpenUrl={onOpenUrl}
-                ariaLabel="Chat context: project, model, and branch"
-              />
+              <div className="cave-composer-footer-band__cluster">
+                <ComposerContextChips
+                  projects={projects}
+                  projectValue={resolvedProjectId}
+                  onProjectChange={setProjectIdDraft}
+                  allowNoProject
+                  familiarId={familiar.id ?? null}
+                  createProject={createProject}
+                  runtime={modelHarness}
+                  modelValue={composerModelValue}
+                  modelOptions={composerModelOptions}
+                  onPickRuntime={handleSelectRuntime}
+                  onPickModel={handleSelectModel}
+                  modelDisabled={busy}
+                  projectRoot={activeProjectRoot}
+                  onOpenUrl={onOpenUrl}
+                />
+              </div>
               {linkedContextRow}
             </div>
           </div>

--- a/src/components/composer-actions-menu.test.ts
+++ b/src/components/composer-actions-menu.test.ts
@@ -138,22 +138,17 @@ assert.match(
 );
 assert.match(context, /export\s+type\s+ComposerContextProps\s*=\s*\{/);
 assert.match(context, /export\s+function\s+useComposerContextActions/);
-assert.match(context, /export\s+function\s+ComposerContextActionRows/);
+assert.match(context, /export\s+function\s+ComposerContextChips/);
 assert.match(
   context,
-  /itemSemantic\?: PopoverItemSemantic/,
-  "reusable context rows accept an optional item semantic",
-);
-assert.match(
-  context,
-  /<PopoverItem\s+semantic=\{itemSemantic\}/,
-  "context rows forward the requested semantic to their PopoverItems",
+  /className="cave-context-chip focus-ring"/,
+  "the context controls are native chip buttons (the semantic-forwarding hub rows retired with the split, cave-g21f)",
 );
 assert.match(context, /export\s+function\s+ComposerContextPickers/);
-assert.match(context, /context\.hasGit && context\.branch \? \[context\.branch\] : \[\]/);
-assert.match(context, /title=\{summary\}/);
-assert.match(context, /icon="ph:git-branch"[\s\S]*title=\{`Branch: \$\{context\.branch\} · \$\{context\.dirtyLabel\}/);
-assert.match(context, /icon="ph:git-branch"[\s\S]*>\s*\{context\.branch\}/);
+assert.match(context, /\{context\.hasGit \? \(/);
+assert.match(context, /modelLabel \?\? runtimeName,\s*\n\s*\]\.join\(" · "\);/);
+assert.match(context, /title=\{`Branch: \$\{context\.branch\} · \$\{context\.dirtyLabel\}[\s\S]*?name="ph:git-branch"/);
+assert.match(context, /name="ph:git-branch"[\s\S]*?>\s*\{context\.branch\}/);
 
 assert.match(linkedWork, /createSmartTaskFromChat/);
 assert.match(linkedWork, /TaskLinkPicker/);
@@ -210,7 +205,7 @@ assert.match(
 );
 
 assert.match(home, /<ComposerPlusMenu/);
-assert.match(home, /<ComposerContextPill/);
+assert.match(home, /<ComposerContextChips/);
 assert.match(home, /<ComposerOptionsMenu/);
 assert.doesNotMatch(home, /<ComposerActionsMenu/);
 

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -2,25 +2,18 @@
 
 import "@/styles/cave-composer.css";
 
-// ComposerContextPill — the composer's one quiet context control (chat revamp
-// 1d): a single pill showing "Project · Model · branch" that replaces the
-// visible ProjectPicker + ComposerRuntimeChip + ComposerGitChip row. Clicking
-// it opens a hub popover with three sections; each section chains to the
-// existing picker popover (ProjectPickerPopover, ComposerRuntimePopover,
-// GitBranchMenuPopover) anchored to this same pill, so every existing flow —
-// project switching + add-project, runtime/model switching, branch switch /
-// new worktree / PR open / git-changes drill-through — survives relocation.
+// ComposerContextChips — the composer footer's context controls (cave-g21f):
+// project, model, and (for repo-rooted chats) branch ride as separate,
+// individually labelled chips. Each opens its own picker popover anchored to
+// the chip itself (ProjectPickerPopover, ComposerRuntimePopover,
+// GitBranchMenuPopover), so every existing flow — project switching +
+// add-project, runtime/model switching, branch switch / new worktree / PR
+// open / git-changes drill-through — stays one click away. This replaced the
+// combined "Project · Model · branch" pill and its hub popover (2026-07-22)
+// on both the chat and home composers.
 
 import { useMemo, useRef, useState, type RefObject } from "react";
 import { Icon } from "@/lib/icon";
-import {
-  Popover,
-  PopoverBody,
-  PopoverItem,
-  PopoverLabel,
-  PopoverSeparator,
-  type PopoverItemSemantic,
-} from "@/components/ui/popover";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { ProjectPickerPopover, useAddProjectFlow } from "@/components/project-picker";
 import {
@@ -57,13 +50,12 @@ export type ComposerContextProps = {
   onPickModel: (id: string) => void;
   /** Chat disables model switching while streaming (runtime-chip parity). */
   modelDisabled?: boolean;
-  /** Enables the Branch section for repo-rooted chats (undefined/non-repo
+  /** Enables the branch chip for repo-rooted chats (undefined/non-repo
    *  roots elide it, git-chip parity). */
   projectRoot?: string;
   /** Opens the branch PR in the app's browser pane; falls back to window.open. */
   onOpenUrl?: (url: string) => void;
   disabled?: boolean;
-  ariaLabel: string;
 };
 
 export type ComposerContextController = ReturnType<typeof useComposerContextActions>;
@@ -126,112 +118,18 @@ export function useComposerContextActions(config: ComposerContextProps) {
   };
 }
 
-export function ComposerContextActionRows({
-  context,
-  onOpenProject,
-  onOpenModel,
-  onOpenBranch,
-  onClose,
-  showLabels = false,
-  itemSemantic,
-}: {
-  context: ComposerContextController;
-  onOpenProject: () => void;
-  onOpenModel: () => void;
-  onOpenBranch: () => void;
-  onClose: () => void;
-  showLabels?: boolean;
-  itemSemantic?: PopoverItemSemantic;
-}) {
-  return (
-    <>
-      {showLabels ? <PopoverLabel>Project</PopoverLabel> : null}
-      <PopoverItem
-        semantic={itemSemantic}
-        leading={
-          context.selectedProject ? (
-            <ProjectAvatar
-              name={context.selectedProject.name}
-              root={context.selectedProject.root}
-              color={context.selectedProject.color}
-              size="sm"
-            />
-          ) : (
-            <Icon name="ph:folder" width={13} aria-hidden />
-          )
-        }
-        title={context.selectedProject?.root}
-        onSelect={onOpenProject}
-      >
-        {context.selectedProject?.name ?? "No project"}
-      </PopoverItem>
-      {showLabels ? (
-        <>
-          <PopoverSeparator />
-          <PopoverLabel>Model</PopoverLabel>
-        </>
-      ) : null}
-      <PopoverItem
-        semantic={itemSemantic}
-        leading={
-          <span className="cave-runtime-chip__logo" aria-hidden>
-            <RuntimeLogo runtime={context.config.runtime} size={13} />
-          </span>
-        }
-        disabled={context.config.modelDisabled}
-        title={`Runtime: ${context.runtimeName}${context.modelLabel ? ` · Model: ${context.modelLabel}` : ""}`}
-        onSelect={onOpenModel}
-      >
-        {context.modelLabel
-          ? `${context.runtimeName} · ${context.modelLabel}`
-          : context.runtimeName}
-      </PopoverItem>
-      {context.hasGit ? (
-        <>
-          {showLabels ? (
-            <>
-              <PopoverSeparator />
-              <PopoverLabel>Branch</PopoverLabel>
-            </>
-          ) : null}
-          <PopoverItem
-            semantic={itemSemantic}
-            icon="ph:git-branch"
-            title={`Branch: ${context.branch} · ${context.dirtyLabel}${context.worktree ? ` · Worktree: ${context.worktree}` : ""} — switch branch or create a worktree`}
-            onSelect={onOpenBranch}
-          >
-            {context.branch}
-            {context.count > 0 ? ` · +${context.count}` : ""}
-            {context.worktree ? ` · ${context.worktree}` : ""}
-          </PopoverItem>
-          {context.pr ? (
-            <PopoverItem
-              semantic={itemSemantic}
-              icon="ph:git-pull-request"
-              title={`Open PR #${context.pr.number} (${context.pr.isDraft ? "draft" : context.pr.state.toLowerCase()})`}
-              onSelect={() => {
-                onClose();
-                if (context.config.onOpenUrl) context.config.onOpenUrl(context.pr!.url);
-                else window.open(context.pr!.url, "_blank", "noopener,noreferrer");
-              }}
-            >
-              PR #{context.pr.number}
-            </PopoverItem>
-          ) : null}
-          <PopoverItem
-            semantic={itemSemantic}
-            icon="ph:git-diff"
-            onSelect={() => {
-              onClose();
-              window.dispatchEvent(new CustomEvent("cave:changes-open"));
-            }}
-          >
-            Open Git changes
-          </PopoverItem>
-        </>
-      ) : null}
-    </>
-  );
+// The branch menu's footer rows (PR · Git changes) — shared by the footer's
+// branch chip and the actions-menu "Branch…" flow so both keep parity with
+// the retired hub's git section.
+function branchPopoverExtras(context: ComposerContextController) {
+  return {
+    pr: context.pr,
+    onOpenPr: (url: string) => {
+      if (context.config.onOpenUrl) context.config.onOpenUrl(url);
+      else window.open(url, "_blank", "noopener,noreferrer");
+    },
+    onOpenChanges: () => window.dispatchEvent(new CustomEvent("cave:changes-open")),
+  };
 }
 
 export function ComposerContextPickers({
@@ -275,6 +173,7 @@ export function ComposerContextPickers({
         anchorRef={anchorRef}
         projectRoot={context.root}
         onSwitched={context.reload}
+        {...branchPopoverExtras(context)}
       />
       {context.addFlow.addError ? (
         <span className="cave-project-picker__error" role="alert">
@@ -286,111 +185,29 @@ export function ComposerContextPickers({
   );
 }
 
-export function ComposerContextPill(props: ComposerContextProps & { splitControls?: boolean }) {
-  const [menu, setMenu] = useState<"hub" | ComposerContextView>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
+export function ComposerContextChips(props: ComposerContextProps) {
+  const [menu, setMenu] = useState<ComposerContextView>(null);
   const projectRef = useRef<HTMLButtonElement | null>(null);
   const modelRef = useRef<HTMLButtonElement | null>(null);
+  const branchRef = useRef<HTMLButtonElement | null>(null);
   const context = useComposerContextActions(props);
-  const summary = [
-    context.summary,
-    ...(context.hasGit && context.branch ? [context.branch] : []),
-  ].join(" · ");
-
-  // Split mode (home refinement 2026-07-22): project and model ride as two
-  // distinct, separately-labelled trigger buttons instead of one ambiguous
-  // combined pill. Each opens its own picker; the anchor is the button itself
-  // so the popover lands under the control the user clicked.
-  if (props.splitControls) {
-    const projectLabel = context.selectedProject?.name ?? "No project";
-    const modelLabel = context.modelLabel ?? context.runtimeName;
-    return (
-      <>
-        <button
-          ref={projectRef}
-          type="button"
-          className="cave-context-chip focus-ring"
-          disabled={props.disabled}
-          aria-haspopup="dialog"
-          aria-expanded={menu === "project"}
-          aria-label={`Project: ${projectLabel} — change project`}
-          title={context.selectedProject?.root ?? "No project selected"}
-          onClick={() => setMenu((c) => (c === "project" ? null : "project"))}
-        >
-          <span className="cave-context-chip__lead" aria-hidden>
-            {context.selectedProject ? (
-              <ProjectAvatar
-                name={context.selectedProject.name}
-                root={context.selectedProject.root}
-                color={context.selectedProject.color}
-                size="sm"
-              />
-            ) : (
-              <Icon name="ph:folder" width={13} aria-hidden />
-            )}
-          </span>
-          <span className="cave-context-chip__text">{projectLabel}</span>
-          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
-        </button>
-        <button
-          ref={modelRef}
-          type="button"
-          className="cave-context-chip focus-ring"
-          disabled={props.disabled || context.config.modelDisabled}
-          aria-haspopup="dialog"
-          aria-expanded={menu === "model"}
-          aria-label={`Model: ${modelLabel} — change model`}
-          title={`Runtime: ${context.runtimeName}${context.modelLabel ? ` · Model: ${context.modelLabel}` : ""}`}
-          onClick={() => setMenu((c) => (c === "model" ? null : "model"))}
-        >
-          <span className="cave-context-chip__lead cave-runtime-chip__logo" aria-hidden>
-            <RuntimeLogo runtime={context.config.runtime} size={13} />
-          </span>
-          <span className="cave-context-chip__text">{modelLabel}</span>
-          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
-        </button>
-
-        <ProjectPickerPopover
-          open={menu === "project"}
-          onOpenChange={(open) => setMenu(open ? "project" : null)}
-          anchorRef={projectRef}
-          projects={context.config.projects}
-          value={context.config.projectValue}
-          onChange={context.config.onProjectChange}
-          allowNoProject={context.config.allowNoProject}
-          onAddProject={context.config.createProject ? context.addFlow.beginAddProject : undefined}
-          addingProject={context.addFlow.adding}
-          ariaLabel="Choose project"
-        />
-        <ComposerRuntimePopover
-          open={menu === "model"}
-          onOpenChange={(open) => setMenu(open ? "model" : null)}
-          anchorRef={modelRef}
-          runtime={context.config.runtime}
-          modelValue={context.config.modelValue}
-          modelOptions={context.config.modelOptions}
-          onPickRuntime={context.config.onPickRuntime}
-          onPickModel={context.config.onPickModel}
-        />
-        {context.config.createProject ? context.addFlow.addProjectModal : null}
-      </>
-    );
-  }
+  const projectLabel = context.selectedProject?.name ?? "No project";
+  const modelLabel = context.modelLabel ?? context.runtimeName;
 
   return (
     <>
       <button
-        ref={triggerRef}
+        ref={projectRef}
         type="button"
-        className="cave-context-pill focus-ring"
+        className="cave-context-chip focus-ring"
         disabled={props.disabled}
         aria-haspopup="dialog"
-        aria-expanded={menu !== null}
-        aria-label={props.ariaLabel}
-        title={summary}
-        onClick={() => setMenu((current) => (current === null ? "hub" : null))}
+        aria-expanded={menu === "project"}
+        aria-label={`Project: ${projectLabel} — change project`}
+        title={context.selectedProject?.root ?? "No project selected"}
+        onClick={() => setMenu((c) => (c === "project" ? null : "project"))}
       >
-        <span className="cave-context-pill__swatch" aria-hidden>
+        <span className="cave-context-chip__lead" aria-hidden>
           {context.selectedProject ? (
             <ProjectAvatar
               name={context.selectedProject.name}
@@ -402,42 +219,88 @@ export function ComposerContextPill(props: ComposerContextProps & { splitControl
             <Icon name="ph:folder" width={13} aria-hidden />
           )}
         </span>
-        <span className="cave-context-pill__text">{summary}</span>
-        <Icon
-          name="ph:caret-down"
-          width={10}
-          aria-hidden
-          className="cave-context-pill__chevron"
-        />
+        <span className="cave-context-chip__text">{projectLabel}</span>
+        <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
       </button>
-
-      <Popover
-        open={menu === "hub"}
-        onOpenChange={(open) => setMenu(open ? "hub" : null)}
-        anchorRef={triggerRef}
-        placement="top-start"
-        minWidth={252}
-        ariaLabel={props.ariaLabel}
-        className="cave-context-pill__hub"
+      <button
+        ref={modelRef}
+        type="button"
+        className="cave-context-chip focus-ring"
+        disabled={props.disabled || context.config.modelDisabled}
+        aria-haspopup="dialog"
+        aria-expanded={menu === "model"}
+        aria-label={`Model: ${modelLabel} — change model`}
+        title={`Runtime: ${context.runtimeName}${context.modelLabel ? ` · Model: ${context.modelLabel}` : ""}`}
+        onClick={() => setMenu((c) => (c === "model" ? null : "model"))}
       >
-        <PopoverBody>
-          <ComposerContextActionRows
-            context={context}
-            onOpenProject={() => setMenu("project")}
-            onOpenModel={() => setMenu("model")}
-            onOpenBranch={() => setMenu("branch")}
-            onClose={() => setMenu(null)}
-            showLabels
-          />
-        </PopoverBody>
-      </Popover>
+        <span className="cave-context-chip__lead cave-runtime-chip__logo" aria-hidden>
+          <RuntimeLogo runtime={context.config.runtime} size={13} />
+        </span>
+        <span className="cave-context-chip__text">{modelLabel}</span>
+        <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+      </button>
+      {context.hasGit ? (
+        <button
+          ref={branchRef}
+          type="button"
+          className="cave-context-chip focus-ring"
+          disabled={props.disabled}
+          aria-haspopup="menu"
+          aria-expanded={menu === "branch"}
+          aria-label={`Branch: ${context.branch} — switch branch or create a worktree`}
+          title={`Branch: ${context.branch} · ${context.dirtyLabel}${context.worktree ? ` · Worktree: ${context.worktree}` : ""}`}
+          onClick={() => setMenu((c) => (c === "branch" ? null : "branch"))}
+        >
+          <span className="cave-context-chip__lead" aria-hidden>
+            <Icon name="ph:git-branch" width={13} aria-hidden />
+          </span>
+          <span className="cave-context-chip__text">
+            {context.branch}
+            {context.count > 0 ? ` · +${context.count}` : ""}
+            {context.worktree ? ` · ${context.worktree}` : ""}
+          </span>
+          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+        </button>
+      ) : null}
 
-      <ComposerContextPickers
-        view={menu === "hub" ? null : menu}
-        onViewChange={setMenu}
-        anchorRef={triggerRef}
-        context={context}
+      <ProjectPickerPopover
+        open={menu === "project"}
+        onOpenChange={(open) => setMenu(open ? "project" : null)}
+        anchorRef={projectRef}
+        projects={context.config.projects}
+        value={context.config.projectValue}
+        onChange={context.config.onProjectChange}
+        allowNoProject={context.config.allowNoProject}
+        onAddProject={context.config.createProject ? context.addFlow.beginAddProject : undefined}
+        addingProject={context.addFlow.adding}
+        ariaLabel="Choose project"
       />
+      <ComposerRuntimePopover
+        open={menu === "model"}
+        onOpenChange={(open) => setMenu(open ? "model" : null)}
+        anchorRef={modelRef}
+        runtime={context.config.runtime}
+        modelValue={context.config.modelValue}
+        modelOptions={context.config.modelOptions}
+        onPickRuntime={context.config.onPickRuntime}
+        onPickModel={context.config.onPickModel}
+      />
+      {context.hasGit ? (
+        <GitBranchMenuPopover
+          open={menu === "branch"}
+          onOpenChange={(open) => setMenu(open ? "branch" : null)}
+          anchorRef={branchRef}
+          projectRoot={context.root}
+          onSwitched={context.reload}
+          {...branchPopoverExtras(context)}
+        />
+      ) : null}
+      {context.addFlow.addError ? (
+        <span className="cave-project-picker__error" role="alert">
+          {context.addFlow.addError}
+        </span>
+      ) : null}
+      {context.config.createProject ? context.addFlow.addProjectModal : null}
     </>
   );
 }

--- a/src/components/composer-density.test.ts
+++ b/src/components/composer-density.test.ts
@@ -22,7 +22,7 @@ assert.doesNotMatch(source, /<ComposerPlusMenu/, "the plus menu should not own t
 // the controls — the control row itself stays pill-free.
 assert.doesNotMatch(
   source.match(/className="cave-composer-control-row">[\s\S]*?className="cave-composer-footer-band"/)?.[0] ?? "",
-  /<ComposerContextPill/,
+  /<ComposerContextChips/,
   "the context pill should not own the composer control row",
 );
 

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -12,9 +12,9 @@ const css = readFileSync(new URL("../styles/composer-git-chip.css", import.meta.
 const pill = readFileSync(new URL("./composer-context-pill.tsx", import.meta.url), "utf8");
 
 // ── The chat composer carries git context from the chat's active root ───────
-// Task 3's triggerless extraction moved branch/PR/change actions into shared
-// ComposerContextActionRows + ComposerContextPickers, with ComposerContextPill
-// staying as the wrapper that owns the anchor/menu state.
+// The 2026-07-22 split (cave-g21f) puts branch/PR/change actions on the
+// branch chip's GitBranchMenuPopover (via branchPopoverExtras);
+// ComposerContextPickers keeps the actions-menu flow on the same wiring.
 assert.match(
   chatView,
   /<ComposerActionsMenu[\s\S]*?context=\{\{[\s\S]*?projectRoot: activeProjectRoot,[\s\S]*?onOpenUrl,[\s\S]*?\}\}/,
@@ -27,7 +27,7 @@ assert.match(
   "the pill reads branch/worktree/dirty state from the shared changes-summary hook",
 );
 assert.match(pill, /const pr = useBranchPr\(root, branch\);/, "shared context actions derive the branch PR once from root + branch");
-assert.match(pill, /export function ComposerContextActionRows\(/, "branch/PR/change rows are extracted from the pill trigger");
+assert.match(pill, /function branchPopoverExtras\(context: ComposerContextController\)/, "the PR/changes rows are built once and shared by the chip and the actions-menu flow");
 assert.match(
   pill,
   /export function ComposerContextPickers\(/,
@@ -40,8 +40,8 @@ assert.match(
 );
 assert.match(
   pill,
-  /const context = useComposerContextActions\(props\);[\s\S]*?<ComposerContextActionRows[\s\S]*?<ComposerContextPickers[\s\S]*?context=\{context\}/,
-  "ComposerContextPill still wraps the extracted branch rows/pickers on the shared anchor",
+  /const context = useComposerContextActions\(props\);[\s\S]*?<GitBranchMenuPopover[\s\S]*?\{\.\.\.branchPopoverExtras\(context\)\}/,
+  "the chips mount the branch menu with the PR/changes extras on the chip anchor",
 );
 assert.match(
   pill,

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -158,4 +158,29 @@ assert.match(
   "the branch trigger stops propagation so it never fires the chip's open-changes click",
 );
 
+// ── The branch menu carries PR + changes rows (post-hub grammar, cave-g21f) ──
+// The footer's branch chip opens this menu directly; the PR link and the
+// Git-changes drill-through that used to live in the pill's hub ride along as
+// optional footer rows so nothing regresses.
+assert.match(
+  chip,
+  /pr\?: BranchPr \| null;[\s\S]*?onOpenPr\?: \(url: string\) => void;[\s\S]*?onOpenChanges\?: \(\) => void;/,
+  "the branch menu takes optional PR/changes rows so the footer chip keeps hub parity",
+);
+assert.match(
+  chip,
+  /\{pr \|\| onOpenChanges \? <PopoverSeparator \/> : null\}/,
+  "the extra rows sit behind a separator and render only when provided",
+);
+assert.match(
+  chip,
+  /closeMenu\(\);\s*\n\s*onOpenPr\?\.\(pr\.url\);[\s\S]{0,120}?Open PR #\{pr\.number\}/,
+  "the PR row closes the menu and defers to the host's URL opener",
+);
+assert.match(
+  chip,
+  /closeMenu\(\);\s*\n\s*onOpenChanges\(\);[\s\S]{0,120}?Open Git changes/,
+  "the changes row closes the menu and fires the host's drill-through",
+);
+
 console.log("composer-git-chip.test.ts: ok");

--- a/src/components/composer-git-chip.tsx
+++ b/src/components/composer-git-chip.tsx
@@ -106,6 +106,9 @@ export function GitBranchMenuPopover({
   anchorRef,
   projectRoot,
   onSwitched,
+  pr,
+  onOpenPr,
+  onOpenChanges,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -114,6 +117,12 @@ export function GitBranchMenuPopover({
   projectRoot: string | undefined;
   /** Called after a successful branch switch (e.g. reload the status poll). */
   onSwitched?: () => void;
+  /** Optional footer rows (post-hub grammar, cave-g21f): the branch's PR… */
+  pr?: BranchPr | null;
+  /** …opened via the host's URL handler… */
+  onOpenPr?: (url: string) => void;
+  /** …and the Git-changes drill-through. */
+  onOpenChanges?: () => void;
 }) {
   const root = projectRoot?.trim() ? projectRoot : undefined;
   const menuOpen = open;
@@ -301,6 +310,30 @@ export function GitBranchMenuPopover({
             New worktree…
           </PopoverItem>
         )}
+        {pr || onOpenChanges ? <PopoverSeparator /> : null}
+        {pr ? (
+          <PopoverItem
+            icon="ph:git-pull-request"
+            title={`Open PR #${pr.number} (${pr.isDraft ? "draft" : pr.state.toLowerCase()})`}
+            onSelect={() => {
+              closeMenu();
+              onOpenPr?.(pr.url);
+            }}
+          >
+            Open PR #{pr.number}
+          </PopoverItem>
+        ) : null}
+        {onOpenChanges ? (
+          <PopoverItem
+            icon="ph:git-diff"
+            onSelect={() => {
+              closeMenu();
+              onOpenChanges();
+            }}
+          >
+            Open Git changes
+          </PopoverItem>
+        ) : null}
         {menuError ? (
           <div className="cave-composer-git-chip__menu-error" role="alert">
             {menuError}

--- a/src/components/composer-plus-menu.tsx
+++ b/src/components/composer-plus-menu.tsx
@@ -45,7 +45,7 @@ export function ComposerPlusMenu({
     /** Platform-aware shortcut hint (e.g. "⌘⇧A"). */
     hint?: string;
   };
-  /** "Add to project ›" flyout — mirrors the footer-band context pill. */
+  /** "Add to project ›" flyout — mirrors the footer-band context chips. */
   projects?: AddMenuProjectsSection;
   /** Skills flyout; picking inserts `/skill <id> ` into the composer. */
   skills?: { onPickSkill: (skill: SkillOption) => void };

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -22,18 +22,18 @@ const contextPill = readFileSync(new URL("./composer-context-pill.tsx", import.m
 // revamp 1d) — same ComposerRuntimePopover, same live model state.
 assert.match(
   homeComposer,
-  /<ComposerContextPill[\s\S]*?runtime=\{selectedRuntime\}[\s\S]*?modelValue=\{selectedModelId\}[\s\S]*?modelOptions=\{runtimeModelOptions\}[\s\S]*?onPickRuntime=\{handleSelectRuntime\}[\s\S]*?onPickModel=\{handleSelectModel\}/,
-  "the home composer's context pill hosts the runtime picker from its own model state",
+  /<ComposerContextChips[\s\S]*?runtime=\{selectedRuntime\}[\s\S]*?modelValue=\{selectedModelId\}[\s\S]*?modelOptions=\{runtimeModelOptions\}[\s\S]*?onPickRuntime=\{handleSelectRuntime\}[\s\S]*?onPickModel=\{handleSelectModel\}/,
+  "the home composer's context chips host the runtime picker from its own model state",
 );
 assert.match(
   homeComposer,
-  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextPill/,
-  "the home pill anchors the composer footer band (2026-07-21 home parity pass moved it down from the utility row)",
+  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextChips/,
+  "the chips anchor the composer footer band",
 );
 assert.match(
   contextPill,
-  /export function ComposerContextActionRows\(/,
-  "runtime/model rows are reusable outside the Home pill wrapper",
+  /aria-label=\{`Model: \$\{modelLabel\} — change model`\}/,
+  "the model chip is a separately labelled control (split grammar, cave-g21f)",
 );
 assert.match(
   contextPill,
@@ -47,8 +47,8 @@ assert.match(
 );
 assert.match(
   contextPill,
-  /const context = useComposerContextActions\(props\);[\s\S]*?<ComposerContextActionRows[\s\S]*?<ComposerContextPickers[\s\S]*?context=\{context\}/,
-  "ComposerContextPill still wraps the extracted runtime/model rows and pickers",
+  /const context = useComposerContextActions\(props\);[\s\S]*?<ComposerRuntimePopover[\s\S]*?onPickModel=\{context\.config\.onPickModel\}/,
+  "the chips mount the shared runtime popover from the same context controller",
 );
 
 // ── Runtime switches refresh the familiar roster immediately (cave-v25g) ────
@@ -83,7 +83,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextPill/,
+  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextChips/,
   "the pill anchors the composer footer band — always visible, session or not (2026-07-21 wide-column pass moved it down from the utility row)",
 );
 

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -65,8 +65,8 @@ assert.match(
 // ───────── Command-bar hierarchy ─────────
 // Chat revamp 1d + 2026-07-21 home parity pass: one "+" menu (attach ·
 // dictation · call · enhance · Model & tuning) leads the utility row, then the
-// Chat/Task pills; the circular send hugs the right. The context pill
-// (Project · Model) anchors the footer band beneath — matching the chat
+// Chat/Task pills; the circular send hugs the right. The context chips
+// (Project · Model) anchor the footer band beneath — matching the chat
 // composer's grammar.
 assert.match(
   source,
@@ -75,7 +75,7 @@ assert.match(
 );
 assert.match(
   source,
-  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextPill/,
+  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextChips/,
   "the context pill anchors the footer band beneath the control row",
 );
 assert.match(

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -91,7 +91,7 @@ assert.match(
 // which project a new chat runs in (mirrors the chat composer).
 assert.match(
   source,
-  /<ComposerContextPill[\s\S]*projectValue=\{selectedProjectId \|\| null\}[\s\S]*onProjectChange=\{setSelectedProjectId\}/,
+  /<ComposerContextChips[\s\S]*projectValue=\{selectedProjectId \|\| null\}[\s\S]*onProjectChange=\{setSelectedProjectId\}/,
   "the context pill hosts the project picker, wired to selectedProjectId",
 );
 
@@ -469,12 +469,12 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?hc-dest-pills--inline[\s\S]*?cave-composer-submit-row[\s\S]*?aria-label="Send"[\s\S]*?<ComposerOptionsMenu[\s\S]*?className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextPill/,
+  /cave-composer-utility-row[\s\S]*?<ComposerPlusMenu[\s\S]*?hc-dest-pills--inline[\s\S]*?cave-composer-submit-row[\s\S]*?aria-label="Send"[\s\S]*?<ComposerOptionsMenu[\s\S]*?className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextChips/,
   "Control row: the + menu and Chat/Task pills lead; the circular send hugs the right; the context pill anchors the footer band beneath (2026-07-21 home parity pass)",
 );
 assert.doesNotMatch(
   source.match(/className="cave-composer-utility-row">[\s\S]*?hc-dest-pills hc-dest-pills--inline/)?.[0] ?? "",
-  /<ComposerContextPill/,
+  /<ComposerContextChips/,
   "the utility row stays pill-free — context moved down to the footer band",
 );
 // The "↵ send · ⇧↵ newline" typing hint is gone (2026-07-21 parity with the

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -52,7 +52,7 @@ import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/co
 import { ComposerPlusMenu } from "@/components/composer-plus-menu";
 import { useAddProjectFlow } from "@/components/project-picker";
 import { sortProjectsAlphabetically } from "@/lib/cave-projects-types";
-import { ComposerContextPill } from "@/components/composer-context-pill";
+import { ComposerContextChips } from "@/components/composer-context-pill";
 import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useRuntimeModelOptions } from "@/lib/use-runtime-model-options";
@@ -1084,20 +1084,15 @@ export function HomeComposer({
             ]}
           />
         </div>
-        {/* Footer band — the darker strip attached to the card's underside
-            carries the context pill (Project · Model; every picker opens from
-            it). Moved down from the control row (2026-07-21 home parity pass,
-            matching the chat composer) so the write surface above stays
-            minimal. Home has no git context or linked-work strip, so the
-            pill rides alone. */}
-        {/* Footer toolbar — refinement pass (2026-07-22): a clean bottom bar
-            inside the composer. Left cluster carries project + model as two
-            SEPARATE controls (no ambiguous "No project · Model" combined
-            label); the segmented Chat/Task control and attach live in the
-            control row above. Send hugs bottom-right, vertically aligned. */}
+        {/* Footer toolbar — a clean bottom bar inside the composer. The left
+            cluster carries project + model as two SEPARATE labelled chips
+            (shared ComposerContextChips grammar with the chat composer,
+            cave-g21f; home passes no git root, so no branch chip). The
+            segmented Chat/Task control and attach live in the control row
+            above. Send hugs bottom-right, vertically aligned. */}
         <div className="cave-composer-footer-band home-composer-toolbar">
           <div className="home-composer-toolbar__left">
-            <ComposerContextPill
+            <ComposerContextChips
               projects={projects}
               projectValue={selectedProjectId || null}
               onProjectChange={setSelectedProjectId}
@@ -1110,8 +1105,6 @@ export function HomeComposer({
               onPickRuntime={handleSelectRuntime}
               onPickModel={handleSelectModel}
               disabled={sending}
-              ariaLabel="Composer context: project and model"
-              splitControls
             />
           </div>
         </div>

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -39,7 +39,7 @@ assert.doesNotMatch(
 // The selector lets the user choose which project a new chat runs in (mirrors
 // the chat composer). The pill chains to the shared ProjectPickerPopover, so
 // selection reads the same everywhere (chat revamp 1d).
-assert.match(homeComposer, /<ComposerContextPill[\s\S]*?projectValue=\{selectedProjectId \|\| null\}/, "home composer's context pill hosts the shared project picker");
+assert.match(homeComposer, /<ComposerContextChips[\s\S]*?projectValue=\{selectedProjectId \|\| null\}/, "home composer's context chips host the shared project picker");
 const contextPill = readFileSync(new URL("./composer-context-pill.tsx", import.meta.url), "utf8");
 assert.match(contextPill, /export type ComposerContextProps = \{/, "context props are reusable");
 assert.match(
@@ -51,13 +51,14 @@ assert.match(contextPill, /export function ComposerContextPickers\(/, "picker si
 assert.match(contextPill, /const context = useComposerContextActions\(props\);/, "the pill wrapper still builds one shared context controller");
 assert.match(
   contextPill,
-  /<ComposerContextActionRows[\s\S]*?onOpenProject=\{\(\) => setMenu\("project"\)\}/,
-  "the pill wrapper still renders the extracted project row entry point",
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?<ProjectPickerPopover/,
+  "the project chip is a labelled control that opens the shared ProjectPickerPopover",
 );
+const actionsMenu = readFileSync(new URL("./composer-actions-menu.tsx", import.meta.url), "utf8");
 assert.match(
-  contextPill,
+  actionsMenu,
   /<ComposerContextPickers[\s\S]*?context=\{context\}/,
-  "the pill wrapper still threads the extracted context into the shared pickers",
+  "the actions menu still threads the shared context into the extracted pickers",
 );
 assert.match(contextPill, /<ProjectPickerPopover/, "the context pill opens the shared ProjectPickerPopover");
 assert.match(contextPill, /useAddProjectFlow\(\{/, "the context pill folds in the shared add-project flow");

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -960,62 +960,69 @@
   .composer-actions__icon--live { animation: none; }
 }
 
-/* The one quiet context pill — project swatch · "Project · Model · branch" ·
-   chevron. Control radius, hairline border, 6% text tint, 12px text. */
-.cave-context-pill {
-  display: inline-flex;
+/* Footer context chips (cave-g21f) — project · model · branch ride as
+   separate quiet controls in the footer band; each opens its own picker
+   anchored to the chip. Shared by the chat and home composers. */
+.cave-composer-footer-band__cluster {
+  display: flex;
   align-items: center;
-  gap: 7px;
-  height: 30px;
+  gap: 6px;
   min-width: 0;
-  max-width: min(46vw, 340px);
-  flex: 0 1 auto;
-  padding: 0 10px;
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  background: color-mix(in oklch, var(--text-primary) 6%, transparent);
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background-color var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
+  flex: 1 1 auto;
 }
 
-.cave-context-pill:hover:not(:disabled) {
-  background: var(--bg-raised);
+.cave-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 13rem;
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 450;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.cave-context-chip:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
   color: var(--text-primary);
 }
 
-.cave-context-pill[aria-expanded="true"] {
+.cave-context-chip[aria-expanded="true"] {
   border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-strong));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-primary);
 }
 
-.cave-context-pill:disabled {
+.cave-context-chip:disabled {
   cursor: default;
   opacity: 0.55;
 }
 
-.cave-context-pill__swatch {
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
+.cave-context-chip__lead {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--text-muted);
 }
 
-.cave-context-pill__text {
+.cave-context-chip__text {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.cave-context-pill__chevron {
-  flex: 0 0 auto;
+.cave-context-chip__chevron {
+  flex-shrink: 0;
   color: var(--text-muted);
+  opacity: 0.7;
 }
 
 /* Circular 32px send: accent outline on transparent at rest; ~18% accent tint
@@ -1077,9 +1084,10 @@
     -webkit-tap-highlight-color: transparent;
   }
 
-  .cave-context-pill {
+  .cave-context-chip {
     height: var(--touch-target);
     min-height: var(--touch-target);
+    max-width: 9rem;
     -webkit-tap-highlight-color: transparent;
   }
 

--- a/src/styles/home-composer/landing-composer.css
+++ b/src/styles/home-composer/landing-composer.css
@@ -298,46 +298,6 @@
   flex: 1 1 auto;
 }
 
-.cave-context-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  max-width: 42%;
-  min-width: 0;
-  height: 28px;
-  padding: 0 var(--space-2);
-  border: 1px solid transparent;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  font-weight: 450;
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-.cave-context-chip:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--foreground) 6%, transparent);
-  color: var(--text-primary);
-}
-.cave-context-chip:disabled { opacity: 0.55; cursor: default; }
-.cave-context-chip__lead {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  color: var(--text-muted);
-}
-.cave-context-chip__text {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.cave-context-chip__chevron {
-  flex-shrink: 0;
-  color: var(--text-muted);
-  opacity: 0.7;
-}
-
 @container (max-width: 620px) {
   .cave-context-chip { max-width: 46%; height: var(--touch-target); }
 }

--- a/tests/composer-runtime-chip.spec.ts
+++ b/tests/composer-runtime-chip.spec.ts
@@ -1,16 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
 
 // Verifies the composer runtime picker (cave-yq5l / cave-v25g / cave-bfwk,
-// relocated behind the context pill by chat revamp 1d): the chat composer's
-// context pill always shows the effective model, its Model section opens the
-// Runtime/Model picker with radio semantics, and picking a runtime rebinds
-// the familiar through /api/config — flipping the pill, re-listing the Model
-// group in the still-open menu (the pick isn't complete until a model is
-// chosen), refetching the familiar roster (cave:familiars-refresh), and
-// catching the empty-state identity line up without a reload. A model pick
-// then closes the menu.
+// split-chip grammar since cave-g21f): the chat composer footer's model chip
+// always shows the effective model and opens the Runtime/Model picker
+// directly with radio semantics; picking a runtime rebinds the familiar
+// through /api/config — flipping the chip, re-listing the Model group in the
+// still-open menu (the pick isn't complete until a model is chosen),
+// refetching the familiar roster (cave:familiars-refresh), and catching the
+// empty-state identity line up without a reload. A model pick then closes
+// the menu.
 //
-// Desktop only (the pill lives in the chat composer). All APIs are mocked;
+// Desktop only (the chip lives in the chat composer). All APIs are mocked;
 // the config mock is stateful so the roster refetch observably changes what
 // the app sees — exactly the loop the feature exists to close.
 

--- a/tests/composer-runtime-chip.spec.ts
+++ b/tests/composer-runtime-chip.spec.ts
@@ -90,18 +90,17 @@ async function seed(page: Page): Promise<Mutable> {
   return state;
 }
 
-test.describe("composer runtime picker (context pill)", () => {
+test.describe("composer runtime picker (context chips)", () => {
   test("always visible with the runtime + model, popover carries radio groups", async ({ page }) => {
     await seed(page);
     await page.goto("/?mode=chat");
-    const pill = page.getByRole("button", { name: "Chat context: project, model, and branch" });
-    await expect(pill).toBeVisible({ timeout: 45_000 });
-    // toContainText retries — the pill settles once model-state hydrates.
-    await expect(pill).toContainText("GPT-5.5", { timeout: 15_000 });
+    const modelChip = page.getByRole("button", { name: /change model/ });
+    await expect(modelChip).toBeVisible({ timeout: 45_000 });
+    // toContainText retries — the chip settles once model-state hydrates.
+    await expect(modelChip).toContainText("GPT-5.5", { timeout: 15_000 });
 
-    await pill.click();
-    // Hub popover → Model section row opens the Runtime/Model picker.
-    await page.getByRole("menuitem", { name: /Codex · GPT-5\.5/ }).click();
+    // Split chips (cave-g21f): the model chip opens the picker directly.
+    await modelChip.click();
     const menu = page.getByRole("menu", { name: "Runtime and model" });
     await expect(menu).toBeVisible();
     // Runtime group: all four runtimes, the active one checked.
@@ -116,7 +115,7 @@ test.describe("composer runtime picker (context pill)", () => {
   test("picking a runtime rebinds via /api/config, flips the chip, and refreshes the roster", async ({ page }) => {
     const state = await seed(page);
     await page.goto("/?mode=chat");
-    const pill = page.getByRole("button", { name: "Chat context: project, model, and branch" });
+    const pill = page.getByRole("button", { name: /change model/ });
     await expect(pill).toBeVisible({ timeout: 45_000 });
     await expect(pill).toContainText("GPT-5.5", { timeout: 15_000 });
     // The empty-state identity line reads the roster's familiar.harness.
@@ -125,7 +124,6 @@ test.describe("composer runtime picker (context pill)", () => {
     const modelStateGetsBefore = state.modelStateServed;
 
     await pill.click();
-    await page.getByRole("menuitem", { name: /Codex · GPT-5\.5/ }).click();
     const menu = page.getByRole("menu", { name: "Runtime and model" });
     await menu.getByRole("menuitemradio", { name: "Claude Code", exact: true }).click();
 


### PR DESCRIPTION
Separates project and model selection in the chat composer footer (home parity) and gives git context its own chip.

- ComposerContextPill → ComposerContextChips: split chips are the only mode; hub popover + ComposerContextActionRows retired
- New branch chip (repo-rooted chats) opens GitBranchMenuPopover, which gains PR + Open-Git-changes rows (hub parity, also reachable from the actions-menu Branch… flow)
- .cave-context-chip CSS moved to shared cave-composer.css; .cave-context-pill CSS retired
- Source pins + e2e updated to the new grammar

Verified: pnpm test:app (891 files), pnpm typecheck, playwright tests/composer-runtime-chip.spec.ts locally green.

Spec: docs/specs/2026-07-22-chat-footer-split-context-chips-design.md
Plan: docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
Bead: cave-g21f