### PR TITLE
fix(css): emit standard backdrop-filter app-wide (Chromium/WebView2 blur)

### DIFF
--- a/src/components/glass-overlay-chrome.test.ts
+++ b/src/components/glass-overlay-chrome.test.ts
@@ -6,6 +6,7 @@
 // unreadable over scrolling content).
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { cssFilesInScope } from "../../scripts/codemods/tokenize-css.mjs";
 
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const palette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
@@ -59,10 +60,30 @@ assert.match(
   "the OS reduced-transparency setting restores opaque, blur-free chrome",
 );
 
-// Every glass consumer keeps -webkit-backdrop-filter for WebKit (the Tauri
-// webview on macOS is WebKit — the native platform this vibe is for).
-const webkitPairs = css.match(/backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);\s*\n\s*-webkit-backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/g) ?? [];
-assert.ok(webkitPairs.length >= 2, "glass consumers carry the -webkit- prefix pair");
+// ── Author the STANDARD backdrop-filter only — never a hand-written -webkit- pair ──
+// The Tauri macOS webview is WebKit and DOES need -webkit-backdrop-filter, but
+// Tailwind v4's lightningcss ADDS it automatically. Critically, when BOTH the
+// standard and the -webkit- property are hand-authored, lightningcss DROPS the
+// standard one from the compiled output — so the blur then works only in WebKit
+// and silently no-ops in Chromium / Windows WebView2 (they ignore the lone
+// -webkit- alias). Guard app-wide against reintroducing the manual prefix.
+const manualWebkitDecls = [];
+for (const rel of cssFilesInScope()) {
+  const sheet = readFileSync(rel, "utf8");
+  // A `-webkit-backdrop-filter:` declaration — on any line EXCEPT an
+  // `@supports not (… or (-webkit-backdrop-filter: blur(1px)))` feature query,
+  // where the token legitimately appears inside the condition parens.
+  const hits = sheet
+    .split("\n")
+    .filter((line) => /-webkit-backdrop-filter:/.test(line) && !/@supports/.test(line));
+  if (hits.length) manualWebkitDecls.push(`${rel} (${hits.length})`);
+}
+assert.deepEqual(
+  manualWebkitDecls,
+  [],
+  "no hand-authored -webkit-backdrop-filter declarations — lightningcss auto-prefixes; " +
+    "manual pairing makes it drop the standard property and the blur breaks in Chromium/WebView2",
+);
 
 // ── Component-class surfaces ride the shared utility ─────────────────────────
 assert.match(palette, /className="glass-overlay mt-\[12vh\]/, "the command palette dialog is glass");
@@ -74,7 +95,7 @@ assert.match(bell, /notification-bell__popover glass-overlay/, "the notification
 // translucent glass fill with backdrop blur, and every one of them appears in
 // BOTH opaque-fallback blocks (@supports-not and reduced-transparency), so
 // nothing goes see-through where the blur can't render.
-const GLASS_RE = String.raw`background: var\(--glass-(?:elevated|raised)\);\s*\n\s*backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);\s*\n\s*-webkit-backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);`;
+const GLASS_RE = String.raw`background: var\(--glass-(?:elevated|raised)\);\s*\n\s*backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);`;
 const frostedGlobals = [
   String.raw`\.shell-nav-panel > \.shell-nav--peek`,
   String.raw`\.ui-dock-chat`,

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -90,7 +90,6 @@ html[data-backdrop-on] .cave-chat-linear .cave-chat-thread,
 html[data-backdrop-on] .cave-group-chat-shell {
   background: color-mix(in oklch, var(--bg-base) 62%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
@@ -104,7 +103,6 @@ html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
    behind it so the title and session actions stay steady. */
 html[data-backdrop-on] .cave-chat-linear-header {
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 /* One-step contrast lift for the quiet text while the image is on — meta
@@ -131,7 +129,6 @@ html[data-backdrop-on] .cave-group-chat-shell {
 html[data-backdrop-on] .home-composer-root.home-dash {
   background: color-mix(in oklch, var(--bg-base) 62%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 /* Chat landing (no thread yet): the greeting/identity/suggestions cluster
@@ -139,7 +136,6 @@ html[data-backdrop-on] .home-composer-root.home-dash {
 html[data-backdrop-on] .cave-chat-empty-shell {
   background: color-mix(in oklch, var(--bg-base) 55%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-radius: var(--radius-xl);
   padding: clamp(16px, 3vh, 28px) clamp(14px, 2.5vw, 24px);
 }
@@ -152,7 +148,6 @@ html[data-backdrop-on] .cave-chat-empty-shell {
 html[data-backdrop-on] .familiar-tab {
   background: color-mix(in oklch, var(--bg-base) 62%, transparent);
   backdrop-filter: blur(50px) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(50px) saturate(var(--glass-saturate));
   border-radius: var(--radius-xl);
   --text-muted: var(--text-secondary);
 }
@@ -193,7 +188,6 @@ html[data-backdrop-on] .home-composer-root {
   html[data-backdrop-on] .cave-group-chat-shell {
     background: transparent;
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 
   html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
@@ -205,13 +199,11 @@ html[data-backdrop-on] .home-composer-root {
   html[data-backdrop-on] .home-composer-root.home-dash {
     background: var(--bg-base);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 
   html[data-backdrop-on] .cave-chat-empty-shell {
     background: transparent;
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
     padding: 0;
   }
 
@@ -219,7 +211,6 @@ html[data-backdrop-on] .home-composer-root {
   html[data-backdrop-on] .familiar-tab {
     background: transparent;
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles/board/gantt-fallbacks.css
+++ b/src/styles/board/gantt-fallbacks.css
@@ -248,13 +248,11 @@
   .board-drawer {
     background: var(--bg-raised);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .gh-pat-dialog,
   .gh-action-popover:not(.gh-action-popover--wide),
   .gh-profile-card {
     background: var(--bg-elevated);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }

--- a/src/styles/board/github-detail.css
+++ b/src/styles/board/github-detail.css
@@ -413,7 +413,6 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   border-radius:14px;
   background:var(--glass-elevated);
   backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow:0 16px 44px rgba(0,0,0,0.34);
   display:flex;
   flex-direction:column;

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -104,7 +104,6 @@
   border:1px solid var(--border-hairline);
   background:var(--glass-elevated);
   backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate));
   padding:1.5rem;
   box-shadow:var(--shadow-popover, 0 25px 50px -12px rgb(0 0 0 / .25));
 }
@@ -270,8 +269,8 @@
 .gh-actions.reveal-on-hover:has(.gh-action-error) { opacity:1; }
 .gh-action-wrap { position:relative; display:inline-flex; }
 .gh-action-error { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; margin-left:4px; border-radius:50%; background:var(--color-danger); color:var(--color-danger-foreground); font-size:10px; font-weight:700; }
-.gh-action-popover { position:absolute; top:calc(100% + 4px); right:0; z-index:60; min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--glass-elevated); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); box-shadow:0 12px 30px rgba(0,0,0,.18); }
-.gh-action-popover--wide { padding:0; min-width:280px; background:transparent; border:none; box-shadow:none; backdrop-filter:none; -webkit-backdrop-filter:none; }
+.gh-action-popover { position:absolute; top:calc(100% + 4px); right:0; z-index:60; min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--glass-elevated); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); box-shadow:0 12px 30px rgba(0,0,0,.18); }
+.gh-action-popover--wide { padding:0; min-width:280px; background:transparent; border:none; box-shadow:none; backdrop-filter:none; }
 .gh-action-popover-title { padding:0 4px 6px; font-size:11px; color:var(--text-muted); }
 .gh-action-popover-list { list-style:none; margin:0; padding:0; max-height:220px; overflow-y:auto; }
 .gh-action-popover-item { display:flex; align-items:center; gap:8px; width:100%; padding:5px 7px; border:none; background:transparent; color:var(--text-secondary); font-size:11.5px; text-align:left; cursor:pointer; border-radius:var(--radius-control); }

--- a/src/styles/board/kanban-inspector.css
+++ b/src/styles/board/kanban-inspector.css
@@ -178,7 +178,7 @@
 
 .board-drawer-backdrop { position:fixed; inset:0; background:rgba(0,0,0,.30); z-index:300; animation:board-backdrop-in .18s ease; }
 @keyframes board-backdrop-in { from{opacity:0} to{opacity:1} }
-.board-drawer { position:fixed; top:0; right:0; bottom:0; width:480px; max-width:100vw; background:var(--glass-raised); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); -webkit-backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); border-left:1px solid var(--border-strong); z-index:301; display:flex; flex-direction:column; overflow:hidden; box-shadow:-8px 0 32px rgba(0,0,0,.20); animation:board-drawer-in .22s ease-out; }
+.board-drawer { position:fixed; top:0; right:0; bottom:0; width:480px; max-width:100vw; background:var(--glass-raised); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); border-left:1px solid var(--border-strong); z-index:301; display:flex; flex-direction:column; overflow:hidden; box-shadow:-8px 0 32px rgba(0,0,0,.20); animation:board-drawer-in .22s ease-out; }
 @keyframes board-drawer-in { from{transform:translateX(100%)} to{transform:translateX(0)} }
 .board-drawer--closing { animation:board-drawer-out .18s ease-in forwards; }
 @keyframes board-drawer-out { from{transform:translateX(0)} to{transform:translateX(100%)} }

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -838,7 +838,6 @@ details[open] > .cave-tool-summary::before {
   border-radius: var(--radius-control);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--text-primary);
   box-shadow: 0 24px 80px color-mix(in oklch, var(--bg-base) 76%, transparent);
 }

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -990,7 +990,6 @@
   border-left: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
   backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
   color: var(--text-muted);
   cursor: pointer;
   transition:
@@ -1005,12 +1004,10 @@
   .workspace-rail-reopen {
     background: var(--bg-raised);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .voice-call-overlay__dialog {
     background: var(--bg-raised);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 .workspace-rail-reopen:hover {

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -466,7 +466,6 @@
   border-radius: var(--radius-control);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   padding: 9px;
   box-shadow: 0 14px 34px color-mix(in oklch, var(--bg-base) 64%, transparent);
   color: var(--text-secondary);
@@ -776,7 +775,6 @@
   .cave-chat-model-popover {
     background: var(--bg-elevated);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles/cave-md/interactions.css
+++ b/src/styles/cave-md/interactions.css
@@ -109,7 +109,6 @@
   .cave-table-lightbox__panel {
     background: var(--bg-panel);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles/cave-md/tables-mermaid.css
+++ b/src/styles/cave-md/tables-mermaid.css
@@ -38,7 +38,6 @@
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-sm);
   background: color-mix(in oklch, var(--bg-elevated) 88%, transparent);
-  -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   color: var(--text-muted);
   font-size: var(--text-2xs);
@@ -78,7 +77,6 @@
   justify-content: center;
   padding: clamp(12px, 4vw, 48px);
   background: color-mix(in oklch, var(--bg-base) 72%, transparent);
-  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   animation: cave-table-lightbox-in var(--duration-fast) var(--ease-standard);
 }
@@ -95,7 +93,6 @@
   border-radius: var(--radius-panel);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: 0 24px 70px color-mix(in oklch, black 45%, transparent);
   overflow: hidden;
 }
@@ -258,7 +255,6 @@
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--bg-panel) 78%, transparent);
   backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
 }
 .cm-mermaid-viewer__btn {

--- a/src/styles/dash-act.css
+++ b/src/styles/dash-act.css
@@ -51,7 +51,6 @@
   border-radius: 10px;
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong);
   box-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.45);
 }
@@ -87,6 +86,5 @@
   .dash-snooze__menu {
     background: var(--bg-elevated);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -109,7 +109,6 @@
       color-mix(in oklch, var(--bg-base) 44%, transparent)
     );
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   -webkit-app-region: drag;
 }
 
@@ -128,12 +127,10 @@
     background:
       linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .spark-tip {
     background: var(--bg-elevated);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 
@@ -454,7 +451,6 @@
   padding: 3px 7px; border-radius: 6px; font-size: 10.5px; line-height: 1.2;
   color: var(--text-primary); background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong); box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
   font-variant-numeric: tabular-nums; }
 .spark-tip b { font-weight: 700; }

--- a/src/styles/globals/calendar-agenda.css
+++ b/src/styles/globals/calendar-agenda.css
@@ -450,7 +450,6 @@
     min-height: calc(var(--touch-target) + 4px);
     background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
     backdrop-filter: blur(14px) saturate(140%);
-    -webkit-backdrop-filter: blur(14px) saturate(140%);
   }
 
   .chat-scope-tabs [role="tab"] {
@@ -558,7 +557,6 @@
     z-index: 45;
     background: color-mix(in oklch, var(--bg-base) 96%, transparent);
     backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
   }
 
   .chat-list-dossier > * {

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -127,7 +127,6 @@ button:active > .edge-rail-chip {
 :root[data-tauri-titlebar] .shell-top {
   background: color-mix(in oklch, var(--bg-base) 46%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   :root[data-tauri-titlebar] .shell-top { background: transparent; }
@@ -136,7 +135,6 @@ button:active > .edge-rail-chip {
   :root[data-tauri-titlebar] .shell-top {
     background: transparent;
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 
@@ -1221,7 +1219,6 @@ button:active > .edge-rail-chip {
   border: 1px solid var(--border-hairline);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: var(--shadow-popover, 0 8px 28px rgb(0 0 0 / 0.28));
   overflow: hidden;
 }

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -13,7 +13,6 @@
   background: var(--backdrop-scrim);
   /* Soft depth cue: the app recedes behind the scrim instead of just dimming. */
   backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -43,7 +42,6 @@
   /* Glassmorphic sheet — the dimmed app blurs through the dialog body. */
   background: var(--glass-raised);
   backdrop-filter: blur(calc(var(--glass-blur) + 2px)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(calc(var(--glass-blur) + 2px)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   display: flex;
@@ -483,7 +481,6 @@ textarea.required-inputs-control {
   max-width: calc(100vw - 2 * var(--space-4));
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   box-shadow: 0 16px 48px oklch(0 0 0 / 50%);
@@ -1338,7 +1335,6 @@ textarea.required-inputs-control {
      Opaque fallbacks live in the @supports / reduced-transparency blocks. */
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-control);
   box-shadow: 0 16px 40px oklch(0 0 0 / 45%);
@@ -1361,7 +1357,6 @@ textarea.required-inputs-control {
 .glass-overlay {
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 /* Contrast floor while a scene backdrop is frontmost: 74% glass over a busy
@@ -1405,7 +1400,6 @@ html[data-backdrop-on] .glass-overlay {
   .familiar-switcher__popover {
     background: var(--bg-elevated);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .ui-modal,
   .ui-dock-chat,
@@ -1414,17 +1408,14 @@ html[data-backdrop-on] .glass-overlay {
   .familiar-studio__drawer {
     background: var(--bg-raised);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .quick-chat-overlay,
   .quick-chat-overlay__caret {
     background: var(--bg-panel);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
   .ui-modal-backdrop {
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 
@@ -1542,7 +1533,6 @@ html[data-backdrop-on] .glass-overlay {
   z-index: 70;
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--text-primary);
   font-size: var(--text-2xs);
   padding: var(--space-1) var(--space-2);

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -114,7 +114,6 @@
   gap: var(--space-1);
   background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
   backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
   overflow-y: auto;
 }
 
@@ -137,7 +136,6 @@
      @supports / reduced-transparency blocks below. */
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-right: 1px solid var(--border-hairline);
   box-shadow: 0 12px 40px rgb(0 0 0 / 0.35);
   animation: shellNavPeekIn 0.13s ease;
@@ -456,7 +454,6 @@
   min-height: 40px;
   padding: var(--space-1) 6px var(--space-1) var(--space-2);
   background: color-mix(in oklch, var(--bg-raised) 96%, var(--foreground) 4%);
-  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   color: var(--text-secondary);
   transition: color var(--duration-fast) var(--ease-standard);

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -396,7 +396,6 @@
   flex-direction: column;
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   box-shadow: -8px 0 24px color-mix(in oklch, var(--text-primary) 10%, transparent);
   z-index: 10;
@@ -452,7 +451,6 @@
   grid-template-columns: max-content 1fr;
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   box-shadow: -12px 0 40px color-mix(in oklch, var(--text-primary) 16%, transparent);
   z-index: 45;
@@ -630,7 +628,6 @@
   max-width: calc(100vw - 16px);
   background: var(--bg-elevated);
   backdrop-filter: none;
-  -webkit-backdrop-filter: none;
   overflow-x: hidden;
   padding: 0;
 }
@@ -1386,7 +1383,6 @@
     linear-gradient(to top, color-mix(in oklch, var(--bg-base) 92%, transparent), color-mix(in oklch, var(--bg-raised) 88%, transparent)),
     color-mix(in oklch, var(--bg-raised) 92%, transparent);
   backdrop-filter: blur(18px) saturate(145%);
-  -webkit-backdrop-filter: blur(18px) saturate(145%);
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 88%, transparent);
   box-shadow: 0 -14px 32px color-mix(in oklch, black 18%, transparent);
 }

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -443,7 +443,6 @@
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
   backdrop-filter: blur(16px) saturate(140%);
-  -webkit-backdrop-filter: blur(16px) saturate(140%);
 }
 
 .automation-create-dialog__body {
@@ -611,7 +610,6 @@
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
   backdrop-filter: blur(16px) saturate(140%);
-  -webkit-backdrop-filter: blur(16px) saturate(140%);
 }
 
 @media (max-width: 920px) {

--- a/src/styles/globals/surface-marketplace.css
+++ b/src/styles/globals/surface-marketplace.css
@@ -1374,7 +1374,6 @@
   border: 1px solid var(--border-strong);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: 0 4px 24px rgb(0 0 0 / 35%);
   overflow: hidden;
   animation: ui-undo-toast-enter 0.18s var(--ease-decelerate, ease-out);

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -30,7 +30,6 @@
      the sticky band shows through as a saturated blur, macOS-chrome style. */
   background: color-mix(in oklch, var(--bg-base) 86%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-bottom: 1px solid var(--border-hairline);
 }
 .dr-back {
@@ -1414,7 +1413,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-size: var(--text-sm);
   background: color-mix(in oklch, var(--bg-base) 84%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 .fa-topbar a {
   color: var(--text-secondary);
@@ -3181,7 +3179,6 @@ details[open] > .cave-edit-card__summary::before {
   border: 1px solid var(--border-hairline);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   color: var(--fg-primary);
   /* Layered elevation: an inner top highlight + two soft drop shadows read as a
      crisp floating panel rather than one flat blur. */
@@ -3201,7 +3198,6 @@ details[open] > .cave-edit-card__summary::before {
   /* Matches the overlay's frosted fill so the caret doesn't read solid. */
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border-left: 1px solid var(--border-hairline);
   border-top: 1px solid var(--border-hairline);
   border-top-left-radius: 3px;

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -21,7 +21,6 @@
   border-bottom: 1px solid var(--border);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 .role-surface-header-title {
@@ -128,7 +127,6 @@
   border-radius: var(--radius-md);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow: 0 12px 32px rgb(0 0 0 / 0.4);
 }
 
@@ -622,7 +620,6 @@
   border-top: 1px solid var(--border);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
 }
 
 .role-surface-drawer-toggle {

--- a/src/styles/grimoire-launcher.css
+++ b/src/styles/grimoire-launcher.css
@@ -150,7 +150,6 @@
   border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 9%, color-mix(in oklch, var(--bg-base) 55%, transparent));
   backdrop-filter: blur(18px) saturate(1.35);
-  -webkit-backdrop-filter: blur(18px) saturate(1.35);
   padding: var(--space-4) var(--space-4) var(--space-3);
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
 }
@@ -360,7 +359,6 @@ button.gl-card:hover {
   border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 8%, color-mix(in oklch, var(--bg-raised) 60%, transparent));
   backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
 }
 
 .gl-week .gl-shine {

--- a/src/styles/home-composer/feed-menus.css
+++ b/src/styles/home-composer/feed-menus.css
@@ -213,7 +213,6 @@
   border-radius: var(--radius-2xl, 14px);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   box-shadow:
     0 14px 32px -16px color-mix(in oklch, var(--accent-presence) 22%, transparent),
     0 4px 18px -6px rgb(0 0 0 / 0.35);
@@ -231,7 +230,6 @@
   .hc-slash-menu {
     background: var(--bg-base);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 /* Skills picker: option list + detail preview side by side. */

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -424,7 +424,6 @@
   color: var(--text-primary);
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-strong));
   border-radius: var(--radius-card);
   box-shadow: 0 18px 50px -18px rgba(0, 0, 0, 0.6);
@@ -443,7 +442,6 @@
   .journal-notice {
     background: var(--bg-elevated, var(--bg-raised));
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 @keyframes journal-notice-in {

--- a/src/styles/notch-quick-chat.css
+++ b/src/styles/notch-quick-chat.css
@@ -45,7 +45,6 @@ html[data-glass] .notch-quick-chat__pill {
   border-color: color-mix(in oklch, var(--foreground) 18%, transparent);
   background: color-mix(in oklch, var(--bg-panel) 58%, transparent);
   backdrop-filter: blur(14px) saturate(1.25);
-  -webkit-backdrop-filter: blur(14px) saturate(1.25);
 }
 
 .notch-quick-chat__pill-label {
@@ -107,7 +106,6 @@ html[data-glass] .notch-quick-chat__panel {
 html[data-glass] .notch-quick-chat__toolbar {
   background: color-mix(in oklch, var(--bg-panel) 35%, transparent);
   backdrop-filter: blur(14px) saturate(1.25);
-  -webkit-backdrop-filter: blur(14px) saturate(1.25);
 }
 
 /* The pane borrows the tray window's layout: thread fills, composer pins. */
@@ -135,7 +133,6 @@ html[data-glass] .notch-quick-chat__toolbar {
   html[data-glass] .notch-quick-chat__toolbar {
     background: var(--bg-panel);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles/quick-chat-glass.css
+++ b/src/styles/quick-chat-glass.css
@@ -44,7 +44,6 @@ html[data-glass] .tray-quick-chat__frame {
 html[data-glass] .tray-quick-chat__header {
   background: color-mix(in oklch, var(--bg-panel) 35%, transparent);
   backdrop-filter: blur(14px) saturate(1.25);
-  -webkit-backdrop-filter: blur(14px) saturate(1.25);
 }
 
 /* ── Tab strip ── */
@@ -79,7 +78,6 @@ html[data-glass] .tray-quick-chat__header {
 
 html[data-glass] .quick-tab--active {
   backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 
 .quick-tab__button {
@@ -172,7 +170,6 @@ html[data-glass] .quick-chat-select__trigger {
 html[data-glass] .quick-chat-overlay__composer {
   background: color-mix(in oklch, var(--bg-panel) 40%, transparent);
   backdrop-filter: blur(14px) saturate(1.25);
-  -webkit-backdrop-filter: blur(14px) saturate(1.25);
 }
 
 html[data-glass] .quick-chat-overlay__input {
@@ -182,13 +179,11 @@ html[data-glass] .quick-chat-overlay__input {
 html[data-glass] .quick-chat-bubble--familiar {
   background: color-mix(in oklch, var(--bg-elevated) 68%, transparent);
   backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 
 html[data-glass] .quick-chat-bubble--user {
   background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
   backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 
 /* ── Accessibility fallbacks ── */
@@ -206,7 +201,6 @@ html[data-glass] .quick-chat-bubble--user {
   html[data-glass] .quick-chat-bubble--user {
     background: var(--bg-panel);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles/summoning-circle.css
+++ b/src/styles/summoning-circle.css
@@ -23,7 +23,6 @@
   overflow: hidden;
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-panel);
   box-shadow: 0 24px 64px oklch(0 0 0 / 35%);
@@ -41,7 +40,6 @@
   .summoning-dialog {
     background: var(--bg-raised);
     backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
## Problem
Glass surfaces across the app hand-author **both** `backdrop-filter` and `-webkit-backdrop-filter`. Tailwind v4's **lightningcss drops the standard property when both are present in source** (reproduced directly with `lightningcss.transform`), emitting `-webkit-`-only output. Chromium and Windows WebView2 ignore the lone `-webkit-` alias, so the blur:

- **worked** on WebKit (macOS Tauri webview), but
- **silently no-op'd** in Chromium desktop / Windows WebView2 / web browsers.

Confirmed at runtime: the dashboard glass root computed `backdrop-filter: none` in headless Chromium.

## Fix
Author the **standard `backdrop-filter` only** and let lightningcss auto-prefix. Given standard-only input, lightningcss correctly emits **both** `-webkit-backdrop-filter` (Safari <18 / WebKit) **and** `backdrop-filter` (Chromium / Firefox / Safari 18+ — Safari only added the unprefixed property in 18).

- Removed **82** hand-written `-webkit-backdrop-filter` declarations across **27** stylesheets.
- `@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)))` feature queries keep their `-webkit-` token (untouched — no trailing `;`, so left intact).
- **`glass-overlay-chrome.test.ts`**: flipped the guard — instead of *requiring* the manual `-webkit-` pair (the anti-pattern that caused this), it now **forbids** any hand-authored `-webkit-backdrop-filter` declaration app-wide, so this can't regress.

## Verification
- `pnpm build` → **exit 0** (home first-load CSS 918/920 KB).
- Compiled chunks now carry **both** properties (`-webkit-backdrop-filter` ×120, standard `backdrop-filter` ×106 — before, the standard was dropped).
- Headless **Chromium** computes `backdrop-filter: blur(20px) saturate(1.4)` on the glass root (was `none`).
- drift ratchet, accent-token, css-module-order, `glass-overlay-chrome`, `backdrop-scrim`, `cave-backdrop`, and all other glass/backdrop tests → green.

Fixes the blur on **every** glass surface (chat, familiar tab, quick-chat, popovers/modals/tooltips, board drawers, the Home dashboard backdrop, …) in Chromium/WebView2 while keeping WebKit working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)