### PR TITLE
fix(worktrees): auto-navigate new-worktree chats + harden provisioning

### DIFF
--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -110,6 +110,15 @@ assert.match(
   "create-worktree provisions through the shared issue-worktree-provision lib",
 );
 
+// Branch rows carry the absolute path of the worktree that has each branch
+// checked out, so the client can offer "open a chat in that worktree" instead
+// of a dead disabled row (cave-tmst).
+assert.match(
+  source,
+  /worktree: worktreeDir \? path\.basename\(worktreeDir\) : null,\s*\n\s*worktreePath: worktreeDir,/,
+  "branch rows expose both the worktree basename (display) and absolute path (jump target)",
+);
+
 // The branch listing marks the current branch and which worktree holds each
 // checked-out branch, so the menu can disable non-switchable rows.
 assert.match(

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -135,6 +135,8 @@ type BranchRow = {
   current: boolean;
   /** Checkout dir basename when some worktree has the branch checked out. */
   worktree: string | null;
+  /** Absolute path of that worktree — lets the client open a chat there. */
+  worktreePath: string | null;
 };
 
 /** Branch-menu payload cap: enough for real repos, bounded for pathological ones. */
@@ -154,7 +156,7 @@ async function listBranches(repoRoot: string) {
   for (const line of wtOut.split("\n")) {
     if (line.startsWith("worktree ")) dir = line.slice("worktree ".length).trim();
     else if (line.startsWith("branch refs/heads/") && dir) {
-      checkedOut.set(line.slice("branch refs/heads/".length).trim(), path.basename(dir));
+      checkedOut.set(line.slice("branch refs/heads/".length).trim(), dir);
     }
   }
   const branches: BranchRow[] = [];
@@ -164,10 +166,12 @@ async function listBranches(repoRoot: string) {
     // Tool-internal refs (e.g. beads' __dolt_remote_info__) aren't human
     // switch targets — keep them out of the menu.
     if (/^__.*__$/.test(name)) continue;
+    const worktreeDir = checkedOut.get(name) ?? null;
     branches.push({
       name,
       current: name === current,
-      worktree: checkedOut.get(name) ?? null,
+      worktree: worktreeDir ? path.basename(worktreeDir) : null,
+      worktreePath: worktreeDir,
     });
     if (branches.length >= MAX_BRANCH_ROWS) break;
   }

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -201,6 +201,16 @@ assert.doesNotMatch(
   "ChatView must not echo the raw activeProjectRoot (session cwd) as the send request's explicit projectRoot",
 );
 
+// REGRESSION (2026-07-23): "New worktree…" opens a chat at the fresh
+// `.worktrees/<branch>` checkout. That root maps to no registered project, so
+// the No-project branch used to blank activeProjectRoot and the chat silently
+// ran in the shared checkout instead of the worktree.
+assert.match(
+  source,
+  /resolvedProjectId === NO_PROJECT_ID\s*\?\s*\(projectSelection\.unregisteredRoot \?\? ""\)/,
+  "ChatView should keep an opener-provided unregistered root (worktree hand-off) as the active root",
+);
+
 // ── #2618: a failed chat send keeps the user in-chat with the message preserved,
 // and the coven-CLI-missing case offers a soft "Open Setup" link (overlay, not a
 // hard navigation to the wizard). ──────────────────────────────────────────────

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2003,8 +2003,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   });
   const resolvedProjectId = projectSelection.projectId;
   const selectedProject = projectSelection.project;
+  // No-project normally means "no root asserted" (the familiar's own
+  // workspace), but an opener-provided unregistered root — a freshly created
+  // `.worktrees/<branch>` checkout — IS the chat's home: keep it active so the
+  // first send runs there and the git chip/env panel show the worktree.
   const activeProjectRoot =
-    resolvedProjectId === NO_PROJECT_ID ? "" : (selectedProject?.root ?? session?.project_root ?? projectRoot ?? "");
+    resolvedProjectId === NO_PROJECT_ID
+      ? (projectSelection.unregisteredRoot ?? "")
+      : (selectedProject?.root ?? session?.project_root ?? projectRoot ?? "");
   // Root asserted to the server on send. A session's recorded cwd is NOT an
   // explicit project choice: a no-project chat boots in the familiar's own
   // workspace and the daemon records that dir as project_root. Echoing it back

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -124,8 +124,8 @@ assert.match(
 );
 assert.match(
   chip,
-  /closeMenu\(\);\s*\n\s*onSwitched\?\.\(\);/,
-  "a successful switch notifies the host so it can refresh immediately",
+  /closeMenu\(\);\s*\n\s*announce\(`Switched to branch \$\{name\}\.`\);\s*\n\s*onSwitched\?\.\(\);/,
+  "a successful switch announces the result and notifies the host so it can refresh immediately",
 );
 assert.match(
   chip,
@@ -134,8 +134,26 @@ assert.match(
 );
 assert.match(
   chip,
-  /disabled=\{menuBusy \|\| row\.current \|\| row\.worktree !== null\}/,
-  "branches checked out in another worktree (and the current one) are not switch targets",
+  /disabled=\{menuBusy \|\| row\.current \|\| \(row\.worktree !== null && !jumpable\)\}/,
+  "the current branch stays disabled; other-worktree branches only enable as jump targets",
+);
+// REGRESSION (cave-tmst): rows for branches living in another worktree were
+// dead ends — disabled with only a tooltip. They now open a chat rooted in
+// that worktree via the same hand-off event worktree creation uses.
+assert.match(
+  chip,
+  /const jumpable = !row\.current && row\.worktree !== null && !!row\.worktreePath;/,
+  "other-worktree rows become jump targets when the server sends the worktree path",
+);
+assert.match(
+  chip,
+  /if \(jumpable\) openWorktreeChat\(row\);\s*\n\s*else void switchBranch\(row\.name\);/,
+  "selecting a jumpable row opens a chat in that worktree instead of attempting a switch",
+);
+assert.match(
+  chip,
+  /const openWorktreeChat = [\s\S]{0,400}?new CustomEvent\("cave:agents-new-chat", \{\s*\n\s*detail: \{ projectRoot: target \}/,
+  "the worktree jump dispatches the same new-chat hand-off event as creation",
 );
 assert.match(
   chip,
@@ -146,6 +164,16 @@ assert.match(
   chip,
   /action: "create-worktree", branch: name/,
   "creating a worktree posts the create-worktree action",
+);
+assert.match(
+  chip,
+  /announce\(\s*\n?\s*`Worktree \$\{json\.created === false \? "reused" : "created"\} for \$\{json\.branch \?\? name\} — opening a chat there\.`,/,
+  "worktree creation announces created vs reused for assistive tech (the visible UI navigates away)",
+);
+assert.match(
+  chip,
+  /usePopoverEscapeLayer\(menuOpen && creating,/,
+  "Escape in the inline new-branch form backs out to the menu instead of dismissing the popover",
 );
 assert.match(
   chip,

--- a/src/components/composer-git-chip.tsx
+++ b/src/components/composer-git-chip.tsx
@@ -34,7 +34,9 @@ import {
   PopoverItem,
   PopoverLabel,
   PopoverSeparator,
+  usePopoverEscapeLayer,
 } from "@/components/ui/popover";
+import { useAnnouncer } from "@/components/ui/live-region";
 import "@/styles/composer-git-chip.css";
 
 export type BranchPr = {
@@ -52,6 +54,8 @@ type BranchRow = {
   current: boolean;
   /** Checkout dir basename when some worktree has the branch checked out. */
   worktree: string | null;
+  /** Absolute path of that worktree — jump target for "open a chat there". */
+  worktreePath?: string | null;
 };
 
 /** The branch's PR, fetched once per (projectRoot, branch) — null when the
@@ -131,6 +135,20 @@ export function GitBranchMenuPopover({
   const [menuError, setMenuError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [newBranch, setNewBranch] = useState("");
+  const { announce } = useAnnouncer();
+
+  // Escape while the inline new-branch form is open backs out to the menu
+  // (deepest-first, like a submenu) instead of dismissing the whole popover.
+  usePopoverEscapeLayer(menuOpen && creating, () => {
+    setCreating(false);
+    setNewBranch("");
+    requestAnimationFrame(() => {
+      document
+        .querySelector<HTMLElement>(".ui-popover")
+        ?.querySelector<HTMLElement>("button:not(:disabled)")
+        ?.focus();
+    });
+  });
 
   // One branch-list fetch per menu open — the list is only as fresh as the
   // moment the menu opened, which is exactly when it's read.
@@ -183,6 +201,7 @@ export function GitBranchMenuPopover({
       const json = (await res.json()) as { ok?: boolean; error?: string; branch?: string };
       if (!res.ok || !json.ok) throw new Error(json.error ?? `switch HTTP ${res.status}`);
       closeMenu();
+      announce(`Switched to branch ${name}.`);
       onSwitched?.();
     } catch (err) {
       setMenuError(err instanceof Error ? err.message : "branch switch failed");
@@ -217,6 +236,9 @@ export function GitBranchMenuPopover({
         throw new Error(json.error ?? `worktree HTTP ${res.status}`);
       }
       closeMenu();
+      announce(
+        `Worktree ${json.created === false ? "reused" : "created"} for ${json.branch ?? name} — opening a chat there.`,
+      );
       // Hand off to a fresh chat rooted in the worktree — the same event the
       // GitHub safe-merge flow uses, so routing/familiar defaults match.
       window.dispatchEvent(
@@ -229,6 +251,18 @@ export function GitBranchMenuPopover({
     } finally {
       setMenuBusy(false);
     }
+  };
+
+  const openWorktreeChat = (row: BranchRow) => {
+    const target = row.worktreePath;
+    if (!target) return;
+    closeMenu();
+    announce(`Opening a chat in worktree ${row.worktree ?? row.name}.`);
+    window.dispatchEvent(
+      new CustomEvent("cave:agents-new-chat", {
+        detail: { projectRoot: target },
+      }),
+    );
   };
 
   return (
@@ -249,25 +283,35 @@ export function GitBranchMenuPopover({
           <div className="cave-composer-git-chip__menu-note">Loading branches…</div>
         ) : (
           <>
-            {rows.map((row) => (
-              <PopoverItem
-                key={row.name}
-                icon="ph:git-branch"
-                checked={row.current}
-                disabled={menuBusy || row.current || row.worktree !== null}
-                title={
-                  row.worktree && !row.current
-                    ? `Checked out in worktree ${row.worktree}`
-                    : row.current
-                      ? "Current branch"
-                      : `Switch to ${row.name}`
-                }
-                onSelect={() => void switchBranch(row.name)}
-              >
-                {row.name}
-                {row.worktree && !row.current ? ` · ${row.worktree}` : ""}
-              </PopoverItem>
-            ))}
+            {rows.map((row) => {
+              // A branch living in another worktree can't be switched to here,
+              // but it IS one click from useful: jump into a chat rooted there.
+              const jumpable = !row.current && row.worktree !== null && !!row.worktreePath;
+              return (
+                <PopoverItem
+                  key={row.name}
+                  icon={jumpable ? "ph:tree-structure" : "ph:git-branch"}
+                  checked={row.current}
+                  disabled={menuBusy || row.current || (row.worktree !== null && !jumpable)}
+                  title={
+                    jumpable
+                      ? `Open a chat in worktree ${row.worktree}`
+                      : row.worktree && !row.current
+                        ? `Checked out in worktree ${row.worktree}`
+                        : row.current
+                          ? "Current branch"
+                          : `Switch to ${row.name}`
+                  }
+                  onSelect={() => {
+                    if (jumpable) openWorktreeChat(row);
+                    else void switchBranch(row.name);
+                  }}
+                >
+                  {row.name}
+                  {row.worktree && !row.current ? ` · ${row.worktree}` : ""}
+                </PopoverItem>
+              );
+            })}
             {rows.length === 0 && !menuError ? (
               <div className="cave-composer-git-chip__menu-note">No local branches</div>
             ) : null}

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -50,8 +50,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const activeProjectRoot =\s*resolvedProjectId === NO_PROJECT_ID \? "" : \(selectedProject\?\.root \?\? session\?\.project_root \?\? projectRoot \?\? ""\)/,
-  "ChatView keeps an explicit No-project selection rootless instead of falling back to the opener/session root",
+  /const activeProjectRoot =\s*resolvedProjectId === NO_PROJECT_ID\s*\?\s*\(projectSelection\.unregisteredRoot \?\? ""\)\s*:\s*\(selectedProject\?\.root \?\? session\?\.project_root \?\? projectRoot \?\? ""\)/,
+  "ChatView keeps an explicit No-project selection rootless — except an opener-provided unregistered root (worktree hand-off), which stays active",
 );
 assert.match(
   chatView,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -87,6 +87,29 @@ export function usePopoverInitialFocus(open: boolean, panelSelector: string) {
 }
 
 /**
+ * While `active`, Escape presses collapse this inline layer (an in-popover
+ * form or drill-in view) instead of closing the whole popover — the same
+ * deepest-first routing cascading submenus use. The root Popover's
+ * window-capture Escape listener pops one layer per press; the popover itself
+ * closes only when no layer remains.
+ */
+export function usePopoverEscapeLayer(active: boolean, close: () => void) {
+  const closeRef = useRef(close);
+  useEffect(() => {
+    closeRef.current = close;
+  });
+  useEffect(() => {
+    if (!active) return;
+    const closeSelf = () => closeRef.current();
+    submenuEscapeStack.push(closeSelf);
+    return () => {
+      const i = submenuEscapeStack.indexOf(closeSelf);
+      if (i !== -1) submenuEscapeStack.splice(i, 1);
+    };
+  }, [active]);
+}
+
+/**
  * Lightweight portal-rendered popover. Closes on Escape, outside click,
  * scroll, or window resize. Positions itself relative to the anchor; for
  * complex flipping/collision use a real positioning library.

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -440,6 +440,84 @@ console.log("chat-projects.test.ts: ok");
     { projectId: NO_PROJECT_ID, project: null },
     "recency never re-roots an EXISTING session in an unregistered cwd",
   );
+
+  // ── Unregistered opener roots (worktree hand-off) ──────────────────────────
+  // REGRESSION (2026-07-23): "New worktree…" dispatches a new chat at the
+  // freshly provisioned `.worktrees/<branch>` checkout. That root maps to no
+  // registered project, so the resolver used to drop it and fall through to
+  // the recent/first project — the chat silently ran in the shared checkout
+  // the worktree was created to avoid. An explicit opener root now resolves
+  // to No-project WITH the root carried as unregisteredRoot.
+  const worktreeRoot = "/work/alpha/.worktrees/feat-x";
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      fallbackProjectRoot: worktreeRoot,
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "a new chat opened at a worktree root keeps that root — never the recent/first project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      fallbackProjectRoot: `${worktreeRoot}/`,
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "the opener root is normalized (trailing slash trimmed)",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: worktreeRoot,
+      fallbackProjectRoot: worktreeRoot,
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "the worktree root survives the first send (session recorded at the same root)",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/Users/me/.coven/workspaces/familiars/cody",
+      fallbackProjectRoot: worktreeRoot,
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "a DIFFERENT session opened into a worktree-rooted view keeps its own home",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: "p2",
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      fallbackProjectRoot: worktreeRoot,
+    }),
+    { projectId: "p2", project: roster[1] },
+    "an explicit user pick still beats the opener's worktree root",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      taskProjectId: "p1",
+      fallbackProjectRoot: worktreeRoot,
+    }),
+    { projectId: "p1", project: roster[0] },
+    "a linked task's project still beats the opener's worktree root",
+  );
 }
 
 // ── recentChatProjectRoot ────────────────────────────────────────────────────

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -55,6 +55,11 @@ export type ChatProjectSelection = {
   projectId: string | null;
   /** The registered project the chat is scoped to; null for no-project. */
   project: CaveProject | null;
+  /** Explicit opener-provided root that maps to no registered project — e.g. a
+   *  `.worktrees/<branch>` checkout handed off by the worktree-creation flow.
+   *  The chat runs here; it must NOT be re-rooted to a registered project.
+   *  Only present when the selection resolved through that path. */
+  unregisteredRoot?: string;
 };
 
 /**
@@ -70,7 +75,11 @@ export type ChatProjectSelection = {
  * registered project is "No project" — it runs in the familiar's own
  * workspace or another unregistered dir, and defaulting it to the first
  * registered project would re-root the next turn's cwd there and fork the
- * harness session (`--continue` misses in the new dir). Only a brand new chat
+ * harness session (`--continue` misses in the new dir). An opener-provided
+ * root that maps to no registered project (`fallbackProjectRoot`, e.g. a
+ * freshly provisioned `.worktrees/<branch>` checkout) resolves to No-project
+ * with `unregisteredRoot` carrying the root, so the chat actually runs there.
+ * Only a brand new chat
  * (no session yet) defaults: to the most recent chat's registered project
  * (`recentProjectRoot`, see recentChatProjectRoot) so new chats pick up where
  * the user is actually working, then to the first project.
@@ -105,6 +114,26 @@ export function resolveChatProjectSelection(args: {
     args.projects,
   );
   if (mappedId) return { projectId: mappedId, project: chatProjectById(mappedId, args.projects) };
+  // An explicit opener root that maps to no registered project (a
+  // `.worktrees/<branch>` checkout from the composer's "New worktree…" flow or
+  // the GitHub safe-merge hand-off) is an intentional choice of where the chat
+  // runs. Falling through to the recent/first project would silently re-root
+  // the chat back into the shared checkout — the exact collision the worktree
+  // was created to avoid. Honored for the view's own session too (the root
+  // must match), so the worktree context survives the first send; a DIFFERENT
+  // session opened into this view keeps its own home instead.
+  const explicitRoot = args.fallbackProjectRoot?.trim()
+    ? normalizeChatProjectRoot(args.fallbackProjectRoot)
+    : null;
+  if (
+    explicitRoot &&
+    (!args.hasSession ||
+      (args.sessionProjectRoot?.trim()
+        ? normalizeChatProjectRoot(args.sessionProjectRoot) === explicitRoot
+        : false))
+  ) {
+    return { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: explicitRoot };
+  }
   if (args.hasSession) return { projectId: NO_PROJECT_ID, project: null };
   const recentProject = projectForRoot(args.recentProjectRoot, args.projects);
   if (recentProject) return { projectId: recentProject.id, project: recentProject };

--- a/src/lib/server/issue-worktree-provision.test.ts
+++ b/src/lib/server/issue-worktree-provision.test.ts
@@ -18,7 +18,7 @@ const root = await realpath(await mkdtemp(path.join(tmpdir(), "cave-repo-root-")
 const originalWorkspaceRoot = process.env.WORKSPACE_ROOT;
 process.env.WORKSPACE_ROOT = root;
 
-const { resolveRepoRoot } = await import("./issue-worktree-provision.ts");
+const { provisionBranchWorktree, resolveRepoRoot } = await import("./issue-worktree-provision.ts");
 
 after(async () => {
   if (originalWorkspaceRoot === undefined) delete process.env.WORKSPACE_ROOT;
@@ -26,10 +26,10 @@ after(async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-async function makeRepo() {
-  const repo = path.join(root, "repo");
+async function makeRepo(name = "repo") {
+  const repo = path.join(root, name);
   await mkdir(repo, { recursive: true });
-  await exec("git", ["init"], { cwd: repo });
+  await exec("git", ["init", "-b", "main"], { cwd: repo });
   await writeFile(path.join(repo, "README.md"), "fixture\n");
   await exec("git", ["add", "README.md"], { cwd: repo });
   await exec("git", ["-c", "user.name=Cave Tests", "-c", "user.email=cave@example.invalid", "commit", "-m", "fixture"], { cwd: repo });
@@ -64,4 +64,76 @@ test("missing, non-repository, and relative roots return stable actionable 4xx r
     status: 422,
     error: "not a git repository",
   });
+});
+
+test("provisionBranchWorktree creates once and reuses only on the SAME branch", async () => {
+  const repo = await realpath(await makeRepo("provision-reuse"));
+
+  const first = await provisionBranchWorktree(repo, "feat/chat-x");
+  assert.ok(first.ok, `create failed: ${first.ok ? "" : first.error}`);
+  assert.equal(first.created, true);
+  assert.equal(first.branch, "feat/chat-x");
+  const { stdout: head } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: first.worktree });
+  assert.equal(head.trim(), "feat/chat-x", "worktree HEAD is the requested branch");
+
+  const again = await provisionBranchWorktree(repo, "feat/chat-x");
+  assert.ok(again.ok);
+  assert.equal(again.created, false, "same branch reuses the existing worktree");
+  assert.equal(again.worktree, first.worktree);
+});
+
+// REGRESSION (cave-tmst): distinct branch names flatten to the same directory
+// (`feat/chat-x` and `feat-chat-x` both live at `.worktrees/feat-chat-x`).
+// Reuse keyed on path existence alone returned ok with the REQUESTED branch
+// name while the worktree sat on the other branch — the chat opened claiming a
+// branch it never checked out. Conflicts must be explicit.
+test("provisionBranchWorktree rejects a directory collision with the actual branch named", async () => {
+  const repo = await realpath(await makeRepo("provision-collide"));
+
+  const first = await provisionBranchWorktree(repo, "feat/chat-y");
+  assert.ok(first.ok);
+
+  const collided = await provisionBranchWorktree(repo, "feat-chat-y");
+  assert.ok(!collided.ok, "a different branch flattening to the same dir must not reuse");
+  assert.equal(collided.status, 409);
+  assert.match(collided.error, /feat\/chat-y/, "the conflict names the branch actually checked out");
+});
+
+// REGRESSION (cave-tmst): a worktree dir deleted with `rm -rf` stays
+// registered in git until pruned. Path-presence reuse returned ok with a path
+// that no longer existed, so the chat's first send failed with a dead cwd.
+test("provisionBranchWorktree prunes a stale registration and recreates the worktree", async () => {
+  const repo = await realpath(await makeRepo("provision-stale"));
+
+  const first = await provisionBranchWorktree(repo, "feat/stale");
+  assert.ok(first.ok);
+  await rm(first.worktree, { recursive: true, force: true });
+
+  const revived = await provisionBranchWorktree(repo, "feat/stale");
+  assert.ok(revived.ok, `recreate failed: ${revived.ok ? "" : revived.error}`);
+  assert.equal(revived.created, true, "a husk (git-listed, gone on disk) is pruned and recreated");
+  assert.equal(revived.worktree, first.worktree);
+  const { stdout: head } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: revived.worktree });
+  assert.equal(head.trim(), "feat/stale");
+});
+
+// REGRESSION (cave-tmst): new branches were cut from whatever origin/main the
+// local clone last fetched — hours or days stale. Creation now does a bounded
+// best-effort `git fetch origin main` first (silently skipped when offline or
+// remote-less, as in the fixtures above).
+test("provisionBranchWorktree branches new worktrees from a freshly fetched origin/main", async () => {
+  const upstream = await makeRepo("provision-upstream");
+  const clone = path.join(root, "provision-clone");
+  await exec("git", ["clone", upstream, clone]);
+  // Advance upstream AFTER the clone so the clone's origin/main snapshot is stale.
+  await writeFile(path.join(upstream, "NEW.md"), "fresh\n");
+  await exec("git", ["add", "NEW.md"], { cwd: upstream });
+  await exec("git", ["-c", "user.name=Cave Tests", "-c", "user.email=cave@example.invalid", "commit", "-m", "fresh"], { cwd: upstream });
+  const { stdout: upstreamTip } = await exec("git", ["rev-parse", "main"], { cwd: upstream });
+
+  const created = await provisionBranchWorktree(await realpath(clone), "feat/from-fresh-main");
+  assert.ok(created.ok, `create failed: ${created.ok ? "" : created.error}`);
+  assert.equal(created.baseRef, "origin/main");
+  const { stdout: worktreeTip } = await exec("git", ["rev-parse", "HEAD"], { cwd: created.worktree });
+  assert.equal(worktreeTip.trim(), upstreamTip.trim(), "the new worktree starts at upstream's CURRENT tip");
 });

--- a/src/lib/server/issue-worktree-provision.ts
+++ b/src/lib/server/issue-worktree-provision.ts
@@ -30,10 +30,11 @@ import {
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
+const FETCH_TIMEOUT_MS = 10_000;
 const MAX_GIT_BUFFER = 16 * 1024 * 1024;
 
-function git(cwd: string, args: string[]) {
-  return execFileAsync("git", args, { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
+function git(cwd: string, args: string[], timeout: number = GIT_TIMEOUT_MS) {
+  return execFileAsync("git", args, { cwd, timeout, maxBuffer: MAX_GIT_BUFFER });
 }
 
 export type RepoRootResolution =
@@ -106,16 +107,44 @@ async function pickBaseRef(repoRoot: string, requested?: string | null): Promise
   return "HEAD";
 }
 
-async function worktreeExists(repoRoot: string, absPath: string): Promise<boolean> {
+/**
+ * Best-effort refresh of origin/main before branching a NEW worktree off it,
+ * so worktrees don't start from a stale local snapshot. Bounded and silent:
+ * offline, remote-less (test fixtures), or slow remotes just branch from
+ * whatever origin/main already points at.
+ */
+async function bestEffortFetchMain(repoRoot: string): Promise<void> {
   try {
-    const { stdout } = await git(repoRoot, ["worktree", "list", "--porcelain"]);
+    await git(repoRoot, ["fetch", "--no-tags", "--quiet", "origin", "main"], FETCH_TIMEOUT_MS);
+  } catch {
+    /* branch from the local snapshot */
+  }
+}
+
+type WorktreeEntry = { path: string; branch: string | null };
+
+/** Parse `git worktree list --porcelain` into path + checked-out-branch pairs. */
+async function listWorktreeEntries(repoRoot: string): Promise<WorktreeEntry[]> {
+  const { stdout } = await git(repoRoot, ["worktree", "list", "--porcelain"]);
+  const entries: WorktreeEntry[] = [];
+  let current: WorktreeEntry | null = null;
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      current = { path: line.slice("worktree ".length).trim(), branch: null };
+      entries.push(current);
+    } else if (current && line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length).trim().replace(/^refs\/heads\//, "");
+    }
+  }
+  return entries;
+}
+
+function samePath(registered: string, absPath: string): boolean {
+  if (registered === absPath) return true;
+  try {
+    const rp = fs.existsSync(registered) ? fs.realpathSync(registered) : registered;
     const real = fs.existsSync(absPath) ? fs.realpathSync(absPath) : absPath;
-    return stdout.split("\n").some((line) => {
-      if (!line.startsWith("worktree ")) return false;
-      const p = line.slice("worktree ".length).trim();
-      const rp = fs.existsSync(p) ? fs.realpathSync(p) : p;
-      return rp === real || p === absPath;
-    });
+    return rp === real;
   } catch {
     return false;
   }
@@ -135,6 +164,66 @@ export type ProvisionResult =
   | { ok: false; status: number; error: string };
 
 /**
+ * Shared provisioning core. Reuses the worktree at `absPath` only when it is
+ * both present on disk AND checked out on the requested branch:
+ *
+ * - Same dir, DIFFERENT branch → 409 naming the actual branch. Distinct branch
+ *   names can flatten to the same directory (`feat/x` and `feat-x` both map to
+ *   `.worktrees/feat-x`), and silently returning the requested branch name for
+ *   a worktree sitting on another branch made the chat claim a branch it never
+ *   checked out.
+ * - Registered but missing on disk (`rm -rf`'d husk) → prune the stale
+ *   registration and provision fresh instead of returning a dead path.
+ */
+async function provisionWorktreeAt(
+  repoRoot: string,
+  absPath: string,
+  branch: string,
+  baseRefRequest?: string | null,
+): Promise<ProvisionResult> {
+  let stale = false;
+  try {
+    const entry = (await listWorktreeEntries(repoRoot)).find((e) => samePath(e.path, absPath));
+    if (entry) {
+      if (fs.existsSync(absPath)) {
+        if (entry.branch === branch) {
+          return { ok: true, worktree: absPath, branch, created: false, baseRef: null };
+        }
+        const at = entry.branch ? `is on branch "${entry.branch}"` : "has a detached HEAD";
+        return {
+          ok: false,
+          status: 409,
+          error: `worktree ${path.basename(absPath)} already exists and ${at}, not "${branch}" — pick a different branch name`,
+        };
+      }
+      stale = true;
+    }
+  } catch {
+    /* listing failed — fall through and let `git worktree add` be the arbiter */
+  }
+  if (stale) {
+    try {
+      await git(repoRoot, ["worktree", "prune"]);
+    } catch {
+      /* add below will surface the real error */
+    }
+  }
+
+  const haveBranch = await branchExists(repoRoot, branch);
+  if (!haveBranch) await bestEffortFetchMain(repoRoot);
+  const baseRef = await pickBaseRef(repoRoot, baseRefRequest ?? null);
+  try {
+    const args = haveBranch
+      ? ["worktree", "add", absPath, branch]
+      : ["worktree", "add", "-b", branch, absPath, baseRef];
+    await git(repoRoot, args);
+    return { ok: true, worktree: absPath, branch, created: true, baseRef };
+  } catch (err) {
+    return { ok: false, status: 500, error: err instanceof Error ? err.message : "git worktree add failed" };
+  }
+}
+
+/**
  * Idempotently provision the worktree for `ref` under an already-resolved
  * repoRoot. Returns the existing worktree (created:false) if present, otherwise
  * creates a branch off the best base ref and adds the worktree.
@@ -148,30 +237,17 @@ export async function provisionIssueWorktree(
   const branch = issueWorktreeBranch(ref);
   const absPath = resolveWorktreePath(repoRoot, relDir);
   if (!absPath) return { ok: false, status: 400, error: "invalid worktree path" };
-
-  if (await worktreeExists(repoRoot, absPath)) {
-    return { ok: true, worktree: absPath, branch, created: false, baseRef: null };
-  }
-
-  const baseRef = await pickBaseRef(repoRoot, baseRefRequest ?? null);
-  try {
-    const args = (await branchExists(repoRoot, branch))
-      ? ["worktree", "add", absPath, branch]
-      : ["worktree", "add", "-b", branch, absPath, baseRef];
-    await git(repoRoot, args);
-    return { ok: true, worktree: absPath, branch, created: true, baseRef };
-  } catch (err) {
-    return { ok: false, status: 500, error: err instanceof Error ? err.message : "git worktree add failed" };
-  }
+  return provisionWorktreeAt(repoRoot, absPath, branch, baseRefRequest);
 }
 
 /**
  * Idempotently provision a worktree for a user-named branch (the chat
  * composer's "New worktree…" flow) under `.worktrees/<flattened-branch>`.
- * Reuses the existing worktree when present; otherwise creates the branch off
- * the best base ref (origin/main preferred) — or checks out the existing local
- * branch — and adds the worktree. A branch already checked out in another
- * worktree fails with git's own "already checked out" error, surfaced verbatim.
+ * Reuses the existing worktree only when it's checked out on `branch`
+ * (409 otherwise); creates the branch off the best base ref (freshly fetched
+ * origin/main preferred) — or checks out the existing local branch — and adds
+ * the worktree. A branch already checked out in another worktree fails with
+ * git's own "already checked out" error, surfaced verbatim.
  */
 export async function provisionBranchWorktree(
   repoRoot: string,
@@ -183,19 +259,5 @@ export async function provisionBranchWorktree(
   }
   const absPath = resolveWorktreePath(repoRoot, branchWorktreeDir(branch));
   if (!absPath) return { ok: false, status: 400, error: "invalid worktree path" };
-
-  if (await worktreeExists(repoRoot, absPath)) {
-    return { ok: true, worktree: absPath, branch, created: false, baseRef: null };
-  }
-
-  const baseRef = await pickBaseRef(repoRoot, baseRefRequest ?? null);
-  try {
-    const args = (await branchExists(repoRoot, branch))
-      ? ["worktree", "add", absPath, branch]
-      : ["worktree", "add", "-b", branch, absPath, baseRef];
-    await git(repoRoot, args);
-    return { ok: true, worktree: absPath, branch, created: true, baseRef };
-  } catch (err) {
-    return { ok: false, status: 500, error: err instanceof Error ? err.message : "git worktree add failed" };
-  }
+  return provisionWorktreeAt(repoRoot, absPath, branch, baseRefRequest);
 }


### PR DESCRIPTION
Audit of the worktree-creation flow (bead **cave-tmst**) surfaced 6 bugs; all fixed here. Flagship: **creating a worktree now actually navigates the new chat into it.**

## Bugs fixed

1. **Auto-navigate broken (flagship).** `New worktree…` dispatched `cave:agents-new-chat` with the worktree root, but `resolveChatProjectSelection` dropped unregistered roots and fell through to the recent/first registered project — the chat silently ran in the shared checkout the worktree was created to avoid. The resolver now returns `NO_PROJECT_ID` + `unregisteredRoot` for explicit opener roots (guarded so a DIFFERENT session opened into the same view keeps its own home), and ChatView keeps that root active. Also fixes the GitHub safe-merge worktree hand-off and github-action-popover launches.
2. **Wrong-branch reuse.** `feat/x` and `feat-x` both flatten to `.worktrees/feat-x`; reuse keyed on path existence returned ok with the *requested* branch while the worktree sat on the other one. Provision now parses `git worktree list --porcelain` and returns **409 naming the actual branch**.
3. **Stale registration.** A worktree dir deleted on disk but still git-registered returned a dead path (first send failed). Now: `git worktree prune` + recreate.
4. **Dead-end menu rows.** Branch rows checked out in another worktree were disabled with only a tooltip. They're now **jump targets**: selecting one opens a chat rooted in that worktree (`BranchRow.worktreePath`, same hand-off event).
5. **Stale base ref.** New branches were cut from whatever `origin/main` was last fetched. Creation now does a bounded (10s) best-effort `git fetch origin main` first — silent when offline/remote-less.
6. **A11y/UX.** Branch switch, worktree create/reuse, and jumps now `announce()` via the live region; **Escape** in the inline new-branch form backs out one layer (new `usePopoverEscapeLayer`, same deepest-first stack submenus use) instead of dismissing the whole popover.

## Validation

- `chat-projects.test.ts` — 6 new behavioral cases (worktree root wins over recency, survives first send, stale-view guard, draft/task precedence)
- `issue-worktree-provision.test.ts` — 4 new real-git tests: reuse-same-branch, collision-409, husk prune+recreate, fresh-fetch-from-upstream
- `changes/route.test.ts`, `composer-git-chip.test.ts`, `chat-view.test.ts` — pins updated/added for worktreePath, jump rows, announcements, escape layer
- popover + submenu + github-action-popover-chat-launch suites green; `pnpm typecheck` clean

Known follow-up (out of scope): reopening a worktree session later still shows "No project" when the view root no longer matches — familiar-workspace behavior for enhance/mentions modes.
