### PR TITLE
refactor(analytics): move the last .fa-* stragglers out of the global bundle (#3264)

### DIFF
--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -510,10 +510,9 @@ describe("FamiliarAnalyticsView", () => {
   });
 
   it("modernized chrome: sticky freshness topbar, drill flashes, actionable insight (cave UX audit)", () => {
-    const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-    // .fa-* surface rules are component-imported (#3264); the reduced-motion
-    // .fa-page override rides the shared global reduced-motion block, so it
-    // stays in globals below.
+    // All .fa-* surface rules — including the reduced-motion and phone-width
+    // overrides — are component-imported (#3264), so they live in the
+    // familiar-analytics sheet, not the global facade.
     const faCss = readFileSync(new URL("../styles/familiar-analytics.css", import.meta.url), "utf8");
 
     // Truthful freshness stamp + visible refresh progress in a sticky topbar.
@@ -536,7 +535,7 @@ describe("FamiliarAnalyticsView", () => {
 
     // All decorative motion holds still under prefers-reduced-motion.
     assert.match(
-      globals,
+      faCss,
       /@media \(prefers-reduced-motion: reduce\)\s*\{[^}]*\.fa-page\s*\{\s*scroll-behavior:\s*auto/,
       "smooth scrolling is disabled under reduced motion",
     );

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -1764,3 +1764,23 @@
   .fa-contract-grid { grid-template-columns: 1fr; }
   .fa-topbar__updated { display: none; }
 }
+
+/* Phone-width page padding — the analytics container query cannot size its own
+   container, so the page/topbar padding stays a viewport @media rule. */
+@media (max-width: 560px) {
+  .fa-page { padding: 16px; }
+  /* Sticky topbar's edge-to-edge negative margins track the tighter padding. */
+  .fa-topbar { margin: -16px -16px 0; padding: 8px 16px; }
+}
+
+/* Analytics motion is decorative — all of it holds still on request. */
+@media (prefers-reduced-motion: reduce) {
+  .fa-page { scroll-behavior: auto; }
+  .fa-topbar .retro-icon-btn.is-refreshing svg { animation: none; opacity: 0.6; }
+  .fa-section:target {
+    animation: none;
+    border-color: var(--accent-presence);
+  }
+  .fa-kpi:hover { transform: none; }
+  .fa-kpi__head svg.fa-kpi__go { transition: none; }
+}

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -1511,21 +1511,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .retro-run-row__top { align-items: stretch; flex-direction: column; }
   .retro-pill { width: max-content; }
   .growth-surface { padding: 16px; }
-  .fa-page { padding: 16px; }
-  /* Sticky topbar's edge-to-edge negative margins track the tighter padding. */
-  .fa-topbar { margin: -16px -16px 0; padding: 8px 16px; }
-}
-
-/* Analytics motion is decorative — all of it holds still on request. */
-@media (prefers-reduced-motion: reduce) {
-  .fa-page { scroll-behavior: auto; }
-  .fa-topbar .retro-icon-btn.is-refreshing svg { animation: none; opacity: 0.6; }
-  .fa-section:target {
-    animation: none;
-    border-color: var(--accent-presence);
-  }
-  .fa-kpi:hover { transform: none; }
-  .fa-kpi__head svg.fa-kpi__go { transition: none; }
 }
 
 /* Recommended follow-up: the agent lists next steps best-first, so the top


### PR DESCRIPTION
## What

Completes the cave-5rqi / #3264 extraction that landed in **#3780**. That PR moved the bulk of the `.fa-*` familiar-analytics CSS into the component-imported `src/styles/familiar-analytics.css`, but **three analytics-only rules stayed in the global `surface-reporting.css`** and still rode the every-route root layout + home first-load bundle:

- the mobile `@media (max-width: 560px)` `.fa-page` / `.fa-topbar` padding, and
- the reduced-motion `@media` block (`.fa-page` scroll-behavior, refresh-spin halt, `.fa-section:target`, `.fa-kpi` hover/chevron).

This moves them into `familiar-analytics.css` alongside the rest of the surface. The mobile padding stays a viewport `@media` rule (a container query can't size its own container).

## Result

- `surface-reporting.css` now has **zero** `.fa-*` rules. The only `.fa-topbar` references left in globals are the intentional `:root[data-tauri-titlebar]` chrome overrides in `desktop-chrome.css` (pinned by `shell-edge-rails`).
- Repointed the one remaining reduced-motion assertion in `familiar-analytics-view.test.ts` from `globals.css` to the component sheet.
- Measured CSS bundle: **root 648 KB** / **home 892 KB** — a hair below #3780's already-banked 660/900 caps. `.fa-page` now lives only in the analytics route chunk.

## Verification

- ✅ 901 app test files pass · `tsc` clean · production build green · bundle-budget within limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)