### PR TITLE
feat(chat): opt-in periodic auto-rename of chats to match latest context

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -730,6 +730,7 @@ export const SUITES = {
     "src/lib/task-archive-nudge-wiring.test.ts",
     "src/lib/chat-archive-nudge.test.ts",
     "src/lib/chat-auto-archive.test.ts",
+    "src/lib/chat-auto-rename.test.ts",
     "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -10,12 +10,19 @@ import {
   loadState,
   recordSessionFamiliar,
   setSessionTitle,
+  setSessionTitleAuto,
 } from "@/lib/cave-config";
 import {
   chatSummaryTitle,
   chatTitleFromPrompt,
   defaultChatTitleForSession,
 } from "@/lib/cave-chat-titles";
+import {
+  isAutoOwnedTitle,
+  isRenameDueAtTurn,
+  normalizeChatAutoRenamePolicy,
+  renameTitleFromLatestExchange,
+} from "@/lib/chat-auto-rename";
 import {
   buildPromptWithAttachments,
   normalizeChatAttachments,
@@ -285,6 +292,59 @@ async function autoNameSessionFromFirstExchange(
     if (current && !autoDefaults.has(current)) return;
     if (current === summary) return;
     await setSessionTitle(sessionId, summary);
+  } catch {
+    /* best effort */
+  }
+}
+
+/**
+ * Periodic, context-aware rename (chat-auto-rename.ts). Opt-in via the
+ * `chatAutoRename` policy: once a thread reaches a multiple of `everyTurns`
+ * assistant turns, re-derive its title from the LATEST exchange so a long
+ * conversation's name tracks where it actually went. Never overwrites a title
+ * a person set by hand (provenance in `sessionTitleAuto`). Best effort: any
+ * failure leaves the current title in place. `firstPromptText` seeds the set of
+ * auto-derived defaults the first-exchange name may have left behind.
+ */
+async function maybeAutoRenameFromContext(
+  sessionId: string,
+  firstPromptText: string,
+): Promise<void> {
+  try {
+    const config = await loadConfig();
+    const policy = normalizeChatAutoRenamePolicy(config.chatAutoRename);
+    if (!policy.enabled) return;
+
+    const conversation = await loadConversation(sessionId);
+    const turns = conversation?.turns ?? [];
+    const assistantTurns = turns.filter((t) => t.role === "assistant").length;
+    if (!isRenameDueAtTurn(assistantTurns, policy.everyTurns)) return;
+
+    const lastUser = [...turns].reverse().find((t) => t.role === "user")?.text ?? null;
+    const lastAssistant = [...turns].reverse().find((t) => t.role === "assistant")?.text ?? null;
+    const next = renameTitleFromLatestExchange({ userText: lastUser, assistantText: lastAssistant });
+    if (!next) return;
+
+    const state = await loadState();
+    const current = state.sessionTitles[sessionId];
+    if (current === next) return;
+    const firstPrompt = turns.find((t) => t.role === "user")?.text ?? firstPromptText;
+    const autoDefaults = new Set(
+      [defaultChatTitleForSession(sessionId), chatTitleFromPrompt(firstPrompt)].filter(
+        (t): t is string => Boolean(t),
+      ),
+    );
+    if (
+      !isAutoOwnedTitle({
+        current,
+        lastAutoTitle: state.sessionTitleAuto[sessionId],
+        autoDefaults,
+        preserveManualTitles: policy.preserveManualTitles,
+      })
+    ) {
+      return;
+    }
+    await setSessionTitleAuto(sessionId, next);
   } catch {
     /* best effort */
   }
@@ -745,6 +805,9 @@ function openClawChatResponse(args: {
           if (isFirstExchange && !isError) {
             await autoNameSessionFromFirstExchange(sessionId, args.promptText);
           }
+          // Periodic context-aware rename runs on every completed turn (the
+          // cadence gate inside decides when it's actually due).
+          if (!isError) await maybeAutoRenameFromContext(sessionId, args.promptText);
           pushProgress("save-transcript", "Transcript saved", "done");
         }
 
@@ -2388,6 +2451,10 @@ export async function POST(req: Request) {
         await saveConversation(conv);
         if (isFirstExchange && !result.is_error && !cancelledByUser) {
           await autoNameSessionFromFirstExchange(finalSessionId, promptText);
+        }
+        // Periodic context-aware rename on every completed turn (cadence gated inside).
+        if (!result.is_error && !cancelledByUser) {
+          await maybeAutoRenameFromContext(finalSessionId, promptText);
         }
         pushProgress("save-transcript", "Transcript saved", "done");
       }

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -14,6 +14,7 @@ const ALLOWED_TOP_LEVEL_KEYS = new Set([
   "multiHost",
   "omnigent",
   "chatAutoArchive",
+  "chatAutoRename",
 ]);
 type ConfigPatchBody = Record<string, unknown>;
 

--- a/src/components/chat-settings-view.test.ts
+++ b/src/components/chat-settings-view.test.ts
@@ -93,6 +93,36 @@ assert.match(
   "failed PATCHes revert the optimistic policy update",
 );
 
+// --- chat-settings-view: auto-rename policy round-trips through /api/config ----
+assert.match(
+  settingsView,
+  /normalizeChatAutoRenamePolicy\(json\.config\?\.chatAutoRename\)/,
+  "settings view normalizes the stored auto-rename policy too",
+);
+assert.match(
+  settingsView,
+  /JSON\.stringify\(\{ chatAutoRename: patch \}\)/,
+  "auto-rename edits persist through the same config PATCH merge",
+);
+for (const field of ["enabled", "everyTurns", "preserveManualTitles"]) {
+  assert.match(
+    settingsView,
+    new RegExp(`updateRename\\(\\{ ${field} \\}\\)`),
+    `settings view edits auto-rename ${field}`,
+  );
+}
+assert.match(
+  settingsView,
+  /\.catch\(\(\) => \{\s*setRenamePolicy\(previous\);/,
+  "failed auto-rename PATCHes revert the optimistic update",
+);
+assert.match(settingsView, /Auto-rename/, "the auto-rename card is labeled");
+assert.match(
+  settingsView,
+  /Keep titles I set/,
+  "the preserve-manual-titles toggle is labeled for what it does",
+);
+
 // --- chat-view: reflect flows react to a reflection-triggered archive ---------
 
 assert.match(

--- a/src/components/chat-settings-view.tsx
+++ b/src/components/chat-settings-view.tsx
@@ -5,6 +5,12 @@ import {
   normalizeChatAutoArchivePolicy,
   type ChatAutoArchivePolicy,
 } from "@/lib/chat-auto-archive";
+import {
+  MAX_RENAME_TURNS,
+  MIN_RENAME_TURNS,
+  normalizeChatAutoRenamePolicy,
+  type ChatAutoRenamePolicy,
+} from "@/lib/chat-auto-rename";
 
 /**
  * Consolidated chat settings — the chat page's Settings tab. One place for the
@@ -108,22 +114,79 @@ function PolicyDays({
   );
 }
 
+/** Turns input (auto-rename cadence). Commits on blur/Enter, clamped in range. */
+function PolicyTurns({
+  label,
+  value,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  disabled?: boolean;
+  onCommit: (turns: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => setDraft(String(value)), [value]);
+  const commit = () => {
+    const parsed = Number.parseInt(draft, 10);
+    const turns = Number.isFinite(parsed)
+      ? Math.min(Math.max(parsed, MIN_RENAME_TURNS), MAX_RENAME_TURNS)
+      : value;
+    setDraft(String(turns));
+    if (turns !== value) onCommit(turns);
+  };
+  return (
+    <label className="chat-settings__days">
+      every
+      <input
+        type="number"
+        min={MIN_RENAME_TURNS}
+        max={MAX_RENAME_TURNS}
+        value={draft}
+        disabled={disabled}
+        aria-label={label}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+        }}
+        className="chat-settings__days-input focus-ring"
+      />
+      turns
+    </label>
+  );
+}
+
 export function ChatSettingsView() {
   const [policy, setPolicy] = useState<ChatAutoArchivePolicy | null>(null);
+  const [renamePolicy, setRenamePolicy] = useState<ChatAutoRenamePolicy | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const policyRef = useRef<ChatAutoArchivePolicy | null>(null);
   policyRef.current = policy;
+  const renamePolicyRef = useRef<ChatAutoRenamePolicy | null>(null);
+  renamePolicyRef.current = renamePolicy;
 
   useEffect(() => {
     const ctl = new AbortController();
     fetch("/api/config", { cache: "no-store", signal: ctl.signal })
       .then((r) => r.json())
-      .then((json: { ok?: boolean; config?: { chatAutoArchive?: Partial<ChatAutoArchivePolicy> }; error?: string }) => {
-        if (ctl.signal.aborted) return;
-        if (!json.ok) throw new Error(json.error ?? "failed to load config");
-        setPolicy(normalizeChatAutoArchivePolicy(json.config?.chatAutoArchive));
-      })
+      .then(
+        (json: {
+          ok?: boolean;
+          config?: {
+            chatAutoArchive?: Partial<ChatAutoArchivePolicy>;
+            chatAutoRename?: Partial<ChatAutoRenamePolicy>;
+          };
+          error?: string;
+        }) => {
+          if (ctl.signal.aborted) return;
+          if (!json.ok) throw new Error(json.error ?? "failed to load config");
+          setPolicy(normalizeChatAutoArchivePolicy(json.config?.chatAutoArchive));
+          setRenamePolicy(normalizeChatAutoRenamePolicy(json.config?.chatAutoRename));
+        },
+      )
       .catch((err) => {
         if (ctl.signal.aborted) return;
         setLoadError(err instanceof Error ? err.message : "failed to load config");
@@ -153,7 +216,30 @@ export function ChatSettingsView() {
       });
   }, []);
 
+  // Same optimistic round-trip for the auto-rename policy.
+  const updateRename = useCallback((patch: Partial<ChatAutoRenamePolicy>) => {
+    const previous = renamePolicyRef.current;
+    if (!previous) return;
+    setRenamePolicy({ ...previous, ...patch });
+    setSaveState("saving");
+    fetch("/api/config", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatAutoRename: patch }),
+    })
+      .then((r) => r.json())
+      .then((json: { ok?: boolean; error?: string }) => {
+        if (!json.ok) throw new Error(json.error ?? "failed to save");
+        setSaveState("idle");
+      })
+      .catch(() => {
+        setRenamePolicy(previous);
+        setSaveState("error");
+      });
+  }, []);
+
   const sweepOff = policy ? !policy.enabled : false;
+  const renameOff = renamePolicy ? !renamePolicy.enabled : false;
 
   return (
     <div className="chat-settings-view min-h-0 flex-1 overflow-y-auto">
@@ -249,6 +335,54 @@ export function ChatSettingsView() {
                 </PolicyRow>
               </div>
             </div>
+
+            {renamePolicy ? (
+              <>
+                <p className="chat-settings__kicker">Auto-rename</p>
+                <p className="chat-settings__hint">
+                  Periodically rename a chat to match where the conversation has
+                  gone, instead of freezing on its opening prompt. A title you set
+                  by hand is never changed.
+                </p>
+                <div className="chat-settings__card">
+                  <PolicyRow
+                    label="Auto-rename"
+                    description="Master switch for periodic, context-aware renaming."
+                  >
+                    <PolicySwitch
+                      label="Auto-rename"
+                      checked={renamePolicy.enabled}
+                      onChange={(enabled) => updateRename({ enabled })}
+                    />
+                  </PolicyRow>
+                  <div className={`chat-settings__children${renameOff ? " is-disabled" : ""}`}>
+                    <PolicyRow
+                      label="Re-name cadence"
+                      description="How often to re-derive the title from the thread's latest exchange."
+                    >
+                      <PolicyTurns
+                        label="Re-name every N assistant turns"
+                        value={renamePolicy.everyTurns}
+                        disabled={renameOff}
+                        onCommit={(everyTurns) => updateRename({ everyTurns })}
+                      />
+                    </PolicyRow>
+                    <PolicyRow
+                      label="Keep titles I set"
+                      description="Never overwrite a chat title you renamed by hand — auto-rename only touches its own titles."
+                    >
+                      <PolicySwitch
+                        label="Preserve manual titles"
+                        checked={renamePolicy.preserveManualTitles}
+                        disabled={renameOff}
+                        onChange={(preserveManualTitles) => updateRename({ preserveManualTitles })}
+                      />
+                    </PolicyRow>
+                  </div>
+                </div>
+              </>
+            ) : null}
+
             <p aria-live="polite" className="chat-settings__save">
               {saveState === "error"
                 ? "Saving failed — change reverted. Try again."

--- a/src/lib/cave-config.test.ts
+++ b/src/lib/cave-config.test.ts
@@ -15,6 +15,7 @@ try {
   assert.deepEqual(await config.loadState(), {
     sessionFamiliar: {},
     sessionTitles: {},
+    sessionTitleAuto: {},
     sessionArchived: {},
     sessionSacrificed: {},
     sessionKeep: {},
@@ -69,6 +70,25 @@ try {
   state = await config.loadState();
   assert.deepEqual(state.sessionTitles, {});
 
+  // Auto-rename provenance (chat-auto-rename): setSessionTitleAuto records that
+  // this feature owns the title; a later manual setSessionTitle clears it so the
+  // periodic rename backs off. Empty auto titles are a no-op.
+  assert.equal(await config.setSessionTitleAuto("session-3", "  Ship the widget "), "Ship the widget");
+  state = await config.loadState();
+  assert.deepEqual(state.sessionTitles["session-3"], "Ship the widget");
+  assert.deepEqual(state.sessionTitleAuto["session-3"], "Ship the widget");
+  assert.equal(await config.setSessionTitleAuto("session-3", "   "), null, "blank auto title is a no-op");
+  await config.setSessionTitle("session-3", "My hand-picked name");
+  state = await config.loadState();
+  assert.equal(state.sessionTitles["session-3"], "My hand-picked name");
+  assert.equal(
+    state.sessionTitleAuto["session-3"],
+    undefined,
+    "a manual rename clears auto-rename provenance",
+  );
+  // Clear session-3 so the whole-state assertion below still sees empty titles.
+  await config.setSessionTitle("session-3", "");
+
   const sacrificedAt = await config.sacrificeSessionLocal("session-1");
   assert.ok(Number.isFinite(Date.parse(sacrificedAt)));
 
@@ -105,6 +125,7 @@ try {
   assert.deepEqual(rawState, {
     sessionFamiliar: { "session-1": "cody" },
     sessionTitles: {},
+    sessionTitleAuto: {},
     sessionArchived: {},
     sessionSacrificed: { "session-1": sacrificedAt },
     sessionKeep: {},

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -12,6 +12,10 @@ import {
   SUMMON_GRACE_DAYS,
 } from "./chat-auto-archive.ts";
 import {
+  type ChatAutoRenamePolicy,
+  normalizeChatAutoRenamePolicy,
+} from "./chat-auto-rename.ts";
+import {
   type FamiliarRuntime,
   normalizeFamiliarRuntime,
 } from "./familiar-runtime.ts";
@@ -68,6 +72,7 @@ const DEFAULT_CONFIG: CaveConfig = {
 const DEFAULT_STATE: CaveState = {
   sessionFamiliar: {},
   sessionTitles: {},
+  sessionTitleAuto: {},
   sessionArchived: {},
   sessionSacrificed: {},
   sessionKeep: {},
@@ -137,6 +142,7 @@ function defaultState(): CaveState {
   return {
     sessionFamiliar: {},
     sessionTitles: {},
+    sessionTitleAuto: {},
     sessionArchived: {},
     sessionSacrificed: {},
     sessionKeep: {},
@@ -190,13 +196,17 @@ type FamiliarBindingPatch = {
   [K in keyof FamiliarBinding]?: FamiliarBinding[K] | null;
 };
 
-type CaveConfigPatch = Omit<Partial<CaveConfig>, "defaults" | "familiars" | "chatAutoArchive"> & {
+type CaveConfigPatch = Omit<
+  Partial<CaveConfig>,
+  "defaults" | "familiars" | "chatAutoArchive" | "chatAutoRename"
+> & {
   defaults?: Partial<FamiliarBinding>;
   familiars?: Record<string, FamiliarBindingPatch | null>;
   multiHost?: Partial<CaveMultiHostConfig>;
   omnigent?: Partial<CaveOmnigentConfig>;
   remoteHosts?: CaveRemoteHost[];
   chatAutoArchive?: Partial<ChatAutoArchivePolicy>;
+  chatAutoRename?: Partial<ChatAutoRenamePolicy>;
 };
 
 export type RoleConfigEntry = {
@@ -310,6 +320,8 @@ export type CaveConfig = {
   profile?: UserProfile;
   /** Auto-archive policy for chats (see chat-auto-archive.ts). Absent = defaults. */
   chatAutoArchive?: ChatAutoArchivePolicy;
+  /** Periodic context-aware rename policy for chats (see chat-auto-rename.ts). Absent = defaults. */
+  chatAutoRename?: ChatAutoRenamePolicy;
 };
 
 export type CaveState = {
@@ -317,6 +329,10 @@ export type CaveState = {
   sessionFamiliar: Record<string, string>;
   /** Session to Cave-side title override. Wins over the daemon's title when present. */
   sessionTitles: Record<string, string>;
+  /** Session to the last title auto-rename set (provenance). Present only while the
+   *  current override still equals it — a manual rename clears the entry. Lets the
+   *  periodic rename tell its own titles from a person's (chat-auto-rename.ts). */
+  sessionTitleAuto: Record<string, string>;
   /** Session to ISO timestamp when archived in the Cave. Empty when unarchived. */
   sessionArchived: Record<string, string>;
   /** Session to ISO timestamp when sacrificed (soft-deleted) in the Cave. Hidden from lists. */
@@ -380,6 +396,9 @@ async function loadConfigUnlocked(): Promise<CaveConfig> {
       profile: parsed.profile,
       ...(parsed.chatAutoArchive !== undefined
         ? { chatAutoArchive: normalizeChatAutoArchivePolicy(parsed.chatAutoArchive) }
+        : {}),
+      ...(parsed.chatAutoRename !== undefined
+        ? { chatAutoRename: normalizeChatAutoRenamePolicy(parsed.chatAutoRename) }
         : {}),
     };
     // Self-healing migration (cave-1v95): a pre-existing config may still
@@ -509,6 +528,13 @@ export async function saveConfig(patch: CaveConfigPatch): Promise<CaveConfig> {
             ...patch.chatAutoArchive,
           })
         : current.chatAutoArchive,
+    chatAutoRename:
+      patch.chatAutoRename !== undefined
+        ? normalizeChatAutoRenamePolicy({
+            ...current.chatAutoRename,
+            ...patch.chatAutoRename,
+          })
+        : current.chatAutoRename,
   };
   // Split an embedded hub access token out before persisting (cave-1v95):
   // pasting the tokened invite URL stays the pairing UX, but the credential
@@ -603,6 +629,7 @@ async function loadStateUnlocked(): Promise<CaveState> {
     return {
       sessionFamiliar: parsed.sessionFamiliar ?? {},
       sessionTitles: parsed.sessionTitles ?? {},
+      sessionTitleAuto: parsed.sessionTitleAuto ?? {},
       sessionArchived: parsed.sessionArchived ?? {},
       sessionSacrificed: parsed.sessionSacrificed ?? {},
       sessionKeep: parsed.sessionKeep ?? {},
@@ -824,7 +851,28 @@ export async function setSessionTitle(sessionId: string, title: string): Promise
     } else {
       state.sessionTitles[sessionId] = trimmed;
     }
+    // A plain (manual / first-exchange) set clears auto-rename provenance so the
+    // periodic rename treats the new title as a person's choice and backs off.
+    delete state.sessionTitleAuto[sessionId];
     return trimmed || null;
+  });
+  invalidateSessionsListCache();
+  return next;
+}
+
+/**
+ * Set a session title from the periodic auto-rename (chat-auto-rename.ts),
+ * recording provenance so a later rename knows it still owns the title while a
+ * person's manual rename (which clears the provenance via setSessionTitle) is
+ * left untouched. Pass an empty title to no-op.
+ */
+export async function setSessionTitleAuto(sessionId: string, title: string): Promise<string | null> {
+  const trimmed = title.trim();
+  if (!trimmed) return null;
+  const next = await updateState((state) => {
+    state.sessionTitles[sessionId] = trimmed;
+    state.sessionTitleAuto[sessionId] = trimmed;
+    return trimmed;
   });
   invalidateSessionsListCache();
   return next;

--- a/src/lib/chat-auto-rename.test.ts
+++ b/src/lib/chat-auto-rename.test.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  DEFAULT_CHAT_AUTO_RENAME_POLICY,
+  MAX_RENAME_TURNS,
+  MIN_RENAME_TURNS,
+  clampRenameTurns,
+  isAutoOwnedTitle,
+  isRenameDueAtTurn,
+  normalizeChatAutoRenamePolicy,
+  renameTitleFromLatestExchange,
+} from "./chat-auto-rename.ts";
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+// Opt-in: renaming a chat out from under someone is surprising, so it is off.
+assert.equal(DEFAULT_CHAT_AUTO_RENAME_POLICY.enabled, false);
+assert.equal(DEFAULT_CHAT_AUTO_RENAME_POLICY.everyTurns, 4);
+assert.equal(DEFAULT_CHAT_AUTO_RENAME_POLICY.preserveManualTitles, true);
+
+// ── Normalizer tolerates junk, clamps the cadence ────────────────────────────
+assert.deepEqual(normalizeChatAutoRenamePolicy(null), DEFAULT_CHAT_AUTO_RENAME_POLICY);
+assert.deepEqual(normalizeChatAutoRenamePolicy("nope"), DEFAULT_CHAT_AUTO_RENAME_POLICY);
+assert.equal(normalizeChatAutoRenamePolicy({ everyTurns: 0 }).everyTurns, MIN_RENAME_TURNS);
+assert.equal(normalizeChatAutoRenamePolicy({ everyTurns: 999 }).everyTurns, MAX_RENAME_TURNS);
+assert.equal(normalizeChatAutoRenamePolicy({ everyTurns: 6.9 }).everyTurns, 6);
+assert.equal(normalizeChatAutoRenamePolicy({ everyTurns: "x" }).everyTurns, 4);
+assert.equal(normalizeChatAutoRenamePolicy({ enabled: true }).enabled, true);
+assert.equal(
+  normalizeChatAutoRenamePolicy({ preserveManualTitles: false }).preserveManualTitles,
+  false,
+);
+assert.equal(clampRenameTurns(1, 4), MIN_RENAME_TURNS);
+assert.equal(clampRenameTurns(NaN, 4), 4);
+
+// ── Cadence: due at positive multiples of everyTurns, never before ───────────
+assert.equal(isRenameDueAtTurn(1, 4), false, "turn 1 is the first-exchange name's job");
+assert.equal(isRenameDueAtTurn(3, 4), false);
+assert.equal(isRenameDueAtTurn(4, 4), true);
+assert.equal(isRenameDueAtTurn(8, 4), true);
+assert.equal(isRenameDueAtTurn(6, 4), false);
+assert.equal(isRenameDueAtTurn(2, 2), true);
+assert.equal(isRenameDueAtTurn(0, 4), false);
+assert.equal(isRenameDueAtTurn(4.5, 4), false, "non-integer turn counts never fire");
+
+// ── Ownership: manual titles are sacred (preserveManualTitles on) ────────────
+const defaults = new Set(["New chat", "Fix the sync path"]);
+assert.equal(
+  isAutoOwnedTitle({ current: null, lastAutoTitle: null, autoDefaults: defaults, preserveManualTitles: true }),
+  true,
+  "no title yet → ours to set",
+);
+assert.equal(
+  isAutoOwnedTitle({ current: "New chat", lastAutoTitle: null, autoDefaults: defaults, preserveManualTitles: true }),
+  true,
+  "still an auto default → replaceable",
+);
+assert.equal(
+  isAutoOwnedTitle({ current: "Deploying to prod", lastAutoTitle: "Deploying to prod", autoDefaults: defaults, preserveManualTitles: true }),
+  true,
+  "we set it last → replaceable",
+);
+assert.equal(
+  isAutoOwnedTitle({ current: "My hand-picked name", lastAutoTitle: "Deploying to prod", autoDefaults: defaults, preserveManualTitles: true }),
+  false,
+  "a human's title is never overwritten while preserve is on",
+);
+assert.equal(
+  isAutoOwnedTitle({ current: "My hand-picked name", lastAutoTitle: null, autoDefaults: defaults, preserveManualTitles: false }),
+  true,
+  "preserve off → auto-rename may take over any title",
+);
+
+// ── Derivation reuses the pure chatSummaryTitle over the LATEST exchange ──────
+assert.equal(
+  renameTitleFromLatestExchange({ userText: "help me migrate the auth service to OAuth", assistantText: "" }),
+  "Migrate the auth service to OAuth",
+);
+assert.equal(renameTitleFromLatestExchange({ userText: "", assistantText: "" }), null);
+assert.equal(
+  renameTitleFromLatestExchange({ userText: null, assistantText: "## Rollback plan\nsteps…" }),
+  "Rollback plan",
+  "falls back to an assistant heading when the user turn is empty",
+);
+
+console.log("chat-auto-rename.test.ts ok");

--- a/src/lib/chat-auto-rename.ts
+++ b/src/lib/chat-auto-rename.ts
@@ -1,0 +1,100 @@
+// Chat auto-rename policy + decision logic. When enabled, a chat's title is
+// periodically re-derived from its LATEST exchange so a long thread's name
+// tracks where the conversation actually went (not just its opening prompt).
+//
+// "Apply rules intelligently": a title a person set by hand is sacred — the
+// periodic rename only ever overwrites a title it still owns (an auto-derived
+// default, or one this feature itself set last). Provenance is tracked in
+// cave-config state (`sessionTitleAuto`); the decision here is pure and
+// unit-tested (see chat-auto-rename.test.ts) with no config/network access.
+
+import { chatSummaryTitle } from "./cave-chat-titles.ts";
+
+export type ChatAutoRenamePolicy = {
+  /** Master switch for periodic context-aware renaming. */
+  enabled: boolean;
+  /** Re-derive the title every N assistant turns (2–50). */
+  everyTurns: number;
+  /** Never overwrite a title a person set by hand. */
+  preserveManualTitles: boolean;
+};
+
+// Off by default — renaming a chat out from under someone is surprising, so it
+// is opt-in. The cadence tracks the conversation without thrashing the title.
+export const DEFAULT_CHAT_AUTO_RENAME_POLICY: ChatAutoRenamePolicy = {
+  enabled: false,
+  everyTurns: 4,
+  preserveManualTitles: true,
+};
+
+export const MIN_RENAME_TURNS = 2;
+export const MAX_RENAME_TURNS = 50;
+
+export function clampRenameTurns(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  const turns = Math.floor(value);
+  return Math.min(Math.max(turns, MIN_RENAME_TURNS), MAX_RENAME_TURNS);
+}
+
+/** Tolerate partial/corrupt stored policies; unknown fields are dropped. */
+export function normalizeChatAutoRenamePolicy(
+  raw: Partial<ChatAutoRenamePolicy> | null | undefined,
+): ChatAutoRenamePolicy {
+  const d = DEFAULT_CHAT_AUTO_RENAME_POLICY;
+  if (!raw || typeof raw !== "object") return { ...d };
+  return {
+    enabled: typeof raw.enabled === "boolean" ? raw.enabled : d.enabled,
+    everyTurns: clampRenameTurns(raw.everyTurns, d.everyTurns),
+    preserveManualTitles:
+      typeof raw.preserveManualTitles === "boolean"
+        ? raw.preserveManualTitles
+        : d.preserveManualTitles,
+  };
+}
+
+/**
+ * The cadence gate: a rename is due once the thread has reached a positive
+ * multiple of `everyTurns` assistant turns. Modulo (rather than a stored
+ * "last renamed at" counter) keeps the trigger stateless — the first-exchange
+ * auto-name already covers turn 1, so periodic renames land at N, 2N, 3N…
+ */
+export function isRenameDueAtTurn(assistantTurns: number, everyTurns: number): boolean {
+  if (!Number.isInteger(assistantTurns) || assistantTurns < everyTurns) return false;
+  if (everyTurns <= 0) return false;
+  return assistantTurns % everyTurns === 0;
+}
+
+/**
+ * Whether the periodic rename is allowed to replace `current`. It owns the
+ * title when there is none yet, when it is still one of the auto-derived
+ * defaults (New chat / first-prompt summary), or when this feature set it last
+ * (`lastAutoTitle`). Anything else is a human's choice and is left untouched
+ * while `preserveManualTitles` is on.
+ */
+export function isAutoOwnedTitle(input: {
+  current: string | null | undefined;
+  lastAutoTitle: string | null | undefined;
+  autoDefaults: ReadonlySet<string>;
+  preserveManualTitles: boolean;
+}): boolean {
+  const current = input.current?.trim();
+  if (!current) return true;
+  if (input.autoDefaults.has(current)) return true;
+  if (input.lastAutoTitle && current === input.lastAutoTitle) return true;
+  return !input.preserveManualTitles;
+}
+
+export type RenameExchange = { userText?: string | null; assistantText?: string | null };
+
+/**
+ * Re-derive a title from the LATEST exchange (the freshest signal for where a
+ * thread is now), reusing the same pure heuristic the first-exchange auto-name
+ * uses. Returns null when nothing meaningful can be derived — callers keep the
+ * current title.
+ */
+export function renameTitleFromLatestExchange(exchange: RenameExchange): string | null {
+  return chatSummaryTitle({
+    userText: exchange.userText ?? null,
+    assistantText: exchange.assistantText ?? null,
+  });
+}


### PR DESCRIPTION
Adds a **Chat Settings → Auto-rename** policy that, when enabled, periodically re-derives a chat's title from its **latest exchange** so a long thread's name tracks where the conversation actually went — instead of freezing on its opening prompt.

## Applies rules intelligently
- **Manual titles are sacred.** A title a person set by hand is never overwritten. Provenance is tracked in cave-config (`sessionTitleAuto`); a manual `setSessionTitle` clears it, so the periodic rename backs off.
- **Cadence, not thrash.** Re-derives every *N* assistant turns (configurable 2–50; default 4). Stateless modulo gate — the existing first-exchange auto-name still covers turn 1; periodic renames land at N, 2N, 3N…
- **Opt-in.** Off by default — renaming a chat out from under someone is surprising.

## Changes
- **New `src/lib/chat-auto-rename.ts`** — policy type + normalizer, the cadence gate (`isRenameDueAtTurn`), the ownership rule (`isAutoOwnedTitle`), and latest-exchange derivation (reuses the pure `chatSummaryTitle`). Fully unit-tested.
- **`cave-config.ts`** — `chatAutoRename` config plumbing + `sessionTitleAuto` provenance map + `setSessionTitleAuto`; manual set clears provenance.
- **`/api/config`** — allow the `chatAutoRename` key.
- **`/api/chat/send`** — after each completed turn, `maybeAutoRenameFromContext` runs the opt-in, cadence-gated, best-effort rename over the conversation's latest exchange (reads `conv.turns`), mirroring the existing first-exchange auto-name.
- **Chat Settings view** — an Auto-rename card (master switch · cadence · preserve-manual toggle) round-tripping through `/api/config` exactly like auto-archive.

## Validation
- `tsc --noEmit` — 0 errors
- `pnpm test:app` — **893 files passed** (new lib unit test + cave-config provenance test + settings-view pins; wired into the app suite)
- design codemod / token-drift ratchet / eslint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)