### PR TITLE
feat(chat): queue follow-up messages

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -138,14 +138,20 @@ assert.match(
 
 assert.match(
   source,
-  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) \{[\s\S]*?enqueueMessage\(\{[\s\S]*?text: outgoingText,[\s\S]*?attachments: outgoingAttachments,[\s\S]*?mentionedFiles: outgoingMentions,[\s\S]*?controls:/,
+  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy \|\| abortRef\.current\) \{[\s\S]*?enqueueMessage\(\{[\s\S]*?text: outgoingText,[\s\S]*?attachments: outgoingAttachments,[\s\S]*?mentionedFiles: outgoingMentions,[\s\S]*?controls:/,
   "send() must queue a rich follow-up while busy instead of dropping it (CHAT-D5-01)",
 );
 
 assert.match(
   source,
-  /const sendRaw = async [\s\S]*?\|\| \(busy && !allowBusy\)\) return;/,
-  "sendRaw should keep its busy guard while allowing the queue drain to hand off exactly one settled item",
+  /const sendRaw = async [\s\S]*?if \(\(busy \|\| abortRef\.current\) && !allowBusy\) \{[\s\S]*?enqueueMessage\(/,
+  "sendRaw should queue all programmatic sends while any runtime is in flight, while allowing the queue drain to hand off exactly one settled item",
+);
+
+assert.match(
+  source,
+  /if \(command === "\/run" \|\| command === "\/codex" \|\| command === "\/claude"\)[\s\S]*?setTimeout\(\(\) => sendRaw\(args\), 0\);[\s\S]*?const sendRaw = async [\s\S]*?enqueueMessage\(/,
+  "slash sends for Codex, Claude, and other harness-backed commands must queue through sendRaw instead of being dropped mid-response",
 );
 
 assert.match(
@@ -192,8 +198,8 @@ assert.match(
 
 assert.match(
   source,
-  /if \(busy \|\| abortRef\.current\) \{[\s\S]*?announce\("Queued message will send next\.", "polite"\);/,
-  "send-next must only reprioritize while every supported runtime host is busy, including non-streaming hosts without an AbortController",
+  /if \(busy \|\| abortRef\.current\) \{[\s\S]*?announce\("Queued message will send next\.", "polite"\);[\s\S]*?const sendRaw = async [\s\S]*?if \(\(busy \|\| abortRef\.current\) && !allowBusy\)/,
+  "send-next and normal sends must recognize every supported runtime as in flight, including non-streaming hosts and the render gap before busy updates",
 );
 
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -6,7 +6,7 @@ const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8")
 const turnStateSource = readFileSync(new URL("../lib/chat-turn-state.ts", import.meta.url), "utf8");
 const draftHook = readFileSync(new URL("../lib/use-composer-draft.ts", import.meta.url), "utf8");
 const streamEvents = readFileSync(new URL("../lib/stream-events.ts", import.meta.url), "utf8");
-const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"]
+const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat", "cave-chat/activity"]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 
@@ -146,6 +146,24 @@ assert.match(
   source,
   /const sendRaw = async [\s\S]*?\|\| \(busy && !allowBusy\)\) return;/,
   "sendRaw should keep its busy guard while allowing the queue drain to hand off exactly one settled item",
+);
+
+assert.match(
+  source,
+  /type ChatSendControls = \{[\s\S]*?permissionMode: CommandPermissionMode;/,
+  "queued messages must preserve the selected access level",
+);
+
+assert.match(
+  source,
+  /const sendOptions: ChatSendOptions = \{[\s\S]*?projectRoot: requestProjectRoot,[\s\S]*?mentionedFilesRoot: mentionRoot[\s\S]*?modelOverride:[\s\S]*?options: sendOptions,[\s\S]*?permissionMode,/,
+  "queued messages must retain queue-time model, project, file-mention, and access metadata",
+);
+
+assert.match(
+  source,
+  /const projectRootForRequest = opts\?\.projectRoot \?\? requestProjectRoot;[\s\S]*?const mentionedFilesRootForRequest = opts\?\.mentionedFilesRoot \?\? mentionRoot;[\s\S]*?const modelOverrideForRequest =[\s\S]*?projectRoot: projectRootForRequest,[\s\S]*?permissionMode: controlsOverride\?\.permissionMode \?\? permissionMode,[\s\S]*?mentionedFilesRoot: mentionedFilesRootForRequest/,
+  "delayed dispatch must use queued metadata rather than the latest composer state",
 );
 
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -192,6 +192,12 @@ assert.match(
 
 assert.match(
   source,
+  /if \(busy \|\| abortRef\.current\) \{[\s\S]*?announce\("Queued message will send next\.", "polite"\);/,
+  "send-next must only reprioritize while every supported runtime host is busy, including non-streaming hosts without an AbortController",
+);
+
+assert.match(
+  source,
   /title="Queue message"[\s\S]*?aria-label="Queue message"[\s\S]*?title="Cancel \(esc\)"/,
   "a live response must expose both Queue and Cancel controls",
 );

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -138,14 +138,32 @@ assert.match(
 
 assert.match(
   source,
-  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) return;[\s\S]*?setInput\(""\);[\s\S]*?clearAttachments\(\);[\s\S]*?await sendRaw\(outgoingText, outgoingAttachments, outgoingMentions/,
-  "send() must run slash intents first, then bail on busy BEFORE clearing the composer — a mid-stream Enter must not destroy the draft (CHAT-D5-01)",
+  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy\) \{[\s\S]*?enqueueMessage\(\{[\s\S]*?text: outgoingText,[\s\S]*?attachments: outgoingAttachments,[\s\S]*?mentionedFiles: outgoingMentions,[\s\S]*?controls:/,
+  "send() must queue a rich follow-up while busy instead of dropping it (CHAT-D5-01)",
 );
 
 assert.match(
   source,
-  /const sendRaw = async [\s\S]*?\|\| busy\) return;/,
-  "sendRaw should keep its own busy guard as the backstop behind send()'s",
+  /const sendRaw = async [\s\S]*?\|\| \(busy && !allowBusy\)\) return;/,
+  "sendRaw should keep its busy guard while allowing the queue drain to hand off exactly one settled item",
+);
+
+assert.match(
+  source,
+  /const drainNextQueuedMessage = useCallback\(\(\) => \{[\s\S]*?const \[next, \.\.\.rest\] = queuedMessagesRef\.current;[\s\S]*?void sendQueuedMessageRef\.current\(next\);[\s\S]*?if \(sawDone && !streamFailed && !controller\.signal\.aborted\) \{[\s\S]*?drainNextQueuedMessage\(\);/,
+  "only a naturally successful stream completion should drain one queued follow-up",
+);
+
+assert.match(
+  source,
+  /aria-label="Queued messages"[\s\S]*?steerQueuedMessage\(message\.id\)[\s\S]*?removeQueuedMessage\(message\.id\)/,
+  "queued messages should remain visible with send-next and remove controls",
+);
+
+assert.match(
+  source,
+  /title="Queue message"[\s\S]*?aria-label="Queue message"[\s\S]*?title="Cancel \(esc\)"/,
+  "a live response must expose both Queue and Cancel controls",
 );
 
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -174,6 +174,12 @@ assert.match(
 
 assert.match(
   source,
+  /if \(\(busy \|\| abortRef\.current\) && !allowBusy\) \{[\s\S]*?parentTurnId:\s*opts\?\.parentTurnId !== undefined \? opts\.parentTurnId : \(activeLeafId \|\| null\)/,
+  "programmatic sends that queue through sendRaw must capture their visible branch leaf before later navigation can change it",
+);
+
+assert.match(
+  source,
   /"queuedRuntimeHost" in controlsOverride[\s\S]*?\? controlsOverride\.queuedRuntimeHost[\s\S]*?: \(controlsOverride\?\.runtimeHost \?\? runtimeHost\)/,
   "a queued automatic host choice must not be replaced by a later host picker change",
 );

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -138,7 +138,7 @@ assert.match(
 
 assert.match(
   source,
-  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?if \(busy \|\| abortRef\.current\) \{[\s\S]*?enqueueMessage\(\{[\s\S]*?text: outgoingText,[\s\S]*?attachments: outgoingAttachments,[\s\S]*?mentionedFiles: outgoingMentions,[\s\S]*?controls:/,
+  /const send = async \(override\?: string\) => \{[\s\S]*?intentFromSlash\(text\)[\s\S]*?const queueing = busy \|\| abortRef\.current;[\s\S]*?if \(queueing\) \{[\s\S]*?enqueueMessage\(\{[\s\S]*?text: outgoingText,[\s\S]*?attachments: outgoingAttachments,[\s\S]*?mentionedFiles: outgoingMentions,[\s\S]*?controls:/,
   "send() must queue a rich follow-up while busy instead of dropping it (CHAT-D5-01)",
 );
 
@@ -164,6 +164,12 @@ assert.match(
   source,
   /const sendOptions: ChatSendOptions = \{[\s\S]*?projectRoot: requestProjectRoot,[\s\S]*?mentionedFilesRoot: mentionRoot[\s\S]*?modelOverride:[\s\S]*?options: sendOptions,[\s\S]*?permissionMode,[\s\S]*?queuedRuntimeHost: runtimeHost/,
   "queued messages must retain queue-time model, project, file-mention, access, and host metadata",
+);
+
+assert.match(
+  source,
+  /const queueing = busy \|\| abortRef\.current;[\s\S]*?const queuedParentTurnId = queueing[\s\S]*?branchParent !== undefined \? branchParent : \(activeLeafId \|\| null\)[\s\S]*?parentTurnId: queuedParentTurnId[\s\S]*?if \(queueing\) \{[\s\S]*?options: sendOptions/,
+  "queued messages must capture their visible branch leaf before later navigation can change it",
 );
 
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -168,6 +168,12 @@ assert.match(
 
 assert.match(
   source,
+  /\.\.\.\(fleetHost \? \{ runtimeHost: fleetHost \} : \{\}\),/,
+  "the queued host choice must be forwarded to every chat bridge request, not only Omnigent runs",
+);
+
+assert.match(
+  source,
   /const projectRootForRequest = opts\?\.projectRoot \?\? requestProjectRoot;[\s\S]*?const mentionedFilesRootForRequest = opts\?\.mentionedFilesRoot \?\? mentionRoot;[\s\S]*?const modelOverrideForRequest =[\s\S]*?projectRoot: projectRootForRequest,[\s\S]*?permissionMode: controlsOverride\?\.permissionMode \?\? permissionMode,[\s\S]*?mentionedFilesRoot: mentionedFilesRootForRequest/,
   "delayed dispatch must use queued metadata rather than the latest composer state",
 );

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -156,8 +156,14 @@ assert.match(
 
 assert.match(
   source,
-  /const sendOptions: ChatSendOptions = \{[\s\S]*?projectRoot: requestProjectRoot,[\s\S]*?mentionedFilesRoot: mentionRoot[\s\S]*?modelOverride:[\s\S]*?options: sendOptions,[\s\S]*?permissionMode,/,
-  "queued messages must retain queue-time model, project, file-mention, and access metadata",
+  /const sendOptions: ChatSendOptions = \{[\s\S]*?projectRoot: requestProjectRoot,[\s\S]*?mentionedFilesRoot: mentionRoot[\s\S]*?modelOverride:[\s\S]*?options: sendOptions,[\s\S]*?permissionMode,[\s\S]*?queuedRuntimeHost: runtimeHost/,
+  "queued messages must retain queue-time model, project, file-mention, access, and host metadata",
+);
+
+assert.match(
+  source,
+  /"queuedRuntimeHost" in controlsOverride[\s\S]*?\? controlsOverride\.queuedRuntimeHost[\s\S]*?: \(controlsOverride\?\.runtimeHost \?\? runtimeHost\)/,
+  "a queued automatic host choice must not be replaced by a later host picker change",
 );
 
 assert.match(

--- a/src/components/chat-view-polish-attachments-mentions.test.ts
+++ b/src/components/chat-view-polish-attachments-mentions.test.ts
@@ -268,7 +268,7 @@ assert.match(
 );
 assert.match(
   mentionSource,
-  /\.\.\.\(outgoingMentions\.length && mentionRoot\s*\n\s*\? \{\s*\n\s*mentionedFiles: outgoingMentions\.slice\(0, MAX_FILE_MENTIONS\),\s*\n\s*mentionedFilesRoot: mentionRoot,/,
+  /\.\.\.\(outgoingMentions\.length && mentionedFilesRootForRequest\s*\n\s*\? \{\s*\n\s*mentionedFiles: outgoingMentions\.slice\(0, MAX_FILE_MENTIONS\),\s*\n\s*mentionedFilesRoot: mentionedFilesRootForRequest,/,
   "The send body must carry mentionedFiles plus the root they are relative to",
 );
 assert.match(

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -115,8 +115,8 @@ assert.match(
 );
 assert.match(
   source,
-  /busy\s*\? "Streaming… \(esc to cancel\)"/,
-  "Streaming keeps its own placeholder ahead of the recommendation branch",
+  /busy\s*\? "Streaming… \(send to queue · esc to cancel\)"/,
+  "Streaming explains that the composer now queues follow-ups ahead of the recommendation branch",
 );
 
 assert.match(
@@ -550,7 +550,7 @@ assert.doesNotMatch(
 );
 assert.match(
   applyStreamEventSection,
-  /if \(ev\.kind === "done"\) sawDone = true;[\s\S]*?if \(ev\.kind === "assistant_chunk"\)/,
+  /if \(ev\.kind === "done"\) \{[\s\S]*?sawDone = true;[\s\S]*?streamFailed = Boolean\(ev\.isError\);[\s\S]*?if \(ev\.kind === "assistant_chunk"\)/,
   "A parsed done event is observed immediately before any later reader failure",
 );
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3849,6 +3849,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         mentionedFiles: outgoingMentions,
         options: {
           ...opts,
+          // Programmatic sends (for example /run and /skill) enter here
+          // directly rather than through send(), so snapshot their branch at
+          // queue time as well. An explicit parent (including null) still
+          // wins for regenerate/edit flows.
+          parentTurnId:
+            opts?.parentTurnId !== undefined ? opts.parentTurnId : (activeLeafId || null),
           projectRoot: opts?.projectRoot ?? requestProjectRoot,
           ...(outgoingMentions.length
             ? { mentionedFilesRoot: opts?.mentionedFilesRoot ?? mentionRoot }

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2327,7 +2327,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       const next = queuedMessagesRef.current[index];
       if (!next) return;
       const rest = queuedMessagesRef.current.filter((message) => message.id !== id);
-      if (abortRef.current) {
+      // Most chat streams have an AbortController, but some supported runtime
+      // hosts (for example Omnigent) are busy before they expose one. Treat
+      // either case as in-flight so Send next only reprioritizes rather than
+      // starting a concurrent request.
+      if (busy || abortRef.current) {
         queuedMessagesRef.current = [next, ...rest];
         setQueuedMessages(queuedMessagesRef.current);
         announce("Queued message will send next.", "polite");
@@ -2338,7 +2342,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       announce("Sending queued message.", "polite");
       void sendQueuedMessageRef.current(next);
     },
-    [announce],
+    [announce, busy],
   );
   /** Keys for POST /api/chat/stop — a deliberate Stop must be an explicit
    *  server call; a bare fetch abort now reads as a transport drop and the

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4574,8 +4574,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // Read-and-clear atomically so it only applies to THIS send or queue item.
     const branchParent = pendingBranchParent;
     setPendingBranchParent(undefined);
+    // A queued follow-up must remain on the branch that was visible while it
+    // was composed. Branch navigation stays available during a live turn, so
+    // resolving activeLeafId later could otherwise attach it to a sibling.
+    const queueing = busy || abortRef.current;
+    const queuedParentTurnId = queueing
+      ? (branchParent !== undefined ? branchParent : (activeLeafId || null))
+      : undefined;
     const sendOptions: ChatSendOptions = {
-      ...(branchParent !== undefined ? { parentTurnId: branchParent } : {}),
+      ...(queuedParentTurnId !== undefined
+        ? { parentTurnId: queuedParentTurnId }
+        : branchParent !== undefined
+          ? { parentTurnId: branchParent }
+          : {}),
       // Queue-time metadata must not be re-read after a host, access, model,
       // or project selection changes while the current turn is streaming.
       projectRoot: requestProjectRoot,
@@ -4600,7 +4611,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // doesn't linger over the now-empty composer and let Revert repopulate
     // the composer with the message the user already sent.
     promptEnhance.reset();
-    if (busy || abortRef.current) {
+    if (queueing) {
       enqueueMessage({
         text: outgoingText,
         attachments: outgoingAttachments,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4047,7 +4047,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           permissionMode: controlsOverride?.permissionMode ?? permissionMode,
           // Composer Host chip: only an explicit pick rides; the server
           // resolves it against the registered-host registry fail-closed.
-          ...((controlsOverride?.runtimeHost ?? runtimeHost) ? { runtimeHost: controlsOverride?.runtimeHost ?? runtimeHost } : {}),
+          ...(fleetHost ? { runtimeHost: fleetHost } : {}),
           // Forward the picked model explicitly so it reaches `coven run
           // --model` for THIS turn — don't rely on the PATCH to model-state
           // having persisted to the conversation file before this send (a

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -301,10 +301,16 @@ type FailedSend = {
 type ChatSendOptions = {
   promptOverride?: string;
   parentTurnId?: string | null;
+  /** Explicit queue-time metadata. `undefined` keeps the direct-send default;
+   *  `null` intentionally preserves that no session model was selected. */
+  modelOverride?: string | null;
+  projectRoot?: string;
+  mentionedFilesRoot?: string;
 };
 type ChatSendControls = {
   thinkingEffort: ComposerThinkingEffort;
   responseSpeed: ComposerResponseSpeed;
+  permissionMode: CommandPermissionMode;
   runtimeHost?: string;
 };
 /** A follow-up held until the active turn settles successfully. Kept outside
@@ -3859,6 +3865,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ...(outgoingMentions.length ? { mentionedFiles: outgoingMentions } : {}),
       ...(opts?.promptOverride ? { promptOverride: opts.promptOverride } : {}),
     };
+    const projectRootForRequest = opts?.projectRoot ?? requestProjectRoot;
+    const mentionedFilesRootForRequest = opts?.mentionedFilesRoot ?? mentionRoot;
+    const modelOverrideForRequest =
+      opts?.modelOverride !== undefined
+        ? opts.modelOverride
+        : modelState?.source === "session" &&
+            modelState.effectiveModel &&
+            modelState.effectiveModel !== "unknown"
+          ? modelState.effectiveModel
+          : null;
     setBusy(true);
     setError(null);
     setDebugError(null);
@@ -4015,12 +4031,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
           ...(origin ? { origin } : {}),
           sessionId: liveGeneration.sessionId,
-          projectRoot: requestProjectRoot,
+          projectRoot: projectRootForRequest,
           reasoningEffort: controlsOverride?.thinkingEffort ?? thinkingEffort,
           responseSpeed: controlsOverride?.responseSpeed ?? responseSpeed,
           // Advisory permission mode for the picked access level; the daemon may
           // ignore it if the harness doesn't support per-turn permission scoping.
-          permissionMode,
+          permissionMode: controlsOverride?.permissionMode ?? permissionMode,
           // Composer Host chip: only an explicit pick rides; the server
           // resolves it against the registered-host registry fail-closed.
           ...((controlsOverride?.runtimeHost ?? runtimeHost) ? { runtimeHost: controlsOverride?.runtimeHost ?? runtimeHost } : {}),
@@ -4030,20 +4046,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           // race), and so a brand-new chat (no sessionId yet) still pins its
           // session model. Only session-scoped picks need this; familiar- and
           // global-default models already resolve server-side from config.
-          ...(modelState?.source === "session" &&
-          modelState.effectiveModel &&
-          modelState.effectiveModel !== "unknown"
+          ...(modelOverrideForRequest
             ? {
-                modelOverride: modelState.effectiveModel,
+                modelOverride: modelOverrideForRequest,
                 modelOverrideScope: "session" as const,
               }
             : {}),
           // CHAT-D1-04: @-mentioned repo files ride with the root they are
           // relative to — resumed sessions don't resend projectRoot above.
-          ...(outgoingMentions.length && mentionRoot
+          ...(outgoingMentions.length && mentionedFilesRootForRequest
             ? {
                 mentionedFiles: outgoingMentions.slice(0, MAX_FILE_MENTIONS),
-                mentionedFilesRoot: mentionRoot,
+                mentionedFilesRoot: mentionedFilesRootForRequest,
               }
             : {}),
           // Branching: when regenerating or re-editing from a non-leaf
@@ -4511,8 +4525,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // Read-and-clear atomically so it only applies to THIS send or queue item.
     const branchParent = pendingBranchParent;
     setPendingBranchParent(undefined);
-    const sendOptions =
-      branchParent !== undefined ? { parentTurnId: branchParent } satisfies ChatSendOptions : undefined;
+    const sendOptions: ChatSendOptions = {
+      ...(branchParent !== undefined ? { parentTurnId: branchParent } : {}),
+      // Queue-time metadata must not be re-read after a host, access, model,
+      // or project selection changes while the current turn is streaming.
+      projectRoot: requestProjectRoot,
+      ...(outgoingMentions.length ? { mentionedFilesRoot: mentionRoot } : {}),
+      modelOverride:
+        modelState?.source === "session" &&
+        modelState.effectiveModel &&
+        modelState.effectiveModel !== "unknown"
+          ? modelState.effectiveModel
+          : null,
+    };
     setReplyTarget(null);
     setInput("");
     // Clear the persisted draft synchronously. The debounced writer (250ms) is
@@ -4531,10 +4556,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         text: outgoingText,
         attachments: outgoingAttachments,
         mentionedFiles: outgoingMentions,
-        ...(sendOptions ? { options: sendOptions } : {}),
+        options: sendOptions,
         controls: {
           thinkingEffort,
           responseSpeed,
+          permissionMode,
           ...(runtimeHost ? { runtimeHost } : {}),
         },
       });
@@ -4589,7 +4615,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         [],
         undefined,
         normalized
-          ? { ...normalized, runtimeHost: initialControls?.runtimeHost }
+          ? { ...normalized, permissionMode, runtimeHost: initialControls?.runtimeHost }
           : undefined,
       );
     }, 0);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -298,6 +298,26 @@ type FailedSend = {
   mentionedFiles?: string[];
   promptOverride?: string;
 };
+type ChatSendOptions = {
+  promptOverride?: string;
+  parentTurnId?: string | null;
+};
+type ChatSendControls = {
+  thinkingEffort: ComposerThinkingEffort;
+  responseSpeed: ComposerResponseSpeed;
+  runtimeHost?: string;
+};
+/** A follow-up held until the active turn settles successfully. Kept outside
+ *  the transcript until delivery so a queued prompt is never mistaken for a
+ *  turn the familiar has already received. */
+type QueuedChatMessage = {
+  id: string;
+  text: string;
+  attachments: ChatAttachment[];
+  mentionedFiles: string[];
+  options?: ChatSendOptions;
+  controls: ChatSendControls;
+};
 type LiveStreamGeneration = {
   sessionId: string | null;
   originSessionId: string | null;
@@ -1836,6 +1856,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // and prepended as a markdown blockquote to the outgoing prompt at send time.
   const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
   const [busy, setBusy] = useState(false);
+  const [queuedMessages, setQueuedMessages] = useState<QueuedChatMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Debug context for the inline error strip below the chat: which turn failed
   // and an optional machine code. `seq` increments per occurrence so the strip
@@ -2257,6 +2278,59 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const activeSlashOptionRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Queue state is ref-mirrored because a stream's settle path drains it from
+  // an async closure, where React state alone could be one render behind.
+  const queuedMessagesRef = useRef<QueuedChatMessage[]>([]);
+  const sendQueuedMessageRef = useRef<(message: QueuedChatMessage) => Promise<void>>(
+    async () => {},
+  );
+  const drainNextQueuedMessage = useCallback(() => {
+    const [next, ...rest] = queuedMessagesRef.current;
+    if (!next) return;
+    queuedMessagesRef.current = rest;
+    setQueuedMessages(rest);
+    void sendQueuedMessageRef.current(next);
+  }, []);
+  const enqueueMessage = useCallback(
+    (message: Omit<QueuedChatMessage, "id">) => {
+      const item: QueuedChatMessage = { id: crypto.randomUUID(), ...message };
+      queuedMessagesRef.current = [...queuedMessagesRef.current, item];
+      setQueuedMessages(queuedMessagesRef.current);
+      announce(
+        `Queued message ${queuedMessagesRef.current.length}. It will send after the current response finishes.`,
+        "polite",
+      );
+    },
+    [announce],
+  );
+  const removeQueuedMessage = useCallback(
+    (id: string) => {
+      queuedMessagesRef.current = queuedMessagesRef.current.filter((message) => message.id !== id);
+      setQueuedMessages(queuedMessagesRef.current);
+      announce("Removed queued message.", "polite");
+    },
+    [announce],
+  );
+  const steerQueuedMessage = useCallback(
+    (id: string) => {
+      const index = queuedMessagesRef.current.findIndex((message) => message.id === id);
+      if (index < 0) return;
+      const next = queuedMessagesRef.current[index];
+      if (!next) return;
+      const rest = queuedMessagesRef.current.filter((message) => message.id !== id);
+      if (abortRef.current) {
+        queuedMessagesRef.current = [next, ...rest];
+        setQueuedMessages(queuedMessagesRef.current);
+        announce("Queued message will send next.", "polite");
+        return;
+      }
+      queuedMessagesRef.current = rest;
+      setQueuedMessages(rest);
+      announce("Sending queued message.", "polite");
+      void sendQueuedMessageRef.current(next);
+    },
+    [announce],
+  );
   /** Keys for POST /api/chat/stop — a deliberate Stop must be an explicit
    *  server call; a bare fetch abort now reads as a transport drop and the
    *  turn finishes server-side. runId targets a run this instance started
@@ -2981,6 +3055,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const isThreadSwitch = currentSessionRef.current !== sessionId;
     currentSessionRef.current = sessionId;
     liveSessionIdRef.current = null;
+    // A queued follow-up belongs to the conversation that was visible when it
+    // was composed. Never let a thread switch dispatch it into another chat.
+    if (isThreadSwitch) {
+      queuedMessagesRef.current = [];
+      setQueuedMessages([]);
+    }
     // Reset the settle-refetch marker on every (re)load; the live-snapshot
     // branches below re-arm it when there is actually an adopted or possibly-
     // orphaned stream to reconcile. A marker left armed after a normal disk
@@ -3730,12 +3810,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     text: string,
     outgoingAttachments: ChatAttachment[] = [],
     outgoingMentions: string[] = [],
-    opts?: { promptOverride?: string; parentTurnId?: string | null },
-    controlsOverride?: { thinkingEffort: ComposerThinkingEffort; responseSpeed: ComposerResponseSpeed; runtimeHost?: string },
+    opts?: ChatSendOptions,
+    controlsOverride?: ChatSendControls,
+    allowBusy = false,
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
-    if ((!trimmed && outgoingAttachments.length === 0) || busy) return;
+    if ((!trimmed && outgoingAttachments.length === 0) || (busy && !allowBusy)) return;
 
     // Omnigent fleet host chip: create a session on the control plane and open
     // it in Omnigent (does not stream into Cave chat transcript).
@@ -3743,6 +3824,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (isOmnigentHostOptionId(fleetHost) && submitPrompt) {
       setBusy(true);
       setError(null);
+      let started = false;
       try {
         const result = await startOmnigentRunFromBrowser({
           prompt: submitPrompt,
@@ -3761,10 +3843,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         );
         void openExternalUrl(result.webUrl);
         announce("Omnigent session started");
+        started = true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Omnigent run failed");
       } finally {
         setBusy(false);
+        if (started) drainNextQueuedMessage();
       }
       return;
     }
@@ -3889,6 +3973,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       flushPendingStreamHealthEvent();
     };
     let sawDone = false;
+    let streamFailed = false;
     let needsTranscriptResync = false;
     abortRef.current = controller;
     stopKeysRef.current = { runId, sessionId: initialLiveSessionId ?? null };
@@ -4045,7 +4130,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           cursor = Math.max(cursor, eventCursor);
           pendingStreamHealthEvent = { cursor, at: new Date().toISOString() };
         }
-        if (ev.kind === "done") sawDone = true;
+        if (ev.kind === "done") {
+          sawDone = true;
+          streamFailed = Boolean(ev.isError);
+        } else if (ev.kind === "error") {
+          streamFailed = true;
+        }
         if (ev.kind === "assistant_chunk") {
           // Hot path: buffer instead of committing per token.
           chunkCoalescer.push(ev.text);
@@ -4182,9 +4272,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         abortRef.current = null;
         stopKeysRef.current = { runId: null, sessionId: null };
         setBusy(false);
+        // Deliver exactly one follow-up only after a natural, successful
+        // completion. Failed and deliberately stopped turns leave the queue
+        // intact, so a correction never runs unexpectedly after a bad turn.
+        if (sawDone && !streamFailed && !controller.signal.aborted) {
+          drainNextQueuedMessage();
+        }
       }
     }
   };
+
+  sendQueuedMessageRef.current = (message) =>
+    sendRaw(
+      message.text,
+      message.attachments,
+      message.mentionedFiles,
+      message.options,
+      message.controls,
+      true,
+    );
 
   const cancelSend = () => {
     const { runId, sessionId } = stopKeysRef.current;
@@ -4389,11 +4495,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       clearDraft();
       return;
     }
-    // CHAT-D5-01: sendRaw early-returns while a response is streaming, so
-    // clearing the composer first would silently destroy the typed message
-    // (and staged attachments). Bail before touching state — slash intents
-    // above still run mid-stream; plain sends keep the draft intact.
-    if (busy) return;
     const outgoingAttachments = attachments.map(({ id: _id, ...attachment }) => attachment);
     // Only mentions whose `@path` token survived editing ride along — a
     // deleted reference must not silently re-enter the prompt.
@@ -4406,6 +4507,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // Reply to Chat: fold the quoted target into the outgoing prompt so the
     // model sees it and it persists in the transcript; pass-through when unset.
     const outgoingText = buildQuotedPrompt(replyTarget, text);
+    // Branching: consume a pending branch parent set by editTurnInComposer.
+    // Read-and-clear atomically so it only applies to THIS send or queue item.
+    const branchParent = pendingBranchParent;
+    setPendingBranchParent(undefined);
+    const sendOptions =
+      branchParent !== undefined ? { parentTurnId: branchParent } satisfies ChatSendOptions : undefined;
     setReplyTarget(null);
     setInput("");
     // Clear the persisted draft synchronously. The debounced writer (250ms) is
@@ -4419,11 +4526,21 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // doesn't linger over the now-empty composer and let Revert repopulate
     // the composer with the message the user already sent.
     promptEnhance.reset();
-    // Branching: consume a pending branch parent set by editTurnInComposer.
-    // Read-and-clear atomically so it only applies to THIS send.
-    const branchParent = pendingBranchParent;
-    setPendingBranchParent(undefined);
-    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, branchParent !== undefined ? { parentTurnId: branchParent } : undefined);
+    if (busy) {
+      enqueueMessage({
+        text: outgoingText,
+        attachments: outgoingAttachments,
+        mentionedFiles: outgoingMentions,
+        ...(sendOptions ? { options: sendOptions } : {}),
+        controls: {
+          thinkingEffort,
+          responseSpeed,
+          ...(runtimeHost ? { runtimeHost } : {}),
+        },
+      });
+      return;
+    }
+    await sendRaw(outgoingText, outgoingAttachments, outgoingMentions, sendOptions);
   };
 
   // Latest-ref for the memoized transcript's per-row actions (cave-likl).
@@ -4848,7 +4965,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // ⌘⇧A opens the attach picker — the "+" menu's Attach-file shortcut.
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "a" || e.key === "A")) {
       e.preventDefault();
-      if (!busy && attachments.length < 10) fileInputRef.current?.click();
+      if (attachments.length < 10) fileInputRef.current?.click();
       return;
     }
     if (mentionOpen) {
@@ -5740,7 +5857,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               onPaste={handlePaste}
               placeholder={
                 busy
-                  ? "Streaming… (esc to cancel)"
+                  ? "Streaming… (send to queue · esc to cancel)"
                   : recommendedNextPath
                     ? `${recommendedNextPath}  ⇥ to fill`
                     : `Message ${familiar.display_name}…  ↵ to send`
@@ -5769,6 +5886,38 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               onRevert={promptEnhance.revert}
               onCancel={promptEnhance.cancel}
             />
+            {queuedMessages.length > 0 ? (
+              <div className="cave-composer-queue" role="group" aria-label="Queued messages">
+                {queuedMessages.map((message) => (
+                  <div key={message.id} className="cave-composer-queue__chip" title={message.text}>
+                    <button
+                      type="button"
+                      className="cave-composer-queue__steer focus-ring"
+                      onClick={() => steerQueuedMessage(message.id)}
+                      aria-label={busy ? "Send queued message next" : "Send queued message"}
+                      title={busy ? "Send this queued message next" : "Send queued message"}
+                    >
+                      <Icon name="ph:clock" width={12} aria-hidden />
+                      <span className="cave-composer-queue__text">
+                        {message.text.trim() || `${message.attachments.length} file${message.attachments.length === 1 ? "" : "s"}`}
+                      </span>
+                      {message.attachments.length > 0 && message.text.trim() ? (
+                        <span className="cave-composer-queue__count">📎{message.attachments.length}</span>
+                      ) : null}
+                    </button>
+                    <button
+                      type="button"
+                      className="cave-composer-queue__remove focus-ring"
+                      onClick={() => removeQueuedMessage(message.id)}
+                      aria-label="Remove queued message"
+                      title="Remove from queue"
+                    >
+                      <Icon name="ph:x" width={12} aria-hidden />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
             {dictation.listening ? (
               <div className="hc-dictation-caption">
                 {dictation.partial || "Listening…"}
@@ -5805,7 +5954,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   <ComposerActionsMenu
                     attach={{
                       onSelect: () => fileInputRef.current?.click(),
-                      disabled: busy || attachments.length >= 10,
+                      disabled: attachments.length >= 10,
                       hint: keys.mod === "⌘" ? "⌘⇧A" : "Ctrl+Shift+A",
                     }}
                     skills={{
@@ -5874,15 +6023,28 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       rest, ~18% accent tint while the draft is non-empty;
                       busy keeps the cancel behavior in the same circle. */}
                   {busy ? (
-                    <button
-                      type="button"
-                      onClick={cancelSend}
-                      className="cave-composer-send cave-composer-send--busy focus-ring transition-colors"
-                      title="Cancel (esc)"
-                      aria-label="Cancel response"
-                    >
-                      <Icon name="ph:x-bold" width={13} aria-hidden />
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => void send()}
+                        disabled={!input.trim() && attachments.length === 0}
+                        data-typing={input.trim() ? "true" : undefined}
+                        className="cave-composer-send cave-composer-send--queue focus-ring transition-colors"
+                        title="Queue message"
+                        aria-label="Queue message"
+                      >
+                        <Icon name="ph:arrow-up-bold" width={13} aria-hidden />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelSend}
+                        className="cave-composer-send cave-composer-send--busy focus-ring transition-colors"
+                        title="Cancel (esc)"
+                        aria-label="Cancel response"
+                      >
+                        <Icon name="ph:x-bold" width={13} aria-hidden />
+                      </button>
+                    </>
                   ) : (
                     <button
                       type="button"

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -312,6 +312,9 @@ type ChatSendControls = {
   responseSpeed: ComposerResponseSpeed;
   permissionMode: CommandPermissionMode;
   runtimeHost?: string;
+  /** Present only for queued messages: null means preserve the queue-time
+   *  automatic host choice rather than reading a later composer selection. */
+  queuedRuntimeHost?: string | null;
 };
 /** A follow-up held until the active turn settles successfully. Kept outside
  *  the transcript until delivery so a queued prompt is never mistaken for a
@@ -3826,7 +3829,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
     // Omnigent fleet host chip: create a session on the control plane and open
     // it in Omnigent (does not stream into Cave chat transcript).
-    const fleetHost = controlsOverride?.runtimeHost ?? runtimeHost;
+    // A queued message must retain even an automatic (null) host choice. The
+    // regular controls override remains optional for existing direct sends.
+    const fleetHost =
+      controlsOverride && "queuedRuntimeHost" in controlsOverride
+        ? controlsOverride.queuedRuntimeHost
+        : (controlsOverride?.runtimeHost ?? runtimeHost);
     if (isOmnigentHostOptionId(fleetHost) && submitPrompt) {
       setBusy(true);
       setError(null);
@@ -4561,7 +4569,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           thinkingEffort,
           responseSpeed,
           permissionMode,
-          ...(runtimeHost ? { runtimeHost } : {}),
+          queuedRuntimeHost: runtimeHost,
         },
       });
       return;

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3829,7 +3829,44 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
-    if ((!trimmed && outgoingAttachments.length === 0) || (busy && !allowBusy)) return;
+    if (!trimmed && outgoingAttachments.length === 0) return;
+    // Slash commands and other programmatic sends also arrive here. Keep the
+    // queue at this boundary (rather than only in the composer click handler)
+    // so every harness follows the same sequential path, including runtimes
+    // whose busy state has not yet reached React but already own a controller.
+    if ((busy || abortRef.current) && !allowBusy) {
+      const queuedModelOverride =
+        opts?.modelOverride !== undefined
+          ? opts.modelOverride
+          : modelState?.source === "session" &&
+              modelState.effectiveModel &&
+              modelState.effectiveModel !== "unknown"
+            ? modelState.effectiveModel
+            : null;
+      enqueueMessage({
+        text,
+        attachments: outgoingAttachments,
+        mentionedFiles: outgoingMentions,
+        options: {
+          ...opts,
+          projectRoot: opts?.projectRoot ?? requestProjectRoot,
+          ...(outgoingMentions.length
+            ? { mentionedFilesRoot: opts?.mentionedFilesRoot ?? mentionRoot }
+            : {}),
+          modelOverride: queuedModelOverride,
+        },
+        controls: {
+          thinkingEffort: controlsOverride?.thinkingEffort ?? thinkingEffort,
+          responseSpeed: controlsOverride?.responseSpeed ?? responseSpeed,
+          permissionMode: controlsOverride?.permissionMode ?? permissionMode,
+          queuedRuntimeHost:
+            controlsOverride && "queuedRuntimeHost" in controlsOverride
+              ? controlsOverride.queuedRuntimeHost
+              : (controlsOverride?.runtimeHost ?? runtimeHost),
+        },
+      });
+      return;
+    }
 
     // Omnigent fleet host chip: create a session on the control plane and open
     // it in Omnigent (does not stream into Cave chat transcript).
@@ -4563,7 +4600,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // doesn't linger over the now-empty composer and let Revert repopulate
     // the composer with the message the user already sent.
     promptEnhance.reset();
-    if (busy) {
+    if (busy || abortRef.current) {
       enqueueMessage({
         text: outgoingText,
         attachments: outgoingAttachments,

--- a/src/lib/stop-phrase.test.ts
+++ b/src/lib/stop-phrase.test.ts
@@ -123,7 +123,7 @@ test("chat composer send() intercepts the stop phrase before busy queueing", () 
   assert.match(src, /matchesStopPhrase, readStopPhrase \} from "@\/lib\/stop-phrase"/);
   const intercept = src.indexOf("busy && matchesStopPhrase(text, readStopPhrase())");
   assert.ok(intercept > 0, "send() consults the stop phrase while busy");
-  const queue = src.indexOf("if (busy || abortRef.current) {", intercept);
+  const queue = src.indexOf("const queueing = busy || abortRef.current;", intercept);
   assert.ok(queue > intercept, "intercept sits before the busy queue path");
   const between = src.slice(intercept, queue);
   assert.match(between, /cancelSend\(\)/);

--- a/src/lib/stop-phrase.test.ts
+++ b/src/lib/stop-phrase.test.ts
@@ -123,7 +123,7 @@ test("chat composer send() intercepts the stop phrase before busy queueing", () 
   assert.match(src, /matchesStopPhrase, readStopPhrase \} from "@\/lib\/stop-phrase"/);
   const intercept = src.indexOf("busy && matchesStopPhrase(text, readStopPhrase())");
   assert.ok(intercept > 0, "send() consults the stop phrase while busy");
-  const queue = src.indexOf("if (busy) {", intercept);
+  const queue = src.indexOf("if (busy || abortRef.current) {", intercept);
   assert.ok(queue > intercept, "intercept sits before the busy queue path");
   const between = src.slice(intercept, queue);
   assert.match(between, /cancelSend\(\)/);

--- a/src/lib/stop-phrase.test.ts
+++ b/src/lib/stop-phrase.test.ts
@@ -118,14 +118,14 @@ test("validatePreferencesPatch validates stopPhrase as a trimmed bounded string"
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 
-test("chat composer send() intercepts the stop phrase before the busy bail", () => {
+test("chat composer send() intercepts the stop phrase before busy queueing", () => {
   const src = readFileSync(path.join(repoRoot, "src/components/chat-view.tsx"), "utf8");
   assert.match(src, /matchesStopPhrase, readStopPhrase \} from "@\/lib\/stop-phrase"/);
   const intercept = src.indexOf("busy && matchesStopPhrase(text, readStopPhrase())");
   assert.ok(intercept > 0, "send() consults the stop phrase while busy");
-  const bail = src.indexOf("if (busy) return;", intercept);
-  assert.ok(bail > intercept, "intercept sits before the CHAT-D5-01 busy bail");
-  const between = src.slice(intercept, bail);
+  const queue = src.indexOf("if (busy) {", intercept);
+  assert.ok(queue > intercept, "intercept sits before the busy queue path");
+  const between = src.slice(intercept, queue);
   assert.match(between, /cancelSend\(\)/);
 });
 

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -84,7 +84,7 @@
 .cave-composer-queue {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1);
   padding: 0 var(--space-3) var(--space-2);
 }
 
@@ -111,8 +111,8 @@
 
 .cave-composer-queue__steer {
   min-width: 0;
-  gap: 5px;
-  padding: 4px 4px 4px 8px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
 }
 
 .cave-composer-queue__text {
@@ -127,7 +127,7 @@
 }
 
 .cave-composer-queue__remove {
-  padding: 4px 7px 4px 3px;
+  padding: var(--space-1) var(--space-2) var(--space-1) var(--space-1);
 }
 
 .cave-composer-queue__steer:hover,

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -79,6 +79,62 @@
   justify-content: flex-end;
 }
 
+/* Follow-ups composed while a turn streams stay visible and actionable, but
+   remain outside the transcript until the normal send path dispatches them. */
+.cave-composer-queue {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 var(--space-3) var(--space-2);
+}
+
+.cave-composer-queue__chip {
+  display: inline-flex;
+  min-width: 0;
+  max-width: min(100%, 28rem);
+  align-items: center;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, var(--border-hairline));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
+  color: var(--text-secondary);
+}
+
+.cave-composer-queue__steer,
+.cave-composer-queue__remove {
+  display: inline-flex;
+  align-items: center;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.cave-composer-queue__steer {
+  min-width: 0;
+  gap: 5px;
+  padding: 4px 4px 4px 8px;
+}
+
+.cave-composer-queue__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-xs);
+}
+
+.cave-composer-queue__count {
+  font-size: var(--text-2xs);
+}
+
+.cave-composer-queue__remove {
+  padding: 4px 7px 4px 3px;
+}
+
+.cave-composer-queue__steer:hover,
+.cave-composer-queue__remove:hover {
+  color: var(--text-primary);
+}
+
 /* ── Footer band ─────────────────────────────────────────────────────────────
  * The darker strip attached to the panel's underside (home composer's
  * hc-footer-band, same grammar): the chat's session metadata — project ·
@@ -1062,6 +1118,10 @@
 
 .cave-composer-send--busy:hover {
   background: var(--color-danger);
+}
+
+.cave-composer-send--queue {
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
 }
 
 /* Input wrap — positioning anchor for affordances layered over the input


### PR DESCRIPTION
## Summary

Implements #3705 so a full-chat composer can queue follow-up prompts while a familiar is streaming.

- Keeps text, attachments, surviving file mentions, branch target, response controls, and runtime-host selection with each queued item.
- Shows removable queued-message chips and lets the user move an item to send next.
- Exposes Queue alongside Cancel during a live response; successful completions drain one queued item, while stop/failure leaves the queue parked.
- Clears queue state on an actual conversation switch, preventing cross-thread delivery.
- Keeps queued sends sequential even for busy runtime hosts that do not expose a stream AbortController.

Queued requests capture their runtime-host choice at queue time, including the automatic choice. A later host-picker change therefore cannot reroute a queued prompt across the supported local/remote runtime and harness configurations.

The queue remains deliberately host- and harness-agnostic: it preserves the selected host token (or automatic routing) without assuming a particular installation method. That keeps existing server-side resolution and capability detection in charge for Node-based, native Windows/macOS/Linux, and registered harness setups such as Codex, OpenClaw, Hermes, and future adapters.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `node --test src/components/chat-view-lifecycle.test.ts src/components/chat-view-polish-header-composer.test.ts`
- `node scripts/run-tests.mjs app`
- `node node_modules/eslint/bin/eslint.js src/components/chat-view.tsx --max-warnings=0`

Fixes #3705
