### PR TITLE
fix(theme): rename OpenAI theme to Codex; fix invisible button labels on monochrome accents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Changed
+- **OpenAI theme renamed to Codex** — same void-dark monochrome palette under `data-theme="codex"`; stored `openai` preferences migrate automatically via the legacy rename map.
+
+### Fixed
+- **Button label visibility** — filled primary buttons (`.ui-btn--primary`, calendar Salem go) now use the paired on-accent foreground token instead of `--text-primary`/hard-coded white, which rendered labels invisible on the Codex theme's monochrome accent.
+
+
 ## [0.1.6] - 2026-07-22
 
 > 🏡 **Calmer hearth, sharper GitHub surfaces, and a quieter API footprint.** The launch home settles into a cards-only hearth with appearance-radius theming, Projects becomes a per-familiar access matrix, and GitHub surfaces gain diff syntax highlighting and an instant activity-heatmap tooltip. Under the hood, session PR context now resolves over REST instead of GraphQL, migrations gain stronger destructive-action guards, and the research desk gets a wide stability sweep.

--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -77,7 +77,7 @@ enum ThemeRoster {
               accentDark: "#818cf8", accentLight: "#5457e9", bgDark: "#1e1b18", bgLight: "#e7e5e4"),
         .init("claude", "Claude", "Warm parchment, muted ink, burnt-clay primary.",
               accentDark: "#d97757", accentLight: "#c96442", bgDark: "#262624", bgLight: "#faf9f5"),
-        .init("openai", "OpenAI", "Codex black. Void-dark monochrome.",
+        .init("codex", "Codex", "Codex black. Void-dark monochrome.",
               accentDark: "#ececec", accentLight: "#0d0d0d", bgDark: "#0d0d0d", bgLight: "#ffffff"),
         .init("pastel-dreams", "Pastel Dreams", "Soft violet pastels, lifted surfaces.",
               accentDark: "#c0aafd", accentLight: "#9377e6", bgDark: "#1c1917", bgLight: "#f7f3f9"),

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -81,7 +81,7 @@ color.
 
 ### Theming
 `data-theme` (21 palettes: coven, tide, grove, ember, bloom, dusk, mist, hex,
-bane, slate, ghosty, claymorphism, claude, openai, pastel-dreams, meatseeks,
+bane, slate, ghosty, claymorphism, claude, codex, pastel-dreams, meatseeks,
 trucker, snow, contrast, beacon, solstice)
 × `data-mode` (dark/light) are orthogonal attributes on `:root`, hydrated by
 `theme-script.tsx`. External shadcn themes import via tweakcn and are enriched

--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -199,8 +199,8 @@
   }
 
   try {
-    var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
-    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","openai","pastel-dreams","meatseeks","trucker","snow","contrast","beacon","solstice","custom"];
+    var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate", "openai": "codex" };
+    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","codex","pastel-dreams","meatseeks","trucker","snow","contrast","beacon","solstice","custom"];
     var theme = String(stored("coven-theme", themePrefs.id || "coven"));
     if (rename[theme]) theme = rename[theme];
     if (!isChoice(theme, valid)) theme = "coven";

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -50,7 +50,7 @@ console.log("globals.css.test.ts (task 3) OK");
 // solstice), which the original loop of 9 never covered.
 const otherThemes = [
   "tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate",
-  "ghosty", "claymorphism", "claude", "openai", "pastel-dreams", "meatseeks",
+  "ghosty", "claymorphism", "claude", "codex", "pastel-dreams", "meatseeks",
   "trucker", "snow", "contrast", "beacon", "solstice",
 ];
 for (const id of otherThemes) {
@@ -61,7 +61,7 @@ for (const id of otherThemes) {
 }
 
 // Old preset ids no longer present as CSS selectors.
-for (const old of ["midnight", "orchid", "sky"]) {
+for (const old of ["midnight", "orchid", "sky", "openai"]) {
   const re = new RegExp(`\\[data-theme="${old}"\\]`);
   assert.doesNotMatch(css, re, `old preset ${old} removed`);
 }

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -90,12 +90,12 @@ assert.match(bootScript, /reading\.leading[\s\S]*--cave-reading-leading/, "boots
 assert.match(bootScript, /appearance\.cornerRadius[\s\S]*--radius-control/, "bootstrap applies corner radius");
 assert.match(bootScript, /appearance\.backdrop[\s\S]*data-backdrop/, "bootstrap applies backdrop settings");
 
-for (const legacy of ["mood-c", "sky", "orchid", "midnight"]) {
+for (const legacy of ["mood-c", "sky", "orchid", "midnight", "openai"]) {
   assert.ok(bootScript.includes(`"${legacy}"`), `legacy theme migration contains ${legacy}`);
 }
 for (const id of [
   "coven", "tide", "grove", "ember", "bloom", "dusk", "mist", "hex",
-  "bane", "slate", "ghosty", "claymorphism", "claude", "openai",
+  "bane", "slate", "ghosty", "claymorphism", "claude", "codex",
   "pastel-dreams", "meatseeks", "trucker", "snow", "contrast", "beacon",
   "solstice", "custom",
 ]) {

--- a/src/lib/preferences-schema.test.ts
+++ b/src/lib/preferences-schema.test.ts
@@ -203,6 +203,10 @@ assert.equal(legacyPatch.general?.newsHeadlines, false);
 assert.equal(legacyPatch.phone?.mobileMode, false);
 assert.equal(Object.hasOwn(legacyPatch, "authToken"), false);
 
+// Single-theme rename: stored "openai" normalizes to "codex".
+const codexRenamePatch = legacyStorageToPreferencesPatch({ "coven-theme": "openai" });
+assert.equal(codexRenamePatch.appearance?.theme?.id, "codex");
+
 const compatibilityCache = preferencesToLegacyStorage(selectedAgain);
 assert.equal(compatibilityCache["coven-theme"], "tide");
 assert.equal(compatibilityCache["cave:font:sans"], "source-sans-3");

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -200,6 +200,7 @@ const LEGACY_THEME_RENAME: Record<string, CaveThemeId> = {
   sky: "tide",
   orchid: "dusk",
   midnight: "slate",
+  openai: "codex",
 };
 
 const THEME_ID_SET = new Set<string>([...THEME_IDS, "custom"]);

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -14,6 +14,7 @@ assert.deepEqual(
     "bloom",
     "claude",
     "claymorphism",
+    "codex",
     "contrast",
     "coven",
     "dusk",
@@ -23,7 +24,6 @@ assert.deepEqual(
     "hex",
     "meatseeks",
     "mist",
-    "openai",
     "pastel-dreams",
     "slate",
     "snow",
@@ -52,12 +52,13 @@ for (const id of THEME_IDS) {
   assert.equal(light.accent, THEME_META[id].accentLight);
 }
 
-// Legacy rename map covers all 4 old ids.
+// Legacy rename map covers the 4 old ids plus openai → codex.
 assert.deepEqual(LEGACY_THEME_RENAME, {
   "mood-c": "coven",
   "sky": "tide",
   "orchid": "dusk",
   "midnight": "slate",
+  "openai": "codex",
 });
 
 // Inverse coverage: no stray THEME_META keys outside THEME_IDS.
@@ -72,9 +73,9 @@ assert.equal(THEME_META.ghosty.accentDark, "#a6a6a6");
 assert.equal(THEME_META.ghosty.accentLight, "#808080");
 assert.equal(THEME_META.claymorphism.name, "Claymorphism");
 assert.equal(THEME_META.claude.name, "Claude");
-assert.equal(THEME_META.openai.name, "OpenAI");
-assert.equal(THEME_META.openai.accentDark, "#ececec");
-assert.equal(THEME_META.openai.accentLight, "#0d0d0d");
+assert.equal(THEME_META.codex.name, "Codex");
+assert.equal(THEME_META.codex.accentDark, "#ececec");
+assert.equal(THEME_META.codex.accentLight, "#0d0d0d");
 assert.equal(THEME_META["pastel-dreams"].name, "Pastel Dreams");
 assert.equal(THEME_META["pastel-dreams"].accentDark, "#c0aafd");
 assert.equal(THEME_META["pastel-dreams"].accentLight, "#9377e6");

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -25,7 +25,7 @@ export const THEME_IDS = [
   "ghosty",
   "claymorphism",
   "claude",
-  "openai",
+  "codex",
   "pastel-dreams",
   "meatseeks",
   "trucker",
@@ -127,8 +127,8 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     hue: 17, accentDark: "#d97757", accentLight: "#c96442",
     bgDark: "#262624", bgLight: "#faf9f5",
   },
-  openai: {
-    name: "OpenAI",
+  codex: {
+    name: "Codex",
     description: "Codex black. Void-dark monochrome; the cursor blinks back.",
     hue: 0, accentDark: "#ececec", accentLight: "#0d0d0d",
     bgDark: "#0d0d0d", bgLight: "#ffffff",

--- a/src/lib/theme-storage.ts
+++ b/src/lib/theme-storage.ts
@@ -13,7 +13,8 @@ export const COVEN_MODE_KEY = "coven-mode";
 export const COVEN_CUSTOM_THEME_KEY = "coven-custom-theme";
 
 /**
- * Renames from the dark-only preset roster to the 8-theme roster.
+ * Renames from the dark-only preset roster to the 8-theme roster,
+ * plus later single-theme renames (openai → codex).
  * Applied one-shot on first run after upgrade.
  */
 export const LEGACY_THEME_RENAME: Record<string, string> = {
@@ -21,6 +22,7 @@ export const LEGACY_THEME_RENAME: Record<string, string> = {
   "sky": "tide",
   "orchid": "dusk",
   "midnight": "slate",
+  "openai": "codex",
 };
 
 export type Mode = "light" | "dark";

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -815,7 +815,9 @@ textarea.required-inputs-control {
 .ui-btn--primary {
   background: var(--accent-presence);
   border-color: var(--accent-presence);
-  color: var(--text-primary);
+  /* Paired on-accent foreground, not --text-primary: monochrome palettes
+     (codex, slate) resolve both to the same tone, vanishing the label. */
+  color: var(--accent-presence-foreground);
 }
 .ui-btn--primary:hover {
   background: color-mix(in oklch, var(--accent-presence) 88%, white 12%);

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -871,7 +871,7 @@
 .salem-pf-entry__go {
   flex-shrink: 0; height: 32px; padding: 0 12px; border-radius: 7px;
   border: 1px solid var(--accent-presence); background: var(--accent-presence);
-  color: #fff; font-size: 12px; cursor: pointer;
+  color: var(--accent-presence-foreground); font-size: 12px; cursor: pointer;
 }
 .salem-pf-entry__go:disabled { opacity: 0.6; cursor: default; }
 .salem-pf-entry__error { margin: 0; font-size: 11.5px; color: var(--color-danger); }

--- a/src/styles/globals/themes.css
+++ b/src/styles/globals/themes.css
@@ -778,12 +778,12 @@
   --chart-5: #b4552d;
 }
 
-/* ---- OpenAI — Codex black; void-dark monochrome with paper-white keys ----
+/* ---- Codex — Codex black; void-dark monochrome with paper-white keys ----
    Modeled on the Codex/ChatGPT surfaces: #0d0d0d canvas over a true-black
    panel rail, grayscale elevation ladder, and a white filled accent (black
    ink on it) like the composer send key. Light mode inverts to white paper
    with black keys. Heritage teal survives only as a chart series. */
-[data-theme="openai"] {
+[data-theme="codex"] {
   --background: #0d0d0d;
   --foreground: #ececec;
   --card: #171717;
@@ -820,7 +820,7 @@
   --chart-4: #8f8f8f;
   --chart-5: #5d5d5d;
 }
-[data-theme="openai"][data-mode="light"] {
+[data-theme="codex"][data-mode="light"] {
   --background: #ffffff;
   --foreground: #0d0d0d;
   --card: #f9f9f9;


### PR DESCRIPTION
## What

**Button label visibility.** Two filled controls painted their labels with a color that collapses into the fill on monochrome-accent palettes:

- `.ui-btn--primary` used `color: var(--text-primary)` on an `--accent-presence` fill — on the Codex theme (accent `#ececec` dark / `#0d0d0d` light) label and fill resolve to the same tone, so primary buttons rendered blank.
- `.salem-pf-entry__go` (calendar Salem path entry) hard-coded `color: #fff` — white-on-white in Codex dark.

Both now use `--accent-presence-foreground`, the paired on-accent token that `theme-contrast-audit.test.ts` holds to AA 4.5:1 across all 21 themes × 2 modes. Other full accent fills (`.dr-btn--primary`, `.retro-btn--primary`, settings segments, familiar-switcher checkbox) already used it.

**Theme rename `openai` → `codex`** (display name **Codex**), following the established legacy-rename migration pattern (`mood-c`/`sky`/`orchid`/`midnight`):

- `THEME_IDS`/`THEME_META` (theme-palettes.ts), `[data-theme="codex"]` selectors (themes.css), pre-paint allowlist + rename map (theme-init.js), `LEGACY_THEME_RENAME` in theme-storage.ts and preferences-schema.ts — stored `openai` prefs migrate one-shot on next boot/validate.
- iOS `ThemeRoster.swift` id+name (parity pinned by `ios-theme-override.test.ts`), design-language doc, CHANGELOG.

## Verification

- `theme-palettes`, `theme-contrast-audit`, `theme-script`, `globals.css`, `preferences-schema`, `ios-theme-override`, `quick-chat-polish`, `session-changes-panel`, `minimalism-invariants`, `design-token-drift` tests all pass locally
- `pnpm typecheck` clean
- `grep -rn openai` across theme surfaces: only the intentional rename-map entries remain