### PR TITLE
feat(chat): new chats start in the most recent chat's project

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -144,6 +144,7 @@ import { ChatStageHeader } from "@/components/chat-stage-header";
 import {
   NO_PROJECT_ID,
   projectIdForRoot,
+  recentChatProjectRoot,
   resolveChatProjectSelection,
 } from "@/lib/chat-projects";
 import { addChatProject, projectNameForRoot } from "@/lib/chat-add-project";
@@ -1979,6 +1980,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const { projects, createProject, reload: reloadProjects } = useProjects({ familiarId: familiar.id });
   const firstProject = projects[0] ?? null;
   const [projectIdDraft, setProjectIdDraft] = useState<string | null>(null);
+  // The project the most recent chat ran in — the default a brand-new chat
+  // inherits (kept live: sessions can land seconds after boot).
+  const recentProjectRoot = useMemo(
+    () => recentChatProjectRoot(sessions ?? [], projects),
+    [sessions, projects],
+  );
   // A session whose recorded cwd maps to no registered project resolves to
   // NO_PROJECT_ID here — never to the first project, whose root would re-root
   // the next turn's cwd and fork the harness session (`--continue` misses).
@@ -1991,6 +1998,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     fallbackProjectRoot: projectRoot,
     taskProjectId: linkedContext?.task?.projectId,
     taskCwd: linkedContext?.task?.cwd,
+    recentProjectRoot,
     projects,
   });
   const resolvedProjectId = projectSelection.projectId;
@@ -5143,31 +5151,42 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
-  // Sync the selected project when switching sessions. Also initialise the draft
-  // the first time projects load (when it is still null). Do NOT overwrite a
+  // Sync the selected project when switching sessions. Do NOT overwrite a
   // user-set draft just because the projects list was re-fetched (e.g. after a
   // rename or create), which would discard an in-session selection. (The header
   // delete confirm resets itself — HeaderDeleteButton is keyed on sessionId.)
+  //
+  // Brand-new chats keep a NULL draft on purpose: the default project (opener
+  // root → linked task → most recent chat's project → first project) resolves
+  // LIVE in resolveChatProjectSelection until the user explicitly picks, so
+  // the recency signal still applies when sessions land after boot (an eager
+  // first-project seed would freeze it out), and a background sessions
+  // refresh can never clobber an explicit pick. Only switching compose
+  // targets clears a prior pick — and only while sessionId is still null: a
+  // just-minted session whose row hasn't landed in the list yet must keep the
+  // pick its first send used.
+  const draftViewKeyRef = useRef<string | null>(null);
   useEffect(() => {
+    const viewKey = `${sessionId ?? ""}|${projectRoot ?? ""}`;
+    const viewChanged = draftViewKeyRef.current !== viewKey;
+    draftViewKeyRef.current = viewKey;
     setProjectIdDraft((prev) => {
+      if (!session) return sessionId === null && viewChanged ? null : prev;
       // Mirrors resolveChatProjectSelection: the linked task's project first
       // (a task chat belongs in its task's project), then a registered project
       // mapped from the session/opener root, then NO_PROJECT_ID for an
-      // existing session in an unregistered cwd, then the first project only
-      // for brand-new chats. linkedContext loads async with the conversation,
-      // so its deps re-seed the draft once the task arrives.
-      const resolved =
-        resolveChatProjectSelection({
-          draftId: null,
-          hasSession: Boolean(session),
-          sessionProjectRoot: session?.project_root,
-          fallbackProjectRoot: projectRoot,
-          taskProjectId: linkedContext?.task?.projectId,
-          taskCwd: linkedContext?.task?.cwd,
-          projects,
-        }).projectId ??
-        firstProject?.id ??
-        null;
+      // existing session in an unregistered cwd. linkedContext loads async
+      // with the conversation, so its deps re-seed the draft once the task
+      // arrives.
+      const resolved = resolveChatProjectSelection({
+        draftId: null,
+        hasSession: true,
+        sessionProjectRoot: session.project_root,
+        fallbackProjectRoot: projectRoot,
+        taskProjectId: linkedContext?.task?.projectId,
+        taskCwd: linkedContext?.task?.cwd,
+        projects,
+      }).projectId;
       // Initialise when unset, or always resync on session switch.
       return prev === null ? resolved : resolved ?? prev;
     });
@@ -5499,7 +5518,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   inputRef.current?.focus();
                 }}
                 onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
-                projectId={projectIdDraft}
+                projectId={resolvedProjectId}
                 onProjectChange={setProjectIdDraft}
                 projects={projects}
                 createProject={createProject}

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -88,17 +88,33 @@ assert.doesNotMatch(
 
 // Project selection lives in the composer's context pill (chat revamp 1d):
 // the pill chains to the shared ProjectPickerPopover so the user can choose
-// which project a new chat runs in (mirrors the chat composer).
+// which project a new chat runs in (mirrors the chat composer). The picker
+// displays the RESOLVED project — an unset pick shows the live default (most
+// recent chat's project, then the first project), matching what send uses.
 assert.match(
   source,
-  /<ComposerContextChips[\s\S]*projectValue=\{selectedProjectId \|\| null\}[\s\S]*onProjectChange=\{setSelectedProjectId\}/,
-  "the context pill hosts the project picker, wired to selectedProjectId",
+  /<ComposerContextChips[\s\S]*projectValue=\{displayProjectId\}[\s\S]*onProjectChange=\{setSelectedProjectId\}/,
+  "the context pill hosts the project picker, wired to the resolved display id",
 );
 
 assert.match(
   composerContext,
   /if \(selectedProjectId === noProjectId\) return null/,
   "An explicit No-project selection should resolve to a null project (not fall back to projects[0])",
+);
+
+// REGRESSION: an unset pick must stay unset — seeding state to projects[0]
+// froze the default before sessions loaded, so the most-recent-chat project
+// could never apply. Only a stale pick (its project vanished) gets cleared.
+assert.doesNotMatch(
+  source,
+  /setSelectedProjectId\(projects\[0\]/,
+  "the composer must not seed the project pick to the first project",
+);
+assert.match(
+  source,
+  /recentChatProjectRoot\(sessions, projects\)/,
+  "the composer derives the live default from the most recent chat's project",
 );
 
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -47,7 +47,7 @@ import { canonicalize } from "@/lib/slash-commands";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { useProjects } from "@/lib/use-projects";
-import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import { NO_PROJECT_ID, recentChatProjectRoot } from "@/lib/chat-projects";
 import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/composer-options-menu";
 import { ComposerPlusMenu } from "@/components/composer-plus-menu";
 import { useAddProjectFlow } from "@/components/project-picker";
@@ -227,10 +227,20 @@ export function HomeComposer({
   // Host chip: where the opened chat should execute. Per-composer state, not a
   // sticky pref — mirrors the chat composer's Host chip (#2337/#2340).
   const [runtimeHost, setRuntimeHost] = useState<string | null>(null);
-  const selectedProject = useMemo(
-    () => resolveHomeComposerProject(projects, selectedProjectId, NO_PROJECT_ID),
-    [projects, selectedProjectId],
+  // The project the most recent chat ran in: the default for the next chat
+  // when the user hasn't explicitly picked one (kept live as sessions load).
+  const recentProjectRoot = useMemo(
+    () => recentChatProjectRoot(sessions, projects),
+    [sessions, projects],
   );
+  const selectedProject = useMemo(
+    () => resolveHomeComposerProject(projects, selectedProjectId, NO_PROJECT_ID, recentProjectRoot),
+    [projects, selectedProjectId, recentProjectRoot],
+  );
+  // What the pickers display: the explicit pick when set (including
+  // "No project"), otherwise the resolved live default the send would use.
+  const displayProjectId =
+    selectedProjectId === NO_PROJECT_ID ? NO_PROJECT_ID : selectedProject?.id ?? null;
   const selectedRuntime = canonicalHarnessId(
     modelState?.harness ?? selectedFamiliar?.harness ?? selectedFamiliar?.defaultHarness ?? "claude",
   );
@@ -255,10 +265,13 @@ export function HomeComposer({
     [],
   );
 
+  // An unset pick stays unset — the live default (most recent chat's project,
+  // then the first project) resolves in resolveHomeComposerProject so it can
+  // upgrade as sessions land. Only clear a stale pick whose project vanished.
   useEffect(() => {
-    if (selectedProjectId === NO_PROJECT_ID) return; // an explicit No-project choice is valid
-    if (selectedProjectId && projects.some((project) => project.id === selectedProjectId)) return;
-    setSelectedProjectId(projects[0]?.id ?? "");
+    if (!selectedProjectId || selectedProjectId === NO_PROJECT_ID) return;
+    if (projects.some((project) => project.id === selectedProjectId)) return;
+    setSelectedProjectId("");
   }, [projects, selectedProjectId]);
 
   // "Add to project ›" flyout data + the "Start a new project" flow (same
@@ -934,7 +947,7 @@ export function HomeComposer({
                 }}
                 projects={{
                   projects: plusMenuProjects,
-                  selectedId: selectedProjectId || null,
+                  selectedId: displayProjectId,
                   onPick: setSelectedProjectId,
                   noProjectId: NO_PROJECT_ID,
                   onStartNewProject: plusAddProject.beginAddProject,
@@ -1089,7 +1102,7 @@ export function HomeComposer({
           <div className="home-composer-toolbar__left">
             <ComposerContextChips
               projects={projects}
-              projectValue={selectedProjectId || null}
+              projectValue={displayProjectId}
               onProjectChange={setSelectedProjectId}
               allowNoProject
               familiarId={selectedFamiliarId || null}

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -39,7 +39,7 @@ assert.doesNotMatch(
 // The selector lets the user choose which project a new chat runs in (mirrors
 // the chat composer). The pill chains to the shared ProjectPickerPopover, so
 // selection reads the same everywhere (chat revamp 1d).
-assert.match(homeComposer, /<ComposerContextChips[\s\S]*?projectValue=\{selectedProjectId \|\| null\}/, "home composer's context chips host the shared project picker");
+assert.match(homeComposer, /<ComposerContextChips[\s\S]*?projectValue=\{displayProjectId\}/, "home composer's context chips host the shared project picker");
 const contextPill = readFileSync(new URL("./composer-context-pill.tsx", import.meta.url), "utf8");
 assert.match(contextPill, /export type ComposerContextProps = \{/, "context props are reusable");
 assert.match(

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -22,8 +22,18 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
-  "ChatView resolves the selected project through resolveChatProjectSelection, feeding the linked task's project (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
+  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*recentProjectRoot,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
+  "ChatView resolves the selected project through resolveChatProjectSelection, feeding the linked task's project and the most recent chat's project (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
+);
+// A brand-new chat keeps a NULL draft so the default (opener root → linked
+// task → most recent chat's project → first project) resolves LIVE — sessions
+// load async, so an eager seed would freeze out the recency signal. Only
+// switching compose targets clears a prior explicit pick, and only while
+// sessionId is still null (a just-minted session keeps the pick send used).
+assert.match(
+  chatView,
+  /if \(!session\) return sessionId === null && viewChanged \? null : prev;/,
+  "Brand-new chats keep a null project draft so the recency default stays live",
 );
 // REGRESSION (2026-07-02): a session in an unregistered cwd must NOT default
 // the picker to the first project — sending that root re-roots the next
@@ -194,7 +204,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*projects,\s*\}\)\.projectId \?\?/,
+  /taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*projects,\s*\}\)\.projectId;/,
   "The draft-init effect seeds the picker from the linked task's project once the context loads",
 );
 assert.match(

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -367,6 +367,145 @@ console.log("chat-projects.test.ts: ok");
     { projectId: "p2", project: roster[1] },
     "a brand-new task chat opens scoped to the task's project, not the first project",
   );
+
+  // ── Most recent chat's project (recentProjectRoot) ─────────────────────────
+  // A brand-new chat with no other context starts in the project the most
+  // recent chat ran in, so back-to-back chats stay in the working project
+  // instead of snapping to the alphabetically-first one.
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "a brand-new chat inherits the most recent chat's project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      fallbackProjectRoot: "/work/alpha",
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: "p1", project: roster[0] },
+    "an opener root (e.g. a project group's + button) outranks the recency default",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      taskProjectId: "p1",
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: "p1", project: roster[0] },
+    "a linked task's project outranks the recency default",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: NO_PROJECT_ID,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "an explicit No-project pick beats the recency default",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      recentProjectRoot: "/somewhere/unregistered",
+    }),
+    { projectId: null, project: roster[0] },
+    "an unregistered recent root falls through to the first project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/Users/me/.coven/workspaces/familiars/cody",
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "recency never re-roots an EXISTING session in an unregistered cwd",
+  );
+}
+
+// ── recentChatProjectRoot ────────────────────────────────────────────────────
+// The root fed into the recency default above: the registered project of the
+// newest visible chat. Unregistered/no-project chats are skipped (they can't
+// seed a registered-project picker); archived and generated rows never count.
+{
+  const { recentChatProjectRoot } = await import("./chat-projects.ts");
+  const roster = [
+    { id: "alpha", name: "Alpha", root: "/work/alpha", createdAt: "", updatedAt: "" },
+    { id: "beta", name: "Beta", root: "/work/beta", createdAt: "", updatedAt: "" },
+  ];
+
+  assert.equal(
+    recentChatProjectRoot(
+      [
+        session("older-beta", "/work/beta", "2026-06-01T00:00:00.000Z", "nova"),
+        session("newest-alpha", "/work/alpha", "2026-06-03T00:00:00.000Z", "cody"),
+      ],
+      roster,
+    ),
+    "/work/alpha",
+    "the newest chat's registered project wins",
+  );
+
+  assert.equal(
+    recentChatProjectRoot(
+      [
+        session("newest-scratch", "", "2026-06-05T00:00:00.000Z", "charm"),
+        session("unregistered", "/somewhere/else", "2026-06-04T00:00:00.000Z", "sage"),
+        session("registered", "/work/beta", "2026-06-02T00:00:00.000Z", "nova"),
+      ],
+      roster,
+    ),
+    "/work/beta",
+    "no-project and unregistered chats are skipped, not treated as a default",
+  );
+
+  assert.equal(
+    recentChatProjectRoot(
+      [
+        { ...session("stashed", "/work/alpha", "2026-06-09T00:00:00.000Z", "cody"), archived_at: "2026-06-09T01:00:00.000Z" },
+        session("status-archived", "/work/alpha", "2026-06-08T00:00:00.000Z", "cody", "archived"),
+        session("live", "/work/beta", "2026-06-07T00:00:00.000Z", "nova"),
+      ],
+      roster,
+    ),
+    "/work/beta",
+    "archived chats don't drive the default",
+  );
+
+  assert.equal(
+    recentChatProjectRoot(
+      [session("normalized", "/work/beta/", "2026-06-02T00:00:00.000Z", "nova")],
+      roster,
+    ),
+    "/work/beta",
+    "roots are normalized to the registered project's canonical root",
+  );
+
+  assert.equal(recentChatProjectRoot([], roster), null, "no sessions → no recency default");
+  assert.equal(
+    recentChatProjectRoot([session("any", "/work/alpha", "2026-06-01T00:00:00.000Z", "nova")], []),
+    null,
+    "no registered projects → no recency default",
+  );
 }
 
 // ── Journal-narrative noise stays out of the chat lists (cave-buih) ─────────

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -71,7 +71,9 @@ export type ChatProjectSelection = {
  * workspace or another unregistered dir, and defaulting it to the first
  * registered project would re-root the next turn's cwd there and fork the
  * harness session (`--continue` misses in the new dir). Only a brand new chat
- * (no session yet) defaults to the first project.
+ * (no session yet) defaults: to the most recent chat's registered project
+ * (`recentProjectRoot`, see recentChatProjectRoot) so new chats pick up where
+ * the user is actually working, then to the first project.
  */
 export function resolveChatProjectSelection(args: {
   draftId: string | null;
@@ -82,6 +84,9 @@ export function resolveChatProjectSelection(args: {
    *  the card's stable projectId, with its cwd as a fallback mapping. */
   taskProjectId?: string | null;
   taskCwd?: string | null;
+  /** Root of the most recent chat's registered project (recentChatProjectRoot):
+   *  the brand-new-chat default when no other context picked a project. */
+  recentProjectRoot?: string | null;
   projects: CaveProject[];
 }): ChatProjectSelection {
   const firstProject = args.projects[0] ?? null;
@@ -101,6 +106,8 @@ export function resolveChatProjectSelection(args: {
   );
   if (mappedId) return { projectId: mappedId, project: chatProjectById(mappedId, args.projects) };
   if (args.hasSession) return { projectId: NO_PROJECT_ID, project: null };
+  const recentProject = projectForRoot(args.recentProjectRoot, args.projects);
+  if (recentProject) return { projectId: recentProject.id, project: recentProject };
   return { projectId: null, project: firstProject };
 }
 
@@ -168,6 +175,27 @@ export function filterVisibleChatSessions(
     .filter((session) => !isGeneratedChatSession(session))
     .filter((session) => familiarId === null || session.familiarId === familiarId)
     .sort((a, b) => (sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1));
+}
+
+/** The registered project the most recent visible chat ran in, as a root for
+ *  resolveChatProjectSelection's `recentProjectRoot` — so a brand-new chat
+ *  starts off in the project the user was just working in instead of the
+ *  alphabetically-first one. Walks newest-first (all familiars: project
+ *  context follows the work across familiar switches) and skips chats whose
+ *  recorded cwd maps to no entry in `projects` — an unregistered or
+ *  no-project chat can't meaningfully seed a picker that only offers
+ *  registered projects, and `projects` is already scoped to the familiar's
+ *  grants, so an inaccessible project can never be inherited. */
+export function recentChatProjectRoot(
+  sessions: SessionRow[],
+  projects: CaveProject[],
+): string | null {
+  if (projects.length === 0) return null;
+  for (const session of filterVisibleChatSessions(sessions, null)) {
+    const project = projectForRoot(session.project_root, projects);
+    if (project) return project.root;
+  }
+  return null;
 }
 
 export function deriveChatProjectGroups(

--- a/src/lib/home-composer-context.test.ts
+++ b/src/lib/home-composer-context.test.ts
@@ -19,3 +19,35 @@ test("home composer project selection honors no-project and stable fallback", ()
   assert.equal(resolveHomeComposerProject(projects, "missing", "__no-project__")?.id, "one");
   assert.equal(resolveHomeComposerProject(projects, "__no-project__", "__no-project__"), null);
 });
+
+test("home composer defaults an unset pick to the most recent chat's project", () => {
+  const projects = [
+    { id: "one", name: "One", root: "/work/one" },
+    { id: "two", name: "Two", root: "/work/two" },
+  ] as never[];
+  assert.equal(
+    resolveHomeComposerProject(projects, "", "__no-project__", "/work/two")?.id,
+    "two",
+    "an unset pick resolves to the recent chat's project before projects[0]",
+  );
+  assert.equal(
+    resolveHomeComposerProject(projects, "one", "__no-project__", "/work/two")?.id,
+    "one",
+    "an explicit pick beats the recency default",
+  );
+  assert.equal(
+    resolveHomeComposerProject(projects, "__no-project__", "__no-project__", "/work/two"),
+    null,
+    "an explicit No-project pick beats the recency default",
+  );
+  assert.equal(
+    resolveHomeComposerProject(projects, "", "__no-project__", "/somewhere/unregistered")?.id,
+    "one",
+    "an unregistered recent root falls through to projects[0]",
+  );
+  assert.equal(
+    resolveHomeComposerProject(projects, "", "__no-project__", null)?.id,
+    "one",
+    "no recency signal keeps the stable projects[0] fallback",
+  );
+});

--- a/src/lib/home-composer-context.ts
+++ b/src/lib/home-composer-context.ts
@@ -1,5 +1,6 @@
 import type { CaveProject } from "./cave-projects-types";
 import type { Familiar } from "./types";
+import { projectForRoot } from "./chat-projects.ts";
 
 export function resolveHomeComposerFamiliar(
   familiars: readonly Familiar[],
@@ -22,7 +23,15 @@ export function resolveHomeComposerProject(
   projects: readonly CaveProject[],
   selectedProjectId: string,
   noProjectId: string,
+  /** Root of the most recent chat's registered project (recentChatProjectRoot):
+   *  the default when the user hasn't explicitly picked, before projects[0]. */
+  recentProjectRoot?: string | null,
 ): CaveProject | null {
   if (selectedProjectId === noProjectId) return null;
-  return projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
+  return (
+    projects.find((project) => project.id === selectedProjectId) ??
+    projectForRoot(recentProjectRoot, projects.slice()) ??
+    projects[0] ??
+    null
+  );
 }


### PR DESCRIPTION
New chats (chat composer and Home) now default to the project the most recent chat ran in, instead of the alphabetically-first project. Zero-config recency inheritance — requested as "set a default project OR let new chats start with the most recent chat's project".

## Precedence (unchanged where it matters)

user pick → linked task's project → opener/session root → **most recent chat's project (new)** → first project

- Explicit picks (including No project) always win.
- Existing sessions in unregistered cwds stay **No project** — the 2026-07-02 regression pin (re-rooting forks the harness session) is untouched.
- `projects` is familiar-grant-scoped, so a non-granted project can never be inherited.

## How

- `chat-projects.ts`: new `recentChatProjectRoot(sessions, projects)` — newest visible chat whose recorded cwd maps to a registered project; `resolveChatProjectSelection` gains `recentProjectRoot` used only in the brand-new-chat fallback.
- `chat-view.tsx`: recency resolves **live** at render (sessions land seconds after boot; an eager seed would freeze it out). Brand-new chats keep a null draft; only switching compose targets clears a prior pick — and only while `sessionId` is null, so a just-minted session keeps the pick its first send used. Empty-state picker displays the resolved id.
- `home-composer.tsx` / `home-composer-context.ts`: same fallback before `projects[0]`; the seeding effect no longer writes `projects[0]` into state (clear-only for stale picks); pickers display the resolved live default.

## Verification

- `pnpm test:app` — 888 test files passed
- `pnpm typecheck` — clean
- Updated pinned source-shape tests (task-chat-cwd, project-picker, home-composer) + new unit coverage for the resolver, `recentChatProjectRoot`, and `resolveHomeComposerProject` recency cases.