### PR TITLE
fix(grimoire): raise 10px body-adjacent text to legible token sizes

### DIFF
--- a/src/components/grimoire-graph-view.test.ts
+++ b/src/components/grimoire-graph-view.test.ts
@@ -80,4 +80,23 @@ assert.match(
   "wheel zoom registers non-passive so the page doesn't scroll",
 );
 
+// ── Legibility floor (cave-zhk6) ─────────────────────────────────────────────
+// Prose notices in the filter card read at 12px (--text-sm); the status pill
+// at 11px. 10px stays reserved for uppercase eyebrows and count chips.
+assert.match(
+  view,
+  /text-\[length:var\(--text-sm\)\] leading-snug text-\[var\(--text-muted\)\]">\s*\n\s*Scanned the/,
+  "the memory-truncation notice reads at --text-sm, not 10px",
+);
+assert.match(
+  view,
+  /text-\[length:var\(--text-sm\)\] leading-snug text-\[var\(--color-warning\)\]">\s*\n\s*Full scan unavailable/,
+  "the scan-error warning reads at --text-sm, not 10px",
+);
+assert.match(
+  view,
+  /pointer-events-none absolute bottom-2 left-2[^"]*text-\[length:var\(--text-xs\)\]/,
+  "the graph status pill reads at --text-xs, not 10px",
+);
+
 console.log("grimoire-graph-view.test.ts: ok");

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -952,12 +952,12 @@ export function GrimoireGraphView({
               </label>
             </div>
             {memoryTruncated && meta ? (
-              <p className="text-[length:var(--text-2xs)] leading-snug text-[var(--text-muted)]">
+              <p className="text-[length:var(--text-sm)] leading-snug text-[var(--text-muted)]">
                 Scanned the {meta.memory.scanned} most recent of {meta.memory.total} memory files.
               </p>
             ) : null}
             {scanError ? (
-              <p className="text-[length:var(--text-2xs)] leading-snug text-[var(--color-warning)]">
+              <p className="text-[length:var(--text-sm)] leading-snug text-[var(--color-warning)]">
                 Full scan unavailable — showing knowledge-vault connections only.
               </p>
             ) : null}
@@ -988,7 +988,7 @@ export function GrimoireGraphView({
       </div>
 
       {/* Status line. */}
-      <div className="pointer-events-none absolute bottom-2 left-2 rounded-full border border-[var(--border-hairline)] bg-[var(--bg-raised)]/90 px-2.5 py-1 text-[length:var(--text-2xs)] text-[var(--text-muted)] backdrop-blur">
+      <div className="pointer-events-none absolute bottom-2 left-2 rounded-full border border-[var(--border-hairline)] bg-[var(--bg-raised)]/90 px-2.5 py-1 text-[length:var(--text-xs)] text-[var(--text-muted)] backdrop-blur">
         {summary}
         {scanning ? " · scanning…" : ""}
       </div>

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -299,4 +299,29 @@ assert.match(view, /aria-label=\{`Close \$\{tabTitle\(tab\)\}\$\{dirtyTabs\[key\
 assert.match(view, /if \(dirtyTabs\[key\]\) \{\s*\n\s*const ok = await confirm\(/, "closing a dirty tab confirms first");
 assert.match(view, /onClick=\{\(\) => void requestCloseTab\(key, tabTitle\(tab\)\)\}/, "the tab strip close goes through the confirm path");
 
+// ── Legibility floor (cave-zhk6) ─────────────────────────────────────────────
+// 10px (--text-2xs) is reserved for uppercase eyebrow labels and count chips.
+// Prose hints, alerts, and rail-row meta were bumped and must not creep back
+// down: sentences read at 12px (--text-sm), secondary UI text at 11px.
+assert.match(
+  view,
+  /text-\[length:var\(--text-sm\)\] text-\[var\(--text-muted\)\]">\s*\n\s*Tip: type/,
+  "the links-strip tip sentence reads at --text-sm, not 10px",
+);
+assert.match(
+  view,
+  /text-\[length:var\(--text-sm\)\] text-\[var\(--text-muted\)\]">\s*\n\s*“\{unresolvedHint\}”/,
+  "the unresolved-link hint sentence reads at --text-sm",
+);
+assert.match(
+  view,
+  /role="alert" className="min-w-0 truncate text-\[length:var\(--text-sm\)\]/,
+  "the footer delete-error alert reads at --text-sm",
+);
+assert.match(
+  view,
+  /mt-0\.5 flex items-center gap-1\.5 text-\[length:var\(--text-xs\)\]/,
+  "rail-row meta (subtitle · date) reads at --text-xs, not 10px",
+);
+
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -381,7 +381,7 @@ function NavRow({
         <span className="min-w-0 flex-1 truncate text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">{title}</span>
         {badge}
       </span>
-      <span className="mt-0.5 flex items-center gap-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+      <span className="mt-0.5 flex items-center gap-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
         {subtitle ? <span className="min-w-0 truncate font-mono">{subtitle}</span> : null}
         {meta ? <span className="shrink-0">{meta}</span> : null}
       </span>
@@ -601,7 +601,7 @@ function GrimoireDocLinks({
     if (!loaded || markdown.trim().length === 0) return null;
     return (
       <div className="grimoire-doc-links shrink-0 border-t border-[var(--border-hairline)] px-3 py-2">
-        <p className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+        <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
           Tip: type <code className="rounded bg-[var(--bg-elevated)] px-1">[[a doc&apos;s title]]</code> anywhere in
           the text to link documents — links show up here and weave the graph.
         </p>
@@ -649,7 +649,7 @@ function GrimoireDocLinks({
       ) : null}
       {unresolvedHint ? (
         <div className="space-y-1" role="status">
-          <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
+          <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
             “{unresolvedHint}” has no matching doc yet — create a stitch with that title to
             link it.
           </p>
@@ -1746,7 +1746,7 @@ export function GrimoireView({
               <span className="text-[length:var(--text-xs)] text-[var(--text-secondary)] @min-[880px]/grimoire:hidden">Documents</span>
               <span className="min-w-0 flex-1" />
               {deleteError ? (
-                <span role="alert" className="min-w-0 truncate text-[length:var(--text-2xs)] text-[var(--color-warning)]">
+                <span role="alert" className="min-w-0 truncate text-[length:var(--text-sm)] text-[var(--color-warning)]">
                   {deleteError}
                 </span>
               ) : null}
@@ -1755,7 +1755,7 @@ export function GrimoireView({
                   type="button"
                   onClick={() => void deleteSelection()}
                   disabled={deleting}
-                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[length:var(--text-2xs)] text-[var(--text-secondary)] enabled:hover:border-[var(--color-danger)]/40 enabled:hover:bg-[var(--color-danger)]/10 enabled:hover:text-[var(--color-danger)] disabled:opacity-50"
+                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[length:var(--text-xs)] text-[var(--text-secondary)] enabled:hover:border-[var(--color-danger)]/40 enabled:hover:bg-[var(--color-danger)]/10 enabled:hover:text-[var(--color-danger)] disabled:opacity-50"
                 >
                   <Icon name="ph:trash" width={11} aria-hidden />
                   {deleting


### PR DESCRIPTION
## Why

cave-zhk6 (grimoire-audit): rail rows, the links strip, the filter card, and the footer set body-adjacent text at `--text-2xs` (10px) — below a comfortable reading floor for sentences and alerts, and thin under zoom (a11y). The audit-era `text-[10px]`/`text-[11px]` literals had since been tokenized, but the *sizes* stayed; this pass fixes the judgment half.

## What

Bumps that preserve hierarchy (titles stay one step above their meta):

**→ `--text-sm` (12px)** — full sentences and warnings:
- links-strip tip ("Tip: type `[[a doc's title]]` …")
- unresolved-link hint ("…has no matching doc yet — create a stitch…")
- footer delete-error `role="alert"`
- graph filter-card memory-truncation notice + scan-error warning

**→ `--text-xs` (11px)** — secondary UI text stuck at 10px:
- navigator rail-row meta line (subtitle · date, under 12px titles)
- footer Delete / Move-to-trash button label (matches the adjacent "Documents" label)
- graph status pill ("N of M nodes, K connections shown")

**Kept at `--text-2xs` deliberately** — the design language's blessed tiny-label patterns where the size step *is* the hierarchy: uppercase eyebrow micro-labels (section headers, Links/Mentions, graph panel kickers) and count chips trailing an 11px label (filter rows, flag counts). Launcher untouched (fresh redesign, all its 2xs uses are eyebrow/kind-chip patterns).

Legibility-floor pins added to `grimoire-view.test.ts` + `grimoire-graph-view.test.ts` so the prose/meta floors don't creep back down.

## Testing

- Grimoire family green: view, graph-view, stub-links, launcher, nav-state (`# pass 5`).
- `pnpm typecheck` + `pnpm lint` clean; design-token-drift ratchet passes (token→token change, no raw px introduced).

Closes cave-zhk6.
