### PR TITLE
ci(windows): run the SidecarCleanupGuard drop/reap test (cave-x9zv)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,19 @@ jobs:
             throw 'Idempotent sidecar cleanup filter did not run exactly one test.'
           }
 
+      - name: Test Windows sidecar cleanup guard reaps process
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::dropping_application_cleanup_guard_stops_and_reaps_sidecar -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'Sidecar cleanup guard reap filter did not run exactly one test.'
+          }
+
       - name: Test Windows sidecar descendant cleanup
         if: matrix.os == 'windows-latest'
         shell: pwsh


### PR DESCRIPTION
Closes **cave-x9zv**. The Windows `sidecar-runtime` CI job pins the idempotent-stop cleanup test by `--exact` name, but **`app_lifecycle_tests::dropping_application_cleanup_guard_stops_and_reaps_sidecar`** — the guard that stops + reaps a spawned sidecar on `Drop` — ran **nowhere** in `ci.yml` (grep-confirmed gap). This adds a mirror step so the process-reaping guarantee is pinned on `windows-latest`.

## Change
One CI step in the `sidecar-runtime` job, mirroring the sibling "Test Windows idempotent sidecar cleanup" step (same `--exact` filter + "exactly one test" assertion), targeting the guard-drop/reap test.

## Notes
- The bead said the tests live in `lib.rs`; they had moved to `src-tauri/src/app_lifecycle_tests.rs` (`SidecarCleanupGuard` itself lives in `sidecar_lifecycle.rs`). Corrected on the bead.
- The gh-2905 gate is moot — the runtime archive + guard landed via other paths and exist in the current tree.

## Validation
- `ci.yml` parses (YAML) ✓; the step slots between the idempotent and descendant cleanup steps.
- **Ran locally on macOS**: `cargo test … app_lifecycle_tests::dropping_application_cleanup_guard_stops_and_reaps_sidecar -- --exact` → `1 passed; 0 failed; 41 filtered out` (exactly matches the step's assertion).
- The `sidecar-runtime (windows-latest)` job runs on PRs, so this PR's CI will execute the new step on a real Windows runner — end-to-end validation, not deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)