### PR TITLE
fix(analytics): clear stale skillsNeedingAccess rows — latest report wins (cave-raqz)

### DIFF
--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -207,3 +207,80 @@ describe("aggregateThreadSignals vital capabilities", () => {
     );
   });
 });
+
+describe("aggregateThreadSignals skill access gaps", () => {
+  function reportWithSkills(
+    id: string,
+    reportedAt: string,
+    opts: { used?: string[]; access?: ThreadSelfReport["skillsNeedingAccess"] },
+  ): ThreadSelfReport {
+    return {
+      ...fullReport(),
+      id,
+      sessionId: id,
+      reportedAt,
+      skillsUsed: opts.used ?? [],
+      skillsNeedingAccess: opts.access ?? [],
+    };
+  }
+
+  it("clears an access gap once a newer report uses the skill without re-filing it", () => {
+    // Regression: skill-creator was reported blocked mid-install (07-12/07-14),
+    // then worked in every later session — the row must not stay `blocked`
+    // for the whole report window (same latest-wins semantics as cave-hdkx).
+    const stale = reportWithSkills("session-old", "2026-07-14T15:22:31.000Z", {
+      used: ["skill-creator"],
+      access: [{ skillId: "skill-creator", reason: "Freshly installed skills aren't visible mid-session." }],
+    });
+    const recovered = reportWithSkills("session-new", "2026-07-23T19:00:00.000Z", {
+      used: ["skill-creator"],
+    });
+    // Order of the input array must not matter — only reportedAt recency.
+    for (const reports of [
+      [stale, recovered],
+      [recovered, stale],
+    ]) {
+      assert.deepEqual(aggregateThreadSignals(reports).skillsNeedingAccess, []);
+    }
+  });
+
+  it("keeps the complaint when the newest mention of the skill still files one", () => {
+    const usedFine = reportWithSkills("session-old", "2026-07-10T08:00:00.000Z", {
+      used: ["github"],
+    });
+    const nowBlocked = reportWithSkills("session-new", "2026-07-14T09:00:00.000Z", {
+      access: [{ skillId: "github", reason: "Needs PR merge access." }],
+    });
+    assert.deepEqual(aggregateThreadSignals([usedFine, nowBlocked]).skillsNeedingAccess, [
+      { skillId: "github", reason: "Needs PR merge access." },
+    ]);
+  });
+
+  it("lets a report's own complaint win over its own skillsUsed mention", () => {
+    // A thread can drive a skill through a bash fallback (so it lands in
+    // skillsUsed) while skill-tool access is still broken — that report's
+    // complaint must stand until a NEWER report uses the skill cleanly.
+    const fallbackRun = reportWithSkills("session-only", "2026-07-14T15:22:31.000Z", {
+      used: ["skill-creator"],
+      access: [{ skillId: "skill-creator", reason: "Drove it via bash scripts instead of skill invocation." }],
+    });
+    assert.deepEqual(aggregateThreadSignals([fallbackRun]).skillsNeedingAccess, [
+      { skillId: "skill-creator", reason: "Drove it via bash scripts instead of skill invocation." },
+    ]);
+  });
+
+  it("tracks distinct skill ids independently", () => {
+    const older = reportWithSkills("session-a", "2026-07-13T10:00:00.000Z", {
+      access: [
+        { skillId: "skill-creator", reason: "Not installed yet." },
+        { skillId: "github", reason: "Needs PR merge access." },
+      ],
+    });
+    const newer = reportWithSkills("session-b", "2026-07-14T10:00:00.000Z", {
+      used: ["skill-creator"],
+    });
+    assert.deepEqual(aggregateThreadSignals([older, newer]).skillsNeedingAccess, [
+      { skillId: "github", reason: "Needs PR merge access." },
+    ]);
+  });
+});

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -230,6 +230,7 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
   const skillsUsed = new Map<string, number>();
   const clarity = new Map<string, { skillId: string; reason: string }>();
   const access = new Map<string, { skillId: string; reason: string }>();
+  const accessDecided = new Set<string>();
   const capVital = new Map<string, { name: string; currentState: CapabilityState; notes?: string }>();
   const capLacking = new Map<string, { name: string; importance: CapabilityImportance; detail: string }>();
   const blockerFreq = new Map<string, number>();
@@ -241,7 +242,22 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
     contextCounts[r.contextPressure]++;
     for (const s of r.skillsUsed) libIncrement(skillsUsed, s);
     for (const s of r.skillsNeedingClarity) if (!clarity.has(s.skillId)) clarity.set(s.skillId, s);
-    for (const s of r.skillsNeedingAccess) if (!access.has(s.skillId)) access.set(s.skillId, s);
+    // Latest report wins per skillId: an access gap is a *current* state, not
+    // complaint history. The newest report mentioning a skill decides — either
+    // it re-files the complaint, or it lists the skill in `skillsUsed` without
+    // one, which clears the row. Without the clearing rule, one old "not
+    // installed" report pinned `status: blocked` for the whole window even
+    // after later threads used the skill successfully (skill-creator; same bug
+    // class as the capabilitiesVital fix below, cave-hdkx). Within a single
+    // report the complaint wins over its own `skillsUsed` mention: threads can
+    // use a skill through a fallback path while access is still broken.
+    for (const s of r.skillsNeedingAccess) {
+      if (!accessDecided.has(s.skillId)) {
+        accessDecided.add(s.skillId);
+        access.set(s.skillId, s);
+      }
+    }
+    for (const skillId of r.skillsUsed) accessDecided.add(skillId);
     for (const c of r.capabilitiesVital) {
       // Latest report wins: `currentState` is a *current* observation, and
       // reports iterate newest-first. Letting an older, worse state override


### PR DESCRIPTION
Lands the orphaned cave-raqz fix from session 3f2c9f54 (implemented in the primary checkout, uncommitted — this PR moves it through the protected-main flow unchanged).

## Bug

`aggregateThreadSignals` kept any `skillsNeedingAccess` complaint for the whole 30-report window with **no clearing rule** — unlike `capabilitiesVital`, which got latest-wins semantics in cave-hdkx. One stale skill-creator report (2026-07-14, mid-install) pinned `status: blocked` on `/dashboard/familiars/cody/analytics` even though the skill worked in every later session.

## Fix

Latest-report-wins per skillId. Reports already iterate newest-first; an `accessDecided` set marks each skillId at its newest mention — either re-filing the complaint or clearing it via `skillsUsed` without one. Within a single report the complaint beats its own `skillsUsed` mention (bash-fallback runs while access is broken).

## Tests (4 new, 15/15 file total)

- clear-on-recovery, input-order-independent
- newest complaint kept over an older clean use
- same-report fallback complaint stands
- distinct skillIds decided independently

## Verification

- `pnpm typecheck` clean
- 120/120 targeted + all 9 downstream consumer test files green
- Full `pnpm test:api` (239) + `pnpm test:app` (892) green

Bead: cave-raqz
