### PR TITLE
chore(release): stamp v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-07-22
+
+> 🏡 **Calmer hearth, sharper GitHub surfaces, and a quieter API footprint.** The launch home settles into a cards-only hearth with appearance-radius theming, Projects becomes a per-familiar access matrix, and GitHub surfaces gain diff syntax highlighting and an instant activity-heatmap tooltip. Under the hood, session PR context now resolves over REST instead of GraphQL, migrations gain stronger destructive-action guards, and the research desk gets a wide stability sweep.
+
+### Added
+- **Cards-only hearth** — the launch home drops the pill row, centers Continue cards, and adopts appearance radius tokens; hearth centered vertically with radius-token chat glass (#3673, #3679).
+- **Projects as access matrix** — chats › Projects rebuilt as a per-familiar access matrix; profile cards stretch to fill the page (#3689, #3692).
+- **GitHub surfaces** — GitHub-style instant hover tooltip on the session activity heatmap; a shared Shiki singleton powering review-thread diff syntax highlighting (#3697, #3694).
+- **Composer & chat** — footer context pill split into project · model · branch chips; composer linked-work shows one task at a time with an overflow dropdown; sidepanel hover-archive button plus a Show archived option (#3696, #3693, #3688).
+
+### Fixed
+- **Session PR context over REST** — branch/PR lookups on the sessions-list poll now use GitHub REST instead of `gh pr view` (GraphQL), so the 4s poll can no longer exhaust the GraphQL rate-limit budget (#3698).
+- **Migration guards** — destructive keep/recover resolutions gated behind size-imbalance confirmation; discard guard extended to directories with confirms pinned to content tokens (#3683, #3691).
+- **Research desk sweep** — desk-wide bug sweep (reconcile crashes, stuck missions, silent action failures), travel-replay run re-pointing, ACTIVE-automation guard, default-tab latch, and pre-approved tools for unattended copilot flow spawns (#3680, #3684, #3676).
+- **Theme fidelity** — normalize unprefixed custom-theme keys in live apply, de-finick appearance color overrides, and restore custom theme accent when the backdrop releases `--accent-presence` (#3695, #3686, #3674).
+- **Home & chat polish** — flatten the launch background (retire radial washes and hearth halo), round the hearth backdrop scrim with appearance radius tokens, and compact the operator avatar to the familiars' optical size (#3690, #3681, #3687).
+- **Familiar tab** — landed the 12 post-merge review follow-ups from #3655 (#3682).
+- **Task-work & dashboard** — fill the conversation panel with task-chat alignment; open familiar profile pages from the top-collaborators footer (#3677, #3675).
+- **Voice & canvas** — voice connect fails gracefully with an in-place vault key fix; canvas uniquifies corrupt-aside capture names (#3685, #3678).
+
 ## [0.1.5] - 2026-07-22
 
 > 🏠 **Refined home, richer iOS, and new runtimes.** The launch home gets a unified hearth cluster with Continue cards and a split composer toolbar. iOS gains a focused 4-tab bar, turn-completion notifications, Live Activity, Canvas view mode, and motion polish. New runtimes: Grok Build, OpenCode, and a native Tailscale Server Hub connection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "block2",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.5"
+version = "0.1.6"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps all six version locations to **0.1.6** and adds the CHANGELOG section.

- package.json, Cargo.toml, Cargo.lock (app), tauri.conf.json, Info.ios.plist, gen/apple Info.plist → 0.1.6
- CHANGELOG: new `## [0.1.6] - 2026-07-22` section covering the 26 PRs merged since v0.1.5, including the GraphQL→REST session-PR-context fix (#3698).

Tag `v0.1.6` will be cut from the merge commit once CI is green.