### PR TITLE
feat: cooldown model for session-settle + memory-save flares (cave-q06w)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -552,6 +552,8 @@ export const SUITES = {
     "src/app/globals-reveal-on-hover.test.ts",
     "src/components/board-reward-flare.test.ts",
     "src/components/github-card-reward.test.ts",
+    "src/components/settle-save-flare.test.ts",
+    "src/lib/flare-cooldown.test.ts",
     "src/components/familiar-roster-card.test.ts",
     "src/components/workspace-milestone-quiet.test.ts",
     "src/lib/familiar-growth-signals.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -17,6 +17,8 @@ import { resolveFileRefTarget, type FileRef } from "@/lib/file-ref";
 import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
 import { ChatEnvironmentPanel } from "@/components/chat-environment-panel";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
+import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
+import { SETTLE_MIN_RUN_MS, shouldFlare } from "@/lib/flare-cooldown";
 import { segmentTurn } from "@/lib/turn-segments";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
@@ -1409,6 +1411,24 @@ function MetaLine({
   children?: React.ReactNode;
 }) {
   const state = metaLineState({ busy, lifecycle, error, daemonRunning });
+  // Session-settle flare (cave-q06w): the summoning bloom fires when a LONG
+  // run settles — the case where the user context-switched away and the
+  // completion is an event. Short replies are their own feedback, so a
+  // significance floor (SETTLE_MIN_RUN_MS) plus a global per-kind cooldown
+  // keep parallel familiars from strobing. Visual-only: this row is already
+  // role=status/aria-live, so AT hears the settle regardless; celebrations
+  // off stills the bloom without touching the announcement.
+  const [settleFlare, setSettleFlare] = useState(false);
+  const prevStateRef = useRef(state);
+  useEffect(() => {
+    const prev = prevStateRef.current;
+    prevStateRef.current = state;
+    if (prev !== "streaming" || state !== "complete") return;
+    if ((durationMs ?? 0) < SETTLE_MIN_RUN_MS) return;
+    if (!readCelebrationsEnabled() || !shouldFlare("session-settle")) return;
+    setSettleFlare(true);
+    window.setTimeout(() => setSettleFlare(false), 900);
+  }, [state, durationMs]);
   // Resolve once: the effective model id drives both the meta segments and the
   // context meter (the meter needs the model to size the window).
   const metaModel =
@@ -1450,7 +1470,7 @@ function MetaLine({
       ? `Task: ${task.title}`
       : null;
   return (
-    <div className={`cave-chat-meta-line cave-chat-meta-line--${state}`} role="status" aria-live="polite" data-lifecycle={state}>
+    <div className={`cave-chat-meta-line cave-chat-meta-line--${state}${settleFlare ? " cave-chat-meta-line--reward" : ""}`} role="status" aria-live="polite" data-lifecycle={state}>
       {state !== "complete" ? <span className="cave-chat-meta-line__dot" aria-hidden /> : null}
       {/* Chat-revamp 1b: the session's familiar leads the header as a small
           circular avatar, so the title row reads avatar · title · meta. */}

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -88,8 +88,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /setTimeout\(\(\) => void saveRef\.current\(\), AUTOSAVE_DEBOUNCE_MS\)/,
-  "autosave is debounced and routes through the shared save path",
+  /setTimeout\(\(\) => void saveRef\.current\("auto"\), AUTOSAVE_DEBOUNCE_MS\)/,
+  "autosave is debounced, routes through the shared save path, and declares itself auto (cave-q06w: only manual saves flare)",
 );
 assert.match(shell, /clearTimeout\(timer\)/, "a pending autosave is cancelled on change/unmount");
 // Idempotent surfaces opt in; the mtime-guarded memory editor must NOT.

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -29,6 +29,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 /** Trailing debounce before an autosave fires once typing pauses. */
 const AUTOSAVE_DEBOUNCE_MS = 1200;
 import { Icon } from "@/lib/icon";
+import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
+import { shouldFlare } from "@/lib/flare-cooldown";
 import { CodeEditor } from "@/components/code-editor";
 import {
   normalizeMdTags,
@@ -125,6 +127,7 @@ export function MdEditor({
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
+  const [saveFlare, setSaveFlare] = useState(false);
   // A 409-style concurrent-write conflict: the transport reported the document
   // changed underneath us. While set, the body shows the resolution panel.
   const [conflict, setConflict] = useState<MdEditorConflict | null>(null);
@@ -181,7 +184,7 @@ export function MdEditor({
     });
   }, []);
 
-  const save = useCallback(async () => {
+  const save = useCallback(async (source: "manual" | "auto" = "manual") => {
     if (readOnly || saving) return;
     const snapshot = rawRef.current;
     setSaving(true);
@@ -193,6 +196,14 @@ export function MdEditor({
         setConflict(null);
         setSavedFlash(true);
         window.setTimeout(() => setSavedFlash(false), 1500);
+        // Memory-save flare (cave-q06w): manual saves only — autosave is
+        // ambient bookkeeping, not an accomplishment — and a global cooldown
+        // keeps save-happy editing from strobing. Visual-only garnish: the
+        // role=status "Saved" flash above is the actual confirmation.
+        if (source === "manual" && readCelebrationsEnabled() && shouldFlare("memory-save")) {
+          setSaveFlare(true);
+          window.setTimeout(() => setSaveFlare(false), 900);
+        }
       } else if (result.conflict) {
         setConflict(result.conflict);
       } else {
@@ -252,7 +263,7 @@ export function MdEditor({
   saveRef.current = save;
   useEffect(() => {
     if (!autoSave || readOnly || saving || conflict !== null || !dirty || !raw.trim()) return;
-    const timer = window.setTimeout(() => void saveRef.current(), AUTOSAVE_DEBOUNCE_MS);
+    const timer = window.setTimeout(() => void saveRef.current("auto"), AUTOSAVE_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
   }, [autoSave, readOnly, saving, conflict, dirty, raw]);
 
@@ -275,7 +286,7 @@ export function MdEditor({
 
   return (
     <div
-      className="md-editor flex h-full min-h-0 flex-col"
+      className={`md-editor flex h-full min-h-0 flex-col${saveFlare ? " md-editor--reward" : ""}`}
       onKeyDown={(e) => {
         if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
           e.preventDefault();

--- a/src/components/settle-save-flare.test.ts
+++ b/src/components/settle-save-flare.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+// Pins for the completion-flare cooldown model (cave-q06w) — session-settle
+// and memory-save join the summoning-flare vocabulary (cave-hshy, cave-kx5y)
+// but, unlike PR-merge/card-done, these events are high-frequency, so both
+// wirings must keep the two cooldown gates: significance (long runs only /
+// manual saves only) and frequency (global per-kind cooldown). Flares stay
+// visual-only garnish — role=status announcements carry the information —
+// and reduced-motion collapses them entirely.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const mdEditor = readFileSync(new URL("./md-editor/md-editor.tsx", import.meta.url), "utf8");
+const activityCss = readFileSync(new URL("../styles/cave-chat/activity.css", import.meta.url), "utf8");
+const mdEditorCss = readFileSync(new URL("../styles/md-editor.css", import.meta.url), "utf8");
+
+// ── Session-settle (chat-view MetaLine) ─────────────────────────────────────
+assert.match(
+  chatView,
+  /if \(prev !== "streaming" \|\| state !== "complete"\) return;/,
+  "settle flare fires only on the streaming→complete transition, not on mount or re-render",
+);
+assert.match(
+  chatView,
+  /if \(\(durationMs \?\? 0\) < SETTLE_MIN_RUN_MS\) return;/,
+  "significance gate: only long runs flare — short replies are their own feedback",
+);
+assert.match(
+  chatView,
+  /if \(!readCelebrationsEnabled\(\) \|\| !shouldFlare\("session-settle"\)\) return;/,
+  "settle flare respects the celebrations pref and the global per-kind cooldown",
+);
+assert.match(
+  chatView,
+  /setSettleFlare\(true\);\n\s*window\.setTimeout\(\(\) => setSettleFlare\(false\), 900\);/,
+  "settle reward state self-clears so re-renders can't replay the flare",
+);
+assert.match(
+  chatView,
+  /settleFlare \? " cave-chat-meta-line--reward" : ""/,
+  "the meta line root wears the reward class",
+);
+
+// ── Memory-save (MdEditor) ──────────────────────────────────────────────────
+assert.match(
+  mdEditor,
+  /const save = useCallback\(async \(source: "manual" \| "auto" = "manual"\)/,
+  "save() carries its trigger source; unannotated callers (toolbar, Cmd+S, conflict keep-mine) count as manual",
+);
+assert.match(
+  mdEditor,
+  /void saveRef\.current\("auto"\), AUTOSAVE_DEBOUNCE_MS/,
+  "the debounced autosave path declares itself auto — ambient bookkeeping never flares",
+);
+assert.match(
+  mdEditor,
+  /if \(source === "manual" && readCelebrationsEnabled\(\) && shouldFlare\("memory-save"\)\) \{/,
+  "save flare is manual-only, pref-gated, and cooldown-gated",
+);
+assert.match(
+  mdEditor,
+  /setSaveFlare\(true\);\n\s*window\.setTimeout\(\(\) => setSaveFlare\(false\), 900\);/,
+  "save reward state self-clears so re-renders can't replay the flare",
+);
+assert.match(
+  mdEditor,
+  /saveFlare \? " md-editor--reward" : ""/,
+  "the editor root wears the reward class",
+);
+
+// ── CSS: summoning vocabulary + reduced-motion collapse ─────────────────────
+assert.match(
+  activityCss,
+  /cave-chat-settle-flare 700ms var\(--ease-decelerate\) forwards/,
+  "settle flare speaks the 700ms decelerate one-shot vocabulary",
+);
+assert.match(
+  activityCss,
+  /@media \(prefers-reduced-motion: reduce\) \{\n\s*\.cave-chat-meta-line--reward \{ animation: none; \}/,
+  "reduced motion collapses the settle flare entirely",
+);
+assert.match(
+  mdEditorCss,
+  /md-editor-save-flare 700ms var\(--ease-decelerate\) forwards/,
+  "save flare speaks the 700ms decelerate one-shot vocabulary",
+);
+assert.match(
+  mdEditorCss,
+  /@media \(prefers-reduced-motion: reduce\) \{\n\s*\.md-editor--reward \{ animation: none; \}/,
+  "reduced motion collapses the save flare entirely",
+);
+
+console.log("settle-save-flare: all pins hold");

--- a/src/lib/flare-cooldown.test.ts
+++ b/src/lib/flare-cooldown.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  FLARE_COOLDOWN_MS,
+  SETTLE_MIN_RUN_MS,
+  resetFlareCooldowns,
+  shouldFlare,
+} from "./flare-cooldown.ts";
+
+describe("flare-cooldown (cave-q06w)", () => {
+  beforeEach(() => resetFlareCooldowns());
+
+  it("grants the first flare of a kind", () => {
+    assert.equal(shouldFlare("session-settle", 1_000), true);
+  });
+
+  it("denies within the cooldown window and grants after it", () => {
+    assert.equal(shouldFlare("session-settle", 1_000), true);
+    assert.equal(shouldFlare("session-settle", 1_000 + FLARE_COOLDOWN_MS - 1), false);
+    assert.equal(shouldFlare("session-settle", 1_000 + FLARE_COOLDOWN_MS), true);
+  });
+
+  it("tracks kinds independently", () => {
+    assert.equal(shouldFlare("session-settle", 1_000), true);
+    assert.equal(shouldFlare("memory-save", 1_000), true);
+    assert.equal(shouldFlare("memory-save", 2_000), false);
+  });
+
+  it("does not record denials — a steady drizzle still flares once per window", () => {
+    assert.equal(shouldFlare("memory-save", 0), true);
+    // Saves every minute: each denial must not push the next grant out.
+    for (let t = 60_000; t < FLARE_COOLDOWN_MS; t += 60_000) {
+      assert.equal(shouldFlare("memory-save", t), false);
+    }
+    assert.equal(shouldFlare("memory-save", FLARE_COOLDOWN_MS), true);
+  });
+
+  it("reset forgets grants (test isolation hook)", () => {
+    assert.equal(shouldFlare("session-settle", 1_000), true);
+    resetFlareCooldowns();
+    assert.equal(shouldFlare("session-settle", 1_001), true);
+  });
+
+  it("constants: 5-minute window, 60s settle significance floor", () => {
+    // Pinned so a drive-by retune is a conscious, reviewed decision — these
+    // two numbers ARE the cooldown model cave-q06w specifies.
+    assert.equal(FLARE_COOLDOWN_MS, 300_000);
+    assert.equal(SETTLE_MIN_RUN_MS, 60_000);
+  });
+});

--- a/src/lib/flare-cooldown.ts
+++ b/src/lib/flare-cooldown.ts
@@ -1,0 +1,53 @@
+// Cooldown model for high-frequency completion flares (cave-q06w).
+//
+// The PR-merge and board card-done flares (cave-hshy) are naturally rare —
+// merging a PR or dragging a card to Done is a deliberate, spaced-out act.
+// Session-settle and memory-save are not: parallel familiars can settle
+// within seconds of each other, and a busy editing session saves constantly.
+// Blooming on every one would turn the summoning-flare vocabulary into
+// noise — the opposite of a reward.
+//
+// Two gates keep the vocabulary meaningful:
+//
+// 1. SIGNIFICANCE (owned by callers): session-settle only counts when the
+//    settled turn ran ≥ SETTLE_MIN_RUN_MS — long runs are the ones where the
+//    user context-switched away and the completion is an event; short replies
+//    are their own feedback. Memory-save only counts for MANUAL saves —
+//    autosave is ambient bookkeeping, not an accomplishment.
+// 2. FREQUENCY (owned here): at most one flare per kind per
+//    FLARE_COOLDOWN_MS, tracked globally rather than per-session/per-editor
+//    so simultaneous settles across parallel panes collapse into a single
+//    bloom instead of a strobe.
+//
+// Only GRANTED flares advance the clock — a denied attempt doesn't extend
+// the quiet window, so a steady drizzle of events still yields one flare per
+// window instead of zero. State is in-memory per window on purpose: a reload
+// resetting the cooldown is harmless because under-flaring is always safe
+// (flares are visual-only garnish — announce()/MetaLine carry the actual
+// information) while over-flaring is the failure mode this lib exists to
+// prevent.
+
+/** Minimum quiet time between flares of the same kind. */
+export const FLARE_COOLDOWN_MS = 5 * 60_000;
+
+/** Session-settle significance floor: only runs at least this long flare. */
+export const SETTLE_MIN_RUN_MS = 60_000;
+
+const lastFlareAt = new Map<string, number>();
+
+/**
+ * Ask permission to flare. Returns true (and records the grant) when the
+ * kind's cooldown window has passed; false otherwise. Denials are not
+ * recorded, so they never push the next eligible flare further out.
+ */
+export function shouldFlare(kind: string, now: number = Date.now()): boolean {
+  const last = lastFlareAt.get(kind);
+  if (last !== undefined && now - last < FLARE_COOLDOWN_MS) return false;
+  lastFlareAt.set(kind, now);
+  return true;
+}
+
+/** Test hook: forget all grants. */
+export function resetFlareCooldowns(): void {
+  lastFlareAt.clear();
+}

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -661,6 +661,29 @@ details[open] > .cave-tool-summary::before {
   animation: cave-chat-meta-blip 1.2s ease-in-out infinite;
 }
 
+/* One-shot session-settle flare (cave-q06w) — the summoning bloom (700ms,
+   decelerate, radiate + fade) in success green as a LONG run settles.
+   Shadow-only: the meta line is borderless and nothing may shift layout.
+   Gated in MetaLine by a 60s significance floor + a global per-kind
+   cooldown (src/lib/flare-cooldown.ts) + the celebrations pref; the row's
+   role=status announcement carries the information either way. */
+.cave-chat-meta-line--reward {
+  border-radius: var(--radius-md);
+  animation: cave-chat-settle-flare 700ms var(--ease-decelerate) forwards;
+}
+@keyframes cave-chat-settle-flare {
+  0% {
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--color-success) 45%, transparent),
+      0 0 18px color-mix(in oklch, var(--color-success) 40%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 10px transparent, 0 0 34px transparent;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-chat-meta-line--reward { animation: none; }
+}
+
 .cave-chat-meta-line--failed,
 .cave-chat-meta-line--offline {
   color: var(--color-danger);

--- a/src/styles/md-editor.css
+++ b/src/styles/md-editor.css
@@ -124,3 +124,25 @@
   font-style: italic;
   opacity: 0.7;
 }
+
+/* One-shot memory-save flare (cave-q06w) — the summoning bloom (700ms,
+   decelerate, radiate + fade) in success green as a MANUAL save lands.
+   Shadow-only on the borderless editor root; autosaves never flare and a
+   global cooldown (src/lib/flare-cooldown.ts) keeps save-happy editing
+   quiet. The footer's role=status "Saved" flash is the real confirmation. */
+.md-editor--reward {
+  border-radius: var(--radius-md);
+  animation: md-editor-save-flare 700ms var(--ease-decelerate) forwards;
+}
+@keyframes md-editor-save-flare {
+  0% {
+    box-shadow: 0 0 0 1px color-mix(in oklch, var(--color-success) 45%, transparent),
+      0 0 18px color-mix(in oklch, var(--color-success) 40%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 10px transparent, 0 0 34px transparent;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .md-editor--reward { animation: none; }
+}


### PR DESCRIPTION
Extends the summoning-flare vocabulary (cave-hshy: PR-merge + card-done) to the two deferred high-frequency events — **session-settle** and **memory-save** — with the cooldown model cave-q06w asked for.

## Design: two gates

| Gate | session-settle | memory-save |
|---|---|---|
| **Significance** | settled turn ran ≥ 60s (`SETTLE_MIN_RUN_MS`) — long runs are where the user context-switched away; short replies are their own feedback | manual saves only — autosave is ambient bookkeeping and never flares |
| **Frequency** | one flare per kind per 5 min (`FLARE_COOLDOWN_MS`), **global** so parallel familiars settling together collapse into a single bloom instead of a strobe | same window, independent kind |

`src/lib/flare-cooldown.ts`: record-on-grant only — denials don't extend the quiet window, so a steady drizzle still flares once per window instead of zero. In-memory per window on purpose: under-flaring is always safe (flares are visual-only garnish; `role=status` announcements carry the information), over-flaring is the failure mode.

## Wiring (dignity guardrails from cave-kx5y intact)
- **MetaLine** (chat-view): fires only on the `streaming→complete` transition; `.cave-chat-meta-line--reward` blooms shadow-only in `activity.css` (borderless row, no layout shift), reduced-motion collapses it, celebrations-pref gates it.
- **MdEditor**: `save()` gains a `source: "manual" | "auto" = "manual"` param; the debounced autosave declares `"auto"`. Manual success → `.md-editor--reward` (md-editor.css), same vocabulary/gates. Footer "Saved" flash remains the real confirmation.
- 700ms `var(--ease-decelerate)` one-shot, success-green `color-mix`, tokens only — hex ratchet stays 0.

## Tests
- `src/lib/flare-cooldown.test.ts` — grant/deny window, kind independence, no-record-on-deny drizzle case, reset hook, constants pinned.
- `src/components/settle-save-flare.test.ts` — source + CSS pins in the board/github reward-flare style (reads split CSS directly; no facade hook needed).
- `src/components/md-editor/md-editor.test.ts` autosave pin updated to the source-annotated call.
- Verified: targeted suites green, `pnpm typecheck`, `pnpm lint`, design-token-drift green.

Closes cave-q06w (parent epic cave-kx5y; predecessor cave-hshy).
