### PR TITLE
feat(queue): move Queue project setup out of onboarding onto the Queue tab

### DIFF
--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -76,10 +76,10 @@ assert.doesNotMatch(
   "the frequently-polled status route never invokes package-registry discovery",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /cachedQueueProjectReadiness\(\)/,
-  "the onboarding heartbeat reuses the short Queue readiness cache instead of spawning Git and bd every poll",
+  /cachedQueueProjectReadiness|checkQueueProject/,
+  "the onboarding heartbeat no longer probes Queue readiness — Queue setup lives on the Tasks page's Queue tab",
 );
 
 assert.match(
@@ -152,16 +152,21 @@ const onboardingModel = readFileSync(
   "utf8",
 );
 assert.match(onboardingModel, /git\?: Step/, "onboarding model accepts the git step");
+assert.doesNotMatch(
+  onboardingModel,
+  /project: Step/,
+  "the Queue project is not an onboarding step — selection lives on the Tasks page's Queue tab",
+);
 assert.match(overlay, /title: "Find Git"/, "overlay renders the required git checklist row");
-assert.match(
+assert.doesNotMatch(
   overlay,
-  /key: "git"[\s\S]*?title: "Find Git"[\s\S]*?key: "project"[\s\S]*?title: "Choose your Queue project"/,
-  "Git is presented before the Queue project it is required to validate",
+  /key: "project"|Choose your Queue project/,
+  "the wizard no longer hosts Queue project selection",
 );
 assert.match(
   overlay,
-  /Git is required before selecting a Queue project/,
-  "the Git pane explains the required Queue prerequisite rather than calling Git optional",
+  /Git is required before choosing a Queue project on\s+the Tasks page/,
+  "the Git pane points at the Tasks-page Queue setup rather than calling Git optional",
 );
 
 const projectFiles = readFileSync(

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -19,7 +19,6 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
-import { cachedQueueProjectReadiness } from "@/lib/queue-project-readiness";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -40,9 +39,10 @@ function gitInstallHint(): string {
 }
 
 /**
- * Queue project selection is a required Git-repository boundary. Cave can
- * render some surfaces without Git, but it cannot safely initialize or load
- * the selected Queue project until Git is available.
+ * Queue project selection lives on the Tasks page's Queue tab now, not in
+ * onboarding — but it remains a Git-repository boundary. Cave can render some
+ * surfaces without Git, yet it cannot safely initialize or load a selected
+ * Queue project until Git is available.
  */
 async function checkGit(): Promise<Step> {
   const found = await commandPath("git");
@@ -288,33 +288,14 @@ async function checkBinding(
   };
 }
 
-/**
- * A Git project is mandatory for the Queue. An otherwise-valid repository
- * without Beads is ready for the explicit Generate action on the Queue page,
- * so it satisfies project selection during onboarding.
- *
- * The daemon-less e2e harness (COVEN_CAVE_E2E=1, see playwright.config.ts)
- * has no selected Queue project by design; report the step satisfied there
- * so a stored dismissal keeps the wizard closed, exactly like the daemon
- * short-circuit. Specs that exercise project readiness mock this route.
- */
-async function checkQueueProject(): Promise<Step> {
-  if (process.env.COVEN_CAVE_E2E === "1") {
-    return { ok: true, detail: "e2e harness stub — no Queue project in daemon-less runs" };
-  }
-  const readiness = await cachedQueueProjectReadiness();
-  return { ok: readiness.ok || readiness.canGenerate, detail: readiness.message };
-}
-
 export async function GET() {
   const openclawAgentCount = await countOpenClawAgents();
-  const [openCovenTools, covenHome, git, daemon, familiarsRes, queueProject] = await Promise.all([
+  const [openCovenTools, covenHome, git, daemon, familiarsRes] = await Promise.all([
     openCovenToolReadinessStatuses(),
     checkCovenHome(),
     checkGit(),
     checkDaemon(),
     checkFamiliars(),
-    checkQueueProject(),
   ]);
   const covenCli = checkCovenCli(
     openCovenTools.find((tool) => tool.id === "coven-cli"),
@@ -330,7 +311,6 @@ export async function GET() {
   const steps: Record<string, Step> = {
     covenCli,
     covenHome,
-    project: queueProject,
     git,
     adapters: adapters.step,
     daemon,
@@ -341,7 +321,8 @@ export async function GET() {
     binding: { ...binding, optional: true },
   };
   // Optional familiar and binding steps surface in the checklist but never
-  // gate completion. Git and the Queue project remain required boundaries.
+  // gate completion. Git remains a required boundary; the Queue project is
+  // chosen on the Tasks page's Queue tab, not during onboarding.
   const complete = Object.values(steps).every((s) => s.ok || s.optional);
 
   return NextResponse.json({ ok: true, complete, steps, tools: openCovenTools });

--- a/src/components/familiar-work-queue-view.test.ts
+++ b/src/components/familiar-work-queue-view.test.ts
@@ -12,6 +12,7 @@ const view = [
   readFileSync(new URL("./familiar-work-queue-view.tsx", import.meta.url), "utf8"),
   readFileSync(new URL("./familiar-work-queue-sections.tsx", import.meta.url), "utf8"),
 ].join("\n");
+const setup = readFileSync(new URL("./queue-project-setup.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../styles/familiar-work-queue.css", import.meta.url), "utf8");
 
 // Lane headers are real disclosure controls, not decorative rows.
@@ -160,9 +161,41 @@ assert.match(view, /readiness\?\.code === "not-git-repository"/, "ordinary non-G
 assert.match(view, /const projectUnavailable = !readinessUnavailable && !sourcesUnavailable && !canGenerate && !selectionRemediable && readiness\?\.project !== null/, "only non-repairable selected projects suppress Generate");
 assert.match(view, /Clear all prior-project controls synchronously/, "selection clears Queue state before the next readiness response");
 assert.match(view, /headline=\{readinessUnavailable \? "Queue check unavailable" : sourcesUnavailable \? "Queue sources unavailable" : canGenerate \? "Generate your Queue" : projectUnavailable \? "Queue project needs attention" : "Queue needs a project"\}/);
-assert.match(view, /readinessUnavailable \|\| sourcesUnavailable \|\| projectUnavailable \? null : canGenerate \? \(/, "Generate wins before a selected-project warning and stale roots offer Choose project");
+assert.match(view, /readinessUnavailable \|\| sourcesUnavailable \|\| projectUnavailable \? null : canGenerate \? \(/, "Generate wins before a selected-project warning and stale roots offer the inline picker");
 assert.match(view, />\s*Generate\s*<\/Button>/, "empty Queue state offers Generate");
 assert.doesNotMatch(view, /readSurfaceResource\("tasks:queue"/, "Queue no longer consumes an unscoped warm cache");
+
+// ── Queue project setup happens on the tab, not in onboarding ────────────────
+// A missing/remediable selection renders the picker inline; choosing a project
+// POSTs the selection and publishes it, and the view's own subscription
+// (resetForProject + load) refreshes every mounted Queue surface.
+assert.match(
+  view,
+  /<QueueProjectSetup selectedProjectId=\{readiness\?\.project\?\.id \?\? null\} \/>/,
+  "the needs-a-project empty state hosts the inline Queue project picker",
+);
+assert.doesNotMatch(
+  view,
+  /cave:onboarding-open/,
+  "the Queue never bounces users to the onboarding wizard for project selection",
+);
+assert.match(setup, /ariaLabel="Choose Queue project"/, "the inline picker keeps its AT name");
+assert.match(
+  setup,
+  /JSON\.stringify\(\{ action: "select", projectId \}\)/,
+  "the picker persists selection through the readiness route",
+);
+assert.match(
+  setup,
+  /publishQueueProjectSelection\(body\.readiness\.project\)/,
+  "a saved selection is published so every mounted Queue surface reloads",
+);
+assert.match(
+  setup,
+  /const generation = \+\+requestGeneration\.current;[\s\S]{0,900}if \(generation !== requestGeneration\.current\) return;[\s\S]{0,700}if \(generation === requestGeneration\.current\) setSelecting\(false\);/,
+  "out-of-order Queue-project selections cannot overwrite or unlock the latest selection",
+);
+assert.match(setup, /createProject=\{createProject\}/, "registering a new root stays available from the Queue tab");
 
 // ── cave-p63a: forward-to-familiar menu (redesign) ───────────────────────────
 // The split control's picker is now a custom dropdown (design's "Forward to

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -13,6 +13,7 @@ import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { relativeTime } from "@/lib/relative-time";
 import { subscribeToQueueProjectSelection, type QueueProjectSelection } from "@/lib/queue-project-selection";
+import { QueueProjectSetup } from "@/components/queue-project-setup";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   buildWorkQueue,
@@ -617,15 +618,16 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = fa
             headline={readinessUnavailable ? "Queue check unavailable" : sourcesUnavailable ? "Queue sources unavailable" : canGenerate ? "Generate your Queue" : projectUnavailable ? "Queue project needs attention" : "Queue needs a project"}
             subtitle={readinessUnavailable ? readinessFailure : error}
             actions={
-              <div className="flex flex-wrap justify-center gap-2">
+              <div className="flex flex-wrap items-center justify-center gap-2">
                 {readinessUnavailable || sourcesUnavailable || projectUnavailable ? null : canGenerate ? (
                   <Button variant="primary" leadingIcon="ph:magic-wand-fill" loading={generating} onClick={() => void generateQueue()}>
                     Generate
                   </Button>
                 ) : (
-                  <Button variant="secondary" leadingIcon="ph:folder-open" onClick={() => window.dispatchEvent(new Event("cave:onboarding-open"))}>
-                    Choose project
-                  </Button>
+                  // Queue setup happens here, on the tab itself — selection
+                  // publishes, the subscription resets state, and load(true)
+                  // re-reads readiness for the newly chosen repository.
+                  <QueueProjectSetup selectedProjectId={readiness?.project?.id ?? null} />
                 )}
                 <Button variant="secondary" leadingIcon="ph:arrow-clockwise" onClick={() => void load(true)}>
                   Retry

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -52,10 +52,10 @@ for (const key of stepOrder) {
   assert.ok(at > -1, `guided step ${key} present and in order`);
   cursor = at;
 }
-for (const gone of ['key: "binding",', 'key: "familiars",']) {
+for (const gone of ['key: "binding",', 'key: "familiars",', 'key: "project",']) {
   assert.ok(
     !source.includes(gone),
-    `retired wizard step ${gone} must not return — creation lives in the summoning circle`,
+    `retired wizard step ${gone} must not return — creation lives in the summoning circle and Queue setup on the Tasks page's Queue tab`,
   );
 }
 
@@ -119,10 +119,13 @@ assert.match(
   "Node.js setup instructions render inline when npm is missing",
 );
 
-assert.match(
+// Queue project selection retired from the wizard: its picker (and the
+// request-generation race guard) live in queue-project-setup.tsx on the
+// Tasks page's Queue tab, pinned by familiar-work-queue-view.test.ts.
+assert.doesNotMatch(
   source,
-  /const generation = \+\+requestGeneration\.current;[\s\S]{0,900}if \(generation !== requestGeneration\.current\) return;[\s\S]{0,700}if \(generation === requestGeneration\.current\) setSelecting\(false\);/,
-  "out-of-order Queue-project selections cannot overwrite or unlock the latest selection",
+  /QueueProjectSetup|requestGeneration/,
+  "the wizard no longer embeds the Queue project picker",
 );
 
 // ── Cross-platform instructions ─────────────────────────────────────────────

--- a/src/components/onboarding-model.ts
+++ b/src/components/onboarding-model.ts
@@ -16,7 +16,6 @@ export type OnboardingStatus = {
   steps: {
     covenCli: Step;
     covenHome: Step;
-    project: Step;
     git?: Step;
     adapters: Step;
     daemon: Step;

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -13,9 +13,6 @@ import type { IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Button } from "@/components/ui/button";
-import { ProjectPicker } from "@/components/project-picker";
-import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import { useProjects } from "@/lib/use-projects";
 import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry";
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
 import { openExternalUrl } from "@/lib/open-external";
@@ -26,7 +23,6 @@ import {
   type LatestCheckDisplay,
 } from "@/lib/opencoven-tools-status-display";
 import { requestSummonFamiliar } from "@/lib/summon-events";
-import { publishQueueProjectSelection } from "@/lib/queue-project-selection";
 import {
   classifySetupFailure,
   setupRetryLabel,
@@ -923,20 +919,14 @@ export function OnboardingOverlay({
       {
         key: "git",
         title: "Find Git",
-        // Queue project selection is a required Git-repository boundary.
+        // Queue project selection (on the Tasks page's Queue tab) is a
+        // required Git-repository boundary.
         ok: !!s?.git?.ok,
         detail:
           s?.git?.detail ??
           s?.git?.hint ??
           "Git is required to select and use a Queue project.",
         icon: "ph:git-branch-bold",
-      },
-      {
-        key: "project",
-        title: "Choose your Queue project",
-        ok: !!s?.project?.ok,
-        detail: s?.project?.detail ?? s?.project?.hint ?? "checking…",
-        icon: "ph:folder-simple-dashed",
       },
     ];
   }, [status]);
@@ -1467,14 +1457,13 @@ export function OnboardingOverlay({
                               ) : null}
                             </div>
                           </div>
-                        ) : step.key === "project" ? (
-                          <QueueProjectSetup onSelected={() => void refresh()} />
                         ) : step.key === "git" ? (
                           <div className="flex flex-col gap-2">
                             <p className="text-[length:var(--text-sm)] leading-5 text-[var(--text-secondary)]">
-                              Git is required before selecting a Queue project.
-                              Chat can work without Git, but Queue setup, the
-                              changes panel, project file tree, and checkpoints all use it.
+                              Git is required before choosing a Queue project on
+                              the Tasks page. Chat can work without Git, but the
+                              Queue, the changes panel, project file tree, and
+                              checkpoints all use it.
                             </p>
                             <p className="text-[length:var(--text-sm)] leading-5 text-[var(--text-muted)]">
                               {status?.steps.git?.hint ??
@@ -1537,112 +1526,6 @@ export function OnboardingOverlay({
 }
 
 // ── Step bodies ───────────────────────────────────────────────────────────────
-
-type QueueReadinessView = {
-  ok: boolean;
-  message: string;
-  canGenerate: boolean;
-  project: { id: string; name: string; root: string } | null;
-};
-
-/** The Queue always starts with a concrete, host-native project selection.
- * This component deliberately uses the same project picker as the rest of
- * Cave, including the native folder chooser used to register a new root. */
-function QueueProjectSetup({ onSelected }: { onSelected: () => void }) {
-  const { projects, loading, createProject } = useProjects();
-  const [readiness, setReadiness] = useState<QueueReadinessView | null>(null);
-  const [selecting, setSelecting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const requestGeneration = useRef(0);
-
-  const refreshReadiness = useCallback(async () => {
-    const generation = ++requestGeneration.current;
-    try {
-      const response = await fetch("/api/queue/readiness", { cache: "no-store" });
-      const body = (await response.json()) as {
-        ok?: boolean;
-        readiness?: QueueReadinessView;
-        error?: string;
-      };
-      if (!response.ok || !body.ok || !body.readiness) {
-        throw new Error(body.error ?? "Couldn’t check the Queue project.");
-      }
-      if (generation === requestGeneration.current) {
-        setReadiness(body.readiness);
-        setError(null);
-      }
-    } catch (cause) {
-      if (generation === requestGeneration.current) {
-        setError(cause instanceof Error ? cause.message : "Couldn’t check the Queue project.");
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    void refreshReadiness();
-  }, [refreshReadiness]);
-
-  const selectProject = async (projectId: string) => {
-    const generation = ++requestGeneration.current;
-    setSelecting(true);
-    setError(null);
-    try {
-      const response = await fetch("/api/queue/readiness", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ action: "select", projectId }),
-      });
-      const body = (await response.json()) as {
-        ok?: boolean;
-        readiness?: QueueReadinessView;
-        error?: string;
-      };
-      if (!response.ok || !body.ok || !body.readiness) {
-        throw new Error(body.error ?? "Couldn’t save the Queue project.");
-      }
-      if (generation !== requestGeneration.current) return;
-      setReadiness(body.readiness);
-      publishQueueProjectSelection(body.readiness.project);
-      onSelected();
-    } catch (cause) {
-      if (generation === requestGeneration.current) {
-        setError(cause instanceof Error ? cause.message : "Couldn’t save the Queue project.");
-      }
-    } finally {
-      if (generation === requestGeneration.current) setSelecting(false);
-    }
-  };
-
-  return (
-    <div className="flex flex-col gap-3">
-      <p className="text-[length:var(--text-sm)] leading-5 text-[var(--text-secondary)]">
-        Choose the local Git repository Cave should use for Queue work. Cave stores this
-        host-native path and never substitutes the app&rsquo;s own runtime folder.
-      </p>
-      <ProjectPicker
-        projects={projects}
-        value={readiness?.project?.id ?? NO_PROJECT_ID}
-        onChange={(projectId) => void selectProject(projectId)}
-        createProject={createProject}
-        disabled={loading || selecting}
-        ariaLabel="Choose Queue project"
-      />
-      {readiness ? (
-        <p role="status" className={`text-[length:var(--text-xs)] ${readiness.ok || readiness.canGenerate ? "text-[var(--color-success)]" : "text-[var(--text-muted)]"}`}>
-          {readiness.message}
-        </p>
-      ) : null}
-      {error ? (
-        <div className="flex items-center gap-2 text-[length:var(--text-xs)] text-[var(--color-danger)]" role="alert">
-          <span>{error}</span>
-          <Button size="xs" variant="ghost" onClick={() => void refreshReadiness()}>
-            Retry
-          </Button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
 
 /** The three-beat first-run journey: infrastructure (this wizard) → summon a
  *  familiar (the in-app circle) → first chat. Orientation only — beats light

--- a/src/components/queue-project-setup.tsx
+++ b/src/components/queue-project-setup.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { ProjectPicker } from "@/components/project-picker";
+import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import { useProjects } from "@/lib/use-projects";
+import { publishQueueProjectSelection } from "@/lib/queue-project-selection";
+
+type QueueReadinessView = {
+  ok: boolean;
+  message: string;
+  canGenerate: boolean;
+  project: { id: string; name: string; root: string } | null;
+};
+
+/** The Queue always starts with a concrete, host-native project selection.
+ * Setup lives on the Tasks page's Queue tab — not the onboarding wizard — so
+ * the choice is only asked for when the Queue is actually opened. This
+ * component deliberately uses the same project picker as the rest of Cave,
+ * including the native folder chooser used to register a new root. A saved
+ * selection is published so every mounted Queue surface reloads together. */
+export function QueueProjectSetup({
+  selectedProjectId,
+  onSelected,
+}: {
+  /** The currently persisted Queue project id, if any. */
+  selectedProjectId?: string | null;
+  onSelected?: (readiness: QueueReadinessView) => void;
+}) {
+  const { projects, loading, createProject } = useProjects();
+  const [selecting, setSelecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestGeneration = useRef(0);
+
+  const selectProject = async (projectId: string) => {
+    const generation = ++requestGeneration.current;
+    setSelecting(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/queue/readiness", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ action: "select", projectId }),
+      });
+      const body = (await response.json()) as {
+        ok?: boolean;
+        readiness?: QueueReadinessView;
+        error?: string;
+      };
+      if (!response.ok || !body.ok || !body.readiness) {
+        throw new Error(body.error ?? "Couldn’t save the Queue project.");
+      }
+      if (generation !== requestGeneration.current) return;
+      publishQueueProjectSelection(body.readiness.project);
+      onSelected?.(body.readiness);
+    } catch (cause) {
+      if (generation === requestGeneration.current) {
+        setError(cause instanceof Error ? cause.message : "Couldn’t save the Queue project.");
+      }
+    } finally {
+      if (generation === requestGeneration.current) setSelecting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <ProjectPicker
+        projects={projects}
+        value={selectedProjectId ?? NO_PROJECT_ID}
+        onChange={(projectId) => void selectProject(projectId)}
+        createProject={createProject}
+        disabled={loading || selecting}
+        ariaLabel="Choose Queue project"
+      />
+      {error ? (
+        <p className="text-[length:var(--text-xs)] text-[var(--color-danger)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1426,14 +1426,13 @@ export function Workspace() {
         const res = await fetch("/api/onboarding/status", { cache: "no-store" });
         if (!res.ok || cancelled) return;
         const json = (await res.json()) as OnboardingStatusPayload;
-        const queueProjectNeedsRepair = json.steps?.project?.ok === false;
         if (
           shouldApplyStartupOnboardingStatus({
             status: json,
             cancelled,
             manuallyOpened: manualOnboardingOpenedRef.current,
           }) &&
-          (!skipped || queueProjectNeedsRepair)
+          !skipped
         ) {
           setAutoFinishOnboarding(true);
           setOnboardingOpen(true);

--- a/src/lib/onboarding-gate.test.ts
+++ b/src/lib/onboarding-gate.test.ts
@@ -19,7 +19,6 @@ const allStepsOk = {
   covenCli: { ok: true },
   covenHome: { ok: true },
   adapters: { ok: true },
-  project: { ok: true },
   daemon: { ok: true },
   binding: { ok: true },
   familiars: { ok: true },
@@ -47,8 +46,8 @@ assert.equal(
   shouldAutoOpenOnboarding(
     payload({ complete: false, steps: { ...allStepsOk, project: { ok: false }, daemon: { ok: false } } }),
   ),
-  true,
-  "an unavailable Queue project reopens onboarding even when the daemon is down",
+  false,
+  "a Queue project is not a setup step — selection lives on the Tasks page's Queue tab, so it never reopens the wizard",
 );
 
 // ── Coven Code is not a setup requirement (the cave-219 AND-gate is gone) ────

--- a/src/lib/onboarding-gate.ts
+++ b/src/lib/onboarding-gate.ts
@@ -46,13 +46,14 @@ export type OnboardingAutoFinishGateDecision = {
  * reachable, any remaining incompleteness (a missing tool or runtime) is
  * genuine setup work, so the wizard opens. A machine with no familiars is NOT
  * unfinished — the status route reports familiars/binding as advisory since
- * creation moved to the in-app Summoning Circle.
+ * creation moved to the in-app Summoning Circle. The Queue project is not a
+ * setup step either: its selection lives on the Tasks page's Queue tab.
  */
 export function shouldAutoOpenOnboarding(payload: OnboardingStatusPayload): boolean {
   if (payload.complete) return false;
   const step = (key: string) => payload.steps?.[key]?.ok === true;
   const structuralMissing =
-    !step("covenCli") || !step("covenHome") || !step("adapters") || !step("project");
+    !step("covenCli") || !step("covenHome") || !step("adapters");
   const daemonUpButUnfinished = step("daemon");
   return structuralMissing || daemonUpButUnfinished;
 }

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -38,7 +38,7 @@ test.beforeEach(async ({ page }) => {
     route.fulfill({ json: { ok: true, readiness: QUEUE_READINESS } }),
   );
   await page.route("**/api/onboarding/status**", (route) =>
-    route.fulfill({ json: { ok: true, complete: true, steps: { project: { ok: true } }, tools: [] } }),
+    route.fulfill({ json: { ok: true, complete: true, steps: {}, tools: [] } }),
   );
 });
 
@@ -269,7 +269,7 @@ test.describe("familiar work queue (PR control tower)", () => {
           return route.fulfill({ json: { ok: true, readiness: { ...QUEUE_READINESS, project: selectedProject } } });
         });
         await page.route("**/api/onboarding/status**", (route) =>
-          route.fulfill({ json: { ok: true, complete: true, steps: { project: { ok: true } }, tools: [] } }),
+          route.fulfill({ json: { ok: true, complete: true, steps: {}, tools: [] } }),
         );
       }
       // These pages belong to an explicitly created BrowserContext, so the
@@ -301,6 +301,61 @@ test.describe("familiar work queue (PR control tower)", () => {
     } finally {
       await context.close();
     }
+  });
+
+  test("an unselected Queue offers inline project setup on the tab itself", async ({ page }) => {
+    // No project selected yet: readiness reports no-project until the picker
+    // POSTs a selection, then flips to ready for the chosen repository. The
+    // onboarding wizard is never part of this flow.
+    const selectBodies: Array<{ action?: string; projectId?: string }> = [];
+    let selectedProject: typeof QUEUE_PROJECT | null = null;
+    const readinessFor = (project: typeof QUEUE_PROJECT) => ({
+      ok: true,
+      code: "ready",
+      message: "Queue project is ready.",
+      canGenerate: false,
+      project,
+    });
+    await page.route("**/api/projects", (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      return route.fulfill({ json: { ok: true, projects: [QUEUE_PROJECT, QUEUE_PROJECT_B] } });
+    });
+    await page.route("**/api/queue/readiness", (route) => {
+      const request = route.request();
+      if (request.method() === "POST") {
+        const body = request.postDataJSON() as { action?: string; projectId?: string };
+        selectBodies.push(body);
+        selectedProject = [QUEUE_PROJECT, QUEUE_PROJECT_B].find((p) => p.id === body.projectId) ?? null;
+        return route.fulfill({ json: { ok: true, readiness: readinessFor(selectedProject ?? QUEUE_PROJECT) } });
+      }
+      if (!selectedProject) {
+        return route.fulfill({
+          json: {
+            ok: true,
+            readiness: { ok: false, code: "no-project", message: "Choose a Queue project to load work.", canGenerate: false, project: null },
+          },
+        });
+      }
+      return route.fulfill({ json: { ok: true, readiness: readinessFor(selectedProject) } });
+    });
+    await gotoWorkQueue(page);
+
+    const fwq = page.locator(".fwq");
+    await expect(fwq.getByText("Queue needs a project")).toBeVisible();
+
+    // The picker is inline — selection must not bounce through the wizard.
+    await fwq.getByRole("button", { name: "Choose Queue project" }).click();
+    await expect(page.getByRole("dialog", { name: "Onboarding" })).toHaveCount(0);
+    await page
+      .getByRole("dialog", { name: "Choose Queue project" })
+      .getByRole("menuitemradio", { name: /Queue test project B/ })
+      .click();
+
+    await expect.poll(() => selectBodies).toEqual([{ action: "select", projectId: QUEUE_PROJECT_B.id }]);
+    // The published selection reloads the view for the chosen repository.
+    await expect(fwq.getByText(/5 actionable/)).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
+    await expect(fwq.getByText("Queue needs a project")).toHaveCount(0);
   });
 
   test("claiming for a familiar posts the selected assignee", async ({ page }) => {

--- a/tests/mobile/code-rail-sheet.spec.ts
+++ b/tests/mobile/code-rail-sheet.spec.ts
@@ -40,13 +40,12 @@ async function base(page: Page) {
   await page.route("**/api/familiars**", (route) =>
     route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
   );
-  // Dismissed onboarding no longer short-circuits the startup status probe
-  // (a broken Queue project must resurface the wizard), so every boot hits
-  // this route. Left unmocked, the real handler's cold compile + probes race
-  // the lazy code-rail chunk on the slowest mobile project and the sheet
-  // renders empty past the expect window. Mock it like the queue specs do.
+  // Dismissed onboarding still probes startup status on every boot. Left
+  // unmocked, the real handler's cold compile + probes race the lazy
+  // code-rail chunk on the slowest mobile project and the sheet renders
+  // empty past the expect window. Mock it like the queue specs do.
   await page.route("**/api/onboarding/status**", (route) =>
-    route.fulfill({ json: { ok: true, complete: true, steps: { project: { ok: true } }, tools: [] } }),
+    route.fulfill({ json: { ok: true, complete: true, steps: {}, tools: [] } }),
   );
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions: [REPO_SESSION] } }),

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -19,7 +19,6 @@ const FRESH_STATUS = {
     git: { ok: true, optional: true, detail: "/usr/bin/git" },
     adapters: { ok: false, detail: "no adapters detected" },
     daemon: { ok: false, detail: "daemon socket not reachable" },
-    project: { ok: false, detail: "Choose a Queue project" },
     // Advisory since familiar creation moved to the in-app summoning circle.
     familiars: { ok: false, optional: true, detail: "no familiars" },
     binding: { ok: false, optional: true, detail: "no binding configured" },
@@ -38,7 +37,6 @@ const DAEMON_DOWN_VETERAN_STATUS = {
     git: { ok: true, optional: true, detail: "/usr/bin/git" },
     adapters: { ok: true, detail: "Codex" },
     daemon: { ok: false, detail: "daemon socket not reachable" },
-    project: { ok: true, detail: "Queue project is ready." },
     familiars: { ok: false, optional: true, detail: "daemon offline" },
     binding: { ok: false, optional: true, detail: "Waiting for the daemon" },
   },
@@ -54,7 +52,6 @@ const GIT_REQUIRED_STATUS = {
     adapters: { ok: true, detail: "Codex" },
     daemon: { ok: true, detail: "running" },
     git: { ok: false, detail: "Git is required to select and use a Queue project.", hint: "Install Git from https://git-scm.com, then re-check." },
-    project: { ok: false, detail: "Git is required before selecting a Queue project." },
     familiars: { ok: false, optional: true, detail: "no familiars" },
     binding: { ok: false, optional: true, detail: "no binding configured" },
   },
@@ -74,7 +71,6 @@ const COMPLETE_NO_FAMILIARS_STATUS = {
     git: { ok: true, optional: true, detail: "/usr/bin/git" },
     adapters: { ok: true, detail: "Codex" },
     daemon: { ok: true, detail: "running" },
-    project: { ok: true, detail: "Queue project is ready." },
     familiars: { ok: false, optional: true, detail: "no familiars" },
     binding: { ok: false, optional: true, detail: "no binding configured" },
   },
@@ -151,12 +147,12 @@ test.describe("onboarding wizard", () => {
     await expect(current.first()).toContainText("Install the Coven CLI");
   });
 
-  test("puts Git remediation before an unavailable Queue project selector", async ({ page }) => {
+  test("surfaces Git remediation naming the Tasks-page Queue prerequisite", async ({ page }) => {
     await gotoApp(page, GIT_REQUIRED_STATUS);
     await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
     const current = wizard(page).locator('li[aria-current="step"]');
     await expect(current).toContainText("Find Git");
-    await expect(current).toContainText("Git is required before selecting a Queue project.");
+    await expect(current).toContainText("Git is required before choosing a Queue project on the Tasks page.");
     await expect(current).toContainText("Install Git from https://git-scm.com");
   });
 
@@ -171,9 +167,9 @@ test.describe("onboarding wizard", () => {
   });
 
   test("stays hidden once dismissed", async ({ page }) => {
-    // A persisted dismissal is not permitted to bypass a missing required
-    // Queue project. Use a genuinely complete setup to exercise the stored
-    // dismissal behavior without masking a prerequisite regression.
+    // A stored dismissal keeps the wizard closed on a set-up machine. Use a
+    // genuinely complete setup so this exercises the dismissal path rather
+    // than masking a prerequisite regression.
     await gotoApp(page, COMPLETE_NO_FAMILIARS_STATUS, { dismissed: true });
     await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
     await page.waitForTimeout(1_000);


### PR DESCRIPTION
## Summary

Removes the **Choose your Queue project** step from the onboarding wizard. Queue project selection now lives where it's needed: inline on the **Tasks page's Queue tab**, shown only when the user opens the Queue and no valid project is selected.

## Changes

### Onboarding
- `onboarding-overlay.tsx` — drop the `project` guided step and the embedded `QueueProjectSetup` component; the git pane copy now points at the Tasks-page Queue setup.
- `api/onboarding/status` — stop probing Queue readiness (`cachedQueueProjectReadiness`) on every 2s poll; `project` removed from the steps payload. Git stays a required boundary with its existing hint.
- `onboarding-model.ts` — `project: Step` removed from the status type.
- `onboarding-gate.ts` — `!step("project")` removed from the auto-open rule.
- `workspace.tsx` — `queueProjectNeedsRepair` force-reopen removed; a stored dismissal now always keeps the wizard closed.

### Queue tab
- **New** `queue-project-setup.tsx` — inline `ProjectPicker` (with Add-project/native folder chooser) rendered in the Queue's *needs a project* empty state. POSTs `{action:"select"}` to `/api/queue/readiness`, keeps the request-generation race guard, and publishes via `publishQueueProjectSelection` so every mounted Queue surface reloads through the existing subscription.
- `familiar-work-queue-view.tsx` — the empty-state **Choose project** button (which bounced users to the wizard via `cave:onboarding-open`) is replaced by the inline picker.

### Tests
- Source pins updated: `route.test.ts`, `onboarding-guided-steps.test.ts`, `onboarding-gate.test.ts`, `familiar-work-queue-view.test.ts` (generation-guard pin moved with the component; new doesNotMatch guards keep the step from returning).
- e2e: wizard stubs drop the `project` step; the git-remediation test asserts the new copy; **new e2e** drives the full inline flow (no-project → picker → select POST → lanes render); queue/mobile stubs cleaned.

## Verification
- `pnpm typecheck` ✓, `pnpm lint` ✓ (design gates + eslint), `pnpm test` ✓ (899 files)
- `playwright test tests/familiar-work-queue.spec.ts tests/onboarding-wizard.spec.ts` — **28/28 passed** (single-worker; parallel runs on this machine were failing identically on clean `origin/main` due to load ~130)