### PR TITLE
Sessions list: single click opens the session

### DIFF
--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -53,7 +53,7 @@ assert.match(
 
 assert.match(
   chatList,
-  /\{chatDate\(s\.updated_at, dtPrefs\)\}[\s\S]*\{rel\}/,
+  /\{rel\}[\s\S]*\{chatDate\(s\.updated_at, dtPrefs\)\}/,
   "Chat rows should show the absolute date next to the relative updated age",
 );
 

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -354,11 +354,11 @@ assert.match(source, /const \[selectedIds, setSelectedIds\] = useState<Set<strin
 assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\)/, "the header Select toggle clears any selection");
 assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
-// Expandable rows (Sessions redesign): a single click toggles the inline
-// detail disclosure; double-click and Enter keep the fast open path. Mobile
-// keeps tap = open — the disclosure is a desktop affordance.
-assert.match(source, /if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} if \(isMobile\) \{ setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); return; \} setExpandedRowId\(\(cur\) => \(cur === s\.id \? null : s\.id\)\)/, "a row click selects in select mode, opens directly on mobile, otherwise toggles the detail strip");
-assert.match(source, /onDoubleClick=\{\(\) => \{ if \(selectMode\) return; setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); \}\}/, "double-click still opens the session immediately");
+// Row click = open (Sessions): clicking a row opens the session directly on
+// every device; select mode still toggles selection. The old inline detail
+// disclosure (single-click expand + double-click open) is gone.
+assert.match(source, /onClick=\{\(\) => \{ if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); \}\}/, "a row click selects in select mode, otherwise opens the session directly");
+assert.doesNotMatch(source, /expandedRowId|onDoubleClick/, "no disclosure state or double-click path remains on rows");
 assert.match(source, /const bulkDelete = \(\) =>/, "bulk delete handler exists (deferred/undoable)");
 assert.match(source, /const bulkArchive = async \(archived: boolean\)/, "bulk archive/unarchive handler exists");
 assert.match(source, /Promise\.all\([\s\S]{0,80}fetch\(`\/api\/chat\/conversation\//, "bulk delete runs the per-chat deletes in parallel");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -202,12 +202,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   const [activeId, setActiveId] = useState<string | null>(null);
   // Toolbar group-by (none / project / date), persisted as a plain string.
   const [groupBy, setGroupBy] = useState<ChatSessionGroupBy>("none");
-  // Expandable-row disclosure: a single click opens an inline detail strip
-  // (Resume/Open + Archive); double-click and Enter keep the fast open path.
-  // Mobile keeps tap = open (messengers' convention; double-tap is awkward on
-  // touch) — the disclosure is a desktop affordance.
-  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
-  useEffect(() => { setExpandedRowId(null); }, [familiar?.id]);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const [selection, setSelection] = useState<ProjectSelection>("all");
   const [sidebarHydrated, setSidebarHydrated] = useState(false);
@@ -292,11 +286,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         e.preventDefault();
         searchRef.current?.focus();
         return;
-      }
-      // Escape collapses the expanded row first (mock behavior); anything that
-      // already consumed the key (popovers, modals) wins.
-      if (e.key === "Escape" && !e.defaultPrevented) {
-        setExpandedRowId((cur) => (cur ? null : cur));
       }
     };
     window.addEventListener("keydown", handler);
@@ -794,12 +783,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               onChange={(e) => setSearch(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key !== "Escape") return;
-                // Escape collapses an expanded row first, then clears search.
-                if (expandedRowId) {
-                  e.preventDefault();
-                  setExpandedRowId(null);
-                  return;
-                }
                 if (search) {
                   e.preventDefault();
                   setSearch("");
@@ -1155,8 +1138,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                       sectioned && (pinned ? collapsedSections.has("pinned") : collapsedSections.has("sessions"));
                     const rowName = s.title || s.id;
                     const daySection = daySectionsByIndex?.get(idx) ?? null;
-                    const isExpanded = !selectMode && expandedRowId === s.id;
-                    const detailId = `chat-list-row-detail-${s.id}`;
 
                     return (
                       <Fragment key={s.id}>
@@ -1193,40 +1174,27 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           role={selectMode ? "checkbox" : "button"}
                           aria-checked={selectMode ? selectedIds.has(s.id) : undefined}
                           aria-current={!selectMode && isActive ? "true" : undefined}
-                          aria-expanded={selectMode ? undefined : isExpanded}
-                          aria-controls={isExpanded ? detailId : undefined}
                           tabIndex={0}
-                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } if (isMobile) { setActiveId(s.id); onOpen(s.id, s.familiarId); return; } setExpandedRowId((cur) => (cur === s.id ? null : s.id)); }}
-                          onDoubleClick={() => { if (selectMode) return; setActiveId(s.id); onOpen(s.id, s.familiarId); }}
+                          onClick={() => { if (selectMode) { toggleSelect(s.id); return; } setActiveId(s.id); onOpen(s.id, s.familiarId); }}
                           onMouseEnter={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
                           onMouseLeave={cancelHoverPrefetch}
                           onFocus={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
                           onBlur={cancelHoverPrefetch}
                           onKeyDown={(e) => {
-                            if (e.key === "Enter" || (selectMode && e.key === " ")) {
+                            if (e.key === "Enter" || e.key === " ") {
                               e.preventDefault();
                               if (selectMode) { toggleSelect(s.id); return; }
                               setActiveId(s.id); onOpen(s.id, s.familiarId);
-                              return;
-                            }
-                            // Space toggles the inline detail disclosure —
-                            // Enter stays the fast open path.
-                            if (e.key === " ") {
-                              e.preventDefault();
-                              setExpandedRowId((cur) => (cur === s.id ? null : s.id));
                             }
                           }}
                           data-selected={selectMode && selectedIds.has(s.id) ? "true" : undefined}
                           data-status={st.label}
                           data-active={isActive ? "true" : undefined}
-                          data-expanded={isExpanded ? "true" : undefined}
                           className={[
                             "chat-list-row focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
                             isActive
                               ? "bg-[var(--bg-raised)]"
-                              : isExpanded
-                                ? "bg-[var(--bg-raised)]/60"
-                                : "hover:bg-[var(--bg-raised)]/50",
+                              : "hover:bg-[var(--bg-raised)]/50",
                             selectMode && selectedIds.has(s.id) ? "bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)]" : "",
                           ].join(" ")}
                         >
@@ -1531,44 +1499,6 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             </span>
                           ))}
                         </div>
-                        {/* Inline detail strip — the row's disclosure target.
-                            Resume/Open is the existing open-session action;
-                            Archive reuses the undo-safe archive PATCH. */}
-                        {isExpanded && (
-                          <div
-                            id={detailId}
-                            className="chat-list-row-detail mb-2 ml-[26px] mr-4 mt-1 flex items-center gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3.5 py-2.5"
-                          >
-                            <span className="min-w-0 flex-1 truncate text-[length:var(--text-xs)] text-[var(--text-muted)]">
-                              {rowFamiliarName}
-                              {" · "}
-                              {project || "no project"}
-                              {" · "}
-                              {s.status === "running" ? "running now" : "idle"}
-                              {" · last activity "}
-                              {rel}
-                            </span>
-                            <Button
-                              variant="primary"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setActiveId(s.id);
-                                onOpen(s.id, s.familiarId);
-                              }}
-                            >
-                              {s.status === "running" ? "Resume" : "Open"}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={archivingId !== null}
-                              onClick={(e) => void setSessionArchived(e, s.id, !s.archived_at)}
-                            >
-                              {s.archived_at ? "Unarchive" : "Archive"}
-                            </Button>
-                          </div>
-                        )}
                         </>
                         )}
                       </SortableChatListItem>

--- a/src/lib/chat-session-grouping.test.ts
+++ b/src/lib/chat-session-grouping.test.ts
@@ -112,54 +112,39 @@ test("railGroupPreview + railMoreLabel: 6-row cap with Show N more / fewer", () 
   assert.equal(railMoreLabel(true, 0), "Show fewer");
 });
 
-// ── Source pins: expandable-row disclosure semantics (chat-list.tsx) ─────────
+// ── Source pins: rows open directly on click (chat-list.tsx) ─────────────────
 
-test("chat-list: rows are proper disclosures (aria-expanded + aria-controls)", () => {
+test("chat-list: a row click opens the session directly (no disclosure strip)", () => {
   assert.match(
     chatList,
-    /aria-expanded=\{selectMode \? undefined : isExpanded\}/,
-    "the row button reports its disclosure state outside select mode",
+    /onClick=\{\(\) => \{ if \(selectMode\) \{ toggleSelect\(s\.id\); return; \} setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\); \}\}/,
+    "a row click selects in select mode, otherwise opens the session",
   );
-  assert.match(
+  assert.doesNotMatch(
     chatList,
-    /aria-controls=\{isExpanded \? detailId : undefined\}/,
-    "the expanded row points at its detail strip",
+    /expandedRowId|setExpandedRowId/,
+    "the inline detail-strip disclosure state is gone",
   );
-  assert.match(
+  assert.doesNotMatch(
     chatList,
-    /const detailId = `chat-list-row-detail-\$\{s\.id\}`/,
-    "detail strips carry stable per-session ids",
+    /chat-list-row-detail|onDoubleClick/,
+    "no detail strip or double-click fast path remains — click IS the open path",
   );
 });
 
-test("chat-list: detail strip carries Resume/Open (existing open path) + Archive", () => {
+test("chat-list: Enter and Space both open the focused row", () => {
   assert.match(
     chatList,
-    /\{s\.status === "running" \? "Resume" : "Open"\}/,
-    "the primary action is Resume while running, Open otherwise",
-  );
-  assert.match(
-    chatList,
-    /chat-list-row-detail[\s\S]{0,1400}setActiveId\(s\.id\);\s*\n\s*onOpen\(s\.id, s\.familiarId\);/,
-    "Resume/Open routes through the existing open-session action",
-  );
-  assert.match(
-    chatList,
-    /onClick=\{\(e\) => void setSessionArchived\(e, s\.id, !s\.archived_at\)\}/,
-    "Archive reuses the existing archive PATCH action",
+    /if \(e\.key === "Enter" \|\| e\.key === " "\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*if \(selectMode\) \{ toggleSelect\(s\.id\); return; \}\s*\n\s*setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\);/,
+    "keyboard activation mirrors the click: select in select mode, open otherwise",
   );
 });
 
-test("chat-list: Escape collapses the expanded row before clearing search", () => {
+test("chat-list: Escape in search clears the query", () => {
   assert.match(
     chatList,
-    /if \(expandedRowId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setExpandedRowId\(null\);\s*\n\s*return;\s*\n\s*\}\s*\n\s*if \(search\) \{/,
-    "the search field's Escape handler collapses first, clears second",
-  );
-  assert.match(
-    chatList,
-    /if \(e\.key === "Escape" && !e\.defaultPrevented\) \{\s*\n\s*setExpandedRowId\(\(cur\) => \(cur \? null : cur\)\);/,
-    "a global Escape collapses the expanded row (deferring to consumers that already handled it)",
+    /if \(e\.key !== "Escape"\) return;\s*\n\s*if \(search\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setSearch\(""\);/,
+    "the search field's Escape handler clears the query",
   );
 });
 

--- a/src/styles/chat-list.css
+++ b/src/styles/chat-list.css
@@ -65,25 +65,6 @@
   background: color-mix(in oklch, var(--foreground) 6%, transparent);
 }
 
-/* Expandable-row detail strip (Sessions redesign): the disclosure target under
-   a clicked row fades in on motion tokens; reduced motion renders it static. */
-@keyframes chat-list-detail-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-.chat-list-row-detail {
-  animation: chat-list-detail-fade var(--duration-fast) var(--ease-standard);
-}
-@media (prefers-reduced-motion: reduce) {
-  .chat-list-row-detail {
-    animation: none;
-  }
-}
-
 /* Footer keyboard hints (↵ open · / search) — hairline kbd chips. */
 .chat-list-kbd {
   padding: 0 var(--space-1);


### PR DESCRIPTION
## Summary

"Selecting a given session in the sessions page should just open it."

Clicking a session row in the Chats home list now opens the session directly on every device. Previously desktop hid the open action behind a two-step flow: single click expanded an inline detail strip, and only double-click/Enter opened the session.

## Changes

- **Row click = open** (select mode still toggles selection); Enter and Space match.
- Removed the inline detail-strip disclosure entirely: `expandedRowId` state, detail strip markup (Resume/Open + Archive — both already redundant with the row hover quick-actions), double-click handler, Space-toggle, both Escape-collapse handlers, and the `aria-expanded`/`aria-controls`/`data-expanded` plumbing.
- Dropped the now-unused `.chat-list-row-detail` fade animation from `chat-list.css`.
- Retargeted source pins: `chat-list-delete.test.ts` + `chat-session-grouping.test.ts` now assert click-opens-directly and the absence of the disclosure machinery; `chat-all-familiars-project-list.test.ts` date-order pin flipped (`rel` before `chatDate`) since the strip's duplicate `rel` usage is gone.

## Verification

- Full app suite: **892 test files green**
- `pnpm typecheck` clean

Closes bead cave-r1in.
