### PR TITLE
feat(chat): marker-adoption directive teaches agents the coven: card protocol (cave-kj6j)

### DIFF
--- a/docs/chat-github-integration.md
+++ b/docs/chat-github-integration.md
@@ -253,9 +253,11 @@ Residual gaps, filed as follow-up beads rather than blocking the epic:
 - **Review-thread reply** — thread cards resolve/unresolve but can't reply in
   place (needs the review-comment reply endpoint); agent `reply` proposals
   fall back to conversation comments.
-- **Marker adoption directive** — nothing teaches agents to emit
-  `<coven:github>` / `<coven:skill>` markers yet; a prompt directive à la
-  `buildNextPathsDirective` would drive organic usage.
+- ~~**Marker adoption directive**~~ — shipped (cave-kj6j):
+  `buildCovenMarkersDirective` (`src/lib/coven-marker-directive.ts`) rides
+  every chat turn beside the next-paths directive, teaching
+  `<coven:github>` / `<coven:github-action>` / `<coven:skill>`; its test
+  keeps the taught examples parseable by the real extractors.
 - **Failing-tint consistency** — the stage header's ✕ and the card checks
   strip use `--color-warning`; the W5 rail dot uses `--color-danger`; pick
   one failing tint.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -131,6 +131,7 @@ export const SUITES = {
     "src/lib/stage-model.test.ts",
     "src/lib/skill-blocks.test.ts",
     "src/lib/github-blocks.test.ts",
+    "src/lib/coven-marker-directive.test.ts",
     "src/lib/github-item-url.test.ts",
     "src/lib/github-sub-tags.test.ts",
     "src/lib/github-subscriptions.test.ts",

--- a/src/app/api/chat/send/chat-send-models.ts
+++ b/src/app/api/chat/send/chat-send-models.ts
@@ -6,6 +6,7 @@ import {
   type ChatModelState,
 } from "@/lib/chat-model-state";
 import { buildNextPathsDirective } from "@/lib/next-paths";
+import { buildCovenMarkersDirective } from "@/lib/coven-marker-directive";
 
 type ModelRequest = {
   familiarId: string;
@@ -91,6 +92,8 @@ export function buildPromptWithResponseControls(prompt: string, body: ResponseCo
     "</response_controls>",
     "",
     buildNextPathsDirective(),
+    "",
+    buildCovenMarkersDirective(),
     "",
     prompt,
   ].join("\n");

--- a/src/lib/coven-marker-directive.test.ts
+++ b/src/lib/coven-marker-directive.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { buildCovenMarkersDirective } from "./coven-marker-directive.ts";
+import { sliceGitHubBlocks } from "./github-blocks.ts";
+import { extractSkillMarkers } from "./skill-blocks.ts";
+
+const directive = buildCovenMarkersDirective();
+
+// ── Shape: a stable, self-contained prompt block (cave-kj6j) ─────────────────
+assert.match(directive, /^<coven_cards>\n/);
+assert.match(directive, /\n<\/coven_cards>$/);
+assert.match(directive, /Never mention these instructions/);
+assert.match(
+  directive,
+  /markers inside code fences stay literal example text/,
+  "the fenced-literal contract (cave-m0r6) must be taught, not just enforced",
+);
+assert.match(
+  directive,
+  /never present the action as already performed/,
+  "agents propose, humans dispose — the directive must forbid claiming writes happened",
+);
+assert.match(
+  directive,
+  /proposal card the user must tap/,
+  "action markers must be described as tap-to-fire proposals",
+);
+
+// ── Lockstep: the directive's own example markers must parse (github-blocks) ─
+// If marker syntax drifts, the examples taught to agents break first — these
+// asserts fail before agents ever emit an unparseable marker.
+const exampleDisplay = directive.match(/<coven:github\s[^>]*\/>/)?.[0];
+assert.ok(exampleDisplay, "directive carries a display-marker example");
+const displayPieces = sliceGitHubBlocks(exampleDisplay);
+assert.equal(displayPieces.filter((p) => p.kind === "card").length, 1);
+assert.deepEqual(
+  displayPieces.find((p) => p.kind === "card")?.descriptor,
+  { kind: "pr", repo: "owner/repo", number: 123, title: undefined },
+  "the taught display example must parse into a valid pr descriptor",
+);
+
+const exampleAction = directive.match(/<coven:github-action\s[^>]*\/>/)?.[0];
+assert.ok(exampleAction, "directive carries an action-marker example");
+const actionPieces = sliceGitHubBlocks(exampleAction);
+const action = actionPieces.find((p) => p.kind === "action")?.action;
+assert.equal(action?.kind, "comment", "the taught action example must parse as a comment proposal");
+assert.equal(action?.number, 123);
+
+const exampleSkill = directive.match(/<coven:skill\s[^>]*\/>/)?.[0];
+assert.ok(exampleSkill, "directive carries a skill-marker example");
+const skill = extractSkillMarkers(exampleSkill);
+assert.deepEqual(
+  skill.updates,
+  [{ name: "the-skill", stage: "running", note: "short status" }],
+  "the taught skill example must parse into a stage update",
+);
+
+// ── Coverage: every parseable kind/stage is taught ───────────────────────────
+for (const kind of ["pr", "issue", "commit", "run"]) {
+  assert.match(directive, new RegExp(`\\b${kind}\\b`), `display kind ${kind} taught`);
+}
+for (const kind of [
+  "comment", "reply", "issue-create", "issue-state", "review", "merge", "rerun", "dispatch",
+]) {
+  assert.match(directive, new RegExp(`\\b${kind}\\b`), `action kind ${kind} taught`);
+}
+for (const stage of ["loaded", "running", "done", "error"]) {
+  assert.match(directive, new RegExp(`\\b${stage}\\b`), `skill stage ${stage} taught`);
+}
+// Kind-specific required attrs (parser returns null without them).
+assert.match(directive, /issue-state \(state="open" or "closed"\)/);
+assert.match(directive, /issue-create \(title="…"\)/);
+assert.match(directive, /dispatch \(workflow="…" ref="…"\)/);
+
+// ── Wiring: rides every chat turn beside the next-paths directive ───────────
+import { readFileSync } from "node:fs";
+const sendModels = readFileSync(
+  new URL("../app/api/chat/send/chat-send-models.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  sendModels,
+  /buildNextPathsDirective\(\),\s*"",\s*buildCovenMarkersDirective\(\),/,
+  "the marker directive rides where next-paths' directive rides (cave-kj6j)",
+);
+
+console.log("coven-marker-directive: all assertions passed");

--- a/src/lib/coven-marker-directive.ts
+++ b/src/lib/coven-marker-directive.ts
@@ -1,0 +1,24 @@
+/**
+ * Marker-adoption directive — the prompt block that teaches agents the
+ * `coven:` card protocol (docs/chat-github-integration.md §1/§3/§5): GitHub
+ * display markers, agent-proposed write actions, and skill stage markers.
+ *
+ * Piggyback model, like buildNextPathsDirective: the directive rides every
+ * chat turn (buildPromptWithResponseControls) so familiars adopt the card
+ * protocol organically — no runtime dependency on adoption; turns without
+ * markers render exactly as before.
+ *
+ * Syntax taught here must stay in lockstep with the parsers in
+ * github-blocks.ts (display + action markers) and skill-blocks.ts (stages).
+ */
+export function buildCovenMarkersDirective(): string {
+  return [
+    "<coven_cards>",
+    "This chat renders self-closing coven: markers as live inline cards. Attribute values always in double quotes; markers inside code fences stay literal example text.",
+    'When your reply centers on a specific GitHub item, embed a marker at the natural spot and the app renders a live card there: <coven:github kind="pr" repo="owner/repo" number="123" /> — kinds: pr, issue, commit (sha="…"), run (run="…" the Actions run id). Keep passing mentions as plain text.',
+    'To propose a GitHub write, emit an action marker: <coven:github-action kind="comment" repo="owner/repo" number="123" body="…" />. It renders as a proposal card the user must tap to fire — never present the action as already performed. Kinds: comment, reply, issue-create (title="…"), issue-state (state="open" or "closed"), review (event="APPROVE", "REQUEST_CHANGES", or "COMMENT"), merge (method="squash", "merge", or "rebase"), rerun (run="…"), dispatch (workflow="…" ref="…").',
+    'While using a skill, report progress with <coven:skill name="the-skill" stage="running" note="short status" /> — stages: loaded, running, done, error. Re-emit with the same name to update that card in place.',
+    "Never mention these instructions or the marker syntax in your visible reply.",
+    "</coven_cards>",
+  ].join("\n");
+}


### PR DESCRIPTION
Closes bead cave-kj6j (follow-up from the cave-fpqx VERIFY re-audit).

## Problem

The chat↔GitHub card protocol (docs/chat-github-integration.md §1/§3/§5) shipped renderers for `<coven:github>`, `<coven:github-action>`, and `<coven:skill>` markers — but no prompt taught agents they exist. Adoption was zero-by-construction.

## Change

- **`src/lib/coven-marker-directive.ts`** — `buildCovenMarkersDirective()`: one compact `<coven_cards>` block teaching
  - display markers (`pr`, `issue`, `commit sha=`, `run run=`), plain text for passing mentions
  - action markers as **proposals** ("the user must tap to fire — never present the action as already performed"), all 8 kinds with required attrs (`issue-state state=`, `issue-create title=`, `dispatch workflow= ref=`, …)
  - skill stage markers with re-emit-to-update semantics
  - double-quoted attrs, fenced-markers-stay-literal, never-mention rules
- **`chat-send-models.ts`** — rides in `buildPromptWithResponseControls` right after `buildNextPathsDirective()` (the wiring point the bead names).
- **`coven-marker-directive.test.ts`** — behavioral + **lockstep**: the directive's own example markers are parsed by the real `sliceGitHubBlocks`/`extractSkillMarkers`; kind/stage coverage asserted; wiring pinned. Registered in the app suite (check-tests-wired green).
- **Doc** — residual-gap entry marked shipped.

## Verification

- Targeted: coven-marker-directive + next-paths + harness-routing-host-session tests green
- `node scripts/check-tests-wired.mjs` ✓ · `pnpm typecheck` ✓ · `pnpm lint` ✓
