### PR TITLE
feat(eval): double-blind eval — arm-token routing (design-eva)

### DIFF
--- a/docs/specs/double-blind-eval.md
+++ b/docs/specs/double-blind-eval.md
@@ -1,0 +1,328 @@
+# Double-Blind Agent Evaluation — Spec
+
+> Clean-room design. Built from first principles + OpenCoven's existing eval
+> substrate. No third-party source was read, copied, or referenced.
+
+**Goal:** A blinding + unbiased-collection layer over the existing eval-loop and
+runtime registry, so neither the agent nor the evaluator can bias toward the
+other during A/B evaluation of runtime/variant arms.
+
+**Architecture:** Approach 1 — Blinding Envelope. A thin layer wraps the daemon
+eval-loop. Each trial assigns two opaque tokens (arm-token masks which
+runtime/variant serves; session-token masks the evaluator/context). The
+runtime→arm mapping lives server-side only and is sealed until the reveal
+ceremony. Reveal model: **Locked reveal** — blinded until a pre-committed
+stopping rule (N trials / rule) is hit, then auto-reveals. This prevents
+peeking-to-stop, the main bias vector in adaptive A/B.
+
+**Tech stack:** TypeScript, existing `eval-loop-daemon.ts`,
+`runtime-registry.gen.ts`, `research-missions.ts` orchestration pattern,
+`theme-palettes.ts` tokens (no new design language).
+
+---
+
+## Concepts
+
+- **Trial** — one blinded A/B run over ≥2 arms.
+- **Arm** — a runtime/variant under test. Identified externally only by its
+  `arm-token` (opaque, e.g. `arm_7f3a…`). The real runtime id is sealed.
+- **arm-token** — per-trial opaque handle assigned by a seeded Fisher–Yates
+  shuffle. Masks which runtime/variant serves a given slot.
+- **session-token** — per-turn opaque handle. The agent sees a neutral prompt
+  and never the reviewer/context identity.
+- **Blinding envelope** — the sealed server-side record mapping tokens → real
+  ids + the seed. Encrypted-at-rest, released only by the reveal ceremony.
+- **Reveal ceremony (Locked reveal)** — automatic unblind the moment the trial's
+  pre-committed `stoppingRule` is satisfied. Logged: rule, seed, who/when, and
+  the full token→id map. No manual mid-trial peek path.
+
+## Invariants
+
+1. The arm→runtime map is never emitted in any pre-reveal API response, log, or
+   SSE frame. Only tokens cross the boundary.
+2. The stopping rule is committed at trial creation and is immutable thereafter.
+3. Reveal is deterministic + reproducible from `{ seed, arms }`.
+4. Blinding failures fail closed: if we can't guarantee masking, the trial
+   errors rather than leaking.
+
+## File structure
+
+- Create `src/lib/double-blind-eval.ts` — token minting, seeded shuffle, envelope
+  seal/reveal, stopping-rule evaluation. Pure + total; no I/O.
+- Create `src/lib/double-blind-eval.test.ts` — unit tests for shuffle
+  determinism, envelope seal/reveal round-trip, stopping-rule triggers, and the
+  no-leak invariant.
+- Modify eval-loop daemon integration point (thin) to route arms by arm-token.
+- UI rides existing theme tokens; no new palette.
+
+---
+
+## Task 1: Core types + seeded shuffle
+
+**Files:**
+- Create: `src/lib/double-blind-eval.ts`
+- Test: `src/lib/double-blind-eval.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { seededShuffle, mintArmToken } from "./double-blind-eval.ts";
+
+test("seededShuffle is deterministic for a fixed seed", () => {
+  const arms = ["copilot", "grok", "hermes", "opencode"];
+  const a = seededShuffle(arms, 42);
+  const b = seededShuffle(arms, 42);
+  assert.deepEqual(a, b);
+  assert.notDeepEqual(a, arms); // 42 permutes this input
+  assert.deepEqual([...a].sort(), [...arms].sort()); // permutation, not loss
+});
+
+test("mintArmToken is opaque and stable per (trialId, slot)", () => {
+  const t = mintArmToken("trial_1", 0);
+  assert.match(t, /^arm_[0-9a-f]{12}$/);
+  assert.equal(t, mintArmToken("trial_1", 0));
+  assert.notEqual(t, mintArmToken("trial_1", 1));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import "./scripts/test-alias-register.mjs" --experimental-strip-types src/lib/double-blind-eval.test.ts`
+Expected: FAIL — module/exports not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { createHash } from "node:crypto";
+
+/** Mulberry32 PRNG — deterministic, seedable, fast. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Deterministic Fisher–Yates shuffle. Returns a new array. */
+export function seededShuffle<T>(items: readonly T[], seed: number): T[] {
+  const out = [...items];
+  const rng = mulberry32(seed);
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** Opaque, stable per (trialId, slot). Never derivable back to runtime id. */
+export function mintArmToken(trialId: string, slot: number): string {
+  const h = createHash("sha256").update(`${trialId}:${slot}`).digest("hex");
+  return `arm_${h.slice(0, 12)}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import "./scripts/test-alias-register.mjs" --experimental-strip-types src/lib/double-blind-eval.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/double-blind-eval.ts src/lib/double-blind-eval.test.ts
+git commit -m "feat(eval): seeded shuffle + opaque arm-token minting"
+```
+
+---
+
+## Task 2: Blinding envelope seal/reveal
+
+**Files:**
+- Modify: `src/lib/double-blind-eval.ts`
+- Test: `src/lib/double-blind-eval.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { sealEnvelope, revealEnvelope } from "./double-blind-eval.ts";
+
+test("envelope seals runtime ids and reveals them by token", () => {
+  const env = sealEnvelope({ trialId: "trial_2", seed: 7,
+    arms: ["copilot", "grok", "hermes"] });
+  // Pre-reveal surface exposes tokens only, never runtime ids.
+  assert.deepEqual(env.publicArms.map((a) => a.armToken).sort(),
+    env.publicArms.map((a) => a.armToken).sort());
+  for (const a of env.publicArms) {
+    assert.match(a.armToken, /^arm_[0-9a-f]{12}$/);
+    assert.equal((a as Record<string, unknown>).runtimeId, undefined);
+  }
+  const map = revealEnvelope(env);
+  assert.equal(Object.keys(map).length, 3);
+  assert.deepEqual([...Object.values(map)].sort(),
+    ["copilot", "grok", "hermes"]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import "./scripts/test-alias-register.mjs" --experimental-strip-types src/lib/double-blind-eval.test.ts`
+Expected: FAIL — `sealEnvelope` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export type SealInput = {
+  trialId: string;
+  seed: number;
+  arms: readonly string[]; // runtime ids under test
+};
+
+export type PublicArm = { armToken: string; slot: number };
+
+export type BlindingEnvelope = {
+  trialId: string;
+  seed: number;
+  publicArms: PublicArm[];
+  /** Sealed: token -> runtime id. Never serialized to pre-reveal surfaces. */
+  readonly sealed: Readonly<Record<string, string>>;
+};
+
+export function sealEnvelope(input: SealInput): BlindingEnvelope {
+  const shuffled = seededShuffle(input.arms, input.seed);
+  const publicArms: PublicArm[] = [];
+  const sealed: Record<string, string> = {};
+  shuffled.forEach((runtimeId, slot) => {
+    const armToken = mintArmToken(input.trialId, slot);
+    publicArms.push({ armToken, slot });
+    sealed[armToken] = runtimeId;
+  });
+  return { trialId: input.trialId, seed: input.seed, publicArms,
+    sealed: Object.freeze(sealed) };
+}
+
+/** Reveal: token -> runtime id. Call only from the reveal ceremony. */
+export function revealEnvelope(env: BlindingEnvelope): Record<string, string> {
+  return { ...env.sealed };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the test file. Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/double-blind-eval.ts src/lib/double-blind-eval.test.ts
+git commit -m "feat(eval): blinding envelope seal/reveal (tokens-only public surface)"
+```
+
+---
+
+## Task 3: Locked-reveal stopping rule
+
+**Files:**
+- Modify: `src/lib/double-blind-eval.ts`
+- Test: `src/lib/double-blind-eval.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { shouldReveal } from "./double-blind-eval.ts";
+
+test("locked reveal fires only when the pre-committed rule is met", () => {
+  const rule = { kind: "min-trials" as const, n: 20 };
+  assert.equal(shouldReveal(rule, { completedTrials: 5 }), false);
+  assert.equal(shouldReveal(rule, { completedTrials: 19 }), false);
+  assert.equal(shouldReveal(rule, { completedTrials: 20 }), true);
+  assert.equal(shouldReveal(rule, { completedTrials: 25 }), true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the test file. Expected: FAIL — `shouldReveal` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export type StoppingRule = { kind: "min-trials"; n: number };
+
+export type TrialProgress = { completedTrials: number };
+
+/** Locked reveal: pre-committed, immutable, no mid-trial peek. */
+export function shouldReveal(rule: StoppingRule, p: TrialProgress): boolean {
+  switch (rule.kind) {
+    case "min-trials":
+      return p.completedTrials >= rule.n;
+    default:
+      return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the test file. Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/double-blind-eval.ts src/lib/double-blind-eval.test.ts
+git commit -m "feat(eval): locked-reveal stopping rule"
+```
+
+---
+
+## Task 4: No-leak invariant test
+
+**Files:**
+- Test: `src/lib/double-blind-eval.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test("no pre-reveal surface serializes runtime ids", () => {
+  const env = sealEnvelope({ trialId: "trial_4", seed: 99,
+    arms: ["copilot", "grok"] });
+  // Simulate what an API/SSE frame would send: publicArms only.
+  const wire = JSON.stringify({ trialId: env.trialId, arms: env.publicArms });
+  assert.ok(!wire.includes("copilot"));
+  assert.ok(!wire.includes("grok"));
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run the test file. Expected: PASS — publicArms carry tokens only.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/double-blind-eval.test.ts
+git commit -m "test(eval): assert no runtime id leaks on pre-reveal surface"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** blinding (Task 1–2), unbiased collection via locked reveal
+  (Task 3), no-leak invariant (Task 4). Routing/identity-masking = arm-token +
+  session-token. ✅
+- **Reproducibility:** reveal is deterministic from `{ seed, arms }`. ✅
+- **Clean room:** no third-party source consulted; design derived from
+  OpenCoven's own eval-loop + registry + theme tokens. ✅
+
+## Open follow-ups (post-plan)
+
+- Wire arm-token routing into the daemon eval-loop's track dispatch.
+- session-token minting on the evaluator side (mirror of arm-token).
+- Reveal-ceremony audit log persistence (who/when/rule/seed/map).
+- UI: blinded trial board on existing theme tokens; unblind view post-reveal.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 export const SUITES = {
   app: [
     "src/lib/array-content-equal.test.ts",
+    "src/lib/double-blind-eval.test.ts",
     "src/lib/session-list-equal.test.ts",
     "src/lib/familiar-workspace-sessions.test.ts",
     "src/lib/session-list-deletes.test.ts",

--- a/src/lib/double-blind-eval.test.ts
+++ b/src/lib/double-blind-eval.test.ts
@@ -12,6 +12,9 @@ import {
   resolveSessionToken,
   publicArmTokens,
   shouldReveal,
+  buildRevealAudit,
+  verifyRevealAudit,
+  serializeRevealAudit,
 } from "./double-blind-eval.ts";
 
 // --- seeded shuffle + arm-token ---
@@ -116,6 +119,76 @@ test("locked reveal fires only when the pre-committed rule is met", () => {
   assert.equal(shouldReveal(rule, { completedTrials: 19 }), false);
   assert.equal(shouldReveal(rule, { completedTrials: 20 }), true);
   assert.equal(shouldReveal(rule, { completedTrials: 25 }), true);
+});
+
+// --- reveal-ceremony audit log (design-10q) ---
+
+function sealedTrial() {
+  const base = sealEnvelope({ trialId: "trial_7", seed: 5, arms: ["copilot", "grok"] });
+  const { env } = sealSession(base, 0, "reviewer-alice");
+  return env;
+}
+
+test("buildRevealAudit captures who/when/rule/seed + full maps and self-verifies", () => {
+  const env = sealedTrial();
+  const rule = { kind: "min-trials" as const, n: 10 };
+  const progress = { completedTrials: 10 };
+  const now = new Date("2026-07-24T10:44:00.000Z");
+  const audit = buildRevealAudit(env, rule, progress, "ceremony-bot", now);
+
+  assert.equal(audit.trialId, "trial_7");
+  assert.equal(audit.seed, 5);
+  assert.equal(audit.revealedAt, "2026-07-24T10:44:00.000Z");
+  assert.equal(audit.revealedBy, "ceremony-bot");
+  assert.deepEqual(audit.rule, rule);
+  assert.deepEqual([...Object.values(audit.arms)].sort(), ["copilot", "grok"]);
+  assert.equal(Object.values(audit.sessions)[0], "reviewer-alice");
+  assert.equal(verifyRevealAudit(audit), true);
+});
+
+test("buildRevealAudit fails closed when the stopping rule is unmet", () => {
+  const env = sealedTrial();
+  assert.throws(
+    () =>
+      buildRevealAudit(
+        env,
+        { kind: "min-trials", n: 10 },
+        { completedTrials: 9 },
+        "ceremony-bot",
+        new Date("2026-07-24T10:44:00.000Z"),
+      ),
+    /stopping rule not satisfied/,
+  );
+});
+
+test("verifyRevealAudit detects tampering with the revealed map", () => {
+  const env = sealedTrial();
+  const audit = buildRevealAudit(
+    env,
+    { kind: "min-trials", n: 10 },
+    { completedTrials: 10 },
+    "ceremony-bot",
+    new Date("2026-07-24T10:44:00.000Z"),
+  );
+  // Round-trip through JSONL, then tamper: swap one arm's runtime id.
+  const parsed = JSON.parse(serializeRevealAudit(audit));
+  const firstToken = Object.keys(parsed.arms)[0];
+  parsed.arms[firstToken] = "malicious-runtime";
+  assert.equal(verifyRevealAudit(parsed), false);
+});
+
+test("reveal audit integrity is stable regardless of map key order", () => {
+  const env = sealedTrial();
+  const audit = buildRevealAudit(
+    env,
+    { kind: "min-trials", n: 10 },
+    { completedTrials: 10 },
+    "ceremony-bot",
+    new Date("2026-07-24T10:44:00.000Z"),
+  );
+  // Re-serialize arms in reversed key order; integrity must still verify.
+  const reordered = { ...audit, arms: Object.fromEntries(Object.entries(audit.arms).reverse()) };
+  assert.equal(verifyRevealAudit(reordered), true);
 });
 
 // --- no-leak invariant ---

--- a/src/lib/double-blind-eval.test.ts
+++ b/src/lib/double-blind-eval.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  seededShuffle,
+  mintArmToken,
+  sealEnvelope,
+  revealEnvelope,
+  resolveArmToken,
+  publicArmTokens,
+  shouldReveal,
+} from "./double-blind-eval.ts";
+
+// --- seeded shuffle + arm-token ---
+
+test("seededShuffle is deterministic for a fixed seed", () => {
+  const arms = ["copilot", "grok", "hermes", "opencode"];
+  const a = seededShuffle(arms, 42);
+  const b = seededShuffle(arms, 42);
+  assert.deepEqual(a, b);
+  assert.notDeepEqual(a, arms);
+  assert.deepEqual([...a].sort(), [...arms].sort());
+});
+
+test("mintArmToken is opaque and stable per (trialId, slot)", () => {
+  const t = mintArmToken("trial_1", 0);
+  assert.match(t, /^arm_[0-9a-f]{12}$/);
+  assert.equal(t, mintArmToken("trial_1", 0));
+  assert.notEqual(t, mintArmToken("trial_1", 1));
+});
+
+// --- blinding envelope seal/reveal ---
+
+test("envelope seals runtime ids and reveals them by token", () => {
+  const env = sealEnvelope({
+    trialId: "trial_2",
+    seed: 7,
+    arms: ["copilot", "grok", "hermes"],
+  });
+  for (const arm of env.publicArms) {
+    assert.match(arm.armToken, /^arm_[0-9a-f]{12}$/);
+    assert.equal((arm as Record<string, unknown>).runtimeId, undefined);
+  }
+  const map = revealEnvelope(env);
+  assert.equal(Object.keys(map).length, 3);
+  assert.deepEqual([...Object.values(map)].sort(), ["copilot", "grok", "hermes"]);
+});
+
+// --- arm-token routing (design-eva) ---
+
+test("resolveArmToken maps a public token back to its runtime for dispatch", () => {
+  const env = sealEnvelope({
+    trialId: "trial_3",
+    seed: 11,
+    arms: ["copilot", "grok", "hermes"],
+  });
+  const tokens = publicArmTokens(env);
+  assert.equal(tokens.length, 3);
+  // Every public token resolves to exactly one distinct runtime.
+  const resolved = tokens.map((t) => resolveArmToken(env, t));
+  assert.deepEqual([...resolved].sort(), ["copilot", "grok", "hermes"]);
+  // Resolution matches the sealed map exactly.
+  for (const t of tokens) {
+    assert.equal(resolveArmToken(env, t), env.sealed[t]);
+  }
+});
+
+test("resolveArmToken fails closed on an unknown token", () => {
+  const env = sealEnvelope({ trialId: "trial_3b", seed: 1, arms: ["a", "b"] });
+  assert.throws(() => resolveArmToken(env, "arm_deadbeef0000"), /unknown arm-token/);
+});
+
+// --- locked-reveal stopping rule ---
+
+test("locked reveal fires only when the pre-committed rule is met", () => {
+  const rule = { kind: "min-trials" as const, n: 20 };
+  assert.equal(shouldReveal(rule, { completedTrials: 5 }), false);
+  assert.equal(shouldReveal(rule, { completedTrials: 19 }), false);
+  assert.equal(shouldReveal(rule, { completedTrials: 20 }), true);
+  assert.equal(shouldReveal(rule, { completedTrials: 25 }), true);
+});
+
+// --- no-leak invariant ---
+
+test("no pre-reveal surface serializes runtime ids", () => {
+  const env = sealEnvelope({ trialId: "trial_4", seed: 99, arms: ["copilot", "grok"] });
+  // publicArms + publicArmTokens are the only sanctioned pre-reveal surfaces.
+  const wire = JSON.stringify({
+    trialId: env.trialId,
+    arms: env.publicArms,
+    tokens: publicArmTokens(env),
+  });
+  assert.ok(!wire.includes("copilot"));
+  assert.ok(!wire.includes("grok"));
+});

--- a/src/lib/double-blind-eval.test.ts
+++ b/src/lib/double-blind-eval.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 import {
   seededShuffle,
   mintArmToken,
+  mintSessionToken,
   sealEnvelope,
+  sealSession,
   revealEnvelope,
+  revealSessions,
   resolveArmToken,
+  resolveSessionToken,
   publicArmTokens,
   shouldReveal,
 } from "./double-blind-eval.ts";
@@ -69,6 +73,41 @@ test("resolveArmToken fails closed on an unknown token", () => {
   assert.throws(() => resolveArmToken(env, "arm_deadbeef0000"), /unknown arm-token/);
 });
 
+// --- session-token minting (design-doo) ---
+
+test("mintSessionToken is opaque, stable per (trialId, turn), and never collides with arm-token", () => {
+  const s = mintSessionToken("trial_5", 0);
+  assert.match(s, /^sess_[0-9a-f]{12}$/);
+  assert.equal(s, mintSessionToken("trial_5", 0));
+  assert.notEqual(s, mintSessionToken("trial_5", 1));
+  // Domain separation: arm slot 0 and session turn 0 must differ.
+  assert.notEqual(s.replace(/^sess_/, ""), mintArmToken("trial_5", 0).replace(/^arm_/, ""));
+});
+
+test("sealSession masks the evaluator id and resolves it only on reveal", () => {
+  const base = sealEnvelope({ trialId: "trial_6", seed: 3, arms: ["copilot", "grok"] });
+  const r0 = sealSession(base, 0, "reviewer-alice");
+  const r1 = sealSession(r0.env, 1, "reviewer-bob");
+  // Public session handles carry tokens + turn only.
+  assert.match(r0.session.sessionToken, /^sess_[0-9a-f]{12}$/);
+  assert.equal((r0.session as Record<string, unknown>).evaluatorId, undefined);
+  // sealSession is pure — the original frozen envelope is untouched.
+  assert.equal(Object.keys(base.sealedSessions).length, 0);
+  // Reveal maps both turns back to their evaluators.
+  const sessions = revealSessions(r1.env);
+  assert.equal(sessions[r0.session.sessionToken], "reviewer-alice");
+  assert.equal(sessions[r1.session.sessionToken], "reviewer-bob");
+  assert.equal(resolveSessionToken(r1.env, r0.session.sessionToken), "reviewer-alice");
+});
+
+test("resolveSessionToken fails closed on an unknown token", () => {
+  const env = sealEnvelope({ trialId: "trial_6b", seed: 2, arms: ["a"] });
+  assert.throws(
+    () => resolveSessionToken(env, "sess_deadbeef0000"),
+    /unknown session-token/,
+  );
+});
+
 // --- locked-reveal stopping rule ---
 
 test("locked reveal fires only when the pre-committed rule is met", () => {
@@ -81,14 +120,18 @@ test("locked reveal fires only when the pre-committed rule is met", () => {
 
 // --- no-leak invariant ---
 
-test("no pre-reveal surface serializes runtime ids", () => {
-  const env = sealEnvelope({ trialId: "trial_4", seed: 99, arms: ["copilot", "grok"] });
-  // publicArms + publicArmTokens are the only sanctioned pre-reveal surfaces.
+test("no pre-reveal surface serializes runtime ids or evaluator ids", () => {
+  const base = sealEnvelope({ trialId: "trial_4", seed: 99, arms: ["copilot", "grok"] });
+  const { env, session } = sealSession(base, 0, "reviewer-eve");
+  // publicArms, publicArmTokens, and the public session handle are the only
+  // sanctioned pre-reveal surfaces.
   const wire = JSON.stringify({
     trialId: env.trialId,
     arms: env.publicArms,
     tokens: publicArmTokens(env),
+    session,
   });
   assert.ok(!wire.includes("copilot"));
   assert.ok(!wire.includes("grok"));
+  assert.ok(!wire.includes("reviewer-eve"));
 });

--- a/src/lib/double-blind-eval.ts
+++ b/src/lib/double-blind-eval.ts
@@ -1,0 +1,131 @@
+// Double-blind agent evaluation — blinding envelope + locked reveal.
+//
+// Clean-room design (spec: docs/specs/double-blind-eval.md). Two opaque tokens
+// per trial mask which runtime/variant serves a slot (arm-token) and the
+// evaluator/context identity (session-token, minted the same way on the
+// evaluator side). The runtime->arm map is sealed server-side and released only
+// by the reveal ceremony, which fires automatically once a pre-committed
+// stopping rule is met (locked reveal — no mid-trial peek path).
+//
+// This module is pure + zero-dep (crypto only). It NEVER touches the daemon,
+// SSE, or any API surface; callers route through resolveArmToken and must not
+// serialize the sealed map to a pre-reveal surface.
+
+import { createHash } from "node:crypto";
+
+// --- seeded shuffle + arm-token ---------------------------------------------
+
+/** Mulberry32 PRNG — deterministic, seedable, fast. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Deterministic Fisher–Yates shuffle. Returns a new array. */
+export function seededShuffle<T>(items: readonly T[], seed: number): T[] {
+  const out = [...items];
+  const rng = mulberry32(seed);
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = out[i]!;
+    out[i] = out[j]!;
+    out[j] = tmp;
+  }
+  return out;
+}
+
+/** Opaque, stable per (trialId, slot). Never derivable back to a runtime id. */
+export function mintArmToken(trialId: string, slot: number): string {
+  const h = createHash("sha256").update(`${trialId}:${slot}`).digest("hex");
+  return `arm_${h.slice(0, 12)}`;
+}
+
+// --- blinding envelope seal/reveal ------------------------------------------
+
+export type SealInput = {
+  trialId: string;
+  seed: number;
+  arms: readonly string[]; // runtime ids under test
+};
+
+export type PublicArm = { armToken: string; slot: number };
+
+export type BlindingEnvelope = {
+  trialId: string;
+  seed: number;
+  publicArms: PublicArm[];
+  /** Sealed: token -> runtime id. Never serialized to pre-reveal surfaces. */
+  readonly sealed: Readonly<Record<string, string>>;
+};
+
+export function sealEnvelope(input: SealInput): BlindingEnvelope {
+  const shuffled = seededShuffle(input.arms, input.seed);
+  const publicArms: PublicArm[] = [];
+  const sealed: Record<string, string> = {};
+  shuffled.forEach((runtimeId, slot) => {
+    const armToken = mintArmToken(input.trialId, slot);
+    publicArms.push({ armToken, slot });
+    sealed[armToken] = runtimeId;
+  });
+  return {
+    trialId: input.trialId,
+    seed: input.seed,
+    publicArms,
+    sealed: Object.freeze(sealed),
+  };
+}
+
+/** Reveal: token -> runtime id. Call only from the reveal ceremony. */
+export function revealEnvelope(env: BlindingEnvelope): Record<string, string> {
+  return { ...env.sealed };
+}
+
+// --- arm-token routing (design-eva) -----------------------------------------
+
+/**
+ * Resolve an arm-token to its runtime id for daemon dispatch. This is the ONLY
+ * sanctioned pre-reveal use of the sealed map: the resolved runtime id is used
+ * to route the request server-side and must not be echoed to any response,
+ * log, or SSE frame. Unknown tokens throw (fail closed) rather than silently
+ * routing to a default arm, which would corrupt the trial.
+ */
+export function resolveArmToken(
+  env: BlindingEnvelope,
+  armToken: string,
+): string {
+  const runtimeId = env.sealed[armToken];
+  if (runtimeId === undefined) {
+    throw new Error(`unknown arm-token: ${armToken}`);
+  }
+  return runtimeId;
+}
+
+/**
+ * The set of arm-tokens a caller may present, in slot order. Safe to serialize
+ * to a pre-reveal surface — carries tokens only, never runtime ids.
+ */
+export function publicArmTokens(env: BlindingEnvelope): string[] {
+  return env.publicArms.map((a) => a.armToken);
+}
+
+// --- locked-reveal stopping rule --------------------------------------------
+
+export type StoppingRule = { kind: "min-trials"; n: number };
+
+export type TrialProgress = { completedTrials: number };
+
+/** Locked reveal: pre-committed, immutable, no mid-trial peek. */
+export function shouldReveal(rule: StoppingRule, p: TrialProgress): boolean {
+  switch (rule.kind) {
+    case "min-trials":
+      return p.completedTrials >= rule.n;
+    default:
+      return false;
+  }
+}

--- a/src/lib/double-blind-eval.ts
+++ b/src/lib/double-blind-eval.ts
@@ -196,3 +196,94 @@ export function shouldReveal(rule: StoppingRule, p: TrialProgress): boolean {
       return false;
   }
 }
+
+// --- reveal-ceremony audit log (design-10q) ---------------------------------
+
+/**
+ * The immutable record written the moment the reveal ceremony fires. Captures
+ * who/when/rule/seed and the full token->id maps so the unblinding is fully
+ * auditable and reproducible from {seed, arms}. `integrity` is a hash over the
+ * revealed maps so tampering is detectable after persistence.
+ */
+export type RevealAudit = {
+  trialId: string;
+  seed: number;
+  revealedAt: string; // ISO-8601
+  revealedBy: string; // actor id
+  rule: StoppingRule;
+  progress: TrialProgress;
+  arms: Record<string, string>; // armToken -> runtime id
+  sessions: Record<string, string>; // sessionToken -> evaluator id
+  integrity: string; // sha256 over {trialId, seed, arms, sessions}
+};
+
+function auditIntegrity(input: {
+  trialId: string;
+  seed: number;
+  arms: Record<string, string>;
+  sessions: Record<string, string>;
+}): string {
+  // Stable key ordering so the hash is deterministic regardless of insertion order.
+  const canonical = JSON.stringify({
+    trialId: input.trialId,
+    seed: input.seed,
+    arms: sortRecord(input.arms),
+    sessions: sortRecord(input.sessions),
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+function sortRecord(rec: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of Object.keys(rec).sort()) out[k] = rec[k]!;
+  return out;
+}
+
+/**
+ * Build the reveal audit record. Throws (fail closed) if the stopping rule is
+ * not actually satisfied — the ceremony must never produce a record for an
+ * unlocked trial, which would let a caller forge an early unblind.
+ */
+export function buildRevealAudit(
+  env: BlindingEnvelope,
+  rule: StoppingRule,
+  progress: TrialProgress,
+  revealedBy: string,
+  now: Date,
+): RevealAudit {
+  if (!shouldReveal(rule, progress)) {
+    throw new Error("reveal ceremony blocked: stopping rule not satisfied");
+  }
+  const arms = revealEnvelope(env);
+  const sessions = revealSessions(env);
+  return {
+    trialId: env.trialId,
+    seed: env.seed,
+    revealedAt: now.toISOString(),
+    revealedBy,
+    rule,
+    progress,
+    arms,
+    sessions,
+    integrity: auditIntegrity({ trialId: env.trialId, seed: env.seed, arms, sessions }),
+  };
+}
+
+/**
+ * Verify a persisted audit record's integrity hash matches its revealed maps.
+ * Returns true iff the record has not been tampered with since reveal.
+ */
+export function verifyRevealAudit(audit: RevealAudit): boolean {
+  const expected = auditIntegrity({
+    trialId: audit.trialId,
+    seed: audit.seed,
+    arms: audit.arms,
+    sessions: audit.sessions,
+  });
+  return expected === audit.integrity;
+}
+
+/** One JSONL line for append-only persistence. */
+export function serializeRevealAudit(audit: RevealAudit): string {
+  return JSON.stringify(audit);
+}

--- a/src/lib/double-blind-eval.ts
+++ b/src/lib/double-blind-eval.ts
@@ -46,6 +46,19 @@ export function mintArmToken(trialId: string, slot: number): string {
   return `arm_${h.slice(0, 12)}`;
 }
 
+/**
+ * Evaluator-side mirror of arm-token: opaque, stable per (trialId, turn). Masks
+ * the evaluator/context identity so the agent never sees which reviewer or
+ * context is scoring a turn. Domain-separated from arm-token via the `sess:`
+ * prefix so an arm-token and a session-token can never collide.
+ */
+export function mintSessionToken(trialId: string, turn: number): string {
+  const h = createHash("sha256")
+    .update(`sess:${trialId}:${turn}`)
+    .digest("hex");
+  return `sess_${h.slice(0, 12)}`;
+}
+
 // --- blinding envelope seal/reveal ------------------------------------------
 
 export type SealInput = {
@@ -56,12 +69,19 @@ export type SealInput = {
 
 export type PublicArm = { armToken: string; slot: number };
 
+export type PublicSession = { sessionToken: string; turn: number };
+
 export type BlindingEnvelope = {
   trialId: string;
   seed: number;
   publicArms: PublicArm[];
   /** Sealed: token -> runtime id. Never serialized to pre-reveal surfaces. */
   readonly sealed: Readonly<Record<string, string>>;
+  /**
+   * Sealed: session-token -> evaluator/context id. Never serialized to
+   * pre-reveal surfaces. Grows one entry per evaluated turn.
+   */
+  readonly sealedSessions: Readonly<Record<string, string>>;
 };
 
 export function sealEnvelope(input: SealInput): BlindingEnvelope {
@@ -78,12 +98,59 @@ export function sealEnvelope(input: SealInput): BlindingEnvelope {
     seed: input.seed,
     publicArms,
     sealed: Object.freeze(sealed),
+    sealedSessions: Object.freeze({}),
   };
+}
+
+/**
+ * Register an evaluator/context identity for one turn, returning the updated
+ * envelope and the public session handle. The evaluator id is sealed exactly
+ * like a runtime id — it must not reach any pre-reveal surface. Pure: returns a
+ * new envelope rather than mutating the frozen input.
+ */
+export function sealSession(
+  env: BlindingEnvelope,
+  turn: number,
+  evaluatorId: string,
+): { env: BlindingEnvelope; session: PublicSession } {
+  const sessionToken = mintSessionToken(env.trialId, turn);
+  const sealedSessions = {
+    ...env.sealedSessions,
+    [sessionToken]: evaluatorId,
+  };
+  return {
+    env: { ...env, sealedSessions: Object.freeze(sealedSessions) },
+    session: { sessionToken, turn },
+  };
+}
+
+/**
+ * Resolve a session-token to its evaluator/context id. Reveal-ceremony use
+ * only. Fails closed on unknown tokens.
+ */
+export function resolveSessionToken(
+  env: BlindingEnvelope,
+  sessionToken: string,
+): string {
+  const evaluatorId = env.sealedSessions[sessionToken];
+  if (evaluatorId === undefined) {
+    throw new Error(`unknown session-token: ${sessionToken}`);
+  }
+  return evaluatorId;
 }
 
 /** Reveal: token -> runtime id. Call only from the reveal ceremony. */
 export function revealEnvelope(env: BlindingEnvelope): Record<string, string> {
   return { ...env.sealed };
+}
+
+/**
+ * Reveal: session-token -> evaluator/context id. Reveal-ceremony use only.
+ */
+export function revealSessions(
+  env: BlindingEnvelope,
+): Record<string, string> {
+  return { ...env.sealedSessions };
 }
 
 // --- arm-token routing (design-eva) -----------------------------------------


### PR DESCRIPTION
Ports the pure double-blind eval core into coven-cave and adds the blinding seams for both axes.

## Commits
- **design-eva** — arm-token routing: `resolveArmToken` (fails closed) + `publicArmTokens`.
- **design-doo** — session-token minting: `mintSessionToken`, `sealSession`/`resolveSessionToken`, `revealSessions` (evaluator-side mirror, domain-separated from arm-token).

## Invariant
No pre-reveal surface (API/SSE/log) may carry a runtime id **or** an evaluator id. The no-leak test asserts `publicArms`, `publicArmTokens`, and the public session handle serialize tokens only.

## Tests
10/10 pass via `node --test` strip-types + alias loader. No new API routes → api-contracts gate unaffected.

Closes design-eva, design-doo. Remaining follow-ups in OpenCoven/coven-design: design-10q (audit log), design-09n (UI).