### PR TITLE
chore(chat/github): unify failing-checks tint to --color-danger (cave-w6tw)

### DIFF
--- a/src/components/github-card.tsx
+++ b/src/components/github-card.tsx
@@ -331,7 +331,7 @@ function stateGlyph(
       return { icon: "ph:check-circle", color: "var(--color-success)", label: "Workflow run succeeded" };
     }
     if (run && isFailConclusion(run.conclusion)) {
-      return { icon: "ph:x-circle-fill", color: "var(--color-warning)", label: "Workflow run failed" };
+      return { icon: "ph:x-circle-fill", color: "var(--color-danger)", label: "Workflow run failed" };
     }
     if (run && run.status !== "completed") {
       return { icon: "ph:circle-notch-bold", color: "var(--text-secondary)", label: "Workflow run in progress" };
@@ -602,7 +602,7 @@ function ChecksStrip({ data }: { data: ChecksData }) {
   if (!counts.total) return null;
   const tint =
     rollup === "failing"
-      ? "var(--color-warning)"
+      ? "var(--color-danger)"
       : rollup === "passing"
         ? "var(--color-success)"
         : "var(--text-secondary)";
@@ -623,7 +623,7 @@ function ChecksStrip({ data }: { data: ChecksData }) {
 function checkRunGlyph(run: CheckRunDetail): { icon: IconName; color: string } {
   if (run.status !== "completed") return { icon: "ph:circle-notch-bold", color: "var(--text-secondary)" };
   if (run.conclusion === "success") return { icon: "ph:check-circle", color: "var(--color-success)" };
-  if (isFailConclusion(run.conclusion)) return { icon: "ph:x-circle-fill", color: "var(--color-warning)" };
+  if (isFailConclusion(run.conclusion)) return { icon: "ph:x-circle-fill", color: "var(--color-danger)" };
   return { icon: "ph:minus-circle", color: "var(--text-secondary)" };
 }
 

--- a/src/components/skill-stage-card.tsx
+++ b/src/components/skill-stage-card.tsx
@@ -18,7 +18,7 @@ function stageVisual(stage: SkillStage | "invoked"): { label: string; cls: strin
     case "done":
       return { label: "done", cls: "text-[var(--color-success)]" };
     case "error":
-      return { label: "error", cls: "text-[var(--color-warning)]" };
+      return { label: "error", cls: "text-[var(--color-danger)]" };
     case "running":
       return { label: "running", cls: "text-[var(--accent-presence)]" };
     case "loaded":


### PR DESCRIPTION
Closes **cave-w6tw**. A genuinely-failed checks state should read in **`--color-danger`** (danger reads truer), not `--color-warning`. `github-view` already tints a failing `checkStatus` with danger — this aligns the remaining spots that still used warning.

## Changed (4 flips, warning → danger)
- **`github-card.tsx`** — `checkRunGlyph` (both the card glyph and the checks-strip glyph): `isFailConclusion` → danger.
- **`github-card.tsx`** — `ChecksStrip` rollup tint: `failing` → danger.
- **`skill-stage-card.tsx`** — the chat stage card that replaced the retired `chat-stage-header.tsx`: the `error` stage → danger.

Left intentionally unchanged: **pending/running** stay `--color-warning` / `--text-secondary`, **passing** stays `--color-success`, and the general chat **stream-error strip** (`cave-chat-error-strip`) — that's a transient error banner, not a checks surface.

> Note: the bead named `chat-stage-header.tsx`/`cave-chat.css badge--alert`, but those were retired/renamed since it was filed (2026-07-15). I re-audited the current surfaces and applied the same intent to where the failing-checks tint actually lives now.

## Validation
- `tsc --noEmit` — 0 errors
- `pnpm test:app` — **899 files passed**
- eslint · design codemod · token-drift ratchet — clean (token swap only, no new hardcoded values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)