### PR TITLE
feat(ui): fill the New chat CTA with solid accent (cave-xr5z)

### DIFF
--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -271,11 +271,14 @@
   height: 34px;
   padding: 0 var(--space-2);
   border-radius: 10px;
-  /* Brand accent (--accent-presence); var(--accent) is the shadcn surface
-     token and rendered this button's chrome nearly invisible. */
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
-  color: var(--text-primary);
+  /* Filled brand accent (--accent-presence): New chat is the panel's primary
+     action, so it gets the solid treatment with its paired on-accent ink.
+     Hover shifts through --accent-presence-hover (WCAG-AA pair, cave-c7hy).
+     var(--accent) is the shadcn surface token and rendered this button's
+     chrome nearly invisible. */
+  border: 1px solid var(--accent-presence);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
   font-size: var(--text-sm);
   font-weight: 560;
   text-align: left;
@@ -283,12 +286,12 @@
     border-color var(--duration-fast) var(--ease-standard);
 }
 .cnav__new:hover {
-  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
-  border-color: color-mix(in oklch, var(--accent-presence) 48%, transparent);
+  background: var(--accent-presence-hover);
+  border-color: var(--accent-presence-hover);
 }
 .cnav__new-icon {
   flex-shrink: 0;
-  color: var(--accent-presence);
+  color: var(--accent-presence-foreground);
 }
 .cnav__new-label {
   flex: 1;

--- a/src/styles/sidebar-minimal/activity-rail.css
+++ b/src/styles/sidebar-minimal/activity-rail.css
@@ -225,20 +225,22 @@
   color: var(--text-primary);
 }
 
-/* Compose ("new chat") shares the exact same square — drop its loud 2px accent
-   outline — and stays recognisable purely through its accent glyph. */
+/* Compose ("new chat") is the rail's one FILLED control: a solid accent
+   square with on-accent glyph, so the primary action stands out from the
+   otherwise quiet icon family while keeping the shared 36px geometry. */
 .shell-nav--rail .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--accent-presence);
+  border: 1px solid var(--accent-presence);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
   font-weight: 500;
 }
 .shell-nav--rail .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
-  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
-  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+  background: var(--accent-presence-hover);
+  border-color: var(--accent-presence-hover);
+  color: var(--accent-presence-foreground);
 }
 
-/* The active destination is the one persistent fill: a single accent-tinted
+/* The active destination keeps its own persistent fill: a single accent-tinted
    square (no left bar, which looks off-centre under a centred icon). */
 .shell-nav--rail .sidebar-folder-row--active {
   background: color-mix(in oklch, var(--accent-presence) 16%, transparent);

--- a/src/styles/sidebar-minimal/shell-chrome.css
+++ b/src/styles/sidebar-minimal/shell-chrome.css
@@ -160,20 +160,22 @@
   color: var(--text-primary);
 }
 
-/* "New chat" is the top CTA — an outlined accent button: the accent reads on
-   the border + label rather than a solid fill, so it stays prominent without
-   dominating the panel. A faint accent wash on hover gives press feedback. */
+/* "New chat" is the top CTA — a filled accent button: solid --accent-presence
+   with its paired on-accent ink (--accent-presence-foreground, not
+   --text-primary — monochrome palettes vanish the label otherwise), so the
+   panel's one primary action stands out. Hover shifts through
+   --accent-presence-hover, the direction-aware WCAG-AA pair (cave-c7hy). */
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
-  background: transparent;
-  color: var(--accent-presence);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
   border: 2px solid var(--accent-presence);
   font-weight: 600;
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
-  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
-  color: var(--accent-presence);
-  border-color: var(--accent-presence);
+  background: var(--accent-presence-hover);
+  color: var(--accent-presence-foreground);
+  border-color: var(--accent-presence-hover);
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row .sidebar-action-icon {


### PR DESCRIPTION
## What

Makes the **New chat** button the standout, filled control — solid accent fill in all three sidebar states (user request: "make New chat button standout and make it filled").

| Surface | Before | After |
|---|---|---|
| Expanded panel top CTA (`.sidebar-action-row`) | outlined accent | solid `--accent-presence` fill, `--accent-presence-foreground` ink |
| Collapsed rail compose square | quiet transparent icon | the rail's one filled control, same tokens |
| Chat WorkspaceSidebar (`.cnav__new`) | 12% accent wash | solid fill, icon ink on-accent |

Hover uses `--accent-presence-hover` (direction-aware token from #3729). The fg/hover pair is already audited at WCAG AA by theme-contrast-audit — no new contrast pairs introduced.

## Verification

- CSS pin suites green: shell-chrome-revamp, sidebar-minimal, theme-contrast-audit (with facade hook), design-token-drift (raw), workspace-sidebar-wiring
- `pnpm lint` + `pnpm build` green (home-CSS + standalone budgets within limits)
- Playwright screenshots of all three states from a prod build — solid fill renders with readable on-accent ink in expanded, rail, and Chat sidebar

Closes bead: cave-xr5z