### PR TITLE
fix(home): restore backdrop image treatment for the 3a dashboard

### DIFF
--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -7,26 +7,37 @@ import { readFileSync } from "node:fs";
 // readability surface on the existing hearth card instead.
 const css = readFileSync(new URL("../styles/backdrop.css", import.meta.url), "utf8");
 
-// ── Home hearth glass ─────────────────────────────────────────────────────────
+// ── Home dashboard glass (launcher 3a) ────────────────────────────────────────
+// The dashboard is a dense surface (section labels + board rows sit on the
+// photo), so it earns the Familiar-tab glass idiom: a translucent theme-derived
+// ground with a real blur over the whole surface. The rail + docked composer
+// keep their own solid --bg-panel fills, so the image shows through the board
+// content area only.
 assert.match(
   css,
-  /html\[data-backdrop-on\] \.home-hearth-card \{[^}]*background: color-mix\(in oklch, var\(--bg-base\) 72%, transparent\);[^}]*\}/,
-  "Home uses one uniform theme-derived hearth surface while a backdrop is active",
+  /html\[data-backdrop-on\] \.home-composer-root\.home-dash \{[^}]*background: color-mix\(in oklch, var\(--bg-base\) 62%, transparent\);[^}]*\}/,
+  "Home uses one uniform theme-derived glass ground while a backdrop is active",
 );
 assert.match(
   css,
-  /html\[data-backdrop-on\] \.home-hearth-card \{[^}]*border-radius: var\(--radius-xl\);[^}]*\}/,
-  "the hearth surface rounds with the Appearance corner-radius tokens, not square corners",
+  /html\[data-backdrop-on\] \.home-composer-root\.home-dash \{[^}]*backdrop-filter: blur\(var\(--glass-blur\)\)[^}]*\}/,
+  "the dashboard ground earns a real blur so its on-surface type stays legible over the image",
 );
 assert.doesNotMatch(
   css,
   /html\[data-backdrop-on\] \.home-composer-root::before/,
-  "Home no longer paints a full-area pseudo-element behind the hearth",
+  "Home no longer paints a full-area pseudo-element behind the content",
 );
 assert.doesNotMatch(
   css,
-  /html\[data-backdrop-on\] \.home-hearth-card(?:::before|::after)? \{[^}]*radial-gradient\(/s,
+  /html\[data-backdrop-on\] \.home-composer-root\.home-dash(?:::before|::after)? \{[^}]*radial-gradient\(/s,
   "the backdrop-only Home treatment contains no radial gradient",
+);
+// The retired hearth card no longer carries a backdrop treatment.
+assert.doesNotMatch(
+  css,
+  /html\[data-backdrop-on\] \.home-hearth-card/,
+  "the retired hearth-card backdrop rules are gone (Home is the dashboard shell now)",
 );
 
 // ── Chat landing glass ───────────────────────────────────────────────────────
@@ -63,8 +74,8 @@ assert.match(
 );
 assert.match(
   css,
-  /prefers-reduced-transparency: reduce[\s\S]*html\[data-backdrop-on\] \.home-hearth-card \{[^}]*background: color-mix\(in oklch, var\(--bg-panel\) 55%, transparent\);[^}]*\}/,
-  "reduced transparency restores the normal Home card fill",
+  /prefers-reduced-transparency: reduce[\s\S]*html\[data-backdrop-on\] \.home-composer-root\.home-dash \{[^}]*background: var\(--bg-base\);[^}]*backdrop-filter: none;[^}]*\}/,
+  "reduced transparency restores the Home dashboard's opaque base surface",
 );
 assert.match(
   css,

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -97,16 +97,17 @@ html[data-backdrop-on] .cave-group-chat-shell {
    (faces, props) fights the copy. Ground the centered content clusters
    without dulling the scene at its edges. */
 
-/* Home: one uniform, theme-derived readability surface on the existing
-   hearth card (cave-hct3). The old full-area radial ground behind the whole
-   column read as a blurry oval over busy imagery; the card is the thing that
-   needs the contrast, so deepen ITS fill instead and leave the scene visible
-   around it. */
-html[data-backdrop-on] .home-hearth-card {
-  background: color-mix(in oklch, var(--bg-base) 72%, transparent);
-  /* --radius-xl (not a hard-coded px / square corner) so the hearth glass
-     follows the Appearance → Corner radius setting like the chat glass. */
-  border-radius: var(--radius-xl);
+/* Home (launcher 3a dashboard): a glass ground over the whole surface — the
+   same idiom the Familiar tab earns, since the dashboard is another dense
+   surface whose section labels, greeting, and board rows sit straight on the
+   photo. The image reads as a soft tinted wash behind the board content, while
+   the rail and docked composer keep their own solid --bg-panel fills, so they
+   stay grounded and the scene shows through the content area only. (The old
+   centered hearth card is gone; this replaces its fill.) */
+html[data-backdrop-on] .home-composer-root.home-dash {
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 /* Chat landing (no thread yet): the greeting/identity/suggestions cluster
@@ -149,6 +150,12 @@ html[data-backdrop-on] .home-composer-root {
   html[data-backdrop-on] .familiar-tab {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
   }
+
+  /* Same for the Home dashboard ground — no blur means a see-through wash is
+     unreadable, so go near-opaque over the photo. */
+  html[data-backdrop-on] .home-composer-root.home-dash {
+    background: color-mix(in oklch, var(--bg-base) 92%, transparent);
+  }
 }
 
 @media (prefers-reduced-transparency: reduce) {
@@ -169,10 +176,12 @@ html[data-backdrop-on] .home-composer-root {
     padding-inline: 0;
   }
 
-  /* Same reasoning for the new grounds: no image → no deepened fill; restore
-     the hearth card's normal translucent panel fill. */
-  html[data-backdrop-on] .home-hearth-card {
-    background: color-mix(in oklch, var(--bg-panel) 55%, transparent);
+  /* Same reasoning for the new grounds: no image → no glass over nothing;
+     restore the Home dashboard's normal opaque base surface. */
+  html[data-backdrop-on] .home-composer-root.home-dash {
+    background: var(--bg-base);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 
   html[data-backdrop-on] .cave-chat-empty-shell {


### PR DESCRIPTION
Follow-up to #3758. The launcher 3a redesign made Home an opaque full-bleed dashboard, which hid the user's **backdrop image** on Home, and left the backdrop CSS keyed off the now-retired `.home-hearth-card`.

## Fix
Re-point the backdrop treatment at the dashboard shell:

- `html[data-backdrop-on] .home-composer-root.home-dash` gets a **translucent, theme-derived glass ground** (`bg-base 62%`) with a real blur — the same idiom the **Familiar tab** (the other dense surface whose small type sits straight on the photo) already earns.
- The **rail and docked composer keep their solid `--bg-panel` fills**, so they stay grounded and the image shows through the **board content area only** — matching the backdrop contract ("side panes stay solid; image shows through the content area").
- Both degradation paths follow the existing pattern: **near-opaque** (`92%`) where `backdrop-filter` is unavailable, and the **opaque base surface** under `prefers-reduced-transparency: reduce`.
- `backdrop-scrim.test.ts` updated to pin the new dashboard rules and assert the hearth-card treatment is gone.

## Verification
- `pnpm build` → **exit 0** (home first-load CSS **914/915 KB**)
- typecheck (0 errors), design-token drift ratchet, accent-token-usage, `backdrop-scrim` test → pass
- **In-app computed-style check** confirmed the structure: dashboard root becomes translucent (`0.62` alpha) while the rail/dock stay opaque `--bg-panel`, and the shell chain (`.shell-detail` → `.shell-root` …) is transparent — the same compositing path the prior working hearth treatment used.

### Honest caveat
The **end-to-end image render** wasn't pixel-verified in the headless harness: enabling the real backdrop requires the server-persisted `appearance.backdrop` preference plus an uploaded image (IDB), which a daemon-less run can't easily set. The change is correct by construction — it only moves the translucent fill from `.home-hearth-card` to the dashboard root; the fixed z-0 image layer and transparent shell chain are unchanged from the treatment that already worked on the old Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)