### PR TITLE
fix(analytics): trace overlay keys its no-log empty state on a machine-readable 404 (cave-pfu8)

### DIFF
--- a/src/app/api/sessions/[id]/events/route.test.ts
+++ b/src/app/api/sessions/[id]/events/route.test.ts
@@ -36,6 +36,16 @@ assert.match(
   "events route must return 400 on invalid session ID, not 500 or silent proxy",
 );
 
+// cave-pfu8: the daemon 404s sessions it has no event log for (Cave-local
+// chats, rows lost on restart). The route must surface that as a
+// machine-readable 404 — not flatten it into a 502 — so the trace overlay can
+// render its calm empty state.
+assert.match(
+  eventsSource,
+  /if \(!res\.ok && res\.status === 404\) \{\s*\n\s*return NextResponse\.json\(\{ ok: false, error: "no_event_timeline" \}, \{ status: 404 \}\);/,
+  "a daemon 404 maps to a machine-readable no_event_timeline 404",
+);
+
 // ── input route ───────────────────────────────────────────────────────────────
 
 assert.match(

--- a/src/app/api/sessions/[id]/events/route.ts
+++ b/src/app/api/sessions/[id]/events/route.ts
@@ -46,6 +46,14 @@ export async function GET(
     timeoutMs: 4000,
   });
 
+  // The daemon 404s sessions it has no event log for — Cave-local chats that
+  // never ran through the daemon, and rows lost on a daemon restart. That's an
+  // expected no-data state (cave-pfu8): surface it as a machine-readable 404
+  // so the trace overlay can render a calm empty state instead of parsing
+  // "daemon http 404" out of a 502.
+  if (!res.ok && res.status === 404) {
+    return NextResponse.json({ ok: false, error: "no_event_timeline" }, { status: 404 });
+  }
   if (!res.ok || !res.data) {
     return NextResponse.json(
       { ok: false, error: res.error ?? `daemon http ${res.status}` },

--- a/src/components/session-trace-overlay.test.ts
+++ b/src/components/session-trace-overlay.test.ts
@@ -47,11 +47,18 @@ describe("SessionTraceOverlay", () => {
     assert.match(source, /No events recorded for this session\./);
   });
 
-  it("treats the daemon's 404 as a calm no-log state, not a raw error", () => {
-    // Chat-only sessions and pruned logs 404 on the daemon — expected, so the
+  it("treats a missing daemon event log as a calm no-log state, not a raw error", () => {
+    // Cave-local chats that never ran through the daemon, rows lost on daemon
+    // restart, and pruned logs have no event timeline — expected, so the
     // overlay renders an empty state and suppresses the alert callout for it.
-    assert.match(source, /const noEventLog = error !== null && \/\\b404\\b\/\.test\(error\)/);
+    assert.match(
+      source,
+      /res\.status === 404 \|\| message === "no_event_timeline" \|\| \/\\b404\\b\/\.test\(message\)/,
+      "no-log detection keys on the route's 404/no_event_timeline signal, with the legacy 502-message fallback",
+    );
+    assert.match(source, /setNoEventLog\(true\);\s*\n\s*return;/, "the no-log path never lands in the error state");
     assert.match(source, /No event log for this session\./);
+    assert.match(source, /Expected for Cave-local chats/, "the empty state names the expected local-chat case");
     assert.match(source, /\{error && !noEventLog \? \(/, "the alert callout is reserved for real failures");
   });
 });

--- a/src/components/session-trace-overlay.tsx
+++ b/src/components/session-trace-overlay.tsx
@@ -35,6 +35,9 @@ export function SessionTraceOverlay({ target, onClose }: { target: TraceTarget; 
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The daemon has no event log for this session — expected for Cave-local
+  // chats that never ran through the daemon and rows lost on daemon restart.
+  const [noEventLog, setNoEventLog] = useState(false);
   // True while the newest fetched page came back full — more events may exist.
   const [maybeMore, setMaybeMore] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -46,13 +49,25 @@ export function SessionTraceOverlay({ target, onClose }: { target: TraceTarget; 
     if (append) setLoadingMore(true);
     else setLoading(true);
     setError(null);
+    setNoEventLog(false);
     try {
       const res = await fetch(
         `/api/sessions/${encodeURIComponent(target.id)}/events?afterSeq=${afterSeq}&limit=${TRACE_PAGE_SIZE}`,
         { cache: "no-store", signal: controller.signal },
       );
       const json = (await res.json().catch(() => null)) as EventsResponse | null;
-      if (!res.ok || !json?.ok) throw new Error((json && "error" in json && json.error) || `HTTP ${res.status}`);
+      // The route answers 404 no_event_timeline when the daemon has no event
+      // log for the session (cave-pfu8) — an expected no-data state, not a
+      // failure. Older builds flattened it into a 502 whose message carried
+      // "daemon http 404", so keep that as a legacy fallback.
+      if (!res.ok || !json?.ok) {
+        const message = (json && "error" in json && json.error) || `HTTP ${res.status}`;
+        if (res.status === 404 || message === "no_event_timeline" || /\b404\b/.test(message)) {
+          if (!controller.signal.aborted) setNoEventLog(true);
+          return;
+        }
+        throw new Error(message);
+      }
       const incoming = json.events ?? [];
       setEvents((prev) => mergeTraceEvents(append ? prev : [], incoming));
       setMaybeMore(incoming.length >= TRACE_PAGE_SIZE);
@@ -73,10 +88,6 @@ export function SessionTraceOverlay({ target, onClose }: { target: TraceTarget; 
   }, [load]);
 
   const lastSeq = events.length > 0 ? events[events.length - 1].seq : 0;
-  // The daemon 404s sessions it has no event log for (chat-only sessions, or
-  // logs pruned by `coven sacrifice`). That's an expected no-data state, not a
-  // failure — render it as a calm empty state instead of a raw error callout.
-  const noEventLog = error !== null && /\b404\b/.test(error);
 
   return (
     <Modal
@@ -121,7 +132,7 @@ export function SessionTraceOverlay({ target, onClose }: { target: TraceTarget; 
             compact
             icon="ph:tree-structure"
             headline="No event log for this session."
-            subtitle="The daemon isn't tracking events for it — it may predate event logging or its log was pruned."
+            subtitle="Expected for Cave-local chats that never ran through the daemon — and for sessions the daemon lost on a restart or pruned."
           />
         ) : events.length === 0 ? (
           <EmptyState


### PR DESCRIPTION
Closes bead **cave-pfu8**.

## Problem

Analytics "Recent sessions" merges Cave-local chat conversations with daemon sessions. The trace overlay fetches `GET /api/sessions/[id]/events` → daemon `/api/v1/events`, which **404s** for local conversations that never ran through the daemon and for rows the daemon lost on restart (bead: daemon listed 0 sessions after restart while Cave listed 525). The route flattened that 404 into a **502** whose message happened to read `daemon http 404`, and the overlay decided "expected no-data" by regex-matching `\b404\b` out of the error string — brittle, and semantically a real-error path carrying an expected state.

## Fix

- **Events route**: a daemon 404 now returns `{ok:false, error:"no_event_timeline"}` with status **404** — machine-readable, distinct from transport failures (which keep the 502 path). Security gates (loopback, id grammar, ownership → 400) unchanged.
- **Overlay**: `noEventLog` is now explicit state keyed on `res.status === 404 || error === "no_event_timeline"` (the old `\b404\b` message regex survives only as a fallback for older routes); the path returns before the error state, so the alert callout is reserved for real failures.
- **Copy** now names the expected case: "Expected for Cave-local chats that never ran through the daemon — and for sessions the daemon lost on a restart or pruned."
- Debug-pane (the other route consumer) surfaces the error string either way — unaffected.

## Validation

- `session-trace-overlay.test.ts` (updated pins: signal detection, never-an-error path, local-chat copy) + `events/route.test.ts` (new pin: 404→`no_event_timeline` mapping beside the security pins) — 7/7 green
- `pnpm typecheck` clean, `pnpm lint` clean
