### PR TITLE
feat(code): session inspector — branches, worktrees, env

### DIFF
--- a/src/components/code-inspector.tsx
+++ b/src/components/code-inspector.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+/**
+ * CodeInspector — the workbench's right-hand details panel (cave-k0ua):
+ * session environment (harness, model, work root), local branches with
+ * one-click switch, and fresh-worktree provisioning — the same /api/changes
+ * surface chat's composer git chip uses (?branches=1, action=switch-branch,
+ * action=create-worktree), scoped to the session's work root (cave-9q24).
+ *
+ * Switching a branch mutates the CHECKOUT at the work root — for worktree
+ * sessions that's their private worktree; for shared-checkout sessions it's
+ * the shared root (identical semantics to chat's git chip, user-explicit).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { relativeTime } from "@/lib/relative-time";
+import { codeSessionWorkRoot } from "@/lib/code-surface";
+import type { SessionRow } from "@/lib/types";
+
+type BranchRow = {
+  name: string;
+  current: boolean;
+  /** Checkout dir basename when some worktree has the branch checked out. */
+  worktree: string | null;
+  worktreePath?: string | null;
+};
+
+type BranchesState =
+  | { phase: "loading" }
+  | { phase: "ready"; branches: BranchRow[] }
+  | { phase: "error"; message: string };
+
+function useBranches(projectRoot: string): BranchesState & { refresh: () => void } {
+  const [state, setState] = useState<BranchesState>({ phase: "loading" });
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    setState((prev) => (tick > 0 && prev.phase === "ready" ? prev : { phase: "loading" }));
+    (async () => {
+      try {
+        const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(projectRoot)}&branches=1`, {
+          cache: "no-store",
+        });
+        const json = (await res.json().catch(() => null)) as
+          | { ok?: boolean; error?: string; branches?: BranchRow[] }
+          | null;
+        if (cancelled) return;
+        if (!res.ok || !json?.ok || !Array.isArray(json.branches)) {
+          setState({ phase: "error", message: json?.error ?? `branches HTTP ${res.status}` });
+          return;
+        }
+        setState({ phase: "ready", branches: json.branches });
+      } catch (err) {
+        if (!cancelled)
+          setState({ phase: "error", message: err instanceof Error ? err.message : "couldn't list branches" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectRoot, tick]);
+  const refresh = useCallback(() => setTick((t) => t + 1), []);
+  return { ...state, refresh };
+}
+
+function EnvRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-baseline gap-2 text-[length:var(--text-xs)]">
+      <span className="w-16 shrink-0 text-[var(--text-muted)]">{label}</span>
+      <span
+        className={`min-w-0 truncate text-[var(--text-secondary)] ${mono ? "font-mono" : ""}`}
+        title={value}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function CodeInspector({ row, onChanged }: { row: SessionRow; onChanged?: () => void }) {
+  const workRoot = codeSessionWorkRoot(row);
+  const branches = useBranches(workRoot);
+  const [busyBranch, setBusyBranch] = useState<string | null>(null);
+  const [newBranch, setNewBranch] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [notice, setNotice] = useState<{ kind: "ok" | "err"; text: string } | null>(null);
+
+  async function post(body: Record<string, unknown>): Promise<{ ok: boolean; error?: string; worktree?: string }> {
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; worktree?: string }
+        | null;
+      if (!res.ok || !json?.ok) return { ok: false, error: json?.error ?? `HTTP ${res.status}` };
+      return { ok: true, worktree: json.worktree };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "network error" };
+    }
+  }
+
+  async function switchBranch(name: string) {
+    if (busyBranch) return;
+    setBusyBranch(name);
+    setNotice(null);
+    const result = await post({ projectRoot: workRoot, action: "switch-branch", branch: name });
+    setBusyBranch(null);
+    if (result.ok) {
+      setNotice({ kind: "ok", text: `Switched to ${name}.` });
+      branches.refresh();
+      onChanged?.();
+    } else {
+      setNotice({ kind: "err", text: result.error ?? "Switch failed." });
+    }
+  }
+
+  async function createWorktree() {
+    const name = newBranch.trim();
+    if (!name || creating) return;
+    setCreating(true);
+    setNotice(null);
+    const result = await post({ projectRoot: workRoot, action: "create-worktree", branch: name });
+    setCreating(false);
+    if (result.ok) {
+      setNewBranch("");
+      setNotice({ kind: "ok", text: `Worktree ready${result.worktree ? ` at ${result.worktree}` : ""}.` });
+      branches.refresh();
+      onChanged?.();
+    } else {
+      setNotice({ kind: "err", text: result.error ?? "Worktree creation failed." });
+    }
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 overflow-y-auto p-3">
+      <section aria-label="Session environment" className="flex flex-col gap-1">
+        <h3 className="text-[length:var(--text-2xs)] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          Session
+        </h3>
+        <EnvRow label="Harness" value={row.harness || "—"} />
+        {row.model ? <EnvRow label="Model" value={row.model} /> : null}
+        <EnvRow label="Root" value={workRoot} mono />
+        <EnvRow label="Updated" value={relativeTime(row.updated_at)} />
+      </section>
+
+      <section aria-label="Branches" className="flex min-h-0 flex-col gap-1">
+        <h3 className="text-[length:var(--text-2xs)] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          Branches
+        </h3>
+        {branches.phase === "loading" ? (
+          <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">Loading…</p>
+        ) : branches.phase === "error" ? (
+          <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">{branches.message}</p>
+        ) : (
+          <ul className="flex flex-col">
+            {branches.branches.map((b) => (
+              <li key={b.name}>
+                <button
+                  type="button"
+                  className={`focus-ring flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left text-[length:var(--text-xs)] ${
+                    b.current
+                      ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                      : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                  }`}
+                  disabled={b.current || busyBranch != null}
+                  onClick={() => void switchBranch(b.name)}
+                  title={b.current ? `${b.name} (checked out here)` : `Switch to ${b.name}`}
+                >
+                  <Icon name="ph:git-branch" width={10} height={10} />
+                  <span className="min-w-0 flex-1 truncate font-mono">{b.name}</span>
+                  {busyBranch === b.name ? <span className="shrink-0">…</span> : null}
+                  {b.current ? <span aria-hidden className="shrink-0 text-[var(--color-success)]">✓</span> : null}
+                  {b.worktree ? (
+                    <span
+                      className="shrink-0 text-[length:var(--text-2xs)] text-[var(--text-muted)]"
+                      title={b.worktreePath ?? undefined}
+                    >
+                      ⑂ {b.worktree}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-label="New worktree" className="flex flex-col gap-1.5">
+        <h3 className="text-[length:var(--text-2xs)] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          New worktree
+        </h3>
+        <div className="flex items-center gap-1.5">
+          <input
+            type="text"
+            className="focus-ring-inset min-w-0 flex-1 rounded border border-[var(--border-hairline)] bg-transparent px-2 py-1 font-mono text-[length:var(--text-xs)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+            placeholder="branch name"
+            value={newBranch}
+            onChange={(e) => setNewBranch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void createWorktree();
+            }}
+            disabled={creating}
+            aria-label="New worktree branch name"
+          />
+          <Button size="sm" disabled={!newBranch.trim() || creating} onClick={() => void createWorktree()}>
+            {creating ? "…" : "Create"}
+          </Button>
+        </div>
+      </section>
+
+      {notice ? (
+        <p
+          role={notice.kind === "err" ? "alert" : "status"}
+          className={`text-[length:var(--text-xs)] ${notice.kind === "err" ? "text-[var(--color-danger)]" : "text-[var(--color-success)]"}`}
+        >
+          {notice.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -235,6 +235,59 @@ assert.match(
   "the composer rides under every tab except Terminal (which owns its input)",
 );
 
+// ── Inspector: branches / worktrees / session env (right column) ─────────────
+
+// The inspector reuses the exact /api/changes surface chat's composer git chip
+// speaks (?branches=1, switch-branch, create-worktree) but scopes every call
+// to the session's WORK ROOT — a worktree session mutates its own checkout,
+// never the shared root (cave-9q24).
+const inspector = await readFile(new URL("./code-inspector.tsx", import.meta.url), "utf8");
+assert.match(
+  inspector,
+  /const workRoot = codeSessionWorkRoot\(row\);/,
+  "every inspector call is scoped to the session's work root",
+);
+assert.match(
+  inspector,
+  /\/api\/changes\?projectRoot=\$\{encodeURIComponent\(projectRoot\)\}&branches=1/,
+  "branch list comes from the same ?branches=1 contract as chat's git chip",
+);
+assert.match(
+  inspector,
+  /action: "switch-branch", branch: name/,
+  "one-click branch switch posts the existing switch-branch action",
+);
+assert.match(
+  inspector,
+  /action: "create-worktree", branch: name/,
+  "fresh-worktree provisioning posts the existing create-worktree action",
+);
+assert.match(
+  inspector,
+  /disabled=\{b\.current \|\| busyBranch != null\}/,
+  "the checked-out branch is not a switch target and switches don't overlap",
+);
+assert.match(
+  workbench,
+  /aria-pressed=\{inspectorOpen\}/,
+  "the header exposes an accessible inspector toggle",
+);
+assert.match(
+  workbench,
+  /\{inspectorOpen \? \(\s*<aside/,
+  "the inspector column mounts only when toggled open",
+);
+assert.match(
+  workbench,
+  /<LazyInspector key=\{workRoot\} row=\{row\} onChanged=\{onRefresh\} \/>/,
+  "inspector mutations re-poll the enriched session list via onRefresh",
+);
+assert.match(
+  codeView,
+  /onRefresh=\{onTasksRefresh\}/,
+  "code-view threads the workspace's tasks refresh into the workbench",
+);
+
 // ── Chat stays untouched this phase ──────────────────────────────────────────
 
 // Phase 1 builds the surface *behind the flag* without slimming Chat: the code

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -161,6 +161,7 @@ export function CodeView({
                 row={selected}
                 initialTab={deepLink?.sessionId === selected.id ? deepLink?.workbenchTab : undefined}
                 onJumpToSession={onJumpToSession}
+                onRefresh={onTasksRefresh}
               />
             ) : (
               <div className="flex h-full items-center justify-center p-6 text-[length:var(--text-xs)] text-[var(--text-muted)]">

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -18,6 +18,8 @@
  *   - PR → CodeSessionPrPanel (stage pipeline, checks, review threads,
  *     approve/merge via /api/github/*), dynamic() alongside its fetch hooks
  *
+ * Right of the tabs (toggleable, md+ only): the inspector
+ * (code-inspector.tsx) — session env, branch switcher, worktree creation.
  * Below the tabs (except Terminal, which owns its input): the follow-up
  * composer (code-composer.tsx) — sends to THIS session's agent.
  */
@@ -50,6 +52,10 @@ const LazyPrTab = dynamic(
   () => import("@/components/code-session-pr-panel").then((m) => m.CodeSessionPrPanel),
   { ssr: false },
 );
+const LazyInspector = dynamic(
+  () => import("@/components/code-inspector").then((m) => m.CodeInspector),
+  { ssr: false },
+);
 
 const TAB_LABELS: Array<{ id: CodeWorkbenchTab; label: string; icon: Parameters<typeof Icon>[0]["name"] }> = [
   { id: "diff", label: "Diff", icon: "ph:git-diff" },
@@ -62,13 +68,19 @@ export function CodeWorkbench({
   row,
   initialTab,
   onJumpToSession,
+  onRefresh,
 }: {
   row: SessionRow;
   /** Deep-linked workbench tab (?wtab=). */
   initialTab?: CodeWorkbenchTab;
   onJumpToSession: (sessionId: string, familiarId?: string | null) => void;
+  /** Re-poll the enriched session list (branch/worktree chips) after inspector mutations. */
+  onRefresh?: () => void;
 }) {
   const [tab, setTab] = useState<CodeWorkbenchTab>(initialTab ?? "diff");
+  // Inspector (branches/worktrees/env) is an opt-in right column; md+ only —
+  // the narrow-screen treatment lands with the mobile layout pass.
+  const [inspectorOpen, setInspectorOpen] = useState(false);
   // Terminal keepalive: once visited, keep the pty mounted (hidden) so the
   // shell and scrollback survive tab switches within the session.
   const [terminalOpened, setTerminalOpened] = useState(false);
@@ -116,9 +128,25 @@ export function CodeWorkbench({
               <span className="shrink-0">Updated {relativeTime(row.updated_at)}</span>
             </div>
           </div>
-          <Button size="sm" onClick={() => onJumpToSession(row.id, row.familiarId)}>
-            Open in Chat
-          </Button>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              type="button"
+              aria-pressed={inspectorOpen}
+              aria-label="Toggle inspector"
+              title="Inspector — branches, worktrees, session env"
+              onClick={() => setInspectorOpen((v) => !v)}
+              className={`focus-ring hidden items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] md:inline-flex ${
+                inspectorOpen
+                  ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              <Icon name="ph:sliders-bold" width={12} height={12} />
+            </button>
+            <Button size="sm" onClick={() => onJumpToSession(row.id, row.familiarId)}>
+              Open in Chat
+            </Button>
+          </div>
         </div>
         <div role="tablist" aria-label="Session workbench" className="mt-2 flex items-center gap-1">
           {TAB_LABELS.map((t) => (
@@ -140,21 +168,31 @@ export function CodeWorkbench({
           ))}
         </div>
       </div>
-      <div className="min-h-0 flex-1">
-        {tab === "diff" ? (
-          // Keyed by work root: the panel's file/diff/checkpoint state is
-          // per-repo, and switching sessions must never show stale rows.
-          <SessionChangesInner key={workRoot} projectRoot={workRoot} running={running} />
+      <div className="flex min-h-0 flex-1">
+        <div className="min-w-0 flex-1">
+          {tab === "diff" ? (
+            // Keyed by work root: the panel's file/diff/checkpoint state is
+            // per-repo, and switching sessions must never show stale rows.
+            <SessionChangesInner key={workRoot} projectRoot={workRoot} running={running} />
+          ) : null}
+          {tab === "files" ? (
+            <LazyFilesTab key={workRoot} projectRoot={workRoot} familiarId={row.familiarId} />
+          ) : null}
+          {terminalOpened ? (
+            <div className={tab === "terminal" ? "h-full min-h-0" : "hidden"}>
+              <LazyTerminalTab sessionId={row.id} projectRoot={workRoot} active={tab === "terminal"} />
+            </div>
+          ) : null}
+          {tab === "pr" ? <LazyPrTab key={row.id} row={row} /> : null}
+        </div>
+        {inspectorOpen ? (
+          <aside
+            aria-label="Session inspector"
+            className="hidden w-72 shrink-0 border-l border-[var(--border-hairline)] md:block"
+          >
+            <LazyInspector key={workRoot} row={row} onChanged={onRefresh} />
+          </aside>
         ) : null}
-        {tab === "files" ? (
-          <LazyFilesTab key={workRoot} projectRoot={workRoot} familiarId={row.familiarId} />
-        ) : null}
-        {terminalOpened ? (
-          <div className={tab === "terminal" ? "h-full min-h-0" : "hidden"}>
-            <LazyTerminalTab sessionId={row.id} projectRoot={workRoot} active={tab === "terminal"} />
-          </div>
-        ) : null}
-        {tab === "pr" ? <LazyPrTab key={row.id} row={row} /> : null}
       </div>
       {tab !== "terminal" ? <CodeComposer row={row} onJumpToSession={onJumpToSession} /> : null}
     </div>


### PR DESCRIPTION
Fifth slice of the dedicated Code surface (cave-k0ua, series: #3716 → #3719 → #3722 → #3724).

## What

The workbench grows a **toggleable right-hand inspector** (ph:sliders-bold in the session header, `aria-pressed`, md+ only):

- **Session env** — harness, model, work root, last-updated.
- **Branches** — local branch list with current-✓ and worktree-⑂ marks, one-click switch.
- **New worktree** — branch name → fresh worktree provisioning.

## How

- Reuses the exact `/api/changes` contracts chat's composer git chip speaks: `?branches=1`, `action=switch-branch`, `action=create-worktree`. No API changes.
- Every call scoped to the session's **work root** (cave-9q24): worktree sessions mutate their own checkout, never the shared root.
- `dynamic()` import keyed by work root; mutations call through to `onTasksRefresh` so the enriched session list (branch chips) re-polls.
- Narrow-screen treatment deferred to the mobile layout pass (next PR).

## Verification

- Pin suite `code-surface-mode.test.ts` extended (work-root scoping, `?branches=1` contract, switch/create action pins, toggle accessibility, refresh threading)
- `tsc --noEmit`, eslint clean
- Full `pnpm test:app` (892 files) + `pnpm test:api` (239 files) green