### PR TITLE
Chat row keydown: ignore keys from nested controls (restore keyboard reorder)

### DIFF
--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1181,6 +1181,10 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                           onFocus={() => { if (!selectMode) hoverPrefetchConversation(s.id); }}
                           onBlur={cancelHoverPrefetch}
                           onKeyDown={(e) => {
+                            // Nested controls (drag handle, quick actions) own
+                            // their keys — dnd-kit's Space/Enter lift prevents
+                            // default but does not stop propagation.
+                            if (e.target !== e.currentTarget) return;
                             if (e.key === "Enter" || e.key === " ") {
                               e.preventDefault();
                               if (selectMode) { toggleSelect(s.id); return; }

--- a/src/lib/chat-session-grouping.test.ts
+++ b/src/lib/chat-session-grouping.test.ts
@@ -138,6 +138,14 @@ test("chat-list: Enter and Space both open the focused row", () => {
     /if \(e\.key === "Enter" \|\| e\.key === " "\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*if \(selectMode\) \{ toggleSelect\(s\.id\); return; \}\s*\n\s*setActiveId\(s\.id\); onOpen\(s\.id, s\.familiarId\);/,
     "keyboard activation mirrors the click: select in select mode, open otherwise",
   );
+  // dnd-kit's Space/Enter drag activation prevents default but does NOT stop
+  // propagation — without this guard, activating keyboard reorder on the drag
+  // handle bubbles to the row and navigates away, destroying the drag.
+  assert.match(
+    chatList,
+    /if \(e\.target !== e\.currentTarget\) return;\s*\n\s*if \(e\.key === "Enter" \|\| e\.key === " "\)/,
+    "the row keydown ignores events from nested controls (drag handle keeps keyboard reorder)",
+  );
 });
 
 test("chat-list: Escape in search clears the query", () => {


### PR DESCRIPTION
## Summary

Post-merge code review of #3754 found a keyboard-accessibility regression: pressing Space or Enter on a chat row's **drag handle** (dnd-kit keyboard reorder activation) bubbled to the row's keydown handler, which now opens the session — unmounting the list and destroying the just-lifted drag. Keyboard drag-to-reorder was unreachable, and the interaction did the opposite of what dnd-kit's screen-reader instructions announce.

Root cause: dnd-kit's keyboard activator calls `preventDefault()` but **not** `stopPropagation()`; the handle stops `click` propagation but not `keydown`.

## Fix

The row `onKeyDown` ignores events whose `target !== currentTarget`, so nested controls (drag handle, hover quick-actions) own their keys. Row-focused Enter/Space still open the session exactly as #3754 intended.

Added a source pin in `chat-session-grouping.test.ts` so the guard can't silently regress.

## Verification

- chat-list pin suites (chat-session-grouping, chat-list-delete, chat-all-familiars-project-list): 14/14 pass
- `pnpm typecheck` clean

Closes bead cave-ohqy.
