### PR TITLE
feat(code): mobile drill-in + flag-on e2e coverage

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -121,6 +121,11 @@ export default defineConfig({
     reuseExistingServer: false,
     env: {
       COVEN_CAVE_E2E: "1",
+      // The dedicated Code surface (cave-k0ua) is validated flag-ON here so
+      // tests/code-surface.spec.ts and the mobile drill-in spec exercise the
+      // real landing; existing specs never asserted the GitHub sidebar row,
+      // and ?mode=github stays canonical either way.
+      NEXT_PUBLIC_CAVE_CODE_SURFACE: "1",
       // Keep app-owned preferences and backdrop bytes out of the developer's
       // real ~/.coven directory. A per-config UUID prevents concurrent runs or
       // later PID reuse from sharing stale state while remaining stable for

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -288,6 +288,62 @@ assert.match(
   "code-view threads the workspace's tasks refresh into the workbench",
 );
 
+// ── Mobile drill-in (list-first below md) ────────────────────────────────────
+
+// Below the md breakpoint the rail is the landing screen: no newest-session
+// auto-pick on narrow mounts, an explicit Back (null) suppresses re-selection,
+// and the rail/workbench swap is pure CSS (hidden md:block / hidden md:flex)
+// so desktop keeps the three-pane layout untouched.
+assert.match(
+  codeView,
+  /useState<string \| null \| undefined>\(\s*deepLink\?\.sessionId \?\? undefined,?\s*\)/,
+  "selection is tri-state: undefined = auto-pick allowed, null = user went Back",
+);
+assert.match(
+  codeView,
+  /if \(selectedId === null\) return;/,
+  "an explicit Back is terminal — auto-pick must not re-select",
+);
+// StrictMode double-invokes state initializers in dev: parsing must stay pure
+// there and the URL strip must live in a mount effect, or the second
+// initializer run reads an already-stripped URL and loses the deep link
+// (caught by tests/code-surface.spec.ts against next dev).
+assert.match(
+  codeView,
+  /return parseCodeDeepLink\(new URLSearchParams\(window\.location\.search\)\);/,
+  "the deep-link initializer is pure (StrictMode-safe)",
+);
+assert.match(
+  codeView,
+  /useEffect\(\(\) => \{\s*const params = new URLSearchParams\(window\.location\.search\);\s*if \(!params\.has\("session"\)/,
+  "the ?session/ctab/wtab strip happens in a mount effect, not the initializer",
+);
+assert.match(
+  codeView,
+  /window\.matchMedia\("\(max-width: 767px\)"\)\.matches/,
+  "narrow mounts land on the session list, not the newest workbench",
+);
+assert.match(
+  codeView,
+  /if \(narrowMountRef\.current\) return;/,
+  "the auto-pick effect honors the narrow-mount guard",
+);
+assert.match(
+  codeView,
+  /\$\{selected \? "hidden md:block" : "block"\}/,
+  "picking a session hides the rail below md only",
+);
+assert.match(
+  codeView,
+  /\$\{selected \? "flex" : "hidden md:flex"\}/,
+  "the workbench column is hidden below md until a session is picked",
+);
+assert.match(
+  codeView,
+  /aria-label="Back to sessions"[\s\S]{0,80}onClick=\{\(\) => setSelectedId\(null\)\}/,
+  "the mobile Back affordance clears the selection explicitly",
+);
+
 // ── Chat stays untouched this phase ──────────────────────────────────────────
 
 // Phase 1 builds the surface *behind the flag* without slimming Chat: the code

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -52,30 +52,43 @@ export function CodeView({
   onTasksRefresh,
 }: CodeViewProps) {
   // `?mode=code&session=<id>&ctab=<sessions|github>&wtab=<diff|files|terminal|pr>`
-  // deep link — read once on mount, then strip (the workspace's ?mode= idiom)
-  // so reloads stay clean. wtab is forwarded to the workbench for the
-  // deep-linked session only.
+  // deep link — parsed once (initializer stays PURE: React StrictMode runs it
+  // twice, so stripping here would feed the second run an already-stripped
+  // URL and lose the target), then stripped in a mount effect (the
+  // workspace's ?mode= idiom) so reloads stay clean. wtab is forwarded to the
+  // workbench for the deep-linked session only.
   const [deepLink] = useState(() => {
     if (typeof window === "undefined") return null;
-    const params = new URLSearchParams(window.location.search);
-    const parsed = parseCodeDeepLink(params);
-    if (params.has("session") || params.has("ctab") || params.has("wtab")) {
-      params.delete("session");
-      params.delete("ctab");
-      params.delete("wtab");
-      const query = params.toString();
-      window.history.replaceState(null, "", window.location.pathname + (query ? `?${query}` : "") + window.location.hash);
-    }
-    return parsed;
+    return parseCodeDeepLink(new URLSearchParams(window.location.search));
   });
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("session") && !params.has("ctab") && !params.has("wtab")) return;
+    params.delete("session");
+    params.delete("ctab");
+    params.delete("wtab");
+    const query = params.toString();
+    window.history.replaceState(null, "", window.location.pathname + (query ? `?${query}` : "") + window.location.hash);
+  }, []);
   const [topTab, setTopTab] = useState<CodeTopTab>(
     githubTarget ? "github" : deepLink?.topTab ?? "sessions",
   );
-  const [selectedId, setSelectedId] = useState<string | null>(deepLink?.sessionId ?? null);
+  // Selection is tri-state for the mobile drill-in: `undefined` = nothing
+  // chosen yet (auto-pick allowed), `null` = the user explicitly went Back to
+  // the session list (auto-pick must NOT re-select), string = a session.
+  const [selectedId, setSelectedId] = useState<string | null | undefined>(
+    deepLink?.sessionId ?? undefined,
+  );
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   // A session created HERE isn't in the polled list yet; hold its selection
   // until /api/sessions/list catches up instead of auto-picking the newest.
   const pendingNewIdRef = useRef<string | null>(null);
+  // On a phone the rail IS the landing screen — auto-picking the newest
+  // session would skip the list and drop the user straight into a workbench
+  // with no context. Captured once at mount (Tailwind md breakpoint).
+  const narrowMountRef = useRef(
+    typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches,
+  );
 
   const groups = useMemo(() => groupCodeRailSessions(sessions), [sessions]);
   const selected = useMemo(() => {
@@ -88,12 +101,15 @@ export function CodeView({
   }, [groups, selectedId]);
 
   // Land on the newest session so the surface is immediately useful; keep the
-  // user's explicit pick as long as that session is still visible.
+  // user's explicit pick as long as that session is still visible. Skipped
+  // after an explicit Back (null) and on narrow mounts (list-first drill-in).
   useEffect(() => {
     if (selected) {
       if (pendingNewIdRef.current === selected.id) pendingNewIdRef.current = null;
       return;
     }
+    if (selectedId === null) return;
+    if (narrowMountRef.current) return;
     if (selectedId && pendingNewIdRef.current === selectedId) return;
     const first = groups[0]?.sessions[0];
     if (first) setSelectedId(first.id);
@@ -146,23 +162,42 @@ export function CodeView({
         </div>
       ) : (
         <div className="flex min-h-0 flex-1">
-          <div className="w-64 shrink-0 border-r border-[var(--border-hairline)]">
+          {/* Mobile drill-in: below md the rail is the landing screen and the
+              workbench replaces it once a session is picked (Back returns). */}
+          <div
+            className={`${selected ? "hidden md:block" : "block"} w-full shrink-0 border-[var(--border-hairline)] md:w-64 md:border-r`}
+          >
             <CodeSessionRail
               sessions={sessions}
-              selectedId={selectedId}
+              selectedId={selectedId ?? null}
               onSelect={setSelectedId}
               onNewSession={() => setNewSessionOpen(true)}
             />
           </div>
-          <div className="min-w-0 flex-1">
+          <div className={`${selected ? "flex" : "hidden md:flex"} min-w-0 flex-1 flex-col`}>
             {selected ? (
-              <CodeWorkbench
-                key={selected.id}
-                row={selected}
-                initialTab={deepLink?.sessionId === selected.id ? deepLink?.workbenchTab : undefined}
-                onJumpToSession={onJumpToSession}
-                onRefresh={onTasksRefresh}
-              />
+              <>
+                <div className="shrink-0 border-b border-[var(--border-hairline)] px-2 py-1 md:hidden">
+                  <button
+                    type="button"
+                    aria-label="Back to sessions"
+                    onClick={() => setSelectedId(null)}
+                    className="focus-ring inline-flex items-center gap-1 rounded px-1.5 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                  >
+                    <Icon name="ph:caret-left" width={12} height={12} />
+                    Sessions
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1">
+                  <CodeWorkbench
+                    key={selected.id}
+                    row={selected}
+                    initialTab={deepLink?.sessionId === selected.id ? deepLink?.workbenchTab : undefined}
+                    onJumpToSession={onJumpToSession}
+                    onRefresh={onTasksRefresh}
+                  />
+                </div>
+              </>
             ) : (
               <div className="flex h-full items-center justify-center p-6 text-[length:var(--text-xs)] text-[var(--text-muted)]">
                 Select a session to see its branch, diff, and PR context.

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -96,7 +96,7 @@ export function CodeWorkbench({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-2">
+      <div className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-2" data-testid="code-workbench-header">
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h2 className="truncate text-[length:var(--text-sm)] font-semibold text-[var(--text-primary)]">

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// The dedicated Code surface (cave-k0ua): a Codex-style multi-session coding
+// tab — session rail grouped by project, per-session workbench
+// (Diff | Files | Terminal | PR), inspector column, and a GitHub top tab.
+// Runs flag-ON via NEXT_PUBLIC_CAVE_CODE_SURFACE=1 in playwright.config.ts's
+// webServer env (NEXT_PUBLIC_ flags are inlined at dev-server start, so a
+// per-test toggle is impossible by construction).
+//
+// Daemon-less — onboarding dismissed, every endpoint mocked via page.route.
+
+const OLD_ISO = "2026-06-12T10:00:00.000Z";
+const NEW_ISO = "2026-06-12T12:00:00.000Z";
+
+const mkSession = (over: Record<string, unknown>) => ({
+  status: "running",
+  origin: "chat",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local",
+  exit_code: null,
+  archived_at: null,
+  created_at: OLD_ISO,
+  updated_at: OLD_ISO,
+  ...over,
+});
+
+// Newest session: worktree-attributed branch + PR + diffstat (the enriched
+// shape /api/sessions/list emits after session-git-enrich).
+const NEWEST = mkSession({
+  id: "s-new",
+  title: "Wire the flux capacitor",
+  project_root: "/repo/alpha",
+  updated_at: NEW_ISO,
+  workBranch: "feat/flux",
+  git: { branch: "feat/flux", worktreeRoot: "/repo/alpha/.worktrees/feat-flux", isWorktree: true },
+  pullRequest: { repo: "acme/alpha", number: 7, url: "https://github.com/acme/alpha/pull/7", state: "open" },
+  diff: { additions: 12, deletions: 3 },
+});
+const OLDER = mkSession({ id: "s-old", title: "Fix login retry", project_root: "/repo/alpha" });
+
+async function base(page: Page, sessions: unknown[] = [NEWEST, OLDER]) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions } }),
+  );
+  // One handler, two contracts: ?branches=1 (inspector) vs status (Diff tab).
+  await page.route("**/api/changes**", (route) => {
+    const url = route.request().url();
+    if (url.includes("branches=1")) {
+      route.fulfill({
+        json: {
+          ok: true,
+          branches: [
+            { name: "main", current: false, worktree: null },
+            { name: "feat/flux", current: true, worktree: "feat-flux", worktreePath: "/repo/alpha/.worktrees/feat-flux" },
+          ],
+        },
+      });
+      return;
+    }
+    route.fulfill({
+      json: {
+        ok: true,
+        repo: true,
+        repoRoot: "/repo/alpha",
+        files: [{ path: "src/flux.ts", status: "modified" }],
+      },
+    });
+  });
+  await page.route("**/api/project-tree**", (route) =>
+    route.fulfill({ json: { ok: true, entries: [{ name: "README.md", path: "/repo/alpha/README.md", isDir: false }] } }),
+  );
+  await page.route("**/api/project-file**", (route) =>
+    route.fulfill({ json: { ok: true, kind: "text", content: "# Alpha\n\nHello.", size: 16 } }),
+  );
+}
+
+test.describe("code surface (flag on)", () => {
+  test("landing: rail groups sessions, newest auto-selected, attribution chips in the header", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page);
+    await page.goto("/?mode=code");
+
+    // Top tabs: Sessions active, GitHub reachable (the absorbed surface).
+    const topTabs = page.getByRole("tablist", { name: "Code surface" });
+    await expect(topTabs).toBeVisible({ timeout: 30_000 });
+    await expect(topTabs.getByRole("tab", { name: "Sessions" })).toHaveAttribute("aria-selected", "true");
+    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toBeVisible();
+
+    // Rail: both sessions listed under their project group.
+    const rail = page.getByRole("navigation", { name: "Coding sessions" });
+    await expect(rail.getByText("Wire the flux capacitor")).toBeVisible();
+    await expect(rail.getByText("Fix login retry")).toBeVisible();
+
+    // Newest session auto-selected → its workbench header shows the
+    // worktree-attributed branch (cave-9q24), PR badge, and diffstat.
+    // Scoped to the header testid: the rail row and the nav's Recent
+    // Activity roll-up legitimately repeat the same diffstat text.
+    const header = page.getByTestId("code-workbench-header");
+    await expect(header.getByRole("heading", { name: "Wire the flux capacitor" })).toBeVisible();
+    await expect(header.getByText("feat/flux")).toBeVisible();
+    await expect(header.getByText("#7 (open)")).toBeVisible();
+    await expect(header.getByText("+12 −3")).toBeVisible();
+
+    // Diff tab is the default and shows the mocked changed file (the row
+    // renders basename + dir separately, so target the row button's name).
+    const wb = page.getByRole("tablist", { name: "Session workbench" });
+    await expect(wb.getByRole("tab", { name: "Diff" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByRole("button", { name: "modified flux.ts src" })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("workbench tabs switch; Files shows tree + preview; inspector lists branches", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page);
+    await page.goto("/?mode=code");
+
+    const wb = page.getByRole("tablist", { name: "Session workbench" });
+    await expect(wb).toBeVisible({ timeout: 30_000 });
+
+    // Files: ProjectTree renders, picking a file loads the editable preview.
+    await wb.getByRole("tab", { name: "Files" }).click();
+    await expect(page.locator('[role="tree"]')).toBeVisible({ timeout: 15_000 });
+    await page.getByText("README.md", { exact: false }).first().click();
+    await expect(page.getByText("Hello.")).toBeVisible({ timeout: 15_000 });
+
+    // Inspector: toggling the header control reveals branches with the
+    // current-✓ / worktree-⑂ marks from the ?branches=1 contract.
+    await page.getByRole("button", { name: "Toggle inspector" }).click();
+    const inspector = page.getByRole("complementary", { name: "Session inspector" });
+    await expect(inspector).toBeVisible();
+    await expect(inspector.getByText("main", { exact: true })).toBeVisible({ timeout: 15_000 });
+    // The worktree mark on the branch row (the Root env row also contains
+    // "feat-flux" inside the worktree path, so match the ⑂-prefixed form).
+    await expect(inspector.getByText("⑂ feat-flux")).toBeVisible();
+  });
+
+  test("?mode=code&session=<id>&wtab=files deep link selects the session and tab", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page);
+    await page.goto("/?mode=code&session=s-old&wtab=files");
+
+    // The deep-linked (NOT newest) session is selected…
+    await expect(page.getByRole("heading", { name: "Fix login retry" })).toBeVisible({ timeout: 30_000 });
+    // …with its Files tab active, and the params stripped from the URL.
+    const wb = page.getByRole("tablist", { name: "Session workbench" });
+    await expect(wb.getByRole("tab", { name: "Files" })).toHaveAttribute("aria-selected", "true");
+    await expect
+      .poll(() => page.evaluate(() => window.location.search))
+      .not.toContain("session=");
+  });
+});

--- a/tests/mobile/code-surface-drill-in.spec.ts
+++ b/tests/mobile/code-surface-drill-in.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Code surface mobile drill-in (cave-k0ua): below the md breakpoint the
+// session rail IS the landing screen — no auto-pick of the newest session —
+// and choosing a session replaces the list with the full-width workbench,
+// returned from via the "Back to sessions" affordance.
+//
+// Lives under tests/mobile/ because Playwright's mobile projects
+// (pixel-5 / iphone-13) only match specs there (see playwright.config.ts
+// testMatch); guarded mobile-only so the desktop project self-skips (the
+// desktop three-pane path is covered in tests/code-surface.spec.ts).
+// Daemon-less: onboarding dismissed, APIs mocked, flag ON via webServer env.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+
+const SESSION = {
+  id: "s-repo",
+  title: "Refactor auth flow",
+  project_root: "/repo/alpha",
+  status: "running",
+  origin: "chat",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+async function base(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [SESSION] } }),
+  );
+  await page.route("**/api/changes**", (route) =>
+    route.fulfill({ json: { ok: true, repo: true, repoRoot: "/repo/alpha", files: [] } }),
+  );
+}
+
+test.describe("code surface mobile drill-in", () => {
+  test("list first (no auto-pick), tap → workbench, Back → list", async ({ page, isMobile }) => {
+    test.skip(!isMobile, "mobile-only (desktop path in tests/code-surface.spec.ts)");
+    await base(page);
+    await page.goto("/?mode=code");
+
+    // Landing: the session list owns the screen; nothing was auto-selected,
+    // so the workbench (and its Back bar) is absent.
+    const rail = page.getByRole("navigation", { name: "Coding sessions" });
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    const railRow = rail.getByText("Refactor auth flow");
+    await expect(railRow).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back to sessions" })).toHaveCount(0);
+    await expect(page.getByRole("tablist", { name: "Session workbench" })).toHaveCount(0);
+
+    // Drill in: the workbench replaces the list.
+    await railRow.click();
+    await expect(page.getByRole("heading", { name: "Refactor auth flow" })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole("tablist", { name: "Session workbench" })).toBeVisible();
+    await expect(railRow).toBeHidden();
+
+    // Back: the list returns and stays (no auto-pick re-selects the session).
+    await page.getByRole("button", { name: "Back to sessions" }).click();
+    await expect(railRow).toBeVisible();
+    await expect(page.getByRole("tablist", { name: "Session workbench" })).toHaveCount(0);
+    await page.waitForTimeout(600);
+    await expect(page.getByRole("tablist", { name: "Session workbench" })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Final slice of the dedicated Code surface series (cave-k0ua: #3716 → #3719 → #3722 → #3724 → #3727).

## Mobile drill-in (below md)

- The session rail is the **landing screen** — newest-session auto-pick is skipped on narrow mounts, so phones land on the list.
- Picking a session swaps in the full-width workbench with a **Back to sessions** bar. Selection is tri-state (`undefined` = auto-pick allowed, `null` = user went Back — terminal), so Back isn't clobbered by re-selection.
- Pure CSS swap (`hidden md:block` / `hidden md:flex`) — desktop three-pane untouched. No hover-only chrome in the surface (no `touch-always-visible` needed); drawer reachability holds by construction.

## Deep-link StrictMode fix (found by the new e2e)

`?session/ctab/wtab` parsing lived in a `useState` initializer that **also stripped the URL** — StrictMode's double-invoke fed the second run a stripped URL and lost the target. Parse is now pure; the strip moved to a mount effect. Pinned.

## E2E (daemon-less, API-mocked)

- `playwright.config.ts` webServer env sets `NEXT_PUBLIC_CAVE_CODE_SURFACE=1` — the suite now validates the **flag-ON world**. No existing spec asserted the GitHub sidebar row; `?mode=github` stays canonical either way.
- `tests/code-surface.spec.ts` (desktop): landing, rail grouping, newest auto-select, attribution chips, tab switching, Files tree/preview, inspector branches, deep link.
- `tests/mobile/code-surface-drill-in.spec.ts` (pixel-5/iphone-13): list-first landing, drill-in, Back without re-select.

## Verification

- Pin suite extended (drill-in tri-state, narrow-mount guard, StrictMode-safe deep link)
- `tsc --noEmit`, eslint clean; 892 app + 239 api test files green
- **Full local Playwright suite: 63 passed / 0 failed (19.6m)** with the flag on