### PR TITLE
feat(settings): GitHub organization scope control (#3701)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -288,6 +288,7 @@ export const SUITES = {
     "src/lib/app-preferences-runtime.test.ts",
     "src/lib/app-preferences-paint-bootstrap.test.ts",
     "src/components/settings-appearance.test.ts",
+    "src/components/settings-github.test.ts",
     "src/components/settings-profile.test.ts",
     "src/components/settings-search.test.ts",
     "src/components/settings-daemon-multihost.test.ts",

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -26,6 +26,7 @@ import {
 } from "react-resizable-panels";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
+import { useAppPreferences } from "@/lib/app-preferences";
 import { Icon, type IconName } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -2459,21 +2460,24 @@ export function GitHubView({
   }, [refreshLinkedWork]);
 
   const items = activity?.items ?? [];
-  const filtered = useMemo(
-    () => (filter === "all" ? items : items.filter((i) => i.kind === filter)),
-    [items, filter],
-  );
+  // The configured organization scope (Settings → GitHub). Empty = all
+  // memberships; a non-empty list limits the whole surface to those orgs.
+  const orgScope = useAppPreferences().github.orgScope;
+  const filtered = useMemo(() => {
+    const byKind = filter === "all" ? items : items.filter((i) => i.kind === filter);
+    return orgScope.length === 0 ? byKind : byKind.filter((i) => orgScope.includes(orgOf(i.repo)));
+  }, [items, filter, orgScope]);
 
   // Memberships define the account's organization scope; activity adds any
   // organization represented by the current items. Repository options still
   // narrow to the chosen org so the two selects cascade (org → repo).
   const orgOptions = useMemo(
     () => Array.from(new Set([
-      ...(activity?.organizations ?? []),
+      ...(activity?.organizations ?? []).filter((o) => orgScope.length === 0 || orgScope.includes(o)),
       ...filtered.map((i) => orgOf(i.repo)),
       ...(orgFilter === "all" ? [] : [orgFilter]),
     ])).sort((a, b) => a.localeCompare(b)),
-    [activity?.organizations, filtered, orgFilter],
+    [activity?.organizations, filtered, orgFilter, orgScope],
   );
   const repoOptions = useMemo(() => {
     const base = orgFilter === "all" ? filtered : filtered.filter((i) => orgOf(i.repo) === orgFilter);

--- a/src/components/settings-github.test.ts
+++ b/src/components/settings-github.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const section = readFileSync(new URL("./settings-github.tsx", import.meta.url), "utf8");
+const sections = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const view = readFileSync(new URL("./github-view.tsx", import.meta.url), "utf8");
+
+test("the GitHub section is registered and rendered by the shell", () => {
+  assert.match(sections, /id: "github", label: "GitHub"/);
+  assert.match(sections, /github: \[/); // SECTION_HIGHLIGHTS entry
+  assert.match(sections, /section: "github", group: "Organizations"/); // search index
+  assert.match(shell, /import \{ GithubSection \} from "\.\/settings-github"/);
+  assert.match(shell, /section === "github"\s*&&\s*<GithubSection \/>/);
+});
+
+test("the section reads and writes the org scope preference", () => {
+  assert.match(section, /useAppPreferences\(\)\.github\.orgScope/);
+  assert.match(section, /updateAppPreferences\(\{ github: \{ orgScope: \[\] \} \}\)/); // reset to all
+  assert.match(section, /updateAppPreferences\(\{ github: \{ orgScope: next \} \}\)/); // toggle
+  assert.match(section, /SettingsOverview section="github"/);
+});
+
+test("the section reads memberships from the activity API and stays accessible", () => {
+  assert.match(section, /\/api\/github\/activity/);
+  assert.match(section, /type="checkbox"/);
+  assert.match(section, /role="alert"/);
+});
+
+test("the GitHub surface applies the configured org scope", () => {
+  assert.match(view, /const orgScope = useAppPreferences\(\)\.github\.orgScope;/);
+  // filtered items are constrained to the scope when non-empty
+  assert.match(view, /orgScope\.length === 0 \? byKind : byKind\.filter\(\(i\) => orgScope\.includes\(orgOf\(i\.repo\)\)\)/);
+  // the org dropdown only lists scoped memberships
+  assert.match(view, /orgScope\.length === 0 \|\| orgScope\.includes\(o\)/);
+});

--- a/src/components/settings-github.tsx
+++ b/src/components/settings-github.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * GitHub settings — the organization scope the GitHub surface pulls from.
+ *
+ * By default Cave surfaces every organization the authenticated account belongs
+ * to. Here the operator can narrow that to a chosen subset; the scope persists
+ * in app preferences (`github.orgScope`, empty = all) and the GitHub surface
+ * applies it consistently. The membership list is read live from
+ * `/api/github/activity`, the same source the surface's own org filter uses.
+ */
+
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { SettingsOverview } from "@/components/settings-overview";
+import { SettingsGroup } from "@/components/ui/settings-group";
+import { SettingControlRow, Segmented } from "@/components/ui/settings-controls";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { useAppPreferences, updateAppPreferences } from "@/lib/app-preferences";
+import { normalizeOrgScope } from "@/lib/preferences-schema";
+import type { ActivityResult } from "@/components/github-view-data";
+
+type OrgLoad =
+  | { status: "loading" }
+  | { status: "unauthed" }
+  | { status: "error" }
+  | { status: "ready"; login: string | null; organizations: string[] };
+
+type ScopeMode = "all" | "selected";
+
+export function GithubSection() {
+  const baseId = useId();
+  const { announce } = useAnnouncer();
+  const scope = useAppPreferences().github.orgScope;
+  const scoped = scope.length > 0;
+
+  const [load, setLoad] = useState<OrgLoad>({ status: "loading" });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoad({ status: "loading" });
+    (async () => {
+      try {
+        const res = await fetch("/api/github/activity", { cache: "no-store" });
+        const json = res.ok ? ((await res.json()) as ActivityResult | { ok: false }) : null;
+        if (cancelled) return;
+        if (!json || json.ok !== true) {
+          setLoad({ status: "error" });
+        } else if (!json.authed) {
+          setLoad({ status: "unauthed" });
+        } else {
+          setLoad({ status: "ready", login: json.login, organizations: json.organizations });
+        }
+      } catch {
+        if (!cancelled) setLoad({ status: "error" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const memberships = load.status === "ready" ? load.organizations : [];
+
+  // The rows to render: every membership, plus any scoped org that is no longer
+  // a membership (so a stale pick stays visible and removable).
+  const rows = useMemo(() => {
+    const set = new Set<string>(memberships);
+    for (const org of scope) set.add(org);
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [memberships, scope]);
+
+  const setMode = useCallback(
+    (mode: ScopeMode) => {
+      if (mode === "all") {
+        updateAppPreferences({ github: { orgScope: [] } });
+        announce("GitHub scope set to all organizations", "polite");
+      } else {
+        // Enter subset mode seeded with every membership selected, so nothing
+        // disappears until the operator unchecks something.
+        updateAppPreferences({ github: { orgScope: normalizeOrgScope(memberships) } });
+      }
+    },
+    [memberships, announce],
+  );
+
+  const toggleOrg = useCallback(
+    (org: string) => {
+      const next = scope.includes(org) ? scope.filter((o) => o !== org) : [...scope, org];
+      updateAppPreferences({ github: { orgScope: next } });
+    },
+    [scope],
+  );
+
+  const canSelect = memberships.length > 0 || scoped;
+
+  return (
+    <section className="max-w-none space-y-6" aria-labelledby={`${baseId}-title`}>
+      <h2 id={`${baseId}-title`} className="sr-only">
+        GitHub
+      </h2>
+      <SettingsOverview section="github" />
+
+      <SettingsGroup
+        label="Organizations"
+        description="Choose which GitHub organizations the GitHub surface pulls issues, pull requests, and repositories from."
+      >
+        <SettingControlRow
+          label="Organization scope"
+          hint={
+            scoped
+              ? `Limited to ${scope.length} organization${scope.length === 1 ? "" : "s"}.`
+              : "All organizations you belong to."
+          }
+        >
+          <Segmented
+            options={["all", "selected"] as const}
+            value={scoped ? "selected" : "all"}
+            onChange={setMode}
+            getLabel={(o) => (o === "all" ? "All" : "Selected")}
+            getTitle={(o) =>
+              o === "all"
+                ? "Include every organization you belong to"
+                : "Include only the organizations you choose below"
+            }
+            ariaLabel="GitHub organization scope"
+          />
+        </SettingControlRow>
+
+        <div className="px-4 pb-4">
+          {load.status === "loading" ? (
+            <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">Reading your GitHub memberships…</p>
+          ) : load.status === "unauthed" ? (
+            <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
+              Connect a GitHub token on the GitHub surface to choose specific organizations.
+            </p>
+          ) : load.status === "error" ? (
+            <p className="flex flex-wrap items-center gap-2 text-[length:var(--text-sm)] text-[var(--text-muted)]" role="alert">
+              Couldn’t read your organizations.
+              <Button variant="ghost" size="sm" onClick={() => setReloadKey((k) => k + 1)}>
+                Try again
+              </Button>
+            </p>
+          ) : !scoped ? (
+            <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
+              {memberships.length > 0
+                ? `Every organization is included (${memberships.length} available). Switch to “Selected” to narrow the surface.`
+                : "No organization memberships found for this account."}
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <ul className="grid gap-1.5 sm:grid-cols-2" aria-label="Included organizations">
+                {rows.map((org) => {
+                  const checked = scope.includes(org);
+                  const stale = !memberships.includes(org);
+                  return (
+                    <li key={org}>
+                      <label className="flex cursor-pointer items-center gap-2 rounded-[var(--radius-control)] px-2 py-1.5 text-[length:var(--text-sm)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]">
+                        <input
+                          type="checkbox"
+                          className="focus-ring h-4 w-4 accent-[var(--accent-presence)]"
+                          checked={checked}
+                          onChange={() => toggleOrg(org)}
+                        />
+                        <Icon name="ph:users-three" width={13} height={13} aria-hidden className="text-[var(--text-muted)]" />
+                        <span className="min-w-0 truncate">{org}</span>
+                        {stale ? (
+                          <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">not a current member</span>
+                        ) : null}
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+              {canSelect ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  leadingIcon="ph:arrow-counter-clockwise"
+                  onClick={() => setMode("all")}
+                >
+                  Reset to all organizations
+                </Button>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </SettingsGroup>
+    </section>
+  );
+}

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -12,7 +12,7 @@ import {
 // ── settings-sections catalog (pure) ─────────────────────────────────────────
 
 test("every section has full overview metadata + a highlight strip", () => {
-  const ids = ["profile", "general", "daemon", "familiars", "mobile", "appearance", "about"];
+  const ids = ["profile", "general", "daemon", "familiars", "github", "mobile", "appearance", "about"];
   assert.deepEqual(SECTIONS.map((s) => s.id), ids, "the section set matches the shell nav");
   for (const s of SECTIONS) {
     assert.ok(s.label && s.icon.startsWith("ph:") && s.description.length > 0, `${s.id} has label/icon/description`);

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -10,6 +10,7 @@ export type Section =
   | "general"
   | "daemon"
   | "familiars"
+  | "github"
   | "mobile"
   | "appearance"
   | "about";
@@ -30,6 +31,7 @@ export const SECTIONS: SectionMeta[] = [
   { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9386d0" },
   { id: "daemon", label: "Daemon", icon: "ph:terminal-window", description: "Local runtime status and process controls.", accent: "#69d6a6" },
   { id: "familiars", label: "Familiars", icon: "ph:users-three", description: "Roster, identity, permissions, and pin order.", accent: "#d8a9ff" },
+  { id: "github", label: "GitHub", icon: "ph:github-logo", description: "Which GitHub organizations the surface pulls in.", accent: "#8b98a8" },
   { id: "mobile", label: "Phone", icon: "ph:device-mobile", description: "Native iOS handoff over your Tailscale network.", accent: "#73d9d0" },
   { id: "appearance", label: "Appearance", icon: "ph:paint-brush", description: "Theme, typography, and reading controls.", accent: "#ff9fb5" },
   { id: "about", label: "About", icon: "ph:info", description: "Version, updates, and project links.", accent: "#b8d8ff" },
@@ -40,6 +42,7 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
   general: ["Workspace path", "Encrypted backup", "Launch behavior"],
   daemon: ["Runtime health", "Local/hub routing", "Socket & version"],
   familiars: ["Roster & identity", "Per-familiar permissions", "Pinned strip order"],
+  github: ["Organization scope", "From your memberships", "Applied on the GitHub surface"],
   mobile: ["Mobile mode", "Tailscale handoff", "Native iOS guide"],
   appearance: ["Theme & colors", "Typography", "Reading comfort"],
   about: ["App version", "Tool updates", "Project links"],
@@ -65,6 +68,7 @@ export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "familiars", group: "Projects", familiarTab: "projects", keywords: "projects access grants allow deny tool policy guard security audit requests permissions read write level" },
   { section: "familiars", group: "Access groups", keywords: "access groups group grants base projects read write level team role shared membership permissions" },
   { section: "familiars", group: "Vault", familiarTab: "vault", keywords: "vault secrets env environment keys tokens credentials 1password" },
+  { section: "github", group: "Organizations", keywords: "github organization org orgs scope memberships filter repos issues prs surface activity" },
   { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
   { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
   { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -49,6 +49,7 @@ import { FontSettings } from "./settings-fonts";
 import { SettingsTabbed } from "./settings-section-tabs";
 import type { TabItem } from "@/components/ui/tabs";
 import { ProfileSection } from "./settings-profile";
+import { GithubSection } from "./settings-github";
 import { AccessGroupsSection } from "./access-groups-section";
 import { SettingsOverview } from "./settings-overview";
 import {
@@ -401,6 +402,7 @@ export function SettingsShell() {
               onTabTargetConsumed={() => setFamiliarsTabTarget(null)}
             />
           )}
+          {section === "github"   && <GithubSection />}
           {section === "mobile"   && <MobileSection onUseAsHub={(url) => { setSuggestedHubUrl(url); openSection("daemon"); }} />}
           {section === "appearance" && <AppearanceSection scrollTarget={scrollTarget} />}
           {section === "about"    && <AboutSection />}

--- a/src/lib/preferences-schema.test.ts
+++ b/src/lib/preferences-schema.test.ts
@@ -406,3 +406,37 @@ assert.equal(defaults.appearance.backdrop.style, "image");
   const imported = legacyStorageToPreferencesPatch(mirrored);
   assert.equal(imported.appearance?.backdrop?.style, "blaze", "legacy import restores the style");
 }
+
+// ── GitHub organization scope (issue #3701) ──────────────────────────────────
+{
+  // Default is "all organizations" → an empty scope list.
+  assert.deepEqual(createDefaultPreferences(false).github.orgScope, []);
+}
+{
+  // Normalize trims, drops non-strings/blanks, and dedupes.
+  const p = normalizeCavePreferences({ github: { orgScope: ["  Acme ", "Acme", "", 5, "Beta", null] } });
+  assert.deepEqual(p.github.orgScope, ["Acme", "Beta"], "orgScope is trimmed, deduped, string-only");
+  assert.deepEqual(normalizeCavePreferences({}).github.orgScope, [], "absent github → empty scope");
+}
+{
+  // Patch validation accepts an orgScope array and rejects a non-array / bad keys.
+  const patch = validatePreferencesPatch({ github: { orgScope: ["OpenCoven", "OpenCoven", " x "] } });
+  assert.deepEqual(patch.github?.orgScope, ["OpenCoven", "x"]);
+  assert.throws(
+    () => validatePreferencesPatch({ github: { orgScope: "OpenCoven" } }),
+    PreferencesValidationError,
+    "orgScope must be an array",
+  );
+  assert.throws(
+    () => validatePreferencesPatch({ github: { unknownKey: true } }),
+    PreferencesValidationError,
+    "unknown github keys are rejected",
+  );
+}
+{
+  // Applying a scope patch replaces the list; clearing returns to all.
+  const scoped = applyPreferencesPatch(createDefaultPreferences(true), { github: { orgScope: ["OpenCoven"] } });
+  assert.deepEqual(scoped.github.orgScope, ["OpenCoven"]);
+  const cleared = applyPreferencesPatch(scoped, { github: { orgScope: [] } });
+  assert.deepEqual(cleared.github.orgScope, [], "empty patch clears back to all");
+}

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -118,6 +118,14 @@ export type CavePreferences = {
   phone: {
     mobileMode: boolean;
   };
+  github: {
+    /**
+     * Org logins the GitHub surface is scoped to. Empty means "all of the
+     * authenticated account's memberships" (the default); a non-empty list
+     * restricts the surface to just those orgs.
+     */
+    orgScope: string[];
+  };
 };
 
 export type CavePreferencesPatch = {
@@ -135,6 +143,7 @@ export type CavePreferencesPatch = {
   };
   general?: Partial<CavePreferences["general"]>;
   phone?: Partial<CavePreferences["phone"]>;
+  github?: Partial<CavePreferences["github"]>;
 };
 
 const DEFAULT_THEME: CaveThemePreferences = {
@@ -154,6 +163,21 @@ const DEFAULT_THEME: CaveThemePreferences = {
 export const DEFAULT_STOP_PHRASE = "stop, cancel, halt, abort";
 /** Longest phrase list the preference stores; UI and matcher share this bound. */
 export const STOP_PHRASE_MAX_LENGTH = 160;
+
+/**
+ * A GitHub org-scope list: deduped, trimmed, non-empty org logins. Anything
+ * that isn't a string is dropped; an empty result means "all memberships".
+ */
+export function normalizeOrgScope(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const login = entry.trim();
+    if (login) seen.add(login);
+  }
+  return [...seen];
+}
 
 function normalizeStopPhrase(value: unknown): string {
   if (typeof value !== "string") return DEFAULT_STOP_PHRASE;
@@ -193,6 +217,7 @@ export function createDefaultPreferences(initialized = false): CavePreferences {
     },
     general: { newsHeadlines: true, stopPhrase: DEFAULT_STOP_PHRASE, celebrations: true },
     phone: { mobileMode: true },
+    github: { orgScope: [] },
   };
 }
 
@@ -346,6 +371,7 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
   const image = record(backdrop.image);
   const general = record(source.general);
   const phone = record(source.phone);
+  const github = record(source.github);
 
   const modePreference = oneOf(theme.modePreference, MODE_PREFERENCES, "dark");
   const resolvedMode = oneOf(
@@ -427,6 +453,7 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
       celebrations: general.celebrations !== false,
     },
     phone: { mobileMode: phone.mobileMode !== false },
+    github: { orgScope: normalizeOrgScope(github.orgScope) },
   };
 }
 
@@ -520,7 +547,7 @@ function strictAccentSeed(value: unknown, path: string): CaveBackdropAccentSeed 
 
 export function validatePreferencesPatch(value: unknown): CavePreferencesPatch {
   const input = strictRecord(value, "preferences patch");
-  assertAllowedKeys(input, ["appearance", "general", "phone"], "preferences patch");
+  assertAllowedKeys(input, ["appearance", "general", "phone", "github"], "preferences patch");
   const patch: CavePreferencesPatch = {};
 
   if (Object.hasOwn(input, "appearance")) {
@@ -682,6 +709,16 @@ export function validatePreferencesPatch(value: unknown): CavePreferencesPatch {
       ? { mobileMode: strictBoolean(phone.mobileMode, "phone.mobileMode") }
       : {};
   }
+  if (Object.hasOwn(input, "github")) {
+    const github = strictRecord(input.github, "github");
+    assertAllowedKeys(github, ["orgScope"], "github");
+    const githubPatch: NonNullable<CavePreferencesPatch["github"]> = {};
+    if (Object.hasOwn(github, "orgScope")) {
+      if (!Array.isArray(github.orgScope)) fail("github.orgScope", "must be an array of strings");
+      githubPatch.orgScope = normalizeOrgScope(github.orgScope);
+    }
+    patch.github = githubPatch;
+  }
 
   return patch;
 }
@@ -759,6 +796,7 @@ export function applyPreferencesPatch(
     },
     general: { ...current.general, ...(patch.general ?? {}) },
     phone: { ...current.phone, ...(patch.phone ?? {}) },
+    github: { ...current.github, ...(patch.github ?? {}) },
   };
 
   const semanticCurrent = { ...current, initialized: true, revision: 0, updatedAt: "" };


### PR DESCRIPTION
Implements **issue #3701** — a Settings control for the GitHub organization scope Cave uses.

Follows PR #3700 (merged), which populates the org list from the authenticated account's memberships. This adds the persisted **scope** on top: which of those orgs the GitHub surface actually pulls in.

## What changed
- **Preferences** (`preferences-schema.ts`): new `github.orgScope: string[]` on `CavePreferences`. **Empty = all memberships** (the default). Normalized (trimmed, deduped, string-only), patch-validated, added to the top-level allow-list, and merged — with schema unit tests.
- **Settings UI** (`settings-github.tsx`, new **GitHub** section): an **All / Selected** segmented control plus a membership checkbox list read live from `/api/github/activity` (the same source the surface's own org filter uses), a **Reset to all** action, and honest loading / not-connected / error states. Registered in `settings-sections.ts` and rendered by `settings-shell.tsx`.
- **Surface** (`github-view.tsx`): the configured scope constrains both the activity items and the org-filter dropdown, so the whole GitHub surface applies it consistently.

## Acceptance criteria (from #3701)
- ✅ Settings exposes a clear control for the org scope.
- ✅ Populated from the authenticated GitHub membership list.
- ✅ Scope persists (app preferences) with a documented default (**all**) and reset (**Reset to all** / empty list).
- ✅ The GitHub surface consistently applies the configured scope.

## Verification
- `tsc`: 0 errors · design ESLint / codemod / drift: clean · full app test suite: 0 failures · `pnpm build`: exit 0, within budget.
- New tests: `preferences-schema.test.ts` (github.orgScope normalize/validate/apply) + `settings-github.test.ts` (section/shell/view wiring), both wired into the app suite.

Closes #3701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)