### PR TITLE
feat(code): split the Code Workshop's GitHub tab into PRs · Issues · Reviews

### DIFF
--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -19,11 +19,15 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import {
+  CODE_GITHUB_TABS,
   codeSessionWorkRoot,
   groupCodeRailSessions,
+  isCodeGithubTab,
   parseCodeDeepLink,
+  type CodeGithubTab,
   type CodeTopTab,
 } from "@/lib/code-surface";
+import type { Filter as GitHubFilter } from "@/components/github-view-data";
 import { CodeSessionRail } from "@/components/code-session-rail";
 import { CodeWorkbench } from "@/components/code-workbench";
 import { CodeNewSession } from "@/components/code-new-session";
@@ -38,6 +42,21 @@ const LazyGitHubView = dynamic(
   () => import("@/components/github-view").then((m) => m.GitHubView),
   { ssr: false },
 );
+
+// The GitHub content tabs and the GitHubView filter each one drives.
+const GITHUB_TAB_FILTER: Record<CodeGithubTab, GitHubFilter> = {
+  prs: "pr",
+  issues: "issue",
+  reviews: "review_request",
+};
+const GITHUB_TAB_META: Record<
+  CodeGithubTab,
+  { label: string; icon: Parameters<typeof Icon>[0]["name"] }
+> = {
+  prs: { label: "PRs", icon: "ph:git-pull-request" },
+  issues: { label: "Issues", icon: "ph:circle-dashed" },
+  reviews: { label: "Reviews", icon: "ph:check-circle" },
+};
 
 export type CodeViewProps = {
   sessions: SessionRow[];
@@ -85,8 +104,9 @@ export function CodeView({
     window.history.replaceState(null, "", window.location.pathname + (query ? `?${query}` : "") + window.location.hash);
   }, []);
   const [topTab, setTopTab] = useState<CodeTopTab>(
-    githubTarget ? "github" : deepLink?.topTab ?? initialTopTab ?? "sessions",
+    githubTarget ? "prs" : deepLink?.topTab ?? initialTopTab ?? "sessions",
   );
+  const githubTab: CodeGithubTab | null = isCodeGithubTab(topTab) ? topTab : null;
   // Selection is tri-state for the mobile drill-in: `undefined` = nothing
   // chosen yet (auto-pick allowed), `null` = the user explicitly went Back to
   // the session list (auto-pick must NOT re-select), string = a session.
@@ -180,27 +200,31 @@ export function CodeView({
           <Icon name="ph:code" width={14} height={14} />
           Sessions
         </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={topTab === "github"}
-          onClick={() => setTopTab("github")}
-          className={`focus-ring inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
-            topTab === "github"
-              ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
-              : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-          }`}
-        >
-          <Icon name="ph:github-logo" width={14} height={14} />
-          GitHub
-        </button>
+        {CODE_GITHUB_TABS.map((id) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={topTab === id}
+            onClick={() => setTopTab(id)}
+            className={`focus-ring inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
+              topTab === id
+                ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            }`}
+          >
+            <Icon name={GITHUB_TAB_META[id].icon} width={14} height={14} />
+            {GITHUB_TAB_META[id].label}
+          </button>
+        ))}
       </div>
-      {topTab === "github" ? (
+      {githubTab ? (
         <div className="min-h-0 flex-1">
           <LazyGitHubView
             onJumpToSession={onJumpToSession}
             onFocusCard={onFocusCard}
             initialTarget={githubTarget}
+            initialFilter={GITHUB_TAB_FILTER[githubTab]}
             onTasksRefresh={onTasksRefresh}
           />
         </div>

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -77,6 +77,10 @@ type Props = {
   /** Deep-link target from a GitHub-event inbox notification — opens that
    *  PR/issue's detail natively, even when it isn't in the activity list. */
   initialTarget?: GitHubItemTarget | null;
+  /** When set, the host owns the content filter (e.g. the Code Workshop's
+   *  PRs/Issues/Reviews top tabs). The view is driven to this filter and hides
+   *  its own filter control to avoid a redundant second switch. */
+  initialFilter?: Filter | null;
 };
 
 type ActivityPayload = ActivityResult | { ok: false; error?: string };
@@ -2290,13 +2294,26 @@ const COLS: ColDef[] = [
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initialTarget }: Props = {}) {
+export function GitHubView({
+  onJumpToSession,
+  onFocusCard,
+  onTasksRefresh,
+  initialTarget,
+  initialFilter,
+}: Props = {}) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [activity, setActivity] = useState<ActivityResult | null>(null);
   const [patStatus, setPatStatus] = useState<PatStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useSurfacePreference(surfacePreferenceSpecs.github.filter);
+  // Host-driven filter (Code Workshop's PRs/Issues/Reviews tabs): follow the
+  // prop whenever it changes so switching tabs re-filters the same mounted view.
+  useEffect(() => {
+    if (initialFilter && initialFilter !== filter) setFilter(initialFilter);
+    // Only react to the host's prop, not the user's own later chip changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFilter]);
   const [orgFilter, setOrgFilter] = useSurfacePreference(surfacePreferenceSpecs.github.organization);
   const [repoFilter, setRepoFilter] = useSurfacePreference(surfacePreferenceSpecs.github.repository);
   const [query, setQuery] = useState("");
@@ -2717,19 +2734,23 @@ export function GitHubView({ onJumpToSession, onFocusCard, onTasksRefresh, initi
           )}
         </div>
 
-        <Tabs
-          className="gh-compact-tabs"
-          variant="segment"
-          size="sm"
-          ariaLabel="Filter GitHub activity"
-          value={filter}
-          onChange={setFilter}
-          items={(["all", "pr", "review_request", "issue"] as Filter[]).map((f) => ({
-            id: f,
-            label: ({ all: "All", pr: "PRs", review_request: "Reviews", issue: "Issues" } as Record<Filter, string>)[f],
-            count: counts[f] > 0 ? counts[f] : undefined,
-          })) satisfies TabItem<Filter>[]}
-        />
+        {/* Host-driven filter (Code Workshop tabs) owns the switch — hide the
+            in-view chips so there is only one control. */}
+        {initialFilter ? null : (
+          <Tabs
+            className="gh-compact-tabs"
+            variant="segment"
+            size="sm"
+            ariaLabel="Filter GitHub activity"
+            value={filter}
+            onChange={setFilter}
+            items={(["all", "pr", "review_request", "issue"] as Filter[]).map((f) => ({
+              id: f,
+              label: ({ all: "All", pr: "PRs", review_request: "Reviews", issue: "Issues" } as Record<Filter, string>)[f],
+              count: counts[f] > 0 ? counts[f] : undefined,
+            })) satisfies TabItem<Filter>[]}
+          />
+        )}
 
         <div className="gh-compact-filters">
           <div className="gh-search">

--- a/src/lib/code-surface.test.ts
+++ b/src/lib/code-surface.test.ts
@@ -6,9 +6,11 @@ import {
   codeSessionDiffstat,
   codeSessionWorkRoot,
   groupCodeRailSessions,
+  isCodeGithubTab,
   isCodeRailSession,
   isCodeTopTab,
   isCodeWorkbenchTab,
+  normalizeCodeTopTab,
   parseCodeDeepLink,
 } from "./code-surface.ts";
 import type { SessionRow } from "./types.ts";
@@ -118,17 +120,30 @@ test("work root prefers the session's worktree over the shared project root", ()
 });
 
 test("deep-link parsing falls back to defaults on unknown values", () => {
-  const parsed = parseCodeDeepLink(new URLSearchParams("session=abc&ctab=github&wtab=files"));
-  assert.deepEqual(parsed, { sessionId: "abc", topTab: "github", workbenchTab: "files" });
+  const parsed = parseCodeDeepLink(new URLSearchParams("session=abc&ctab=reviews&wtab=files"));
+  assert.deepEqual(parsed, { sessionId: "abc", topTab: "reviews", workbenchTab: "files" });
+  // Legacy `ctab=github` (minted before the PRs/Issues/Reviews split) lands on PRs.
+  const legacy = parseCodeDeepLink(new URLSearchParams("ctab=github"));
+  assert.equal(legacy.topTab, "prs");
   const fallback = parseCodeDeepLink(new URLSearchParams("ctab=bogus&wtab=nope"));
   assert.deepEqual(fallback, { sessionId: null, topTab: "sessions", workbenchTab: "diff" });
 });
 
 test("tab guards accept exactly the fixed vocabularies", () => {
   for (const tab of ["diff", "files", "terminal", "pr"]) assert.ok(isCodeWorkbenchTab(tab));
-  for (const tab of ["sessions", "github"]) assert.ok(isCodeTopTab(tab));
+  for (const tab of ["sessions", "prs", "issues", "reviews"]) assert.ok(isCodeTopTab(tab));
+  for (const tab of ["prs", "issues", "reviews"]) assert.ok(isCodeGithubTab(tab));
+  assert.ok(!isCodeGithubTab("sessions"));
   assert.ok(!isCodeWorkbenchTab("overview"));
   assert.ok(!isCodeTopTab("code"));
+  assert.ok(!isCodeTopTab("github"), "the legacy single github tab is no longer a top tab");
   assert.ok(!isCodeWorkbenchTab(null));
   assert.ok(!isCodeTopTab(undefined));
+});
+
+test("normalizeCodeTopTab maps legacy + unknown values", () => {
+  assert.equal(normalizeCodeTopTab("github"), "prs", "legacy github → PRs");
+  assert.equal(normalizeCodeTopTab("issues"), "issues");
+  assert.equal(normalizeCodeTopTab("bogus"), "sessions");
+  assert.equal(normalizeCodeTopTab(null), "sessions");
 });

--- a/src/lib/code-surface.ts
+++ b/src/lib/code-surface.ts
@@ -16,12 +16,30 @@ export function isCodeWorkbenchTab(value: string | null | undefined): value is C
   return (CODE_WORKBENCH_TABS as readonly string[]).includes(value ?? "");
 }
 
-/** Top-level surface tabs: the session workbench, or the absorbed GitHub view. */
-export const CODE_TOP_TABS = ["sessions", "github"] as const;
+/** Top-level surface tabs: the session workbench, then GitHub content split into
+ *  its own tabs (PRs · Issues · Reviews) — the single generic "github" tab was
+ *  replaced so each content type lands directly on its own list. */
+export const CODE_TOP_TABS = ["sessions", "prs", "issues", "reviews"] as const;
 export type CodeTopTab = (typeof CODE_TOP_TABS)[number];
 
 export function isCodeTopTab(value: string | null | undefined): value is CodeTopTab {
   return (CODE_TOP_TABS as readonly string[]).includes(value ?? "");
+}
+
+/** The GitHub content tabs (every top tab except the session workbench). */
+export const CODE_GITHUB_TABS = ["prs", "issues", "reviews"] as const;
+export type CodeGithubTab = (typeof CODE_GITHUB_TABS)[number];
+
+export function isCodeGithubTab(value: string | null | undefined): value is CodeGithubTab {
+  return (CODE_GITHUB_TABS as readonly string[]).includes(value ?? "");
+}
+
+/** Normalize a raw `ctab` value to a top tab. The legacy `github` value (from
+ *  deep links minted before the split) lands on PRs so old links keep working. */
+export function normalizeCodeTopTab(raw: string | null | undefined): CodeTopTab {
+  if (isCodeTopTab(raw)) return raw;
+  if (raw === "github") return "prs";
+  return "sessions";
 }
 
 /** A project group in the session rail: one repo/root, newest work first. */
@@ -143,7 +161,7 @@ export function parseCodeDeepLink(params: Pick<URLSearchParams, "get">): CodeDee
   const rawTab = params.get("wtab");
   return {
     sessionId: params.get("session") || null,
-    topTab: isCodeTopTab(rawTop) ? rawTop : "sessions",
+    topTab: normalizeCodeTopTab(rawTop),
     workbenchTab: isCodeWorkbenchTab(rawTab) ? rawTab : "diff",
   };
 }

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -2,7 +2,8 @@ import { expect, test, type Page } from "@playwright/test";
 
 // The dedicated Code surface (cave-k0ua): a Codex-style multi-session coding
 // workbench — session rail grouped by project, per-session workbench
-// (Diff | Files | Terminal | PR), inspector column, and a GitHub top tab.
+// (Diff | Files | Terminal | PR), inspector column, and the GitHub content top
+// tabs (PRs | Issues | Reviews).
 // Default-on since phase 2 (cave-m6ys); since cave-cc5r it lives as the
 // Coding familiar's Role Surface room (`?mode=code` aliases onto
 // `surface:code`), so the mocked familiar carries the explicit
@@ -91,11 +92,15 @@ test.describe("code surface (Coding familiar's room)", () => {
     await base(page);
     await page.goto("/?mode=code");
 
-    // Top tabs: Sessions active, GitHub reachable (the absorbed surface).
+    // Top tabs: Sessions active, then the GitHub content tabs (PRs · Issues ·
+    // Reviews) that replaced the single generic GitHub tab.
     const topTabs = page.getByRole("tablist", { name: "Code surface" });
     await expect(topTabs).toBeVisible({ timeout: 30_000 });
     await expect(topTabs.getByRole("tab", { name: "Sessions" })).toHaveAttribute("aria-selected", "true");
-    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "PRs" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "Issues" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "Reviews" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "GitHub", exact: true })).toHaveCount(0);
 
     // Rail: both sessions listed under their project group.
     const rail = page.getByRole("navigation", { name: "Coding sessions" });


### PR DESCRIPTION
Replaces the single generic **GitHub** top tab on the Code surface (the Coding familiar's room / **Code Workshop**) with three content tabs — **PRs · Issues · Reviews** — each landing the GitHub view directly on that content.

## What changed
- **`code-surface.ts`** — `CODE_TOP_TABS` is now `sessions · prs · issues · reviews`. Adds `CODE_GITHUB_TABS` / `isCodeGithubTab` / `normalizeCodeTopTab`. A **legacy `ctab=github`** deep link (minted before the split) normalizes to **PRs**, so old links keep working.
- **`code-view.tsx`** — the top-tab row renders Sessions + the three GitHub tabs, each mapped to the GitHubView filter it drives (`pr` / `issue` / `review_request`). One `GitHubView` stays mounted and re-filters as the active tab changes (no remount/scroll loss); a github-item deep link lands on PRs.
- **`github-view.tsx`** — new optional `initialFilter` prop. When the host owns the filter, the view follows it and **hides its own filter chips** so there's a single control (no redundant switch).

The standalone `github` **workspace mode** (which renders `GitHubView` directly with an All/PRs/Reviews/Issues switch) is unchanged — this only restructures the Code Workshop's tabs.

## Validation
- `tsc --noEmit` — 0 errors
- `pnpm test:app` — **892 files passed** (code-surface unit test updated: new vocab + legacy `github → prs` mapping)
- eslint · design codemod · token-drift ratchet · tests-wired — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)