### PR TITLE
fix(notifications): match bell icon + count badge hue, distinguish by fill (cave-jso3)

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -184,8 +184,13 @@ assert.match(
 );
 assert.match(
   desktopChrome,
-  /\.notification-bell__badge \{[^}]*background:\s*var\(--color-danger\);/,
-  "notification badges use the danger background",
+  /\.notification-bell__badge \{[^}]*background:\s*color-mix\(in oklch, var\(--color-warning\) 14%, var\(--bg-raised\)\);/,
+  "notification badges tint from the bell's warning hue over an opaque surface (the chip overlaps the glyph)",
+);
+assert.match(
+  desktopChrome,
+  /\.notification-bell__badge \{[^}]*border:\s*1px solid color-mix\(in oklch, var\(--color-warning\) 40%, var\(--bg-raised\)\);/,
+  "the count chip is the bordered element — fill vs outline separates it from the solid glyph",
 );
 assert.match(
   foundations,
@@ -199,8 +204,13 @@ assert.match(
 );
 assert.match(
   desktopChrome,
-  /\.notification-bell__badge \{[^}]*color:\s*var\(--color-danger-foreground\);/,
-  "notification badges use the semantic danger foreground",
+  /\.notification-bell__badge \{[^}]*color:\s*var\(--color-warning\);/,
+  "the count is solid warning text — same hue as the unread bell icon, per the one-token tint recipe",
+);
+assert.match(
+  notificationBell,
+  /name=\{displayBadgeCount > 0 \? "ph:bell-fill" : "ph:bell"\}/,
+  "unread solidifies the bell glyph; idle keeps the outline — fill, not a second hue, is the unread channel",
 );
 
 // Wiring in the workspace: the bar mounts in the Shell topBar slot with the

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -320,7 +320,10 @@ export function NotificationBell({
         title={`${displayBadgeCount} unread`}
         aria-label={`Notifications, ${displayBadgeCount} unread`}
       >
-        <Icon name="ph:bell-fill" aria-hidden />
+        {/* Fill (not hue) is the second unread channel: the glyph solidifies
+            while the count chip stays border+tint, so the two read as one
+            warning-hued control with distinct treatments. */}
+        <Icon name={displayBadgeCount > 0 ? "ph:bell-fill" : "ph:bell"} aria-hidden />
 
         {displayBadgeCount > 0 ? (
           <span aria-hidden className="notification-bell__badge">

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -860,8 +860,15 @@ button:active > .edge-rail-chip {
   height: 16px;
   padding: 0 var(--space-1);
   border-radius: var(--radius-pill);
-  color: var(--color-danger-foreground);
-  background: var(--color-danger);
+  /* The count chip shares the bell's warning hue (unread is attention, not
+     danger) via the one-token tint recipe: solid text, 14% fill, ~40%
+     border. Fill vs outline keeps icon and count distinct — the glyph is
+     the solid element, the chip the bordered one. Both mixes end on
+     --bg-raised (opaque) because the chip overlaps the glyph; transparent
+     fills would let the bell bleed through the count. */
+  color: var(--color-warning);
+  background: color-mix(in oklch, var(--color-warning) 14%, var(--bg-raised));
+  border: 1px solid color-mix(in oklch, var(--color-warning) 40%, var(--bg-raised));
   font-size: var(--text-2xs);
   font-weight: 700;
   line-height: 1;


### PR DESCRIPTION
## What

The notification bell colored its icon `--color-warning` on unread while the count badge sat on solid `--color-danger` — **two hues on one control**, violating the design language's one-token tint rule (§4). The red also clashed with the notification family's established warning hue (reminder/response-needed toasts via `KIND_ACCENT`, the popover's past-due chips) and mismatched the solid-accent Tasks/Rituals badges beside it in the menu bar.

## How

Both elements now share the **warning hue** and differ by **treatment** instead of hue:

- **Icon = the solid element**: `ph:bell-fill` on unread (warning), outline `ph:bell` when idle (secondary) — fill itself now signals unread.
- **Badge = the bordered element**: the design-language tint recipe (solid warning text, 14% fill, 40% border), mixed over opaque `--bg-raised` so the overlapped glyph can't bleed through the count.

Alternatives considered: solid warning badge with dark ink (rejected — two competing solid-badge systems in one bar next to the accent Tasks/Rituals badges); accent hue (rejected — the popover's past-due language is warning; accent would split the family).

## Screenshots

| dark, unread | light, unread | dark, idle |
|---|---|---|
| filled amber bell + amber tinted chip | same, darker amber | outline bell, secondary, no badge |

(Verified live at 1440px against the desktop menu bar: matched hue, chip legible over the glyph, clearly distinct from the neighboring solid-accent badges; light mode picks up the darker `oklch(0.58 0.16 78)` warning automatically.)

## Tests

- `familiar-menu-bar.test.ts`: danger-badge pins → warning-recipe pins + new icon fill/outline swap pin (foundations danger-token pins kept — other consumers).
- All bell-adjacent pin suites pass under the CSS contract hook: familiar-menu-bar, notification-bell-series, notification-bell-mutations, mobile-shell-smoke, sidebar-minimal, daily-summary-notifications, top-bar, shell-chrome-revamp, glass-overlay-chrome.
- `pnpm lint`, `ui-consistency.test.mjs`, `design-token-drift.test.ts` green.

Bead: cave-jso3