### PR TITLE
fix(design-doc): cite shipped ph:gear-six-bold; pin doc-cited icon names (cave-es7y)

### DIFF
--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -219,7 +219,7 @@ wired into `prebuild`):
    name, preferring `-fill`.
 
 Weight conventions: `-bold` for chrome actions (`ph:plus-bold`, `ph:x-bold`,
-`ph:magnifying-glass-bold`, `ph:gear-bold`), `-fill` for status/presence
+`ph:magnifying-glass-bold`, `ph:gear-six-bold`), `-fill` for status/presence
 glyphs (`ph:check-circle-fill`, `ph:warning-circle-fill`,
 `ph:paw-print-fill`), regular for inline content. Sizes come from the
 `--icon-2xs..xl` ladder / `CAVE_ICON_SIZE` map — top chrome is pinned to

--- a/scripts/ui-consistency.test.mjs
+++ b/scripts/ui-consistency.test.mjs
@@ -197,17 +197,28 @@ assert.ok(
   `doc states the --border-strong mixes (${strongPct(foundations)}/${strongPct(lightSlice)})`,
 );
 
-// 5. Icon-count claim stays within 15% of the real ICON_NAMES roster.
+// 5. Icon-count claim stays within 15% of the real ICON_NAMES roster, and
+//    every ph:* icon name the doc cites must exist in that roster.
 const iconSource = readFileSync(new URL("src/lib/icon.tsx", repoRoot), "utf8");
 const iconBlock = iconSource.match(/ICON_NAMES = \[([\s\S]*?)\] as const/);
 assert.ok(iconBlock, "icon.tsx declares ICON_NAMES");
-const iconCount = (iconBlock[1].match(/"ph:[a-z0-9-]+"/g) ?? []).length;
+const iconNames = new Set(
+  (iconBlock[1].match(/"ph:[a-z0-9-]+"/g) ?? []).map((name) => name.slice(1, -1)),
+);
+const iconCount = iconNames.size;
 const iconClaim = designLanguage.match(/\(~(\d+) icons\)/);
 assert.ok(iconClaim, "doc §5 states an approximate icon count");
 assert.ok(
   Math.abs(Number(iconClaim[1]) - iconCount) / iconCount <= 0.15,
   `doc §5 claims ~${iconClaim[1]} icons but ICON_NAMES has ${iconCount} — refresh the claim`,
 );
+for (const cited of designLanguage.match(/`ph:[a-z0-9-]+`/g) ?? []) {
+  const name = cited.slice(1, -1);
+  assert.ok(
+    iconNames.has(name),
+    `doc cites \`${name}\` but ICON_NAMES has no such icon — use a shipped name`,
+  );
+}
 
 // 6. Agent entry points keep pointing at the design system.
 assert.match(


### PR DESCRIPTION
## What

Follow-up to #3739, from its post-merge code review.

- **Bug**: `docs/coven-design-language.md` §5 cited `ph:gear-bold` as a weight-convention example, but `ICON_NAMES` ships only `ph:gear-six` / `ph:gear-six-bold`. `IconName` is a union type, so an agent copying the example verbatim gets a compile error — or adds a duplicate gear icon following the doc's new-icon procedure. Fixed to `ph:gear-six-bold`.
- **Guard**: extended the `ui-consistency.test.mjs` icon pin — every backticked `ph:*` name cited in the doc must now exist in `ICON_NAMES` (the count-only pin couldn't catch a bad example name).
- Icon count now counts **unique** names: `ICON_NAMES` has 19 duplicate entries (315 raw → 296 unique union members). The doc's ~300 claim is within 1.4% of the real union size. (Deduping `ICON_NAMES` itself is out of scope — noted on the bead.)

## Validation

- `node scripts/ui-consistency.test.mjs` → ok (21 palettes, 296 icons)
- Negative test: planted `ph:gear-bold` back → pin fails with `doc cites \`ph:gear-bold\` but ICON_NAMES has no such icon`; restored
- Bead: cave-es7y