### PR TITLE
feat(studio): Brain surfaces local recognition readiness at config time (cave-qfyx)

### DIFF
--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -357,3 +357,38 @@ assert.match(
   /const pendingImageModel = draftImageModel\.trim\(\);\s*if \(pendingImageModel !== \(familiar\.imageModel \?\? ""\)\) patch\.imageModel = pendingImageModel \|\| null;/,
   "a dirty custom image model id is tracked for the unmount flush",
 );
+
+// ── Local (on-device) recognition readiness at config time (cave-qfyx) ──────
+// Picking Local probes the native speech engine right here, so a missing
+// on-device dictation model is discovered while configuring — not as
+// stt_on_device_unsupported when a call finally connects.
+assert.match(
+  source,
+  /draftVoiceProvider !== "local" \|\| !isTauri\(\)/,
+  "the readiness probe is desktop-gated and only runs for the Local provider",
+);
+assert.match(
+  source,
+  /nativeSttAvailability\(bridge, navigator\.language\)/,
+  "readiness reuses the same native availability probe as the call path",
+);
+assert.match(
+  source,
+  /kind === "no-on-device"[\s\S]{0,400}System Settings → Keyboard → Dictation/,
+  "the missing-model warning tells the user where to download the dictation model",
+);
+assert.match(
+  source,
+  /familiar-studio-brain__hint familiar-studio-brain__hint--warn" role="status"/,
+  "not-ready states render as warning hints announced via role=status",
+);
+assert.match(
+  source,
+  /kind === "on-device"[\s\S]{0,200}runs fully on-device/,
+  "the ready state confirms recognition stays on-device",
+);
+assert.match(
+  css,
+  /\.familiar-studio-brain__hint--warn \{ color: var\(--color-warning\); \}/,
+  "the warn hint modifier colors via the warning token only",
+);

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -35,8 +35,21 @@ import {
   imageGenSizesForModel,
   isImageGenProvider,
 } from "@/lib/image-generation";
+import { isTauri } from "@/lib/tauri-platform";
+import { loadNativeSttBridge, nativeSttAvailability } from "@/lib/voice/native-stt";
 
 type Props = { familiar: ResolvedFamiliar };
+
+/**
+ * Recognition-engine readiness for the Local (on-device) provider, probed at
+ * configuration time (cave-qfyx) so "your Mac can't run this strictly
+ * on-device" surfaces here — not as stt_on_device_unsupported when a call
+ * finally connects. Desktop-gated: web builds never probe and render nothing.
+ */
+type LocalSttReadiness =
+  | { kind: "on-device"; locale: string | null }
+  | { kind: "no-on-device"; locale: string | null }
+  | { kind: "unsupported" };
 
 type HarnessReport = {
   id: string;
@@ -78,6 +91,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     familiar.omnigent?.workspace ?? "",
   );
   const [draftVoiceProvider, setDraftVoiceProvider] = useState(familiar.voiceProvider ?? "");
+  const [localSttReadiness, setLocalSttReadiness] = useState<LocalSttReadiness | null>(null);
   const [draftVoiceModel, setDraftVoiceModel] = useState(familiar.voiceModel ?? "");
   const [draftVoiceName, setDraftVoiceName] = useState(familiar.voiceName ?? "");
   const [draftImageProvider, setDraftImageProvider] = useState(familiar.imageProvider ?? "");
@@ -422,6 +436,37 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     })();
     return () => { cancelled = true; };
   }, [draftVoiceProvider, elevenCatalog.status]);
+
+  // Probe the native speech engine when Local (on-device) is picked, so a
+  // missing dictation model is discovered here instead of at call connect,
+  // where local-loop's requireOnDevice contract rejects the session. Probe
+  // failures and web builds stay silent — no hint rather than a wrong one.
+  useEffect(() => {
+    if (draftVoiceProvider !== "local" || !isTauri()) {
+      setLocalSttReadiness(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const bridge = await loadNativeSttBridge();
+        if (!bridge || cancelled) return;
+        const availability = await nativeSttAvailability(bridge, navigator.language);
+        if (cancelled || !availability) return;
+        const locale = availability.locale ?? navigator.language ?? null;
+        if (availability.supported !== true) {
+          setLocalSttReadiness({ kind: "unsupported" });
+        } else if (availability.onDevice === true) {
+          setLocalSttReadiness({ kind: "on-device", locale });
+        } else {
+          setLocalSttReadiness({ kind: "no-on-device", locale });
+        }
+      } catch {
+        // Silent: readiness is advisory; the call path still enforces it.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [draftVoiceProvider]);
 
   // Dropdown options for the ElevenLabs pickers. A saved id that's no longer
   // in the account library stays selectable so rendering never clears it.
@@ -807,6 +852,27 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
 
             {draftVoiceProvider === "elevenlabs" && elevenCatalog.status === "error" && elevenCatalog.note && (
               <p className="familiar-studio-brain__hint" role="status">{elevenCatalog.note}</p>
+            )}
+
+            {draftVoiceProvider === "local" && localSttReadiness?.kind === "on-device" && (
+              <p className="familiar-studio-brain__hint" role="status">
+                Ready — speech recognition runs fully on-device
+                {localSttReadiness.locale ? ` for ${localSttReadiness.locale}` : ""}.
+              </p>
+            )}
+
+            {draftVoiceProvider === "local" && localSttReadiness?.kind === "no-on-device" && (
+              <p className="familiar-studio-brain__hint familiar-studio-brain__hint--warn" role="status">
+                No on-device dictation model
+                {localSttReadiness.locale ? ` for ${localSttReadiness.locale}` : ""} — calls
+                will refuse to start. Download it under System Settings → Keyboard → Dictation.
+              </p>
+            )}
+
+            {draftVoiceProvider === "local" && localSttReadiness?.kind === "unsupported" && (
+              <p className="familiar-studio-brain__hint familiar-studio-brain__hint--warn" role="status">
+                This device has no native speech engine — Local calls can&apos;t listen here.
+              </p>
             )}
 
             {(draftVoiceProvider === "openai" || draftVoiceProvider === "local" || draftVoiceProvider === "familiar" || draftVoiceProvider === "elevenlabs") && (

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -871,6 +871,7 @@
 .familiar-studio-brain__row { display: flex; flex-direction: column; gap: 6px; }
 .familiar-studio-brain__label { font-size: var(--text-2xs); font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
 .familiar-studio-brain__hint { margin: 6px 0 0; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
+.familiar-studio-brain__hint--warn { color: var(--color-warning); }
 
 .familiar-studio-brain__control { display: flex; min-width: 0; gap: 6px; align-items: flex-start; }
 


### PR DESCRIPTION
Closes bead cave-qfyx.

## Problem

The Brain tab let you pick "Local (on-device)" with zero feedback about whether this device can actually run it. local-loop's requireOnDevice contract (cave-vpe1) rejects at call connect with `stt_on_device_unsupported` — config time was silent, so the failure surfaced at the worst moment.

## Change

- **familiar-studio-brain-tab.tsx** — `localSttReadiness` state + effect: when `draftVoiceProvider === "local"` && `isTauri()`, load the native STT bridge and call `nativeSttAvailability(bridge, navigator.language)` (the exact probe the call path uses). Three hint states under the provider select, all `role="status"`:
  - **on-device** → "Ready — speech recognition runs fully on-device for <locale>."
  - **no-on-device** → warn: "No on-device dictation model for <locale> — calls will refuse to start. Download it under System Settings → Keyboard → Dictation."
  - **unsupported** → warn: "This device has no native speech engine — Local calls can't listen here."
  - Probe failure / web build → renders nothing (advisory only; the call path still enforces).
- **shell-responsive.css** — `.familiar-studio-brain__hint--warn { color: var(--color-warning); }` (one-token modifier, matches `__capabilities-line--warn` idiom).
- **familiar-studio-brain-tab.test.ts** — pins for the desktop gate, shared probe, warn copy, role=status, and the CSS token.

## Verification

- `familiar-studio-brain-tab.test.ts` green (with css-source-contract hook)
- `design-token-drift.test.ts` green; `pnpm typecheck` + `pnpm lint` clean
