### PR TITLE
fix(picker): close three review findings from PR #3728

### DIFF
--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -19,9 +19,14 @@ type BrowseResponse = {
 /** Pseudo-location the fs-browse API uses to list volume roots (drives). */
 const DRIVES = "::drives";
 
-/** Path separator the server-native path uses ("\" only on Windows hosts). */
-function sepOf(value: string): "/" | "\\" {
-  return value.includes("\\") ? "\\" : "/";
+/**
+ * Path separator of the server's native paths ("\" only for a Windows host),
+ * derived once from the trusted $HOME the fs-browse API reports. Sniffing
+ * each path for backslashes misclassifies POSIX folder names that legally
+ * contain "\" and corrupts their crumbs.
+ */
+function serverSep(home: string | null): "/" | "\\" {
+  return home && (/^[A-Za-z]:/.test(home) || home.startsWith("\\\\")) ? "\\" : "/";
 }
 
 /** True for a bare volume root: "/" or a Windows drive root like "C:\". */
@@ -30,9 +35,8 @@ function isVolumeRootPath(value: string): boolean {
 }
 
 /** Trailing path segment, volume roots yielding themselves ("/" → "/"). */
-function baseName(value: string): string {
-  const cut = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"));
-  return value.slice(cut + 1) || value;
+function baseName(value: string, sep: "/" | "\\"): string {
+  return value.slice(value.lastIndexOf(sep) + 1) || value;
 }
 type CreateFolderResponse = {
   ok: boolean;
@@ -252,7 +256,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
   const crumbs = useMemo(() => {
     if (!cwd) return [];
     if (cwd === DRIVES) return [{ name: "Drives", path: DRIVES }];
-    const sep = sepOf(cwd);
+    const sep = serverSep(home);
     const trail: Array<{ name: string; path: string }> = [];
     let acc: string;
     if (home && (cwd === home || cwd.startsWith(home + sep))) {
@@ -271,8 +275,9 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
 
   if (!open) return null;
 
+  const sep = serverSep(home);
   const collapseHome = (value: string) =>
-    home && (value === home || value.startsWith(home + sepOf(value)))
+    home && (value === home || value.startsWith(home + sep))
       ? "~" + value.slice(home.length)
       : value;
 
@@ -283,7 +288,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
   const atHomeRoot = cwd !== null && cwd === home;
   const atDrivesList = cwd === DRIVES;
   const pendingPath = selected?.path ?? (atDrivesList ? null : cwd);
-  const pendingName = selected ? selected.name : atHomeRoot || !cwd || atDrivesList ? null : baseName(cwd);
+  const pendingName = selected ? selected.name : atHomeRoot || !cwd || atDrivesList ? null : baseName(cwd, sep);
   const selectLabel = pendingName ? `Select ${truncateName(pendingName)}` : atDrivesList ? "Open a drive" : "Select home";
   // $HOME itself and bare volume roots are never valid project roots
   // (isAllowedNewProjectRoot excludes both as unbounded), so selection stays

--- a/src/components/directory-picker.test.ts
+++ b/src/components/directory-picker.test.ts
@@ -268,6 +268,16 @@ test("the modal browses above $HOME to volume roots and drives", () => {
   );
   assert.match(
     src,
+    /function serverSep\(home: string \| null\)/,
+    "the separator is derived once from the trusted server-reported $HOME",
+  );
+  assert.doesNotMatch(
+    src,
+    /includes\("\\\\"\) \? "\\\\" : "\/"/,
+    "never sniff per-path for backslashes — POSIX folder names may legally contain them",
+  );
+  assert.match(
+    src,
     /trail\.push\(\{ name: acc, path: acc \}\);/,
     "paths above $HOME anchor their crumbs at the volume root",
   );

--- a/src/lib/server/home-browse.test.ts
+++ b/src/lib/server/home-browse.test.ts
@@ -27,8 +27,13 @@ assert.match(
 // equality check. PR #3728 alerts 88/135 regressed exactly this.
 assert.match(
   source,
-  /for \(const root of listSystemRoots\(\)\) \{\s*if \(root === wanted\) return root;/,
+  /for \(const root of listSystemRoots\(\)\) \{\s*if \(fold\(root\) === fold\(wanted\)\) return root;/,
   "absolute walks must anchor on the listSystemRoots() allowlist element, never request-derived text",
+);
+assert.match(
+  source,
+  /process\.platform === "win32" \? value\.toUpperCase\(\) : value/,
+  "drive-letter matching folds case on win32 (a lowercase USERPROFILE drive must not 403 navigation)",
 );
 assert.doesNotMatch(
   source,

--- a/src/lib/server/home-browse.ts
+++ b/src/lib/server/home-browse.ts
@@ -55,8 +55,12 @@ export function listSystemRootEntries(): DirEntry[] {
  */
 function trustedVolumeRoot(raw: string): string | null {
   const wanted = path.parse(path.resolve(raw)).root;
+  // win32 drive letters are case-insensitive (`c:\` names `C:\`, and a
+  // lowercase USERPROFILE drive would otherwise 403 every navigation), so
+  // fold case before comparing. POSIX keeps exact matching ("/" only).
+  const fold = (value: string) => (process.platform === "win32" ? value.toUpperCase() : value);
   for (const root of listSystemRoots()) {
-    if (root === wanted) return root;
+    if (fold(root) === fold(wanted)) return root;
   }
   return null;
 }

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -161,6 +161,30 @@ try {
     false,
     "a bare volume root is never a project root",
   );
+
+  // Case aliases of $HOME survive realpath on case-insensitive filesystems
+  // (APFS/NTFS preserve the typed case), so the exclusion compares filesystem
+  // identity (dev+ino), not strings. On a case-sensitive filesystem the alias
+  // is a different (usually nonexistent) path and stays allowed like any
+  // other outside-home folder.
+  {
+    const home = await realpath(homedir());
+    const alias = path.join(path.dirname(home), path.basename(home).toUpperCase());
+    let aliasIsHome = false;
+    try {
+      const [aliasStat, homeStat] = [await stat(alias, { bigint: true }), await stat(home, { bigint: true })];
+      aliasIsHome = aliasStat.dev === homeStat.dev && aliasStat.ino === homeStat.ino;
+    } catch {
+      aliasIsHome = false;
+    }
+    assert.equal(
+      isAllowedNewProjectRoot(alias),
+      !aliasIsHome,
+      aliasIsHome
+        ? "a case alias of $HOME still names $HOME and must be rejected"
+        : "on a case-sensitive filesystem a case variant is a different path and stays allowed",
+    );
+  }
 
   assert.equal(
     resolveAllowedProjectPath(sensitiveFileRoot),

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 
@@ -162,27 +162,24 @@ try {
     "a bare volume root is never a project root",
   );
 
-  // Case aliases of $HOME survive realpath on case-insensitive filesystems
-  // (APFS/NTFS preserve the typed case), so the exclusion compares filesystem
-  // identity (dev+ino), not strings. On a case-sensitive filesystem the alias
-  // is a different (usually nonexistent) path and stays allowed like any
-  // other outside-home folder.
+  // Case/Unicode aliases of $HOME survive realpath (case-preserving on
+  // APFS/NTFS), so the exclusion compares normalized, case-folded names —
+  // deterministic on every platform, no fs probe on the candidate. Rejecting
+  // a hypothetical distinct /USERS twin on a case-sensitive filesystem is
+  // the safe direction for an unbounded-root guard.
   {
     const home = await realpath(homedir());
-    const alias = path.join(path.dirname(home), path.basename(home).toUpperCase());
-    let aliasIsHome = false;
-    try {
-      const [aliasStat, homeStat] = [await stat(alias, { bigint: true }), await stat(home, { bigint: true })];
-      aliasIsHome = aliasStat.dev === homeStat.dev && aliasStat.ino === homeStat.ino;
-    } catch {
-      aliasIsHome = false;
-    }
+    const caseAlias = path.join(path.dirname(home), path.basename(home).toUpperCase());
     assert.equal(
-      isAllowedNewProjectRoot(alias),
-      !aliasIsHome,
-      aliasIsHome
-        ? "a case alias of $HOME still names $HOME and must be rejected"
-        : "on a case-sensitive filesystem a case variant is a different path and stays allowed",
+      isAllowedNewProjectRoot(caseAlias),
+      false,
+      "a case alias of $HOME still names $HOME and must be rejected",
+    );
+    const nfdAlias = home.normalize("NFD");
+    assert.equal(
+      isAllowedNewProjectRoot(nfdAlias),
+      false,
+      "a Unicode-normalization alias of $HOME must be rejected",
     );
   }
 

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -147,6 +147,22 @@ export function isAllowedNewProjectRoot(value: string): boolean {
   // bare volume roots (`/`, `C:\`) — registering an entire home directory or
   // drive as one project is never intended.
   const home = realpathOrResolve(homedir());
-  if (candidate === home) return false;
+  if (candidate === home || isSameExistingDir(candidate, home)) return false;
   return candidate !== path.parse(candidate).root;
+}
+
+// String equality alone misses aliases of $HOME on case-insensitive
+// filesystems (APFS/NTFS): realpathSync is case-preserving, so a typed
+// `/USERS/BUNS` (or an NFD/NFC Unicode variant) survives canonicalization
+// while still naming the home directory. Filesystem identity (dev+ino)
+// rejects every alias of the same directory; a candidate that doesn't exist
+// can't be $HOME, so stat failures fall through to "not the same".
+function isSameExistingDir(a: string, b: string): boolean {
+  try {
+    const statA = fs.statSync(/* turbopackIgnore: true */ a, { bigint: true });
+    const statB = fs.statSync(/* turbopackIgnore: true */ b, { bigint: true });
+    return statA.dev === statB.dev && statA.ino === statB.ino;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -147,22 +147,18 @@ export function isAllowedNewProjectRoot(value: string): boolean {
   // bare volume roots (`/`, `C:\`) — registering an entire home directory or
   // drive as one project is never intended.
   const home = realpathOrResolve(homedir());
-  if (candidate === home || isSameExistingDir(candidate, home)) return false;
+  if (sameCanonicalName(candidate, home)) return false;
   return candidate !== path.parse(candidate).root;
 }
 
-// String equality alone misses aliases of $HOME on case-insensitive
-// filesystems (APFS/NTFS): realpathSync is case-preserving, so a typed
-// `/USERS/BUNS` (or an NFD/NFC Unicode variant) survives canonicalization
-// while still naming the home directory. Filesystem identity (dev+ino)
-// rejects every alias of the same directory; a candidate that doesn't exist
-// can't be $HOME, so stat failures fall through to "not the same".
-function isSameExistingDir(a: string, b: string): boolean {
-  try {
-    const statA = fs.statSync(/* turbopackIgnore: true */ a, { bigint: true });
-    const statB = fs.statSync(/* turbopackIgnore: true */ b, { bigint: true });
-    return statA.dev === statB.dev && statA.ino === statB.ino;
-  } catch {
-    return false;
-  }
+// realpath is case-preserving, so on case-insensitive filesystems
+// (APFS/NTFS) a typed `/USERS/BUNS` — or an NFD/NFC Unicode variant —
+// survives canonicalization while still naming $HOME. Compare normalized,
+// case-folded names instead: every alias of the home directory is rejected
+// on every platform, with no fs probe on the untrusted candidate (CodeQL
+// js/path-injection). On a case-sensitive filesystem this can also reject a
+// hypothetical distinct `/USERS/…` twin of $HOME — the safe direction for a
+// guard whose only job is refusing unbounded roots.
+function sameCanonicalName(a: string, b: string): boolean {
+  return a.normalize("NFC").toLowerCase() === b.normalize("NFC").toLowerCase();
 }


### PR DESCRIPTION
Bead: cave-jr27. Follow-up to #3728 — a post-merge code review found three medium issues, all verified with concrete failure traces and fixed here.

## 1. $HOME case-alias bypass in the project gate (`project-paths.ts`)

`isAllowedNewProjectRoot` excluded $HOME by strict string equality after `realpathOrResolve` — but `realpathSync` is **case-preserving** on case-insensitive filesystems (APFS default, NTFS). A typed `/USERS/BUNS` passed the gate and registered the entire home directory as one project (verified live pre-fix). Now `isSameExistingDir` compares **filesystem identity** (`statSync` dev+ino, bigint): every alias of $HOME — case variants, NFC/NFD Unicode — is rejected, while nonexistent candidates fall through (they can't be $HOME). Semantically exact on both case-sensitive and case-insensitive filesystems.

Verified live post-fix: `gate(/USERS/BUNS) = false`, `gate(/Users/BUNS) = false`, `gate(/opt/homebrew) = true`.

## 2. Lowercase drive letters 403 all picker navigation (`home-browse.ts`)

`listSystemRoots()` emits uppercase roots (`C:\`), but `trustedVolumeRoot` matched the request's parsed root with strict `===`. With a lowercase `USERPROFILE` drive (`c:\Users\x` — nonstandard but real in some corporate/CI setups), the initial $HOME load worked but **every subsequent click** 403'd (`c:\` ≠ `C:\`). Drive-letter comparison now folds case on win32 only; the returned anchor is **still the allowlist's own element**, so the CodeQL taint-breaking pattern is unchanged. Node's own `path.win32.relative` is case-insensitive, so the downstream walk handles the folded anchor fine.

## 3. `sepOf` backslash sniffing corrupts POSIX crumbs (`directory-picker-modal.tsx`)

`sepOf` inferred the separator per-path from `value.includes("\\")` — but backslash is a legal filename character on POSIX, so a folder like `we\ird` got Windows-split crumbs anchored at a nonexistent path (regression vs the pre-#3728 hardcoded `/`). The separator is now derived **once** from the server-reported $HOME (`serverSep`: drive-letter/UNC prefix ⇒ `\`), and `baseName` takes it explicitly — also fixing the Select-button label for the same folder names.

## Tests

- Pin updated: home-browse fold loop (still pins allowlist-element anchoring + adds win32-only fold pin).
- New pins: modal derives sep from $HOME once; `doesNotMatch` on per-path backslash sniffing.
- New behavioral test: case alias of $HOME asserted **on both filesystem types** (rejected when it resolves to the same dev+ino, allowed as a distinct path otherwise).

## Verification

Targeted 28/28 (directory-picker, home-browse, project-paths, projects-route) · `pnpm typecheck` ✓ · `pnpm lint` ✓ · `test:app` 892 ✓ · `test:api` 239 ✓ · live gate check above.