### PR TITLE
fix(chat): reopened worktree chats keep their recorded .worktrees/ home

### DIFF
--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -518,6 +518,80 @@ console.log("chat-projects.test.ts: ok");
     { projectId: "p1", project: roster[0] },
     "a linked task's project still beats the opener's worktree root",
   );
+
+  // ── Reopened worktree chats (cave-k0ra) ─────────────────────────────────────
+  // REGRESSION (2026-07-23): a chat created in a `.worktrees/<branch>` checkout
+  // kept its root only while the opener's fallbackProjectRoot still matched.
+  // Reopened later from the chat list, the view root differs (or is absent),
+  // the resolver returned bare No-project, and the chat lost its home: git
+  // chip hidden, enhance in "chat" mode. A recorded cwd under a registered
+  // project's `.worktrees/` dir now carries through as unregisteredRoot.
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: worktreeRoot,
+      fallbackProjectRoot: null,
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "a worktree chat reopened without an opener root keeps its recorded worktree home",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: worktreeRoot,
+      fallbackProjectRoot: "/work/beta",
+      recentProjectRoot: "/work/beta",
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "a mismatched view root never strips a worktree session of its recorded home",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: `${worktreeRoot}/`,
+      fallbackProjectRoot: null,
+    }),
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: worktreeRoot },
+    "the recorded worktree root is normalized (trailing slash trimmed)",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/elsewhere/.worktrees/feat-x",
+      fallbackProjectRoot: null,
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "a worktree under an UNREGISTERED parent stays bare No-project — its cwd is never surfaced",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/work/alphax/.worktrees/feat-x",
+      fallbackProjectRoot: null,
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "containment is separator-exact: /work/alphax never matches project root /work/alpha",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha/.worktrees-evasion/feat-x",
+      fallbackProjectRoot: null,
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "only the literal .worktrees/ directory qualifies — sibling dirs sharing the prefix do not",
+  );
 }
 
 // ── recentChatProjectRoot ────────────────────────────────────────────────────

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -79,6 +79,10 @@ export type ChatProjectSelection = {
  * root that maps to no registered project (`fallbackProjectRoot`, e.g. a
  * freshly provisioned `.worktrees/<branch>` checkout) resolves to No-project
  * with `unregisteredRoot` carrying the root, so the chat actually runs there.
+ * The same applies to an existing session whose recorded cwd lives under a
+ * registered project's `.worktrees/` directory: reopened later — when the
+ * view's opener root no longer matches — the chat keeps its worktree home
+ * instead of degrading to a root-less No-project (cave-k0ra).
  * Only a brand new chat
  * (no session yet) defaults: to the most recent chat's registered project
  * (`recentProjectRoot`, see recentChatProjectRoot) so new chats pick up where
@@ -133,6 +137,23 @@ export function resolveChatProjectSelection(args: {
         : false))
   ) {
     return { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: explicitRoot };
+  }
+  // A chat that RAN in a project's worktree keeps that root when reopened
+  // later, when the view's opener root no longer matches (cave-k0ra): a
+  // recorded cwd under a registered project's `.worktrees/` directory is as
+  // intentional as the opener hand-off above — the git chip, env panel, and
+  // enhance mode belong to that checkout, not to "No project". Scoped to
+  // `.worktrees/` containment on purpose: a session recorded in the
+  // familiar's own workspace (or any other unregistered dir) still resolves
+  // to bare No-project, so its cwd is never surfaced or re-asserted.
+  if (args.hasSession && args.sessionProjectRoot?.trim()) {
+    const sessionRoot = normalizeChatProjectRoot(args.sessionProjectRoot);
+    const inProjectWorktrees = args.projects.some((project) =>
+      sessionRoot.startsWith(`${normalizeChatProjectRoot(project.root)}/.worktrees/`),
+    );
+    if (inProjectWorktrees) {
+      return { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: sessionRoot };
+    }
   }
   if (args.hasSession) return { projectId: NO_PROJECT_ID, project: null };
   const recentProject = projectForRoot(args.recentProjectRoot, args.projects);


### PR DESCRIPTION
## Problem (cave-k0ra, follow-up from cave-tmst / #3714)

A chat created in a `.worktrees/<branch>` checkout keeps its root during the live session — the opener's `fallbackProjectRoot` matches, so `resolveChatProjectSelection` carries it as `unregisteredRoot`. But **reopened later from the chat list**, the view's root no longer matches (or is absent), the resolver returned bare No-project, and `activeProjectRoot` resolved empty: git chip hidden, env panel blank, prompt-enhance downgraded to 'chat' mode — the chat lost its home.

## Fix

`resolveChatProjectSelection` now honors the **session's recorded cwd** when it lives under a registered project's `.worktrees/` directory: it resolves to No-project **with** `unregisteredRoot` carrying that cwd — the same treatment the opener hand-off already gets.

Deliberately scoped:
- **`.worktrees/` containment only**, separator-exact (`<projectRoot>/.worktrees/…`) — no prefix bypass (`/work/alphax` never matches `/work/alpha`; `.worktrees-evasion/` doesn't qualify).
- A session recorded in the **familiar's own workspace** (or any other unregistered dir) still resolves to bare No-project — its cwd is never surfaced or re-asserted (2026-07-01 regression guard intact).
- Send-side unchanged: the `requestProjectRoot` equality guard still blanks the echo for recorded cwds, so the server keeps deriving the resume cwd from the conversation record / daemon (#3720).

## Tests
- 6 new `resolveChatProjectSelection` cases in `chat-projects.test.ts`: reopen without opener root, mismatched view root, trailing-slash normalization, unregistered-parent negative, separator-exactness negative, `.worktrees`-prefix-sibling negative.

## Verification
- [x] `pnpm test:app` — 892 files
- [x] `pnpm test:api` — 239 files
- [x] `pnpm typecheck`, `pnpm lint` — clean
- [x] Rebased on `main` @ d04f2cf1e

Closes bead `cave-k0ra`.