### PR TITLE
fix: collision-safe corrupt-aside names across all four JSON stores

### DIFF
--- a/src/lib/cave-canvas.ts
+++ b/src/lib/cave-canvas.ts
@@ -4,11 +4,11 @@
 // are user content with no undo — the load path must never let a bad read turn
 // into an empty save that destroys them (see loadCanvas).
 
-import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { corruptAsidePath } from "./server/corrupt-aside.ts";
 
 import type { CanvasPosition, CanvasPositions } from "@/lib/canvas-layout";
 import {
@@ -86,11 +86,9 @@ export async function loadCanvas(): Promise<CanvasFile> {
     // The file holds bytes that aren't a canvas store (torn write, foreign
     // content). This store now carries user sketches with no undo — reading
     // it as empty made the NEXT save silently destroy all of them. Move the
-    // bad file aside (bytes preserved for recovery) and start fresh. The
-    // timestamp is for humans; the random suffix keeps two corruption events
-    // in the same millisecond from renaming onto the SAME aside path (rename
-    // clobbers, so the second capture silently destroyed the first).
-    const aside = `${CANVAS_PATH}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+    // bad file aside (bytes preserved for recovery, collision-safe name —
+    // see corruptAsidePath) and start fresh.
+    const aside = corruptAsidePath(CANVAS_PATH);
     try {
       await rename(CANVAS_PATH, aside);
       console.error(`cave-canvas: unreadable store moved aside to ${aside}`);

--- a/src/lib/server/corrupt-aside.ts
+++ b/src/lib/server/corrupt-aside.ts
@@ -1,0 +1,16 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Aside path used when preserving the bytes of a corrupt store file:
+ * `<source>.corrupt-<timestamp>-<random>`.
+ *
+ * The timestamp is millisecond-resolution and exists for humans triaging a
+ * capture. On its own it is NOT unique — two corruption events in the same
+ * millisecond would target the same path, and both rename() and copyFile()
+ * silently replace an existing destination, destroying the first capture.
+ * The random suffix keeps every capture distinct.
+ */
+export function corruptAsidePath(source: string): string {
+  const stamp = new Date().toISOString().replace(/[^0-9]/g, "");
+  return `${source}.corrupt-${stamp}-${randomUUID().slice(0, 8)}`;
+}

--- a/src/lib/server/preferences-store.test.ts
+++ b/src/lib/server/preferences-store.test.ts
@@ -193,6 +193,35 @@ try {
     "successful atomic writes leave no temporary files",
   );
 
+  // Same-millisecond double corruption: the aside name's timestamp is
+  // millisecond-resolution, so without the random suffix the second capture
+  // would copy onto the SAME path and destroy the first (see corruptAsidePath).
+  const beforeBurst = new Set((await readdir(root)).filter((name) => name.includes(".corrupt-")));
+  const RealDate = Date;
+  const frozenMs = new RealDate("2026-01-01T00:00:00.000Z").getTime();
+  globalThis.Date = class extends RealDate {
+    constructor() {
+      super(frozenMs);
+    }
+  };
+  try {
+    await writeFile(preferencesFile, "{ corrupt take one", "utf8");
+    await store.patchPreferences({});
+    await writeFile(preferencesFile, "{ corrupt take two", "utf8");
+    await store.patchPreferences({});
+  } finally {
+    globalThis.Date = RealDate;
+  }
+  const burstCaptures = (await readdir(root)).filter(
+    (name) => name.includes(".corrupt-") && !beforeBurst.has(name),
+  );
+  assert.equal(burstCaptures.length, 2, "same-ms corruption events each keep their own capture");
+  const burstContents = await Promise.all(
+    burstCaptures.map((name) => readFile(path.join(root, name), "utf8")),
+  );
+  assert.ok(burstContents.includes("{ corrupt take one"), "the first capture survives");
+  assert.ok(burstContents.includes("{ corrupt take two"), "the second capture survives");
+
   // Empty initialization is meaningful for a genuinely fresh profile.
   await rm(preferencesFile, { force: true });
   const defaults = await store.patchPreferences({});

--- a/src/lib/server/preferences-store.ts
+++ b/src/lib/server/preferences-store.ts
@@ -16,6 +16,7 @@ import {
 } from "@/lib/preferences-schema";
 import { writeJsonAtomic } from "@/lib/server/atomic-write";
 import { withCaveHomeReconciledStore } from "./cave-home-migration.ts";
+import { corruptAsidePath } from "./corrupt-aside.ts";
 
 export function preferencesPath(): string {
   const override = process.env.COVEN_PREFERENCES_PATH?.trim();
@@ -84,8 +85,7 @@ async function readLegacyThemeSeed(): Promise<CavePreferencesPatch | null> {
 
 async function preserveMalformedFile(): Promise<void> {
   const source = preferencesPath();
-  const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
-  await copyFile(/* turbopackIgnore: true */ source, `${source}.corrupt-${suffix}`).catch(() => {});
+  await copyFile(/* turbopackIgnore: true */ source, corruptAsidePath(source)).catch(() => {});
 }
 
 async function writePreferences(preferences: CavePreferences): Promise<void> {

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -389,6 +389,46 @@ test("a corrupt store file is preserved aside, never silently wiped", async () =
   assert.ok(backups.length >= 1, "malformed file preserved as .corrupt-<ts>");
 });
 
+test("same-millisecond corruption events keep distinct aside captures", async () => {
+  const target = researchGenerationsPath("nova");
+  const dir = path.dirname(target);
+  const valid = await readFile(target, "utf8");
+  const before = new Set((await readdir(dir)).filter((name) => name.includes(".corrupt-")));
+
+  // Freeze the clock: the aside name's timestamp is millisecond-resolution,
+  // so without the random suffix both captures below would target the SAME
+  // path and copyFile would clobber the first (see corruptAsidePath).
+  const RealDate = Date;
+  const frozenMs = new RealDate("2026-01-01T00:00:00.000Z").getTime();
+  globalThis.Date = class extends RealDate {
+    constructor() {
+      super(frozenMs);
+    }
+  } as DateConstructor;
+  try {
+    await writeFile(target, "{ corrupt take one", "utf8");
+    assert.deepEqual(await listResearchGenerations("nova"), [], "a corrupt store reads as empty");
+    await writeFile(target, "{ corrupt take two", "utf8");
+    assert.deepEqual(
+      await listResearchGenerations("nova"),
+      [],
+      "the second corruption also reads as empty",
+    );
+  } finally {
+    globalThis.Date = RealDate;
+  }
+
+  const fresh = (await readdir(dir)).filter(
+    (name) => name.includes(".corrupt-") && !before.has(name),
+  );
+  assert.equal(fresh.length, 2, "each corruption event keeps its own capture");
+  const captured = await Promise.all(fresh.map((name) => readFile(path.join(dir, name), "utf8")));
+  assert.ok(captured.includes("{ corrupt take one"), "the first capture survives");
+  assert.ok(captured.includes("{ corrupt take two"), "the second capture survives");
+
+  await writeFile(target, valid, "utf8");
+});
+
 test("path safety: traversal-shaped familiar ids are rejected outright", async () => {
   await assert.rejects(() => listResearchGenerations("../evil"), /invalid familiar id/);
   await assert.rejects(() => removeResearchGeneration("a/b", "x"), /invalid familiar id/);

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -36,6 +36,7 @@ import {
 import type { ResearchArtifactRef, ResearchMission } from "../research-missions.ts";
 import { caveHome } from "../coven-paths.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
+import { corruptAsidePath } from "./corrupt-aside.ts";
 import {
   loadResearchMission,
   readValidatedMissionFile,
@@ -152,8 +153,7 @@ async function loadFile(familiarId: string): Promise<ResearchGenerationsFile> {
 
 async function preserveMalformedFile(familiarId: string): Promise<void> {
   const source = researchGenerationsPath(familiarId);
-  const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
-  await copyFile(/* turbopackIgnore: true */ source, `${source}.corrupt-${suffix}`).catch(() => {});
+  await copyFile(/* turbopackIgnore: true */ source, corruptAsidePath(source)).catch(() => {});
 }
 
 async function saveFile(familiarId: string, file: ResearchGenerationsFile): Promise<void> {

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -96,6 +96,42 @@ test("a corrupt store file is preserved aside, never silently wiped by a save", 
   assert.match(backup, /pre-corruption/, "the backup holds the pre-corruption content");
 });
 
+test("same-millisecond corruption events keep distinct aside captures", async () => {
+  const target = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE!;
+  const dir = path.dirname(target);
+  const valid = await readFile(target, "utf8");
+  const before = new Set((await readdir(dir)).filter((name) => name.includes(".corrupt-")));
+
+  // Freeze the clock: the aside name's timestamp is millisecond-resolution,
+  // so without the random suffix both captures below would target the SAME
+  // path and copyFile would clobber the first (see corruptAsidePath).
+  const RealDate = Date;
+  const frozenMs = new RealDate("2026-01-01T00:00:00.000Z").getTime();
+  globalThis.Date = class extends RealDate {
+    constructor() {
+      super(frozenMs);
+    }
+  } as DateConstructor;
+  try {
+    await writeFile(target, "{ corrupt take one", "utf8");
+    assert.deepEqual(await listSavedLinks(), [], "a corrupt store reads as empty");
+    await writeFile(target, "{ corrupt take two", "utf8");
+    assert.deepEqual(await listSavedLinks(), [], "the second corruption also reads as empty");
+  } finally {
+    globalThis.Date = RealDate;
+  }
+
+  const fresh = (await readdir(dir)).filter(
+    (name) => name.includes(".corrupt-") && !before.has(name),
+  );
+  assert.equal(fresh.length, 2, "each corruption event keeps its own capture");
+  const captured = await Promise.all(fresh.map((name) => readFile(path.join(dir, name), "utf8")));
+  assert.ok(captured.includes("{ corrupt take one"), "the first capture survives");
+  assert.ok(captured.includes("{ corrupt take two"), "the second capture survives");
+
+  await writeFile(target, valid, "utf8");
+});
+
 test("unreadable stores surface errors instead of reading as empty", async () => {
   const previous = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE;
   // Point the store AT A DIRECTORY: reads fail with EISDIR (not ENOENT).

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -20,6 +20,7 @@ import {
   type SavedLink,
 } from "../link-organizer.ts";
 import { caveHome } from "../coven-paths.ts";
+import { corruptAsidePath } from "./corrupt-aside.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
 
 export const MAX_SAVED_LINKS = 500;
@@ -93,8 +94,7 @@ async function loadFile(): Promise<ResearchLinksFile> {
 
 async function preserveMalformedFile(): Promise<void> {
   const source = researchLinksPath();
-  const suffix = new Date().toISOString().replace(/[^0-9]/g, "");
-  await copyFile(/* turbopackIgnore: true */ source, `${source}.corrupt-${suffix}`).catch(() => {});
+  await copyFile(/* turbopackIgnore: true */ source, corruptAsidePath(source)).catch(() => {});
 }
 
 async function saveFile(file: ResearchLinksFile): Promise<void> {


### PR DESCRIPTION
Fixes the millisecond-resolution corrupt-aside filename collision (bead **cave-f6rv**) in the three sibling stores that still had it, by extracting the fix already landed for cave-canvas (cave-z8je, PR #3678) into a shared helper.

## The bug

`preserveMalformedFile()` named its capture `<store>.corrupt-<ms-timestamp>`. `copyFile`/`rename` silently replace an existing destination, so two corruption events in the same millisecond targeted the same path and the second capture destroyed the first — exactly the flake cave-canvas hit on fast CI.

## The fix

- **New `src/lib/server/corrupt-aside.ts`** — `corruptAsidePath(source)` appends `-<8 random hex>` after the timestamp (timestamp for humans triaging, random slice for uniqueness).
- Wired into `preferences-store.ts`, `research-links.ts`, `research-generations.ts` (path change only; each site keeps its copy-vs-rename semantics).
- `cave-canvas.ts` now uses the same helper instead of its inline construction (comment trimmed, unused `randomUUID` import dropped).

## Tests

Frozen-clock double-corruption tests added to all three store suites: corrupt → load → corrupt (different bytes, same frozen ms) → load, then assert **two distinct asides exist with their respective bytes**. Canvas already had the equivalent burst test (only asserts prefix + count, so the unified name format passes unchanged).

## Validation

- Targeted: 4 touched suites green (22 subtests incl. 3 new)
- Full: `pnpm test:app` (892 files), `pnpm test:api` (239 files), `pnpm typecheck` — all green
