### PR TITLE
Code becomes the Coding familiar's room — explicit familiar Type picker (cave-cc5r)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ breaking config changes; patch releases stay additive.
 ## [Unreleased]
 
 ### Changed
+- **Code becomes the Coding familiar's room** — the Code workbench now lives as a Role Surface room ("Code Workshop") granted by an explicit familiar Type, matching how Research gates its desk. Familiar Studio → Identity gains a Type picker (General, Coding, Research, Review, Writing, Comms, Watch, Planning, Indexing) that unlocks the matching room; role labels keep granting rooms as before (types add, never subtract). The standalone GitHub surface returns as a quiet sidebar row for every familiar, hiding only while the active familiar's Code room is visible. `?mode=code` deep links now alias onto the room.
 - **OpenAI theme renamed to Codex** — same void-dark monochrome palette under `data-theme="codex"`; stored `openai` preferences migrate automatically via the legacy rename map.
 
 ### Fixed

--- a/docs/specs/2026-07-23-code-coding-familiar-room-design.md
+++ b/docs/specs/2026-07-23-code-coding-familiar-room-design.md
@@ -1,0 +1,104 @@
+# Code as a Coding-familiar room + explicit familiar Types
+
+- **Date:** 2026-07-23
+- **Bead:** cave-cc5r
+- **Status:** approved (design review in session; owner approved all flagged behavior changes)
+
+## Problem
+
+The Code surface (cave-k0ua/cave-m6ys) is a top-level destination visible to
+every familiar. Research, by contrast, is a *Role Surface*: a room the Cave
+opens only for familiars whose vocation matches. The owner wants Code gated
+the same way — visible only via a **Coding** familiar type — and wants the
+type assignment to be **explicit and modifiable**, not inferred-only from
+free-text role labels.
+
+## Decisions (owner-approved)
+
+1. **Architecture:** convert Code into a registered Role Surface room (not a
+   familiar-gated top-level mode).
+2. **Non-coding familiars** see the standalone **GitHub** row again
+   (pre-absorption behavior, assigned-work badge kept).
+3. **"All familiars" scope:** strict — no active familiar means no Code room
+   (GitHub row shows).
+4. **Type assignment:** an explicit **Type** picker in Familiar Studio →
+   Identity, stored as an override; the free-text Role label keeps granting
+   rooms as before (types add, never subtract).
+
+## Design
+
+### 1. Code room (Role Surface)
+
+- `register.tsx` registers `id: "code"` (`CODE_SURFACE_ID` in ids.ts),
+  `role: "coder"`, aliases `["coding", "developer", "engineer", "programmer",
+  "software-engineer", "code"]` — the "Code reviewer" summoning preset
+  (token `code`) qualifies.
+- A thin adapter (`code-room.tsx`) renders the existing `CodeView` inside the
+  room. No CodeView internals change.
+- `RoleSurfaceContext` gains two generic shell services (same posture as
+  `openUrl`/`openSession`): `focusCard(cardId)` and `refreshTasks()`; wired
+  through `use-role-surfaces` from Workspace.
+- `pending-code-open.ts` becomes a small module store
+  (`useSyncExternalStore`): Workspace's `cave:open-project-file` /
+  `cave:open-file-diff` / `cave:browse-project-files` handlers write it and
+  `setMode("code")`; the room adapter consumes it. Workspace's local
+  `pendingCodeOpen` state is removed.
+- **Behavior changes:** (a) the room's session rail scopes to the active
+  familiar's sessions plus unattributed ones (context's native shape);
+  (b) the room's sidebar row carries no numeric badge (the GitHub row keeps
+  the assigned count for non-coding familiars); (c) non-coding deep links hit
+  RoleSurfaceHost's explicit "room stays closed" door.
+
+### 2. Modes & deep links
+
+- `github` returns to `CanonicalWorkspaceMode`, rendering the standalone
+  `GitHubView` (dynamic wrapper restored in lazy-surfaces). GitHub-item URL
+  opens (`openGitHubTarget`) land there for everyone.
+- `code` moves to `AliasWorkspaceMode`; `MODE_ALIASES.code = "surface:code"`
+  (the table's value type widens to `CanonicalWorkspaceMode |
+  RoleSurfaceMode`). `setMode` rewrites `code` → `surface:code` (the
+  `journal`/`flow` idiom), so `?mode=code`, palette intents, and
+  `cave:navigate-mode` all land in the room; `sidebar-nav-state` lights the
+  room row for code-mode splits via the same table.
+- Familiar-switch fallback: the existing generic effect (role-surface mode +
+  familiar can't see it → Home) already covers Code.
+
+### 3. Sidebar & palette
+
+- FOLDER_MODES: the static Code row is replaced by the restored GitHub row
+  (quiet, assigned-count badge). SidebarMinimal hides the GitHub row while
+  the Code room is visible for the active familiar
+  (`hideGithubRow` prop computed in Workspace from `visibleSurfaces`).
+- The Code room row rides the existing role-surfaces "Rooms" cluster.
+- CommandPalette gains an optional `roleSurfaces` prop so "Go to Code
+  Workshop" (and other rooms) keep ⌘K parity with sidebar rows.
+
+### 4. Explicit familiar Type
+
+- New `src/lib/familiar-types.ts`: a static `FAMILIAR_TYPES` table —
+  General (default, grants nothing), Coding → `coder`, Research →
+  `researcher`, Review → `reviewer`, Writing → `scribe`, Comms →
+  `messenger`, Watch → `sentinel`, Planning → `navigator`, Indexing →
+  `indexer` — each with label, unlock description, and icon.
+- `familiarType` field added to: `Familiar` (types.ts), `FamiliarBinding`
+  (cave-config.ts — PATCH `/api/config` merge is generic, no route change),
+  `/api/familiars` enrichment, `FamiliarOverride` +
+  `familiar-resolve.ts` resolution.
+- `familiarRoleIds()` accepts the optional `familiarType` and adds the
+  type's id + role token to the granted set — so the picker also unlocks
+  research/review/… rooms. Role-label tokens keep granting exactly as
+  before.
+- Familiar Studio → Identity gets a "Type" chip radio-row above the text
+  fields with per-type unlock descriptions.
+
+## Testing
+
+- Rewrite `code-surface-mode.test.ts` pins to the new shape (room
+  registration, alias funnel, standalone GitHub branch, adapter wiring).
+- Update `workspace-alias-modes.test.ts`, `canonical-nav-names.test.ts`,
+  `palette-canonical-names.test.ts`, sidebar pins.
+- New `familiar-types.test.ts` (table ↔ role tokens, familiarRoleIds
+  integration); identity-tab pin for the Type picker.
+- `tests/code-surface.spec.ts`: the mocked familiar becomes Coding-type.
+- Remove the dead `NEXT_PUBLIC_CAVE_CODE_SURFACE` env from
+  playwright.config.ts if still present.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -42,6 +42,7 @@ export const SUITES = {
     "src/components/workspace-surface-warmup.test.ts",
     "src/lib/workspace-github-task-context.test.ts",
     "src/lib/role-surfaces.test.ts",
+    "src/lib/familiar-types.test.ts",
     "src/lib/research-missions.test.ts",
     "src/lib/research-mission-client.test.ts",
     "src/lib/roving-list.test.ts",

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -97,6 +97,7 @@ export async function GET(req: Request) {
       ...f,
       display_name: binding.display_name ?? f.display_name,
       role: binding.role ?? f.role,
+      familiarType: binding.familiarType,
       pronouns: binding.pronouns ?? f.pronouns,
       description: binding.description ?? f.description,
       color: binding.color,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -9,10 +9,11 @@ import { readFile } from "node:fs/promises";
 // The owner requested a Codex-style multi-session coding surface — diffs,
 // files, terminal, per-session PR context, worktrees, branches, with GitHub
 // absorbed as a tab — so the mode returned behind caveCodeSurface(). Phase 2
-// (cave-m6ys) made it default-on: the flag is retired, the standalone GitHub
-// surface/row is absorbed ("github" is a tab alias in MODE_ALIASES), and
-// Chat's own code rail stays untouched until the flagged follow-up that
-// slims it. These pins document that sanctioned shape.
+// (cave-m6ys) made it default-on. Phase 3 (cave-cc5r) moved the surface into
+// the Coding familiar's Role Surface room: "code" is now an alias landing on
+// `surface:code` (role-gated, explicit familiar Type picker in the Studio),
+// while the standalone GitHub surface returned as a canonical mode every
+// familiar keeps. These pins document that sanctioned shape.
 
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
@@ -22,10 +23,38 @@ const lazySurfaces = await readFile(new URL("./lazy-surfaces.tsx", import.meta.u
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatRouter = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
 const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const registerRooms = await readFile(new URL("./role-surfaces/register.tsx", import.meta.url), "utf8");
+const codeRoom = await readFile(new URL("./role-surfaces/code-room.tsx", import.meta.url), "utf8");
 
 // ── Mode vocabulary ──────────────────────────────────────────────────────────
 
-assert.match(modeType, /\|\s*"code"/, "WorkspaceMode includes the Code surface again (cave-k0ua)");
+assert.match(modeType, /\|\s*"code"/, "the code mode stays in the vocabulary (as an alias) so deep links keep working");
+
+// ── The Code room (cave-cc5r) ────────────────────────────────────────────────
+
+// Code is the Coding familiar's room: registered in the Role Surface registry
+// under the "coder" role, granted by the Studio's explicit Type picker or a
+// matching role label — never rendered as an ungated top-level surface.
+assert.match(
+  registerRooms,
+  /id: CODE_SURFACE_ID,\s*role: "coder",\s*aliases: \["coding", "developer", "engineer", "programmer", "software-engineer", "code"\]/,
+  "the Code room registers under the coder role with the sanctioned alias set",
+);
+assert.match(
+  registerRooms,
+  /const CodeRoom = dynamic\(\s*\(\) => import\("\.\/code-room"\)\.then\(\(m\) => m\.CodeRoom\)/,
+  "the Code room is code-split — the workbench chunk (CodeMirror et al.) must not join the boot bundle",
+);
+assert.match(
+  codeRoom,
+  /<CodeView\s+sessions=\{context\.runtimeState\.sessions\}/,
+  "the room adapter feeds CodeView the context's familiar-scoped sessions",
+);
+assert.match(
+  codeRoom,
+  /pendingOpen=\{pendingOpen\}\s+onPendingOpenHandled=\{clearPendingCodeOpen\}/,
+  "the room consumes pending file/diff opens from the module store and clears them",
+);
 
 // ── Workspace wiring ─────────────────────────────────────────────────────────
 
@@ -36,18 +65,28 @@ assert.match(
 );
 assert.match(
   workspace,
-  /mode === "code" \|\| mode === "github" \? \([\s\S]{0,300}?<CodeView/,
-  "Workspace renders CodeView on the code mode and the absorbed github alias",
+  /if \(next === "code"\) \{[\s\S]{0,700}?setModeRaw\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
+  "setMode funnels every code entry point (deep links, palette, navigate-mode, persisted restore) into the room",
+);
+assert.match(
+  workspace,
+  /mode === "github" \?[\s\S]{0,400}?<GitHubView/,
+  "Workspace renders the standalone GitHub surface on the canonical github mode",
 );
 assert.match(
   lazySurfaces,
-  /const loadCodeView = \(\) => import\("@\/components\/code-view"\)\.then\(\(m\) => m\.CodeView\)/,
-  "CodeView stays code-split behind lazy-surfaces — its chunk must not join the boot bundle",
+  /export const GitHubView = dynamic\(\s*timed\("github", loadGitHubView\)/,
+  "GitHubView stays code-split behind lazy-surfaces — its chunk must not join the boot bundle",
+);
+assert.doesNotMatch(
+  lazySurfaces,
+  /loadCodeView|export const CodeView/,
+  "no lazy CodeView wrapper survives — the workbench chunk rides the Code room's dynamic import",
 );
 
 // Default-on (cave-m6ys): the build-time flag is retired. No workspace wiring
 // may resurrect a gate in front of the surface, and the vocabulary records
-// GitHub's absorption — "github" is an alias landing on Code's GitHub tab.
+// the room routing — "code" is an alias landing on the surface:code room.
 const featureFlags = await readFile(new URL("../lib/feature-flags.ts", import.meta.url), "utf8");
 assert.doesNotMatch(
   featureFlags,
@@ -61,17 +100,17 @@ assert.doesNotMatch(
 );
 assert.match(
   modeType,
-  /github: "code"/,
-  "MODE_ALIASES routes the absorbed GitHub surface onto Code (cave-m6ys)",
+  /code: "surface:code"/,
+  "MODE_ALIASES routes the code alias onto the Coding familiar's room (cave-cc5r)",
 );
 
 // File/diff links from chat transcripts, inbox cards, the Projects hub —
-// everywhere — land on the Code surface (cave-ohcj): the workspace bridges
-// the events into code mode with the raising chat session attached.
+// everywhere — land on the Code room (cave-ohcj, cave-cc5r): the workspace
+// enqueues into the pending-code-open store and navigates; the room consumes.
 assert.match(
   workspace,
-  /File\/diff links land on the Code surface[\s\S]*?setPendingCodeOpen\([\s\S]*?setMode\("code"\)/,
-  "file-open events route to the Code surface, not Chat's code rail",
+  /File\/diff links land on the Code room[\s\S]*?enqueuePendingCodeOpen\([\s\S]*?setMode\("code"\)/,
+  "file-open events route to the Code room, not Chat's code rail",
 );
 
 // The primary keyboard cluster is unchanged: Code is a quiet destination, not
@@ -84,19 +123,24 @@ assert.match(
 
 // ── Sidebar row ──────────────────────────────────────────────────────────────
 
-// One quiet slot, one vocabulary (cave-m6ys): the Code row owns it and keeps
-// carrying the assigned-work badge; the standalone GitHub row is gone for
-// good — its surface lives under Code's GitHub tab and mode "github" aliases
-// there, so old muscle memory and deep links still land on the content.
+// One quiet slot, one vocabulary (cave-cc5r): the standalone GitHub row is
+// back for every familiar and keeps the assigned-work badge; the Code room's
+// row arrives via the registry-driven roleSurfaces cluster, and the GitHub
+// row hides while the room is visible (the room carries its own GitHub tab).
 assert.match(
   sidebar,
-  /\{ id: "code", label: "Code", iconName: "ph:code"[\s\S]{0,200}?badge: \(p\) => badgeText\(p\.githubAssignedCount\)/,
-  "the Code quiet row owns the slot and carries the assigned-work badge",
+  /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"[\s\S]{0,300}?badge: \(p\) => badgeText\(p\.githubAssignedCount\)/,
+  "the GitHub quiet row owns the slot and carries the assigned-work badge",
 );
 assert.doesNotMatch(
   sidebar,
-  /id: "github"/,
-  "no standalone GitHub row survives in FOLDER_MODES",
+  /\{ id: "code", label: "Code"/,
+  "no static Code row survives in FOLDER_MODES — the room row is registry-driven",
+);
+assert.match(
+  workspace,
+  /hideGithubRow=\{roleSurfaceSession\.visibleSurfaces\.some\(\(s\) => s\.id === CODE_SURFACE_ID\)\}/,
+  "the GitHub row hides while the Code room is visible for the active familiar",
 );
 assert.match(
   codeView,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -53,7 +53,7 @@ type PaletteIntent =
   | { kind: "open-tui-session"; sessionId: string }
   | { kind: "open-board" }
   | { kind: "set-board-view"; view: "kanban" | "table" | "gantt" }
-  | { kind: "go-to-surface"; mode: FolderMode }
+  | { kind: "go-to-surface"; mode: FolderMode | `surface:${string}` }
   | { kind: "open-project"; root: string }
   | { kind: "focus-card"; cardId: string }
   | { kind: "create-task"; title: string }
@@ -98,6 +98,10 @@ type Props = {
   familiars: Familiar[];
   sessions: SessionRow[];
   activeFamiliarId: string | null;
+  /** Role Surface rooms visible for the active familiar — appended to the
+   *  "Go to" launcher rows so ⌘K reaches rooms exactly like sidebar surfaces
+   *  (cave-cc5r). Registry-driven; empty/omitted adds nothing. */
+  roleSurfaces?: readonly { mode: `surface:${string}`; label: string; description: string }[];
   initialQuery?: string;
   onQueryChange?: (query: string) => void;
   onIntent: (intent: PaletteIntent) => void;
@@ -160,6 +164,7 @@ export function CommandPalette({
   familiars,
   sessions,
   activeFamiliarId,
+  roleSurfaces,
   initialQuery = "",
   onQueryChange,
   onIntent,
@@ -478,10 +483,12 @@ export function CommandPalette({
 
     // "Go to <surface>" rows make ⌘K a launcher for the visible sidebar
     // surfaces. Hidden while typing a slash command or a familiar scope (where
-    // surface nav would be noise).
+    // surface nav would be noise). Role Surface rooms (cave-cc5r) append with
+    // the same treatment so "Go to Code Workshop" works like any surface.
     const surfaceRows: Row[] = (scoped || slashToken)
       ? []
-      : rank(FOLDER_MODES
+      : [
+          ...rank(FOLDER_MODES
           // Fuzzy on the short label/id; substring-only on the long description
           // (subsequence-matching prose surfaces irrelevant items).
           .filter((fm) => !q || fz(fm.label) || fz(fm.id) || fm.description.toLowerCase().includes(q)),
@@ -491,8 +498,21 @@ export function CommandPalette({
             kind: "command" as const,
             name: `Go to ${fm.label}`,
             hint: fm.kbd ? `${fm.description} · ${fm.kbd}` : fm.description,
-            intent: { kind: "go-to-surface", mode: fm.id },
-          }));
+            intent: { kind: "go-to-surface", mode: fm.id } as PaletteIntent,
+          })),
+          ...rank(
+            (roleSurfaces ?? []).filter(
+              (room) => !q || fz(room.label) || room.description.toLowerCase().includes(q),
+            ),
+            (room) => [room.label],
+          ).map((room) => ({
+            id: `room:${room.mode}`,
+            kind: "command" as const,
+            name: `Go to ${room.label}`,
+            hint: room.description,
+            intent: { kind: "go-to-surface", mode: room.mode } as PaletteIntent,
+          })),
+        ];
 
     // "Open project <name>" rows jump into a project's chats (the Projects tab,
     // expanded + scrolled to that project). Hidden while scoped or typing slash.
@@ -584,7 +604,7 @@ export function CommandPalette({
     // Salem row is still rows[0], so unmatched queries keep their one-Enter
     // AI path.
     return [...localRows, ...salemRows];
-  }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects]);
+  }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects, roleSurfaces]);
 
   const counts = useMemo(() => paletteResultCounts(allRows), [allRows]);
   const rows = useMemo(

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -8,6 +8,8 @@ import {
   useFamiliarOverrides,
   type FamiliarOverride,
 } from "@/lib/cave-familiar-overrides";
+import { FAMILIAR_TYPES, resolveFamiliarType } from "@/lib/familiar-types";
+import { Icon } from "@/lib/icon";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type Props = {
@@ -33,6 +35,7 @@ export function FamiliarStudioIdentityTab({ familiar, rawDaemonValues }: Props) 
 
   return (
     <div className="familiar-studio-identity">
+      <FamiliarTypePicker familiar={familiar} />
       {FIELDS.map((f) => (
         <IdentityField
           key={`${familiar.id}:${f.key}`}
@@ -45,6 +48,47 @@ export function FamiliarStudioIdentityTab({ familiar, rawDaemonValues }: Props) 
           onReset={() => clearFamiliarOverrideField(familiar.id, f.key)}
         />
       ))}
+    </div>
+  );
+}
+
+/**
+ * The explicit familiar Type picker (cave-cc5r): a chip radio-row over the
+ * static FAMILIAR_TYPES table. The choice is stored as a Cave override
+ * (`familiarType`) and synced to cave-config like every other identity field;
+ * it ADDS the type's role token to the familiar's Role Surface grants, so the
+ * free-text Role label below keeps working exactly as before. Picking General
+ * (the default) clears the override.
+ */
+function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
+  const selected = resolveFamiliarType(familiar.familiarType);
+  const labelId = `familiar-type-label-${familiar.id}`;
+  return (
+    <div className="familiar-studio-identity__row">
+      <span className="familiar-studio-identity__label" id={labelId}>
+        Type
+      </span>
+      <div role="radiogroup" aria-labelledby={labelId} className="familiar-studio-identity__types">
+        {FAMILIAR_TYPES.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="radio"
+            aria-checked={selected.id === t.id}
+            title={t.description}
+            className={`focus-ring familiar-studio-type-chip${selected.id === t.id ? " familiar-studio-type-chip--active" : ""}`}
+            onClick={() =>
+              setFamiliarOverride(familiar.id, {
+                familiarType: t.id === "general" ? "" : t.id,
+              })
+            }
+          >
+            <Icon name={t.iconName} width={12} height={12} aria-hidden />
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <p className="familiar-studio-identity__hint">{selected.description}</p>
     </div>
   );
 }

--- a/src/components/github-native-open.test.ts
+++ b/src/components/github-native-open.test.ts
@@ -36,12 +36,12 @@ assert.match(
 );
 assert.match(
   workspace,
-  /<CodeView[\s\S]{0,300}githubTarget=\{githubTarget\}/,
-  "the Code surface receives the deep-link target (GitHub is its tab, cave-m6ys)",
+  /<GitHubView[\s\S]{0,300}initialTarget=\{githubTarget\}/,
+  "the standalone GitHub surface receives the deep-link target (cave-cc5r)",
 );
 assert.match(
   workspace,
-  /if \(mode !== "github" && mode !== "code" && githubTarget\) setGithubTarget\(null\);/,
+  /if \(mode !== "github" && githubTarget\) setGithubTarget\(null\);/,
   "leaving the surface clears the target so later visits don't re-open a stale item",
 );
 

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -64,7 +64,6 @@ function timed<C>(name: string, loader: () => Promise<C>): () => Promise<C> {
 // warm-up must call the loaders directly to fetch a sidebar's chunks without
 // mounting the surface (and therefore without running any of its effects).
 const loadGitHubView = () => import("@/components/github-view").then((m) => m.GitHubView);
-const loadCodeView = () => import("@/components/code-view").then((m) => m.CodeView);
 const loadCalendarView = () => import("@/components/calendar-view").then((m) => m.CalendarView);
 const loadBoardView = () => import("@/components/board-view").then((m) => m.BoardView);
 const loadMarketplaceView = () =>
@@ -88,17 +87,18 @@ export type WarmableSidebarSurface =
   | "grimoire"
   | "agents";
 
-// The standalone GitHubView dynamic wrapper is gone (cave-m6ys): GitHub
-// mounts only as Code's GitHub tab (code-view.tsx owns that lazy import).
-// loadGitHubView stays for preloadSidebarSurface — warming the chunk still
-// pays off when the user opens the tab.
-
-// Code surface (cave-k0ua): hosts diffs, file tree + editor, terminal and the
-// GitHub tab — its chunk (CodeMirror et al.) must stay out of the boot bundle.
-export const CodeView = dynamic(
-  timed("code", loadCodeView),
+// The standalone GitHubView surface is back (cave-cc5r): the Code workbench
+// moved into the Coding familiar's Role Surface room, and every familiar
+// keeps GitHub as its own canonical surface again. loadGitHubView also feeds
+// preloadSidebarSurface — warming the chunk before the row is clicked.
+export const GitHubView = dynamic(
+  timed("github", loadGitHubView),
   { ssr: false, loading: SurfaceFallback },
 );
+
+// The Code workbench chunk (CodeMirror et al.) now rides the Code room's
+// dynamic import (role-surfaces/register.tsx → code-room.tsx), keeping it out
+// of the boot bundle without a wrapper here.
 
 export const CalendarView = dynamic(
   timed("calendar", loadCalendarView),

--- a/src/components/role-surfaces/code-room.tsx
+++ b/src/components/role-surfaces/code-room.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * Code Workshop — the Coding familiar's room (cave-cc5r).
+ *
+ * A thin adapter that mounts the existing CodeView inside the Role Surface
+ * chrome. The workbench itself is unchanged; this file only translates the
+ * room contract (RoleSurfaceContext) into CodeView's props:
+ *
+ *  - sessions come familiar-scoped from the context (the active familiar's
+ *    own sessions plus unattributed ones), so the room's rail reads as "your
+ *    coding familiar's work" rather than the whole Cave;
+ *  - navigation and shell services (open a chat session, spotlight a Board
+ *    card, refresh GitHub feeds) ride the context's generic callbacks;
+ *  - file/diff opens raised anywhere in the shell arrive through the
+ *    pending-code-open module store — Workspace enqueues + navigates here,
+ *    the room consumes.
+ *
+ * GitHub-item URL opens (`githubTarget`) intentionally stay OUT of the room:
+ * they land on the standalone GitHub surface, which every familiar keeps.
+ */
+
+import { useSyncExternalStore } from "react";
+import { CodeView } from "@/components/code-view";
+import {
+  clearPendingCodeOpen,
+  getPendingCodeOpen,
+  subscribePendingCodeOpen,
+} from "@/lib/pending-code-open";
+import type { RoleSurfaceContext } from "@/lib/role-surfaces";
+
+export function CodeRoom({ context }: { context: RoleSurfaceContext }) {
+  const pendingOpen = useSyncExternalStore(
+    subscribePendingCodeOpen,
+    getPendingCodeOpen,
+    () => null,
+  );
+  return (
+    <CodeView
+      sessions={context.runtimeState.sessions}
+      onJumpToSession={(sessionId, familiarId) => context.openSession(sessionId, familiarId ?? undefined)}
+      onFocusCard={context.focusCard}
+      pendingOpen={pendingOpen}
+      onPendingOpenHandled={clearPendingCodeOpen}
+      onTasksRefresh={context.refreshTasks}
+    />
+  );
+}

--- a/src/components/role-surfaces/ids.ts
+++ b/src/components/role-surfaces/ids.ts
@@ -9,3 +9,4 @@ export const SENTINEL_SURFACE_ID = "sentinel-watchtower";
 export const SCRIBE_SURFACE_ID = "scribe-writing-desk";
 export const NAVIGATOR_SURFACE_ID = "navigator-chart-room";
 export const REVIEWER_SURFACE_ID = "reviewer-review-deck";
+export const CODE_SURFACE_ID = "code";

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -27,6 +27,7 @@ import { deskSummary, scribeStatus } from "./scribe-craft";
 import { chartRoomStatus } from "./navigator-charts";
 import { reviewDeckStatus } from "./review-deck";
 import {
+  CODE_SURFACE_ID,
   INDEXER_SURFACE_ID,
   MESSENGER_SURFACE_ID,
   NAVIGATOR_SURFACE_ID,
@@ -72,6 +73,10 @@ const ReviewerSurface = dynamic(
   () => import("./reviewer-surface").then((m) => m.ReviewerSurface),
   { ssr: false, loading: RoomFallback },
 );
+const CodeRoom = dynamic(
+  () => import("./code-room").then((m) => m.CodeRoom),
+  { ssr: false, loading: RoomFallback },
+);
 
 /** Flip the shared `drawerOpen` bit of a room's persisted state. The state
  *  hooks shallow-merge stored partials over their initial state, so partial
@@ -111,6 +116,36 @@ registerRoleSurface({
     };
   },
   render: (context) => <ResearcherSurface context={context} />,
+});
+
+// The Coding familiar's room (cave-cc5r): the full Code workbench, granted by
+// the "coder" role token — the Studio's Coding type or a role label carrying
+// any of the aliases below. GitHub-item opens stay on the standalone GitHub
+// surface, which every familiar keeps.
+registerRoleSurface({
+  id: CODE_SURFACE_ID,
+  role: "coder",
+  aliases: ["coding", "developer", "engineer", "programmer", "software-engineer", "code"],
+  title: "Code Workshop",
+  iconName: "ph:code",
+  description: "Multi-session coding workbench — diffs, files, terminals, branches, and GitHub",
+  accentHue: 250,
+  priority: 40,
+  shouldDisplay: () => true,
+  getContributions(context) {
+    return {
+      notifications: daemonNotices(context),
+      statusIndicators: [
+        {
+          id: "code.engine",
+          label: context.runtimeState.daemonRunning ? "workbench live" : "workbench offline",
+          tone: context.runtimeState.daemonRunning ? "ok" : "warn",
+          detail: "Sessions, diffs, and terminals ride the familiar's live daemon",
+        },
+      ],
+    };
+  },
+  render: (context) => <CodeRoom context={context} />,
 });
 
 registerRoleSurface({

--- a/src/components/settings-action-buttons.test.ts
+++ b/src/components/settings-action-buttons.test.ts
@@ -46,7 +46,7 @@ function jsxElementBlocks(fileName: string, source: string, tagName: string): st
 }
 
 const reviewedSemanticControl = (button: string): boolean =>
-  /goToSetting\(e\)|selectDevice\(device\)|settings-nav__item|role="switch"|aria-pressed=|aria-label=\{`Pick \$\{label\} color`\}|aria-haspopup="dialog"|role="option"|setEnlarged\(true\)|Drag to reorder|familiar-studio-lifecycle__row-main/.test(
+  /goToSetting\(e\)|selectDevice\(device\)|settings-nav__item|role="switch"|aria-pressed=|aria-label=\{`Pick \$\{label\} color`\}|aria-haspopup="dialog"|role="option"|role="radio"|setEnlarged\(true\)|Drag to reorder|familiar-studio-lifecycle__row-main/.test(
     button,
   );
 

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -79,8 +79,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /VISIBLE_MODES\.map\(\(fm, i\) =>/,
-  "Sidebar renders the visible folder modes (navHidden surfaces filtered out)",
+  /props\.hideGithubRow \? VISIBLE_MODES\.filter\(\(fm\) => fm\.id !== "github"\) : VISIBLE_MODES/,
+  "Sidebar renders the visible folder modes, dropping the GitHub row while the Code room already carries a GitHub tab (cave-cc5r)",
 );
 assert.match(
   source,
@@ -292,8 +292,13 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "code", label: "Code", iconName: "ph:code"/,
-  "Code is visible by default (GitHub lives on its GitHub tab, cave-m6ys)",
+  /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"/,
+  "The standalone GitHub row is back (cave-cc5r): Code lives in the Coding familiar's room",
+);
+assert.doesNotMatch(
+  source,
+  /\{ id: "code", label: "Code"/,
+  "Code is no longer a static folder row — the Coding familiar's room row arrives via roleSurfaces (cave-cc5r)",
 );
 
 // Recent Activity items must navigate: RecentActivityRollup's onClick calls
@@ -452,8 +457,8 @@ assert.match(
 );
 assert.match(
   source,
-  /quietLead=\{Boolean\(fm\.quiet\) && !VISIBLE_MODES\[i - 1\]\?\.quiet\}/,
-  "the first quiet row opens the spacing gap (indexed on the VISIBLE list)",
+  /quietLead=\{Boolean\(fm\.quiet\) && !rows\[i - 1\]\?\.quiet\}/,
+  "the first quiet row opens the spacing gap (indexed on the RENDERED list, which may drop the GitHub row)",
 );
 assert.match(
   styles,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -73,6 +73,10 @@ export type SidebarMinimalProps = {
   boardOpenCount?: number;
   scheduleNeedsCount?: number;
   githubAssignedCount?: number;
+  /** Hide the standalone GitHub row while the Code room is visible for the
+   *  active familiar (cave-cc5r) — the room carries its own GitHub tab, so
+   *  both rows at once would double-list the same content. */
+  hideGithubRow?: boolean;
 };
 
 // Format a count as a compact nav badge; 0/undefined yields no badge.
@@ -131,11 +135,12 @@ const FOLDER_MODES: Array<FolderModeRow> = [
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
   //
-  // Code (cave-k0ua, default-on since cave-m6ys): the Codex-style coding
-  // surface owns this quiet slot; GitHub is a tab inside it (the row keeps
-  // carrying the assigned-work badge). The standalone GitHub row is gone —
-  // mode "github" is a tab alias that lands on Code's GitHub tab.
-  { id: "code", label: "Code", iconName: "ph:code", description: "Multi-session coding — diffs, files, branches, worktrees, and GitHub", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
+  // GitHub — the standalone assigned-work surface, restored when the Code
+  // workbench moved into the Coding familiar's room (cave-cc5r). Every
+  // familiar keeps this row (with the assigned-work badge) EXCEPT while the
+  // Code room is visible for the active familiar — the room carries its own
+  // GitHub tab, so the workspace passes hideGithubRow to avoid double-listing.
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Assigned PRs, issues, and review requests across your repos", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
 ];
 
 // Rows actually rendered in the sidebar — everything except on-demand surfaces
@@ -287,7 +292,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        {VISIBLE_MODES.map((fm, i) => (
+        {(props.hideGithubRow ? VISIBLE_MODES.filter((fm) => fm.id !== "github") : VISIBLE_MODES).map((fm, i, rows) => (
           <FolderRow
             key={fm.id}
             id={fm.id}
@@ -301,9 +306,9 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             kbd={fm.kbd}
             description={fm.description}
             quiet={fm.quiet}
-            // Index the VISIBLE list, not FOLDER_MODES — a navHidden entry between
-            // quiet rows must not throw off the "first quiet row" gap.
-            quietLead={Boolean(fm.quiet) && !VISIBLE_MODES[i - 1]?.quiet}
+            // Index the RENDERED list — a navHidden or hidden-GitHub entry
+            // between quiet rows must not throw off the "first quiet row" gap.
+            quietLead={Boolean(fm.quiet) && !rows[i - 1]?.quiet}
             onClick={() => handleModeSelect(fm.id)}
           />
         ))}

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -62,11 +62,21 @@ assert.match(
   "the roles/capabilities aliases render the Marketplace hub on their sections (keyed remount)",
 );
 
-assert.equal(MODE_ALIASES.github, "code");
+assert.equal(MODE_ALIASES.code, "surface:code");
 assert.match(
   workspace,
-  /mode === "code" \|\| mode === "github"[\s\S]{0,500}?<CodeView\s+key=\{mode\}[\s\S]{0,200}?initialTopTab=\{mode === "github" \? "github" : undefined\}/,
-  "the github alias renders the Code surface on its GitHub tab (keyed remount, cave-m6ys)",
+  /if \(next === "code"\) \{[\s\S]{0,700}?setModeRaw\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
+  'setMode\'s "code" branch must land on the Coding familiar\'s room (MODE_ALIASES.code = "surface:code", cave-cc5r)',
+);
+assert.match(
+  workspace,
+  /mode === "github" \?[\s\S]{0,500}?<GitHubView[\s\S]{0,300}?initialTarget=\{githubTarget\}/,
+  "the canonical github mode renders the standalone GitHub surface with its deep-link target (cave-cc5r)",
+);
+assert.doesNotMatch(
+  workspace,
+  /mode === "code" \|\| mode === "github"/,
+  "the old combined Code/GitHub render branch is gone — Code renders inside the Role Surface room",
 );
 
 // ── Every mode-string entry point validates/routes through the shared

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -12,6 +12,7 @@ const codeWorkbench = await readFile(new URL("./code-workbench.tsx", import.meta
 const codeWorkbenchFiles = await readFile(new URL("./code-workbench-files.tsx", import.meta.url), "utf8");
 const workspaceRail = await readFile(new URL("./workspace-rail.tsx", import.meta.url), "utf8");
 const railFilesPanel = await readFile(new URL("./rail-files-panel.tsx", import.meta.url), "utf8");
+const codeRoom = await readFile(new URL("./role-surfaces/code-room.tsx", import.meta.url), "utf8");
 
 assert.match(
   pendingChatActionLib,
@@ -132,8 +133,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /import type \{ PendingCodeOpen \} from "@\/lib\/pending-code-open"/,
-  "Workspace should import the shared pending code open type",
+  /import \{ enqueuePendingCodeOpen, type PendingCodeOpen \} from "@\/lib\/pending-code-open"/,
+  "Workspace should import the shared pending code open store",
 );
 assert.doesNotMatch(
   chatSurface,
@@ -141,9 +142,9 @@ assert.doesNotMatch(
   "ChatSurface no longer participates in file/diff open routing (cave-ohcj)",
 );
 assert.match(
-  workspace,
-  /const \[pendingCodeOpen, setPendingCodeOpen\] = useState<PendingCodeOpen \| null>\(null\)/,
-  "Workspace should retain file/diff open detail across the mode switch into code",
+  pendingCodeOpenLib,
+  /export function enqueuePendingCodeOpen[\s\S]*export function clearPendingCodeOpen[\s\S]*export function subscribePendingCodeOpen/,
+  "the module store retains file/diff open detail across the mode switch into the room (cave-cc5r)",
 );
 assert.match(
   workspace,
@@ -152,13 +153,13 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const sessionId = activeChatSessionIdRef\.current \?\? undefined;[\s\S]*setPendingCodeOpen\([\s\S]*kind === "files"[\s\S]*path: detail\.path[\s\S]*line: detail\.line[\s\S]*sessionId[\s\S]*path: detail\.path[\s\S]*sessionId[\s\S]*nonce: Date\.now\(\)[\s\S]*\);[\s\S]*setMode\("code"\)/,
+  /const sessionId = activeChatSessionIdRef\.current \?\? undefined;[\s\S]*enqueuePendingCodeOpen\([\s\S]*kind === "files"[\s\S]*path: detail\.path[\s\S]*line: detail\.line[\s\S]*sessionId[\s\S]*path: detail\.path[\s\S]*sessionId[\s\S]*nonce: Date\.now\(\)[\s\S]*\);[\s\S]*setMode\("code"\)/,
   "Workspace should attach the raising chat session and switch into code mode",
 );
 assert.match(
-  workspace,
-  /pendingOpen=\{pendingCodeOpen\}[\s\S]*onPendingOpenHandled=\{\(\) => setPendingCodeOpen\(null\)\}/,
-  "Workspace should pass pending file/diff opens into CodeView and clear them after consumption",
+  codeRoom,
+  /pendingOpen=\{pendingOpen\}[\s\S]*onPendingOpenHandled=\{clearPendingCodeOpen\}/,
+  "the Code room should pass pending file/diff opens into CodeView and clear them after consumption",
 );
 assert.match(
   railController,
@@ -222,7 +223,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /onBrowseProjectFiles = \(e: Event\) => \{[\s\S]*if \(!detail\?\.root\) return;[\s\S]*setPendingCodeOpen\(\{ kind: "files", root: detail\.root, nonce: Date\.now\(\) \}\)[\s\S]*setMode\("code"\)/,
+  /onBrowseProjectFiles = \(e: Event\) => \{[\s\S]*if \(!detail\?\.root\) return;[\s\S]*enqueuePendingCodeOpen\(\{ kind: "files", root: detail\.root, nonce: Date\.now\(\) \}\)[\s\S]*setMode\("code"\)/,
   "Workspace preserves the browse root and switches to code",
 );
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -72,7 +72,7 @@ import {
   FamiliarsView,
   FamiliarWorkQueueView,
   FamiliarGlyphPicker,
-  CodeView,
+  GitHubView,
   GrimoireView,
   InboxEscalationsView,
   MarketplaceView,
@@ -117,6 +117,7 @@ import {
 } from "@/lib/role-surfaces";
 import { useRoleSurfaceSession } from "@/lib/use-role-surfaces";
 import { RoleSurfaceHost } from "@/components/role-surface-host";
+import { CODE_SURFACE_ID } from "@/components/role-surfaces/ids";
 // Role Surfaces self-register via this manifest — the shell only ever handles
 // the generic `surface:<id>` mode and never names a role.
 import "@/components/role-surfaces/register";
@@ -143,7 +144,7 @@ import {
 } from "@/lib/first-project-gate-retry";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
 import { consumePendingAgentsNewChat } from "@/lib/agents-new-chat";
-import type { PendingCodeOpen } from "@/lib/pending-code-open";
+import { enqueuePendingCodeOpen, type PendingCodeOpen } from "@/lib/pending-code-open";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import { startVoiceConversation, voiceChatStartErrorMessage } from "@/lib/voice/start-voice-chat";
 import {
@@ -365,6 +366,15 @@ export function Workspace() {
       setModeRaw("inbox");
       return;
     }
+    if (next === "code") {
+      // Code is the Coding familiar's room (cave-cc5r): every legacy entry
+      // point (?mode=code deep links, palette intents, cave:navigate-mode,
+      // persisted last-surface) funnels onto the registered Role Surface, so
+      // `mode` state never holds "code". Familiars without the coder role hit
+      // RoleSurfaceHost's explicit closed-room door.
+      setModeRaw(roleSurfaceMode(CODE_SURFACE_ID));
+      return;
+    }
     setModeRaw(next);
   }, []);
   // Chat mode replaces the global nav with the project-grouped Chats sidebar.
@@ -471,7 +481,6 @@ export function Workspace() {
   // attach the CURRENT session without re-subscribing on every change.
   const activeChatSessionIdRef = useRef<string | null>(null);
   activeChatSessionIdRef.current = activeChatSessionId;
-  const [pendingCodeOpen, setPendingCodeOpen] = useState<PendingCodeOpen | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [onboardingResolved, setOnboardingResolved] = useState(false);
   const [autoFinishOnboarding, setAutoFinishOnboarding] = useState(false);
@@ -507,13 +516,12 @@ export function Workspace() {
   }>({ fireAt: "", title: "", whenText: "" });
   const [editingReminder, setEditingReminder] = useState<InboxItem | null>(null);
   // Deep-link target for the native GitHub surface (a GitHub-event inbox
-  // notification's PR/issue). GitHub lives on the Code surface's GitHub tab
-  // (cave-m6ys), so the target survives within the whole surface — mode
-  // "github" (the tab alias) or "code" — and clears on leaving it so a later
-  // manual visit doesn't re-open a stale item.
+  // notification's PR/issue). The standalone GitHub surface hosts it for every
+  // familiar (cave-cc5r); the target clears on leaving so a later manual visit
+  // doesn't re-open a stale item.
   const [githubTarget, setGithubTarget] = useState<GitHubItemTarget | null>(null);
   useEffect(() => {
-    if (mode !== "github" && mode !== "code" && githubTarget) setGithubTarget(null);
+    if (mode !== "github" && githubTarget) setGithubTarget(null);
   }, [mode, githubTarget]);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
@@ -787,16 +795,18 @@ export function Workspace() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // File/diff links land on the Code surface (cave-ohcj): every open — from
-  // chat transcripts, the Projects hub, anywhere — routes into code mode with
-  // the raising chat session attached so CodeView can select its workbench.
-  // The event detail is preserved in state until CodeView mounts.
+  // File/diff links land on the Code room (cave-ohcj, cave-cc5r): every open —
+  // from chat transcripts, the Projects hub, anywhere — enqueues into the
+  // pending-code-open module store and navigates to the coder's room, where
+  // CodeRoom consumes it. The store preserves the detail until CodeView
+  // mounts; non-coding familiars hit the room's closed door with the open
+  // left pending.
   useEffect(() => {
     const enqueue = (kind: PendingCodeOpen["kind"], e: Event) => {
       const detail = (e as CustomEvent<{ path?: string; line?: number }>).detail;
       if (!detail?.path) return;
       const sessionId = activeChatSessionIdRef.current ?? undefined;
-      setPendingCodeOpen(
+      enqueuePendingCodeOpen(
         kind === "files"
           ? { kind, path: detail.path, line: detail.line, sessionId, nonce: Date.now() }
           : { kind, path: detail.path, sessionId, nonce: Date.now() },
@@ -811,7 +821,7 @@ export function Workspace() {
     const onBrowseProjectFiles = (e: Event) => {
       const detail = (e as CustomEvent<{ root?: string }>).detail;
       if (!detail?.root) return;
-      setPendingCodeOpen({ kind: "files", root: detail.root, nonce: Date.now() });
+      enqueuePendingCodeOpen({ kind: "files", root: detail.root, nonce: Date.now() });
       setMode("code");
     };
     window.addEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
@@ -2503,6 +2513,16 @@ export function Workspace() {
   // Role Surfaces: build the shared context from the live session and resolve
   // which registered surfaces the active familiar should see. Entirely
   // registry-driven — the shell never branches on a specific role.
+  // `onPaletteIntent` is re-created every render, so the room's focus-card
+  // service goes through a ref to keep the context identity stable.
+  const onPaletteIntentRef = useRef<(intent: PaletteIntent) => void>(() => {});
+  onPaletteIntentRef.current = onPaletteIntent;
+  const focusCardFromRoom = useCallback((cardId: string) => {
+    onPaletteIntentRef.current({ kind: "focus-card", cardId });
+  }, []);
+  const refreshTasksFromRoom = useCallback(() => {
+    void loadGitHubTasks(true);
+  }, [loadGitHubTasks]);
   const roleSurfaceSession = useRoleSurfaceSession({
     familiar: active,
     sessions,
@@ -2510,6 +2530,8 @@ export function Workspace() {
     daemonRunning,
     openUrl: openUrlInAppBrowser,
     openSession: openFamiliarSession,
+    focusCard: focusCardFromRoom,
+    refreshTasks: refreshTasksFromRoom,
   });
 
   // If the current mode is a Role Surface this familiar can't see (role
@@ -2616,6 +2638,9 @@ export function Workspace() {
       boardOpenCount={boardTaskCount}
       scheduleNeedsCount={scheduleNeedsCount}
       githubAssignedCount={githubAssignedCount}
+      // The Code room carries its own GitHub tab — hide the standalone row
+      // while the room is visible for the active familiar (cave-cc5r).
+      hideGithubRow={roleSurfaceSession.visibleSurfaces.some((s) => s.id === CODE_SURFACE_ID)}
     />
   );
 
@@ -2836,19 +2861,14 @@ export function Workspace() {
         navigationRequest={browserNavigationQueue[0] ?? null}
         onNavigationConsumed={acknowledgeBrowserNavigation}
       />
-    ) : mode === "code" || mode === "github" ? (
-      // "github" is a tab alias (cave-m6ys): the standalone surface was
-      // absorbed as Code's GitHub tab. Keyed remount so ?mode=github deep
-      // links land on the tab even when Code is already the active surface.
-      <CodeView
-        key={mode}
-        sessions={sessions}
-        initialTopTab={mode === "github" ? "github" : undefined}
+    ) : mode === "github" ? (
+      // Standalone GitHub surface — every familiar keeps it (cave-cc5r). The
+      // Code workbench (which carries its own GitHub tab) lives in the Coding
+      // familiar's room; GitHub-item deep links land here for everyone.
+      <GitHubView
         onJumpToSession={openFamiliarSession}
         onFocusCard={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-        githubTarget={githubTarget}
-        pendingOpen={pendingCodeOpen}
-        onPendingOpenHandled={() => setPendingCodeOpen(null)}
+        initialTarget={githubTarget}
         onTasksRefresh={() => void loadGitHubTasks(true)}
       />
     ) : mode === "marketplace" || mode === "roles" || mode === "capabilities" ? (
@@ -3115,6 +3135,11 @@ export function Workspace() {
           familiars={familiars}
           sessions={sessions}
           activeFamiliarId={activeId}
+          roleSurfaces={roleSurfaceSession.visibleSurfaces.map((surface) => ({
+            mode: roleSurfaceMode(surface.id),
+            label: surface.title,
+            description: surface.description,
+          }))}
           initialQuery={topSearchQuery}
           onQueryChange={setTopSearchQuery}
           onIntent={onPaletteIntent}

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -159,6 +159,8 @@ export type FamiliarBinding = {
   model: string;
   display_name?: string;
   role?: string;
+  /** Explicit familiar Type id (familiar-types.ts). Absent = "general". */
+  familiarType?: string;
   pronouns?: string;
   description?: string;
   color?: string;
@@ -574,6 +576,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
     model: f.model ?? config.defaults.model,
     display_name: f.display_name,
     role: f.role,
+    familiarType: f.familiarType,
     pronouns: f.pronouns,
     description: f.description,
     color: f.color,

--- a/src/lib/cave-familiar-overrides.ts
+++ b/src/lib/cave-familiar-overrides.ts
@@ -20,6 +20,8 @@ const OVERRIDES_KEY = "cave:familiar-overrides:v1";
 export type FamiliarOverride = {
   display_name?: string;
   role?: string;
+  /** Explicit familiar Type id (familiar-types.ts). Empty string clears. */
+  familiarType?: string;
   pronouns?: string;
   description?: string;
   /** CSS color string (hex, oklch, named). Drives the rail accent ring. */

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -52,6 +52,7 @@ export function resolveFamiliar(base: Familiar, ctx: ResolveContext): ResolvedFa
     ...base,
     display_name: ov.display_name ?? base.display_name,
     role: ov.role ?? base.role,
+    familiarType: ov.familiarType ?? base.familiarType,
     pronouns: ov.pronouns ?? base.pronouns,
     description: ov.description ?? base.description,
     color: ov.color ?? base.color ?? "var(--accent-presence)",

--- a/src/lib/familiar-types.test.ts
+++ b/src/lib/familiar-types.test.ts
@@ -1,0 +1,97 @@
+// familiar-types (cave-cc5r): the explicit familiar Type vocabulary that
+// unlocks Role Surface rooms. The table is the single documented mapping from
+// the Studio's Type picker to room grants, so these tests pin its shape and
+// its integration with familiarRoleIds/surfaceMatchesRoles.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_FAMILIAR_TYPE,
+  FAMILIAR_TYPES,
+  familiarTypeRoleIds,
+  isFamiliarTypeId,
+  resolveFamiliarType,
+} from "./familiar-types.ts";
+import { familiarRoleIds, normalizeRoleId, surfaceMatchesRoles } from "./role-surfaces.ts";
+
+test("General is the explicit default and grants no room", () => {
+  assert.equal(DEFAULT_FAMILIAR_TYPE, "general");
+  assert.equal(FAMILIAR_TYPES[0].id, "general");
+  assert.equal(FAMILIAR_TYPES[0].roleToken, null);
+  assert.deepEqual(familiarTypeRoleIds("general"), []);
+  assert.deepEqual(familiarTypeRoleIds(undefined), []);
+  assert.deepEqual(familiarTypeRoleIds(null), []);
+});
+
+test("every non-General type grants its room's role token", () => {
+  const tokens = Object.fromEntries(
+    FAMILIAR_TYPES.filter((t) => t.roleToken).map((t) => [t.id, t.roleToken]),
+  );
+  // The registered rooms' roles (role-surfaces/register.tsx). If a room's
+  // role changes, this table — the Studio picker's contract — must follow.
+  assert.deepEqual(tokens, {
+    coding: "coder",
+    research: "researcher",
+    review: "reviewer",
+    writing: "scribe",
+    comms: "messenger",
+    watch: "sentinel",
+    planning: "navigator",
+    indexing: "indexer",
+  });
+});
+
+test("role tokens are already normalizeRoleId-shaped", () => {
+  for (const t of FAMILIAR_TYPES) {
+    assert.equal(t.id, normalizeRoleId(t.id));
+    if (t.roleToken) assert.equal(t.roleToken, normalizeRoleId(t.roleToken));
+    assert.ok(t.label.length > 0);
+    assert.ok(t.description.length > 0);
+  }
+});
+
+test("resolveFamiliarType falls back to General on unknown/stale values", () => {
+  assert.equal(resolveFamiliarType("coding").id, "coding");
+  assert.equal(resolveFamiliarType(" CODING ").id, "coding");
+  assert.equal(resolveFamiliarType("retired-type").id, "general");
+  assert.equal(resolveFamiliarType("").id, "general");
+  assert.equal(resolveFamiliarType(undefined).id, "general");
+  assert.ok(isFamiliarTypeId("coding"));
+  assert.ok(!isFamiliarTypeId("coder")); // token, not a type id
+});
+
+test("familiarTypeRoleIds grants the type id AND its role token", () => {
+  assert.deepEqual(familiarTypeRoleIds("coding"), ["coding", "coder"]);
+  assert.deepEqual(familiarTypeRoleIds("research"), ["research", "researcher"]);
+});
+
+// ── Integration with the Role Surface matcher ────────────────────────────────
+
+const codeRoomShape = {
+  role: "coder",
+  aliases: ["coding", "developer", "engineer", "programmer", "software-engineer", "code"],
+};
+
+test("an explicit Coding type unlocks the Code room without touching the role label", () => {
+  const ids = familiarRoleIds({ id: "fam-1", role: "Orchestrator", familiarType: "coding" });
+  assert.ok(surfaceMatchesRoles(codeRoomShape, ids));
+});
+
+test("a coder role label keeps granting with no type set (types add, never subtract)", () => {
+  const byLabel = familiarRoleIds({ id: "fam-1", role: "Software Engineer" });
+  assert.ok(surfaceMatchesRoles(codeRoomShape, byLabel));
+  const byPreset = familiarRoleIds({ id: "fam-2", role: "Code reviewer" });
+  assert.ok(surfaceMatchesRoles(codeRoomShape, byPreset));
+});
+
+test("a General/absent type grants nothing extra", () => {
+  const ids = familiarRoleIds({ id: "fam-1", role: "Orchestrator", familiarType: "general" });
+  assert.ok(!surfaceMatchesRoles(codeRoomShape, ids));
+  const noType = familiarRoleIds({ id: "fam-1", role: "Orchestrator" });
+  assert.ok(!surfaceMatchesRoles(codeRoomShape, noType));
+});
+
+test("a non-coding type still unlocks its own room", () => {
+  const ids = familiarRoleIds({ id: "fam-1", role: "Orchestrator", familiarType: "research" });
+  assert.ok(surfaceMatchesRoles({ role: "researcher" }, ids));
+  assert.ok(!surfaceMatchesRoles(codeRoomShape, ids));
+});

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -1,0 +1,73 @@
+/**
+ * familiar-types — the Cave's explicit familiar Type vocabulary (cave-cc5r).
+ *
+ * A familiar's *type* is an explicit, user-modifiable vocation that unlocks
+ * Role Surface rooms — the same matching machinery the free-text Role label
+ * feeds, made visible and deliberate. Each type grants one role token; the
+ * room registry (role-surfaces.ts) matches surfaces against the combined set,
+ * so types ADD grants and never subtract what a role label already gives.
+ *
+ * The table is static on purpose: it is the single documented mapping from
+ * "what the user picks in Familiar Studio → Identity" to "which room opens",
+ * unit-testable without the component registry.
+ */
+
+import type { IconName } from "./icon.tsx";
+
+export type FamiliarTypeId =
+  | "general"
+  | "coding"
+  | "research"
+  | "review"
+  | "writing"
+  | "comms"
+  | "watch"
+  | "planning"
+  | "indexing";
+
+export type FamiliarTypeSpec = {
+  id: FamiliarTypeId;
+  label: string;
+  /** The role token this type grants (matched against RoleSurface.role /
+   *  aliases after normalizeRoleId). Null for General — no room. */
+  roleToken: string | null;
+  /** One-line unlock description shown under the Identity-tab picker. */
+  description: string;
+  iconName: IconName;
+};
+
+export const FAMILIAR_TYPES: readonly FamiliarTypeSpec[] = [
+  { id: "general", label: "General", roleToken: null, description: "No dedicated room — every shared surface, nothing extra.", iconName: "ph:sparkle" },
+  { id: "coding", label: "Coding", roleToken: "coder", description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
+  { id: "research", label: "Research", roleToken: "researcher", description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
+  { id: "review", label: "Review", roleToken: "reviewer", description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
+  { id: "writing", label: "Writing", roleToken: "scribe", description: "Unlocks the Writing Desk — drafts, revisions, and publishing flow.", iconName: "ph:pencil-simple" },
+  { id: "comms", label: "Comms", roleToken: "messenger", description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
+  { id: "watch", label: "Watch", roleToken: "sentinel", description: "Unlocks the Watchtower — monitors, alerts, and incident timelines.", iconName: "ph:shield-warning" },
+  { id: "planning", label: "Planning", roleToken: "navigator", description: "Unlocks the Chart Room — plans, milestones, and course corrections.", iconName: "ph:compass" },
+  { id: "indexing", label: "Indexing", roleToken: "indexer", description: "Unlocks the Index — corpus health, coverage, and retrieval quality.", iconName: "ph:books" },
+];
+
+/** The explicit default: a familiar with no stored type is General. */
+export const DEFAULT_FAMILIAR_TYPE: FamiliarTypeId = "general";
+
+export function isFamiliarTypeId(value: string): value is FamiliarTypeId {
+  return FAMILIAR_TYPES.some((t) => t.id === value);
+}
+
+/** Stored value → table entry; unknown/absent values resolve to General so a
+ *  stale config never hides the picker or crashes matching. */
+export function resolveFamiliarType(value: string | undefined | null): FamiliarTypeSpec {
+  const id = (value ?? "").trim().toLowerCase();
+  return FAMILIAR_TYPES.find((t) => t.id === id) ?? FAMILIAR_TYPES[0];
+}
+
+/**
+ * Role-id grants for a stored type value: the type id itself plus its role
+ * token (both already normalizeRoleId-shaped). General grants nothing.
+ */
+export function familiarTypeRoleIds(value: string | undefined | null): string[] {
+  const spec = resolveFamiliarType(value);
+  if (!spec.roleToken) return [];
+  return [spec.id, spec.roleToken];
+}

--- a/src/lib/pending-code-open.ts
+++ b/src/lib/pending-code-open.ts
@@ -21,3 +21,33 @@ export type PendingCodeOpen =
       sessionId?: string;
       nonce: number;
     };
+
+// ── Module store (cave-cc5r) ─────────────────────────────────────────────────
+// The Code surface lives inside a Role Surface room, but file/diff opens are
+// raised by shell-level handlers in Workspace (cave:open-project-file etc.).
+// This tiny store bridges them: Workspace enqueues + navigates to the room;
+// the room's CodeView consumes the open and clears it. Kept module-level so
+// the open survives the room mounting after navigation.
+
+let pending: PendingCodeOpen | null = null;
+const listeners = new Set<() => void>();
+
+export function enqueuePendingCodeOpen(open: PendingCodeOpen): void {
+  pending = open;
+  for (const fn of listeners) fn();
+}
+
+export function clearPendingCodeOpen(): void {
+  if (pending === null) return;
+  pending = null;
+  for (const fn of listeners) fn();
+}
+
+export function getPendingCodeOpen(): PendingCodeOpen | null {
+  return pending;
+}
+
+export function subscribePendingCodeOpen(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -42,6 +42,8 @@ function makeContext(overrides: Partial<RoleSurfaceContext> = {}): RoleSurfaceCo
     plugins: { listPlugins: async () => [] },
     openUrl: () => {},
     openSession: () => {},
+    focusCard: () => {},
+    refreshTasks: () => {},
     ...overrides,
   };
 }
@@ -102,6 +104,22 @@ test("surfaceMatchesRoles honors alias roles with the same normalization", () =>
   assert.ok(surfaceMatchesRoles({ role: "navigator", aliases: ["Planner"] }, planner));
   assert.ok(!surfaceMatchesRoles({ role: "navigator" }, planner));
   assert.ok(!surfaceMatchesRoles({ role: "navigator", aliases: ["editor"] }, planner));
+});
+
+test("familiarRoleIds grants the explicit familiar Type's tokens (cave-cc5r)", () => {
+  const ids = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "coding" });
+  assert.ok(ids.has("coding"));
+  assert.ok(ids.has("coder"));
+  assert.ok(surfaceMatchesRoles({ role: "coder" }, ids));
+  // types add, never subtract: the role label's tokens still ride along
+  assert.ok(ids.has("orchestrator"));
+});
+
+test("a General or absent familiar Type grants no extra tokens", () => {
+  const general = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "general" });
+  assert.ok(!surfaceMatchesRoles({ role: "coder" }, general));
+  const unknown = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "not-a-type" });
+  assert.ok(!surfaceMatchesRoles({ role: "coder" }, unknown));
 });
 
 test("resolveVisibleRoleSurfaces shows alias-matched rooms", () => {

--- a/src/lib/role-surfaces.ts
+++ b/src/lib/role-surfaces.ts
@@ -17,6 +17,7 @@
 import type { ReactNode } from "react";
 import type { Familiar, SessionRow } from "./types";
 import type { IconName } from "./icon";
+import { familiarTypeRoleIds } from "./familiar-types.ts";
 
 export type RoleSurfaceId = string;
 
@@ -80,6 +81,10 @@ export interface RoleSurfaceContext {
   openUrl(url: string): void;
   /** Jump to a session in the chat surface. */
   openSession(sessionId: string, familiarId?: string): void;
+  /** Spotlight a Board card (opens the Board focused on it). */
+  focusCard(cardId: string): void;
+  /** Ask the shell to refresh its GitHub/task feeds. */
+  refreshTasks(): void;
 }
 
 // ── Contributions ────────────────────────────────────────────────────────────
@@ -210,11 +215,14 @@ export function normalizeRoleId(value: string): string {
 /**
  * The normalized role-id set assigned to a familiar:
  *  - its `role` label (whole normalized string plus individual word tokens,
- *    so "Research Analyst" grants both "research-analyst" and "analyst"), and
+ *    so "Research Analyst" grants both "research-analyst" and "analyst"),
+ *  - its explicit `familiarType` (familiar-types.ts) — the type id plus the
+ *    role token it grants, so the Studio's Type picker unlocks rooms without
+ *    touching the free-text label (types add, never subtract), and
  *  - the id + name of every ACTIVE role manifest belonging to it.
  */
 export function familiarRoleIds(
-  familiar: Pick<Familiar, "id" | "role">,
+  familiar: Pick<Familiar, "id" | "role" | "familiarType">,
   manifests: readonly FamiliarRoleManifest[] = [],
 ): Set<string> {
   const ids = new Set<string>();
@@ -222,6 +230,7 @@ export function familiarRoleIds(
   const whole = normalizeRoleId(label);
   if (whole) ids.add(whole);
   for (const token of whole.split("-")) if (token) ids.add(token);
+  for (const id of familiarTypeRoleIds(familiar.familiarType)) ids.add(id);
   for (const manifest of manifests) {
     if (!manifest.active || manifest.familiar !== familiar.id) continue;
     const byId = normalizeRoleId(manifest.id);

--- a/src/lib/sidebar-nav-state.test.ts
+++ b/src/lib/sidebar-nav-state.test.ts
@@ -40,7 +40,12 @@ test("deep-linkable modes hosted by another surface light the host row (cave-s9p
   assert.equal(sidebarRowState("inbox", "calendar"), "active", "calendar renders on Schedules");
   assert.equal(sidebarRowState("board", "familiar-work-queue"), "active", "the Queue is a Tasks-hub tab");
   assert.equal(sidebarRowState("inbox", "flow"), "active", "retired flow remaps to Schedules");
-  assert.equal(sidebarRowState("code", "github"), "active", "github is Code's GitHub tab (cave-m6ys)");
+  assert.equal(
+    sidebarRowState("surface:code", "code"),
+    "active",
+    "a code deep link lights the Coding familiar's room row (cave-cc5r)",
+  );
+  assert.equal(sidebarRowState("github", "github"), "active", "GitHub is standalone again (cave-cc5r)");
 });
 
 test("Journal is a Memories tab — the Memories (grimoire) row hosts it", () => {

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -57,11 +57,11 @@ assert.match(
 assert.match(chatView, /openTargetFile = \(e: ReactMouseEvent\) => \{[\s\S]*?stopPropagation\(\)/, "open handler stops propagation");
 
 // (ComuxView's cave:open-project-file listener left with the component,
-// cave-c3yt — the workspace bridge into the Code surface is the live
-// consumer, cave-ohcj.)
+// cave-c3yt — the workspace bridge into the Code room is the live
+// consumer, cave-ohcj/cave-cc5r.)
 assert.match(
   workspace,
-  /File\/diff links land on the Code surface[\s\S]*?setPendingCodeOpen\([\s\S]*?setMode\("code"\)/,
+  /File\/diff links land on the Code room[\s\S]*?enqueuePendingCodeOpen\([\s\S]*?setMode\("code"\)/,
   "workspace preserves file-open event detail while switching into code",
 );
 assert.doesNotMatch(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,12 @@ export type Familiar = {
   avatarUrl?: string;
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
+  /**
+   * Explicit familiar Type (FamiliarTypeId from familiar-types.ts): the
+   * user-modifiable vocation that unlocks Role Surface rooms alongside the
+   * free-text `role` label. Absent = "general".
+   */
+  familiarType?: string;
   defaultHarness?: string;
   harnessOverride?: string | null;
   model?: string;

--- a/src/lib/use-role-surfaces.ts
+++ b/src/lib/use-role-surfaces.ts
@@ -59,8 +59,10 @@ export function useRoleSurfaceSession(input: {
   daemonRunning: boolean;
   openUrl: (url: string) => void;
   openSession: (sessionId: string, familiarId?: string) => void;
+  focusCard: (cardId: string) => void;
+  refreshTasks: () => void;
 }): RoleSurfaceSession {
-  const { familiar, sessions, activeSessionId, daemonRunning, openUrl, openSession } = input;
+  const { familiar, sessions, activeSessionId, daemonRunning, openUrl, openSession, focusCard, refreshTasks } = input;
   const familiarId = familiar?.id ?? null;
 
   const [manifests, setManifests] = useState<RoleEntryWire[]>([]);
@@ -164,6 +166,8 @@ export function useRoleSurfaceSession(input: {
     (sessionId: string, forFamiliar?: string) => openSession(sessionId, forFamiliar),
     [openSession],
   );
+  const focusCardStable = useCallback((cardId: string) => focusCard(cardId), [focusCard]);
+  const refreshTasksStable = useCallback(() => refreshTasks(), [refreshTasks]);
 
   const context: RoleSurfaceContext | null = useMemo(() => {
     if (!familiar) return null;
@@ -178,8 +182,10 @@ export function useRoleSurfaceSession(input: {
       plugins,
       openUrl: openUrlStable,
       openSession: openSessionStable,
+      focusCard: focusCardStable,
+      refreshTasks: refreshTasksStable,
     };
-  }, [familiar, sessions, activeSessionId, daemonRunning, memory, tools, plugins, openUrlStable, openSessionStable]);
+  }, [familiar, sessions, activeSessionId, daemonRunning, memory, tools, plugins, openUrlStable, openSessionStable, focusCardStable, refreshTasksStable]);
 
   const visibleSurfaces = useMemo(() => {
     if (!familiar || !context) return [];

--- a/src/lib/workspace-mode.test.ts
+++ b/src/lib/workspace-mode.test.ts
@@ -12,11 +12,12 @@ import {
 // mode lands (issue #3283, cave-m4ih.3). These tests pin its invariants;
 // workspace-alias-modes.test.ts pins the Workspace wiring to it.
 
-test("every alias resolves to a canonical mode, never to another alias", () => {
+test("every alias resolves to a canonical mode or a Role Surface room, never another alias", () => {
   for (const [alias, target] of Object.entries(MODE_ALIASES)) {
     assert.ok(
-      (CANONICAL_WORKSPACE_MODES as readonly string[]).includes(target),
-      `alias "${alias}" must land on a canonical surface, got "${target}"`,
+      (CANONICAL_WORKSPACE_MODES as readonly string[]).includes(target) ||
+        target.startsWith("surface:"),
+      `alias "${alias}" must land on a canonical surface or a room, got "${target}"`,
     );
     assert.ok(!isAliasWorkspaceMode(target), `alias "${alias}" must not chain to another alias`);
   }
@@ -60,6 +61,13 @@ test("the documented alias landings hold", () => {
   assert.equal(MODE_ALIASES["familiar-work-queue"], "board", "the Queue is a Tasks tab");
   assert.equal(MODE_ALIASES.roles, "marketplace", "Roles is a Marketplace hub section");
   assert.equal(MODE_ALIASES.capabilities, "marketplace", "Capabilities is a Marketplace hub section");
+  assert.equal(MODE_ALIASES.code, "surface:code", "Code is the Coding familiar's room (cave-cc5r)");
+});
+
+test("github is a canonical standalone surface again (cave-cc5r)", () => {
+  assert.ok((CANONICAL_WORKSPACE_MODES as readonly string[]).includes("github"));
+  assert.ok(!isAliasWorkspaceMode("github"), "github must not be remapped through MODE_ALIASES");
+  assert.equal(resolveWorkspaceModeAlias("github"), "github");
 });
 
 test("salem is a canonical standalone surface, not an alias", () => {

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -17,7 +17,7 @@ export type CanonicalWorkspaceMode =
   | "board"
   | "inbox"
   | "browser"
-  | "code"
+  | "github"
   | "marketplace"
   | "submissions"
   | "grimoire"
@@ -31,9 +31,13 @@ export type AliasWorkspaceMode =
   | "familiar-work-queue"
   | "roles"
   | "capabilities"
-  | "github";
+  | "code";
 
 export type WorkspaceMode = CanonicalWorkspaceMode | AliasWorkspaceMode;
+
+/** A Role Surface room mode ("surface:<id>") — the shape produced by
+ *  roleSurfaceMode() in role-surfaces.ts. Alias remaps may target a room. */
+type RoleSurfaceModeString = `surface:${string}`;
 
 export const CANONICAL_WORKSPACE_MODES: readonly CanonicalWorkspaceMode[] = [
   "agents",
@@ -42,10 +46,10 @@ export const CANONICAL_WORKSPACE_MODES: readonly CanonicalWorkspaceMode[] = [
   "board",
   "inbox",
   "browser",
-  // Code — the Codex-style multi-session coding surface (cave-k0ua). Reverses
-  // the earlier Code-mode retirement; default-on since phase 2 (cave-m6ys),
-  // with GitHub absorbed as its GitHub tab ("github" is now an alias below).
-  "code",
+  // GitHub — the standalone assigned-work surface. Restored to canonical when
+  // Code moved into the Coding familiar's Role Surface room (cave-cc5r): every
+  // familiar keeps GitHub; the Code workbench is the coder's room.
+  "github",
   "marketplace",
   "submissions",
   "grimoire",
@@ -60,14 +64,15 @@ export const CANONICAL_WORKSPACE_MODES: readonly CanonicalWorkspaceMode[] = [
  *
  * - Rewritten in Workspace.setMode, so `mode` state never holds them:
  *   `groupchat` opens Chat's Group tab, `journal` opens Memories' Journal
- *   tab, `flow` (retired surface) lands on Rituals.
+ *   tab, `flow` (retired surface) lands on Rituals, and `code` opens the
+ *   Coding familiar's Code Workshop room (cave-cc5r) — old `?mode=code` deep
+ *   links and persisted last-surface strings keep landing on the workbench,
+ *   now behind the room's role gate.
  * - Kept in `mode` state as tab/section selectors: the render branch mounts
  *   the canonical surface on the matching tab, keyed by the alias so deep
  *   links remount onto it — `calendar` (Rituals' Calendar tab),
  *   `familiar-work-queue` (Tasks' Queue tab), `roles` / `capabilities`
- *   (Marketplace hub sections), `github` (Code's GitHub tab — the standalone
- *   surface was absorbed in cave-m6ys; old deep links and persisted
- *   last-surface strings keep landing on the same content).
+ *   (Marketplace hub sections).
  *
  * workspace-alias-modes.test.ts pins Workspace's branches to this table;
  * sidebar-nav-state derives row highlighting from it.
@@ -80,8 +85,8 @@ export const MODE_ALIASES = {
   "familiar-work-queue": "board",
   roles: "marketplace",
   capabilities: "marketplace",
-  github: "code",
-} as const satisfies Record<AliasWorkspaceMode, CanonicalWorkspaceMode>;
+  code: "surface:code",
+} as const satisfies Record<AliasWorkspaceMode, CanonicalWorkspaceMode | RoleSurfaceModeString>;
 
 export function isAliasWorkspaceMode(mode: string): mode is AliasWorkspaceMode {
   return Object.prototype.hasOwnProperty.call(MODE_ALIASES, mode);
@@ -94,8 +99,11 @@ export function isWorkspaceMode(mode: string): mode is WorkspaceMode {
   );
 }
 
-/** The canonical surface a mode renders on: aliases resolve through
- *  MODE_ALIASES, canonical modes return themselves. */
-export function resolveWorkspaceModeAlias(mode: WorkspaceMode): CanonicalWorkspaceMode {
+/** The surface a mode renders on: aliases resolve through MODE_ALIASES
+ *  (possibly onto a Role Surface room mode), canonical modes return
+ *  themselves. */
+export function resolveWorkspaceModeAlias(
+  mode: WorkspaceMode,
+): CanonicalWorkspaceMode | RoleSurfaceModeString {
   return isAliasWorkspaceMode(mode) ? MODE_ALIASES[mode] : mode;
 }

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -789,6 +789,30 @@
   transition: border-color var(--duration-fast) var(--ease-standard), box-shadow var(--duration-fast) var(--ease-standard);
 }
 .familiar-studio-identity__input:focus { outline: none; border-color: var(--accent-presence); box-shadow: 0 0 0 3px var(--ring-focus-soft); }
+/* Explicit familiar Type chips (cave-cc5r) — picks a vocation from the static
+   FAMILIAR_TYPES table; the active chip uses the filled accent pair. */
+.familiar-studio-identity__types { display: flex; flex-wrap: wrap; gap: var(--space-1); }
+.familiar-studio-type-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard), background var(--duration-fast) var(--ease-standard);
+}
+.familiar-studio-type-chip:hover { border-color: var(--accent-presence); color: var(--text-primary); }
+.familiar-studio-type-chip--active {
+  background: var(--accent-presence);
+  border-color: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+}
+.familiar-studio-identity__hint { margin: 0; font-size: var(--text-2xs); color: var(--text-muted); }
 
 .familiar-studio-look { display: flex; flex-direction: column; gap: 18px; }
 .familiar-studio-look__section { display: flex; flex-direction: column; gap: 8px; }

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test, type Page } from "@playwright/test";
 
 // The dedicated Code surface (cave-k0ua): a Codex-style multi-session coding
-// tab — session rail grouped by project, per-session workbench
+// workbench — session rail grouped by project, per-session workbench
 // (Diff | Files | Terminal | PR), inspector column, and a GitHub top tab.
-// Default-on since phase 2 (cave-m6ys) — no flag env needed.
+// Default-on since phase 2 (cave-m6ys); since cave-cc5r it lives as the
+// Coding familiar's Role Surface room (`?mode=code` aliases onto
+// `surface:code`), so the mocked familiar carries the explicit
+// familiarType "coding" that unlocks the room.
 //
 // Daemon-less — onboarding dismissed, every endpoint mocked via page.route.
 
@@ -44,8 +47,9 @@ async function base(page: Page, sessions: unknown[] = [NEWEST, OLDER]) {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
   await page.route("**/api/familiars**", (route) =>
-    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", familiarType: "coding", status: "active", icon: "ph:sparkle-fill" }] } }),
   );
+  await page.route("**/api/roles**", (route) => route.fulfill({ json: { ok: true, roles: [] } }));
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions } }),
   );
@@ -81,7 +85,7 @@ async function base(page: Page, sessions: unknown[] = [NEWEST, OLDER]) {
   );
 }
 
-test.describe("code surface (flag on)", () => {
+test.describe("code surface (Coding familiar's room)", () => {
   test("landing: rail groups sessions, newest auto-selected, attribution chips in the header", async ({ page, isMobile }) => {
     test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
     await base(page);

--- a/tests/mobile/code-surface-drill-in.spec.ts
+++ b/tests/mobile/code-surface-drill-in.spec.ts
@@ -35,8 +35,9 @@ async function base(page: Page) {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
   await page.route("**/api/familiars**", (route) =>
-    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", familiarType: "coding", status: "active", icon: "ph:sparkle-fill" }] } }),
   );
+  await page.route("**/api/roles**", (route) => route.fulfill({ json: { ok: true, roles: [] } }));
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions: [SESSION] } }),
   );


### PR DESCRIPTION
## What

Moves the Code workbench from an always-on top-level surface into a **Role Surface room** ("Code Workshop"), gated exactly like Research's desk — and adds an **explicit, modifiable familiar Type** so the assignment is obvious rather than inferred from free-text role labels.

### Design (approved, spec in `docs/specs/2026-07-23-code-coding-familiar-room-design.md`)
- **familiar Type picker** — Familiar Studio → Identity gains a chip radiogroup over a static 9-type table (`src/lib/familiar-types.ts`): General (default, grants nothing) + Coding, Research, Review, Writing, Comms, Watch, Planning, Indexing. Each type adds its room's role token; **role labels keep granting rooms as before (types add, never subtract)**. Stored as a Cave override (`familiarType`), synced through cave-config like every identity field.
- **Code Workshop room** — registered at `surface:code` (role `coder`, aliases coding/developer/engineer/programmer/software-engineer/code, accent 250). `code-room.tsx` adapts `RoleSurfaceContext` → the existing CodeView (familiar-scoped sessions, openSession/focusCard/refreshTasks via context).
- **GitHub returns standalone** — canonical `github` mode renders GitHubView for *every* familiar; its quiet sidebar row (assigned-work badge intact) hides only while the active familiar's Code room row is visible.
- **Deep links keep working** — `?mode=code` is now an alias: setMode funnels it onto the room. File/diff opens (`cave:open-project-file`/`cave:open-file-diff`/`cave:browse-project-files`) enqueue into the `pending-code-open` module store and navigate; the room consumes on mount.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (post-rebase onto current main)
- `pnpm test:app` **891 files** ✅ · `pnpm test:api` **239 files** ✅ (includes new `familiar-types.test.ts` — 9 tests — wired into CI; realigned pins: workspace-alias-modes, code-surface-mode, sidebar-nav-state, workspace-mode, github-native-open, workspace-chat-handoff, tool-target-file, sidebar-minimal, settings-action-buttons)
- `pnpm build` ✅ (bundle + standalone budgets green)
- Playwright `tests/code-surface.spec.ts` + `tests/mobile/code-surface-drill-in.spec.ts`: **8 passed** locally (mocked familiar now carries `familiarType: "coding"`)

Closes bead: cave-cc5r