### PR TITLE
fix(sessions): resolve branch PR context via REST, not GraphQL

### DIFF
--- a/src/lib/branch-pr-context.test.ts
+++ b/src/lib/branch-pr-context.test.ts
@@ -32,6 +32,47 @@ test("parseBranchPr rejects junk", () => {
   assert.equal(parseBranchPr(JSON.stringify({ url: "https://github.com/o/r/pull/1" }), "b"), null);
 });
 
+test("parseBranchPr accepts the REST list shape (html_url + draft, head-filtered)", () => {
+  const restList = JSON.stringify([
+    {
+      number: 42,
+      html_url: "https://github.com/OpenCoven/coven-cave/pull/42",
+      state: "open",
+      draft: true,
+    },
+  ]);
+  const pr = parseBranchPr(restList, "feat/x");
+  assert.deepEqual(pr, {
+    repo: "OpenCoven/coven-cave",
+    number: 42,
+    url: "https://github.com/OpenCoven/coven-cave/pull/42",
+    state: "open",
+    branch: "feat/x",
+    draft: true,
+  });
+});
+
+test("parseBranchPr accepts a single REST object (URL-keyed lookup)", () => {
+  const restOne = JSON.stringify({
+    number: 7,
+    html_url: "https://github.com/o/r/pull/7",
+    state: "CLOSED",
+    draft: false,
+  });
+  const pr = parseBranchPr(restOne);
+  assert.deepEqual(pr, {
+    repo: "o/r",
+    number: 7,
+    url: "https://github.com/o/r/pull/7",
+    state: "closed",
+    draft: false,
+  });
+});
+
+test("parseBranchPr returns null for an empty REST list (no PR for branch)", () => {
+  assert.equal(parseBranchPr("[]", "main"), null);
+});
+
 test("first read misses but schedules a background fetch; next read serves it", async () => {
   let calls = 0;
   const cache = createBranchPrCache({

--- a/src/lib/branch-pr-context.ts
+++ b/src/lib/branch-pr-context.ts
@@ -2,72 +2,136 @@
 //
 // The composer git chip resolves its PR once per (root, branch) client-side
 // (`/api/changes?pr=1`). The sessions list needs the same context for every
-// visible thread on a 4s poll, so `gh pr view` (network-bound, ~hundreds of
+// visible thread on a 4s poll, so the PR lookup (network-bound, ~hundreds of
 // ms) can never sit on the request path. This module is a stale-while-
 // revalidate cache: reads are synchronous from memory; a miss or an expired
-// entry schedules one background `gh pr view` per (root, branch) and keeps
+// entry schedules one background lookup per (root, branch) and keeps
 // serving the previous value (or nothing) meanwhile. Failures — no PR for the
 // branch, gh missing/unauthenticated — negative-cache as null for a full TTL
 // so an unauthenticated machine doesn't hammer gh.
+//
+// The lookup uses `gh api` (GitHub REST) rather than `gh pr view` (GraphQL):
+// the 4s poll across many project roots trivially drains the 5000/hr GraphQL
+// budget, while the REST bucket is a separate, far roomier 5000/hr. REST
+// `GET /repos/:owner/:repo/pulls?head=:owner::branch` returns the same PR
+// fields, and PR-URL lookups hit `GET /repos/:owner/:repo/pulls/:number`.
 
 import { execFile } from "node:child_process";
 import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import type { SessionPullRequestContext } from "@/lib/types";
 
 const PR_URL_RE = /https:\/\/github\.com\/([^/\s]+\/[^/\s]+)\/pull\/(\d+)/;
+const GH_ENV = () => scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" });
 
-/** stdout of `gh pr view <branch> --json number,url,state,isDraft` in `root`. */
+/** stdout of the branch PR lookup (REST list JSON) in `root`. */
 export type BranchPrRunner = (root: string, branch: string) => Promise<string>;
 
-/** Parse gh's JSON into the SessionRow.pullRequest shape (state lowercased).
- *  `branch` is stamped when known (branch-keyed lookups); URL-keyed lookups
- *  omit it. */
+/** Normalize a single REST pull object into the SessionRow.pullRequest shape.
+ *  REST uses `html_url` and `draft`; GraphQL used `url`/`isDraft`. `parseBranchPr`
+ *  accepts either shape so cached callers and tests stay stable. */
+function normalizePull(
+  pull: { number?: unknown; url?: unknown; html_url?: unknown; state?: unknown; isDraft?: unknown; draft?: unknown },
+  branch?: string,
+): SessionPullRequestContext | null {
+  const url = typeof pull.html_url === "string" ? pull.html_url : typeof pull.url === "string" ? pull.url : undefined;
+  if (typeof pull.number !== "number" || !url) return null;
+  const match = PR_URL_RE.exec(url);
+  if (!match) return null;
+  return {
+    repo: match[1]!,
+    number: pull.number,
+    url: match[0],
+    state: typeof pull.state === "string" ? pull.state.toLowerCase() : "open",
+    ...(branch ? { branch } : {}),
+    draft: pull.draft === true || pull.isDraft === true,
+  };
+}
+
+/** Parse the PR lookup stdout into the SessionRow.pullRequest shape (state
+ *  lowercased). Accepts a REST list (`[{...}]`), a single REST/GraphQL object
+ *  (`{...}`), or the legacy `gh pr view` object. `branch` is stamped when known
+ *  (branch-keyed lookups); URL-keyed lookups omit it. */
 export function parseBranchPr(
   stdout: string,
   branch?: string,
 ): SessionPullRequestContext | null {
-  let parsed: { number?: unknown; url?: unknown; state?: unknown; isDraft?: unknown };
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout) as typeof parsed;
+    parsed = JSON.parse(stdout);
   } catch {
     return null;
   }
-  if (typeof parsed.number !== "number" || typeof parsed.url !== "string") return null;
-  const match = PR_URL_RE.exec(parsed.url);
-  if (!match) return null;
-  return {
-    repo: match[1]!,
-    number: parsed.number,
-    url: match[0],
-    state: typeof parsed.state === "string" ? parsed.state.toLowerCase() : "open",
-    ...(branch ? { branch } : {}),
-    draft: parsed.isDraft === true,
-  };
+  // REST list endpoint returns an array; the head filter yields 0 or 1 open PR.
+  if (Array.isArray(parsed)) {
+    const first = parsed[0];
+    return first ? normalizePull(first as Parameters<typeof normalizePull>[0], branch) : null;
+  }
+  if (parsed && typeof parsed === "object") {
+    return normalizePull(parsed as Parameters<typeof normalizePull>[0], branch);
+  }
+  return null;
 }
 
-const defaultRunner: BranchPrRunner = (root, branch) =>
-  new Promise((resolve, reject) => {
+/** Resolve a repo's `owner/name` from its origin remote via `git`, so the REST
+ *  list query can be scoped to the right repository. */
+function repoSlug(root: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "git",
+      ["-C", root, "remote", "get-url", "origin"],
+      { timeout: 10_000, env: GH_ENV() },
+      (err, stdout) => {
+        if (err) return reject(err);
+        const m = /github\.com[:/]([^/\s]+\/[^/\s]+?)(?:\.git)?\s*$/.exec(stdout.trim());
+        if (!m) return reject(new Error("origin is not a github remote"));
+        resolve(m[1]!);
+      },
+    );
+  });
+}
+
+const defaultRunner: BranchPrRunner = async (root, branch) => {
+  const slug = await repoSlug(root);
+  const owner = slug.split("/")[0]!;
+  return new Promise((resolve, reject) => {
     execFile(
       "gh",
-      ["pr", "view", branch, "--json", "number,url,state,isDraft"],
-      { cwd: root, timeout: 10_000, env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }) },
+      [
+        "api",
+        "-X",
+        "GET",
+        `repos/${slug}/pulls`,
+        "-f",
+        `head=${owner}:${branch}`,
+        "-f",
+        "state=all",
+        "-f",
+        "per_page=1",
+      ],
+      { cwd: root, timeout: 10_000, env: GH_ENV() },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });
+};
 
-/** stdout of `gh pr view <url> --json number,url,state,isDraft` (repo inferred
+/** stdout of the PR-URL lookup (REST single-PR JSON; repo + number inferred
  *  from the URL, so no project cwd is needed). */
 export type UrlPrRunner = (url: string) => Promise<string>;
 
-const defaultUrlRunner: UrlPrRunner = (url) =>
-  new Promise((resolve, reject) => {
+const defaultUrlRunner: UrlPrRunner = (url) => {
+  const match = PR_URL_RE.exec(url);
+  if (!match) return Promise.reject(new Error("not a github PR url"));
+  const slug = match[1]!;
+  const number = match[2]!;
+  return new Promise((resolve, reject) => {
     execFile(
       "gh",
-      ["pr", "view", url, "--json", "number,url,state,isDraft"],
-      { timeout: 10_000, env: scrubSidecarInternalEnv({ ...process.env, GH_PROMPT_DISABLED: "1" }) },
+      ["api", "-X", "GET", `repos/${slug}/pulls/${number}`],
+      { timeout: 10_000, env: GH_ENV() },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });
+};
 
 type CacheEntry = {
   value: SessionPullRequestContext | null;

--- a/src/lib/branch-pr-context.ts
+++ b/src/lib/branch-pr-context.ts
@@ -61,7 +61,7 @@ export function parseBranchPr(
   } catch {
     return null;
   }
-  // REST list endpoint returns an array; the head filter yields 0 or 1 open PR.
+  // REST list endpoint returns an array; with `state=all` + `per_page=1` this yields at most one PR of any state.
   if (Array.isArray(parsed)) {
     const first = parsed[0];
     return first ? normalizePull(first as Parameters<typeof normalizePull>[0], branch) : null;


### PR DESCRIPTION
## Problem

The sessions list re-runs every **4s** and schedules one background PR lookup per (root, branch) with a 60s TTL. Those lookups used `gh pr view`, which hits GitHub's **GraphQL** API. With many project roots open, the poll drained the 5000/hr GraphQL budget to **0 every hour** (recurring rate-limit alerts).

## Fix

Swap both runners in `branch-pr-context.ts` to `gh api` (**REST**):
- Branch lookups: `GET /repos/:slug/pulls?head=:owner::branch&state=all&per_page=1`
- URL lookups: `GET /repos/:slug/pulls/:number`

REST has its own separate 5000/hr bucket, so the 4s poll can no longer exhaust GraphQL. `parseBranchPr` now accepts the REST list/object shape (`html_url` + `draft`) while staying back-compatible with the old `gh pr view` object shape.

## Tests
- 4 new `parseBranchPr` cases (REST list, single REST object, empty list, back-compat). All 12 module tests + tsc green; changes-route and coven-bin consumer tests pass.