### PR TITLE
feat(backdrop): explicit Off style + WebGL context-loss remount (cave-kbh1)

### DIFF
--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -193,7 +193,7 @@
       intensity: typeof backdrop.intensity === "number" ? backdrop.intensity : 50,
       matchAccent: backdrop.matchAccent !== false,
       accentSeed: backdrop.accentSeed || null,
-      style: backdrop.style === "blaze" ? "blaze" : "image"
+      style: backdrop.style === "blaze" ? "blaze" : backdrop.style === "off" ? "off" : "image"
     }));
     safeSet("cave:home-news-enabled", general.newsHeadlines === false ? "false" : "true");
     safeSet("cave:mobile-mode-enabled", phone.mobileMode === false ? "false" : "true");

--- a/src/components/backdrop-settings.tsx
+++ b/src/components/backdrop-settings.tsx
@@ -15,8 +15,9 @@ import {
 import { BACKDROP_STYLES, type CaveBackdropStyle } from "@/lib/preferences-schema";
 import { useArmedConfirm } from "@/lib/use-armed-confirm";
 
-const STYLE_LABELS: Record<CaveBackdropStyle, string> = { image: "Image", blaze: "Blaze" };
+const STYLE_LABELS: Record<CaveBackdropStyle, string> = { off: "Off", image: "Image", blaze: "Blaze" };
 const STYLE_TITLES: Record<CaveBackdropStyle, string> = {
+  off: "No backdrop — Home and Chat stay solid",
   image: "A picture you choose shows behind Home and Chat",
   blaze: "Animated embers and smoke, tinted to your theme accent",
 };
@@ -98,6 +99,14 @@ export function BackdropSettings() {
   }
 
   function setStyle(style: CaveBackdropStyle) {
+    if (style === "off") {
+      // Explicit off (cave-kbh1): non-destructive — the stored image and
+      // accent seed survive, so Image/Blaze restore the previous look.
+      if (prefs.style === "off" && !prefs.enabled) return;
+      writeBackdropPrefs({ style, enabled: false });
+      announce("Backdrop off.");
+      return;
+    }
     if (style === "blaze") {
       // No early return on prefs.style: re-clicking the active segment
       // re-asserts enablement, healing a stomped enabled:false (e.g. a

--- a/src/components/cave-backdrop-blaze.tsx
+++ b/src/components/cave-backdrop-blaze.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { blazeColorsFromAccent, BLAZE_OPTIONS } from "@/lib/cave-backdrop-blaze-colors";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 
 // The ~22 KB vendored WebGL file loads only when the Blaze style is shown.
 const Blaze = dynamic(() => import("@/components/canvasui/Blaze"), { ssr: false });
+
+/** How many times a lost WebGL context earns a fresh mount before giving up —
+ *  a crashing GPU/driver loop should not thrash remounts forever. Past the
+ *  cap the layer stays blank, which is the pre-recovery behavior. */
+const MAX_CONTEXT_RESTARTS = 3;
 
 function readAccentCss(): string {
   return getComputedStyle(document.documentElement).getPropertyValue("--accent-presence").trim();
@@ -24,6 +29,12 @@ function readAccentCss(): string {
 export function CaveBackdropBlaze() {
   const reducedMotion = usePrefersReducedMotion();
   const [accentCss, setAccentCss] = useState<string | null>(null);
+  // Bumps on WebGL context loss to remount the vendored component (which has
+  // no recovery of its own — vendor-verbatim, cave-kbh1): a fresh mount means
+  // a fresh canvas and a fresh context instead of a permanently blank layer.
+  const [glEpoch, setGlEpoch] = useState(0);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const showing = !reducedMotion && accentCss !== null;
 
   // One observer covers every accent source: preset swaps rewrite
   // data-theme/data-mode; custom themes carry the accent as an inline style
@@ -40,11 +51,26 @@ export function CaveBackdropBlaze() {
     return () => observer.disconnect();
   }, []);
 
-  if (reducedMotion || accentCss === null) return null;
+  // webglcontextlost fires on the output <canvas> and does not bubble, but
+  // capture-phase listeners on ancestors still see it — so the wrapper can
+  // watch without touching the vendored file.
+  useEffect(() => {
+    if (!showing) return;
+    const node = wrapRef.current;
+    if (!node) return;
+    const onContextLost = () => {
+      setGlEpoch((epoch) => (epoch < MAX_CONTEXT_RESTARTS ? epoch + 1 : epoch));
+    };
+    node.addEventListener("webglcontextlost", onContextLost, true);
+    return () => node.removeEventListener("webglcontextlost", onContextLost, true);
+  }, [showing]);
+
+  if (!showing) return null;
   const { sparkColor, smokeColor } = blazeColorsFromAccent(accentCss);
   return (
-    <div className="cave-backdrop-blaze" aria-hidden>
+    <div ref={wrapRef} className="cave-backdrop-blaze" aria-hidden>
       <Blaze
+        key={glEpoch}
         {...BLAZE_OPTIONS}
         sparkColor={sparkColor}
         smokeColor={smokeColor}

--- a/src/components/familiar-studio-look-tab.tsx
+++ b/src/components/familiar-studio-look-tab.tsx
@@ -435,7 +435,7 @@ function FamiliarBackdropSection({ familiarId }: { familiarId: string }) {
             ? "Shows in chat while this familiar is active — this image overrides the app backdrop."
             : prefs.style === "blaze"
               ? "No image uploaded — the animated Blaze backdrop shows."
-              : appImagePresent
+              : prefs.style === "image" && appImagePresent
                 ? "No image uploaded — the app backdrop image is used."
                 : "No image uploaded — only the backdrop tint shows until an image is set here or in Settings → Appearance."
           : "Off — the app backdrop (Settings → Appearance) applies as usual."}

--- a/src/lib/cave-backdrop-blaze.test.ts
+++ b/src/lib/cave-backdrop-blaze.test.ts
@@ -53,7 +53,12 @@ assert.deepEqual(BLAZE_OPTIONS, {
 const component = readFileSync(new URL("../components/cave-backdrop-blaze.tsx", import.meta.url), "utf8");
 assert.match(
   component,
-  /if \(reducedMotion \|\| accentCss === null\) return null;/,
+  /const showing = !reducedMotion && accentCss !== null;/,
+  "reduced motion (or an unread accent) keeps the GPU loop from mounting",
+);
+assert.match(
+  component,
+  /if \(!showing\) return null;/,
   "reduced motion skips mounting the GPU loop entirely",
 );
 assert.match(
@@ -65,6 +70,35 @@ assert.match(
   component,
   /attributeFilter: \["data-theme", "data-mode", "style"\]/,
   "colors re-derive live on theme/mode/custom-accent changes",
+);
+
+// ── WebGL context-loss recovery (cave-kbh1) ──────────────────────────────────
+// The vendored Blaze file is vendor-verbatim and has no context-restore path;
+// the wrapper remounts it (fresh canvas, fresh context) when the GPU drops.
+assert.match(
+  component,
+  /node\.addEventListener\("webglcontextlost", onContextLost, true\);/,
+  "context loss is watched capture-phase on the wrapper (the event does not bubble)",
+);
+assert.match(
+  component,
+  /node\.removeEventListener\("webglcontextlost", onContextLost, true\);/,
+  "the capture listener detaches on cleanup",
+);
+assert.match(
+  component,
+  /const MAX_CONTEXT_RESTARTS = 3;/,
+  "remounts are capped so a crashing GPU loop cannot thrash forever",
+);
+assert.match(
+  component,
+  /setGlEpoch\(\(epoch\) => \(epoch < MAX_CONTEXT_RESTARTS \? epoch \+ 1 : epoch\)\);/,
+  "past the cap the epoch stops advancing (layer stays blank — the pre-recovery behavior)",
+);
+assert.match(
+  component,
+  /<Blaze\n\s+key=\{glEpoch\}/,
+  "the epoch keys the vendored component, so a bump remounts it",
 );
 
 // ── Layer integration ────────────────────────────────────────────────────────
@@ -145,6 +179,37 @@ assert.match(
   "the image chooser and accent-match rows are image-style-only",
 );
 
+// ── Explicit off (cave-kbh1) ─────────────────────────────────────────────────
+{
+  const schema = readFileSync(new URL("./preferences-schema.ts", import.meta.url), "utf8");
+  assert.match(
+    schema,
+    /export const BACKDROP_STYLES = \["off", "image", "blaze"\] as const;/,
+    "Off is a first-class style segment (Segmented renders BACKDROP_STYLES directly)",
+  );
+  assert.match(
+    schema,
+    /enabled: backdrop\.enabled === true && oneOf\(backdrop\.style, BACKDROP_STYLES, "image"\) !== "off",/,
+    "normalize coerces the off style to disabled — {style:'off', enabled:true} cannot paint an empty scrim",
+  );
+  const store = readFileSync(new URL("./cave-backdrop.ts", import.meta.url), "utf8");
+  assert.match(
+    store,
+    /if \(next\.style === "off"\) next\.enabled = false;/,
+    "the synchronous write path holds the same off⇒disabled invariant",
+  );
+}
+assert.match(
+  settings,
+  /if \(prefs\.style === "off" && !prefs\.enabled\) return;\n\s+writeBackdropPrefs\(\{ style, enabled: false \}\);/,
+  "choosing Off disables the backdrop without discarding the stored image or accent seed",
+);
+assert.match(
+  settings,
+  /announce\("Backdrop off\."\);/,
+  "turning the backdrop off is announced",
+);
+
 // ── Boot script: pre-paint parity with the hydrated runtime ──────────────────
 const boot = readFileSync(new URL("../../public/scripts/theme-init.js", import.meta.url), "utf8");
 assert.match(
@@ -154,8 +219,8 @@ assert.match(
 );
 assert.match(
   boot,
-  /style: backdrop\.style === "blaze" \? "blaze" : "image"/,
-  "the boot legacy-mirror write carries style, so it round-trips instead of being stomped every boot",
+  /style: backdrop\.style === "blaze" \? "blaze" : backdrop\.style === "off" \? "off" : "image"/,
+  "the boot legacy-mirror write carries style (including explicit off), so it round-trips instead of being stomped every boot",
 );
 
 // ── Familiar Look tab: fallback copy knows about the Blaze style ─────────────
@@ -167,6 +232,11 @@ assert.match(
   lookTab,
   /the animated Blaze backdrop shows/,
   "the no-familiar-image fallback note describes Blaze when that style is selected",
+);
+assert.match(
+  lookTab,
+  /: prefs\.style === "image" && appImagePresent/,
+  "the 'app backdrop image is used' note requires the image style — an app set to Off shows tint-only copy",
 );
 
 console.log("cave-backdrop-blaze.test.ts: ok");

--- a/src/lib/cave-backdrop.ts
+++ b/src/lib/cave-backdrop.ts
@@ -96,6 +96,10 @@ export function readBackdropPrefs(): BackdropPrefs {
 
 export function writeBackdropPrefs(patch: Partial<BackdropPrefs>): BackdropPrefs {
   const next = { ...readBackdropPrefs(), ...patch };
+  // Invariant (cave-kbh1): the explicit "off" style is always disabled. The
+  // schema coerces persisted reads the same way; holding it here too keeps
+  // the synchronous cache from ever painting an empty scrim.
+  if (next.style === "off") next.enabled = false;
   cachedPrefs = next;
   updateAppPreferences({ appearance: { backdrop: next } });
   try {

--- a/src/lib/preferences-schema.test.ts
+++ b/src/lib/preferences-schema.test.ts
@@ -308,6 +308,41 @@ assert.throws(
   PreferencesValidationError,
   "the strict validator bounds the familiars map size",
 );
+
+// ── appearance.backdrop.style "off" (cave-kbh1) ──────────────────────────────
+// The explicit no-backdrop choice: a persisted style, always disabled.
+const offNormalized = normalizeCavePreferences({
+  appearance: { backdrop: { style: "off", enabled: true } },
+});
+assert.equal(offNormalized.appearance.backdrop.style, "off", "off round-trips as a persisted style");
+assert.equal(
+  offNormalized.appearance.backdrop.enabled,
+  false,
+  "normalize coerces the off style to disabled — no empty-scrim contradiction can persist",
+);
+assert.equal(
+  normalizeCavePreferences({ appearance: { backdrop: { style: "sparkles" } } })
+    .appearance.backdrop.style,
+  "image",
+  "an unknown style still defaults to image",
+);
+assert.equal(
+  normalizeCavePreferences({ appearance: { backdrop: { style: "blaze", enabled: true } } })
+    .appearance.backdrop.enabled,
+  true,
+  "the off coercion leaves the other styles' enablement alone",
+);
+assert.equal(
+  validatePreferencesPatch({ appearance: { backdrop: { style: "off" } } })
+    .appearance?.backdrop?.style,
+  "off",
+  "the strict validator accepts the off style",
+);
+const offApplied = applyPreferencesPatch(createDefaultPreferences(true), {
+  appearance: { backdrop: { style: "off", enabled: false } },
+});
+assert.equal(offApplied.appearance.backdrop.style, "off");
+assert.equal(offApplied.appearance.backdrop.enabled, false);
 assert.throws(
   () => validatePreferencesPatch({
     appearance: { backdrop: { familiars: { ["f".repeat(129)]: true } } },

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -66,8 +66,11 @@ export type CaveBackdropImageMetadata = {
   updatedAt: string;
 };
 
-/** Backdrop style option set — grows as animated styles land (cave-99s9). */
-export const BACKDROP_STYLES = ["image", "blaze"] as const;
+/** Backdrop style option set — grows as animated styles land (cave-99s9).
+ *  "off" is the explicit no-backdrop choice (cave-kbh1): it always pairs with
+ *  enabled:false (normalize coerces), while keeping the stored image and
+ *  accent seed intact so switching back restores the previous look. */
+export const BACKDROP_STYLES = ["off", "image", "blaze"] as const;
 export type CaveBackdropStyle = (typeof BACKDROP_STYLES)[number];
 
 export type CaveBackdropPreferences = {
@@ -401,7 +404,10 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
         : [],
       cornerRadius: oneOf(appearance.cornerRadius, CORNER_RADII, "default"),
       backdrop: {
-        enabled: backdrop.enabled === true,
+        // The explicit "off" style always reads back disabled — a stale or
+        // hand-edited {style:"off", enabled:true} would otherwise paint an
+        // empty scrim (no image fetch, no Blaze) over every surface.
+        enabled: backdrop.enabled === true && oneOf(backdrop.style, BACKDROP_STYLES, "image") !== "off",
         intensity: typeof backdrop.intensity === "number" && Number.isFinite(backdrop.intensity)
           ? Math.min(100, Math.max(0, backdrop.intensity)) : 50,
         matchAccent: backdrop.matchAccent !== false,


### PR DESCRIPTION
Two accepted minors from the Blaze backdrop reviews (PR #3764, cave-99s9).

## Explicit Off style

- `"off"` joins `BACKDROP_STYLES` — the Settings segmented control renders **Off | Image | Blaze**. Previously enablement was implicit (image: pick/clear; blaze: no off-path at all besides switching to Image with no stored image).
- **Non-destructive**: Off keeps the stored image bytes and accent seed, so switching back to Image/Blaze restores the previous look. (Clear remains the destructive path.)
- **Invariant — off ⇒ disabled**, held at both layers so `{style:"off", enabled:true}` can never paint an empty scrim (that state would fetch no image and mount no Blaze, leaving a bare tint over every surface):
  - `normalizeCavePreferences` coerces `enabled:false` whenever the style reads `"off"`;
  - `writeBackdropPrefs` applies the same coercion on the synchronous cache.
- Boot mirror (`theme-init.js`) carries `"off"` so the legacy round-trip doesn't stomp the choice; the strict patch validator accepts it via the shared const.
- Familiar Look tab: the "app backdrop image is used" fallback note now requires the image style — with the app set to Off it shows the tint-only copy instead of claiming an image will render.

## WebGL context-loss remount

- Vendored `canvasui/Blaze.tsx` stays vendor-verbatim — it has no context-restore path, so a lost context previously left the decorative layer blank until a full app remount.
- `CaveBackdropBlaze` now listens for `webglcontextlost` **capture-phase on the wrapper** (the event fires on the canvas and does not bubble) and bumps a `key` to remount with a fresh canvas + context.
- Capped at **3 restarts** — a crashing GPU/driver loop stops thrashing and degrades to today's blank-layer behavior.

## Validation

- `cave-backdrop-blaze.test.ts` — pins for the segment, both invariant sites, boot mirror, Look-tab copy, capture listener + cap + key.
- `preferences-schema.test.ts` — behavioral coverage: off round-trips, coercion to disabled, unknown style still defaults to image, blaze enablement untouched, strict validator accepts off.
- Targeted suites green (blaze, schema, backdrop store, scrim, app-prefs, look-tab, theme-script, font-boot, settings-appearance, action-buttons + a11y with the CSS hook); `pnpm typecheck` + `pnpm lint` clean.

Closes cave-kbh1.
