### PR TITLE
fix(chat): resolve analytics-thread sessions to their daemon root + inline project fix for projectRoot-required 400

### DIFF
--- a/src/app/api/chat/send/chat-send-runtime.ts
+++ b/src/app/api/chat/send/chat-send-runtime.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { loadConversation } from "@/lib/cave-conversations";
+import { callDaemon } from "@/lib/coven-daemon";
 import {
   familiarWorkspacesRoot,
   readFamiliarWorkspaces,
@@ -18,6 +19,32 @@ export async function conversationCwd(sessionId?: string): Promise<string | unde
     }
   } catch {
     /* fall back to the caller's default */
+  }
+  return undefined;
+}
+
+type DaemonSessionRow = { id?: string; project_root?: string };
+
+/**
+ * Resume-cwd fallback for sessions the Cave conversation store has no local
+ * runtime for — e.g. threads opened from Familiar analytics (`/#chat-<id>`)
+ * that were spawned by the daemon rather than the chat bridge. Without this,
+ * their first chat turn had no root anywhere and died on the 400
+ * "projectRoot is required" refusal (cave-yjnr). The daemon is the right
+ * trust anchor: it already ran a harness in this session's `project_root`
+ * (same argument as session-project-roots.ts), so resuming there is exactly
+ * "the directory the conversation started in" — never a homedir downgrade.
+ */
+export async function daemonSessionCwd(sessionId?: string): Promise<string | undefined> {
+  if (!sessionId) return undefined;
+  try {
+    const res = await callDaemon<DaemonSessionRow[]>({ path: "/api/v1/sessions" });
+    if (!res.ok || !Array.isArray(res.data)) return undefined;
+    const row = res.data.find((session) => session?.id === sessionId);
+    const root = row?.project_root?.trim();
+    if (root && path.isAbsolute(root)) return root;
+  } catch {
+    /* daemon offline — the caller keeps its remaining fallbacks */
   }
   return undefined;
 }

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -410,6 +410,37 @@ assert.match(
   "Resumed turns reuse the conversation's recorded cwd — harness stores are cwd-scoped",
 );
 
+// cave-yjnr: threads opened from Familiar analytics (`/#chat-<id>`) can
+// predate any Cave conversation record — only the daemon knows their cwd.
+// Its session record is the trust anchor (session-project-roots.ts), so the
+// resume falls back to it instead of dying on the 400 project_root_required
+// refusal. A conversation that DID record a runtime stays authoritative
+// (never cross an ssh: runtime onto a local root).
+assert.match(
+  chatRoute,
+  /const resumeCwd =\s*conversationResumeCwd \?\?\s*\(!sshRuntime && !body\.projectRoot && existingConversation\?\.runtime == null\s*\? await daemonSessionCwd\(body\.sessionId\)\s*: undefined\);/,
+  "Rootless sessions without a conversation-recorded runtime resume in the daemon session's project_root",
+);
+assert.match(
+  chatRoute,
+  /import \{ conversationCwd, daemonSessionCwd, resolveFamiliarWorkspace \} from "\.\/chat-send-runtime";/,
+  "The daemon-session resume fallback comes from the shared chat-send-runtime helper",
+);
+const sendRuntimeHelpers = await readFile(
+  new URL("./chat-send-runtime.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  sendRuntimeHelpers,
+  /export async function daemonSessionCwd\(sessionId\?: string\): Promise<string \| undefined> \{[\s\S]*?callDaemon<DaemonSessionRow\[\]>\(\{ path: "\/api\/v1\/sessions" \}\)[\s\S]*?path\.isAbsolute\(root\)[\s\S]*?\n\}/,
+  "daemonSessionCwd resolves the session's project_root from the daemon's own session list and only trusts absolute paths",
+);
+assert.match(
+  chatRoute,
+  /args\.body\.projectRoot \?\?\s*\(await conversationCwd\(args\.body\.sessionId\)\) \?\?\s*\(await daemonSessionCwd\(args\.body\.sessionId\)\)/,
+  "The OpenClaw bridge resume gets the same daemon-session cwd fallback",
+);
+
 assert.match(
   chatRoute,
   /await resolveLocalRuntimeCwd\(body\.projectRoot \?\? resumeCwd \?\? resolvedFamiliarWorkspace\)/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -166,7 +166,7 @@ import {
   resolveSendModelMetadata,
 } from "./chat-send-models";
 import { chatSse, startChatSseHeartbeat } from "./chat-send-sse";
-import { conversationCwd, resolveFamiliarWorkspace } from "./chat-send-runtime";
+import { conversationCwd, daemonSessionCwd, resolveFamiliarWorkspace } from "./chat-send-runtime";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -472,7 +472,9 @@ function openClawChatResponse(args: {
       let cwd: string;
       try {
         cwd = await resolveLocalRuntimeCwd(
-          args.body.projectRoot ?? (await conversationCwd(args.body.sessionId)),
+          args.body.projectRoot ??
+            (await conversationCwd(args.body.sessionId)) ??
+            (await daemonSessionCwd(args.body.sessionId)),
         );
       } catch (error) {
         if (error instanceof RuntimeScopeError) {
@@ -960,10 +962,22 @@ export async function POST(req: Request) {
   // directory the conversation started in, not homedir or the familiar
   // workspace, or `--continue <id>` misses (and the transparent retry forks
   // the chat into a fresh session).
-  const resumeCwd =
+  const conversationResumeCwd =
     !sshRuntime && !body.projectRoot && existingConversation?.runtime?.startsWith("local:")
       ? existingConversation.runtime.slice("local:".length).trim() || undefined
       : undefined;
+  // Threads opened from Familiar analytics (`/#chat-<id>`) can predate any
+  // Cave conversation record — the daemon spawned them, so only IT knows the
+  // cwd. Its session record is the trust anchor (see daemonSessionCwd);
+  // without this fallback those chats died on the 400 "projectRoot is
+  // required" refusal with nowhere to go (cave-yjnr). Conversations that
+  // recorded a runtime keep it authoritative (never cross an ssh: runtime
+  // onto a local root).
+  const resumeCwd =
+    conversationResumeCwd ??
+    (!sshRuntime && !body.projectRoot && existingConversation?.runtime == null
+      ? await daemonSessionCwd(body.sessionId)
+      : undefined);
   const projects = sshRuntime ? [] : await loadProjects();
   const resolvedFamiliarWorkspace = !sshRuntime
     ? await resolveFamiliarWorkspace(body.familiarId)

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -234,3 +234,28 @@ assert.doesNotMatch(
   /router\.(push|replace)\([`"'][^`"']*onboard/i,
   "a send failure must never hard-navigate the router to onboarding",
 );
+
+// ── cave-yjnr: a 400 project_root_required (analytics-opened thread with no
+// root anywhere) must not dead-end at jargon + a Retry that can never work.
+// The strip swaps in plain copy and an inline project picker that adopts the
+// chosen project and re-sends the failed message explicitly rooted there. ────
+assert.match(
+  source,
+  /res\.status === 400 && \/project_root_required\|projectRoot is required\/i\.test\(message\)[\s\S]{0,200}setProjectRootRequired\(true\)/,
+  "the projectRoot-required 400 is detected and flips the inline-resolve state instead of surfacing server jargon",
+);
+assert.match(
+  source,
+  /function handlePickProjectFix\(projectId: string\) \{[\s\S]*?setProjectIdDraft\(projectId\);[\s\S]*?void sendRaw\(\s*failed\.text,[\s\S]*?projectRoot: project\.root,[\s\S]*?\n  \}/,
+  "picking a project from the strip adopts it as the chat's selection and retries the failed send rooted there",
+);
+assert.match(
+  source,
+  /onPickProject=\{projectRootRequired \? handlePickProjectFix : undefined\}/,
+  "the inline project picker only renders for the projectRoot-required failure class",
+);
+assert.match(
+  source,
+  /projectRootRequired && projects\.length === 0\s*\? overflowAddProject\.beginAddProject/,
+  "with zero registered projects the strip offers the shared register-a-folder flow instead of a dead select",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -143,6 +143,7 @@ import { SkillStageCard } from "@/components/skill-stage-card";
 import { ChatStageHeader } from "@/components/chat-stage-header";
 import {
   NO_PROJECT_ID,
+  chatProjectById,
   projectIdForRoot,
   recentChatProjectRoot,
   resolveChatProjectSelection,
@@ -528,6 +529,9 @@ function ChatErrorStrip({
   onOpenProjects,
   onUseHarness,
   harnessId,
+  pickProjectOptions,
+  onPickProject,
+  onRegisterProject,
 }: {
   message: string;
   code?: string;
@@ -554,6 +558,14 @@ function ChatErrorStrip({
   /** The runtime the failing send used — lets the auth-failure fix row name
    *  it and offer its exact login command (cave-f6ol). */
   harnessId?: string | null;
+  /** When set, this failure was a 400 project_root_required: the chat has no
+   *  root anywhere. Render an inline registered-project picker; choosing one
+   *  adopts it for the chat and retries the failed send there (cave-yjnr). */
+  pickProjectOptions?: { id: string; name: string }[];
+  onPickProject?: (projectId: string) => void;
+  /** Zero registered projects: the inline resolve is registering a folder —
+   *  opens the shared add-project flow (native picker + web fallback). */
+  onRegisterProject?: () => void;
 }) {
   const { copied, copy } = useCopy();
   const erroredTools = (failingTurn?.tools ?? []).filter((t) => t.status === "error");
@@ -687,6 +699,46 @@ function ChatErrorStrip({
             <Icon name="ph:wrench" width={11} aria-hidden />
             Open Setup
           </button>
+        </div>
+      ) : null}
+      {!harnessFailure && !authFailure && !covenMissing && onPickProject && pickProjectOptions ? (
+        <div className="flex flex-wrap items-center gap-2 px-5 pb-2 text-[length:var(--text-xs)]">
+          {pickProjectOptions.length ? (
+            <>
+              <span className="min-w-0">Run this chat in one of your projects:</span>
+              <select
+                className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_42%,transparent)] bg-[var(--bg-base)]/60 px-2 py-1 text-[length:var(--text-xs)] font-medium text-[var(--text-primary)]"
+                defaultValue=""
+                disabled={busy}
+                aria-label="Pick a project to run this chat in"
+                onChange={(event) => {
+                  if (event.target.value) onPickProject(event.target.value);
+                }}
+              >
+                <option value="" disabled>
+                  Pick a project…
+                </option>
+                {pickProjectOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : (
+            <>
+              <span className="min-w-0">
+                No projects are registered yet — register the folder this chat should run in,
+                then retry.
+              </span>
+              {onRegisterProject ? (
+                <button type="button" onClick={onRegisterProject} className={btn}>
+                  <Icon name="ph:folders-bold" width={11} aria-hidden />
+                  Register a folder…
+                </button>
+              ) : null}
+            </>
+          )}
         </div>
       ) : null}
       {hasDetail && open ? (
@@ -1893,6 +1945,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // send 400s with code project_root_unavailable and Retry can never succeed —
   // the recovery is re-pointing the project, not retrying (cave-ivcc).
   const [projectRootMissing, setProjectRootMissing] = useState(false);
+  // 400 project_root_required: the chat has no root anywhere (analytics-opened
+  // daemon thread with no recorded cwd + familiar without a workspace). The
+  // error strip renders an inline project picker that retries the send in the
+  // chosen project (cave-yjnr).
+  const [projectRootRequired, setProjectRootRequired] = useState(false);
   const [addingProject, setAddingProject] = useState(false);
   const [voiceCallOpen, setVoiceCallOpen] = useState(false);
   // The session id the OPEN overlay was auto-created for (voice new-chat), or
@@ -3957,6 +4014,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setLastFailedSend(null);
     setProjectAccessRoot(null);
     setProjectRootMissing(false);
+    setProjectRootRequired(false);
     const initialLiveSessionId = currentSessionRef.current;
     liveSessionIdRef.current = initialLiveSessionId;
     setHistoryState("loaded");
@@ -4167,6 +4225,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             missingRoot
               ? `This chat's project folder is missing (${missingRoot}) — it may have been moved or deleted. Open Projects to fix its path, or pick a different project for this chat.`
               : "This chat's project folder is missing — it may have been moved or deleted. Open Projects to fix its path, or pick a different project for this chat.";
+        }
+        // A 400 project_root_required means this chat has no root anywhere:
+        // no explicit project, no conversation-recorded cwd, no daemon
+        // session record, no familiar workspace. Retry alone can never
+        // succeed, and the server's refusal is jargon — surface plain copy
+        // plus an inline project picker that re-sends the failed message in
+        // the chosen project (cave-yjnr).
+        if (res.status === 400 && /project_root_required|projectRoot is required/i.test(message)) {
+          setProjectRootRequired(true);
+          surfacedMessage =
+            "This chat isn't tied to a project folder yet, so there's nowhere to run it. Pick a project below and your message will be retried there.";
         }
         setError(surfacedMessage);
         upsertTurnProgress(assistantId, {
@@ -4471,6 +4540,31 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     } finally {
       setAddingProject(false);
     }
+  }
+
+  // Recovery for a 400 project_root_required failure: the chat has no root
+  // anywhere. Adopt the picked project as this chat's selection and re-send
+  // the failed message explicitly rooted there (the explicit opts.projectRoot
+  // sidesteps the stale requestProjectRoot closure of this render).
+  function handlePickProjectFix(projectId: string) {
+    if (busy || !lastFailedSend) return;
+    const project = chatProjectById(projectId, projects);
+    if (!project) return;
+    const failed = lastFailedSend;
+    setProjectIdDraft(projectId);
+    setProjectRootRequired(false);
+    setError(null);
+    setDebugError(null);
+    setLastFailedSend(null);
+    void sendRaw(
+      failed.text,
+      failed.attachments,
+      failed.mentionedFiles ?? [],
+      {
+        projectRoot: project.root,
+        ...(failed.promptOverride ? { promptOverride: failed.promptOverride } : {}),
+      },
+    );
   }
 
   // CHAT-D6-01: edit-and-resend. Loads a user turn's text into the composer so
@@ -5662,11 +5756,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               ? () => window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT))
               : undefined
           }
+          pickProjectOptions={
+            projectRootRequired
+              ? projects.map((project) => ({ id: project.id, name: project.name }))
+              : undefined
+          }
+          onPickProject={projectRootRequired ? handlePickProjectFix : undefined}
+          onRegisterProject={
+            projectRootRequired && projects.length === 0
+              ? overflowAddProject.beginAddProject
+              : undefined
+          }
           onDismiss={() => {
             setError(null);
             setDebugError(null);
             setProjectAccessRoot(null);
             setProjectRootMissing(false);
+            setProjectRootRequired(false);
           }}
         />
       ) : null}


### PR DESCRIPTION
## Problem (cave-yjnr)

Opening a chat session from the **familiar analytics threads table** (`/#chat-<id>`) and sending a message dead-ends with:

> request failed (400): projectRoot is required; refusing to start a homedir-scoped fallback session.

Analytics threads are daemon-spawned, so the Cave conversation store has no record (no `local:<cwd>` runtime), and the send route's resume chain (`body.projectRoot ?? resumeCwd ?? resolvedFamiliarWorkspace`) comes up empty → `resolveLocalRuntimeCwd` throws `project_root_required`. The error strip showed server jargon and a Retry that could never succeed.

## Fix

**1. Resolve a proper root first (server):**
- `chat-send-runtime.ts`: new `daemonSessionCwd(sessionId)` — looks up the session's recorded `project_root` from the daemon's `/api/v1/sessions` (the same trust anchor as `session-project-roots.ts`: the daemon already ran a harness there, so the dir is user-sanctioned). Absolute paths only; undefined when the daemon is offline or the session is unknown.
- `route.ts`: falls back to that daemon-recorded root when the conversation store has no runtime — main send path **and** the OpenClaw branch. Never crosses an `ssh:` runtime onto a local root; existing access gates still apply downstream.

**2. Graceful inline resolve (client), when no root exists anywhere:**
- `chat-view.tsx` detects the `project_root_required` 400 and replaces the jargon with plain copy: *"This chat isn't tied to a project folder yet…"*
- The error strip renders an inline **project picker**; choosing a project adopts it as the chat's selection and auto-retries the failed send explicitly rooted there (mirrors the existing 403 one-click register+retry pattern).
- With zero registered projects, it offers the shared **Register a folder…** flow instead of a dead select.

## Tests
- `harness-routing-host-session.test.ts`: pins the resume-chain fallback, `daemonSessionCwd` shape (daemon endpoint + absolute-only), and the OpenClaw fallback chain.
- `chat-view.test.ts`: pins 400 detection, pick-project retry with explicit `projectRoot`, strip gating, and the zero-project register path.

## Verification
- [x] `pnpm test:app` — 891 files
- [x] `pnpm test:api` — 239 files
- [x] `pnpm typecheck`, `pnpm lint` — clean
- [x] Rebased on `main` @ b4e1303a8; targeted tests re-run post-rebase

Closes bead `cave-yjnr`.