### PR TITLE
fix(sessions): prune fallback sacrifices daemon rows instead of DELETEing a nonexistent route (cave-sufj)

### DIFF
--- a/src/app/api/sessions/prune/prune-response.test.ts
+++ b/src/app/api/sessions/prune/prune-response.test.ts
@@ -39,4 +39,19 @@ const none = prunePayload({ dryRun: true, count: 0, method: "daemon" });
 assert.equal(has(none, "wouldPrune"), 0);
 assert.equal(none.pruned, 0);
 
+// --- route source pins (cave-sufj): the client fallback must delete daemon
+// rows via `coven sacrifice`, not DELETE /api/v1/sessions/{id} — the daemon
+// has no HTTP delete route, so that path silently no-oped every prune.
+import { readFileSync } from "node:fs";
+const route = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+assert.match(route, /"sacrifice", s\.id, "--yes"/, "daemon rows are deleted via coven sacrifice");
+assert.match(route, /await sacrificeSessionLocal\(s\.id\);/, "each swept row is tombstoned locally regardless");
+assert.match(route, /isValidSessionId\(s\.id\)/, "session ids are validated before reaching argv");
+assert.doesNotMatch(route, /method: "DELETE"/, "no fallback DELETE to a route the daemon doesn't have");
+assert.match(
+  route,
+  /if \(candidates\.length > 0\) invalidateSessionsListCache\(\);/,
+  "cache invalidates when anything was attempted — tombstones land even on CLI failure",
+);
+
 console.log("prune-response: all assertions passed");

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -1,7 +1,16 @@
 import { NextResponse } from "next/server";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { sacrificeSessionLocal } from "@/lib/cave-config";
+import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
 import { invalidateSessionsListCache } from "@/lib/server/sessions-list-cache";
+import { isValidSessionId } from "@/lib/server/session-id";
 import { prunePayload } from "./prune-response";
+
+const execFileAsync = promisify(execFile);
+
+const SACRIFICE_TIMEOUT_MS = 8000;
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +24,11 @@ export const dynamic = "force-dynamic";
  *   { pruned: number }
  *
  * If the daemon doesn't support the endpoint yet, we perform client-side
- * pruning: we list all sessions, filter locally, and DELETE each one.
+ * pruning: we list all sessions, filter locally, and remove each one via
+ * `coven sacrifice` — the daemon has no HTTP delete route (DELETE
+ * /api/v1/sessions/{id} 404s), so the CLI is the only real deletion path
+ * (same as stuck-created-sweep). Each swept row is also tombstoned locally
+ * so the merged session list hides it even when the CLI call fails.
  *
  * Query/body params:
  *   olderThanHours  number  default 24
@@ -85,14 +98,28 @@ export async function POST(req: Request) {
 
   let pruned = 0;
   for (const s of candidates) {
-    const del = await callDaemon({
-      method: "DELETE",
-      path: `/api/v1/sessions/${s.id}`,
-      timeoutMs: 4_000,
-    });
-    if (del.ok) pruned++;
+    // Mirrors the sessions/[id] route's id validation — no argv surprises.
+    if (!isValidSessionId(s.id)) continue;
+    try {
+      const { command, fixedArgs } = covenLaunchCommand();
+      await execFileAsync(command, [...fixedArgs, "sacrifice", s.id, "--yes"], {
+        env: covenSpawnEnv(),
+        timeout: SACRIFICE_TIMEOUT_MS,
+      });
+      pruned++;
+    } catch {
+      // The daemon row survives (daemon down or CLI missing); the local
+      // tombstone below still hides it from every session list.
+    }
+    try {
+      await sacrificeSessionLocal(s.id);
+    } catch {
+      // State write failed; the daemon-side sacrifice above still counts.
+    }
   }
 
-  if (pruned > 0) invalidateSessionsListCache();
+  // Local tombstones are written even when the CLI call fails, so the merged
+  // list changes whenever anything was attempted — not just on CLI successes.
+  if (candidates.length > 0) invalidateSessionsListCache();
   return NextResponse.json(prunePayload({ dryRun: false, count: pruned, method: "client" }));
 }

--- a/src/lib/server/sessions-list-cache.test.ts
+++ b/src/lib/server/sessions-list-cache.test.ts
@@ -134,8 +134,8 @@ function fnBlock(source, name) {
   );
   assert.match(
     prune,
-    /if \(pruned > 0\) invalidateSessionsListCache\(\)/,
-    "the client prune path invalidates only when sessions were actually pruned",
+    /if \(candidates\.length > 0\) invalidateSessionsListCache\(\)/,
+    "the client prune path invalidates whenever candidates were attempted — local tombstones land even when the CLI sacrifice fails (cave-sufj)",
   );
 }
 


### PR DESCRIPTION
Closes bead **cave-sufj** (P2 bug, filed 2026-07-24).

## Problem

The prune route's client-side fallback (used whenever the daemon lacks `/api/v1/sessions/prune`) DELETEd `/api/v1/sessions/{id}` per stale session — but the daemon **has no DELETE route** (verified live: `{error:{code:'not_found',message:'Route not found.'}}`, HTTP 404). Every prune "deletion" silently no-oped: `del.ok` was false, `pruned` stayed 0, and the stale rows survived. `stuck-created-sweep.ts` already documented "the daemon has no HTTP delete route."

## Fix

The fallback now mirrors the sweep's deletion idiom:
- **Real deletion** via `coven sacrifice <id> --yes` (`covenLaunchCommand` + `covenSpawnEnv`, 8s timeout) — counted in `pruned` on CLI success.
- **Local tombstone** per row (`sacrificeSessionLocal`) regardless of CLI outcome, so the merged session list hides the row even when the daemon is down or the CLI is missing.
- Ids validated with `isValidSessionId` before touching argv.
- `invalidateSessionsListCache()` now fires when **anything was attempted** (`candidates.length > 0`), not just on CLI successes — tombstones change the merged list even when the CLI fails.

Daemon-native path, dry-run behavior, and the `prunePayload` response contract are unchanged.

## Validation

- `prune-response.test.ts` green — extended with route source pins: sacrifice CLI call, per-row tombstone, id validation, **no** `method: "DELETE"` fallback, attempted-work cache invalidation
- `pnpm typecheck` clean, `pnpm lint` clean
