### PR TITLE
feat(migration): explicit card-id union merge for divergent board copies

### DIFF
--- a/src/lib/server/cave-home-migration-json-merge.test.ts
+++ b/src/lib/server/cave-home-migration-json-merge.test.ts
@@ -237,6 +237,96 @@ try {
     assert.equal((await json(path.join(cave, "preferences.json"))).general.newsHeadlines, false);
   }
 
+  // Divergent board copies never auto-merge (conservative philosophy from
+  // cave-5ax2): a one-sided card is ambiguous, so startup reconciliation
+  // leaves both files and the durable summary advertises the explicit
+  // card-id merge alongside the whole-file choices (cave-6z41).
+  {
+    const { coven, cave } = await home("board-no-auto");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-board.json"), JSON.stringify({ version: 1, cards: [
+      { id: "legacy-only", title: "Legacy card", status: "backlog", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-02T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "board.json"), JSON.stringify({ version: 1, cards: [
+      { id: "canonical-only", title: "Canonical card", status: "backlog", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-03T00:00:00Z" },
+    ] }));
+    const result = await migrateCaveHome({ createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(result.skipped.includes("cave-board.json"), "board conflict must not auto-resolve");
+    assert.deepEqual((await json(path.join(cave, "board.json"))).cards.map((card) => card.id), ["canonical-only"], "canonical copy untouched without an explicit choice");
+    const status = await caveHomeMigrationStatus();
+    assert.equal(status.conflicts.includes("cave-board.json"), true);
+    const detail = status.details.find((entry) => entry.legacy === "cave-board.json");
+    assert.equal(detail.strategy, "board");
+    assert.deepEqual(detail.actions, ["merge", "keep-canonical", "recover-legacy", "defer"], "the card-id merge is offered first among the resolutions");
+    assert.match(detail.summary, /card-id merge/, "the conflict summary suggests the lossless merge");
+
+    // The explicit merge unions by card id: every one-sided card from BOTH
+    // copies is kept — the whole point after the near-loss incident.
+    const merged = await migrateCaveHome({ legacy: "cave-board.json", action: "merge", createSymlink: denySymlink });
+    assert.deepEqual(merged.errors, []);
+    assert.ok(merged.resolved.includes("cave-board.json"));
+    const board = await json(path.join(cave, "board.json"));
+    assert.deepEqual(board.cards.map((card) => card.id), ["canonical-only", "legacy-only"], "canonical order first, recovered legacy cards appended");
+    assert.equal((await caveHomeMigrationStatus()).migrated, true);
+  }
+
+  // A card present in both copies resolves to the newest per-card updatedAt,
+  // and the file version keeps the larger of the two.
+  {
+    const { coven, cave } = await home("board-newest-wins");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-board.json"), JSON.stringify({ version: 3, cards: [
+      { id: "shared", title: "newer legacy edit", status: "review", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-03-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "board.json"), JSON.stringify({ version: 2, cards: [
+      { id: "shared", title: "older canonical edit", status: "backlog", createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    const result = await migrateCaveHome({ legacy: "cave-board.json", action: "merge", createSymlink: denySymlink });
+    assert.deepEqual(result.errors, []);
+    assert.ok(result.resolved.includes("cave-board.json"));
+    const board = await json(path.join(cave, "board.json"));
+    assert.equal(board.cards.length, 1);
+    assert.equal(board.cards[0].title, "newer legacy edit");
+    assert.equal(board.version, 3);
+  }
+
+  // A shared card whose copies differ at the same updatedAt has no safe
+  // winner; the explicit merge refuses instead of guessing.
+  {
+    const { coven, cave } = await home("board-ambiguous-edit");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-board.json"), JSON.stringify({ version: 1, cards: [
+      { id: "shared", title: "legacy words", status: "backlog", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "board.json"), JSON.stringify({ version: 1, cards: [
+      { id: "shared", title: "canonical words", status: "backlog", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    const result = await migrateCaveHome({ legacy: "cave-board.json", action: "merge", createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-board.json"));
+    assert.equal((await json(path.join(cave, "board.json"))).cards[0].title, "canonical words", "canonical copy untouched by the refused merge");
+    const detail = (await caveHomeMigrationStatus()).details.find((entry) => entry.legacy === "cave-board.json");
+    assert.match(detail.summary, /without a usable updatedAt order/);
+  }
+
+  // Duplicate card ids inside one copy are malformed: a Map union would
+  // silently discard one of the records, so the merge refuses.
+  {
+    const { coven, cave } = await home("board-duplicate-id");
+    await mkdir(cave, { recursive: true });
+    await writeFile(path.join(coven, "cave-board.json"), JSON.stringify({ version: 1, cards: [
+      { id: "duplicate", title: "first", updatedAt: "2026-01-01T00:00:00Z" },
+      { id: "duplicate", title: "second", updatedAt: "2026-02-01T00:00:00Z" },
+    ] }));
+    await writeFile(path.join(cave, "board.json"), JSON.stringify({ version: 1, cards: [] }));
+    const result = await migrateCaveHome({ legacy: "cave-board.json", action: "merge", createSymlink: denySymlink });
+    assert.ok(result.skipped.includes("cave-board.json"));
+    assert.match(
+      (await caveHomeMigrationStatus()).details.find((entry) => entry.legacy === "cave-board.json").summary,
+      /duplicate card ID/,
+    );
+  }
+
   console.log("cave-home-migration-json-merge.test.ts: ok");
 } finally {
   for (const root of roots) await rm(root, { recursive: true, force: true });

--- a/src/lib/server/cave-home-migration.ts
+++ b/src/lib/server/cave-home-migration.ts
@@ -11,6 +11,8 @@ import {
  * Cave-owned legacy paths and their canonical names/strategies.
  *
  * Entries with schema-aware strategies are merged automatically when safe.
+ * The board strategy is schema-aware but explicit-only: its card-id union is
+ * offered as a resolution action, never run unprompted (cave-6z41).
  * Directory children are merged by name. Every other entry is explicitly
  * manual: differing copies are backed up and left unresolved until the user
  * chooses which copy to keep. Daemon-owned ledgers and ad-hoc backups are not
@@ -19,7 +21,7 @@ import {
 export const CAVE_HOME_MIGRATIONS: readonly CaveHomeReconciliationEntry[] = [
   { legacy: "cave-config.json", next: "config.json", strategy: "manual" },
   { legacy: "cave-state.json", next: "state.json", strategy: "state" },
-  { legacy: "cave-board.json", next: "board.json", strategy: "manual" },
+  { legacy: "cave-board.json", next: "board.json", strategy: "board" },
   { legacy: "cave-canvas.json", next: "canvas.json", strategy: "manual" },
   { legacy: "cave-inbox.json", next: "inbox.json", strategy: "inbox" },
   { legacy: "cave-inbox-prefs.json", next: "inbox-prefs.json", strategy: "manual" },

--- a/src/lib/server/cave-home-reconciliation-types.ts
+++ b/src/lib/server/cave-home-reconciliation-types.ts
@@ -1,6 +1,6 @@
 import type { rename, symlink } from "node:fs/promises";
 
-export type ReconciliationStrategy = "inbox" | "state" | "preferences" | "directory" | "manual";
+export type ReconciliationStrategy = "inbox" | "state" | "preferences" | "board" | "directory" | "manual";
 
 export type CaveHomeReconciliationEntry = {
   legacy: string;

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1104,6 +1104,69 @@ function mergePreferences(legacy: unknown, canonical: unknown): MergeOutcome {
   return { ok: true, value: merged, summary: "Merged independent preference sections by revision and timestamp." };
 }
 
+/** Cards keyed by stable id, or a review reason when the copy is malformed. */
+function boardCardsById(value: unknown): Map<string, Record<string, unknown>> | string {
+  const raw = record(value);
+  if (!raw || !Array.isArray(raw.cards)) return "Board data is malformed and requires review.";
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const rawCard of raw.cards) {
+    const card = record(rawCard);
+    if (!card || typeof card.id !== "string" || !card.id) return "Board card without a stable ID requires review.";
+    if (byId.has(card.id)) return `Board contains duplicate card ID ${card.id} and requires review.`;
+    byId.set(card.id, card);
+  }
+  return byId;
+}
+
+/**
+ * Card-id union merge for divergent board copies (cave-6z41, deferred
+ * follow-up from the 2026-07-22 board near-loss incident). Explicit-only:
+ * a one-sided card is ambiguous (new on this side vs deleted on the other),
+ * so the union — which resurrects rather than discards — never runs
+ * unprompted; the caller gates it on the user picking "merge" for this
+ * entry. Shared ids keep the newer per-card updatedAt; a shared id whose
+ * copies differ without a usable timestamp order refuses the merge.
+ */
+function mergeBoard(legacy: unknown, canonical: unknown): MergeOutcome {
+  const left = boardCardsById(legacy);
+  if (typeof left === "string") return { ok: false, summary: left };
+  const right = boardCardsById(canonical);
+  if (typeof right === "string") return { ok: false, summary: right };
+  let recovered = 0;
+  let newerLegacy = 0;
+  const cards: Record<string, unknown>[] = [];
+  for (const [id, canonicalCard] of right) {
+    const legacyCard = left.get(id);
+    if (!legacyCard || JSON.stringify(legacyCard) === JSON.stringify(canonicalCard)) {
+      cards.push(canonicalCard);
+      continue;
+    }
+    const legacyTime = parseDate(legacyCard.updatedAt);
+    const canonicalTime = parseDate(canonicalCard.updatedAt);
+    if (!legacyTime || !canonicalTime || legacyTime === canonicalTime) {
+      return { ok: false, summary: `Board card ${id} differs without a usable updatedAt order and requires review.` };
+    }
+    if (legacyTime > canonicalTime) newerLegacy += 1;
+    cards.push(legacyTime > canonicalTime ? legacyCard : canonicalCard);
+  }
+  for (const [id, legacyCard] of left) {
+    if (right.has(id)) continue;
+    cards.push(legacyCard);
+    recovered += 1;
+  }
+  const leftRaw = record(legacy) as Record<string, unknown>;
+  const rightRaw = record(canonical) as Record<string, unknown>;
+  const version = Math.max(
+    typeof leftRaw.version === "number" ? leftRaw.version : 1,
+    typeof rightRaw.version === "number" ? rightRaw.version : 1,
+  );
+  return {
+    ok: true,
+    value: { ...rightRaw, version, cards },
+    summary: `Merged ${cards.length} card(s) by stable ID (${recovered} recovered from legacy, ${newerLegacy} newer legacy edit(s) kept).`,
+  };
+}
+
 async function mergeJson(strategy: ReconciliationStrategy, legacyPath: string, canonicalPath: string): Promise<MergeOutcome> {
   let legacy: unknown;
   let canonical: unknown;
@@ -1116,6 +1179,7 @@ async function mergeJson(strategy: ReconciliationStrategy, legacyPath: string, c
   if (strategy === "inbox") return mergeInbox(legacy, canonical);
   if (strategy === "state") return mergeState(legacy, canonical);
   if (strategy === "preferences") return mergePreferences(legacy, canonical);
+  if (strategy === "board") return mergeBoard(legacy, canonical);
   return { ok: false, summary: "This file type requires an explicit choice." };
 }
 
@@ -1142,6 +1206,12 @@ async function validateCanonical(
       if (!value || STATE_MAPS.some((key) => !record(value[key] ?? {})) || !record(value.travel ?? {})) throw new Error("canonical state validation failed");
     } else if (entry.strategy === "preferences" && !validPreferences(parsed)) {
       throw new Error("canonical preferences validation failed");
+    } else if (entry.strategy === "board") {
+      const value = record(parsed);
+      if (!value || !Array.isArray(value.cards) || value.cards.some((card) => {
+        const id = record(card)?.id;
+        return typeof id !== "string" || !id;
+      })) throw new Error("canonical board validation failed");
     }
   }
 }
@@ -1558,13 +1628,22 @@ async function reconcileEntry(
       ? (await reconcileDirectory(entry, legacyPath, canonicalPath, legacyInfo, canonicalInfo, result, options)).outcome
       : { ok: false, summary: "Directory entries differ and require an explicit merge or whole-directory choice." };
   }
-  else if (["inbox", "state", "preferences"].includes(entry.strategy)) {
+  else if (
+    ["inbox", "state", "preferences"].includes(entry.strategy) ||
+    (entry.strategy === "board" && options.action === "merge")
+  ) {
     // Merge the exact snapshots recorded in the verified bundle. Reading the
     // live paths here would let an uncoordinated store writer change either
     // input after backup verification.
     const legacyBackup = await verifiedBundleRole(backup.directory, "legacy");
     const canonicalBackup = await verifiedBundleRole(backup.directory, "canonical");
     merged = await mergeJson(entry.strategy, legacyBackup.source, canonicalBackup.source);
+  }
+  else if (entry.strategy === "board") {
+    // A one-sided board card is ambiguous (new vs deleted-on-the-other-side),
+    // so the union never runs unprompted — it is offered as the suggested
+    // resolution instead (cave-6z41; conservative philosophy from cave-5ax2).
+    merged = { ok: false, summary: "Divergent board copies support an explicit card-id merge — every card from both copies is kept, the newest edit wins per card — or a whole-file choice." };
   }
   else merged = { ok: false, summary: "This file has no lossless automatic merge and requires an explicit choice." };
 


### PR DESCRIPTION
## Why

Deferred follow-up #3 from the board near-loss incident (cave-5ax2, 2026-07-22). When `cave-board.json` and legacy `board.json` diverge, reconciliation offered only whole-file keep-canonical / recover-legacy — either choice discards the other copy's cards (the size-disparity guard exists precisely because that's lossy).

## What

`cave-board.json` moves from `manual` to a new schema-aware **`board`** strategy with a card-id union merge:

- **Union by stable card id** — canonical cards first (canonical order), legacy-only cards appended (legacy order). Shared ids keep the newer per-card `updatedAt`; `version` keeps the larger value; canonical top-level extras preserved.
- **Explicit-only, never auto** — a card present on one side only is ambiguous (newly added vs deliberately deleted on the other side), so startup reconciliation refuses to auto-merge boards. The durable conflict summary now advertises the merge option, and status actions offer `merge` alongside keep/recover/defer. Resolution via the existing `POST /api/cave-home-migration` `{ action: "merge", legacy: "board.json" }` path (banner renders it as "Merge safely").
- **Conservative refusals** — malformed copies, duplicate ids within one copy, or shared ids that differ without a usable `updatedAt` order leave both files untouched for manual review.
- **Same safety rails as inbox/state/preferences** — merges read verified recovery-bundle snapshots (writer-race barrier), and canonical board validation requires stable string card ids before the bundle is trusted.

## Testing

- `cave-home-migration-json-merge.test.ts`: 5 new board scenarios — no-auto-merge with suggestion summary + offered actions; explicit union (recovered legacy card, canonical-first ordering); newest-updatedAt wins + version max; same-timestamp ambiguity refusal; duplicate-id refusal.
- Existing family green: json-merge, discard-guard, status, backup-recovery, locks-takeover, windows cross-env (`# pass 4`).
- `pnpm typecheck` + `pnpm lint` clean.

Closes cave-6z41.
