### PR TITLE
fix: WCAG AA hover contrast for solid accent CTAs

### DIFF
--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -49,8 +49,11 @@ const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024
 // current measurements are 665 KiB root / 904 KiB home. Budget raised 900→910
 // in the home-minimal PR (2026-07-22): new home Continue cards + context-chip
 // styles are home-startup surface CSS (not cross-route), +~18 KiB net.
+// Raised 910→915 (2026-07-23, cave-c7hy): --accent-presence-hover token
+// definitions (foundations + 15 theme overrides) are cascade-wide a11y
+// tokens, +~1 KiB; the measured home set was already at 910.
 const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 690) * 1024;
-const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 910) * 1024;
+const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 915) * 1024;
 
 if (!existsSync(chunksDir)) {
   console.error(

--- a/src/lib/theme-contrast-audit.test.ts
+++ b/src/lib/theme-contrast-audit.test.ts
@@ -7,6 +7,7 @@ import {
   parseThemeColor,
   flattenOnto,
   contrastRatio,
+  rgbToOklab,
   type TokenMap,
   type Rgba,
 } from "./theme-contrast.ts";
@@ -74,6 +75,9 @@ const PAIRS: Pair[] = [
   { fg: "--accent-foreground", bg: "--accent", min: 4.5 },
   { fg: "--primary-foreground", bg: "--primary", min: 4.5 },
   { fg: "--accent-presence-foreground", bg: "--accent-presence", min: 4.5 },
+  // cave-c7hy: the label must stay AA while the fill is in its hover state
+  // (.ui-btn--primary:hover et al. use --accent-presence-hover).
+  { fg: "--accent-presence-foreground", bg: "--accent-presence-hover", min: 4.5 },
   { fg: "--destructive-foreground", bg: "--destructive", min: 4.5 },
   { fg: "--brand-foreground", bg: "--brand", min: 4.5 },
   { fg: "--accent-presence", bg: "--bg-base", min: 3 },
@@ -131,6 +135,32 @@ for (const mode of ["dark", "light"] as const) {
 }
 
 console.log(`theme-contrast-audit: ${checked} pairs across ${THEME_IDS.length} themes × 2 modes, 0 failures`);
+
+// ── hover feedback stays visible (cave-c7hy) ────────────────────────────────
+// The AA pair above keeps hover readable; this keeps it *noticeable*. A theme
+// override that resolved hover to (nearly) the rest fill would pass contrast
+// while silently killing the hover affordance. Direction-aware 12% mixes give
+// a worst-case OKLab ΔL of ~0.027 across the premade palettes; hold 0.02.
+{
+  const shiftFailures: string[] = [];
+  for (const id of THEME_IDS) {
+    for (const mode of ["dark", "light"] as const) {
+      const tokens = themeTokens(css, id, mode);
+      const rest = surface(tokens, "--accent-presence");
+      const hover = surface(tokens, "--accent-presence-hover");
+      assert.ok(rest && hover, `${id}/${mode}: accent rest+hover fills must resolve`);
+      const delta = Math.abs(rgbToOklab(rest!).L - rgbToOklab(hover!).L);
+      if (delta < 0.02) {
+        shiftFailures.push(`${id} ${mode}: hover ΔL=${delta.toFixed(3)} (needs ≥0.02)`);
+      }
+    }
+  }
+  assert.deepEqual(
+    shiftFailures,
+    [],
+    `hover states must shift visibly from rest:\n${shiftFailures.join("\n")}`,
+  );
+}
 
 // ── fixed dark code chrome (cave-md.css, CHAT-D13-01/02) ────────────────────
 // Code blocks and system turns keep a fixed dark-terminal surface in BOTH

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -285,7 +285,7 @@
 }
 
 .settings-tool-action--primary:hover {
-  background: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
+  background: var(--accent-presence-hover);
   border-color: color-mix(in oklch, var(--accent-presence) 82%, white 18%);
   box-shadow:
     0 0 0 1px color-mix(in oklch, var(--accent-presence) 32%, transparent) inset,

--- a/src/styles/globals/foundations.css
+++ b/src/styles/globals/foundations.css
@@ -59,6 +59,11 @@
   --accent-presence: #9386d0;
   --accent-presence-foreground: var(--primary-foreground);
   --accent-presence-soft: oklch(0.70 0.10 293);
+  /* Hover fill for solid accent CTAs. The mix direction is per-theme: a
+     fixed direction fails AA somewhere (cave-c7hy — lightening under light
+     ink, darkening under dark ink). Light-root flips to black below;
+     themes.css re-overrides where a palette's measured direction differs. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --brand: var(--accent-presence);
   /* Follows the per-theme ink choice — hardcoded white failed AA on every
      palette whose accent is light (22 of 32 theme×mode combos). */
@@ -310,6 +315,8 @@
   --accent-presence: #6859ac;
   --accent-presence-foreground: var(--primary-foreground);
   --accent-presence-soft: oklch(0.53 0.10 291);
+  /* Light surfaces pair light ink with a mid accent: darken on hover. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, black 12%);
 
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.004 291);

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -820,8 +820,8 @@ textarea.required-inputs-control {
   color: var(--accent-presence-foreground);
 }
 .ui-btn--primary:hover {
-  background: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
-  border-color: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
+  background: var(--accent-presence-hover);
+  border-color: var(--accent-presence-hover);
 }
 .ui-btn--secondary {
   background: var(--bg-raised);

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -124,7 +124,7 @@
   color: var(--accent-presence-foreground);
 }
 .dr-btn--primary:hover {
-  background: color-mix(in oklch, var(--accent-presence) 88%, #000);
+  background: var(--accent-presence-hover);
   border-color: transparent;
 }
 .dr-btn--sm { height: 32px; padding: 0 12px; font-size: 12.5px; }

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -110,7 +110,7 @@
 
 .role-surface-chip--accent:hover {
   color: var(--accent-presence-foreground);
-  background: color-mix(in oklch, var(--accent-presence) 88%, white);
+  background: var(--accent-presence-hover);
 }
 
 .role-surface-commands { position: relative; }

--- a/src/styles/globals/themes.css
+++ b/src/styles/globals/themes.css
@@ -334,6 +334,7 @@
   --accent-presence: oklch(0.6180 0.0778 65.5444);
   --accent-presence-foreground: #111111;
   --accent-presence-soft: oklch(0.6180 0.060 65);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --ring: oklch(0.6180 0.0778 65.5444);
   --border: oklch(0.8606 0.0321 84.5881);
   --input: oklch(0.8606 0.0321 84.5881);
@@ -486,6 +487,7 @@
   --secondary: oklch(0.90 0.030 25);
   --muted-foreground: oklch(0.44 0.040 25);
   --accent-presence: #A41C24;
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --ring: oklch(0.52 0.22 25);
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.016 25);
@@ -505,6 +507,8 @@
   --secondary: oklch(0.17 0.054 125);
   --muted-foreground: oklch(0.70 0.040 125);
   --accent-presence: #A5F050;
+  /* Near-white accent: lightening is invisible — darken for hover. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, black 12%);
   --ring: oklch(0.78 0.18 125);
   --bg-base: var(--background);
   --bg-panel: oklch(0.07 0.044 125);
@@ -593,6 +597,7 @@
   --accent-presence: #808080;
   --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #808080 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #808080 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #f8f8f8;
@@ -763,6 +768,7 @@
   --accent-presence: #c96442;
   --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #c96442 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #c96442 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #f5f4ee;
@@ -806,6 +812,8 @@
   --accent-presence: #ececec;
   --accent-presence-foreground: #0d0d0d;
   --accent-presence-soft: color-mix(in oklch, #ececec 78%, transparent);
+  /* Near-white accent: lightening is invisible — darken for hover. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, black 12%);
   --accent-faint: color-mix(in oklch, #ececec 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #000000;
@@ -843,6 +851,7 @@
   --accent-presence: #0d0d0d;
   --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #0d0d0d 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #0d0d0d 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #f9f9f9;
@@ -931,6 +940,7 @@
   --accent-presence: #9377e6;
   --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #a78bfa 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #a78bfa 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #e9d8fd;
@@ -979,6 +989,8 @@
   --accent-presence: #1d7449;
   --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #006239 78%, transparent);
+  /* Dark meatseeks pairs white ink with a light-leaning green: darken. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, black 12%);
   --accent-faint: color-mix(in oklch, #006239 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #121212;
@@ -1016,6 +1028,7 @@
   --accent-presence: #279c6b;
   --accent-presence-foreground: #0d120f;
   --accent-presence-soft: color-mix(in oklch, #72e3ad 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #72e3ad 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #fcfcfc;
@@ -1092,6 +1105,7 @@
   --accent-presence: #005735;
   --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #005735 78%, transparent);
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --accent-faint: color-mix(in oklch, #005735 14%, transparent);
   --bg-base: var(--background);
   --bg-panel: #ffffff;
@@ -1227,6 +1241,7 @@
   --secondary: oklch(0.92 0.000 0);
   --muted-foreground: oklch(0.40 0.000 0);
   --accent-presence: #525258;
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --ring: oklch(0.42 0.000 0);
   --bg-base: var(--background);
   --bg-panel: oklch(1.00 0.000 0);
@@ -1250,6 +1265,8 @@
   --muted-foreground: #d9d9d9;
   --accent-presence: #ffd60a;
   --accent-presence-foreground: #000000;
+  /* Near-white accent: lightening is invisible — darken for hover. */
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, black 12%);
   --ring: #ffd60a;
   --border: #666666;
   --border-strong: #9a9a9a;
@@ -1317,6 +1334,7 @@
   --muted-foreground: oklch(0.40 0.030 250);
   --accent-presence: #a34d00;
   --accent-presence-foreground: #ffffff;
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --ring: oklch(0.50 0.13 65);
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.008 250);
@@ -1356,6 +1374,7 @@
   --muted-foreground: oklch(0.40 0.036 85);
   --accent-presence: #7a5c00;
   --accent-presence-foreground: #ffffff;
+  --accent-presence-hover: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
   --ring: oklch(0.48 0.11 85);
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.012 90);


### PR DESCRIPTION
## Bug (cave-c7hy)

`.ui-btn--primary:hover` hard-coded `color-mix(... 88%, white 12%)`. After #3718 switched solid-CTA ink to the per-theme `--accent-presence-foreground`, whitening the fill under **light ink** dropped hover contrast below WCAG AA in **11 of 42 theme-mode combos** (worst: tide/light 3.91, snow/light 3.96 vs 4.5 required). Same pattern copy-pasted in `dr-btn--primary`, `role-surface-chip--accent`, and `settings-tool-action--primary`.

## Fix: direction-aware `--accent-presence-hover` token

- **foundations.css** defines the token: white-mix default (`:root`), black-mix on `:root[data-mode="light"]` (light surfaces pair light ink with mid accents - darken instead).
- **themes.css** re-overrides where a palette measured differently: 11 light themes keep their original white-mix look; meatseeks dark + near-white accents (bane `#A5F050`, codex `#ececec`, contrast `#ffd60a`) darken - for those three, lightening was also *invisible* (dL < 0.015).
- All 4 hover rules consume the token; zero new hex literals (ratchet unchanged at 52).

## Verification

- `theme-contrast-audit` extended two ways (both would have caught this bug):
  1. new AA pair: `--accent-presence-foreground` on `--accent-presence-hover` (897 pairs total, 0 failures)
  2. hover must *visibly* shift: OKLab dL >= 0.02 vs rest fill across all 42 combos (worst post-fix ~0.027)
- Post-fix minimum hover ratio: beacon/light 4.51; all 42 combos >= 4.5.
- Full: `pnpm typecheck`, `test:api` (239), `test:app` (892) green locally; targeted drift + pin tests green.

Closes cave-c7hy.
