### PR TITLE
fix(onboarding): match Browse/Create button height to the input line

### DIFF
--- a/src/components/first-project-gate.tsx
+++ b/src/components/first-project-gate.tsx
@@ -302,7 +302,7 @@ export function FirstProjectGate({
                       size="sm"
                       onClick={() => void handleBrowse()}
                       disabled={Boolean(registeredProject) || submitting}
-                      className="h-10 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-3 text-[length:var(--text-sm)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                      className="!h-10 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-3 text-[length:var(--text-sm)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
                       leadingIcon="ph:folder-open"
                     >
                       Browse
@@ -321,7 +321,7 @@ export function FirstProjectGate({
                     size="sm"
                     loading={submitting}
                     disabled={submitting || loadingProjects || Boolean(projectsError) || !canSubmit}
-                    className="h-10 rounded-[var(--radius-control)] px-4 text-[length:var(--text-sm)] font-medium disabled:opacity-50"
+                    className="!h-10 rounded-[var(--radius-control)] px-4 text-[length:var(--text-sm)] font-medium disabled:opacity-50"
                   >
                     {registeredProject ? "Retry access" : "Create"}
                   </Button>


### PR DESCRIPTION
The "Create your first project" gate's **Browse** and **Create** buttons rendered ~14px shorter than the input fields (see below), breaking the row alignment.

## Root cause
Both buttons use `size="sm"` → `.ui-btn--sm { height: 26px }`. They already carried an `h-10` utility class intending to match the `h-10` (40px) inputs — but `primitives.css` is **unlayered** while Tailwind utilities live in `@layer utilities`, so under Tailwind v4 layer priority the primitive's `height: 26px` **always** wins over `h-10`. The override never took effect.

## Fix
Switch both buttons to **`!h-10`** — the same important-override pattern the codebase already uses to force a custom height on `Button` (e.g. `new-reminder-modal.tsx`). Now both sit flush at 40px with the input line. Two-character change, no logic touched.

## Verification
- `eslint` (design gate): clean · `pnpm build`: exit 0, within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)